### PR TITLE
add command `brew cask cleanup`

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -71,6 +71,7 @@ This will both uninstall the Cask and remove symlinks which were created in
 * `info` -- displays information about the given Cask
 * `list` -- with no args, lists installed Casks; given installed Casks, lists installed files
 * `doctor` -- checks for configuration issues
+* `cleanup` -- cleans up cached downloads (with `--outdated`, only cleans old downloads)
 * `home` -- opens the homepage of the given Cask; or with no arguments, the homebrew-cask project page
 * `alfred` -- modifies Alfred's scope to include the Caskroom
 

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -45,6 +45,10 @@ names, and other aspects of this manual are still subject to change.
   * `checklinks`:
     Check for bad Cask links.
 
+  * `cleanup` [--outdated]:
+    Clean up cached downloads.  With `--outdated`, only clean up cached
+    downloads older than 10 days old.
+
   * `create` <Cask>:
     Generate a Cask for the Caskfile named <Cask> and open a template for
     it in your favorite editor.

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -6,6 +6,7 @@ require 'shellwords'
 require 'cask/cli/alfred'
 require 'cask/cli/audit'
 require 'cask/cli/checklinks'
+require 'cask/cli/cleanup'
 require 'cask/cli/create'
 require 'cask/cli/doctor'
 require 'cask/cli/edit'
@@ -117,6 +118,9 @@ class Cask::CLI
       end
       opts.on("--debug") do |v|
         Cask.debug = true
+      end
+      opts.on("--outdated") do |v|
+        Cask.outdated = true
       end
     end
   end

--- a/lib/cask/cli/cleanup.rb
+++ b/lib/cask/cli/cleanup.rb
@@ -1,0 +1,46 @@
+class Cask::CLI::Cleanup
+  def self.run(*_ignored)
+    remove_dead_symlinks
+    remove_cached_downloads
+  end
+
+  def self.remove_dead_symlinks
+    ohai "Removing dead symlinks"
+    HOMEBREW_CACHE_CASKS.children.select(&:symlink?).each do |symlink|
+      unless symlink.exist?
+        puts symlink
+        symlink.unlink
+      end
+    end
+  end
+
+  def self.remove_cached_downloads
+    message = "Removing cached downloads"
+    days = 10
+    outdated_timestamp = Time.now - (60 * 60 * 24 * days)
+    if Cask.outdated
+      message.concat(" older than #{days} days old")
+    end
+    ohai message
+    HOMEBREW_CACHE_CASKS.children.select(&:symlink?).each do |symlink|
+      file = Dir.chdir HOMEBREW_CACHE_CASKS do
+        symlink.readlink.realpath
+      end
+      if !Cask.outdated or file.stat.mtime < outdated_timestamp
+        puts file
+        file.unlink
+        symlink.unlink
+      end
+      incomplete_file = Pathname.new(file.to_s.concat('.incomplete'))
+      if incomplete_file.exist? and
+          (!Cask.outdated or incomplete_file.stat.mtime < outdated_timestamp)
+        puts incomplete_file
+        incomplete_file.unlink
+      end
+    end
+  end
+
+  def self.help
+    "cleans up cached downloads"
+  end
+end

--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -10,7 +10,12 @@ class Cask::Download
     cask = @cask
     downloader = Cask::CurlDownloadStrategy.new(cask)
     downloaded_path = downloader.fetch
-
+    begin
+      # this symlink helps track which downloads are ours
+      File.symlink downloaded_path,
+                   HOMEBREW_CACHE_CASKS.join(downloaded_path.basename)
+    rescue
+    end
     _check_sums(downloaded_path, cask.sums) unless cask.sums === 0
     downloaded_path
   end

--- a/lib/cask/options.rb
+++ b/lib/cask/options.rb
@@ -19,5 +19,13 @@ module Cask::Options
     def debug=(_debug)
       @debug = _debug
     end
+
+    def outdated
+      @outdated ||= false
+    end
+
+    def outdated=(_outdated)
+      @outdated = _outdated
+    end
   end
 end

--- a/test/cask/cli/cleanup_test.rb
+++ b/test/cask/cli/cleanup_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Cask::CLI::Cleanup do
+  it 'does nothing with --outdated in the clean test environment' do
+    Cask.outdated = true
+    out, err = capture_io do
+      Cask::CLI::Cleanup.run
+    end
+    out.must_equal <<-OUTPUT.undent
+    ==> Removing dead symlinks
+    ==> Removing cached downloads older than 10 days old
+    OUTPUT
+  end
+
+  # note: this test will fail in isolation.  It depends on other
+  # portions of the test suite leaving some files to do cleanup.
+  it 'cleans up new files in the test environment' do
+    Cask.outdated = false
+    out, err = capture_io do
+      Cask::CLI::Cleanup.run
+    end
+    out.must_match(/^==> Removing dead symlinks\n==> Removing cached downloads\n\//)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,7 @@ require 'test/testing_env'
 
 # making homebrew's cache dir allows us to actually download casks in tests
 HOMEBREW_CACHE.mkpath
+HOMEBREW_CACHE.join('Casks').mkpath
 
 # must be called after testing_env so at_exit hooks are in proper order
 require 'minitest/autorun'


### PR DESCRIPTION
It came to my attention that Homebrew's `brew cleanup` is not reliably cleaning up cached downloads from homebrew-cask.

There is no easy way to solve that for old downloads (users must figure out that the cache directory is huge and clean it out manually).

This PR addresses downloads going forward, by making a tracker symlink to all files downloaded by homebrew-cask, and adding a new command `brew cask cleanup` which chases the tracker symlinks and deletes cached downloads older than 7 days.
