### PR TITLE
Add docs for versions repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ class MyNewCask < Cask
 end
 ```
 
+If you are submitting a non-stable version of an application that already has a
+cask (e.g. beta or nightly), then the cask should be submitted to the
+[caskroom/versions](https://github.com/caskroom/homebrew-versions) repo.
+
 Fill in the following fields for your Cask:
 
 | field              | explanation |

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,6 +12,12 @@ Tap this repository and install the `brew-cask` tool:
     $ brew tap phinze/homebrew-cask
     $ brew install brew-cask
 
+Optional: to install alternate versions of casks (e.g. betas or nightly
+releases), tap the [caskroom/versions](https://github.com/caskroom/homebrew-versions)
+repo:
+
+    $ brew tap caskroom/versions
+
 ## Searching for Casks
 
 Let's see if there's a Cask for Chrome:


### PR DESCRIPTION
Follow-up to #1495 so that the current policy is documented outside of the issue where it was discussed. For someone new coming in it's very difficult to find where the Sublime Text 3 cask is, for example.
