### PR TITLE
Added new casket for omni-focus standard edition

### DIFF
--- a/Casks/omni-focus-standard.rb
+++ b/Casks/omni-focus-standard.rb
@@ -1,0 +1,7 @@
+class OmniFocusStandard < Cask
+  url 'https://www.omnigroup.com/download/latest/omnigraffle'
+  homepage 'http://www.omnigroup.com/products/omnigraffle'
+  version 'latest'
+  no_checksum
+  link 'OmniGraffle Standard'
+end


### PR DESCRIPTION
Added new casket for omni-focus standard edition.
As omni-focus uses another license than omni-focus-standard this is a
necessary distinction
