### PR TITLE
Add direct download version of PaintCode 1.3.4

### DIFF
--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,0 +1,7 @@
+class Paintcode < Cask
+  url 'http://download.macheist.com/nano4/pc.zip'
+  homepage 'http://www.paintcodeapp.com/'
+  version '1.3.4'
+  sha256 '84e3794458851f42783fb8bebc53a8ca5bd068ddb5ef7fedb27db52e989e39a6'
+  link 'PaintCode.app'
+end

--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,7 +1,7 @@
 class Paintcode < Cask
   url 'http://download.macheist.com/nano4/pc.zip'
   homepage 'http://www.paintcodeapp.com/'
-  version '1.3.4'
-  sha256 '84e3794458851f42783fb8bebc53a8ca5bd068ddb5ef7fedb27db52e989e39a6'
+  version 'latest'
+  no_checksum
   link 'PaintCode.app'
 end


### PR DESCRIPTION
PaintCode was available through a recent MacHeist bundle, where it was
made available as a direct download for the first time -- the normal
distribution method is Mac App Store. This cask can be used for non-MAS
owners of PaintCode to access the direct download version.
