### PR TITLE
more robust plist parsing, and better error handling

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -14,7 +14,7 @@ class Cask::SystemCommand
     end
     _assert_success($?, command, output) if options[:must_succeed]
     if options[:plist]
-      Plist::parse_xml(output)
+      _parse_plist(command, output)
     else
       output
     end
@@ -48,5 +48,19 @@ class Cask::SystemCommand
 
   def self._quote(string)
     %Q('#{string}')
+  end
+
+  def self._parse_plist(command, output)
+    begin
+      Plist::parse_xml(output)
+    rescue Plist::ParseError
+      raise CaskError.new(<<-ERRMSG)
+Error parsing plist output from command.
+  command was:
+  #{command}
+  output we attempted to parse:
+  #{output}
+        ERRMSG
+    end
   end
 end

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -68,7 +68,14 @@ module Plist
         @xml = plist_data_or_file
       end
 
+      trim_to_xml_start!
+
       @listener = listener
+    end
+
+    def trim_to_xml_start!
+      _, xml_tag, rest = @xml.partition(/^<\?xml/)
+      @xml = [xml_tag, rest].join
     end
 
     TEXT       = /([^<]+)/
@@ -101,7 +108,7 @@ module Plist
         elsif @scanner.scan(end_tag)
           @listener.tag_end(@scanner[1])
         else
-          raise "Unimplemented element"
+          raise ParseError.new("Unimplemented element #{@xml}")
         end
       end
     end
@@ -127,7 +134,7 @@ module Plist
     end
 
     def to_ruby
-      raise "Unimplemented: " + self.class.to_s + "#to_ruby on #{self.inspect}"
+      raise ParseError.new("Unimplemented: " + self.class.to_s + "#to_ruby on #{self.inspect}")
     end
   end
 
@@ -222,4 +229,6 @@ module Plist
       end
     end
   end
+
+  class ParseError < RuntimeError; end
 end

--- a/test/plist/parser_test.rb
+++ b/test/plist/parser_test.rb
@@ -1,0 +1,106 @@
+require 'test_helper'
+
+describe Plist do
+  it 'parses some hdiutil output okay' do
+    hdiutil_output = <<-HDIUTILOUTPUT
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>system-entities</key>
+  <array>
+    <dict>
+      <key>content-hint</key>
+      <string>Apple_partition_map</string>
+      <key>dev-entry</key>
+      <string>/dev/disk3s1</string>
+      <key>potentially-mountable</key>
+      <false/>
+      <key>unmapped-content-hint</key>
+      <string>Apple_partition_map</string>
+    </dict>
+    <dict>
+      <key>content-hint</key>
+      <string>Apple_partition_scheme</string>
+      <key>dev-entry</key>
+      <string>/dev/disk3</string>
+      <key>potentially-mountable</key>
+      <false/>
+      <key>unmapped-content-hint</key>
+      <string>Apple_partition_scheme</string>
+    </dict>
+    <dict>
+      <key>content-hint</key>
+      <string>Apple_HFS</string>
+      <key>dev-entry</key>
+      <string>/dev/disk3s2</string>
+      <key>mount-point</key>
+      <string>/private/tmp/dmg.BhfS2g</string>
+      <key>potentially-mountable</key>
+      <true/>
+      <key>unmapped-content-hint</key>
+      <string>Apple_HFS</string>
+      <key>volume-kind</key>
+      <string>hfs</string>
+    </dict>
+  </array>
+</dict>
+</plist>
+    HDIUTILOUTPUT
+
+    parsed = Plist.parse_xml(hdiutil_output)
+
+    parsed.keys.must_equal ['system-entities']
+    parsed['system-entities'].length.must_equal 3
+    parsed['system-entities'].map { |e| e['dev-entry'] }.must_equal %w[
+      /dev/disk3s1
+      /dev/disk3
+      /dev/disk3s2
+    ]
+  end
+
+  it 'can ignore garbage output before xml starts' do
+    hdiutil_output = <<-HDIUTILOUTPUT
+Hello there! I am in no way XML am I?!?!
+
+  That's a little silly... you were expexting XML here!
+
+What is a parser to do?
+
+Hopefully <not> explode!
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>system-entities</key>
+  <array>
+    <dict>
+      <key>content-hint</key>
+      <string>Apple_HFS</string>
+      <key>dev-entry</key>
+      <string>/dev/disk3s2</string>
+      <key>mount-point</key>
+      <string>/private/tmp/dmg.BhfS2g</string>
+      <key>potentially-mountable</key>
+      <true/>
+      <key>unmapped-content-hint</key>
+      <string>Apple_HFS</string>
+      <key>volume-kind</key>
+      <string>hfs</string>
+    </dict>
+  </array>
+</dict>
+</plist>
+    HDIUTILOUTPUT
+
+    parsed = Plist.parse_xml(hdiutil_output)
+
+    parsed.keys.must_equal ['system-entities']
+    parsed['system-entities'].length.must_equal 1
+  end
+
+  it 'does not choke on empty input' do
+    Plist.parse_xml('').must_equal {}
+  end
+end


### PR DESCRIPTION
hdiutil can output DMG agreement information before the output plist
xml, and our plist parser was choking on that text before the xml
started.

so now we scan to the beginning of an xml document before trying to
parse the xml.

also added much more explicit error handling around the plist parsing,
to hopefully catch related and future plist-related errors.

refs #914
