### PR TITLE
Added Camtasia Cask

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,0 +1,7 @@
+class Camtasia < Cask
+  url 'http://download.techsmith.com/camtasiamac/enu/Camtasia.dmg'
+  homepage 'http://www.techsmith.com/camtasia.html'
+  version 'latest'
+  no_checksum
+  link 'Camtasia 2.app'
+end


### PR DESCRIPTION
Added Camtasia (latest) cask for 'Camtasia for Mac' from TechSmith. This is currently Camtasia 2, but they do not appear to have any versioning on their .dmg download.

Camtasia is a commercial screen recording / video editing tool.
