### PR TITLE
SdrDx – OS X and Windows SDR Software

### DIFF
--- a/Casks/sdrdx.rb
+++ b/Casks/sdrdx.rb
@@ -1,7 +1,7 @@
 class Sdrdx < Cask
   url 'http://fyngyrz.com/SdrDx-AA7AS-Light.zip'
   homepage 'http://fyngyrz.com/?p=915'
-  version '2.12q'
-  sha1 '4131202f03da899ac96ef45480ae2b69d0a8aab0'
+  version 'latest'
+  no_checksum
   link 'SdrDx.app'
 end

--- a/Casks/sdrdx.rb
+++ b/Casks/sdrdx.rb
@@ -1,0 +1,7 @@
+class Sdrdx < Cask
+  url 'http://fyngyrz.com/SdrDx-AA7AS-Light.zip'
+  homepage 'http://fyngyrz.com/?p=915'
+  version '2.12q'
+  sha1 '4131202f03da899ac96ef45480ae2b69d0a8aab0'
+  link 'SdrDx.app'
+end


### PR DESCRIPTION
SdrDx, an application originally based upon CuteSDR, Moe Wheatly’s open source application that supported RFSPACE software defined radios.
