### PR TITLE
Changed Mailplane 3.app to latest

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,7 +1,7 @@
 class Mailplane < Cask
-  url 'http://dist.mailplaneapp.com/builds/Mailplane_3_878.tbz'
-  homepage 'http://mailplaneapp.com/'
-  version '3.1.1 (878)'
-  sha256 'a9729a4f43752a39fc57235b2d2d6cd1f5167a12cd1624b7b3b1774d27ca362e'
+  url 'http://update.mailplaneapp.com/mailplane_3.php'
+  homepage 'http://mailplaneapp.com'
+  version 'latest'
+  sha256 :no_check
   link 'Mailplane 3.app'
 end


### PR DESCRIPTION
Use 'latest' for Mailplane 3.app because we don't support versioned downloads.
