### PR TITLE
Airdisplay - iOS display mirroring etc

### DIFF
--- a/Casks/airdisplay.rb
+++ b/Casks/airdisplay.rb
@@ -1,0 +1,8 @@
+class Airdisplay < Cask
+  url 'http://avatron.com/downloads/AirDisplayInstaller.zip'
+  homepage 'http://avatron.com/apps/air-display/'
+  version 'latest'
+  no_checksum
+  install 'Air Display Installer.pkg'
+  uninstall :pkgutil => 'com.avatron.pkg.AirDisplay'
+end


### PR DESCRIPTION
This adds support for avatron software AirDisplay's mac connector, a popular iOS display mirroring/extending app.

Had to link the uninstaller to their uninstall binary, which works but it does cause a GUI prompt - I don't think there is really much that can be done about this.
