### PR TITLE
Add new cask for Prey project.

### DIFF
--- a/Casks/prey.rb
+++ b/Casks/prey.rb
@@ -1,0 +1,17 @@
+class Prey < Cask
+  url 'http://preyproject.com/releases/current/prey-0.6.0-mac-batch.mpkg.zip'
+  homepage 'https://preyproject.com'
+  version '0.6.0'
+  sha1 'cb16471070e4c998d6178e7e96284b908c4ad18b'
+  install 'prey-0.6.0-mac-batch.mpkg'
+  def caveats; <<-EOS.undent
+    Prey requires an API key to be installed. If None is found, next step will fail.
+    To set up your API key, type the following command in your terminal and relaunch Prey installation:
+
+        export API_KEY="abcdef123456"
+        brew cask uninstall prey
+        brew cask install prey
+
+    EOS
+  end
+end


### PR DESCRIPTION
This cask install the batch version of Prey package, as detailed in:
http://support.preyproject.com/kb/installation/how-to-deploy-prey-in-batch-mode-mac-os

As it requires an API key to be installed, a warning is displayed to the
user with an explanation on how to fix the issue.
