### PR TITLE
Simpletag for Homebrew/Cask

### DIFF
--- a/Casks/jawbone-updater.rb
+++ b/Casks/jawbone-updater.rb
@@ -1,0 +1,7 @@
+class JawboneUpdater < Cask
+  url 'http://content.jawbone.com/store/dashboard/Jawbone_Updater-2.2.3.pkg'
+  homepage 'http://jawbone.com/'
+  version '2.2.3'
+  no_checksum
+  install 'Jawbone_Updater-2.2.3.pkg'
+end

--- a/Casks/simpletag.rb
+++ b/Casks/simpletag.rb
@@ -1,0 +1,7 @@
+class Simpletag < Cask
+  url 'http://kaz.dl.sourceforge.net/project/simpletag/Mac/simpletag-gui-1.5.3-osx.zip'
+  homepage 'http://sourceforge.net/projects/simpletag/'
+  version '1.5.3'
+  no_checksum
+  link 'simpletag-gui-jface-1.5.3/SimpleTAG-GUI.app'
+end


### PR DESCRIPTION
Installation fails with 'latest' due to the way the developer has zipped program. (Inside zip file there is a folder with version in the name: 'simpletag-gui-jface-1.5.3/SimpleTAG-GUI.app' So I created this cask without 'latest'
