### PR TITLE
Fixed Texmaker 4.1.1 to allow install

### DIFF
--- a/Casks/texmaker.rb
+++ b/Casks/texmaker.rb
@@ -3,5 +3,5 @@ class Texmaker < Cask
   homepage 'http://www.xm1math.net/texmaker'
   version 'latest'
   no_checksum
-  link 'texmaker.app'
+  link 'TexmakerMacosxLion/texmaker.app'
 end


### PR DESCRIPTION
Previous version was unable to install ("symlink source is not there").  Added path relative to folder in zipfile to repair.
