### PR TITLE
set pandoc version to 1.12.3

### DIFF
--- a/Casks/pandoc.rb
+++ b/Casks/pandoc.rb
@@ -1,7 +1,7 @@
 class Pandoc < Cask
   homepage 'http://johnmacfarlane.net/pandoc'
   url 'https://pandoc.googlecode.com/files/pandoc-1.12.3.pkg.zip'
-  version '1.12.2.1'
+  version '1.12.3'
   sha1 '3fbdcbebb7f0fc966918933d792a08bbeda127c1'
   install 'pandoc-1.12.3.pkg'
 end


### PR DESCRIPTION
Pandoc was using correct files but `version` was still point to previous.
