### PR TITLE
Add cask for iTools

### DIFF
--- a/Casks/itools.rb
+++ b/Casks/itools.rb
@@ -1,0 +1,7 @@
+class Itools < Cask
+  url 'http://dl2.itools.hk/dl/iTools_2.3.0.dmg'
+  homepage 'http://www.itools.cn/download.php?v=mac_en'
+  version '2.3.0'
+  sha1 '7edb17103ceb8fb481ddc96214d4664f47df581e'
+  link 'iTools.app'
+end


### PR DESCRIPTION
iTools is an alternative to iTunes. It's light-weight and easy to use.
