### PR TITLE
Update/fix Disk Drill

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,7 +1,7 @@
 class DiskDrill < Cask
-  url 'http://cdn-1.metacdn.net/vffrhkfp/5RZmb/diskdrill.dmg'
+  url 'http://dl.cleverfiles.com/diskdrill.dmg'
   homepage 'http://www.cleverfiles.com/'
-  version '2.0'
-  sha1 'be43cf2860b9f3a8f0323e5bb0e423b97722cf36'
+  version 'latest'
+  no_checksum
   link 'Disk Drill.app'
 end


### PR DESCRIPTION
Old link was broken, updated link (which points to `latest`, not `2.0` or any specific version). Using SHA256 instead of SHA1.
