### PR TITLE
Appdir creation

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -50,7 +50,6 @@ class Cask
       system "sudo mkdir -p #{caskroom}"
       system "sudo chown -R #{current_user}:staff #{caskroom.parent}"
     end
-    appdir.mkpath unless appdir.exist?
   end
 
   def self.path(cask_title)

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -18,6 +18,7 @@ class Cask::CLI
     Cask.init
     command, *rest = *arguments
     rest = process_options(rest)
+    Cask.appdir.mkpath unless Cask.appdir.exist?
     lookup_command(command).run(*rest)
   end
 


### PR DESCRIPTION
This patch fixes an issue where regardless of your `HOMEBREW_CASK_OPTS` settings (mine look like `export HOMEBREW_CASK_OPTS="--appdir=/Applications"`) every single time you run `brew cask` your `~/Applications` folder is created. This defers the folder creation until after the custom `HOMEBREW_CASK_OPTS` is taken into account.
