### PR TITLE
Add iTunes Volume Control

### DIFF
--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -1,0 +1,7 @@
+class ItunesVolumeControl < Cask
+  url 'https://github.com/alberti42/iTunes-Volume-Control/raw/288c9f3f2c0d00dc76afde2fcc6a7362505113f1/iTunes%20Volume%20Control.dmg'
+  homepage 'https://github.com/alberti42/iTunes-Volume-Control'
+  version '1.4.6'
+  sha1 '0dbf90d5e6ba8d693609bf5e26884ceb55040304'
+  link 'iTunes Volume Control.app'
+end


### PR DESCRIPTION
iTunes Volume Control is a nifty little app that lets you control volume of airplayed music with keyboard volume buttons.
