### PR TITLE
Fix Disk Inventory X 403 error

### DIFF
--- a/Casks/disk-inventory-x.rb
+++ b/Casks/disk-inventory-x.rb
@@ -1,5 +1,6 @@
 class DiskInventoryX < Cask
-  url 'http://www.alice-dsl.net/tjark.derlien/DIX1.0Universal.dmg'
+  url 'http://www.alice-dsl.net/tjark.derlien/DIX1.0Universal.dmg',
+    :user_agent => :fake
   homepage 'http://www.derlien.com/'
   version '1.0'
   sha256 'f61c070a1ec8f29ee78b8a7c84dd4124553098acc87134e2ef05dbaf2a442636'


### PR DESCRIPTION
Fixes  #3517

As @jsmitley said, the new URL is: `http://www.derlien.com/download.php?file=DiskInventoryX` should I update the url to use that new url and change version to latest?
