### PR TITLE
Added ProXPN

### DIFF
--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,0 +1,7 @@
+class Proxpn < Cask
+  url 'http://proxpn.com/mac.dmg'
+  homepage 'http://proxpn.com'
+  version 'latest'
+  no_checksum
+  link 'ProXPN.app'
+end


### PR DESCRIPTION
ProXPN is the Mac client to the freemium VPN service, ProXPN.

proXPN is a free, easy to use service that secures your internet
connection against eavesdropping, masks your location, and allows you
to access your favorite sites no matter where you live or travel to.
