### PR TITLE
Fixed uninstall for GoogleHangouts cask

### DIFF
--- a/Casks/google-hangouts.rb
+++ b/Casks/google-hangouts.rb
@@ -4,5 +4,6 @@ class GoogleHangouts < Cask
   version 'latest'
   no_checksum
   install 'Google Voice and Video.pkg'
-  uninstall :pkgutil => 'com.google.pkg.GoogleVoiceAndVideo'
+  uninstall :script => '/usr/bin/open',
+            :args => %w[/Library/Application\ Support/Google/GoogleVoiceAndVideoUninstaller.app/Contents/MacOS/GoogleVoiceAndVideoUninstaller]
 end


### PR DESCRIPTION
I kept getting permission problems with the original pkgutil uninstall method. In order to get this to work, I called '/usr/bin/open' and passed the uninstaller application path as an arg. I'm not sure I did the right thing, but didn't see a good way to do this otherwise. If there is a better way to pass an application to uninstall, please reply and reject this pull request and I will fix.
