### PR TITLE
Remove tab character from Transmit cask

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -3,5 +3,5 @@ class Transmit < Cask
   homepage 'http://panic.com/transmit'
   version '4.4.1'
   sha1 '8878d15c0cb8913159a30f70da45bbf4fa9ee6c5'
-	link 'Transmit.app'
+  link 'Transmit.app'
 end


### PR DESCRIPTION
The transmit cask had a tab character that would display the file like so: 

![screen shot 2013-07-09 19 10 55 0000](https://f.cloud.github.com/assets/1889575/770384/545a0338-e8cb-11e2-9a49-483bc7229d1f.png)

I replaced the tab characters with spaces.
