### PR TITLE
Make speedtao cask more generic

### DIFF
--- a/Casks/speedtao.rb
+++ b/Casks/speedtao.rb
@@ -1,7 +1,7 @@
 class Speedtao < Cask
-  url 'http://www.speedtao.net/download/SpeedTao_Beta26.dmg'
+  url 'http://www.speedtao.net/beta_latest'
   homepage 'http://www.speedtao.net/'
-  version 'Beta26'
-  sha256 '2a1c6a742a4a1e52c2459c0958e3bc2f93f80f4f6977ee35c674b06399502058'
+  version 'latest'
+  sha256 :no_check
   link 'SpeedTao.app'
 end


### PR DESCRIPTION
There were some issues with SHA checksum + I found out that there's a universal link for the latest version so I used that link.
