### PR TITLE
Create Prismatik.app v5.10.5

### DIFF
--- a/Casks/prismatik.rb
+++ b/Casks/prismatik.rb
@@ -1,0 +1,7 @@
+class Prismatik < Cask
+  url 'https://github.com/Atarity/Lightpack/releases/download/5.10.5/Prismatik.5.10.5.dmg'
+  homepage 'http://lightpack.tv/'
+  version '5.10.5'
+  sha1 'b3ce3b0a81c1cababfab873636ad83039beced08'
+  link 'Prismatik.app'
+end


### PR DESCRIPTION
Capturing software for Lightpack. DMG-package with all dependencies for
Mac OS X versions not less than 10.6.
