### PR TITLE
Added Reflector Cask

### DIFF
--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -1,4 +1,4 @@
-class Reflectorapp < Cask
+class Reflector < Cask
   url 'http://download.airsquirrels.com/Reflector/Mac/Reflector.dmg'
   homepage 'http://www.airsquirrels.com/reflector/'
   version 'latest'

--- a/Casks/reflectorapp.rb
+++ b/Casks/reflectorapp.rb
@@ -1,0 +1,7 @@
+class Reflectorapp < Cask
+  url 'http://download.airsquirrels.com/Reflector/Mac/Reflector.dmg'
+  homepage 'http://www.airsquirrels.com/reflector/'
+  version 'latest'
+  no_checksum 
+  link 'Reflector.app'
+end


### PR DESCRIPTION
This adds a cask to install Reflector by Airsquirrels.
Their download link always points to the latest version,
hence no hash as that would break when they update.
When first launching after installation the app will
request to be copied into /Applications rather than run
from ~/Applications.
