### PR TITLE
pandoc: update cask to v. 1.12.0.1

### DIFF
--- a/Casks/pandoc.rb
+++ b/Casks/pandoc.rb
@@ -1,7 +1,7 @@
 class Pandoc < Cask
   homepage 'http://johnmacfarlane.net/pandoc'
-  url "https://pandoc.googlecode.com/files/pandoc-1.11.1.dmg"
-  sha1 '00fc2bde8a51e6d004e20948ac9b4a6fca466daf'
-  version '1.11.1'
-  install 'pandoc-1.11.1.pkg'
+  url "https://pandoc.googlecode.com/files/pandoc-1.12.0.1.dmg"
+  sha1 'c941b86faa062fe7fa65e152eacbdc0b85ab143f'
+  version '1.12.0.1'
+  install 'pandoc-1.12.0.1.pkg'
 end


### PR DESCRIPTION
changed download link and sha to use current pandoc build.
