### PR TITLE
New Cask for pgAdmin3 (PostgreSQL GUI)

### DIFF
--- a/Casks/pgadmin3.rb
+++ b/Casks/pgadmin3.rb
@@ -1,0 +1,7 @@
+class Pgadmin3 < Cask
+  url 'http://ftp.postgresql.org/pub/pgadmin3/release/v1.8.4/osx/pgadmin3-1.8.4.dmg'
+  homepage 'http://pgadmin.org'
+  version '1.8.4'
+  sha1 '6f916c133d4456b9f777b8ad0368b0f986cf7272'
+  link 'pgAdmin3.app'
+end


### PR DESCRIPTION
Add a cask for the latest version (1.8.4) of pgAdmin3, which is a GUI client
for PostgreSQL
