### PR TITLE
Add CCMenu cask

### DIFF
--- a/Casks/cc-menu.rb
+++ b/Casks/cc-menu.rb
@@ -1,0 +1,7 @@
+class CcMenu < Cask
+  url 'http://downloads.sourceforge.net/project/ccmenu/CCMenu/1.6.3/ccmenu-1.6.3-b.dmg'
+  homepage 'http://ccmenu.sourceforge.net/'
+  version '1.6.3'
+  sha1 'dea62d5597d5ebe0cb0e0c5b07de30708cd14f39'
+  link 'CC Menu.app'
+end


### PR DESCRIPTION
CCMenu displays the project status of CruiseControl continuous integration servers as an item in the Mac OS X menu bar.
