### PR TITLE
houdahspot `after_install`: full paths+list form

### DIFF
--- a/Casks/houdahspot.rb
+++ b/Casks/houdahspot.rb
@@ -7,6 +7,6 @@ class Houdahspot < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write com.houdah.HoudahSpot moveToApplicationsFolderAlertSuppress -bool true'
+    system '/usr/bin/defaults', 'write', 'com.houdah.HoudahSpot', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
 end


### PR DESCRIPTION
use safer list form of `system`.  use full paths to external
utilities.
