### PR TITLE
explicitly unload :launchctl service before remove

### DIFF
--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -104,6 +104,8 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
         [false, true].each do |with_sudo|
           xml_status = @command.run('/bin/launchctl', :args => ['list', '-x', service], :sudo => with_sudo)
           if %r{^<\?xml}.match(xml_status)
+            @command.run('/bin/launchctl',  :args => ['unload', '-w', '--', service], :sudo => with_sudo)
+            sleep 1
             @command.run!('/bin/launchctl', :args => ['remove', '--', service], :sudo => with_sudo)
             sleep 1
           end

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -108,6 +108,7 @@ describe Cask::Artifact::Pkg do
       )
 
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'remove', '--', 'my.fancy.package.service'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'unload', '-w', '--', 'my.fancy.package.service'])
 
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/kextstat', '-l', '-b', 'my.fancy.package.kernelextension'], 'loaded')
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', '--', 'my.fancy.package.kernelextension'])


### PR DESCRIPTION
Added this after noticing that `:quit` is required to stop services in #3514.
This change does not solve the specific issue with Citrix, but is also reasonable
in a "can't hurt anything" way.
