### PR TITLE
fixing bug with full casks listing introduced recently

### DIFF
--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -9,7 +9,7 @@ class Cask::CLI::Search
       all_titles = Cask.all_titles
       simplified_titles = all_titles.map { |t| t.gsub('-', '') }
       if search_term.nil?
-	cask_names = simplified_titles
+	cask_names = all_titles
       else
         simplified_search_term = search_term.gsub('-', '')
         cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -8,8 +8,12 @@ class Cask::CLI::Search
     else
       all_titles = Cask.all_titles
       simplified_titles = all_titles.map { |t| t.gsub('-', '') }
-      simplified_search_term = search_term.gsub('-', '')
-      cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }
+      if search_term.nil?
+	cask_names = simplified_titles
+      else
+        simplified_search_term = search_term.gsub('-', '')
+        cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }
+      end
     end
     unless cask_names.empty?
     	puts_columns Cask::CLI.nice_listing cask_names

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -7,10 +7,10 @@ class Cask::CLI::Search
       cask_names = Cask.all_titles.grep(/#{search_regexp}/i)
     else
       all_titles = Cask.all_titles
-      simplified_titles = all_titles.map { |t| t.gsub('-', '') }
       if search_term.nil?
 	cask_names = all_titles
       else
+	simplified_titles = all_titles.map { |t| t.gsub('-', '') }
         simplified_search_term = search_term.gsub('-', '')
         cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }
       end


### PR DESCRIPTION
Full package listing is broken with some recent changes so fixing that.

```
brew cask search
class Cask::CLI::Search
Error: private method `gsub' called for nil:NilClass
Please report this bug:
    https://github.com/Homebrew/homebrew/wiki/troubleshooting
/usr/local/Cellar/brew-cask/0.27.0/rubylib/cask/cli/search.rb:14:in `run'
/usr/local/Cellar/brew-cask/0.27.0/rubylib/cask/cli.rb:36:in `process'
/usr/local/bin/brew-cask.rb:6
/usr/local/Library/brew.rb:67:in `require'
/usr/local/Library/brew.rb:67:in `require?'
/usr/local/Library/brew.rb:113
```
