### PR TITLE
Update Pharo 3.0 SHA sum

### DIFF
--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -2,6 +2,6 @@ class Pharo < Cask
   url 'http://files.pharo.org/platform/Pharo3.0-mac.zip'
   homepage 'http://www.pharo-project.org/home'
   version '3.0'
-  sha256 'f28424c66f296aae9628c9d54b6fc8590d6db0cd512b7116b06180aded6da428'
+  sha256 '57f251d31726176bf7dff866198ca75f03bb477e1dd024307eb157725acf596f'
   link 'Pharo3.0.app'
 end


### PR DESCRIPTION
```
Error: SHA2 mismatch
Expected: f28424c66f296aae9628c9d54b6fc8590d6db0cd512b7116b06180aded6da428
Actual: 57f251d31726176bf7dff866198ca75f03bb477e1dd024307eb157725acf596f
Archive: /Library/Caches/Homebrew/pharo-3.0.zip
To retry an incomplete download, remove the file above.
```
