### PR TITLE
Delete PandoraJam

### DIFF
--- a/Casks/pandorajam.rb
+++ b/Casks/pandorajam.rb
@@ -1,7 +1,0 @@
-class Pandorajam < Cask
-  url 'http://www.bitcartel.com/downloads/pandorajam.zip'
-  homepage 'http://www.bitcartel.com/pandorajam/'
-  version 'latest'
-  no_checksum
-  link 'PandoraJam.app'
-end


### PR DESCRIPTION
> Sadly, as of November 5th 2013, PandoraJam is no longer available.

http://www.bitcartel.com/thejam
