### PR TITLE
force the DMG file extension in git-annex.rb

### DIFF
--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -3,6 +3,12 @@ class GitAnnex < Cask
     url 'http://downloads.kitenet.net/git-annex/OSX/current/10.9_Mavericks/git-annex.dmg'
   else
     url 'http://downloads.kitenet.net/git-annex/OSX/current/10.8.2_Mountain_Lion/git-annex.dmg.bz2'
+    # This is a horrible hack to force the file extension.  The
+    # backend code should be fixed so that this is not needed.
+    before_install do
+      system '/bin/mv', destination_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
+    end
+    nested_container 'git-annex-latest.dmg'
   end
   homepage 'http://git-annex.branchable.com/'
   version 'latest'


### PR DESCRIPTION
For non-Mavericks installs.  Also add needed nested_container
stanza.  Fixes #3650.
