### PR TITLE
Make ActoTracker cask more generic

### DIFF
--- a/Casks/actotracker.rb
+++ b/Casks/actotracker.rb
@@ -1,7 +1,7 @@
 class Actotracker < Cask
   url 'https://dl.dropboxusercontent.com/u/7614970/ActoTracker.zip'
   homepage 'http://onflapp.wordpress.com/actotracker'
-  version '0.9-BETA'
-  sha256 '5ac8837e039444a46ae29d9920186e7ff14d52a4f80e7efa7eb6a5d887e3aff7'
+  version 'latest'
+  sha256 :no_check
   link 'ActoTracker.app'
 end


### PR DESCRIPTION
They seems to be overwriting the Dropbox file when they release a new version, so I'd assume it's always the latest version.

The current checksum does not match.
