### PR TITLE
Fix colorpicker-developer symlink path

### DIFF
--- a/Casks/colorpicker-developer.rb
+++ b/Casks/colorpicker-developer.rb
@@ -3,5 +3,5 @@ class ColorpickerDeveloper < Cask
   homepage 'http://panic.com/~wade/picker/'
   version 'latest'
   no_checksum
-  colorpicker 'DeveloperColorPicker.colorPicker'
+  colorpicker 'Developer Color Picker/DeveloperColorPicker.colorPicker'
 end


### PR DESCRIPTION
Fixes colorpicker-developer's colorpicker path to resolve installation symlink error:

```
Error: it seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/colorpicker-developer/latest/DeveloperColorPicker.colorPicker'
```
