### PR TITLE
`brew cask home` with no args opens project page

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -71,7 +71,7 @@ This will both uninstall the Cask and remove symlinks which were created in
 * `info` -- displays information about the given Cask
 * `list` -- with no args, lists installed Casks; given installed Casks, lists installed files
 * `doctor` -- checks for configuration issues
-* `home` -- opens the homepage of the given Cask
+* `home` -- opens the homepage of the given Cask; or with no arguments, the homebrew-cask project page
 * `alfred` -- modifies Alfred's scope to include the Caskroom
 
 The following commands are for Cask authors:

--- a/lib/cask/cli/home.rb
+++ b/lib/cask/cli/home.rb
@@ -1,9 +1,12 @@
 module Cask::CLI::Home
   def self.run(*cask_names)
-    raise CaskUnspecifiedError if cask_names.empty?
-    cask_names.each do |cask_name|
-      cask = Cask.load(cask_name)
-      system "/usr/bin/open", cask.homepage
+    if cask_names.empty?
+      system "/usr/bin/open", 'http://caskroom.io/'
+    else
+      cask_names.each do |cask_name|
+        cask = Cask.load(cask_name)
+        system "/usr/bin/open", cask.homepage
+      end
     end
   end
 

--- a/test/cask/cli/home_test.rb
+++ b/test/cask/cli/home_test.rb
@@ -38,10 +38,11 @@ describe Cask::CLI::Home do
     ]
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Home.run
-    }.must_raise CaskUnspecifiedError
+  it "opens the project page when no cask is specified" do
+    Cask::CLI::Home.run
+    Cask::CLI::Home.system_commands.must_equal [
+      ['/usr/bin/open', 'http://caskroom.io/'],
+    ]
   end
 end
 


### PR DESCRIPTION
- in duplication of similar functionality in Homebrew
- in celebration of proposed design by @ndr-qef
