### PR TITLE
Add PATH caveats to MacTeX Cask

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -5,4 +5,12 @@ class Mactex < Cask
   no_checksum
   install 'MacTeX.pkg'
   uninstall :pkgutil => 'org.tug.mactex.texlive2013'
+  
+  def caveats; <<-EOS.undent
+    You may need to add the MacTeX bin directory to your PATH.
+    
+    export PATH=/usr/texbin:$PATH
+    
+    EOS
+  end
 end


### PR DESCRIPTION
Warns user that they may need to add the mactex `bin` directory to their PATH manually, as the package does not seem to do this or symlink automatically.

Fixes #2277.
