### PR TITLE
add optional appcast stanza to DSL

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -10,6 +10,8 @@ module Cask::DSL
 
   def url; self.class.url; end
 
+  def appcast; self.class.appcast; end
+
   def version; self.class.version; end
 
   def depends_on_formula; self.class.depends_on_formula; end
@@ -34,6 +36,15 @@ module Cask::DSL
       end
       @url ||= begin
         Cask::URL.new(*args) unless args.empty?
+      end
+    end
+
+    def appcast(*args)
+      if @appcast and !args.empty?
+        raise CaskInvalidError.new(self.title, "'appcast' stanza may only appear once")
+      end
+      @appcast ||= begin
+        Cask::UnderscoreSupportingURI.parse(*args) unless args.empty?
       end
     end
 

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -51,7 +51,16 @@ def odumpcask cask
   if Cask.respond_to?(:debug) and Cask.debug
     odebug "Cask instance dumps in YAML:"
     odebug "Cask instance toplevel:", cask.to_yaml
-    [:homepage, :url, :version, :sums, :artifacts, :caveats, :depends_on_formula].each do |method|
+    [
+     :homepage,
+     :url,
+     :appcast,
+     :version,
+     :sums,
+     :artifacts,
+     :caveats,
+     :depends_on_formula,
+    ].each do |method|
       odebug "Cask instance method '#{method}':", cask.send(method).to_yaml
     end
   end


### PR DESCRIPTION
Appcasts are a standard way for applications to publish
information about available updates via RSS.  Sparkle and
other update frameworks are built upon appcasts.

In a quick test, appcasts were found for 188/360 Casks examined.

This PR adds an optional `appcast` stanza, but does not add
`appcast` to any Cask or make use of the info in any way.  It is
intentionally left undocumented, the idea being that we could
test it out on selected Casks and discover how well we can
make use of it.

Example usage for `evernote.rb`:

``` ruby
  appcast 'http://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml'
```
