### PR TITLE
Fix firefox-aurora - Update sha1 hash value

### DIFF
--- a/Casks/firefox-aurora.rb
+++ b/Casks/firefox-aurora.rb
@@ -2,6 +2,6 @@ class FirefoxAurora < Cask
   url 'https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-26.0a2.en-US.mac.dmg'
   homepage 'http://www.mozilla.org/en-US/firefox/aurora/'
   version '26.0a2'
-  sha1 'e86568eb1ccc4483d15d7c8660b4724fa7197dcd'
+  sha1 '9ecf3da45382284e97762345b59dcc9c5865ea4d'
   link 'FirefoxAurora.app'
 end


### PR DESCRIPTION
according to https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-26.0a2.en-US.mac.checksums
