### PR TITLE
Make SystemCommand escape arguments

### DIFF
--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -74,9 +74,9 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     if uninstall_options.key? :quit
       [*uninstall_options[:quit]].each do |id|
         ohai "Quitting application ID #{id}"
-        num_running = @command.run!('/usr/bin/osascript', :args => ['-e', "tell application \"System Events\" to count processes whose bundle identifier is \"#{id}\""], :sudo => true).to_i
+        num_running = @command.run!('/usr/bin/osascript', :args => ['-e', %{"tell application \\\"System Events\\\" to count processes whose bundle identifier is \\\"#{id}\\\""}], :sudo => true).to_i
         if num_running > 0
-          @command.run!('/usr/bin/osascript', :args => ['-e', "tell application id \"#{id}\" to quit"], :sudo => true)
+          @command.run!('/usr/bin/osascript', :args => ['-e', %{"tell application id \\\"#{id}\\\" to quit"}], :sudo => true)
         end
       end
     end
@@ -100,7 +100,7 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     if uninstall_options.key? :files
       uninstall_options[:files].each do |file|
         ohai "Removing file #{file}"
-        @command.run!('/bin/rm', :args => ['-rf', file], :sudo => true)
+        @command.run!('/bin/rm', :args => ['-rf', '--', file], :sudo => true)
       end
     end
   end

--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -74,7 +74,7 @@ class Cask::CLI::Alfred
   end
 
   def self.save_alfred_scopes(scopes)
-    alfred_preference(KEY, "(#{scopes.map { |s| "'#{s}'" }.join(",")})")
+    alfred_preference(KEY, %Q{"(#{scopes.map { |s| "'#{s}'" }.join(",")})"})
   end
 
   def self.alfred_installed?
@@ -105,9 +105,9 @@ class Cask::CLI::Alfred
 
   def self.alfred_preference(key, value=nil)
     if value
-      @system_command.run(%Q(/usr/bin/defaults write #{DOMAIN} #{key} "#{value}"))
+      @system_command.run('/usr/bin/defaults', :args => ["write", "#{DOMAIN}", "#{key}", "#{value}"])
     else
-      @system_command.run("/usr/bin/defaults read #{DOMAIN} #{key}")
+      @system_command.run('/usr/bin/defaults', :args => ["read", "#{DOMAIN}", "#{key}"])
     end
   end
 

--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -1,6 +1,6 @@
 class Cask::Pkg
   def self.all_matching(regexp, command)
-    command.run(%Q(/usr/sbin/pkgutil --pkgs="#{regexp}")).split("\n").map do |package_id|
+    command.run('/usr/sbin/pkgutil', :args => [%Q{--pkgs="#{regexp}"}]).split("\n").map do |package_id|
       new(package_id.chomp, command)
     end
   end
@@ -14,7 +14,7 @@ class Cask::Pkg
 
   def uninstall
     list('files').each_slice(500) do |file_slice|
-      @command.run('/bin/rm', :args => file_slice.unshift('-f'), :sudo => true)
+      @command.run('/bin/rm', :args => file_slice.unshift('-f', '--'), :sudo => true)
     end
     _deepest_path_first(list('dirs')).each do |dir|
       if dir.exist?
@@ -51,7 +51,7 @@ class Cask::Pkg
 
   def _rmdir(path)
     if path.children.empty?
-      @command.run!('/bin/rmdir', :args => [path], :sudo => true)
+      @command.run!('/bin/rmdir', :args => ['--', path], :sudo => true)
     end
   end
 
@@ -77,14 +77,14 @@ class Cask::Pkg
   def _clean_broken_symlinks(dir)
     dir.children.each do |child|
       if _broken_symlink?(child)
-        @command.run!('/bin/rm', :args => [child], :sudo => true)
+        @command.run!('/bin/rm', :args => ['--', child], :sudo => true)
       end
     end
   end
 
   def _clean_ds_store(dir)
     ds_store = dir.join('.DS_Store')
-    @command.run!('/bin/rm', :args => [ds_store], :sudo => true) if ds_store.exist?
+    @command.run!('/bin/rm', :args => ['--', ds_store], :sudo => true) if ds_store.exist?
   end
 
   def _broken_symlink?(path)

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -12,7 +12,7 @@ describe Cask::Artifact::Pkg do
     it 'runs the system installer on the specified pkgs' do
       pkg = Cask::Artifact::Pkg.new(@cask, Cask::FakeSystemCommand)
 
-      expected_command = "/usr/bin/sudo -E '/usr/sbin/installer' '-pkg' '#{@cask.destination_path/'MyFancyPkg'/'Fancy.pkg'}' '-target' '/' 2>&1"
+      expected_command = "/usr/bin/sudo -E /usr/sbin/installer -pkg #{@cask.destination_path/'MyFancyPkg'/'Fancy.pkg'} -target / 2>&1"
       Cask::FakeSystemCommand.stubs_command(expected_command)
 
       shutup do
@@ -27,10 +27,10 @@ describe Cask::Artifact::Pkg do
     it 'runs the specified uninstaller for the cask' do
       pkg = Cask::Artifact::Pkg.new(@cask, Cask::FakeSystemCommand)
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/bin/osascript' '-e' 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"' 2>&1), '1')
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/bin/osascript' '-e' 'tell application id "my.fancy.package.app" to quit' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%{/usr/bin/sudo -E /usr/bin/osascript -e \"tell application \\\"System Events\\\" to count processes whose bundle identifier is \\\"my.fancy.package.app\\\"\" 2>&1}, '1')
+      Cask::FakeSystemCommand.stubs_command(%{/usr/bin/sudo -E /usr/bin/osascript -e \"tell application id \\\"my.fancy.package.app\\\" to quit\" 2>&1})
 
-      expected_command = "/usr/bin/sudo -E '#{@cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool'}' '--please' 2>&1"
+      expected_command = "/usr/bin/sudo -E #{@cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool'} --please 2>&1"
       Cask::FakeSystemCommand.stubs_command(expected_command)
 
       shutup do
@@ -45,7 +45,7 @@ describe Cask::Artifact::Pkg do
       pkg = Cask::Artifact::Pkg.new(cask, Cask::FakeSystemCommand)
 
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil --pkgs="my.fancy.package.*" 2>&1),
+        %Q(/usr/sbin/pkgutil --pkgs\\=\\"my.fancy.package.\\*\\" 2>&1),
         [
           'my.fancy.package.main',
           'my.fancy.package.agent',
@@ -53,14 +53,14 @@ describe Cask::Artifact::Pkg do
       )
 
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil '--only-files' '--files' 'my.fancy.package.main' 2>&1),
+        %Q(/usr/sbin/pkgutil --only-files --files my.fancy.package.main 2>&1),
         [
           'fancy/bin/fancy.exe',
           'fancy/var/fancy.data',
         ].join("\n")
       )
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil '--only-dirs' '--files' 'my.fancy.package.main' 2>&1),
+        %Q(/usr/sbin/pkgutil --only-dirs --files my.fancy.package.main 2>&1),
         [
           'fancy',
           'fancy/bin',
@@ -68,7 +68,7 @@ describe Cask::Artifact::Pkg do
         ].join("\n")
       )
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil '--pkg-info-plist' 'my.fancy.package.main' 2>&1),
+        %Q(/usr/sbin/pkgutil --pkg-info-plist my.fancy.package.main 2>&1),
         <<-PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -82,12 +82,12 @@ describe Cask::Artifact::Pkg do
 </plist>
         PLIST
       )
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/kextstat' '-l' '-b' 'my.fancy.package.kernelextension' 2>&1), 'loaded')
-      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E '/sbin/kextunload' '-b' 'my.fancy.package.kernelextension' 2>&1))
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.main' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E /usr/sbin/kextstat -l -b my.fancy.package.kernelextension 2>&1), 'loaded')
+      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E /sbin/kextunload -b my.fancy.package.kernelextension 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E /usr/sbin/pkgutil --forget my.fancy.package.main 2>&1))
 
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil '--only-files' '--files' 'my.fancy.package.agent' 2>&1),
+        %Q(/usr/sbin/pkgutil --only-files --files my.fancy.package.agent 2>&1),
         [
           'fancy/agent/fancy-agent.exe',
           'fancy/agent/fancy-agent.pid',
@@ -95,14 +95,14 @@ describe Cask::Artifact::Pkg do
         ].join("\n")
       )
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil '--only-dirs' '--files' 'my.fancy.package.agent' 2>&1),
+        %Q(/usr/sbin/pkgutil --only-dirs --files my.fancy.package.agent 2>&1),
         [
           'fancy',
           'fancy/agent',
         ].join("\n")
       )
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/sbin/pkgutil '--pkg-info-plist' 'my.fancy.package.agent' 2>&1),
+        %Q(/usr/sbin/pkgutil --pkg-info-plist my.fancy.package.agent 2>&1),
         <<-PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -123,13 +123,13 @@ describe Cask::Artifact::Pkg do
         /tmp/fancy/bin
         /tmp/fancy/var
       ].each do |dir|
-        Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/bin/chmod' '777' '#{dir}' 2>&1))
+        Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E /bin/chmod 777 #{dir} 2>&1))
       end
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.agent' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E /usr/sbin/pkgutil --forget my.fancy.package.agent 2>&1))
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/bin/rm' '-f' '/tmp/fancy/bin/fancy.exe' '/tmp/fancy/var/fancy.data' 2>&1))
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/bin/rm' '-f' '/tmp/fancy/agent/fancy-agent.exe' '/tmp/fancy/agent/fancy-agent.pid' '/tmp/fancy/agent/fancy-agent.log' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E /bin/rm -f -- /tmp/fancy/bin/fancy.exe /tmp/fancy/var/fancy.data 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E /bin/rm -f -- /tmp/fancy/agent/fancy-agent.exe /tmp/fancy/agent/fancy-agent.pid /tmp/fancy/agent/fancy-agent.log 2>&1))
 
       # No assertions after call since all assertions are implicit from the interactions setup above.
       # TODO: verify rmdir commands (requires setting up actual file tree or faking out .exists?

--- a/test/cask/cli/alfred_test.rb
+++ b/test/cask/cli/alfred_test.rb
@@ -78,7 +78,7 @@ describe Cask::CLI::Alfred do
       SCOPE_RESPONSE
 
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/bin/defaults write com.runningwithcrayons.Alfred-Preferences features.defaultresults.scope "('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','#{Cask.caskroom}')" 2>&1)
+        %Q(/usr/bin/defaults write com.runningwithcrayons.Alfred-Preferences features.defaultresults.scope \"('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','#{Cask.caskroom}')\" 2>&1)
       )
 
       TestHelper.must_output(self, lambda {

--- a/test/cask/container/naked_test.rb
+++ b/test/cask/container/naked_test.rb
@@ -10,8 +10,8 @@ describe Cask::Container::Naked do
 
     cask                 = SpaceyCask.new
     path                 = '/tmp/downloads/kevin-spacey-1.2.pkg'
-    expected_destination = cask.destination_path.join('kevin spacey.pkg')
-    expected_command     = %Q(/usr/bin/ditto '#{path}' '#{expected_destination}' 2>&1)
+    expected_destination = cask.destination_path.join('kevin\\ spacey.pkg')
+    expected_command     = %Q(/usr/bin/ditto #{path} #{expected_destination} 2>&1)
     Cask::FakeSystemCommand.stubs_command(expected_command)
 
     container = Cask::Container::Naked.new(cask, path, Cask::FakeSystemCommand)

--- a/test/cask/pkg_test.rb
+++ b/test/cask/pkg_test.rb
@@ -23,14 +23,14 @@ describe Cask::Pkg do
       pkg = Cask::Pkg.new('my.fake.pkg', Cask::FakeSystemCommand)
 
       Cask::FakeSystemCommand.stubs_command(
-        "/usr/sbin/pkgutil '--only-files' '--files' 'my.fake.pkg' 2>&1"
+        "/usr/sbin/pkgutil --only-files --files my.fake.pkg 2>&1"
       )
       Cask::FakeSystemCommand.stubs_command(
-        "/usr/sbin/pkgutil '--only-dirs' '--files' 'my.fake.pkg' 2>&1"
+        "/usr/sbin/pkgutil --only-dirs --files my.fake.pkg 2>&1"
       )
 
       Cask::FakeSystemCommand.expects_command(
-        %q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fake.pkg' 2>&1)
+        %q(/usr/bin/sudo -E /usr/sbin/pkgutil --forget my.fake.pkg 2>&1)
       )
 
       pkg.uninstall

--- a/test/support/fake_system_command.rb
+++ b/test/support/fake_system_command.rb
@@ -17,6 +17,10 @@ class Cask::FakeSystemCommand
     @system_calls = nil
   end
 
+  # The command string should be formatted to execute from the shell and then escaped again for the hash key.
+  # example:
+  #  %{echo "test"} --> %{echo \"hi\"}
+  #  %{echo "test \"test\" test"} --> %{echo \"test \\\"test\\\" test\"}
   def self.stubs_command(command, response='')
     responses[command] = response
   end


### PR DESCRIPTION
Previously, SystemCommand executed shell commands in string form which
forced the caller to escape the command.  This patch changes this
behavior so that arguments are passed in a list and thus also escaping
the command properly.

The testing facilities required the most change as they require an
exact command -- escape characters and all.  It may be worth
revisiting in this in the future to allow for fuzzy matching of the
command strings to ease the writing of test cases.
