### PR TITLE
Add Minbox version 2.0.9

### DIFF
--- a/Casks/minbox.rb
+++ b/Casks/minbox.rb
@@ -1,0 +1,7 @@
+class Minbox < Cask
+  url 'https://minbox-public.s3.amazonaws.com/osx/Minbox.zip'
+  homepage 'https://minbox.com'
+  version 'latest'
+  sha256 :no_check
+  link 'Minbox.app'
+end


### PR DESCRIPTION
The better way to share your work. The new standard in file sharing. [https://minbox.com](https://minbox.com)

**Question:**
Minbox provides a download link on their website [https://minbox.com/download](https://minbox.com/download). When this link is added as URL and when I run `brew cask install minbox` it returns following:

``` bash
$ Error: Uh oh, could not identify primary container for '/Library/Caches/Homebrew/minbox-latest'
```

Is there a option a forget to add or isn't it possible to add referral URLs to `url`?
