### PR TITLE
support non-ruby-backed casks

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -7,6 +7,7 @@ class Cask; end
 require 'cask/artifact'
 require 'cask/audit'
 require 'cask/auditor'
+require 'cask/without_source'
 require 'cask/checkable'
 require 'cask/cli'
 require 'cask/container'
@@ -59,11 +60,11 @@ class Cask
   end
 
   def caskroom_path
-    self.class.caskroom.join(self.title)
+    self.class.caskroom.join(title)
   end
 
   def destination_path
-    caskroom_path.join(self.version)
+    caskroom_path.join(version)
   end
 
   def installed?

--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -19,7 +19,7 @@ class Cask::CLI::List
   end
 
   def self.list_installed
-    puts_columns Cask::CLI.nice_listing(Cask.installed)
+    puts_columns Cask.installed.map(&:to_s)
   end
 
   def self.help

--- a/lib/cask/scopes.rb
+++ b/lib/cask/scopes.rb
@@ -23,7 +23,10 @@ module Cask::Scopes
     end
 
     def installed
-      all_titles.select { |c| Cask.load(c).installed? }
+      installed_cask_dirs = Pathname.glob(caskroom.join("*"))
+      installed_cask_dirs.map do |dir|
+        Cask.load(dir.basename.to_s)
+      end
     end
   end
 end

--- a/lib/cask/source.rb
+++ b/lib/cask/source.rb
@@ -1,5 +1,6 @@
 module Cask::Source; end
 
+require 'cask/source/gone'
 require 'cask/source/path'
 require 'cask/source/tap'
 require 'cask/source/uri'
@@ -10,10 +11,13 @@ module Cask::Source
       Cask::Source::URI,
       Cask::Source::Path,
       Cask::Source::Tap,
+      Cask::Source::Gone,
     ]
   end
 
   def self.for_query(query)
-    sources.find { |source| source.me?(query) }.new(query)
+    source = sources.find { |s| s.me?(query) }
+    raise CaskUnavailableError.new(query) unless source
+    source.new(query)
   end
 end

--- a/lib/cask/source/gone.rb
+++ b/lib/cask/source/gone.rb
@@ -1,0 +1,15 @@
+class Cask::Source::Gone
+  def self.me?(query)
+    Cask::WithoutSource.new(query).installed?
+  end
+
+  attr_reader :query
+
+  def initialize(query)
+    @query = query
+  end
+
+  def load
+    Cask::WithoutSource.new(query)
+  end
+end

--- a/lib/cask/without_source.rb
+++ b/lib/cask/without_source.rb
@@ -1,0 +1,13 @@
+class Cask::WithoutSource < Cask
+  def destination_path
+    caskroom_path.children.first
+  end
+
+  def to_s
+    "#{title} (!)"
+  end
+
+  def installed?
+    caskroom_path.exist?
+  end
+end

--- a/test/cask/artifact/app_test.rb
+++ b/test/cask/artifact/app_test.rb
@@ -28,18 +28,26 @@ describe Cask::Artifact::App do
         link 'subdir/Caffeine.app'
       end
 
-      subdir_cask = SubDirCask.new.tap do |cask|
-        TestHelper.install_without_artifacts(cask)
+      begin
+        subdir_cask = SubDirCask.new.tap do |cask|
+          TestHelper.install_without_artifacts(cask)
+        end
+
+        appsubdir = (subdir_cask.destination_path/'subdir').tap(&:mkpath)
+        FileUtils.mv((subdir_cask.destination_path/'Caffeine.app'), appsubdir)
+
+        shutup do
+          Cask::Artifact::App.new(subdir_cask).install
+        end
+
+        TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
+      ensure
+        if defined?(subdir_cask)
+          shutup do
+            Cask::Installer.new(subdir_cask).uninstall
+          end
+        end
       end
-
-      appsubdir = (subdir_cask.destination_path/'subdir').tap(&:mkpath)
-      FileUtils.mv((subdir_cask.destination_path/'Caffeine.app'), appsubdir)
-
-      shutup do
-        Cask::Artifact::App.new(subdir_cask).install
-      end
-
-      TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
     end
 
     it "only uses linkables when they are specified" do

--- a/test/cask/cli/list_test.rb
+++ b/test/cask/cli/list_test.rb
@@ -14,6 +14,26 @@ describe Cask::CLI::List do
     OUTPUT
   end
 
+  describe 'when casks have been renamed' do
+    before do
+      @renamed_path = Cask.caskroom.join('ive-been-renamed','latest','Renamed.app').tap(&:mkpath)
+      @renamed_path.join('Info.plist').open('w') { |f| f.puts "Oh plist" }
+    end
+
+    after do
+      @renamed_path.rmtree if @renamed_path.exist?
+    end
+
+    it 'lists installed casks without backing ruby files (due to renames or otherwise)' do
+      lambda {
+        Cask::CLI::List.run
+      }.must_output <<-OUTPUT.gsub(/^ */, '')
+        ive-been-renamed (!)
+      OUTPUT
+    end
+  end
+
+
   it 'given a set of installed casks, lists the installed files for those casks' do
     casks = %w[local-caffeine local-transmission].map { |c| Cask.load(c) }
 

--- a/test/cask/cli/uninstall_test.rb
+++ b/test/cask/cli/uninstall_test.rb
@@ -35,6 +35,25 @@ describe Cask::CLI::Uninstall do
     Cask.appdir.join('Caffeine.app').wont_be :symlink?
   end
 
+  describe "when casks have been renamed" do
+    before do
+      @renamed_path = Cask.caskroom.join('ive-been-renamed','latest','Renamed.app').tap(&:mkpath)
+      @renamed_path.join('Info.plist').open('w') { |f| f.puts "Oh plist" }
+    end
+
+    after do
+      @renamed_path.rmtree if @renamed_path.exist?
+    end
+
+    it "can uninstall non-ruby-backed casks" do
+      shutup do
+        Cask::CLI::Uninstall.run('ive-been-renamed')
+      end
+
+      @renamed_path.wont_be :exist?
+    end
+  end
+
   it "raises an exception when no cask is specified" do
     lambda {
       Cask::CLI::Uninstall.run

--- a/test/cask/scopes_test.rb
+++ b/test/cask/scopes_test.rb
@@ -9,11 +9,7 @@ describe Cask::Scopes do
         Cask::Installer.new(caffeine).install
       end
 
-      installed_casks = Cask.installed
-      installed_casks.count.must_be :>, 0
-      installed_casks.each do |c|
-        c.must_be_kind_of String
-      end
+      Cask.installed.map(&:to_s).must_equal [caffeine].map(&:to_s)
     end
   end
 end


### PR DESCRIPTION
- brew cask list now displays casks without backing ruby files
- casks without a source are displayed as "caskname (!)"
- these casks can be uninstalled, with the caveat that it only removes
  their files from the caskroom (doesn't run pkg uninstall or anything,
  since there's no ruby file to define what to do)
