### PR TITLE
Fix broken linkapps command

### DIFF
--- a/lib/cask/cli/linkapps.rb
+++ b/lib/cask/cli/linkapps.rb
@@ -1,6 +1,8 @@
 class Cask::CLI::Linkapps
   def self.run(*arguments)
-    Cask.installed.map(&:linkapps)
+    Cask.installed.map { |app|
+      Cask.load(app).linkapp
+    }
   end
 
   def self.help


### PR DESCRIPTION
Yerr, ahem, oops. I broke the `brew cask linkapps` command while adding tap support. Fortunately:
- It was easy to fix.
- The `brew-cask` formula hasn't been updated yet (0.3.0 isn't there yet, heh), so nobody noticed (but me!).

Sorry --' orz
