### PR TITLE
doc: "Cask definition file", not "Caskfile"

### DIFF
--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -50,15 +50,15 @@ names, and other aspects of this manual are still subject to change.
     downloads older than 10 days old.
 
   * `create` <Cask>:
-    Generate a Cask for the Caskfile named <Cask> and open a template for
-    it in your favorite editor.
+    Generate a Cask definition file for the Cask named <Cask> and open a
+    template for it in your favorite editor.
 
   * `doctor` or `dr`:
     Check for configuration issues.  Can be useful to upload as a gist for
     developers along with a bug report.
 
   * `edit` <Cask>:
-    Open the given Caskfile for editing.
+    Open the given Cask definition file for editing.
 
   * `fetch` <Cask> [--force]:
     Fetch remote resources for the given Cask to the local cache.  With


### PR DESCRIPTION
"Caskfile" is used in `AUTOMATION.md` by analogy to Brewfile
