### PR TITLE
Update Aquamacs to version 2.5

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,7 +1,7 @@
 class Aquamacs < Cask
-  url 'http://braeburn.aquamacs.org/~dreitter/Aquamacs/24/Aquamacs-nightly.tar.bz2'
+  url 'http://braeburn.aquamacs.org/releases/Aquamacs-Emacs-2.5.dmg'
   homepage 'http://aquamacs.org/'
-  version '3.x Nightly'
-  no_checksum
+  version '2.5'
+  sha1 '2d9052b94751b0454e109700ff8d0204d80310f4'
   link 'Aquamacs.app'
 end


### PR DESCRIPTION
This PR replaces the nightly builds on behalf of the latest stable release
