### PR TITLE
add `:allow_untrusted` modifier on `install`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Fill in the following fields for your Cask:
 | `sha256`           | SHA-256 checksum of the file; checked when the file is downloaded to prevent any funny business (can be omitted with `no_checksum`)
 | __artifact info__  | information about artifacts inside the Cask (can be specified multiple times)
 | `link`             | relative path to a file that should be linked into the `Applications` folder on installation (see __Link Details__ for more information)
-| `install`          | relative path to `pkg` that should be run to install the application
+| `install`          | relative path to `pkg` that should be run to install the application (see __Install Details__ for more information)
 | `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see __Uninstall Details__ for more information)
 
 Additional fields you might need for special use-cases:
@@ -241,6 +241,26 @@ link 'TexmakerMacosxLion/texmaker.app'
 ```
 
 Linking to the .app file without reference to the containing folder will result in installation failing with a "symlink source is not there" error.
+
+### Install Details
+
+The first argument to `install` should be a relative path to the `pkg` file
+to be installed.  For example:
+
+```ruby
+install 'Vagrant.pkg'
+```
+
+Subsequent arguments to `install` are key/value pairs which modify the
+install process.  Currently supported keys are
+
+  * `:allow_untrusted` -- pass `-allowUntrusted` to `/usr/sbin/installer`
+
+Example:
+
+```ruby
+install 'Soundflower.pkg', :allow_untrusted => true
+```
 
 ### Uninstall Details
 

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -75,7 +75,8 @@ module Cask::DSL
       :binary,
       :caskroom_only,
       :input_method,
-      :screen_saver
+      :screen_saver,
+      :install,
     ]
 
     ARTIFACT_TYPES.each do |type|
@@ -85,7 +86,6 @@ module Cask::DSL
     end
 
     SPECIAL_ARTIFACT_TYPES = [
-      :install,
       :nested_container,
       :uninstall
     ]

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -90,7 +90,7 @@ describe Cask::DSL do
     end
 
     instance = CaskWithInstallables.new
-    Array(instance.artifacts[:install]).sort.must_equal %w[Bar.pkg Foo.pkg]
+    Array(instance.artifacts[:install]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
   end
 
   it "prevents defining multiple urls" do


### PR DESCRIPTION
This is intended to address #2685, though the `soundflower.rb` Cask would
have to be patched separately this change was in release.
