### PR TITLE
rename serial-cloner.rb

### DIFF
--- a/Casks/serialcloner.rb
+++ b/Casks/serialcloner.rb
@@ -1,4 +1,4 @@
-class SerialCloner < Cask
+class Serialcloner < Cask
   url 'http://serialbasics.free.fr/Serial_Cloner-Download_files/SerialCloner2-6.dmg'
   homepage 'http://serialbasics.free.fr/Serial_Cloner.html'
   version '2.6.1'


### PR DESCRIPTION
to serialcloner.rb
per naming rules in CONTRIBUTING.md
following up on #2659
