### PR TITLE
Fix Lion DiskMaker version and link.

### DIFF
--- a/Casks/lion-disk-maker.rb
+++ b/Casks/lion-disk-maker.rb
@@ -2,6 +2,6 @@ class LionDiskMaker < Cask
   url 'http://liondiskmaker.com/downloads/LionDiskMaker.zip'
   homepage 'http://liondiskmaker.com/'
   version '2.0.2'
-  no_checksum
+  sha1 '1e0c898f48b1eb1f45fe8e33cc01cf40d237e378'
   link "Lion DiskMaker #{version}/Lion DiskMaker 2.app"
 end

--- a/Casks/lion-disk-maker.rb
+++ b/Casks/lion-disk-maker.rb
@@ -1,7 +1,7 @@
 class LionDiskMaker < Cask
   url 'http://liondiskmaker.com/downloads/LionDiskMaker.zip'
   homepage 'http://liondiskmaker.com/'
-  version 'lastest'
+  version '2.0.2'
   no_checksum
-  link 'Lion DiskMaker 2.app'
+  link "Lion DiskMaker #{version}/Lion DiskMaker 2.app"
 end


### PR DESCRIPTION
[Lion DiskMaker](http://liondiskmaker.com/) installation fails:

```
Error: it seems the symlink source is not there: /opt/homebrew-cask/Caskroom/lion-disk-maker/lastest/Lion DiskMaker 2.app
```

The directory structure is now: `Lion DiskMaker {{ VERSION }}/Lion DiskMaker 2.app`.

This PR fixes version and link.

Hope it helps.
