### PR TITLE
Add Rust, version 0.10

### DIFF
--- a/Casks/rust.rb
+++ b/Casks/rust.rb
@@ -1,0 +1,8 @@
+class Rust < Cask
+   url "http://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.pkg"
+   homepage 'http://www.rust-lang.org/'
+   version '0.10'
+   sha256 '332253023b8f641b6d0b21289a1542521d83d1e77c6aa4d1a9b94c2927769407'
+   install 'rust-0.10-x86_64-apple-darwin.pkg'
+   uninstall :pkgutil => 'org.rust-lang.rust'
+end


### PR DESCRIPTION
As a point of interest, the [Rust homepage](www.rust-lang.org) recommends the Nightly version (which is already available in our caskroom/versions tap) over the latest stable release.

Which release should we consider canonical, and thus include it in the main repo?
