### PR TITLE
carefully unload launchctl services at uninstall

### DIFF
--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -67,7 +67,12 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     if uninstall_options.key? :launchctl
       [*uninstall_options[:launchctl]].each do |service|
         ohai "Removing launchctl service #{service}"
-        @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => true)
+        [false, true].each do |with_sudo|
+          xml_status = @command.run('/bin/launchctl', :args => ['list', '-x', service], :sudo => with_sudo)
+          if %r{^<\?xml}.match(xml_status)
+            @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
+          end
+        end
       end
     end
 

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -82,6 +82,37 @@ describe Cask::Artifact::Pkg do
 </plist>
         PLIST
       )
+      Cask::FakeSystemCommand.stubs_command(
+        %Q(/bin/launchctl 'list' '-x' 'my.fancy.package.service' 2>&1),
+        "launchctl list returned unknown response\n"
+      )
+      Cask::FakeSystemCommand.stubs_command(
+        %Q(/usr/bin/sudo -E '/bin/launchctl' 'list' '-x' 'my.fancy.package.service' 2>&1),
+        <<-PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>my.fancy.package.service</string>
+	<key>LastExitStatus</key>
+	<integer>0</integer>
+	<key>LimitLoadToSessionType</key>
+	<string>System</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>argument</string>
+	</array>
+	<key>TimeOut</key>
+	<integer>30</integer>
+</dict>
+</plist>
+        PLIST
+      )
+      Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E '/bin/launchctl' 'remove' 'my.fancy.package.service' 2>&1))
+
       Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/kextstat' '-l' '-b' 'my.fancy.package.kernelextension' 2>&1), 'loaded')
       Cask::FakeSystemCommand.expects_command(%Q(/usr/bin/sudo -E '/sbin/kextunload' '-b' 'my.fancy.package.kernelextension' 2>&1))
       Cask::FakeSystemCommand.stubs_command(%Q(/usr/bin/sudo -E '/usr/sbin/pkgutil' '--forget' 'my.fancy.package.main' 2>&1))

--- a/test/support/Casks/with-pkgutil-uninstall.rb
+++ b/test/support/Casks/with-pkgutil-uninstall.rb
@@ -4,5 +4,7 @@ class WithPkgutilUninstall < TestCask
   version '1.2.3'
   sha1 '8588bd8175a54b8e0a1310cc18e6567d520ab7c4'
   install 'Fancy.pkg'
-  uninstall :pkgutil => 'my.fancy.package.*', :kext => 'my.fancy.package.kernelextension'
+  uninstall :pkgutil => 'my.fancy.package.*',
+            :kext => 'my.fancy.package.kernelextension',
+            :launchctl => 'my.fancy.package.service'
 end


### PR DESCRIPTION
Fixes #2601
- do a soft test to see if the service is loaded before attempting remove
- test/unload as both superuser and user, as the service can be installed
  differently according to the original package
- add tests for `uninstall` `:launchctl`; there were none previously
