### PR TITLE
Fix PathFinder Cask

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,7 @@
 class PathFinder < Cask
   url 'http://get.cocoatech.com/PF6_LION.zip'
   homepage 'http://www.cocoatech.com/pathfinder/'
-  version '6.1.5'
-  sha1 '5c05b1f4b9c9f9e0cd31d58f1e3c3417cf1ef3c8'
+  version 'latest'
+  no_checksum
+  link 'Path Finder.app'
 end


### PR DESCRIPTION
- Add proper version
- Add link tag
- Fix checksum

The cask is failing when attempting an install due to the zip file linked being the latest build and having a different checksum.
