### PR TITLE
Update gimp to v2.8.10

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,7 +1,7 @@
 class Gimp < Cask
-  url 'ftp://ftp.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.4-nopython-dmg-1.dmg'
+  url 'ftp://ftp.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.10-dmg-1.dmg'
   homepage 'http://www.gimp.org'
-  version '2.8.4'
-  sha1 'f478ffd8c865bb67b50b6c75f2a68278544d6f79'
+  version '2.8.10'
+  sha1 'd4610fb4d9164179112a7b1d0cb43387887301c8'
   link 'GIMP.app'
 end


### PR DESCRIPTION
This is a newer version of gimp. 
According to the release note, it includes a fix for Mavericks.
https://git.gnome.org/browse/gimp/plain/NEWS?h=gimp-2-8
