### PR TITLE
append the .rb extension on Cask::Source::Path

### DIFF
--- a/lib/cask/source/path.rb
+++ b/lib/cask/source/path.rb
@@ -1,6 +1,12 @@
 class Cask::Source::Path
   def self.me?(query)
-    File.file?(query)
+    query_with_ext = "#{query}"
+    query_with_ext.concat('.rb') unless query_with_ext.match(%r{\.rb\Z}i)
+    # bug? arguably, we should not pick up a relative path
+    # containing a Cask file so easily, since this source
+    # is tested before the default Tap.  Perhaps there
+    # should be two Path sources, absolute and relative.
+    File.file?(query_with_ext)
   end
 
   attr_reader :path


### PR DESCRIPTION
Unless `.rb` is already present on the query string.  Failure
to append the extension caused confusing effects, including
selective failure of "brew cask list" when invoked from
`/usr/local/bin` working directory.  Fixes #4077 .
Credit to @mroth on the detective work.
