### PR TITLE
display artifact summary in `brew cask info`

### DIFF
--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -20,12 +20,13 @@ class Cask::CLI::Info
                      "Not installed"
                    end
 
-    <<-PURPOSE.undent
-    #{cask}: #{cask.version}
-    #{cask.homepage}
-    #{installation}
-    #{github_info(cask)}
-    PURPOSE
+    <<-PURPOSE
+#{cask}: #{cask.version}
+#{cask.homepage}
+#{installation}
+#{github_info(cask)}
+#{artifact_info(cask)}
+PURPOSE
   end
 
   def self.github_info(cask)
@@ -34,5 +35,18 @@ class Cask::CLI::Info
     tap, name = tap.split "/"
     user, repo = tap.split "-"
     "https://github.com/#{user}/homebrew-#{repo}/commits/master/Casks/#{name}.rb"
+  end
+
+  def self.artifact_info(cask)
+    retval = ''
+    Cask::DSL::ClassMethods.ordinary_artifact_types.each do |type|
+      if cask.artifacts[type].length > 0
+        retval = "#{Tty.blue}==>#{Tty.white} Contents#{Tty.reset}\n" unless retval.length > 0
+        cask.artifacts[type].each do |artifact|
+          retval.concat "  #{artifact.first} (#{type.to_s})\n"
+        end
+      end
+    end
+    retval.sub!(/\n\Z/, '')
   end
 end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -84,22 +84,26 @@ module Cask::DSL
       end
     end
 
-    ARTIFACT_TYPES = [
-      :link,
-      :prefpane,
-      :qlplugin,
-      :font,
-      :widget,
-      :service,
-      :colorpicker,
-      :binary,
-      :caskroom_only,
-      :input_method,
-      :screen_saver,
-      :install,
-    ]
+    def self.ordinary_artifact_types
+      @@ordinary_artifact_types ||= [
+                                     :link,
+                                     :prefpane,
+                                     :qlplugin,
+                                     :font,
+                                     :widget,
+                                     :service,
+                                     :colorpicker,
+                                     :binary,
+                                     :input_method,
+                                     :screen_saver,
+                                     :install,
+                                    ]
+    end
 
-    ARTIFACT_TYPES.each do |type|
+    installable_artifact_types = ordinary_artifact_types
+    installable_artifact_types.push :caskroom_only
+
+    installable_artifact_types.each do |type|
       define_method(type) do |*args|
         artifacts[type] << args
       end

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -9,6 +9,8 @@ describe Cask::CLI::Info do
       http://example.com/local-caffeine
       Not installed
       https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
+      ==> Contents
+        Caffeine.app (link)
     CLIOUTPUT
   end
 
@@ -20,10 +22,14 @@ describe Cask::CLI::Info do
       http://example.com/local-caffeine
       Not installed
       https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
+      ==> Contents
+        Caffeine.app (link)
       local-transmission: 2.61
       http://example.com/local-transmission
       Not installed
       https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-transmission.rb
+      ==> Contents
+        Transmission.app (link)
     CLIOUTPUT
   end
 
@@ -35,6 +41,8 @@ describe Cask::CLI::Info do
       http://example.com/local-caffeine
       Not installed
       https://github.com/phinze/homebrew-testcasks/commits/master/Casks/with-caveats.rb
+      ==> Contents
+        Caffeine.app (link)
       ==> Caveats
       Here are some things you might want to know.
 


### PR DESCRIPTION
Per discussion with @drew-gross in closed issue #3280.
Limitation: does not show link targets.
