### PR TITLE
Add (unoffical) Google Music app v1.0.2

### DIFF
--- a/Casks/google-music.rb
+++ b/Casks/google-music.rb
@@ -1,0 +1,7 @@
+class GoogleMusic < Cask
+  url 'https://github.com/kbhomes/google-music-mac/releases/download/v1.0.2/Google.Music.zip'
+  homepage 'http://kbhomes.github.io/google-music-mac/'
+  version '1.0.2'
+  sha256 '0d480a42a31e0a712e8646913950135c777677b315bfae4723b2fbd277705cac'
+  link 'Google Music.app'
+end


### PR DESCRIPTION
On the front page of HN was [this new app](http://kbhomes.github.io/google-music-mac/).

Do let me know if there are any issues, this is my first time contributing to this project.
