### PR TITLE
fix a small bug that could stop the check link process.

### DIFF
--- a/lib/cask/link_checker.rb
+++ b/lib/cask/link_checker.rb
@@ -52,11 +52,13 @@ class Cask::LinkChecker
     case cask.url.scheme
     when 'http', 'https' then
       @response_status = response_lines.grep(/^HTTP/).last
-      http_headers = response_lines[(response_lines.index(@response_status)+1)..-1]
-      http_headers.each { |line|
-        header_name, header_value = line.split(': ')
-        @headers[header_name] = header_value
-      }
+      unless response_lines.index(@response_status).nil?
+        http_headers = response_lines[(response_lines.index(@response_status)+1)..-1]
+        http_headers.each { |line|
+          header_name, header_value = line.split(': ')
+          @headers[header_name] = header_value
+        }
+      end
     when 'ftp' then
       @response_status = 'OK'
       response_lines.each { |line|


### PR DESCRIPTION
Just a small fix for the issue below during link checks:

```
Error: undefined method `+' for nil:NilClass
Please report this bug:
    https://github.com/mxcl/homebrew/wiki/troubleshooting
/usr/local/Cellar/brew-cask/0.18.2/rubylib/cask/link_checker.rb:55:in `_get_data_from_request'
/usr/local/Cellar/brew-cask/0.18.2/rubylib/cask/link_checker.rb:19:in `run'
/usr/local/Cellar/brew-cask/0.18.2/rubylib/cask/cli/checklinks.rb:6:in `run'
/usr/local/Cellar/brew-cask/0.18.2/rubylib/cask/cli/checklinks.rb:4:in `each'
/usr/local/Cellar/brew-cask/0.18.2/rubylib/cask/cli/checklinks.rb:4:in `run'
/usr/local/Cellar/brew-cask/0.18.2/rubylib/cask/cli.rb:35:in `process'
/usr/local/bin/brew-cask.rb:6
/usr/local/Library/brew.rb:51:in `require'
/usr/local/Library/brew.rb:51:in `require?'
/usr/local/Library/brew.rb:101
```
