### PR TITLE
Add uninstall stanza for Logitech Unifying

### DIFF
--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -4,4 +4,5 @@ class LogitechUnifying < Cask
   version '1.10.421'
   sha256 'd9e196411cc4c0aec72fd01575eaffed228f95bc7d7ededc532d53f8602caa03'
   install 'Logitech Unifying Software.mpkg'
+  uninstall :pkgutil => 'com.Logitech.*pkg'
 end


### PR DESCRIPTION
Uninstalls two packages from the system. Checked for `kext`s and `launchjob`s, and there are none.
