### PR TITLE
bugfix: caveats DSL `os_version_only` spelling

### DIFF
--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -118,7 +118,7 @@ class Cask::CaveatsDSL
   # appear even if no warning is output.  One workaround would
   # be to spin out os-version-detection from caveats into a separate
   # Cask stanza, and that is probably a sensible design.
-  def os_versions_only(*supported_versions)
+  def os_version_only(*supported_versions)
     known_versions = %w{10.0 10.1 10.2 10.3 10.3 10.5 10.6 10.7 10.8 10.9}
     supported_versions.each do |version|
       unless known_versions.include?(version)

--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -18,7 +18,7 @@ class WithCaveats < TestCask
     manual_installer('Installer.app')
     # since all known OS versions are specified, no output should be
     # generated here during the test
-    os_versions_only('10.0', '10.1', '10.2', '10.3', '10.3', '10.5', '10.6', '10.7', '10.8', '10.9')
+    os_version_only('10.0', '10.1', '10.2', '10.3', '10.3', '10.5', '10.6', '10.7', '10.8', '10.9')
   end
   caveats do
     # since both valid arches are specified, no output should be


### PR DESCRIPTION
change method name to follow documentation
