### PR TITLE
add missing underscores in OS release symbols

### DIFF
--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,7 +1,7 @@
 class Middleclick < Cask
-  if MacOS.version == :snowleopard or MacOS.version == :lion
+  if MacOS.version == :snow_leopard or MacOS.version == :lion
     url 'http://clement.beffa.org/labs/downloads/MiddleClick.zip'
-  elsif MacOS.version == :mountainlion
+  elsif MacOS.version == :mountain_lion
     url 'http://clement.beffa.org/labs/downloads/MiddleClick_ml.zip'
   else
     url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -1,9 +1,9 @@
 class Onyx < Cask
-  if MacOS.version == :snowleopard
+  if MacOS.version == :snow_leopard
     url 'http://www.titanium.free.fr/download/106/OnyX.dmg'
   elsif MacOS.version == :lion
     url 'http://www.titanium.free.fr/download/107/OnyX.dmg'
-  elsif MacOS.version == :mountainlion
+  elsif MacOS.version == :mountain_lion
     url 'http://joel.barriere.pagesperso-orange.fr/dl/108/OnyX.dmg'
   else
     url 'http://joel.barriere.pagesperso-orange.fr/dl/109/OnyX.dmg'

--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,5 +1,5 @@
 class Opensesame < Cask
-  if MacOS.version == :snowleopard
+  if MacOS.version == :snow_leopard
     url 'http://files.cogsci.nl/software/opensesame/opensesame_0.26-macos-2.zip'
     version '0.26'
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'


### PR DESCRIPTION
These symbols are provided by Homebrew.  It seems that
a typo was propagated by copy/paste.  Fixes #3645.
