### PR TITLE
rename mirror-displays.rb

### DIFF
--- a/Casks/mirrordisplays.rb
+++ b/Casks/mirrordisplays.rb
@@ -1,4 +1,4 @@
-class MirrorDisplays < Cask
+class Mirrordisplays < Cask
   url 'http://www.fabiancanas.com/downloads/MirrorDisplays.zip',
     :referer => 'http://www.fabiancanas.com/Projects/MirrorDisplays'
   homepage 'http://www.fabiancanas.com/Projects/MirrorDisplays'


### PR DESCRIPTION
to mirrordisplays.rb
per naming rules in CONTRIBUTING.md
following up on #2659
