### PR TITLE
removed vox

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,7 +1,0 @@
-class Vox < Cask
-  url 'http://coppertino.com/getVox/'
-  homepage 'http://coppertino.com/vox/'
-  version 'latest'
-  no_checksum
-  link 'Vox.app'
-end


### PR DESCRIPTION
The `url` line leads nowhere, and Vox is a MAS-only app, anyway. There’s still a legacy version available for direct download, however, so I’ll add that one to [versions](https://github.com/caskroom/homebrew-versions).
