### PR TITLE
Fix Pycharm sha256 metadata

### DIFF
--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -2,6 +2,6 @@ class Pycharm < Cask
   url 'http://download.jetbrains.com/python/pycharm-professional-3.1.3.dmg'
   homepage 'http://www.jetbrains.com/pycharm/'
   version '3.1.3'
-  sha256 '3c1025db0520e19cdec3d8f7e4497b5de55f103b9a677770097f64e4f1c69c48'
+  sha256 'a1cd576dde0d49b6212b19932adc1192743b7fb50034396168e1521fe39f37cc'
   link 'PyCharm.app'
 end


### PR DESCRIPTION
Sorry, I Made a mistake

``` sh
shasum -a 256 pycharm-professional-3.1.3.dmg
a1cd576dde0d49b6212b19932adc1192743b7fb50034396168e1521fe39f37cc  pycharm-professional-3.1.3.dmg
```
