### PR TITLE
Added LaunchRocket

### DIFF
--- a/Casks/launchrocket.rb
+++ b/Casks/launchrocket.rb
@@ -1,0 +1,7 @@
+class Launchrocket < Cask
+  url 'https://github.com/jimbojsb/launchrocket/releases/download/v0.5.1/LaunchRocket.prefPane.zip'
+  homepage 'http://guthub.com/jimbojsb/launchrocket'
+  version '0.5.1'
+  sha1 '8aab19f421ab15e48e250b3de824eb3d60236e0f'
+  prefpane 'LaunchRocket.prefPane'
+end


### PR DESCRIPTION
**NOTE**: The caskfile is identical to that provided by the author, who is currently hosting the cask from his own `jimbojsb/homebrew-launchrocket`. I opened an issue at https://github.com/jimbojsb/launchrocket/issues/29 to notify the author as well.

---

A Mac PreferencePane for managing services with launchd/launchctl.
LaunchRocket was primarily created for managing various services
installed by Homebrew, though it should work with most
launchd-compatible plists.
