### PR TITLE
Bump size-up to version 1.5 (1227)

### DIFF
--- a/Casks/size-up.rb
+++ b/Casks/size-up.rb
@@ -1,6 +1,6 @@
 class SizeUp < Cask
   url 'http://www.irradiatedsoftware.com/download/SizeUp.zip'
   homepage 'http://www.irradiatedsoftware.com/sizeup/index.html'
-  version '1.3.2'
-  sha1 'c26dea7e3341e1467ff08768c9ce8bf53216de6b'
+  version '1.5 (1227)'
+  sha1 '1559738dca20a82d075c46b3db00ff6be4a494d9'
 end


### PR DESCRIPTION
Verified that I could install it properly on my machine after updating the sha1.
