### PR TITLE
Downgrade Aptana Studio to version 3.4.2

### DIFF
--- a/Casks/aptana-studio.rb
+++ b/Casks/aptana-studio.rb
@@ -1,7 +1,7 @@
 class AptanaStudio < Cask
-  url 'http://download.aptana.com/studio3/standalone/3.5.0/mac/Aptana_Studio_3_Setup_3.5.0.dmg'
+  url 'http://download.aptana.com/studio3/standalone/3.4.2/mac/Aptana_Studio_3_Setup_3.4.2.dmg'
   homepage 'http://www.aptana.com/'
-  version '3.5.0'
-  sha1 '6a509859583a53ef72d240dee1c4552bc2382614'
   link 'Aptana Studio 3'
+  version '3.4.2'
+  sha1 '2c73735ada5a5cf81c149787ec1b3665b1813917'
 end


### PR DESCRIPTION
The previous version 3.5.0 is no longer available, and the url
is dead.  Perhaps it was a pre-release.
