### PR TITLE
node-webkit 0.8.4

### DIFF
--- a/Casks/node-webkit.rb
+++ b/Casks/node-webkit.rb
@@ -1,7 +1,7 @@
 class NodeWebkit < Cask
-  url 'https://s3.amazonaws.com/node-webkit/v0.8.3/node-webkit-v0.8.3-osx-ia32.zip'
+  url 'https://s3.amazonaws.com/node-webkit/v0.8.4/node-webkit-v0.8.4-osx-ia32.zip'
   homepage 'https://github.com/rogerwang/node-webkit'
-  version '0.8.3'
-  sha1 'b24411cc789352a8be3935444367482b137969dd'
+  version '0.8.4'
+  sha1 'd9ed2379077c3d322c4759aa1337393196697acc'
   link 'node-webkit.app'
 end


### PR DESCRIPTION
Update node-webkit binaries to v0.8.4, released 2013-30-12.
