### PR TITLE
Add Musictube version 1.2.7

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,0 +1,7 @@
+class Musictube < Cask
+  url 'http://flavio.tordini.org/files/musictube/musictube.dmg'
+  homepage 'http://flavio.tordini.org/musictube'
+  version 'latest'
+  no_checksum
+  link 'Musictube.app'
+end


### PR DESCRIPTION
Listen to millions of songs on YouTube in a convenient way, much like using a traditional player. Musictube plays album tracks in their original order and integrates album covers, artist pictures and lyrics. [http://flavio.tordini.org/musictube](http://flavio.tordini.org/musictube)
