### PR TITLE
caveat: clamxav installs files into /usr/local

### DIFF
--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -8,4 +8,8 @@ class Clamxav < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'uk.co.markallan.clamxav', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  caveats do
+    # this happens sometime after installation, but still worth warning about
+    files_in_usr_local
+  end
 end


### PR DESCRIPTION
Specifically `/usr/local/clamXav`.  This actually happens after Cask
installation; the user will be prompted to install on first execution
of ClamXav, but not informed about the location.  Therefore it makes
sense to warn the user here.
