### PR TITLE
KeyRemap4MacBook 8.4.0

### DIFF
--- a/Casks/keyremap4macbook.rb
+++ b/Casks/keyremap4macbook.rb
@@ -1,7 +1,7 @@
 class Keyremap4macbook < Cask
-  url 'https://pqrs.org/macosx/keyremap4macbook/files/KeyRemap4MacBook-8.3.0.dmg'
+  url 'https://pqrs.org/macosx/keyremap4macbook/files/KeyRemap4MacBook-8.4.0.dmg'
   homepage 'https://pqrs.org/macosx/keyremap4macbook/'
-  version '8.3.0'
-  sha1 '9b9412d69a7509ae0df7aac672e08e6363fe0ca3'
+  version '8.4.0'
+  sha1 'c2839a17437eebeb3e70684154b1715beefda511'
   install 'KeyRemap4MacBook.pkg'
 end


### PR DESCRIPTION
Updated KeyRemap4MacBook to version 8.4.0 (compatible with OS X 10.9 Mavericks).
