### PR TITLE
Yemuzip: new formula.

### DIFF
--- a/Casks/yemuzip.rb
+++ b/Casks/yemuzip.rb
@@ -1,0 +1,7 @@
+class Yemuzip < Cask
+  url 'http://www.yellowmug.com/download/YemuZip.dmg'
+  homepage 'http://www.yellowmug.com/yemuzip'
+  version 'latest'
+  no_checksum
+  link 'YemuZip.app'
+end


### PR DESCRIPTION
Yemuzip is a zipper that allows to exclude the osx-specific
metadata (__MACOSX, ._*, etc.)
