### PR TITLE
Fixed version of Calibre (1.27.0)

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -1,7 +1,7 @@
 class Calibre < Cask
-  url 'http://status.calibre-ebook.com/dist/osx32'
+  url 'http://download.calibre-ebook.com/1.27.0/calibre-1.27.0.dmg'
   homepage 'http://calibre-ebook.com/'
-  version 'latest'
-  no_checksum
+  sha256 '2aed089971cee2847472314f5460414148447cbd6a438a9f282d6d0d2d52bb02'
+  version '1.27.0'
   link 'calibre.app'
 end


### PR DESCRIPTION
Calibre actually provides downloads of specific versions and doesn't have real
autoupdating, so it's better to leave updates to "cask"
