### PR TITLE
doc: expand CASK_LANGUAGE_REFERENCE, shrink CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,21 +77,21 @@ end
 
 Fill in the following stanzas for your Cask:
 
-| field              | value       |
+| name               | value       |
 | ------------------ | ----------- |
 | __cask metadata__  | information about the Cask (required)
-| `url`              | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application (see also [URL Stanza Details](doc/THE_CASK_LANGUAGE.md#url-stanza-details))
+| `url`              | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application (see also [URL Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#url-stanza-details))
 | `homepage`         | application homepage; used for the `brew cask home` command
 | `version`          | application version; give value of `'latest'` if versioned downloads are not offered
-| `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be omitted on unversioned downloads with `no_checksum`. (see also [Checksum Stanza Details](doc/THE_CASK_LANGUAGE.md#checksum-stanza-details))
+| `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be omitted on unversioned downloads by substituting `no_checksum`. (see also [Checksum Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#checksum-stanza-details))
 | __artifact info__  | information about artifacts inside the Cask (can be specified multiple times)
-| `link`             | relative path to a file that should be linked into the `Applications` folder on installation (see also [Link Stanza Details](doc/THE_CASK_LANGUAGE.md#link-stanza-details))
-| `install`          | relative path to `pkg` that should be run to install the application (see also [Install Stanza Details](doc/THE_CASK_LANGUAGE.md#install-stanza-details))
-| `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see also [Uninstall Stanza Details](doc/THE_CASK_LANGUAGE.md#uninstall-stanza-details))
+| `link`             | relative path to a file that should be linked into the `Applications` folder on installation (see also [Link Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#link-stanza-details))
+| `install`          | relative path to `pkg` that should be run to install the application (see also [Install Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#install-stanza-details))
+| `uninstall`        | indicates what commands/scripts must be run to uninstall a pkg-based application (see also [Uninstall Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details))
 
 Additional stanzas you might need for special use-cases:
 
-| field              | value       |
+| name               | value       |
 | ------------------ | ----------- |
 | `prefpane`         | relative path to a preference pane that should be linked into the `~/Library/PreferencePanes` folder on installation
 | `colorpicker`      | relative path to a ColorPicker plugin that should be linked into the `~/Library/ColorPickers` folder on installation
@@ -103,10 +103,9 @@ Additional stanzas you might need for special use-cases:
 | `input_method`     | relative path to a input method that should be linked into the `~/Library/Input Methods` folder on installation
 | `screen_saver`     | relative path to a Screen Saver that should be linked into the `~/Library/Screen Savers` folder on installation
 | `nested_container` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
-| `depends_on_formula` | a list of Homebrew Formulae upon which this Cask depends
-| `caveats`          | a string or Ruby block providing the user with Cask-specific information at install time (see also [Caveats Details](doc/THE_CASK_LANGUAGE.md#caveats-details))
-| `after_install`    | a Ruby block containing postflight install operations
-| `after_uninstall`  | a Ruby block containing postflight uninstall operations
+| `caveats`          | a string or Ruby block providing the user with Cask-specific information at install time (see also [Caveats Details](doc/CASK_LANGUAGE_REFERENCE.md#caveats-details))
+
+Additional special-use stanzas are listed at [Optional Stanzas](doc/CASK_LANGUAGE_REFERENCE.md#optional-stanzas) and [Legacy Stanzas](doc/CASK_LANGUAGE_REFERENCE.md#legacy-stanzas).
 
 
 ### SourceForge URLs

--- a/FAQ.md
+++ b/FAQ.md
@@ -3,31 +3,9 @@
 ## What is a Cask?
 
 A `Cask` is like a `Formula` in Homebrew except it describes how to download
-and install a binary application.
-
-Casks currently have five required fields:
-
- * __url__: (required) points to binary distribution of the application
- * __homepage__: the same as Homebrew's - it doesn't do anything yet, but will be wired in
- * __version__: (required) describes the version of the application available at the URL
- * __sha256__: (required unless using no_checksum) SHA-256 checksum of the file
- * __link__: (required for `.app`) indicates which file(s) should be linked into the Applications folder on installation
- * __install__: (required for `.pkg`) indicates which package should be installed
- * __prefpane__: (required for `.prefPane`) indicates which file(s) should be linked into the PreferencePanes folder on installation
- * __qlplugin__: (required for `.qlgenerator`) indicates which file(s) should be linked into the QuickLook folder on installation
- * __font__ : (required for fonts) indicates which file(s) should be linked into the Fonts folder on installation
- * __input_method__: (required for input method) indicates which file(s) should be linked into the Input Methods folder on installation
- * __screen_saver__: (required for `.saver`) indicates which file(s) should be linked into the Screen Saver folder on installation
-
-and six optional fields:
-
-* __binary__: relative path to a binary to be installed
-* __uninstall__: (optional for `.pkg`) indicates how to uninstall a package
-* __nested_container__: relative path to a nested inner container
-* __depends_on_formula__: a list of Homebrew Formulae upon which this Cask depends
-* __caveats__: a string or Ruby block providing the user with Cask-specific information at install time
-* __after_install__: a Ruby block containing postflight install operations
-* __after_uninstall__: a Ruby block containing postflight uninstall operations
+and install a binary application.  To learn how to write a Cask, see
+[CONTRIBUTING.md](CONTRIBUTING.md).  For a complete reference, see
+[CASK_LANGUAGE_REFERENCE.md](doc/CASK_LANGUAGE_REFERENCE.md).
 
 ## What's the status of this project?  Where's it headed?
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ open ~/Applications/"Google Chrome.app"
  * Find basic documentation on using homebrew-cask in [USAGE.md](USAGE.md)
  * Want to contribute a Cask? Awesome! See [CONTRIBUTING.md](CONTRIBUTING.md)
  * Want to hack on our code? Also awesome! See [doc/HACKING.md](doc/HACKING.md)
- * More project-related details and discussion are available in [FAQ.md](FAQ.md)
+ * More project-related details and discussion are available in [FAQ.md](FAQ.md) and [doc/CASK_LANGUAGE_REFERENCE.md](doc/CASK_LANGUAGE_REFERENCE.md)
 
 ## Questions? Wanna chat?
 


### PR DESCRIPTION
following up on #3094
- rename `THE_CASK_LANGUAGE.md` to `CASK_LANGUAGE_REFERENCE.md`
- expand `CASK_LANGUAGE_REFERENCE.md` to more fully specify the Cask DSL
- add sections: "Casks Are Ruby Classes" and "The Cask Language Is Declarative"
- import content from `FAQ.md` to `CASK_LANGUAGE_REFERENCE.md`, create multiple sections
  listing all stanzas according to category.
- document which stanzas are permitted multiple times
- add previously undocumented `before_install` and `before_uninstall`
- doc that `Hardware::CPU.is_64_bit?` (and 32-bit) are acceptable in conditionals
- doc that `:target` may contain an absolute path (this works more reliably after #3075)
- doc that `uninstall` is optional in the DSL, but required by the community
- link examples
- standardize mixed language on "stanza" over "field"
- further shrink `CONTRIBUTING.md` by deleting rarely used stanzas
  and referencing `CASK_LANGUAGE_REFERENCE.md`
