### PR TITLE
add missing `HOMEBREW_CACHE_CASKS.mkpath`

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -43,6 +43,7 @@ class Cask
   def self.init
     odebug 'Creating directories'
     HOMEBREW_CACHE.mkpath unless HOMEBREW_CACHE.exist?
+    HOMEBREW_CACHE_CASKS.mkpath unless HOMEBREW_CACHE_CASKS.exist?
     unless caskroom.exist?
       ohai "We need to make Caskroom for the first time at #{caskroom}"
       ohai "We'll set permissions properly so we won't need sudo in the future"


### PR DESCRIPTION
If `mkpath` must be done for the parent dir, then it certainly
must also be done for the child dir.
