### PR TITLE
Add Haskell-Platform v2013.2.0.0

### DIFF
--- a/Casks/haskell-platform.rb
+++ b/Casks/haskell-platform.rb
@@ -1,0 +1,7 @@
+class HaskellPlatform < Cask
+  url 'http://lambda.haskell.org/platform/download/2013.2.0.0/Haskell%20Platform%202013.2.0.0%2064bit.pkg'
+  homepage 'http://www.haskell.org/platform/'
+  version '2013.2.0.0'
+  sha1 '89e6fb747816af69acabc5c04cee103257855614'
+  install 'Haskell Platform 2013.2.0.0 64bit.pkg'
+end


### PR DESCRIPTION
For end users who want the complete Haskell Platform, instead of installing components individually such as `GHC`, `Cabal`, `GHCI` and so on. 
