### PR TITLE
Update/fix MoneyWell

### DIFF
--- a/Casks/moneywell.rb
+++ b/Casks/moneywell.rb
@@ -1,7 +1,7 @@
 class Moneywell < Cask
   url 'http://downloads.nothirst.com/MoneyWell_23.zip'
   homepage 'http://nothirst.com/moneywell/'
-  version '2.3.1'
-  sha1 '4160b0f41584dd8408838b9a81b3ba995a7600f5'
+  version '2.3.3'
+  sha256 '2cce3e006f178d80d0531037e9dd75fe754d2fd1eef8bb37e52b97048c8d3557'
   link 'MoneyWell.app'
 end


### PR DESCRIPTION
Updated version (URL did not change on remote end, however), using SHA256 instead of SHA1.
