### PR TITLE
Upgrade TotalTerminal to v1.4.11

### DIFF
--- a/Casks/totalterminal.rb
+++ b/Casks/totalterminal.rb
@@ -1,8 +1,8 @@
 class Totalterminal < Cask
-  url 'http://downloads.binaryage.com/TotalTerminal-1.4.10.dmg'
+  url 'http://downloads.binaryage.com/TotalTerminal-1.4.11.dmg'
   homepage 'http://totalterminal.binaryage.com'
-  version '1.4.10'
-  sha256 '5f2b518a65274797d92a76e95697ace99eb879f00047747334ee8c53e7a9ca8b'
+  version '1.4.11'
+  sha256 'c0689bc4912042441c5e056cae9a04a681d4dbe34c1fc157c890cc3febcd41f2'
   install 'TotalTerminal.pkg'
   uninstall :script => {
     :executable => 'TotalTerminal Uninstaller.app/Contents/MacOS/TotalTerminal Uninstaller',


### PR DESCRIPTION
Updated url, version and sha256 keys to allow upgrade to current version 1.4.11.
