### PR TITLE
DSP Radio - Software Defined Radio for Mac OS X

### DIFF
--- a/Casks/dsp-radio.rb
+++ b/Casks/dsp-radio.rb
@@ -1,0 +1,7 @@
+class DspRadio < Cask
+  url 'http://dl2sdr.homepage.t-online.de/files/DSP_Radio_140.zip'
+  homepage 'http://dl2sdr.homepage.t-online.de/'
+  version '1.4.0'
+  sha1 'eb54eaba94648c9cd5127e9dd792cbf89c221bb9'
+  link 'DSP Radio 1.4.0.app'
+end


### PR DESCRIPTION
Supported SDR frontends are quadrature sampling mixers which provide an IQ (inphase/quadrature) signal.
