### PR TITLE
Add KeyFinder 1.22

### DIFF
--- a/Casks/keyfinder.rb
+++ b/Casks/keyfinder.rb
@@ -1,0 +1,7 @@
+class Keyfinder < Cask
+  url 'http://www.ibrahimshaath.co.uk/keyfinder/KeyFinder-OSX.zip'
+  homepage 'http://www.ibrahimshaath.co.uk/keyfinder/'
+  version '1.22'
+  sha1 '9e49554c36bda6ae7e4f248fb72ee95951103895'
+  link 'KeyFinder.app'
+end

--- a/Casks/keyfinder.rb
+++ b/Casks/keyfinder.rb
@@ -1,7 +1,7 @@
 class Keyfinder < Cask
   url 'http://www.ibrahimshaath.co.uk/keyfinder/KeyFinder-OSX.zip'
   homepage 'http://www.ibrahimshaath.co.uk/keyfinder/'
-  version '1.22'
-  sha1 '9e49554c36bda6ae7e4f248fb72ee95951103895'
+  version 'latest'
+  no_checksum
   link 'KeyFinder.app'
 end


### PR DESCRIPTION
"KeyFinder is an open source key detection tool, for DJs interested in harmonic and tonal mixing. Designed primarily for electronic and dance music, it is highly configurable and can be applied to many genres. It supports a huge range of codecs thanks to LibAV, and writes to metadata tags using TagLib."

More info at http://www.ibrahimshaath.co.uk/keyfinder/ 
