### PR TITLE
remove md5 checksum support

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -115,14 +115,6 @@ module Cask::DSL
       hash_type.to_s == 'sha2' ? 'sha256' : hash_type.to_s
     end
 
-    def md5(md5=nil)
-      if @sums == 0
-        raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'md5'")
-      end
-      @sums ||= []
-      @sums << Checksum.new(:md5, md5) unless md5.nil?
-    end
-
     def sha1(sha1=nil)
       if @sums == 0
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'sha1'")

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -8,16 +8,14 @@ describe Cask::DSL do
     test_cask.version.must_equal '1.2.3'
   end
 
-  it "lets you set checksum via sha1, sha256, and/or md5" do
+  it "lets you set checksum via sha1 and/or sha256" do
     ChecksumCask = Class.new(Cask)
     ChecksumCask.class_eval do
-      md5 'imamd5'
       sha1 'imasha1'
       sha256 'imasha2'
     end
     instance = ChecksumCask.new
     instance.sums.must_equal [
-      Checksum.new(:md5, 'imamd5'),
       Checksum.new(:sha1, 'imasha1'),
       Checksum.new(:sha2, 'imasha2')
     ]


### PR DESCRIPTION
Following up on #2719.  MD5 checksums are
- nowhere mentioned in our docs
- not used in any existing Cask
- deprecated in Homebrew

Therefore it seems sensible to delete this code.
