### PR TITLE
Added cask for The Archive Browser

### DIFF
--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -1,0 +1,9 @@
+class TheArchiveBrowser < Cask
+  url 'http://wakaba.c3.cx/releases/mac/TheArchiveBrowser1.9.1.zip'
+  homepage 'http://archivebrowser.c3.cx'
+  version '1.9.1'
+  sha1 '2889b68c1e6e207d0c4703d561fc770f54fd3ed4'
+  link 'The Archive Browser.app'
+  caveats 'The Archive Browser is a paid app. This is only a trial version.
+A full license is available for purchase from the official website.'
+end


### PR DESCRIPTION
New cask for paid app 'The Archive Browser'. Installs a 30 day trial version, in which the user is prompted for a license number they can purchase.

DISCLAIMER: I am not affiliated with 'The Archive Browser' project or the developers. I am simply an end-user.
