### PR TITLE
Cask for SoundCleod.app

### DIFF
--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -1,0 +1,7 @@
+class Soundcleod < Cask
+  url 'https://github.com/salomvary/soundcleod/raw/master/dist/SoundCleod.dmg'
+  homepage 'http://salomvary.github.io/soundcleod/'
+  version 'latest'
+  no_checksum
+  link 'SoundCleod.app'
+end


### PR DESCRIPTION
SoundCleod is a standalone Mac OS X browser for SoundCloud.
