### PR TITLE
Update eclipse to 4.2.2 and add link line

### DIFF
--- a/Casks/eclipse.rb
+++ b/Casks/eclipse.rb
@@ -1,6 +1,7 @@
 class Eclipse < Cask
   homepage 'http://eclipse.org'
-  url 'http://mirrors.med.harvard.edu/eclipse/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-macosx-cocoa-x86_64.tar.gz'
-  version '4.2.1'
-  sha1 'b535207c06799e0034a9aa6a1262baf152560dba'
+  url 'http://eclipse.mirror.kangaroot.net/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-macosx-cocoa-x86_64.tar.gz'
+  version '4.2.2'
+  sha1 '209ee0aa194aea5869c56546eb77f89da515252d'
+  link :app, 'Eclipse.app'
 end


### PR DESCRIPTION
Previous version of eclipse.rb didn't include a link line and the version was outdated.
