### PR TITLE
exit with errorcode 1 when a list error occurs

### DIFF
--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -1,26 +1,37 @@
 class Cask::CLI::List
   def self.run(*arguments)
     if arguments.any?
-      list_files(*arguments)
+      retval = list_files(*arguments)
     else
-      list_installed
+      retval = list_installed
+    end
+    # retval is ternary: true/false/nil
+    if retval.nil?
+      raise CaskError.new("nothing to list")
+    elsif ! retval
+      raise CaskError.new("listing incomplete")
     end
   end
 
   def self.list_files(*cask_names)
+    count = 0
     cask_names.each do |cask_name|
       odebug "Listing files for Cask #{cask_name}"
       cask = Cask.load(cask_name)
       if cask.installed?
+        count += 1
         Cask::PrettyListing.new(cask).print
       else
         opoo "#{cask} is not installed"
       end
     end
+    count == 0 ? nil : count == cask_names.length
   end
 
   def self.list_installed
-    puts_columns Cask.installed.map(&:to_s)
+    columns = Cask.installed.map(&:to_s)
+    puts_columns columns
+    columns.empty? ? nil : Cask.installed.length == columns.length
   end
 
   def self.help

--- a/test/cask/cli_test.rb
+++ b/test/cask/cli_test.rb
@@ -17,7 +17,7 @@ describe Cask::CLI do
     it "creates the appdir if it does not exist" do
       Cask.appdir.rmdir
       shutup {
-        Cask::CLI.process('list')
+          Cask::CLI.process('doctor')
       }
       Cask.appdir.directory?.must_equal true
     end
@@ -34,7 +34,7 @@ describe Cask::CLI do
       begin
         ENV['HOMEBREW_CASK_OPTS'] = "--appdir=#{custom_applications_dir}"
         shutup {
-          Cask::CLI.process('list')
+          Cask::CLI.process('doctor')
         }
       ensure
         ENV.delete 'HOMEBREW_CASK_OPTS'
@@ -47,7 +47,7 @@ describe Cask::CLI do
     it "creates the qlplugindir if it does not exist" do
       Cask.qlplugindir.rmdir
       shutup {
-        Cask::CLI.process('list')
+        Cask::CLI.process('doctor')
       }
       Cask.qlplugindir.directory?.must_equal true
     end
@@ -64,7 +64,7 @@ describe Cask::CLI do
       begin
         ENV['HOMEBREW_CASK_OPTS'] = "--qlplugindir=#{custom_qlplugin_dir}"
         shutup {
-          Cask::CLI.process('list')
+          Cask::CLI.process('doctor')
         }
       ensure
         ENV.delete 'HOMEBREW_CASK_OPTS'
@@ -86,7 +86,7 @@ describe Cask::CLI do
       begin
         ENV['HOMEBREW_CASK_OPTS'] = "--caskroom=#{custom_caskroom_dir}"
         shutup {
-          Cask::CLI.process('list')
+          Cask::CLI.process('doctor')
         }
       ensure
         ENV.delete 'HOMEBREW_CASK_OPTS'
@@ -100,7 +100,7 @@ describe Cask::CLI do
       Cask::CLI.expects(:exit).with(1)
       Cask::CLI.expects(:lookup_command).raises(CaskError)
       shutup {
-        Cask::CLI.process('list')
+        Cask::CLI.process('doctor')
       }
     end
   end


### PR DESCRIPTION
Fixes #2817.  This is now more consistent with Homebrew's
`list`, though not completely, because Homebrew's `list`
refuses to give any output when there is an invalid Formula
argument.  Our `list` stumbles forward instead, giving such
output as is possible based on valid args, but still exiting
with error when invalid args are seen.
