### PR TITLE
add Cask::SubversionDownloadStrategy

### DIFF
--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -8,7 +8,11 @@ class Cask::Download
   def perform
     require 'software_spec'
     cask = @cask
-    downloader = Cask::CurlDownloadStrategy.new(cask)
+    if cask.url.using == :svn
+      downloader = Cask::SubversionDownloadStrategy.new(cask)
+    else
+      downloader = Cask::CurlDownloadStrategy.new(cask)
+    end
     downloaded_path = downloader.fetch
 
     _check_sums(downloaded_path, cask.sums) unless cask.sums === 0

--- a/lib/cask/url.rb
+++ b/lib/cask/url.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 class Cask::URL
   FAKE_USER_AGENT = 'Chrome/32.0.1000.00'
 
-  attr_reader :uri, :cookies, :referer
+  attr_reader :using, :revision, :trust_cert, :uri, :cookies, :referer
 
   extend Forwardable
   def_delegators :uri, :path, :scheme, :to_s
@@ -13,6 +13,9 @@ class Cask::URL
     @user_agent = options[:user_agent]
     @cookies    = options[:cookies]
     @referer    = options[:referer]
+    @using      = options[:using]
+    @revision   = options[:revision]
+    @trust_cert = options[:trust_cert]
   end
 
   def user_agent

--- a/test/cask/download_strategy_test.rb
+++ b/test/cask/download_strategy_test.rb
@@ -94,4 +94,121 @@ describe Cask::CurlDownloadStrategy do
 
     shutup { downloader.fetch }
   end
+
+  describe Cask::SubversionDownloadStrategy do
+    it 'recognizes the SVN download strategy' do
+      cask = Cask.load('svn-download-cask')
+      cask.url.using.must_equal :svn
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      downloader.must_respond_to(:fetch)
+    end
+
+    it 'properly assigns a name and Resource based on the cask' do
+      cask = Cask.load('svn-download-cask')
+
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      downloader.name.must_equal 'svn-download-cask'
+      downloader.resource.name.must_equal 'svn-download-cask'
+      downloader.resource.url.must_equal cask.url.to_s
+      downloader.resource.version.to_s.must_equal cask.version
+    end
+
+    it 'returns a tarball path on fetch' do
+      cask = Cask.load('svn-download-cask')
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      downloader.stubs(:fetch_repo)
+      downloader.stubs(:compress)
+      shutup { downloader.fetch }.must_equal downloader.tarball_path
+    end
+
+    it 'calls fetch_repo with default arguments for a simple Cask' do
+      cask = Cask.load('svn-download-cask')
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      downloader.stubs(:compress)
+      downloader.expects(:fetch_repo).with(
+                                           downloader.cached_location,
+                                           cask.url.to_s
+                                           )
+      shutup { downloader.fetch }.must_equal downloader.tarball_path
+    end
+
+    it 'calls svn with default arguments for a simple Cask' do
+      cask = Cask.load('svn-download-cask')
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      Cask::FakeSystemCommand.expects_command([
+                                               '/usr/bin/svn',
+                                               'checkout',
+                                               '--force',
+                                               cask.url.to_s,
+                                               downloader.cached_location,
+                                              ])
+      downloader.stubs(:compress)
+      shutup { downloader.fetch }.must_equal downloader.tarball_path
+    end
+
+    it 'adds svn arguments for :trust_cert' do
+      cask = Cask.load('svn-download-trust-cask')
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      Cask::FakeSystemCommand.expects_command([
+                                               '/usr/bin/svn',
+                                               'checkout',
+                                               '--force',
+                                               '--trust-server-cert',
+                                               '--non-interactive',
+                                               cask.url.to_s,
+                                               downloader.cached_location,
+                                              ])
+      downloader.stubs(:compress)
+      shutup { downloader.fetch }.must_equal downloader.tarball_path
+    end
+
+    it 'adds svn arguments for :revision' do
+      cask = Cask.load('svn-download-revision-cask')
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      Cask::FakeSystemCommand.expects_command([
+                                               '/usr/bin/svn',
+                                               'checkout',
+                                               '--force',
+                                               cask.url.to_s,
+                                               downloader.cached_location,
+                                               '-r',
+                                               '10',
+                                              ])
+      downloader.stubs(:compress)
+      shutup { downloader.fetch }.must_equal downloader.tarball_path
+    end
+
+    it 'runs tar to serialize svn downloads' do
+      cask = Cask.load('svn-download-cask')
+      downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
+      # special mocking required for tar to have something to work with
+      def downloader.fetch_repo(target, url, revision=nil, ignore_externals=false)
+        target.mkpath
+      end
+      Cask::FakeSystemCommand.expects_command([
+                                               '/usr/bin/tar',
+                                               '-s/^\\.//',
+                                               '--exclude',
+                                               '.svn',
+                                               '-cf',
+                                               downloader.tarball_path,
+                                               '--',
+                                               '.',
+                                              ])
+      shutup { downloader.fetch }.must_equal downloader.tarball_path
+    end
+  end
+  # does not work yet, for numerous reasons
+  # it 'creates a tarball matching the expected checksum' do
+  #   cask = Cask.load('svn-download-check-cask')
+  #   downloader = Cask::SubversionDownloadStrategy.new(cask)
+  #   # special mocking required for tar to have something to work with
+  #   def downloader.fetch_repo(target, url, revision=nil, ignore_externals=false)
+  #     target.mkpath
+  #     FileUtils.touch(target.join('empty_file'))
+  #   end
+  #   shutup { downloader.fetch }.must_equal downloader.tarball_path
+  #   d = Cask::Download.new(cask)
+  #   d._check_sums(downloader.tarball_path, cask.sums)
+  # end
 end

--- a/test/support/Casks/svn-download-cask.rb
+++ b/test/support/Casks/svn-download-cask.rb
@@ -1,0 +1,7 @@
+class SvnDownloadCask < TestCask
+  url 'http://example.com/trunk/projectdir/subdir', :using => :svn
+  homepage 'http://example.com/'
+  version '1.2.3'
+  sha1 '39f3444fcb5d49618c2d62dd7b34304ea5f97a3a'
+  link 'TestCask.app'
+end

--- a/test/support/Casks/svn-download-check-cask.rb
+++ b/test/support/Casks/svn-download-check-cask.rb
@@ -1,0 +1,7 @@
+class SvnDownloadCheckCask < TestCask
+  url 'http://example.com/trunk/projectdir/subdir', :using => :svn
+  homepage 'http://example.com/'
+  version '1.2.3'
+  sha1 '39f3444fcb5d49618c2d62dd7b34304ea5f97a3a'
+  link 'TestCask.app'
+end

--- a/test/support/Casks/svn-download-revision-cask.rb
+++ b/test/support/Casks/svn-download-revision-cask.rb
@@ -1,0 +1,7 @@
+class SvnDownloadRevisionCask < TestCask
+  url 'http://example.com/trunk/projectdir/subdir', :using => :svn, :revision => '10'
+  homepage 'http://example.com/'
+  version '1.2.3'
+  sha1 '39f3444fcb5d49618c2d62dd7b34304ea5f97a3a'
+  link 'TestCask.app'
+end

--- a/test/support/Casks/svn-download-trust-cask.rb
+++ b/test/support/Casks/svn-download-trust-cask.rb
@@ -1,0 +1,7 @@
+class SvnDownloadTrustCask < TestCask
+  url 'http://example.com/trunk/projectdir/subdir', :using => :svn, :trust_cert => true
+  homepage 'http://example.com/'
+  version '1.2.3'
+  sha1 '39f3444fcb5d49618c2d62dd7b34304ea5f97a3a'
+  link 'TestCask.app'
+end


### PR DESCRIPTION
abstract out module `Cask::DownloadStrategy`, add some commentary

The interface is through new `url` keys: `:using`, `:trust_cert`, and `:revision`.

There's one oddity about this implementation, which is that I tarball the directory that SVN gives us.  At first glance this sounds like a horrible hack, but I've decided that it is actually a solid way to go.  Here are my comments on the subject from the code:
- A single file is tractable to the rest of the Cask toolchain,
- An alternative would be to create a Directory container type.  However, some type of file-serialization trick would still be needed in order to enable calculating a single checksum over a directory.  So, in that alternative implementation, the special cases would propagate outside this class, including the use of tar or equivalent.
- SubversionDownloadStrategy.cached_location is not versioned
- tarball_path provides a needed return value for our overridden fetch method.
- We can also take this private opportunity to strip files from the download which are protocol-specific.

And here is an example Cask that would use this functionality in the fonts repo, addressing caskroom/homebrew-fonts#29, where multiple Casks are required to supply a single font.

``` ruby
class FontLekton < Cask
  url 'https://github.com/w0ng/googlefontdirectory/trunk/fonts/lekton', :using => :svn, :trust_cert => true
  homepage 'http://www.google.com/fonts/specimen/Lekton'
  version 'latest'
  no_checksum
  font 'Lekton-Bold.ttf'
  font 'Lekton-Italic.ttf'
  font 'Lekton-Regular.ttf'
end
```
