### PR TITLE
add cask for gimp-lisanet

### DIFF
--- a/Casks/gimp-lisanet.rb
+++ b/Casks/gimp-lisanet.rb
@@ -1,0 +1,7 @@
+class GimpLisanet < Cask
+  url 'http://downloads.sourceforge.net/gimponosx/Gimp-2.8.6p1-MountainLion.dmg'
+  homepage 'http://gimp.lisanet.de'
+  version '2.8.6'
+  sha1 '0b93fc41a5c7705c403453452b91c6c034829d4f'
+  link 'GIMP.app'
+end


### PR DESCRIPTION
gimp-lisanet is an alternative GIMP installation with additional plugins
