### PR TITLE
Fix widget install and uninstall using hardlinks.

### DIFF
--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -2,6 +2,7 @@ module Cask::Artifact; end
 
 require 'cask/artifact/base'
 require 'cask/artifact/symlinked'
+require 'cask/artifact/hardlinked'
 
 require 'cask/artifact/app'
 require 'cask/artifact/block'

--- a/lib/cask/artifact/hardlinked.rb
+++ b/lib/cask/artifact/hardlinked.rb
@@ -1,0 +1,18 @@
+class Cask::Artifact::Hardlinked < Cask::Artifact::Symlinked
+  def islink?(path)
+    return false unless path.respond_to?(:stat)
+    path.stat.nlink > 1
+  end
+
+  def link_action(source, target)
+    File.link(source, target)
+  end
+
+  def unlink_action(target)
+    FileUtils.rm_rf target
+  end
+
+  def link_name
+    'hardlink'
+  end
+end

--- a/lib/cask/artifact/widget.rb
+++ b/lib/cask/artifact/widget.rb
@@ -1,2 +1,2 @@
-class Cask::Artifact::Widget < Cask::Artifact::Symlinked
+class Cask::Artifact::Widget < Cask::Artifact::Hardlinked
 end


### PR DESCRIPTION
Fixes #2206
Related to ongoing discussion on #2264
Related to #2258 (merge conflicts?)

@rolandwalker This fixes the widget problem without showing a popup dialog to install.

`File.link` seems to do the job of hard linking directories.
