### PR TITLE
Add Brow.app v1.0

### DIFF
--- a/Casks/brow.rb
+++ b/Casks/brow.rb
@@ -1,0 +1,7 @@
+class Brow < Cask
+  url 'http://www.timschroeder.net/brow/brow.zip'
+  homepage 'http://www.timschroeder.net/brow/'
+  version '1.0'
+  sha256 'f646b89e63853edab7dfae701f10074b0b966f624d2c1e412f0c07cdeeff2eeb'
+  link 'Brow.app'
+end


### PR DESCRIPTION
From the homepage:

Brow adds your Google Chrome and Mozilla Firefox bookmarks to the OS X Spotlight Service. Spotlight will show the bookmarks (including previews), as it already does now with Safari bookmarks, and will open them with your default web browser. Brow runs as a menubar app or, if you choose, invisible in the background. That's all.
