### PR TITLE
Remove YANVI

### DIFF
--- a/Casks/yanvi.rb
+++ b/Casks/yanvi.rb
@@ -1,7 +1,0 @@
-class Yanvi < Cask
-  url 'http://download1167.mediafire.com/2ve2xmcd85ug/iy2s1yp233pzj80/Yet_Another_NFO_Viewer_v1.0.2.dmg'
-  homepage 'https://www.macupdate.com/app/mac/39748/yet-another-nfo-viewer'
-  version '1.0.2'
-  sha256 '7e7db828e404d1594ca847c4ccbb4fe7924dd5d3a116e69ddef94884345749ed'
-  link 'YaNvi.app'
-end


### PR DESCRIPTION
The download for this _cask_ is from mediafire. Similar to the case with [FreeRapid](https://github.com/phinze/homebrew-cask/pull/615), having the download source be a one click hoster means the download url expires (being then unreliable).

Will leave this open for a few days, in case someone has an alternative.
