### PR TITLE
make version number available within brew-cask

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -30,6 +30,7 @@ require 'cask/system_command'
 require 'cask/underscore_supporting_uri'
 require 'cask/url'
 require 'cask/utils'
+require 'cask/version'
 
 require 'plist/parser'
 


### PR DESCRIPTION
`brew cask doctor` was showing `1.8.7` as the homebrew-cask software version
