### PR TITLE
Updating Spectacle version to 0.8.4, the currently link is also broken

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -1,7 +1,7 @@
 class Spectacle < Cask
-  url 'https://s3.amazonaws.com/spectacle/downloads/Spectacle+0.8.3-74e5543.zip'
+  url 'https://s3.amazonaws.com/spectacle/downloads/Spectacle+0.8.4.zip'
   homepage 'http://www.spectacleapp.com/'
-  version '0.8.3-74e5543'
-  sha1 '2324b19b2aaf71e0b8823a1498a0b341fef35594'
+  version '0.8.4'
+  sha1 'd2585cd30ec2c14f14c05bdc1d743d631cb616a9'
   link 'Spectacle.app'
 end


### PR DESCRIPTION
Extra info:

```
$ brew cask audit spectacle --download
==> Downloading https://s3.amazonaws.com/spectacle/downloads/Spectacle+0.8.4.zip
######################################################################## 100.0%
audit for spectacle: passed
```

Let me know if any extra information is necessary.
