### PR TITLE
Add Nimbus (0.7.1)

### DIFF
--- a/Casks/nimbus.rb
+++ b/Casks/nimbus.rb
@@ -1,0 +1,7 @@
+class Nimbus < Cask
+  url 'https://github.com/jnordberg/irccloudapp/releases/download/0.7.1/Nimbus-0.7.1.zip'
+  homepage 'https://github.com/jnordberg/irccloudapp'
+  version '0.7.1'
+  sha1 'daa60412e78bcb22e2fa65f5a0175c53e5142f82'
+  link 'Nimbus.app'
+end


### PR DESCRIPTION
> Standalone irccloud.com client for OS X.

![Screenshot](https://github-camo.global.ssl.fastly.net/18e3736b805e5a09dc1ae1454e11cc7785f44650/687474703a2f2f786e2d2d626c2d7769612e73652f6e696d6275732e706e67)
