### PR TITLE
Fix sha256 in plex_media_server

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -2,6 +2,6 @@ class PlexMediaServer < Cask
   url 'http://downloads.plexapp.com/plex-media-server/0.9.9.7.429-f80a8d6/PlexMediaServer-0.9.9.7.429-f80a8d6-OSX.zip'
   homepage 'http://plexapp.com'
   version '0.9.9.7.429'
-  sha256 '7c74eab9da4cd4ecbb8b27595ff6f5b0df006aba8333263471ccf27790dad27d'
+  sha256 '7d00adaf8b3254d0a34d4c4cb6ec65f97f9fc5101a16005c2ef1297b41f71900'
   link 'Plex Media Server.app'
 end


### PR DESCRIPTION
Cask can not install plex media server cause sha256 which downloaded file is wrong.
