### PR TITLE
downgrade ScreenFlow to 4.5

### DIFF
--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -1,7 +1,7 @@
 class Screenflow < Cask
-  url 'http://www.telestream.net/download-files/screenflow/4-5/ScreenFlow-4.5.1.dmg'
+  url 'http://www.telestream.net/download-files/screenflow/4-5/ScreenFlow-4.5.dmg'
   homepage 'http://www.telestream.net/screenflow/'
-  version '4.5.1'
-  sha256 '29a7bd463ae6ed4ea7f630ff2e8d0248784a0293a9001df064dea7255ce82c12'
+  version '4.5'
+  sha256 '9ec0f4c1bb1b778ea37f3e37bf0ad494baffe08e567553027c13178f05c2fbcd'
   link 'ScreenFlow.app'
 end


### PR DESCRIPTION
as discussed at https://github.com/caskroom/homebrew-cask/pull/4576#issuecomment-45395117
