### PR TITLE
Paragon NTFS

### DIFF
--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -1,0 +1,7 @@
+class ParagonNtfs < Cask
+  url 'http://dl.paragon-software.com/demo/ntfsmac_trial_u.dmg'
+  homepage 'http://www.paragon-software.com/home/ntfs-mac/'
+  version 'latest'
+  no_checksum
+  install 'FSInstaller.app/Contents/Resources/Paragon NTFS for Mac OS X.pkg'
+end


### PR DESCRIPTION
I tried to configure the `uninstall` setting, but when I tested `brew cask uninstall paragon-ntfs` something deleted a system file and I had to reinstall OSX.

The `pkg` value is `com.paragon-software.filesystems.NTFS.pkg` (run `pkgutil --volume / --pkgs | grep paragon` to confirm), but beware of hooking up the `uninstall` part of the Cask.
