### PR TITLE
path-finder `after_install`: full paths+list form

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -7,6 +7,6 @@ class PathFinder < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write com.cocoatech.PathFinder kNTMoveToApplicationsFolderAlertSuppress -bool true'
+    system '/usr/bin/defaults', 'write', 'com.cocoatech.PathFinder', 'kNTMoveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
 end


### PR DESCRIPTION
use safer list form of `system`.  use full paths to external
utilities.
