### PR TITLE
Added Arduino IDE for Intel Galileo

### DIFF
--- a/Casks/arduino-galileo.rb
+++ b/Casks/arduino-galileo.rb
@@ -1,0 +1,7 @@
+class ArduinoGalileo < Cask
+  url 'http://downloadmirror.intel.com/23171/eng/Intel_Galileo_Arduino_SW_1.5.3_on_MacOSX%20_v0.7.5.zip'
+  homepage 'https://communities.intel.com/docs/DOC-22226'
+  version '1.5.3'
+  sha1 '90ac9dc375eb65b725970fb4b3b48f3ec6e24367'
+  link 'Arduino.app'
+end


### PR DESCRIPTION
For use with Intel's x86 Arduinos only.
