### PR TITLE
transition docs/tests/messages to sha256 :no_check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Fill in the following stanzas for your Cask:
 | `url`              | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application (see also [URL Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#url-stanza-details))
 | `homepage`         | application homepage; used for the `brew cask home` command
 | `version`          | application version; give value of `'latest'` if versioned downloads are not offered
-| `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be omitted on unversioned downloads by substituting `no_checksum`. (see also [Checksum Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#checksum-stanza-details))
+| `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be suppressed for unversioned downloads by using the special value `:no_check`. (see also [Checksum Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#checksum-stanza-details))
 | __artifact info__  | information about artifacts inside the Cask (can be specified multiple times)
 | `link`             | relative path to a file that should be linked into the `Applications` folder on installation (see also [Link Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#link-stanza-details))
 | `install`          | relative path to `pkg` that should be run to install the application (see also [Install Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#install-stanza-details))

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -51,14 +51,12 @@ paradigm.
 
 Each of the following stanzas is required for every Cask.
 
-Exception: currently `sha256` may be omitted if `no_checksum` is substituted.
-
 | name               | multiple occurrences allowed? | value       |
 | ------------------ |------------------------------ | ----------- |
 | `url`              | No                            | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application (see also [URL Stanza Details](#url-stanza-details))
 | `homepage`         | No                            | application homepage; used for the `brew cask home` command
 | `version`          | No                            | application version; give value of `'latest'` if versioned downloads are not offered
-| `sha256`           | No                            | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be omitted on unversioned downloads by substituting `no_checksum`. (see also [Checksum Stanza Details](#checksum-stanza-details))
+| `sha256`           | No                            | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be suppressed for unversioned downloads by using the special value `:no_check`. (see also [Checksum Stanza Details](#checksum-stanza-details))
 
 
 ## At Least One Artifact Stanza Is Also Required
@@ -102,8 +100,8 @@ and slated for retirement.
 
 | name               | multiple occurrences allowed? | meaning     |
 | ------------------ |------------------------------ | ----------- |
-| `md5`              | No                            | an alternative to `sha256`
-| `sha1`             | No                            | an alternative to `sha256`
+| `sha1`             | No                            | an obsolete alternative to `sha256`
+| `no_checksum`      | No                            | an obsolete alternative to `sha256 :no_check`
 
 
 ## Conditional Statements

--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -13,7 +13,7 @@ class Cask::Audit
   def run!(download = false)
     _check_required_fields
     _check_checksums
-    _check_no_checksums_if_latest
+    _check_sha256_no_check_if_latest
     _check_sourceforge_download_url_format
     _check_download(download) if download
     return !(errors? or warnings?)
@@ -34,12 +34,12 @@ class Cask::Audit
   def _check_checksums
     odebug "Auditing checksums"
     return if cask.sums == :no_check
-    add_error "could not find checksum or no_checksum" unless cask.sums.is_a?(Array) && cask.sums.length > 0
+    add_error "sha256 is required" unless cask.sums.is_a?(Array) && cask.sums.length > 0
   end
 
-  def _check_no_checksums_if_latest
-    odebug "Verifying no_checkum with version 'latest'"
-    add_error "you should use no_checksum when version is latest" if cask.version == "latest" && cask.sums.is_a?(Array)
+  def _check_sha256_no_check_if_latest
+    odebug "Verifying sha256 :no_check with version 'latest'"
+    add_error "you should use sha256 :no_check when version is 'latest'" if cask.version == "latest" && cask.sums.is_a?(Array)
   end
 
   def _check_download(download)

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -139,6 +139,7 @@ module Cask::DSL
       hash_type.to_s == 'sha2' ? 'sha256' : hash_type.to_s
     end
 
+    # @@@ todo remove support for sha1 stanza
     def sha1(sha1=nil)
       if @sums == :no_check
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'sha1'")
@@ -152,6 +153,7 @@ module Cask::DSL
     end
 
     def sha256(sha2=nil)
+      # @@@ todo remove this after deleting support for legacy no_checksum stanza
       if @sums == :no_check
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'sha256'")
       end
@@ -163,6 +165,7 @@ module Cask::DSL
       end
     end
 
+    # @@@ todo remove support for no_checksum stanza
     def no_checksum
       unless @sums.nil? or @sums.empty?
         raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with '#{hash_name(@sums.first.hash_type)}'")

--- a/test/cask/audit_test.rb
+++ b/test/cask/audit_test.rb
@@ -82,7 +82,7 @@ describe Cask::Audit do
       it "adds an error if version is latest and using sha256" do
         audit = Cask::Audit.new(CaskVersionLatestWithChecksum.new)
         audit.run!
-        audit.errors.must_include 'you should use no_checksum when version is latest'
+        audit.errors.must_include %q{you should use sha256 :no_check when version is 'latest'}
       end
     end
 

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -112,6 +112,7 @@ describe Cask::DSL do
     err.message.must_include "'version' stanza may only appear once"
   end
 
+  # @@@ todo this test can be removed when support for no_checksum is dropped
   it "prevents defining conflicting checksums (first order)" do
     err = lambda {
       invalid_cask = Cask.load('invalid/invalid-checksum-conflict1')
@@ -119,6 +120,7 @@ describe Cask::DSL do
     err.message.must_include "'no_checksum' stanza conflicts with"
   end
 
+  # @@@ todo this test can be removed when support for no_checksum is dropped
   it "prevents defining conflicting checksums (second order)" do
     err = lambda {
       invalid_cask = Cask.load('invalid/invalid-checksum-conflict2')

--- a/test/support/Casks/invalid/invalid-checksum-conflict1.rb
+++ b/test/support/Casks/invalid/invalid-checksum-conflict1.rb
@@ -1,4 +1,5 @@
 class InvalidChecksumConflict1 < TestCask
+  # @@@ todo this test cask can be removed when support for no_checksum is dropped
   url TestHelper.local_binary('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'

--- a/test/support/Casks/invalid/invalid-checksum-conflict2.rb
+++ b/test/support/Casks/invalid/invalid-checksum-conflict2.rb
@@ -1,4 +1,5 @@
 class InvalidChecksumConflict2 < TestCask
+  # @@@ todo this test cask can be removed when support for no_checksum is dropped
   url TestHelper.local_binary('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'


### PR DESCRIPTION
`sha256 :no_check` has been supported syntax for a couple of months,
and now is being transitioned to the preferred syntax, replacing
the `no_checksum` stanza (which will still be supported, but
deprecated)
