### PR TITLE
Fixed wrong hash for istat-menus

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -2,6 +2,6 @@ class IstatMenus < Cask
   url 'http://s3.amazonaws.com/bjango/files/istatmenus4/istatmenus4.21.zip'
   homepage 'http://bjango.com/mac/istatmenus/'
   version '4.21'
-  sha256 '376dfa849d5e2dcdd0d50c08b7329743b7a5b21dd6ab762f99b65fac710d169e'
+  sha256 'c0747dad57116f538d06c24bddbc962bd33f05320339f8884ac3f0e0cf04757a'
   link 'iStat Menus.app'
 end


### PR DESCRIPTION
The previous hash was incorrect.
![image](https://cloud.githubusercontent.com/assets/474794/2701998/b6abf998-c42a-11e3-9635-4a0e2c06053e.png)
