### PR TITLE
Adding cask for MavensMate.app

### DIFF
--- a/Casks/mavens-mate.rb
+++ b/Casks/mavens-mate.rb
@@ -1,0 +1,7 @@
+class MavensMate < Cask
+  url 'http://push.mavensconsulting.netdna-cdn.com/mavensmate/builds/MavensMate.zip'
+  homepage 'http://mavensmate.com'
+  version 'latest'
+  no_checksum
+  link 'MavensMate.app'
+end


### PR DESCRIPTION
Commit to homebrew-cask to add cask for MavensMate, a force.com IDE
with plugins for Sublime Text 2 and 3
