### PR TITLE
Updated caveat in MacTeX to zsh-only

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -7,6 +7,6 @@ class Mactex < Cask
   uninstall :pkgutil => 'org.tug.mactex.texlive2013',
             :files   => '/etc/paths.d/TeX'
   caveats do
-    path_environment_variable '/usr/texbin'
+    zsh_path_helper '/usr/texbin'
   end
 end


### PR DESCRIPTION
MacTeX already adds itself to `$PATH` for non-zsh shells, so no need to have the user manually do it. Changed the caveat from `path_environment_variable` to `zsh_path_helper`, as added in #3699.

Addresses part of #3597.
