### PR TITLE
typo sha1 -> sha256

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -4,7 +4,7 @@ class Paraview < Cask
     sha256 '1eef4a2ee155049059967733e40010e86cc6cd05458de676217af5c276995817'
   else
     url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit-Lion-Python27.dmg'
-    sha1 '8784481c90b58b0c6158e21b7f978a7d78caa67c63d28d6d5d770ef43f0ad890'
+    sha256 '8784481c90b58b0c6158e21b7f978a7d78caa67c63d28d6d5d770ef43f0ad890'
   end
   homepage 'http://www.paraview.org/'
   version '4.1.0'


### PR DESCRIPTION
@alebcay here is a drawback to using conditionals:

Because my testing machine was running Mavericks, the error in the `else` block was not seen by `audit` or even `install`.

I suppose we could rewrite the test suite to audit each cask with overrides on a matrix of permissible conditional values.  But: slow, fragile, extra maintenance work.

@phinze is right, we should develop a first-class way of handling OS and hardware variants in the DSL.   Then the test suite could ask the cask: "hey, what are your variants?"

For the moment, conditionals are only used in 15 Casks.
