### PR TITLE
Add PS3 Media Server

### DIFF
--- a/Casks/ps3-media-server.rb
+++ b/Casks/ps3-media-server.rb
@@ -1,0 +1,7 @@
+class Ps3MediaServer < Cask
+  url 'https://ps3mediaserver.googlecode.com/files/pms-macosx-1.82.0.dmg'
+  homepage 'http://www.ps3mediaserver.org/'
+  version '1.82.0'
+  sha1 'b3a04f59f8f3f449410dd058dea668b53e279a39'
+  link 'PS3 Media Server.app'
+end


### PR DESCRIPTION
PS3 Media Server is a DLNA compliant Upnp Media Server for the PS3, written in Java, with the purpose of streaming or transcoding any kind of media files, with minimum configuration. It's backed up with the powerful Mplayer/FFmpeg packages.
