### PR TITLE
Add SlimBatteryMonitor cask.

### DIFF
--- a/Casks/slim-battery-monitor.rb
+++ b/Casks/slim-battery-monitor.rb
@@ -1,0 +1,7 @@
+class SlimBatteryMonitor < Cask
+  url 'http://quux.orange-carb.org/dist/SlimBatteryMonitor-1.5.dmg'
+  homepage 'http://www.orange-carb.org/SBM/'
+  version '1.5'
+  sha1 '974b06836c7f91506846580849defd7cd971d73e'
+  link 'SlimBatteryMonitor.app'
+end


### PR DESCRIPTION
SlimBatteryMonitor is a replacement power gauge for Apple's Mac OS X
that tracks both laptop batteries and many UPS batteries.
