### PR TITLE
Add a cask for Apptivate.app, 2.1 (12)

### DIFF
--- a/Casks/apptivate.rb
+++ b/Casks/apptivate.rb
@@ -1,0 +1,7 @@
+class Apptivate < Cask
+  url 'http://www.apptivateapp.com/resources/Apptivate.app.zip'
+  homepage 'http://www.apptivateapp.com'
+  version '2.1_12'
+  sha1 '6135ba88e2aa3b6141c6a2a76cd4142518ba35fc'
+  link 'Apptivate.app'
+end

--- a/Casks/apptivate.rb
+++ b/Casks/apptivate.rb
@@ -1,7 +1,7 @@
 class Apptivate < Cask
   url 'http://www.apptivateapp.com/resources/Apptivate.app.zip'
   homepage 'http://www.apptivateapp.com'
-  version '2.1_12'
-  sha1 '6135ba88e2aa3b6141c6a2a76cd4142518ba35fc'
+  version 'latest'
+  no_checksum
   link 'Apptivate.app'
 end


### PR DESCRIPTION
This diff creates a new cask for Homebrew Cask for the app called
Apptivate, which can be found at http://www.apptivateapp.com. I followed
the instructions on contributing found on Homebrew Cask to create
this.
Test plan: install using `brew cask install apptivate`, launch
Apptivate using `open -a "Apptivate"`, and check the version and if
everything works.
