### PR TITLE
Fixing sf download links

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 class Chromium < Cask
   homepage 'http://www.freesmug.org/chromium'
-  url 'http://sourceforge.net/projects/osxportableapps/files/Chromium/ChromiumOSX_22.0.1229.92.dmg/download'
+  url 'http://downloads.sourceforge.net/sourceforge/osxportableapps/ChromiumOSX_22.0.1229.92.dmg'
   version '22.0.1229.92'
   sha1 'afb9ae77e4aa2a6e3321ffa314869698105bb22f'
 end

--- a/Casks/free-cad.rb
+++ b/Casks/free-cad.rb
@@ -1,5 +1,5 @@
 class FreeCad < Cask
-  url 'http://sourceforge.net/projects/free-cad/files/FreeCAD%20MacOSX/FreeCAD_0.12_MacOSX10.7_20120110_x64.dmg'
+  url 'http://downloads.sourceforge.net/sourceforge/free-cad/FreeCAD_0.12_MacOSX10.7_20120110_x64.dmg'
   homepage 'http://sourceforge.net/projects/free-cad/'
   version '0.12'
   sha1 'f2629f5d113e7bd59b27364d9940d857b0433359'

--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -1,5 +1,5 @@
 class Mumble < Cask
-  url 'http://ignum.dl.sourceforge.net/project/mumble/Mumble/1.2.3a/Mumble-1.2.3a.dmg'
+  url 'http://downloads.sourceforge.net/sourceforge/mumble/Mumble-1.2.3a.dmg'
   homepage 'http://mumble.sourceforge.net'
   version '1.2.3a'
   sha1 '5831f6bcd630c338a898cf67b93ab6d083d0dc41'

--- a/Casks/open-office.rb
+++ b/Casks/open-office.rb
@@ -1,5 +1,5 @@
 class OpenOffice < Cask
-  url 'http://sourceforge.net/projects/openofficeorg.mirror/files/stable/3.4.1/Apache_OpenOffice_incubating_3.4.1_MacOS_x86_install_en-US.dmg/download'
+  url 'http://downloads.sourceforge.net/sourceforge/openofficeorg.mirror/Apache_OpenOffice_incubating_3.4.1_MacOS_x86_install_en-US.dmg'
   homepage 'http://www.openoffice.org/'
   version '3.4.1'
   sha1 '63623a1cc77bfc3c0fe207c317ecd087eded3016'

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,5 +1,5 @@
 class Seashore < Cask
-  url 'https://sourceforge.net/projects/seashore/files/seashore%20binaries/Seashore%200.5.1/Seashore.zip/download'
+  url 'http://downloads.sourceforge.net/sourceforge/seashore/Seashore.zip'
   homepage 'http://seashore.sourceforge.net/'
   version '0.5.1'
   sha1 'd8661189b4e526fbb9c73602a77c0c5936eb5297'

--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -1,6 +1,6 @@
 class Unetbootin < Cask
-  url 'http://unetbootin.sourceforge.net/unetbootin-mac-latest.zip'
+  url 'http://downloads.sourceforge.net/sourceforge/unetbootin/unetbootin-mac-583.zip'
   homepage 'http://unetbootin.sourceforge.net/'
-  version 'latest'
+  version '583'
   sha1 'afdf677dc7fa6668a4772c25ce279c91900df86a'
 end


### PR DESCRIPTION
Chromium, free-cad, mumble, open-office, seashore, and unetbootin
were all using url's that ended in download rather than the
filename. This has been changed, sha's are preserved.

Mumble does not have a 'latest' download alias in the new url
scheme. It does however specifiy a version so the Cask was updated
to reflect this.
