### PR TITLE
rename Google Quick Search Box, removing "Google"

### DIFF
--- a/Casks/quick-search-box.rb
+++ b/Casks/quick-search-box.rb
@@ -1,9 +1,9 @@
-class GoogleQuickSearchBox < Cask
+class QuickSearchBox < Cask
   url 'http://qsb-mac.googlecode.com/files/GoogleQuickSearchBox-2.0.0.1447.Release.dmg'
   homepage 'http://www.google.com/quicksearchbox/'
   version '2.0.0.1447'
   sha256 '3fec80343c50a5b492e140fef13bd1bc4cce835beb3952591e8b4638e5940470'
-  link 'Google Quick Search Box.app'
+  link 'Quick Search Box.app'
   after_install do
     system '/bin/chmod', '-R', '--', 'u+w', destination_path
   end


### PR DESCRIPTION
upstream appears to have renamed the app
