### PR TITLE
Added Nicecast

### DIFF
--- a/Casks/nicecast.rb
+++ b/Casks/nicecast.rb
@@ -1,0 +1,7 @@
+class Nicecast < Cask
+  url 'http://rogueamoeba.com/nicecast/download/Nicecast.zip'
+  homepage 'http://rogueamoeba.com/nicecast'
+  version 'latest'
+  no_checksum
+  link 'Nicecast.app'
+end


### PR DESCRIPTION
Nicecast is the easiest way to broadcast music from your Mac. Broadcast
to listeners around the world. Nicecast can help you create your own
internet radio station or allow you to listen to your iTunes Music
Library from anywhere in the world!
