### PR TITLE
Make Amazon Previewer cask more generic

### DIFF
--- a/Casks/kindle-previewer.rb
+++ b/Casks/kindle-previewer.rb
@@ -1,7 +1,7 @@
 class KindlePreviewer < Cask
   url 'http://kindlepreviewer.s3.amazonaws.com/KindlePreviewer.zip'
   homepage 'http://www.amazon.com/gp/feature.html/?docId=1000765261'
-  version '2.92'
-  sha256 '6d156bcc29d9283b0326c35abfce34941d6c4b454cea6518a331c13fa0de17be'
+  version 'latest'
+  sha256 :no_check
   link 'Kindle Previewer.app'
 end


### PR DESCRIPTION
Apparently Amazon publishes new versions of their Previewer under the same URL which is then breaking the SHA-checks. I found no way how to download a specific version, so I assume the URL is always giving the latest version.

This should fix the problem.
