### PR TITLE
Fixes homepage URL for Mozart cask

### DIFF
--- a/Casks/mozart.rb
+++ b/Casks/mozart.rb
@@ -1,6 +1,6 @@
 class Mozart < Cask
   url 'http://www.mozart-oz.org/download/mozart-ftp/store/1.4.0-2012-02-01-macosx/Mozart-1.4.0.20120201.zip'
-  homepage 'www.mozart-oz.org'
+  homepage 'http://www.mozart-oz.org'
   version '1.4.0'
   sha1 '0003fdce29d26bf58ff5216bc0b89a19a51a527d'
   link 'Mozart.app'


### PR DESCRIPTION
Homepage for Mozart cask was missing the http://

``` shell
$ brew cask home mozart
The file /Users/crcastle/www.mozart-oz.org does not exist.
Perhaps you meant 'http://www.mozart-oz.org'?
```
