### PR TITLE
add new CurlPostDownloadStrategy

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -184,9 +184,11 @@ of key/value pairs appended to `url`:
 
 | key                | value       |
 | ------------------ | ----------- |
+| `:using`           | the symbol `:post` is the only legal value
 | `:cookies`         | a hash of cookies to be set in the download request
 | `:referer`         | a string holding the URL to set as referrer in the download request
 | `:user_agent`      | a string holding the user agent to set for the download request. Can also be set to the symbol `:fake`, which will use a generic Browser-like user agent string. we prefer `:fake` when the server does not require a specific user agent.
+| `:data`            | a hash of parameters to be set in the POST request
 
 Example: [java.rb](../Casks/java.rb)
 

--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -10,6 +10,8 @@ class Cask::Download
     cask = @cask
     if cask.url.using == :svn
       downloader = Cask::SubversionDownloadStrategy.new(cask)
+    elsif cask.url.using == :post
+      downloader = Cask::CurlPostDownloadStrategy.new(cask)
     else
       downloader = Cask::CurlDownloadStrategy.new(cask)
     end

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -77,6 +77,25 @@ class Cask::CurlDownloadStrategy < CurlDownloadStrategy
   end
 end
 
+class Cask::CurlPostDownloadStrategy < Cask::CurlDownloadStrategy
+
+  def curl_args
+    super
+    default_curl_args.concat(post_args)
+  end
+
+  def post_args
+    if cask_url.data
+      # sort_by is for predictability between Ruby versions
+      cask_url.data.sort_by{ |key, value| key.to_s }.map do |key, value|
+        ['-d', "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"]
+      end.flatten()
+    else
+      ['-X', 'POST']
+    end
+  end
+end
+
 class Cask::SubversionDownloadStrategy < SubversionDownloadStrategy
   include Cask::DownloadStrategy
 

--- a/lib/cask/url.rb
+++ b/lib/cask/url.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 class Cask::URL
   FAKE_USER_AGENT = 'Chrome/32.0.1000.00'
 
-  attr_reader :using, :revision, :trust_cert, :uri, :cookies, :referer
+  attr_reader :using, :revision, :trust_cert, :uri, :cookies, :referer, :data
 
   extend Forwardable
   def_delegators :uri, :path, :scheme, :to_s
@@ -16,6 +16,7 @@ class Cask::URL
     @using      = options[:using]
     @revision   = options[:revision]
     @trust_cert = options[:trust_cert]
+    @data       = options[:data]
   end
 
   def user_agent


### PR DESCRIPTION
- lib/cask/url.rb: initialize(): add new `:data` attribute to hold post parameters
- lib/cask/download.rb: perform(): dispatch to new class based on `:using => :post`
- lib/cask/download_strategy.rb: Cask::CurlPostDownloadStrategy:
          extend curl_args with x-www-form-urlencoded data
- doc/CASK_LANGUAGE_REFERENCE.md: HTTP URLs: document new strategy
