### PR TITLE
Update CotEditor to 1.4.0

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -1,12 +1,7 @@
 class Coteditor < Cask
-  if MacOS.version < "10.7"
-    url 'http://dl.sourceforge.jp/coteditor/54872/CotEditor_1.3.1.dmg'
-    sha256 '5c871bd9de30fc3c76fc66acb4ea258d4d3762ae341181d65a7ef1f8de4751c5'
-  else
-    url 'http://dl.sourceforge.jp/coteditor/54872/CotEditor_1.3.1_For10.7.dmg'
-    sha256 'b064830db8438682f620c0b14aec595022a331defd2f09001fc0578ae91e21b5'
-  end
-  homepage 'http://sourceforge.jp/projects/coteditor/'
-  version '1.3.1'
+  url 'https://github.com/coteditor/CotEditor/releases/download/1.4/CotEditor_1.4.dmg'
+  sha256 '2a223ed59f6970dd786a87383a30d377f5b27f70517a4003ed8424d791f79290'
+  homepage 'http://coteditor.github.io/'
+  version '1.4.0'
   link 'CotEditor.app'
 end


### PR DESCRIPTION
There're few major changes in this release:
1. Drop official support for OS X < 10.7
2. Move from SourceForge to GitHub

Thanks!
