### PR TITLE
Add Opera Next Cask

### DIFF
--- a/Casks/opera-next.rb
+++ b/Casks/opera-next.rb
@@ -1,0 +1,7 @@
+class OperaNext < Cask
+  url 'http://www.opera.com' << %x( curl -Ls 'http://www.opera.com/download/get/?partner=www&opsys=MacOS&product=Opera%20Next' | grep '/download/' | head -1 | perl -pe 's/.*'\\''(\\/.*)'\\''.*/$1/' | tr -d '\n' ) << '&amp;ext=.dmg'
+  homepage 'http://www.opera.com/developer/next'
+  version 'latest'
+  no_checksum
+  link 'Opera Next.app'
+end


### PR DESCRIPTION
Add Opera Next cask which grabs the URL of the 'latest' version from the Opera Next website. The string `&amp;ext=.dmg` is being appended to the URL to allow Cask to add the proper file extension to the downloaded file; this may be considered a bug in Cask.

May also pertain to #142.
