### PR TITLE
Added Hermes

### DIFF
--- a/Casks/hermes.rb
+++ b/Casks/hermes.rb
@@ -1,0 +1,7 @@
+class Hermes < Cask
+  url 'https://s3.amazonaws.com/alexcrichton-hermes/Hermes-1.1.20.zip'
+  homepage 'http://alexcrichton.com/hermes/'
+  version '1.1.20'
+  sha256 '196c7b9d8cf9e0e8ffb92d912ae40d6e24eaa5e84b931049a39ac47eef09b5cd'
+  link 'Hermes.app'
+end


### PR DESCRIPTION
Free lightweight and fast Pandora client for OS X. Hermes pauses music
when your computer sleeps, and it doesn't resume on wake. It fixes
errors and picks up the song right where you left off. You can
like/dislike songs and create/edit/delete stations, just as on Pandora.
Also, things like last.fm integration, and Growl notifications just
aren't possible with Pandora.
