### PR TITLE
Updated Eclipse and added x86 stable build.

### DIFF
--- a/Casks/eclipse-ide-x86.rb
+++ b/Casks/eclipse-ide-x86.rb
@@ -1,0 +1,7 @@
+class EclipseIdeX86 < Cask
+  url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR2/eclipse-standard-kepler-SR2-macosx-cocoa.tar.gz'
+  homepage 'http://eclipse.org/'
+  version '4.3.2'
+  sha256 '0a1a5b6924daa1a3bd2482a537fac6f59c177da2265ed13f57cf0e5a5772b903'
+  link 'eclipse/Eclipse.app'
+end

--- a/Casks/eclipse-ide-x86.rb
+++ b/Casks/eclipse-ide-x86.rb
@@ -1,7 +1,0 @@
-class EclipseIdeX86 < Cask
-  url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR2/eclipse-standard-kepler-SR2-macosx-cocoa.tar.gz'
-  homepage 'http://eclipse.org/'
-  version '4.3.2'
-  sha256 '0a1a5b6924daa1a3bd2482a537fac6f59c177da2265ed13f57cf0e5a5772b903'
-  link 'eclipse/Eclipse.app'
-end

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,7 +1,7 @@
 class EclipseIde < Cask
-  url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR1/eclipse-standard-kepler-SR1-macosx-cocoa-x86_64.tar.gz'
-  homepage 'http://eclipse.org'
-  version '4.3.1'
-  sha256 'a491476cf91893e8e0495ae16bafd1352c80103be4bf7d09b087e1047561636a'
+  url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR2/eclipse-standard-kepler-SR2-macosx-cocoa-x86_64.tar.gz'
+  homepage 'http://eclipse.org/'
+  version '4.3.2'
+  sha256 '7fd761853ae7f5b280963059fcf8da6cea14c93563a3dfe7cc3491a7a977966e'
   link 'eclipse/Eclipse.app'
 end

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,7 +1,13 @@
 class EclipseIde < Cask
-  url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR2/eclipse-standard-kepler-SR2-macosx-cocoa-x86_64.tar.gz'
+  if Hardware::CPU.is_64_bit?
+    url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR2/eclipse-standard-kepler-SR2-macosx-cocoa-x86_64.tar.gz'
+    version '4.3.2'
+    sha256 '7fd761853ae7f5b280963059fcf8da6cea14c93563a3dfe7cc3491a7a977966e'
+  else
+    url 'http://download.eclipse.org/technology/epp/downloads/release/kepler/SR2/eclipse-standard-kepler-SR2-macosx-cocoa.tar.gz'
+    version '4.3.2'
+    sha256 '0a1a5b6924daa1a3bd2482a537fac6f59c177da2265ed13f57cf0e5a5772b903'
+  end
   homepage 'http://eclipse.org/'
-  version '4.3.2'
-  sha256 '7fd761853ae7f5b280963059fcf8da6cea14c93563a3dfe7cc3491a7a977966e'
   link 'eclipse/Eclipse.app'
 end


### PR DESCRIPTION
The hashes here were derived from a copy hosted on a local mirror; `download.eclipse.org` is unusably slow for me.

Could someone help `brew cask audit eclipse-ide-x86 --download` and `brew cask audit eclipse-ide --download`?
