### PR TITLE
omni-graffle-pro link fix

### DIFF
--- a/Casks/omni-graffle-pro.rb
+++ b/Casks/omni-graffle-pro.rb
@@ -3,5 +3,5 @@ class OmniGrafflePro < Cask
   homepage 'http://www.omnigroup.com/products/omnigraffle'
   version 'latest'
   no_checksum
-  link 'OmniGraffle Professional'
+  link 'OmniGraffle Professional 5.app'
 end


### PR DESCRIPTION
Linking omni-graffle-pro was linking to Contents/MacOS/OmniGraffle
Professional instead of to the application. Fix by referencing .app.
