### PR TITLE
Update/fix Navicat for PostgreSQL

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,7 +1,7 @@
 class NavicatForPostgresql < Cask
   url 'http://download.navicat.com/download/navicat110_pgsql_en.dmg'
   homepage 'http://www.navicat.com/products/navicat-for-postgresql'
-  version '11.0.14'
-  sha1 '350e590c97b2b066db43a33f2c6aa2a49544a01f'
+  version '11.0.15'
+  sha256 'cfd50181fe9f6d8c6a0bf39d0a675c5bfe5832299613214e029cb2a93dc0cd4e'
   link 'Navicat for PostgreSQL.app'
 end


### PR DESCRIPTION
Using SHA256 instead of SHA1, and updated version numbers (no change in URL).
