### PR TITLE
removed wunderlist

### DIFF
--- a/Casks/wunderlist.rb
+++ b/Casks/wunderlist.rb
@@ -1,7 +1,0 @@
-class Wunderlist < Cask
-  url 'https://www.macupdate.com/download/35862/Wunderlist.zip'
-  homepage 'https://www.wunderlist.com/en/'
-  version '2.3.2'
-  sha256 'd7adf0cb3b9ab0cd4265ccc7c1e757cd38e74dbcf8c56017baf443dd2abec1b8'
-  link 'Wunderlist.app'
-end


### PR DESCRIPTION
It’s a free app available _officially_ on the MAS. The latest version currently on
MacUpdate (2.2.1 — even though this _cask_ says 2.3.2) is also behind the MAS version (2.3.5), so it makes no sense to continue providing the app here.
