### PR TITLE
Use videolan.org to download VLC

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,6 +1,6 @@
 class Vlc < Cask
   homepage 'http://www.videolan.org/vlc/'
-  url 'http://downloads.sourceforge.net/project/vlc/2.0.7/macosx/vlc-2.0.7.dmg'
+  url 'http://get.videolan.org/vlc/2.0.7/macosx/vlc-2.0.7.dmg'
   version '2.0.7'
   sha1 'ea190de6108f77d5ed9eb775b872eea4ce9eee3c'
   link 'VLC.app'


### PR DESCRIPTION
It looks like VLC 2.0.7 isn't on sourceforge yet, or at least the files
section of the project is unavailable. We can point to the actual VLC
site for downloads.

Fixes #515
