### PR TITLE
Add OmniOutliner Standard

### DIFF
--- a/Casks/omnioutliner-pro.rb
+++ b/Casks/omnioutliner-pro.rb
@@ -1,0 +1,7 @@
+class OmnioutlinerPro < Cask
+  url 'http://www.omnigroup.com/download/latest/omnioutlinerPro'
+  homepage 'http://www.omnigroup.com/omnioutliner/'
+  version 'latest'
+  no_checksum
+  link 'OmniOutliner Professional.app'
+end

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,7 +1,7 @@
 class Omnioutliner < Cask
-  url 'http://www.omnigroup.com/download/latest/omnioutlinerpro'
-  homepage 'http://www.omnigroup.com/products/omnioutliner/'
+  url 'http://www.omnigroup.com/download/latest/omnioutliner'
+  homepage 'http://www.omnigroup.com/omnioutliner/'
   version 'latest'
   no_checksum
-  link 'OmniOutliner Professional.app'
+  link 'OmniOutliner.app'
 end


### PR DESCRIPTION
- Rename Pro to omnioutliner-pro and update URL slightly
- Update homepage

I'm using pro myself but thought it would clearer if the cask was called `omnioutliner-pro`, and this makes both editions available via homebrew-cask.
