### PR TITLE
Fix Sublime Text

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,4 +1,4 @@
-class SublimeText2 < Cask
+class SublimeText < Cask
   url 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.1.dmg'
   homepage 'http://www.sublimetext.com/2'
   version '2.0.1'


### PR DESCRIPTION
There was an inconsistency between the cask filename and the class name which caused an exception to be thrown when running `brew cask search` (and possibly other commands).

This should be pulled in asap (sorry!).
