### PR TITLE
Added MCEdit

### DIFF
--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -1,0 +1,7 @@
+class Mcedit < Cask
+  url 'https://bitbucket.org/codewarrior0/mcedit/downloads/MCEdit-0.1.7.1.macosx-10_6-x86_64.zip'
+  homepage 'http://www.mcedit.net'
+  version '0.1.7.1'
+  sha1 '39e0203c78f9d2b85ab3d6035a140bf2c988bf6b'
+  link 'MCEdit.app'
+end


### PR DESCRIPTION
MCEdit is a Java-based tool for editing world maps used in the popular, Java-based indie game _Minecraft_.
