### PR TITLE
add PT fonts

### DIFF
--- a/Casks/font-pt-mono.rb
+++ b/Casks/font-pt-mono.rb
@@ -1,0 +1,8 @@
+class FontPtMono < Cask
+  url 'http://www.fontstock.com/public/PTMono.zip'
+  homepage 'http://www.paratype.com/public/'
+  version '1.002'
+  sha1 '1e06f32df070d93adb1b5f5b515d8af770b6cd28'
+  font 'PTM55F.ttf',
+       'PTM75F.ttf'
+end

--- a/Casks/font-pt-sans.rb
+++ b/Casks/font-pt-sans.rb
@@ -1,0 +1,14 @@
+class FontPtSans < Cask
+  url 'http://www.fontstock.com/public/PTSans.zip'
+  homepage 'http://www.paratype.com/public/'
+  version '2.004'
+  sha1 '3e14c921c2c9eb524ad5680eff931d1d5cbca00a'
+  font 'PTC55F.ttf',
+       'PTC75F.ttf',
+       'PTN57F.ttf',
+       'PTN77F.ttf',
+       'PTS55F.ttf',
+       'PTS56F.ttf',
+       'PTS75F.ttf',
+       'PTS76F.ttf'
+end

--- a/Casks/font-pt-serif.rb
+++ b/Casks/font-pt-serif.rb
@@ -1,0 +1,12 @@
+class FontPtSerif < Cask
+  url 'http://www.fontstock.com/public/PTSerif.zip'
+  homepage 'http://www.paratype.com/public/'
+  version '1.001'
+  sha1 'b445d4cc49a18581852bab27a204d4b4a44a403f'
+  font 'PTF55F.ttf',
+       'PTF56F.ttf',
+       'PTF75F.ttf',
+       'PTF76F.ttf',
+       'PTZ55F.ttf',
+       'PTZ56F.ttf'
+end


### PR DESCRIPTION
PT Mono in particular is useful for coders who use Cyrillic text.
Included in this commit: PT Mono v 1.002, PT Sans v 2.004,
PT Serif v 1.001.
