### PR TITLE
Add a cask for cert-quicklook plugin

### DIFF
--- a/Casks/cert-quicklook.rb
+++ b/Casks/cert-quicklook.rb
@@ -1,0 +1,7 @@
+class CertQuicklook < Cask
+  url 'https://cert-quicklook.googlecode.com/files/CertQuickLook-v3.qlgenerator.zip'
+  homepage 'https://code.google.com/p/cert-quicklook/'
+  version '3'
+  sha1 'e21cca7216f029609941e5f763e16dd8a41c12c8'
+  qlplugin 'CertQuickLook.qlgenerator'
+end


### PR DESCRIPTION
Simple cask addition for https://code.google.com/p/cert-quicklook/
