### PR TITLE
Add cask for Apache Directory Studio.

### DIFF
--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -1,0 +1,7 @@
+class ApacheDirectoryStudio < Cask
+  url 'http://mirrors.sonic.net/apache//directory/studio/dist/2.0.0.v20130628/ApacheDirectoryStudio-macosx-x86_64-2.0.0.v20130628.dmg'
+  homepage 'http://directory.apache.org/studio/'
+  version '2.0.0.v20130628'
+  sha256 '60914cc67f893afdc8bf537fa67a48cb7cd96357e7d28595a2c22a74a19f02e3'
+  link 'Apache Directory Studio.app'
+end


### PR DESCRIPTION
Apache Directory Studio is an LDAP browser.
