### PR TITLE
Update TimeMachineScheduler for new naming conventions

### DIFF
--- a/Casks/timemachinescheduler-beta.rb
+++ b/Casks/timemachinescheduler-beta.rb
@@ -1,4 +1,4 @@
-class TimeMachineSchedulerBeta < Cask
+class TimemachineschedulerBeta < Cask
   url 'http://www.klieme.com/Downloads/TimeMachineScheduler/TimeMachineScheduler_4.0b2Full.zip'
   homepage 'http://www.klieme.com/TimeMachineScheduler.html'
   version '4.0b2(470)'


### PR DESCRIPTION
Per https://github.com/phinze/homebrew-cask/blob/master/CONTRIBUTING.md#naming-casks

This one also seems like it should get the https://github.com/caskroom/homebrew-versions treatment since there is a stable and a beta. What's the process for doing that, one PR here to switch to stable and another PR there to add the beta cask?
