### PR TITLE
Use the Mountain Lion version of MacVim for non-Mavericks machines.

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,7 +1,12 @@
 class Macvim < Cask
-  url 'https://github.com/b4winckler/macvim/releases/download/snapshot-72/MacVim-snapshot-72-Mavericks.tbz'
+  if MacOS.version == :mavericks
+    url 'https://github.com/b4winckler/macvim/releases/download/snapshot-72/MacVim-snapshot-72-Mavericks.tbz'
+    sha1 'dc983ae1e3ffae1c80f06eea9eacee49019a0c8a'
+  else
+    url 'https://github.com/eee19/macvim/releases/download/snapshot-72/MacVim-snapshot-72-Mountain-Lion.tbz'
+    sha1 'bc3b899634d73908ddba5afd9b9a74778988aec3'
+  end
   homepage 'http://code.google.com/p/macvim/'
   version '7.4-72'
-  sha1 'dc983ae1e3ffae1c80f06eea9eacee49019a0c8a'
   link 'MacVim-snapshot-72/MacVim.app'
 end


### PR DESCRIPTION
The commit that started using the Mavericks version of MacVim made it so Mountain Lion no longer works due to a dynamic linker lookup failure. The new one is linked against a version of perl that isn't present on non-Mavericks machines. This is causing maximum-awesome to fail its setup on non-Mavericks machines.
