### PR TITLE
Allow installation of package 'witch' in the presence of 'hyper-switch'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ Fill in the following fields for your Cask:
 | __artifact info__  | information about artifacts inside the cask (can be specified multiple times)
 | `nested_container` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
 | `link`             | relative path to a file that should be linked into the `Applications` folder on installation
+| `prefpane`         | relative path to a file that should be linked on install to the correct location for it to show up in System Preferences
 | `install`          | relative path to `pkg` that should be run to install the application
 | `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see "Uninstall Support" for more information)
 

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -54,7 +54,7 @@ class Cask
     if cask_title.include?('/')
       cask_with_tap = cask_title
     else
-      cask_with_tap = all_titles.grep(/#{cask_title}$/).first
+      cask_with_tap = all_titles.grep(/^#{cask_title}$/).first
     end
 
     if cask_with_tap


### PR DESCRIPTION
I'm actually not familiar enough with homebrew to know how to test this change, but looking through the code it looks like this was the intent?  I couldn't imagine why the '$' anchor should be in the regex without the '^'.

Feel free to close this and patch yourself if you feel like this is incomplete.  For example, I didn't look in other parts of the code to see if a similar change needs to be made.

Also, while getting witch to work, I almost gave up because CONTRIBUTING.md was not updated with the awesome prefpane functionality.  Is there any other documentation that needs to be changed?
