### PR TITLE
Preserve environment when running a command with sudo.

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -17,7 +17,7 @@ class Cask::SystemCommand
 
   def self._process_options(command, options)
     if options[:sudo]
-      command = "sudo #{_quote(command)}"
+      command = "sudo -E #{_quote(command)}"
     end
     if options[:args]
       command = "#{command} #{options[:args].map { |arg| _quote(arg) }.join(' ')}"


### PR DESCRIPTION
I tried to create a Cask for Prey (see #953). This package is special as it
requires an API key to be set, else it will refuse to be installed.

The user can set the key beforehand with the following command:

```
$ export API_KEY="abcdef123456"
```

But Prey will ignore the key value because sudo isolate environments.

To fix this issue, I proposed to let sudo preserve the environment.
