### PR TITLE
new cask: treesheets

### DIFF
--- a/Casks/treesheets.rb
+++ b/Casks/treesheets.rb
@@ -1,0 +1,7 @@
+class Treesheets < Cask
+  url 'http://strlen.com/treesheets/treesheets_osx.zip'
+  homepage 'http://strlen.com/treesheets/'
+  version 'latest'
+  no_checksum
+  link 'TreeSheetsBeta/TreeSheets.app'
+end


### PR DESCRIPTION
TreeSheets is newly open source but they distribute beta OSX binaries. They don't really seem to do versions, in that there is only one download URL, but the changelog has release dates, so I used that.
