### PR TITLE
Upgrade torbrowserbundle to v3.6

### DIFF
--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,0 +1,7 @@
+class Torbrowser < Cask
+  url 'https://www.torproject.org/dist/torbrowser/3.6/TorBrowser-3.6-osx32_en-US.dmg'
+  homepage 'https://www.torproject.org/projects/torbrowser.html'
+  version '3.6'
+  sha256 '54f98f22d95663144d7c31fa3f1b2690574abbed9be6ca1718be99c9a9c74623'
+  link 'TorBrowser.app'
+end

--- a/Casks/torbrowserbundle.rb
+++ b/Casks/torbrowserbundle.rb
@@ -1,7 +1,0 @@
-class Torbrowserbundle < Cask
-  url 'https://www.torproject.org/dist/torbrowser/3.5.4/TorBrowserBundle-3.5.4-osx32_en-US.zip'
-  homepage 'https://www.torproject.org/projects/torbrowser.html'
-  version '3.5.4'
-  sha256 'e2ffd4173a618097e61e4b5391b832b5cceec38613599b67a3bfb5bafdbdca48'
-  link 'TorBrowserBundle_en-US.app'
-end


### PR DESCRIPTION
3.5.4 was 404

The name of the dmg and app bundle changed (dropping "Bundle"). 
The [website](https://www.torproject.org/projects/torbrowser.html.en) still uses "Tor Browser" and "Tor Browser Bundle" interchangeably so the formula name was left as-is.
