### PR TITLE
Fixed version of dropbox: 2.6.18

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,7 +1,8 @@
 class Dropbox < Cask
-  url 'https://www.dropbox.com/download?plat=mac&full=1'
+  # latest version can be found here: https://www.dropbox.com/release_notes
+  url 'https://dl-web.dropbox.com/u/17/Dropbox%202.6.18.dmg'
   homepage 'https://www.dropbox.com/'
-  version 'latest'
-  no_checksum
+  sha256 '0e78c923a4909ade08ff8b73ce8bd8b6f2e9127e5f3e723e6aa91004f741b66e'
+  version '2.6.18'
   link 'Dropbox.app'
 end


### PR DESCRIPTION
Dropbox provides versioned downloads and doesn't provide a working autoupdate
feature. New versions can be found via https://www.dropbox.com/release_notes
page, which links to corresponding forum-topics.
