### PR TITLE
updated to latest OS X version, new link-value

### DIFF
--- a/Casks/keyfinder.rb
+++ b/Casks/keyfinder.rb
@@ -3,5 +3,5 @@ class Keyfinder < Cask
   homepage 'http://www.ibrahimshaath.co.uk/keyfinder/'
   version 'latest'
   no_checksum
-  link 'KeyFinder.app'
+  link 'KeyFinder-OSX/KeyFinder.app'
 end


### PR DESCRIPTION
Updated to latest OS X Version which fixes a Maverick bug. Adjusted link.

"New version 1.25. Mac only at present. Should work on Mavericks, and fixes a small Key tag bug."
