### PR TITLE
Add Cask for LastPass Universal Mac OS X

### DIFF
--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -4,5 +4,4 @@ class LastpassUniversal < Cask
   version '2.5.0'
   sha1 '0efa71f9b5efb9b4bed2574025eb9c0bedc1eada'
   install 'lpmacosx.pkg'
-  uninstall 'LastPass Uninstall.app'
 end

--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -1,0 +1,8 @@
+class LastpassUniversal < Cask
+  url 'https://lastpass.com/lpmacosx.dmg'
+  homepage 'https://lastpass.com/'
+  version '2.5.0'
+  sha1 '0efa71f9b5efb9b4bed2574025eb9c0bedc1eada'
+  install 'lpmacosx.pkg'
+  uninstall 'LastPass Uninstall.app'
+end

--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -1,7 +1,6 @@
 class LastpassUniversal < Cask
   url 'https://lastpass.com/lpmacosx.dmg'
   homepage 'https://lastpass.com/'
-  version '2.5.0'
-  sha1 '0efa71f9b5efb9b4bed2574025eb9c0bedc1eada'
+  version 'latest'
   install 'lpmacosx.pkg'
 end

--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -2,5 +2,6 @@ class LastpassUniversal < Cask
   url 'https://lastpass.com/lpmacosx.dmg'
   homepage 'https://lastpass.com/'
   version 'latest'
+  sha1 'no_checksum'
   install 'lpmacosx.pkg'
 end


### PR DESCRIPTION
This patch adds support for the LastPass Universal
Installer for Mac, which is a .dmg containing
all of the LastPass browser extensions.
