### PR TITLE
Factor programming language 0.96 - latest stable release

### DIFF
--- a/Casks/factor.rb
+++ b/Casks/factor.rb
@@ -1,0 +1,7 @@
+class Factor < Cask
+  url 'http://downloads.factorcode.org/releases/0.96/factor-macosx-x86-64-0.96.dmg'
+  homepage 'http://factorcode.org/'
+  version '0.96'
+  sha256 'bd5dca1393c444a9491ef0c70f48b94ae7e39712ea0748a061cd721d26e83c40'
+  link 'factor/Factor.app'
+end


### PR DESCRIPTION
Latest stable release of Factor programming environment: version 0.96. I am not certain if the 32-bit version should be included, so only the 64-bit release is linked.
