### PR TITLE
Add iPhone Configuration Utility Cask

### DIFF
--- a/Casks/iphone-configuration-utility.rb
+++ b/Casks/iphone-configuration-utility.rb
@@ -1,0 +1,7 @@
+class IphoneConfigurationUtility < Cask
+  url 'http://support.apple.com/downloads/DL1465/en_US/iPhoneConfigUtility.dmg'
+  homepage 'http://support.apple.com/kb/DL1465'
+  version '3.5'
+  sha1 '006aa9846f79793b34b7419affe442e1a8e8fb0d'
+  install 'iPhoneConfigurationUtility.pkg'
+end


### PR DESCRIPTION
iPhone Configuration Utility lets you easily create, maintain, encrypt,
and install configuration profiles, track and install provisioning
profiles and authorized applications, and capture device information
including console logs.
