### PR TITLE
Reword f.lux after_install comment

### DIFF
--- a/Casks/f-lux.rb
+++ b/Casks/f-lux.rb
@@ -6,7 +6,7 @@ class FLux < Cask
   link 'Flux.app'
 
   after_install do
-    # Prevent f.lux from asking the user whether he wants the app bundle moved to /Applications
+    # Don't ask to move the app bundle to /Applications
     system 'defaults write org.herf.Flux moveToApplicationsFolderAlertSuppress -int 1'
   end
 end


### PR DESCRIPTION
I'm going to work on some PRs to add `moveToApplicationsFolderAlertSuppress` to other casks but I was looking at the f.lux commit (fb19d4d) and thought the comment could be improved. The biggest problem to me is that the comment assumes the user is male. Here is a comment without gender pronouns that also has the benefit of being reusable for any cask, in the end I don't think it's useful to mention f.lux in the comment :)
