### PR TITLE
DeciTime.app

### DIFF
--- a/Casks/decitime.rb
+++ b/Casks/decitime.rb
@@ -1,0 +1,14 @@
+class Decitime < Cask
+  url 'http://download.filewell.com/DeciTime101.dmg.zip'
+  homepage 'http://www.tinbert.com/DeciTimeMac/'
+  version '1.0.1'
+  sha1 'a3c5c995656c865c6a3b4b8b699e105a65f96d2b'
+  nested_container 'DeciTime101.dmg'
+  link 'DeciTime.app'
+
+  # fix wonky DMG by mounting it once read-write per discussion at
+  # https://github.com/phinze/homebrew-cask/pull/2654
+  before_install do
+    system %Q{/usr/bin/hdiutil eject "$(/usr/bin/hdiutil mount -readwrite -noidme -nobrowse -mountrandom /tmp #{destination_path.join(artifacts[:nested_container].first)} | /usr/bin/cut -f3 | /usr/bin/grep '.')" >/dev/null 2>&1}
+  end
+end


### PR DESCRIPTION
The inner dmg here fails to mount with a strange error message. Here's the debug output:

``` bash
~ 1.9-staging brew cask install decitime --debug
==> Downloading http://download.filewell.com/DeciTime101.dmg.zip
Already downloaded: /Library/Caches/Homebrew/decitime-1.0.1.zip
==> Extracting nested container DeciTime101.dmg
Error: Command failed to execute!

==> Failed command:
/usr/bin/hdiutil 'mount' '-plist' '-nobrowse' '-readonly' '-noidme' '-mountrandom' '/tmp' '/opt/homebrew-cask/Caskroom/decitime/1.0.1/DeciTime101.dmg' 2>&1

==> Output of failed command:
hdiutil: mount failed - no mountable file systems
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/system_command.rb:45:in `_assert_success'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/system_command.rb:15:in `run'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/system_command.rb:24:in `run!'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/container/dmg.rb:23:in `mount!'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/container/dmg.rb:13:in `extract'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/artifact/nested_container.rb:17:in `extract'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/artifact/nested_container.rb:3:in `install'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/set.rb:195:in `each'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/set.rb:195:in `each_key'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/set.rb:195:in `each'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/artifact/nested_container.rb:3:in `install'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/installer.rb:59:in `install_artifacts'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/installer.rb:58:in `each'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/installer.rb:58:in `install_artifacts'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/installer.rb:32:in `install'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/cli/install.rb:8:in `run'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/cli/install.rb:6:in `each'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/cli/install.rb:6:in `run'
/usr/local/Cellar/brew-cask/0.27.1/rubylib/cask/cli.rb:36:in `process'
/usr/local/bin/brew-cask.rb:6
/usr/local/Library/brew.rb:67:in `require'
/usr/local/Library/brew.rb:67:in `require?'
/usr/local/Library/brew.rb:113
```

Downloading and unzipping manually and then running the same hdiutil incantation works just fine, though :(
