### PR TITLE
Updated dogecoin to version 1.6

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -1,7 +1,7 @@
 class Dogecoin < Cask
-  url 'https://github.com/dogecoin/dogecoin/releases/download/1.5.2/dogecoin-qt-1_5_2-mac.zip'
+  url 'https://github.com/dogecoin/dogecoin/releases/download/1.6/dogecoin-qt-1_6_0-mac.zip'
   homepage 'http://dogecoin.com/'
-  version '1.5.2'
-  sha256 '95a5a1ec8fce333bc25200467172d11261292e816d38be73af47a830ac4ae200'
+  version '1.6.0'
+  sha256 '087fc6c8d0ab0715144434b147659649417d21901d4dda3024d8712fcc23bf06'
   link 'Dogecoin-Qt.app'
 end


### PR DESCRIPTION
This is a mandatory upgrade, see:

https://github.com/dogecoin/dogecoin/releases/tag/1.6

Wow. So upgrading. Such new version. Many brew!
