### PR TITLE
Add cask for DictUnifier

### DIFF
--- a/Casks/dict-unifier.rb
+++ b/Casks/dict-unifier.rb
@@ -1,0 +1,7 @@
+class DictUnifier < Cask
+  url 'http://mac-dictionary-kit.googlecode.com/files/DictUnifier-2.1.zip'
+  homepage 'http://code.google.com/p/mac-dictionary-kit/'
+  version '2.1'
+  sha1 '73773b3483f9120ef1969cffe2309abe5f1f915b'
+  link 'DictUnifier.app'
+end


### PR DESCRIPTION
Mac Dictionary Kit is a collection of tools to help convert and build dictionaries on Mac OS X platform. The source dictionary could be in any format, but currently only stardict format is supported. The target dictionary must be Dictionary 2.0 format defined in Mac OS X 10.5. 
