### PR TITLE
Intellij idea casks renamed to include full product name

### DIFF
--- a/Casks/intellij-idea-community.rb
+++ b/Casks/intellij-idea-community.rb
@@ -1,4 +1,4 @@
-class IntellijCommunity < Cask
+class IntellijIdeaCommunity < Cask
   url 'http://download.jetbrains.com/idea/ideaIC-12.1.6.dmg'
   homepage 'https://www.jetbrains.com/idea/index.html'
   version '12.1.6'

--- a/Casks/intellij-idea-ultimate.rb
+++ b/Casks/intellij-idea-ultimate.rb
@@ -1,4 +1,4 @@
-class IntellijUltimate < Cask
+class IntellijIdeaUltimate < Cask
   url 'http://download.jetbrains.com/idea/ideaIU-12.1.6.dmg'
   homepage 'https://www.jetbrains.com/idea/index.html'
   version '12.1.6'

--- a/test/cask/cli/search_test.rb
+++ b/test/cask/cli/search_test.rb
@@ -5,8 +5,8 @@ describe Cask::CLI::Search do
     lambda {
       Cask::CLI::Search.run('intellij')
     }.must_output <<-OUTPUT.gsub(/^ */, '')
-      intellij-community
-      intellij-ultimate
+      intellij-idea-community
+      intellij-idea-ultimate
     OUTPUT
   end
 end


### PR DESCRIPTION
See http://www.jetbrains.com/idea/ for product name

Renames:
intellij-ultimate -> intellij-idea-ultimate
intellij-community -> intellij-idea-community

This should ease finding the casks and prevent spending time on creating casks for intellij idea that exist but you didn't find (like in my case :)) as well.
