### PR TITLE
Improve error checking and messages on Cask load

### DIFF
--- a/lib/cask/source/uri.rb
+++ b/lib/cask/source/uri.rb
@@ -14,10 +14,12 @@ class Cask::Source::URI
     path = HOMEBREW_CACHE_CASKS.join(File.basename(uri))
     ohai "Downloading #{uri}"
     odebug "Download target -> #{path.to_s}"
-    curl(uri, '-o', path.to_s)
+    begin
+      curl(uri, '-o', path.to_s)
+    rescue ErrorDuringExecution
+      raise CaskUnavailableError.new uri
+    end
     Cask::Source::PathSlashOptional.new(path).load
-  rescue ErrorDuringExecution
-    raise CaskUnavailableError, uri
   end
 
   def to_s


### PR DESCRIPTION
Other Cask sources ultimately invoke the `load` method in the
abstract class `Cask::Source::PathBase`, so these changes apply
to all other sources.
