### PR TITLE
Update firefox-aurora.rb to point to latest download link

### DIFF
--- a/Casks/firefox-aurora.rb
+++ b/Casks/firefox-aurora.rb
@@ -1,7 +1,7 @@
 class FirefoxAurora < Cask
-  url 'https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-26.0a2.en-US.mac.dmg'
+  url 'https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-27.0a2.en-US.mac.dmg'
   homepage 'http://www.mozilla.org/en-US/firefox/aurora/'
-  version '26.0a2'
+  version '27.0a2'
   no_checksum
   link 'FirefoxAurora.app'
 end


### PR DESCRIPTION
The link ending in "firefox-26.0a2.en-US.mac.dmg" is 404ing, should be "firefox-27"
