### PR TITLE
make order consistent across Ruby vsns w/sort

### DIFF
--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -38,11 +38,13 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
   end
 
   def install
-    @cask.artifacts[self.class.artifact_dsl_key].each { |artifact| link(artifact) }
+    # the sort is for predictability between Ruby versions
+    @cask.artifacts[self.class.artifact_dsl_key].sort.each { |artifact| link(artifact) }
   end
 
   def uninstall
-    @cask.artifacts[self.class.artifact_dsl_key].each { |artifact| unlink(artifact) }
+    # the sort is for predictability between Ruby versions
+    @cask.artifacts[self.class.artifact_dsl_key].sort.each { |artifact| unlink(artifact) }
   end
 
   def preflight_checks(source, target)

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -46,7 +46,8 @@ class Cask::DownloadStrategy < CurlDownloadStrategy
     if cask_url.cookies
       [
         '-b',
-        cask_url.cookies.map do |key, value|
+        # sort_by is for predictability between Ruby versions
+        cask_url.cookies.sort_by{ |key, value| key.to_s }.map do |key, value|
           "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
         end.join(';')
       ]


### PR DESCRIPTION
Fixes #2635.  In particular, link and cookie order differ
between Ruby 1.8.7 and 2.x, causing the test suite to fail
under 1.8.7.

These `sort` operations force the orders generated by 2.x Ruby in
all cases.

This PR is a prerequisite for #2625 .
