### PR TITLE
Fix HipChat Cask name

### DIFF
--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -1,4 +1,4 @@
-class HipChat < Cask
+class Hipchat < Cask
   url 'http://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.3.zip'
   homepage 'https://www.hipchat.com/'
   version '2.3'


### PR DESCRIPTION
Searching for 'hipchat' failed because of the hyphen.
It's stylized as 'HipChat' rather than 'Hip Chat' so
there should be no hyphen.
