### PR TITLE
New cask: pi-filler

### DIFF
--- a/Casks/pi-filler.rb
+++ b/Casks/pi-filler.rb
@@ -1,0 +1,7 @@
+class PiFiller < Cask
+  url 'http://ivanx.com/raspberrypi/files/PiFiller.zip'
+  homepage 'http://ivanx.com/raspberrypi'
+  version '1.1.1'
+  sha1 '88bf9376f312ecea84a430123a300d60923e55ef'
+  link 'Pi Filler.app'
+end


### PR DESCRIPTION
New cask: pi-filler, a tool to write SD cards for the
raspberry pi project
