### PR TITLE
New Cask: MAME OS X, v0.135

### DIFF
--- a/Casks/mame-os-x.rb
+++ b/Casks/mame-os-x.rb
@@ -1,0 +1,7 @@
+class MameOsX < Cask
+  url 'http://downloads.sourceforge.net/mameosx/MAMEOSX-0.135.dmg'
+  homepage 'http://mameosx.sourceforge.net/'
+  version '0.135'
+  sha1 '3da5ff069077a1eda66fa9dd02d198026e411198'
+  link 'MAME OS X.app'
+end


### PR DESCRIPTION
MAME OS X is a native Mac OS X port of the popular MAME emulator. It
is designed to take advantage of all the latest Mac OS X technologies,
like Core Video and Core Image.
