### PR TITLE
add dependencies for Homebrew formulae

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ Additional fields you might need for special use-cases:
 | `binary`           | relative path to a binary that should be linked into the `~/usr/local/bin` folder on installation
 | `input_method`     | relative path to a input method that should be linked into the `~/Library/Input Methods` folder on installation
 | `nested_container` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
+| `depends_on_formula` | a list of Homebrew Formulae upon which this Cask depends
 | `caveats`          | a string or Ruby block providing the user with Cask-specific information at install time (see __Caveats Details__ for more information)
 | `after_install`    | a Ruby block containing postflight install operations
 | `after_uninstall`  | a Ruby block containing postflight uninstall operations

--- a/FAQ.md
+++ b/FAQ.md
@@ -18,11 +18,12 @@ Casks currently have five required fields:
  * __font__ : (required for fonts) indicates which file(s) should be linked into the Fonts folder on installation
  * __input_method__: (required for input method) indicates which file(s) should be linked into the Input Methods folder on installation
 
-and five optional fields:
+and six optional fields:
 
 * __binary__: relative path to a binary to be installed
 * __uninstall__: (optional for `.pkg`) indicates how to uninstall a package
 * __nested_container__: relative path to a nested inner container
+* __depends_on_formula__: a list of Homebrew Formulae upon which this Cask depends
 * __caveats__: a string or Ruby block providing the user with Cask-specific information at install time
 * __after_install__: a Ruby block containing postflight install operations
 * __after_uninstall__: a Ruby block containing postflight uninstall operations

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -12,6 +12,8 @@ module Cask::DSL
 
   def version; self.class.version; end
 
+  def depends_on_formula; self.class.depends_on_formula; end
+
   def sums; self.class.sums || []; end
 
   def artifacts; self.class.artifacts; end
@@ -31,6 +33,10 @@ module Cask::DSL
 
     def version(version=nil)
       @version ||= version
+    end
+
+    def depends_on_formula(*args)
+      @depends_on_formula ||= args
     end
 
     def artifacts


### PR DESCRIPTION
uses new DSL key `depends_on_brew`.

Pursuant to #1992 and relevant to discussion in #2264, it was the request of @phinze on IRC _not_ to add `depends_on` stanzas to `brew-cask.rb`, but to defer dependencies until install-time for individual Casks.

This means adding to the DSL so we can specify which Casks have dependencies.  I have chosen the key `depends_on_brew` to leave room for specifying dependencies between Casks at a later time.  Homebrew will handle the dependency chain if the given dependency has dependencies of its own within Homebrew.

I'm not familiar with the test suite at this point. I wouldn't mind some help/pointers on tests for some of my PRs.  For this particular case, homebrew's own test suite already has good coverage of the principal functionality.
