### PR TITLE
Direct download URL fot ShadowSweeper

### DIFF
--- a/Casks/shadow-sweeper.rb
+++ b/Casks/shadow-sweeper.rb
@@ -1,5 +1,5 @@
 class ShadowSweeper < Cask
-  url 'http://www.irradiatedsoftware.com/downloads/?file=ShadowSweeper.zip'
+  url 'http://www.irradiatedsoftware.com/download/ShadowSweeper.zip'
   homepage 'http://www.irradiatedsoftware.com/labs/'
   version 'latest'
   no_checksum


### PR DESCRIPTION
Irradiated nor redirects the former URL, confusing cask.
