### PR TITLE
Add sublime-text3 cask for Sublime Text BUILD 3061

### DIFF
--- a/Casks/sublime-text2.rb
+++ b/Casks/sublime-text2.rb
@@ -1,4 +1,4 @@
-class SublimeText < Cask
+class SublimeText2 < Cask
   url 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.dmg'
   homepage 'http://www.sublimetext.com/2'
   version '2.0.2'

--- a/Casks/sublime-text3.rb
+++ b/Casks/sublime-text3.rb
@@ -1,0 +1,11 @@
+class SublimeText3 < Cask
+  url 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203061.dmg'
+  homepage 'http://www.sublimetext.com/3dev'
+  version 'Build 3061'
+  sha256 '2c49418b2d9c021c276f1b84bcdeca45fc433cc3c3787c0297b264d14fd0e5c9'
+  link 'Sublime Text.app'
+  binary 'Sublime Text.app/Contents/SharedSupport/bin/subl'
+  caveats do
+    files_in_usr_local
+  end
+end


### PR DESCRIPTION
- Add `sublime-text3` cask for Sublime Text BUILD 3061
- Renames cask `sublime-text` to `sublime-text2` to match convention for installing multiple versions of Sublime Text (`sublime-text2`, `sublime-text3`)
