### PR TITLE
Add cask for VisTrails 2.0.3.

### DIFF
--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -1,0 +1,7 @@
+class Vistrails < Cask
+  url 'http://downloads.sourceforge.net/project/vistrails/vistrails/v2.0.3/vistrails-mac-10.6-intel-2.0.3-a6ad79347667.dmg'
+  homepage 'http://www.vistrails.org/index.php/Main_Page'
+  version '2.0.3'
+  sha1 '1381f58a8946792ed448ae072607cee9ed32a041'
+  link 'VisTrails'
+end


### PR DESCRIPTION
Add cask for VisTrails, an open-source scientific workflow and
provenance management system that supports data exploration and
visualization.

The disk image contains a folder, which is a little unusual. I linked the whole folder because it includes docs, examples, and scripts.
