### PR TITLE
Allow naked OTF and TTF files, follow-up on #1860

### DIFF
--- a/lib/cask/container/naked.rb
+++ b/lib/cask/container/naked.rb
@@ -1,7 +1,9 @@
 class Cask::Container::Naked < Cask::Container::Base
   def self.me?(criteria)
     %w[
+      .otf
       .pkg
+      .ttf
     ].include?(criteria.path.extname)
   end
 


### PR DESCRIPTION
This should not be needed for .qlgenerator or .prefPane, because
(like .app) those are always directories/bundles and therefore must
be transported in some type of container.
