### PR TITLE
update keepassx to 2.0 series

### DIFF
--- a/Casks/keepassx.rb
+++ b/Casks/keepassx.rb
@@ -1,7 +1,7 @@
 class Keepassx < Cask
-  url 'http://downloads.sourceforge.net/keepassx/KeePassX-0.4.3.dmg'
+  url 'https://www.keepassx.org/dev/attachments/download/59/KeePassX-2.0-alpha5.dmg'
   homepage 'http://www.keepassx.org'
-  version '0.4.3'
-  sha256 '15ce2e950ab78ccb6956de985c1fcbf11d27df6a58ab7bf19e106f0a1dc2fedd'
+  version '2.0-alpha5'
+  sha256 '7d1e3de8446421d1c4cb920364907de3d03cd3eaedfa96602fac8983479a5303'
   link 'KeePassX.app'
 end


### PR DESCRIPTION
In spite of the alpha version scheme, this is the most usable version available, support for the previous release series was EOL'ed a long while back and they are completely unmaintained (last patch release over 4 years ago). The 2.0 series was started 4 years ago and has been releasing builds labeled alpha since May 2012. Anybody actually using this software is using these builds in spite of the version labeling scheme.
