### PR TITLE
add caveat to Tunnelblick

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -4,4 +4,5 @@ class Tunnelblick < Cask
   version '3.3.2'
   sha256 '1e17563771a9536313e68d5a7ff4bddfebcc97a19704ed2a504517b9c7796026'
   link 'Tunnelblick.app'
+  caveats 'For security reasons, Tunnelblick must be installed to /Applications and will request to be moved at launch.'
 end


### PR DESCRIPTION
Tunnelblick must be installed to /Applications and requests to be moved at app launch. Added a caveat to this effect.
