### PR TITLE
force UTF-8 encodings

### DIFF
--- a/bin/brew-cask.rb
+++ b/bin/brew-cask.rb
@@ -1,4 +1,40 @@
-# this file expects to be required from within homebrew's ruby environment
+# this file expects to be required from within Homebrew's Ruby environment
+
+# Force UTF-8 encodings.
+# * This is not very nice, but we have no control over how Homebrew was
+#   invoked, nor with which Ruby interpreter.
+# * The correct way would be to invoke Ruby with "ruby -EUTF-8:UTF-8".
+# * The Homebrew project prefers to have heterogeneous encodings among
+#   its string values.
+# * This logic may conceivably cause problems with code that calls back
+#   into Homebrew, such as implicit Tapping and Formula dependencies.
+# * ARGV may not be the only special variable which needs treatment here.
+if defined?(Encoding)
+  # simulate "ruby -EUTF-8:UTF-8", but safe for Ruby 1.8,
+  # as this block will not be entered.
+  Encoding.default_internal = Encoding::UTF_8
+  Encoding.default_external = Encoding::UTF_8
+  # encode ARGV
+  utf8_argv = ARGV.map do |arg|
+    if arg.encoding == Encoding::UTF_8    or
+       arg.encoding == Encoding::US_ASCII or    # these two happen when
+       arg.encoding == Encoding::US_ASCII_8BIT  # LANG is unset
+      arg.dup.force_encoding('UTF-8')
+    else
+      arg.dup.encode('UTF-8')
+    end
+  end
+  ARGV.clear
+  ARGV.push *utf8_argv
+  # encode Homebrew objects which we use within Homebrew-cask
+  HOMEBREW_BREW_FILE   = HOMEBREW_BREW_FILE.dup.force_encoding('UTF-8')
+  HOMEBREW_VERSION     = HOMEBREW_VERSION.dup.force_encoding('UTF-8')
+  HOMEBREW_CACHE       = Pathname.new(HOMEBREW_CACHE.to_s.force_encoding('UTF-8'))
+  HOMEBREW_CELLAR      = Pathname.new(HOMEBREW_CELLAR.to_s.force_encoding('UTF-8'))
+  HOMEBREW_LIBRARY     = Pathname.new(HOMEBREW_LIBRARY.to_s.force_encoding('UTF-8'))
+  HOMEBREW_PREFIX      = Pathname.new(HOMEBREW_PREFIX.to_s.force_encoding('UTF-8'))
+  HOMEBREW_REPOSITORY  = Pathname.new(HOMEBREW_REPOSITORY.to_s.force_encoding('UTF-8'))
+end
 
 $LOAD_PATH.unshift(File.expand_path('../../lib', Pathname.new(__FILE__).realpath))
 require 'cask'

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -116,13 +116,13 @@ class Cask::CaveatsDSL
     known_arches = %w{intel-64 intel-32}
     supported_arches.each do |arch|
       unless known_arches.include?(arch)
-        raise CaskInvalidError.new(@cask, "The only valid arguments to caveats arch_only are: #{known_arches.inspect}")
+        raise CaskInvalidError.new(@cask, "The only valid arguments to caveats arch_only are: #{known_arches.utf8_inspect}")
       end
     end
     this_arch = "#{Hardware::CPU.type}-#{Hardware::CPU.bits}"
     unless supported_arches.include?(this_arch)
       puts <<-EOS.undent
-      Cask #{@cask} provides binaries for these architectures: #{supported_arches.inspect}.
+      Cask #{@cask} provides binaries for these architectures: #{supported_arches.utf8_inspect}.
       But you appear to be running on an unsupported architecture:
 
         #{this_arch}
@@ -142,7 +142,7 @@ class Cask::CaveatsDSL
     known_versions = %w{10.0 10.1 10.2 10.3 10.3 10.5 10.6 10.7 10.8 10.9}
     supported_versions.each do |version|
       unless known_versions.include?(version)
-        raise CaskInvalidError.new(@cask, "The only valid arguments to caveats os_version_only are: #{known_versions.inspect}")
+        raise CaskInvalidError.new(@cask, "The only valid arguments to caveats os_version_only are: #{known_versions.utf8_inspect}")
       end
     end
     unless supported_versions.include?(MACOS_VERSION)

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -28,7 +28,7 @@ class Cask::CurlDownloadStrategy < CurlDownloadStrategy
   include Cask::DownloadStrategy
 
   def _fetch
-    odebug "Calling curl with args #{curl_args.inspect}"
+    odebug "Calling curl with args #{curl_args.utf8_inspect}"
     curl(*curl_args)
   end
 

--- a/lib/cask/link_checker.rb
+++ b/lib/cask/link_checker.rb
@@ -36,7 +36,7 @@ class Cask::LinkChecker
   def _check_response_status
     ok = OK_RESPONSES[cask.url.scheme]
     unless ok.include?(@response_status)
-      add_error "unexpected http response, expecting #{ok.map(&:inspect).join(' or ')}, got #{@response_status.inspect}"
+      add_error "unexpected http response, expecting #{ok.map(&:utf8_inspect).join(' or ')}, got #{@response_status.utf8_inspect}"
     end
   end
 

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -3,7 +3,7 @@ require 'open3'
 class Cask::SystemCommand
   def self.run(executable, options={})
     command = _process_options(executable, options)
-    odebug "Executing: #{command.inspect}"
+    odebug "Executing: #{command.utf8_inspect}"
     output = ''
     Open3.popen3(*command) do |stdin, stdout, stderr|
       if options[:input]
@@ -51,7 +51,7 @@ class Cask::SystemCommand
 
   def self._assert_success(status, command, output)
     unless status.success?
-      raise CaskCommandFailedError.new(command.inspect, output)
+      raise CaskCommandFailedError.new(command.utf8_inspect, output)
     end
   end
 
@@ -62,7 +62,7 @@ class Cask::SystemCommand
       raise CaskError.new(<<-ERRMSG)
 Error parsing plist output from command.
   command was:
-  #{command.inspect}
+  #{command.utf8_inspect}
   output we attempted to parse:
   #{output}
         ERRMSG

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -4,6 +4,23 @@
 require 'yaml'
 require 'open3'
 
+# monkeypatch Object - not a great idea
+class Object
+  def utf8_inspect
+    if not defined?(Encoding)
+      self.inspect
+    else
+      if self.respond_to?(:map)
+        self.map do |sub_elt|
+          sub_elt.utf8_inspect
+        end
+      else
+        self.inspect.force_encoding('UTF-8').sub(%r{\A"(.*)"\Z}, '\1')
+      end
+    end
+  end
+end
+
 # monkeypatch Tty
 class Tty
   class << self


### PR DESCRIPTION
Fixes #4677.  This change is necessitated by Homebrew's recent
switch to Ruby 2.x.  These changes may be incomplete and/or
may not work well with Ruby 1.8.  Travis should test Ruby 1.8
compatibility.
