### PR TITLE
Adding Puredata Extended 0.43 (stable)

### DIFF
--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -1,0 +1,7 @@
+class PdExtended < Cask
+  url 'http://downloads.sourceforge.net/project/pure-data/pd-extended/0.43.4/Pd-0.43.4-extended-macosx105-i386.dmg'
+  homepage 'http://puredata.info/downloads/pd-extended'
+  version '0.43.4'
+  sha256 'abe7bd637b1495ad9d5a500f0a18550c1600e34ee17e60aa1a48e4dbdee59bb9'
+  link 'Pd-extended.app'
+end


### PR DESCRIPTION
Installs Puredata Extended v0.43. Does not currently uninstall.
The app has 0555 permissions on some of the files and the cask cannot
simply 'rm' the files since we don't have write access to them. Need
some further guidance on how to handle this.
