### PR TITLE
 Adding Hostbuddy cask

### DIFF
--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,0 +1,7 @@
+class Hostbuddy < Cask
+  url 'http://clickontyler.com/hostbuddy/download/'
+  homepage 'http://clickontyler.com'
+  version 'latest'
+  no_checksum
+  link 'Hostbuddy.app'
+end


### PR DESCRIPTION
Hostbuddy is a way to manage and update the /etc/hosts file on your Mac.
