### PR TITLE
force writable perms on Google Quick Search Box

### DIFF
--- a/Casks/google-quick-search-box.rb
+++ b/Casks/google-quick-search-box.rb
@@ -4,4 +4,7 @@ class GoogleQuickSearchBox < Cask
   version '2.0.0.1447'
   sha256 '3fec80343c50a5b492e140fef13bd1bc4cce835beb3952591e8b4638e5940470'
   link 'Google Quick Search Box.app'
+  after_install do
+    system '/bin/chmod', '-R', '--', 'u+w', destination_path
+  end
 end


### PR DESCRIPTION
Fixes #4402.  It might be reasonable to do this on all
installations by default.
