### PR TITLE
Fix daisy-disk cask.

### DIFF
--- a/Casks/daisy-disk.rb
+++ b/Casks/daisy-disk.rb
@@ -1,7 +1,7 @@
 class DaisyDisk < Cask
-  url 'http://www.daisydiskapp.com/downloads/DaisyDisk.dmg'
+  url 'http://www.daisydiskapp.com/downloads/DaisyDisk.zip'
   homepage 'http://www.daisydiskapp.com'
-  version '2.1.2'
-  sha1 '584eb479c41e2e73142fd69ce77bc57470d718de'
-  link 'DaisyDisk.app'
+  version 'latest'
+  no_checksum
+  link 'DaisyDisk.app'                                                                                                                                
 end


### PR DESCRIPTION
Now that DaisyDisk has gone 3.0, this cask is broken. I made the following changes:
- Updated the download URL (now a zip archive instead of a disk image)
- Changed the cask version to 'latest'
- Removed the checksum requirement
