### PR TITLE
move font-specific docs to the font repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,23 +192,7 @@ When all this is sorted out, this message will go away.
 
 ### Font Casks
 
-#### Naming Font Casks
-
-Fonts casks are named as described above for applications, with the following amendments:
-
-  * The string `font-` should be prepended to the Cask name, to prevent clashes with application names.
-  * The canonical font name is the font family name as returned by the command `otfinfo --family`. (`otfinfo` is a free utility available as part of the TeX distribution.)
-  * The font version string is as returned by the command `otfinfo --font-version`.
-
-Example:
-
-Canonical Font Name | Cask Name             | Cask Class
---------------------|-----------------------|------------------------
-Anonymous Pro       | `font-anonymous-pro`  | `FontAnonymousPro`
-
-#### Multiple Fonts per Cask
-
-Multiple font faces or families are often supplied in a single distribution. When fonts are distributed together, they should be installed together. Each Cask should correspond to a single binary distribution, not necessarily a single font face.
+Fonts are maintained separately.  Please see [CONTRIBUTING.md](https://github.com/caskroom/homebrew-fonts/blob/master/CONTRIBUTING.md) in the [homebrew-fonts](https://github.com/caskroom/homebrew-fonts) repository.
 
 ### Link Details
 


### PR DESCRIPTION
I think it is possible for `CONTRIBUTING.md` to become too large and intimidate a first-time Cask author.

We added a section on squashing at the bottom.  But what are the odds that someone reads that far?
