### PR TITLE
Added Bit Slicer

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,0 +1,7 @@
+class BitSlicer < Cask
+  url 'https://bitbucket.org/zorgiepoo/bit-slicer/downloads/Bit%20Slicer%201.6.1.zip'
+  homepage 'https://github.com/zorgiepoo/bit-slicer/'
+  version '1.6.1'
+  sha256 '57ec0e9a1aa855c29a562bf1df0782bd717f65d6fd2b2108e33f29b51903c180'
+  link 'Bit Slicer.app'
+end


### PR DESCRIPTION
Bit Slicer is an open-source universal game trainer for OS X, written
using Cocoa and Mach kernel APIs.

It allows you to cheat in video games by searching and modifying values
such as your score, lives, ammunition, and much more.
