### PR TITLE
Fix Mactracker checksum

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -2,6 +2,6 @@ class Mactracker < Cask
   url 'http://www.mactracker.ca/downloads/Mactracker_7.2.zip'
   homepage 'http://mactracker.ca/'
   version '7.2'
-  sha1 '86bd3e35bda13a948b0b9c7bb8626b348ee6460d'
+  sha1 '643389b7832e74f5429543b963926820e0c84954'
   link 'Mactracker.app'
 end


### PR DESCRIPTION
```
$ curl -s http://www.mactracker.ca/downloads/Mactracker_7.2.zip | shasum -
643389b7832e74f5429543b963926820e0c84954  -
```
