### PR TITLE
Store metadata with installed Casks.

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -96,9 +96,10 @@ class Cask
     end
   end
 
-  attr_reader :token
-  def initialize(token=self.class.token)
-    @token = token
+  attr_reader :token, :sourcefile_path
+  def initialize(sourcefile_path=nil)
+    @sourcefile_path = sourcefile_path
+    @token = self.class.token
   end
 
   def caskroom_path

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -59,6 +59,7 @@ class Cask::Installer
       download
       extract_primary_container
       install_artifacts
+      save_caskfile force
       enable_accessibility_access
     rescue StandardError => e
       purge_versioned_files
@@ -215,6 +216,22 @@ class Cask::Installer
         automatically on this version of OS X.  See System Preferences.
       EOS
     end
+  end
+
+  def save_caskfile(force=false)
+    timestamp = :now
+    create    = true
+    savedir   = @cask.metadata_subdir('Casks', timestamp, create)
+    if Dir.entries(savedir).size > 2
+      # should not happen
+      if force
+        savedir.rmtree
+        FileUtils.mkdir_p savedir
+      else
+        raise CaskAlreadyInstalledError.new(@cask)
+      end
+    end
+    FileUtils.copy(@cask.sourcefile_path, savedir) if @cask.sourcefile_path
   end
 
   def uninstall(force=false)

--- a/lib/cask/source/path_base.rb
+++ b/lib/cask/source/path_base.rb
@@ -78,7 +78,7 @@ class Cask::Source::PathBase
       raise e
     end
     begin
-      Object.const_get(cask_class_name).new
+      Object.const_get(cask_class_name).new(path)
     rescue CaskError, StandardError, ScriptError => e
       # bug: e.message.concat doesn't work with CaskError exceptions
       e.message.concat(" while instantiating '#{cask_class_name}' from '#{path}'")

--- a/lib/cask/without_source.rb
+++ b/lib/cask/without_source.rb
@@ -3,6 +3,11 @@ class Cask::WithoutSource < Cask
     caskroom_path.children.first
   end
 
+  def initialize(sourcefile_path=nil)
+    @sourcefile_path = sourcefile_path
+    @token = sourcefile_path
+  end
+
   def to_s
     "#{token} (!)"
   end


### PR DESCRIPTION
Step 1: Snapshot the Cask file used at install-time.

Using a simple filesystem-is-a-database approach, set up a
`.metadata` directory for each installed Cask in which we can
record any information, starting with a copy of the Cask
definition which was used at install-time.

This should be useful for various cases such as:
- a fallback when the Cask was renamed/removed.  We currently cannot recover any uninstall info in that scenario
- installation of multiple versions of the same software

There might be a smarter way to discover the source filename
for the Cask through introspection or some deep Ruby voodoo.
All I could come up with was to pass the filename in on the
constructor, which seems perfectly reasonable if voodoo is
not available.  The existing code was taking the title as an
argument to the constructor, which is dispensable.

This PR contains no code to actually make use of the metadata,
but only takes care of the relevant book-keeping: creation,
destruction, as well as organization of metadata according to
software version number and timestamp.
