### PR TITLE
[WIP] CLIX latest

### DIFF
--- a/Casks/clix.rb
+++ b/Casks/clix.rb
@@ -1,0 +1,7 @@
+class Clix < Cask
+  url 'https://www.macupdate.com/download/13983/CLIX.zip'
+  homepage 'http://rixstep.com/4/0/clix/index.shtml'
+  version 'latest'
+  no_checksum
+  link 'CLIX/CLIX-64/CLIX.app'
+end


### PR DESCRIPTION
[The developer](http://rixstep.com/4/0/clix/index.shtml) links to CNET for the latest version. I'm not sure how brew-cask is handling CNET links; the link is not direct and downloads an HTML file and I'm not sure if the link changes with new versions. Is developer contact required?
