### PR TITLE
Add Qdesktop version 0.1.1

### DIFF
--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -1,0 +1,7 @@
+class Qdesktop < Cask
+  url 'https://bitbucket.org/qvacua/qvacua/downloads/Qdesktop-0.1.1.zip'
+  homepage 'http://qvacua.com'
+  version '0.1.1'
+  sha256 '1eddd3513cca892fb8e53452d79d4589ef5b1e3cd885a1f52748b6df64588094'
+  link 'Qdesktop.app'
+end


### PR DESCRIPTION
Qdesktop lets you set a web page of your liking as the desktop background of your Mac. [http://qvacua.com](http://qvacua.com/)
