### PR TITLE
Add Deluge cask

### DIFF
--- a/Casks/deluge.rb
+++ b/Casks/deluge.rb
@@ -1,0 +1,7 @@
+class Deluge < Cask
+  url 'http://download.deluge-torrent.org/mac_osx/Deluge.app.1.3.6-3.x86.tbz2'
+  homepage 'http://deluge-torrent.org/'
+  version '1.3.6'
+  sha1 '739b49778dbac6cd24af99fecb3f4817d914fc67'
+  link 'Deluge.app'
+end


### PR DESCRIPTION
Deluge is a lightweight, Free Software, cross-platform BitTorrent client.
