### PR TITLE
Add Backblaze Downloader Cask

### DIFF
--- a/Casks/backblaze-downloader.rb
+++ b/Casks/backblaze-downloader.rb
@@ -1,0 +1,7 @@
+class BackblazeDownloader < Cask
+  url 'https://secure.backblaze.com/mac_restore_downloader'
+  homepage 'http://www.backblaze.com/'
+  version 'latest'
+  no_checksum
+  link 'Backblaze Downloader.app'
+end


### PR DESCRIPTION
Online backup provider [Backblaze](http://www.backblaze.com/) offers this software for users who may be downloading large ZIP'ed backups. The application itself is free, but requires a Backblaze account (natch).
