### PR TITLE
Add Porthole cask

### DIFF
--- a/Casks/porthole.rb
+++ b/Casks/porthole.rb
@@ -1,0 +1,7 @@
+class Porthole < Cask
+  url 'http://getporthole.com/downloads/trial'
+  homepage 'http://getporthole.com/'
+  version 'latest'
+  no_checksum
+  link 'Porthole.app'
+end


### PR DESCRIPTION
Porthole streams music from your favorite music player to all your AirPlay speakers, in sync.
