### PR TITLE
Add MoreAmp (0.1.28)

### DIFF
--- a/Casks/moreamp.rb
+++ b/Casks/moreamp.rb
@@ -1,0 +1,7 @@
+class Moreamp < Cask
+  url 'http://downloads.sourceforge.net/project/moreamp/moreamp/MoreAmp-0.1.28/MoreAmp-0.1.28-binOSXintel.dmg'
+  homepage 'http://sourceforge.net/projects/moreamp/'
+  version '0.1.28'
+  sha1 'cfde9ed841b9f066dc108338f459d305540ee0bc'
+  link 'MoreAmp.app'
+end


### PR DESCRIPTION
MoreAmp is an audio player, transcoder, and CD ripper for Mac OS X, Mac OS 9, Windows, Unix, and Linux. It plays and creates ogg, flac, mp3, aac, m4a, mp4, wav, and aif files, and plays wma files. It features a 31-band equalizer, repeat loop, variable pitch/tempo, ram or ramdisk preload, and more. 
