### PR TITLE
Add PATH caveats to BasicTeX cask.

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -5,4 +5,12 @@ class Basictex < Cask
   no_checksum
   install 'mactex-basic.pkg'
   uninstall :pkgutil => 'org.tug.mactex.basictex2013'
+
+  def caveats; <<-EOS.undent
+    You may need to add the MacTeX bin directory to your PATH.
+
+    export PATH=/usr/texbin:$PATH
+
+    EOS
+  end
 end


### PR DESCRIPTION
Warns user that they may need to add LaTeX-related executables to
their PATH.

Similar to #2284, related to #2277.
