### PR TITLE
remove magicprefs

### DIFF
--- a/Casks/magicprefs.rb
+++ b/Casks/magicprefs.rb
@@ -1,7 +1,0 @@
-class Magicprefs < Cask
-  url 'http://magicprefs.com/MagicPrefs.app.zip'
-  homepage 'http://magicprefs.com/'
-  version 'latest'
-  no_checksum
-  link 'MagicPrefs.app'
-end


### PR DESCRIPTION
It has some problems I didn’t check earlier, like moving itself to `/Applications/` without prompting, so it’ll be removed for now, until a way more consistent with _homebrew-cask_’s usage is found.
