### PR TITLE
updated power-key download url and upgraded to 1.1

### DIFF
--- a/Casks/power-key.rb
+++ b/Casks/power-key.rb
@@ -1,7 +1,7 @@
 class PowerKey < Cask
-  url 'https://github.com/pkamb/PowerKey/raw/master/Release/PowerKey.zip'
+  url 'https://github.com/pkamb/PowerKey/releases/download/v1.1/PowerKey.zip'
   homepage 'http://pkamb.github.io/PowerKey/'
-  version 'latest'
-  no_checksum
+  version '1.1'
+  sha1 '3403eee29940e287f9013a93b89e0605ad6aae30'
   link 'PowerKey.app'
 end


### PR DESCRIPTION
fixes https://github.com/phinze/homebrew-cask/issues/994
