### PR TITLE
Add ViMediaManager cask

### DIFF
--- a/Casks/vi-media-manager.rb
+++ b/Casks/vi-media-manager.rb
@@ -1,0 +1,7 @@
+class ViMediaManager < Cask
+  url 'http://mariusth.channelwood.org/vimediamanager/files/vimediamanager_v0.7a10c.dmg'
+  homepage 'http://mariusth.channelwood.org/vimediamanager/'
+  version '0.7a10'
+  sha1 'b725527cf72ea6d56b5ad226591165449702c812'
+  link 'ViMediaManager.app'
+end


### PR DESCRIPTION
ViMediaManager is a media manager for Mac OS X, allowing you to gather, store, and manage information, extra art, trailers and television tunes for your movie, television and anime collections, and can be used on it’s own, or in combination with XBMC, YAMJ or Boxee.
