### PR TITLE
virtualbox sha1 fix

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -2,6 +2,6 @@ class Virtualbox < Cask
   url 'http://download.virtualbox.org/virtualbox/4.2.14/VirtualBox-4.2.14-86644-OSX.dmg'
   homepage 'http://www.virtualbox.org'
   version '4.2.14-86644'
-  sha1 'c7f02ce0f60a0db45c060a99856fc4e139006616eb799b5fb60dc2bebf2a5a75'
+  sha1 '93c36db799d53acaed7bb18c1402c6f11671f40a'
   install 'VirtualBox.pkg'
 end


### PR DESCRIPTION
virtualbox's listed sha1 is incorrect, and I neglected to test it :(

I took the first one from [here](http://dlc.sun.com.edgesuite.net/virtualbox/4.2.14/SHA256SUMS). No idea why they don't match up.
