### PR TITLE
Fix menu-meters installer error

### DIFF
--- a/Casks/menu-meters.rb
+++ b/Casks/menu-meters.rb
@@ -3,5 +3,10 @@ class MenuMeters < Cask
   homepage 'http://www.ragingmenace.com/software/menumeters/'
   version 'latest'
   no_checksum
-  install 'MenuMeters Installer.app'
+  link 'MenuMeters Installer.app'
+
+  def caveats; <<-EOS.undent
+    You need to run #{destination_path/'MenuMeters Installer.app'} to actually install MenuMetres
+    EOS
+  end
 end


### PR DESCRIPTION
This issue is similar to #1255
It is an installer.app inside a dmg.
