### PR TITLE
f.lux: Use bool instead of int for defaults write

### DIFF
--- a/Casks/f-lux.rb
+++ b/Casks/f-lux.rb
@@ -7,6 +7,6 @@ class FLux < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write org.herf.Flux moveToApplicationsFolderAlertSuppress -int 1'
+    system 'defaults write org.herf.Flux moveToApplicationsFolderAlertSuppress -bool true'
   end
 end


### PR DESCRIPTION
Might as well use the right data type, even if the result is the same.
