### PR TITLE
Media Converter 1.2

### DIFF
--- a/Casks/media-converter.rb
+++ b/Casks/media-converter.rb
@@ -1,0 +1,7 @@
+class MediaConverter < Cask
+  url 'http://downloads.sourceforge.net/project/media-converter/media-converter/1.2/media-converter-1.2.zip'
+  homepage 'http://media-converter.sourceforge.net/'
+  version '1.2'
+  sha1 '8f8f0697447b298a45e36a385df667bb902a9aae'
+  link 'Media Converter.app'
+end


### PR DESCRIPTION
Simple but advanced converting for Mac OS X.
Media Converter uses ffmpeg to convert video files, lot of file formats are supported.
Convert avi, wmv, mkv, rm, mov and more to other formats.
