### PR TITLE
add extended attributes for `:target` links

### DIFF
--- a/lib/cask/artifact/hardlinked.rb
+++ b/lib/cask/artifact/hardlinked.rb
@@ -10,6 +10,7 @@ class Cask::Artifact::Hardlinked < Cask::Artifact::Symlinked
 
   def create_filesystem_link(source, target)
     @command.run!('/bin/ln', :args => ['-hf', '--', source, target])
+    add_altname_metadata source, target
   end
 
   def summarize_one_link(artifact_spec)

--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -9,6 +9,26 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
 
   def create_filesystem_link(source, target)
     @command.run!('/bin/ln', :args => ['-hfs', '--', source, target])
+    add_altname_metadata source, target
+  end
+
+  # Try to make the asset searchable under the target name.  Spotlight
+  # respects this attribute for many filetypes, but ignores it for App
+  # bundles.  Alfred 2.2 respects it even for App bundles.
+  def add_altname_metadata(source, target)
+    attribute = 'com.apple.metadata:kMDItemAlternateNames'
+    return unless source.basename.to_s.casecmp(target.basename)
+    odebug "Adding #{attribute} metadata"
+    altnames = @command.run('/usr/bin/xattr',
+                            :args => ['-p', attribute, target],
+                            :stderr => :silence).sub(/\A\((.*)\)\Z/, "#{$1}")
+    odebug "Existing metadata is: '#{altnames}'"
+    altnames.concat(', ') if altnames.length > 0
+    altnames.concat(%Q{"#{target.basename}"})
+    altnames = %Q{(#{altnames})}
+    @command.run!('/usr/bin/xattr',
+                  :args => ['-w', attribute, altnames, target],
+                  :stderr => :silence)
   end
 
   def summary

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -18,6 +18,20 @@ describe Cask::Artifact::App do
       TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
     end
 
+    it "creates metadata containing the altername target name" do
+      cask = local_alt_caffeine
+
+      shutup do
+        Cask::Artifact::App.new(cask).install
+      end
+
+      Cask::SystemCommand.run('/usr/bin/xattr',
+                              :args => ['-p',
+                                        'com.apple.metadata:kMDItemAlternateNames',
+                                        Cask.appdir/'AnotherName.app'],
+                              :stderr => :silence).must_match(/AnotherName/)
+    end
+
     it "works with an application in a subdir" do
       AltSubDirCask = Class.new(Cask)
       AltSubDirCask.class_eval do


### PR DESCRIPTION
fixes #2847.  This PR adds OS X-specific extended attributes
(metadata) whenever `:target` is used on an artifact.  The
extended attributes are available for search software such
as Spotlight or Alfred to discover the artifact under the
`:target` name (rather than the source name)

Limitations: Spotlight specifically chooses to ignore this
attribute for App bundles.  Alfred will also ignore this
attribute until the upcoming 2.2 release.
