### PR TITLE
fix overzealous cask already created error

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -68,7 +68,10 @@ class Cask
     if cask_title.include?('/')
       cask_with_tap = cask_title
     else
-      cask_with_tap = all_titles.grep(/#{cask_title}$/).first
+      cask_with_tap = all_titles.detect { |tap_and_title|
+        _, title = tap_and_title.split('/')
+        title == cask_title
+      }
     end
 
     if cask_with_tap

--- a/test/cli/create_test.rb
+++ b/test/cli/create_test.rb
@@ -22,7 +22,7 @@ describe Cask::CLI::Create do
   before { Cask::CLI::Create.reset! }
 
   after {
-    %w[ new-cask additional-cask another-cask ].each do |cask|
+    %w[ new-cask additional-cask another-cask feine ].each do |cask|
       path = Cask.path(cask)
       path.delete if path.exist?
     end
@@ -60,5 +60,12 @@ describe Cask::CLI::Create do
     lambda {
       Cask::CLI::Create.run('caffeine')
     }.must_raise CaskAlreadyCreatedError
+  end
+
+  it 'allows creating casks that are substrings of existing casks' do
+    Cask::CLI::Create.run('feine')
+    Cask::CLI::Create.editor_commands.must_equal [
+      [Cask.path('feine')]
+    ]
   end
 end


### PR DESCRIPTION
this prevented any cask being created via `brew cask create` that was a
suffix substring of an existing cask.

refs #998
