### PR TITLE
Modified previously submitted Middleclick cask

### DIFF
--- a/Casks/middleclick-mavericks.rb
+++ b/Casks/middleclick-mavericks.rb
@@ -1,0 +1,7 @@
+class MiddleclickMavericks < Cask
+  url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'
+  homepage 'http://clement.beffa.org/labs/projects/middleclick'
+  version '20131027'
+  sha1 'bbe6deb4363ebebad6ecd6f92dc8d16fd6adf5e2'
+  link 'MiddleClick.app'
+end

--- a/Casks/middleclick-mavericks.rb
+++ b/Casks/middleclick-mavericks.rb
@@ -1,7 +1,0 @@
-class MiddleclickMavericks < Cask
-  url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'
-  homepage 'http://clement.beffa.org/labs/projects/middleclick'
-  version '20131027'
-  sha1 'bbe6deb4363ebebad6ecd6f92dc8d16fd6adf5e2'
-  link 'MiddleClick.app'
-end

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,8 +1,8 @@
 class Middleclick < Cask
   url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'
   homepage 'http://clement.beffa.org/labs/projects/middleclick'
-  version '20131027'
-  sha1 'bbe6deb4363ebebad6ecd6f92dc8d16fd6adf5e2'
+  version 'latest'
+  no_checksum
   link 'MiddleClick.app'
 
   def caveats; <<-EOS.undent

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,0 +1,16 @@
+class Middleclick < Cask
+  url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'
+  homepage 'http://clement.beffa.org/labs/projects/middleclick'
+  version '20131027'
+  sha1 'bbe6deb4363ebebad6ecd6f92dc8d16fd6adf5e2'
+  link 'MiddleClick.app'
+
+  def caveats; <<-EOS.undent
+    This cask requires OS X 10.9 Mavericks for the installed application to
+    function correctly. 
+
+    Casks for installing this application under older versions of OS X, Mountain 
+    Lion and Snow Leopard, can be found in caskroom/homebrew-versions.
+    EOS
+  end
+end


### PR DESCRIPTION
Changed cask and class names to middleclick.rb and Middleclick,
respectively. Added caveat stating OS requirements.

Renamed branch to middleclick, from middleclick-mavericks, hence new pull request.
