### PR TITLE
Update the Adium cask to 1.5.4

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -1,7 +1,7 @@
 class Adium < Cask
-  url 'http://download.adium.im/Adium_1.5.3.dmg'
+  url 'http://download.adium.im/Adium_1.5.4.dmg'
   homepage 'http://www.adium.im/'
-  version '1.5.3'
-  content_length '23726161'
-  sha1 'ea16f7b65b8b37caa9025f4d68c0dd71845a4027'
+  version '1.5.4'
+  content_length '23840321'
+  sha1 '4aff5c040143fb8a8176662c1881815c41874bd0'
 end


### PR DESCRIPTION
Adium 1.5.4 is out, I've updated the cask to match.

As an aside, I've updated https://trac.adium.im/wiki/PreviousReleases SHA1 hashes for the previous couple of releases, and I intend to also include them for future releases.
