### PR TITLE
Add cask for 'MacPAR deLuxe'

### DIFF
--- a/Casks/macpardeluxe.rb
+++ b/Casks/macpardeluxe.rb
@@ -1,7 +1,7 @@
 class Macpardeluxe < Cask
   url 'http://www.xs4all.nl/~gp/MacPAR_deLuxe/MacPARdeLuxe.dmg'
   homepage 'http://gp.home.xs4all.nl/Site/MacPAR_deLuxe.html'
-  version '4.4.1'
-  sha1 'e5981e54e1a37c1d2c2e193e84506786d7bd2518'
+  version 'latest'
+  no_checksum
   link 'MacPAR deLuxe.app'
 end

--- a/Casks/macpardeluxe.rb
+++ b/Casks/macpardeluxe.rb
@@ -1,0 +1,7 @@
+class Macpardeluxe < Cask
+  url 'http://www.xs4all.nl/~gp/MacPAR_deLuxe/MacPARdeLuxe.dmg'
+  homepage 'http://gp.home.xs4all.nl/Site/MacPAR_deLuxe.html'
+  version 'latest'
+  sha1 'e5981e54e1a37c1d2c2e193e84506786d7bd2518'
+  link 'MacPAR deLuxe.app'
+end

--- a/Casks/macpardeluxe.rb
+++ b/Casks/macpardeluxe.rb
@@ -1,7 +1,7 @@
 class Macpardeluxe < Cask
   url 'http://www.xs4all.nl/~gp/MacPAR_deLuxe/MacPARdeLuxe.dmg'
   homepage 'http://gp.home.xs4all.nl/Site/MacPAR_deLuxe.html'
-  version 'latest'
+  version '4.4.1'
   sha1 'e5981e54e1a37c1d2c2e193e84506786d7bd2518'
   link 'MacPAR deLuxe.app'
 end


### PR DESCRIPTION
MacPAR deLuxe is a utility program that runs on the Apple Macintosh. It is useful to you if you download (or upload) binary files from internet newsgroups (a.k.a. “Usenet”).
Often, binary content comes in the form of sets of many files that together form a “rar” archive. MacPAR deLuxe assist you in combining these files after the download finishes.

http://gp.home.xs4all.nl/Site/MacPAR_deLuxe.html
