### PR TITLE
add navicat casks

### DIFF
--- a/Casks/navicat-data-modeler.rb
+++ b/Casks/navicat-data-modeler.rb
@@ -1,0 +1,7 @@
+class NavicatDataModeler < Cask
+  url 'http://download.navicat.com/download/modeler010_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-data-modeler'
+  version '1.0.5'
+  sha1 'd620ab17c89a9eadd614454177a2becb3850c408'
+  link 'Navicat Data Modeler.app'
+end

--- a/Casks/navicat-mariadb.rb
+++ b/Casks/navicat-mariadb.rb
@@ -1,0 +1,7 @@
+class NavicatMariadb < Cask
+  url 'http://download.navicat.com/download/navicat110_mariadb_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-for-mariadb'
+  version '11.0.14'
+  sha1 'c14df959b00f0b6ec0658d61d0546198d5e9229e'
+  link 'Navicat for MariaDB.app'
+end

--- a/Casks/navicat-mysql.rb
+++ b/Casks/navicat-mysql.rb
@@ -1,0 +1,7 @@
+class NavicatMysql < Cask
+  url 'http://download.navicat.com/download/navicat110_mysql_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-for-mysql'
+  version '11.0.14'
+  sha1 '6fbafd271b2d9d9575566b6a052c9799caa01df5'
+  link 'Navicat for MySQL.app'
+end

--- a/Casks/navicat-oracle.rb
+++ b/Casks/navicat-oracle.rb
@@ -1,0 +1,7 @@
+class NavicatOracle < Cask
+  url 'http://download.navicat.com/download/navicat110_ora_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-for-oracle'
+  version '11.0.14'
+  sha1 '49562c0c8ceb09dbeba63d82aaf92ccd9d6a90ea'
+  link 'Navicat for Oracle.app'
+end

--- a/Casks/navicat-postgresql.rb
+++ b/Casks/navicat-postgresql.rb
@@ -1,0 +1,7 @@
+class NavicatPostgresql < Cask
+  url 'http://download.navicat.com/download/navicat110_pgsql_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-for-postgresql'
+  version '11.0.14'
+  sha1 '350e590c97b2b066db43a33f2c6aa2a49544a01f'
+  link 'Navicat for PostgreSQL.app'
+end

--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,0 +1,7 @@
+class NavicatPremium < Cask
+  url 'http://download.navicat.com/download/navicat110_premium_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-premium'
+  version '11.0.14'
+  sha1 '2df819b113fc2a4e4cb29433c4b69164bcf613de'
+  link 'Navicat Premium.app'
+end

--- a/Casks/navicat-sql-server.rb
+++ b/Casks/navicat-sql-server.rb
@@ -1,0 +1,7 @@
+class NavicatSqlServer < Cask
+  url 'http://download.navicat.com/download/navicat110_sqlserver_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-for-sqlserver'
+  version '11.0.14'
+  sha1 'c43978a0a45e6e60592d337008cb3a5f6eb79a17'
+  link 'Navicat For SQL Server.app'
+end

--- a/Casks/navicat-sqlite.rb
+++ b/Casks/navicat-sqlite.rb
@@ -1,0 +1,7 @@
+class NavicatSqlite < Cask
+  url 'http://download.navicat.com/download/navicat110_sqlite_en.dmg'
+  homepage 'http://www.navicat.com/products/navicat-for-sqlite'
+  version '11.0.14'
+  sha1 '5584b6b9c9201511bc99c2511c78014329ed679e'
+  link 'Navicat for SQLite.app'
+end


### PR DESCRIPTION
added a cask for each navicat:
Data Modeler, MariaDB, MySQL, Oracle, PostgreSQL, Premium, SQLite, and SQL Server
