### PR TITLE
Add uninstall stanza for xmarks-safari

### DIFF
--- a/Casks/xmarks-safari.rb
+++ b/Casks/xmarks-safari.rb
@@ -4,4 +4,8 @@ class XmarksSafari < Cask
   version '2.0.13'
   sha256 '802666565765dd5d60b6aa6d61e073cea4fb4f59a899b105b6195e7525409775'
   install 'Xmarks for Safari Installer.pkg'
+  uninstall :pkgutil => [
+                         'com.xmarks.XmarksForSafari.pkg',
+                         'com.xmarks.XmarksPreferencePane.pkg',
+                        ]
 end


### PR DESCRIPTION
The `:pkgutil` directives are supposed to include the `.pkg` suffix in this case, they are actual parts of the package name.
