### PR TITLE
Reverted Chromium to the latest stable version

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,7 +1,7 @@
 class Chromium < Cask
-  url 'https://download-chromium.appspot.com/dl/Mac'
-  homepage 'https://download-chromium.appspot.com/'
-  version 'latest'
-  no_checksum
-  link 'chrome-mac/Chromium.app'
+  url 'http://downloads.sourceforge.net/sourceforge/osxportableapps/ChromiumOSX_32.0.1700.107.dmg'
+  homepage 'http://www.freesmug.org/chromium'
+  version '32.0.1700.107'
+  sha1 '45891ec0f94bac57602d7d98dceb4e1c037595c9'
+  link 'Chromium.app'
 end


### PR DESCRIPTION
According to what @NanoXD said here [https://github.com/phinze/homebrew-cask/pull/2708](https://github.com/phinze/homebrew-cask/pull/2708) homebrew-cask focuses on stable versions so I reverted Chromium to the latest stable.
