### PR TITLE
add uninstall stanza to flavours app

### DIFF
--- a/Casks/flavours.rb
+++ b/Casks/flavours.rb
@@ -4,8 +4,18 @@ class Flavours < Cask
   version 'latest'
   sha256 :no_check
   link 'Flavours.app'
-  caveats <<-EOS.undent
-    Do not use an uninstaller like AppCleaner. Instead, launch Flavours.app
-    and use the menu Flavours > Uninstall Flavours...
-  EOS
+  caveats do
+    files_in_usr_local
+  end
+
+  caskroom_only true     # hack to make uninstall fire
+  uninstall :launchctl => 'net.interacto.flavours.helper',
+            :quit  => 'net.interacto.Flavours',
+            :files => [
+                       '/usr/local/bin/flavours.agent',
+                       '/usr/local/bin/flavours.ignitor',
+                       '/usr/local/bin/restoreui',
+                       '/usr/local/lib/libflavours.dylib',
+                       '/usr/local/lib/libflavoursui.dylib',
+                      ]
 end


### PR DESCRIPTION
Use the normalized files_in_usr_local caveats, and try to uninstall those files during uninstall

I tested this, but the uninstall stanza I think still left those files...
