### PR TITLE
add Curse Client

### DIFF
--- a/Casks/curse-client.rb
+++ b/Casks/curse-client.rb
@@ -1,0 +1,7 @@
+class CurseClient < Cask
+  url 'http://addons.cursecdn.com/files/595/169/Curse_Client-4.0.0.425.dmg'
+  homepage 'http://www.curse.com/client'
+  version '4.0.0.425'
+  sha1 '4a095cff47e4bd9d68bafba9bfb8420fdfbc06d4'
+  link 'Curse Client.app'
+end


### PR DESCRIPTION
[Curse Client](http://www.curse.com/client) is a add-on manager for several MMO games (world of warcraft, etc).

The mac version has been discontinued, yet the last version is working.
