### PR TITLE
update light-table to 0.6.0

### DIFF
--- a/Casks/light-table.rb
+++ b/Casks/light-table.rb
@@ -1,7 +1,7 @@
 class LightTable < Cask
-  url 'https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.5.20/LightTableMac.zip'
+  url 'http://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.0/LightTableMac.zip'
   homepage 'http://www.lighttable.com/'
-  version '0.5.20'
-  sha1 '6a005d31e1d4efc57150298821bc6d47c1dbf5f2'
+  version '0.6.0'
+  sha1 '98d881e5e445f74a990fbdb47fd9835cf4334a79'
   link 'LightTable/LightTable.app'
 end


### PR DESCRIPTION
0.6.0 is now open source and adds plugins, wee!
