### PR TITLE
Cask for Marked for Snow Leopard

### DIFF
--- a/Casks/marked-s-l.rb
+++ b/Casks/marked-s-l.rb
@@ -1,0 +1,7 @@
+class MarkedSL < Cask
+  url 'http://assets.markedapp.com/MarkedSL.zip'
+  homepage 'http://support.markedapp.com/kb/documentation/frequently-asked-questions'
+  version 'latest'
+  no_checksum
+  link 'MarkedSL.app'
+end


### PR DESCRIPTION
Install [Marked](http://markedapp.com/) for Snow Leopard, unfortunately the postfix, SL, cannot be removed.
