### PR TITLE
Fixes for broken casks

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,7 +1,7 @@
 class Acorn < Cask
   url 'http://flyingmeat.com/download/Acorn.zip'
   homepage 'http://flyingmeat.com/acorn/'
-  version '4.0.4'
-  sha1 'c3c307377bbf11a6782a02c5eeac501f96761b29'
+  version 'latest'
+  no_checksum
   link 'Acorn.app'
 end

--- a/Casks/cura.rb
+++ b/Casks/cura.rb
@@ -1,7 +1,7 @@
 class Cura < Cask
-  url 'http://software.ultimaker.com/current/Cura-13.06.3-MacOS.dmg'
+  url 'http://software.ultimaker.com/current/Cura-13.06.5-MacOS.dmg'
   homepage 'http://daid.github.com/Cura/'
-  version '13.06.3'
-  sha1 'db5764ecb2678b0a7e0cae4476eb2ac98053136d'
+  version '13.06.5'
+  sha1 'e040e0dc6387d3e9b2ae941fdfc86c39bf4b2db7'
   link 'Cura.app'
 end

--- a/Casks/eggscellent.rb
+++ b/Casks/eggscellent.rb
@@ -1,7 +1,0 @@
-class Eggscellent < Cask
-  url 'http://eggscellent.s3.amazonaws.com/betas/Eggscellent_Beta2.zip'
-  homepage 'http://www.eggscellentapp.com/'
-  version 'beta2'
-  sha1 '0fee4fb819fc51541322d671c4a6ca2829137f9f'
-  link 'Eggscellent.app'
-end

--- a/Casks/firefox-aurora.rb
+++ b/Casks/firefox-aurora.rb
@@ -2,6 +2,6 @@ class FirefoxAurora < Cask
   url 'https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-23.0a2.en-US.mac.dmg'
   homepage 'http://www.mozilla.org/en-US/firefox/aurora/'
   version '23.0a2'
-  sha1 '20b8d306ff5e15fedd3650a11411365943e53710'
+  sha1 'e363dbb9cf6d3f476414f6d8be3723f27c38de7a'
   link 'FirefoxAurora.app'
 end

--- a/Casks/fuzzy-clock.rb
+++ b/Casks/fuzzy-clock.rb
@@ -1,7 +1,0 @@
-class FuzzyClock < Cask
-  url 'http://www.objectpark.org/Releases/FuzzyClock-1-2-10.dmg'
-  homepage 'http://www.objectpark.org/FuzzyClock.html'
-  version '1.2.10'
-  sha1 'f4d49e5819d7af020f202e7561b15ae203be357b'
-  link 'FuzzyClock.app'
-end

--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -2,6 +2,6 @@ class Gnucash < Cask
   url 'http://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-2.4.13.dmg'
   homepage 'http://www.gnucash.org'
   version '2.4.13'
-  sha1 'ba13690e0e3d9ca0052069fba9a3a8e53d041d99'
+  sha1 '3c17ee79d45c30e7bbc9f1ff9fd8bd72b654e1d1'
   link 'Gnucash.app'
 end

--- a/Casks/hip-chat.rb
+++ b/Casks/hip-chat.rb
@@ -1,7 +1,7 @@
 class HipChat < Cask
-  url 'http://downloads.hipchat.com.s3.amazonaws.com/mac-beta/HipChat-0.34-01uennzomg01wmg.zip'
+  url 'http://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.0.zip'
   homepage 'https://www.hipchat.com/'
-  version '0.34'
-  sha1 '7472a565182444d2cb5eb16e7c9c6e34420e1d07'
+  version '2.0'
+  sha1 '1552c87662d6d31161fba447c28e9f9c3ace1377'
   link 'HipChat.app'
 end

--- a/Casks/houdah-geo.rb
+++ b/Casks/houdah-geo.rb
@@ -1,7 +1,7 @@
 class HoudahGeo < Cask
-  url 'http://houdah.com/houdahGeo/download_assets/HoudahGeo3.4.4.zip'
+  url 'http://houdah.com/houdahGeo/download_assets/HoudahGeo_latest.zip'
   homepage 'http://houdah.com/houdahGeo/'
-  version '3.4.4'
-  sha1 'cd1332206fcffc798913a1d18e2cedeb514a2244'
+  version 'latest'
+  no_checksum
   link 'HoudahGeo.app'
 end

--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,7 +1,7 @@
 class Integrity < Cask
   url 'http://peacockmedia.co.uk/integrity/integrity.dmg'
   homepage 'http://peacockmedia.co.uk/integrity/'
-  version '4.1'
-  sha1 'e3c08645d38cc72545202b351e5c243da7d89721'
+  version 'latest'
+  no_checksum
   link 'Integrity.app'
 end

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -1,7 +1,7 @@
 class Transmission < Cask
-  url 'http://download.transmissionbt.com/files/Transmission-2.77.dmg'
+  url 'http://download.transmissionbt.com/files/Transmission-2.80.dmg'
   homepage 'http://www.transmissionbt.com/'
-  version '2.77'
-  sha1 '68acc8644a3ccb4f70225832ef52375df7e42a43'
+  version '2.80'
+  sha1 'cee439443d2ebf658f5b4d74fc583b287f39ca3c'
   link 'Transmission.app'
 end


### PR DESCRIPTION
These casks here didn't install for differnet reasons:
- Some were not available any more (or went to mac AppStore after beta)
- Some version changes
- Some hash problem - even if the version did not change.
