### PR TITLE
Update IntelliJ Casks 

### DIFF
--- a/Casks/intellij-community.rb
+++ b/Casks/intellij-community.rb
@@ -1,6 +1,6 @@
 class IntellijCommunity < Cask
-  url 'http://download.jetbrains.com/idea/ideaIC-11.1.4.dmg'
+  url 'http://download.jetbrains.com/idea/ideaIC-12.0.dmg'
   homepage 'https://www.jetbrains.com/idea/index.html'
-  version '11.1.4'
-  content_length '113789795'
+  version '12.0'
+  content_length '115776432'
 end

--- a/Casks/intellij-ultimate.rb
+++ b/Casks/intellij-ultimate.rb
@@ -1,6 +1,6 @@
 class IntellijUltimate < Cask
-  url 'http://download.jetbrains.com/idea/ideaIU-11.1.4.dmg'
+  url 'http://download.jetbrains.com/idea/ideaIU-12.0.dmg'
   homepage 'https://www.jetbrains.com/idea/index.html'
-  version '11.1.4'
-  content_length '198099319'
+  version '12.0'
+  content_length '209034753'
 end


### PR DESCRIPTION
New versions, new content_length value and passes `brew cask audit`.
