### PR TITLE
Incorrect cask name broke linkapps, I simply fixed it.

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,4 +1,4 @@
-class AdobeAirInstaller < Cask
+class AdobeAir < Cask
   url 'http://airdownload.adobe.com/air/mac/download/3.5/AdobeAIR.dmg'
   homepage 'https://get.adobe.com/air/'
   version '3.5'


### PR DESCRIPTION
As simple as that.
