### PR TITLE
Add ProFontX

### DIFF
--- a/Casks/font-profontx.rb
+++ b/Casks/font-profontx.rb
@@ -1,0 +1,7 @@
+class FontProfontx < Cask
+  url 'http://faisal.com/software/profontx/ProFontX.zip'
+  homepage 'http://faisal.com/software/profontx/'
+  version '1.0'
+  sha1 '88282957161fcc77cf49c02cf814bdf03bf357c6'
+  font 'ProFontX'
+end


### PR DESCRIPTION
ProFontX is a mono spaced programming font. It is based on ProFont, but has had the ligatures removed so it plays nicer with Cocoa text fields
