### PR TITLE
Add TinkerTool v5.0

### DIFF
--- a/Casks/tinkertool.rb
+++ b/Casks/tinkertool.rb
@@ -1,0 +1,7 @@
+class Tinkertool < Cask
+  url 'http://dl.macupdate.com/prod/TinkerTool.dmg'
+  homepage 'http://www.bresink.com/osx/TinkerTool.html'
+  version '5.0'
+  sha1 '37842cc5e1790697352786508adb4469224e74c5'
+  link 'TinkerTool.app'
+end


### PR DESCRIPTION
TODO: Change from macupdate's URL to a permanent URL from http://bresink.com
