### PR TITLE
Add cask for NetBeans

### DIFF
--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -1,0 +1,27 @@
+class Netbeans < Cask
+  url 'http://download.netbeans.org/netbeans/7.3.1/final/bundles/netbeans-7.3.1-macosx.dmg'
+  homepage 'https://netbeans.org/'
+  version '7.3.1'
+  sha1 '2dadd046e7d60b8ce74bf26b685eff092e4c5fb3'
+  install 'NetBeans 7.3.1.mpkg'
+  # Theoretically this uninstall could conflict with a separate GlassFish
+  # installation.
+  #
+  # In practice, it appears that the normal GlassFish installation process does
+  # not use the OS X installer and so isn't in the pkgutil receipts database.
+  #
+  # https://glassfish.java.net/docs/4.0/installation-guide.pdf
+  #
+  # Arguably if the GlassFish installation by NetBeans inside its own target
+  # directory were to conflict with a standard GlassFish installation in the
+  # receipts database that would be a bug upstream with NetBeans not prefixing
+  # its GlassFish package with "org.netbeans."
+  #
+  # The NetBeans installer does some postflight unpacking of paths installed by
+  # the OS X installer, so it's insufficient to just delete the paths exposed
+  # by pkgutil, hence the additional `:files` option below.
+  uninstall(
+    :pkgutil => 'org.netbeans.ide.*|glassfish-.*',
+    :files => '/Applications/NetBeans'
+  )
+end


### PR DESCRIPTION
Cask for NetBeans. Note uninstall is kinda greedy, applying to packages
matching org.netbeans._|glassfish-_. However, GlassFish proper doesn't
install using Mac OS X installer, so this hopefully won't cause problems
in practice.
