### PR TITLE
WIP: multiple URLs per Cask

### DIFF
--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -25,7 +25,7 @@ class Cask::Audit
 
   def _check_required_fields
     odebug "Auditing required fields"
-    add_error "url is required" unless cask.url
+    add_error "url is required" unless cask.url.length > 0
     add_error "version is required" unless cask.version
     add_error "homepage is required" unless cask.homepage
   end
@@ -56,12 +56,15 @@ class Cask::Audit
   end
 
   def _bad_sourceforge_url?
-    return false unless cask.url.to_s =~ /sourceforge/
     valid_url_formats = [
       %r{https?://sourceforge.net/projects/.*/files/latest/download},
       %r{https?://downloads.sourceforge.net/},
       %r{https?://dl.sourceforge.jp/},
     ]
-    valid_url_formats.none? { |format| cask.url.to_s =~ format }
+    cask.url.each do |cask_url|
+      return true if cask_url.to_s =~ /sourceforge/ and
+                     valid_url_formats.none? { |format| cask_url.to_s =~ format }
+    end
+    return false
   end
 end

--- a/lib/cask/cli/fetch.rb
+++ b/lib/cask/cli/fetch.rb
@@ -7,8 +7,10 @@ class Cask::CLI::Fetch
     cask_names.each do |cask_name|
       ohai "Fetching resources for Cask #{cask_name}"
       cask = Cask.load(cask_name)
-      @downloaded_path = Cask::Download.new(cask).perform force
-      ohai "Success! Downloaded to -> #{@downloaded_path}"
+      @downloaded_path = Cask::Download.new(cask).perform(force)
+      @downloaded_path.each do |path|
+        ohai "Success! Downloaded to -> #{path}"
+      end
     end
   end
 

--- a/lib/cask/container/naked.rb
+++ b/lib/cask/container/naked.rb
@@ -12,6 +12,6 @@ class Cask::Container::Naked < Cask::Container::Base
   end
 
   def target_file
-    URI.decode(File.basename(@cask.url.path))
+    Pathname.new(@path).basename
   end
 end

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -9,17 +9,27 @@ require 'cgi'
 module Cask::DownloadStrategy
   attr_reader :cask, :cask_url
 
-  def initialize(cask, command=Cask::SystemCommand)
+  def initialize(cask, cask_url=cask.url.first, command=Cask::SystemCommand)
     @cask     = cask
+    @cask_url = cask_url
     @command  = command
-    @cask_url = cask.url
     super(
       cask.title,
       ::Resource.new(cask.title) do |r|
-        r.url     cask.url.to_s
+        r.url     cask_url.to_s
         r.version cask.version
       end
     )
+  end
+
+  def tarball_path
+    if cask_url.target == :basename
+      Pathname.new("#{HOMEBREW_CACHE}/#{basename_without_params}")
+    elsif cask_url.target
+      Pathname.new("#{HOMEBREW_CACHE}/#{cask_url.target}")
+    else
+      super
+    end
   end
 end
 

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -33,11 +33,12 @@ module Cask::DSL
     end
 
     def url(*args)
-      if @url and !args.empty?
-        raise CaskInvalidError.new(self.title, "'url' stanza may only appear once")
-      end
-      @url ||= begin
-        Cask::URL.new(*args) unless args.empty?
+      @url ||= []
+      if ! args.empty?
+        @url << Cask::URL.new(*args)
+      else
+        # accessor
+        @url
       end
     end
 

--- a/lib/cask/link_checker.rb
+++ b/lib/cask/link_checker.rb
@@ -16,9 +16,11 @@ class Cask::LinkChecker
   end
 
   def run
-    _get_data_from_request
-    return if errors?
-    _check_response_status
+    cask.url.each do |cask_url|
+      _get_data_from_request(cask_url)
+      return if errors?
+      _check_response_status(cask_url)
+    end
   end
 
   HTTP_RESPONSES = [
@@ -33,24 +35,29 @@ class Cask::LinkChecker
     'ftp'   => [ 'OK' ]
   }
 
-  def _check_response_status
-    ok = OK_RESPONSES[cask.url.scheme]
+  def _check_response_status(cask_url)
+    ok = OK_RESPONSES[cask_url.scheme]
     unless ok.include?(@response_status)
       add_error "unexpected http response, expecting #{ok.map(&:inspect).join(' or ')}, got #{@response_status.inspect}"
     end
   end
 
-  def _get_data_from_request
-    response = @fetcher.head(cask.url)
+  def _get_data_from_request(cask_url)
+    @response_status = nil
+    @headers = {}
+    @errors = []
+    @warnings = []
+
+    response = @fetcher.head(cask_url)
 
     if response.empty?
-      add_error "timeout while requesting #{cask.url}"
-      return
-    end
+      add_error "timeout while requesting #{cask_url}"
+        return
+      end
 
     response_lines = response.split("\n").map(&:chomp)
 
-    case cask.url.scheme
+    case cask_url.scheme
     when 'http', 'https' then
       @response_status = response_lines.grep(/^HTTP/).last.strip
       unless response_lines.index(@response_status).nil?
@@ -67,7 +74,7 @@ class Cask::LinkChecker
         @headers[header_name] = header_value
       }
     else
-      add_error "unknown scheme for #{cask.url}"
+      add_error "unknown scheme for #{cask_url}"
     end
   end
 end

--- a/lib/cask/url.rb
+++ b/lib/cask/url.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 class Cask::URL
   FAKE_USER_AGENT = 'Chrome/32.0.1000.00'
 
-  attr_reader :using, :revision, :trust_cert, :uri, :cookies, :referer, :data
+  attr_reader :using, :revision, :trust_cert, :uri, :cookies, :referer, :data, :target, :multipart, :sums
 
   extend Forwardable
   def_delegators :uri, :path, :scheme, :to_s
@@ -17,6 +17,17 @@ class Cask::URL
     @revision   = options[:revision]
     @trust_cert = options[:trust_cert]
     @data       = options[:data]
+    @target     = options[:target]
+    @multipart  = options[:multipart]
+    @sums       = []
+    if options.key?(:sha256)
+      if options[:sha256] == :no_check
+        @sums = options[:sha256]
+      else
+        @sums  << Checksum.new(:sha2, options[:sha256])
+      end
+    end
+    @sums       = :no_check if options.key?(:no_checksum) and options[:no_checksum]
   end
 
   def user_agent

--- a/test/cask/container/dmg_test.rb
+++ b/test/cask/container/dmg_test.rb
@@ -7,7 +7,7 @@ describe Cask::Container::Dmg do
 
       dmg = Cask::Container::Dmg.new(
         transmission,
-        Pathname(transmission.url.path),
+        Pathname(transmission.url.first.path),
         Cask::SystemCommand
       )
 

--- a/test/cask/download_strategy_test.rb
+++ b/test/cask/download_strategy_test.rb
@@ -12,7 +12,7 @@ describe Cask::CurlDownloadStrategy do
     downloader = Cask::CurlDownloadStrategy.new(BasicCask)
     downloader.name.must_equal 'basic-cask'
     downloader.resource.name.must_equal 'basic-cask'
-    downloader.resource.url.must_equal cask.url.to_s
+    downloader.resource.url.must_equal cask.url.first.to_s
     downloader.resource.version.to_s.must_equal cask.version
   end
 
@@ -22,7 +22,7 @@ describe Cask::CurlDownloadStrategy do
     downloader = Cask::CurlDownloadStrategy.new(cask)
     downloader.temporary_path.stubs(:rename)
     downloader.expects(:curl).with(
-      cask.url,
+      cask.url.first,
       '-C', 0,
       '-o', kind_of(Pathname)
     )
@@ -102,7 +102,7 @@ describe Cask::CurlDownloadStrategy do
       downloader = Cask::CurlPostDownloadStrategy.new(BasicCask)
       downloader.name.must_equal 'basic-cask'
       downloader.resource.name.must_equal 'basic-cask'
-      downloader.resource.url.must_equal cask.url.to_s
+      downloader.resource.url.must_equal cask.url.first.to_s
       downloader.resource.version.to_s.must_equal cask.version
     end
 
@@ -143,7 +143,7 @@ describe Cask::CurlDownloadStrategy do
   describe Cask::SubversionDownloadStrategy do
     it 'recognizes the SVN download strategy' do
       cask = Cask.load('svn-download-cask')
-      cask.url.using.must_equal :svn
+      cask.url.first.using.must_equal :svn
       downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
       downloader.must_respond_to(:fetch)
     end
@@ -154,7 +154,7 @@ describe Cask::CurlDownloadStrategy do
       downloader = Cask::SubversionDownloadStrategy.new(cask, Cask::FakeSystemCommand)
       downloader.name.must_equal 'svn-download-cask'
       downloader.resource.name.must_equal 'svn-download-cask'
-      downloader.resource.url.must_equal cask.url.to_s
+      downloader.resource.url.must_equal cask.url.first.to_s
       downloader.resource.version.to_s.must_equal cask.version
     end
 
@@ -172,7 +172,7 @@ describe Cask::CurlDownloadStrategy do
       downloader.stubs(:compress)
       downloader.expects(:fetch_repo).with(
                                            downloader.cached_location,
-                                           cask.url.to_s
+                                           cask.url.first.to_s
                                            )
       shutup { downloader.fetch }.must_equal downloader.tarball_path
     end
@@ -186,7 +186,7 @@ describe Cask::CurlDownloadStrategy do
                                                '--force',
                                                '--config-option',
                                                'config:miscellany:use-commit-times=yes',
-                                               cask.url.to_s,
+                                               cask.url.first.to_s,
                                                downloader.cached_location,
                                               ])
       downloader.stubs(:compress)
@@ -204,7 +204,7 @@ describe Cask::CurlDownloadStrategy do
                                                'config:miscellany:use-commit-times=yes',
                                                '--trust-server-cert',
                                                '--non-interactive',
-                                               cask.url.to_s,
+                                               cask.url.first.to_s,
                                                downloader.cached_location,
                                               ])
       downloader.stubs(:compress)
@@ -220,7 +220,7 @@ describe Cask::CurlDownloadStrategy do
                                                '--force',
                                                '--config-option',
                                                'config:miscellany:use-commit-times=yes',
-                                               cask.url.to_s,
+                                               cask.url.first.to_s,
                                                downloader.cached_location,
                                                '-r',
                                                '10',

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Cask::DSL do
   it "lets you set url, homepage, and version" do
     test_cask = Cask.load('basic-cask')
-    test_cask.url.to_s.must_equal 'http://example.com/TestCask.dmg'
+    test_cask.url.first.to_s.must_equal 'http://example.com/TestCask.dmg'
     test_cask.homepage.must_equal 'http://example.com/'
     test_cask.version.must_equal '1.2.3'
   end
@@ -89,13 +89,6 @@ describe Cask::DSL do
 
     instance = CaskWithInstallables.new
     Array(instance.artifacts[:install]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
-  end
-
-  it "prevents defining multiple urls" do
-    err = lambda {
-      invalid_cask = Cask.load('invalid/invalid-two-url')
-    }.must_raise(CaskInvalidError)
-    err.message.must_include "'url' stanza may only appear once"
   end
 
   it "prevents defining multiple homepages" do

--- a/test/cask/link_checker_test.rb
+++ b/test/cask/link_checker_test.rb
@@ -4,14 +4,14 @@ describe Cask::LinkChecker do
   describe "request processing" do
     it "adds an error if response is empty" do
       cask = TestHelper.test_cask
-      TestHelper.fake_response_for(cask.url, "")
+      TestHelper.fake_response_for(cask.url.first, "")
       checker = Cask::LinkChecker.new(cask, TestHelper.fake_fetcher)
       checker.run
-      checker.errors.must_include "timeout while requesting #{cask.url}"
+      checker.errors.must_include "timeout while requesting #{cask.url.first}"
     end
 
     it "properly populates the response code and headers from an http response" do
-      TestHelper.fake_response_for(TestHelper.test_cask.url, <<-RESPONSE.gsub(/^ */, ''))
+      TestHelper.fake_response_for(TestHelper.test_cask.url.first, <<-RESPONSE.gsub(/^ */, ''))
         HTTP/1.1 200 OK
         Content-Type: application/x-apple-diskimage
         ETag: "b4208f3e84967be4b078ecaa03fba941"


### PR DESCRIPTION
- Work-in-progress because there are no docs/tests at present.  Some current tests fail.
- Permits `url` stanza to be repeated multiple times
- checksum keys such as `:sha256` may be appended to each `url`
- `:target` may be appended to `url` to specify a target download name,
  with special value `:basename` indicating the basename extracted from the URL
- `:multipart => true` may be appended to `url` to indicate assets which will
  not be subjected to container analysis or explicit unarchiving.  `:multipart`
  may not be the best name for that. `:fetch_only` ?
