### PR TITLE
Added cask for GitX-dev (rowanj's fork).

### DIFF
--- a/Casks/gitx-dev.rb
+++ b/Casks/gitx-dev.rb
@@ -1,0 +1,7 @@
+class GitxDev < Cask
+  url 'https://github.com/rowanj/gitx/releases/download/builds/0.14/95/GitX-dev-95.dmg'
+  homepage 'https://github.com/rowanj/gitx'
+  version '0.14.95'
+  sha1 'cf94fdb6410673afd1a87f60c0fd59019050ba7a'
+  link 'GitX.app'
+end


### PR DESCRIPTION
This is the other popular fork besides gitx-l. It is also recommended by the original author of GitX (see https://github.com/pieter/gitx/wiki).
