### PR TITLE
updated Dropbox to version 2.0.5

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,6 +1,8 @@
 class Dropbox < Cask
-  url 'https://d1ilhw0800yew8.cloudfront.net/client/Dropbox%202.0.0.dmg'
+  url 'https://d1ilhw0800yew8.cloudfront.net/client/Dropbox%202.0.5.dmg'
   homepage 'http://www.dropbox.com/'
-  version '2.0'
-  sha1 '80ee4ea6b34ffe1220430aea5e7ed035013850aa'
+  version '2.0.5'
+  md5 '161bf3d427b5cf0c6297653f09eed7be'
+  sha1 '6e88e76e3787de6c4367da0f0a1b1427c6984bd6'
+  sha256 '1169d604ed3db8b15449753f7cf9c5af2b86afefcf598231d44dc29551c4a489'
 end

--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -2,7 +2,5 @@ class Dropbox < Cask
   url 'https://d1ilhw0800yew8.cloudfront.net/client/Dropbox%202.0.5.dmg'
   homepage 'http://www.dropbox.com/'
   version '2.0.5'
-  md5 '161bf3d427b5cf0c6297653f09eed7be'
   sha1 '6e88e76e3787de6c4367da0f0a1b1427c6984bd6'
-  sha256 '1169d604ed3db8b15449753f7cf9c5af2b86afefcf598231d44dc29551c4a489'
 end


### PR DESCRIPTION
Added md5, sha256 to cask

Tested on OSX 10.8.3

I'm a little new to Cask - looks awesome. I was curious about the behavior of updating/upgrading an existing package, such as Dropbox 2.0.

If 2.0 is installed in in `/usr/local/Caskroom/dropbox/2.0` and 2.0.5 gets installed in `/usr/local/Caskroom/dropbox/2.0.5` - then when `brew cask linkapps` runs, it does make two symlinks, just the second one clobbers the first (which is ok).

Is there a better way to do this, and clean up the older version? `brew cask uninstall dropbox` will only remove the current one, apparently.
