### PR TITLE
refine & document order of uninstall keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,12 +196,15 @@ of the following keys:
 * `:script` (string) - relative path to an uninstall script to be run via sudo
   - `:args` - array of arguments to the uninstall script
   - `:input` - array of lines of input to be sent to `stdin` of the script
+* `:launchctl` (string or array) - ids of launchctl services to remove
 * `:quit` (string or array) - bundle id of running applications to quit before proceeding with the uninstaller
 * `:kext` (string or array) - bundle id of kext(s) to unload from the system before proceeding with the uninstaller
 * `:pkgutil` (string or regexp) - regexp matching bundle id(s) of packages to uninstall using `pkgutil`
-* `:launchctl` (string or array) - ids of launchctl services to remove
 * `:files` (array) - absolute paths of files or directories to remove
   - should only be used as a last resort, since this is the blunt force approach
+
+Each defined `uninstall` method is applied according to the order above. The order
+in which `uninstall` keys appear in the Cask file is ignored.
 
 ### Good Things to Know
 

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -36,6 +36,13 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
       )
     end
 
+    if uninstall_options.key? :launchctl
+      [*uninstall_options[:launchctl]].each do |service|
+        ohai "Removing launchctl service #{service}"
+        @command.run!('launchctl', :args => ['remove', service], :sudo => true)
+      end
+    end
+
     if uninstall_options.key? :quit
       [*uninstall_options[:quit]].each do |id|
         ohai "Quitting application ID #{id}"
@@ -56,13 +63,6 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     if uninstall_options.key? :pkgutil
       pkgs = Cask::Pkg.all_matching(uninstall_options[:pkgutil], @command)
       pkgs.each(&:uninstall)
-    end
-
-    if uninstall_options.key? :launchctl
-      [*uninstall_options[:launchctl]].each do |service|
-        ohai "Removing launchctl service #{service}"
-        @command.run!('launchctl', :args => ['remove', service], :sudo => true)
-      end
     end
 
     if uninstall_options.key? :files


### PR DESCRIPTION
Proposed order - :script, :launchctl, :quit, :kext, :pkgutil, :files.  Quit
a process before attempting to unload an assocated kext, unload kext before
attempting to delete the associated file, etc.  Arguably :script fits
loically with :files near the end of the list.  However, we also have
:after_uninstall which implicitly fires immediately after :files.
Therefore, running :script early provides greater functionality.
