### PR TITLE
Resolve #3992

### DIFF
--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -5,10 +5,8 @@ class Baiduinput < Cask
   version '3.2'
   sha256 'a8599116bb9248a06b7a26f7be73061cb00263263fe685cb0b7c6c99fce6cf56'
   install '安装百度输入法.pkg'
-  uninstall(
-    :pkgutil  => 'com.baidu.inputmethod.*',
-    :files    => [
-      '/Library/Input Methods/BaiduIM.app'
-    ]
-  )
+  uninstall :pkgutil  => 'com.baidu.inputmethod.*',
+            :files    => [
+                          '/Library/Input Methods/BaiduIM.app'
+                         ]
 end

--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -5,23 +5,23 @@ class Chefdk < Cask
   sha256 '41a101786cf72b65d267782826ace70cbd8153f1d025c95f2e451c5c7dee8ded'
   install 'chefdk.pkg'
   uninstall :pkgutil => 'com.getchef.pkg.chefdk',
-            :files => [
-                       '/opt/chefdk/',
-                       '/usr/bin/berks',
-                       '/usr/bin/chef',
-                       '/usr/bin/chef-apply',
-                       '/usr/bin/chef-client',
-                       '/usr/bin/chef-shell',
-                       '/usr/bin/chef-solo',
-                       '/usr/bin/chef-zero',
-                       '/usr/bin/fauxhai',
-                       '/usr/bin/foodcritic',
-                       '/usr/bin/kitchen',
-                       '/usr/bin/knife',
-                       '/usr/bin/ohai',
-                       '/usr/bin/rubocop',
-                       '/usr/bin/shef',
-                       '/usr/bin/strain',
-                       '/usr/bin/strainer'
-                      ]
+            :files   => [
+                         '/opt/chefdk/',
+                         '/usr/bin/berks',
+                         '/usr/bin/chef',
+                         '/usr/bin/chef-apply',
+                         '/usr/bin/chef-client',
+                         '/usr/bin/chef-shell',
+                         '/usr/bin/chef-solo',
+                         '/usr/bin/chef-zero',
+                         '/usr/bin/fauxhai',
+                         '/usr/bin/foodcritic',
+                         '/usr/bin/kitchen',
+                         '/usr/bin/knife',
+                         '/usr/bin/ohai',
+                         '/usr/bin/rubocop',
+                         '/usr/bin/shef',
+                         '/usr/bin/strain',
+                         '/usr/bin/strainer'
+                        ]
 end

--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -4,8 +4,6 @@ class Crashplan < Cask
   version '3.6.3'
   sha256 'af6959a5a2e8584195fa7381014ba462ced114763995b50266d6353a95b84a7d'
   install 'Install CrashPlan.pkg'
-  uninstall(
-    :script => 'Uninstall.app/Contents/Resources/uninstall.sh',
-    :pkgutil => 'com.crashplan.app.pkg'
-  )
+  uninstall :script  => 'Uninstall.app/Contents/Resources/uninstall.sh',
+            :pkgutil => 'com.crashplan.app.pkg'
 end

--- a/Casks/flip4mac.rb
+++ b/Casks/flip4mac.rb
@@ -4,7 +4,5 @@ class Flip4mac < Cask
   version '3.2.0.16'
   sha256 'd1574ca9896f8f40bf4d868e8ff91b1da1ac1dcd91a5b7898f3580543b02988e'
   install 'Flip4Mac.pkg'
-  uninstall(
-    :pkgutil => 'net.telestream.Flip4Mac'
-  )
+  uninstall :pkgutil => 'net.telestream.Flip4Mac'
 end

--- a/Casks/mailfollowup.rb
+++ b/Casks/mailfollowup.rb
@@ -6,9 +6,8 @@ class Mailfollowup < Cask
   nested_container 'MailFollowUp_1.6.2.dmg'
   install 'Install MailFollowUp.pkg'
 
-  uninstall(
-    :quit => 'com.apple.mail',
-    :files => '~/Library/Mail/Bundles/MailFollowUp.mailbundle/'
-  )
-
+  uninstall :quit  => 'com.apple.mail',
+            :files => [
+                       '~/Library/Mail/Bundles/MailFollowUp.mailbundle/'
+                      ]
 end

--- a/Casks/netbeans-cpp.rb
+++ b/Casks/netbeans-cpp.rb
@@ -4,7 +4,7 @@ class NetbeansCpp < Cask
   version '8.0'
   sha256 '55e58e5c01d38860919b8765a9ed5b048aef20d474c913305973bc03343b9d98'
   install 'NetBeans 8.0.mpkg'
-  uninstall(
-    :files => '/Applications/NetBeans'
-  )
+  uninstall :files => [
+                       '/Applications/NetBeans'
+                      ]
 end

--- a/Casks/netbeans-php.rb
+++ b/Casks/netbeans-php.rb
@@ -4,7 +4,7 @@ class NetbeansPhp < Cask
   version '8.0'
   sha256 'b33830cb86bc5d626717a9dbbd0a94bf37530b8cfd06b1e4526b060921115ec5'
   install 'NetBeans 8.0.mpkg'
-  uninstall(
-    :files => '/Applications/NetBeans'
-  )
+  uninstall :files => [
+                       '/Applications/NetBeans'
+                      ]
 end

--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -20,8 +20,8 @@ class Netbeans < Cask
   # The NetBeans installer does some postflight unpacking of paths installed by
   # the OS X installer, so it's insufficient to just delete the paths exposed
   # by pkgutil, hence the additional `:files` option below.
-  uninstall(
-    :pkgutil => 'org.netbeans.ide.*|glassfish-.*',
-    :files => '/Applications/NetBeans'
-  )
+  uninstall :pkgutil => 'org.netbeans.ide.*|glassfish-.*',
+              :files => [
+                         '/Applications/NetBeans'
+                        ]
 end

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -4,11 +4,9 @@ class Teamviewer < Cask
   version 'latest'
   no_checksum
   install 'Install TeamViewer.pkg'
-  uninstall(
-    :pkgutil   => 'com.teamviewer.*',
-    :launchctl => 'com.teamviewer.service',
-    :files     => %w[
-      /Library/LaunchDaemons/com.teamviewer.teamviewer_service.plist
-    ]
-  )
+  uninstall :pkgutil   => 'com.teamviewer.*',
+            :launchctl => 'com.teamviewer.service',
+            :files     => [
+                           '/Library/LaunchDaemons/com.teamviewer.teamviewer_service.plist'
+                          ]
 end

--- a/Casks/unity3d.rb
+++ b/Casks/unity3d.rb
@@ -4,7 +4,5 @@ class Unity3d < Cask
   version '4.3.4.1'
   sha256 '09e073e68fd54533338fc2f79ffa255cc4f9b8effa4b1ef22865b9c2548d6f86'
   install 'Unity.pkg'
-  uninstall(
-    :pkgutil => 'com.unity3d.*'
-  )
+  uninstall :pkgutil => 'com.unity3d.*'
 end

--- a/Casks/whatpulse.rb
+++ b/Casks/whatpulse.rb
@@ -4,8 +4,9 @@ class Whatpulse < Cask
   version '2.4'
   sha256 'baa7f17829cf70241845642891bceb4c4e4f276152a90e804eb271bdf1ffdbe8'
   install 'WhatPulse 2.4.mpkg'
-  uninstall(
-    :files => ['/Applications/WhatPulse.app', '/Library/StartupItems/ChmodBPF'],
-    :quit => 'com.whatpulse.mac'
-  )
+  uninstall :files => [
+                       '/Applications/WhatPulse.app',
+                       '/Library/StartupItems/ChmodBPF'
+                      ],
+            :quit  => 'com.whatpulse.mac'
 end


### PR DESCRIPTION
Cleans up parenthesis for uninstall commands and aligns `=>` nicely.
I setup all of the `:file` key value pairs as arrays even if there was only one file to make it a little more obvious that there could be multiple files included. If this is not desirable I can certainly change it.
