### PR TITLE
WebP Quicklook 2.1 Plugin

### DIFF
--- a/Casks/webp-quicklook.rb
+++ b/Casks/webp-quicklook.rb
@@ -1,0 +1,7 @@
+class WebpQuicklook < Cask
+  url 'https://github.com/dchest/webp-quicklook/releases/download/v2.1/WebP-2.1.qlgenerator.zip'
+  homepage 'https://github.com/dchest/webp-quicklook'
+  version '2.1'
+  sha1 'b702a25c72a4db8ef7ed6bee5a0acdecf8a72438'
+  qlplugin 'WebP.qlgenerator'
+end


### PR DESCRIPTION
This is an open-source QuickLook plugin to generate thumbnails and previews for WebP images. Requires Mac OS X 10.7 or later (but tested on 10.8).

New version supports WebP lossy, lossless, and alpha channels.
