### PR TITLE
remove OmniOutliner Pro Cask

### DIFF
--- a/Casks/omnioutliner-pro.rb
+++ b/Casks/omnioutliner-pro.rb
@@ -1,7 +1,0 @@
-class OmnioutlinerPro < Cask
-  url 'http://www.omnigroup.com/download/latest/omnioutlinerPro'
-  homepage 'http://www.omnigroup.com/omnioutliner/'
-  version 'latest'
-  no_checksum
-  link 'OmniOutliner Professional.app'
-end


### PR DESCRIPTION
closes #2777.  This was discontinued as a separate product.
