### PR TITLE
Add cask for VisIt 2.6.3.

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,0 +1,7 @@
+class Visit < Cask
+  url 'http://portal.nersc.gov/svn/visit/trunk/releases/2.6.3/VisIt-2.6.3-x86_64-installer.dmg'
+  homepage 'https://wci.llnl.gov/codes/visit/home.html'
+  version '2.6.3'
+  sha1 '3091da14bdad48e4f0faa0f543743d5befde11f2'
+  link 'VisIt.app'
+end


### PR DESCRIPTION
Add cask for VisIt, an interactive visualization and graphical analysis
tool used for viewing and analyzing scientific data.

The latest version is 2.7.0, however, downloading and installing it
triggered a virus warning on my computer, and the binary executable
will not run. I am in the process of reporting this issue upstream.
Version 2.6.3 downloads cleanly, installs, and runs on my system,
so the cask downloads that version instead.
