### PR TITLE
revert 4ee9df6, restoring Intel Chainsaw.app

### DIFF
--- a/Casks/chainsaw.rb
+++ b/Casks/chainsaw.rb
@@ -1,7 +1,7 @@
 class Chainsaw < Cask
-  url 'http://logging.apache.org/chainsaw/webstart/chainsaw.dmg'
+  url 'http://people.apache.org/~sdeboy/apache-chainsaw-2.1.0-SNAPSHOT.dmg'
   homepage 'http://logging.apache.org/chainsaw/'
-  version 'latest'
-  sha256 :no_check
+  version '2.1.0'
+  sha256 '06171e5bc285224611c4a1f22922ab781276ce387f8f290948617de7bbfc6f6d'
   link 'Chainsaw.app'
 end


### PR DESCRIPTION
and update checksum

@vitorgalvao the so-called "latest" chainsaw build is old  — PPC only
