### PR TITLE
Add Apache Chainsaw.app

### DIFF
--- a/Casks/chainsaw.rb
+++ b/Casks/chainsaw.rb
@@ -1,0 +1,7 @@
+class Chainsaw < Cask
+  url 'http://people.apache.org/~sdeboy/apache-chainsaw-2.1.0-SNAPSHOT.dmg'
+  homepage 'http://logging.apache.org/chainsaw/'
+  version '2.1.0'
+  sha1 '55d40886a8cbf93e2f27d162cedaa3e4a14898e8'
+  link 'Chainsaw.app'
+end


### PR DESCRIPTION
This commit contains Apache Chainsaw.app version 2.1.0.  Note that even
though the DMG is labeled "snapshot", this is the only functioning binary
available from apache.org.
