### PR TITLE
Update macupdate-desktop.rb

### DIFF
--- a/Casks/macupdate-desktop.rb
+++ b/Casks/macupdate-desktop.rb
@@ -2,6 +2,6 @@ class MacupdateDesktop < Cask
   url 'https://www.macupdate.com/download/8544/MacUpdate-Desktop-5.2.3.dmg'
   homepage 'https://www.macupdate.com/desktop'
   version '5.2.3'
-  sha1 '0c97cc7a03eb165c1455208c531797ad5beeacb'
+  sha1 'b0c97cc7a03eb165c1455208c531797ad5beeacb'
   link 'MacUpdate Desktop.app'
 end


### PR DESCRIPTION
Fixed sha1 sum for macupdate-desktop (initial commit forgot a leading b)

brew cask install macupdate-desktop
==> Downloading https://www.macupdate.com/download/8544/MacUpdate-Desktop-5.2.3.
###### ################################################################## 100.0%

Error: SHA1 mismatch
Expected: 0c97cc7a03eb165c1455208c531797ad5beeacb
Actual: b0c97cc7a03eb165c1455208c531797ad5beeacb
