### PR TITLE
instead 2.0.3

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,0 +1,7 @@
+class Instead < Cask
+  url 'http://downloads.sourceforge.net/project/instead/instead/2.0.3/Instead-2.0.3.dmg'
+  homepage 'http://instead.syscall.ru/'
+  version '2.0.3'
+  sha256 'ccad05fce186df643c1312eb07f8b6e2c537df56de54f5a2f7059830822b5500'
+  link 'Instead.app'
+end


### PR DESCRIPTION
INterpreter of Simple TExt ADventures
INSTEAD was designed to interpret the games that are the mix of visual novels, text quests and classical 90'ss quests.
also, see https://github.com/instead-hub/instead
