### PR TITLE
Change the extension from .mpkg to .pkg

### DIFF
--- a/Casks/asepsis.rb
+++ b/Casks/asepsis.rb
@@ -3,6 +3,6 @@ class Asepsis < Cask
   homepage 'http://asepsis.binaryage.com/'
   version '1.4.1'
   sha256 '1e757a51bfeb1cf57e179761d7f931a1bf3e0216dd9d66fb56158273c7acdf9e'
-  install 'Asepsis.mpkg'
+  install 'Asepsis.pkg'
   uninstall :pkgutil => 'com.binaryage.pkg.asepsis'
 end


### PR DESCRIPTION
The new version as an .pkg extension, and not a .mpkg. Thus the install fail. Changing this make the installation pass.
