### PR TITLE
Add bb-edit cask for installing BBEdit

### DIFF
--- a/Casks/bb-edit.rb
+++ b/Casks/bb-edit.rb
@@ -1,0 +1,7 @@
+class BbEdit < Cask
+  url 'http://pine.barebones.com/files/BBEdit_10.5.5.dmg'
+  homepage 'http://www.barebones.com/products/bbedit/'
+  version '10.5.5'
+  sha1 'a181466e1044ba5360232722d2f610dd3015579a'
+  link 'BBEdit.app'
+end


### PR DESCRIPTION
As an aside, and relating to #365, the naming of both the file and the class feels weird on this. Just as my 2¢, all technical concerns aside, `bbedit.rb` with a class name of `BBEdit` would have felt most natural here, to me. But that [did not work](https://gist.github.com/benspaulding/f457c60a9aa2c852b004). But this works for now until #365 gets sorted out.

And thanks for all your work on cask — it is a great utility.
