### PR TITLE
Upgrade Google's Music Manager to v1.0.104.6528.

### DIFF
--- a/Casks/musicmanager.rb
+++ b/Casks/musicmanager.rb
@@ -1,7 +1,7 @@
 class Musicmanager < Cask
-  url 'https://dl.google.com/dl/androidjumper/mac/718015/musicmanager.dmg'
-  homepage 'https://music.google.com'
-  version '1.0.71.8015'
-  sha256 '16f93db5f672313fb3da66b3abbaf4408a136cc677a00851d5cf7221d76c25a5'
-  link 'MusicManager.app'
+  url 'https://dl.google.com/dl/androidjumper/mac/1046528/musicmanager.dmg'
+  homepage 'https://play.google.com/music/'
+  version '1.0.104.6528'
+  sha256 'a1e4e48e008958f9a725bfee1e2d8360dc8efad38ef2532fc1b3e4b9c3df8f0d'
+  link 'Music Manager.app'
 end


### PR DESCRIPTION
Updated url, homepage, version, sha256 and link to work with latest.
