### PR TITLE
Add gpsbabel cask file

### DIFF
--- a/Casks/gpsbabel.rb
+++ b/Casks/gpsbabel.rb
@@ -1,0 +1,7 @@
+class Gpsbabel < Cask
+  url 'http://download2us.softpedia.com/dl/feef8699d84c0a913206f2edfb10d8aa/538b3b9e/400008828/mac/Utilities/GPSBabel-1.5.1.dmg'
+  homepage 'http://www.gpsbabel.org'
+  version '1.5.1'
+  sha256 '042d50ee75a95ed41b5d2c3957cf7a83da21ab057a7754bf1bde720615f1473f'
+  link 'GPSBabelFE.app'
+end


### PR DESCRIPTION
Adds a cask file for the binary distribution of gpsbabel including the
GUI. Unfortunately, the download URL from the original homepage is
terribly hidden behind a form that needs POST submitting data.
Therefore, I had to use a different download site. I hope the URL is
persistent.
