### PR TITLE
Fix LibreOffice cask for older OS X versions

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,7 +1,13 @@
 class Libreoffice < Cask
-  url 'http://download.documentfoundation.org/libreoffice/stable/4.2.3/mac/x86_64/LibreOffice_4.2.3_MacOS_x86-64.dmg'
+  if Hardware::CPU.is_64_bit? && OS::Mac.version >= '10.8'
+    url 'http://download.documentfoundation.org/libreoffice/stable/4.2.3/mac/x86_64/LibreOffice_4.2.3_MacOS_x86-64.dmg'
+    sha256 'b54917f4784b17c2c6a0778559f3f9de03480bc4528b181681336d9cc2dba904'
+  else
+    url 'http://download.documentfoundation.org/libreoffice/stable/4.2.3/mac/x86/LibreOffice_4.2.3_MacOS_x86.dmg'
+    sha256 '6b5bf833824076acf0cdb86b869ba418043295855f1a539fa0d7bf18eba3de13'
+  end
+
   homepage 'http://www.libreoffice.org/'
   version '4.2.3'
-  sha256 'b54917f4784b17c2c6a0778559f3f9de03480bc4528b181681336d9cc2dba904'
   link 'LibreOffice.app'
 end


### PR DESCRIPTION
See #4331. This installs the `x86_64` version only on 64bit CPUs and OS X >= 10.8. Works on my machine (i5, 10.7).
