### PR TITLE
Add Google Refine.app

### DIFF
--- a/Casks/google-refine.rb
+++ b/Casks/google-refine.rb
@@ -1,0 +1,7 @@
+class GoogleRefine < Cask
+  url 'https://github.com/OpenRefine/OpenRefine/releases/download/2.5/google-refine-2.5-r2407.dmg'
+  homepage 'http://openrefine.org/'
+  version '2.5-r2407'
+  sha1 'f0e50b07ca8ce2aa2241cc1b14c42bad3adaa433'
+  link 'Google Refine.app'
+end


### PR DESCRIPTION
This commit contains Google Refine.app version 2.5.  Google Refine.app will be re-branded to OpenRefine.app in the next release.  I will PR the relevant beta in the versions repo.
