### PR TITLE
Adds .com to example for testing casks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Fork the homebrew-cask repository as per instructions in the
 ```bash
 github_user='<my-github-username>'
 cd $(brew --prefix)/Library/Taps/phinze-cask
-git remote add $github_user https://github/$github_user/homebrew-cask
+git remote add $github_user https://github.com/$github_user/homebrew-cask
 ```
 
 ## Adding a Cask


### PR DESCRIPTION
I went through the contributing guidelines before submitting a cask and noticed the remote url for adding your own fork of homebrew-cask is missing .com
