### PR TITLE
Add Anxiety

### DIFF
--- a/Casks/anxiety.rb
+++ b/Casks/anxiety.rb
@@ -1,0 +1,8 @@
+class Anxiety < Cask
+  url 'http://www.anxietyapp.com/Anxiety.zip'
+  homepage 'http://www.anxietyapp.com/'
+  version 'latest'
+  no_checksum
+  nested_container 'Anxiety.dmg'
+  link 'Anxiety.app'
+end


### PR DESCRIPTION
Anxiety is a super-lightweight To-do list application for Mac OS X that synchronizes with iCal and Mail. Its aim is to provide a streamlined, easily accessible interface to add and check off your tasks, while remaining poised to melt into the background at a moments notice.
