### PR TITLE
Added Psychopy 1.79.01

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,5 +1,5 @@
 class Psychopy < Cask
-  url 'http://sourceforge.net/projects/psychpy/files/PsychoPy/StandalonePsychoPy-1.79.01-OSX.dmg'
+  url 'http://downloads.sourceforge.net/sourceforge/psychpy/StandalonePsychoPy-1.79.01-OSX.dmg'
   homepage 'http://www.psychopy.org/'
   version '1.79.00'
   sha1 'cbeaa6e747b3c3ccd6834829df36744ccf1ae382'

--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,0 +1,7 @@
+class Psychopy < Cask
+  url 'http://sourceforge.net/projects/psychpy/files/PsychoPy/StandalonePsychoPy-1.79.01-OSX.dmg'
+  homepage 'http://www.psychopy.org/'
+  version '1.79.00'
+  sha1 'cbeaa6e747b3c3ccd6834829df36744ccf1ae382'
+  link 'PsychoPy2.app'
+end


### PR DESCRIPTION
Sourceforge URL (latest) according to guide downloads windows version.  URL used here functions and DLs mac version. Sorry about the audit warning, let me know if this needs to change.
