### PR TITLE
Added a Cask for EasySIMBL

### DIFF
--- a/Casks/easysimbl.rb
+++ b/Casks/easysimbl.rb
@@ -1,0 +1,7 @@
+class Easysimbl < Cask
+  url 'http://github.com/norio-nomura/EasySIMBL/releases/download/EasySIMBL-1.6/EasySIMBL-1.6.zip'
+  homepage 'https://github.com/norio-nomura/EasySIMBL/'
+  version '1.6'
+  sha1 '52ac6c3575cbefcad25bb13703e8b09de319bbe9'
+  link 'EasySIMBL.app'
+end


### PR DESCRIPTION
EasySIMBL is a MacOSX Lion-friendly version of SIMBL, a bundle loader.
