### PR TITLE
Correct 1password’s name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,14 +125,14 @@ BetterTouchTool    | `bettertouchtool`   | `Bettertouchtool`
 iTerm2             | `iterm2`            | `Iterm2`
 Akai LPK25 Editor  | `akai-lpk25-editor` | `AkaiLpk25Editor`
 Sublime Text 3     | `sublime-text-3`    | `SublimeText3`
-1Password          | `1password`         | `OnePassword` (see __NAMING NOTE__)
+1Password          | `1password`         | `Onepassword` (see __NAMING NOTE__)
 
 
 #### NAMING NOTE
 
 When a Cask's _name_ does not map to a valid ruby class (like when it starts with a number) there's an incoming feature to allow Cask _classes_ to indicate the proper name using a keyword.
 
-This feature is not yet complete, so you'll see some __Cask name__s that don't fully conform to the rules. For example, currently the cask for 1Password is called `one-password` instead of `1password`.
+This feature is not yet complete, so you'll see some __Cask name__s that don't fully conform to the rules. For example, currently the cask for 1Password is called `onepassword` instead of `1password`.
 
 When all this is sorted out, this message will go away.
 

--- a/Casks/onepassword.rb
+++ b/Casks/onepassword.rb
@@ -1,4 +1,4 @@
-class OnePassword < Cask
+class Onepassword < Cask
   url 'http://i.agilebits.com/dist/1P/mac4/1Password-4.0.5.zip'
   homepage 'https://agilebits.com/onepassword'
   version '4.0.5'


### PR DESCRIPTION
Considering the names for 1Password and iTerm 2 from the respective websites, aren’t they inconsistent with the new rules?

1Password
![](http://imgur.com/xLaNBfG.png)

iTerm 2
![](http://imgur.com/qtzvemx.png)

(This would mean we’d also need to correct [this old version’s name](https://github.com/caskroom/homebrew-versions/pull/1)).
