### PR TITLE
[Fix #1695] Update link for postgres.app

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -3,5 +3,5 @@ class Postgres < Cask
   homepage 'http://www.postgresapp.com/'
   version 'latest'
   no_checksum
-  link 'Postgres.app'
+  link 'Postgres93.app'
 end


### PR DESCRIPTION
The filename for `Postgres.app` changed to `Postgres93.app` in the downloaded zip.
