### PR TITLE
rename mysql-workbench.rb

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -1,4 +1,4 @@
-class MysqlWorkbench < Cask
+class Mysqlworkbench < Cask
   url 'http://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-6.0.9-osx-i686.dmg'
   homepage 'http://www.mysql.com/products/workbench'
   version '6.0.9'


### PR DESCRIPTION
to mysqlworkbench.rb
per naming rules in CONTRIBUTING.md
following up on #2659
