### PR TITLE
Add Master Key.app version 5.6.2

### DIFF
--- a/Casks/master-key.rb
+++ b/Casks/master-key.rb
@@ -1,0 +1,7 @@
+class MasterKey < Cask
+  url 'http://macinmind.com/MasterKey.dmg'
+  homepage 'http://macinmind.com/?area=app&app=masterkey&pg=info'
+  version '5.6.2'
+  sha256 '3b952d0e40a5bb937b4e85684e480d7fb364c17e319c1963f94e89bd382e2353'
+  link 'Master Key.app'
+end


### PR DESCRIPTION
Created a new Cask for Master Key 5.6.2 following the naming
conventions, converting it to master-key.rb. Included a sha256, and
successfully passed both install and audit --download prior to
committing.
