### PR TITLE
Fixed Handbrake SHA1 Mismatch

### DIFF
--- a/Casks/handbrake.rb
+++ b/Casks/handbrake.rb
@@ -1,5 +1,5 @@
 class Handbrake < Cask
-  url 'http://handbrake.fr/rotation.php?file=HandBrake-0.9.9-MacOSX.6_GUI_x86_64.dmg'
+  url 'http://downloads.sourceforge.net/sourceforge/handbrake/HandBrake-0.9.9-MacOSX.6_GUI_x86_64.dmg'
   homepage 'http://handbrake.fr/'
   version '0.9.9'
   sha1 '9b6f0259f3378b0cc136378d7859162aa95c0eb7'


### PR DESCRIPTION
Old download URL resulted in inconsistent SHA1 outputs upon each
download. Changed to more reliable URL.
