### PR TITLE
HTTPScoop 1.4.3

### DIFF
--- a/Casks/httpscoop.rb
+++ b/Casks/httpscoop.rb
@@ -1,0 +1,7 @@
+class Httpscoop < Cask
+  url 'http://s3.amazonaws.com/Trueridge/HTTPScoop_1.4.3.dmg'
+  homepage 'http://www.tuffcode.com'
+  version '1.4.3'
+  sha1 '645bf67a841616e67be96155b15addb0b2123f8a'
+  link 'HTTPScoop.app'
+end


### PR DESCRIPTION
HTTPScoop allows capturing and inspecting HTTP traffic, regardless of browser or server technology.
