### PR TITLE
add new Cask for 4K YouTube to Mp3

### DIFF
--- a/Casks/fourk-youtube-to-mp3.rb
+++ b/Casks/fourk-youtube-to-mp3.rb
@@ -1,0 +1,7 @@
+class FourkYoutubeToMp3 < Cask
+  url 'https://4kdownload.googlecode.com/files/4kyoutubetomp3_2.5.dmg'
+  homepage 'http://www.4kdownload.com/products/product-youtubetomp3'
+  version '3.2.5'
+  sha1 '41f2ad57b6c9416f62520e2ee9d847cb24edda15'
+  link '4K YouTube to MP3.app'
+end


### PR DESCRIPTION
From the <a href="http://www.4kdownload.com/products/product-youtubetomp3">app homepage</a>:

<blockquote>4K YouTube to MP3 was specifically created to extract audio from YouTube, Vimeo, Facebook and other online video hosting services</blockquote>
