### PR TITLE
update flash to 12.0.44

### DIFF
--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -1,8 +1,9 @@
 class Flash < Cask
-  url 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/mac/install_flash_player_12_osx.dmg'
+  url 'http://download.macromedia.com/pub/flashplayer/installers/archive/fp_12.0.0.44_archive.zip'
   homepage 'http://get.adobe.com/flashplayer/'
-  version '12'
-  no_checksum
+  version '12.0.44'
+  sha1 '164f77db93028acc7c1642c539020cc31f1848f2'
+  nested_container 'fp_12.0.0.44_archive/12_0_r0_44/flashplayer12_0r0_44_mac.dmg'
   install 'Install Adobe Flash Player.app/Contents/Resources/Adobe Flash Player.pkg'
   uninstall :pkgutil => 'com.adobe.pkg.FlashPlayer',
             :files => '/Library/Internet Plug-Ins/Flash Player.plugin'


### PR DESCRIPTION
Fixes #2805

This fixes the flash player security issue from 2/04/14. I could not finder a more direct route to the 12.0.44 .dmg file besides getting it from the big archive that includes a bunch of unnecessary things.

Source here: http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html#Flash%20Player%20archives
