### PR TITLE
Added Scala IDE 3.0.2

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,0 +1,7 @@
+class ScalaIde < Cask
+  url 'http://downloads.typesafe.com/scalaide-pack/3.0.2.vfinal-210-20131028/scala-SDK-3.0.2-vfinal-2.10-macosx.cocoa.x86_64.zip'
+  homepage 'http://scala-ide.org/'
+  version '3.0.2'
+  sha1 '5d467d9054d940cf7e2f750ff60aa3bd11e8dae3'
+  link 'eclipse/Eclipse.app'
+end


### PR DESCRIPTION
New formula for Scala IDE. Output of 'cask audit':

<pre>
$ brew cask audit scala-ide --download
==> Downloading http://downloads.typesafe.com/scalaide-pack/3.0.2.vfinal-210-20131028/scala-SDK-3.0.2-vfinal-2.10-macosx.cocoa.x86_64.zip
Already downloaded: /Library/Caches/Homebrew/scala-ide-3.0.2.zip
audit for scala-ide: passed
</pre>
