### PR TITLE
Add audit check for version != latest

### DIFF
--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -14,6 +14,7 @@ class Cask::Audit
     _check_required_fields
     _check_checksums
     _check_sha256_no_check_if_latest
+    _check_sha_if_version_not_latest
     _check_sourceforge_download_url_format
     _check_download(download) if download
     return !(errors? or warnings?)
@@ -40,6 +41,11 @@ class Cask::Audit
   def _check_sha256_no_check_if_latest
     odebug "Verifying sha256 :no_check with version 'latest'"
     add_error "you should use sha256 :no_check when version is 'latest'" if cask.version == "latest" && cask.sums.is_a?(Array)
+  end
+
+  def _check_sha_if_version_not_latest
+    odebug "Verifying sha256 with version is not 'latest'"
+    add_error "you should use sha256 when version is not latest" if cask.version != "latest" && !cask.sums.is_a?(Array)
   end
 
   def _check_download(download)

--- a/test/cask/audit_test.rb
+++ b/test/cask/audit_test.rb
@@ -38,6 +38,11 @@ class CaskVersionLatestWithChecksum < Cask
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 end
 
+class CaskVersionWithNoChecksum < Cask
+  version '1.2.3'
+  no_checksum
+end
+
 describe Cask::Audit do
   describe "result" do
     it "is 'failed' if there are have been any errors added" do
@@ -83,6 +88,12 @@ describe Cask::Audit do
         audit = Cask::Audit.new(CaskVersionLatestWithChecksum.new)
         audit.run!
         audit.errors.must_include %q{you should use sha256 :no_check when version is 'latest'}
+      end
+
+      it "adds an error if no_checksum but with version" do
+        audit = Cask::Audit.new(CaskVersionWithNoChecksum.new)
+        audit.run!
+        audit.errors.must_include 'you should use sha256 when version is not latest'
       end
     end
 


### PR DESCRIPTION
The only case for no_checksum is version equal to 'latest'

This audit check helps contributors to fit the guideline.
