### PR TITLE
New Cask: Pandora One Desktop App 2.0.8

### DIFF
--- a/Casks/pandora-one.rb
+++ b/Casks/pandora-one.rb
@@ -1,0 +1,7 @@
+class PandoraOne < Cask
+  url 'http://www.pandora.com/static/desktop_app/pandora_2_0_8.air'
+  homepage 'http://www.pandora.com/'
+  version '2.0.8'
+  sha1 '1f14fa086ce54845b49dc35de4f7b583f1878ec8'
+  link 'Pandora.app'
+end


### PR DESCRIPTION
With the Pandora Desktop Application, you can play your Pandora
stations right from your desktop – without opening a new browser
window. Plus, because the desktop app is only available as part of
Pandora One, your music is completely free of all advertising.
