### PR TITLE
use exact matching when loading a cask

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -55,7 +55,7 @@ class Cask
     if cask_title.include?('/')
       cask_with_tap = cask_title
     else
-      cask_with_tap = all_titles.grep(/#{cask_title}$/).first
+      cask_with_tap = all_titles.find { |t| t.split('/').last == cask_title }
     end
 
     if cask_with_tap

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -7,7 +7,7 @@ describe "Cask" do
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Adium)
     end
-    
+
     it "returns an instance of the cask from a specific file location" do
       location = File.expand_path('./Casks/dia.rb')
       c = Cask.load(location)
@@ -33,6 +33,11 @@ describe "Cask" do
       c = Cask.load("./Casks/dia.rb")
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Dia)
+    end
+
+    it "uses exact match when loading by name" do
+      Cask.load('rest-client').must_be_instance_of(RestClient)
+      Cask.load('cocoa-rest-client').must_be_instance_of(CocoaRestClient)
     end
 
     it "raises an error when attempting to load a cask that doesn't exist" do


### PR DESCRIPTION
fixes issue where casks with names that were a strict prefix of other
casks would always shadow them.

refs #1035
