### PR TITLE
Remove textual demo

### DIFF
--- a/Casks/textual.rb
+++ b/Casks/textual.rb
@@ -1,7 +1,0 @@
-class Textual < Cask
-  url 'http://www.codeux.com/textual/private/downloads/builds/Textual_Demo_12536.zip'
-  homepage 'http://www.codeux.com/textual/'
-  version '2.1.1'
-  sha1 'af057d11e3578afa3b80f4f26093978389982ca2'
-  link 'Textual.app'
-end


### PR DESCRIPTION
It's not working anyway (404). I think it's better
to remove this demo from cask at all.

If you want to buy full version you need to use AppStore.
