### PR TITLE
Added Cask for FnFlip, a Prefpane for managing your Fn keys.

### DIFF
--- a/Casks/fn-flip.rb
+++ b/Casks/fn-flip.rb
@@ -1,0 +1,7 @@
+class FnFlip < Cask
+  url 'http://kevingessner.com/public/downloads/FunctionFlip/2.2.2/FunctionFlip.prefPane.zip'
+  homepage 'http://kevingessner.com/software/functionflip/'
+  version '2.2.2'
+  sha1 '3e901f4e3a1d4eae17d3e8ae6c6cf7cad9a95457'
+  prefpane 'FunctionFlip.prefPane'
+end


### PR DESCRIPTION
> FunctionFlip individually controls your MacBook or MacBook Pro's
> function keys, turning special keys back to regular F-keys, or vice-
> versa. FunctionFlip is a preference pane; you'll find it in the "Other"
> category in System Preferences.

http://kevingessner.com/software/functionflip/
