### PR TITLE
Symlink diffmerge command line binary to /usr/local/bin

### DIFF
--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -4,4 +4,5 @@ class Diffmerge < Cask
   version '4.2.0.697'
   sha256 '2c6368653af2440bb4460aef9bb1b2b5d8b84b5a3f47994c4abafc4d7ddbff9e'
   link 'DiffMerge.app'
+  binary 'Extras/diffmerge.sh', :target => 'diffmerge'
 end


### PR DESCRIPTION
Symlinks the diffmerge command to /usr/local/bin since the .dmg does not do it automatically.
