### PR TITLE
Add a Cask for PandoraJam.

### DIFF
--- a/Casks/pandora-jam.rb
+++ b/Casks/pandora-jam.rb
@@ -1,0 +1,6 @@
+class PandoraJam < Cask
+  url 'http://www.bitcartel.com/downloads/pandorajam.zip'
+  homepage 'http://www.bitcartel.com/pandorajam/'
+  version 'latest'
+  content_length '5366519'
+end


### PR DESCRIPTION
PandoraJam lets you listen, record and stream music to an Airport Express or TV from Pandora. It also lets you scrobble tracks to Last.fm.
