### PR TITLE
Rename platypus to platypus-app.

### DIFF
--- a/Casks/platypus-app.rb
+++ b/Casks/platypus-app.rb
@@ -1,4 +1,4 @@
-class Platypus < Cask
+class PlatypusApp < Cask
   url 'http://sveinbjorn.org/files/software/platypus.zip'
   homepage 'http://sveinbjorn.org/platypus'
   version '4.8'


### PR DESCRIPTION
Rename resolves file name collision noted in Issue #2440. Also renamed
cask class for consistency with cask naming guidelines.

I'm not particularly wedded to the idea of appending `-app` to casks that
conflict with source code brew formulas; I'm happy to modify my PR to
whatever convention the project wishes to adopt. Conceivably, this
issue could come up again, as there are many projects that distribute
binary executables and source code downloads, so it would probably be
a good idea to have a policy in mind for this type of collision.
