### PR TITLE
Added QuickNFO QuickLook Plugin

### DIFF
--- a/Casks/quicknfo.rb
+++ b/Casks/quicknfo.rb
@@ -1,0 +1,7 @@
+class Quicknfo < Cask
+  url 'https://github.com/The-Master777/QuickNFO/releases/download/v1.2/QuickNFO.qlgenerator.zip'
+  homepage 'https://github.com/planbnet/QuickNFO'
+  version '1.2'
+  sha256 'ee5c03f78ff60e69e776bec39896ac48496915de35fcb3e2bd0d9c20ad92b5bb'
+  qlplugin 'QuickNFO.qlgenerator'
+end


### PR DESCRIPTION
This PR adds a simple NFO QuickLook Plugin. However, I'm having trouble getting QL to recognize the symlink. If I manually move the downloaded and extracted qlgenerator file to the QL library directory, everything works correctly. Any idea what could be causing this?
