### PR TITLE
rescue download failure; don't show traceback

### DIFF
--- a/lib/cask/download.rb
+++ b/lib/cask/download.rb
@@ -16,7 +16,11 @@ class Cask::Download
       downloader = Cask::CurlDownloadStrategy.new(cask)
     end
     downloader.clear_cache if force
-    downloaded_path = downloader.fetch
+    begin
+      downloaded_path = downloader.fetch
+    rescue StandardError
+      raise CaskError.new("Download failed on Cask '#{@cask}'")
+    end
     begin
       # this symlink helps track which downloads are ours
       File.symlink downloaded_path,


### PR DESCRIPTION
instead, give a more specific error message.  Closes #4556.
