### PR TITLE
Update SHA2 hash of iannix

### DIFF
--- a/Casks/iannix.rb
+++ b/Casks/iannix.rb
@@ -2,6 +2,6 @@ class Iannix < Cask
   url 'http://www.iannix.org/download/iannix_mac_64__0_9_16.dmg'
   homepage 'http://www.iannix.org/'
   version '0.9.16'
-  sha256 'db8cef8f1250cbd6aab6b87ed3a50aa6b3dc0e8f3246ca91c211a314149c86dd'
+  sha256 'b45d332fc450342ad9a5b73fedcd554c299d435f989f0fe099522554434d00de'
   link 'IanniX/IanniX.app'
 end


### PR DESCRIPTION
Installing the `iannix` cask is currently triggering following error:

```
Error: SHA2 mismatch
Expected: db8cef8f1250cbd6aab6b87ed3a50aa6b3dc0e8f3246ca91c211a314149c86dd
Actual: b45d332fc450342ad9a5b73fedcd554c299d435f989f0fe099522554434d00de
Archive: /Library/Caches/Homebrew/iannix-0.9.16.dmg
To retry an incomplete download, remove the file above.
```

This is fixing it.
