### PR TITLE
Fixed camelCase spelling of textwrangler and virtualbox

### DIFF
--- a/Casks/textwrangler.rb
+++ b/Casks/textwrangler.rb
@@ -1,4 +1,4 @@
-class TextWrangler < Cask
+class Textwrangler < Cask
     homepage 'http://www.barebones.com/products/textwrangler'
     version '4.0.1'
     url 'http://ash.barebones.com/TextWrangler_4.0.1.dmg'

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,4 +1,4 @@
-class VirtualBox < Cask
+class Virtualbox < Cask
     homepage 'http://www.virtualbox.org'
     version '4.2.4.81684'
     url 'http://download.virtualbox.org/virtualbox/4.2.4/VirtualBox-4.2.4-81684-OSX.dmg'


### PR DESCRIPTION
Got a nasty message when listing out casks after adding TextWrangler and VirtualBox. The mapping was off for the class names, which I spelled with CamelCase (error below)... Update now spells the class names as Textwrangler and Virtualbox...

```
mbp:~ brew cask list
Error: uninitialized constant Cask::Virtualbox
Please report this bug:
    https://github.com/mxcl/homebrew/wiki/troubleshooting
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask.rb:51:in `const_get'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask.rb:51:in `load'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask/scopes.rb:19:in `all'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask/scopes.rb:9:in `map'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask/scopes.rb:9:in `all'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask/scopes.rb:25:in `installed'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask/cli/list.rb:3:in `run'
/usr/local/Cellar/brew-cask/0.4.0/rubylib/cask/cli.rb:17:in `process'
/usr/local/bin/brew-cask.rb:6
/usr/local/bin/brew:51:in `require'
/usr/local/bin/brew:51:in `require?'
/usr/local/bin/brew:91
```
