### PR TITLE
Postbox updated to latest version

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,7 +1,7 @@
 class Postbox < Cask
-  url 'http://www.postbox-inc.com/php/download.php?a=3010m'
+  url 'http://www.postbox-inc.com/php/download.php?a=3011m'
   homepage 'http://www.postbox-inc.com/'
-  version '3.0.10'
-  sha256 '2c4ccb1fe34edc7b680516d6fb998b67a8e0d1c972d5d5d91a0ef86d5c0a2461'
+  version 'latest'
+  sha256 :no_check
   link 'Postbox.app'
 end


### PR DESCRIPTION
No appcast feed found, the same URL is now `302`-ing to the latest version (no matter what's the value of the parameter) so I see no point in keeping the version in cask.
