### PR TITLE
Add XCA - X Certificate and key management (latest)

### DIFF
--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,0 +1,8 @@
+class Xca < Cask
+  url 'http://sourceforge.net/projects/xca/files/latest/download',
+    :user_agent => :fake
+  homepage 'http://xca.sourceforge.net/'
+  version 'latest'
+  no_checksum
+  link 'xca.app'
+end


### PR DESCRIPTION
:fake user agent is required so sf.net will serve us the dmg
instead of the source archive or Windows exe. Minimally, this seems
to be dependent on the presence of the 'Intel Mac OS X' string in the UA
