### PR TITLE
System command followups

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -28,7 +28,7 @@ class Cask::SystemCommand
     end
   end
 
-  def self.run!(command, options)
+  def self.run!(command, options={})
     run(command, options.merge(:must_succeed => true))
   end
 

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -37,7 +37,8 @@ class Cask::SystemCommand
     if options[:sudo]
       command.unshift('/usr/bin/sudo', '-E', '--')
     end
-    if ! options[:args].empty?
+    if options.key?(:args) and
+        ! options[:args].empty?
       command.concat options[:args]
     end
     command

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -33,6 +33,7 @@ class Cask::SystemCommand
   end
 
   def self._process_options(executable, options)
+    options.assert_valid_keys :input, :print, :stderr, :args, :must_succeed, :sudo, :plist
     command = [executable]
     if options[:sudo]
       command.unshift('/usr/bin/sudo', '-E', '--')

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -10,6 +10,16 @@ class Tty
   end
 end
 
+# monkeypatch Hash
+class Hash
+  def assert_valid_keys(*valid_keys)
+    unknown_keys = self.keys - valid_keys
+    unless unknown_keys.empty?
+      raise "Unknown keys: #{unknown_keys.join(", :")}. Running `brew update; brew upgrade brew-cask` will likely fix it."
+    end
+  end
+end
+
 def odebug title, *sput
   if Cask.respond_to?(:debug) and Cask.debug
     width = Tty.width * 4 - 6


### PR DESCRIPTION
allow `@command.run!` without `:args`, same as `@command.run` (no bang)
test valid keys in `_process_options` (works by monkeypatch on `Hash` in `utils.rb`.
