### PR TITLE
Adding Vagrant 1.0.6

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,0 +1,7 @@
+class Vagrant < Cask
+  url 'http://files.vagrantup.com/packages/476b19a9e5f499b5d0b9d4aba5c0b16ebe434311/Vagrant.dmg'
+  homepage 'http://www.vagrantup.com'
+  version '1.0.6'
+  content_length '25674666'
+  sha256 '30d3cc92c2376ddf940a30f20ae3fa6d8248b83bd4f810a3050217385b03ead0'
+end


### PR DESCRIPTION
This one is a little strange. Vagrant is a ruby command line tool but
the recommended distribution is a `pkg` (though you can also install it
as a gem). Since you have `pkg` support in your roadmap (presumably using
`installer`), I figured I'd submit this PR in case you see this type of
scenario as being an appropriate usage of `brew-cask`.
