### PR TITLE
Doubledash hygiene for external commands

### DIFF
--- a/developer/bin/develop_brew_cask
+++ b/developer/bin/develop_brew_cask
@@ -88,7 +88,7 @@ _develop_brew_cask () {
     local git_root="$(/bin/pwd)"
     local brew_prefix="$(brew --prefix)"
     local cellar_dir="$brew_prefix/Cellar/brew-cask"
-    local version_dir="$(/bin/ls "$cellar_dir/" | /usr/bin/sort | /usr/bin/tail -1)"
+    local version_dir="$(/bin/ls -- "$cellar_dir/" | /usr/bin/sort | /usr/bin/tail -1)"
     local tap_dir="$brew_prefix/$tap_subdir"
 
     # sanity check

--- a/developer/bin/develop_brew_cask
+++ b/developer/bin/develop_brew_cask
@@ -66,13 +66,13 @@ create_dev_links () {
     local git_root="$2"
     /bin/mv -- rubylib production_rubylib
     /bin/mv -- Casks   production_Casks
-    /bin/ln -s "$git_root/Casks" .
-    /bin/ln -s "$git_root/lib"   rubylib
+    /bin/ln -s -- "$git_root/Casks" .
+    /bin/ln -s -- "$git_root/lib"   rubylib
     cd "$tap_dir"
     /bin/mv -- lib   production_lib
     /bin/mv -- Casks production_Casks
-    /bin/ln -s "$git_root/Casks" .
-    /bin/ln -s "$git_root/lib"   .
+    /bin/ln -s -- "$git_root/Casks" .
+    /bin/ln -s -- "$git_root/lib"   .
     printf "brew-cask is now in development mode\n"
     printf "Note: it is not safe to run 'brew update' while in development mode\n"
 }

--- a/developer/bin/develop_brew_cask
+++ b/developer/bin/develop_brew_cask
@@ -64,13 +64,13 @@ not_inside_homebrew () {
 create_dev_links () {
     local tap_dir="$1"
     local git_root="$2"
-    /bin/mv rubylib production_rubylib
-    /bin/mv Casks   production_Casks
+    /bin/mv -- rubylib production_rubylib
+    /bin/mv -- Casks   production_Casks
     /bin/ln -s "$git_root/Casks" .
     /bin/ln -s "$git_root/lib"   rubylib
     cd "$tap_dir"
-    /bin/mv lib   production_lib
-    /bin/mv Casks production_Casks
+    /bin/mv -- lib   production_lib
+    /bin/mv -- Casks production_Casks
     /bin/ln -s "$git_root/Casks" .
     /bin/ln -s "$git_root/lib"   .
     printf "brew-cask is now in development mode\n"

--- a/developer/bin/develop_brew_cask
+++ b/developer/bin/develop_brew_cask
@@ -56,7 +56,7 @@ cd_to_version_dir () {
 not_inside_homebrew () {
     local tap_dir="$1"
     local git_root="$2"
-    if [[ "$(/usr/bin/stat -L -f '%i' "$tap_dir")" -eq "$(/usr/bin/stat -L -f '%i' "$git_root")" ]]; then
+    if [[ "$(/usr/bin/stat -L -f '%i' -- "$tap_dir")" -eq "$(/usr/bin/stat -L -f '%i' -- "$git_root")" ]]; then
         die "\nERROR: Run this script in your private repo, not inside Homebrew.\n"
     fi
 }

--- a/developer/bin/list_ids_in_pkg
+++ b/developer/bin/list_ids_in_pkg
@@ -49,7 +49,7 @@ mark_up_sources () {
 _list_ids_in_pkg () {
 
     tmpdir=`/usr/bin/mktemp -d -t list_ids_in_pkg`
-    trap "/bin/rm -rf '$tmpdir'" EXIT
+    trap "/bin/rm -rf -- '$tmpdir'" EXIT
 
     /usr/sbin/pkgutil --expand "$1" "$tmpdir/unpack"
 

--- a/developer/bin/production_brew_cask
+++ b/developer/bin/production_brew_cask
@@ -85,7 +85,7 @@ _production_brew_cask () {
     local git_root="$(/bin/pwd)"
     local brew_prefix="$(brew --prefix)"
     local cellar_dir="$brew_prefix/Cellar/brew-cask"
-    local version_dir="$(/bin/ls "$cellar_dir/" | /usr/bin/sort | /usr/bin/tail -1)"
+    local version_dir="$(/bin/ls -- "$cellar_dir/" | /usr/bin/sort | /usr/bin/tail -1)"
     local tap_dir="$brew_prefix/$tap_subdir"
 
     # sanity check

--- a/developer/bin/production_brew_cask
+++ b/developer/bin/production_brew_cask
@@ -64,12 +64,12 @@ not_inside_homebrew () {
 remove_dev_links () {
     local tap_dir="$1"
     /bin/rm rubylib Casks
-    /bin/mv production_rubylib rubylib
-    /bin/mv production_Casks   Casks
+    /bin/mv -- production_rubylib rubylib
+    /bin/mv -- production_Casks   Casks
     cd "$tap_dir"
     /bin/rm lib Casks
-    /bin/mv production_lib   lib
-    /bin/mv production_Casks Casks
+    /bin/mv -- production_lib   lib
+    /bin/mv -- production_Casks Casks
     printf "brew-cask is now in production mode\n"
     printf "It is safe to run 'brew update' if you are in production mode for all Caskroom repos.\n"
 }

--- a/developer/bin/production_brew_cask
+++ b/developer/bin/production_brew_cask
@@ -56,7 +56,7 @@ cd_to_version_dir () {
 not_inside_homebrew () {
     local tap_dir="$1"
     local git_root="$2"
-    if [[ "$(/usr/bin/stat -L -f '%i' "$tap_dir")" -eq "$(/usr/bin/stat -L -f '%i' "$git_root")" ]]; then
+    if [[ "$(/usr/bin/stat -L -f '%i' -- "$tap_dir")" -eq "$(/usr/bin/stat -L -f '%i' -- "$git_root")" ]]; then
         die "\nERROR: Run this script in your private repo, not inside Homebrew.\n"
     fi
 }

--- a/developer/bin/production_brew_cask
+++ b/developer/bin/production_brew_cask
@@ -63,11 +63,11 @@ not_inside_homebrew () {
 
 remove_dev_links () {
     local tap_dir="$1"
-    /bin/rm rubylib Casks
+    /bin/rm -- rubylib Casks
     /bin/mv -- production_rubylib rubylib
     /bin/mv -- production_Casks   Casks
     cd "$tap_dir"
-    /bin/rm lib Casks
+    /bin/rm -- lib Casks
     /bin/mv -- production_lib   lib
     /bin/mv -- production_Casks Casks
     printf "brew-cask is now in production mode\n"

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -51,8 +51,8 @@ class Cask
         system '/bin/mkdir', caskroom
       else
         # sudo in system is rude.
-        system '/usr/bin/sudo', '/bin/mkdir', '-p', caskroom
-        system '/usr/bin/sudo', '/usr/sbin/chown', '-R', "#{current_user}:staff", caskroom.parent
+        system '/usr/bin/sudo', '--', '/bin/mkdir', '-p', '--', caskroom
+        system '/usr/bin/sudo', '--', '/usr/sbin/chown', '-R', '--', "#{current_user}:staff", caskroom.parent
       end
     end
     appdir.mkpath unless appdir.exist?

--- a/lib/cask/artifact/hardlinked.rb
+++ b/lib/cask/artifact/hardlinked.rb
@@ -9,6 +9,6 @@ class Cask::Artifact::Hardlinked < Cask::Artifact::Symlinked
   end
 
   def create_filesystem_link(source, target)
-    @command.run!('/bin/ln', :args => ['-hf', source, target])
+    @command.run!('/bin/ln', :args => ['-hf', '--', source, target])
   end
 end

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -74,7 +74,7 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
         [false, true].each do |with_sudo|
           xml_status = @command.run('/bin/launchctl', :args => ['list', '-x', service], :sudo => with_sudo)
           if %r{^<\?xml}.match(xml_status)
-            @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
+            @command.run!('/bin/launchctl', :args => ['remove', '--', service], :sudo => with_sudo)
           end
         end
       end

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -97,7 +97,7 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
         ohai "Unloading kernel extension #{kext}"
         is_loaded = @command.run!('/usr/sbin/kextstat', :args => ['-l', '-b', kext], :sudo => true)
         if is_loaded.length > 1
-          @command.run!('/sbin/kextunload', :args => ['-b', kext], :sudo => true)
+          @command.run!('/sbin/kextunload', :args => ['-b', '--', kext], :sudo => true)
         end
       end
     end

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -118,7 +118,7 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     if uninstall_options.key? :files
       uninstall_options[:files].each do |file|
         ohai "Removing file #{file}"
-        @command.run!('/bin/rm', :args => ['-rf', file], :sudo => true)
+        @command.run!('/bin/rm', :args => ['-rf', '--', file], :sudo => true)
       end
     end
   end

--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -8,7 +8,7 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
   end
 
   def create_filesystem_link(source, target)
-    @command.run!('/bin/ln', :args => ['-hfs', source, target])
+    @command.run!('/bin/ln', :args => ['-hfs', '--', source, target])
   end
 
   def link(artifact_relative_path)

--- a/lib/cask/cli/home.rb
+++ b/lib/cask/cli/home.rb
@@ -2,12 +2,12 @@ module Cask::CLI::Home
   def self.run(*cask_names)
     if cask_names.empty?
       odebug "Opening project homepage"
-      system "/usr/bin/open", 'http://caskroom.io/'
+      system "/usr/bin/open", '--', 'http://caskroom.io/'
     else
       cask_names.each do |cask_name|
         odebug "Opening homepage for Cask #{cask_name}"
         cask = Cask.load(cask_name)
-        system "/usr/bin/open", cask.homepage
+        system "/usr/bin/open", '--', cask.homepage
       end
     end
   end

--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -7,7 +7,7 @@ class Cask::Container::Criteria
   end
 
   def file
-    @file ||= @command.run('/usr/bin/file', :args => ['-Izb', path])
+    @file ||= @command.run('/usr/bin/file', :args => ['-Izb', '--', path])
   end
 
   def imageinfo

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -13,7 +13,7 @@ class Cask::Container::Dmg < Cask::Container::Base
     mount!
     assert_mounts_found
     @mounts.each do |mount|
-      @command.run('/usr/bin/ditto', :args => [mount, @cask.destination_path])
+      @command.run('/usr/bin/ditto', :args => ['--', mount, @cask.destination_path])
     end
   ensure
     eject!

--- a/lib/cask/container/naked.rb
+++ b/lib/cask/container/naked.rb
@@ -8,7 +8,7 @@ class Cask::Container::Naked < Cask::Container::Base
   end
 
   def extract
-    @command.run!('/usr/bin/ditto', :args => [@path, @cask.destination_path.join(target_file)])
+    @command.run!('/usr/bin/ditto', :args => ['--', @path, @cask.destination_path.join(target_file)])
   end
 
   def target_file

--- a/lib/cask/container/tar.rb
+++ b/lib/cask/container/tar.rb
@@ -8,7 +8,7 @@ class Cask::Container::Tar < Cask::Container::Base
   def extract
     Dir.mktmpdir do |staging_dir|
       @command.run!('/usr/bin/tar', :args => ['xf', @path, '-C', staging_dir])
-      @command.run!('/usr/bin/ditto', :args => [staging_dir, @cask.destination_path])
+      @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
     end
   end
 end

--- a/lib/cask/container/zip.rb
+++ b/lib/cask/container/zip.rb
@@ -8,7 +8,7 @@ class Cask::Container::Zip < Cask::Container::Base
   def extract
     Dir.mktmpdir do |staging_dir|
       @command.run!('/usr/bin/unzip', :args => ['-qq', '-d', staging_dir, @path, '-x', '__MACOSX/*'])
-      @command.run!('/usr/bin/ditto', :args => [staging_dir, @cask.destination_path])
+      @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
     end
   end
 end

--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -60,11 +60,11 @@ class Cask::Pkg
 
   def _with_full_permissions(path, &block)
     original_mode = (path.stat.mode % 01000).to_s(8)
-    @command.run!('/bin/chmod', :args => ['777', path], :sudo => true)
+    @command.run!('/bin/chmod', :args => ['--', '777', path], :sudo => true)
     block.call
   ensure
     if path.exist? # block may have removed dir
-      @command.run!('/bin/chmod', :args => [original_mode, path], :sudo => true)
+      @command.run!('/bin/chmod', :args => ['--', original_mode, path], :sudo => true)
     end
   end
 

--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -54,7 +54,7 @@ class Cask::Pkg
 
   def _rmdir(path)
     if path.children.empty?
-      @command.run!('/bin/rmdir', :args => [path], :sudo => true)
+      @command.run!('/bin/rmdir', :args => ['--', path], :sudo => true)
     end
   end
 

--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -15,7 +15,7 @@ class Cask::Pkg
   def uninstall
     odebug "Deleting pkg files"
     list('files').each_slice(500) do |file_slice|
-      @command.run('/bin/rm', :args => file_slice.unshift('-f'), :sudo => true)
+      @command.run('/bin/rm', :args => file_slice.unshift('-f', '--'), :sudo => true)
     end
     odebug "Deleting pkg directories"
     _deepest_path_first(list('dirs')).each do |dir|
@@ -80,14 +80,14 @@ class Cask::Pkg
   def _clean_broken_symlinks(dir)
     dir.children.each do |child|
       if _broken_symlink?(child)
-        @command.run!('/bin/rm', :args => [child], :sudo => true)
+        @command.run!('/bin/rm', :args => ['--', child], :sudo => true)
       end
     end
   end
 
   def _clean_ds_store(dir)
     ds_store = dir.join('.DS_Store')
-    @command.run!('/bin/rm', :args => [ds_store], :sudo => true) if ds_store.exist?
+    @command.run!('/bin/rm', :args => ['--', ds_store], :sudo => true) if ds_store.exist?
   end
 
   def _broken_symlink?(path)

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -27,7 +27,7 @@ class Cask::SystemCommand
 
   def self._process_options(command, options)
     if options[:sudo]
-      command = "/usr/bin/sudo -E #{_quote(command)}"
+      command = "/usr/bin/sudo -E -- #{_quote(command)}"
     end
     if options[:args]
       command = "#{command} #{options[:args].map { |arg| _quote(arg) }.join(' ')}"

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -12,7 +12,7 @@ describe Cask::Artifact::Pkg do
     it 'runs the system installer on the specified pkgs' do
       pkg = Cask::Artifact::Pkg.new(@cask, Cask::FakeSystemCommand)
 
-      expected_command = "/usr/bin/sudo -E '/usr/sbin/installer' '-pkg' '#{@cask.destination_path/'MyFancyPkg'/'Fancy.pkg'}' '-target' '/' 2>&1"
+      expected_command = "/usr/bin/sudo -E -- '/usr/sbin/installer' '-pkg' '#{@cask.destination_path/'MyFancyPkg'/'Fancy.pkg'}' '-target' '/' 2>&1"
       Cask::FakeSystemCommand.stubs_command(expected_command)
 
       shutup do
@@ -27,10 +27,10 @@ describe Cask::Artifact::Pkg do
     it 'runs the specified uninstaller for the cask' do
       pkg = Cask::Artifact::Pkg.new(@cask, Cask::FakeSystemCommand)
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/bin/osascript' '-e' 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"' 2>&1), '1')
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/bin/osascript' '-e' 'tell application id "my.fancy.package.app" to quit' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/usr/bin/osascript' '-e' 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"' 2>&1), '1')
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/usr/bin/osascript' '-e' 'tell application id "my.fancy.package.app" to quit' 2>&1))
 
-      expected_command = "/usr/bin/sudo -E '#{@cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool'}' '--please' 2>&1"
+      expected_command = "/usr/bin/sudo -E -- '#{@cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool'}' '--please' 2>&1"
       Cask::FakeSystemCommand.stubs_command(expected_command)
 
       shutup do
@@ -82,12 +82,13 @@ describe Cask::Artifact::Pkg do
 </plist>
         PLIST
       )
+
       Cask::FakeSystemCommand.stubs_command(
         %Q(/bin/launchctl 'list' '-x' 'my.fancy.package.service' 2>&1),
         "launchctl list returned unknown response\n"
       )
       Cask::FakeSystemCommand.stubs_command(
-        %Q(/usr/bin/sudo -E '/bin/launchctl' 'list' '-x' 'my.fancy.package.service' 2>&1),
+        %Q(/usr/bin/sudo -E -- '/bin/launchctl' 'list' '-x' 'my.fancy.package.service' 2>&1),
         <<-PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -111,11 +112,11 @@ describe Cask::Artifact::Pkg do
 </plist>
         PLIST
       )
-      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E '/bin/launchctl' 'remove' 'my.fancy.package.service' 2>&1))
+      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E -- '/bin/launchctl' 'remove' '--' 'my.fancy.package.service' 2>&1))
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/kextstat' '-l' '-b' 'my.fancy.package.kernelextension' 2>&1), 'loaded')
-      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E '/sbin/kextunload' '-b' 'my.fancy.package.kernelextension' 2>&1))
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.main' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/usr/sbin/kextstat' '-l' '-b' 'my.fancy.package.kernelextension' 2>&1), 'loaded')
+      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E -- '/sbin/kextunload' '-b' '--' 'my.fancy.package.kernelextension' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.main' 2>&1))
 
       Cask::FakeSystemCommand.stubs_command(
         %Q(/usr/sbin/pkgutil '--only-files' '--files' 'my.fancy.package.agent' 2>&1),
@@ -154,13 +155,13 @@ describe Cask::Artifact::Pkg do
         /tmp/fancy/bin
         /tmp/fancy/var
       ].each do |dir|
-        Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/bin/chmod' '777' '#{dir}' 2>&1))
+        Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/bin/chmod' '--' '777' '#{dir}' 2>&1))
       end
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.agent' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.agent' 2>&1))
 
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/bin/rm' '-f' '/tmp/fancy/bin/fancy.exe' '/tmp/fancy/var/fancy.data' 2>&1))
-      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/bin/rm' '-f' '/tmp/fancy/agent/fancy-agent.exe' '/tmp/fancy/agent/fancy-agent.pid' '/tmp/fancy/agent/fancy-agent.log' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/bin/rm' '-f' '--' '/tmp/fancy/bin/fancy.exe' '/tmp/fancy/var/fancy.data' 2>&1))
+      Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E -- '/bin/rm' '-f' '--' '/tmp/fancy/agent/fancy-agent.exe' '/tmp/fancy/agent/fancy-agent.pid' '/tmp/fancy/agent/fancy-agent.log' 2>&1))
 
       # No assertions after call since all assertions are implicit from the interactions setup above.
       # TODO: verify rmdir commands (requires setting up actual file tree or faking out .exists?

--- a/test/cask/cli/home_test.rb
+++ b/test/cask/cli/home_test.rb
@@ -26,22 +26,22 @@ describe Cask::CLI::Home do
   it 'opens the homepage for the specified cask' do
     Cask::CLI::Home.run('alfred')
     Cask::CLI::Home.system_commands.must_equal [
-      ['/usr/bin/open', 'http://www.alfredapp.com/']
+      ['/usr/bin/open', '--', 'http://www.alfredapp.com/']
     ]
   end
 
   it 'works for multiple casks' do
     Cask::CLI::Home.run('alfred', 'adium')
     Cask::CLI::Home.system_commands.must_equal [
-      ['/usr/bin/open', 'http://www.alfredapp.com/'],
-      ['/usr/bin/open', 'https://www.adium.im/']
+      ['/usr/bin/open', '--', 'http://www.alfredapp.com/'],
+      ['/usr/bin/open', '--', 'https://www.adium.im/']
     ]
   end
 
   it "opens the project page when no cask is specified" do
     Cask::CLI::Home.run
     Cask::CLI::Home.system_commands.must_equal [
-      ['/usr/bin/open', 'http://caskroom.io/'],
+      ['/usr/bin/open', '--', 'http://caskroom.io/'],
     ]
   end
 end

--- a/test/cask/container/naked_test.rb
+++ b/test/cask/container/naked_test.rb
@@ -11,7 +11,7 @@ describe Cask::Container::Naked do
     cask                 = SpaceyCask.new
     path                 = '/tmp/downloads/kevin-spacey-1.2.pkg'
     expected_destination = cask.destination_path.join('kevin spacey.pkg')
-    expected_command     = %Q(/usr/bin/ditto '#{path}' '#{expected_destination}' 2>&1)
+    expected_command     = %Q(/usr/bin/ditto '--' '#{path}' '#{expected_destination}' 2>&1)
     Cask::FakeSystemCommand.stubs_command(expected_command)
 
     container = Cask::Container::Naked.new(cask, path, Cask::FakeSystemCommand)

--- a/test/cask/pkg_test.rb
+++ b/test/cask/pkg_test.rb
@@ -30,7 +30,7 @@ describe Cask::Pkg do
       )
 
       Cask::FakeSystemCommand.expects_command(
-        %q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fake.pkg' 2>&1)
+        %q(/usr/bin/sudo -E -- '/usr/sbin/pkgutil' '--forget' 'my.fake.pkg' 2>&1)
       )
 
       pkg.uninstall


### PR DESCRIPTION
Many Unix utilities follow the convention of doubledash (`--`) to segregate
filenames/branchnames/usernames, _etc_ from flags.  For example, if you wish
to delete a file named `-f`, you can say

``` bash
rm -- -f
```

Everything to the right side of doubledash is read by `rm` as a filename.
Using doudbledash is best practice whenever calling Unix utilities
programatically.  It does lower the attack surface for malicious inputs, but
the main benefit is avoiding unintended consequences from legitimate inputs.

In cases where a flag takes an argument, _eg_ `tar -f <file>`, there is no
ambiguity about `<file>`, and doubledash or other tricks are not needed.

For reference, [here](https://gist.github.com/rolandwalker/8618997) are various examples of command forms which
accept doubledash.  This PR audits homebrew-cask for all of those listed,
though some of them may not have been present.

Other commands exist which do not support doubledash, for which a separate
PR will follow.

This is a followup to #2595, and is relevant to #2556, though it does not itself fix that bug.
