### PR TITLE
fix broken app link for CLIX.app

### DIFF
--- a/Casks/clix.rb
+++ b/Casks/clix.rb
@@ -1,7 +1,7 @@
 class Clix < Cask
   url 'https://www.macupdate.com/download/13983/CLIX.zip'
   homepage 'http://rixstep.com/4/0/clix/index.shtml'
-  version 'latest'
-  no_checksum
-  link 'CLIX/CLIX-64/CLIX.app'
+  version '2.1'
+  sha256 'ab85b3d1d9b298a6f476854de778203767fd13c1ede16e3cdd3aeea0f63e9c05'
+  link 'CLIX2.1/CLIX.app'
 end


### PR DESCRIPTION
I don't really approve of using macupdate for the URL, but there does not
seem to be any working upstream source.
