### PR TITLE
use new `:allow_untrusted` modifier on soundflower

### DIFF
--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -3,7 +3,7 @@ class Soundflower < Cask
   homepage 'https://code.google.com/p/soundflower/'
   version '1.6.6b'
   sha1 '9c94abe7dd59eb25bb167efee4a14350a3e9dd90'
-  install 'Soundflower.pkg'
+  install 'Soundflower.pkg', :allow_untrusted => true
   uninstall :pkgutil => 'com.cycling74.soundflower.*'
   caveats do
     reboot


### PR DESCRIPTION
**This PR must be held back until the next release, as it uses a new addition to the DSL.**
