### PR TITLE
Add Hashcat version 0.47

### DIFF
--- a/Casks/hashcat.rb
+++ b/Casks/hashcat.rb
@@ -1,0 +1,7 @@
+class Hashcat < Cask
+  url 'https://hashcat.net/files/hashcat-0.47.7z'
+  homepage 'https://hashcat.net/hashcat/'
+  version '0.47'
+  sha256 '239acb25b88d529314f2f98af0d6a66772e886c9efbb4ed2b94b7587c9a68455'
+  binary 'hashcat-0.47/hashcat-cli64.app', :target => 'hashcat'
+end


### PR DESCRIPTION
This is a simple cask for the Hashcat tool, which is closed-source and
only distributes binaries (hence it is not suitable for a Homebrew
formula).

This installs a single binary to the system path, there is no GUI
component.

This tool has been rejected by the main Homebrew team multiple times, as the developer does not release the source code to the application (example: https://github.com/shaneog/homebrew/commit/aafaa9206bb93697741a85b5912ed3073591b595) 
