### PR TITLE
Added tip about mac file chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,7 @@ $ brew cask install --appdir="~/Applications" a-cask
 
 # Alfred Integration
 
-I've been using Casks along with Alfred to great effect.  Just add
-`/usr/local/Cellar` as a Search Scope in Alfred's preferences, and then
-applications become available in Alfred immediately after a `brew cask
-install`.  Your fingertips will thank you.
+I've been using Casks along with Alfred to great effect.  Just add `/usr/local/Cellar` as a Search Scope in Alfred's preferences (may need to press `cmd+shift+g` in the file chooser), and then applications become available in Alfred immediately after a `brew cask install`.  Your fingertips will thank you.
 
 With this setup, you don't actually need `brew cask linkapps` if you always
 open your apps from Alfred. This means that everything stays nice and tidy.


### PR DESCRIPTION
By default, the mac file chooser won't list folders like /usr/, added tip to readme
