### PR TITLE
New cask: omni-graffle-standard

### DIFF
--- a/Casks/omni-graffle-standard.rb
+++ b/Casks/omni-graffle-standard.rb
@@ -1,0 +1,7 @@
+class OmniGraffleStandard < Cask
+  url 'https://www.omnigroup.com/download/latest/omnigraffle'
+  homepage 'http://www.omnigroup.com/products/omnigraffle'
+  version 'latest'
+  no_checksum
+  link 'OmniGraffle'
+end

--- a/Casks/omni-graffle-standard.rb
+++ b/Casks/omni-graffle-standard.rb
@@ -3,5 +3,5 @@ class OmniGraffleStandard < Cask
   homepage 'http://www.omnigroup.com/products/omnigraffle'
   version 'latest'
   no_checksum
-  link 'OmniGraffle'
+  link 'OmniGraffle.app'
 end


### PR DESCRIPTION
New cask: omni-graffle-standard
As omni-graffle is the pro version, requiring a different
license, omni-graffle-standard installs the standard
version of the omni-graffle software.
