### PR TITLE
Added LinCastor

### DIFF
--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -1,0 +1,7 @@
+class Lincastor < Cask
+  url 'https://dl.dropboxusercontent.com/u/7614970/LinCastor.zip'
+  homepage 'http://onflapp.wordpress.com/lincastor/'
+  version '0.8.5'
+  sha256 '629a1b02ed2c97221a1652bd8209ea5104b6ead8221995252f7da98208a7a98f'
+  link 'LinCastor.app'
+end


### PR DESCRIPTION
_IMPORTANT_: I **know** that the URL looks sketchy on this one, but honestly, that's the developer's own link (open the `homepage` and check it out for yourself). In fact, the entire app and developer looks kind of sketchy (hosting a on WordPress and hosting files from Dropbox), but it looks safe enough, considering that it's been reviewed by MacUpdate and CNET.

---

LinCastor enables you to register your own custom URL protocol scheme
(e.g. mylink://foo/bar) and associate it with an application, shell or
AppleScript handler.

As most OS X application support embedding links as part of a text, a
custom URL protocol scheme provides a great way to connect different
applications together or trigger custom workflows. For example: a link
jira://issue1234 could open a JIRA tracker with specific issue. This
link could then be placed in iCal’s reminder or any other text fields
supporting links.
