### PR TITLE
Added Namely

### DIFF
--- a/Casks/namely.rb
+++ b/Casks/namely.rb
@@ -1,0 +1,7 @@
+class Namely < Cask
+  url 'http://amarsagoo.info/namely/Namely.dmg'
+  homepage 'http://amarsagoo.info/namely'
+  version 'latest'
+  no_checksum
+  link 'Namely.app'
+end


### PR DESCRIPTION
Namely is possibly the fastest way to open applications. And unlike
some other launchers, it doesn't require any learning.

You simply activate it using your preferred keyboard shortcut, start
typing part of an application's name and see a list of matches as you
type. Most of the time, one or two letters are enough. In fact, Namely
learns your habits and makes your most-used apps even quicker to access
over time. It's basically Spotlight for applications, only much faster,
and highly addictive.
