### PR TITLE
Added Mac Informer

### DIFF
--- a/Casks/mac-informer.rb
+++ b/Casks/mac-informer.rb
@@ -1,0 +1,7 @@
+class MacInformer < Cask
+  url 'http://files.informer.com/simac.dmg'
+  homepage 'http://macdownload.informer.com/landing/'
+  version 'latest'
+  no_checksum
+  link 'Mac Informer.app'
+end


### PR DESCRIPTION
Mac Informer has all the updates for your apps in one place, even for
those that don't come from the Mac App Store. It automatically detects
which of the installed apps need updating, fetches the download links,
and displays them in a clean and simple interface.
