### PR TITLE
Add options to the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ packages, so the community part is important! Every little bit counts.
 You can add Casks to your existing (or new) taps: just create a directory named
 `Casks` inside your tap, put your Casks there, and everything will just work.
 
+# Options
+
+You can set options on the command-line and/or using the `HOMEBREW_CASK_OPTS`
+environment variable, e.g.:
+
+```bash
+# This probably should happen in your ~/.{ba|z}shrc
+$ export HOMEBREW_CASK_OPTS="/Applications"
+
+# Installs to /Applications
+$ brew cask install a-cask
+
+# Trumps the ENV and installs to ~/Applications
+$ brew cask install --appdir="~/Applications" a-cask
+```
+
 # Alfred Integration
 
 I've been using Casks along with Alfred to great effect.  Just add

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -26,8 +26,8 @@ class Cask
     @appdir ||= Pathname.new(File.expand_path("~/Applications"))
   end
 
-  def self.set_appdir(canned_appdir)
-    @appdir = canned_appdir
+  def self.appdir=(_appdir)
+    @appdir = _appdir
   end
   
   def self.init

--- a/test/cli/options_test.rb
+++ b/test/cli/options_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+describe Cask::CLI do
+  it "supports setting the appdir" do
+    shutup do
+      Cask::CLI.process %w{help --appdir=/some/path}
+    end
+
+    Cask.appdir.must_equal Pathname.new File.expand_path "/some/path"
+  end
+
+  it "supports setting the appdir from ENV" do
+    ENV['HOMEBREW_CASK_OPTS'] = "--appdir=/some/path"
+
+    shutup do
+      Cask::CLI.process %w{help}
+    end
+
+    Cask.appdir.must_equal Pathname.new File.expand_path "/some/path"
+  end
+
+  after do
+    ENV['HOMEBREW_CASK_OPTS'] = nil
+    Cask.appdir = CANNED_APPDIR
+  end
+end

--- a/test/support/fake_appdir.rb
+++ b/test/support/fake_appdir.rb
@@ -1,6 +1,6 @@
 # wire in a fake appdir for linkapps
 CANNED_APPDIR = (HOMEBREW_REPOSITORY/"Applications")
-Cask.set_appdir(CANNED_APPDIR)
+Cask.appdir = CANNED_APPDIR
 
 module FakeAppdirHooks
   def before_setup


### PR DESCRIPTION
_Non-breaking change from #114 – this one has tests, too._

Inspired by the discussion on #30 and #38.

---

Options can be passed on the command-line and/or using the `HOMEBREW_CASK_OPTS` environment variable (which has lowest priority). There is a single `--appdir=PATH` option right now, but this commit enables future awesomeness!

Other minor changes:
- `brew cask help` now returns the same thing as `brew cask` instead of saying there was “no such command as help”.
- The heredoc block for the usage message now uses Homebrew's #undent instead of the customed-rolled #gsub version. Cleaner and more flexible.
- `Cask.set_appdir` has been renamed to `Cask.appdir=`. This is more Rubyish, and of little consequence (the only place it was previously used was in the tests).
