### PR TITLE
Avoid multiple `uninstall` artifacts.

### DIFF
--- a/Casks/dnscrypt.rb
+++ b/Casks/dnscrypt.rb
@@ -4,6 +4,6 @@ class Dnscrypt < Cask
   version '0.19'
   sha256 '36b684cc1a90a540e8c38759f509914818a1d3ca0e374ea0ab82e259cb72e1ec'
   install 'DNSCrypt.mpkg'
-  uninstall :pkgutil => 'com.opendns.osx.dnscryptClient.*'
-  uninstall :launchctl => 'com.opendns.osx.*'
+  uninstall :pkgutil => 'com.opendns.osx.dnscryptClient.*',
+            :launchctl => 'com.opendns.osx.*'
 end

--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -4,6 +4,6 @@ class Eagle < Cask
   version '6.5.0'
   sha256 '902e6f8ebdf0991a7b26a997e66540bf1e2b984b82a683be97fa469b95d35239'
   install 'eagle-6.5.0.pkg'
-  uninstall :pkgutil => 'com.CadSoftComputerGmbH.EAGLE'
-  uninstall :files => '/Applications/EAGLE-6.5.0'
+  uninstall :pkgutil => 'com.CadSoftComputerGmbH.EAGLE',
+            :files => '/Applications/EAGLE-6.5.0'
 end

--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -4,7 +4,6 @@ class Pagico < Cask
   version '6.5 (r1549)'
   sha256 'ad28214b082208025f9103dfbc2149b8224f0c488dfdcb06b51090e23d285bed'
   install 'Install Pagico 6.pkg'
-  uninstall :pkgutil => 'com.pagico.*pkg'
-  uninstall :pkgutil => 'com.pagico.*'
-  uninstall :files => '/Applications/Pagico'
+  uninstall :pkgutil => 'com.pagico.*',
+            :files => '/Applications/Pagico'
 end


### PR DESCRIPTION
In #3431, we recently discovered that this form is valid
to the DSL, but can exercise a bug at uninstall time.
