### PR TITLE
rename dart-editor.rb

### DIFF
--- a/Casks/darteditor.rb
+++ b/Casks/darteditor.rb
@@ -1,4 +1,4 @@
-class DartEditor < Cask
+class Darteditor < Cask
   url 'http://storage.googleapis.com/dart-archive/channels/stable/release/latest/editor/darteditor-macos-x64.zip'
   homepage 'https://www.dartlang.org/tools/editor/'
   version 'latest'


### PR DESCRIPTION
to darteditor.rb
per naming rules in CONTRIBUTING.md
