### PR TITLE
Adds Runtastic Connect.

### DIFF
--- a/Casks/runtastic-connect.rb
+++ b/Casks/runtastic-connect.rb
@@ -1,0 +1,7 @@
+class RuntasticConnect < Cask
+  url 'http://download.runtastic.com/connect/mac/runtasticConnect.dmg'
+  homepage 'https://www.runtastic.com/connect'
+  version 'latest'
+  no_checksum
+  link 'Runtastic Connect.app'
+end


### PR DESCRIPTION
Adds support for [Runtastic Connect](https://www.runtastic.com/connect) which is the client application of the Runtastic GPS Watch. I'm not sure about that this should be here or not. If it isn't, you can just close the pull request.
