### PR TITLE
Upgrade eclipse-platform to v4.3.2

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,7 +1,7 @@
 class EclipsePlatform < Cask
-  url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-macosx-cocoa-x86_64.tar.gz'
+  url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.3.2-201402211700/eclipse-SDK-4.3.2-macosx-cocoa-x86_64.tar.gz'
   homepage 'http://eclipse.org'
-  version '4.3.1'
-  sha256 '7001ddb2e29e1e81aa3e415ae7e5686a4aa15abb30786a57825c8b8f10746ced'
+  version '4.3.2'
+  sha256 '9a77cc829aa1174a98abd180a35f628d72620f2a961e21fa12d3a88e48c6ce71'
   link 'eclipse/Eclipse.app'
 end


### PR DESCRIPTION
Upgraded eclipse-platform from v4.3.1 to v4.3.2
