### PR TITLE
Fix typo in usage explanation for unlinking Alfred

### DIFF
--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -120,7 +120,7 @@ class Cask::CLI::Alfred
       subcommands:
         status - reports whether Alfred is linked
         link   - adds Caskroom to alfred search paths
-        unlink - removes Cakroom from Alfred search paths
+        unlink - removes Caskroom from Alfred search paths
     ALFREDHELP
   end
 end


### PR DESCRIPTION
`Cakroom` changed to `Caskroom`
