### PR TITLE
Fix SHA1 mismatch for Carbon Copy Cloner version 3.5.4

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -2,6 +2,6 @@ class CarbonCopyCloner < Cask
   url 'http://files.bombich.com/ccc-3.5.4.zip'
   homepage 'http://bombich.com/'
   version '3.5.4'
-  sha1 'e24115cb03fd902d5465785f6fc35675a06f6f45'
+  sha1 'd586a1e3bd745ad6955fc8242a078e7b059fa356'
   link 'Carbon Copy Cloner.app'
 end


### PR DESCRIPTION
Getting errors when running `brew cask install carbon-copy-cloner` 
