### PR TITLE
Add 'Cn3D.app' v4.3.1

### DIFF
--- a/Casks/cn3d.rb
+++ b/Casks/cn3d.rb
@@ -1,0 +1,7 @@
+class Cn3D < Cask
+  url 'ftp://ftp.ncbi.nlm.nih.gov/cn3d/Cn3D-4.3.1-OSX.zip'
+  homepage 'http://www.ncbi.nlm.nih.gov/Structure/CN3D/cn3d.shtml'
+  version '4.3.1'
+  sha256 '0d47a1ec7ee2e445d997eee2caa56f9cdffd68cba0384f5dd71edc00d8812df4'
+  link 'Cn3D.app'
+end


### PR DESCRIPTION
Cn3D ("see in 3D") is a helper application for your web browser that allows you to view 3-dimensional structures from NCBI's Entrez Structure database.
