### PR TITLE
Added Pashua

### DIFF
--- a/Casks/pashua.rb
+++ b/Casks/pashua.rb
@@ -1,0 +1,7 @@
+class Pashua < Cask
+  url 'http://www.bluem.net/files/Pashua.dmg'
+  homepage 'http://www.bluem.net/en/mac/pashua/'
+  version 'latest'
+  no_checksum
+  link 'Pashua.app'
+end


### PR DESCRIPTION
Pashua is a tool for creating native Aqua dialog windows from
programming languages that have none or only limi­ted support for
graphic user inter­faces on Mac OS X. Currently, it supports
Apple­Script, Perl, PHP, Python, Groovy, Rexx, Ruby, shell scripts and
Tcl—and if your favourite language is not included in this list:
writing the glue code for communicating with Pashua is pretty simple.
