### PR TITLE
pull cask loading out into classes

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -20,6 +20,7 @@ require 'cask/locations'
 require 'cask/pkg'
 require 'cask/pretty_listing'
 require 'cask/scopes'
+require 'cask/source'
 require 'cask/system_command'
 require 'cask/underscore_supporting_uri'
 
@@ -29,14 +30,6 @@ class Cask
   include Cask::DSL
   include Cask::Locations
   include Cask::Scopes
-
-  def self._file_source?(requested_cask)
-    File.file?(requested_cask)
-  end
-
-  def self._uri_source?(requested_cask)
-    !!(requested_cask =~ URI.regexp)
-  end
 
   def self.init
     HOMEBREW_CACHE.mkpath unless HOMEBREW_CACHE.exist?
@@ -51,54 +44,8 @@ class Cask
     appdir.mkpath unless appdir.exist?
   end
 
-  def self._load_from_tap(cask_title)
-    if cask_title.include?('/')
-      cask_with_tap = cask_title
-    else
-      cask_with_tap = all_titles.find { |t| t.split('/').last == cask_title }
-    end
-
-    if cask_with_tap
-      tap, cask = cask_with_tap.split('/')
-      source = tapspath.join(tap, 'Casks', "#{cask}.rb")
-    else
-      source = tapspath.join(default_tap, 'Casks', "#{cask_title}.rb")
-    end
-    raise CaskUnavailableError, cask_title unless source.exist?
-    _load_from_file(source)
-  end
-
-  def self._load_from_path(cask_path)
-    _load_from_file(Pathname.new(File::expand_path(cask_path)))
-  end
-
-  def self._load_from_uri(url)
-    HOMEBREW_CACHE_CASKS.mkpath
-    path = HOMEBREW_CACHE_CASKS.join(File.basename(url))
-    curl(url, '-o', path.to_s)
-    _load_from_path(path.to_s)
-  rescue ErrorDuringExecution
-    raise CaskUnavailableError, url
-  end
-
-  def self._load_from_file(source)
-    raise CaskUnavailableError, source unless source.exist?
-    require source
-    const_get(cask_class_name(source)).new
-  end
-
-  def self.load(requested_cask)
-    if _uri_source?(requested_cask)
-      _load_from_uri(requested_cask)
-    elsif _file_source?(requested_cask)
-      _load_from_path(requested_cask)
-    else
-      _load_from_tap(requested_cask)
-    end
-  end
-
-  def self.cask_class_name(pathname)
-    pathname.basename.to_s.sub(/\.rb/, '').split('-').map(&:capitalize).join
+  def self.load(query)
+    Cask::Source.for_query(query).load
   end
 
   def self.title

--- a/lib/cask/source.rb
+++ b/lib/cask/source.rb
@@ -1,0 +1,19 @@
+module Cask::Source; end
+
+require 'cask/source/path'
+require 'cask/source/tap'
+require 'cask/source/uri'
+
+module Cask::Source
+  def self.sources
+    [
+      Cask::Source::URI,
+      Cask::Source::Path,
+      Cask::Source::Tap,
+    ]
+  end
+
+  def self.for_query(query)
+    sources.find { |source| source.me?(query) }.new(query)
+  end
+end

--- a/lib/cask/source/path.rb
+++ b/lib/cask/source/path.rb
@@ -1,0 +1,21 @@
+class Cask::Source::Path
+  def self.me?(query)
+    File.file?(query)
+  end
+
+  attr_reader :path
+
+  def initialize(path)
+    @path = Pathname(path).expand_path
+  end
+
+  def load
+    require path
+    Cask.const_get(cask_class_name).new
+  end
+
+  def cask_class_name
+    path.basename.to_s.sub(/\.rb/, '').split('-').map(&:capitalize).join
+  end
+end
+

--- a/lib/cask/source/tap.rb
+++ b/lib/cask/source/tap.rb
@@ -1,0 +1,28 @@
+class Cask::Source::Tap
+  def self.me?(query)
+    true # this is the fallback source
+  end
+
+  attr_reader :title
+
+  def initialize(title)
+    @title = title
+  end
+
+  def load
+    if title.include?('/')
+      cask_with_tap = title
+    else
+      cask_with_tap = Cask.all_titles.find { |t| t.split('/').last == title }
+    end
+
+    if cask_with_tap
+      tap, cask = cask_with_tap.split('/')
+      source = Cask.tapspath.join(tap, 'Casks', "#{cask}.rb")
+    else
+      source = Cask.tapspath.join(Cask.default_tap, 'Casks', "#{title}.rb")
+    end
+    raise CaskUnavailableError, title unless source.exist?
+    Cask::Source::Path.new(source).load
+  end
+end

--- a/lib/cask/source/uri.rb
+++ b/lib/cask/source/uri.rb
@@ -1,0 +1,20 @@
+class Cask::Source::URI
+  def self.me?(query)
+    !!(query =~ URI.regexp)
+  end
+
+  attr_reader :uri
+
+  def initialize(uri)
+    @uri = uri
+  end
+
+  def load
+    HOMEBREW_CACHE_CASKS.mkpath
+    path = HOMEBREW_CACHE_CASKS.join(File.basename(uri))
+    curl(uri, '-o', path.to_s)
+    Cask::Source::Path.new(path).load
+  rescue ErrorDuringExecution
+    raise CaskUnavailableError, uri
+  end
+end


### PR DESCRIPTION
- introduce Cask::Source to encapsulate different types of loading
  behind a consistent interface
- mostly this is method-level reorg, kept refactoring of the internals
  of these methods to a minimum for this pass
- this is preparatory cleanup for adding the ability to represent a
  cask without a backing ruby file
