### PR TITLE
Eclipse

### DIFF
--- a/Casks/eclipse.rb
+++ b/Casks/eclipse.rb
@@ -1,0 +1,5 @@
+class Eclipse < Cask
+  url 'http://www.gtlib.gatech.edu/pub/eclipse/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-macosx-cocoa-x86_64.tar.gz'
+  homepage 'http://www.eclipse.org'
+  version '4.2.1'
+end

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -187,6 +187,15 @@ class Cask
       ensure
         `rm -rf '#{destdir}'`
       end
+    elsif _tar_gzip?(path)
+      destdir = "/tmp/brewcask_#{@title}_extracted"
+      `mkdir -p '#{destdir}'`
+      `tar zxf '#{path}' -C '#{destdir}'`
+      begin
+        yield destdir
+      ensure
+        `rm -rf '#{destdir}'`
+      end
     else
       raise "uh oh, could not identify type of #{path}"
     end


### PR DESCRIPTION
Added a cask for Eclipse.  It depends on support for `tar.gz` files (https://github.com/phinze/homebrew-cask/pull/45)
