### PR TITLE
rename vlc-streamer.rb

### DIFF
--- a/Casks/vlcstreamer.rb
+++ b/Casks/vlcstreamer.rb
@@ -1,4 +1,4 @@
-class VlcStreamer < Cask
+class Vlcstreamer < Cask
   url 'http://hobbyistsoftware.com/Downloads/VLCStreamer/latest-mac.php?cdn'
   homepage 'http://hobbyistsoftware.com/vlcstreamer'
   version 'latest'


### PR DESCRIPTION
to vlcstreamer.rb
per naming rules in CONTRIBUTING.md
following up on #2659
