### PR TITLE
Update pckeyboardhack to 10.6.0.

### DIFF
--- a/Casks/pckeyboardhack.rb
+++ b/Casks/pckeyboardhack.rb
@@ -1,8 +1,8 @@
 class Pckeyboardhack < Cask
-  url 'https://pqrs.org/macosx/keyremap4macbook/files/PCKeyboardHack-10.5.0.dmg'
+  url 'https://pqrs.org/macosx/keyremap4macbook/files/PCKeyboardHack-10.6.0.dmg'
   homepage 'https://pqrs.org/macosx/keyremap4macbook/pckeyboardhack.html.en'
-  version '10.5.0'
-  sha256 '68432c0ad039bcd5e4ae61401e897acaa68ddefc6e2b874204d2adc95640bfc9'
+  version '10.6.0'
+  sha256 '4b44f93fefda81fa526399548079a0f6c0b01a68d5c31aacf703ac26e4d482a3'
   install 'PCKeyboardHack.pkg'
   uninstall :quit => 'org.pqrs.PCKeyboardHack',
             :kext => 'org.pqrs.driver.PCKeyboardHack',


### PR DESCRIPTION
v10.6.0 is the latest stable version of PCKeyboardHack.

https://pqrs.org/macosx/keyremap4macbook/pckeyboardhack.html.en#history
