### PR TITLE
Upgrade TeXShop to v3.36

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,7 +1,7 @@
 class Texshop < Cask
-  url 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshop335.zip'
+  url 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshop336.zip'
   homepage 'http://pages.uoregon.edu/koch/texshop'
-  version '3.35'
-  sha256 '26fb20bb7c63abb2a59c334741e967899bf34b6cb47c29d7173d3d1c4538143f'
+  version '3.36'
+  sha256 '3fed35e4a8ab2b8deb7119d7b6774fdbf50b0a275f980a3ca73cf44461f4ccd0'
   link 'TexShop.app'
 end


### PR DESCRIPTION
New TeXShop version 3.36 is out 2014-05-13.
Please upgarde Cask/texshop.rb

Best Wishes,
Signed-off-by: Youhei SASAKI uwabami@gfd-dennou.org
