### PR TITLE
Add -qq parameter to unzip to eradicate the unzip __MACOSX caution.

### DIFF
--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -20,7 +20,7 @@ class Cask::Installer
       ohai "Success! #{cask} installed to #{cask.destination_path}"
 
       unless cask.caveats.empty?
-        ohai 'Caveats', cask.caveats 
+        ohai 'Caveats', cask.caveats
       end
     end
 
@@ -50,7 +50,7 @@ class Cask::Installer
       elsif _zip?(path)
         destdir = "/tmp/brewcask_#{@title}_extracted"
         `mkdir -p '#{destdir}'`
-        `unzip -d '#{destdir}' '#{path}' -x '__MACOSX/*'`
+        `unzip -qq -d '#{destdir}' '#{path}' -x '__MACOSX/*'`
         begin
           yield destdir
         ensure


### PR DESCRIPTION
![screen shot 2013-07-21 19 06 22 0000](https://f.cloud.github.com/assets/1889575/832232/0e8f0396-f23d-11e2-9339-8b5b2cddc0d5.png)

I added the -qq parameter to remove the Caution when unzipping a file due to forks. See [man unzip](http://www.info-zip.org/mans/unzip.html) for more information
