### PR TITLE
Correct `uninstall` stanza documentation

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -300,7 +300,7 @@ is the most useful.
 * `:launchctl` (string or array) - ids of `launchctl` jobs to remove
 * `:quit` (string or array) - bundle ids of running applications to quit
 * `:kext` (string or array) - bundle ids of kexts to unload from the system
-* `:pkgutil` (regexp or array) - regexps matching bundle ids of packages to uninstall using `pkgutil`
+* `:pkgutil` (string, regexp or array of strings and regexps) - strings or regexps matching bundle ids of packages to uninstall using `pkgutil`
 * `:script` (string or hash) - relative path to an uninstall script to be run via sudo; use hash if args are needed
   - `:executable` - relative path to an uninstall script to be run via sudo (required for hash form)
   - `:args` - array of arguments to the uninstall script


### PR DESCRIPTION
The `pkgutil` option can take strings as parameters, as mentioned in #3961. The current documentation states it can take only regexp or arrays.
