### PR TITLE
Add Anypass version 1.0.0

### DIFF
--- a/Casks/anypass.rb
+++ b/Casks/anypass.rb
@@ -1,0 +1,7 @@
+class Anypass < Cask
+  url 'http://www.icyblaze.com/anypass/anypass_mac_1.0.zip'
+  homepage 'http://www.icyblaze.com/anypass'
+  version '1.0.0'
+  sha256 '364d108736eddfdb6e7db56430806d790b79e9f8561aedc544fc78d7e41bac54'
+  link 'Anypass.app'
+end


### PR DESCRIPTION
Quickly Transfer Files Between Mac, iPhone and iPadNo matter it is a Office Document, Photo, Short Text, Movie or Music. Anypass is the neat solution for transfer files between Mac and iPhone. [http://www.icyblaze.com/anypass](http://www.icyblaze.com/anypass/)
