### PR TITLE
new cask: my-phone-desktop

### DIFF
--- a/Casks/my-phone-desktop.rb
+++ b/Casks/my-phone-desktop.rb
@@ -1,0 +1,7 @@
+class MyPhoneDesktop < Cask
+  url 'http://www.myphonedesktop.com/dwn/myPhoneDesktop_macos_2_0_2.dmg'
+  homepage 'http://www.myphonedesktop.com/'
+  version '2.0.2'
+  sha1 'd4971486645547cc83980f53dfea50112855d38e'
+  link 'myPhoneDesktop.app'
+end


### PR DESCRIPTION
new cask: my-phone-desktop, the desktop part of a communication
software for linking computer and iPhone/iPad/iPod
