### PR TITLE
Add Slicy cask

### DIFF
--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -1,0 +1,6 @@
+class Slicy < Cask
+  url 'https://s3.amazonaws.com/macrabbit/downloads/Slicy+1.1.4.zip'
+  homepage 'http://macrabbit.com/slicy/'
+  version '1.1.4'
+  sha1 '04dae551319422cb9c5ecb1c65aab9427ddaeb42'
+end


### PR DESCRIPTION
Slicy truly reinvents Photoshop slicing. To export PSD elements as assets for your website or app, rename your layer groups once and let Slicy do everything else. Designers and developers, rejoice!
