### PR TITLE
Fix MacPass cask: update .app path for v0.4.1-alpha

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -3,5 +3,5 @@ class Macpass < Cask
   homepage 'http://mstarke.github.io/MacPass/'
   version '0.4.1-alpha'
   sha256 '1beaec4f0f8e33e5bf2575a4706befe6ef513f46ddc49f7662b6af3721680039'
-  link 'MacPass/MacPass.app'
+  link 'MacPass.app'
 end


### PR DESCRIPTION
In the previous version of MacPass ([0.3.8-alpha](https://github.com/mstarke/MacPass/releases/download/0.3.8-alpha/MacPass-0.3.8-alpha.zip)) the .app was inside a directory within the zip. In [0.4.1-alpha](https://github.com/mstarke/MacPass/releases/download/0.4.1-alpha/MacPass-0.4.1-alpha.zip), it is not, so this cask fails to install.
