### PR TITLE
new preferred sourceforge url style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,24 @@ Fill in the following fields for your Cask:
 | `install`          | relative path to `pkg` that should be run to install the application
 | `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see "Uninstall Support" for more information)
 
+### Sourceforge URLs
+
+Sourceforge projects are a common way to distribute binaries, but they provide many different styles of URLs to get to the goods.
+
+We prefer URLs of this format:
+
+```
+http://sourceforge.net/projects/$PROJECTNAME/files/latest/download
+```
+
+This lets the project maintainers choose the best URL for download.
+
+If the "latest" URL does not point to a valid file for a mac app, then we fall back this format:
+
+```
+http://downloads.sourceforge.net/sourceforge/$PROJECTNAME/$FILENAME.$EXT
+```
+
 ### Naming Casks
 
 We try to maintain a consistent naming policy so everything stays clean and predictable.

--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -40,10 +40,17 @@ class Cask::Audit
   end
 
   def _check_sourceforge_download_url_format
-    if cask.url.to_s.match(/\S*sourceforge\.\S*\/\S*/i)
-      unless cask.url.to_s.match(/\S*downloads.sourceforge.net\/\S+/i)
-        add_warning "SourceForge URL format incorrect. See https://github.com/phinze/homebrew-cask/pull/225#issuecomment-16536889 for details"
-      end
+    if _bad_sourceforge_url?
+      add_warning "SourceForge URL format incorrect. See https://github.com/phinze/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls"
     end
+  end
+
+  def _bad_sourceforge_url?
+    return false unless cask.url.to_s =~ /sourceforge/
+    valid_url_formats = [
+      %r{https?://sourceforge.net/projects/.*/files/latest/download},
+      %r{https?://downloads.sourceforge.net/},
+    ]
+    valid_url_formats.none? { |format| cask.url.to_s =~ format }
   end
 end

--- a/test/cask/audit_test.rb
+++ b/test/cask/audit_test.rb
@@ -27,6 +27,13 @@ class CaskSourceForgeCorrectURLFormat < Cask
   url 'http://downloads.sourceforge.net/project/something/Something-1.2.3.dmg'
 end
 
+class CaskSourceForgeOtherCorrectURLFormat < Cask
+  version 'latest'
+  homepage 'http://sourceforge.net/projects/something/'
+  url 'http://sourceforge.net/projects/something/files/latest/download'
+end
+
+
 describe Cask::Audit do
   describe "result" do
     it "is 'failed' if there are have been any errors added" do
@@ -71,13 +78,18 @@ describe Cask::Audit do
 
     describe "preferred download URL formats" do
       it "adds a warning if SourceForge doesn't use download subdomain" do
-        warning_msg = 'SourceForge URL format incorrect. See https://github.com/phinze/homebrew-cask/pull/225#issuecomment-16536889 for details'
+        warning_msg = 'SourceForge URL format incorrect. See https://github.com/phinze/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls'
+
 
         audit = Cask::Audit.new(CaskSourceForgeIncorrectURLFormat.new)
         audit.run!
         audit.warnings.must_include warning_msg
 
         audit = Cask::Audit.new(CaskSourceForgeCorrectURLFormat.new)
+        audit.run!
+        audit.warnings.wont_include warning_msg
+
+        audit = Cask::Audit.new(CaskSourceForgeOtherCorrectURLFormat.new)
         audit.run!
         audit.warnings.wont_include warning_msg
       end


### PR DESCRIPTION
- document sf link policy
- change audit to accept old and new style links
- need to keep old style links for projects where the 'latest' link
  does not point to something usable
- link to official policy in audit warning message

refs #1436
