### PR TITLE
OSX port of the awesome gqrx SDR software

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,0 +1,7 @@
+class Gqrx < Cask
+  url 'http://dekar.wc3edit.net/wp-content/uploads/2012/09/gqrx_8.dmg'
+  homepage 'http://dekar.wc3edit.net/2012/09/30/osx-port-of-the-awesome-gqrx-sdr-software/'
+  version '8'
+  sha1 '66b9f6952aff5cb0bc995556c633b3cc7f5d990e'
+  link 'gqrx.app'
+end


### PR DESCRIPTION
This release bundles all the rtl-sdr, gr-osmosdr, GNU Radio, libUSB, boost and Qt dependencies allowing it to work out of the box.
