### PR TITLE
MiddleClick Mavericks

### DIFF
--- a/Casks/middleclick-mavericks.rb
+++ b/Casks/middleclick-mavericks.rb
@@ -1,0 +1,7 @@
+class MiddleclickMavericks < Cask
+  url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'
+  homepage 'http://clement.beffa.org/labs/projects/middleclick'
+  version '20131027'
+  sha1 'bbe6deb4363ebebad6ecd6f92dc8d16fd6adf5e2'
+  link 'MiddleClick.app'
+end


### PR DESCRIPTION
Added new cask for open-source application MiddleClick for Mavericks.

**Note**: _Not entirely sure about naming conventions here. Developer has multiple binaries of this app on their homepage, each one for different recent OS X versions (Mavericks, ML, etc.). This cask specifically installs the Mavericks version, as I only have a Mavericks machine to test on, hence I've named it "middleclick-mavericks". The .app file is simply called "MiddleClick.app" though, which will most likely conflict with casks made for the other versions of MiddleClick... I've just discovered homebrew-cask last night, so if you've encountered a similar situation with other applications some suggestion as to what action to take would be appreciated_ :)
