### PR TITLE
Add Fugu.app

### DIFF
--- a/Casks/fugu.rb
+++ b/Casks/fugu.rb
@@ -1,0 +1,7 @@
+class Fugu < Cask
+  url 'http://downloads.sourceforge.net/project/fugussh/Unstable/fugu-1.2.1pre1/Fugu-1.2.1pre1.zip'
+  homepage 'http://rsug.itd.umich.edu/software/fugu/'
+  version '1.2.1pre1'
+  sha1 '43b50d1fec476a26f9e015f0d6808ab8c15c11d4'
+  link 'Fugu.app'
+end


### PR DESCRIPTION
This commit contains Fugu.app version 1.2.1pre1.  Although the version
string contains "pre1", this is the recommended build for Intel Mac
hardware.
