### PR TITLE
Adding consul v0.2.0

### DIFF
--- a/Casks/consul.rb
+++ b/Casks/consul.rb
@@ -1,0 +1,10 @@
+class Consul < Cask
+  url 'https://dl.bintray.com/mitchellh/consul/0.2.0_darwin_amd64.zip'
+  homepage 'http://www.consul.io/'
+  version '0.2.0'
+  sha256 '0a03a42fa3ea945d19152bc2429b4098a195a68f7a8f10a1b63e805f7f251fe9'
+  binary 'consul'
+  after_install do
+    system "chmod", "755", "#{destination_path}/consul"
+  end
+end


### PR DESCRIPTION
Hashicorp's [consul](https://github.com/hashicorp/consul) is distributed as a binary compiled golang project, much like their other project: [serf](https://github.com/hashicorp/serf) 

So this cask is very similar to [serf.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/serf.rb)
