### PR TITLE
Update/fix Navicat for MariaDB

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,7 +1,7 @@
 class NavicatForMariadb < Cask
   url 'http://download.navicat.com/download/navicat110_mariadb_en.dmg'
   homepage 'http://www.navicat.com/products/navicat-for-mariadb'
-  version '11.0.14'
-  sha1 'c14df959b00f0b6ec0658d61d0546198d5e9229e'
+  version '11.0.15'
+  sha256 'ae3c3d54452d5a5344ed5758303430e74cad3be021a751adfc71f6e9d441021a'
   link 'Navicat for MariaDB.app'
 end


### PR DESCRIPTION
Using SHA256 instead of SHA256, and updated version number (no change in URL).
