### PR TITLE
Update MacMoney to 3.6.6

### DIFF
--- a/Casks/macmoney.rb
+++ b/Casks/macmoney.rb
@@ -1,8 +1,8 @@
 class Macmoney < Cask
   url 'http://www.devon.riceball.net/downloads/macmoney36.zip'
   homepage 'http://www.devon.riceball.net/display.php?file=m01'
-  version '3.6.4'
-  sha256 '2ccbc4e6758d301a10f44711cdf1147d27e3ef6dd5b4b8c8b7d7c5ab90df80b8'
-  nested_container 'MacMoney_3.6.4.dmg'
+  version '3.6.6'
+  sha256 '34168a92ab65daf5280c879887011e30e9a3e01398f5402a32034049932a075b'
+  nested_container 'MacMoney_3.6.6.dmg'
   link 'MacMoney.app'
 end


### PR DESCRIPTION
The link is remaining the same for the major 3.6 version but as there is a nested container, `sha256 :no_check` is imo not a solution as it will break with every new minor release anyway.
