### PR TITLE
remove dupe Cask sim-pholders.rb, update fields

### DIFF
--- a/Casks/sim-pholders.rb
+++ b/Casks/sim-pholders.rb
@@ -1,7 +1,0 @@
-class SimPholders < Cask
-  url 'http://simpholders.com/site/assets/files/1007/simpholders-1_5_0.dmg'
-  homepage 'http://simpholders.com/'
-  version '1.5.0'
-  sha1 '6ed67eb09973a2d6092bc54825b8effeab0ee533'
-  link 'SimPholders.app'
-end

--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -1,7 +1,7 @@
 class Simpholders < Cask
-  url 'http://simpholders.com/site/assets/files/1016/simpholders-1_2_0.dmg'
-  homepage 'http://simpholders.com'
-  version '1.2.0'
-  sha1 '07a573f89133195e2adcd150259c552aa869e544'
-  link 'Simpholders.app'
+  url 'http://simpholders.com/site/assets/files/1007/simpholders-1_5_0.dmg'
+  homepage 'http://simpholders.com/'
+  version '1.5.0'
+  sha1 '6ed67eb09973a2d6092bc54825b8effeab0ee533'
+  link 'SimPholders.app'
 end


### PR DESCRIPTION
The dupe under the incorrect name had more up-to-date data,
which is now transferred to `simpholders.rb`, the preferred
name according to `CONTRIBUTING.md`
