### PR TITLE
Rename Axure RP Pro, remove version for non-versioned download

### DIFF
--- a/Casks/axure-rp-pro.rb
+++ b/Casks/axure-rp-pro.rb
@@ -1,7 +1,7 @@
-class Axureprpro < Cask
+class AxureRpPro < Cask
   url 'http://axure.cachefly.net/AxureRP-Pro-Setup.dmg'
   homepage 'http://www.axure.com/'
-  version '7.0.0.3146'
-  sha256 '0d77fab85185aa8957eea754faa001fcbb202cc9162b29c65526637580b02f32'
+  version 'latest'
+  sha256 :no_check
   link 'Axure RP Pro 7.0.app'
 end


### PR DESCRIPTION
- Cask was `axureprpro`, it is now correctly named `axurerppro`
- Bump version
  - URL doesn't point to versioned download; should we use `version 'latest'` and `sha256 :no_check` instead?
