### PR TITLE
Upgrade IntelliJ and IntelliJ CE to 13.1.3.

### DIFF
--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -1,8 +1,8 @@
 class IntellijIdeaCe < Cask
-  url 'http://download-cf.jetbrains.com/idea/ideaIC-13.1.2.dmg'
+  url 'http://download-cf.jetbrains.com/idea/ideaIC-13.1.3.dmg'
   homepage 'https://www.jetbrains.com/idea/index.html'
-  version '13.1.2'
-  sha256 '99422ba5faacd4d6aabf029b83cf1f9dd22fe445116b984df25d49ae8609e46e'
+  version '13.1.3'
+  sha256 '4b0e3cb665aa2e3523d3c90b0075292f5ba3eaaff2bfc4872e4438193e561067'
   link 'IntelliJ IDEA 13 CE.app'
   caveats do
     <<-EOS.undent

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -1,8 +1,8 @@
 class IntellijIdea < Cask
-  url 'http://download-cf.jetbrains.com/idea/ideaIU-13.1.2.dmg'
+  url 'http://download-cf.jetbrains.com/idea/ideaIU-13.1.3.dmg'
   homepage 'https://www.jetbrains.com/idea/index.html'
-  version '13.1.2'
-  sha256 '7968149499106fb078d89fe41135bd1611cfcd124fc2992f55e1090da8f71365'
+  version '13.1.3'
+  sha256 'ae5239e0a5670dec88c39a5157103084d0ddd2c0b8d732d6af07764f0b98b624'
   link 'IntelliJ IDEA 13.app'
   caveats do
     <<-EOS.undent


### PR DESCRIPTION
Previous version was `13.1.2`, new version came out yesterday.

https://www.jetbrains.com/idea/download/
http://blog.jetbrains.com/idea/2014/05/intellij-idea-13-1-3-update-is-available/
http://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+13.1.3+Release+Notes

> Version: 13.1.3 Build: 135.909 Released: 26 May, 2014
