### PR TITLE
Improve performance of brew cask list 

### DIFF
--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -19,7 +19,7 @@ class Cask::CLI::List
   end
 
   def self.list_installed
-    puts_columns Cask::CLI.nice_listing(Cask.installed)
+    system "ls", "/opt/homebrew-cask/Caskroom"
   end
 
   def self.help


### PR DESCRIPTION
See Issue #911 for original bug. This hack will list the contents of Caskroom. This should work reasonably well because the directory name of the installed cask is exactly the same as the cask name. 

TODO: Use Cask::Locations::caskroom instead of absolute path name

I don't know how to use Cask::Locations::caskroom, can someone patch instead?

The previous commit has

```
def self.run(*arguments)
      puts_columns Cask::CLI.nice_listing(Cask.installed)
end
```

`*arguments` does not seem to be used. Can it be removed, so that there is no need to wrap the code in `if-else`?
