### PR TITLE
DaisyDisk: Suppress move to /Applications prompt

### DIFF
--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -3,5 +3,10 @@ class Daisydisk < Cask
   homepage 'http://www.daisydiskapp.com'
   version 'latest'
   no_checksum
-  link 'DaisyDisk.app'                                                                                                                                
+  link 'DaisyDisk.app'
+
+  after_install do
+    # Don't ask to move the app bundle to /Applications
+    system 'defaults write com.daisydiskapp.DaisyDiskStandAlone moveToApplicationsFolderAlertSuppress -bool true'
+  end
 end


### PR DESCRIPTION
Small bonus: this gets rid of some trailing whitespace.
