### PR TITLE
Add support for VMware Fusion

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,0 +1,7 @@
+class VmwareFusion < Cask
+  url 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-5.0.3-1040386-light.dmg'
+  homepage 'http://www.vmware.com/products/fusion/'
+  version '5.0.3'
+  sha1 'a34284daa1d0e66494530498a57fac933ca68aff'
+  link 'VMware Fusion.app'
+end

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,7 +1,7 @@
 class VmwareFusion < Cask
   url 'https://s3.amazonaws.com/boxen-downloads/vmware/VMware-Fusion-5.0.3-1040386-light.dmg'
   homepage 'http://www.vmware.com/products/fusion/'
-  version '5.0.3'
+  version '5.0.3-1040386'
   sha1 'a34284daa1d0e66494530498a57fac933ca68aff'
   link 'VMware Fusion.app'
 end


### PR DESCRIPTION
This is my first git and Github commit pretty much _ever_, so apologies if I've done something wrong. Just adds a cask for VMware Fusion. Because you have to login to download the binary directly from VMware, the link uses Boxen's link for VMware Fusion (https://github.com/boxen/puppet-vmware_fusion) but uses a sha1sum obtained from VMware to ensure the binary is genuine.
