### PR TITLE
make travis test w/ same Ruby we target on desktop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: objective-c
 before_install:
- - brew update
- - brew install cabextract
-install: bundle
-script: bundle exec rake test
+  - rvm use system
+  - brew update
+  - brew install cabextract
+  - sudo /usr/bin/gem install bundler
+install:
+  - sudo /usr/bin/bundle
+script: /usr/bin/bundle exec /usr/bin/rake test
 notifications:
   irc:
     channels:


### PR DESCRIPTION
version 1.8.7 .

As discussed in #2615, the test suite can act differently than the `brew-cask` command if it runs under a different Ruby version.

This patch does not address the issue of running plain `rake test` for developers.
