### PR TITLE
can't init a CONSTANT with ||= in Ruby 1.8.x

### DIFF
--- a/test/cask/cli/doctor_test.rb
+++ b/test/cask/cli/doctor_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'cask/version'
 
-HOMEBREW_BREW_FILE ||= '/usr/local/bin/brew'
+HOMEBREW_BREW_FILE = '/usr/local/bin/brew'
 
 describe Cask::CLI::Doctor do
   it 'displays some nice info about the environment' do


### PR DESCRIPTION
test suite could only run under Ruby 1.9 or above
#2625 will fail on Travis until this and other backports are merged
