### PR TITLE
remove constant HOMEBREW_TAP_FORMULA_REGEX

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@ require 'bundler'
 require 'bundler/setup'
 
 # set some Homebrew constants used in our code
-HOMEBREW_TAP_FORMULA_REGEX = %r{^(\w+)/(\w+)/([^/]+)$}
 HOMEBREW_BREW_FILE = '/usr/local/bin/brew'
 
 # add cask lib to load path


### PR DESCRIPTION
we no longer need to set this, as Homebrew added it to
testing_env.rb
