### PR TITLE
Rename DigitalOcean Droplet Manager and change host to be github releases

### DIFF
--- a/Casks/dropletmanager.rb
+++ b/Casks/dropletmanager.rb
@@ -1,0 +1,7 @@
+class Dropletmanager < Cask
+  url 'https://github.com/deivuh/DODropletManager-OSX/releases/download/v0.3.1/DropletManagerv0.3.1.zip'
+  homepage 'https://github.com/deivuh/DODropletManager-OSX'
+  version '0.3.1'
+  sha256 '70351fc8c77a9c4f71f1f25567b33ab623fce1cf899469f5e31d9cad171ceedd'
+  link 'DropletManager.app'
+end

--- a/Casks/dropletsmanager.rb
+++ b/Casks/dropletsmanager.rb
@@ -1,7 +1,0 @@
-class Dropletsmanager < Cask
-  url 'https://dl.dropboxusercontent.com/u/115750/files/DropletsManager0.1.zip'
-  homepage 'https://github.com/deivuh/DODropletManager-OSX'
-  version '0.1'
-  sha256 'e41875c0b4c24f510aff324d189dfc4fc7227e78117fff2374c5064c2ecf00bd'
-  link 'DropletsManager.app'
-end


### PR DESCRIPTION
They renamed the app slightly (non-plural ) and also have moved over to github releases. They will also now be putting up new releases rather than having a single URL for all builds. This should help prevent the SHA errors from earlier, see deivuh/DODropletManager-OSX#14.
