### PR TITLE
Add TravisCI irc integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: objective-c
 install: bundle
 script: bundle exec rake test
+notifications:
+  irc:
+    - "chat.freenode.net#homebrew-cask"


### PR DESCRIPTION
This adds TravisCI integration into our IRC channel. It can be configured even more using: http://about.travis-ci.org/docs/user/notifications/
