### PR TITLE
Handle CaskAlreadyInstalledError more graceful

### DIFF
--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -33,6 +33,10 @@ class Cask::CLI
     rest = process_options(rest)
     Cask.init
     lookup_command(command).run(*rest)
+  rescue CaskAlreadyInstalledError => e
+    opoo e
+    $stderr.puts e.backtrace if @debug
+    exit 0
   rescue CaskError => e
     onoe e
     $stderr.puts e.backtrace if @debug


### PR DESCRIPTION
I'm using a [Brewfile](https://github.com/pstadler/dotfiles/blob/master/Caskfile) to install casks. Now the problem is that `brew bundle` exits if there's an error (i.e. non-zero exit code). To continue the execution of the Brewfile when a `CaskAlreadyInstalledError` happens, the `cask install` command should exit with 0.

Before:

``` bash
$ brew bundle
Warning: brew-cask-0.24.0 already installed
Error: Cask for qlcolorcode is already installed. Use `--force` to install anyways.
Error: Command failed: L8:brew cask install qlcolorcode
```

After:

``` bash
$ brew bundle   
Warning: brew-cask-0.24.0 already installed
Warning: Cask for qlcolorcode is already installed. Use `--force` to install anyways.
Warning: Cask for qlstephen is already installed. Use `--force` to install anyways.
Warning: Cask for qlmarkdown is already installed. Use `--force` to install anyways.
Warning: Cask for quicklook-json is already installed. Use `--force` to install anyways.
Warning: Cask for quicklook-csv is already installed. Use `--force` to install anyways.
Warning: Cask for betterzipql is already installed. Use `--force` to install anyways.
```
