### PR TITLE
Add FotoMagico cask

### DIFF
--- a/Casks/foto-magico.rb
+++ b/Casks/foto-magico.rb
@@ -1,0 +1,7 @@
+class FotoMagico < Cask
+  url 'https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_4.3-18574.zip'
+  homepage 'http://www.boinx.com/fotomagico/'
+  version '4.3-18574'
+  sha1 '154c78dca1cfab2f71455b16db27216fd83ec936'
+  link 'FotoMagico.app'
+end


### PR DESCRIPTION
As a wedding photographer, you want to make great pictures that tug at the bride and groom's emotions. FotoMagico allows you to flow those pictures freely into a slideshow and to mix them with movies to impress the newlyweds and their families. Sound is just a drag and drop away, too. FotoMagico gives you sophisticated shows with sound and high-end transitions in minutes. Like the Mac itself, it never stands in your way.
