### PR TITLE
Implement `input_method` artifact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,7 @@ Additional fields you might need for special use-cases:
 | `widget`           | relative path to a widget that should be linked into the `~/Library/Widgets` folder on installation
 | `service`          | relative path to a service that should be linked into the `~/Library/Services` folder on installation
 | `binary`           | relative path to a binary that should be linked into the `~/usr/local/bin` folder on installation
+| `input_method`     | relative path to a input method that should be linked into the `~/Library/Input Methods` folder on installation
 | `nested_container` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
 | `caveats`          | a Ruby block providing the user with Cask-specific information at install time
 | `after_install`    | a Ruby block containing postflight install operations

--- a/Casks/openvanilla.rb
+++ b/Casks/openvanilla.rb
@@ -1,0 +1,12 @@
+class Openvanilla < Cask
+  url 'http://dl.openvanilla.org/file/openvanilla/OpenVanilla-Installer-Mac-1.0.10.zip'
+  homepage 'http://openvanilla.org/'
+  version '1.0.10'
+  sha1 '53926d5b4348344de862dd2154e2b7cac9314916'
+  input_method 'OpenVanillaInstaller.app/Contents/Resources/OpenVanilla.app'
+
+  def caveats; <<-EOS.undent
+    After installing OpenVanilla, please log out and then log in again.
+    EOS
+  end
+end

--- a/FAQ.md
+++ b/FAQ.md
@@ -16,6 +16,7 @@ Casks currently have five required fields:
  * __prefpane__: (required for `.prefPane`) indicates which file(s) should be linked into the PreferencePanes folder on installation
  * __qlplugin__: (required for `.qlgenerator`) indicates which file(s) should be linked into the QuickLook folder on installation
  * __font__ : (required for fonts) indicates which file(s) should be linked into the Fonts folder on installation
+ * __input_method__: (required for input method) indicates which file(s) should be linked into the Input Methods folder on installation
 
 and five optional fields:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -167,6 +167,8 @@ Default is `~/Library/Widgets`
 Default is `~/Library/Fonts`
 * `--binarydir=/my/path` changes the path for binary symlinks.
 Default is `/usr/local/bin`
+* `--input_methoddir=/my/path` changes the path for Input Methods symlinks.
+Default is `~/Library/Input Methods`
 
 To make these settings persistent, you might want to add the following line to your `.bash_profile` or `.zshenv`:
 

--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -16,6 +16,7 @@ require 'cask/artifact/qlplugin'
 require 'cask/artifact/widget'
 require 'cask/artifact/service'
 require 'cask/artifact/caskroom_only'
+require 'cask/artifact/input_method'
 
 
 module Cask::Artifact
@@ -37,6 +38,7 @@ module Cask::Artifact
       Cask::Artifact::CaskroomOnly,
       Cask::Artifact::Block,
       Cask::Artifact::Binary,
+      Cask::Artifact::InputMethod,
     ]
   end
 

--- a/lib/cask/artifact/input_method.rb
+++ b/lib/cask/artifact/input_method.rb
@@ -1,0 +1,2 @@
+class Cask::Artifact::InputMethod < Cask::Artifact::Symlinked
+end

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -92,6 +92,9 @@ class Cask::CLI
       opts.on("--binarydir=MANDATORY") do |v|
         Cask.binarydir = Pathname(v).expand_path
       end
+      opts.on("--input_methoddir=MANDATORY") do |v|
+        Cask.input_methoddir = Pathname(v).expand_path
+      end
       opts.on("--no-binaries") do |v|
         Cask.no_binaries = true
       end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -50,6 +50,7 @@ module Cask::DSL
       :colorpicker,
       :binary,
       :caskroom_only,
+      :input_method,
     ]
 
     ARTIFACT_TYPES.each do |type|

--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -80,6 +80,14 @@ module Cask::Locations
       @binarydir = _binarydir
     end
 
+    def input_methoddir
+      @input_methoddir ||= Pathname.new('~/Library/Input Methods').expand_path
+    end
+
+    def input_methoddir=(_input_methoddir)
+      @input_methoddir = _input_methoddir
+    end
+
     def default_tap
       @default_tap ||= 'phinze-cask'
     end


### PR DESCRIPTION
This artifact will link the input method to `~/Library/Input Methods`.

I have also attached a cask(`openvanilla.rb`) using the new artifact.

After installing the new cask, user can add the new input method in Input Sources inside Keyboard prefpane.

![screen shot 2014-01-14 at 1 24 23 am](https://f.cloud.github.com/assets/667272/1902824/064e8de4-7c78-11e3-94ad-5fb3a58ba7f8.png)

Thanks @rolandwalker helping me out on the new Symlinked class and debugging the `input_method` artifact.

P.S. Input Method is different from Input Manager.  
