### PR TITLE
wireshark: update download URL

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,5 +1,5 @@
 class Wireshark < Cask
-  url 'https://2.na.dl.wireshark.org/osx/Wireshark%201.10.7%20Intel%2064.dmg'
+  url 'http://wiresharkdownloads.riverbed.com/wireshark/osx/Wireshark%201.10.7%20Intel%2064.dmg'
   homepage 'http://www.wireshark.org'
   version '1.10.7'
   sha256 'df89621fdca8bd09aa633b2af6fa3e193872797a1cdf3feaf86f2183d68e2a5a'


### PR DESCRIPTION
The previous URL is no longer valid.
