### PR TITLE
Add Cask for Comictagger version 1.1.9-beta

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,0 +1,7 @@
+class Comictagger < Cask
+  url 'http://comictagger.googlecode.com/files/ComicTagger-1.1.9-beta.dmg'
+  homepage 'http://code.google.com/p/comictagger/'
+  version '1.1.9-beta'
+  sha1 'a98c730c2f41bec4c7b9ecfb57c13167f11bc6df'
+  link 'ComicTagger.app'
+end


### PR DESCRIPTION
Comictagger is a cross-platform GUI/CLI app for writing metadata to comic archives.
Though the version number includes "beta", this is the standard version, there is no "stable" offered upstream.
