### PR TITLE
add `after_install` for mamp.rb permissions

### DIFF
--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -4,7 +4,9 @@ class Mamp < Cask
   version '2.2'
   sha256 'd01d43a881e0c0fbaa06301364b3e25931dff5863dd987d91ccf856626572e76'
   install 'MAMP_2.2.pkg'
-  uninstall(
-    :pkgutil => 'de.appsolute.installer.mamp*'
-  )
+  after_install do
+    system 'sudo', '-E', '--',
+           '/usr/sbin/chown', '-R', "#{Etc.getpwuid(Process.euid).name}:staff", '/Applications/MAMP', '/Applications/MAMP PRO'
+  end
+  uninstall :pkgutil => 'de.appsolute.installer.(mamp|mampacticon|mampendinstall|mamppro).pkg'
 end


### PR DESCRIPTION
fixes #2453. Also refines `uninstall` stanza with no functional
change
