### PR TITLE
add Red Hat Liberation font family

### DIFF
--- a/Casks/font-liberation-sans.rb
+++ b/Casks/font-liberation-sans.rb
@@ -1,0 +1,18 @@
+class FontLiberationSans < Cask
+  url 'https://fedorahosted.org/releases/l/i/liberation-fonts/liberation-fonts-ttf-2.00.1.tar.gz'
+  homepage 'https://fedorahosted.org/liberation-fonts/'
+  version '2.00.1'
+  sha1 '84b40d7f8bb0cd085dd70b3abed197133d761557'
+  font 'liberation-fonts-ttf-2.00.1/LiberationMono-Bold.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationMono-BoldItalic.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationMono-Italic.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationMono-Regular.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSans-Bold.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSans-BoldItalic.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSans-Italic.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSans-Regular.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSerif-Bold.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSerif-BoldItalic.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSerif-Italic.ttf',
+       'liberation-fonts-ttf-2.00.1/LiberationSerif-Regular.ttf'
+end


### PR DESCRIPTION
This commit includes versions 2.00.1 of Liberation Sans, Liberation Mono,
and Liberation Serif
