### PR TITLE
Corrected logitech control center uninstall

### DIFF
--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -4,5 +4,5 @@ class LogitechControlCenter < Cask
   version '3.9.0.60'
   sha256 '1eab6118dc5ad0b3c790b9132b5968050dab0117b07d8f338c471aff00078df1'
   install 'LCC Installer.app/Contents/Resources/Logitech Control Center.mpkg'
-  uninstall 'LCC Installer.app/Contents/Resources/LCC Uninstaller Tool'
+  uninstall :script => 'LCC Installer.app/Contents/Resources/LCC Uninstaller Tool'
 end


### PR DESCRIPTION
It was missing `:script =>`.
