### PR TITLE
Add Stackroom.app v2.0b

### DIFF
--- a/Casks/stackroom.rb
+++ b/Casks/stackroom.rb
@@ -1,0 +1,7 @@
+class Stackroom < Cask
+  url 'http://www.geocities.jp/aromaticssoft/stackroom/download/stackroom_2.0b.zip'
+  homepage 'http://www.geocities.jp/aromaticssoft/stackroom/index.html'
+  version '2.0b'
+  sha256 'b5904f8c39a3941a827cea31e77dc9c62b12025cccddc5b42869615392a543ce'
+  link 'Stackroom.app'
+end


### PR DESCRIPTION
There is only beta for later OSX 10.5
