### PR TITLE
Added Private Eye.

### DIFF
--- a/Casks/private-eye.rb
+++ b/Casks/private-eye.rb
@@ -1,0 +1,9 @@
+class PrivateEye < Cask
+  url 'http://radiosilenceapp.com/downloads/Private%20Eye.pkg'
+  homepage 'http://radiosilenceapp.com/private-eye'
+  version 'latest'
+  no_checksum
+  install 'Private Eye.pkg'
+  # We have to try unloading the kext twice to work around a bug. See https://github.com/phinze/homebrew-cask/pull/1802#issuecomment-34171151
+  uninstall :kext => ['com.radiosilenceapp.nke.PrivateEye', 'com.radiosilenceapp.nke.PrivateEye'], :pkgutil => 'com.radiosilenceapp.privateEye.*'
+end


### PR DESCRIPTION
The `.pkg` installs `/Applications/Private Eye.app` and `/Library/LaunchDaemons/com.radiosilenceapp.nke.PrivateEye.plist`.

The uninstall process can unload+remove the `kext` just fine, but runs into permission errors when removing the app:

> ==> Running uninstall process for private-eye; your password may be necessary.
> ==> Unloading kernel extension com.radiosilenceapp.nke.PrivateEye
> Error: Permission denied - /Applications/Private Eye.app/Contents/Resources/Private Eye.kext/Contents/Resources/en.lproj

It's happening for me even after nuking and reinstalling. There is no uninstall script, so I'm not sure what to do.
