### PR TITLE
BUGFIX: readlink requires chdir for relative links

### DIFF
--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -88,6 +88,6 @@ class Cask::Pkg
   end
 
   def _broken_symlink?(path)
-    path.symlink? && !path.readlink.exist?
+    path.symlink? and !path.exist?
   end
 end


### PR DESCRIPTION
Fixes #2650 (although there is more work to be done).  The issue is that
`path.readlink.exist?` returned false for **all** relative links, because `readlink`
reads relative to the current working directory.  This caused relative
symlinks such as `/usr/bin/tar` to be deleted, because package `mosh` identified
`/usr/bin` as one of its container directories.
