### PR TITLE
New cask: stella 3.9.3

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,0 +1,7 @@
+class Stella < Cask
+  url 'http://downloads.sourceforge.net/project/stella/stella/3.9.3/Stella-3.9.3_intel-macosx.dmg'
+  homepage 'http://stella.sourceforge.net'
+  version '3.9.3'
+  sha256 '83870088368be20224ed51f52e9babe53a75575495279adc596203f123e8477c'
+  link 'Stella.app'
+end


### PR DESCRIPTION
Stella is a multi-platform Atari 2600 VCS emulator released under the GNU General Public License (GPL). 
