### PR TITLE
Serial Tools is a set of serial port tools for Mac OS X

### DIFF
--- a/Casks/serial-tools.rb
+++ b/Casks/serial-tools.rb
@@ -1,0 +1,7 @@
+class SerialTools < Cask
+  url 'http://www.w7ay.net/site/Downloads/Serial%20Tools/Serial%20Tools%20app.dmg'
+  homepage 'http://www.w7ay.net/site/Applications/Serial%20Tools/'
+  version 'latest'
+  no_checksum
+  link 'Serial Tools.app'
+end


### PR DESCRIPTION
It includes a Terminal Emulator, a Protocol Analyzer, an NMEA parser and a serial port monitor to watch for connections and removals of serial ports.
