### PR TITLE
Update/fix Navicat for SQL Server

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,7 +1,7 @@
 class NavicatForSqlServer < Cask
   url 'http://download.navicat.com/download/navicat110_sqlserver_en.dmg'
   homepage 'http://www.navicat.com/products/navicat-for-sqlserver'
-  version '11.0.14'
-  sha1 'c43978a0a45e6e60592d337008cb3a5f6eb79a17'
+  version '11.0.15'
+  sha256 'f1fb36b01eb0925f9d8b23c6550467eccd3781b5f8b372bda3a5d47eee4e91cc'
   link 'Navicat For SQL Server.app'
 end


### PR DESCRIPTION
Using SHA256 instead of SHA1, and updated version numbers (no change in URL).
