### PR TITLE
Added permissions fix after_install for VoiceMac

### DIFF
--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -4,4 +4,7 @@ class Voicemac < Cask
   version 'latest'
   no_checksum
   link 'VoiceMac/VoiceMac.app'
+  after_install do
+    system '/bin/chmod', 'a+r', "#{destination_path}/VoiceMac/VoiceMac.app/Contents/Info.plist"
+  end
 end


### PR DESCRIPTION
VoiceMac's `Info.plist` file is not world-readable even though the rest of the app is. This should fix it.
