### PR TITLE
Update PCKeyboardHack to version 10.2.0

### DIFF
--- a/Casks/pckeyboardhack.rb
+++ b/Casks/pckeyboardhack.rb
@@ -1,7 +1,7 @@
 class Pckeyboardhack < Cask
-  url 'https://pqrs.org/macosx/keyremap4macbook/files/PCKeyboardHack-10.0.0.dmg'
+  url 'https://pqrs.org/macosx/keyremap4macbook/files/PCKeyboardHack-10.2.0.dmg'
   homepage 'https://pqrs.org/macosx/keyremap4macbook/pckeyboardhack.html.en'
-  version '10.0.0'
-  sha1 'b9df8ba7e6417391394b6e086afeb5d0d25f07f5'
+  version '10.2.0'
+  sha1 'f37d06a84ec75adb45040a144067709a6beb64fd'
   install 'PCKeyboardHack.pkg'
 end


### PR DESCRIPTION
Nothing too fancy going on here, but it removes an warning message about an unsigned kernel extension.
