### PR TITLE
update Couchbse Server Enterprise Edition to 2.5.1

### DIFF
--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -1,7 +1,7 @@
 class CouchbaseServerEnterprise < Cask
-  url 'http://packages.couchbase.com/releases/2.5.0/couchbase-server-enterprise_2.5.0_x86_64.zip'
+  url 'http://packages.couchbase.com/releases/2.5.1/couchbase-server-enterprise_2.5.1_x86_64.zip'
   homepage 'http://www.couchbase.com/'
-  version '2.5.0'
-  sha256 'ea607f1b9fefd861849d8210ce12f2cc80fc66f295b691083853c9aba29473b7'
+  version '2.5.1'
+  sha256 'fce890b3c68893ad651da2103ae56d8be6a6310e607aa42b0376fea1a1ca1b41'
   link 'Couchbase Server.app'
 end


### PR DESCRIPTION
The Couchbase Server Enterprise version has been updated; retrying this after having been defeated by `git rebase` in attempts to squash commits in last PR ;)
