### PR TITLE
Update/fix UncrustifyX

### DIFF
--- a/Casks/uncrustifyx.rb
+++ b/Casks/uncrustifyx.rb
@@ -1,7 +1,7 @@
 class Uncrustifyx < Cask
-  url 'http://www.cactuslab.com/uncrustifyx/UncrustifyX-0.4.3.zip'
+  url 'https://github.com/ryanmaxwell/UncrustifyX/releases/download/0.4.3/UncrustifyX-0.4.3.zip'
   homepage 'https://github.com/ryanmaxwell/UncrustifyX'
   version '0.4.3'
-  sha1 '10dea3d913dfc1a0c39404e244d0f0225a2ba880'
+  sha256 '017c0781ce05db59c1a3fe52a140166df55aa2d87286a7cf5ba5e3eb6b06c7df'
   link 'UncrustifyX.app'
 end


### PR DESCRIPTION
Update version number and URL, now uses SHA256 instead of SHA1.
