### PR TITLE
Add SSHFS

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -4,5 +4,5 @@ class Osxfuse < Cask
   version '2.6.1'
   sha1 '2e43a6593aee5fa45166b8abc70ad054a83d083b'
   install 'Install OSXFUSE 2.6.pkg'
-  uninstall :pkgutil => 'com.github.osxfuse.*'
+  uninstall :pkgutil => 'com.github.osxfuse.pkg.Core|com.github.osxfuse.pkg.PrefPane'
 end

--- a/Casks/sshfs.rb
+++ b/Casks/sshfs.rb
@@ -1,0 +1,8 @@
+class Sshfs < Cask
+  url 'https://github.com/downloads/osxfuse/sshfs/SSHFS-2.4.1.pkg'
+  homepage 'http://osxfuse.github.io/'
+  version '2.4.1'
+  sha1 '6966c455384c59d7acefd66a4c6eb765c31afe5a'
+  install 'SSHFS-2.4.1.pkg'
+  uninstall :pkgutil => 'com.github.osxfuse.pkg.SSHFS'
+end


### PR DESCRIPTION
This commit includes SSHFS version 2.4.1.  The `uninstall` specification
of OSXFuse was also refined so that it does not collide with SSHFS.
