### PR TITLE
doubledash convention in cask external commands

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -8,7 +8,7 @@ class AdobeArh < Cask
   container_type :naked
 
   after_install do
-    system '/bin/chmod', '755', "#{destination_path}/arh"
+    system '/bin/chmod', '--', '755', "#{destination_path}/arh"
   end
 
   caveats "Please refer to the documention at #{homepage}"

--- a/Casks/consul.rb
+++ b/Casks/consul.rb
@@ -5,6 +5,6 @@ class Consul < Cask
   sha256 '0a03a42fa3ea945d19152bc2429b4098a195a68f7a8f10a1b63e805f7f251fe9'
   binary 'consul'
   after_install do
-    system '/bin/chmod', '755', "#{destination_path}/consul"
+    system '/bin/chmod', '--', '755', "#{destination_path}/consul"
   end
 end

--- a/Casks/crosspack-avr.rb
+++ b/Casks/crosspack-avr.rb
@@ -5,7 +5,7 @@ class CrosspackAvr < Cask
   sha256 '959f9bf00429a0e46e649a14d7891cb4086c9cf2d032d9f66899d6efbb628f6e'
   install 'CrossPack-AVR.pkg'
   after_uninstall do
-    IO.popen('yes | sudo -E /usr/local/CrossPack-AVR/uninstall && sudo pkgutil --forget at.obdev.CrossPack-AVR', 'r+') do |pipe|
+    IO.popen('/usr/bin/yes | /usr/bin/sudo -E -- /usr/local/CrossPack-AVR/uninstall && /usr/bin/sudo -- /usr/sbin/pkgutil --forget at.obdev.CrossPack-AVR', 'r+') do |pipe|
       pipe.close_write
       while line = pipe.gets
         puts line

--- a/Casks/decitime.rb
+++ b/Casks/decitime.rb
@@ -9,6 +9,6 @@ class Decitime < Cask
   # fix wonky DMG by mounting it once read-write per discussion at
   # https://github.com/caskroom/homebrew-cask/pull/2654
   before_install do
-    system %Q{/usr/bin/hdiutil eject "$(/usr/bin/hdiutil mount -readwrite -noidme -nobrowse -mountrandom /tmp #{destination_path.join(artifacts[:nested_container].first)} | /usr/bin/cut -f3 | /usr/bin/grep '.')" >/dev/null 2>&1}
+    system %Q{/usr/bin/hdiutil eject "$(/usr/bin/hdiutil mount -readwrite -noidme -nobrowse -mountrandom /tmp #{destination_path.join(artifacts[:nested_container].first)} | /usr/bin/cut -f3 -- - | /usr/bin/grep -- '.' -)" >/dev/null 2>&1}
   end
 end

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -6,7 +6,7 @@ class GitAnnex < Cask
     # This is a horrible hack to force the file extension.  The
     # backend code should be fixed so that this is not needed.
     before_install do
-      system '/bin/mv', destination_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
+      system '/bin/mv', '--', destination_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
     end
     nested_container 'git-annex-latest.dmg'
   end

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -34,9 +34,9 @@ class Gpgtools < Cask
                        "ENV['HOME']/Library/PreferencePanes/GPGPreferences.prefPane",
                       ]
   after_uninstall do
-    system '/bin/bash', '-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm /usr/local/bin/gpg2'
-    system '/bin/bash', '-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm /usr/local/bin/gpg'
-    system '/bin/bash', '-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm /usr/local/bin/gpg-agent'
+    system '/bin/bash', '-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm -- /usr/local/bin/gpg2'
+    system '/bin/bash', '-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm -- /usr/local/bin/gpg'
+    system '/bin/bash', '-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm -- /usr/local/bin/gpg-agent'
   end
   caveats do
     files_in_usr_local

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -5,6 +5,6 @@ class Jxplorer < Cask
   sha256 'b51995a93203590e6690d8ad54f73cd7af1c9f2bef6219adca79c58eda71d860'
   link 'jxplorer-3.3.1.app'
   after_install do
-    system '/bin/chmod', 'a+x', "#{destination_path}/jxplorer-3.3.1.app/Contents/MacOS/jxplorer"
+    system '/bin/chmod', '--', 'a+x', "#{destination_path}/jxplorer-3.3.1.app/Contents/MacOS/jxplorer"
   end
 end

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -6,7 +6,7 @@ class Mamp < Cask
   install 'MAMP_MAMP_PRO_3.0.5.pkg'
   after_install do
     system '/usr/bin/sudo', '-E', '--',
-           '/usr/sbin/chown', '-R', "#{Etc.getpwuid(Process.euid).name}:staff", '/Applications/MAMP', '/Applications/MAMP PRO'
+           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", '/Applications/MAMP', '/Applications/MAMP PRO'
   end
   uninstall :pkgutil => 'de.appsolute.installer.(mamp|mampacticon|mampendinstall|mamppro).pkg',
             :files   => [

--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -4,7 +4,7 @@ class Nodeclipse < Cask
   version '0.11-preview'
   sha256 '01f630446313cb981ce2ee9b934977cfdbf318e09761dee244a3256f9a559003'
   before_install do
-    system '/bin/mv', destination_path.join('eclipse/Eclipse.app'), destination_path.join('eclipse/Nodeclipse.app')
+    system '/bin/mv', '--', destination_path.join('eclipse/Eclipse.app'), destination_path.join('eclipse/Nodeclipse.app')
   end
   link 'eclipse/Nodeclipse.app'
 end

--- a/Casks/programmer-dvorak.rb
+++ b/Casks/programmer-dvorak.rb
@@ -14,7 +14,7 @@ class ProgrammerDvorak < Cask
   if MacOS.version == :mavericks
     after_install do
       # clear the layout cache before new layouts are recognized
-      system 'rm', '-f', '/System/Library/Caches/com.apple.IntlDataCache.le*'
+      system 'rm', '-f', '--', '/System/Library/Caches/com.apple.IntlDataCache.le*'
     end
   end
 end

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -5,7 +5,7 @@ class Ridibooks < Cask
   sha256 :no_check
   container_type :naked
   before_install do
-    system '/bin/mv', destination_path.join('getapp'), destination_path.join('ridibooks.pkg')
+    system '/bin/mv', '--', destination_path.join('getapp'), destination_path.join('ridibooks.pkg')
   end
   install 'ridibooks.pkg'
   uninstall :pkgutil => 'com.ridibooks.Ridibooks'

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -5,6 +5,6 @@ class Voicemac < Cask
   sha256 :no_check
   link 'VoiceMac/VoiceMac.app'
   after_install do
-    system '/bin/chmod', 'a+r', "#{destination_path}/VoiceMac/VoiceMac.app/Contents/Info.plist"
+    system '/bin/chmod', '--', 'a+r', "#{destination_path}/VoiceMac/VoiceMac.app/Contents/Info.plist"
   end
 end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -16,7 +16,7 @@ class Wireshark < Cask
               EOS
     else
       system '/usr/bin/sudo', '-E', '--',
-             '/usr/sbin/dseditgroup', '-o', 'edit', '-a', Etc.getpwuid(Process.euid).name, '-t', 'user', 'access_bpf'
+             '/usr/sbin/dseditgroup', '-o', 'edit', '-a', Etc.getpwuid(Process.euid).name, '-t', 'user', '--', 'access_bpf'
     end
   end
 


### PR DESCRIPTION
as well as full paths, and explicit '-' for stdin, following the same
conventions used in our Ruby codebase.
