### PR TITLE
update praat to 5.3.64

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,8 +1,13 @@
 class Praat < Cask
-  url 'http://www.fon.hum.uva.nl/praat/praat5363_mac64.dmg'
+  if Hardware::CPU.is_64_bit?
+    url 'http://www.fon.hum.uva.nl/praat/praat5364_mac64.dmg'
+    version '5.3.64'
+    sha256 'e2cc984401d44832f552d11a72d9ea24cdecffda96dcb58330ff7d8d1279ecad'
+  else
+    url 'http://www.fon.hum.uva.nl/praat/praat5364_mac32.dmg'
+    version '5.3.64'
+    sha256 'c982b3e5d66b383d9928ff66b5e8b2332fccfde377d67d1650b04680dbf1efcd'
+  end
   homepage 'http://www.fon.hum.uva.nl/praat/'
-  version '5.3.63'
-  sha1 'e7f120d6b40d0331784d34fd7ac8a559decaa7eb'
   link 'Praat.app'
-  caveats 'This installs the 64-bit Mac Version of Praat (significantly faster on modern machines).  The 32-bit version is available from praat.org'
 end


### PR DESCRIPTION
previous link was broken. use conditionals to install
hardware-appropriate binaries instead of `caveats`.
