### PR TITLE
Transmit 3.7

### DIFF
--- a/Casks/transmit-3.rb
+++ b/Casks/transmit-3.rb
@@ -1,0 +1,7 @@
+class Transmit3 < Cask
+  url 'http://panic.com/museum/transmit/Transmit%203.7.zip'
+  homepage 'https://www.panic.com/transmit'
+  version '3.7'
+  sha1 '8843d797a32f39622d9c76be62af3ec2b7cf718c'
+  link 'Transmit.app'
+end


### PR DESCRIPTION
Add cask for Transmit 3.7 by Panic

Panic is nice enough to keep all the software they've ever shipped available for download, in case you've lost older versions of their products, at e.g. http://panic.com/museum/transmit/. This pull request adds a cask for installing version 3 of Transmit.
