### PR TITLE
rename movist-fork.rb to movist.rb

### DIFF
--- a/Casks/movist.rb
+++ b/Casks/movist.rb
@@ -1,4 +1,4 @@
-class MovistFork < Cask
+class Movist < Cask
   url 'https://github.com/downloads/samiamwork/Movist/Movist.app.zip'
   homepage 'https://github.com/samiamwork/Movist'
   version 'latest'


### PR DESCRIPTION
There is no need to maintain this under a name which is
different from the app (Movist.app)  We do not offer a
separate "movist" Cask, and the original project (from
which this forked) is dead.
