### PR TITLE
TorBrowser

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,0 +1,7 @@
+class TorBrowserAlpha < Cask
+  homepage 'https://www.torproject.org/projects/torbrowser.html'
+  url 'https://www.torproject.org/dist/torbrowser/osx/TorBrowser-2.4.9-alpha-1-osx-x86_64-en-US.zip
+  version '2.4.9-alpha-1'
+  content_length '38613261'
+  sha1 'f593127548f8ea9b900fb6ed680c5b5c5ace8cef'
+end

--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,0 +1,7 @@
+class TorBrowser < Cask
+  homepage 'https://www.torproject.org/projects/torbrowser.html'
+  url 'https://www.torproject.org/dist/torbrowser/osx/TorBrowser-2.3.25-2-osx-x86_64-en-US.zip'
+  version '2.3.25-2'
+  content_length '35405646'
+  sha1 'bb36926c46ede3d1f841df42ed288abed365f3d3'
+end


### PR DESCRIPTION
I've added two new Casks for TorBrowser on OS X for x86_64. One is the normal stable branch that most users should use and the other is our alpha release channel.

I'm not sure of the best way to add the 32bit releases to the same Cask files - is there a way that you plan to do this? Or should I just create torbrowser-i386 and torbrowser-alpha-i386 or should I just forget that 32bit architectures exist? :)
