### PR TITLE
Add ChronoMate

### DIFF
--- a/Casks/chronomate.rb
+++ b/Casks/chronomate.rb
@@ -1,0 +1,7 @@
+class Chronomate < Cask
+  url 'http://studio-qb.com/sites/studio-qb.com/files/releases/chronomate_0.9.2.dmg'
+  homepage 'http://chronomateapp.com/'
+  version '0.9.2'
+  sha256 '76b2f87b088c57aac7dfd18215b07e078d453ed351af056db25bb78d67e4862b'
+  link 'ChronoMate.app'
+end


### PR DESCRIPTION
ChronoMate is a full featured Mac OS X desktop timer for FreshBooks,
it keeps track of the time you spend on your different projects.
