### PR TITLE
Add uninstall stanza for MacPorts

### DIFF
--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -10,4 +10,5 @@ class Macports < Cask
   end
   homepage 'http://www.macports.org'
   version '2.2.1'
+  uninstall :pkgutil => 'org.macports.MacPorts'
 end


### PR DESCRIPTION
Uninstalls one package from the system. No `kext`s or `launchjob`s. Tested on Mountain Lion, but quickly digging through the Mavericks package reveals that it's the same package name.
