### PR TITLE
Add CapSee 1.2

### DIFF
--- a/Casks/capsee.rb
+++ b/Casks/capsee.rb
@@ -1,0 +1,8 @@
+class Capsee < Cask
+  url 'http://www.threemagination.com/CapSee12.zip'
+  homepage 'http://www.threemagination.com/capsee/'
+  version '1.2'
+  sha256 'e78cdfe435cca259e0111a2b2131ad3be7d5ba6160cf69c8e7cbcc033eac2fc4'
+  nested_container 'CapSee12.dmg'
+  link 'CapSee.app'
+end


### PR DESCRIPTION
Have you ever bumped the caps lock key and typed a lengthy sentence in ALL CAPS?! Yeah, we've done it a few times too, and apparently there's an epidemic of people physically removing their caps lock key just to prevent it from happening. Well, to save a few keyboards, we built a simple little Mac utility called CapSee that presents a subtle alert to let you know YOU NEED TO TURN OFF THE CAPS LOCK!
