### PR TITLE
Add Chronicle cask

### DIFF
--- a/Casks/chronicle.rb
+++ b/Casks/chronicle.rb
@@ -1,0 +1,7 @@
+class Chronicle < Cask
+  url 'http://chronicleapp.com/static/downloads/chronicle.zip'
+  homepage 'http://chronicleapp.com/'
+  version 'latest'
+  no_checksum
+  link 'Chronicle.app'
+end


### PR DESCRIPTION
PAY BILLS? YOU NEED CHRONICLE.

Here's why: A single late payment can cost you $30 or more, and cause your credit score to plummet by 100 points or more. Chronicle reminds you to pay your bills even when it isn't running.
