### PR TITLE
Adding Pycharm Community version

### DIFF
--- a/Casks/pycharm-community.rb
+++ b/Casks/pycharm-community.rb
@@ -1,0 +1,7 @@
+class PycharmCommunity < Cask
+  url 'http://download.jetbrains.com/python/pycharm-community-3.0.dmg'
+  homepage 'http://www.jetbrains.com/pycharm'
+  version 'latest'
+  no_checksum
+  link 'PyCharm CE.app'
+end

--- a/Casks/pycharm-community.rb
+++ b/Casks/pycharm-community.rb
@@ -1,7 +1,7 @@
 class PycharmCommunity < Cask
   url 'http://download.jetbrains.com/python/pycharm-community-3.0.dmg'
   homepage 'http://www.jetbrains.com/pycharm'
-  version 'latest'
-  no_checksum
+  version '3.0.0'
+  sha1 'c7fec41e4ba9c8d4ddfb78bde7d50029bdf8fd82'
   link 'PyCharm CE.app'
 end


### PR DESCRIPTION
Version 3 of PyCharm split it into two versions, Community and Professional. The current cask, pycharm.rb, links to Professional, which is the paid version (opened a pull request to update the name of the current cask: https://github.com/phinze/homebrew-cask/pull/1197). This cask links to the Community version which is free. 
