### PR TITLE
Upgrade Leap Motion to 1.2.0+10933

### DIFF
--- a/Casks/leap-motion.rb
+++ b/Casks/leap-motion.rb
@@ -1,8 +1,8 @@
 class LeapMotion < Cask
-  url 'https://warehouse.leapmotion.com/apps/2818/download'
+  url 'https://warehouse.leapmotion.com/apps/3250/download'
   homepage 'https://www.leapmotion.com/setup'
-  version 'latest'
-  no_checksum
+  version '1.2.0'
+  sha256 '5a9b38764367d91e3a5ebf5bfabc960051605a8532b271a98c95dc5341cbb99d'
   install 'Leap Motion.pkg'
   uninstall :script => '/Applications/Leap Motion.app/Contents/MacOS/uninstall'
 end


### PR DESCRIPTION
Not sure how their releases map to URLs since it's a redirect, so kept `no_checksum`.
