### PR TITLE
explicit utf-8 encoding for xee.rb

### DIFF
--- a/Casks/xee.rb
+++ b/Casks/xee.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 class Xee < Cask
   url 'http://wakaba.c3.cx/releases/mac/Xee3.3.dmg'
   homepage 'http://xee.c3.cx/'


### PR DESCRIPTION
This helps older Ruby interpreters.
