### PR TITLE
Add Qmind version 0.3.4

### DIFF
--- a/Casks/qmind.rb
+++ b/Casks/qmind.rb
@@ -1,0 +1,7 @@
+class Qmind < Cask
+  url 'https://github.com/qvacua/qmind/releases/download/v0.3.4-22/Qmind-0.3.4.zip'
+  homepage 'http://qvacua.com'
+  version '0.3.4'
+  sha256 '498dc5b753804d25cbf15afbdb8641af1ddcf53b65ab04d3188c7a8b669f6695'
+  link 'Qmind.app'
+end


### PR DESCRIPTION
Qmind is a mind mapping app for your Mac which is meant to be compatible to FreeMind. [http://qvacua.com](http://qvacua.com/)
