### PR TITLE
Add Hush.app v1.0

### DIFF
--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -1,0 +1,8 @@
+class Hush < Cask
+  url 'http://coffitivity.com/hush/files/Hush.dmg.zip'
+  homepage 'http://coffitivity.com/hush/'
+  version '1.0'
+  sha256 'da31f0abd7c531e87c9f171493d318535cb24f1335e7e2b1c0fa68eeed685b2e'
+  nested_container 'Hush.dmg'
+  link 'Hush.app'
+end


### PR DESCRIPTION
[Hush](http://coffitivity.com/hush/) silences your Mac Notification Center.

![logo](http://coffitivity.com/hush/img/large-dog.png)
