### PR TITLE
Remove versinoing details

### DIFF
--- a/Casks/miro.rb
+++ b/Casks/miro.rb
@@ -1,7 +1,7 @@
 class Miro < Cask
   url 'http://ftp.osuosl.org/pub/pculture.org/miro/osx/Miro.dmg'
   homepage 'http://www.getmiro.com/'
-  version '6.0'
-  sha1 '242f3b7a279d7b2885c3161249b7c5ba19c15226'
+  version 'latest'
+  no_checksum
   link 'Miro.app'
 end


### PR DESCRIPTION
Remove Miro versioning details as the provided link always downloads the latest available version
