### PR TITLE
update all references to new caskroom org home

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ all pretty happy about this.  Here's how to get started:
 
 ```bash
 $ github_user='<my-github-username>'
-$ cd "$(brew --prefix)"/Library/Taps/phinze/homebrew-cask
+$ cd "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
 $ git remote add "$github_user" "https://github.com/$github_user/homebrew-cask"
 ```
 
@@ -66,14 +66,14 @@ is simply the Cask name with the extension `.rb` appended.
 
 The easiest way to name a Cask is to run this command:
 ```bash
-$ "$(brew --prefix)/Library/Taps/phinze/homebrew-cask/developer/bin/cask_namer" '/full/path/to/new/software.app'
+$ "$(brew --prefix)/Library/Taps/caskroom/homebrew-cask/developer/bin/cask_namer" '/full/path/to/new/software.app'
 ```
 
 If the software you wish to Cask is not installed, or does not have an
 associated App bundle, just give the full proper name of the software
 instead of a pathname:
 ```bash
-$ "$(brew --prefix)/Library/Taps/phinze/homebrew-cask/developer/bin/cask_namer" 'Google Chrome'
+$ "$(brew --prefix)/Library/Taps/caskroom/homebrew-cask/developer/bin/cask_namer" 'Google Chrome'
 ```
 
 If the `cask_namer` script does not work for you, see [Cask Naming Details](#cask-naming-details).
@@ -213,7 +213,7 @@ with
 `brew cask audit my-new-cask --download`
 
 If your application and homebrew-cask do not work well together, feel free to
-[file an issue](https://github.com/phinze/homebrew-cask/issues) after checking
+[file an issue](https://github.com/caskroom/homebrew-cask/issues) after checking
 out open issues.
 
 
@@ -223,7 +223,7 @@ We maintain separate Taps for different types of binaries.
 
 ### Latest Stable Versions
 
-Latest stable versions live in the main repository at [phinze/homebrew-cask](https://github.com/phinze/homebrew-cask).
+Latest stable versions live in the main repository at [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask).
 Software in the main repo should run on the latest release of OS X or the previous
 point release (currently: Mavericks and Mountain Lion).
 
@@ -256,7 +256,7 @@ for details.
 Hop into your Tap and check to make sure your new Cask is there:
 
 ```bash
-$ cd "$(brew --prefix)"/Library/Taps/phinze/homebrew-cask
+$ cd "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
 $ git status
 # On branch master
 # Untracked files:
@@ -343,7 +343,7 @@ After your Pull Request is away, you might want to get yourself back onto
 `master`, so that `brew update` will pull down new Casks properly.
 
 ```bash
-cd "$(brew --prefix)"/Library/Taps/phinze/homebrew-cask
+cd "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
 git checkout master
 ```
 

--- a/Casks/decitime.rb
+++ b/Casks/decitime.rb
@@ -7,7 +7,7 @@ class Decitime < Cask
   link 'DeciTime.app'
 
   # fix wonky DMG by mounting it once read-write per discussion at
-  # https://github.com/phinze/homebrew-cask/pull/2654
+  # https://github.com/caskroom/homebrew-cask/pull/2654
   before_install do
     system %Q{/usr/bin/hdiutil eject "$(/usr/bin/hdiutil mount -readwrite -noidme -nobrowse -mountrandom /tmp #{destination_path.join(artifacts[:nested_container].first)} | /usr/bin/cut -f3 | /usr/bin/grep '.')" >/dev/null 2>&1}
   end

--- a/Casks/delivery-status.rb
+++ b/Casks/delivery-status.rb
@@ -9,7 +9,7 @@ class DeliveryStatus < Cask
     Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
-        https://github.com/phinze/homebrew-cask/issues/2206
+        https://github.com/caskroom/homebrew-cask/issues/2206
 
     It is recommended that you do not install this Cask unless you are
     a developer working on the problem.

--- a/Casks/pemdas-widget.rb
+++ b/Casks/pemdas-widget.rb
@@ -9,7 +9,7 @@ class PemdasWidget < Cask
     Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
-        https://github.com/phinze/homebrew-cask/issues/2206
+        https://github.com/caskroom/homebrew-cask/issues/2206
 
     It is recommended that you do not install this Cask unless you are
     a developer working on the problem.

--- a/Casks/private-eye.rb
+++ b/Casks/private-eye.rb
@@ -5,7 +5,7 @@ class PrivateEye < Cask
   no_checksum
   install 'Private Eye.pkg'
   # We intentionally unload the kext twice as a workaround
-  # See https://github.com/phinze/homebrew-cask/pull/1802#issuecomment-34171151
+  # See https://github.com/caskroom/homebrew-cask/pull/1802#issuecomment-34171151
   uninstall :early_script => {
               :executable => '/sbin/kextunload',
               :args => ['-b', 'com.radiosilenceapp.nke.PrivateEye'],

--- a/Casks/tv-show-tracker.rb
+++ b/Casks/tv-show-tracker.rb
@@ -9,7 +9,7 @@ class TvShowTracker < Cask
     Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
-        https://github.com/phinze/homebrew-cask/issues/2206
+        https://github.com/caskroom/homebrew-cask/issues/2206
 
     It is recommended that you do not install this Cask unless you are
     a developer working on the problem.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # "To install, drag this icon..." no more!
 
-[![Build Status](https://travis-ci.org/phinze/homebrew-cask.png?branch=master)](https://travis-ci.org/phinze/homebrew-cask)
-[![Code Climate](https://codeclimate.com/github/phinze/homebrew-cask.png)](https://codeclimate.com/github/phinze/homebrew-cask)
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/phinze/homebrew-cask/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+[![Build Status](https://travis-ci.org/caskroom/homebrew-cask.png?branch=master)](https://travis-ci.org/caskroom/homebrew-cask)
+[![Code Climate](https://codeclimate.com/github/caskroom/homebrew-cask.png)](https://codeclimate.com/github/caskroom/homebrew-cask)
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/caskroom/homebrew-cask/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
 
 Let's see if we can get the elegance, simplicity, and speed of Homebrew for the
@@ -17,7 +17,7 @@ command](https://github.com/mxcl/homebrew/wiki/External-Commands)" called
 
 ## Let's try it!
 ```sh
-$ brew tap phinze/cask
+$ brew tap caskroom/cask
 $ brew install brew-cask
 $ brew cask install google-chrome
 => Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
@@ -39,13 +39,13 @@ open ~/Applications/"Google Chrome.app"
 
 We're really rather friendly! Here are the best places to talk about the project:
 
- * Start an [issue on GitHub](https://github.com/phinze/homebrew-cask/issues/new)
+ * Start an [issue on GitHub](https://github.com/caskroom/homebrew-cask/issues/new)
  * Join us on IRC, we're at `#homebrew-cask` on Freenode
 
 ## Reporting Bugs
 
 We still have bugs -- and we are busy fixing them!  If you have a problem, don't
-be shy about reporting it on our [GitHub issues page](https://github.com/phinze/homebrew-cask/issues?state=open).
+be shy about reporting it on our [GitHub issues page](https://github.com/caskroom/homebrew-cask/issues?state=open).
 
 When reporting bugs, remember that homebrew-cask is an independent project from
 Homebrew.  Do your best to direct bug reports to the appropriate project.  If

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,7 @@ $ brew --version
 Install the homebrew-cask tool:
 
 ```bash
-$ brew install phinze/cask/brew-cask
+$ brew install caskroom/cask/brew-cask
 ```
 
 ## Frequently Used Commands
@@ -108,7 +108,7 @@ $ brew cask info caffeine
 caffeine: 1.1.1
 http://lightheadsw.com/caffeine/
 Not installed
-https://github.com/phinze/homebrew-cask/commits/master/Casks/caffeine.rb
+https://github.com/caskroom/homebrew-cask/commits/master/Casks/caffeine.rb
 ```
 
 ## Updating/Upgrading Casks
@@ -223,7 +223,7 @@ above, a Cask name on the command line can take the form of:
 `brew cask` also accepts two other forms for Cask names:
 
 * a fully-qualified pathname to a Cask file, _eg_: `/usr/local/Cellar/brew-cask/0.25.0/Casks/google-chrome.rb`
-* a `curl`-retrievable URI to a Cask file, _eg_: `https://raw.github.com/phinze/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`
+* a `curl`-retrievable URI to a Cask file, _eg_: `https://raw.github.com/caskroom/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`
 
 The last two forms are intended for users who wish to maintain private Casks.
 

--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -4,10 +4,10 @@ require 'formula'
 require Pathname(__FILE__).realpath.dirname.join('lib', 'cask', 'version')
 
 class BrewCask < Formula
-  homepage 'https://github.com/phinze/homebrew-cask/'
-  url 'https://github.com/phinze/homebrew-cask.git', :tag => "v#{HOMEBREW_CASK_VERSION}"
+  homepage 'https://github.com/caskroom/homebrew-cask/'
+  url 'https://github.com/caskroom/homebrew-cask.git', :tag => "v#{HOMEBREW_CASK_VERSION}"
 
-  head 'https://github.com/phinze/homebrew-cask.git', :branch => 'master'
+  head 'https://github.com/caskroom/homebrew-cask.git', :branch => 'master'
 
   skip_clean 'bin'
 

--- a/developer/bin/develop_brew_cask
+++ b/developer/bin/develop_brew_cask
@@ -15,7 +15,7 @@ shopt -s nocasematch # case-insensitive regular expressions
 ### configurable global variables
 ###
 
-tap_subdir="Library/Taps/phinze/homebrew-cask"
+tap_subdir="Library/Taps/caskroom/homebrew-cask"
 
 ###
 ### functions

--- a/developer/bin/generate_changelog
+++ b/developer/bin/generate_changelog
@@ -14,7 +14,7 @@ require 'set'
 ### configurable constants
 ###
 
-PROJECT_URL = 'https://github.com/phinze/homebrew-cask'
+PROJECT_URL = 'https://github.com/caskroom/homebrew-cask'
 
 MAINTAINERS = %w[
                   phinze

--- a/developer/bin/list_pkg_ids_by_regexp
+++ b/developer/bin/list_pkg_ids_by_regexp
@@ -71,7 +71,7 @@ essential system files due to an exuberant regexp.
 
 For more information, see
 
-    https://github.com/phinze/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details
+    https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details
 
 "
     exit

--- a/developer/bin/production_brew_cask
+++ b/developer/bin/production_brew_cask
@@ -15,7 +15,7 @@ shopt -s nocasematch # case-insensitive regular expressions
 ### configurable global variables
 ###
 
-tap_subdir="Library/Taps/phinze/homebrew-cask"
+tap_subdir="Library/Taps/caskroom/homebrew-cask"
 
 ###
 ### functions

--- a/doc/AUTOMATION.md
+++ b/doc/AUTOMATION.md
@@ -18,7 +18,7 @@ A Caskfile is a plain text document containing a set of Homebrew commands, one p
 For example, on a freshly installed OS X, you could `brew bundle` the following `Caskfile` to set up Homebrew Cask and a few basic tools:
 ```bash
 # Install Cask
-install phinze/cask/brew-cask
+install caskroom/cask/brew-cask
 
 # Productivity tools
 cask install alfred
@@ -49,5 +49,5 @@ If you want to fully automate the deployment process by scripting the execution 
 - install git
 - install Homebrew
 1. `brew update`
-2. `brew install phinze/cask/brew-cask`, either in the script or as part of the first Caskfile loaded
+2. `brew install caskroom/cask/brew-cask`, either in the script or as part of the first Caskfile loaded
 3. `brew bundle` your Caskfiles.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,9 +16,9 @@
 * __Breaking Changes__
  - none
 
-[#4095]: https://github.com/phinze/homebrew-cask/issues/4095
-[#4094]: https://github.com/phinze/homebrew-cask/issues/4094
-[#4064]: https://github.com/phinze/homebrew-cask/issues/4064
+[#4095]: https://github.com/caskroom/homebrew-cask/issues/4095
+[#4094]: https://github.com/caskroom/homebrew-cask/issues/4094
+[#4064]: https://github.com/caskroom/homebrew-cask/issues/4064
 [@linc01n]: https://github.com/linc01n
 [@jcgay]: https://github.com/jcgay
 
@@ -39,9 +39,9 @@
  - The default Tap directory was moved to accommodate a change
    in the Homebrew project.
 
-[#4042]: https://github.com/phinze/homebrew-cask/issues/4042
-[#4039]: https://github.com/phinze/homebrew-cask/issues/4039
-[#2971]: https://github.com/phinze/homebrew-cask/issues/2971
+[#4042]: https://github.com/caskroom/homebrew-cask/issues/4042
+[#4039]: https://github.com/caskroom/homebrew-cask/issues/4039
+[#2971]: https://github.com/caskroom/homebrew-cask/issues/2971
 [@voanhduy1512]: https://github.com/voanhduy1512
 [@MattiSG]: https://github.com/MattiSG
 [@adamchainz]: https://github.com/adamchainz
@@ -65,13 +65,13 @@
 * __Breaking Changes__
  - none
 
-[#3667]: https://github.com/phinze/homebrew-cask/issues/3667
-[#3700]: https://github.com/phinze/homebrew-cask/issues/3700
-[#3699]: https://github.com/phinze/homebrew-cask/issues/3699
-[#2706]: https://github.com/phinze/homebrew-cask/issues/2706
-[#3662]: https://github.com/phinze/homebrew-cask/issues/3662
-[#3668]: https://github.com/phinze/homebrew-cask/issues/3668
-[#3647]: https://github.com/phinze/homebrew-cask/issues/3647
+[#3667]: https://github.com/caskroom/homebrew-cask/issues/3667
+[#3700]: https://github.com/caskroom/homebrew-cask/issues/3700
+[#3699]: https://github.com/caskroom/homebrew-cask/issues/3699
+[#2706]: https://github.com/caskroom/homebrew-cask/issues/2706
+[#3662]: https://github.com/caskroom/homebrew-cask/issues/3662
+[#3668]: https://github.com/caskroom/homebrew-cask/issues/3668
+[#3647]: https://github.com/caskroom/homebrew-cask/issues/3647
 [@jasonkarns]: https://github.com/jasonkarns
 [@drew-gross]: https://github.com/drew-gross
 
@@ -89,7 +89,7 @@
 * __Breaking Changes__
  - none
 
-[#3587]: https://github.com/phinze/homebrew-cask/issues/3587
+[#3587]: https://github.com/caskroom/homebrew-cask/issues/3587
 [@bartoszj]: https://github.com/bartoszj
 
 ## 0.31.0
@@ -117,23 +117,23 @@
 * __Breaking Changes__
  - none
 
-[#3515]: https://github.com/phinze/homebrew-cask/issues/3515
-[#3540]: https://github.com/phinze/homebrew-cask/issues/3540
-[#3541]: https://github.com/phinze/homebrew-cask/issues/3541
-[#3518]: https://github.com/phinze/homebrew-cask/issues/3518
-[#3516]: https://github.com/phinze/homebrew-cask/issues/3516
-[#3500]: https://github.com/phinze/homebrew-cask/issues/3500
-[#3503]: https://github.com/phinze/homebrew-cask/issues/3503
-[#3443]: https://github.com/phinze/homebrew-cask/issues/3443
-[#3422]: https://github.com/phinze/homebrew-cask/issues/3422
+[#3515]: https://github.com/caskroom/homebrew-cask/issues/3515
+[#3540]: https://github.com/caskroom/homebrew-cask/issues/3540
+[#3541]: https://github.com/caskroom/homebrew-cask/issues/3541
+[#3518]: https://github.com/caskroom/homebrew-cask/issues/3518
+[#3516]: https://github.com/caskroom/homebrew-cask/issues/3516
+[#3500]: https://github.com/caskroom/homebrew-cask/issues/3500
+[#3503]: https://github.com/caskroom/homebrew-cask/issues/3503
+[#3443]: https://github.com/caskroom/homebrew-cask/issues/3443
+[#3422]: https://github.com/caskroom/homebrew-cask/issues/3422
 [@pedros]: https://github.com/pedros
 [@cgcai]: https://github.com/cgcai
 [@cubranic]: https://github.com/cubranic
-[#3459]: https://github.com/phinze/homebrew-cask/issues/3459
-[#3441]: https://github.com/phinze/homebrew-cask/issues/3441
-[#3106]: https://github.com/phinze/homebrew-cask/issues/3106
-[#3217]: https://github.com/phinze/homebrew-cask/issues/3217
-[#2672]: https://github.com/phinze/homebrew-cask/issues/2672
+[#3459]: https://github.com/caskroom/homebrew-cask/issues/3459
+[#3441]: https://github.com/caskroom/homebrew-cask/issues/3441
+[#3106]: https://github.com/caskroom/homebrew-cask/issues/3106
+[#3217]: https://github.com/caskroom/homebrew-cask/issues/3217
+[#2672]: https://github.com/caskroom/homebrew-cask/issues/2672
 
 ## 0.30.1
 
@@ -149,9 +149,9 @@
 * __Breaking Changes__
  - none
 
-[#3335]: https://github.com/phinze/homebrew-cask/issues/3335
-[#3327]: https://github.com/phinze/homebrew-cask/issues/3327
-[#3324]: https://github.com/phinze/homebrew-cask/issues/3324
+[#3335]: https://github.com/caskroom/homebrew-cask/issues/3335
+[#3327]: https://github.com/caskroom/homebrew-cask/issues/3327
+[#3324]: https://github.com/caskroom/homebrew-cask/issues/3324
 
 ## 0.30.0
 
@@ -181,42 +181,42 @@
  - [#2931][] remove md5 checksum support
  - [#3025][] temporarily suppress searching the font Tap to reduce false positives
 
-[#3323]: https://github.com/phinze/homebrew-cask/issues/3323
-[#3011]: https://github.com/phinze/homebrew-cask/issues/3011
-[#3275]: https://github.com/phinze/homebrew-cask/issues/3275
+[#3323]: https://github.com/caskroom/homebrew-cask/issues/3323
+[#3011]: https://github.com/caskroom/homebrew-cask/issues/3011
+[#3275]: https://github.com/caskroom/homebrew-cask/issues/3275
 [@mecca831]: https://github.com/mecca831
-[#3190]: https://github.com/phinze/homebrew-cask/issues/3190
-[#3241]: https://github.com/phinze/homebrew-cask/issues/3241
-[#3242]: https://github.com/phinze/homebrew-cask/issues/3242
-[#3013]: https://github.com/phinze/homebrew-cask/issues/3013
-[#3188]: https://github.com/phinze/homebrew-cask/issues/3188
+[#3190]: https://github.com/caskroom/homebrew-cask/issues/3190
+[#3241]: https://github.com/caskroom/homebrew-cask/issues/3241
+[#3242]: https://github.com/caskroom/homebrew-cask/issues/3242
+[#3013]: https://github.com/caskroom/homebrew-cask/issues/3013
+[#3188]: https://github.com/caskroom/homebrew-cask/issues/3188
 [@muescha]: https://github.com/muescha
-[#3014]: https://github.com/phinze/homebrew-cask/issues/3014
-[#3039]: https://github.com/phinze/homebrew-cask/issues/3039
-[#3040]: https://github.com/phinze/homebrew-cask/issues/3040
-[#3178]: https://github.com/phinze/homebrew-cask/issues/3178
-[#2705]: https://github.com/phinze/homebrew-cask/issues/2705
-[#2744]: https://github.com/phinze/homebrew-cask/issues/2744
-[#2970]: https://github.com/phinze/homebrew-cask/issues/2970
+[#3014]: https://github.com/caskroom/homebrew-cask/issues/3014
+[#3039]: https://github.com/caskroom/homebrew-cask/issues/3039
+[#3040]: https://github.com/caskroom/homebrew-cask/issues/3040
+[#3178]: https://github.com/caskroom/homebrew-cask/issues/3178
+[#2705]: https://github.com/caskroom/homebrew-cask/issues/2705
+[#2744]: https://github.com/caskroom/homebrew-cask/issues/2744
+[#2970]: https://github.com/caskroom/homebrew-cask/issues/2970
 [@voanhduy1512]: https://github.com/voanhduy1512
-[#3058]: https://github.com/phinze/homebrew-cask/issues/3058
-[#3073]: https://github.com/phinze/homebrew-cask/issues/3073
-[#3105]: https://github.com/phinze/homebrew-cask/issues/3105
-[#3107]: https://github.com/phinze/homebrew-cask/issues/3107
-[#3131]: https://github.com/phinze/homebrew-cask/issues/3131
-[#2467]: https://github.com/phinze/homebrew-cask/issues/2467
+[#3058]: https://github.com/caskroom/homebrew-cask/issues/3058
+[#3073]: https://github.com/caskroom/homebrew-cask/issues/3073
+[#3105]: https://github.com/caskroom/homebrew-cask/issues/3105
+[#3107]: https://github.com/caskroom/homebrew-cask/issues/3107
+[#3131]: https://github.com/caskroom/homebrew-cask/issues/3131
+[#2467]: https://github.com/caskroom/homebrew-cask/issues/2467
 [@vmrob]: https://github.com/vmrob
 [@tmonney]: https://github.com/tmonney
 [@doits]: https://github.com/doits
-[#3155]: https://github.com/phinze/homebrew-cask/issues/3155
-[#3079]: https://github.com/phinze/homebrew-cask/issues/3079
-[#3108]: https://github.com/phinze/homebrew-cask/issues/3108
-[#2931]: https://github.com/phinze/homebrew-cask/issues/2931
-[#3076]: https://github.com/phinze/homebrew-cask/issues/3076
-[#3075]: https://github.com/phinze/homebrew-cask/issues/3075
-[#3057]: https://github.com/phinze/homebrew-cask/issues/3057
-[#3042]: https://github.com/phinze/homebrew-cask/issues/3042
-[#3025]: https://github.com/phinze/homebrew-cask/issues/3025
+[#3155]: https://github.com/caskroom/homebrew-cask/issues/3155
+[#3079]: https://github.com/caskroom/homebrew-cask/issues/3079
+[#3108]: https://github.com/caskroom/homebrew-cask/issues/3108
+[#2931]: https://github.com/caskroom/homebrew-cask/issues/2931
+[#3076]: https://github.com/caskroom/homebrew-cask/issues/3076
+[#3075]: https://github.com/caskroom/homebrew-cask/issues/3075
+[#3057]: https://github.com/caskroom/homebrew-cask/issues/3057
+[#3042]: https://github.com/caskroom/homebrew-cask/issues/3042
+[#3025]: https://github.com/caskroom/homebrew-cask/issues/3025
 
 ## 0.29.2
 
@@ -234,13 +234,13 @@
 * __Breaking Changes__
  - none
 
-[#3044]: https://github.com/phinze/homebrew-cask/issues/3044
-[#3015]: https://github.com/phinze/homebrew-cask/issues/3015
+[#3044]: https://github.com/caskroom/homebrew-cask/issues/3044
+[#3015]: https://github.com/caskroom/homebrew-cask/issues/3015
 [@Red54]: https://github.com/Red54
 [@skivvies]: https://github.com/skivvies
-[#2994]: https://github.com/phinze/homebrew-cask/issues/2994
-[#2991]: https://github.com/phinze/homebrew-cask/issues/2991
-[#2961]: https://github.com/phinze/homebrew-cask/issues/2961
+[#2994]: https://github.com/caskroom/homebrew-cask/issues/2994
+[#2991]: https://github.com/caskroom/homebrew-cask/issues/2991
+[#2961]: https://github.com/caskroom/homebrew-cask/issues/2961
 
 ## 0.29.1
 
@@ -254,7 +254,7 @@
 * __Breaking Changes__
  - none
 
-[#2957]: https://github.com/phinze/homebrew-cask/issues/2957
+[#2957]: https://github.com/caskroom/homebrew-cask/issues/2957
 
 ## 0.29.0
 
@@ -288,67 +288,67 @@
 * __Breaking Changes__
  - artifacts may no longer be specified as a list (since 0.28.0).  Instead the artifact should be repeated on multiple lines.
 
-[#2945]: https://github.com/phinze/homebrew-cask/issues/2945
-[#2761]: https://github.com/phinze/homebrew-cask/issues/2761
-[#2925]: https://github.com/phinze/homebrew-cask/issues/2925
-[#2932]: https://github.com/phinze/homebrew-cask/issues/2932
-[#2923]: https://github.com/phinze/homebrew-cask/issues/2923
-[#2822]: https://github.com/phinze/homebrew-cask/issues/2822
-[#2742]: https://github.com/phinze/homebrew-cask/issues/2742
-[#2625]: https://github.com/phinze/homebrew-cask/issues/2625
-[#2890]: https://github.com/phinze/homebrew-cask/issues/2890
-[#2875]: https://github.com/phinze/homebrew-cask/issues/2875
-[#2734]: https://github.com/phinze/homebrew-cask/issues/2734
-[#2739]: https://github.com/phinze/homebrew-cask/issues/2739
-[#2874]: https://github.com/phinze/homebrew-cask/issues/2874
-[#2392]: https://github.com/phinze/homebrew-cask/issues/2392
+[#2945]: https://github.com/caskroom/homebrew-cask/issues/2945
+[#2761]: https://github.com/caskroom/homebrew-cask/issues/2761
+[#2925]: https://github.com/caskroom/homebrew-cask/issues/2925
+[#2932]: https://github.com/caskroom/homebrew-cask/issues/2932
+[#2923]: https://github.com/caskroom/homebrew-cask/issues/2923
+[#2822]: https://github.com/caskroom/homebrew-cask/issues/2822
+[#2742]: https://github.com/caskroom/homebrew-cask/issues/2742
+[#2625]: https://github.com/caskroom/homebrew-cask/issues/2625
+[#2890]: https://github.com/caskroom/homebrew-cask/issues/2890
+[#2875]: https://github.com/caskroom/homebrew-cask/issues/2875
+[#2734]: https://github.com/caskroom/homebrew-cask/issues/2734
+[#2739]: https://github.com/caskroom/homebrew-cask/issues/2739
+[#2874]: https://github.com/caskroom/homebrew-cask/issues/2874
+[#2392]: https://github.com/caskroom/homebrew-cask/issues/2392
 [@AlJohri]: https://github.com/AlJohri
-[#2873]: https://github.com/phinze/homebrew-cask/issues/2873
-[#2872]: https://github.com/phinze/homebrew-cask/issues/2872
-[#2851]: https://github.com/phinze/homebrew-cask/issues/2851
-[#2759]: https://github.com/phinze/homebrew-cask/issues/2759
-[#2850]: https://github.com/phinze/homebrew-cask/issues/2850
-[#2841]: https://github.com/phinze/homebrew-cask/issues/2841
-[#2829]: https://github.com/phinze/homebrew-cask/issues/2829
-[#2840]: https://github.com/phinze/homebrew-cask/issues/2840
+[#2873]: https://github.com/caskroom/homebrew-cask/issues/2873
+[#2872]: https://github.com/caskroom/homebrew-cask/issues/2872
+[#2851]: https://github.com/caskroom/homebrew-cask/issues/2851
+[#2759]: https://github.com/caskroom/homebrew-cask/issues/2759
+[#2850]: https://github.com/caskroom/homebrew-cask/issues/2850
+[#2841]: https://github.com/caskroom/homebrew-cask/issues/2841
+[#2829]: https://github.com/caskroom/homebrew-cask/issues/2829
+[#2840]: https://github.com/caskroom/homebrew-cask/issues/2840
 [@lgarron]: https://github.com/lgarron
 [@phillipalexander]: https://github.com/phillipalexander
 [@sgtpep]: https://github.com/sgtpep
 [@tamird]: https://github.com/tamird
 [@juuso]: https://github.com/juuso
 [@tsantor]: https://github.com/tsantor
-[#2719]: https://github.com/phinze/homebrew-cask/issues/2719
-[#1992]: https://github.com/phinze/homebrew-cask/issues/1992
-[#2820]: https://github.com/phinze/homebrew-cask/issues/2820
-[#2809]: https://github.com/phinze/homebrew-cask/issues/2809
-[#2807]: https://github.com/phinze/homebrew-cask/issues/2807
-[#2803]: https://github.com/phinze/homebrew-cask/issues/2803
-[#2748]: https://github.com/phinze/homebrew-cask/issues/2748
-[#2624]: https://github.com/phinze/homebrew-cask/issues/2624
+[#2719]: https://github.com/caskroom/homebrew-cask/issues/2719
+[#1992]: https://github.com/caskroom/homebrew-cask/issues/1992
+[#2820]: https://github.com/caskroom/homebrew-cask/issues/2820
+[#2809]: https://github.com/caskroom/homebrew-cask/issues/2809
+[#2807]: https://github.com/caskroom/homebrew-cask/issues/2807
+[#2803]: https://github.com/caskroom/homebrew-cask/issues/2803
+[#2748]: https://github.com/caskroom/homebrew-cask/issues/2748
+[#2624]: https://github.com/caskroom/homebrew-cask/issues/2624
 [@vmrob]: https://github.com/vmrob
-[#2792]: https://github.com/phinze/homebrew-cask/issues/2792
-[#2767]: https://github.com/phinze/homebrew-cask/issues/2767
-[#2701]: https://github.com/phinze/homebrew-cask/issues/2701
-[#2787]: https://github.com/phinze/homebrew-cask/issues/2787
-[#2786]: https://github.com/phinze/homebrew-cask/issues/2786
-[#2785]: https://github.com/phinze/homebrew-cask/issues/2785
-[#2637]: https://github.com/phinze/homebrew-cask/issues/2637
-[#2741]: https://github.com/phinze/homebrew-cask/issues/2741
-[#2760]: https://github.com/phinze/homebrew-cask/issues/2760
-[#2762]: https://github.com/phinze/homebrew-cask/issues/2762
-[#2784]: https://github.com/phinze/homebrew-cask/issues/2784
-[#2783]: https://github.com/phinze/homebrew-cask/issues/2783
-[#2782]: https://github.com/phinze/homebrew-cask/issues/2782
-[#2733]: https://github.com/phinze/homebrew-cask/issues/2733
-[#2623]: https://github.com/phinze/homebrew-cask/issues/2623
-[#2613]: https://github.com/phinze/homebrew-cask/issues/2613
-[#2743]: https://github.com/phinze/homebrew-cask/issues/2743
-[#2732]: https://github.com/phinze/homebrew-cask/issues/2732
-[#2631]: https://github.com/phinze/homebrew-cask/issues/2631
-[#2725]: https://github.com/phinze/homebrew-cask/issues/2725
-[#2724]: https://github.com/phinze/homebrew-cask/issues/2724
-[#2689]: https://github.com/phinze/homebrew-cask/issues/2689
-[#2698]: https://github.com/phinze/homebrew-cask/issues/2698
+[#2792]: https://github.com/caskroom/homebrew-cask/issues/2792
+[#2767]: https://github.com/caskroom/homebrew-cask/issues/2767
+[#2701]: https://github.com/caskroom/homebrew-cask/issues/2701
+[#2787]: https://github.com/caskroom/homebrew-cask/issues/2787
+[#2786]: https://github.com/caskroom/homebrew-cask/issues/2786
+[#2785]: https://github.com/caskroom/homebrew-cask/issues/2785
+[#2637]: https://github.com/caskroom/homebrew-cask/issues/2637
+[#2741]: https://github.com/caskroom/homebrew-cask/issues/2741
+[#2760]: https://github.com/caskroom/homebrew-cask/issues/2760
+[#2762]: https://github.com/caskroom/homebrew-cask/issues/2762
+[#2784]: https://github.com/caskroom/homebrew-cask/issues/2784
+[#2783]: https://github.com/caskroom/homebrew-cask/issues/2783
+[#2782]: https://github.com/caskroom/homebrew-cask/issues/2782
+[#2733]: https://github.com/caskroom/homebrew-cask/issues/2733
+[#2623]: https://github.com/caskroom/homebrew-cask/issues/2623
+[#2613]: https://github.com/caskroom/homebrew-cask/issues/2613
+[#2743]: https://github.com/caskroom/homebrew-cask/issues/2743
+[#2732]: https://github.com/caskroom/homebrew-cask/issues/2732
+[#2631]: https://github.com/caskroom/homebrew-cask/issues/2631
+[#2725]: https://github.com/caskroom/homebrew-cask/issues/2725
+[#2724]: https://github.com/caskroom/homebrew-cask/issues/2724
+[#2689]: https://github.com/caskroom/homebrew-cask/issues/2689
+[#2698]: https://github.com/caskroom/homebrew-cask/issues/2698
 
 ## 0.28.0
 
@@ -373,31 +373,31 @@
 * __Breaking Changes__
  - none
 
-[#2532]: https://github.com/phinze/homebrew-cask/issues/2532
+[#2532]: https://github.com/caskroom/homebrew-cask/issues/2532
 [@voanhduy1512]: https://github.com/voanhduy1512
-[#2647]: https://github.com/phinze/homebrew-cask/issues/2647
+[#2647]: https://github.com/caskroom/homebrew-cask/issues/2647
 [@jedahan]: https://github.com/jedahan
-[#2305]: https://github.com/phinze/homebrew-cask/issues/2305
-[#2594]: https://github.com/phinze/homebrew-cask/issues/2594
-[#2592]: https://github.com/phinze/homebrew-cask/issues/2592
-[#2581]: https://github.com/phinze/homebrew-cask/issues/2581
+[#2305]: https://github.com/caskroom/homebrew-cask/issues/2305
+[#2594]: https://github.com/caskroom/homebrew-cask/issues/2594
+[#2592]: https://github.com/caskroom/homebrew-cask/issues/2592
+[#2581]: https://github.com/caskroom/homebrew-cask/issues/2581
 [@goxberry]: https://github.com/goxberry
-[#2576]: https://github.com/phinze/homebrew-cask/issues/2576
-[#2555]: https://github.com/phinze/homebrew-cask/issues/2555
-[#2697]: https://github.com/phinze/homebrew-cask/issues/2697
-[#2593]: https://github.com/phinze/homebrew-cask/issues/2593
-[#2418]: https://github.com/phinze/homebrew-cask/issues/2418
-[#2676]: https://github.com/phinze/homebrew-cask/issues/2676
-[#2560]: https://github.com/phinze/homebrew-cask/issues/2560
-[#2567]: https://github.com/phinze/homebrew-cask/issues/2567
-[#2536]: https://github.com/phinze/homebrew-cask/issues/2536
-[#2670]: https://github.com/phinze/homebrew-cask/issues/2670
-[#2650]: https://github.com/phinze/homebrew-cask/issues/2650
+[#2576]: https://github.com/caskroom/homebrew-cask/issues/2576
+[#2555]: https://github.com/caskroom/homebrew-cask/issues/2555
+[#2697]: https://github.com/caskroom/homebrew-cask/issues/2697
+[#2593]: https://github.com/caskroom/homebrew-cask/issues/2593
+[#2418]: https://github.com/caskroom/homebrew-cask/issues/2418
+[#2676]: https://github.com/caskroom/homebrew-cask/issues/2676
+[#2560]: https://github.com/caskroom/homebrew-cask/issues/2560
+[#2567]: https://github.com/caskroom/homebrew-cask/issues/2567
+[#2536]: https://github.com/caskroom/homebrew-cask/issues/2536
+[#2670]: https://github.com/caskroom/homebrew-cask/issues/2670
+[#2650]: https://github.com/caskroom/homebrew-cask/issues/2650
 [@wallacewinfrey]: https://github.com/wallacewinfrey
 [@vmrob]: https://github.com/vmrob
-[#2545]: https://github.com/phinze/homebrew-cask/issues/2545
-[#2391]: https://github.com/phinze/homebrew-cask/issues/2391
-[#2618]: https://github.com/phinze/homebrew-cask/issues/2618
+[#2545]: https://github.com/caskroom/homebrew-cask/issues/2545
+[#2391]: https://github.com/caskroom/homebrew-cask/issues/2391
+[#2618]: https://github.com/caskroom/homebrew-cask/issues/2618
 [@stylerw]: https://github.com/stylerw
 
 ## 0.27.1
@@ -412,7 +412,7 @@
 * __Breaking Changes__
  - none
 
-[#2496]: https://github.com/phinze/homebrew-cask/issues/2496
+[#2496]: https://github.com/caskroom/homebrew-cask/issues/2496
 
 ## 0.27.0
 
@@ -438,33 +438,33 @@
  - In rare cases, the new `caveats` form may not be backward-compatible with
    old Casks which used undocumented features.
 
-[#2416]: https://github.com/phinze/homebrew-cask/issues/2416
+[#2416]: https://github.com/caskroom/homebrew-cask/issues/2416
 [@linc01n]: https://github.com/linc01n
-[#2471]: https://github.com/phinze/homebrew-cask/issues/2471
-[#2461]: https://github.com/phinze/homebrew-cask/issues/2461
-[#2152]: https://github.com/phinze/homebrew-cask/issues/2152
+[#2471]: https://github.com/caskroom/homebrew-cask/issues/2471
+[#2461]: https://github.com/caskroom/homebrew-cask/issues/2461
+[#2152]: https://github.com/caskroom/homebrew-cask/issues/2152
 [@voanhduy1512]: https://github.com/voanhduy1512
 [@vmrob]: https://github.com/vmrob
 [@Dillon-Benson]: https://github.com/Dillon-Benson
-[#2426]: https://github.com/phinze/homebrew-cask/issues/2426
-[#2303]: https://github.com/phinze/homebrew-cask/issues/2303
-[#2235]: https://github.com/phinze/homebrew-cask/issues/2235
+[#2426]: https://github.com/caskroom/homebrew-cask/issues/2426
+[#2303]: https://github.com/caskroom/homebrew-cask/issues/2303
+[#2235]: https://github.com/caskroom/homebrew-cask/issues/2235
 [@sonots]: https://github.com/sonots
-[#2417]: https://github.com/phinze/homebrew-cask/issues/2417
-[#2444]: https://github.com/phinze/homebrew-cask/issues/2444
+[#2417]: https://github.com/caskroom/homebrew-cask/issues/2417
+[#2444]: https://github.com/caskroom/homebrew-cask/issues/2444
 
-[#2329]: https://github.com/phinze/homebrew-cask/issues/2329
+[#2329]: https://github.com/caskroom/homebrew-cask/issues/2329
 [@karbassi]: https://github.com/karbassi
-[#2360]: https://github.com/phinze/homebrew-cask/issues/2360
+[#2360]: https://github.com/caskroom/homebrew-cask/issues/2360
 [@jfb]: https://github.com/jfb
-[#2263]: https://github.com/phinze/homebrew-cask/issues/2263
+[#2263]: https://github.com/caskroom/homebrew-cask/issues/2263
 [@philoserf]: https://github.com/philoserf
-[#2370]: https://github.com/phinze/homebrew-cask/issues/2370
+[#2370]: https://github.com/caskroom/homebrew-cask/issues/2370
 [@troter]: https://github.com/troter
-[#2258]: https://github.com/phinze/homebrew-cask/issues/2258
+[#2258]: https://github.com/caskroom/homebrew-cask/issues/2258
 [@jgarber623]: https://github.com/jgarber623
-[#2456]: https://github.com/phinze/homebrew-cask/issues/2456
-[#2240]: https://github.com/phinze/homebrew-cask/issues/2240
+[#2456]: https://github.com/caskroom/homebrew-cask/issues/2456
+[#2240]: https://github.com/caskroom/homebrew-cask/issues/2240
 
 ## 0.26.1
 
@@ -474,7 +474,7 @@
 * __Breaking Changes__
  - none
 
-[#2275]: https://github.com/phinze/homebrew-cask/issues/2275
+[#2275]: https://github.com/caskroom/homebrew-cask/issues/2275
 
 ## 0.26.0
 
@@ -486,7 +486,7 @@
 * __Breaking Changes__
  - none
 
-[#2275]: https://github.com/phinze/homebrew-cask/issues/2275
+[#2275]: https://github.com/caskroom/homebrew-cask/issues/2275
 
 ## 0.25.0
 
@@ -506,11 +506,11 @@
 [@pstadler]: https://github.com/pstadler
 [@halo]: https://github.com/halo
 [caskroom/fonts]: https://github.com/caskroom/homebrew-fonts
-[#1944]:  https://github.com/phinze/homebrew-cask/issues/1944
-[#2066]:  https://github.com/phinze/homebrew-cask/issues/2066
-[#2081]:  https://github.com/phinze/homebrew-cask/issues/2081
-[#2084]:  https://github.com/phinze/homebrew-cask/issues/2084
-[#2100]:  https://github.com/phinze/homebrew-cask/issues/2100
+[#1944]:  https://github.com/caskroom/homebrew-cask/issues/1944
+[#2066]:  https://github.com/caskroom/homebrew-cask/issues/2066
+[#2081]:  https://github.com/caskroom/homebrew-cask/issues/2081
+[#2084]:  https://github.com/caskroom/homebrew-cask/issues/2084
+[#2100]:  https://github.com/caskroom/homebrew-cask/issues/2100
 
 ## 0.24.0
 
@@ -521,8 +521,8 @@
 * __Breaking Changes__
   - none
 
-[#2018]: https://github.com/phinze/homebrew-cask/issues/2018
-[#2019]: https://github.com/phinze/homebrew-cask/issues/2019
+[#2018]: https://github.com/caskroom/homebrew-cask/issues/2018
+[#2019]: https://github.com/caskroom/homebrew-cask/issues/2019
 
 ## 0.23.0
 
@@ -533,8 +533,8 @@
 * __Breaking Changes__
   - none
 
-[#2012]: https://github.com/phinze/homebrew-cask/issues/2012
-[#2013]: https://github.com/phinze/homebrew-cask/issues/2013
+[#2012]: https://github.com/caskroom/homebrew-cask/issues/2012
+[#2013]: https://github.com/caskroom/homebrew-cask/issues/2013
 
 ## 0.22.0
 
@@ -558,7 +558,7 @@
   - none
 
 [@peeja]: https://github.com/peeja
-[#1882]: https://github.com/phinze/homebrew-cask/issues/1882
+[#1882]: https://github.com/caskroom/homebrew-cask/issues/1882
 
 ## 0.21.0
 
@@ -568,7 +568,7 @@
 * __Breaking Changes__
   - none
 
-[#1733]: https://github.com/phinze/homebrew-cask/issues/1733
+[#1733]: https://github.com/caskroom/homebrew-cask/issues/1733
 [@lgarron]: https://github.com/lgarron
 
 ## 0.20.1
@@ -579,7 +579,7 @@
 * __Breaking Changes__
   - none
 
-[#1765]: https://github.com/phinze/homebrew-cask/issues/1765
+[#1765]: https://github.com/caskroom/homebrew-cask/issues/1765
 [@njam]: https://github.com/njam
 
 ## 0.20.0
@@ -596,16 +596,16 @@
 * __Breaking Changes__
   - [#1436][] - new preferred sourceforge url style
 
-[#1417]: https://github.com/phinze/homebrew-cask/issues/1417
+[#1417]: https://github.com/caskroom/homebrew-cask/issues/1417
 [@aah]: https://github.com/aah
 [@linc01n]: https://github.com/linc01n
 
-[#393]: https://github.com/phinze/homebrew-cask/issues/393
-[#914]: https://github.com/phinze/homebrew-cask/issues/914
-[#1035]: https://github.com/phinze/homebrew-cask/issues/1035
-[#1461]: https://github.com/phinze/homebrew-cask/issues/1461
+[#393]: https://github.com/caskroom/homebrew-cask/issues/393
+[#914]: https://github.com/caskroom/homebrew-cask/issues/914
+[#1035]: https://github.com/caskroom/homebrew-cask/issues/1035
+[#1461]: https://github.com/caskroom/homebrew-cask/issues/1461
 
-[#1436]: https://github.com/phinze/homebrew-cask/issues/1436
+[#1436]: https://github.com/caskroom/homebrew-cask/issues/1436
 
 
 ## 0.19.4
@@ -616,7 +616,7 @@
 * __Breaking Changes__
   - none
 
-[#1274]: https://github.com/phinze/homebrew-cask/issues/1374
+[#1274]: https://github.com/caskroom/homebrew-cask/issues/1374
 
 ## 0.19.3
 
@@ -626,7 +626,7 @@
 * __Breaking Changes__
   - none
 
-[#1274]: https://github.com/phinze/homebrew-cask/issues/1247
+[#1274]: https://github.com/caskroom/homebrew-cask/issues/1247
 
 ## 0.19.2
 
@@ -645,9 +645,9 @@
 * __Breaking Changes__
   - none
 
-[#954]: https://github.com/phinze/homebrew-cask/issues/954
-[@kdeldycke]: https://github.com/phinze/homebrew-cask/commit/f787afdc26cb5a5b81c2d6142d93c77b7aa5d28e
-[#1247]: https://github.com/phinze/homebrew-cask/issues/1247
+[#954]: https://github.com/caskroom/homebrew-cask/issues/954
+[@kdeldycke]: https://github.com/caskroom/homebrew-cask/commit/f787afdc26cb5a5b81c2d6142d93c77b7aa5d28e
+[#1247]: https://github.com/caskroom/homebrew-cask/issues/1247
 
 ## 0.19.0
 
@@ -657,7 +657,7 @@
 * __Breaking Changes__
   - none
 
-[#602]: https://github.com/phinze/homebrew-cask/issues/602
+[#602]: https://github.com/caskroom/homebrew-cask/issues/602
 
 
 ## 0.18.3
@@ -669,9 +669,9 @@
 * __Breaking Changes__
   - none
 
-[#1168]: https://github.com/phinze/homebrew-cask/issues/1168
+[#1168]: https://github.com/caskroom/homebrew-cask/issues/1168
 [@wenbin1989]: https://github.com/wenbin1989
-[#1181]: https://github.com/phinze/homebrew-cask/pull/1181
+[#1181]: https://github.com/caskroom/homebrew-cask/pull/1181
 [@andizzle]: https://github.com/andizzle
 
 ## 0.18.2
@@ -682,7 +682,7 @@
 * __Breaking Changes__
   - none
 
-[#981]: https://github.com/phinze/homebrew-cask/issues/981
+[#981]: https://github.com/caskroom/homebrew-cask/issues/981
 [@sheerun]: https://github.com/sheerun
 
 ## 0.18.1
@@ -708,7 +708,7 @@
 
 * __Features__
 * __Fixes__
-  - Bugfixes addressing ([#1105](https://github.com/phinze/homebrew-cask/issues/1105))
+  - Bugfixes addressing ([#1105](https://github.com/caskroom/homebrew-cask/issues/1105))
 * __Breaking Changes__
   - none
 
@@ -716,7 +716,7 @@
 
 * __Features__
 * __Fixes__
-  - Fixes typo on `Tar` container, preventing tar-based Casks from being installed. ([#1083](https://github.com/phinze/homebrew-cask/issues/1083))
+  - Fixes typo on `Tar` container, preventing tar-based Casks from being installed. ([#1083](https://github.com/caskroom/homebrew-cask/issues/1083))
 * __Breaking Changes__
   - none
 
@@ -738,7 +738,7 @@
 
 * __Features__
 * __Fixes__
-  - homebrew made some changes ([#1015](https://github.com/phinze/homebrew-cask/issues/1015)) that broke our integration; this bugfix release brings us back into parity with the mothership.
+  - homebrew made some changes ([#1015](https://github.com/caskroom/homebrew-cask/issues/1015)) that broke our integration; this bugfix release brings us back into parity with the mothership.
 * __Breaking Changes__
   - none
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -21,7 +21,7 @@ clean up documentation! Anything you can do to help out is very welcome.
 
 It's also [__pretty darn easy__ to create Casks](../CONTRIBUTING.md), so
 please build more of them for the software you use. And if homebrew-cask doesn't
-support the packaging format of your software, please [open an issue](https://github.com/phinze/homebrew-cask/issues)
+support the packaging format of your software, please [open an issue](https://github.com/caskroom/homebrew-cask/issues)
 and we can get it working together.
 
 The whole idea is to build a _community-maintained_ list of easily installable

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -33,7 +33,7 @@ revising our goals and adding new ones.
 
 ## What Needs to be Done?
 
-Plenty. Start with [open issues](https://github.com/phinze/homebrew-cask/issues?state=open) !
+Plenty. Start with [open issues](https://github.com/caskroom/homebrew-cask/issues?state=open) !
 
 ## Are You Interested in New Features?
 
@@ -51,13 +51,13 @@ It's a neat idea!  We have talked about it but nobody has worked
 on it:
 
 - <https://gist.github.com/phinze/7cd361150816bd85304e>
-- <https://github.com/phinze/homebrew-cask/issues/1135>
+- <https://github.com/caskroom/homebrew-cask/issues/1135>
 
 ## What About Installing by Copying Instead of Linking?
 
 It's a neat idea! We have talked about it but nobody has worked on it:
 
-- <https://github.com/phinze/homebrew-cask/pull/2312#issuecomment-31859263>
+- <https://github.com/caskroom/homebrew-cask/pull/2312#issuecomment-31859263>
 
 We would want to make sure that uninstall works equally well when copying.
 
@@ -66,14 +66,14 @@ We would want to make sure that uninstall works equally well when copying.
 Yes, definitely! We have talked about it, and worked on some aspects
 of it. But there is much left to do:
 
-- <https://github.com/phinze/homebrew-cask/issues/309>
+- <https://github.com/caskroom/homebrew-cask/issues/309>
 
 ## What About Installing Multiple Versions of a Package?
 
 Yes, definitely! We have started working on it, so please contact us
 directly if you want to help.
 
-- <https://github.com/phinze/homebrew-cask/issues/142>
+- <https://github.com/caskroom/homebrew-cask/issues/142>
 
 ## What About Dependencies?
 
@@ -99,7 +99,7 @@ under `/usr/local`.  For coding, that is usually not sufficient.
 
 We recommend the following:
 
-1. Fork our repo: <https://github.com/phinze/homebrew-cask/fork>
+1. Fork our repo: <https://github.com/caskroom/homebrew-cask/fork>
 2. Clone a private copy of the repo:
 
 	```bash
@@ -110,11 +110,11 @@ We recommend the following:
 
 	```bash
 	cd homebrew-cask
-	git remote add upstream https://github.com/phinze/homebrew-cask.git
+	git remote add upstream https://github.com/caskroom/homebrew-cask.git
 	```
 
 4. Now you have two copies of the homebrew-cask codebase on disk: the
-   released version in `/usr/local/Library/Taps/phinze/homebrew-cask`, and a
+   released version in `/usr/local/Library/Taps/caskroom/homebrew-cask`, and a
    development version in your private repo.  To symlink the `Casks`
    and `rubylib` folders from `/usr/local/...` into your private repo,
    run the following script:

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -97,7 +97,7 @@ down than floating in a brain somewhere.
 	$ unset NEW_RELEASE_TAG
 	```
 
-13. Open your browser to <https://github.com/phinze/homebrew-cask/releases> .
+13. Open your browser to <https://github.com/caskroom/homebrew-cask/releases> .
     Click the link for your newly-pushed tag. Click the "Edit Tag" button in
     the top right corner of that page.
 14. Paste the markdown summary from `doc/CHANGELOG.md` into the textarea on that

--- a/doc/man/brew-cask.1
+++ b/doc/man/brew-cask.1
@@ -191,7 +191,7 @@ A fully\-qualified Cask name which includes the Tap name, \fIeg\fR \fBcaskroom/f
 A fully\-qualified pathname to a Cask file, \fIeg\fR \fB/usr/local/Cellar/brew\-cask/0\.25\.0/Casks/google\-chrome\.rb\fR
 .
 .IP "\(bu" 4
-A \fBcurl\fR\-retrievable URI to a Cask file, \fIeg\fR \fBhttps://raw\.github\.com/phinze/homebrew\-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google\-chrome\.rb\fR
+A \fBcurl\fR\-retrievable URI to a Cask file, \fIeg\fR \fBhttps://raw\.github\.com/caskroom/homebrew\-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google\-chrome\.rb\fR
 .
 .IP "" 0
 .
@@ -209,7 +209,7 @@ This variable may contain any arguments normally used as options on the command\
 The homebrew\-cask home page: \fIhttp://caskroom\.io\fR\.
 .
 .P
-The homebrew\-cask GitHub page: \fIhttps://github\.com/phinze/homebrew\-cask\fR\.
+The homebrew\-cask GitHub page: \fIhttps://github\.com/caskroom/homebrew\-cask\fR\.
 .
 .P
 Alfred\.app: \fIhttp://www\.alfredapp\.com\fR
@@ -224,7 +224,7 @@ Paul Hinze and Contributors\.
 Man page format based on \fBbrew\.1\.md\fR from Homebrew\.
 .
 .SH "BUGS"
-We still have bugs \-\- and we are busy fixing them! If you have a problem, don\'t be shy about reporting it on our GitHub issues page \fIhttps://github\.com/phinze/homebrew\-cask/issues?state=open\fR\.
+We still have bugs \-\- and we are busy fixing them! If you have a problem, don\'t be shy about reporting it on our GitHub issues page \fIhttps://github\.com/caskroom/homebrew\-cask/issues?state=open\fR\.
 .
 .P
 When reporting bugs, remember that homebrew\-cask is an independent project from Homebrew\. Do your best to direct bug reports to the appropriate project\. If your command\-line started with \fBbrew cask\fR, bring the bug to us first!

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -173,7 +173,7 @@ Homebrew-cask also accepts three other forms for Cask names:
     `/usr/local/Cellar/brew-cask/0.25.0/Casks/google-chrome.rb`
 
   * A `curl`-retrievable URI to a Cask file, _eg_
-   `https://raw.github.com/phinze/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`
+   `https://raw.github.com/caskroom/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`
 
 ## ENVIRONMENT
 
@@ -191,7 +191,7 @@ Environment variables specific to homebrew-cask:
 
 The homebrew-cask home page: <http://caskroom.io>.
 
-The homebrew-cask GitHub page: <https://github.com/phinze/homebrew-cask>.
+The homebrew-cask GitHub page: <https://github.com/caskroom/homebrew-cask>.
 
 Alfred.app: <http://www.alfredapp.com>
 
@@ -206,7 +206,7 @@ Man page format based on `brew.1.md` from Homebrew.
 ## BUGS
 
 We still have bugs -- and we are busy fixing them!  If you have a problem, don't
-be shy about reporting it on our [GitHub issues page](https://github.com/phinze/homebrew-cask/issues?state=open).
+be shy about reporting it on our [GitHub issues page](https://github.com/caskroom/homebrew-cask/issues?state=open).
 
 When reporting bugs, remember that homebrew-cask is an independent project from
 Homebrew.  Do your best to direct bug reports to the appropriate project.  If

--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -52,7 +52,7 @@ class Cask::Audit
   def _check_sourceforge_download_url_format
     odebug "Auditing URL format"
     if _bad_sourceforge_url?
-      add_warning "SourceForge URL format incorrect. See https://github.com/phinze/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls"
+      add_warning "SourceForge URL format incorrect. See https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls"
     end
   end
 

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -20,7 +20,7 @@ require 'cask/cli/uninstall'
 require 'cask/cli/update'
 
 class Cask::CLI
-  ISSUES_URL = "https://github.com/phinze/homebrew-cask/issues"
+  ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
   def self.commands
     Cask::CLI.constants - ["NullCommand", "ISSUES_URL"]
   end

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -35,7 +35,7 @@ PURPOSE
     return nil unless title.respond_to?(:length) and title.length > 0
     path_elements = title.split '/'
     if path_elements.count == 2
-      # eg phinze-cask/google-chrome.
+      # eg caskroom-cask/google-chrome.
       # Not certain this form is needed, but it was supported in the past.
       name = path_elements[1]
       dash_elements = path_elements[0].split('-')

--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -97,7 +97,7 @@ module Cask::Locations
     end
 
     def default_tap
-      @default_tap ||= 'phinze/homebrew-cask'
+      @default_tap ||= 'caskroom/homebrew-cask'
     end
 
     def default_tap=(_tap)

--- a/lib/cask/qualified_cask_name.rb
+++ b/lib/cask/qualified_cask_name.rb
@@ -14,7 +14,7 @@ module Cask::QualifiedCaskName
   end
 
   def self.cask_regexp
-    # per https://github.com/phinze/homebrew-cask/blob/04a8fa88c7b1d05adcd8307b9297e36f83ddbf5d/CONTRIBUTING.md#cask-name
+    # per https://github.com/caskroom/homebrew-cask/blob/04a8fa88c7b1d05adcd8307b9297e36f83ddbf5d/CONTRIBUTING.md#cask-name
     %r{[a-z0-9\-]+}
   end
 
@@ -39,7 +39,7 @@ module Cask::QualifiedCaskName
       dash_elements.pop if dash_elements.count > 1 and dash_elements[-1] + '-' == repo_prefix
       user = dash_elements.join('-')
     else
-      # eg phinze/cask/google-chrome
+      # eg caskroom/cask/google-chrome
       # per https://github.com/Homebrew/homebrew/wiki/brew-tap
       user, repo, cask = path_elements
     end

--- a/test/cask/audit_test.rb
+++ b/test/cask/audit_test.rb
@@ -88,7 +88,7 @@ describe Cask::Audit do
 
     describe "preferred download URL formats" do
       it "adds a warning if SourceForge doesn't use download subdomain" do
-        warning_msg = 'SourceForge URL format incorrect. See https://github.com/phinze/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls'
+        warning_msg = 'SourceForge URL format incorrect. See https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls'
 
 
         audit = Cask::Audit.new(CaskSourceForgeIncorrectURLFormat.new)

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -8,7 +8,7 @@ describe Cask::CLI::Info do
       local-caffeine: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
+      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
       ==> Contents
         Caffeine.app (link)
     CLIOUTPUT
@@ -21,13 +21,13 @@ describe Cask::CLI::Info do
       local-caffeine: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
+      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
       ==> Contents
         Caffeine.app (link)
       local-transmission: 2.61
       http://example.com/local-transmission
       Not installed
-      https://github.com/phinze/homebrew-testcasks/commits/master/Casks/local-transmission.rb
+      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/local-transmission.rb
       ==> Contents
         Transmission.app (link)
     CLIOUTPUT
@@ -40,7 +40,7 @@ describe Cask::CLI::Info do
       with-caveats: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      https://github.com/phinze/homebrew-testcasks/commits/master/Casks/with-caveats.rb
+      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/with-caveats.rb
       ==> Contents
         Caffeine.app (link)
       ==> Caveats

--- a/test/cask/cli/search_test.rb
+++ b/test/cask/cli/search_test.rb
@@ -66,8 +66,8 @@ describe Cask::CLI::Search do
 
   it "does not search the Tap name" do
     out, err = capture_io do
-      Cask::CLI::Search.run('phinze')
+      Cask::CLI::Search.run('caskroom')
     end
-    out.must_match(/^No cask found for "phinze"\.\n/)
+    out.must_match(/^No cask found for "caskroom"\.\n/)
   end
 end

--- a/test/cask/cli_test.rb
+++ b/test/cask/cli_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 describe Cask::CLI do
   it "lists the taps for casks that show up in two taps" do
     Cask::CLI.nice_listing(%w[
-      phinze/cask/adium
-      phinze/cask/google-chrome
+      caskroom/cask/adium
+      caskroom/cask/google-chrome
       passcod/homebrew-cask/adium
     ]).must_equal(%w[
+      caskroom/cask/adium
       google-chrome
       passcod/cask/adium
-      phinze/cask/adium
     ])
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,7 @@ Mocha::Integration::MiniTest.activate
 require 'cask'
 
 # look for casks in testcasks by default
-Cask.default_tap = 'phinze/homebrew-testcasks'
+Cask.default_tap = 'caskroom/homebrew-testcasks'
 
 # our own testy caskroom
 Cask.caskroom = HOMEBREW_PREFIX.join('TestCaskroom')
@@ -98,7 +98,7 @@ require 'tempfile'
 
 # pretend like we installed the cask tap
 project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
-taps_dest = HOMEBREW_LIBRARY/"Taps/phinze"
+taps_dest = HOMEBREW_LIBRARY/"Taps/caskroom"
 
 # create directories
 FileUtils.mkdir_p taps_dest


### PR DESCRIPTION
global replace of:
  'phinze/homebrew-cask' -> 'caskroom/homebrew-cask'
  'phinze/cask' -> 'caskroom/cask'

<3 the homebrew-cask community!
