### PR TITLE
Add Cask for Postgres.app version 9.3.1.0-alpha1

### DIFF
--- a/Casks/postgres-app.rb
+++ b/Casks/postgres-app.rb
@@ -1,0 +1,7 @@
+class PostgresApp < Cask
+  url 'https://github.com/PostgresApp/PostgresApp/releases/download/9.3.1.0-alpha1/Postgres93.zip'
+  homepage 'http://postgresapp.com/'
+  version '9.3.1.0-alpha1'
+  sha1 'fa2c504fd791564484995226dd339b5b9eaa2519'
+  link 'Postgres93.app'
+end


### PR DESCRIPTION
Postgress.app the easiest way to run PostgreSQL on the Mac.
