### PR TITLE
Fix SHA256 of XBMC

### DIFF
--- a/Casks/xbmc.rb
+++ b/Casks/xbmc.rb
@@ -2,6 +2,6 @@ class Xbmc < Cask
   url 'http://mirrors.xbmc.org/releases/osx/x86_64/xbmc-13.0-x86_64.dmg'
   homepage 'http://xbmc.org/'
   version '13.0'
-  sha256 '00b7a5436acd93cbacf2ad2afc25f2ff4833cad6fc83df2e0aae31e7b3684c3a'
+  sha256 '2cd29487170e6f1e6ffa0128c9bcd2510ae8adb2057b241df45d39a0d19f2760'
   link 'XBMC.app'
 end


### PR DESCRIPTION
```
$ brew cask install xbmc --force

==> Downloading http://mirrors.xbmc.org/releases/osx/x86_64/xbmc-13.0-x86_64.dmg
######################################################################## 100.0%
Error: SHA2 mismatch
Expected: 00b7a5436acd93cbacf2ad2afc25f2ff4833cad6fc83df2e0aae31e7b3684c3a
Actual: 2cd29487170e6f1e6ffa0128c9bcd2510ae8adb2057b241df45d39a0d19f2760
Archive: /Library/Caches/Homebrew/xbmc-13.0.dmg
To retry an incomplete download, remove the file above.
Please report this bug:
    https://github.com/phinze/homebrew-cask/issues
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/download.rb:39:in `_check_sums'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/download.rb:33:in `each'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/download.rb:33:in `_check_sums'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/download.rb:26:in `perform'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/installer.rb:58:in `download'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/installer.rb:35:in `install'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/cli/install.rb:10:in `run'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/cli/install.rb:6:in `each'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/cli/install.rb:6:in `run'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/cli.rb:56:in `run_command'
/usr/local/Cellar/brew-cask/0.33.1/rubylib/cask/cli.rb:71:in `process'
/usr/local/bin/brew-cask.rb:6
/usr/local/Library/brew.rb:64:in `require'
/usr/local/Library/brew.rb:64:in `require?'
/usr/local/Library/brew.rb:111
```
