### PR TITLE
Update location for Candybar

### DIFF
--- a/Casks/candybar.rb
+++ b/Casks/candybar.rb
@@ -1,6 +1,6 @@
 class Candybar < Cask
-  url 'http://panic.com/museum/candybar/CandyBar%203.3.4.zip'
-  homepage 'http://panic.com/museum/candybar/'
+  url 'http://panic.com/candybar/d/CandyBar%203.3.4.zip'
+  homepage 'http://www.panic.com/blog/candybar-mountain-lion-and-beyond'
   version '3.3.4'
   sha1 'f645e9da45a621415a07a7492c45923b1a1fd4d4'
   link 'CandyBar.app'


### PR DESCRIPTION
- Update location from deprecated /musuem path to current /d path
- Update homepage location as that 404s as well

Issue: #2911
