### PR TITLE
Retire support for `sha1` stanza.

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -100,7 +100,6 @@ and slated for retirement.
 
 | name               | multiple occurrences allowed? | meaning     |
 | ------------------ |------------------------------ | ----------- |
-| `sha1`             | No                            | an obsolete alternative to `sha256`
 | `no_checksum`      | No                            | an obsolete alternative to `sha256 :no_check`
 
 
@@ -170,8 +169,8 @@ And the following methods may be useful for interpolation:
 
 ## Checksum Stanza Details
 
-Older Casks may still use `sha1` checksums.  This is OK, but new
-Casks and updates should adopt `sha256`.
+Older Casks may still use `no_checksum` stanzas.  This is OK, but new
+Casks and updates should adopt `sha256 :no_check`.
 
 
 ## URL Stanza Details

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -139,19 +139,6 @@ module Cask::DSL
       hash_type.to_s == 'sha2' ? 'sha256' : hash_type.to_s
     end
 
-    # @@@ todo remove support for sha1 stanza
-    def sha1(sha1=nil)
-      if @sums == :no_check
-        raise CaskInvalidError.new(self.title, "'no_checksum' stanza conflicts with 'sha1'")
-      end
-      if sha1 == :no_check
-        @sums = sha1
-      else
-        @sums ||= []
-        @sums << Checksum.new(:sha1, sha1) unless sha1.nil?
-      end
-    end
-
     def sha256(sha2=nil)
       # @@@ todo remove this after deleting support for legacy no_checksum stanza
       if @sums == :no_check

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -8,15 +8,13 @@ describe Cask::DSL do
     test_cask.version.must_equal '1.2.3'
   end
 
-  it "lets you set checksum via sha1 and/or sha256" do
+  it "lets you set checksum via sha256" do
     ChecksumCask = Class.new(Cask)
     ChecksumCask.class_eval do
-      sha1 'imasha1'
       sha256 'imasha2'
     end
     instance = ChecksumCask.new
     instance.sums.must_equal [
-      Checksum.new(:sha1, 'imasha1'),
       Checksum.new(:sha2, 'imasha2')
     ]
   end


### PR DESCRIPTION
We haven't received new submissions using `sha1` for quite
some time.

**HOLD** this until pending relevant PRs in caskroom/homebrew-versions are merged:
- caskroom/homebrew-versions#256
- caskroom/homebrew-versions#257
- caskroom/homebrew-versions#258
- caskroom/homebrew-versions#259
- caskroom/homebrew-versions#260
- caskroom/homebrew-versions#261
- caskroom/homebrew-versions#262

`sha1` is already removed from all Casks in homebrew-unofficial, homebrew-fonts, and the main repo.
