### PR TITLE
Add cask support for Screenflick.app

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,0 +1,7 @@
+class Screenflick < Cask
+  url 'http://www.araelium.com/screenflick/downloads/Screenflick.dmg'
+  homepage 'http://www.araelium.com/screenflick/'
+  version '2.2.14'
+  sha1 '2b278caee0c946b951d07fcd892356b76ce03a04'
+  link 'Screenflick.app'
+end


### PR DESCRIPTION
Permits installation of Screenflick.app, which is not available in the Mac App Store.
