### PR TITLE
safer test for currently running app

### DIFF
--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -39,8 +39,8 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     if uninstall_options.key? :quit
       [*uninstall_options[:quit]].each do |id|
         ohai "Quitting application ID #{id}"
-        is_running = @command.run!('osascript', :args => ['-e', "if application id \"#{id}\" is running then 1"], :sudo => true)
-        if is_running == "1\n"
+        num_running = @command.run!('osascript', :args => ['-e', "tell application \"System Events\" to count processes whose bundle identifier is \"#{id}\""], :sudo => true).to_i
+        if num_running > 0
           @command.run!('osascript', :args => ['-e', "tell application id \"#{id}\" to quit"], :sudo => true)
         end
       end


### PR DESCRIPTION
The previous version could fail if the specified bundle was not installed.
Here we tell "System Events" until determining it is safe to do otherwise.
