### PR TITLE
Airmail Beta URL is 'latest' URL

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,7 +1,7 @@
 class AirmailBeta < Cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
   homepage 'http://airmailapp.com/'
-  version '1.3.0 (218)'
-  sha1 '94f3d1ab3a403ed15d1584a185e991f2d2272c0a'
+  version 'latest'
+  no_checksum
   link 'AirMail Beta.app'
 end


### PR DESCRIPTION
Airmail Beta URL is actually latest URL.  Marking it as such.
