### PR TITLE
Add authoxy v3.6

### DIFF
--- a/Casks/authoxy.rb
+++ b/Casks/authoxy.rb
@@ -1,0 +1,15 @@
+class Authoxy < Cask
+  url 'http://www.hrsoftworks.net/downloads/Authoxy3.6.dmg'
+  homepage 'http://www.hrsoftworks.net'
+  version '3.6'
+  sha256 '921720e5bd1d7cd9f08e29bee928ea667662ba704f59340280194c8b4649b632'
+  install 'Authoxy (double click me).pkg'
+  uninstall(
+    :files => %w[
+      /Library/PreferencePanes/Authoxy.prefPane
+      /Applications/startAuthoxy
+      ~/Library/Preferences/net.hrsoftworks.AuthoxyPref.plist
+      /tmp/authoxyd.pid
+    ]
+  )
+end


### PR DESCRIPTION
Taken from homepage:

> If your Internet connection requires you to use a proxy which needs a username and password, Authoxy may be the solution to a seamless Internet experience. Authoxy runs locally as a proxy server to intercept HTTP and HTTPS requests, forwarding them on to your regular proxy with authentication details you define in a System Preference Pane. Such a process is required to use many web services (MacHelp, QuickTime, iTunes) behind a proxy requiring authentication.
