### PR TITLE
Update: Aquamacs 3.0a.

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,7 +1,12 @@
 class Aquamacs < Cask
-  url 'http://braeburn.aquamacs.org/releases/Aquamacs-Emacs-2.5.dmg'
+  url 'https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-3.0a/Aquamacs-Emacs-3.0a.dmg'
   homepage 'http://aquamacs.org/'
-  version '2.5'
-  sha1 '2d9052b94751b0454e109700ff8d0204d80310f4'
+  version '3.0a'
+  sha1 'db99ae61aeb8fac9016fa197dff7f8910440065b'
   link 'Aquamacs.app'
+  caveats <<-EOS.undent
+    This version of Aquamacs is for 64-bit Intel-based Macs only. If you have
+    a 32-bit Intel-based Mac, please run 'brew tap caskroom/versions' and
+    install aquamacs25.
+    EOS
 end


### PR DESCRIPTION
Download URL on Aquamacs homepage is a redirect to GitHub. The
redirect URL was determined via `curl --write-out redirect_url`.
