### PR TITLE
Add uninstall stanza for iPhone Configuration Utility

### DIFF
--- a/Casks/iphone-configuration-utility.rb
+++ b/Casks/iphone-configuration-utility.rb
@@ -4,4 +4,5 @@ class IphoneConfigurationUtility < Cask
   version '3.5'
   sha256 '822204947ae5f7739bcb1e9694814f8e3ef65cd184952b76104f525d97a28163'
   install 'iPhoneConfigurationUtility.pkg'
+  uninstall :pkgutil => 'com.apple.pkg.iPhoneConfigurationUtility.*'
 end


### PR DESCRIPTION
Removes two packages (a `.bom` and a `.plist`). I don't think it would have any `launchctl` jobs.
