### PR TITLE
Fixed Alfred Cask move to applications suppressing.

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -5,8 +5,9 @@ class Alfred < Cask
   sha256 'd19fe7441c6741bf663521e561b842f35707b1e83de21ca195aa033cade66d1b'
   link 'Alfred 2.app'
   link 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
+
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write com.runningwithcrayons.alfred-2 moveToApplicationsFolderAlertSuppress -bool true'
+    system 'defaults write com.runningwithcrayons.alfred-2 suppressMoveToApplications -bool true'
   end
 end


### PR DESCRIPTION
The previous cask did not suppress the "Move to Applications" message correctly.
Updated cask with the correct `defaults write` string.
