### PR TITLE
Update calibre.rb

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -1,7 +1,7 @@
 class Calibre < Cask
-  url 'http://status.calibre-ebook.com/dist/osx32'
+  url 'https://calibre-ebook.googlecode.com/files/calibre-0.9.32.dmg'
   homepage 'http://calibre-ebook.com/'
-  version 'latest'
-  no_checksum
+  version '0.9.32'
+  sha1 'cbbda7c78ae1483dea2025ad0b612c2962d6595b'
   link :app, 'calibre.app'
 end


### PR DESCRIPTION
Updated Calibre to latest version, replacing 'latest' as although 'latest' installs without a hitch, updates to calibre are not detected due to the version not changing.
