### PR TITLE
Upgrade Vagrant Manager to 1.4.2.

### DIFF
--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -1,7 +1,7 @@
 class VagrantManager < Cask
-  url 'https://github.com/lanayotech/vagrant-manager/releases/download/1.3.2/vagrant-manager-1.3.2.dmg'
+  url 'https://github.com/lanayotech/vagrant-manager/releases/download/1.4.2/vagrant-manager-1.4.2.dmg'
   homepage 'http://vagrantmanager.com/'
-  version '1.3.2'
-  sha256 '7788bfa70e2e1b73a384332403be83547284418b34482f7acb21a98c15fb1232'
+  version '1.4.2'
+  sha256 '56834cc63727e6bcbfcaba247d411353c078f4416e149d1eafd55daf7e249181'
   link 'Vagrant Manager.app'
 end


### PR DESCRIPTION
Hi,

I've updated to the last version of Vagrant Manager to 1.4.2.

Best regards.
