### PR TITLE
Add caveat for Cocktail

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -4,4 +4,11 @@ class Cocktail < Cask
   version 'latest'
   no_checksum
   link 'Cocktail.app'
+  
+  def caveats; <<-EOS.undent
+    This version of Cocktail is for OS X Mavericks only. If you are using other versions of 
+    OS X, please run 'brew tap caskroom/versions' and install cocktail-mountainlion /
+    cocktail-lion / cocktail-snowleopard
+    EOS
+  end
 end


### PR DESCRIPTION
See #1358 For OS X Mavericks only; instructions to tap from caskroom-versions
