### PR TITLE
Update Screenflick to latest

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,7 +1,7 @@
 class Screenflick < Cask
   url 'http://www.araelium.com/screenflick/downloads/Screenflick.dmg'
   homepage 'http://www.araelium.com/screenflick/'
-  version '2.2.14'
-  sha1 '2b278caee0c946b951d07fcd892356b76ce03a04'
+  version 'latest'
+  no_checksum
   link 'Screenflick.app'
 end


### PR DESCRIPTION
- Received a SHA1 mismatch when attempting to install v. 2.2 :facepunch: 
