### PR TITLE
Add recipe for GPGTools. `link` line intentionally ommitted.

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -3,4 +3,6 @@ class Gpgtools < Cask
   homepage 'https://gpgtools.org/index.html'
   version '2013.05.20'
   sha1 '9f9fea935b3ce90d8d04542a754b8778f82a8b1b'
+  install 'GPGTools.pkg'
+  uninstall 'Uninstall.app'
 end

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -1,0 +1,6 @@
+class Gpgtools < Cask
+  url 'https://s3.amazonaws.com/gpgtools/GPGTools-2013.5.20.dmg'
+  homepage 'https://gpgtools.org/index.html'
+  version '2013.05.20'
+  sha1 '9f9fea935b3ce90d8d04542a754b8778f82a8b1b'
+end


### PR DESCRIPTION
I didn't know how to handle the `link` line for this cask because it can install:
- more than one app (`GPG Keychain Access`, `MacGPG 2`)
- items which are not apps (context menus, preference panes)

Each of the items in the install (
[GPGMail](https://gpgtools.org/gpgmail/index.html),
[GPG Keychain Access](https://gpgtools.org/keychain/index.html),
[GPGServices](https://gpgtools.org/gpgservices/index.html),
[GPGPreferences](https://gpgtools.org/gpgpreferences/index.html), and
[MacGPG2](https://gpgtools.org/macgpg2/index.html)) are distinct efforts
 with their own installers, so I will create separate casks for each of
them. However, I think that the combined offering,
[GPGTools](https://gpgtools.org/installer/index.html), should have a
cask as well.
