### PR TITLE
Make File Juicer cask more generic

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,7 +1,7 @@
 class FileJuicer < Cask
-  url 'http://echoone.com/filejuicer/FileJuicer-4.36.zip'
+  url 'http://echoone.com/filejuicer/FileJuicer.dmg'
   homepage 'http://echoone.com/filejuicer/'
-  version '4.36'
-  sha256 '8c3c94d6a7306974d18452f6fc5bb97cc46a94c8fd693f7184da0faa9f892040'
+  version 'latest'
+  sha256 :no_check
   link 'File Juicer.app'
 end


### PR DESCRIPTION
The last SHA checksum was not matching:

```
Error: SHA2 mismatch
Expected: 8c3c94d6a7306974d18452f6fc5bb97cc46a94c8fd693f7184da0faa9f892040
Actual: e25e4d4ed804bf8d34f59ee742aa464098c9c34c728e4dce55d50ec7164d3d9a
Archive: /Library/Caches/Homebrew/file-juicer-4.36.zip
To retry an incomplete download, remove the file above.
```

I found a universal URL for the latest version so we can avoid any further issues with mismatching checksums.
