### PR TITLE
Update git-annex cask

### DIFF
--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -15,6 +15,7 @@ class GitAnnex < Cask
   no_checksum
   link 'git-annex.app'
   binary 'git-annex.app/Contents/MacOS/git-annex'
+  binary 'git-annex.app/Contents/MacOS/git-annex-shell'
   caveats do
     files_in_usr_local
   end


### PR DESCRIPTION
linking git-annex-shell allows the system to be a remote for annex
