### PR TITLE
Add Undercover

### DIFF
--- a/Casks/undercover.rb
+++ b/Casks/undercover.rb
@@ -1,0 +1,12 @@
+class Undercover < Cask
+  url 'http://assets.undercoverhq.com/client/5.5.1/undercover_mac.pkg'
+  homepage 'http://www.orbicule.com/undercover/mac/'
+  version '5.5.1'
+  sha1 'f972daecf2d88f6e21e2d8039bf65355e71a4aaa'
+  install 'undercover_mac.pkg'
+  uninstall :files => [
+    '/Library/LaunchDaemons/com.orbicule.uc.plist',
+    '/Library/LaunchAgents/com.orbicule.UCAgent.plist',
+    '/usr/local/uc'
+  ]
+end


### PR DESCRIPTION
Theft recovery and tracking app.

File uninstallation based on http://www.orbicule.com/undercover/mac/faq.php (_How do I uninstall Undercover 5?_ heading)

I've tested both installation and uninstallation and it works smoothly.
