### PR TITLE
Fix broken alfred cask

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -3,5 +3,5 @@ class Alfred < Cask
   homepage 'http://www.alfredapp.com/'
   version '2.0.9_214'
   sha1 '550cba6dc44250ae5940c3d302cf06e199eb6958'
-  link 'Alfred 2.app', 'Alfred Preferences.app'
+  link 'Alfred 2.app', 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
 end


### PR DESCRIPTION
The ability to link any `.app` file without specifying the full path was
removed by c244385e. This means as of version 0.18.0 of `brew-cask` the
`alfred` cask has been broken, as it raises an error due to being unable
to find `Alfred Preferences.app` (since it is not located in the root
app directory).

This seems like a quick fix for now, but it would be nice to have functionality similar to the previous behavior so that full paths don't need to be specified. Thoughts?
