### PR TITLE
Add a borderless version of iTerm 2

### DIFF
--- a/Casks/iterm2-borderless.rb
+++ b/Casks/iterm2-borderless.rb
@@ -1,0 +1,7 @@
+class Iterm2Borderless < Cask
+  url 'https://github.com/Nasga/iterm2-borderless/archive/master.zip'
+  homepage 'https://github.com/Nasga/iterm2-borderless'
+  version 'latest'
+  no_checksum
+  link 'iterm2-borderless-master/iTerm.app', :target => 'iTerm (Borderless).app'
+end


### PR DESCRIPTION
I added a borderless (yet unstable and everything) version of iTerm 2.
I didn't quite get how to mark this as "beta" or something similar, even if it's not a beta but just a patch.
