### PR TITLE
Add Android Studio Bundle 0.4.2 build-133.970939

### DIFF
--- a/Casks/android-studio-bundle.rb
+++ b/Casks/android-studio-bundle.rb
@@ -1,0 +1,7 @@
+class AndroidStudioBundle < Cask
+  url 'https://dl.google.com/android/studio/install/0.4.2/android-studio-bundle-133.970939-mac.dmg'
+  homepage 'http://developer.android.com/sdk/installing/studio.html'
+  version '0.4.2 build-133.970939'
+  sha256 '28226e2ae7186a12bc196abe28ccc611505e3f6aa84da6afc283d83bb7995a8b'
+  link 'Android Studio.app'
+end


### PR DESCRIPTION
android-studio-bundle is different from android-studio as it comes with the Android SDK already bundled within the .app.

This is the regular .dmg not cutting edge version you would get from http://developer.android.com/sdk/installing/studio.html
