### PR TITLE
Adding support for local casks outside of the casks directory

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -42,7 +42,7 @@ class Cask
   end
 
   def self._file_source?(cask_title)
-    %r{(^file://|^\./|\.rb$)} =~ cask_title
+    File.file?(cask_title)
   end
 
   def self.init

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -41,6 +41,10 @@ class Cask
     @default_tap = _tap
   end
 
+  def self._file_source?(cask_title)
+    %r{(^file://|^\./|\.rb$)} =~ cask_title
+  end
+
   def self.init
     HOMEBREW_CACHE.mkpath unless HOMEBREW_CACHE.exist?
     unless caskroom.exist?
@@ -69,13 +73,43 @@ class Cask
     end
   end
 
-  def self.load(cask_title)
-    cask_path = path(cask_title)
-    unless cask_path.exist?
-      raise CaskUnavailableError, cask_title
+  def self._load_from_tap(cask_title)
+    if cask_title.include?('/')
+      cask_with_tap = cask_title
+    else
+      cask_with_tap = all_titles.grep(/#{cask_title}$/).first
     end
-    require cask_path
-    const_get(cask_title.split('/').last.split('-').map(&:capitalize).join).new
+
+    if cask_with_tap
+      tap, cask = cask_with_tap.split('/')
+      source = tapspath.join(tap, 'Casks', "#{cask}.rb")
+    else
+      source = tapspath.join(default_tap, 'Casks', "#{cask_title}.rb")
+    end
+    raise CaskUnavailableError, cask_title unless source.exist?
+    _load_from_file(source)
+  end
+
+  def self._load_from_path(cask_title)
+    _load_from_file(Pathname.new(File::expand_path(cask_title)))
+  end
+
+  def self._load_from_file(source)
+    raise CaskUnavailableError, source unless source.exist?
+    require source
+    const_get(cask_class_name(source)).new
+  end
+
+  def self.load(cask_title)
+    if _file_source?(cask_title)
+      _load_from_path(cask_title)
+    else
+      _load_from_tap(cask_title)
+    end
+  end
+
+  def self.cask_class_name(pathname)
+    pathname.basename.to_s.sub(/\.rb/, '').split('-').map(&:capitalize).join
   end
 
   def self.title

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -7,6 +7,12 @@ describe "Cask" do
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Adium)
     end
+    
+    it "returns an instance of the cask from a specific file location" do
+      c = Cask.load("./Casks/dia.rb")
+      c.must_be_kind_of(Cask)
+      c.must_be_instance_of(Dia)
+    end
 
     it "raises an error when attempting to load a cask that doesn't exist" do
       lambda {

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -9,6 +9,13 @@ describe "Cask" do
     end
     
     it "returns an instance of the cask from a specific file location" do
+      location = File.expand_path('./Casks/dia.rb')
+      c = Cask.load(location)
+      c.must_be_kind_of(Cask)
+      c.must_be_instance_of(Dia)
+    end
+
+    it "returns an instance of the cask from a relative file location" do
       c = Cask.load("./Casks/dia.rb")
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Dia)


### PR DESCRIPTION
You should now be able to install casks from locations outside of the casks directory.
I tested successfully on my computer with:
brew cask install ~/Downloads/dia.rb
