### PR TITLE
Node.js (without the compile delay)

### DIFF
--- a/Casks/node.rb
+++ b/Casks/node.rb
@@ -4,4 +4,5 @@ class Node < Cask
   version '0.10.21'
   sha1 'de2bd0e858f99098ef24f99f972b8088c1f0405c'
   install  'node-v0.10.21.pkg'
+  uninstall :pkgutil => 'org.nodejs'
 end

--- a/Casks/node.rb
+++ b/Casks/node.rb
@@ -3,4 +3,5 @@ class Node < Cask
   homepage 'http://nodejs.org'
   version '0.10.21'
   sha1 'de2bd0e858f99098ef24f99f972b8088c1f0405c'
+  install  'node-v0.10.21.pkg'
 end

--- a/Casks/node.rb
+++ b/Casks/node.rb
@@ -1,0 +1,6 @@
+class Node < Cask
+  url 'http://nodejs.org/dist/v0.10.21/node-v0.10.21.pkg'
+  homepage 'http://nodejs.org'
+  version '0.10.21'
+  sha1 'de2bd0e858f99098ef24f99f972b8088c1f0405c'
+end


### PR DESCRIPTION
Having suffered long enough waiting for node to compile every time I upgraded using `brew upgrade node`, I decided contributing a cask using the official Mac package provided by nodejs.org was a good idea.

I have tested this via my own fork/branch using my local `brew cask install node` after tapping.

P.S. <3 how much time cask saves me and my team.
