### PR TITLE
Don't fail in "brew cask list" with empty installation

### DIFF
--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -1,15 +1,9 @@
 class Cask::CLI::List
   def self.run(*arguments)
     if arguments.any?
-      retval = list_casks(*arguments)
+      list_casks(*arguments)
     else
-      retval = list_installed
-    end
-    # retval is ternary: true/false/nil
-    if retval.nil?
-      raise CaskError.new("nothing to list")
-    elsif ! retval
-      raise CaskError.new("listing incomplete")
+      list_installed
     end
   end
 
@@ -26,7 +20,9 @@ class Cask::CLI::List
         opoo "#{cask} is not installed"
       end
     end
-    count == 0 ? nil : count == cask_names.length
+    if count != cask_names.length
+      raise CaskError.new("Listing incomplete")
+    end
   end
 
   def self.list_artifacts(cask)
@@ -43,9 +39,7 @@ class Cask::CLI::List
   end
 
   def self.list_installed
-    columns = Cask.installed.map(&:to_s)
-    puts_columns columns
-    columns.empty? ? nil : Cask.installed.length == columns.length
+    puts_columns Cask.installed.map(&:to_s)
   end
 
   def self.help


### PR DESCRIPTION
At the moment `brew cask list` fails if no package is installed:

``` sh
$ brew cask list
Error: nothing to list
$ echo $?
1
```

This makes it [quite hard](https://github.com/njam/osx-setup/commit/a4deda25e6ec9e43a1db9c14b7473b80a6c1b178) to use in another script.
Therefore I would suggest to just list _nothing_ if no packages are installed:

``` sh
$ brew cask list
$ echo $?
0
```

@mariansollmann fyi

What do you think?
