### PR TITLE
Fix Gimp shasum

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -3,5 +3,5 @@ class Gimp < Cask
   homepage 'http://www.gimp.org'
   version '2.8.2'
   content_length '63881252'
-  sha1 '0bd1d9d5b1da69b77217949b788597a952cbd846'
+  sha1 'f9acaf794c7055e9ab3d5699963c684bbaf55f59'
 end


### PR DESCRIPTION
For some reason, the SHA sum of Gimp .dmg did not match the file that is now available.
