### PR TITLE
Rename Google Music to Radiant Player

### DIFF
--- a/Casks/google-music.rb
+++ b/Casks/google-music.rb
@@ -1,7 +1,0 @@
-class GoogleMusic < Cask
-  url 'https://github.com/kbhomes/google-music-mac/releases/download/v1.1.1/Google.Music.zip'
-  homepage 'http://kbhomes.github.io/google-music-mac/'
-  version '1.1.1'
-  sha256 '62f38da3adad507e35ff6aaff01feecb065bab2ba9f59e9684c7c5971fcbdf9c'
-  link 'Google Music.app'
-end

--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -1,0 +1,7 @@
+class RadiantPlayer < Cask
+  url 'https://github.com/kbhomes/google-music-mac/releases/download/v1.1.2/Radiant.Player.zip'
+  homepage 'http://kbhomes.github.io/google-music-mac/'
+  version '1.1.2'
+  sha256 '139e742af85e0ceade606b35478c26d1a01b43973587db5fe54eddaa2641957e'
+  link 'Radiant Player.app'
+end


### PR DESCRIPTION
The project was renamed, I'm guessing Google got upset about it. I changed the name and bumped the version number to the renamed version.
