### PR TITLE
Add Tunnelblick Beta

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,0 +1,7 @@
+class TunnelblickBeta < Cask
+  url 'http://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_3.4beta12.dmg'
+  homepage 'https://code.google.com/p/tunnelblick/'
+  version '3.4beta12'
+  sha1 '4b19a506a1f40bada56a6936660992ed1de9b0a1'
+  link 'Tunnelblick.app'
+end


### PR DESCRIPTION
Given the new policy on beta releases (see #1171 for more information) I would suggest adding the Tunnelblick beta, as OS X Mavericks is only supported in the beta release.
