### PR TITLE
realpath hygiene for external commands

### DIFF
--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -13,7 +13,8 @@ class Cask::Container::Criteria
   def imageinfo
     @imageinfo ||= @command.run(
       '/usr/bin/hdiutil',
-      :args => ['imageinfo', path],
+      # realpath is a failsafe against unusual filenames
+      :args => ['imageinfo', Pathname.new(path).realpath],
       :stderr => :silence,
       :print => false
     )

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -21,7 +21,8 @@ class Cask::Container::Dmg < Cask::Container::Base
 
   def mount!
     plist = @command.run!('/usr/bin/hdiutil',
-      :args => %w[mount -plist -nobrowse -readonly -noidme -mountrandom /tmp] + [@path],
+      # realpath is a failsafe against unusual filenames
+      :args => %w[mount -plist -nobrowse -readonly -noidme -mountrandom /tmp] + [Pathname.new(@path).realpath],
       :input => %w[y],
       :plist => true
     )
@@ -42,7 +43,8 @@ class Cask::Container::Dmg < Cask::Container::Base
 
   def eject!
     @mounts.each do |mount|
-      @command.run!('/usr/bin/hdiutil', :args => ['eject', mount])
+      # realpath is a failsafe against unusual filenames
+      @command.run!('/usr/bin/hdiutil', :args => ['eject', Pathname.new(mount).realpath])
     end
   end
 end

--- a/lib/cask/container/zip.rb
+++ b/lib/cask/container/zip.rb
@@ -7,7 +7,7 @@ class Cask::Container::Zip < Cask::Container::Base
 
   def extract
     Dir.mktmpdir do |staging_dir|
-      @command.run!('/usr/bin/unzip', :args => ['-qq', '-d', staging_dir, @path, '-x', '__MACOSX/*'])
+      @command.run!('/usr/bin/unzip', :args => ['-qq', '-d', Pathname.new(staging_dir).realpath, Pathname.new(@path).realpath, '-x', '__MACOSX/*'])
       @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
     end
   end


### PR DESCRIPTION
For external commands which do not support the doubledash convention
(#2613), wrap file arguments in `Pathname.new(file).realpath` at the
very last minute.  This provides a guarantee against surprises caused
by unusual filenames which might be misinterpreted as flags.

If you follow the current code, the arguments altered by this patch all
_ought_ to be absolute paths already (though not all of them are instances
of Pathname).  So, there is no functional change, only a safety rail
against future changes.

This patch covers the external commands `hdiutil` and `unzip`.
