### PR TITLE
Mention homebrew-binary in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,10 @@ When an App developer does not offer a binary download, please submit the
 Cask to [caskroom/homebrew-unofficial](http://github.com/caskroom/homebrew-unofficial).
 For a location to host unofficial builds, contact our sister project [alehouse](https://github.com/alehouse).
 
+### Command-line-only Apps
+
+When an App provides solely a command line interface version (meaning it would exclusively use the `binary` [artifact stanza](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#at-least-one-artifact-stanza-is-also-required)), it should be submitted first to [homebrew-binary](https://github.com/Homebrew/homebrew-binary). Only if rejected should it be submitted here for consideration.
+
 ### Fonts
 
 Font Casks live in the [caskroom/homebrew-fonts](https://github.com/caskroom/homebrew-fonts)


### PR DESCRIPTION
There have been a lot of cli-only app submissions, recently, and it’s clear that few know of [homebrew-binary](https://github.com/Homebrew/homebrew-binary). [As suggested](https://github.com/caskroom/homebrew-cask/pull/3891#issuecomment-42219305), this documents and clarifies cases when a _cask_ should be submitted first to _hombrew-binary_.
