### PR TITLE
f-lux.rb `after_install`: full paths+list form

### DIFF
--- a/Casks/f-lux.rb
+++ b/Casks/f-lux.rb
@@ -7,6 +7,6 @@ class FLux < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write org.herf.Flux moveToApplicationsFolderAlertSuppress -bool true'
+    system '/usr/bin/defaults', 'write', 'org.herf.Flux', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
 end


### PR DESCRIPTION
use safer list form of `system`.  use full paths to external
utilities.
