### PR TITLE
Install MenuMeters prefpane directly, no caveats

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -3,10 +3,5 @@ class Menumeters < Cask
   homepage 'http://www.ragingmenace.com/software/menumeters/'
   version 'latest'
   no_checksum
-  link 'MenuMeters Installer.app'
-
-  def caveats; <<-EOS.undent
-    You need to run #{destination_path/'MenuMeters Installer.app'} to actually install MenuMeters
-    EOS
-  end
+  prefpane 'MenuMeters Installer.app/Contents/Resources/MenuMeters.prefPane'
 end


### PR DESCRIPTION
The Menumeters.prefpane exists within the cask, so it can be directly
linked, removing the need for the user to run the installer app
separately.
