### PR TITLE
Add iOS7 ScreenSaver.

### DIFF
--- a/Casks/ios7-screensaver.rb
+++ b/Casks/ios7-screensaver.rb
@@ -1,0 +1,9 @@
+class Ios7Screensaver < Cask
+  url 'http://www.weebly.com/uploads/2/5/7/9/25796706/ios_7_lockscreen_by_bodysoulspirit.dmg'
+  homepage 'http://bodysoulspirit.weebly.com/ios-7-screensaver-for-mac-os-x-by-bodysoulspirit.html'
+  version '2.8'
+  sha1 '9f50899e6bb018e34aaea8f8c33c5d0cb5b803c7'
+  caveats <<-EOS.undent
+    To complete the installation of #{title}, you need to install "Install iOS 7 screensaver.app". You also will have to go to "System Preferences" > "Desktop & Screen Saver" > "Screen Saver" and choose "iOS7 lockscreensaver" to make it work.
+    EOS
+end


### PR DESCRIPTION
First version of this cask.

In the future, I would like to be able to start directly `Install iOS 7 screensaver.app` to really install the software (maybe via `after_install`?) instead of linking it. I also would like to add uninstall way. It's just to start "Uninstall.app" in the cask directory.

Any tips (because I don't Ruby) are welcomed!

Thanks.
