### PR TITLE
Add Movist fork

### DIFF
--- a/Casks/movist-fork.rb
+++ b/Casks/movist-fork.rb
@@ -1,0 +1,7 @@
+class MovistFork < Cask
+  url 'https://github.com/downloads/samiamwork/Movist/Movist.app.zip'
+  homepage 'https://github.com/samiamwork/Movist'
+  version 'latest'
+  no_checksum
+  link 'Movist.app'
+end


### PR DESCRIPTION
Fork of multimedia player Movist. Original developer works on Mac App Store version.
Fork developer is currently working on translating the app to modern libraries and frameworks, but this version works OK.
