### PR TITLE
Update/fix Navicat for Oracle

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,7 +1,7 @@
 class NavicatForOracle < Cask
   url 'http://download.navicat.com/download/navicat110_ora_en.dmg'
   homepage 'http://www.navicat.com/products/navicat-for-oracle'
-  version '11.0.14'
-  sha1 '49562c0c8ceb09dbeba63d82aaf92ccd9d6a90ea'
+  version '11.0.15'
+  sha256 '312b7d7fa84f8c7df26de6c07182772a9b449a560d585f9e87706cce2a1bab55'
   link 'Navicat for Oracle.app'
 end


### PR DESCRIPTION
Using SHA256 instead of SHA1, and updated version numbers (no change in URL).
