### PR TITLE
Update Typewriter download URL

### DIFF
--- a/Casks/typewriter.rb
+++ b/Casks/typewriter.rb
@@ -1,5 +1,5 @@
 class Typewriter < Cask
-  url 'http://llllll.li/typewriter/Typewriter.zip'
+  url 'http://llllll.li/typewriter/download/Typewriter.zip'
   homepage 'http://llllll.li/typewriter'
   version 'latest'
   sha256 :no_check


### PR DESCRIPTION
`brew cask install typewriter` currently ends up in

```
Error: Download failed: http://llllll.li/typewriter/Typewriter.zip
```
