### PR TITLE
ignore non-alpha search chars; accept multi terms

### DIFF
--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -1,14 +1,14 @@
 class Cask::CLI::Search
   def self.run(*arguments)
-    search_term, *rest = *arguments
+    search_term = arguments.join
     cask_names = {}
-    if search_term =~ %r{^/(.*)/$}
+    if arguments.first =~ %r{^/(.*)/$}
       search_regexp = $1
       cask_names = Cask.all_titles.grep(/#{search_regexp}/i)
     else
       all_titles = Cask.all_titles
-      simplified_titles = all_titles.map { |t| t.gsub('-', '') }
-      simplified_search_term = search_term.gsub('-', '')
+      simplified_titles = all_titles.map { |t| t.gsub(/[^a-z]+/i, '') }
+      simplified_search_term = search_term.gsub(/[^a-z]+/i, '')
       cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }
     end
     unless cask_names.empty?


### PR DESCRIPTION
Building on the work of @voanhduy1512 in #2471, this patch to `brew cask search` makes two enhancements.
- all non-alphanumeric characters are ignored (not just hyphens).  This makes the following search work as the user might expect: `brew cask search 0xed`
- all terms on the CLI are accepted (instead of respecting only the first argument).  This makes the following search work as the user might expect: `brew cask search google chrome`.

If I get any +1's on this functionality, will add docs and tests to the PR.
