### PR TITLE
Fix broken `brew cask alfred link`

### DIFF
--- a/Casks/obsidian-menu-bar-mountain-lion.rb
+++ b/Casks/obsidian-menu-bar-mountain-lion.rb
@@ -1,8 +1,8 @@
 class ObsidianMenuBarMountainLion < Cask
-  url 'http://www.maxrudberg.com/downloads/Obsidian%20Menu%20Bar%2010.8.dmg'
-  homepage 'http://www.maxrudberg.com'
+  url 'http://www.obsidianmenubar.com/downloads/Obsidian%20Menu%20Bar%2010.8.dmg'
+  homepage 'http://www.obsidianmenubar.com'
   version '10.8'
-  sha1 'e4098264356624803df62b6409a0e2016a2a72cd'
+  sha256 '97c8545c623ec78a0a81c2b7bb6a7afa9d0dd517a64b74f5320e2e279a2786aa'
   install 'Obsidian Menu Bar.pkg'
   # uninstall :script => 'Restore OS X Menu Bar.pkg'
 end

--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -4,6 +4,7 @@ class Cask::CLI::Alfred
     '/Applications/Xcode.app/Contents/Applications',
     '/Developer/Applications',
     '/Library/PreferencePanes',
+    '/System/Library/CoreServices/Applications',
     '/System/Library/PreferencePanes',
     '~/Library/Caches/Metadata/',
     '~/Library/Mobile Documents/',
@@ -108,7 +109,7 @@ class Cask::CLI::Alfred
   def self.alfred_preference(key, value=nil)
     if value
       odebug 'Writing Alfred preferences'
-      @system_command.run('/usr/bin/defaults', :args => ['write', DOMAIN, key, %Q("#{value}")])
+      @system_command.run('/usr/bin/defaults', :args => ['write', DOMAIN, key, %Q(#{value})])
     else
       odebug 'Reading Alfred preferences'
       @system_command.run('/usr/bin/defaults', :args => ['read', DOMAIN, key])

--- a/test/cask/cli/alfred_test.rb
+++ b/test/cask/cli/alfred_test.rb
@@ -78,7 +78,7 @@ describe Cask::CLI::Alfred do
       SCOPE_RESPONSE
 
       Cask::FakeSystemCommand.stubs_command(
-        ['/usr/bin/defaults', 'write', 'com.runningwithcrayons.Alfred-Preferences', 'features.defaultresults.scope', %Q{"('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','#{Cask.caskroom}')"}]
+        ['/usr/bin/defaults', 'write', 'com.runningwithcrayons.Alfred-Preferences', 'features.defaultresults.scope', %Q{('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','#{Cask.caskroom}')}]
       )
 
       TestHelper.must_output(self, lambda {
@@ -95,7 +95,7 @@ describe Cask::CLI::Alfred do
 
       expected_scopes = (Cask::CLI::Alfred::DEFAULT_SCOPES + [Cask.caskroom]).map { |s| "'#{s}'" }
       Cask::FakeSystemCommand.stubs_command(
-        ['/usr/bin/defaults', 'write', 'com.runningwithcrayons.Alfred-Preferences', 'features.defaultresults.scope', %Q{"(#{expected_scopes.join(',')})"}]
+        ['/usr/bin/defaults', 'write', 'com.runningwithcrayons.Alfred-Preferences', 'features.defaultresults.scope', %Q{(#{expected_scopes.join(',')})}]
       )
 
       TestHelper.must_output(self, lambda {
@@ -140,7 +140,7 @@ describe Cask::CLI::Alfred do
       SCOPE_RESPONSE
 
       Cask::FakeSystemCommand.stubs_command(
-        ['/usr/bin/defaults', 'write', 'com.runningwithcrayons.Alfred-Preferences', 'features.defaultresults.scope', %Q{"('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes')"}]
+        ['/usr/bin/defaults', 'write', 'com.runningwithcrayons.Alfred-Preferences', 'features.defaultresults.scope', %Q{('/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes')}]
       )
 
       TestHelper.must_output(self, lambda {


### PR DESCRIPTION
`brew cask alfred link` is broken because `features.defaultresults.scope` is a string instead of a dictionary:

```
[00:13]:) ~ $ brew cask alfred link
==> Successfully linked Alfred to homebrew-cask.
[00:13]:) ~ $ brew cask alfred status
==> Alfred is not linked to homebrew-cask.
[00:15]:) ~ $ defaults read com.runningwithcrayons.Alfred-Preferences
{
    NSNavLastRootDirectory = "~/Documents";
    NSNavPanelExpandedSizeForOpenMode = "{750, 480}";
    "NSWindow Frame alfredpreferences" = "0 56 1383 822 0 0 1440 878 ";
    "features.defaultresults.scope" = "('/Applications','/Applications/Xcode.app/Contents/Applications','/Developer/Applications','/Library/PreferencePanes','/System/Library/PreferencePanes','~/Library/Caches/Metadata/','~/Library/Mobile Documents/','~/Library/PreferencePanes','/opt/homebrew-cask/Caskroom')";
    lastTab = features;
    lastTabBuild = 227;
    lastTabTS = "415265223.980409";
    version = "2.1.1";
}
```
- Remove quotes from `defaults write` args. With quotes the value is
  written as a string instead of a dictionary, which breaks the search
  scope in alfred.
- Make the default scope consistent with alfred default
