### PR TITLE
only set filesystem metadata if :target != source

### DIFF
--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -18,7 +18,7 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
   # bundles.  Alfred 2.2 respects it even for App bundles.
   def add_altname_metadata(source, target)
     attribute = 'com.apple.metadata:kMDItemAlternateNames'
-    return unless source.basename.to_s.casecmp(target.basename)
+    return if source.basename.to_s.casecmp(target.basename) == 0
     odebug "Adding #{attribute} metadata"
     altnames = @command.run('/usr/bin/xattr',
                             :args => ['-p', attribute, target],


### PR DESCRIPTION
fixing a bug in the implementation of #3073 which caused
metadata to be set in all cases.
