### PR TITLE
Add caveats to info like homebrew

### DIFF
--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -4,6 +4,9 @@ class Cask::CLI::Info
       begin
         cask = Cask.load(cask_name)
         puts info(cask)
+        unless cask.caveats.empty?
+          ohai "Caveats", cask.caveats
+        end
       rescue CaskUnavailableError => e
         onoe e
       end

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -26,4 +26,17 @@ describe Cask::CLI::Info do
       https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-transmission.rb
     CLIOUTPUT
   end
+
+  it 'should print caveats if the cask provided one' do
+    lambda {
+      Cask::CLI::Info.run('with-caveats')
+    }.must_output <<-CLIOUTPUT.undent
+      with-caveats: 1.2.3
+      http://example.com/local-caffeine
+      Not installed
+      https://github.com/phinze/homebrew-testcasks/commits/master/Casks/with-caveats.rb
+      ==> Caveats
+      Here are some things you might want to know.
+    CLIOUTPUT
+  end
 end


### PR DESCRIPTION
If a cask contains caveats it will print it out when running `brew cask info`

``` sh
$ brew cask info menu-meters
menu-meters: latest
http://www.ragingmenace.com/software/menumeters/
Not installed
https://github.com/phinze/homebrew-cask/commits/master/Casks/menu-meters.rb
==> Caveats
You need to run /opt/homebrew-cask/Caskroom/menu-meters/latest/MenuMeters Installer.app to actually install MenuMetres
```

Test attached
