### PR TITLE
kaleidoscope `after_install`: full paths+list form

### DIFF
--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -8,7 +8,7 @@ class Kaleidoscope < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write com.blackpixel.kaleidoscope moveToApplicationsFolderAlertSuppress -bool true'
+    system '/usr/bin/defaults', 'write', 'com.blackpixel.kaleidoscope', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
   caveats do
     files_in_usr_local


### PR DESCRIPTION
use safer list form of `system`.  use full paths to external
utilities.
