### PR TITLE
Add Mixture.app latest version

### DIFF
--- a/Casks/mixture.rb
+++ b/Casks/mixture.rb
@@ -1,0 +1,7 @@
+class Mixture < Cask
+  url 'https://s3.amazonaws.com/mixture-mixed-app/mac/Mixture.zip'
+  homepage 'http://mixture.io/'
+  version 'latest'
+  no_checksum
+  link 'Mixture.app'
+end


### PR DESCRIPTION
Added Mixture.app. Download link on Mixture.io always points to latest version so did set version to latest and bypassed the checksum as it would fail when the mixture team update the zip file.
