### PR TITLE
heart.rb `after_install`: list form of `system`

### DIFF
--- a/Casks/heart.rb
+++ b/Casks/heart.rb
@@ -6,7 +6,7 @@ class Heart < Cask
   screen_saver 'presstube-heart.app/Contents/Resources/Presstube - Heart.saver'
 
   after_install do
-    system "/usr/libexec/PlistBuddy -c \"Set :CFBundleName Heart (Presstube)\" #{destination_path}/presstube-heart.app/Contents/Resources/Presstube\\ -\\ Heart.saver/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Heart (Presstube)', "#{destination_path}/presstube-heart.app/Contents/Resources/Presstube - Heart.saver/Contents/Info.plist"
   end
 
   caveats do


### PR DESCRIPTION
use safer list form of `system` and simplify quoting
