### PR TITLE
Add artifact caskroom_only

### DIFF
--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -15,6 +15,7 @@ require 'cask/artifact/prefpane'
 require 'cask/artifact/qlplugin'
 require 'cask/artifact/widget'
 require 'cask/artifact/service'
+require 'cask/artifact/caskroom_only'
 
 
 module Cask::Artifact
@@ -33,6 +34,7 @@ module Cask::Artifact
       Cask::Artifact::Font,
       Cask::Artifact::Widget,
       Cask::Artifact::Service,
+      Cask::Artifact::CaskroomOnly,
       Cask::Artifact::Block,
       Cask::Artifact::Binary,
     ]

--- a/lib/cask/artifact/caskroom_only.rb
+++ b/lib/cask/artifact/caskroom_only.rb
@@ -1,0 +1,9 @@
+class Cask::Artifact::CaskroomOnly < Cask::Artifact::Pkg
+  def self.artifact_dsl_key
+    :caskroom_only
+  end
+
+  def install
+    # do nothing
+  end
+end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -49,6 +49,7 @@ module Cask::DSL
       :service,
       :colorpicker,
       :binary,
+      :caskroom_only,
     ]
 
     ARTIFACT_TYPES.each do |type|


### PR DESCRIPTION
The difference between specifying `caskroom_only` and specifying
no install artifact at all is: `caskroom_only` respects the
`uninstall` stanza.  Obviously this is not the best implementation:
`uninstall` support should be refactored into the base class.
