### PR TITLE
Add serf decentralized service discovery

### DIFF
--- a/Casks/serf.rb
+++ b/Casks/serf.rb
@@ -1,0 +1,9 @@
+# You probably want to change the appdir to /usr/local/bin
+# brew cask install serf --appdir=/usr/local/bin
+class Serf < Cask
+  url 'https://dl.bintray.com/mitchellh/serf/0.2.1_darwin_amd64.zip'
+  homepage 'http://www.serfdom.io'
+  version '0.2.1'
+  sha1 '530df1e78423d22e6f087a1cfd886a9376cbebd3'
+  link 'serf'
+end


### PR DESCRIPTION
Serf is a decentralized solution for service discovery and orchestration that is lightweight, highly available, and fault tolerant from HashiCorp (same people as Vagrant and Packer).

Homebrew cask seems to be the place to put it since it's a binary and doesn't seem to be accepted in homebrew.
