### PR TITLE
suppress email notifications from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ notifications:
       - "%{build_number}: %{branch}@%{commit} %{author} -> %{message} %{build_url}"
     use_notice: true
     skip_join: true
+  email: false


### PR DESCRIPTION
for some reason, I received email notification
"Build #8384 passed" (f51706f Changeset), which might have to
do with the recent migration of the repo.
