### PR TITLE
Cask for ShadowSweeper

### DIFF
--- a/Casks/shadow-sweeper.rb
+++ b/Casks/shadow-sweeper.rb
@@ -1,0 +1,7 @@
+class ShadowSweeper < Cask
+  url 'http://www.irradiatedsoftware.com/downloads/?file=ShadowSweeper.zip'
+  homepage 'http://www.irradiatedsoftware.com/labs/'
+  version 'latest'
+  no_checksum
+  link 'ShadowSweeper.app'
+end


### PR DESCRIPTION
ShadowSweeper disables drop shadows on windows, useful with tiling
managers such as Slate or SizeUp. Insanity's ShadowKiller is more
widely used, but now deprecated and not available from their page
anymore.
