### PR TITLE
Add BlueHarvest

### DIFF
--- a/Casks/blueharvest.rb
+++ b/Casks/blueharvest.rb
@@ -1,0 +1,7 @@
+class Blueharvest < Cask
+  url 'http://zeroonetwenty.com/downloads/BlueHarvest557.dmg'
+  homepage 'http://zeroonetwenty.com/blueharvest/'
+  version '5.5.7'
+  sha1 '642eac9472ee7024066c44df8c538018a622ce50'
+  link 'BlueHarvest.app'
+end


### PR DESCRIPTION
BlueHarvest automatically removes DS_Store and ._ AppleDouble files
(resource forks) from your USB keys, SD cards and file servers, etc.
