### PR TITLE
Added Couchbase Server Community & Enterprise Casks & removed Couchbase Cask

### DIFF
--- a/Casks/couchbase-server-community.rb
+++ b/Casks/couchbase-server-community.rb
@@ -1,0 +1,7 @@
+class CouchbaseServerCommunity < Cask
+  url 'http://packages.couchbase.com/releases/2.1.1/couchbase-server-community_x86_64_2.1.1.zip'
+  homepage 'http://www.couchbase.com/'
+  version '2.1.1'
+  sha1 '2f947be921b77a4d57134eb2b97f14b6e16773c7'
+  link 'Couchbase Server.app'
+end

--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -1,0 +1,7 @@
+class CouchbaseServerEnterprise < Cask
+  url 'http://packages.couchbase.com/releases/2.2.0/couchbase-server-enterprise_2.2.0_x86_64.zip'
+  homepage 'http://www.couchbase.com/'
+  version '2.2.0'
+  sha1 'c62ecae279f89095a27d956a8d4a48dd5a5a44f7'
+  link 'Couchbase Server.app'
+end

--- a/Casks/couchbase.rb
+++ b/Casks/couchbase.rb
@@ -1,7 +1,0 @@
-class Couchbase < Cask
-  url 'http://packages.couchbase.com/releases/2.0.1/couchbase-server-community_x86_64_2.0.1.zip'
-  homepage 'http://www.couchbase.com/'
-  version '2.0.1'
-  sha1 'de8c239be020a50117dd53bc1aedb095a805cd80'
-  link 'Couchbase Server.app'
-end


### PR DESCRIPTION
Hi,

Couchbase Server is now available for OS X in the Community and Enterprise versions, so I've removed the existing Couchbase Cask, and added Couchbase Server Community and Couchbase Server Enterprise Casks at their currently released versions.

The reason I removed the existing Couchbase Cask is due to naming inconsistency (the product is called _Couchbase Server_, the organization itself is _Couchbase_). I hope having two separate Casks is acceptable, and if there is a best practice way to handle 2 different flavors of an application that is preferred over having 2 separate casks, please let me know what that approach is and I'll be happy to make modifications and resubmit my PR.

Cheers!
