### PR TITLE
Add support for taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ together.
 The whole idea is to build a _community-maintained_ list of easily installable
 packages, so the community part is important! Every little bit counts.
 
+# Taps
+
+You can add Casks to your existing (or new) taps: just create a directory named
+`Casks` inside your tap, put your Casks there, and everything will just work.
+
 # Alfred Integration
 
 I've been using Casks along with Alfred to great effect.  Just add

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -199,7 +199,7 @@ class Cask
 
   def _zip?(path)
     output = `file -Izb #{path}`
-    output.chomp == 'application/x-empty compressed-encoding=application/zip; charset=binary; charset=binary'
+    output.chomp.include? 'compressed-encoding=application/zip; charset=binary; charset=binary'
   end
 
   def _tar_bzip?(path)

--- a/lib/cask/cli/edit.rb
+++ b/lib/cask/cli/edit.rb
@@ -1,8 +1,8 @@
 class Cask::CLI::Edit
   def self.run(*arguments)
     cask_name, *rest = *arguments
-    cask_path = Cask.path.join("#{cask_name}.rb")
-    raise CaskUnavailableError, cask_path.basename('.rb').to_s unless cask_path.file?
+    cask_path = Cask.path(cask_name)
+    raise CaskUnavailableError, cask_name + ".rb" if cask_path.nil? || !cask_path.file?
     exec_editor cask_path
   end
 

--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -1,6 +1,6 @@
 class Cask::CLI::List
   def self.run(*arguments)
-    puts Cask.installed.map(&:to_s).join("\n")
+    puts_columns Cask.nice_listing(Cask.installed)
   end
 
   def self.help

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -1,7 +1,21 @@
 class Cask::CLI::Search
   def self.run(*arguments)
     search_term, *rest = *arguments
-    puts Cask.all.map(&:to_s).grep(/#{search_term}/).join("\n")
+    casks = {}
+    Cask.all.grep(/#{search_term}/).each { |c|
+      repo, name = c.split "/"
+      casks[name] ||= []
+      casks[name].push repo
+    }
+    list = []
+    casks.each { |name,repos|
+      if repos.length == 1
+        list.push name
+      else
+        repos.each { |r| list.push [r,name].join "/" }
+      end
+    }
+    puts list.join "\n"
   end
 
   def self.help

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -15,7 +15,7 @@ class Cask::CLI::Search
         repos.each { |r| list.push [r,name].join "/" }
       end
     }
-    puts list.sort.join "\n"
+    puts_columns list.sort.join "\n"
   end
 
   def self.help

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -2,20 +2,7 @@ class Cask::CLI::Search
   def self.run(*arguments)
     search_term, *rest = *arguments
     casks = {}
-    Cask.all.grep(/#{search_term}/).each { |c|
-      repo, name = c.split "/"
-      casks[name] ||= []
-      casks[name].push repo
-    }
-    list = []
-    casks.each { |name,repos|
-      if repos.length == 1
-        list.push name
-      else
-        repos.each { |r| list.push [r,name].join "/" }
-      end
-    }
-    puts_columns list.sort.join "\n"
+    puts_columns Cask.nice_listing(Cask.all.grep(/#{search_term}/))
   end
 
   def self.help

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -15,7 +15,7 @@ class Cask::CLI::Search
         repos.each { |r| list.push [r,name].join "/" }
       end
     }
-    puts list.join "\n"
+    puts list.sort.join "\n"
   end
 
   def self.help


### PR DESCRIPTION
See #12 and the commit messages for 3d3207b, 4de758b for implementation details.

Summary:
- Casks are now looked for in all `.../Taps/*/Casks/*.rb`
- `list` and `search` display results in columns, with fully qualified names for duplicates, e.g.
  
  ```
  $ brew cask search firefox                                     
  firefox                                 phinze-cask/firefox-aurora
  passcod-extra/firefox-aurora
  ```
- Commands are slightly faster due to less `map(&:to_s)` performed
