### PR TITLE
Allow cask instance methods within blocks

### DIFF
--- a/lib/cask/artifact/block.rb
+++ b/lib/cask/artifact/block.rb
@@ -5,11 +5,11 @@ class Cask::Artifact::Block < Cask::Artifact::Base
   end
 
   def install
-    @cask.artifacts[:after_install].each { |block| block.call(@cask) }
+    @cask.artifacts[:after_install].each { |block| @cask.instance_eval &block }
   end
 
   def uninstall
-    @cask.artifacts[:after_uninstall].each { |block| block.call(@cask) }
+    @cask.artifacts[:after_uninstall].each { |block| @cask.instance_eval &block }
   end
 end
 


### PR DESCRIPTION
Per #2449, a Cask author cannot invoke `destination_path` within an `after_install` block.  It seems logical that if the `after_install` block is deferred until runtime, it should default to accessing instance methods, as this patch provides.

Ultimately, I'd like to add more DSL shortcuts into `after_install` as is proposed for `caveats` in #2426.

This patch covers `after_install` and `after_uninstall`.  The `caveats` stanza is treated separately.
