### PR TITLE
Add Paragon ExtFS

### DIFF
--- a/Casks/paragon-extfs.rb
+++ b/Casks/paragon-extfs.rb
@@ -1,0 +1,7 @@
+class ParagonExtfs < Cask
+  url 'http://dl.paragon-software.com/demo/extmac_trial_u.dmg'
+  homepage 'http://www.paragon-software.com/home/extfs-mac/'
+  version 'latest'
+  no_checksum
+  install 'FSInstaller.app/Contents/Resources/Paragon ExtFS for Mac OS X.pkg'
+end


### PR DESCRIPTION
Simple variation based on existing Paragon NTFS.

I installed Paragon NTFS via this system, and was somewhat surprised that ExtFS wasn't already present.
