### PR TITLE
contributing.md: symlink to taps instead of home

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ this:
   ```bash
   $ cd $(brew --prefix brew-cask)
   $ mv rubylib{,.orig}
-  $ ln -s ~/homebrew-cask/lib rubylib
+  $ ln -s $(brew --prefix)/Library/Taps/phinze-cask/lib rubylib
   ```
 
 Now you can hack on `~/homebrew-cask` and use the cli to interact with the code.


### PR DESCRIPTION
The rest of the contribution instructions
have people working on the clone already in brew taps.

This just updates a reference that is still pointing
to the would-be contributors' home directory.
