### PR TITLE
Add LingrRadar.app

### DIFF
--- a/Casks/lingrrader.rb
+++ b/Casks/lingrrader.rb
@@ -1,0 +1,7 @@
+class Lingrrader < Cask
+  url 'http://radar.lingr.com/mac/LingrRadar_2.26.tbz'
+  homepage 'http://radar.lingr.com/'
+  version '2.26'
+  sha1 'f2b35c38ae09e98effaedded0ad075ead9e3c877'
+  link 'LingrRadar.app'
+end


### PR DESCRIPTION
LingrRader is OSX utility for [Lingr](http://lingr.com/).

See http://radar.lingr.com.
