### PR TITLE
Update Imageoptim to latest

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,7 +1,7 @@
 class Imageoptim < Cask
-  url 'http://imageoptim.com/ImageOptim1.4.1.2.tar.bz2'
+  url 'http://imageoptim.com/ImageOptim.tbz2'
   homepage 'http://imageoptim.com/'
-  version '1.4.1.2'
-  sha1 'dff8448cb4ff2ba754769db55cdd13ee88a10cf2'
+  version 'latest'
+  no_checksum
   link 'ImageOptim.app'
 end


### PR DESCRIPTION
With the recent release of 1.4.2, the download naming scheme has changed. It now follows a 'latest' scheme. :+1: 
