### PR TITLE
Defend against unusual Homebrew setups

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,8 @@ Mocha::Integration::MiniTest.activate
 # our baby
 require 'cask'
 
-# look for casks in testcasks by default
+# Look for casks in testcasks by default.  It is elsewhere required that
+# the string "test" appear in the directory name.
 Cask.default_tap = 'caskroom/homebrew-testcasks'
 
 # our own testy caskroom


### PR DESCRIPTION
To aid in Tap transition.  Require Homebrew 0.9.5, rescue
`rename_tags_dir_if_necessary` (`respond_to?` won't work there
because `rename_tags_dir_if_necessary` is a private method.

References: #4192, @Jackiebo in #4096
