### PR TITLE
Add Yasu version 2.9

### DIFF
--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -1,0 +1,7 @@
+class Yasu < Cask
+  url 'http://yasuapp.net/files/Yasu.zip'
+  homepage 'http://yasuapp.net'
+  version 'latest'
+  sha256 :no_check
+  link 'Yasu.app'
+end


### PR DESCRIPTION
Yasu — short for “Yet another system utility” — an Apple OS X maintenance utility developed to do a certain group of tasks quickly with just a few clicks, instead of typing a bunch of complex commands in the Terminal application. [http://yasuapp.net/download](http://yasuapp.net/download/)
