### PR TITLE
Fixed link path in cask for MacVim

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -3,5 +3,5 @@ class Macvim < Cask
   homepage 'http://code.google.com/p/macvim/'
   version '7.4-70'
   sha1 '5ee2219c26219a3fe26ed74a71f3b8e65d79f91c'
-  link 'MacVim.app'
+  link 'MacVim-snapshot-70/MacVim.app'
 end


### PR DESCRIPTION
The latest version of MacVim places app within MacVim-snapshot-70 folder so link
path has to include that folder.

PS. That's my second pull request ever so please be patient and let me know if I disobey contributing rules.
