### PR TITLE
Added cask for 0ad

### DIFF
--- a/Casks/zero-ad.rb
+++ b/Casks/zero-ad.rb
@@ -1,0 +1,7 @@
+class ZeroAd < Cask
+  url 'http://releases.wildfiregames.com/0ad-0.0.14-alpha-osx64.dmg'
+  homepage 'http://www.play0ad.com/'
+  version '0.0.14-alpha'
+  sha1 'c6c1b630a7117210d217da1076a18faf988c86a3'
+  link '0ad.app'
+end


### PR DESCRIPTION
http://play0ad.com/

Due to Ruby's limitations on class names, I had to refer to this game as "Zero-AD". If anyone knows how to make this work with the command `$ brew cask install 0ad`, please let me know!
