### PR TITLE
Updated chromium sha1 - mismatch

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -2,6 +2,6 @@ class Chromium < Cask
   url 'http://downloads.sourceforge.net/project/osxportableapps/Chromium/ChromiumOSX_27.0.1453.116.dmg'
   homepage 'http://www.freesmug.org/chromium'
   version '27.0.1453.116'
-  sha1 'dfcedfe05a87739430bb8d71cf66b05e2bde84f6'
+  sha1 '17a294ad64f9969189d0d3faa06d963bf72be5b3'
   link 'Chromium.app'
 end


### PR DESCRIPTION
The sha1 in the formula was: dfcedfe05a87739430bb8d71cf66b05e2bde84f6 
The actual sha1 is: 17a294ad64f9969189d0d3faa06d963bf72be5b3
