### PR TITLE
add Documentation section to Changelog template

### DIFF
--- a/developer/bin/generate_changelog
+++ b/developer/bin/generate_changelog
@@ -210,6 +210,7 @@ def header
 * __Casks__
 * __Features__
 * __Fixes__
+* __Documentation__
 * __Breaking Changes__
 EOT
 end


### PR DESCRIPTION
We have recently had significant documentation contributions from @goxberry, @lgarron, @stylerw, @phillipalexander , and perhaps others.

To recognize these contributors, I propose to add a Documentation section to the Changelog starting with the next release.  We would not need to itemize changes in this section, just give stats and <3's.
