### PR TITLE
update skim to v1.4.5

### DIFF
--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -1,7 +1,7 @@
 class Skim < Cask
-  url 'http://downloads.sourceforge.net/project/skim-app/Skim/Skim-1.4.4/Skim-1.4.4.dmg'
+  url 'http://downloads.sourceforge.net/project/skim-app/Skim/Skim-1.4.5/Skim-1.4.5.dmg'
   homepage 'http://skim-app.sourceforge.net/'
-  version '1.4.4'
-  sha1 '686232d5d5e1d906f468db7ecee8f8fe337d6272'
+  version '1.4.5'
+  sha1 '22cfaa81a68dfa857790307346b98fb65fee8a7b'
   link 'Skim.app'
 end


### PR DESCRIPTION
Hi there.

I updated cask of skim, a pdf viewer, to reflect its version 1.4.5 .

Download url, version and sha1sum are updated.
The updated cask has been tested locally with `brew cask install` and `brew cask audit`.

I'm new to brew and cask. So please let me know if I did something wrong.
