### PR TITLE
Add Safari Tab Switching 1.2.6 (Cmd-# shortcuts)

### DIFF
--- a/Casks/safaritabswitching.rb
+++ b/Casks/safaritabswitching.rb
@@ -1,0 +1,8 @@
+class Safaritabswitching < Cask
+  url 'https://github.com/rs/SafariTabSwitching/releases/download/1.2.6/Safari.Tab.Switching-1.2.6.pkg'
+  homepage 'https://github.com/rs/SafariTabSwitching'
+  version '1.2.6'
+  sha256 'd2823ec2327c5b5e2602876749f6c6ef352cfe7b5498158cc46c5610f6bf9b69'
+  install 'Safari.Tab.Switching-1.2.6.pkg'
+  uninstall :pkgutil => 'net.rhapsodyk.SafariTabSwitching.pkg'
+end


### PR DESCRIPTION
I'm working with the author to get a more dynamic version of this working. Ideally there will be a "latest" package and an appcast.
