### PR TITLE
ZTerm is a terminal emulation program for the Macintosh

### DIFF
--- a/Casks/zterm.rb
+++ b/Casks/zterm.rb
@@ -1,0 +1,7 @@
+class Zterm < Cask
+  url 'http://www.dalverson.com/zterm/ZTerm1.2.dmg'
+  homepage 'http://www.dalverson.com/zterm/'
+  version '1.2'
+  sha1 '7d350dac27eaa7f39d676f933e64515d55bc3844'
+  link 'ZTerm.app'
+end


### PR DESCRIPTION
ZTerm can talk to ports on USB to serial adapters, through the appropriate driver software supplied with the adapter.
