### PR TITLE
Fix CrashPlan checksum for v3.6.3

### DIFF
--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -2,7 +2,7 @@ class Crashplan < Cask
   url 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.6.3_Mac.dmg'
   homepage 'http://www.crashplan.com/'
   version '3.6.3'
-  sha256 '50a15332c779d9dd6e9a3e4e20360f3baebafee93362e32e4c6621a3cc501f1d'
+  sha256 '85d49c6742e390a24f0a0931d3c2cbb9ab077a1cd5361d980992ba2908acbd23'
   install 'Install CrashPlan.pkg'
   uninstall(
     :script => 'Uninstall.app/Contents/Resources/uninstall.sh',


### PR DESCRIPTION
I'm not sure what happened, but Crashplan v3.6.3 is now giving me a checksum error after I had previously installed it. I only noticed because I use a `Brewfile` so `homebrew-cask` tries to install all my applications every time I run `brew bundle`.

I did the following in my shell to diagnose:

```
wget http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.6.3_Mac.dmg
openssl dgst -sha256 ~/Downloads/CrashPlan_3.6.3_Mac.dmg
```

which gave me

```
SHA256(CrashPlan_3.6.3_Mac.dmg)= 85d49c6742e390a24f0a0931d3c2cbb9ab077a1cd5361d980992ba2908acbd23
```

Can someone confirm my new checksum?
