### PR TITLE
always submit external commands in list form

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -45,11 +45,11 @@ class Cask
       ohai "We'll set permissions properly so we won't need sudo in the future"
       current_user = ENV['USER']
       if caskroom.parent.writable?
-        system "/bin/mkdir #{caskroom}"
+        system '/bin/mkdir', caskroom
       else
         # sudo in system is rude.
-        system "/usr/bin/sudo /bin/mkdir -p #{caskroom}"
-        system "/usr/bin/sudo /usr/sbin/chown -R #{current_user}:staff #{caskroom.parent}"
+        system '/usr/bin/sudo', '/bin/mkdir', '-p', caskroom
+        system '/usr/bin/sudo', '/usr/sbin/chown', '-R', "#{current_user}:staff", caskroom.parent
       end
     end
     appdir.mkpath unless appdir.exist?

--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -105,9 +105,9 @@ class Cask::CLI::Alfred
 
   def self.alfred_preference(key, value=nil)
     if value
-      @system_command.run(%Q(/usr/bin/defaults write #{DOMAIN} #{key} "#{value}"))
+      @system_command.run('/usr/bin/defaults', :args => ['write', DOMAIN, key, %Q("#{value}")])
     else
-      @system_command.run("/usr/bin/defaults read #{DOMAIN} #{key}")
+      @system_command.run('/usr/bin/defaults', :args => ['read', DOMAIN, key])
     end
   end
 

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -47,7 +47,11 @@ class Cask::SystemCommand
   end
 
   def self._quote(string)
-    %Q('#{string}')
+    if %r{^(['"]).*\1$}.match(string)
+      string
+    else
+      %Q('#{string}')
+    end
   end
 
   def self._parse_plist(command, output)

--- a/test/cask/cli/alfred_test.rb
+++ b/test/cask/cli/alfred_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 def fake_alfred_preference(key, response)
-  Cask::FakeSystemCommand.stubs_command("/usr/bin/defaults read com.runningwithcrayons.Alfred-Preferences #{key} 2>&1", response)
+  Cask::FakeSystemCommand.stubs_command("/usr/bin/defaults 'read' 'com.runningwithcrayons.Alfred-Preferences' '#{key}' 2>&1", response)
 end
 
 def fake_alfred_installed(installed=true)
@@ -78,7 +78,7 @@ describe Cask::CLI::Alfred do
       SCOPE_RESPONSE
 
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/bin/defaults write com.runningwithcrayons.Alfred-Preferences features.defaultresults.scope "('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','#{Cask.caskroom}')" 2>&1)
+        %Q(/usr/bin/defaults 'write' 'com.runningwithcrayons.Alfred-Preferences' 'features.defaultresults.scope' "('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','#{Cask.caskroom}')" 2>&1)
       )
 
       TestHelper.must_output(self, lambda {
@@ -95,7 +95,7 @@ describe Cask::CLI::Alfred do
 
       expected_scopes = (Cask::CLI::Alfred::DEFAULT_SCOPES + [Cask.caskroom]).map { |s| "'#{s}'" }
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/bin/defaults write com.runningwithcrayons.Alfred-Preferences features.defaultresults.scope "(#{expected_scopes.join(',')})" 2>&1)
+        %Q(/usr/bin/defaults 'write' 'com.runningwithcrayons.Alfred-Preferences' 'features.defaultresults.scope' "(#{expected_scopes.join(',')})" 2>&1)
       )
 
       TestHelper.must_output(self, lambda {
@@ -140,7 +140,7 @@ describe Cask::CLI::Alfred do
       SCOPE_RESPONSE
 
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/bin/defaults write com.runningwithcrayons.Alfred-Preferences features.defaultresults.scope "('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes')" 2>&1)
+        %Q(/usr/bin/defaults 'write' 'com.runningwithcrayons.Alfred-Preferences' 'features.defaultresults.scope' "('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes')" 2>&1)
       )
 
       TestHelper.must_output(self, lambda {


### PR DESCRIPTION
For safety.
- This is a step toward reworking system_command.rb so that
  invocations are done in list form on the back end, avoiding
  surprises from quoting and shell metacharacters.
- There is one transitional hack here: the _quote method in
  Cask::SystemCommand is modified to avoid double-quoting.  The
  _quote method itself will go away in a future revision when
  only list-forms are used.
- Casks using system are not touched. It seems natural to
  address that when creating the DSL for after_install/before_install.
