### PR TITLE
Update foxmail.rb

### DIFF
--- a/Casks/foxmail.rb
+++ b/Casks/foxmail.rb
@@ -2,6 +2,6 @@ class Foxmail < Cask
   url 'http://dldir1.qq.com/foxmail/MacFoxmail/Foxmail_for_Mac_V1.2.0.dmg'
   homepage 'http://www.foxmail.com'
   version '1.2.0'
-  sha256 'b71c373f96f69835ead265ab47957d3f81920025adeea0d37374415d0d03d06c'
+  sha256 '164f1752d69dc8f4b9e9ee730ee5d55e2dd41f5f30507863b8292a1aee26e6ea'
   link 'Foxmail.app'
 end


### PR DESCRIPTION
``` bash
Error: SHA2 mismatch
Expected: b71c373f96f69835ead265ab47957d3f81920025adeea0d37374415d0d03d06c
Actual: 164f1752d69dc8f4b9e9ee730ee5d55e2dd41f5f30507863b8292a1aee26e6ea
Archive: /Library/Caches/Homebrew/foxmail-1.2.0.dmg
To retry an incomplete download, remove the file above.
```
