### PR TITLE
Remove ISSUES_URL and NullCommand from brew cask help

### DIFF
--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -23,7 +23,7 @@ require 'cask/cli/update'
 class Cask::CLI
   ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
   def self.commands
-    Cask::CLI.constants - ["NullCommand", "ISSUES_URL"]
+    Cask::CLI.constants - [:NullCommand, :ISSUES_URL]
   end
 
   def self.lookup_command(command_string)


### PR DESCRIPTION
Fixes #4726
- Tested to work on 10.10 and 10.9
- Changed the subtraction for symbols instead of strings

![screen shot 2014-06-06 17 37 53 0000](https://cloud.githubusercontent.com/assets/1889575/3203802/4e4d7278-eda1-11e3-837a-a97d485faa0c.png)
