### PR TITLE
Also match non-patchlevel versions

### DIFF
--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -78,7 +78,7 @@ class Cask::CLI::Alfred
   end
 
   def self.alfred_installed?
-    alfred_preference('version') =~ /^[0-9]\.[0-9]\.[0-9]$/
+    alfred_preference('version') =~ /^[0-9]\.[0-9]$/
   end
 
   def self.linked?


### PR DESCRIPTION
The regex only matched 3 number versions, 2.1 its perfectly fine installed with the version string being only "2.1"
