### PR TITLE
dropbox: Download the full installer.

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,5 +1,5 @@
 class Dropbox < Cask
-  url 'https://www.dropbox.com/download?plat=mac'
+  url 'https://www.dropbox.com/download?plat=mac&full=1'
   homepage 'https://www.dropbox.com/'
   version 'latest'
   no_checksum


### PR DESCRIPTION
Dropbox changed the URL previously used such that it now downloads a
meta-installer. Modify the URL to ensure that the full .dmg is acquired.

Based on information from https://github.com/autopkg/recipes/issues/35.
