### PR TITLE
Add Sitesucker Cask

### DIFF
--- a/Casks/sitesucker.rb
+++ b/Casks/sitesucker.rb
@@ -1,0 +1,7 @@
+class Sitesucker < Cask
+  url 'http://www.sitesucker.us/archive/latest/SiteSucker.zip'
+  homepage 'http://www.sitesucker.us/mac/mac.html'
+  version 'latest'
+  no_checksum
+  link 'SiteSucker.app'
+end


### PR DESCRIPTION
> SiteSucker is a Macintosh application that automatically downloads
> Web sites from the Internet. It does this by asynchronously
> copying the site's Web pages, images, backgrounds, movies, and
> other files to your local hard drive, duplicating the site's
> directory structure. Just enter a URL (Uniform Resource Locator),
> press return, and SiteSucker can download an entire Web site.
