### PR TITLE
Scala IDE: rename application link from 'Eclipse.app' to 'Scala IDE.app'

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -3,5 +3,5 @@ class ScalaIde < Cask
   homepage 'http://scala-ide.org/'
   version '3.0.2'
   sha1 '5d467d9054d940cf7e2f750ff60aa3bd11e8dae3'
-  link 'eclipse/Eclipse.app'
+  link 'eclipse/Eclipse.app', :target => 'Scala IDE.app'
 end


### PR DESCRIPTION
This is required to install the Scala IDE together with other Eclipse installations.
