### PR TITLE
add feedback when downloading a URI source

### DIFF
--- a/lib/cask/source/uri.rb
+++ b/lib/cask/source/uri.rb
@@ -12,6 +12,7 @@ class Cask::Source::URI
   def load
     HOMEBREW_CACHE_CASKS.mkpath
     path = HOMEBREW_CACHE_CASKS.join(File.basename(uri))
+    ohai "Downloading #{uri}"
     curl(uri, '-o', path.to_s)
     Cask::Source::Path.new(path).load
   rescue ErrorDuringExecution


### PR DESCRIPTION
otherwise the user sees the `curl` progress bar w/o explanation
