### PR TITLE
explicit UTF-8 encoding for old Rubies

### DIFF
--- a/Casks/baiducloud.rb
+++ b/Casks/baiducloud.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class Baiducloud < Cask
   url 'http://bcscdn.baidu.com/netdisk/BaiduYun_2.4.0.dmg'
   homepage 'http://pan.baidu.com'

--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class Baiduinput < Cask
   url 'http://shouji.baidu.com/download/1000e/baiduinput_mac_v3.2_1000e.dmg'
   homepage 'http://wuxian.baidu.com/input/mac.html'

--- a/Casks/powerword.rb
+++ b/Casks/powerword.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class Powerword < Cask
   url 'http://mac.iciba.com/download/powerword_macosx_beta_1.0.0.dmg'
   homepage 'http://mac.iciba.com'

--- a/Casks/qq-music.rb
+++ b/Casks/qq-music.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class QqMusic < Cask
   url 'http://dldir1.qq.com/music/clntupate/QQMusicForMacV1.3.0.dmg'
   homepage 'http://y.qq.com'

--- a/Casks/tune-instructor.rb
+++ b/Casks/tune-instructor.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class TuneInstructor < Cask
   url 'http://www.tune-instructor.de/_data/TuneInstructor3.4b.dmg'
   homepage 'http://www.tune-instructor.de/com/start.html'


### PR DESCRIPTION
This does no harm, and was sufficient to make the following
command pass on my development machine:

``` bash
ruby1.9 /usr/bin/rake test
```

Relevant to #2615, is a pre-requisite for #2625
