### PR TITLE
Update CONDUCT.md

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,8 +1,8 @@
 # Contributor Code of Conduct
-## Version 0.3a
+## Version 0.3b
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of Homebrew Cask, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-If any participant in this project has issues or takes exception with a contribution, they are obligated to provide constructive feedback and never resort to personal attacks, trolling, public or private harrassment, insults, or other unprofessional conduct.
+We provide constructive feedback and never resort to personal attacks, trolling, harrassment, insults, or other unprofessional conduct. We are considerate of the effort of others. We are tactful when we provide criticism, and graceful when we face it.
 
-We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.
+We extend courtesy and respect to everyone who volunteers their labor for this project. We welcome and encourage contributors regardless of their background or attributes including, but not limited to: age, culture, ethnicity, national origin, gender identity or expression, ability or disability, physical or mental difference, experience, politics, race, religion, sex, sexual orientation, socio-economic status, and subculture.


### PR DESCRIPTION
Some very quick changes to the CoC. Namely:
- More consistent language. Extend the first person to all paragraphs, and treat the ones following the first as an implicit extension of the pledge.
- A few more considerations on communication and tolerance. The statement on diversity is taken from the [Python Community](http://www.python.org/community/diversity/). For future reference, their [Code of Conduct](http://www.python.org/psf/codeofconduct/) is also very good.
