### PR TITLE
Add R

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,0 +1,14 @@
+class R < Cask
+  url 'http://cran.rstudio.com/bin/macosx/R-3.0.2.pkg'
+  homepage 'http://www.r-project.org/'
+  version '3.0.2'
+  sha256 'e40f09447c77e3488964efb0623be26520718555a3ab0eb8e048325e5e4c040a'
+  install 'R-3.0.2.pkg'
+  # packages: 'org.r-project.R.x86_64.fw.pkg',
+  #           'org.r-project.R.x86_64.GUI.pkg',
+  #           'org.r-project.x86_64.tcltk.x11'
+  uninstall :pkgutil => '^org\.r-project\.(R\.)?x86_64\.(fw|GUI|tcltk).*',
+            :files => ['/usr/bin/R', '/usr/bin/Rscript',
+                       '/Library/Frameworks/R.Framework/Versions/3.0',
+                       '/Library/Frameworks/R.Framework/Versions/Current']
+end


### PR DESCRIPTION
Adds R as distributed by the R project. It uses the rstudio.org mirror, because that one uses a CDN, as opposed to the project's main server, r-project.org. See http://cran.r-project.org/mirrors.html for details.

Note: the stanza for uninstalling the cask almost works, but leaves behind a few files that aren't in the 'pkg' manifest and appear to be a cache created when the package was run. For example:

/Library/Frameworks/R.Framework/Versions/3.0/Resources/fontconfig/cache/CACHEDIR.TAG

If you know how these could be (safely) detected and removed, please let me know. Even so, the package can be re-installed after uninstalling like that, and everything still seems to work fine.
