### PR TITLE
Add Orbit.app for App.net

### DIFF
--- a/Casks/orbit.rb
+++ b/Casks/orbit.rb
@@ -1,0 +1,7 @@
+class Orbit < Cask
+  url       'http://orbitapp.net/updates/Orbit.zip'
+  homepage  'http://orbitapp.net'
+  version   'latest'
+  no_checksum
+  link      'Orbit.app'
+end


### PR DESCRIPTION
I've add service for which the app is since it's name is short so it could conflict in future with some other cask
