### PR TITLE
standardize project name: homebrew-cask

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -39,7 +39,7 @@ __Yes, yes, yes!__ Please fork/pull request to update Casks, add features and
 clean up documentation! Anything you can do to help out is very welcome.
 
 It's also [__pretty darn easy__ to create Casks](CONTRIBUTING.md), so
-please build more of them for the software you use. And if `brew-cask` doesn't
+please build more of them for the software you use. And if homebrew-cask doesn't
 support the packaging format of your software, please [open an issue](https://github.com/phinze/homebrew-cask/issues)
 and we can get it working together.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,7 @@ Homebrew-cask is designed to work like a traditional Unix tool:
 
 - All functionality should be accessible from the CLI. The user should
   be freed (**freed!**) from interacting with a GUI.
-- Homebrew-cask should itself be scriptable.
+- homebrew-cask should itself be scriptable.
 
 Homebrew-cask is designed to work like Homebrew:
 
@@ -43,7 +43,7 @@ always comes first.
 ## Are You Interested in New Types of Packages?
 
 Yes! (We call them "artifacts"). If something is useful (and precompiled)
-then we'd like to enable users to install it via Homebrew-cask.
+then we'd like to enable users to install it via homebrew-cask.
 
 ## Could Homebrew-cask Also Be Used to Manage Settings?
 
@@ -77,7 +77,7 @@ directly if you want to help.
 
 We are independent of Homebrew as a project.
 
-From the user's point of view, Homebrew-cask is a subcommand of Homebrew,
+From the user's point of view, homebrew-cask is a subcommand of Homebrew,
 so we try to match Homebrew semantics and philosophy wherever possible.
 
 From the programmer's point of view, very little code is shared with Homebrew.
@@ -96,13 +96,13 @@ $ mv rubylib{,.orig}
 $ ln -s $(brew --prefix)/Library/Taps/phinze-cask/lib rubylib
 ```
 
-Now you can hack on Homebrew-cask in the Tap and use the `brew cask` CLI
+Now you can hack on homebrew-cask in the Tap and use the `brew cask` CLI
 like normal to interact with your latest code.
 
 ## Hanging out on IRC
 
 We're on IRC at `#homebrew-cask` on Freenode. If you are going to develop for
-`homebrew-cask`, it's a great idea to hang out with us there. Here's why:
+homebrew-cask, it's a great idea to hang out with us there. Here's why:
 - discuss your thoughts before coding and maybe get new ideas
 - get feedback from the Travis-CI bot on build failures
 - talk to [caskbot](https://github.com/passcod/caskbot) about checksums, version info, and releases

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Let's see if we can get the elegance, simplicity, and speed of Homebrew for the
 installation and management of GUI Mac applications such as Google Chrome and Adium.
 
-`brew-cask` provides a friendly homebrew-style CLI workflow for the
+Homebrew-cask provides a friendly homebrew-style CLI workflow for the
 administration of Mac applications distributed as binaries.
 
 It's implemented as a `homebrew` "[external
@@ -30,7 +30,7 @@ open ~/Applications/"Google Chrome.app"
 ```
 ## Learn More
 
- * Find basic documentation on using `homebrew-cask` in [USAGE.md](USAGE.md)
+ * Find basic documentation on using homebrew-cask in [USAGE.md](USAGE.md)
  * Want to contribute? Awesome! See [CONTRIBUTING.md](CONTRIBUTING.md)
  * More project-related details and discussion are available in [FAQ.md](FAQ.md)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -9,7 +9,7 @@ $ brew --version
 0.9.5
 ```
 
-Install the Homebrew-cask tool:
+Install the homebrew-cask tool:
 
 ```bash
 $ brew install phinze/cask/brew-cask
@@ -17,7 +17,7 @@ $ brew install phinze/cask/brew-cask
 
 ## Frequently Used Commands
 
-Homebrew-cask is implemented as a subcommand of Homebrew.  All Homebrew-cask
+Homebrew-cask is implemented as a subcommand of Homebrew.  All homebrew-cask
 commands begin with `brew cask`.  Homebrew-cask has its own set of command
 verbs many of which are similar to Homebrew's.  The most frequently-used
 commands are:
@@ -102,9 +102,9 @@ https://github.com/phinze/homebrew-cask/commits/master/Casks/caffeine.rb
 
 ## Updating/Upgrading Casks
 
-Since the Homebrew-cask repository is a Homebrew Tap, you'll pull down the latest
+Since the homebrew-cask repository is a Homebrew Tap, you'll pull down the latest
 Casks every time you issue the regular Homebrew command `brew update`. Currently,
-Homebrew-cask cannot always detect if an Application has been updated. You
+homebrew-cask cannot always detect if an Application has been updated. You
 can force an update via the command `brew cask install --force`. We are working
 on improving this.
 
@@ -112,13 +112,13 @@ It is generally safe to run updates from within an Application.
 
 ## Updating/Upgrading the Homebrew-cask Tool
 
-When a new version Homebrew-cask is released, it will appear in the output of
+When a new version homebrew-cask is released, it will appear in the output of
 `brew outdated` after running `brew update`.  You can upgrade it via the normal
 Homebrew workflow: `brew upgrade brew-cask`.
 
 ## Additional Taps (optional)
 
-The primary Homebrew-cask Tap includes most of the Casks that a typical user will
+The primary homebrew-cask Tap includes most of the Casks that a typical user will
 be interested in. There are a few additional Taps where we store different kinds
 of Casks.
 


### PR DESCRIPTION
- make lower-case and remove backticks for project name
  (backticks kept for commands/filenames/etc)
