### PR TITLE
Make Mountain cask more generic + add appcast

### DIFF
--- a/Casks/mountain.rb
+++ b/Casks/mountain.rb
@@ -1,5 +1,6 @@
 class Mountain < Cask
   url 'http://appgineers.de/mountain/files/Mountain.zip'
+  appcast 'http://appgineers.de/mountain/files/mountaincast.xml'
   homepage 'http://appgineers.de/mountain/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mountain.rb
+++ b/Casks/mountain.rb
@@ -1,7 +1,7 @@
 class Mountain < Cask
   url 'http://appgineers.de/mountain/files/Mountain.zip'
   homepage 'http://appgineers.de/mountain/'
-  version '1.4.6_23'
-  sha256 '86daf10772eeff5dc9a1f65fd97dc31e89a694075cdb84015a4f0d0e3f38f94c'
+  version 'latest'
+  sha256 :no_check
   link 'Mountain.app'
 end


### PR DESCRIPTION
The download URL is pointing to the latest version, so there's no point of keeping SHA nor version in the cask.
