### PR TITLE
Add Shuttle cask

### DIFF
--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -1,0 +1,7 @@
+class Shuttle < Cask
+  url 'https://github.com/fitztrev/shuttle/releases/download/v1.0.0/Shuttle.dmg'
+  homepage 'http://fitztrev.github.io/shuttle/'
+  version '1.0.0'
+  sha1 '100cbd758d036ffb59dda310ba859acb3eb384f2'
+  link 'Shuttle.app'
+end


### PR DESCRIPTION
A simple SSH shortcut menu for OS X
