### PR TITLE
search.rb cleanups

### DIFF
--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -1,18 +1,18 @@
 class Cask::CLI::Search
   def self.run(*arguments)
     search_term, *rest = *arguments
-    casks = {}
+    cask_names = {}
     if search_term =~ %r{^/(.*)/$}
       search_regexp = $1
-      casks = Cask.all_titles.grep(/#{search_regexp}/i)
+      cask_names = Cask.all_titles.grep(/#{search_regexp}/i)
     else
       all_titles = Cask.all_titles
-      no_hyphens_titles = all_titles.map {|t|t.gsub('-', '')}
-      no_hyphens_search_term = search_term.gsub('-', '')
-      casks = no_hyphens_titles.grep(/#{no_hyphens_search_term}/i) {|t| all_titles[no_hyphens_titles.index(t)]}
+      simplified_titles = all_titles.map { |t| t.gsub('-', '') }
+      simplified_search_term = search_term.gsub('-', '')
+      cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }
     end
-    unless casks.empty?
-    	puts_columns Cask::CLI.nice_listing casks
+    unless cask_names.empty?
+    	puts_columns Cask::CLI.nice_listing cask_names
     else
     	puts "No cask found for \"#{search_term}\"."
     end


### PR DESCRIPTION
- whitespace
- variable names: in particular, "casks" is a poor name for a
  variable that does not hold instances of Cask
