### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013, Paul Hinze & Contributors
+Copyright (c) 2013-2014, Paul Hinze & Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
