### PR TITLE
rename nitrous-io.rb

### DIFF
--- a/Casks/nitrous-desktop.rb
+++ b/Casks/nitrous-desktop.rb
@@ -1,4 +1,4 @@
-class NitrousIo < Cask
+class NitrousDesktop < Cask
   url 'https://www.nitrous.io/mac/NitrousDesktop-latest.zip'
   homepage 'https://www.nitrous.io/mac'
   version 'latest'


### PR DESCRIPTION
to nitrous-desktop.rb
per naming rules in CONTRIBUTING.md
