### PR TITLE
Ruby 1.8.7-compat way to undef test classes

### DIFF
--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -9,18 +9,23 @@ describe "Cask" do
     end
 
     it "returns an instance of the cask from a specific file location" do
-      if Object.constants.include?(:Dia)
-        Object.send(:remove_const, :Dia)
+      # defensive constant cleanup is required because Cask
+      # classes may already be loaded due to audit test
+      begin
+        Object.class_eval{remove_const :Dia}
+      rescue
       end
       location = File.expand_path('./Casks/dia.rb')
       c = Cask.load(location)
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Dia)
+      Object.class_eval{remove_const :Dia}
     end
 
     it "returns an instance of the cask from a url" do
-      if Object.constants.include?(:Dia)
-        Object.send(:remove_const, :Dia)
+      begin
+        Object.class_eval{remove_const :Dia}
+      rescue
       end
       url = "file://" + File.expand_path('./Casks/dia.rb')
       c = shutup do
@@ -28,6 +33,7 @@ describe "Cask" do
       end
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Dia)
+      Object.class_eval{remove_const :Dia}
     end
 
     it "raises an error when failing to download a cask from a url" do
@@ -40,12 +46,14 @@ describe "Cask" do
     end
 
     it "returns an instance of the cask from a relative file location" do
-      if Object.constants.include?(:Bbedit)
-        Object.send(:remove_const, :Bbedit)
+      begin
+        Object.class_eval{remove_const :Bbedit}
+      rescue
       end
       c = Cask.load("./Casks/bbedit.rb")
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Bbedit)
+      Object.class_eval{remove_const :Bbedit}
     end
 
     it "uses exact match when loading by name" do


### PR DESCRIPTION
add cleanup after each definition

This is yet another tweak needed for #2625 to pass.
