### PR TITLE
Added a Cask for CocoaDialog

### DIFF
--- a/Casks/cocoadialog.rb
+++ b/Casks/cocoadialog.rb
@@ -1,0 +1,7 @@
+class Cocoadialog < Cask
+  url 'https://github.com/downloads/mstratman/cocoadialog/CocoaDialog-2.1.1.dmg'
+  homepage 'http://mstratman.github.io/cocoadialog/'
+  version '2.1.1'
+  sha1 '373e92db2052caa9889337da39aee4f4ff119751'
+  link 'CocoaDialog.app'
+end


### PR DESCRIPTION
Fixes #2499

CocoaDialog is an OS X application that allows the use of common GUI
controls such as file selectors, text input, progress bars, yes/no
confirmations and more with a command-line application. It requires no
knowledge of Cocoa, and is ideal for use in shell and Perl scripts
(or Ruby, or Python, or... etc).

See also http://mstratman.github.io/cocoadialog/.

This PR introduces a Cask for CocoaDialog from version 2.1.1 on
(current upcoming version 3.0.0 is still beta).
