### PR TITLE
NetNewsWire Cask

### DIFF
--- a/Casks/net-news-wire.rb
+++ b/Casks/net-news-wire.rb
@@ -1,0 +1,7 @@
+class NetNewsWire < Cask
+  url 'http://cdn.netnewswireapp.com/releases/NetNewsWire-4.0.0-108.zip'
+  homepage 'http://netnewswireapp.com/'
+  version '4.0.0-108'
+  sha1 'cc5b28287e59d558c379878e7864e10a91a2c016'
+  link 'NetNewsWire.app'
+end


### PR DESCRIPTION
NetNewsWire 4 is the best way to keep up with the sites and authors you
read most regularly. Let NetNewsWire pull down the latest articles, and
read them in a distraction-free and Mac-like way.
