### PR TITLE
Fix regex pattern of Alfred version

### DIFF
--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -78,7 +78,7 @@ class Cask::CLI::Alfred
   end
 
   def self.alfred_installed?
-    alfred_preference('version') =~ /^[0-9]\.[0-9]\.[0-9]$/
+    alfred_preference('version') =~ /^[0-9]\.[0-9](\.[0-9])?$/
   end
 
   def self.linked?


### PR DESCRIPTION
The version is `2.1` now which cannot match previous pattern. Cask gives:

```
Warning: Could not find Alfred preferences, Alfred is probably not installed.
```
