### PR TITLE
oclint after_install/uninstall is redundant

### DIFF
--- a/Casks/oclint.rb
+++ b/Casks/oclint.rb
@@ -6,15 +6,4 @@ class Oclint < Cask
   binary 'oclint-0.7-x86_64-apple-darwin-10/bin/oclint'
   binary 'oclint-0.7-x86_64-apple-darwin-10/bin/oclint-json-compilation-database'
   binary 'oclint-0.7-x86_64-apple-darwin-10/bin/oclint-xcodebuild'
-
-  after_install do
-    puts "Symlinking 'lib/oclint' to /usr/local/lib/oclint"
-    full_path = "#{self.destination_path}/oclint-0.7-x86_64-apple-darwin-10"
-    system "ln -s #{full_path}/lib/oclint /usr/local/lib/oclint"
-  end
-
-  after_uninstall do
-    puts "Removing symlink /usr/local/lib/oclint"
-    system "rm /usr/local/lib/oclint"
-  end
 end


### PR DESCRIPTION
this is correctly handled by the `binary` artifact
