### PR TITLE
Remove versioning details

### DIFF
--- a/Casks/amazon-cloud-drive.rb
+++ b/Casks/amazon-cloud-drive.rb
@@ -1,7 +1,7 @@
 class AmazonCloudDrive < Cask
   url 'https://d29x207vrinatv.cloudfront.net/AmazonCloudDrive.dmg'
   homepage 'https://www.amazon.com/clouddrive'
-  version '2.1'
-  sha1 'd832aafa413cec1e6dbbc11824a1fd6159ff6662'
+  version 'latest'
+  no_checksum
   link 'Amazon Cloud Drive.app'
 end


### PR DESCRIPTION
Remove the Amazon Cloud Drive versioning details as the provided link always downloads the latest available version
