### PR TITLE
Create ShareTool.app v2.4.2 cask

### DIFF
--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -1,0 +1,7 @@
+class Sharetool < Cask
+  url 'http://mirror.nscocoa.com/~yazsoftc1/files/st2/sharetool2.zip'
+  homepage 'http://www.yazsoft.com/products/sharetool/'
+  version '2.4.2'
+  sha1 '409bbe9e50984187f022cd56f96bf2132d19fe01'
+  link 'ShareTool.app'
+end


### PR DESCRIPTION
ShareTool is a fast, extremely secure, and magical way to remain
connected to your home or office network(s) no matter where you are
physically. While connected with ShareTool, many shared
(Bonjour-enabled) services on your remote home or office network
automatically appear in your Finder, iTunes, iPhoto, and tons of other
applications (as they would if you were physically located at that
network).
