### PR TITLE
Added 7zX 1.7.1

### DIFF
--- a/Casks/sevenzx.rb
+++ b/Casks/sevenzx.rb
@@ -1,0 +1,7 @@
+class Sevenzx < Cask
+  url 'https://www.macupdate.com/download/20526/7zX_1.7.1.-5003b6dcbb4d8.dmg'
+  homepage 'http://sixtyfive.xmghosting.com/products/7zx/'
+  version '1.7.1'
+  sha1 '5ec47834b13e0694040345af853401b5162d4ce4'
+  link '7zX.app'
+end


### PR DESCRIPTION
Wish I could have used a cleaner DL url, but the official site uses a magnet link (lol).  So, MacUpdate it is.  It works, though!
