### PR TITLE
Add noejectdelay cask

### DIFF
--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -1,0 +1,7 @@
+class Noejectdelay < Cask
+  url 'https://pqrs.org/macosx/keyremap4macbook/files/NoEjectDelay-5.0.0.dmg'
+  homepage 'https://pqrs.org/macosx/keyremap4macbook/noejectdelay.html.en'
+  version '5.0.0'
+  sha1 '1e1797c9d12b103a34d7b8ade58d7f3b85634336'
+  install 'NoEjectDelay.pkg'
+end


### PR DESCRIPTION
NoEjectDelay eliminates the eject key delay and disables the F12 eject
feature.
