### PR TITLE
Update Brackets to 0.37; consider numerical versioning

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,7 +1,7 @@
 class Brackets < Cask
-  url 'http://download.brackets.io/file.cfm?platform=OSX&build=36'
+  url 'http://download.brackets.io/file.cfm?platform=OSX&build=37'
   homepage 'http://brackets.io'
-  version 'Sprint 36'
-  sha256 'a7cf879cb32b828b82eea76659617e0d439d2412feff205304bcebcad9f36335'
+  version 'Sprint 37'
+  sha256 '3f9fbbcfa12015b30656d83c5b55f0c11f98a298499d6b9b2fd7c2a92bf38f99'
   link 'Brackets.app'
 end

--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,7 +1,7 @@
 class Brackets < Cask
   url 'http://download.brackets.io/file.cfm?platform=OSX&build=37'
   homepage 'http://brackets.io'
-  version 'Sprint 37'
+  version '0.37.0-12014'
   sha256 '3f9fbbcfa12015b30656d83c5b55f0c11f98a298499d6b9b2fd7c2a92bf38f99'
   link 'Brackets.app'
 end


### PR DESCRIPTION
The first commit updates the Brackets cask to Sprint 37.
The second commit changes the version from the somewhat idiosyncratic 'Sprint' nomenclature to a more conventional build number as shown in Brackets itself.

Feel free to cherry-pick the first commit if the versioning change is not desired; if it is desired, I would squash the commits.
