### PR TITLE
rename qq-music.rb

### DIFF
--- a/Casks/qqmusic.rb
+++ b/Casks/qqmusic.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class QqMusic < Cask
+class Qqmusic < Cask
   url 'http://dldir1.qq.com/music/clntupate/QQMusicForMacV1.3.0.dmg'
   homepage 'http://y.qq.com'
   version '1.3.0'


### PR DESCRIPTION
To `qqmusic.rb` per naming rules in CONTRIBUTING.md.

Even though the App name contains Chinese characters, the English
form is clearly indicated by the vendor within the App bundle. (similar to the
filename of the DMG, no space). In addition, this form matches `qqbrowser.rb`
from the same vendor.
