### PR TITLE
ability to specify container type, not detect

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -92,6 +92,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 | `after_uninstall`    | yes                           | a Ruby block containing postflight uninstall operations
 | `before_install`     | yes                           | a Ruby block containing preflight install operations (needed only in very rare cases)
 | `before_uninstall`   | yes                           | a Ruby block containing preflight uninstall operations (needed only in very rare cases)
+| `container_type`     | no                            | a symbol to override container-type autodetect. may be one of: `:air`, `:bz2`, `:cab`, `:dmg`, `:tar`, `:sevenzip`, `:rar`, `:sit`, `:zip`, `:naked`
 
 
 ## Legacy Stanzas

--- a/lib/cask/container.rb
+++ b/lib/cask/container.rb
@@ -29,11 +29,19 @@ class Cask::Container
   end
 
   def self.for_path(path, command)
-    odebug "Determining which containers to use"
+    odebug "Determining which containers to use based on filetype"
     criteria = Cask::Container::Criteria.new(path, command)
     containers.find do |c|
       odebug "Checking container class #{c}"
       c.me?(criteria)
+    end
+  end
+
+  def self.from_type(type)
+    odebug "Determining which containers to use based on 'container_type'"
+    containers.find do |c|
+      odebug "Checking container class #{c}"
+      c.to_s == "Cask::Container::#{type.to_s.capitalize}"
     end
   end
 end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -16,6 +16,8 @@ module Cask::DSL
 
   def depends_on_formula; self.class.depends_on_formula; end
 
+  def container_type; self.class.container_type; end
+
   def sums; self.class.sums || []; end
 
   def artifacts; self.class.artifacts; end
@@ -46,6 +48,13 @@ module Cask::DSL
       @appcast ||= begin
         Cask::UnderscoreSupportingURI.parse(*args) unless args.empty?
       end
+    end
+
+    def container_type(type=nil)
+      if @container_type and !type.nil?
+        raise CaskInvalidError.new(self.title, "'container_type' stanza may only appear once")
+      end
+      @container_type ||= type
     end
 
     def version(version=nil)

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -55,7 +55,11 @@ class Cask::Installer
   def extract_primary_container
     odebug "Extracting primary container"
     FileUtils.mkdir_p @cask.destination_path
-    container = Cask::Container.for_path(@downloaded_path, @command)
+    container = if @cask.container_type
+       Cask::Container.from_type(@cask.container_type)
+    else
+       Cask::Container.for_path(@downloaded_path, @command)
+    end
     unless container
       raise CaskError.new "Uh oh, could not identify primary container for '#{@downloaded_path}'"
     end

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -60,6 +60,7 @@ def odumpcask cask
      :artifacts,
      :caveats,
      :depends_on_formula,
+     :container_type,
     ].each do |method|
       odebug "Cask instance method '#{method}':", cask.send(method).to_yaml
     end

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -189,6 +189,18 @@ describe Cask::Installer do
       pkg.must_be :file?
     end
 
+    it "works properly with an overridden container_type" do
+      naked_executable = Cask.load('naked-executable')
+
+      shutup do
+        Cask::Installer.new(naked_executable).install
+      end
+
+      dest_path = Cask.caskroom/'naked-executable'/naked_executable.version
+      executable = dest_path/'naked_executable'
+      executable.must_be :file?
+    end
+
     it "works fine with a nested container" do
       nested_app = Cask.load('nested-app')
 

--- a/test/support/Casks/naked-executable.rb
+++ b/test/support/Casks/naked-executable.rb
@@ -1,0 +1,7 @@
+class NakedExecutable < TestCask
+  url TestHelper.local_binary('naked_executable')
+  homepage 'http://example.com/naked-executable'
+  version '1.2.3'
+  sha1 '504519c842b7202250315ef562069e4ce10da99c'
+  container_type :naked
+end

--- a/test/support/binaries/naked_executable
+++ b/test/support/binaries/naked_executable
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0


### PR DESCRIPTION
Fixes #2997.  Interface is optional DSL stanza `container_type`.
This should only be used in rare instances.  It is needed for the
case of a naked executable which should not be unpacked.
