### PR TITLE
MirrorDisplays latest

### DIFF
--- a/Casks/mirror-displays.rb
+++ b/Casks/mirror-displays.rb
@@ -1,0 +1,8 @@
+class MirrorDisplays < Cask
+  url 'http://www.fabiancanas.com/downloads/MirrorDisplays.zip',
+    :referer => 'http://www.fabiancanas.com/Projects/MirrorDisplays'
+  homepage 'http://www.fabiancanas.com/Projects/MirrorDisplays'
+  version 'latest'
+  no_checksum
+  link 'MirrorDisplays.app'
+end


### PR DESCRIPTION
Error installing:

```
Error: uh oh, could not identify primary container for /Library/Caches/Homebrew/mirror-displays-latest.zip
```

Think the problem is URL 
`http://www.fabiancanas.com/downloads/MirrorDisplays.zip` 
fails if it's not referred from Homepage 
`http://www.fabiancanas.com/Projects/MirrorDisplays`
...
Might have to fake the referrer somehow.
