### PR TITLE
Imagemin updated to 0.1.0

### DIFF
--- a/Casks/imagemin.rb
+++ b/Casks/imagemin.rb
@@ -1,7 +1,7 @@
 class Imagemin < Cask
-  url 'https://github.com/kevva/imagemin-app/releases/download/0.0.1/imagemin.app.zip'
+  url 'https://github.com/kevva/imagemin-app/releases/download/0.1.0/imagemin-app-v0.1.0-darwin.zip'
   homepage 'https://github.com/kevva/imagemin-app'
-  version '0.0.1'
-  sha256 '63f298564952b691567a1eeb36c0c472c194c2658e90ebca5feb30038d592ba4'
-  link 'imagemin.app'
+  version '0.1.0'
+  sha256 '8a4304d37eaa8a71fbeb550aece6a80c98dbcdf7a9fb6eb09faae1ad93df40d6'
+  link 'imagemin-app-v0.1.0-darwin/Atom.app', :target => 'imagemin.app'
 end


### PR DESCRIPTION
The `Atom.app` filename may be colliding with the [Atom](https://github.com/caskroom/homebrew-cask/blob/master/Casks/atom.rb) editor.

I'm not sure how much these two have in common or why it's named the way it's named.
Are there any extra steps that should be done in this way? Link it under a different name or add a caveat or?
