### PR TITLE
Fixes a problem due to a new version of CleanMyMac

### DIFF
--- a/Casks/clean-my-mac.rb
+++ b/Casks/clean-my-mac.rb
@@ -1,7 +1,7 @@
 class CleanMyMac < Cask
   url 'http://dl.devmate.com/com.macpaw.CleanMyMac2/CleanMyMac2.dmg'
   homepage 'http://macpaw.com/cleanmymac'
-  version '2.0.3'
-  sha1 '3bd47a6c1849f42389daa92309e24b395d6eb1f2'
+  version 'latest'
+  no_checksum
   link 'CleanMyMac 2.app'
 end


### PR DESCRIPTION
CleanMyMac's 2 download url is the same for every version

Hashing the download is no good idea.
