### PR TITLE
ScreenSteps 2.9.6

### DIFF
--- a/Casks/screensteps.rb
+++ b/Casks/screensteps.rb
@@ -1,0 +1,7 @@
+class Screensteps < Cask
+  url 'http://www.bluemangolearning.com/download/screensteps/2_0/release/ScreenSteps.dmg'
+  homepage 'http://www.bluemangolearning.com/'
+  version '2.9.6'
+  sha1 'e6786f24abf6bc5d760ce220cb4936e485b1e419'
+  link 'ScreenSteps.app'
+end


### PR DESCRIPTION
Install ScreenSteps 2.9.6, the last 2.X version from Blue Mango Learning
