### PR TITLE
New cask for Terminal Notifier 1.5.0.

### DIFF
--- a/Casks/terminal-notifier.rb
+++ b/Casks/terminal-notifier.rb
@@ -1,0 +1,7 @@
+class TerminalNotifier < Cask
+  url 'https://github.com/alloy/terminal-notifier/releases/download/1.5.0/terminal-notifier-1.5.0.zip'
+  homepage 'https://github.com/alloy/terminal-notifier'
+  version '1.5.0'
+  sha1 'd122d1e84f8d34053490dc80bc68381c1b731d47'
+  link 'terminal-notifier-1.5.0/terminal-notifier.app'
+end


### PR DESCRIPTION
A command-line tool to send Mac OS X User Notifications, which are
available in Mac OS X 10.8 and higher.
