### PR TITLE
rename navicat-oracle.rb

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,4 +1,4 @@
-class NavicatOracle < Cask
+class NavicatForOracle < Cask
   url 'http://download.navicat.com/download/navicat110_ora_en.dmg'
   homepage 'http://www.navicat.com/products/navicat-for-oracle'
   version '11.0.14'


### PR DESCRIPTION
to navicat-for-oracle.rb
per naming rules in CONTRIBUTING.md
