### PR TITLE
Update NoEjectDelay to 5.3.0

### DIFF
--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -1,7 +1,7 @@
 class Noejectdelay < Cask
-  url 'https://pqrs.org/macosx/keyremap4macbook/files/NoEjectDelay-5.0.0.dmg'
+  url 'https://pqrs.org/macosx/keyremap4macbook/files/NoEjectDelay-5.3.0.dmg'
   homepage 'https://pqrs.org/macosx/keyremap4macbook/noejectdelay.html.en'
-  version '5.0.0'
-  sha1 '1e1797c9d12b103a34d7b8ade58d7f3b85634336'
+  version '5.3.0'
+  sha1 '806a85565a0652f3d1eefbe742d88dd797566233'
   install 'NoEjectDelay.pkg'
 end


### PR DESCRIPTION
Of note to this project, v5.3.0 no longer requires a reboot on install
