### PR TITLE
Fix bartender cask erroneously linking Sparkle's finish_installation.app

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -3,4 +3,6 @@ class Bartender < Cask
   homepage 'http://www.macbartender.com/'
   version 'latest'
   no_checksum
+
+  link :app, 'Bartender.app'
 end


### PR DESCRIPTION
Until #257 is resolved...
