### PR TITLE
QuicklookCSV

### DIFF
--- a/Casks/quicklook-csv.rb
+++ b/Casks/quicklook-csv.rb
@@ -1,0 +1,7 @@
+class QuicklookCsv < Cask
+  url 'http://quicklook-csv.googlecode.com/files/QuickLookCSV.dmg'
+  homepage 'https://github.com/p2/quicklook-csv'
+  version 'latest'
+  no_checksum
+  qlplugin 'QuickLookCSV.qlgenerator'
+end


### PR DESCRIPTION
Quick look CSV files for Mac OS X 10.5 and newer. Supports files separated by comma (,), tabs (⇥), semicolons (;) pipes (|). The plugin will generate Icons and show a preview, along with some information (like num rows/columns). Many thanks to Ted Fischer for valuable input and testing of version 1.1!
