### PR TITLE
Adding TexShop, the LaTeX editor for MacOsX

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,0 +1,7 @@
+class Texshop < Cask
+  url 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshop.zip'
+  homepage 'http://pages.uoregon.edu/koch/texshope'
+  version '3.2.6'
+  sha1 'b130b5b990e22387dab8144f3ae4c7440ff498fe'
+  link 'TexShop.app'
+end

--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,6 +1,6 @@
 class Texshop < Cask
-  url 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshop.zip'
-  homepage 'http://pages.uoregon.edu/koch/texshope'
+  url 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshop326.zip'
+  homepage 'http://pages.uoregon.edu/koch/texshop'
   version '3.2.6'
   sha1 'b130b5b990e22387dab8144f3ae4c7440ff498fe'
   link 'TexShop.app'


### PR DESCRIPTION
TexShop is a stable, simple and complete LaTeX (and friends) editor for
Mac OSX. It comes normally prebundled with mactex but also exists as an
independent package.
