### PR TITLE
remove empty app dirs from caskroom on uninstall

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -110,8 +110,12 @@ class Cask
     @title = title
   end
 
+  def caskroom_path
+    self.class.caskroom.join(self.title)
+  end
+
   def destination_path
-    self.class.caskroom.join(self.title).join(self.version)
+    caskroom_path.join(self.version)
   end
 
   def installed?

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -66,6 +66,9 @@ class Cask::Installer
   end
 
   def purge_files
-    @cask.destination_path.rmtree if @cask.destination_path.exist?
+    if @cask.destination_path.exist?
+      @cask.destination_path.rmtree
+    end
+    @cask.caskroom_path.rmdir_if_possible
   end
 end

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -139,11 +139,9 @@ describe Cask::Installer do
         installer.uninstall
       end
 
-      dest_path = Cask.caskroom/'local-caffeine'/caffeine.version
-      application = dest_path/'Caffeine.app'
-
-      application.wont_be :directory?
-      dest_path.wont_be :directory?
+      (Cask.caskroom/'local-caffeine'/caffeine.version/'Caffeine.app').wont_be :directory?
+      (Cask.caskroom/'local-caffeine'/caffeine.version).wont_be :directory?
+      (Cask.caskroom/'local-caffeine').wont_be :directory?
     end
   end
 end


### PR DESCRIPTION
previously an install + uninstall would leave around an empty dir with
the app's name. now we clean that up.

refs #1461
