### PR TITLE
Add cask for ComicBookLover

### DIFF
--- a/Casks/comic-book-lover.rb
+++ b/Casks/comic-book-lover.rb
@@ -1,0 +1,7 @@
+class ComicBookLover < Cask
+  url 'http://www.bitcartel.com/downloads/comicbooklover.zip'
+  homepage 'http://www.bitcartel.com/comicbooklover/'
+  version '1.5'
+  sha1 '1daa918550ea59526a6030d9df0963e3fa6b3d23'
+  link 'ComicBookLover.app'
+end

--- a/Casks/comic-book-lover.rb
+++ b/Casks/comic-book-lover.rb
@@ -1,7 +1,7 @@
 class ComicBookLover < Cask
   url 'http://www.bitcartel.com/downloads/comicbooklover.zip'
   homepage 'http://www.bitcartel.com/comicbooklover/'
-  version '1.5'
-  sha1 '1daa918550ea59526a6030d9df0963e3fa6b3d23'
+  version 'latest'
+  no_checksum
   link 'ComicBookLover.app'
 end


### PR DESCRIPTION
"ComicBookLover for Mac OS X enables comic fans to easily view,
collect, and organise digital comics. Find comics to read by
browsing cover artwork, smart lists, or using the advanced search
functions. Read comics on your laptop, on an external display, in
full screen, or perhaps even in Manga mode. Let ComicBookLover do
the hard work of managing thousands of comics while you just enjoy
your reading!"
