### PR TITLE
Update VisIt cask version to 2.7.0.

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,7 +1,7 @@
 class Visit < Cask
-  url 'http://portal.nersc.gov/svn/visit/trunk/releases/2.6.3/VisIt-2.6.3-x86_64-installer.dmg'
+  url 'http://portal.nersc.gov/svn/visit/trunk/releases/2.7.0/VisIt-2.7.0-x86_64-installer.dmg'
   homepage 'https://wci.llnl.gov/codes/visit/home.html'
-  version '2.6.3'
-  sha1 '3091da14bdad48e4f0faa0f543743d5befde11f2'
+  version '2.7.0'
+  sha1 'be44ee53695553396895154e7c9916bb670f772c'
   link 'VisIt.app'
 end


### PR DESCRIPTION
Update VisIt cask version to 2.7.0, the current release.
