### PR TITLE
fixed link to omnigraffle pro download

### DIFF
--- a/Casks/omni-graffle-pro.rb
+++ b/Casks/omni-graffle-pro.rb
@@ -1,5 +1,5 @@
 class OmniGrafflePro < Cask
-  url 'http://www.omnigroup.com/download/latest/omnigrafflePro'
+  url 'http://www.omnigroup.com/download/latest/omnigraffle'
   homepage 'http://www.omnigroup.com/products/omnigraffle'
   version 'latest'
   no_checksum


### PR DESCRIPTION
standard and pro are now distributed as one binary.
