### PR TITLE
add support for installing fonts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ Fill in the following fields for your Cask:
 | `link`             | relative path to a file that should be linked into the `Applications` folder on installation
 | `prefpane`         | relative path to a preference pane that should be linked into the `~/Library/PreferencePanes` folder on installation
 | `qlplugin`         | relative path to a Quicklook plugin that should be linked into the `~/Library/QuickLook` folder on installation
+| `font`             | relative path to a font that should be linked into the `~/Library/Fonts` folder on installation
 | `install`          | relative path to `pkg` that should be run to install the application
 | `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see "Uninstall Support" for more information)
 

--- a/Casks/font-dejavu.rb
+++ b/Casks/font-dejavu.rb
@@ -1,0 +1,27 @@
+class FontDejavu < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/dejavu/dejavu-fonts-ttf-2.34.zip'
+  homepage 'http://dejavu-fonts.org/wiki/Main_Page'
+  version '2.34'
+  sha1 '3417fdcb2bc9a2fb02aff9b8ee8eb236e678ead1'
+  font 'dejavu-fonts-ttf-2.34/ttf/DejaVuSans-Bold.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSans-BoldOblique.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSans-ExtraLight.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSans-Oblique.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSans.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansCondensed-Bold.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansCondensed-BoldOblique.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansCondensed-Oblique.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansCondensed.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansMono-Bold.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansMono-BoldOblique.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansMono-Oblique.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSansMono.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerif-Bold.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerif-BoldItalic.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerif-Italic.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerif.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerifCondensed-Bold.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerifCondensed-BoldItalic.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerifCondensed-Italic.ttf',
+       'dejavu-fonts-ttf-2.34/ttf/DejaVuSerifCondensed.ttf'
+end

--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -7,6 +7,7 @@ require 'cask/artifact/nested_container'
 require 'cask/artifact/pkg'
 require 'cask/artifact/prefpane'
 require 'cask/artifact/qlplugin'
+require 'cask/artifact/font'
 
 module Cask::Artifact
   #
@@ -20,6 +21,7 @@ module Cask::Artifact
       Cask::Artifact::Pkg,
       Cask::Artifact::Prefpane,
       Cask::Artifact::Qlplugin,
+      Cask::Artifact::Font,
     ]
   end
 

--- a/lib/cask/artifact/font.rb
+++ b/lib/cask/artifact/font.rb
@@ -1,0 +1,41 @@
+class Cask::Artifact::Font < Cask::Artifact::Base
+  def self.me?(cask)
+    cask.artifacts[:font].any?
+  end
+
+  def install
+    @cask.artifacts[:font].each { |font| link(font) }
+  end
+
+  def uninstall
+    @cask.artifacts[:font].each { |font| unlink(font) }
+  end
+
+  def link(font_relative_path)
+    source = @cask.destination_path.join(font_relative_path)
+    target = Cask.fontdir.join(source.basename)
+
+    return unless preflight_checks(source, target)
+    ohai "Linking font #{source.basename} to #{target}"
+    @command.run!('/bin/ln', :args => ['-hfs', source, target])
+  end
+
+  def preflight_checks(source, target)
+    if target.exist? && !target.symlink?
+      ohai "It seems there is already a font at #{target}; not linking."
+      false
+    end
+    unless source.exist?
+      raise "it seems the symlink source is not there: #{source}"
+    end
+    true
+  end
+
+  def unlink(font_relative_path)
+    linked_path = Cask.fontdir.join(Pathname(font_relative_path).basename)
+    if linked_path.exist? && linked_path.symlink?
+      ohai "Removing font link: #{linked_path}"
+      linked_path.delete
+    end
+  end
+end

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -68,6 +68,9 @@ class Cask::CLI
       opts.on("--qlplugindir=MANDATORY") do |v|
         Cask.qlplugindir = Pathname(v).expand_path
       end
+      opts.on("--fontdir=MANDATORY") do |v|
+        Cask.fontdir = Pathname(v).expand_path
+      end
       opts.on("--debug") do |v|
         @debug = true
       end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -41,6 +41,7 @@ module Cask::DSL
       :nested_container,
       :prefpane,
       :qlplugin,
+      :font,
       :uninstall,
     ]
 

--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -40,6 +40,14 @@ module Cask::Locations
       @qlplugindir = _qlplugindir
     end
 
+    def fontdir
+      @fontdir ||= Pathname.new('~/Library/Fonts').expand_path
+    end
+
+    def fontdir=(_fontdir)
+      @fontdir = _fontdir
+    end
+
     def default_tap
       @default_tap ||= 'phinze-cask'
     end

--- a/test/cask/cli/options_test.rb
+++ b/test/cask/cli/options_test.rb
@@ -43,6 +43,20 @@ describe Cask::CLI do
     Cask.qlplugindir.must_equal Pathname('/some/path/bar')
   end
 
+  it "supports setting the fontdir" do
+    Cask::CLI.process_options %w{help --fontdir=/some/path/foo}
+
+    Cask.fontdir.must_equal Pathname('/some/path/foo')
+  end
+
+  it "supports setting the fontdir from ENV" do
+    ENV['HOMEBREW_CASK_OPTS'] = "--fontdir=/some/path/bar"
+
+    Cask::CLI.process_options %w{help}
+
+    Cask.fontdir.must_equal Pathname('/some/path/bar')
+  end
+
   it "allows additional options to be passed through" do
     rest = Cask::CLI.process_options %w{edit foo --create --appdir=/some/path/qux}
 


### PR DESCRIPTION
I used a different naming scheme for the example cask, prefixing it with `font-` (`font-dejavu.rb`)  I think some name collisions are inevitable otherwise.

It would also be possible to link just the directory `dejavu-fonts-ttf-2.34` into `~/Library/Fonts` instead of linking each individual font. I don't know if you would consider that to be preferable.
