### PR TITLE
correct the version, in order to update by cask

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,7 +1,7 @@
 class Textmate < Cask
-  url 'http://api.textmate.org/downloads/release'
+  url 'https://github.com/textmate/textmate/releases/download/v2.0-alpha.9503/TextMate_2.0-alpha.9503.tbz'
   homepage 'http://macromates.com/'
-  version 'latest'
-  no_checksum
+  version '2.0-alpha.9503'
+  sha1 '8c57c1b45d2214a64229b7f8791ef53cbc047993'
   link 'TextMate.app'
 end


### PR DESCRIPTION
Due to the version of textmate is "latest", it cannot be update by cask. So I add the correct version information and checksum.
After update textmate.rb, the TextMate which had installed earlier cannot be uninstalled or upgraded by cask. I don't know how to solve the problem.
