### PR TITLE
fixing (removing) the checksum for lastpass universal

### DIFF
--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -2,6 +2,6 @@ class LastpassUniversal < Cask
   url 'https://lastpass.com/lpmacosx.dmg'
   homepage 'https://lastpass.com/'
   version 'latest'
-  sha1 'no_checksum'
+  no_checksum
   install 'lpmacosx.pkg'
 end


### PR DESCRIPTION
It looks like lastpass doesn't version the downloads, and it must have changed. I saw a checksum conflict when I tried installing, so I turned off the checksum.

I think this is what the original author intended.
