### PR TITLE
doc: drop version numbers from end of Cask names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,13 @@ We try to maintain consistent naming so everything stays clean and predictable.
     such as `Google Chrome.app`
   * Remove `.app` from the end
   * Translate the name into English if necessary
+  * Remove from the end: version numbers or incremental release designations such
+    as "alpha", "beta", or "release candidate".  Strings which distinguish different
+    capabilities or codebases such as "Community Edition" are currently accepted.
+    Exception: when a number is not an incremental release counter, but a
+    differentiator for a different product from a different vendor: [iterm2.rb](../Casks/iterm2.rb).
+  * If the version number is arranged to occur in the middle of the App name,
+    it should also be removed.  Example: [IntelliJ IDEA 13 CE.app](../Casks/intellij-idea-ce.rb).
   * Remove from the end: "mac", "for mac", "for OS X".  These terms are generally
     added to ports such as "MAME OS X.app".  Exception: when the software is not
     a port, but "Mac" is an inseparable part of the name or branding, as in


### PR DESCRIPTION
Following up on #2659, #3175, and #3255, further steps toward an algorithmic
derivation of Canonical Name from App Name.

Rationale (just as before)
- encodes the existing practice for the great majority of Casks
- such terms are not helpful in search
- for deeper goals see #2659

Enforcing this rule would affect 4 current Casks: `gpower3.rb`, `marked2.rb`, `airmail-beta.rb`, `logmein-ignition-beta.rb`

Pinging @vitorgalvao.  Here is the next round of proposed naming rules.

I can only find two exceptions where a trailing number differentiates a product from different vendors: iterm2 and pgadmin3.
