### PR TITLE
Refactor similar method structure in dirs and files into one for re-use.

### DIFF
--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -33,14 +33,18 @@ class Cask::Pkg
   end
 
   def dirs
-    @command.run!('pkgutil',
-      :args => ['--only-dirs', '--files', package_id]
-    ).split("\n").map { |path| root.join(path) }
+    fs_command
   end
 
   def files
+    fs_command
+  end
+
+  def fs_command
+    _caller = caller[0][/`([^']*)'/, 1]
+
     @command.run!('pkgutil',
-      :args => ['--only-files', '--files', package_id]
+      :args => ["--only-#{_caller}", '--files', package_id]
     ).split("\n").map { |path| root.join(path) }
   end
 


### PR DESCRIPTION
The only difference between the `dirs` and `files` methods was the argument used to call the internal `run` method inside both. To remove duplication from `Cask::Pkg`, we use *`Kernel#caller` to get the name of the method calling `fs_command` and pass it to the the argument. It's magical like :ramen: 

*compatible from 1.8.x to latest.
