### PR TITLE
Add a cask for Balsamiq Mockups

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -1,0 +1,7 @@
+class BalsamiqMockups < Cask
+  url 'http://builds.balsamiq.com/b/mockups-desktop/MockupsForDesktop.dmg'
+  homepage 'http://balsamiq.com/'
+  version 'latest'
+  no_checksum
+  link 'Balsamiq Mockups.app'
+end


### PR DESCRIPTION
Adds a cask for [Balsamiq Mockups](http://balsamiq.com/products/mockups/), a rapid wireframing tool.
