### PR TITLE
Add Cloudera Hive ODBC v2.5.5

### DIFF
--- a/Casks/cloudera-hive-odbc.rb
+++ b/Casks/cloudera-hive-odbc.rb
@@ -1,0 +1,13 @@
+class ClouderaHiveOdbc < Cask
+  url 'https://downloads.cloudera.com/connectors/hive-2.5.5.1006/MacOSX/ClouderaHiveODBC.dmg'
+  homepage 'http://www.cloudera.com'
+  version '2.5.5'
+  sha256 'cf31ace79ca995e8b7b57f1b49761777168c9f4b103092a74f6cb111084d71d8'
+  install 'ClouderaHiveODBC.pkg'
+  uninstall :pkgutil => 'cloudera.hiveodbc'
+  caveats do
+    <<-EOS.undent
+    See /opt/cloudera/hiveodbc/Readme.txt for configuration instructions.
+    EOS
+  end
+end


### PR DESCRIPTION
Provides an Apache Hive driver for an ODBC manager like iODBC or
unixodbc.
