### PR TITLE
Added check for 'HTTP/1.1 302 Found'

### DIFF
--- a/lib/cask/link_checker.rb
+++ b/lib/cask/link_checker.rb
@@ -23,7 +23,8 @@ class Cask::LinkChecker
 
   HTTP_RESPONSES = [
     'HTTP/1.0 200 OK',
-    'HTTP/1.1 200 OK'
+    'HTTP/1.1 200 OK',
+    'HTTP/1.1 302 Found'
   ]
 
   OK_RESPONSES = {


### PR DESCRIPTION
Before:

``` bash
$ brew cask checklinks cloud-pull 
link check result for cloud-pull: failed
 - unexpected http response, expecting "HTTP/1.0 200 OK" or "HTTP/1.1 200 OK", got "HTTP/1.1 302 Found"
```

After:

``` bash
$ brew cask checklinks cloud-pull 
link check result for cloud-pull: passed
```
