### PR TITLE
regularize whitespace

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -1,14 +1,14 @@
 class Coconutbattery < Cask
   if MacOS.version == :lion or MacOS.version == :mountain_lion or MacOS.version == :mavericks
     url 'http://www.coconut-flavour.com/downloads/coconutBattery_3_0_1.zip'
-  appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml'
+    appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml'
     version '3.0.1'
     sha256 '8affd652b38060324aa11adf30b8e517e8e39166946dc7e08a0c88ee3756bef3'
   elsif MacOS.version == :leopard or MacOS.version == :snow_leopard
     url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.8.zip'
     version '2.8'
     sha256 'fcfc81214ff26afff9f5c6c7cdc455b23ac898b6918f864b641a9e31526692d4'
-  else 
+  else
     url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.6.6.zip'
     version '2.6.6'
     sha256 '8d235b237e42754ceda26af2babc160fd23f890d0fe6d7780b86a8e9c6effe42'

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -20,8 +20,8 @@ class Java < Cask
       '/bin/rm', '-rf', '--', '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'
     system '/usr/bin/sudo', '-E', '--',
       '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'
-	system '/usr/bin/sudo', '-E', '--',
-	  '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home", '/Library/Java/Home'
+    system '/usr/bin/sudo', '-E', '--',
+      '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home", '/Library/Java/Home'
   end
   uninstall :pkgutil => [
                          'com.oracle.jdk8u5',         # manually update this for each version

--- a/doc/AUTOMATION.md
+++ b/doc/AUTOMATION.md
@@ -1,5 +1,6 @@
 # Automating with Homebrew Cask
-Homebrew Cask allows you to install several applications at once. Calling `cask install` with multiple arguments works as you would expect:  
+Homebrew Cask allows you to install several applications at once. Calling `cask install` with multiple arguments works as you would expect:
+
 ```
 brew cask install vagrant virtualbox
 ==> Downloading https://dl.bintray.com/mitchellh/vagrant/Vagrant-1.4.3.dmg
@@ -45,7 +46,8 @@ cask install iterm2
 
 Integrating Homebrew Cask in your dotfiles is immediate; indeed, the `Caskfile` is most commonly used as a dotfiles module, to provision machines with binary apps and precompiled software.
 
-If you want to fully automate the deployment process by scripting the execution of `brew bundle`, it is sufficient to ensure that the following steps happen in the correct order: 
+If you want to fully automate the deployment process by scripting the execution of `brew bundle`, it is sufficient to ensure that the following steps happen in the correct order:
+
 - install git
 - install Homebrew
 1. `brew update`

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -84,25 +84,25 @@ describe Cask::Artifact::Pkg do
       )
       Cask::FakeSystemCommand.stubs_command(
         ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', '-x', 'my.fancy.package.service'],
-        <<-PLIST
+        <<-"PLIST"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Label</key>
-	<string>my.fancy.package.service</string>
-	<key>LastExitStatus</key>
-	<integer>0</integer>
-	<key>LimitLoadToSessionType</key>
-	<string>System</string>
-	<key>OnDemand</key>
-	<true/>
-	<key>ProgramArguments</key>
-	<array>
-		<string>argument</string>
-	</array>
-	<key>TimeOut</key>
-	<integer>30</integer>
+\t<key>Label</key>
+\t<string>my.fancy.package.service</string>
+\t<key>LastExitStatus</key>
+\t<integer>0</integer>
+\t<key>LimitLoadToSessionType</key>
+\t<string>System</string>
+\t<key>OnDemand</key>
+\t<true/>
+\t<key>ProgramArguments</key>
+\t<array>
+\t\t<string>argument</string>
+\t</array>
+\t<key>TimeOut</key>
+\t<integer>30</integer>
 </dict>
 </plist>
         PLIST


### PR DESCRIPTION
- Regularize indenting
- Replace tags with spaces for indenting
- Replace literal tabs with escapes in test suite
- Remove trailing whitespace in Markdown (meaningful in theory, but I think GH-flavored Markdown ignores it)
