### PR TITLE
temporary hack: suppress searching the font tap

### DIFF
--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -6,7 +6,8 @@ class Cask::CLI::Search
       search_regexp = $1
       cask_names = Cask::CLI.nice_listing(Cask.all_titles).grep(/#{search_regexp}/i)
     else
-      all_titles = Cask::CLI.nice_listing Cask.all_titles
+      # suppressing search of the font Tap is a quick hack until behavior can be made configurable
+      all_titles = Cask::CLI.nice_listing Cask.all_titles.reject{ |t| %r{^caskroom-fonts/}.match(t)}
       simplified_titles = all_titles.map { |t| t.gsub(/[^a-z]+/i, '') }
       simplified_search_term = search_term.gsub(/[^a-z]+/i, '')
       cask_names = simplified_titles.grep(/#{simplified_search_term}/i) { |t| all_titles[simplified_titles.index(t)] }


### PR DESCRIPTION
this is needed to reduce noise on searches until search
can be made more configurable
