### PR TITLE
Adding cask for SoqlXplorer.app v.2.00 (Salesforce API v30)

### DIFF
--- a/Casks/soqlxplorer.rb
+++ b/Casks/soqlxplorer.rb
@@ -1,0 +1,7 @@
+class Soqlxplorer < Cask
+  url 'http://www.pocketsoap.com/osx/soqlx/soqlXplorer_v2.00.zip'
+  homepage 'http://www.pocketsoap.com/osx/soqlx/'
+  version '2.00'
+  no_checksum
+  link 'SoqlXplorer.app'
+end


### PR DESCRIPTION
Closes #3729.
