### PR TITLE
Add SteerMouse Cask

### DIFF
--- a/Casks/steer-mouse.rb
+++ b/Casks/steer-mouse.rb
@@ -1,0 +1,7 @@
+class SteerMouse < Cask
+  url 'http://plentycom.jp/ctrl/files_sm/SteerMouse4.1.6.dmg'
+  homepage 'http://plentycom.jp/en/steermouse/'
+  version '4.1.6'
+  sha1 '7cd5569964de3ef10e042cb9048345d9c30f9af1'
+  install 'SteerMouse Installer.app/Contents/Resources/SteerMouse.pkg'
+end


### PR DESCRIPTION
There are a couple of potential issues to note with this app:
1. The actual installer `.pkg` resides inside of an `.app` wrapper the developer made. Running this installer wrapper in the Finder simply opens the `.pkg` file that actually installs the app. I've linked to this `.pkg` directly in the **install** property, and cask is able to run it, install the app successfully, and prompt the user to restart. However, I wasn't sure how the team felt about a `.pkg` within an `.app` wrapper from a policy standpoint.
2. Uninstall functionality can be initiated from within this app, however I am unable to locate a stand-alone uninstall `.pkg`. I'm curious if the absence of said `.pkg` (and therefore the **uninstall** property) is grounds for exclusion, or if automated cask uninstall functionality is viewed as more of a convenience than a requirement for apps that were truly _installed_ from packages. 
   
   Without knowing much about the forthcoming uninstall functionality of cask, one solution for this case could be specifying that the `.app` be uninstalled/removed from its location in /Applications/Utilities. However, a preference pane is also installed at /Library/PreferencePanes so that should be removed as well.

Also — I just wanted to give some props to all of you folks who helped build this awesome timesaver! :metal: 
