### PR TITLE
Support for WavTap

### DIFF
--- a/Casks/wav-tap.rb
+++ b/Casks/wav-tap.rb
@@ -4,4 +4,5 @@ class WavTap < Cask
   version '0.2.0'
   sha1 '9d71dcf769dd546d66278dc9cbf675df6b006fe6'
   install 'WavTap 0.2.0.pkg'
+  uninstall :pkgutil => 'com.wavtap.*', :kext => 'com.wavtap.driver.WavTap'
 end

--- a/Casks/wav-tap.rb
+++ b/Casks/wav-tap.rb
@@ -3,5 +3,5 @@ class WavTap < Cask
   homepage 'https://github.com/pje/wavtap'
   version '0.2.0'
   sha1 '9d71dcf769dd546d66278dc9cbf675df6b006fe6'
-  install 'wav-tap-0.2.0.pkg'
+  install 'WavTap 0.2.0.pkg'
 end

--- a/lib/cask/container/naked.rb
+++ b/lib/cask/container/naked.rb
@@ -10,7 +10,7 @@ class Cask::Container::Naked < Cask::Container::Base
   end
 
   def target_file
-    File.basename(@cask.url.path)
+    URI.decode(File.basename(@cask.url.path))
   end
 end
 

--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -17,6 +17,7 @@ class Cask::Pkg
       @command.run('rm', :args => [file], :sudo => true) if file.exist?
     end
     _deepest_path_first(dirs).each do |dir|
+      @command.run('chmod', :args => ['777', dir], :sudo => true)
       _clean_symlinks(dir)
       @command.run('rmdir', :args => [dir], :sudo => true) if dir.exist? && dir.children.empty?
     end

--- a/lib/cask/pkg_installer.rb
+++ b/lib/cask/pkg_installer.rb
@@ -21,6 +21,13 @@ class Cask::PkgInstaller
         @command.run(@cask.destination_path.join(uninstall_options[:script]), uninstall_options.merge(:sudo => true))
       end
 
+      if uninstall_options.key? :kext
+        [*uninstall_options[:kext]].each do |kext|
+          ohai "Unloading kernel extension #{kext}"
+          @command.run('kextunload', :args => ['-b', kext], :sudo => true)
+        end
+      end
+
       if uninstall_options.key? :pkgutil
         pkgs = Cask::Pkg.all_matching(uninstall_options[:pkgutil], @command)
         pkgs.each(&:uninstall)

--- a/test/cask/container/naked_test.rb
+++ b/test/cask/container/naked_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+describe Cask::Container::Naked do
+  it "saves files with spaces in them from uris with encoded spaces" do
+    SpaceyCask = Class.new(Cask)
+    SpaceyCask.class_eval do
+      url 'http://example.com/kevin%20spacey.pkg'
+      version '1.2'
+    end
+
+    cask                 = SpaceyCask.new
+    path                 = '/tmp/downloads/kevin-spacey-1.2.pkg'
+    expected_destination = cask.destination_path.join('kevin spacey.pkg')
+    expected_command     = %Q(ditto '#{path}' '#{expected_destination}' 2>&1)
+    Cask::FakeSystemCommand.fake_response_for(expected_command)
+
+    container = Cask::Container::Naked.new(cask, path, Cask::FakeSystemCommand)
+    container.extract
+
+    Cask::FakeSystemCommand.system_calls[expected_command].must_equal 1
+  end
+end

--- a/test/cask/pkg_installer_test.rb
+++ b/test/cask/pkg_installer_test.rb
@@ -111,6 +111,16 @@ describe Cask::PkgInstaller do
 </plist>
         PLIST
       )
+
+      %w[
+        /tmp/fancy
+        /tmp/fancy/agent
+        /tmp/fancy/bin
+        /tmp/fancy/var
+      ].each do |dir|
+        Cask::FakeSystemCommand.fake_response_for(%Q(sudo 'chmod' '777' '#{dir}' 2>&1))
+      end
+
       Cask::FakeSystemCommand.fake_response_for(%Q(sudo 'pkgutil' '--forget' 'my.fancy.package.agent' 2>&1))
 
       # No assertions after call since all assertions are implicit from the interactions setup above.

--- a/test/cask/pkg_installer_test.rb
+++ b/test/cask/pkg_installer_test.rb
@@ -79,6 +79,7 @@ describe Cask::PkgInstaller do
 </plist>
         PLIST
       )
+      Cask::FakeSystemCommand.fake_response_for(%Q(sudo 'kextunload' '-b' 'my.fancy.package.kernelextension' 2>&1))
       Cask::FakeSystemCommand.fake_response_for(%Q(sudo 'pkgutil' '--forget' 'my.fancy.package.main' 2>&1))
 
       Cask::FakeSystemCommand.fake_response_for(

--- a/test/support/Casks/with-pkgutil-uninstall.rb
+++ b/test/support/Casks/with-pkgutil-uninstall.rb
@@ -4,5 +4,5 @@ class WithPkgutilUninstall < TestCask
   version '1.2.3'
   sha1 '8588bd8175a54b8e0a1310cc18e6567d520ab7c4'
   install 'Fancy.pkg'
-  uninstall :pkgutil => 'my.fancy.package.*'
+  uninstall :pkgutil => 'my.fancy.package.*', :kext => 'my.fancy.package.kernelextension'
 end


### PR DESCRIPTION
- kext unloading
- spaces in naked pkg filenames
- sudo chmod before examining uninstallable directories

This should finish up all the work necessary for `wav-tap`, the example cask mentioned in #839 
