### PR TITLE
Fix hashcat cask

### DIFF
--- a/Casks/hashcat.rb
+++ b/Casks/hashcat.rb
@@ -3,5 +3,7 @@ class Hashcat < Cask
   homepage 'https://hashcat.net/hashcat/'
   version '0.47'
   sha256 '239acb25b88d529314f2f98af0d6a66772e886c9efbb4ed2b94b7587c9a68455'
+  depends_on_formula 'unar'
+
   binary 'hashcat-0.47/hashcat-cli64.app', :target => 'hashcat'
 end


### PR DESCRIPTION
- Add missing depends_on_formula 'unar'
- Discussion: https://github.com/phinze/homebrew-cask/pull/4010
