### PR TITLE
Change version to latest when using no_checksum

### DIFF
--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -1,7 +1,7 @@
 class AmadeusPro < Cask
   url 'http://s3.amazonaws.com/AmadeusPro2/AmadeusPro.dmg'
   homepage 'http://www.hairersoft.com/pro.html'
-  version '2'
+  version 'latest'
   no_checksum
   link 'Amadeus Pro.app'
 end

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,7 +1,7 @@
 class GoogleChrome < Cask
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
   homepage 'https://www.google.com/chrome/'
-  version 'stable-channel'
+  version 'latest'
   no_checksum
   link 'Google Chrome.app'
 end

--- a/Casks/google-japanese-ime.rb
+++ b/Casks/google-japanese-ime.rb
@@ -1,7 +1,7 @@
 class GoogleJapaneseIme < Cask
   url 'https://dl.google.com/japanese-ime/latest/GoogleJapaneseInput.dmg'
   homepage 'https://www.google.co.jp/ime/'
-  version 'stable-channel'
+  version 'latest'
   no_checksum
   install 'GoogleJapaneseInput.pkg'
   uninstall :pkgutil => 'com.google.pkg.GoogleJapaneseInput',

--- a/Casks/macbreakz.rb
+++ b/Casks/macbreakz.rb
@@ -1,7 +1,7 @@
 class Macbreakz < Cask
   url 'http://www.publicspace.net/download/MacBreakZ5.dmg'
   homepage 'http://www.publicspace.net/MacBreakZ/'
-  version '5'
+  version 'latest'
   no_checksum
   link 'MacBreakZ 5.app'
 end

--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -1,7 +1,7 @@
 class Papers < Cask
   url 'http://papersapp.com/papers/download'
   homepage 'http://www.papersapp.com/papers/'
-  version '3'
+  version 'latest'
   no_checksum
   link 'Papers.app'
 end

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,7 +1,7 @@
 class Spotify < Cask
   url 'http://download.spotify.com/Spotify.dmg'
   homepage 'https://www.spotify.com'
-  version 'stable'
+  version 'latest'
   no_checksum
   link 'Spotify.app'
 end

--- a/Casks/steam.rb
+++ b/Casks/steam.rb
@@ -1,7 +1,7 @@
 class Steam < Cask
   url 'http://media.steampowered.com/client/installer/steam.dmg'
   homepage 'http://store.steampowered.com/about/'
-  version 'stable'
+  version 'latest'
   no_checksum
   link 'Steam.app'
 end

--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,7 +1,7 @@
 class TheEscapersFlux < Cask
   url 'http://instruktion.net/theescapers/downloads/FluxV4.zip'
   homepage 'http://www.theescapers.com/flux/'
-  version '4'
+  version 'latest'
   no_checksum
   link 'Flux.app'
 end

--- a/Casks/valentina-studio.rb
+++ b/Casks/valentina-studio.rb
@@ -1,7 +1,7 @@
 class ValentinaStudio < Cask
   url 'http://www.valentina-db.com/download/release/mac_32/vstudio_5_mac.dmg'
   homepage 'http://www.valentina-db.com/'
-  version '5'
+  version 'latest'
   no_checksum
   link 'Valentina Studio.app'
 end


### PR DESCRIPTION
According to the guideline, version should be latest if the version number not appear in the download url.

The utorrent one may not be suitable in the main repo. It is beta version.
