### PR TITLE
Fix Elm platform download URL & sha sum

### DIFF
--- a/Casks/elm-platform.rb
+++ b/Casks/elm-platform.rb
@@ -1,5 +1,5 @@
 class ElmPlatform < Cask
-  url 'https://www.dropbox.com/s/qfz9n90jszcxa5q/Elm-Platform-0.12.3.pkg'
+  url 'https://dl.dropboxusercontent.com/s/qfz9n90jszcxa5q/Elm-Platform-0.12.3.pkg'
   homepage 'http://www.elm-lang.org'
   version '0.12.3'
   sha256 '155569928a868095b2b27e705f2904496918f28fcb59990ff4449ca4aace330f'


### PR DESCRIPTION
I think there should be a note similar to this one:
https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls
about **Dropbox**.

I can send a PR if you agree. It can be a brief version of the 1st paragraph here:
https://www.dropbox.com/help/201/en
