### PR TITLE
Update Textadept Cask to 6.0 beta3.

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,5 +1,5 @@
 class Textadept < Cask
-  url 'http://foicica.com/textadept/download/textadept_5.4.osx.zip'
+  url 'http://foicica.com/textadept/download/textadept_6.0_beta_3.osx.zip'
   homepage 'http://foicica.com/textadept/'
-  version '5.4'
+  version '6.0-beta-3'
 end


### PR DESCRIPTION
Installation worked, thanks again!
It's okay to use the beta version, as the beta tag is mainly related to an ncurses version also included in the package.
