### PR TITLE
Guard against unspecified cask in CLI

### DIFF
--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -34,7 +34,9 @@ class Cask::CLI
     Cask.init
     lookup_command(command).run(*rest)
   rescue CaskUnspecifiedError => e
-    abort e
+    onoe e
+    $stderr.puts e.backtrace if @debug
+    exit 1
   end
 
   def self.nice_listing(cask_list)
@@ -62,6 +64,9 @@ class Cask::CLI
       end
       opts.on("--prefpanedir=MANDATORY") do |v|
         Cask.prefpanedir = Pathname(v).expand_path
+      end
+      opts.on("--debug") do |v|
+        @debug = true
       end
     end
   end

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -33,6 +33,8 @@ class Cask::CLI
     rest = process_options(rest)
     Cask.init
     lookup_command(command).run(*rest)
+  rescue CaskUnspecifiedError => e
+    abort e
   end
 
   def self.nice_listing(cask_list)

--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -1,5 +1,6 @@
 module Cask::CLI::Create
   def self.run(*arguments)
+    raise CaskUnspecifiedError if arguments.empty?
     cask_name, *_ = *arguments
     cask_path = Cask.path(cask_name)
 

--- a/lib/cask/cli/edit.rb
+++ b/lib/cask/cli/edit.rb
@@ -1,6 +1,7 @@
 module Cask::CLI::Edit
   def self.run(*arguments)
-    cask_name, *args = *arguments
+    raise CaskUnspecifiedError if arguments.empty?
+    cask_name, *_ = *arguments
     cask_path = Cask.path(cask_name)
     unless cask_path.exist?
       raise CaskUnavailableError, "#{cask_name}, use `brew cask create #{cask_name}` to make a new cask with this name"

--- a/lib/cask/cli/home.rb
+++ b/lib/cask/cli/home.rb
@@ -1,5 +1,6 @@
 module Cask::CLI::Home
   def self.run(*cask_names)
+    raise CaskUnspecifiedError if cask_names.empty?
     cask_names.each do |cask_name|
       begin
         cask = Cask.load(cask_name)

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -1,5 +1,6 @@
 class Cask::CLI::Info
   def self.run(*cask_names)
+    raise CaskUnspecifiedError if cask_names.empty?
     cask_names.each do |cask_name|
       begin
         cask = Cask.load(cask_name)

--- a/lib/cask/cli/install.rb
+++ b/lib/cask/cli/install.rb
@@ -1,5 +1,6 @@
 class Cask::CLI::Install
   def self.run(*args)
+    raise CaskUnspecifiedError if args.empty?
     cask_names = args.reject { |a| a == '--force' }
     force = args.include? '--force'
     cask_names.each do |cask_name|

--- a/lib/cask/cli/uninstall.rb
+++ b/lib/cask/cli/uninstall.rb
@@ -1,5 +1,6 @@
 class Cask::CLI::Uninstall
   def self.run(*cask_names)
+    raise CaskUnspecifiedError if cask_names.empty?
     begin
       casks = cask_names.map { |cn| Cask.load(cn) }
       casks.each do |cask|

--- a/lib/cask/exceptions.rb
+++ b/lib/cask/exceptions.rb
@@ -62,3 +62,9 @@ class CaskCommandFailedError < CaskError
     EOS
   end
 end
+
+class CaskUnspecifiedError < CaskError
+  def to_s
+    'This command requires a cask argument'
+  end
+end

--- a/lib/cask/exceptions.rb
+++ b/lib/cask/exceptions.rb
@@ -65,6 +65,6 @@ end
 
 class CaskUnspecifiedError < CaskError
   def to_s
-    'This command requires a cask argument'
+    "This command requires a cask's name"
   end
 end

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -68,4 +68,10 @@ describe Cask::CLI::Create do
       [Cask.path('feine')]
     ]
   end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Create.run
+    }.must_raise CaskUnspecifiedError
+  end
 end

--- a/test/cask/cli/edit_test.rb
+++ b/test/cask/cli/edit_test.rb
@@ -42,4 +42,10 @@ describe Cask::CLI::Edit do
       Cask::CLI::Edit.run('notacask')
     }.must_raise CaskUnavailableError
   end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Edit.run
+    }.must_raise CaskUnspecifiedError
+  end
 end

--- a/test/cask/cli/home_test.rb
+++ b/test/cask/cli/home_test.rb
@@ -37,5 +37,11 @@ describe Cask::CLI::Home do
       ['open', 'https://www.adium.im/']
     ]
   end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Home.run
+    }.must_raise CaskUnspecifiedError
+  end
 end
 

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -26,4 +26,10 @@ describe Cask::CLI::Info do
       https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-transmission.rb
     CLIOUTPUT
   end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Info.run
+    }.must_raise CaskUnspecifiedError
+  end
 end

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -39,4 +39,10 @@ describe Cask::CLI::Install do
       Cask::CLI::Install.run('what-the-balls')
     }, 'Error: No available cask for what-the-balls')
   end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Install.run
+    }.must_raise CaskUnspecifiedError
+  end
 end

--- a/test/cask/cli/options_test.rb
+++ b/test/cask/cli/options_test.rb
@@ -36,6 +36,13 @@ describe Cask::CLI do
     rest.must_equal %w{edit foo --create}
   end
 
+  describe "--debug" do
+    it "sets the CLI's debug variable to true" do
+      Cask::CLI.process_options %w{help --debug}
+      Cask::CLI.instance_variable_get(:@debug).must_equal true
+    end
+  end
+
   after do
     ENV['HOMEBREW_CASK_OPTS'] = nil
   end

--- a/test/cask/cli/uninstall_test.rb
+++ b/test/cask/cli/uninstall_test.rb
@@ -34,4 +34,10 @@ describe Cask::CLI::Uninstall do
     transmission.wont_be :installed?
     Cask.appdir.join('Caffeine.app').wont_be :symlink?
   end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Uninstall.run
+    }.must_raise CaskUnspecifiedError
+  end
 end


### PR DESCRIPTION
Hello, all!

First and foremost, thank you for all of your work on homebrew-cask. It's great.

This pull request improves the way the CLI handles missing arguments, making it more consistent with homebrew proper. Specifically, it ensures that naked calls print a useful message to stderr and exit with a status of 1.

Before:

```
~ $ brew cask edit
Error: undefined method `include?' for nil:NilClass
Please report this bug:
    https://github.com/mxcl/homebrew/wiki/troubleshooting
/usr/local/Cellar/brew-cask/0.19.4/rubylib/cask/locations.rb:44:in `path'
/usr/local/Cellar/brew-cask/0.19.4/rubylib/cask/cli/edit.rb:4:in `run'
/usr/local/Cellar/brew-cask/0.19.4/rubylib/cask/cli.rb:35:in `process'
/usr/local/bin/brew-cask.rb:6
/usr/local/Library/brew.rb:51:in `require'
/usr/local/Library/brew.rb:51:in `require?'
/usr/local/Library/brew.rb:97
```

```
~ $ brew cask install && echo 'foo'
foo
~ $ echo $?
0
```

After:

```
~ $ brew cask edit
This command requires a cask argument
```

``` shell
~ $ brew cask install && echo 'foo'
This command requires a cask argument
~ $ echo $?
1
```
