### PR TITLE
Add MongoDB version 1.2

### DIFF
--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -1,0 +1,7 @@
+class Mongodb < Cask
+  url 'http://github.com/orelord/mongodbx-app/releases/download/v1.2/MongoDBX-1.2-2.4.9.zip'
+  homepage 'http://mongodbx-app.orelord.com/'
+  version '1.2'
+  sha256 '9b7f6e8988a3169bf5f234ee10f93823a16750b3c1d4de524cd2e2f09452fd02'
+  link 'MongoDB.app'
+end


### PR DESCRIPTION
MongoDB Application Wrapper for Mac OS X. [http://mongodbx-app.orelord.com](http://mongodbx-app.orelord.com/)
