### PR TITLE
New cask file for the panini panorama viewer

### DIFF
--- a/Casks/panini.rb
+++ b/Casks/panini.rb
@@ -1,0 +1,7 @@
+class Panini < Cask
+  url 'http://downloads.sourceforge.net/sourceforge/pvqt/Panini-0.71.104B-mac.dmg'
+  homepage 'http://sourceforge.net/projects/pvqt/'
+  version '0.71.104'
+  sha256 '2a2836b0035bc1be8ada1e07138c72276a89624321dbfaa475fc4cd88fffe544'
+  link 'Panini.app'
+end


### PR DESCRIPTION
Adds a new cask file for the panini panorama viewer. Unfortunately, the
latest download link does not seem to provide the mac DMG file, so a
specific version has to be used.
