### PR TITLE
Add appcast stanzas for 186 `latest`-style Casks

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,5 +1,6 @@
 class ABetterFinderRename < Cask
   url 'http://www.publicspace.net/download/ABFRX.dmg'
+  appcast 'http://www.publicspace.net/app/signed_abfr9.xml'
   homepage 'http://www.publicspace.net/ABetterFinderRename/'
   version 'latest'
   sha256 :no_check

--- a/Casks/activity-audit.rb
+++ b/Casks/activity-audit.rb
@@ -1,5 +1,6 @@
 class ActivityAudit < Cask
   url 'https://www.dssw.co.uk/activityaudit/dsswactivityaudit.dmg'
+  appcast 'http://version.dssw.co.uk/activityaudit/standard'
   homepage 'https://www.dssw.co.uk/activityaudit'
   version 'latest'
   sha256 :no_check

--- a/Casks/adventure.rb
+++ b/Casks/adventure.rb
@@ -1,5 +1,6 @@
 class Adventure < Cask
   url 'http://www.lobotomo.com/products/downloads/Adventure.dmg'
+  appcast 'http://www.lobotomo.com/products/Adventure/profileInfo.php'
   homepage 'http://www.lobotomo.com/products/Adventure/index.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/airparrot.rb
+++ b/Casks/airparrot.rb
@@ -1,5 +1,6 @@
 class Airparrot < Cask
   url 'http://download.airsquirrels.com/AirParrot/Mac/AirParrot.dmg'
+  appcast 'http://airparrot.com/updates/AirParrot.xml'
   homepage 'http://www.airsquirrels.com/airparrot/'
   version 'latest'
   sha256 :no_check

--- a/Casks/all2mp3.rb
+++ b/Casks/all2mp3.rb
@@ -1,5 +1,6 @@
 class All2mp3 < Cask
   url 'http://www.tresrrr.com/Program/All2MP3.zip'
+  appcast 'http://www.tresrrr.com/All2MP3/Appcast.xml'
   homepage 'http://www.tresrrr.com/All2MP3/ENGLISH.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/amazon-cloud-drive.rb
+++ b/Casks/amazon-cloud-drive.rb
@@ -1,5 +1,6 @@
 class AmazonCloudDrive < Cask
   url 'https://d29x207vrinatv.cloudfront.net/AmazonCloudDrive.dmg'
+  appcast 'https://d29x207vrinatv.cloudfront.net/Sync/Mac/20130517-2.1/CloudDriveInstallerAppcast.xml'
   homepage 'https://www.amazon.com/clouddrive'
   version 'latest'
   sha256 :no_check

--- a/Casks/anvil.rb
+++ b/Casks/anvil.rb
@@ -1,5 +1,6 @@
 class Anvil < Cask
   url 'http://sparkler.herokuapp.com/apps/3/download'
+  appcast 'http://sparkler.herokuapp.com/apps/3/updates.xml'
   homepage 'http://anvilformac.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/anxiety.rb
+++ b/Casks/anxiety.rb
@@ -1,5 +1,6 @@
 class Anxiety < Cask
   url 'http://www.anxietyapp.com/Anxiety.zip'
+  appcast 'http://www.anxietyapp.com/appcast/appcast.xml'
   homepage 'http://www.anxietyapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/appdelete.rb
+++ b/Casks/appdelete.rb
@@ -1,5 +1,6 @@
 class Appdelete < Cask
   url 'http://www.reggieashworth.com/downloads/AppDelete.dmg'
+  appcast 'http://www.reggieashworth.com/AD4Appcast.xml'
   homepage 'http://www.reggieashworth.com/appdelete'
   version 'latest'
   sha256 :no_check

--- a/Casks/appfresh.rb
+++ b/Casks/appfresh.rb
@@ -1,5 +1,6 @@
 class Appfresh < Cask
   url 'http://backend.metaquark.de/download/appfresh'
+  appcast 'http://backend.metaquark.de/appcast/appfresh.xml'
   homepage 'http://metaquark.de/appfresh/mac'
   version 'latest'
   sha256 :no_check

--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -1,5 +1,6 @@
 class Appzapper < Cask
   url 'http://www.appzapper.com/downloads/appzapper.dmg'
+  appcast 'http://www.appzapper.com/az2appcast.xml'
   homepage 'http://www.appzapper.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,5 +1,6 @@
 class Atext < Cask
   url 'http://www.trankynam.com/atext/downloads/aText.dmg'
+  appcast 'http://www.trankynam.com/atext/aText-Appcast.xml'
   homepage 'http://www.trankynam.com/atext/'
   version 'latest'
   sha256 :no_check

--- a/Casks/atmonitor.rb
+++ b/Casks/atmonitor.rb
@@ -1,5 +1,7 @@
 class Atmonitor < Cask
   url 'http://download.atpurpose.com/atMonitor/atMonitor.zip'
+  # todo: no response
+  # appcast 'http://support.atPurpose.com/atMonitor/updates.xml'
   homepage 'http://www.atpurpose.com/atMonitor/'
   version 'latest'
   sha256 :no_check

--- a/Casks/audio-editor.rb
+++ b/Casks/audio-editor.rb
@@ -1,5 +1,6 @@
 class AudioEditor < Cask
   url 'http://www.macsome.com/AudioEditor.dmg'
+  appcast 'http://www.macsome.com/audio-editor-mac/su_feed.xml'
   homepage 'http://www.macsome.com/audio-editor-mac/index.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -1,5 +1,6 @@
 class Bartender < Cask
   url 'http://www.macbartender.com/Demo/Bartender.zip'
+  appcast 'http://www.macbartender.com/updates/updates.php'
   homepage 'http://www.macbartender.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -1,5 +1,6 @@
 class Base < Cask
   url 'http://menial.co.uk/base/download/'
+  appcast 'http://update.menial.co.uk/software/base/'
   homepage 'http://menial.co.uk/base/'
   version 'latest'
   sha256 :no_check

--- a/Casks/battery-guardian.rb
+++ b/Casks/battery-guardian.rb
@@ -1,5 +1,6 @@
 class BatteryGuardian < Cask
   url 'https://www.dssw.co.uk/batteryguardian/dsswbatteryguardian.dmg'
+  appcast 'http://version.dssw.co.uk/batteryguardian/standard'
   homepage 'https://www.dssw.co.uk/batteryguardian'
   version 'latest'
   sha256 :no_check

--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -1,5 +1,6 @@
 class BatteryReport < Cask
   url 'https://www.dssw.co.uk/batteryreport/dsswbatteryreport.dmg'
+  appcast 'http://version.dssw.co.uk/batteryreport/standard'
   homepage 'https://www.dssw.co.uk/batteryreport'
   version 'latest'
   sha256 :no_check

--- a/Casks/beamer.rb
+++ b/Casks/beamer.rb
@@ -1,5 +1,6 @@
 class Beamer < Cask
   url 'http://beamer-app.com/download'
+  appcast 'http://beamer-app.com/sparkle-appcast.xml'
   homepage 'http://beamer-app.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -1,5 +1,6 @@
 class Bee < Cask
   url 'http://neat.io/bee/download.html'
+  appcast 'http://neat.io/appcasts/bee-appcast.xml'
   homepage 'http://neat.io/bee/'
   version 'latest'
   sha256 :no_check

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -1,5 +1,6 @@
 class Bettertouchtool < Cask
   url 'http://www.boastr.de/BetterTouchTool.zip'
+  appcast 'http://appcast.boastr.net'
   homepage 'http://blog.boastr.net/'
   version 'latest'
   sha256 :no_check

--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -1,5 +1,6 @@
 class Betterzip < Cask
   url 'http://macitbetter.com/BetterZip.zip'
+  appcast 'http://macitbetter.com/BetterZip2.rss'
   homepage 'http://macitbetter.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -1,5 +1,7 @@
 class BittorrentSync < Cask
   url 'http://download-lb.utorrent.com/endpoint/btsync/os/osx/track/stable'
+  # todo: response was not XML
+  # appcast 'http://www.usyncapp.com/cfu.php'
   homepage 'http://www.bittorrent.com/sync'
   version 'latest'
   sha256 :no_check

--- a/Casks/bodega.rb
+++ b/Casks/bodega.rb
@@ -1,5 +1,6 @@
 class Bodega < Cask
   url 'http://downloads.appbodega.com.s3.amazonaws.com/bodega/latest/Bodega.zip'
+  appcast 'https://dev.appbodega.com/sparkle/appcast'
   homepage 'http://appbodega.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/bootchamp.rb
+++ b/Casks/bootchamp.rb
@@ -1,5 +1,6 @@
 class Bootchamp < Cask
   url 'http://www.kainjow.com/downloads/BootChamp.zip'
+  appcast 'http://kainjow.com/updates/bootchamp.xml'
   homepage 'http://www.kainjow.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/boxer.rb
+++ b/Casks/boxer.rb
@@ -1,5 +1,6 @@
 class Boxer < Cask
   url 'http://boxerapp.com/download/latest'
+  appcast 'http://boxerapp.com/appcast'
   homepage 'http://boxerapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,5 +1,6 @@
 class Camtasia < Cask
   url 'http://download.techsmith.com/camtasiamac/enu/Camtasia.dmg'
+  appcast 'http://techsmithredirect.appspot.com/cmac?target=sparkleappcast&product=camtasiamac&lang=enu&ver=2.7.1&os=mac&code=none'
   homepage 'http://www.techsmith.com/camtasia.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/chameleon-ssd-optimizer.rb
+++ b/Casks/chameleon-ssd-optimizer.rb
@@ -1,5 +1,6 @@
 class ChameleonSsdOptimizer < Cask
   url 'http://chameleon.alessandroboschini.it/download.php'
+  appcast 'http://chameleon.alessandroboschini.it/sparkle/profileInfo.php'
   homepage 'http://chameleon.alessandroboschini.it/'
   version 'latest'
   sha256 :no_check

--- a/Casks/changes.rb
+++ b/Casks/changes.rb
@@ -1,5 +1,6 @@
 class Changes < Cask
   url 'http://bitbq.com/changes/download.php'
+  appcast 'https://bitbq_changes.s3.amazonaws.com/changes-production.xml'
   homepage 'http://bitbq.com/changes/'
   version 'latest'
   sha256 :no_check

--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,5 +1,6 @@
 class Chatology < Cask
   url 'http://flexibits.com/chatology/download'
+  appcast 'https://flexibits.com/chatology/appcast.php'
   homepage 'http://flexibits.com/chatology'
   version 'latest'
   sha256 :no_check

--- a/Casks/cheatsheet.rb
+++ b/Casks/cheatsheet.rb
@@ -1,5 +1,6 @@
 class Cheatsheet < Cask
   url 'http://www.cheatsheetapp.com/CheatSheet/download.php'
+  appcast 'http://mediaatelier.com/CheatSheet/feed.php'
   homepage 'http://www.cheatsheetapp.com/CheatSheet/'
   version 'latest'
   sha256 :no_check

--- a/Casks/chocolat.rb
+++ b/Casks/chocolat.rb
@@ -1,5 +1,6 @@
 class Chocolat < Cask
   url 'http://chocolatapp.com/download'
+  appcast 'http://chocolatapp.com/userspace/appcast/appcast_alpha.php'
   homepage 'http://chocolatapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/chromatic.rb
+++ b/Casks/chromatic.rb
@@ -1,5 +1,6 @@
 class Chromatic < Cask
   url 'http://download.mrgeckosmedia.com/Chromatic.zip'
+  appcast 'http://mrgeckosmedia.com/applications/appcast/Chromatic'
   homepage 'https://mrgeckosmedia.com/applications/info/Chromatic'
   version 'latest'
   sha256 :no_check

--- a/Casks/chronicle.rb
+++ b/Casks/chronicle.rb
@@ -1,5 +1,6 @@
 class Chronicle < Cask
   url 'http://chronicleapp.com/static/downloads/chronicle.zip'
+  appcast 'http://www.littlefin.com/downloads/chronicle3.xml'
   homepage 'http://chronicleapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/cinch.rb
+++ b/Casks/cinch.rb
@@ -1,5 +1,6 @@
 class Cinch < Cask
   url 'http://www.irradiatedsoftware.com/download/Cinch.zip'
+  appcast 'https://www.irradiatedsoftware.com/updates/profiles/cinch.php'
   homepage 'http://www.irradiatedsoftware.com/cinch/'
   version 'latest'
   sha256 :no_check

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -1,5 +1,6 @@
 class Cleanmymac < Cask
   url 'http://dl.devmate.com/com.macpaw.CleanMyMac2/CleanMyMac2.dmg'
+  appcast 'http://updates.devmate.com/com.macpaw.CleanMyMac2.xml'
   homepage 'http://macpaw.com/cleanmymac'
   version 'latest'
   sha256 :no_check

--- a/Casks/cloudpull.rb
+++ b/Casks/cloudpull.rb
@@ -1,5 +1,6 @@
 class Cloudpull < Cask
   url 'http://downloads.goldenhillsoftware.com/cloudpull/CloudPull.zip'
+  appcast 'https://secure.goldenhillsoftware.com/updates/cloudpull/appcast.xml'
   homepage 'http://www.goldenhillsoftware.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -1,5 +1,6 @@
 class Cocktail < Cask
   url 'http://usa.maintain.se/CocktailME.dmg'
+  appcast 'http://www.maintain.se/downloads/sparkle/mavericks/mavericks.xml'
   homepage 'http://maintain.se/cocktail'
   version 'latest'
   sha256 :no_check

--- a/Casks/codebug.rb
+++ b/Casks/codebug.rb
@@ -1,5 +1,6 @@
 class Codebug < Cask
   url 'http://codebugapp.com/downloads/Codebug.dmg'
+  appcast 'http://codebugapp.com/update.xml'
   homepage 'http://www.codebugapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/color-picker-pro.rb
+++ b/Casks/color-picker-pro.rb
@@ -1,5 +1,6 @@
 class ColorPickerPro < Cask
   url 'http://fructivity.s3.amazonaws.com/ColorPickerPro/Color%20Picker%20Pro.zip'
+  appcast 'http://fructivity.s3.amazonaws.com/ColorPickerPro/Appcast.xml'
   homepage 'https://github.com/oscardelben/Color-Picker-Pro'
   version 'latest'
   sha256 :no_check

--- a/Casks/colorschemer-studio.rb
+++ b/Casks/colorschemer-studio.rb
@@ -1,5 +1,6 @@
 class ColorschemerStudio < Cask
   url 'http://www.colorschemer.com/colorschemerstudio.dmg'
+  appcast 'http://www.colorschemer.com/appcast/studio2_mac.xml'
   homepage 'http://www.colorschemer.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/comicbooklover.rb
+++ b/Casks/comicbooklover.rb
@@ -1,5 +1,6 @@
 class Comicbooklover < Cask
   url 'http://www.bitcartel.com/downloads/comicbooklover.zip'
+  appcast 'http://www.bitcartel.com/appcast/comicbooklover-1.7-dsa.xml'
   homepage 'http://www.bitcartel.com/comicbooklover/'
   version 'latest'
   sha256 :no_check

--- a/Casks/contexts.rb
+++ b/Casks/contexts.rb
@@ -1,5 +1,6 @@
 class Contexts < Cask
   url 'http://contextsformac.com/releases/Contexts.zip'
+  appcast 'http://www.contextsformac.com/releases/appcast.xml'
   homepage 'http://contextsformac.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/crashlytics.rb
+++ b/Casks/crashlytics.rb
@@ -1,5 +1,6 @@
 class Crashlytics < Cask
   url 'http://crashlytics.com/download/mac'
+  appcast 'https://ssl-download-crashlytics-com.s3.amazonaws.com/mac/version.xml'
   homepage 'http://crashlytics.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -1,5 +1,6 @@
 class Cuppa < Cask
   url 'http://www.nathanatos.com/software/downloads/Cuppa.zip'
+  appcast 'http://www.nathanatos.com/software/cuppa.xml'
   homepage 'http://www.nathanatos.com/software'
   version 'latest'
   sha256 :no_check

--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -1,5 +1,6 @@
 class Daisydisk < Cask
   url 'http://www.daisydiskapp.com/downloads/DaisyDisk.zip'
+  appcast 'http://www.daisydiskapp.com/downloads/appcastFeed.php'
   homepage 'http://www.daisydiskapp.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -1,5 +1,6 @@
 class Dash < Cask
   url 'http://kapeli.com/Dash.zip'
+  appcast 'http://kapeli.com/Dash.xml'
   homepage 'http://kapeli.com/dash'
   version 'latest'
   sha256 :no_check

--- a/Casks/dealalert.rb
+++ b/Casks/dealalert.rb
@@ -1,5 +1,6 @@
 class Dealalert < Cask
   url 'http://littlefin.com/downloads/dealalert.zip'
+  appcast 'http://www.littlefin.com/downloads/dealalert.xml'
   homepage 'http://dealalertapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/delibar.rb
+++ b/Casks/delibar.rb
@@ -1,5 +1,6 @@
 class Delibar < Cask
   url 'http://static.shinyfrog.net/downloads/delibar/Delibar.zip'
+  appcast 'http://apps.shinynode.com/apps/delibar_appcast.xml'
   homepage 'http://www.delibarapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/divvy.rb
+++ b/Casks/divvy.rb
@@ -1,5 +1,6 @@
 class Divvy < Cask
   url 'http://mizage.com/downloads/Divvy.zip'
+  appcast 'http://mizage.com/updates/profiles/divvy.php'
   homepage 'http://mizage.com/divvy/'
   version 'latest'
   sha256 :no_check

--- a/Casks/doubanradio.rb
+++ b/Casks/doubanradio.rb
@@ -1,5 +1,6 @@
 class Doubanradio < Cask
   url 'http://douban.fm/desktop_mac'
+  appcast 'http://douban.fm/static/radio/desktop/doubanradio-appcast.xml'
   homepage 'http://douban.fm'
   version 'latest'
   sha256 :no_check

--- a/Casks/dradio.rb
+++ b/Casks/dradio.rb
@@ -1,5 +1,6 @@
 class Dradio < Cask
   url 'http://dradio.me/download'
+  appcast 'http://dradio.me/updates/appcast.xml'
   homepage 'http://dradio.me'
   version 'latest'
   sha256 :no_check

--- a/Casks/dropin.rb
+++ b/Casks/dropin.rb
@@ -1,5 +1,6 @@
 class Dropin < Cask
   url 'http://excitedatom.com/downloads/dropin/?p=dropin'
+  appcast 'http://excitedatom.com/dropin/updates.xml'
   homepage 'http://excitedatom.com/dropin/'
   version 'latest'
   sha256 :no_check

--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,5 +1,6 @@
 class Dropzone < Cask
   url 'http://aptonic.com/dropzone/latest'
+  appcast 'http://aptonic.com/dropzone/sparkle/updates2.xml'
   homepage 'http://aptonic.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/entropy.rb
+++ b/Casks/entropy.rb
@@ -1,5 +1,6 @@
 class Entropy < Cask
   url 'http://www.eigenlogik.com/entropy/download'
+  appcast 'http://hyperion.eigenlogik.com/appcast/feed/entropy/'
   homepage 'http://www.eigenlogik.com/entropy/'
   version 'latest'
   sha256 :no_check

--- a/Casks/epic.rb
+++ b/Casks/epic.rb
@@ -1,5 +1,6 @@
 class Epic < Cask
   url 'https://ed5b681d56298a85550d-7d665255a6e48f36b11ee3cfeece77e0.ssl.cf1.rackcdn.com/epic_mac_33_alternate/Epic.dmg'
+  appcast 'https://updates.epicbrowser.com/mac_updates/appcast.xml'
   homepage 'http://www.epicbrowser.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -1,5 +1,6 @@
 class Evernote < Cask
   url 'https://www.evernote.com/about/download/get.php?file=EvernoteMac'
+  appcast 'http://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml'
   homepage 'https://evernote.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/evom.rb
+++ b/Casks/evom.rb
@@ -1,5 +1,6 @@
 class Evom < Cask
   url 'http://files.thelittleappfactory.com/evom/Evom.zip'
+  appcast 'https://files.thelittleappfactory.com/evom/appcast.xml'
   homepage 'http://thelittleappfactory.com/evom/'
   version 'latest'
   sha256 :no_check

--- a/Casks/exhaust.rb
+++ b/Casks/exhaust.rb
@@ -1,5 +1,6 @@
 class Exhaust < Cask
   url 'http://download.mrgeckosmedia.com/Exhaust.zip'
+  appcast 'http://mrgeckosmedia.com/applications/appcast/Exhaust'
   homepage 'https://mrgeckosmedia.com/applications/info/Exhaust'
   version 'latest'
   sha256 :no_check

--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,5 +1,6 @@
 class Expandrive < Cask
   url 'http://updates.expandrive.com/apps/expandrive/download_latest'
+  appcast 'http://updates.expandrive.com/appcast/expandrive.xml?version=3'
   homepage 'http://www.expandrive.com/expandrive'
   version 'latest'
   sha256 :no_check

--- a/Casks/flash-decompiler-trillix.rb
+++ b/Casks/flash-decompiler-trillix.rb
@@ -1,5 +1,6 @@
 class FlashDecompilerTrillix < Cask
   url 'http://www.flash-decompiler.com/download/flash_decompiler.dmg'
+  appcast 'http://www.eltima.com/download/fd-mac-update/fd-mac.xml'
   homepage 'http://www.flash-decompiler.com/mac.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/flow.rb
+++ b/Casks/flow.rb
@@ -1,5 +1,6 @@
 class Flow < Cask
   url 'http://fivedetails.com/flow/download'
+  appcast 'http://extendmac.com/flow/updates/update.php'
   homepage 'http://fivedetails.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/flowdock.rb
+++ b/Casks/flowdock.rb
@@ -1,5 +1,6 @@
 class Flowdock < Cask
   url 'https://flowdock-resources.s3.amazonaws.com/mac/Flowdock.zip'
+  appcast 'https://s3.amazonaws.com/flowdock-resources/mac/appcast.xml'
   homepage 'https://www.flowdock.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,5 +1,6 @@
 class Flux < Cask
   url 'https://justgetflux.com/mac/Flux.zip'
+  appcast 'https://justgetflux.com/mac/macflux.xml'
   homepage 'http://justgetflux.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/focus.rb
+++ b/Casks/focus.rb
@@ -1,5 +1,6 @@
 class Focus < Cask
   url 'http://www.heyfocus.com/releases/Focus-latest.zip'
+  appcast 'http://www.heyfocus.com/appcast.xml'
   homepage 'http://www.heyfocus.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -1,5 +1,6 @@
 class Folx < Cask
   url 'http://mac.eltima.com/download/downloader_mac.dmg'
+  appcast 'http://mac.eltima.com/download/folx-update/folx3.xml'
   homepage 'http://mac.eltima.com/de/download-manager.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/freezer.rb
+++ b/Casks/freezer.rb
@@ -1,5 +1,6 @@
 class Freezer < Cask
   url 'http://download.mrgeckosmedia.com/Freezer.zip'
+  appcast 'https://mrgeckosmedia.com/applications/appcast/Freezer'
   homepage 'https://mrgeckosmedia.com/applications/info/Freezer'
   version 'latest'
   sha256 :no_check

--- a/Casks/frizzix.rb
+++ b/Casks/frizzix.rb
@@ -1,5 +1,6 @@
 class Frizzix < Cask
   url 'http://mac.frizzix.de/downloads/currentVersion.dmg'
+  appcast 'http://frizzix.de/downloads/FrizzixUpdate.xml'
   homepage 'http://mac.frizzix.de/'
   version 'latest'
   sha256 :no_check

--- a/Casks/fseventer.rb
+++ b/Casks/fseventer.rb
@@ -1,5 +1,6 @@
 class Fseventer < Cask
   url 'http://www.fernlightning.com/lib/exe/fetch.php?id=software%3Afseventer%3Astart&cache=cache&media=software:fseventer:fseventer.zip'
+  appcast 'http://www.fernLightning.com/appcasts/fseventer.xml'
   homepage 'http://www.fernlightning.com/doku.php?id=software:fseventer:start'
   version 'latest'
   sha256 :no_check

--- a/Casks/gawker.rb
+++ b/Casks/gawker.rb
@@ -1,5 +1,6 @@
 class Gawker < Cask
   url 'http://sourceforge.net/projects/gawker/files/latest/download'
+  appcast 'http://gawker.sourceforge.net/appcast.xml'
   homepage 'http://gawker.sourceforge.net/Gawker.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/ghostlab.rb
+++ b/Casks/ghostlab.rb
@@ -1,5 +1,6 @@
 class Ghostlab < Cask
   url 'http://awesome.vanamco.com/downloads/ghostlab/Ghostlab.dmg'
+  appcast 'http://awesome.vanamco.com/update/ghostlab-cast.xml'
   homepage 'http://vanamco.com/ghostlab/'
   version 'latest'
   sha256 :no_check

--- a/Casks/gitx-rowanj.rb
+++ b/Casks/gitx-rowanj.rb
@@ -1,5 +1,6 @@
 class GitxRowanj < Cask
   url 'http://builds.phere.net/GitX/development/GitX-dev.dmg'
+  appcast 'https://s3.amazonaws.com/builds.phere.net/GitX/development/GitX-dev.xml'
   homepage 'http://rowanj.github.io/gitx/'
   version 'latest'
   sha256 :no_check

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -1,5 +1,6 @@
 class Gitx < Cask
   url 'http://frim.frim.nl/GitXStable.app.zip'
+  appcast 'http://gitx.frim.nl/Downloads/appcast.xml'
   homepage 'http://gitx.frim.nl/'
   version 'latest'
   sha256 :no_check

--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,5 +1,6 @@
 class Grandtotal < Cask
   url 'http://www.mediaatelier.com/GrandTotal3/download.php'
+  appcast 'http://mediaatelier.com/GrandTotal3/feed.php'
   homepage 'http://www.mediaatelier.com/GrandTotal3/'
   version 'latest'
   sha256 :no_check

--- a/Casks/handbrakebatch.rb
+++ b/Casks/handbrakebatch.rb
@@ -1,5 +1,6 @@
 class Handbrakebatch < Cask
   url 'http://www.osomac.com/appcasts/handbrakebatch/HandBrakeBatch.zip'
+  appcast 'https://www.osomac.com/appcasts/handbrakebatch/HandBrakeBatch.xml'
   homepage 'http://www.osomac.com/apps/osx/handbrake-batch/'
   version 'latest'
   sha256 :no_check

--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -1,5 +1,6 @@
 class Harvest < Cask
   url 'http://www.getharvest.com/harvest/mac/Harvest.zip'
+  appcast 'https://www.getharvest.com/harvest/mac/appcast.xml'
   homepage 'http://www.getharvest.com/mac'
   version 'latest'
   sha256 :no_check

--- a/Casks/hiss.rb
+++ b/Casks/hiss.rb
@@ -1,5 +1,6 @@
 class Hiss < Cask
   url 'http://collect3.com.au/hiss/Hiss.zip'
+  appcast 'http://collect3.com.au/hiss/appcast.xml'
   homepage 'http://collect3.com.au/hiss/'
   version 'latest'
   sha256 :no_check

--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,5 +1,6 @@
 class HopperDisassembler < Cask
   url 'http://www.hopperapp.com/HopperWeb/download_last_v3.php'
+  appcast 'http://www.hopperapp.com/HopperWeb/appcast.php'
   homepage 'http://www.hopperapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,5 +1,6 @@
 class Hostbuddy < Cask
   url 'http://clickontyler.com/hostbuddy/download/'
+  appcast 'http://shine.clickontyler.com/appcast.php?id=22'
   homepage 'http://clickontyler.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/houdahgeo.rb
+++ b/Casks/houdahgeo.rb
@@ -1,5 +1,6 @@
 class Houdahgeo < Cask
   url 'http://houdah.com/houdahGeo/download_assets/HoudahGeo_latest.zip'
+  appcast 'http://www.houdah.com/houdahGeo/updates3/profileInfo.php'
   homepage 'http://houdah.com/houdahGeo/'
   version 'latest'
   sha256 :no_check

--- a/Casks/houdahspot.rb
+++ b/Casks/houdahspot.rb
@@ -1,5 +1,6 @@
 class Houdahspot < Cask
   url 'http://www.houdah.com/houdahSpot/download_assets/HoudahSpot_latest.zip'
+  appcast 'http://www.houdah.com/houdahSpot/updates/profileInfo3.php'
   homepage 'http://www.houdah.com/houdahSpot/'
   version 'latest'
   sha256 :no_check

--- a/Casks/hyperswitch.rb
+++ b/Casks/hyperswitch.rb
@@ -1,5 +1,6 @@
 class Hyperswitch < Cask
   url 'http://bahoom.com/hyperswitch/download'
+  appcast 'http://hyperswitch.bahoom.com/appcast.xml'
   homepage 'http://bahoom.com/hyperswitch'
   version 'latest'
   sha256 :no_check

--- a/Casks/ideskcal.rb
+++ b/Casks/ideskcal.rb
@@ -1,5 +1,6 @@
 class Ideskcal < Cask
   url 'http://www.hashbangind.com/files/iDeskCal-Latest.zip'
+  appcast 'https://hashbangind.com/appcasts/iDeskCal-profileInfo.php'
   homepage 'http://www.hashbangind.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/ifunbox.rb
+++ b/Casks/ifunbox.rb
@@ -1,5 +1,6 @@
 class Ifunbox < Cask
   url 'http://dl.i-funbox.com/mac/ifunboxmac.dmg'
+  appcast 'http://dl.i-funbox.com/updates/ifunbox.mac/update.xml'
   homepage 'http://www.i-funbox.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,5 +1,6 @@
 class Imageoptim < Cask
   url 'http://imageoptim.com/ImageOptim.tbz2'
+  appcast 'http://imageoptim.com/appcast.xml'
   homepage 'http://imageoptim.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/img2icns.rb
+++ b/Casks/img2icns.rb
@@ -1,5 +1,6 @@
 class Img2icns < Cask
   url 'http://static.shinyfrog.net/downloads/image2icon/Img2icns.zip'
+  appcast 'http://store.shinyfrog.net/appcast/img2icns.xml'
   homepage 'http://www.img2icnsapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/irip.rb
+++ b/Casks/irip.rb
@@ -1,5 +1,6 @@
 class Irip < Cask
   url 'http://files.thelittleappfactory.com/iRip2/iRip.zip'
+  appcast 'https://files.thelittleappfactory.com/iRip2/appcast.xml'
   version 'latest'
   homepage 'http://thelittleappfactory.com/irip/'
   sha256 :no_check

--- a/Casks/iupx.rb
+++ b/Casks/iupx.rb
@@ -1,5 +1,6 @@
 class Iupx < Cask
   url 'http://sourceforge.net/projects/iupx/files/latest/download'
+  appcast 'http://iupx.sourceforge.net/updates/appcast.xml'
   homepage 'http://iupx.sourceforge.net'
   version 'latest'
   sha256 :no_check

--- a/Casks/jing.rb
+++ b/Casks/jing.rb
@@ -1,5 +1,6 @@
 class Jing < Cask
   url 'http://download.techsmith.com/jing/mac/jing.dmg'
+  appcast 'http://www.techsmith.com/redirect.asp?product=jing&ver=2.0.0&lang=enu&target=SparkleAppcast'
   homepage 'http://www.techsmith.com/jing.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/kext-drop.rb
+++ b/Casks/kext-drop.rb
@@ -1,5 +1,6 @@
 class KextDrop < Cask
   url 'http://www.groths.org/kextdrop/KextDrop.dmg'
+  appcast 'http://groths.org/kextdrop/updates/update.xml'
   homepage 'http://www.groths.org/software/kextdrop/'
   version 'latest'
   sha256 :no_check

--- a/Casks/lastfm.rb
+++ b/Casks/lastfm.rb
@@ -1,5 +1,6 @@
 class Lastfm < Cask
   url 'http://www.lastfm.de/download/mac'
+  appcast 'http://cdn.last.fm/client/Mac/updates.xml'
   homepage 'http://www.lastfm.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,5 +1,6 @@
 class Loom < Cask
   url 'https://loom.com/download/loom-mac.dmg'
+  appcast 'http://www.loom.com/download/macupdate_1.1.xml'
   homepage 'http://loom.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/macpaw-gemini.rb
+++ b/Casks/macpaw-gemini.rb
@@ -1,5 +1,6 @@
 class MacpawGemini < Cask
   url 'http://dl.devmate.com/download/com.macpaw.site.Gemini/macpaw%20gemini.dmg'
+  appcast 'http://updates.devmate.com/com.macpaw.site.Gemini.xml'
   homepage 'http://macpaw.com/gemini'
   version 'latest'
   sha256 :no_check

--- a/Casks/marked.rb
+++ b/Casks/marked.rb
@@ -1,5 +1,6 @@
 class Marked < Cask
   url 'http://marked2app.com/download/Marked.zip'
+  appcast 'http://abyss.designheresy.com/marked/marked.xml'
   homepage 'http://marked2app.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/minco.rb
+++ b/Casks/minco.rb
@@ -1,5 +1,6 @@
 class Minco < Cask
   url 'http://www.celmaro.com/files/minco/Minco.zip'
+  appcast 'https://ssl.webpack.de/celmaro.com/updates/minco/minco.xml'
   homepage 'http://www.celmaro.com/minco/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mindnode-pro.rb
+++ b/Casks/mindnode-pro.rb
@@ -1,5 +1,6 @@
 class MindnodePro < Cask
   url 'http://www.mindnode.com/download/MindNodePro.zip'
+  appcast 'https://www.mindnode.com/softwareupdate/mindnodepro.xml'
   homepage 'https://mindnode.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/miro-video-converter.rb
+++ b/Casks/miro-video-converter.rb
@@ -1,5 +1,6 @@
 class MiroVideoConverter < Cask
   url 'http://ftp.osuosl.org/pub/pculture.org/mirovideoconverter/mac/Miro%20Video%20Converter.dmg'
+  appcast 'http://miro-updates.participatoryculture.org/mvc-appcast-osx.xml'
   homepage 'http://www.mirovideoconverter.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/moneymoney.rb
+++ b/Casks/moneymoney.rb
@@ -1,5 +1,6 @@
 class Moneymoney < Cask
   url 'http://moneymoney-app.com/download/MoneyMoney.zip'
+  appcast 'http://moneymoney-app.com/update/appcast.xml'
   homepage 'http://moneymoney-app.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mongohub.rb
+++ b/Casks/mongohub.rb
@@ -1,5 +1,6 @@
 class Mongohub < Cask
   url 'https://mongohub.s3.amazonaws.com/MongoHub.zip'
+  appcast 'https://mongohub.s3.amazonaws.com/mongohub_su_feed.xml'
   homepage 'https://github.com/fotonauts/MongoHub-Mac'
   version 'latest'
   sha256 :no_check

--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -1,5 +1,6 @@
 class Moom < Cask
   url 'http://manytricks.com/download/moom'
+  appcast 'http://manytricks.com/moom/appcast.xml'
   homepage 'http://manytricks.com/moom/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -1,5 +1,6 @@
 class Mou < Cask
   url 'http://mouapp.com/download/Mou.zip'
+  appcast 'http://mouapp.com/up/updates.xml'
   homepage 'http://mouapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mpfreaker.rb
+++ b/Casks/mpfreaker.rb
@@ -1,5 +1,6 @@
 class Mpfreaker < Cask
   url 'http://www.lairware.com/download/MPFreaker.dmg'
+  appcast 'http://lwupdate.dyndns.org/mpfreaker.xml'
   homepage 'http://www.lairware.com/mpfreaker/'
   version 'latest'
   sha256 :no_check

--- a/Casks/multifirefox.rb
+++ b/Casks/multifirefox.rb
@@ -1,5 +1,6 @@
 class Multifirefox < Cask
   url 'http://mff.s3.amazonaws.com/MFF2_latest.dmg'
+  appcast 'https://s3.amazonaws.com/mff_sparkle/MultiFirefoxAppcast2.xml'
   homepage 'http://davemartorana.com/multifirefox'
   version 'latest'
   sha256 :no_check

--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -1,5 +1,6 @@
 class NameMangler < Cask
   url 'http://manytricks.com/download/namemangler'
+  appcast 'http://manytricks.com/namemangler/appcast.xml'
   version 'latest'
   homepage 'http://manytricks.com/namemangler/'
   sha256 :no_check

--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,5 +1,6 @@
 class Neofinder < Cask
   url 'http://www.cdfinder.de/neofinder.zip'
+  appcast 'http://www.wfs-apps.de/updates/neofinder-appcast-64.xml'
   homepage 'http://www.cdfinder.de'
   version 'latest'
   sha256 :no_check

--- a/Casks/netshade.rb
+++ b/Casks/netshade.rb
@@ -1,5 +1,6 @@
 class Netshade < Cask
   url 'http://raynersoftware.com/downloads/NetShade.app.zip'
+  appcast 'https://secure.raynersw.com/appcast.php'
   homepage 'http://raynersoftware.com/netshade/'
   version 'latest'
   sha256 :no_check

--- a/Casks/netspot.rb
+++ b/Casks/netspot.rb
@@ -1,5 +1,6 @@
 class Netspot < Cask
   url 'http://www.netspotapp.com/download/NetSpot.dmg'
+  appcast 'http://www.netspotapp.com/updates/netspot2-appcast.xml'
   homepage 'http://www.netspotapp.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/notational-velocity.rb
+++ b/Casks/notational-velocity.rb
@@ -1,5 +1,6 @@
 class NotationalVelocity < Cask
   url 'http://notational.net/NotationalVelocity.zip'
+  appcast 'http://notational.net/nvupdates.xml'
   homepage 'http://notational.net'
   version 'latest'
   sha256 :no_check

--- a/Casks/nzbvortex.rb
+++ b/Casks/nzbvortex.rb
@@ -1,5 +1,6 @@
 class Nzbvortex < Cask
   url 'http://www.nzbvortex.com/downloads/NZBVortex.dmg'
+  appcast 'http://www.nzbvortex.com/update/appcast.xml'
   homepage 'http://www.nzbvortex.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/objektiv.rb
+++ b/Casks/objektiv.rb
@@ -1,5 +1,6 @@
 class Objektiv < Cask
   url 'http://nthloop.com/objektiv/objektiv-latest.zip'
+  appcast 'http://nthloop.com/objektiv/appcast.xml'
   homepage 'http://nthloop.github.io/Objektiv/'
   version 'latest'
   sha256 :no_check

--- a/Casks/optimal-layout.rb
+++ b/Casks/optimal-layout.rb
@@ -1,5 +1,6 @@
 class OptimalLayout < Cask
   url 'http://files.windowflow.com/OptimalLayout2.zip'
+  appcast 'http://most-advantageous.com/sparkle/OL-AppCast.cfm'
   homepage 'http://most-advantageous.com/optimal-layout/'
   version 'latest'
   sha256 :no_check

--- a/Casks/orbit.rb
+++ b/Casks/orbit.rb
@@ -1,5 +1,6 @@
 class Orbit < Cask
   url       'http://orbitapp.net/updates/Orbit.zip'
+  appcast 'http://orbitapp.net/updates/appcast.xml'
   homepage  'http://orbitapp.net'
   version   'latest'
   sha256 :no_check

--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -1,5 +1,6 @@
 class Pacifist < Cask
   url 'http://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg'
+  appcast 'http://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi'
   homepage 'http://www.charlessoft.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/peepopen.rb
+++ b/Casks/peepopen.rb
@@ -1,5 +1,6 @@
 class Peepopen < Cask
   url 'http://topfunky.github.io/PeepOpen/dl/PeepOpen.dmg'
+  appcast 'https://peepcode.com/system/apps/PeepOpen/appcast.xml'
   homepage 'http://topfunky.github.io/PeepOpen/'
   version 'latest'
   sha256 :no_check

--- a/Casks/picturesque.rb
+++ b/Casks/picturesque.rb
@@ -1,5 +1,6 @@
 class Picturesque < Cask
   url 'http://www.acqualia.com/files/download.php?product=picturesque'
+  appcast 'http://www.acqualia.com/picturesque/appcast/appcast3.xml'
   homepage 'http://www.acqualia.com/picturesque/'
   version 'latest'
   sha256 :no_check

--- a/Casks/pins.rb
+++ b/Casks/pins.rb
@@ -1,5 +1,6 @@
 class Pins < Cask
   url 'http://pinsapp.com/download/Pins.dmg'
+  appcast 'http://pinsapp.com/appcast.xml'
   homepage 'http://pinsapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/pixelpeeper.rb
+++ b/Casks/pixelpeeper.rb
@@ -1,5 +1,6 @@
 class Pixelpeeper < Cask
   url 'http://www.irradiatedsoftware.com/download/PixelPeeper.zip'
+  appcast 'http://www.irradiatedsoftware.com/updates/profiles/pixelpeeper.php'
   homepage 'http://www.irradiatedsoftware.com/labs'
   version 'latest'
   sha256 :no_check

--- a/Casks/pixelstick.rb
+++ b/Casks/pixelstick.rb
@@ -1,5 +1,6 @@
 class Pixelstick < Cask
   url 'http://plumamazing.com/bin/pixelstick/pixelstick.zip'
+  appcast 'https://plumamazing.com/appcastSSL.php?pid=100'
   homepage 'http://plumamazing.com/mac/pixelstick'
   version 'latest'
   sha256 :no_check

--- a/Casks/plug.rb
+++ b/Casks/plug.rb
@@ -1,5 +1,6 @@
 class Plug < Cask
   url 'http://www.plugformac.com/files/Plug-latest.dmg'
+  appcast 'http://www.plugformac.com/files/sparklecast.xml'
   homepage 'http://www.plugformac.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/porthole.rb
+++ b/Casks/porthole.rb
@@ -1,5 +1,6 @@
 class Porthole < Cask
   url 'http://getporthole.com/downloads/trial'
+  appcast 'http://update.getporthole.com/appcast.rss'
   homepage 'http://getporthole.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/power-manager-pro.rb
+++ b/Casks/power-manager-pro.rb
@@ -1,5 +1,6 @@
 class PowerManagerPro < Cask
   url 'https://www.dssw.co.uk/powermanager/dsswpowermanagerpro.dmg'
+  appcast 'http://version.dssw.co.uk/powermanager/professional'
   homepage 'https://www.dssw.co.uk/powermanager'
   version 'latest'
   sha256 :no_check

--- a/Casks/preference-manager.rb
+++ b/Casks/preference-manager.rb
@@ -1,5 +1,6 @@
 class PreferenceManager < Cask
   url 'http://download.digitalrebellion.com/Pref_Man.dmg'
+  appcast 'http://www.digitalrebellion.com/rss/appcasts/pref_man_appcast.xml'
   homepage 'http://www.digitalrebellion.com/prefman'
   version 'latest'
   sha256 :no_check

--- a/Casks/prizmo.rb
+++ b/Casks/prizmo.rb
@@ -1,5 +1,6 @@
 class Prizmo < Cask
   url 'http://www.creaceed.com/downloads/prizmo2.zip'
+  appcast 'http://www.creaceed.com/appcasts/prizmo2.xml'
   homepage 'http://www.creaceed.com/prizmo'
   version 'latest'
   sha256 :no_check

--- a/Casks/propane.rb
+++ b/Casks/propane.rb
@@ -1,5 +1,6 @@
 class Propane < Cask
   url 'http://propaneapp.com/appcast/Propane.zip'
+  appcast 'http://propaneapp.com/appcast/release.xml'
   homepage 'http://propaneapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,5 +1,6 @@
 class Proxpn < Cask
   url 'http://proxpn.com/mac.dmg'
+  appcast 'http://www.proxpn.org/updater/appcast.rss'
   homepage 'http://proxpn.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/puush.rb
+++ b/Casks/puush.rb
@@ -1,5 +1,6 @@
 class Puush < Cask
   url 'http://puush.me/dl/puush.zip'
+  appcast 'https://puush.me/dl/puush.xml?hax=jax'
   homepage 'http://puush.me/'
   version 'latest'
   sha256 :no_check

--- a/Casks/querious.rb
+++ b/Casks/querious.rb
@@ -1,5 +1,6 @@
 class Querious < Cask
   url 'http://www.araelium.com/querious/downloads/Querious.dmg'
+  appcast 'https://store.araelium.com/updates/querious'
   homepage 'http://www.araelium.com/querious/'
   version 'latest'
   sha256 :no_check

--- a/Casks/quickcast.rb
+++ b/Casks/quickcast.rb
@@ -1,5 +1,6 @@
 class Quickcast < Cask
   url 'https://s3.amazonaws.com/quickcast-app/mac/QuickCast.dmg'
+  appcast 'https://s3.amazonaws.com/quickcast-app/mac/appcast.xml'
   homepage 'http://quickcast.io/'
   version 'latest'
   sha256 :no_check

--- a/Casks/rdio.rb
+++ b/Casks/rdio.rb
@@ -1,5 +1,6 @@
 class Rdio < Cask
   url 'http://www.rdio.com/media/static/desktop/mac/Rdio.dmg'
+  appcast 'http://www.rdio.com/media/static/desktop/mac/appcast.xml'
   homepage 'http://www.rdio.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/recordit.rb
+++ b/Casks/recordit.rb
@@ -1,5 +1,6 @@
 class Recordit < Cask
   url 'https://rink.hockeyapp.net/api/2/apps/5fcda0b48f1dcf0c938b289b9ab57790/app_versions/7?format=zip'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/5fcda0b48f1dcf0c938b289b9ab57790'
   homepage 'http://recordit.co/'
   version 'latest'
   sha256 :no_check

--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -1,5 +1,6 @@
 class Reflector < Cask
   url 'http://download.airsquirrels.com/Reflector/Mac/Reflector.dmg'
+  appcast 'http://reflectorapp.com/updates/reflector.xml'
   homepage 'http://www.airsquirrels.com/reflector/'
   version 'latest'
   sha256 :no_check

--- a/Casks/reveal.rb
+++ b/Casks/reveal.rb
@@ -1,5 +1,6 @@
 class Reveal < Cask
   url 'http://download.revealapp.com/Reveal.app.zip'
+  appcast 'http://download.revealapp.com/reveal-release.xml'
   homepage 'http://revealapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/ringtones.rb
+++ b/Casks/ringtones.rb
@@ -1,5 +1,6 @@
 class Ringtones < Cask
   url 'http://files.thelittleappfactory.com/ringtones/Ringtones.zip'
+  appcast 'https://files.thelittleappfactory.com/ringtones/appcast.xml'
   version 'latest'
   homepage 'http://thelittleappfactory.com/ringtones/'
   sha256 :no_check

--- a/Casks/ripit.rb
+++ b/Casks/ripit.rb
@@ -1,5 +1,6 @@
 class Ripit < Cask
   url 'http://files.thelittleappfactory.com/ripit/RipIt.zip'
+  appcast 'https://files.thelittleappfactory.com/ripit/appcast.xml'
   homepage 'http://thelittleappfactory.com/ripit/'
   version 'latest'
   sha256 :no_check

--- a/Casks/runtastic-connect.rb
+++ b/Casks/runtastic-connect.rb
@@ -1,5 +1,6 @@
 class RuntasticConnect < Cask
   url 'http://download.runtastic.com/connect/mac/runtasticConnect.dmg'
+  appcast 'http://download.runtastic.com/connect/mac/appcast.xml'
   homepage 'https://www.runtastic.com/connect'
   version 'latest'
   sha256 :no_check

--- a/Casks/screenhero.rb
+++ b/Casks/screenhero.rb
@@ -1,5 +1,6 @@
 class Screenhero < Cask
   url 'http://dl.screenhero.com/update/screenhero/Screenhero.dmg'
+  appcast 'http://dl.screenhero.com/update/screenhero/sparkle.xml'
   homepage 'http://screenhero.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,5 +1,6 @@
 class Scrivener < Cask
   url 'http://scrivener.s3.amazonaws.com/Scrivener.dmg'
+  appcast 'http://www.literatureandlatte.com/downloads/scrivener-2.xml'
   homepage 'http://literatureandlatte.com/scrivener.php'
   version 'latest'
   sha256 :no_check

--- a/Casks/sidekick.rb
+++ b/Casks/sidekick.rb
@@ -1,5 +1,6 @@
 class Sidekick < Cask
   url 'http://oomphalot.com/sidekick/release/Sidekick.zip'
+  appcast 'http://updates.oomphalot.com/?app=Sidekick'
   homepage 'http://oomphalot.com/sidekick/'
   version 'latest'
   sha256 :no_check

--- a/Casks/sidplay.rb
+++ b/Casks/sidplay.rb
@@ -1,5 +1,6 @@
 class Sidplay < Cask
   url 'http://www.twinbirds.com/sidplay/SIDPLAY4.zip'
+  appcast 'http://www.sidmusic.org/sidplay/mac/sidplay_appcast.xml'
   homepage 'http://www.sidmusic.org/sidplay/mac/'
   version 'latest'
   sha256 :no_check

--- a/Casks/simulator-folders.rb
+++ b/Casks/simulator-folders.rb
@@ -1,5 +1,6 @@
 class SimulatorFolders < Cask
   url 'http://www.gettracktime.com/dbrd/download.php?id=8'
+  appcast 'http://www.gettracktime.com/dbrd/appcast.php?id=8'
   homepage 'http://nimbleworks.co.uk/blog/simulator-folders/'
   version 'latest'
   sha256 :no_check

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -1,5 +1,6 @@
 class Sizeup < Cask
   url 'http://www.irradiatedsoftware.com/download/SizeUp.zip'
+  appcast 'http://www.irradiatedsoftware.com/updates/profiles/sizeup.php'
   homepage 'http://www.irradiatedsoftware.com/sizeup/index.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -1,5 +1,6 @@
 class Sketch < Cask
   url 'http://bohemiancoding.com/static/download/sketch.zip'
+  appcast 'http://www.bohemiancoding.com/sketch/appcast.xml'
   homepage 'http://www.bohemiancoding.com/sketch/'
   version 'latest'
   sha256 :no_check

--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -1,5 +1,6 @@
 class Slack < Cask
   url 'https://rink.hockeyapp.net/api/2/apps/89dc0a9e3d01fb65e383b13c9ce0d3ac?format=zip'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/89dc0a9e3d01fb65e383b13c9ce0d3ac'
   homepage 'http://slack.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/slate.rb
+++ b/Casks/slate.rb
@@ -1,5 +1,6 @@
 class Slate < Cask
   url 'http://slate.ninjamonkeysoftware.com/Slate.dmg'
+  appcast 'https://www.ninjamonkeysoftware.com/slate/appcast.xml'
   homepage 'https://github.com/jigish/slate'
   version 'latest'
   sha256 :no_check

--- a/Casks/sleep-monitor.rb
+++ b/Casks/sleep-monitor.rb
@@ -1,5 +1,6 @@
 class SleepMonitor < Cask
   url 'https://www.dssw.co.uk/sleepmonitor/dsswsleepmonitor.dmg'
+  appcast 'http://version.dssw.co.uk/sleepmonitor/standard'
   homepage 'https://www.dssw.co.uk/sleepmonitor'
   version 'latest'
   sha256 :no_check

--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -1,5 +1,6 @@
 class Slicy < Cask
   url 'http://macrabbit.com/slicy/get/'
+  appcast 'http://update.macrabbit.com/slicy/1.1.3.xml'
   homepage 'http://macrabbit.com/slicy/'
   version 'latest'
   sha256 :no_check

--- a/Casks/smaller.rb
+++ b/Casks/smaller.rb
@@ -1,5 +1,6 @@
 class Smaller < Cask
   url 'http://smallerapp.com/download/Smaller.zip'
+  appcast 'http://smallerapp.com/up/updates.xml'
   homepage 'http://smallerapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -1,5 +1,6 @@
 class Snagit < Cask
   url 'http://download.techsmith.com/snagitmac/enu/Snagit.dmg'
+  appcast 'http://techsmithredirect.appspot.com/'
   homepage 'http://www.techsmith.com/snagit.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,5 +1,6 @@
 class Soulver < Cask
   url 'http://www.acqualia.com/files/download.php?product=soulver'
+  appcast 'http://www.acqualia.com/soulver/appcast/soulver2.xml'
   homepage 'http://www.acqualia.com/soulver/'
   version 'latest'
   sha256 :no_check

--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -1,5 +1,6 @@
 class Soundcleod < Cask
   url 'https://github.com/salomvary/soundcleod/raw/master/dist/SoundCleod.dmg'
+  appcast 'https://raw.github.com/salomvary/soundcleod/master/appcast.xml'
   homepage 'http://salomvary.github.io/soundcleod/'
   version 'latest'
   sha256 :no_check

--- a/Casks/soundnote.rb
+++ b/Casks/soundnote.rb
@@ -1,5 +1,6 @@
 class Soundnote < Cask
   url 'http://download.mrgeckosmedia.com/SoundNote.zip'
+  appcast 'http://mrgeckosmedia.com/applications/appcast/SoundNote'
   homepage 'https://mrgeckosmedia.com/applications/info/SoundNote'
   version 'latest'
   sha256 :no_check

--- a/Casks/spacemonkey.rb
+++ b/Casks/spacemonkey.rb
@@ -1,5 +1,6 @@
 class Spacemonkey < Cask
   url 'http://downloads.spacemonkey.com/client/mac/latest'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c'
   homepage 'https://www.spacemonkey.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/spark-inspector.rb
+++ b/Casks/spark-inspector.rb
@@ -1,5 +1,6 @@
 class SparkInspector < Cask
   url 'http://sparkinspector.com/downloads/sparkinspector.dmg'
+  appcast 'http://sparkinspector.com/sparkle/feed.xml'
   homepage 'http://sparkinspector.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/sparrow.rb
+++ b/Casks/sparrow.rb
@@ -1,5 +1,6 @@
 class Sparrow < Cask
   url 'http://download.sparrowmailapp.com/appcast/Sparrow-latest.dmg'
+  appcast 'http://download.sparrowmailapp.com/appcast/appcast.xml'
   homepage 'http://www.sparrowmailapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/spirited-away.rb
+++ b/Casks/spirited-away.rb
@@ -1,5 +1,6 @@
 class SpiritedAway < Cask
   url 'https://dl.dropbox.com/u/1025/spiritedaway/Spirited%20Away.zip'
+  appcast 'http://files.getdropbox.com/u/1025/spiritedaway/spiritedaway.xml'
   homepage 'http://drikin.com/2010/11/spirited-away.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/spotdox.rb
+++ b/Casks/spotdox.rb
@@ -1,5 +1,6 @@
 class Spotdox < Cask
   url 'http://spotdox.herokuapp.com/downloads/Spotdox.zip'
+  appcast 'https://spotdox.herokuapp.com/downloads/appcast.xml'
   homepage 'http://spotdox.com/get-started/'
   version 'latest'
   sha256 :no_check

--- a/Casks/spotifree.rb
+++ b/Casks/spotifree.rb
@@ -1,5 +1,6 @@
 class Spotifree < Cask
   url 'http://spotifree.gordinskiy.com/files/Spotifree.dmg'
+  appcast 'http://spotifree.gordinskiy.com/appcast.xml'
   homepage 'http://spotifree.gordinskiy.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/spotify-menubar.rb
+++ b/Casks/spotify-menubar.rb
@@ -1,5 +1,6 @@
 class SpotifyMenubar < Cask
   url 'http://lifeupnorth.co.uk/files/Spotify_Menubar.zip'
+  appcast 'http://lifeupnorth.co.uk/lun/sparkle/sm.xml'
   homepage 'http://lifeupnorth.co.uk/Spotify-Menubar/'
   version 'latest'
   sha256 :no_check

--- a/Casks/swingfish.rb
+++ b/Casks/swingfish.rb
@@ -1,5 +1,6 @@
 class Swingfish < Cask
   url 'http://cloakedcode.com/apps/swingfish/swingfish_latest.zip'
+  appcast 'http://cloakedcode.com/apps/swingfish/profileInfo.php'
   homepage 'http://cloakedcode.com/swingfish.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,5 +1,6 @@
 class Swinsian < Cask
   url 'http://swinsian.com/sparkle/Swinsian.zip'
+  appcast 'http://www.swinsian.com/sparkle/sparklecast.xml'
   homepage 'http://swinsian.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/tagalicious.rb
+++ b/Casks/tagalicious.rb
@@ -1,5 +1,6 @@
 class Tagalicious < Cask
   url 'http://files.thelittleappfactory.com/tagalicious/Tagalicious.zip'
+  appcast 'https://files.thelittleappfactory.com/tagalicious/appcast.xml'
   homepage 'http://thelittleappfactory.com/tagalicious/'
   version 'latest'
   sha256 :no_check

--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,5 +1,6 @@
 class Taskpaper < Cask
   url 'http://taskpaper.s3.amazonaws.com/TaskPaper.dmg'
+  appcast 'http://www.hogbaysoftware.com/products/taskpaper/releases.rss'
   homepage 'http://www.hogbaysoftware.com/products/taskpaper'
   version 'latest'
   sha256 :no_check

--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,5 +1,6 @@
 class TheHitList < Cask
   url 'http://www.potionfactory.com/files/thehitlist/TheHitList.zip'
+  appcast 'http://www.potionfactory.com/appcast/thehitlist.php'
   homepage 'http://www.potionfactory.com/thehitlist'
   version 'latest'
   sha256 :no_check

--- a/Casks/things.rb
+++ b/Casks/things.rb
@@ -1,5 +1,6 @@
 class Things < Cask
   url 'http://culturedcode.com/things/download/'
+  appcast 'http://downloads.culturedcode.com/things/download/Things_Updates.php'
   homepage 'http://culturedcode.com/things/'
   version 'latest'
   sha256 :no_check

--- a/Casks/toau.rb
+++ b/Casks/toau.rb
@@ -1,5 +1,6 @@
 class Toau < Cask
   url 'http://toauapp.com/download/Toau.zip'
+  appcast 'http://toauapp.com/up/updates.xml'
   homepage 'http://toauapp.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/todos.rb
+++ b/Casks/todos.rb
@@ -1,5 +1,6 @@
 class Todos < Cask
   url 'http://dbachrach.com/opensoft/downloads/apps/Todos.dmg'
+  appcast 'http://www.dbachrach.com/opensoft/appcasts/Todos.xml'
   homepage 'http://dbachrach.com/opensoft/index.php?page=Todos'
   version 'latest'
   sha256 :no_check

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,5 +1,6 @@
 class Tower < Cask
   url 'http://www.git-tower.com/download'
+  appcast 'https://macapps.fournova.com/tower1-1060/updates.xml'
   homepage 'http://www.git-tower.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,5 +1,6 @@
 class Trailrunner < Cask
   url 'http://downloads.trailrunnerx.com/TrailRunner.app.zip'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610'
   homepage 'http://trailrunnerx.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -1,5 +1,6 @@
 class TrimEnabler < Cask
   url 'https://s3.amazonaws.com/groths/TrimEnabler.dmg'
+  appcast 'http://groths.org/trimenabler/updates/update.xml'
   homepage 'http://www.groths.org/software/trimenabler/'
   version 'latest'
   sha256 :no_check

--- a/Casks/tubbler.rb
+++ b/Casks/tubbler.rb
@@ -1,5 +1,6 @@
 class Tubbler < Cask
   url 'http://www.celmaro.com/files/tubbler/Tubbler.zip'
+  appcast 'https://ssl.webpack.de/celmaro.com/updates/tubbler/tubbler.xml'
   homepage 'http://www.celmaro.com/tubbler'
   version 'latest'
   sha256 :no_check

--- a/Casks/utorrent.rb
+++ b/Casks/utorrent.rb
@@ -1,5 +1,6 @@
 class Utorrent < Cask
   url 'http://download-new.utorrent.com/endpoint/utmac/os/osx/track/stable/'
+  appcast 'http://update.utorrent.com/checkupdate.php'
   homepage 'http://www.utorrent.com/'
   version 'latest'
   caskroom_only true

--- a/Casks/versions.rb
+++ b/Casks/versions.rb
@@ -1,5 +1,6 @@
 class Versions < Cask
   url 'http://versionsapp.com/redirect/versionslatest'
+  appcast 'https://updates.blackpixel.com/updates?app=vs'
   homepage 'http://versionsapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/vinoteka.rb
+++ b/Casks/vinoteka.rb
@@ -1,5 +1,6 @@
 class Vinoteka < Cask
   url 'http://download.vinotekasoft.com/Vinoteka.zip'
+  appcast 'http://download.vinotekasoft.com/vinoteka_update.xml'
   homepage 'http://www.vinotekasoft.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,5 +1,6 @@
 class Virtualhostx < Cask
   url 'http://clickontyler.com/virtualhostx/download/'
+  appcast 'http://shine.clickontyler.com/appcast.php?id=23'
   homepage 'http://clickontyler.com/virtualhostx/'
   version 'latest'
   sha256 :no_check

--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,5 +1,6 @@
 class Viscosity < Cask
   url 'http://www.sparklabs.com/downloads/Viscosity.dmg'
+  appcast 'http://www.viscosityvpn.com/update/viscosity.xml'
   homepage 'http://www.sparklabs.com/viscosity/'
   version 'latest'
   sha256 :no_check

--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -1,5 +1,6 @@
 class VitaminR < Cask
   url 'http://www.publicspace.net/download/Vitamin.dmg'
+  appcast 'http://www.publicspace.net/app/vitamin2.xml'
   homepage 'http://www.publicspace.net/Vitamin-R/'
   version 'latest'
   sha256 :no_check

--- a/Casks/vlc-remote.rb
+++ b/Casks/vlc-remote.rb
@@ -1,5 +1,6 @@
 class VlcRemote < Cask
   url 'http://hobbyistsoftware.com/Downloads/VLCRemote/latest-mac.php?cdn'
+  appcast 'http://hobbyistsoftware.com/Downloads/VLCRemote/vlcSetupHelperVersions.xml'
   homepage 'http://hobbyistsoftware.com/vlc'
   version 'latest'
   sha256 :no_check

--- a/Casks/vlcstreamer.rb
+++ b/Casks/vlcstreamer.rb
@@ -1,5 +1,6 @@
 class Vlcstreamer < Cask
   url 'http://hobbyistsoftware.com/Downloads/VLCStreamer/latest-mac.php?cdn'
+  appcast 'http://hobbyistsoftware.com/Downloads/VLCStreamer/vlcStreamerVersions.xml'
   homepage 'http://hobbyistsoftware.com/vlcstreamer'
   version 'latest'
   sha256 :no_check

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -1,5 +1,6 @@
 class Voicemac < Cask
   url 'http://download.mrgeckosmedia.com/VoiceMac.zip'
+  appcast 'https://mrgeckosmedia.com/applications/appcast/VoiceMac'
   homepage 'https://mrgeckosmedia.com/applications/info/VoiceMac'
   version 'latest'
   sha256 :no_check

--- a/Casks/wasted.rb
+++ b/Casks/wasted.rb
@@ -1,5 +1,6 @@
 class Wasted < Cask
   url 'http://wasted.werk01.de/Wasted.zip'
+  appcast 'http://wasted.werk01.de/appcast.xml'
   homepage 'http://wasted.werk01.de'
   version 'latest'
   sha256 :no_check

--- a/Casks/wedge.rb
+++ b/Casks/wedge.rb
@@ -1,5 +1,6 @@
 class Wedge < Cask
   url 'http://wedge.natestedman.com/release/Wedge.app.zip'
+  appcast 'http://wedge.natestedman.com/appcast.xml'
   homepage 'http://wedge.natestedman.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/yorufukurou.rb
+++ b/Casks/yorufukurou.rb
@@ -1,5 +1,6 @@
 class Yorufukurou < Cask
   url 'http://aki-null.net/yf/YoruFukurou_SL.zip'
+  appcast 'http://sites.google.com/site/yorufukurou/distribution/appcast.xml'
   homepage 'https://sites.google.com/site/yorufukurou/home-en'
   version 'latest'
   sha256 :no_check

--- a/Casks/youdao.rb
+++ b/Casks/youdao.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 class Youdao < Cask
   url 'http://cidian.youdao.com/download/YoudaoDictForMac.dmg'
+  appcast 'http://cidian.youdao.com/apps/macupdate/update.xml'
   homepage 'http://cidian.youdao.com/mac/'
   version 'latest'
   sha256 :no_check

--- a/Casks/youview.rb
+++ b/Casks/youview.rb
@@ -1,5 +1,6 @@
 class Youview < Cask
   url 'http://download.mrgeckosmedia.com/YouView.zip'
+  appcast 'http://mrgeckosmedia.com/applications/appcast/YouView'
   homepage 'https://mrgeckosmedia.com/applications/info/YouView'
   version 'latest'
   sha256 :no_check

--- a/Casks/zepheer.rb
+++ b/Casks/zepheer.rb
@@ -1,5 +1,6 @@
 class Zepheer < Cask
   url 'http://candysquare.com/files/zepheer/Zepheer.dmg'
+  appcast 'http://candysquare.com/files/zepheer/updates/appcast.xml'
   homepage 'http://candysquare.com/products/zepheer/'
   version 'latest'
   sha256 :no_check

--- a/Casks/zephyros.rb
+++ b/Casks/zephyros.rb
@@ -1,5 +1,6 @@
 class Zephyros < Cask
   url 'https://raw.github.com/sdegutis/zephyros/master/Builds/Zephyros-LATEST.app.tar.gz'
+  appcast 'https://raw.github.com/sdegutis/zephyros/master/appcast.xml'
   homepage 'https://github.com/sdegutis/zephyros'
   version 'latest'
   sha256 :no_check


### PR DESCRIPTION
The `appcast` stanza has been supported by the DSL for some time, though
we aren't doing anything with it (yet).

For Casks using the `latest` schema, the content available at the appcast URL
contains a version-specific URL which may be a preferable alternative.

Appcasts can be used for automated detection of available updates. I have a private
snapshot of appcast content from 3 March which I intend to compare against recent
fetches for these Casks.

The appcast URLs in this PR are not a complete set.  They were extracted only for
the following subset
- Cask uses the `link` artifact to install an App bundle
- Casks uses the `version 'latest'` schema
- Application uses Sparkle for appcasting, in the default form (`SUFeedURL` key readable from `Info.plist`)

@alebcay, I thought you might be interested in incorporating appcast changes into
your nightly Cask check.

Edit: two `appcast` stanzas are commented out due to retrieval issues
