### PR TITLE
Upgrade SeaMonkey.app to v2.25

### DIFF
--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -1,7 +1,7 @@
 class Seamonkey < Cask
-  url 'https://download.mozilla.org/?product=seamonkey-2.24&os=osx&lang=en-US'
+  url 'https://download.mozilla.org/?product=seamonkey-2.25&os=osx&lang=en-US'
   homepage 'http://www.seamonkey-project.org/'
-  version '2.24'
-  sha256 'f52f9bac431c8e711094e759c716209eaf6d96a541e3a3dbcc92765158c48b6f'
+  version '2.25'
+  sha256 '3217e3d1fb94376d01ca38cc926b1b23306579c96e96adfdd50f0f66fc71c5e8'
   link 'SeaMonkey.app'
 end


### PR DESCRIPTION
This updates SeaMonkey to the latest stable version - v2.25.
