### PR TITLE
corrected platypus link

### DIFF
--- a/Casks/platypus.rb
+++ b/Casks/platypus.rb
@@ -1,7 +1,7 @@
 class Platypus < Cask
   url 'http://sveinbjorn.org/files/software/platypus.zip'
   homepage 'http://sveinbjorn.org/platypus'
-  version 'latest'
-  no_checksum
-  link 'Platypus.app'
+  version '4.8'
+  sha1 '3c019ce84f0868f856c4a37db7af14ab5a456416'
+  link 'Platypus-4.8/Platypus.app'
 end


### PR DESCRIPTION
`link` was incorrect. Since the `app` is inside a directory with the version number anyway, might as well add that and shasum to the cask.
