### PR TITLE
Cask/printrun

### DIFF
--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,0 +1,7 @@
+class Printrun < Cask
+  url 'http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-10Mar2014.zip'
+  homepage 'https://github.com/kliment/Printrun'
+  version '1.2'
+  sha256 'b270edb951cbee3e957eab3ecd3bbd4fe25e93ce478393c61f029bfff4e3b902'
+  link 'Printrun-Mac-10Mar2014.app'
+end


### PR DESCRIPTION
version as in the about screen:
![screen shot 2014-05-03 at 18 37 55](https://cloud.githubusercontent.com/assets/50506/2870807/6daece26-d2e1-11e3-8c7e-9a30ff80a43c.png)
