### PR TITLE
Remove ISSUES_URL from cli commands

### DIFF
--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -22,7 +22,7 @@ require 'cask/cli/update'
 class Cask::CLI
   ISSUES_URL = "https://github.com/phinze/homebrew-cask/issues"
   def self.commands
-    Cask::CLI.constants - ["NullCommand"]
+    Cask::CLI.constants - ["NullCommand", "ISSUES_URL"]
   end
 
   def self.lookup_command(command_string)


### PR DESCRIPTION
When user run `brew cask` it will list all commands out.
There is a blank help command call issues_url which caused by the newly
introduced constant from #2971
