### PR TITLE
Added Screens Connect

### DIFF
--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -1,0 +1,7 @@
+class ScreensConnect < Cask
+  url 'https://screensconnect.com/downloads/screensconnect.dmg'
+  homepage 'https://screensconnect.com'
+  version 'latest'
+  no_checksum
+  install 'Screens Connect.pkg'
+end


### PR DESCRIPTION
Screens Connect lets you connect to your Mac when you're away from home or the office. It is the companion app to Screens (available on the App Store).
