### PR TITLE
Add BaseX 7.8.1

### DIFF
--- a/Casks/basex.rb
+++ b/Casks/basex.rb
@@ -1,0 +1,8 @@
+class Basex < Cask
+  url 'http://files.basex.org/releases/7.8.1/BaseX781.app.zip'
+  homepage 'http://basex.org/home/'
+  version '7.8.1'
+  sha256 '495b4c32cb916c02543a5f19b702c01516b1b8f452be537259dd6d1ad040ca87'
+  container_type :zip
+  link 'BaseX.app'
+end

--- a/Casks/basex.rb
+++ b/Casks/basex.rb
@@ -3,6 +3,5 @@ class Basex < Cask
   homepage 'http://basex.org/home/'
   version '7.8.1'
   sha256 '495b4c32cb916c02543a5f19b702c01516b1b8f452be537259dd6d1ad040ca87'
-  container_type :zip
   link 'BaseX.app'
 end


### PR DESCRIPTION
Note: 7.8.2 and latest don't seem to work, at least on OS X 10.9.2
