### PR TITLE
use /bin/ln instead of ln, to prevent link error

### DIFF
--- a/lib/cask/artifact/app.rb
+++ b/lib/cask/artifact/app.rb
@@ -17,7 +17,7 @@ class Cask::Artifact::App < Cask::Artifact::Base
 
     return unless preflight_checks(source, target)
     ohai "Linking #{source.basename} to #{target}"
-    @command.run('ln', :args => ['-hfs', source, target])
+    @command.run('/bin/ln', :args => ['-hfs', source, target])
   end
 
   def preflight_checks(source, target)

--- a/lib/cask/artifact/prefpane.rb
+++ b/lib/cask/artifact/prefpane.rb
@@ -17,7 +17,7 @@ class Cask::Artifact::Prefpane < Cask::Artifact::Base
 
     return unless preflight_checks(source, target)
     ohai "Linking prefPane #{source.basename} to #{target}"
-    @command.run('ln', :args => ['-hfs', source, target])
+    @command.run('/bin/ln', :args => ['-hfs', source, target])
   end
 
   def preflight_checks(source, target)


### PR DESCRIPTION
people who use GNU core utilities's ln doesn't have -h parameter, so ln -hfs will course error.
use /bin/ln instead of ln to prevent this error
