### PR TITLE
Suppress the annoying "Move to /Applications?" prompt

### DIFF
--- a/Casks/f-lux.rb
+++ b/Casks/f-lux.rb
@@ -4,4 +4,7 @@ class FLux < Cask
   version 'latest'
   no_checksum
   link 'Flux.app'
+
+  #Prevent f.lux from asking the user whether he wants the app bundle moved to /Applications
+  system 'defaults write org.herf.Flux moveToApplicationsFolderAlertSuppress -int 1'
 end


### PR DESCRIPTION
Just noticed that f.lux wants to move itself to /Applications if it is not there on launch. Figured out the default value that f.lux uses to remember the user doesn't want this behaviour and added it to the cask.

Usually, I wouldn't want any casks to touch my defaults, but in this case I think that it is in every cask user's interest to leave the app bundle where it is installed to by brew-cask and have it not moved anywhere else.
