### PR TITLE
The sha1 for version 4.20 of istat-menus has changed

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -2,6 +2,6 @@ class IstatMenus < Cask
   url 'http://s3.amazonaws.com/bjango/files/istatmenus4/istatmenus4.20.zip'
   homepage 'http://bjango.com/mac/istatmenus/'
   version '4.20'
-  sha1 '4e020ac45d29ecd5564815ba6b22892b2bfb3a8c'
+  sha1 '16f07ec1620ca8fa07162d884691d541baccb185'
   link 'iStat Menus.app'
 end


### PR DESCRIPTION
```
STDOUT: ==> Downloading http://s3.amazonaws.com/bjango/files/istatmenus4/istatmenus4.20.zip
STDERR: Error: SHA1 mismatch
Expected: 4e020ac45d29ecd5564815ba6b22892b2bfb3a8c
Actual: 16f07ec1620ca8fa07162d884691d541baccb185
```
