### PR TITLE
Update/fix Navicat for SQLite

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,7 +1,7 @@
 class NavicatForSqlite < Cask
   url 'http://download.navicat.com/download/navicat110_sqlite_en.dmg'
   homepage 'http://www.navicat.com/products/navicat-for-sqlite'
-  version '11.0.14'
-  sha1 '5584b6b9c9201511bc99c2511c78014329ed679e'
+  version '11.0.15'
+  sha256 '807adaad112ea07fbbc693b72a0a9066d6e527a90425f962e0f79d22563b96dc'
   link 'Navicat for SQLite.app'
 end


### PR DESCRIPTION
Using SHA256 instead of SHA1, and updated version numbers (no change in URL).
