### PR TITLE
changed mentions of 'brew --prefix' to 'brew --repository'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ all pretty happy about this.  Here's how to get started:
 
 ```bash
 $ github_user='<my-github-username>'
-$ cd "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
+$ cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
 $ git remote add "$github_user" "https://github.com/$github_user/homebrew-cask"
 ```
 
@@ -66,14 +66,14 @@ is simply the Cask name with the extension `.rb` appended.
 
 The easiest way to name a Cask is to run this command:
 ```bash
-$ "$(brew --prefix)/Library/Taps/caskroom/homebrew-cask/developer/bin/cask_namer" '/full/path/to/new/software.app'
+$ "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/cask_namer" '/full/path/to/new/software.app'
 ```
 
 If the software you wish to Cask is not installed, or does not have an
 associated App bundle, just give the full proper name of the software
 instead of a pathname:
 ```bash
-$ "$(brew --prefix)/Library/Taps/caskroom/homebrew-cask/developer/bin/cask_namer" 'Google Chrome'
+$ "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/cask_namer" 'Google Chrome'
 ```
 
 If the `cask_namer` script does not work for you, see [Cask Naming Details](#cask-naming-details).
@@ -256,7 +256,7 @@ for details.
 Hop into your Tap and check to make sure your new Cask is there:
 
 ```bash
-$ cd "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
+$ cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
 $ git status
 # On branch master
 # Untracked files:
@@ -343,7 +343,7 @@ After your Pull Request is away, you might want to get yourself back onto
 `master`, so that `brew update` will pull down new Casks properly.
 
 ```bash
-cd "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
+cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
 git checkout master
 ```
 

--- a/doc/TAP_MIGRATION.md
+++ b/doc/TAP_MIGRATION.md
@@ -11,13 +11,13 @@
 During April-May 2014, the default location of the Homebrew-cask Tap was
 moved to a new location on disk, from
 
-	"$(brew --prefix)"/Library/Taps/phinze-cask
+	"$(brew --repository)"/Library/Taps/phinze-cask
 
 to
 
-	"$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
+	"$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
 
-(where `"$(brew --prefix)"` typically evaluates to `/usr/local`).
+(where `"$(brew --repository)"` typically evaluates to `/usr/local`).
 
 The migration should be seamless, but some users have experienced glitches.
 We are still [making improvements](https://github.com/caskroom/homebrew-cask/pull/4169) to aid in the transition.
@@ -71,14 +71,14 @@ $ brew untap phinze/cask; brew tap caskroom/cask
 The following directory should exist:
 
 ```bash
-$ ls -ld "$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
+$ ls -ld "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
 ```
 
 The following directories should **not** exist:
 
 ```bash
-$ ls -ld "$(brew --prefix)"/Library/Taps/phinze/homebrew-cask
-$ ls -ld "$(brew --prefix)"/Library/Taps/phinze-cask
+$ ls -ld "$(brew --repository)"/Library/Taps/phinze/homebrew-cask
+$ ls -ld "$(brew --repository)"/Library/Taps/phinze-cask
 ```
 
 ### File an Issue
@@ -105,19 +105,19 @@ built on the infrastructure provided by [Homebrew](http://brew.sh).
 On [24 Apr 2014](https://github.com/Homebrew/homebrew/commit/e07584e3fbdc88327bafe23b9c40c904d0fff0a1), the parent project Homebrew changed the layout of
 the Tap directory to follow the form
 
-	"$(brew --prefix)"/Library/Taps/<username>/<repo-fullname>
+	"$(brew --repository)"/Library/Taps/<username>/<repo-fullname>
 
 rather than
 
-	"$(brew --prefix)"/Library/Taps/<username>-<repo-shortname>
+	"$(brew --repository)"/Library/Taps/<username>-<repo-shortname>
 
 causing our project to be moved from
 
-	"$(brew --prefix)"/Library/Taps/phinze-cask
+	"$(brew --repository)"/Library/Taps/phinze-cask
 
 to
 
-	"$(brew --prefix)"/Library/Taps/phinze/homebrew-cask
+	"$(brew --repository)"/Library/Taps/phinze/homebrew-cask
 
 ### Our Project (Homebrew-cask)
 
@@ -134,8 +134,8 @@ https://github.com/caskroom/homebrew-cask
 This means that the username portion of our Tap path changed from `phinze`
 to `caskroom`, *ie*:
 
-	"$(brew --prefix)"/Library/Taps/phinze/homebrew-cask
+	"$(brew --repository)"/Library/Taps/phinze/homebrew-cask
 
 became
 
-	"$(brew --prefix)"/Library/Taps/caskroom/homebrew-cask
+	"$(brew --repository)"/Library/Taps/caskroom/homebrew-cask


### PR DESCRIPTION
Closes #2121.

Please see mentioned issue for (link to) reasoning. Apparently _homebrew_ switched to that, and since we always try to be consistent with them, so should we.
