### PR TITLE
Fixed Xee

### DIFF
--- a/Casks/xee.rb
+++ b/Casks/xee.rb
@@ -1,7 +1,7 @@
 class Xee < Cask
-  url 'http://wakaba.c3.cx/releases/mac/Xee3.3.zip'
+  url 'http://wakaba.c3.cx/releases/mac/Xee3.3.dmg'
   homepage 'http://xee.c3.cx/'
   version '3.3'
   sha256 '8728d70c392b6da025a292ab62b47698c1e7f5a45b75eb797c9832b3a37d0062'
-  link 'Xee.app'
+  link 'Xee³.app'
 end


### PR DESCRIPTION
The app name is doing weird stuff because of the superscript proceeding
the name, and the ZIP download link actually redirects to a DMG, which
might be confusing the container detection, but better safe than sorry.
