### PR TITLE
Add Torpedo version 1.2.2.

### DIFF
--- a/Casks/torpedo.rb
+++ b/Casks/torpedo.rb
@@ -1,0 +1,7 @@
+class Torpedo < Cask
+  url 'http://usetorpedo.com/downloads/mac/Torpedo-1.2.2.app.zip'
+  homepage 'https://usetorpedo.com'
+  version '1.2.2'
+  sha256 '72f0a027ea525755e07e43d90464aa00f1c45167b30d333272017f64e0496dcf'
+  link 'Torpedo.app'
+end


### PR DESCRIPTION
Share files, passwords, and more with self-destructing private links. [https://usetorpedo.com](https://usetorpedo.com)
