### PR TITLE
devscripts: prefer GNU xargs

### DIFF
--- a/developer/bin/list_apps_in_pkg
+++ b/developer/bin/list_apps_in_pkg
@@ -19,6 +19,9 @@ opt_lax=''
 opt_pkg=''
 pkgdir=''
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 ###
 ### functions
 ###
@@ -38,13 +41,13 @@ die () {
 
 app_source_1 () {
     /usr/bin/find "$pkgdir" -name PackageInfo -print0 |   \
-    /usr/bin/xargs -0 /usr/bin/perl -0777 -ne             \
+    "$xargs" -0 /usr/bin/perl -0777 -ne                   \
       'while (m{<pkg-info[^\n]*install-location="/Applications".*?path\s*=\s*"([^"]+)"}sg) { my $p = $1; $p =~ s{\A.*/}{}; print "$p\n" }';
 }
 
 app_source_2 () {
     /usr/bin/find "$pkgdir" -name PackageInfo -print0  |  \
-    /usr/bin/xargs -0 /usr/bin/perl -0777 -ne             \
+    "$xargs" -0 /usr/bin/perl -0777 -ne                   \
       'while (m{<pkg-info[^\n]*install-location="/".*?path\s*=\s*"./Applications/([^"]+)"}sg) { my $p = $1; $p =~ s{\A.*/}{}; print "$p\n" }';
 }
 
@@ -55,13 +58,13 @@ app_source_3 () {
 
 app_source_4 () {
     /usr/bin/find "$pkgdir" -name PackageInfo -print0  |  \
-    /usr/bin/xargs -0 /usr/bin/perl -0777 -ne             \
+    "$xargs" -0 /usr/bin/perl -0777 -ne                   \
       'while (m{path\s*=\s*"([^"]+\.app)"}sg) { my $p = $1; $p =~ s{\A.*/}{}; print "$p\n" }';
 }
 
 app_source_5 () {
     /usr/bin/find "$pkgdir" -name Archive.pax.gz -print0  |           \
-    /usr/bin/xargs -0 -n1 -I{} /bin/bash -c                           \
+    "$xargs" -0 -n1 -I{} /bin/bash -c                                 \
       "/usr/bin/gunzip -c '{}' | /bin/pax | /usr/bin/egrep '\.app'" | \
     /usr/bin/perl -pe 's{\A.*/([^/]+\.app).*\Z}{$1}';
 }
@@ -72,7 +75,7 @@ merge_sources () {
 
 mark_up_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |                     \
-    /usr/bin/xargs -0 -I{} -n1 /bin/bash -c                 \
+    "$xargs" -0 -I{} -n1 /bin/bash -c                       \
       'printf "{}"; /bin/test -n "$(/usr/bin/find /Applications -type d -maxdepth 3 -name "{}" -print0; /usr/bin/find ~/Applications -type d -maxdepth 3 -name "{}")" && printf " (+)"; printf "\n"'
 }
 

--- a/developer/bin/list_id_in_kext
+++ b/developer/bin/list_id_in_kext
@@ -17,13 +17,16 @@ shopt -s nocasematch  # case-insensitive regular expressions
 
 kextdir=''
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 ###
 ### functions
 ###
 
 bundle_id_source_1 () {
     /usr/bin/find "$kextdir" -name Info.plist -print0 |                                \
-    /usr/bin/xargs -0 /usr/bin/plutil -convert xml1 -o - -- |                          \
+    "$xargs" -0 /usr/bin/plutil -convert xml1 -o - -- |                                \
     /usr/bin/perl -0777 -ne                                                            \
       'while (m{<key>\s*CFBundleIdentifier\s*</key>\s*<string>([^<]+?)</string>}sg) { print "$1\n" }'
 }
@@ -38,7 +41,7 @@ clean_sources () {
 
 mark_up_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |                                                \
-    /usr/bin/xargs -0 -I{} -n1 /bin/bash -c                                            \
+    "$xargs" -0 -I{} -n1 /bin/bash -c                                                  \
       'printf "{}"; /bin/test "$(/usr/sbin/kextstat -kl -b "{}" | /usr/bin/wc -l)" -gt 0 && printf " (+)"; printf "\n"'
 }
 

--- a/developer/bin/list_ids_in_app
+++ b/developer/bin/list_ids_in_app
@@ -18,13 +18,16 @@ shopt -s nocasematch  # case-insensitive regular expressions
 appdir=''
 scriptdir="$(dirname "$0")"
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 ###
 ### functions
 ###
 
 bundle_id_source_1 () {
     /usr/bin/find "$appdir" -name Info.plist -print0 |                                 \
-    /usr/bin/xargs -0 /usr/bin/plutil -convert xml1 -o - -- |                          \
+    "$xargs" -0 /usr/bin/plutil -convert xml1 -o - -- |                                \
     /usr/bin/perl -0777 -ne                                                            \
       'while (m{<key>\s*CFBundleIdentifier\s*</key>\s*<string>([^<]+?)</string>}sg) { print "$1\n" }'
 }
@@ -104,7 +107,7 @@ clean_sources () {
 
 mark_up_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |                                                \
-    /usr/bin/xargs -0 -I{} -n1 /bin/bash -c                                            \
+    "$xargs" -0 -I{} -n1 /bin/bash -c                                                  \
       "printf '{}'; $scriptdir/list_running_app_ids -t '{}' >/dev/null 2>&1 && printf ' (+)'; printf "\\\\n""
 }
 

--- a/developer/bin/list_ids_in_pkg
+++ b/developer/bin/list_ids_in_pkg
@@ -17,19 +17,22 @@ shopt -s nocasematch  # case-insensitive regular expressions
 
 pkgdir=''
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 ###
 ### functions
 ###
 
 bundle_id_source_1 () {
     /usr/bin/find "$pkgdir" -name PackageInfo -print0 |                                \
-    /usr/bin/xargs -0 /usr/bin/perl -0777 -ne                                          \
+    "$xargs" -0 /usr/bin/perl -0777 -ne                                                \
       'while (m{<pkg-info.*?\sid(?:entifier)?\s*=\s*"([^"]*?)"}sg) { print "$1\n" }'
 }
 
 bundle_id_source_2 () {
     /usr/bin/find "$pkgdir" -name Info.plist -print0 |                                 \
-    /usr/bin/xargs -0 /usr/bin/plutil -convert xml1 -o - -- |                          \
+    "$xargs" -0 /usr/bin/plutil -convert xml1 -o - -- |                                \
     /usr/bin/perl -0777 -ne                                                            \
       'while (m{<key>\s*CFBundleIdentifier\s*</key>\s*<string>([^<]+?)</string>}sg) { print "$1\n" }'
 }
@@ -45,7 +48,7 @@ clean_sources () {
 
 mark_up_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |                                                \
-    /usr/bin/xargs -0 -I{} -n1 /bin/bash -c                                            \
+    "$xargs" -0 -I{} -n1 /bin/bash -c                                                  \
       'printf "{}"; /usr/sbin/pkgutil --pkg-info "{}" >/dev/null 2>&1 && printf " (+)"; printf "\n"'
 }
 

--- a/developer/bin/list_installed_launchjob_ids
+++ b/developer/bin/list_installed_launchjob_ids
@@ -15,6 +15,9 @@ shopt -s nocasematch  # case-insensitive regular expressions
 ### global variables
 ###
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 ###
 ### functions
 ###
@@ -25,7 +28,7 @@ launchjob_id_source_1 () {
                   /Library/LaunchAgents/           \
                   /Library/LaunchDaemons/          \
                   -type f -print0 2>/dev/null |    \
-    /usr/bin/xargs -0 /usr/bin/perl -0777 -ne      \
+    "$xargs" -0 /usr/bin/perl -0777 -ne            \
       'while (m{<key>\s*Label\s*</key>\s*<string>([^<]+?)</string>}sg) { print "$1\n" }'
 }
 
@@ -39,7 +42,7 @@ clean_sources () {
 
 mark_up_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |                                                \
-    /usr/bin/xargs -0 -I{} -n1 /bin/bash -c                                            \
+    "$xargs" -0 -I{} -n1 /bin/bash -c                                                  \
       'printf "{}"; /bin/launchctl list "{}" >/dev/null 2>&1 && printf " (+)"; printf "\n"'
 }
 

--- a/developer/bin/list_payload_in_pkg
+++ b/developer/bin/list_payload_in_pkg
@@ -18,6 +18,9 @@ shopt -s nocasematch  # case-insensitive regular expressions
 pkg_arg=''
 tmp_boms=''
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 trap cleanup_tmp_boms EXIT
 
 ###
@@ -31,11 +34,11 @@ cleanup_tmp_boms () {
         /usr/bin/touch "$tmpfile";
         echo "$tmp_boms" |                            \
         /usr/bin/perl -pe 's{\n}{\000}sg' |           \
-        /usr/bin/xargs -0 /bin/rm -f --;
+        "$xargs" -0 /bin/rm -f --;
         {
          echo "$tmp_boms" |                           \
          /usr/bin/perl -pe 's{[^/]+\n}{\000}sg' |     \
-         /usr/bin/xargs -0 /bin/rmdir -p -- || true
+         "$xargs" -0 /bin/rmdir -p -- || true
         } 2>/dev/null
         /bin/rm -- "$tmpfile";
     fi
@@ -43,7 +46,7 @@ cleanup_tmp_boms () {
 
 bom_source_1 () {
     /usr/bin/find "$pkg_arg" -iname '*.pkg' -print0 | \
-    /usr/bin/xargs -0 -I{} -n1 /usr/sbin/pkgutil --bom "{}" 2>/dev/null
+    "$xargs" -0 -I{} -n1 /usr/sbin/pkgutil --bom "{}" 2>/dev/null
 }
 
 bom_source_2 () {
@@ -52,7 +55,7 @@ bom_source_2 () {
 
 expand_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |               \
-    /usr/bin/xargs -0 lsbom --
+    "$xargs" -0 lsbom --
 }
 
 merge_sources () {
@@ -67,7 +70,7 @@ clean_sources () {
 
 mark_up_sources () {
     /usr/bin/perl -pe 's{\n}{\000}sg' |               \
-    /usr/bin/xargs -0 -I{} -n1 /bin/bash -c           \
+    "$xargs" -0 -I{} -n1 /bin/bash -c                 \
       'printf "{}"; /bin/test -e "{}" >/dev/null 2>&1 && printf " (+)"; printf "\n"'
 }
 

--- a/developer/bin/project_stats
+++ b/developer/bin/project_stats
@@ -29,6 +29,9 @@ end_object="HEAD"
 
 cask_authors=''
 
+# prefer GNU xargs
+xargs="$(/usr/bin/which gxargs || printf '/usr/bin/xargs')"
+
 ###
 ### functions
 ###
@@ -155,7 +158,7 @@ print_doc_stats () {
     printf "\n  "
     $git_log_cmd -- "${doc_paths[@]}" | /usr/bin/sort | /usr/bin/uniq | \
       /usr/bin/egrep -v $'^\'(paul\\.t\\.hinze@gmail\\.com|fanquake@users\\.noreply\\.github\\.com|fanquake@gmail\\.com|kevin@suttle\\.io|leoj3n@gmail\\.com|nano@fdp\\.io|nanoid\\.xd@gmail\\.com|me@passcod\\.name|walker@pobox\\.com|info@vitorgalvao\\.com|calebcenter@live\\.com|ndr@qef\\.io)\'$' | \
-      /usr/bin/xargs | /usr/bin/perl -pe 's{ }{, }g'           # '
+      "$xargs" | /usr/bin/perl -pe 's{ }{, }g'           # '
     printf "\n"
 }
 


### PR DESCRIPTION
Apple-supplied `xargs` has bugs/limitations, especially
relevant to the `-I` flag
