### PR TITLE
Replace GPSBabel download URL (softpedia) with an official one

### DIFF
--- a/Casks/gpsbabel.rb
+++ b/Casks/gpsbabel.rb
@@ -1,5 +1,20 @@
+def get_token(unix_timestamp)
+  _hour_in_sec = 60 * 60
+  _constant = 1480813383
+
+  unix_hours = unix_timestamp / _hour_in_sec
+  token = _constant + unix_hours
+
+  token.to_s(16)
+end
+
 class Gpsbabel < Cask
-  url 'http://download2us.softpedia.com/dl/feef8699d84c0a913206f2edfb10d8aa/538b3b9e/400008828/mac/Utilities/GPSBabel-1.5.1.dmg'
+  url 'http://www.gpsbabel.org/plan9.php',
+    :data => {
+      'dl' => 'GPSBabel-1.5.1.dmg',
+      'token' => get_token(Time.now.utc.to_i)
+    },
+    :using => :post
   homepage 'http://www.gpsbabel.org'
   version '1.5.1'
   sha256 '042d50ee75a95ed41b5d2c3957cf7a83da21ab057a7754bf1bde720615f1473f'


### PR DESCRIPTION
This is now working, the URL used is from the official website.

Nonetheless I need to make sure it will work with the token provided = I need to ensure the token is not time-sensitive or something like that.

I'd wait couple days and if everything will work then, I'd merge it.
