### PR TITLE
Fixed #1248, Better nested container syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,7 @@ Additional stanzas you might need for special use-cases:
 | `binary`           | relative path to a binary that should be linked into the `/usr/local/bin` folder on installation
 | `input_method`     | relative path to a input method that should be linked into the `~/Library/Input Methods` folder on installation
 | `screen_saver`     | relative path to a Screen Saver that should be linked into the `~/Library/Screen Savers` folder on installation
+| `container`        | relative path to an inner container that must be extracted and link to installation; this allows us to support dmg inside tar, zip inside dmg, etc. (see __Container Details__ for more information)
 | `nested_container` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
 | `caveats`          | a string or Ruby block providing the user with Cask-specific information at install time (see also [Caveats Details](doc/CASK_LANGUAGE_REFERENCE.md#caveats-details))
 

--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -10,6 +10,7 @@ require 'cask/artifact/after_block'
 require 'cask/artifact/before_block'
 require 'cask/artifact/colorpicker'
 require 'cask/artifact/font'
+require 'cask/artifact/container'
 require 'cask/artifact/nested_container'
 require 'cask/artifact/pkg'
 require 'cask/artifact/prefpane'
@@ -20,7 +21,6 @@ require 'cask/artifact/caskroom_only'
 require 'cask/artifact/input_method'
 require 'cask/artifact/screen_saver'
 
-
 module Cask::Artifact
   #
   # NOTE: order is important here, since we want to extract nested containers
@@ -29,6 +29,7 @@ module Cask::Artifact
   def self.artifacts
     [
       Cask::Artifact::BeforeBlock,
+      Cask::Artifact::Container,
       Cask::Artifact::NestedContainer,
       Cask::Artifact::App,
       Cask::Artifact::Colorpicker,

--- a/lib/cask/artifact/container.rb
+++ b/lib/cask/artifact/container.rb
@@ -1,0 +1,20 @@
+class Cask::Artifact::Container < Cask::Artifact::Base
+  def install
+    @cask.artifacts[self.class.artifact_dsl_key].each { |container| extract(container) }
+  end
+
+  def uninstall
+    # no need to take action; we will get removed by rmtree of parent
+  end
+
+  def extract(container_relative_path)
+    source = @cask.destination_path.join(container_relative_path)
+    container = Cask::Container.for_path(source, @command)
+    unless container
+      raise CaskError.new "Aw dang, could not identify nested_container at '#{source}'"
+    end
+    ohai "Extracting nested container #{source.basename}"
+    container.new(@cask, source, @command).extract
+  end
+
+end

--- a/lib/cask/artifact/nested_container.rb
+++ b/lib/cask/artifact/nested_container.rb
@@ -1,19 +1,2 @@
-class Cask::Artifact::NestedContainer < Cask::Artifact::Base
-  def install
-    @cask.artifacts[:nested_container].each { |container| extract(container) }
-  end
-
-  def uninstall
-    # no need to take action; we will get removed by rmtree of parent
-  end
-
-  def extract(container_relative_path)
-    source = @cask.destination_path.join(container_relative_path)
-    container = Cask::Container.for_path(source, @command)
-    unless container
-      raise CaskError.new "Aw dang, could not identify nested_container at '#{source}'"
-    end
-    ohai "Extracting nested container #{source.basename}"
-    container.new(@cask, source, @command).extract
-  end
+class Cask::Artifact::NestedContainer < Cask::Artifact::Container
 end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -133,6 +133,18 @@ module Cask::DSL
       end
     end
 
+    ARTIFACT_AGRS_WITH_BLOCKS_TYPES = [
+      :container
+    ]
+
+    ARTIFACT_AGRS_WITH_BLOCKS_TYPES.each do |type|
+      define_method(type) do |*args, &block|
+        artifacts[type].merge(args)
+        block.call(args)
+      end
+    end
+
+
     attr_reader :sums
 
     def hash_name(hash_type)

--- a/test/cask/artifact/container_test.rb
+++ b/test/cask/artifact/container_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+describe Cask::Artifact::Container do
+  describe 'install' do
+    before {
+      @cask = Cask.load('nested-app-with-container')
+
+      shutup do
+        Cask::Installer.new(@cask).install
+      end
+    }
+
+    it 'extracts the specified paths as containers' do
+      @cask.destination_path.join('MyNestedApp.app').must_be :directory?
+    end
+    it "links the noted applications to the proper directory" do
+      TestHelper.valid_alias?(Cask.appdir/'MyNestedApp.app').must_equal true
+    end
+  end
+end

--- a/test/support/Casks/nested-app-with-container.rb
+++ b/test/support/Casks/nested-app-with-container.rb
@@ -1,0 +1,9 @@
+class NestedAppWithContainer < TestCask
+  url TestHelper.local_binary('NestedApp.dmg.zip')
+  homepage 'http://example.com/nested-app'
+  version '1.2.3'
+  sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
+  container 'NestedApp.dmg' do
+    link 'MyNestedApp.app'
+  end
+end


### PR DESCRIPTION
I add a new `container` dsl. With this new dsl, we can drop `nested_container`.
