### PR TITLE
Dragthing 5.9.12

### DIFF
--- a/Casks/dragthing.rb
+++ b/Casks/dragthing.rb
@@ -1,0 +1,7 @@
+class Dragthing < Cask
+  url 'http://s3.amazonaws.com/tlasystems/DragThing-5.9.12.dmg'
+  homepage 'http://www.dragthing.com'
+  version '5.9.12'
+  sha1 '1996789effdf85329e8dce970bae37c0770b580d'
+  link 'DragThing.app'
+end


### PR DESCRIPTION
DragThing is the original dock designed to tidy up your Macintosh desktop. It puts all your documents, folders, and applications just a single click away. Highly flexible, it allows multiple docks, each customised to suit your exact needs.
