### PR TITLE
Add Codebug cask

### DIFF
--- a/Casks/codebug.rb
+++ b/Casks/codebug.rb
@@ -1,0 +1,7 @@
+class Codebug < Cask
+  url 'http://codebugapp.com/downloads/Codebug.dmg'
+  homepage 'http://www.codebugapp.com/'
+  version 'latest'
+  no_checksum
+  link 'Codebug.app'
+end


### PR DESCRIPTION
Codebug is a standalone Xdebug client front-end for Mac OSX. This application allows PHP developers to debug their code in real-time without needing an external IDE
