### PR TITLE
Added cask for Mac Linux USB Loader.

### DIFF
--- a/Casks/mac-linux-usb-loader.rb
+++ b/Casks/mac-linux-usb-loader.rb
@@ -1,0 +1,7 @@
+class MacLinuxUSBLoader < Cask
+  url 'http://sevenbits.github.io/downloads/Mac-Linux-USB-Loader.zip'
+  homepage 'http://sevenbits.github.io/Mac-Linux-USB-Loader/'
+  version '2.0'
+  no_checksum
+  link 'Mac Linux USB Loader.app'
+end

--- a/Casks/mac-linux-usb-loader.rb
+++ b/Casks/mac-linux-usb-loader.rb
@@ -1,7 +1,7 @@
-class MacLinuxUSBLoader < Cask
+class MacLinuxUsbLoader < Cask
   url 'http://sevenbits.github.io/downloads/Mac-Linux-USB-Loader.zip'
   homepage 'http://sevenbits.github.io/Mac-Linux-USB-Loader/'
-  version '2.0'
+  version 'latest'
   no_checksum
   link 'Mac Linux USB Loader.app'
 end


### PR DESCRIPTION
Added a cask for my application [Mac Linux USB Loader](http://sevenbits.github.io/Mac-Linux-USB-Loader/) version 2.0.

From the homepage:

> Mac Linux USB Loader is an application that allows you to create bootable USB drives containing a Linux distribution that can boot natively on Apple's Macintosh computers using its EFI system, regardless of whether or not the selected distribution has UEFI support.
