### PR TITLE
Added WabbitEmu

### DIFF
--- a/Casks/wabbitemu.rb
+++ b/Casks/wabbitemu.rb
@@ -1,0 +1,7 @@
+class Wabbitemu < Cask
+  url 'https://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=wabbit&DownloadId=187234&FileTime=130242671530600000&Build=20907'
+  homepage 'http://wabbit.codeplex.com'
+  version '2.1'
+  sha256 '23fc164767da10389eec858d022967fb58fdca1debaa5b9e022f2e9280a4f4e8'
+  link 'WabbitEmu.app'
+end


### PR DESCRIPTION
Wabbitemu - An accurate emulator/debugger for the TI-81, TI-82, TI-83, TI-83+(SE), TI-84+(SE), TI-84+CSE, TI-85, and TI-86. ROM files obviously not included.

Note: The weird download link is where the actual file is hosted on Microsoft's CodePlex code hosting system. I tried using the direct link of the button (which works for most software), but it didn't work this time, so I had to dig around a bit.
