### PR TITLE
Report SHA-256 hash (instead of SHA-1) if checksum is missing.

### DIFF
--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -29,6 +29,6 @@ class Cask::Download
         has_sum = true
       end
     end
-    raise ChecksumMissingError.new("Checksum required. SHA1: '#{Digest::SHA1.file(path).hexdigest}'") unless has_sum
+    raise ChecksumMissingError.new("Checksum required. SHA-256: '#{Digest::SHA256.file(path).hexdigest}'") unless has_sum
   end
 end


### PR DESCRIPTION
I accidentally missed this in #2719. Since SHA-256 is the suggested default, the suggested hash if there's one missing should presumably also be SHA-256.

I've checked the repo more thoroughly, and this seems to be the only significant thing missing from #2719 (although a lot of _tests_ are still SHA-1).
