### PR TITLE
Use `no_checksum` instead of a sha1 when getting `latest` version.

### DIFF
--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -3,4 +3,5 @@ class Mou < Cask
   version 'latest'
   homepage 'http://mouapp.com/'
   no_checksum
+  link :app, 'Mou.app'
 end

--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -2,5 +2,5 @@ class Mou < Cask
   url 'http://mouapp.com/download/Mou.zip'
   version 'latest'
   homepage 'http://mouapp.com/'
-  sha1 'e69bc2bbdadea6a2929032506085b6e9501a7fb9'
+  no_checksum
 end


### PR DESCRIPTION
installation currently fails because of a SHA mismatch

```
> brew cask install mou
==> Downloading http://mouapp.com/download/Mou.zip
######################################################################## 100.0%
Error: SHA1 mismatch
Expected: e69bc2bbdadea6a2929032506085b6e9501a7fb9
Actual: 1276772fe649b2556257f6c0cf6e3ad5998fa35b
```

We've already dropped the explicit version. It seems to follow to drop the explicit SHA.
