### PR TITLE
Add Mirage Cask

### DIFF
--- a/Casks/mirage.rb
+++ b/Casks/mirage.rb
@@ -1,0 +1,7 @@
+class Mirage < Cask
+  url 'http://download2us.softpedia.com/dl/a52298e7716cfbb6a9949a91cadc8ccd/51ec53d1/400074508/mac/Desktop/Mirage.zip'
+  homepage 'http://mac.softpedia.com/get/Wallpapers/Ferber-Mirage.shtml'
+  version '1.0.1'
+  no_checksum
+  link 'Mirage.app'
+end

--- a/Casks/mirage.rb
+++ b/Casks/mirage.rb
@@ -1,7 +1,7 @@
 class Mirage < Cask
   url 'http://download2us.softpedia.com/dl/a52298e7716cfbb6a9949a91cadc8ccd/51ec53d1/400074508/mac/Desktop/Mirage.zip'
   homepage 'http://mac.softpedia.com/get/Wallpapers/Ferber-Mirage.shtml'
-  version '1.0.1'
+  version 'latest'
   no_checksum
   link 'Mirage.app'
 end


### PR DESCRIPTION
This PR adds a cask for Mirage 1.0.1.

The `url` and `homepage` fields point to Softpedia as the [original developer's website](http://www.itaiferber.com) is no longer available.

The description of the application on Softpedia's website reads:

``` markdown
Mirage is a free Cocoa based application which will make your dock,
separator, indicator and even Stacks totally clear.

Mirage will allow you to:

- Install a clear dock.
- Install a clear separator.
- Install clear indicators.
- Install clear stacks.
- Restore any combination of those straight from default.
```
