### PR TITLE
add man page brew-cask.1

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,49 +20,52 @@ tag that exists and/or calculate the proposed next release tag.  Docs are at
 We'll get this scripted someday, but until then it's better to have it written
 down than floating in a brain somewhere.
 
-1. Do a `git log` since the last release to see what changed. You can scope it to
+1. Be running on a checkout of master which is `git status` clean.
+2. Re-compile the man page by running `developer/bin/generate_man_pages`.  If
+   the compiled page has updates other than the datestamp, check in the changes.
+3. Do a `git log` since the last release to see what changed. You can scope it to
    `lib` to just pick up code changes and filter out Casks noise.   Like this:
 	```bash
 	git log "$(developer/bin/get_release_tag)"..HEAD lib
 	```
-2. Decide whether to bump the minor or patch fields in the next tag, based on
+4. Decide whether to bump the minor or patch fields in the next tag, based on
    whether or not features were added.  Run the shell command
 	```bash
 	new_tag="$(developer/bin/get_release_tag -next)"; echo "$new_tag"    # or use -next -patch
 	```
    and make sure the value in `$new_tag` is what you want.
-3. Optionally run `developer/bin/project_stats release` for overall release stats.
-4. Bump the `VERSION` string which is stored in the file `lib/cask/version.rb`.
+5. Optionally run `developer/bin/project_stats release` for overall release stats.
+6. Bump the `VERSION` string which is stored in the file `lib/cask/version.rb`.
    It should match `$new_tag`, EXCEPT that the leading `v` character should be
    removed fom the version number in the Ruby code.
-5. Populate `CHANGELOG.md` with a new section for the release you are creating.
+7. Populate `CHANGELOG.md` with a new section for the release you are creating.
    Follow the patterns used elsewhere in the file.
-6. Make a commit containing `CHANGELOG.md` and `lib/cask/version.rb`.  Like this:
+8. Make a commit containing `CHANGELOG.md` and `lib/cask/version.rb`.  Like this:
 	```bash
 	git add CHANGELOG.md lib/cask/version.rb
 	git commit -m "cut $new_tag"
 	```
-7. Tag that commit, ensuring that you provide a message so we get an annotated
+9. Tag that commit, ensuring that you provide a message so we get an annotated
    tag.  Like this:
 	```bash
 	git tag -m "$new_tag" "$new_tag"
 	```
-8. Push the commit and the tag:
+10. Push the commit and the tag:
 	```bash
 	git push --follow-tags
 	```
-9. Unset `$new_tag`; you don't need it anymore.
+11. Unset `$new_tag`; you don't need it anymore.
 	```bash
 	unset new_tag
 	```
-10. Open your browser to <https://github.com/phinze/homebrew-cask/releases> .
+12. Open your browser to <https://github.com/phinze/homebrew-cask/releases> .
     Then click the link for your newly-pushed tag. Click the "Edit Tag" button in
     the top right corner of that page.
-11. Paste the markdown summary from `CHANGELOG.md` into the textarea on that page.
+13. Paste the markdown summary from `CHANGELOG.md` into the textarea on that page.
     The `## <version number>` heading line from the markdown should not be included.
     The `Release title` field on the GitHub web form may be left blank.
-12. Click "Publish Release".
-13. Rejoice! Have a :cookie:.
+14. Click "Publish Release".
+15. Rejoice! Have a :cookie:.
 
 ## Things to Consider
 

--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -12,6 +12,7 @@ class BrewCask < Formula
   skip_clean 'bin'
 
   def install
+    man1.install 'doc/man/brew-cask.1'
     prefix.install 'lib' => 'rubylib'
     inreplace 'bin/brew-cask.rb', '/lib', '/rubylib'
 

--- a/developer/bin/generate_man_pages
+++ b/developer/bin/generate_man_pages
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# generate_man_pages
+#
+# This is temporary, should be replaced with a Rakefile target
+#
+
+set -e;                # exit on uncaught error
+set +o histexpand;     # don't expand history expressions
+shopt -s nocasematch;  # case-insensitive regular expressions
+
+cd_to_project_root () {
+    local script_dir="$(/usr/bin/dirname $0)"
+    cd "$script_dir"
+    local git_root="$(git rev-parse --show-toplevel)"
+    if [[ -z "$git_root" ]]; then
+        printf "Could not find git project root"
+        exit 1;
+    fi
+    cd "$git_root"
+}
+
+cd_to_project_root;
+
+ronn --roff --pipe --organization='Homebrew-cask' --manual='brew-cask' doc/src/brew-cask.1.md > doc/man/brew-cask.1
+
+#

--- a/doc/man/brew-cask.1
+++ b/doc/man/brew-cask.1
@@ -1,0 +1,222 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "HOMEBREW\-CASK" "1" "January 2014" "Homebrew-cask" "brew-cask"
+.
+.SH "NAME"
+\fBhomebrew\-cask\fR \- A friendly binary installer for OS X
+.
+.SH "SYNOPSIS"
+\fBbrew cask\fR command [options] [\fICask\fR \.\.\.]
+.
+.SH "DESCRIPTION"
+Homebrew\-cask is a tool for installing precompiled OS X binaries (such as Applications) from the command line\. The user is never required to use the graphical user interface\.
+.
+.SH "ALPHA\-QUALITY SOFTWARE"
+Homebrew\-cask works robustly enough that we welcome new users, but the project is still in early development\. That means command names, option names, and other aspects of this manual are still subject to change\.
+.
+.SH "FREQUENTLY USED COMMANDS"
+.
+.TP
+\fBinstall\fR \fICask\fR
+Install \fICask\fR\.
+.
+.TP
+\fBuninstall\fR \fICask\fR
+Uninstall \fICask\fR\.
+.
+.TP
+\fBsearch\fR \fItext\fR | /\fIregexp\fR/
+Perform a substring search of Cask names for \fItext\fR\. If the text is delimited by slashes, it is interpreted as a Ruby regular expression\.
+.
+.IP
+The Cask names returned by \fBsearch\fR are suitable as arguments for most other commands, such as \fBinstall\fR or \fBuninstall\fR\.
+.
+.SH "COMMANDS"
+.
+.TP
+\fBaudit\fR [\fICasks\fR]
+Check \fICasks\fR for installability\. If no \fICasks\fR are given on the command line, all Casks are audited\.
+.
+.TP
+\fBalfred\fR
+Modify Alfred\'s search scope to include the Caskroom directory where Applications are stored\.
+.
+.TP
+\fBchecklinks\fR
+Check for bad Cask links\.
+.
+.TP
+\fBcreate\fR \fICask\fR
+Generate a Cask for the Caskfile named \fICask\fR and open a template for it in your favorite editor\.
+.
+.TP
+\fBdoctor\fR
+Check for configuration issues\. Can be useful to upload as a gist for developers along with a bug report\.
+.
+.TP
+\fBedit\fR \fICask\fR
+Open the given Caskfile for editing\.
+.
+.TP
+\fBhome\fR
+Open the project page \fIhttp://caskroom\.io\fR in a browser\.
+.
+.TP
+\fBhome\fR \fICask\fR
+Open the homepage for \fICask\fR in a browser\.
+.
+.TP
+\fBinfo\fR \fICask\fR
+Display information about \fICask\fR\.
+.
+.TP
+\fBinstall [\-\-force]\fR \fICask\fR
+Install \fICask\fR\.
+.
+.IP
+\fICask\fR is usually the name of a Cask as returned by \fBbrew cask search\fR, but see \fIOTHER WAYS TO SPECIFY A CASK\fR for variations\.
+.
+.TP
+\fBlist\fR [\fICasks\fR]
+Without any arguments, list all installed Casks\.
+.
+.IP
+If \fICasks\fR are given, list the installed files for \fICasks\fR\.
+.
+.TP
+\fBuninstall\fR \fICask\fR
+Uninstall \fICask\fR\.
+.
+.TP
+\fBsearch\fR
+Display all Casks available for install\.
+.
+.TP
+\fBsearch\fR \fItext\fR | /\fIregexp\fR/
+Perform a substring search of Cask names for \fItext\fR\. If the text is delimited by slashes, it is interpreted as a Ruby regular expression\.
+.
+.SH "OPTIONS"
+Some of these options (such as \fB\-\-prefpanedir\fR) may be subject to removal in a future version\.
+.
+.TP
+\fB\-\-force\fR
+Force an install to proceed even when a previously\-existing install is detected\.
+.
+.TP
+\fB\-\-caskroom=<path>\fR
+Location of the Caskroom, where all binaries are stored\. The default value is: \fB/opt/homebrew\-cask/Caskroom\fR\.
+.
+.TP
+\fB\-\-verbose\fR
+Give additional feedback during installation\.
+.
+.TP
+\fB\-\-appdir=<path>\fR
+Target location for Application links\. The default value is \fB~/Applications\fR\.
+.
+.TP
+\fB\-\-colorpickerdir=<path>\fR
+Target location for Color Picker links\. The default value is \fB~/Library/Color Pickers\fR\.
+.
+.TP
+\fB\-\-prefpanedir=<path>\fR
+Target location for Preference Pane links\. The default value is \fB~/Library/Preference Panes\fR\.
+.
+.TP
+\fB\-\-qlplugindir=<path>\fR
+Target location for QuickLook Plugin links\. The default value is \fB~/Library/QuickLook\fR\.
+.
+.TP
+\fB\-\-fontdir=<path>\fR
+Target location for Font links\. The default value is \fB~/Library/Fonts\fR\.
+.
+.TP
+\fB\-\-widgetdir=<path>\fR
+Target location for Dashboard Widget links\. The default value is \fB~/Library/Widgets\fR\.
+.
+.TP
+\fB\-\-servicedir=<path>\fR
+Target location for Service links\. The default value is \fB~/Library/Services\fR\.
+.
+.TP
+\fB\-\-input_methoddir=<path>\fR
+Target location for Input Method links\. The default value is \fB~/Library/Input Methods\fR\.
+.
+.TP
+\fB\-\-screen_saverdir=<path>\fR
+Target location for Screen Saver links\. The default value is \fB~/Library/Screen Savers\fR\.
+.
+.TP
+\fB\-\-no\-binaries\fR
+Do not link "helper" executables to \fB/usr/local/bin\fR\.
+.
+.TP
+\fB\-\-binarydir=<path>\fR
+Target location for "helper" executable links\. The default value is \fB/usr/local/bin\fR\.
+.
+.TP
+\fB\-\-debug\fR
+Output debugging information of use to Cask authors and developers\.
+.
+.SH "INTERACTION WITH HOMEBREW"
+Homebrew\-cask is implemented as a external command for Homebrew\. That means this project is entirely built upon the Homebrew infrastructure\. For example, upgrades to the Homebrew\-cask tool are received through Homebrew: brew update && brew upgrade brew\-cask
+.
+.P
+And updates to individual Cask definitions are received whenever you issue the Homebrew command: brew update
+.
+.SH "OTHER WAYS TO SPECIFY A CASK"
+Most homebrew\-cask commands can accept a Cask name as an argument\. As described above, a Cask name on the command line can take the form of:
+.
+.IP "\(bu" 4
+A Cask name as returned by \fBbrew cask search\fR, \fIeg\fR \fBgoogle\-chrome\fR
+.
+.IP "" 0
+.
+.P
+Homebrew\-cask also accepts three other forms for Cask names:
+.
+.IP "\(bu" 4
+A fully\-qualified Cask name which includes the Tap name, \fIeg\fR \fBcaskroom/fonts/font\-symbola\fR
+.
+.IP "\(bu" 4
+A fully\-qualified pathname to a Cask file, \fIeg\fR \fB/usr/local/Cellar/brew\-cask/0\.25\.0/Casks/google\-chrome\.rb\fR
+.
+.IP "\(bu" 4
+A \fBcurl\fR\-retrievable URI to a Cask file, \fIeg\fR \fBhttps://raw\.github\.com/phinze/homebrew\-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google\-chrome\.rb\fR
+.
+.IP "" 0
+.
+.SH "ENVIRONMENT"
+Homebrew\-cask respects many of the environment variables used by the parent command \fBbrew\fR\. Please refer to the \fBbrew\fR(1) man page for more information\.
+.
+.P
+Environment variables specific to homebrew\-cask:
+.
+.TP
+HOMEBREW_CASK_OPTS
+This variable may contain any arguments normally used as options on the command\-line\. Example: \fB\-\-appdir=/some/path/bar\fR\.
+.
+.SH "SEE ALSO"
+The homebrew\-cask home page: \fIhttp://caskroom\.io\fR\.
+.
+.P
+The homebrew\-cask GitHub page: \fIhttps://github\.com/phinze/homebrew\-cask\fR\.
+.
+.P
+Alfred\.app: \fIhttp://www\.alfredapp\.com\fR
+.
+.P
+\fBbrew\fR(1), \fBcurl\fR(1)
+.
+.SH "AUTHORS"
+Paul Hinze and Contributors\.
+.
+.P
+Man page format based on \fBbrew\.1\.md\fR from Homebrew\.
+.
+.SH "BUGS"
+We still have bugs \-\- and we are busy fixing them! If you have a problem, don\'t be shy about reporting it on our GitHub issues page \fIhttps://github\.com/phinze/homebrew\-cask/issues?state=open\fR\.
+.
+.P
+When reporting bugs, remember that homebrew\-cask is an independent project from Homebrew\. Do your best to direct bug reports to the appropriate project\. If your command\-line started with \fBbrew cask\fR, bring the bug to us first!

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -1,0 +1,205 @@
+homebrew-cask(1) -- A friendly binary installer for OS X
+========================================================
+
+## SYNOPSIS
+
+`brew cask` command [options] [<Cask> ...]
+
+## DESCRIPTION
+
+Homebrew-cask is a tool for installing precompiled OS X binaries (such as
+Applications) from the command line.  The user is never required to use the
+graphical user interface.
+
+## ALPHA-QUALITY SOFTWARE
+
+Homebrew-cask works robustly enough that we welcome new users, but the
+project is still in early development.  That means command names, option
+names, and other aspects of this manual are still subject to change.
+
+## FREQUENTLY USED COMMANDS
+
+  * `install` <Cask>:
+    Install <Cask>.
+
+  * `uninstall` <Cask>:
+    Uninstall <Cask>.
+
+  * `search` <text> | /<regexp>/:
+    Perform a substring search of Cask names for <text>.  If the text is
+    delimited by slashes, it is interpreted as a Ruby regular expression.
+
+    The Cask names returned by `search` are suitable as arguments for most
+    other commands, such as `install` or `uninstall`.
+
+## COMMANDS
+
+  * `audit` [<Casks>]:
+   Check <Casks> for installability.
+   If no <Casks> are given on the command line, all Casks are audited.
+
+  * `alfred`:
+    Modify Alfred's search scope to include the Caskroom directory where
+    Applications are stored.
+
+  * `checklinks`:
+    Check for bad Cask links.
+
+  * `create` <Cask>:
+    Generate a Cask for the Caskfile named <Cask> and open a template for
+    it in your favorite editor.
+
+  * `doctor`:
+    Check for configuration issues.  Can be useful to upload as a gist for
+    developers along with a bug report.
+
+  * `edit` <Cask>:
+    Open the given Caskfile for editing.
+
+  * `home`:
+    Open the project page <http://caskroom.io> in a browser.
+
+  * `home` <Cask>:
+    Open the homepage for <Cask> in a browser.
+
+  * `info` <Cask>:
+    Display information about <Cask>.
+
+  * `install [--force]` <Cask>:
+    Install <Cask>.
+
+    <Cask> is usually the name of a Cask as returned by `brew cask search`,
+    but see [OTHER WAYS TO SPECIFY A CASK][] for variations.
+
+  * `list` [<Casks>]:
+    Without any arguments, list all installed Casks.
+
+    If <Casks> are given, list the installed files for <Casks>.
+
+  * `uninstall` <Cask>:
+    Uninstall <Cask>.
+
+  * `search`:
+    Display all Casks available for install.
+
+  * `search` <text> | /<regexp>/:
+    Perform a substring search of Cask names for <text>.  If the text
+    is delimited by slashes, it is interpreted as a Ruby regular
+    expression.
+
+## OPTIONS
+
+Some of these options (such as `--prefpanedir`) may be subject to removal
+in a future version.
+
+  * `--force`:
+    Force an install to proceed even when a previously-existing install
+    is detected.
+
+  * `--caskroom=<path>`:
+    Location of the Caskroom, where all binaries are stored.  The default value is: `/opt/homebrew-cask/Caskroom`.
+
+  * `--verbose`:
+    Give additional feedback during installation.
+
+  * `--appdir=<path>`:
+    Target location for Application links.  The default value is `~/Applications`.
+
+  * `--colorpickerdir=<path>`:
+    Target location for Color Picker links.  The default value is `~/Library/Color Pickers`.
+
+  * `--prefpanedir=<path>`:
+    Target location for Preference Pane links.  The default value is `~/Library/Preference Panes`.
+
+  * `--qlplugindir=<path>`:
+    Target location for QuickLook Plugin links.  The default value is `~/Library/QuickLook`.
+
+  * `--fontdir=<path>`:
+    Target location for Font links.  The default value is `~/Library/Fonts`.
+
+  * `--widgetdir=<path>`:
+    Target location for Dashboard Widget links.  The default value is `~/Library/Widgets`.
+
+  * `--servicedir=<path>`:
+    Target location for Service links.  The default value is `~/Library/Services`.
+
+  * `--input_methoddir=<path>`:
+    Target location for Input Method links.  The default value is `~/Library/Input Methods`.
+
+  * `--screen_saverdir=<path>`:
+    Target location for Screen Saver links.  The default value is `~/Library/Screen Savers`.
+
+  * `--no-binaries`:
+    Do not link "helper" executables to `/usr/local/bin`.
+
+  * `--binarydir=<path>`:
+    Target location for "helper" executable links.  The default value is `/usr/local/bin`.
+
+  * `--debug`:
+    Output debugging information of use to Cask authors and developers.
+
+## INTERACTION WITH HOMEBREW
+
+Homebrew-cask is implemented as a external command for Homebrew.  That means
+this project is entirely built upon the Homebrew infrastructure.  For
+example, upgrades to the Homebrew-cask tool are received through Homebrew:
+    brew update && brew upgrade brew-cask
+
+And updates to individual Cask definitions are received whenever you issue
+the Homebrew command:
+    brew update
+
+## OTHER WAYS TO SPECIFY A CASK
+
+Most homebrew-cask commands can accept a Cask name as an argument.  As
+described above, a Cask name on the command line can take the form of:
+
+  * A Cask name as returned by `brew cask search`, _eg_ `google-chrome`
+
+Homebrew-cask also accepts three other forms for Cask names:
+
+  * A fully-qualified Cask name which includes the Tap name, _eg_
+    `caskroom/fonts/font-symbola`
+
+  * A fully-qualified pathname to a Cask file, _eg_
+    `/usr/local/Cellar/brew-cask/0.25.0/Casks/google-chrome.rb`
+
+  * A `curl`-retrievable URI to a Cask file, _eg_
+   `https://raw.github.com/phinze/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`
+
+## ENVIRONMENT
+
+Homebrew-cask respects many of the environment variables used by the
+parent command `brew`.  Please refer to the `brew`(1) man page for more
+information.
+
+Environment variables specific to homebrew-cask:
+
+  * HOMEBREW\_CASK\_OPTS:
+    This variable may contain any arguments normally used as options on
+    the command-line.  Example: `--appdir=/some/path/bar`.
+
+## SEE ALSO
+
+The homebrew-cask home page: <http://caskroom.io>.
+
+The homebrew-cask GitHub page: <https://github.com/phinze/homebrew-cask>.
+
+Alfred.app: <http://www.alfredapp.com>
+
+`brew`(1), `curl`(1)
+
+## AUTHORS
+
+Paul Hinze and Contributors.
+
+Man page format based on `brew.1.md` from Homebrew.
+
+## BUGS
+
+We still have bugs -- and we are busy fixing them!  If you have a problem, don't
+be shy about reporting it on our [GitHub issues page](https://github.com/phinze/homebrew-cask/issues?state=open).
+
+When reporting bugs, remember that homebrew-cask is an independent project from
+Homebrew.  Do your best to direct bug reports to the appropriate project.  If
+your command-line started with `brew cask`, bring the bug to us first!


### PR DESCRIPTION
- the change to the Formula needs checking/testing
- the source at `doc/src/brew-cask.1.md` must be kept in sync with `USAGE.md` and other docs in the future
- the compiled form is also kept in the repo and must be regenerated after changes
- `ronn` is required to compile the manpage
- a shell script is provided to generate the compiled page, but that should probably be folded into the Rakefile
