### PR TITLE
imageoptim: Only link ImageOptim.app

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,6 +1,7 @@
 class Imageoptim < Cask
   url 'http://imageoptim.com/ImageOptim.tbz2'
-  homepage 'http://imageoptim.com'
+  homepage 'http://imageoptim.com/'
   version '1.4.0'
   sha1 '2199d54cf1c781e48590b8047f55565aec07d74a'
+  link :app, 'ImageOptim.app'
 end


### PR DESCRIPTION
Before:

```
$ brew cask install imageoptim
==> Downloading http://imageoptim.com/ImageOptim.tbz2
######################################################################## 100.0%
==> Success! imageoptim installed to /opt/homebrew-cask/Caskroom/imageoptim/1.4.0
==> Linking ImageOptim.app to /Users/Mathias/Applications/ImageOptim.app
==> Linking finish_installation.app to /Users/Mathias/Applications/finish_installation.app
```

After:

```
$ brew cask install imageoptim
==> Downloading http://imageoptim.com/ImageOptim.tbz2
######################################################################## 100.0%
==> Success! imageoptim installed to /opt/homebrew-cask/Caskroom/imageoptim/1.4.0
==> Linking ImageOptim.app to /Users/Mathias/Applications/ImageOptim.app
```
