### PR TITLE
Update Tor Browser Bundle to Version 2.3.25-15 - OS X (10.6+)

### DIFF
--- a/Casks/tor-browser.rb
+++ b/Casks/tor-browser.rb
@@ -2,6 +2,6 @@ class TorBrowser < Cask
   url 'https://www.torproject.org/dist/torbrowser/osx/TorBrowser-2.3.25-15-osx-x86_64-en-US.zip'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   version '2.3.25-14'
-  sha1 'e1316337819f02bdad78db7d60caa4423dea75e4'
+  sha1 '2cbd2dc7426d88e1f29d2a8e5b810938e5b98df2'
   link 'TorBrowser_en-US.app'
 end

--- a/Casks/tor-browser.rb
+++ b/Casks/tor-browser.rb
@@ -1,7 +1,7 @@
 class TorBrowser < Cask
-  url 'https://www.torproject.org/dist/torbrowser/osx/TorBrowser-2.3.25-14-osx-x86_64-en-US.zip'
+  url 'https://www.torproject.org/dist/torbrowser/osx/TorBrowser-2.3.25-15-osx-x86_64-en-US.zip'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   version '2.3.25-14'
-  sha1 '1d54067d657102ea525f9176e8ebb937bad30985'
+  sha1 'e1316337819f02bdad78db7d60caa4423dea75e4'
   link 'TorBrowser_en-US.app'
 end


### PR DESCRIPTION
Only way I knew how to get hashes... 
https://www.virustotal.com/en/file/55e3b38aa297ddba3ffbaffcf0515be62700aaad6e71704b778aeacb5d4fdd1a/analysis/1384923614/

Confirm independently please. 
