### PR TITLE
System command followups

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -34,6 +34,10 @@ class Cask::SystemCommand
 
   def self._process_options(executable, options)
     options.assert_valid_keys :input, :print, :stderr, :args, :must_succeed, :sudo, :plist
+    # would probably be better to change :stderr to boolean :silence_stderr
+    if options[:stderr] and options[:stderr] != :silence
+      raise CaskError.new "Unknown value #{options[:stderr]} for key :stderr"
+    end
     command = [executable]
     if options[:sudo]
       command.unshift('/usr/bin/sudo', '-E', '--')

--- a/test/support/fake_system_command.rb
+++ b/test/support/fake_system_command.rb
@@ -47,8 +47,8 @@ class Cask::FakeSystemCommand
     end
   end
 
-  def self.run!(*args)
-    run(*args)
+  def self.run!(command, options={})
+    run(command, options.merge(:must_succeed => true))
   end
 end
 


### PR DESCRIPTION
- the fake run! should follow the usual case
- enforce valid values for `:stderr` in `run`.  It would probably be cleaner to change `:stderr` to a boolean `:silent_stderr`.
