### PR TITLE
Upgrading bittorrent-sync to latest version

### DIFF
--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -1,7 +1,7 @@
 class BittorrentSync < Cask
-  url 'http://download-lb.utorrent.com/endpoint/btsync/os/osx/track/stable'
+  url 'http://syncapp.bittorrent.com/1.2.73/BTSync-1.2.73.dmg'
   homepage 'http://www.bittorrent.com/sync'
-  version 'latest'
-  no_checksum
+  version '1.2.73'
+  sha1 '4ed411d2dfc1f89349c84b50bc7692811e6cf85c'
   link 'BitTorrent Sync.app'
 end


### PR DESCRIPTION
BTsync was pointing to the 'latest version', that is there was no
upgrade when you had already installed the soft and the soft was updated
on the pointed URL. Fixed that by pointing to the latest version, with
the premise it will be updated along with new changes.
