### PR TITLE
Add new casks

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,0 +1,5 @@
+class Aquamacs < Cask
+  url 'http://downloads.sourceforge.net/project/aquamacs/Releases/Aquamacs-Emacs-2.4.dmg'
+  homepage 'http://aquamacs.org/'
+  version '2.4'
+end

--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,0 +1,5 @@
+class Arq < Cask
+  url 'http://www.haystacksoftware.com/arq/Arq.zip'
+  homepage 'http://www.haystacksoftware.com/arq/'
+  version 'latest'
+end

--- a/Casks/back-in-time.rb
+++ b/Casks/back-in-time.rb
@@ -1,0 +1,5 @@
+class BackInTime < Cask
+  url 'http://www.tri-edre.com/pub/files/backintime203.dmg'
+  homepage 'http://www.tri-edre.fr/english/backintime.html'
+  version '2.0.3'
+end

--- a/Casks/boot-x-changer.rb
+++ b/Casks/boot-x-changer.rb
@@ -1,0 +1,5 @@
+class BootXChanger < Cask
+  url 'http://namedfork.net/_media/bootxchanger_2.0.dmg'
+  homepage 'http://namedfork.net/bootxchanger'
+  version '2.0'
+end

--- a/Casks/colloquy.rb
+++ b/Casks/colloquy.rb
@@ -1,0 +1,6 @@
+class Colloquy < Cask
+  url 'http://colloquy.info/downloads/colloquy-2.4.zip'
+  homepage 'http://colloquy.info/'
+  version '2.4'
+end
+

--- a/Casks/divvy.rb
+++ b/Casks/divvy.rb
@@ -1,0 +1,5 @@
+class Divvy < Cask
+  url 'http://mizage.com/downloads/Divvy.zip'
+  homepage 'http://mizage.com/divvy/'
+  version 'latest'
+end

--- a/Casks/fluid.rb
+++ b/Casks/fluid.rb
@@ -1,0 +1,5 @@
+class Fluid < Cask
+  url 'http://fluidapp.com/dist/Fluid_1.6.1.zip'
+  homepage 'http://fluidapp.com/'
+  version '1.6.1'
+end

--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,0 +1,5 @@
+class Gimp < Cask
+  url 'ftp://ftp.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.2-dmg-2.dmg'
+  homepage 'http://www.gimp.org'
+  version '2.8.2'
+end

--- a/Casks/gitx-l.rb
+++ b/Casks/gitx-l.rb
@@ -1,0 +1,6 @@
+class GitxL < Cask
+  url 'https://github.com/downloads/laullon/gitx/GitX-L_v0.8.4.zip'
+  homepage 'http://gitx.laullon.com/'
+  version '0.8.4'
+end
+

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -1,0 +1,6 @@
+class Gitx < Cask
+  url 'http://frim.frim.nl/GitXStable.app.zip'
+  homepage 'http://gitx.frim.nl/'
+  version 'latest'
+end
+

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,0 +1,5 @@
+class GoogleChromeCanary < Cask
+  url 'https://storage.googleapis.com/chrome-canary/GoogleChromeCanary.dmg'  
+  homepage 'https://tools.google.com/dlpage/chromesxs'
+  version 'latest'
+end

--- a/Casks/jumpcut.rb
+++ b/Casks/jumpcut.rb
@@ -1,0 +1,6 @@
+class Jumpcut < Cask
+  url 'http://downloads.sourceforge.net/project/jumpcut/jumpcut/0.63/Jumpcut_0.63.tgz'
+  homepage 'http://jumpcut.sourceforge.net/'
+  version '0.63'
+end
+

--- a/Casks/livestation.rb
+++ b/Casks/livestation.rb
@@ -1,0 +1,5 @@
+class Livestation < Cask
+  url 'http://updates.livestation.com/releases/Livestation-3.2.0-intel.dmg'
+  homepage 'http://www.livestation.com'
+  version '3.2.0'
+end

--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -1,0 +1,6 @@
+class Moom < Cask
+  url 'http://manytricks.com/download/moom'
+  homepage 'http://manytricks.com/moom/'
+  version 'latest'
+end
+

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -41,7 +41,7 @@ class Cask::Installer
         ensure
           `rm -rf '#{destdir}'`
         end
-      elsif _tar_bzip?(path)
+      elsif _tar?(path)
         destdir = "/tmp/brewcask_#{@title}_extracted"
         `mkdir -p '#{destdir}'`
         `tar jxf '#{path}' -C '#{destdir}'`
@@ -65,9 +65,18 @@ class Cask::Installer
       output.chomp.include? 'compressed-encoding=application/zip; charset=binary; charset=binary'
     end
 
+    def _tar?(path)
+      _tar_bzip?(path) || _tar_gzip?(path)
+    end
+
     def _tar_bzip?(path)
       output = `file -Izb '#{path}'`
       output.chomp == 'application/x-tar; charset=binary compressed-encoding=application/x-bzip2; charset=binary; charset=binary'
+    end
+
+    def _tar_gzip?(path)
+      output = `file -Izb '#{path}'`
+      output.chomp == 'application/x-tar; charset=binary compressed-encoding=application/x-gzip; charset=binary; charset=binary'
     end
   end
 end


### PR DESCRIPTION
Colloquy- irc client
GitX - git gui (original version)
GitX (L) - git gui (a fork)
Arq - online backup
Aquamacs - OSX emacs
BootXChanger - boot image changer
Back-In-Time - Time machine backup explorer
Moom - Window manager
Fluid - Turn websites into apps
Gimp - Image editor
Divvy - Window Manager
Google Chrome Canary - Latest and greatest chrome
Livestation - Watch TV from around the world
Jumpcut - Clipboard bufferer

Jumpcut support required modifying installer.rb to support tar.gz/.tgz files. This is almost identical to _tar_bzip? in that the required code to run is the same. Combined into a _tar? method check. 

Also, I see the tar command is jxf for options afaict the j isn't needed. Is there a reason I'm not aware of for it. It appears to work correctly w/o it and the tar manpage say j is ignored when extracting.

I didn't added automated tests for the new type because from other recent commit comments, I can see that you are still working out a testing strategy.
