### PR TITLE
bartender.rb `after_install`: full paths+list form

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -7,6 +7,6 @@ class Bartender < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write com.surteesstudios.Bartender moveToApplicationsFolderAlertSuppress -bool true'
+    system '/usr/bin/defaults', 'write', 'com.surteesstudios.Bartender', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
 end


### PR DESCRIPTION
use safer list form of `system`.  use full paths to external
utilities.
