### PR TITLE
added gridwars

### DIFF
--- a/Casks/gridwars.rb
+++ b/Casks/gridwars.rb
@@ -1,0 +1,7 @@
+class Gridwars < Cask
+  url 'http://gridwars.marune.de/bin/gridwars_osx_x86.zip'
+  homepage 'http://gridwars.marune.de/'
+  version '9.3.2006'
+  sha1 '06ffc849c475b4e610673d8757df6f274fab6336'
+  link 'gridwars_osx_x86'
+end


### PR DESCRIPTION
The whole directory has to be linked, or the game won’t run. Maybe we should separate games from the rest of the apps.
