### PR TITLE
add back `:quit` to citrix-receiver `uninstall`

### DIFF
--- a/Casks/citrix-receiver.rb
+++ b/Casks/citrix-receiver.rb
@@ -9,5 +9,9 @@ class CitrixReceiver < Cask
                            'com.citrix.ReceiverHelper',
                            'com.citrix.ServiceRecords',
                           ],
+            :quit      => [
+                           'Citrix.ServiceRecords',
+                           'com.citrix.ReceiverHelper',
+                          ],
             :pkgutil   => 'com.citrix.ICAClient'
 end


### PR DESCRIPTION
Hmm. @chrishas35, after more testing I find that you were right -- Citrix needs `:quit`, too.
