### PR TITLE
Adding cask for weka.

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,0 +1,7 @@
+class Weka < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/weka/weka-3-6-10-oracle-jvm.dmg'
+  homepage 'http://www.cs.waikato.ac.nz/ml/weka/'
+  version '3.6.10'
+  sha1 '5ef970b64cffbe13a074aeef0656c1809f4fc61d'
+  link 'weka-3-6-10-oracle-jvm.app'
+end


### PR DESCRIPTION
Weka is a popular tool for machine learning used by researchers. This cask starts at version 3.6.10.
