### PR TITLE
Add HipHop 0.4.5

### DIFF
--- a/Casks/hiphop.rb
+++ b/Casks/hiphop.rb
@@ -1,0 +1,7 @@
+class Hiphop < Cask
+  url 'http://download.gethiphop.net/releases/0.4.5/mac/HipHop-0.4.5.dmg'
+  homepage 'http://gethiphop.net'
+  version '0.4.5'
+  sha256 '38ac0fa04fdc9d991fde8c5a683baa187c7c3b3e44e5d9399e887c126bae457e'
+  link 'HipHop.app'
+end


### PR DESCRIPTION
HipHop is an application for Windows, Mac and Linux that lets you listen instantly to more than 45 million songs (way more than iTunes that has only 26 million). It requires no sign up, displays no ads and is 100% safe.

---

The fact that it has no ads and no apparent "premium" plans leads me to doubt the legality of this app, but here it is anyways.
