### PR TITLE
BUGFIX: restrict visibility of Cask namespace in Formula

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,11 +1,15 @@
 require 'pathname'
 require 'formula'
 
+class BrewCask < Formula; end
 require Pathname(__FILE__).realpath.dirname.join('lib', 'cask', 'version')
 
 class BrewCask < Formula
+
+  include BrewCask::Version
+
   homepage 'https://github.com/phinze/homebrew-cask/'
-  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{Cask::VERSION}"
+  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{BrewCask::VERSION}"
 
   head 'https://github.com/phinze/homebrew-cask.git', :branch => 'master'
 

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -1,6 +1,7 @@
 HOMEBREW_CACHE_CASKS = HOMEBREW_CACHE.join('Casks')
 
 class Cask; end
+class BrewCask; end
 
 require 'download_strategy'
 
@@ -35,6 +36,7 @@ require 'cask/version'
 require 'plist/parser'
 
 class Cask
+  include BrewCask::Version
   include Cask::DSL
   include Cask::Locations
   include Cask::Scopes

--- a/lib/cask/version.rb
+++ b/lib/cask/version.rb
@@ -1,3 +1,3 @@
-class Cask
+module BrewCask::Version
   VERSION = '0.28.0'
 end


### PR DESCRIPTION
@phinze, I realized that #2503 made the `Cask` class visible in the Formula, which is contributing to #2830 and many others.

I have no idea what the most idiomatic fix would be.  This is one attempt, which turns `cask/version.rb` into a module, and then `include`s `VERSION` as a mixin.

This does solve the namespace clash when loading Formulae, and preserves the visibility of the same `VERSION` number to our internal code so we don't need to set it twice.
