### PR TITLE
tikz-editor.rb Cask missing .app extension

### DIFF
--- a/Casks/tikz-editor.rb
+++ b/Casks/tikz-editor.rb
@@ -3,5 +3,5 @@ class TikzEditor < Cask
   homepage 'https://github.com/fredokun/TikZ-Editor'
   version '1.0'
   sha1 'e497afbb6d47f5ec978abcd4b2d0da3dc07e0d1e'
-  link 'TikZ Editor'
+  link 'TikZ Editor.app'
 end


### PR DESCRIPTION
fails install without this change
