### PR TITLE
Update logmeinignition.rb

### DIFF
--- a/Casks/logmein-client.rb
+++ b/Casks/logmein-client.rb
@@ -1,4 +1,4 @@
-class Logmeinignition < Cask
+class LogmeinClient < Cask
   url 'https://secure.logmein.com/welcome/labs/LogMeInIgnition.dmg'
   homepage 'https://secure.logmein.com/products/pro/learnmore/desktopapp.aspx'
   version 'latest'

--- a/Casks/logmeinignition.rb
+++ b/Casks/logmeinignition.rb
@@ -1,7 +1,7 @@
 class Logmeinignition < Cask
   url 'https://secure.logmein.com/welcome/labs/LogMeInIgnition.dmg'
-  homepage 'https://secure.logmein.com/LABS/#IgnitionforMac'
+  homepage 'https://secure.logmein.com/products/pro/learnmore/desktopapp.aspx'
   version 'latest'
   no_checksum
-  link 'LogMeInIgnition.app'
+  link 'LogMeIn Client.app'
 end


### PR DESCRIPTION
The current Homepage states:

> Looking for Ignition for Mac?
> Now it's called the LogMeIn Client desktop app

And links to a new homepage. I've updated the cask to reflect this change.

The `.dmg` is still called `LogMeInIgnition.dmg` but the app is now named `LogMeIn Client.app`. I've renamed the the app in the link stanza.

However, I'm not sure if the cask should be renamed or not.
