### PR TITLE
PasswordPractice latest

### DIFF
--- a/Casks/password-practice.rb
+++ b/Casks/password-practice.rb
@@ -1,0 +1,7 @@
+class PasswordPractice < Cask
+  url 'https://mrgeckosmedia.com/applications/download/PasswordPractice'
+  homepage 'https://mrgeckosmedia.com/applications/info/PasswordPractice'
+  version 'latest'
+  no_checksum
+  link 'Password Practice.app'
+end


### PR DESCRIPTION
Install error:

```
Error: it seems the symlink source is not there
```

The `.zip` downloads as an extensionless file from: https://mrgeckosmedia.com/applications/download/PasswordPractice

For other apps on this site I was able to get an URL ending in `.zip`, but can't resolve such an URL for this app. Can we rename `password-practice-0.1` to `password-practice-0.1.zip` after the download finishes?
