### PR TITLE
rename yandex-disk.rb to yandexdisk.rb

### DIFF
--- a/Casks/yandexdisk.rb
+++ b/Casks/yandexdisk.rb
@@ -1,4 +1,4 @@
-class YandexDisk < Cask
+class Yandexdisk < Cask
   url 'https://disk.yandex.com/download/Yandex.Disk.Mac.dmg'
   homepage 'https://disk.yandex.com/'
   version 'latest'


### PR DESCRIPTION
in accordance with `cask_namer` and `CASK_NAMING_REFERENCE.md`
