### PR TITLE
Added Banshee

### DIFF
--- a/Casks/banshee.rb
+++ b/Casks/banshee.rb
@@ -1,0 +1,7 @@
+class Banshee < Cask
+  url 'http://ftp.gnome.org/pub/GNOME/binaries/mac/banshee/banshee-2.6.1.macosx.intel.dmg'
+  homepage 'http://banshee.fm'
+  version '2.6.1'
+  sha1 '336a0d7126160a8787cdb83f62a8d2b3ec427339'
+  link 'Banshee.app'
+end


### PR DESCRIPTION
Banshee Media Player (http://banshee.fm), currently somewhat lacking in features but still available on Mac OS X.
