### PR TITLE
Add Zepheer cask

### DIFF
--- a/Casks/zepheer.rb
+++ b/Casks/zepheer.rb
@@ -1,0 +1,7 @@
+class Zepheer < Cask
+  url 'http://candysquare.com/files/zepheer/Zepheer.dmg'
+  homepage 'http://candysquare.com/products/zepheer/'
+  version 'latest'
+  no_checksum
+  link 'Zepheer.app'
+end


### PR DESCRIPTION
Zepheer is designed to be a best friend of every photography enthusiasts on Mac OS. This small app delivers dozens built-in photo styles and allows to make your photos warm, charming, beautiful, impressing, to give them the soul – even when the photos were taken with a low-end camera and bad conditions.
