### PR TITLE
restrict visibility of Cask namespace in Formula

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -5,7 +5,7 @@ require Pathname(__FILE__).realpath.dirname.join('lib', 'cask', 'version')
 
 class BrewCask < Formula
   homepage 'https://github.com/phinze/homebrew-cask/'
-  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{Cask::VERSION}"
+  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{HOMEBREW_CASK_VERSION}"
 
   head 'https://github.com/phinze/homebrew-cask.git', :branch => 'master'
 

--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -14,7 +14,7 @@ class Cask::CLI::Doctor
     ohai 'Homebrew Cellar Path:'
     puts HOMEBREW_CELLAR
     ohai 'Homebrew-cask Version:'
-    puts Cask::VERSION
+    puts HOMEBREW_CASK_VERSION
     ohai 'Contents of $LOAD_PATH:'
     puts $LOAD_PATH
     ohai 'Contents of $RUBYLIB Environment Variable:'

--- a/lib/cask/version.rb
+++ b/lib/cask/version.rb
@@ -1,3 +1,1 @@
-class Cask
-  VERSION = '0.28.0'
-end
+HOMEBREW_CASK_VERSION = '0.28.0'


### PR DESCRIPTION
we had collision issues with homebrew's 'cask' formula (for the emacs
package manager project).

this keeps the in-project and in-formula visibility of the version
number via a different strategy that keeps a `Cask` constant out of view
of the formula.

alternate strategy to #2832 
