### PR TITLE
Add cask for Simpholders 1.2.0

### DIFF
--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -1,0 +1,8 @@
+class Simpholders < Cask
+  url 'http://simpholders.com/site/assets/files/1016/simpholders-1_2_0.dmg'
+  homepage 'http://simpholders.com'
+  version '1.2.0'
+  sha1 '07a573f89133195e2adcd150259c552aa869e544'
+  link 'Simpholders.app'
+end
+


### PR DESCRIPTION
Simpholders is a small utility for fast access to your iPhone Simulator
apps. Opens folder in Finder, resets library and documents, and deletes
the selected app.
