### PR TITLE
Add Jenkins Menu version 0.1.0

### DIFF
--- a/Casks/jenkins-menu.rb
+++ b/Casks/jenkins-menu.rb
@@ -1,0 +1,7 @@
+class JenkinsMenu < Cask
+  url 'https://bitbucket.org/qvacua/qvacua/downloads/JenkinsMenu-0.1.0.zip'
+  homepage 'http://qvacua.com'
+  version '0.1.0'
+  sha256 '8fd5c85a5615bd0470cb69bd8c28cfbfc7189f74c1abd490181bb74b166fce37'
+  link 'Jenkins Menu.app'
+end


### PR DESCRIPTION
Jenkins Menu is a simple menu item for Mac OS X that shows the status of a (also secured) Jenkins CI server. [http://qvacua.com](http://qvacua.com/)
