### PR TITLE
unity-web-player: avoid multiple `uninstall`s

### DIFF
--- a/Casks/unity-web-player.rb
+++ b/Casks/unity-web-player.rb
@@ -4,6 +4,6 @@ class UnityWebPlayer < Cask
   version '4.3.5f1'
   install 'Install Unity Web Player.pkg'
   sha256 'bfdd087df94addaf045d7f5a446c3423b714c1553ff0fd50fc1d9406ea318051'
-  uninstall :pkgutil => 'com.unity.UnityWebPlayer'
-  uninstall :files => ['/Library/Internet Plug-Ins/Unity Web Player.plugin']
+  uninstall :pkgutil => 'com.unity.UnityWebPlayer',
+            :files   => '/Library/Internet Plug-Ins/Unity Web Player.plugin'
 end


### PR DESCRIPTION
It was recently discovered that multiple `uninstall` stanzas
may exercise a bug.  Pending an underlying fix, Casks can
be rewritten to avoid this usage.
