### PR TITLE
Updated 1Password to 4.2.

### DIFF
--- a/Casks/onepassword.rb
+++ b/Casks/onepassword.rb
@@ -1,7 +1,7 @@
 class Onepassword < Cask
-  url 'http://i.agilebits.com/dist/1P/mac4/1Password-4.1.3.zip'
+  url 'http://i.agilebits.com/dist/1P/mac4/1Password-4.2.zip'
   homepage 'https://agilebits.com/onepassword'
-  version '4.1.3'
-  sha256 '7234379a12b09946c22525a789391cdb48dfa07abb1fd95f24631deff42b1f4f'
+  version '4.2'
+  sha256 '5a65d2a6b2d5eb1315d545c78a2b2040c1899ca4985a85ca8d9da06303df1eed'
   link '1Password 4.app'
 end


### PR DESCRIPTION
Sending this PR first so that anyone going to work on this will be aware of some [shenanigans](https://groups.google.com/d/msg/nushackers/91V8kM2gLo0/oPz3aUa16PkJ) regarding the authenticity of the package.

In gist, sending different HTTP headers to the vendor's web server results in two different files being downloaded that have the same build number. I have reached out the AgileBits to see if they can rectify the issue, and **I don't think this should be merged** in the meanwhile.

The hash in the commit below refers to the package obtained using `wget`, without sending `Accept Encoding: gzip`.
