### PR TITLE
hopefully resolved confusion with ‘a-cask’

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,17 @@ You can add Casks to your existing (or new) taps: just create a directory named
 
 # Options
 
-You can set options on the command-line and/or using the `HOMEBREW_CASK_OPTS`
-environment variable, e.g.:
+You can set options on the command-line and/or using the `HOMEBREW_CASK_OPTS` environment variable, e.g. (again, using google-chrome):
 
 ```bash
 # This probably should happen in your ~/.{ba|z}shrc
 $ export HOMEBREW_CASK_OPTS="--appdir=/Applications"
 
 # Installs to /Applications
-$ brew cask install a-cask
+$ brew cask install google-chrome
 
 # Trumps the ENV and installs to ~/Applications
-$ brew cask install --appdir="~/Applications" a-cask
+$ brew cask install --appdir="~/Applications" google-chrome
 ```
 
 # Alfred Integration

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ You can set options on the command-line and/or using the `HOMEBREW_CASK_OPTS` en
 # This probably should happen in your ~/.{ba|z}shrc
 $ export HOMEBREW_CASK_OPTS="--appdir=/Applications"
 
-# Installs to /Applications
+# Installs app links to /Applications
 $ brew cask install google-chrome
 
-# Trumps the ENV and installs to ~/Applications
+# Trumps the ENV and installs app links to ~/Applications
 $ brew cask install --appdir="~/Applications" google-chrome
 ```
 


### PR DESCRIPTION
It seems ‘a‐cask’ in the README can [cause some confusion](https://github.com/phinze/homebrew-cask/issues/195), so hopefully this addresses that, but I didn’t want to merge this without the creator’s consent first.
