### PR TITLE
Adding in Integrity app cask.

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,0 +1,7 @@
+class Integrity < Cask
+  url 'http://peacockmedia.co.uk/integrity/integrity.dmg'
+  homepage 'http://peacockmedia.co.uk/integrity/'
+  version '4.1'
+  sha1 'e3c08645d38cc72545202b351e5c243da7d89721'
+  link 'Integrity.app'
+end


### PR DESCRIPTION
Integrity is a mac app which scans a website for broken links, it's part of my setup enviroment.
