### PR TITLE
fix some erroneous uses of `casecmp`

### DIFF
--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -61,7 +61,7 @@ class Cask::CaveatsDSL
 
   def files_in_usr_local
     localpath = '/usr/local'
-    if localpath.casecmp(HOMEBREW_PREFIX)
+    if HOMEBREW_PREFIX.downcase.index(localpath) == 0
       puts <<-EOS.undent
       Cask #{@cask} installs files under "#{localpath}".  The presence of such
       files can cause warnings when running "brew doctor", which is considered

--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -44,7 +44,7 @@ class Cask::Container::Criteria
 
   def extension(test)
     %r{\.([^\.]+)$}.match(path) do |ext|
-      ext.captures.first.casecmp(test)
+      ext.captures.first.casecmp(test) == 0
     end
   end
 


### PR DESCRIPTION
`casecmp` returns -1/0/1, never false or nil
