### PR TITLE
Add toggl desktop cask

### DIFF
--- a/Casks/toggl-desktop.rb
+++ b/Casks/toggl-desktop.rb
@@ -1,7 +1,7 @@
 class TogglDesktop < Cask
   url 'https://www.toggl.com/api/v8/installer?app=td&platform=darwin&channel=stable'
   homepage 'https://www.toggl.com'
-  version '6.18'
-  sha1 '84b3a495c5addb36171f610d280fcb7aef8db3f1'
+  version 'latest'
+  no_checksum
   link 'TogglDesktop.app'
 end

--- a/Casks/toggl-desktop.rb
+++ b/Casks/toggl-desktop.rb
@@ -1,0 +1,7 @@
+class TogglDesktop < Cask
+  url 'https://www.toggl.com/api/v8/installer?app=td&platform=darwin&channel=stable'
+  homepage 'https://www.toggl.com'
+  version '6.18'
+  sha1 '84b3a495c5addb36171f610d280fcb7aef8db3f1'
+  link 'TogglDesktop.app'
+end


### PR DESCRIPTION
Toggl is an awesome time-tracker webapp that kills timesheets.
