### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ command](https://github.com/mxcl/homebrew/wiki/External-Commands)" called
 
 And there we have it.  Google Chrome installed with a few quick commands; no clicking, no dragging, no dropping.
     
-    open "~/Applications/Google Chrome.app"
+    open ~/Applications/"Google Chrome.app"
 
 ## Learn More
 


### PR DESCRIPTION
`open "~/Applications/Google Chrome.app"` won’t work as intended, since the tilde isn’t expanded in that case.
