### PR TITLE
support --verbose flag for pkg installer

### DIFF
--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -13,11 +13,12 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
 
   def run_installer(pkg_relative_path)
     ohai "Running installer for #{@cask}; your password may be necessary."
-    @command.run!("installer", {
-      :sudo => true,
-      :args => %W[-pkg #{@cask.destination_path.join(pkg_relative_path)} -target /],
-      :print => true
-    })
+    args = [
+      '-pkg',    @cask.destination_path.join(pkg_relative_path),
+      '-target', '/'
+    ]
+    args << '-verboseR' if ARGV.verbose?
+    @command.run!('installer', {:sudo => true, :args => args, :print => true})
   end
 
   def manually_uninstall(uninstall_options)

--- a/lib/cask/cli/install.rb
+++ b/lib/cask/cli/install.rb
@@ -1,7 +1,7 @@
 class Cask::CLI::Install
   def self.run(*args)
     raise CaskUnspecifiedError if args.empty?
-    cask_names = args.reject { |a| a == '--force' }
+    cask_names = args.reject { |a| a.chars.first == '-' }
     force = args.include? '--force'
     cask_names.each do |cask_name|
       cask = Cask.load(cask_name)


### PR DESCRIPTION
refs #1976 

basically just adds `-verboseR` to `installer` when `--verbose` flag is specified.

this is a simple implementation - i'd like to revamp the tests around CLI stuff to make them faster, which will include a refactor that will affect the implementation here.

a nice idea down the road would be to parse the `verboseR` output and display a fancy progress bar. :dress: 
