### PR TITLE
Add HoudahGeo cask

### DIFF
--- a/Casks/houdah-geo.rb
+++ b/Casks/houdah-geo.rb
@@ -1,0 +1,7 @@
+class HoudahGeo < Cask
+  url 'http://houdah.com/houdahGeo/download_assets/HoudahGeo3.4.4.zip'
+  homepage 'http://houdah.com/houdahGeo/'
+  version '3.4.4'
+  sha1 'cd1332206fcffc798913a1d18e2cedeb514a2244'
+  link 'HoudahGeo.app'
+end


### PR DESCRIPTION
HoudahGeo "pins" photos to locations where they were taken. Professional grade processing. Mac ease of use.
Just like an expensive GPS camera, HoudahGeo can store latitude, longitude and altitude information right within the image file - invisibly with no loss of quality. HoudahGeo writes EXIF, XMP and IPTC tags.
