### PR TITLE
Add the missing :link to the google-chrome-canary cask

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -3,4 +3,5 @@ class GoogleChromeCanary < Cask
   homepage 'https://tools.google.com/dlpage/chromesxs'
   version 'latest'
   no_checksum
+  link :app, 'Google Chrome Canary.app'
 end

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -3,5 +3,5 @@ class GoogleChromeCanary < Cask
   homepage 'https://tools.google.com/dlpage/chromesxs'
   version 'latest'
   no_checksum
-  link :app, 'Google Chrome Canary.app'
+  link 'Google Chrome Canary.app'
 end


### PR DESCRIPTION
When installing Google Chrome Canary the .app-file wont be linked into the /Applications folder due to a missing argument in the cask-file.
