### PR TITLE
Add GitX-dev

### DIFF
--- a/Casks/gitx-dev
+++ b/Casks/gitx-dev
@@ -1,0 +1,7 @@
+class GitxDev < Cask
+  url 'http://builds.phere.net/GitX/development/GitX-dev.dmg'
+  homepage 'http://rowanj.github.io/gitx/'
+  version 'latest'
+  sha1 'cf94fdb6410673afd1a87f60c0fd59019050ba7a'
+  link 'GitX.app'
+end


### PR DESCRIPTION
[GitX-dev](http://rowanj.github.io/gitx/) is another fork of GitX, but seems to the most actively-maintained.

GitX-L is already available as a Cask, but it hasn't been updated since August 2011.
