### PR TITLE
Fix CLI tool installation in GitHub for Mac

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -4,6 +4,7 @@ class Github < Cask
   version 'latest'
   no_checksum
   link 'GitHub.app'
+  binary 'GitHub.app/Contents/MacOS/github_cli', :target => 'github'
   after_install do
     system '/usr/bin/defaults', 'write', 'com.github.GitHub', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end


### PR DESCRIPTION
Symlinks the 'github' CLI binary that enables opening GitHub for Mac
from the command line. As per the defaults for the application, the
internal `github_cli` binary is symlinked simply as `github`.

Note this intentionally does _not_ also symlink the bundled versions.
of `git` itself, as anyone using brewcask is going to want to be able
to manage those normally via homebrew.`
