### PR TITLE
Aptana Studio: Normalize cask

### DIFF
--- a/Casks/aptanastudio.rb
+++ b/Casks/aptanastudio.rb
@@ -1,7 +1,7 @@
 class Aptanastudio < Cask
   url 'http://download.aptana.com/studio3/standalone/3.4.2/mac/Aptana_Studio_3_Setup_3.4.2.dmg'
   homepage 'http://www.aptana.com/'
-  link 'Aptana Studio 3/AptanaStudio3.app'
   version '3.4.2'
   sha256 '26d40abf9152f16d8190a1968f16c0158a4992d28333351db6fa455af68958f4'
+  link 'Aptana Studio 3/AptanaStudio3.app'
 end


### PR DESCRIPTION
`link` was in a different location than expected
