### PR TITLE
`linkapps` doesn't work with .app that have spaces in them

### DIFF
--- a/lib/cask/app_linker.rb
+++ b/lib/cask/app_linker.rb
@@ -31,7 +31,7 @@ class Cask
         ohai "It seems there is already an app at #{app_path}; not linking."
         return
       end
-      `ln -s #{app} #{app_path}`
+      `ln -s "#{app}" "#{app_path}"`
     end
   end
 end


### PR DESCRIPTION
``` bash
$ brew cask linkapps alfred
ln: 2.app: No such file or directory
ln: Preferences.app: No such file or directory
```

This happens because the files are named `Alfred 2.app` and `Alfred Preferences.app`, but the space causes it to fail. It sounds like a misquoting incident to me.
