### PR TITLE
BUGFIX: Homebrew chg, 3 args for checksum mismatch

### DIFF
--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -33,7 +33,7 @@ class Cask::Download
         if sum == computed
           odebug "Checksums match"
         else
-          raise ChecksumMismatchError.new(sum, computed)
+          raise ChecksumMismatchError.new(path, sum, computed)
         end
         has_sum = true
       end


### PR DESCRIPTION
Homebrew changed underneath us, requiring 3 arguments to
`ChecksumMismatchError.new`.  This is causing total failure
on Travis, and probably a number of issues will be filed
until we merge and cut a bugfix release.
