### PR TITLE
Update node-webkit download url

### DIFF
--- a/Casks/node-webkit.rb
+++ b/Casks/node-webkit.rb
@@ -1,5 +1,5 @@
 class NodeWebkit < Cask
-  url 'https://s3.amazonaws.com/node-webkit/v0.9.2/node-webkit-v0.9.2-osx-ia32.zip'
+  url 'http://dl.node-webkit.org/v0.9.2/node-webkit-v0.9.2-osx-ia32.zip'
   homepage 'https://github.com/rogerwang/node-webkit'
   version '0.9.2'
   sha256 '2133f498d2607e02a1af1b1988fb191ed0467a268afffabbeb3b99ee62384407'


### PR DESCRIPTION
node-webkit moved their download links to a custom domain; binaries are unchanged.
