### PR TITLE
Document alternative Taps

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -138,6 +138,7 @@ of Casks.
 | -------- | ----------- |
 | [caskroom/versions](https://github.com/caskroom/homebrew-versions) | contains alternate versions of Casks (e.g. betas, nightly releases, old versions)
 | [caskroom/fonts](https://github.com/caskroom/homebrew-fonts) | contains Casks that install fonts, which are kept separate so we can educate users about the different licensing landscape around font installation/usage
+| [caskroom/unofficial](https://github.com/caskroom/homebrew-unofficial) | contains Casks that install unofficial builds or forks
 
 You can tap any of the above with a `brew tap` command:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -140,6 +140,8 @@ of Casks.
 | [caskroom/fonts](https://github.com/caskroom/homebrew-fonts) | contains Casks that install fonts, which are kept separate so we can educate users about the different licensing landscape around font installation/usage
 | [caskroom/unofficial](https://github.com/caskroom/homebrew-unofficial) | contains Casks that install unofficial builds or forks
 
+There are also [alternate Cask Taps](ALTERNATE_CASK_TAPS.md#alternate-cask-taps-maintained-by-users) maintained by users.
+
 You can tap any of the above with a `brew tap` command:
 
 ```bash

--- a/doc/ALTERNATE_CASK_TAPS.md
+++ b/doc/ALTERNATE_CASK_TAPS.md
@@ -28,4 +28,10 @@ Possible uses of this feature include:
 
 5. Tap the repository using the command `brew tap <github-user>/<tapname>`.
 
+6. Let us know if you wish your Tap to be publicly listed here.
+
+## Alternate Cask Taps Maintained by Users
+
+* [casidiablo/custom](https://github.com/casidiablo/homebrew-custom)
+
 [^1]: While we strive to be inclusive, sometimes this does happen: [#3954](https://github.com/caskroom/homebrew-cask/pull/3954) .


### PR DESCRIPTION
We now have some user-maintained alt Cask Taps.
`caskroom/unofficial` had been left out of the docs due to an oversight.
