### PR TITLE
Added NitroShare

### DIFF
--- a/Casks/nitroshare.rb
+++ b/Casks/nitroshare.rb
@@ -1,0 +1,7 @@
+class Nitroshare < Cask
+  url 'https://launchpad.net/nitroshare/0.2/0.2/+download/nitroshare_0.2.app.dmg'
+  homepage 'https://quickmediasolutions.com/apps/14/nitroshare'
+  version '0.2'
+  sha256 '9f208d4b86ca13c4136265fa4a4693c7ef9ba9f0d6a0a84966cfd5f9934abe12'
+  link 'NitroShare.app'
+end


### PR DESCRIPTION
NitroShare makes it easy to transfer files from one machine to another
on the same network. Most of the time, no configuration is necessary -
all of the machines on your network running NitroShare should
immediately find each other and you can instantly begin sharing files.
