### PR TITLE
Rename Plex to PlexHomeTheater and update version to 1.0.7.169.

### DIFF
--- a/Casks/plex-home-theater.rb
+++ b/Casks/plex-home-theater.rb
@@ -1,0 +1,7 @@
+class PlexHomeTheater < Cask
+  url 'http://downloads.plexapp.com/plex-home-theater/1.0.7.169-303ab8cc/PlexHomeTheater-1.0.7.169-303ab8cc-macosx-i386.zip'
+  homepage 'http://plexapp.com'
+  version '1.0.7.169'
+  sha1 '1926d76623c5bb4205db7421042d4b5fdb671bfd'
+  link 'Plex Home Theater.app'
+end

--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,7 +1,0 @@
-class Plex < Cask
-  url 'http://plex.r.worldssl.net/plex-laika/0.9.5.4/Plex-0.9.5.4-973998f.zip'
-  homepage 'http://plexapp.com'
-  version '0.9.5.4'
-  sha1 '6d544de6c56861eab05a5621ecee1777cefe49fc'
-  link 'Plex.app'
-end


### PR DESCRIPTION
The "Plex" app has been renamed to "Plex Home Theater". I've renamed the cask and updated it to the latest version.
