### PR TITLE
Add Google+ Auto Backup.app latest version

### DIFF
--- a/Casks/google-auto-backup.rb
+++ b/Casks/google-auto-backup.rb
@@ -1,0 +1,7 @@
+class GoogleAutoBackup < Cask
+  url 'https://dl.google.com/dl/edgedl/picasa/gpautobackup_setup.dmg'
+  homepage 'http://picasa.google.com/'
+  version 'latest'
+  no_checksum
+  link 'Google+ Auto Backup.app'
+end

--- a/Casks/google-auto-backup.rb
+++ b/Casks/google-auto-backup.rb
@@ -1,0 +1,7 @@
+class GoogleAutoBackup < Cask
+  url 'https://dl.google.com/dl/edgedl/picasa/gpautobackup_setup.dmg'
+  homepage ''
+  version 'latest'
+  no_checksum
+  link 'Google+ Auto Backup.app'
+end

--- a/Casks/google-auto-backup.rb
+++ b/Casks/google-auto-backup.rb
@@ -1,6 +1,6 @@
 class GoogleAutoBackup < Cask
   url 'https://dl.google.com/dl/edgedl/picasa/gpautobackup_setup.dmg'
-  homepage ''
+  homepage 'http://picasa.google.com/'
   version 'latest'
   no_checksum
   link 'Google+ Auto Backup.app'


### PR DESCRIPTION
This is the backup tool that comes with latest version of Picasa.
Add it as its own cask if you don't want to download Picasa.

More info:
https://support.google.com/picasa/answer/4392268?p=gpautobackup&rd=1
