### PR TITLE
QuickLook Plugin Support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ Fill in the following fields for your Cask:
 | `nested_container` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
 | `link`             | relative path to a file that should be linked into the `Applications` folder on installation
 | `prefpane`         | relative path to a preference pane that should be linked into the `~/Library/PreferencePanes` folder on installation
+| `qlplugin`         | relative path to a Quicklook plugin that should be linked into the `~/Library/QuickLook` folder on installation
 | `install`          | relative path to `pkg` that should be run to install the application
 | `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see "Uninstall Support" for more information)
 

--- a/Casks/betterzipql.rb
+++ b/Casks/betterzipql.rb
@@ -1,0 +1,7 @@
+class Betterzipql < Cask
+  url 'http://macitbetter.com/BetterZipQL.zip'
+  homepage 'http://macitbetter.com/BetterZip-Quick-Look-Generator/'
+  version 'latest'
+  no_checksum
+  qlplugin 'BetterZipQL.qlgenerator'
+end

--- a/Casks/jsonlook.rb
+++ b/Casks/jsonlook.rb
@@ -1,0 +1,7 @@
+class Jsonlook < Cask
+  url 'http://dl.dropbox.com/u/3878216/github/jsonlook.qlgenerator.zip'
+  homepage 'https://github.com/rjregenold/jsonlook'
+  version 'latest'
+  no_checksum
+  qlplugin 'jsonlook.qlgenerator'
+end

--- a/Casks/qlcolorcode.rb
+++ b/Casks/qlcolorcode.rb
@@ -1,0 +1,7 @@
+class Qlcolorcode < Cask
+  url 'https://qlcolorcode.googlecode.com/files/QLColorCode-2.0.2.tgz'
+  homepage 'https://code.google.com/p/qlcolorcode/'
+  version '2.0.2'
+  sha256 '317eda251ea5af8412401562395d2fbedb2dd915a7d927479cf09ac7251c4074'
+  qlplugin 'QLColorCode-2.0.2/QLColorCode.qlgenerator'
+end

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -1,0 +1,7 @@
+class Qlmarkdown < Cask
+  url 'https://github.com/downloads/toland/qlmarkdown/QLMarkdown-1.3.zip'
+  homepage 'https://github.com/toland/qlmarkdown'
+  version '1.3'
+  sha256 '8fd344ec0db6ff084cc198ccef51e82da95bfee37cbbd1a7ae1fea937273de03'
+  qlplugin 'QLMarkdown/QLMarkdown.qlgenerator'
+end

--- a/Casks/qlstephen.rb
+++ b/Casks/qlstephen.rb
@@ -1,0 +1,7 @@
+class Qlstephen < Cask
+  url 'https://github.com/downloads/whomwah/qlstephen/QLStephen.qlgenerator.zip'
+  homepage 'http://whomwah.github.io/qlstephen/'
+  version 'latest'
+  no_checksum
+  qlplugin 'QLStephen.qlgenerator'
+end

--- a/Casks/scriptql.rb
+++ b/Casks/scriptql.rb
@@ -1,0 +1,7 @@
+class Scriptql < Cask
+  url 'http://www.kainjow.com/downloads/ScriptQL_qlgenerator.zip'
+  homepage 'http://www.kainjow.com/'
+  version 'latest'
+  no_checksum
+  qlplugin 'ScriptQL.qlgenerator'
+end

--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -1,0 +1,7 @@
+class SuspiciousPackage < Cask
+  url 'http://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
+  homepage 'http://www.mothersruin.com/software/SuspiciousPackage/'
+  version 'latest'
+  no_checksum
+  qlplugin 'Suspicious Package.qlgenerator'
+end

--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -6,6 +6,7 @@ require 'cask/artifact/app'
 require 'cask/artifact/nested_container'
 require 'cask/artifact/pkg'
 require 'cask/artifact/prefpane'
+require 'cask/artifact/qlplugin'
 
 module Cask::Artifact
   #
@@ -18,6 +19,7 @@ module Cask::Artifact
       Cask::Artifact::App,
       Cask::Artifact::Pkg,
       Cask::Artifact::Prefpane,
+      Cask::Artifact::Qlplugin,
     ]
   end
 

--- a/lib/cask/artifact/qlplugin.rb
+++ b/lib/cask/artifact/qlplugin.rb
@@ -1,0 +1,41 @@
+class Cask::Artifact::Qlplugin < Cask::Artifact::Base
+  def self.me?(cask)
+    cask.artifacts[:qlplugin].any?
+  end
+
+  def install
+    @cask.artifacts[:qlplugin].each { |qlplugin| link(qlplugin) }
+  end
+
+  def uninstall
+    @cask.artifacts[:qlplugin].each { |qlplugin| unlink(qlplugin) }
+  end
+
+  def link(qlplugin_relative_path)
+    source = @cask.destination_path.join(qlplugin_relative_path)
+    target = Cask.qlplugindir.join(source.basename)
+
+    return unless preflight_checks(source, target)
+    ohai "Linking QuickLook plugin #{source.basename} to #{target}"
+    @command.run!('/bin/ln', :args => ['-hfs', source, target])
+  end
+
+  def preflight_checks(source, target)
+    if target.directory? && !target.symlink?
+      ohai "It seems there is already a QuickLook plugin at #{target}; not linking."
+      false
+    end
+    unless source.exist?
+      raise "it seems the symlink source is not there: #{source}"
+    end
+    true
+  end
+
+  def unlink(qlplugin_relative_path)
+    linked_path = Cask.qlplugindir.join(Pathname(qlplugin_relative_path).basename)
+    if linked_path.exist? && linked_path.symlink?
+      ohai "Removing QuickLook plugin link: #{linked_path}"
+      linked_path.delete
+    end
+  end
+end

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -65,6 +65,9 @@ class Cask::CLI
       opts.on("--prefpanedir=MANDATORY") do |v|
         Cask.prefpanedir = Pathname(v).expand_path
       end
+      opts.on("--qlplugindir=MANDATORY") do |v|
+        Cask.qlplugindir = Pathname(v).expand_path
+      end
       opts.on("--debug") do |v|
         @debug = true
       end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -40,6 +40,7 @@ module Cask::DSL
       :link,
       :nested_container,
       :prefpane,
+      :qlplugin,
       :uninstall,
     ]
 

--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -32,6 +32,14 @@ module Cask::Locations
       @prefpanedir = _prefpanedir
     end
 
+    def qlplugindir
+      @qlplugindir ||= Pathname.new('~/Library/QuickLook').expand_path
+    end
+
+    def qlplugindir=(_qlplugindir)
+      @qlplugindir = _qlplugindir
+    end
+
     def default_tap
       @default_tap ||= 'phinze-cask'
     end

--- a/test/cask/cli/options_test.rb
+++ b/test/cask/cli/options_test.rb
@@ -29,6 +29,20 @@ describe Cask::CLI do
     Cask.prefpanedir.must_equal Pathname('/some/path/bar')
   end
 
+  it "supports setting the qlplugindir" do
+    Cask::CLI.process_options %w{help --qlplugindir=/some/path/foo}
+
+    Cask.qlplugindir.must_equal Pathname('/some/path/foo')
+  end
+
+  it "supports setting the qlplugindir from ENV" do
+    ENV['HOMEBREW_CASK_OPTS'] = "--qlplugindir=/some/path/bar"
+
+    Cask::CLI.process_options %w{help}
+
+    Cask.qlplugindir.must_equal Pathname('/some/path/bar')
+  end
+
   it "allows additional options to be passed through" do
     rest = Cask::CLI.process_options %w{edit foo --create --appdir=/some/path/qux}
 


### PR DESCRIPTION
OSX [QuickLook plugins](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/Quicklook_Programming_Guide/Articles/QLUserExperience.html#//apple_ref/doc/uid/TP40005020-CH3-SW3) are files with the extension `qlgenerator`. They are conventionally installed to `~/Library/QuickLook/` (or `/Library/QuickLook`).

As far as `homebrew-cask` is concerned, these are fairly similar to `prefpane`s, so I copied the file structure/naming/testing from the treatment of `prefpane`.

Unlike `prefpane`s, most QuickLook plugin installs would be the _primary_ purpose of a `brew cask install` -- without a `.app`. I've included 7 plugins to start with, and they are all like that.

However, some applications ship with optional QuickLook plugins (e.g. `Mathematica.app` offers to install one), so this could also be used to install an application _with_ an accompanying `qlgenerator` file.
