### PR TITLE
Re-enable failing "search" test

### DIFF
--- a/test/cask/cli/search_test.rb
+++ b/test/cask/cli/search_test.rb
@@ -49,13 +49,11 @@ describe Cask::CLI::Search do
     out.length.must_be :<, 100
   end
 
-  # @@@ commented out temporarily, travis showing failures, can't duplicate locally,
-  #     may be a Ruby version problem
-  # it "accepts a regexp argument" do
-  #   lambda {
-  #     Cask::CLI::Search.run('/^google-c[a-z]rome$/')
-  #   }.must_output "==> Regexp matches\ngoogle-chrome\n"
-  # end
+  it "accepts a regexp argument" do
+    lambda {
+      Cask::CLI::Search.run('/^google-c[a-z]rome$/')
+    }.must_output "==> Regexp matches\ngoogle-chrome\n"
+  end
 
   it "Returns both exact and partial matches" do
     out, err = capture_io do


### PR DESCRIPTION
This test used to selectively fail only on Travis.  The problem
was never isolated.  However, it was apparently recently fixed,
probably in #4042.
