### PR TITLE
Add MakeHuman v1.0.0

### DIFF
--- a/Casks/makehuman.rb
+++ b/Casks/makehuman.rb
@@ -1,0 +1,7 @@
+class Makehuman < Cask
+  url 'http://download.tuxfamily.org/makehuman/releases/1.0.0/makehuman-1.0.0-osx.dmg'
+  homepage 'http://www.makehuman.org/'
+  version '1.0.0'
+  sha256 'f104963fc5fcf627069324cc3d3b9dc7bae65608fd9b7354fb914a1f3c755e70'
+  link 'MakeHuman.app'
+end


### PR DESCRIPTION
MakeHuman is the free and open source software to create realistic 3d humans for:
- Illustrations
- Animations
- Games
- Zbrush/Mudbox sculpting

The virtual human is ready to export in external 3d software (Blender, XSI, Max,...) or to quick render with the internal engine.
