### PR TITLE
`sha256 :no_check` as synonym for `no_checksum`

### DIFF
--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -32,7 +32,7 @@ class Cask::Audit
 
   def _check_checksums
     odebug "Auditing checksums"
-    return if cask.sums == 0
+    return if cask.sums == :no_check
     add_error "could not find checksum or no_checksum" unless cask.sums.is_a?(Array) && cask.sums.length > 0
   end
 

--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -20,7 +20,7 @@ class Cask::Download
                    HOMEBREW_CACHE_CASKS.join(downloaded_path.basename)
     rescue
     end
-    _check_sums(downloaded_path, cask.sums) unless cask.sums === 0
+    _check_sums(downloaded_path, cask.sums) unless cask.sums === :no_check
     downloaded_path
   end
 

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -116,26 +116,34 @@ module Cask::DSL
     end
 
     def sha1(sha1=nil)
-      if @sums == 0
+      if @sums == :no_check
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'sha1'")
       end
-      @sums ||= []
-      @sums << Checksum.new(:sha1, sha1) unless sha1.nil?
+      if sha1 == :no_check
+        @sums = sha1
+      else
+        @sums ||= []
+        @sums << Checksum.new(:sha1, sha1) unless sha1.nil?
+      end
     end
 
     def sha256(sha2=nil)
-      if @sums == 0
+      if @sums == :no_check
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'sha256'")
       end
-      @sums ||= []
-      @sums << Checksum.new(:sha2, sha2) unless sha2.nil?
+      if sha2 == :no_check
+        @sums = sha2
+      else
+        @sums ||= []
+        @sums << Checksum.new(:sha2, sha2) unless sha2.nil?
+      end
     end
 
     def no_checksum
       unless @sums.nil? or @sums.empty?
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with '#{hash_name(@sums.first.hash_type)}'")
       end
-      @sums = 0
+      @sums = :no_check
     end
 
     def method_missing(method, *args)


### PR DESCRIPTION
Introduces new form `sha256 :no_check` as a synonym for `no_checksum`.
Backend code also cleaned up to use self-documenting symbol instead of special-behavior zero.

The new syntax is intentionally left undocumented.  The plan would be to have
this code in release for at least a month before transitioning Casks to use it.

Rationale: simplification.
- DSL declaration `md5` was removed in #2931.
- `sha1` is deprecated, we may as well move towards its removal.
- With this PR, the oddball `no_checksum` declaration can also be removed.
- That's 3 fewer declarations in the DSL, with equivalent functionality.
