### PR TITLE
removed julia binary

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,7 +1,0 @@
-class Julia < Cask
-  url 'https://julialang.googlecode.com/files/Julia-0.1.2.dmg'
-  homepage 'http://julialang.org/'
-  version '0.1.2'
-  sha1 'c6e5cf8ba49d3f995821864531a0f31a85bbc31b'
-  link 'Julia.app'
-end


### PR DESCRIPTION
it would be better to install julia as a binary from a normal homebrew formula, since it is also distributed as source. this formula creates a name conflict with [this tap](https://github.com/staticfloat/homebrew-julia).
