### PR TITLE
Add uninstall stanza for send-to-kindle

### DIFF
--- a/Casks/send-to-kindle.rb
+++ b/Casks/send-to-kindle.rb
@@ -4,4 +4,6 @@ class SendToKindle < Cask
   version '1.0.0.218'
   sha256 '9c3a9eca8fe9f09ff43dfb4132a8be163ef517008979075df3d947699c421494'
   install 'SendToKindleForMac-installer-v1.0.0.218.pkg'
+  uninstall :launchctl => 'com.amazon.sendtokindle.launcher',
+            :pkgutil   => 'com.amazon.SendToKindleMacInstaller.pkg'
 end


### PR DESCRIPTION
The naming is the way it's supposed to be on that `:pkgutil` directive. The `:launchctl` directive seems to work, as `com.amazon.sendtokindle.launcher` is no longer on the list of installed launchjobs, but it still remains on the list of loaded launchjobs.
