### PR TITLE
Switch TimeMachineScheduler cask to stable

### DIFF
--- a/Casks/time-machine-scheduler-beta.rb
+++ b/Casks/time-machine-scheduler-beta.rb
@@ -1,8 +1,0 @@
-class TimeMachineSchedulerBeta < Cask
-  url 'http://www.klieme.com/Downloads/TimeMachineScheduler/TimeMachineScheduler_4.0b2Full.zip'
-  homepage 'http://www.klieme.com/TimeMachineScheduler.html'
-  version '4.0b2(470)'
-  sha1 '81325c8158db9e87c9291ecdc28e554c30e903af'
-  nested_container 'TimeMachineScheduler_4.0b2.dmg'
-  link 'TimeMachineScheduler.app'
-end

--- a/Casks/timemachinescheduler.rb
+++ b/Casks/timemachinescheduler.rb
@@ -1,0 +1,8 @@
+class Timemachinescheduler < Cask
+  url 'http://www.klieme.com/Downloads/TimeMachineScheduler/TimeMachineScheduler_3.1.4.zip'
+  homepage 'http://www.klieme.com/TimeMachineScheduler.html'
+  version '3.1.4'
+  sha1 '563c93b963da470e8fca65bf8b5cc47a5e6c2153'
+  nested_container 'TimeMachineScheduler3_Installer.dmg'
+  prefpane 'TimeMachineScheduler3_Installer.app/Contents/Resources/TimeMachineScheduler.prefPane'
+end


### PR DESCRIPTION
Moving beta to https://github.com/caskroom/homebrew-versions, will mention this PR over there so they get cross-linked.

This was a preference pane within an installer app within a DMG within a zip. Could this be the turducken of casks?

From the readme inside the DMG:

> The enclosed installer has to options:
> Install installs or updates TimeMachineScheduler 3 in /Library/PreferencePanes and removes all unused components of previous versions. The settings of TimeMachineScheduler 2 will be preserved.
> You have to enter the admin password twice: during the installation process and once at the first launch.
> 
> Uninstall removes all components of TimeMachineScheduler.
