### PR TITLE
Add Cocktail 7.0.1 (Mavericks)

### DIFF
--- a/Casks/cocktail-mavericks.rb
+++ b/Casks/cocktail-mavericks.rb
@@ -1,0 +1,7 @@
+class CocktailMavericks < Cask
+  url 'http://usa.maintain.se/CocktailME.dmg'
+  homepage 'http://maintain.se/cocktail'
+  version '7.0.1'
+  sha1 'd882fe315762466720b68042445d8829e0c2f4ea'
+  link 'Cocktail.app'
+end


### PR DESCRIPTION
The current Cocktail cask is for Mountain Lion, and will not work properly on Mavericks. 
