### PR TITLE
Update libre-office

### DIFF
--- a/Casks/libre-office.rb
+++ b/Casks/libre-office.rb
@@ -1,7 +1,7 @@
 class LibreOffice < Cask
-  url 'http://download.documentfoundation.org/libreoffice/stable/3.5.7/mac/x86/LibO_3.5.7_MacOS_x86_install_en-US.dmg'
+  url 'http://download.documentfoundation.org/libreoffice/stable/3.6.5/mac/x86/LibO_3.6.5_MacOS_x86_install_en-US.dmg'
   homepage 'http://www.libreoffice.org/'
-  version '3.5.7'
-  content_length '178067623'
-  sha1 'a9c32610d9f9b50be5058c115f62d3660ae74b17'
+  version '3.6.5'
+  content_length '179572795'
+  sha1 'dd976dd18118dea876898de6a1236b63d646f0da'
 end


### PR DESCRIPTION
I've updated libre-office to 3.6.5. The release for 3.5.7 was 404 not found. I tested this Cask and it installed LibreOffice where I previously had no LibreOffice. It runs and works as expected.
