### PR TITLE
Dfont Splitter 0.4.1

### DIFF
--- a/Casks/dfontsplitter.rb
+++ b/Casks/dfontsplitter.rb
@@ -1,0 +1,7 @@
+class Dfontsplitter < Cask
+  url 'http://peter.upfold.org.uk/files/dfontsplitter/dfontsplitter-0.4.1-mac.zip'
+  homepage 'http://peter.upfold.org.uk/projects/dfontsplitter'
+  version '0.4.1'
+  sha256 'd9345ffe0e9be0c096e65114be21fc3aac676a9a3a53e84f1d6cebff0b7796b3'
+  link 'DfontSplitter.app'
+end


### PR DESCRIPTION
Converts Macintosh .dfont files into TTF format
