### PR TITLE
Upgrade MultiBit.app to v0.5.18

### DIFF
--- a/Casks/multibit.rb
+++ b/Casks/multibit.rb
@@ -1,7 +1,7 @@
 class Multibit < Cask
-  url 'https://multibit.org/releases/multibit-0.5.17/multibit-0.5.17.dmg'
+  url 'https://multibit.org/releases/multibit-0.5.18/multibit-0.5.18.dmg'
   homepage 'https://multibit.org/'
-  version '0.5.17'
-  sha256 '1facdaacaec20c24777c26e05f2655a727c7ea92f0cfe84bb1fbdfcb65ae893c'
+  version '0.5.18'
+  sha256 '0d2fe6fa68385c1ca964d9588272787dabffbc2061f29ebaab422317d0972257'
   link 'MultiBit.app'
 end


### PR DESCRIPTION
Downloaded new release. Verified with GPG key. Hashed with `shasum -a
256`. Tested installation. Audit passed.
