### PR TITLE
fix ghostlab download URL

### DIFF
--- a/Casks/ghostlab.rb
+++ b/Casks/ghostlab.rb
@@ -1,5 +1,5 @@
 class Ghostlab < Cask
-  url 'http://awesome.vanamco.com/downloads/ghostlab/latest/Ghostlab.dmg'
+  url 'http://awesome.vanamco.com/downloads/ghostlab/Ghostlab.dmg'
   homepage 'http://vanamco.com/ghostlab/'
   version 'latest'
   sha256 :no_check


### PR DESCRIPTION
The current Ghostlab download URL 404s. I've verified that this new formula works & it passes `brew cask audit`, too.
