### PR TITLE
fork `abv` method with better odd-filename defense

### DIFF
--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -15,7 +15,7 @@ class Cask::CLI::Info
 
   def self.info(cask)
     installation = if cask.installed?
-                     "#{cask.destination_path} (#{cask.destination_path.abv})"
+                     "#{cask.destination_path} (#{cask.destination_path.cabv})"
                    else
                      "Not installed"
                    end

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -20,6 +20,22 @@ class Hash
   end
 end
 
+# monkeypatch Pathname
+class Pathname
+  # our own version of Homebrew's abv, with better defenses
+  # against unusual filenames
+  def cabv
+    out=''
+    n = Cask::SystemCommand.run!('/usr/bin/find',
+                                 :args => [self.realpath, *%w[-type f ! -name .DS_Store]],
+                                 :stderr => :silence).count("\n")
+    out << "#{n} files, " if n > 1
+    out << Cask::SystemCommand.run!('/usr/bin/du',
+                                    :args => ['-hs', '--', self.to_s],
+                                    :stderr => :silence).split("\t").first.strip
+  end
+end
+
 def odebug title, *sput
   if Cask.respond_to?(:debug) and Cask.debug
     width = Tty.width * 4 - 6


### PR DESCRIPTION
Fixes #2917.  New method is named `cabv`. The original `abv`
method is in Homebrew at `Library/Homebrew/extend/pathname.rb`
