### PR TITLE
Homebrew Version 0.9.4 breaks brew cask install .

### DIFF
--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -6,7 +6,7 @@ class Cask::Download
   end
 
   def perform
-    require 'formula_support'
+    require 'software_spec'
     software_spec = SoftwareSpec.new(cask.url.to_s, cask.version)
     downloader = CurlDownloadStrategy.new(cask.title, software_spec)
     downloaded_path = downloader.fetch


### PR DESCRIPTION
 SoftwareSpec is moved out in a seperate file.

ref: https://github.com/mxcl/homebrew/commit/11c4e241248a3ff9e4ed3dd534a06a406da8dccc
