### PR TITLE
Upgrade LyX to v2.0.7.1, Mac only bugfix release

### DIFF
--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -1,7 +1,7 @@
 class Lyx < Cask
-  url 'ftp://ftp.lyx.org/pub/lyx/bin/2.0.7/LyX-2.0.7+qt4.dmg'
+  url 'ftp://ftp.lyx.org/pub/lyx/bin/2.0.7.1/LyX-2.0.7.1+qt4-carbon.dmg'
   homepage 'http://www.lyx.org'
-  version '2.0.7'
-  sha1 '5c1b74645b20ffe85fc0a3c1d3aaf51ea8c9490f'
+  version '2.0.7.1'
+  sha1 '07f48e9b84e3bf15149ce9a0b54880dac0318f54'
   link 'LyX.app'
 end


### PR DESCRIPTION
http://www.lyx.org/News
Bugfix Release for OSX Only: LyX 2.0.7.1 released.

February 1, 2014

We are pleased to announce the release of LyX 2.0.7.1. This is a
bugfix release that affects Mac OSX only. Users of other operating
systems do not need to update to this version, and no binaries will be
provided for other operating systems.

There were some issues with the menus in LyX 2.0.7 on OSX.
Specifically, "dynamic" menu items were lost, and there was a problem
restoring the menus from full-screen operation. Both issues are fixed
in 2.0.7.1.
