### PR TITLE
search docs/test/fix tapname-search

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -28,7 +28,7 @@ commands are:
 
 ## Searching for Casks
 
-The `brew cask search` command accepts a substring (or regular expression) argument.
+The `brew cask search` command accepts a series of substring arguments.
 Let's see if there's a Cask for Google Chrome:
 
 ```bash
@@ -184,6 +184,18 @@ options in the command line:
 # Will force the Chrome app to be linked to ~/Applications
 # even though HOMEBREW_CASK_OPTS specified /Applications
 $ brew cask install --appdir="~/Applications" google-chrome
+```
+
+## Advanced searching
+
+The default search algorithm is a lax substring approach, which does not
+use the command-line arguments exactly as given.  If you need to specify
+a search more precisely, a single search argument enclosed in `/` characters
+will be taken as a Ruby regular expression:
+
+```bash
+$ brew cask search '/^google.c[a-z]rome$/'
+google-chrome
 ```
 
 ## Other Ways to Specify a Cask

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -4,15 +4,15 @@ class Cask::CLI::Search
     cask_names = {}
     if arguments.first =~ %r{^/(.*)/$}
       search_regexp = $1
-      cask_names = Cask.all_titles.grep(/#{search_regexp}/i)
+      cask_names = Cask::CLI.nice_listing(Cask.all_titles).grep(/#{search_regexp}/i)
     else
-      all_titles = Cask.all_titles
+      all_titles = Cask::CLI.nice_listing Cask.all_titles
       simplified_titles = all_titles.map { |t| t.gsub(/[^a-z]+/i, '') }
       simplified_search_term = search_term.gsub(/[^a-z]+/i, '')
       cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }
     end
     unless cask_names.empty?
-      puts_columns Cask::CLI.nice_listing cask_names
+      puts_columns cask_names
     else
       puts "No cask found for \"#{search_term}\"."
     end

--- a/test/cask/cli/search_test.rb
+++ b/test/cask/cli/search_test.rb
@@ -15,4 +15,49 @@ describe Cask::CLI::Search do
       Cask::CLI::Search.run('foo-bar-baz')
     }.must_output("No cask found for \"foo-bar-baz\".\n")
   end
+
+  it "lists all available Casks with no search term" do
+    out, err = capture_io do
+      Cask::CLI::Search.run
+    end
+    out.must_match(/google-chrome/)
+    out.length.must_be :>, 1000
+  end
+
+  it "ignores hyphens in search terms" do
+    out, err = capture_io do
+      Cask::CLI::Search.run('goo-gle-chrome')
+    end
+    out.must_match(/google-chrome/)
+    out.length.must_be :<, 100
+  end
+
+  it "ignores hyphens in Cask names" do
+    out, err = capture_io do
+      Cask::CLI::Search.run('googlechrome')
+    end
+    out.must_match(/google-chrome/)
+    out.length.must_be :<, 100
+  end
+
+  it "accepts multiple arguments" do
+    out, err = capture_io do
+      Cask::CLI::Search.run('google chrome')
+    end
+    out.must_match(/google-chrome/)
+    out.length.must_be :<, 100
+  end
+
+  it "accepts a regexp argument" do
+    lambda {
+      Cask::CLI::Search.run('/^google-c[a-z]rome$/')
+    }.must_output "google-chrome\n"
+  end
+
+  it "does not search the Tap name" do
+    out, err = capture_io do
+      Cask::CLI::Search.run('phinze')
+    end
+    out.must_match(/^No cask found for "phinze"\.\n/)
+  end
 end


### PR DESCRIPTION
This is the promised followup to #2496
- docs
- test
- bugfix: search string was being tested against fully-qualified
  Cask name including Tap, so "brew cask search phinze" would
  (confusingly) return all Casks.
