### PR TITLE
Show managed links in "brew cask list"

### DIFF
--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -24,6 +24,10 @@ class Cask::Artifact::Base
      cask.artifacts[self.artifact_dsl_key].any?
   end
 
+  def summary
+    {}
+  end
+
   def initialize(cask, command=Cask::SystemCommand)
     @cask = cask
     @command = command

--- a/lib/cask/artifact/hardlinked.rb
+++ b/lib/cask/artifact/hardlinked.rb
@@ -11,4 +11,16 @@ class Cask::Artifact::Hardlinked < Cask::Artifact::Symlinked
   def create_filesystem_link(source, target)
     @command.run!('/bin/ln', :args => ['-hf', '--', source, target])
   end
+
+  def summarize_one_link(artifact_relative_path)
+    source_string, target_hash = artifact_relative_path
+    sanity_check source_string, target_hash
+    source = @cask.destination_path.join(source_string)
+    target = Cask.send(self.class.artifact_dirmethod).join(target_hash ? target_hash[:target] : source.basename)
+    linked_path = Cask.send(self.class.artifact_dirmethod).join(Pathname(target).basename)
+    if self.class.islink?(linked_path)
+      printable_linked_path = "'#{linked_path}'"
+      printable_linked_path.sub!(%r{^'#{ENV['HOME']}/*}, %q{~/'})
+    end
+  end
 end

--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -1,7 +1,7 @@
 class Cask::CLI::List
   def self.run(*arguments)
     if arguments.any?
-      retval = list_files(*arguments)
+      retval = list_casks(*arguments)
     else
       retval = list_installed
     end
@@ -13,19 +13,33 @@ class Cask::CLI::List
     end
   end
 
-  def self.list_files(*cask_names)
+  def self.list_casks(*cask_names)
     count = 0
     cask_names.each do |cask_name|
       odebug "Listing files for Cask #{cask_name}"
       cask = Cask.load(cask_name)
       if cask.installed?
         count += 1
-        Cask::PrettyListing.new(cask).print
+        list_artifacts(cask)
+        list_files(cask)
       else
         opoo "#{cask} is not installed"
       end
     end
     count == 0 ? nil : count == cask_names.length
+  end
+
+  def self.list_artifacts(cask)
+    artifacts = Cask::Artifact.for_cask(cask)
+    artifacts.each do |artifact|
+      summary = artifact.new(cask).summary
+      ohai summary[:description], summary[:contents] unless summary.empty?
+    end
+  end
+
+  def self.list_files(cask)
+    ohai "Raw contents of Cask directory:"
+    Cask::PrettyListing.new(cask).print
   end
 
   def self.list_installed

--- a/test/cask/cli/list_test.rb
+++ b/test/cask/cli/list_test.rb
@@ -41,10 +41,17 @@ describe Cask::CLI::List do
 
     caffeine, transmission = casks
 
+    # App Symlinks sections are empty below because the expected links
+    # aren't created under the test harness. Todo: managed links should
+    # be fully mocked and confirmed here.
     lambda {
       Cask::CLI::List.run('local-transmission', 'local-caffeine')
     }.must_output <<-OUTPUT.gsub(/^ */, '')
+      ==> App Symlinks managed by brew-cask:
+      ==> Raw contents of Cask directory:
       #{transmission.destination_path}/Transmission.app/Contents/ (489 files)
+      ==> App Symlinks managed by brew-cask:
+      ==> Raw contents of Cask directory:
       #{caffeine.destination_path}/Caffeine.app/Contents/ (13 files)
     OUTPUT
   end


### PR DESCRIPTION
Fixes #2261 (note: user raises two issues)

`brew cask list` output can be confusing, because raw cask contents can contain symlinks.  @AlJohri (very reasonably) interpreted those symlinks as a confirmation of the (quite different) symlinks managed by brew-cask.
- proposed fix is to return multiple labeled sections for `brew cask list`.
- requires diverging from the semantics of `list` in Homebrew (which only shows "raw contents" with no labeling)
- could be improved by analysis of managed links which are expected-but-absent
- original report was exacerbated by file named <space_character> in the Cask, which is not addressed here
- it's not a minor bug: seen in popular casks `google-chrome` and `evernote`
