### PR TITLE
Update Transmit cask to v4.4.1 from v4.4.0

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,7 +1,7 @@
 class Transmit < Cask
-  url 'http://www.panic.com/transmit/d/Transmit%204.4.zip'
+  url 'http://www.panic.com/transmit/d/Transmit%204.4.1.zip'
   homepage 'http://panic.com/transmit'
-  version '4.4'
-  sha1 'fe4c41ce2945f79ed5b613dc51aea4112bd051f3'
+  version '4.4.1'
+  sha1 '8878d15c0cb8913159a30f70da45bbf4fa9ee6c5'
 	link 'Transmit.app'
 end


### PR DESCRIPTION
This patch updates the version of Transmit to version 4.4.1 from the
current version of 4.4.0. It includes a new checksum, version, and URL.

Audit:

``` sh
❯ brew cask audit transmit
audit for transmit: passed
```

Let me know if there's anything I missed and I'd be happy to fix it.

For reference, v4.4.1 has the following [upgrade notes](http://www.panic.com/transmit/releasenotes.html):
- Fixed a potential crash when using Transmit Disk on a non-admin account
- Fixed Growl support on 10.6
- Fixed an issue where NFS shares would not appear properly in the browser
- Improved DockSend reliability when dragging multiple folders and files
- Improved Retina compatibility
