### PR TITLE
alfred.rb `after_install`: full paths+list form

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -8,6 +8,6 @@ class Alfred < Cask
 
   after_install do
     # Don't ask to move the app bundle to /Applications
-    system 'defaults write com.runningwithcrayons.alfred-2 suppressMoveToApplications -bool true'
+    system '/usr/bin/defaults', 'write', 'com.runningwithcrayons.alfred-2', 'suppressMoveToApplications', '-bool', 'true'
   end
 end


### PR DESCRIPTION
use safer list form of `system`.  use full paths to external
utilities.
