### PR TITLE
Cask for Eclipse JEE version

### DIFF
--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,0 +1,7 @@
+class EclipseJee < Cask
+  url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR1/eclipse-jee-kepler-SR1-macosx-cocoa-x86_64.tar.gz'
+  homepage 'http://eclipse.org'
+  version '4.3.1'
+  sha1 'eda969782c5de49b54fa1dacb5d59e7dd1be29a0'
+  link 'eclipse/Eclipse.app'
+end


### PR DESCRIPTION
There are several difference variations of Eclipse, this cask is for the JEE version of Eclipse.
