### PR TITLE
accept multiple arguments to uninstall/:pkgutil

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -295,7 +295,7 @@ is the most useful.
 * `:launchctl` (string or array) - ids of `launchctl` jobs to remove
 * `:quit` (string or array) - bundle ids of running applications to quit
 * `:kext` (string or array) - bundle ids of kexts to unload from the system
-* `:pkgutil` (string or regexp) - regexp matching bundle ids of packages to uninstall using `pkgutil`
+* `:pkgutil` (regexp or array) - regexps matching bundle ids of packages to uninstall using `pkgutil`
 * `:script` (string or hash) - relative path to an uninstall script to be run via sudo; use hash if args are needed
   - `:executable` - relative path to an uninstall script to be run via sudo (required for hash form)
   - `:args` - array of arguments to the uninstall script

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -145,8 +145,10 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
 
     if uninstall_options.key? :pkgutil
       ohai "Removing files from pkgutil Bill-of-Materials"
-      pkgs = Cask::Pkg.all_matching(uninstall_options[:pkgutil], @command)
-      pkgs.each(&:uninstall)
+      Array(uninstall_options[:pkgutil]).each do |regexp|
+        pkgs = Cask::Pkg.all_matching(regexp, @command)
+        pkgs.each(&:uninstall)
+      end
     end
 
     if uninstall_options.key? :files


### PR DESCRIPTION
We may as well do so, the previous behavior was a bug:
multiple elements were silently concatenated into a single
regexp.
