### PR TITLE
Update TrueCrypt to 2.7 + add warning

### DIFF
--- a/Casks/truecrypt.rb
+++ b/Casks/truecrypt.rb
@@ -1,10 +1,14 @@
 class Truecrypt < Cask
-  url 'http://www.truecrypt.org/download/TrueCrypt%207.1a%20Mac%20OS%20X.dmg'
+  url 'http://downloads.sourceforge.net/sourceforge/truecrypt/TrueCrypt-7.2-Mac-OS-X.dmg'
   homepage 'http://truecrypt.org/'
-  version '7.1a'
-  sha256 '04db58b737c05bb6b0b83f1cb37a29edec844b59ff223b9e213ee1f4e287f586'
-  install 'TrueCrypt 7.1a.mpkg'
+  version '7.2'
+  sha256 '01acf85be9b23a1c718193c40f3ecaaf6551695e0dc67c28345e560cca56c94e'
+  install 'TrueCrypt 7.2.mpkg'
   caveats do
     files_in_usr_local
+    <<-EOS.undent
+    Warning: TrueCrypt IS NOT SECURE and the development was ended, see more:
+      http://truecrypt.sourceforge.net/
+    EOS
   end
 end


### PR DESCRIPTION
There's a new release and TrueCrypt is now officially insecure.

See more:
https://www.google.co.uk/search?q=truecrypt%20is%20not%20secure
http://truecrypt.sourceforge.net/
