### PR TITLE
`collect_concat` is not available in Ruby 1.8

### DIFF
--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -77,7 +77,7 @@ class Cask::CLI::Doctor
   end
 
   def self.locale_variables
-    ENV.keys.grep(/^(?:LC_\S+|LANG|LANGUAGE)\Z/).collect_concat { |v| %Q{#{v}="#{ENV[v]}"} }.sort
+    ENV.keys.grep(/^(?:LC_\S+|LANG|LANGUAGE)\Z/).collect { |v| %Q{#{v}="#{ENV[v]}"} }.sort.join("\n")
   end
 
   def self.privileged_uid


### PR DESCRIPTION
`collect` is fine here. References #4719.
plus bugfix: join into a string so that `render_with_none`
knows to substitute "<NONE>"
