### PR TITLE
rescue LoadError for optional `require`

### DIFF
--- a/developer/bin/cask_namer
+++ b/developer/bin/cask_namer
@@ -17,7 +17,7 @@ require 'open3'
 begin
   # not available by default
   require 'active_support/inflector'
-rescue
+rescue LoadError
 end
 
 ###


### PR DESCRIPTION
Following up on #3503. Should merit a bugfix release.
