### PR TITLE
Add cask for join.me

### DIFF
--- a/Casks/join-me.rb
+++ b/Casks/join-me.rb
@@ -1,0 +1,7 @@
+class JoinMe < Cask
+  url 'https://secure.join.me/Download.aspx?installer=mac&webdownload=true'
+  homepage 'https://join.me/'
+  version 'latest'
+  no_checksum
+  link 'join.me.app'
+end


### PR DESCRIPTION
Add cask for join.me, a screensharing and online meetings app. Downloads
latest version without a checksum as there are no surfaced URLs for old
versions.
