### PR TITLE
new cask: jabref

### DIFF
--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -1,0 +1,7 @@
+class Jabref < Cask
+  url 'http://downloads.sourceforge.net/project/jabref/jabref/2.9.2/JabRef-2.9.2-OSX.zip'
+  homepage 'http://jabref.sourceforge.net/'
+  version '2.9.2'
+  sha1 '2932cfd21a2fb44f024ef865e6c90c21f7e444e4'
+  link 'JabRef.app'
+end


### PR DESCRIPTION
new cask: jabref, an open source bibliography reference manager
