### PR TITLE
java.rb: Missing '0' in version string

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -4,7 +4,7 @@ class Java < Cask
                     'oraclelicense' => 'accept-securebackup-cookie'
                   }
   homepage 'http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html'
-  version '1.8.0_5'
+  version '1.8.0_05'
   sha256 '3dd1047340c2487f7c32c4ae633ba9a9a9e1dee49f6084d7df3846091faece48'
   install 'JDK 8 Update 05.pkg'
   after_install do


### PR DESCRIPTION
The PlistBuddy commands do not work since there is a '0' missing in the version number string, which is part of the path.
