### PR TITLE
alib1.rb `after_install`: list form of `system`

### DIFF
--- a/Casks/alib1.rb
+++ b/Casks/alib1.rb
@@ -6,7 +6,7 @@ class Alib1 < Cask
   screen_saver 'Presstube-ALib1.app/Contents/Resources/Presstube - ALib1.saver'
 
   after_install do
-    system "/usr/libexec/PlistBuddy -c \"Set :CFBundleName ALib1 (Presstube)\" #{destination_path}/presstube-alib1.app/Contents/Resources/Presstube\\ -\\ ALib1.saver/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName ALib1 (Presstube)', "#{destination_path}/presstube-alib1.app/Contents/Resources/Presstube - ALib1.saver/Contents/Info.plist"
   end
 
   caveats do


### PR DESCRIPTION
use safer list form of `system` and simplify quoting
