### PR TITLE
Add cask for ComicBookLoverSync

### DIFF
--- a/Casks/comic-book-lover-sync.rb
+++ b/Casks/comic-book-lover-sync.rb
@@ -1,0 +1,7 @@
+class ComicBookLoverSync < Cask
+  url 'http://www.bitcartel.com/downloads/comicbookloversync.zip'
+  homepage 'http://www.bitcartel.com/comicbooklover'
+  version 'latest'
+  no_checksum
+  link 'ComicBookLoverSync.app'
+end


### PR DESCRIPTION
A companion app to ComicBookLover for iOS, ComicBookLoversync allows
you to transfer comics from your Mac to an iOS device.
