### PR TITLE
Default Folder X 4.5.12

### DIFF
--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -1,0 +1,12 @@
+class DefaultFolderX < Cask
+  url 'http://stclairsoft.s3.amazonaws.com/DefaultFolderX-4.5.12.dmg'
+  homepage 'http://www.stclairsoft.com/DefaultFolderX'
+  version '4.5.12'
+  sha1 '7cee468089c7244ca46e5ceb230a21cf3bf7afa9'
+  link 'Default Folder X Installer.app'
+
+  def caveats; <<-EOS.undent
+    You need to run #{destination_path/'Default Folder X Installer.app'} to actually install Default Folder X
+    EOS
+  end
+end


### PR DESCRIPTION
What to do when the installer is a `.app`?

![default-folder-x](https://f.cloud.github.com/assets/990216/1528325/01815bac-4c08-11e3-9609-7b503e7d68a1.jpg)
