### PR TITLE
move project version to idomatic location

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,10 +1,11 @@
+require 'pathname'
 require 'formula'
 
-HOMEBREW_CASK_VERSION = '0.26.1'
+require Pathname(__FILE__).realpath.dirname.join('lib', 'cask', 'version')
 
 class BrewCask < Formula
   homepage 'https://github.com/phinze/homebrew-cask/'
-  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{HOMEBREW_CASK_VERSION}"
+  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{Cask::VERSION}"
 
   head 'https://github.com/phinze/homebrew-cask.git', :branch => 'master'
 

--- a/lib/cask/version.rb
+++ b/lib/cask/version.rb
@@ -1,0 +1,3 @@
+class Cask
+  VERSION = '0.26.1'
+end


### PR DESCRIPTION
gives project-internal visibility of the version constant for use in
displaying to the user.

the formula now does a targeted require to get the version constant from
the new location.

relevant to discussion in #2418 
