### PR TITLE
fix: Allow for underscores in urls

### DIFF
--- a/Casks/qqbrowser.rb
+++ b/Casks/qqbrowser.rb
@@ -1,5 +1,5 @@
 class Qqbrowser < Cask
-  url 'http://url.cn/0Q7Ev1' # Refer to #933 regarding usage of shortener
+  url 'http://dl_dir.qq.com/invc/tt/QQBrowser_1.5.0.2311.dmg'
   homepage 'http://browser.qq.com/mac/'
   version '1.5.0.2311'
   sha1 '0b390037a045e0ea6b0105d2ace1c40f854106ac'

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -29,6 +29,12 @@ module Cask::DSL
 
     def url(url=nil)
       @url ||= (url && URI.parse(url))
+    rescue URI::InvalidURIError
+      # Ulgly fix for underscores in hostname
+      # As URI::parser is not available in 1.8.7
+      host = url.match(".+\:\/\/([^\/]+)")[1]
+      @url ||= URI.parse(url.sub(host, 'dummy-host'))
+      @url.instance_variable_set('@host', host)
     end
 
     def version(version=nil)

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -108,4 +108,9 @@ describe Cask::DSL do
     instance = CaskWithInstallables.new
     Array(instance.installables).sort.must_equal %w[Bar.pkg Foo.pkg]
   end
+
+  it "allow for underscores in url domain" do
+    test_cask = Cask.load('qqbrowser')
+    test_cask.url.host.must_include '_'
+  end
 end


### PR DESCRIPTION
Should fix #981. Ugly ugly hack, but works.
