### PR TITLE
Fixing checksums for VueScan cask

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 class Vuescan < Cask
   if Hardware::CPU.is_64_bit?
     url 'http://www.hamrick.com/files/vuex6494.dmg'
-    sha256 'af323bf91f52f093dd9ef9385ef734260917f539a3af9037b9a870008b3e4e91'
+    sha256 '040e7abb611bc2bfed2c02c7c8fb08f74ce3618e3e054f1222ff8629cb98a716'
   else
     url 'http://www.hamrick.com/files/vuex3294.dmg'
-    sha256 'aee2583a970301333acb6be8e2eb828f5513101c167c6a99b7ff115bd3f2ee83'
+    sha256 'fc927be998fa970a6a3d49dfa6f67fae1e5bd3486cd1edf8bf762e425bf6c032'
   end
   homepage 'http://www.hamrick.com'
   version '9.4.27'


### PR DESCRIPTION
Not sure why these are already bad, as the version number (9.4.27) hasn't changed. If it happens again this cask might be better off without checksums. 
