### PR TITLE
Add serf binary version 0.4.5

### DIFF
--- a/Casks/serf.rb
+++ b/Casks/serf.rb
@@ -2,6 +2,6 @@ class Serf < Cask
   url 'https://dl.bintray.com/mitchellh/serf/0.4.5_darwin_amd64.zip'
   homepage 'http://www.serfdom.io/'
   version '0.4.5'
-  sha1 '92eca23bd25d4482611e3ac639855828ba241103'
+  sha256 '2dec10ebd084aba2eaacb0052a871db0396910dd6fbedc9ed0ed37ee3b397386'
   binary 'serf'
 end

--- a/Casks/serf.rb
+++ b/Casks/serf.rb
@@ -1,0 +1,7 @@
+class Serf < Cask
+  url 'https://dl.bintray.com/mitchellh/serf/0.4.5_darwin_amd64.zip'
+  homepage 'http://www.serfdom.io/'
+  version '0.4.5'
+  sha1 '92eca23bd25d4482611e3ac639855828ba241103'
+  binary 'serf'
+end


### PR DESCRIPTION
Adding `brew cask install` capability to [serf](http://www.serfdom.io)

They are distributing the zipped binary from: http://www.serfdom.io/downloads.html
