### PR TITLE
Added Kid3

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,0 +1,7 @@
+class Kid3 < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/kid3/kid3-3.0.2-Darwin.dmg'
+  homepage 'http://kid3.sourceforge.net/'
+  version '3.0.2'
+  sha256 'a1b60a4eea11ca62001365dd28d418c595ce2d073dd4e0ba07bd28a94cb5c260'
+  link 'Kid3.app'
+end


### PR DESCRIPTION
If you want to easily tag multiple MP3, Ogg/Vorbis, FLAC, MPC, MP4/AAC,
MP2, Opus, Speex, TrueAudio, WavPack, WMA, WAV and AIFF files (e.g.
full albums) without typing the same information again and again and
have control over both ID3v1 and ID3v2 tags, then Kid3 is the program
you are looking for.
