### PR TITLE
fix for brew 0.9.5 changed tap directory structure

### DIFF
--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -97,7 +97,7 @@ module Cask::Locations
     end
 
     def default_tap
-      @default_tap ||= 'phinze-cask'
+      @default_tap ||= 'phinze/homebrew-cask'
     end
 
     def default_tap=(_tap)


### PR DESCRIPTION
change the tap directory of homebrew-cask while `brew cask update` under brew 0.9.5
