### PR TITLE
Add Keytool Explorer 5.0.1 cask

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,0 +1,7 @@
+class KeystoreExplorer < Cask
+  url 'http://downloads.sourceforge.net/project/keystore-explorer/KSE%205.0.1/kse-501.dmg?r=&ts=1393234297&use_mirror=heanet'
+  homepage 'http://keystore-explorer.sourceforge.net/index.php'
+  version '5.0.1'
+  sha256 '64932fc5a26bd4de32d952b73431307c9a7c3100c1b11e76ab9f55e2a2cf7d49'
+  link 'KeyStore Explorer 5.0.1.app'
+end


### PR DESCRIPTION
Add a cask for the Keytool Explorer, a gui that simplify certificate management for Java developper
