### PR TITLE
Update Brackets.app to Sprint 38

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,7 +1,7 @@
 class Brackets < Cask
-  url 'http://download.brackets.io/file.cfm?platform=OSX&build=37'
+  url 'https://github.com/adobe/brackets/releases/download/sprint-38/Brackets.Sprint.38.dmg'
   homepage 'http://brackets.io'
-  version '0.37.0-12014'
-  sha256 '3f9fbbcfa12015b30656d83c5b55f0c11f98a298499d6b9b2fd7c2a92bf38f99'
+  version '0.38.0'
+  sha256 'afac1657a822cbee928633080a844e9a127144d5e834b710a83d04273e818cc1'
   link 'Brackets.app'
 end


### PR DESCRIPTION
I hope the version number's right.

Blog post: [brackets.io](http://blog.brackets.io/2014/04/15/brackets-0-38-release-multiple-cursors/)
