### PR TITLE
New Cask: Adobe AIR Redistribution Helper

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -1,0 +1,15 @@
+class AdobeArh < Cask
+  url 'http://airdownload.adobe.com/air/distribution/latest/mac/arh'
+  homepage 'http://help.adobe.com/en_US/air/redist/WS485a42d56cd19641-70d979a8124ef20a34b-8000.html'
+  version 'latest'
+  no_checksum
+  caskroom_only true
+  binary 'arh'
+  container_type :naked
+
+  after_install do
+    system "chmod", "755", "#{destination_path}/arh"
+  end
+
+  caveats "Please refer to the documention at #{homepage}"
+end


### PR DESCRIPTION
The Adobe AIR Redistribution Helper (ARH) utility is a small
executable that you can use as part of a custom installer. It can
perform many tasks such as detect the presence and version of an
installed AIR runtime as well as silently install AIR applications.
