### PR TITLE
Add Stay 1.2.3

### DIFF
--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -1,0 +1,7 @@
+class Stay < Cask
+  url 'http://cordlessdog.com/stay/versions/Stay%201.2.3.zip'
+  homepage 'http://cordlessdog.com/stay/'
+  version '1.2.3'
+  sha1 '26a5fe5bdc8263198adabda2b319587db9acfdee'
+  link 'Stay.app'
+end


### PR DESCRIPTION
Adds Cordless Dog's app "Stay", which is used to easily move windows back to the same position.
