### PR TITLE
Update to sha1 for firefox-aurora.rb

### DIFF
--- a/Casks/firefox-aurora.rb
+++ b/Casks/firefox-aurora.rb
@@ -2,6 +2,6 @@ class FirefoxAurora < Cask
   url 'https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-23.0a2.en-US.mac.dmg'
   homepage 'http://www.mozilla.org/en-US/firefox/aurora/'
   version '23.0a2'
-  sha1 '65a4cecdb986765978fc8a1506248beb9c151494'
+  sha1 '20b8d306ff5e15fedd3650a11411365943e53710'
   link 'FirefoxAurora.app'
 end


### PR DESCRIPTION
Original sha1: 65a4cecdb986765978fc8a1506248beb9c151494
Actual sha1: 20b8d306ff5e15fedd3650a11411365943e53710
