### PR TITLE
Fixed ShareTool

### DIFF
--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -1,7 +1,8 @@
 class Sharetool < Cask
-  url 'http://mirror.nscocoa.com/~yazsoftc1/files/st2/sharetool2.zip'
-  homepage 'http://www.yazsoft.com/products/sharetool/'
-  version '2.4.2'
-  sha1 '409bbe9e50984187f022cd56f96bf2132d19fe01'
+  url 'http://software-files-a.cnet.com/s/software/12/85/93/73/sharetool2.zip?lop=link&ptype=3001&ontid=7240&siteId=4&edId=3&spi=b95d1f82803e8d0dd208a759ca8ecc48&pid=12859373&psid=198769&token=1394020831_2637325d8e249b00ddbf1f29824144ac&fileName=sharetool2.zip'
+  homepage 'http://bainsware.com/'
+  version '2.4.1'
+  sha256 '00e65f6bc73209963e3668bf83641528f508093029488fa9cd0f3f882b3895a5'
+  nested_container 'ShareTool 2.dmg'
   link 'ShareTool.app'
 end


### PR DESCRIPTION
Moved download link, using SHA-256 instead of SHA-1. The download link is rather ugly, but pretty much the only one I could find. Part of #3372.
