### PR TITLE
Add uninstall stanza for paragon-ntfs

### DIFF
--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -4,4 +4,11 @@ class ParagonNtfs < Cask
   version 'latest'
   sha256 :no_check
   install 'FSInstaller.app/Contents/Resources/Paragon NTFS for Mac OS X.pkg'
+  uninstall :pkgutil => 'com.paragon-software.filesystems.NTFS.pkg'
+  uninstall :files  => [
+                        '/System/Library/Extensions/ntfs.kext',
+                        '/System/Library/Filesystems/ntfs.fs',
+                        '/System/Library/Filesystems/ufsd.fs',
+                        '/System/Library/Filesystems/ufsd_NTFS.fs',
+                       ]	
 end


### PR DESCRIPTION
The package did come with an uninstall script, but the script had to take in some sort of folder path as an argument, which I can't seem to determine what it is, so it's pretty much unusable. I did determine the kext/fs files that needed to be deleted, it seems that they don't show up on the result of `./list_loaded_kext_ids` - maybe they would have if I had rebooted? I'm not sure. I used a `:files` directive instead, in case people try to remove it before they reboot and the kext becomes loaded.

Again, the `.pkg` suffix is part of the bundle ID. No launchjobs as far as I can tell.
