### PR TITLE
Fixed sha1 checksum for Little Snitch

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -2,5 +2,5 @@ class LittleSnitch < Cask
   url 'http://www.obdev.at/downloads/LittleSnitch/LittleSnitch-2.5.4.dmg'
   homepage 'http://www.obdev.at/products/littlesnitch/index.html'
   version '2.5.4'
-  sha1 '217a83098c1eb3df69560e539d86ef4bc6b3b756'
+  sha1 '42ae2ffc404845b1bc4611f6574e281cd52041ac'
 end


### PR DESCRIPTION
Verified accuracy by checking both a download from my ISP _and_ through a TorBrowser download of the `.dmg`.
