### PR TITLE
Add Popcorn-Time.app v2.7

### DIFF
--- a/Casks/popcorn-time.rb
+++ b/Casks/popcorn-time.rb
@@ -1,7 +1,7 @@
 class PopcornTime < Cask
-  url 'http://static.cdnjd.com/releases/popcorn/Popcorn-Time-2.7-Mac.tgz'
+  url 'http://popcorn.cdnjd.com/releases/Popcorn-Time-2.7-Mac.tgz'
   homepage 'https://popcorn.yts.re/'
-  version '0.2.7'
-  sha256 '51a35b1951ba7c6f4adfc963e6b85ffbed82c5fa6cdc101d64c8d4ec87cd0f39'
+  version '2.7'
+  sha256 'ae0b6bd37e4caded13b3f6ab693530f4510ed1d7246f0afde12a98e415b89305'
   link 'Popcorn-Time.app'
 end

--- a/Casks/popcorn-time.rb
+++ b/Casks/popcorn-time.rb
@@ -1,0 +1,7 @@
+class PopcornTime < Cask
+  url 'http://static.cdnjd.com/releases/popcorn/Popcorn-Time-2.7-Mac.tgz'
+  homepage 'https://popcorn.yts.re/'
+  version '0.2.7'
+  sha256 '51a35b1951ba7c6f4adfc963e6b85ffbed82c5fa6cdc101d64c8d4ec87cd0f39'
+  link 'Popcorn-Time.app'
+end

--- a/Casks/popcorn-time.rb
+++ b/Casks/popcorn-time.rb
@@ -1,7 +1,7 @@
 class PopcornTime < Cask
-  url 'http://popcorn.cdnjd.com/releases/Popcorn-Time-2.7-Mac.tgz'
-  homepage 'https://popcorn.yts.re/'
-  version '2.7'
-  sha256 'ae0b6bd37e4caded13b3f6ab693530f4510ed1d7246f0afde12a98e415b89305'
+  url 'http://popcorn.cdnjd.com/releases/Popcorn-Time-0.2.8-Mac.tar.gz'
+  homepage 'http://popcorn.cdnjd.com'
+  version '0.2.8'
+  sha256 '393bad100a3953f7f31207d81c1b59d83a172f42f4c41efeeaed35da91bc8431'
   link 'Popcorn-Time.app'
 end


### PR DESCRIPTION
That is their homepage url, their site currently seems to be down. Official releases are [here](https://github.com/Yify/popcorn-app/releases).
