### PR TITLE
Added Vico

### DIFF
--- a/Casks/vico.rb
+++ b/Casks/vico.rb
@@ -1,0 +1,7 @@
+class Vico < Cask
+  url 'http://www.vicoapp.com/download/vico-r3132.dmg'
+  homepage 'http://www.vicoapp.com'
+  version 'r3132'
+  sha256 'f5c82f320a1e3929492ecb30ba6b50d48af413b33b8e14dac06c75cd06cb809f'
+  link 'Vico.app'
+end


### PR DESCRIPTION
Vico is a programmers text editor with a strong focus on keyboard
control. Vico uses vi key bindings to let you keep your fingers on the
home row and work effectively with your text.
Vico comes with support for the most common languages, such as html,
php, ruby and javascript. And since Vico can use existing TextMate
bundles, it's easy to add more.
Vico also features integrated SFTP for working with remote files, split
views to let you edit files side-by-side and a file explorer for fast
project navigation.
Quickly navigate between files using fuzzy find, or open files directly
from the ex command line with tab completion. Jumping to symbols is
easy with the symbol list, or use ctags to find the definition under
the cursor. Ctags even works remotely over SFTP.
Vico is scriptable in the Nu language.
