### PR TITLE
Added SlimBoat

### DIFF
--- a/Casks/slimboat.rb
+++ b/Casks/slimboat.rb
@@ -1,0 +1,7 @@
+class Slimboat < Cask
+  url 'http://dl.filehorse.com/mac/browsers-and-plugins/slimboat-for-mac/SlimBoat-for-Mac-1.1.45.dmg?st=quc9LQO-3SW71akjdYcgpw&e=1392514118&fn=slimboat.dmg'
+  homepage 'http://www.slimboat.com'
+  version '1.1.45'
+  sha1 '5cc6d4ef103490faf51ddb5085377027b96077c4'
+  link 'SlimBoat.app'
+end


### PR DESCRIPTION
SlimBoat for Mac is a lightweight, freeware and cross platform internet
browser (available on Windows, Mac and Linux) that enables everyone to
take instant advantage of many plugins and features that other browsers
will have access to only by installing specific plugins and addons. By
giving you those features instantly after you install SlimBoat, you can
save yourself from wasting time on discovering those addons and
instantly start browsing the internet in safe, productive and fast way.
