### PR TITLE
Prepend brew-cask dirs to $LOAD_PATH (not append)

### DIFF
--- a/bin/brew-cask.rb
+++ b/bin/brew-cask.rb
@@ -1,6 +1,6 @@
 # this file expects to be required from within homebrew's ruby environment
 
-$LOAD_PATH << File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
+$LOAD_PATH.unshift(File.expand_path('../../lib', Pathname.new(__FILE__).realpath))
 require 'cask'
 
 Cask::CLI.process(ARGV)


### PR DESCRIPTION
Found while investigating #2275, but probably not a fix, just a sensible
change. Depending on version of ruby interpreter, previous code could
cause brew-cask paths to come later than current-dir `.` in `$LOAD_PATH`,
leading to unpredictable behavior in the wild.
