### PR TITLE
Numerous additions to "brew cask doctor"

### DIFF
--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -1,11 +1,37 @@
 class Cask::CLI::Doctor
-  def self.run(*_ignored)
-    ohai "Ruby Version:"
+  def self.run
+    ohai 'OS X Version:'
+    puts MACOS_FULL_VERSION
+    ohai 'Ruby Version:'
     puts "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
-    ohai "Contents of $LOAD_PATH:"
+    ohai 'Ruby Path:'
+    puts RUBY_PATH
+    ohai 'Homebrew Version:'
+    puts HOMEBREW_VERSION
+    ohai 'Homebrew Executable Path:'
+    puts HOMEBREW_BREW_FILE
+    ohai 'Homebrew Cellar Path:'
+    puts HOMEBREW_CELLAR
+    ohai 'Homebrew-cask Version:'
+    puts Cask::VERSION
+    ohai 'Contents of $LOAD_PATH:'
     puts $LOAD_PATH
-    ohai "Running As Privileged User:"
-    puts  Process.euid == 0 ? 'Yes' : 'No'
+    ohai 'Contents of $RUBYLIB Environment Variable:'
+    puts ENV['RUBYLIB']
+    ohai 'Contents of $RUBYOPT Environment Variable:'
+    puts ENV['RUBYOPT']
+    ohai 'Contents of $RUBYPATH Environment Variable:'
+    puts ENV['RUBYPATH']
+    ohai 'Contents of $RBENV_VERSION Environment Variable:'
+    puts ENV['RBENV_VERSION']
+    ohai 'Contents of $GEM_HOME Environment Variable:'
+    puts ENV['GEM_HOME']
+    ohai 'Contents of $GEM_PATH Environment Variable:'
+    puts ENV['GEM_PATH']
+    ohai 'Contents of $BUNDLE_PATH Environment Variable:'
+    puts ENV['BUNDLE_PATH']
+    ohai 'Running As Privileged User:'
+    puts Process.euid == 0 ? "Yes #{Tty.red}(warning: not recommended)#{Tty.reset}" : 'No'
   end
 
   def self.help

--- a/test/cask/cli/doctor_test.rb
+++ b/test/cask/cli/doctor_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'cask/version'
+
+HOMEBREW_BREW_FILE ||= '/usr/local/bin/brew'
+
+describe Cask::CLI::Doctor do
+  it 'displays some nice info about the environment' do
+    out, err = capture_io do
+      Cask::CLI::Doctor.run
+    end
+    # no point in trying to match more of this environment-specific info
+    out.must_match /\A==> OS X Version:/
+  end
+
+  it "raises an exception when arguments are given" do
+    lambda {
+      Cask::CLI::Doctor.run('argument')
+    }.must_raise ArgumentError
+  end
+end


### PR DESCRIPTION
New versions, paths, environment variables, and tests.
Side effect: release version must be stored in two locations.

There is an alternate method to get the `homebrew-cask` release version number in doctor without storing it in two locations in code:  Do something like

``` ruby
require "#{HOMEBREW_LIBRARY}/Formula/brew-cask.rb"
```

in `doctor.rb`.  My reasoning in deciding against that was: in the "doctor" scenario, when things might be going wrong for the user, that `require` is capable of pulling in the wrong file.  However, storing the version number in two places is undesirable, so criticism is certainly welcomed.
