### PR TITLE
Add Minecraft Cask

### DIFF
--- a/Casks/minecraft.rb
+++ b/Casks/minecraft.rb
@@ -1,0 +1,7 @@
+class Minecraft < Cask
+  url 'https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.dmg'
+  homepage 'http://minecraft.net'
+  version 'latest'
+  no_checksum
+  link 'Minecraft.app'
+end


### PR DESCRIPTION
I saw that issue #219 was previously opened for adding a Minecraft cask, but was closed due to a problem with the Minecraft download. I have verified that the Minecraft download now works when installing through Cask, so hopefully this can be merged in now. :)
