### PR TITLE
add Adobe fonts Source Code Pro, Source Sans Pro

### DIFF
--- a/Casks/font-source-code-pro.rb
+++ b/Casks/font-source-code-pro.rb
@@ -1,0 +1,13 @@
+class FontSourceCodePro < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/sourcecodepro.adobe/SourceCodePro_FontsOnly-1.017.zip'
+  homepage 'http://store1.adobe.com/cfusion/store/html/index.cfm?store=OLS-US&event=displayFontPackage&code=1960'
+  version '1.017'
+  sha1 'c0e3f6f8e25b434c0e28a817539632f8a5ecb9e5'
+  font 'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-Black.otf',
+       'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-Bold.otf',
+       'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-ExtraLight.otf',
+       'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-Light.otf',
+       'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-Medium.otf',
+       'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-Regular.otf',
+       'SourceCodePro_FontsOnly-1.017/OTF/SourceCodePro-Semibold.otf'
+end

--- a/Casks/font-source-sans-pro.rb
+++ b/Casks/font-source-sans-pro.rb
@@ -1,0 +1,18 @@
+class FontSourceSansPro < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/sourcesans.adobe/SourceSansPro_FontsOnly-1.050.zip'
+  homepage 'http://store1.adobe.com/cfusion/store/html/index.cfm?store=OLS-US&event=displayFontPackage&code=1959'
+  version '1.050'
+  sha1 'f3af1201c80a86f1dd6e045a565c96bdd12d445f'
+  font 'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-Black.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-BlackIt.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-Bold.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-BoldIt.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-ExtraLight.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-ExtraLightIt.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-It.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-Light.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-LightIt.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-Regular.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-Semibold.otf',
+       'SourceSansPro_FontsOnly-1.050/OTF/SourceSansPro-SemiboldIt.otf'
+end


### PR DESCRIPTION
These are released under SIL Open Font License. Included in this commit:
Source Code Pro version 1.017, Source Sans Pro version 1.050.
