### PR TITLE
Fix Java 8 missing Home symlink

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -20,6 +20,8 @@ class Java < Cask
       '/bin/rm', '-rf', '--', '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'
     system '/usr/bin/sudo', '-E', '--',
       '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'
+	system '/usr/bin/sudo', '-E', '--',
+	  '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home", '/Library/Java/Home'
   end
   uninstall :pkgutil => [
                          'com.oracle.jdk8u5',         # manually update this for each version
@@ -38,6 +40,7 @@ class Java < Cask
                        "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents",
                        '/Library/PreferencePanes/JavaControlPanel.prefPane',
                        '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK',
+                       '/Library/Java/Home',
                        '/usr/lib/java/libjdns_sd.jnilib',
                       ]
   caveats <<-EOS.undent


### PR DESCRIPTION
As originally included in #4524. Some app launchers look for the link in `/Library`, seems Java 7's installer used to create it.
