### PR TITLE
Added Aria Maestosa

### DIFF
--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -1,0 +1,7 @@
+class AriaMaestosa < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/ariamaestosa/AriaMaestosa-osx-1.4.9.zip'
+  homepage 'http://ariamaestosa.sourceforge.net'
+  version '1.4.9'
+  sha256 '3a8d8bc625a6e27b2312ff1c008e78b64c94faa5ef263c85c6005e72a98ec1bf'
+  link 'AriaMaestosa-1.4.9/Aria Maestosa.app'
+end


### PR DESCRIPTION
Aria Maestosa is an open-source (GPL) midi sequencer/editor. It lets
you compose, edit and play midi files with a few clicks in a
user-friendly interface offering score, keyboard, guitar, drum and
controller views.
