### PR TITLE
[WIP] SketchUp 2013 -> latest

### DIFF
--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -1,7 +1,7 @@
 class Sketchup < Cask
   url 'http://dl.trimble.com/sketchup/SketchUpMEN.dmg'
-  homepage 'http://www.sketchup.com/intl/en/'
-  version '2013'
-  sha1 '839461e9e65181330da8656bd92ae03951a53a9d'
+  homepage 'http://www.sketchup.com'
+  version 'latest'
+  no_checksum
   link 'SketchUp 2013'
 end


### PR DESCRIPTION
Not sure if SketchUp should be versioned. The download URL is dynamic, but the application folder contains a date, `2013`.

This depends on how brew-cask plans to handle latest downloads URLs whose contained filenames change with new releases.
