### PR TITLE
Added cask for LineIn app

### DIFF
--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -1,0 +1,7 @@
+class Linein < Cask
+  url 'http://www.rogueamoeba.com/freebies/download/LineIn.zip'
+  homepage 'http://www.rogueamoeba.com/freebies/'
+  version 'latest'
+  no_checksum
+  link 'LineIn.app'
+end


### PR DESCRIPTION
This patch adds LineIn app from Rogue Amoeba, which enables soft playthru of audio from input devices.
