### PR TITLE
Update Ap-Grapher URL and Homepage

### DIFF
--- a/Casks/ap-grapher.rb
+++ b/Casks/ap-grapher.rb
@@ -1,6 +1,6 @@
 class ApGrapher < Cask
-  url 'http://www.chimoosoft.com/downloads/current/APGrapher.dmg'
-  homepage 'http://www.chimoosoft.com/products/apgrapher/'
+  url 'https://www.macupdate.com/download/11859/APGrapher.dmg'
+  homepage 'https://www.macupdate.com/app/mac/11859/ap-grapher'
   version 'latest'
   no_checksum
   link 'AP Grapher.app'


### PR DESCRIPTION
Ap-Grapher url and homepage doesn't exist. I fixed it by switching to macupdate urls.
