### PR TITLE
Update test cask

### DIFF
--- a/test/support/Casks/test-cask.rb
+++ b/test/support/Casks/test-cask.rb
@@ -2,4 +2,6 @@ class TestCask < Cask
   url 'http://example.com/TestCask.dmg'
   homepage 'http://example.com/'
   version '1.2.3'
+  content_length '123456'
+  sha1 '0123456789012345678901234567890123456789'
 end


### PR DESCRIPTION
Test cask previously contained only attributes `url`, `homepage` and
`version`.  Add also `content_length` and `sha1`.
