### PR TITLE
Add PowerKey Cask

### DIFF
--- a/Casks/power-key.rb
+++ b/Casks/power-key.rb
@@ -1,0 +1,7 @@
+class PowerKey < Cask
+  url 'https://github.com/pkamb/PowerKey/raw/master/Release/PowerKey.zip'
+  homepage 'http://pkamb.github.io/PowerKey/'
+  version 'latest'
+  no_checksum
+  link 'PowerKey.app'
+end


### PR DESCRIPTION
Use PowerKey to remap your Macbook Pro or Macbook Air's power key to a
useful function.
