### PR TITLE
Add Adobe AIR installer

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,0 +1,9 @@
+class AdobeAirInstaller < Cask
+  url 'http://airdownload.adobe.com/air/mac/download/3.5/AdobeAIR.dmg'
+  homepage 'https://get.adobe.com/air/'
+  version '3.5'
+  
+  #caveat 'You need to run {{install_path}}/AdobeAIRInstaller.app to actually install Adobe AIR'
+  
+  sha1 '42e3af2bd82a285e1b3d7d0c9779a8d19dcdd723'
+end


### PR DESCRIPTION
And also note the tentative syntax for caveats/post-install notes. Which is actually just my way of meta-saying:
‘This is an installer, not the actual shtuff!’

(line 6):

``` ruby
caveat 'You need to run {{install_path}}/AdobeAIRInstaller.app to actually install Adobe AIR'
```
