### PR TITLE
change vmware-fusion's permissions before uninstall, so it can proceed

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -4,4 +4,8 @@ class VmwareFusion < Cask
   version '6.0.3-1747349'
   sha256 'd51daed60baef6252136d9024ac6dd59df3b402bc8a9aa7cd1d663d61e6dc6d8'
   link 'VMware Fusion.app'
+  before_uninstall do
+    system '/usr/bin/sudo', '-E', '--',
+           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "#{destination_path}/VMware Fusion.app"
+  end
 end


### PR DESCRIPTION
Taking a page from [mamp](https://github.com/caskroom/homebrew-cask/blob/7c4d6509906594b087ee3c177775bbc5e1dae69b/Casks/mamp.rb).

Fixes #1373.
