### PR TITLE
google-app-engine-launcher 1.8.5

### DIFF
--- a/Casks/google-app-engine-launcher.rb
+++ b/Casks/google-app-engine-launcher.rb
@@ -1,7 +1,7 @@
 class GoogleAppEngineLauncher < Cask
-  url 'https://googleappengine.googlecode.com/files/GoogleAppEngineLauncher-1.8.4.dmg'
+  url 'https://googleappengine.googlecode.com/files/GoogleAppEngineLauncher-1.8.5.dmg'
   homepage 'https://developers.google.com/appengine/'
-  version '1.8.4'
-  sha1 '844b8cf9ae289833f6a79afb67ca79a6b3ca2eda'
+  version '1.8.5'
+  sha1 'c533d9faad9d78d24e30d4875ffcfaa4217858f5'
   link 'GoogleAppEngineLauncher.app'
 end


### PR DESCRIPTION
updated google-app-engine-launcher from 1.8.4 to 1.8.5
