### PR TITLE
add appcast stanza for 77 Casks

### DIFF
--- a/Casks/pwnagetool.rb
+++ b/Casks/pwnagetool.rb
@@ -1,5 +1,6 @@
 class Pwnagetool < Cask
   url 'https://sites.google.com/a/ipad-dev.com/files/pwnagetool/PwnageTool_5.1.1.dmg'
+  appcast 'http://www.iphone-dev.org/appcast/PwnageTool2.xml'
   homepage 'http://blog.iphone-dev.org/tagged/PwnageTool'
   version '5.1.1'
   sha256 '84262734ad9f9186bce14a4f939d7ea290ed187782fdfa549a82c28bf837c808'

--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -1,5 +1,6 @@
 class Qdesktop < Cask
   url 'https://bitbucket.org/qvacua/qvacua/downloads/Qdesktop-0.1.1.zip'
+  appcast 'http://qvacua.com/qdesktop/appcast.xml'
   homepage 'http://qvacua.com'
   version '0.1.1'
   sha256 '1eddd3513cca892fb8e53452d79d4589ef5b1e3cd885a1f52748b6df64588094'

--- a/Casks/qmind.rb
+++ b/Casks/qmind.rb
@@ -1,5 +1,6 @@
 class Qmind < Cask
   url 'https://github.com/qvacua/qmind/releases/download/v0.3.4-22/Qmind-0.3.4.zip'
+  appcast 'http://qvacua.com/qmind/appcast.xml'
   homepage 'http://qvacua.com'
   version '0.3.4'
   sha256 '498dc5b753804d25cbf15afbdb8641af1ddcf53b65ab04d3188c7a8b669f6695'

--- a/Casks/quickradar.rb
+++ b/Casks/quickradar.rb
@@ -1,5 +1,6 @@
 class Quickradar < Cask
   url 'http://www.quickradar.com/0.8.zip'
+  appcast 'http://www.quickradar.com/appcast.xml'
   homepage 'http://www.quickradar.com/'
   version '0.8'
   sha256 'fbe74ffe8f1615a6af64868b697321fe68b505d4f2e3eba7d5e3cf4cab082a1c'

--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,5 +1,6 @@
 class Rapidweaver < Cask
   url 'http://realmacsoftware.com/redirects/rapidweaver/direct'
+  appcast 'http://www.realmacsoftware.com/stats/rapidweaver5.php'
   homepage 'http://realmacsoftware.com/rapidweaver'
   version 'latest'
   sha256 :no_check

--- a/Casks/reggy.rb
+++ b/Casks/reggy.rb
@@ -1,5 +1,6 @@
 class Reggy < Cask
   url 'http://github.com/downloads/samsouder/reggy/Reggy_v1.3.tbz'
+  appcast 'http://reggyapp.com/appcast.xml'
   homepage 'http://reggyapp.com/'
   version '1.3'
   sha256 '5a4d72158bc524ab2f21c6cfad7b703f413707d9d078ec1923c268b110ff8dda'

--- a/Casks/safemonk.rb
+++ b/Casks/safemonk.rb
@@ -1,5 +1,6 @@
 class Safemonk < Cask
   url 'https://www.safemonk.com/downloads/osx'
+  appcast 'https://www.safemonk.com:/data/client/osx/appcast.xml'
   homepage 'https://www.safemonk.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/scapple.rb
+++ b/Casks/scapple.rb
@@ -1,5 +1,6 @@
 class Scapple < Cask
   url 'http://scrivener.s3.amazonaws.com/Scapple.dmg'
+  appcast 'http://www.literatureandlatte.com/downloads/scapple/scapple.xml'
   homepage 'https://www.literatureandlatte.com/scapple.php'
   version 'latest'
   sha256 :no_check

--- a/Casks/screenmailer.rb
+++ b/Casks/screenmailer.rb
@@ -1,5 +1,6 @@
 class Screenmailer < Cask
   url 'http://www.screenmailer.com/download'
+  appcast 'http://www.screenmailer.com/releases/current/releases.xml'
   homepage 'http://www.screenmailer.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/scrup.rb
+++ b/Casks/scrup.rb
@@ -1,5 +1,6 @@
 class Scrup < Cask
   url 'http://data.hunch.se/scrup/Scrup-1.3.3-bd23160.zip'
+  appcast 'https://s.rsms.me/scrup/appcast.xml'
   homepage 'https://github.com/rsms/scrup'
   version '1.3.3'
   sha256 '5004222db9a6ddd4e6cb525d00e95f8a38e9fb623bc1397e5258b2ef2c4bd3b0'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -1,5 +1,6 @@
 class Scummvm < Cask
   url 'http://downloads.sourceforge.net/project/scummvm/scummvm/1.6.0/scummvm-1.6.0-macosx.dmg'
+  appcast 'http://www.scummvm.org/appcasts/macosx/release.xml'
   homepage 'http://scummvm.org/'
   version '1.6.0'
   sha256 '9e23c5e4d5b04400202c61d031d85d2ed09a88662c7cec9b56f354d07cc96f28'

--- a/Casks/secondbar.rb
+++ b/Casks/secondbar.rb
@@ -1,5 +1,6 @@
 class Secondbar < Cask
   url 'http://boastr.de/SecondBar.zip'
+  appcast 'http://blog.boastr.net/secondbar/appcast.xml'
   homepage 'http://blog.boastr.net/?page_id=79'
   version '1.1'
   sha256 '1f2a9d837bc66c93ed2f7a1d83ef95c44888cd266ffb7982ade14f91d996d6a6'

--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -1,5 +1,6 @@
 class Selfcontrol < Cask
   url 'http://downloads.selfcontrolapp.com/SelfControl-1.5.1.zip'
+  appcast 'http://selfcontrolapp.com/SelfControlAppcast.xml'
   homepage 'http://selfcontrolapp.com/'
   version '1.5.1'
   sha256 'd3823a1e9ba0b47dc2cb39c93cd51837c2dafc7d5a5a564825f4a440fd2ab9ad'

--- a/Casks/sequential.rb
+++ b/Casks/sequential.rb
@@ -1,5 +1,6 @@
 class Sequential < Cask
   url 'http://sequentialx.com/Sequential2.1.2.zip'
+  appcast 'http://www.sequentialx.com/sequential.xml'
   homepage 'http://sequentialx.com'
   version '2.1.2'
   sha256 '7a9247e8623da5b6c74b65ad6d9e0be7667b832816134393e871e584c00eee64'

--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -1,5 +1,6 @@
 class Servetome < Cask
   url 'http://downloads.zqueue.com/ServeToMe-v3.9.0.3053.dmg'
+  appcast 'http://zqueue.com/servetome/stm3_mac_appcast.xml'
   homepage 'http://zqueue.com/servetome/'
   version '3.9.0.3053'
   sha256 '87bf1184b7656a96088b25880e7e1c772f30d8dfa1e602f9b43ccbdd0608fdf2'

--- a/Casks/shiftit.rb
+++ b/Casks/shiftit.rb
@@ -1,5 +1,6 @@
 class Shiftit < Cask
   url 'https://github.com/downloads/fikovnik/ShiftIt/ShiftIt-develop-1.6.zip'
+  appcast 'https://raw.github.com/fikovnik/ShiftIt/develop/release/appcast.xml'
   homepage 'https://github.com/fikovnik/ShiftIt'
   version '1.6'
   sha256 '538e0628d6fc99c3562694c0722cb41699d6a802f0032678ef05fa2b53711955'

--- a/Casks/shimo.rb
+++ b/Casks/shimo.rb
@@ -1,5 +1,6 @@
 class Shimo < Cask
   url 'http://www.chungwasoft.com/files/Shimo_3.2.3_2587.zip'
+  appcast 'http://www.chungwasoft.com/library/appcasts/Shimo3/shimocast.php'
   homepage 'http://www.chungwasoft.com/shimo/'
   version '3.2.3_2587'
   sha256 'ff8a5bc7254d6860ecae72a863e1da4faec5948c2b07e8b7da4c96dcb34ec5b4'

--- a/Casks/shiori.rb
+++ b/Casks/shiori.rb
@@ -1,5 +1,6 @@
 class Shiori < Cask
   url 'http://aki-null.net/shiori/release/Shiori_1.0.1.zip'
+  appcast 'http://aki-null.net/shiori/appcast.xml'
   homepage 'http://aki-null.net/shiori/'
   version '1.0.1'
   sha256 'e6ca6cbd9502de280303cb46deade6a6b938da7bae3ecd99bf7b23c539747c26'

--- a/Casks/shortcat.rb
+++ b/Casks/shortcat.rb
@@ -1,5 +1,6 @@
 class Shortcat < Cask
   url 'https://files.shortcatapp.com/v0.7.0/Shortcat.zip'
+  appcast 'https://shortcatapp.com/updates/appcast.xml'
   homepage 'http://shortcatapp.com/'
   version '0.7.0'
   sha256 '90daee12b82157e2025789005688276453ee8fdf243041e056730a5d85ce1cf9'

--- a/Casks/sidestep.rb
+++ b/Casks/sidestep.rb
@@ -1,5 +1,6 @@
 class Sidestep < Cask
   url 'https://github.com/chetan51/sidestep/releases/download/1.4.1/Sidestep.zip'
+  appcast 'http://chetansurpur.com/projects/sidestep/appcast.xml'
   homepage 'http://chetansurpur.com/projects/sidestep'
   version '1.4.1'
   sha256 'c25f7748d73b6f915aff268070ef85ca69f2902de98b044b77c49d1e1341d84e'

--- a/Casks/silverback.rb
+++ b/Casks/silverback.rb
@@ -1,5 +1,6 @@
 class Silverback < Cask
   url 'http://silverback.s3.amazonaws.com/silverback2.zip'
+  appcast 'http://silverback.s3.amazonaws.com/release/appcast.xml'
   homepage 'http://silverbackapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -1,5 +1,6 @@
 class Simpholders < Cask
   url 'http://simpholders.com/site/assets/files/1007/simpholders-1_5_0.dmg'
+  appcast 'http://kfi-apps.com/appcasts/simpholders/'
   homepage 'http://simpholders.com/'
   version '1.5.0'
   sha256 '2f4fb58a20d94a858c4d53648ee37fd082e23f50ef3f367fbaef4d6cea840cd6'

--- a/Casks/slidemode.rb
+++ b/Casks/slidemode.rb
@@ -1,5 +1,6 @@
 class Slidemode < Cask
   url 'http://www.teaksoftware.com/workspace/files/slidemode005.dmg'
+  appcast 'http://teaksoftware.com/appcasts/smappcast.xml'
   homepage 'http://teaksoftware.com/app/slidemode'
   version '0.0.5'
   sha256 '0c417eb7c4ca57da318260ad1d023ed8ad06deab74d3c0ae0a5d9658b34ab68c'

--- a/Casks/slimbatterymonitor.rb
+++ b/Casks/slimbatterymonitor.rb
@@ -1,5 +1,6 @@
 class Slimbatterymonitor < Cask
   url 'http://quux.orange-carb.org/dist/SlimBatteryMonitor-1.5.dmg'
+  appcast 'http://www.orange-carb.org/SBM/updates/sbm.xml'
   homepage 'http://www.orange-carb.org/SBM/'
   version '1.5'
   sha256 '587ce35b534c26b489b60d7f4ca71a96c1dcd83193a30c58676ae8d4665c6aff'

--- a/Casks/slingshot.rb
+++ b/Casks/slingshot.rb
@@ -1,5 +1,6 @@
 class Slingshot < Cask
   url 'http://download.airsquirrels.com/Slingshot/Mac/Slingshot.dmg'
+  appcast 'https://updates.airsquirrels.com/Slingshot/Mac/Slingshot.xml'
   homepage 'http://www.airsquirrels.com/slingshot/'
   version 'latest'
   sha256 :no_check

--- a/Casks/snippets.rb
+++ b/Casks/snippets.rb
@@ -1,5 +1,6 @@
 class Snippets < Cask
   url 'http://snippets.me/download/mac/Snippets-468.zip'
+  appcast 'http://snippets.me/mac/appcast.xml'
   homepage 'http://snippets.me/'
   version '0.8.2'
   sha256 '32167664dacd3301dd89e618093c3ce7a7dcd0204061d34f7759bad3c9a7cc78'

--- a/Casks/sonora.rb
+++ b/Casks/sonora.rb
@@ -1,5 +1,6 @@
 class Sonora < Cask
   url 'https://github.com/downloads/sonoramac/Sonora/Sonora.zip'
+  appcast 'http://getsonora.com/updates/sonora2.xml'
   homepage 'http://getsonora.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/soqlxplorer.rb
+++ b/Casks/soqlxplorer.rb
@@ -1,5 +1,6 @@
 class Soqlxplorer < Cask
   url 'http://www.pocketsoap.com/osx/soqlx/soqlXplorer_v2.00.zip'
+  appcast 'http://www.pocketsoap.com/osx/soqlx/appcast.xml'
   homepage 'http://www.pocketsoap.com/osx/soqlx/'
   version '2.00'
   sha256 '72c5d9dc582bc30d757c5199cdebdc79ffee479a3435252906554d52b236217d'

--- a/Casks/sparkbox.rb
+++ b/Casks/sparkbox.rb
@@ -1,5 +1,6 @@
 class Sparkbox < Cask
   url 'http://t.icyblaze.com/sblatest'
+  appcast 'http://matrix.icyblaze.com/index.php/checkupdate/p/8'
   homepage 'http://www.icyblaze.com/sparkbox'
   version 'latest'
   sha256 :no_check

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -1,5 +1,6 @@
 class Spectacle < Cask
   url 'https://s3.amazonaws.com/spectacle/downloads/Spectacle+0.8.4.zip'
+  appcast 'http://spectacleapp.com/updates/appcast.xml'
   homepage 'http://spectacleapp.com/'
   version '0.8.4'
   sha256 '9afde3a40b04c2e8b1ed4bbdd4a3873319d1e89b2647d51acf804817a0be5d7f'

--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,5 +1,6 @@
 class Sqleditor < Cask
   url 'http://www.malcolmhardie.com/sqleditor/releases/2.7/SQLEditor-2-7.zip'
+  appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml'
   homepage 'http://www.malcolmhardie.com/sqleditor/'
   version '2.7'
   sha256 '38f9d93d0ff7d680eff64949601ee4693eb91c38f89bd2f42a7e86809b36e9b5'

--- a/Casks/squire.rb
+++ b/Casks/squire.rb
@@ -1,5 +1,6 @@
 class Squire < Cask
   url 'https://s3.amazonaws.com/Squire_Mac_Builds/Squire_0.91.zip'
+  appcast 'http://www.sylion.com/squireapp/sparkle/SquireMac/appcastMac.xml'
   homepage 'http://squireapp.com'
   version '0.91'
   sha256 'd37f2cdf5f08ed85e5a1f10a66c70a964e51e3a64e7c7335d97c50b1a7a1691e'

--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -1,5 +1,6 @@
 class Stay < Cask
   url 'http://cordlessdog.com/stay/versions/Stay%201.2.3.zip'
+  appcast 'http://cordlessdog.com/stay/appcast.xml'
   homepage 'http://cordlessdog.com/stay/'
   version '1.2.3'
   sha256 'afe5abc2757bcee547a0d9ad8ebae55744ac197bc28c9fa28fc7987b9b512464'

--- a/Casks/subsmarine.rb
+++ b/Casks/subsmarine.rb
@@ -1,5 +1,6 @@
 class Subsmarine < Cask
   url 'http://www.cocoawithchurros.com/downloads/subsmarine.app.1.2.zip'
+  appcast 'http://www.cocoawithchurros.com/shine/appcast.php?id=7'
   homepage 'http://www.cocoawithchurros.com/subsmarine.php'
   version '1.2'
   sha256 '337722dedb0682d34f11f2decc3ad827849032f9a0e795d2f89c5c4bd0c32286'

--- a/Casks/subtitles.rb
+++ b/Casks/subtitles.rb
@@ -1,5 +1,6 @@
 class Subtitles < Cask
   url 'http://subtitlesapp.com/download/Subtitles-mac-2.2.zip'
+  appcast 'http://subtitlesapp.com/updates.xml'
   homepage 'http://subtitlesapp.com'
   version '2.2'
   sha256 'c8f00cd00a85f16b7a74de846b9f03fcd0cd0e144336438aa09aef50d527ce0f'

--- a/Casks/tagger.rb
+++ b/Casks/tagger.rb
@@ -1,5 +1,6 @@
 class Tagger < Cask
   url 'https://github.com/downloads/Bilalh/Tagger/Tagger_1.6.2.zip'
+  appcast 'http://bilalh.github.com/sparkle/tagger/appcast.xml'
   homepage 'http://bilalh.github.io/projects/tagger/'
   version '1.6.2'
   sha256 'b0c23f7068509f36648da4e3db809064fe53d44cd6d097f6b5f4f81f8fe39b33'

--- a/Casks/tagr.rb
+++ b/Casks/tagr.rb
@@ -1,5 +1,6 @@
 class Tagr < Cask
   url 'http://www.harald-schubert.net/data/Tagr.zip'
+  appcast 'http://www.harald-schubert.net/data/tagr-appcast.xml'
   homepage 'http://www.entwicklungsfreu.de/tagr.html'
   version '3.1.2'
   sha256 '65c6c7296e091aec46acfe2f3ba147e4f77c6437fe9c4b7261d791f1b335a109'

--- a/Casks/testflight.rb
+++ b/Casks/testflight.rb
@@ -1,5 +1,6 @@
 class Testflight < Cask
   url 'https://d193ln56du8muy.cloudfront.net/desktop_app/1381509820/TestFlight-Desktop-1.0-Beta(313).zip'
+  appcast 'https://testflightapp.com/appcast.xml'
   homepage 'http://testflightapp.com'
   version '1.0_beta313'
   sha256 'a8f643b66682f7ec9d710b7452dd9fdc9332edc59bc2c92d10683635c80c861f'

--- a/Casks/texnicle.rb
+++ b/Casks/texnicle.rb
@@ -1,5 +1,6 @@
 class Texnicle < Cask
   url 'http://www.bobsoft-mac.de/resources/TeXnicle/2.2/TeXnicle.app.2.2.11.zip'
+  appcast 'http://www.bobsoft-mac.de/profileInfo.php'
   homepage 'http://www.bobsoft-mac.de/texnicle/texnicle.html'
   version '2.2.11'
   sha256 'b522e551220bfc98ff3d3c09db224c0db2a31c1dff4c73353a26d1f13217733b'

--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,5 +1,6 @@
 class Texpad < Cask
   url 'http://cloud.texpadapp.com/bundles/Texpad_1_6_12.zip'
+  appcast 'https://www.texpadapp.com/static-collected/upgrades/texpadappcast.xml'
   homepage 'https://www.texpadapp.com/osx'
   version '1.6.12'
   sha256 'bca8da9be6c2af599455eb9e936b50667f25b55a842af41e87f2e72e396c243e'

--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,5 +1,6 @@
 class Texshop < Cask
   url 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshop336.1.zip'
+  appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml'
   homepage 'http://pages.uoregon.edu/koch/texshop'
   version '3.36.1'
   sha256 '78940561dde093f9ef2211b0e2f8acb332e4f3d141ffd37e3d654ce7dc112831'

--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,5 +1,6 @@
 class Textexpander < Cask
   url 'http://cdn.smilesoftware.com/TextExpander_4.3.1.zip'
+  appcast 'http://www.smilesoftware.com/appcast/update.php'
   homepage 'http://www.smilesoftware.com/TextExpander/index.html'
   version '4.3.1'
   sha256 '1ab9bcdec7354cdf94da33ad12956799b8982eb3c544c8c89e57800dca8ff5cd'

--- a/Casks/texts.rb
+++ b/Casks/texts.rb
@@ -1,5 +1,6 @@
 class Texts < Cask
   url 'http://www.texts.io/Texts-0.18.4.dmg'
+  appcast 'http://www.texts.io/appcast-osx.xml'
   homepage 'http://www.texts.io'
   version '0.18.4'
   sha256 'dc2613a0793939cb2c5544a9c6c8e4e25c5cf9207f818420d550d3bb9eeeb779'

--- a/Casks/textwrangler.rb
+++ b/Casks/textwrangler.rb
@@ -1,5 +1,6 @@
 class Textwrangler < Cask
   url 'http://ash.barebones.com/TextWrangler_4.5.8.dmg'
+  appcast 'https://versioncheck.barebones.com/TextWrangler.xml'
   homepage 'http://www.barebones.com/products/textwrangler'
   version '4.5.8'
   sha256 'ac63be1a83f6e611a67753e63304a2549f95e031562f6245c5688f3d307537ae'

--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,5 +1,6 @@
 class TheEscapersFlux < Cask
   url 'http://instruktion.net/theescapers/downloads/FluxV4.zip'
+  appcast 'http://www.theescapers.com/flux/flux.xml'
   homepage 'http://www.theescapers.com/flux/'
   version 'latest'
   sha256 :no_check

--- a/Casks/theremin.rb
+++ b/Casks/theremin.rb
@@ -1,5 +1,6 @@
 class Theremin < Cask
   url 'http://f.nn.lv/ms/l5/29/Theremin.app.zip'
+  appcast 'http://theremin.amd.co.at/appcastProfileInfo.php'
   homepage 'https://github.com/TheStalwart/Theremin'
   version '0.7'
   sha256 '809d0f7527d072a43f33b9e1088dc2387e08bb1a3696bb60bfd8e82b8853102d'

--- a/Casks/thisservice.rb
+++ b/Casks/thisservice.rb
@@ -1,5 +1,6 @@
 class Thisservice < Cask
   url 'http://wafflesoftware.net/thisservice/download/ThisService3.0.1.zip'
+  appcast 'http://wafflesoftware.net/thisservice/sparkle/sparkle.xml'
   homepage 'http://wafflesoftware.net/thisservice/'
   version '3.0.1'
   sha256 'ddf9635421834f1d6bd9fb257ad164f7b59ec2d2b65590d691ec5d2699ec8da2'

--- a/Casks/tickets.rb
+++ b/Casks/tickets.rb
@@ -1,5 +1,6 @@
 class Tickets < Cask
   url 'http://www.irradiatedsoftware.com/download/Tickets.zip'
+  appcast 'http://www.irradiatedsoftware.com/updates/profiles/tickets.php'
   homepage 'http://www.irradiatedsoftware.com/tickets/'
   version '2.5'
   sha256 '8f2d7879581fb2604158367fb6e7eda8bc9ebf15e97781b69b64355f2832af6e'

--- a/Casks/tilemill.rb
+++ b/Casks/tilemill.rb
@@ -1,5 +1,6 @@
 class Tilemill < Cask
   url 'http://tilemill.s3.amazonaws.com/latest/TileMill-0.10.1.zip'
+  appcast 'http://mapbox.com/tilemill/platforms/osx/appcast2.xml'
   homepage 'http://www.mapbox.com/tilemill/'
   version '0.10.1'
   sha256 '4d3c9c0a8f7b530d08598b8c245b128c982529a39127fab9dfabd6a2a92ba08f'

--- a/Casks/timings.rb
+++ b/Casks/timings.rb
@@ -1,5 +1,6 @@
 class Timings < Cask
   url 'http://mediaatelier.com/Timings/Timings_1.0.4.zip'
+  appcast 'http://mediaatelier.com/Timings/feed.php'
   homepage 'http://mediaatelier.com/Timings'
   version '1.0.4'
   sha256 'e7601405312bd6142514aef98154b2ebe8e06a3154c7afa7bcc03edf0090ddff'

--- a/Casks/tinygrab.rb
+++ b/Casks/tinygrab.rb
@@ -1,5 +1,6 @@
 class Tinygrab < Cask
   url 'http://tinygrab.com/downloads/app/TinyGrab2.5.1.dmg'
+  appcast 'http://tinygrab.com/appcast/tinygrab-appcast.xml'
   homepage 'http://www.tinygrab.com'
   version '2.5.1'
   sha256 '783a2a739233d715d18c05faa2efdbf4c0360e3a420507ca1c4a50e5f5a731c1'

--- a/Casks/todoist.rb
+++ b/Casks/todoist.rb
@@ -1,5 +1,6 @@
 class Todoist < Cask
   url 'https://d2dq6e731uoz0t.cloudfront.net/3334959e6780bf9ff7dbe8fc936e0700/as/Todoist.app.zip'
+  appcast 'http://todoist.com/static/native_apps/mac_app.xml'
   homepage 'https://todoist.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/tomahawk.rb
+++ b/Casks/tomahawk.rb
@@ -1,5 +1,6 @@
 class Tomahawk < Cask
   url 'http://www.tomahawk-player.org/download.php?file=Tomahawk-0.7.0.dmg'
+  appcast 'http://download.tomahawk-player.org/sparkle/update.php'
   homepage 'http://www.tomahawk-player.org/'
   version '0.7.0'
   sha256 'df82d7c8ce9694f115a2e69e2533bde4233818afad5f6b5020bb881dd8cb6504'

--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -1,5 +1,6 @@
 class Trickster < Cask
     url 'http://dl.apparentsoft.com/Trickster_2.2.1.zip'
+  appcast 'http://dl.apparentsoft.com/trickster.rss'
     homepage 'http://www.apparentsoft.com/trickster/'
     version '2.2.1'
     sha256 '6a6531e8c8c7672bf422c496a478ee26f184f1c63036d7f1125913d69a067292'

--- a/Casks/tunnelbear.rb
+++ b/Casks/tunnelbear.rb
@@ -1,5 +1,6 @@
 class Tunnelbear < Cask
   url 'https://tunnelbear.s3.amazonaws.com/downloads/mac/TunnelBear-2.4.1.zip'
+  appcast 'https://s3.amazonaws.com/tunnelbear/downloads/mac/appcast.xml'
   homepage 'https://www.tunnelbear.com/'
   version '2.4.1'
   sha256 'e07d63fbba94677525d82a5c24b4a0fd7f572f229e3ef042fe83e7669eddf327'

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,5 +1,6 @@
 class Tunnelblick < Cask
   url 'http://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_3.3.2.dmg'
+  appcast 'https://www.tunnelblick.net/appcast.rss'
   homepage 'https://code.google.com/p/tunnelblick/'
   version '3.3.2'
   sha256 '1e17563771a9536313e68d5a7ff4bddfebcc97a19704ed2a504517b9c7796026'

--- a/Casks/twentytwo.rb
+++ b/Casks/twentytwo.rb
@@ -1,5 +1,6 @@
 class Twentytwo < Cask
   url 'https://github.com/marcw/twentytwo/raw/master/dist/TwentyTwo.dmg'
+  appcast 'https://raw.github.com/marcw/soundcleod/master/appcast.xml'
   homepage 'https://github.com/marcw/twentytwo'
   version 'latest'
   sha256 :no_check

--- a/Casks/twitterrific.rb
+++ b/Casks/twitterrific.rb
@@ -1,5 +1,6 @@
 class Twitterrific < Cask
   url 'http://iconfactory.com/assets/software/twitterrific/Twitterrific-4.5.1.zip'
+  appcast 'http://iconfactory.com/appcasts/Twitterrific/appcast.xml'
   homepage 'http://twitterrific.com/mac'
   version '4.5.1'
   sha256 '1b43504307e8a541c97a93ecd4c56bc443f66cdd622d319db965e7e0eb760b46'

--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -1,5 +1,6 @@
 class Ukelele < Cask
   url 'http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_2.2.8&filename=Ukelele_2.2.8.dmg'
+  appcast 'http://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=ukelele_su_feed&filename=ukelele_su_feed.xml'
   homepage 'http://scripts.sil.org/ukelele'
   version '2.2.8'
   sha256 'e6200f418dee4ad10fa126536218086273ef8e896b95ede8ba73ddb42ed02ec3'

--- a/Casks/uncrustifyx.rb
+++ b/Casks/uncrustifyx.rb
@@ -1,5 +1,6 @@
 class Uncrustifyx < Cask
   url 'https://github.com/ryanmaxwell/UncrustifyX/releases/download/0.4.3/UncrustifyX-0.4.3.zip'
+  appcast 'https://raw.github.com/ryanmaxwell/uncrustifyx/appcast/uncrustifyx-appcast.xml'
   homepage 'https://github.com/ryanmaxwell/UncrustifyX'
   version '0.4.3'
   sha256 '017c0781ce05db59c1a3fe52a140166df55aa2d87286a7cf5ba5e3eb6b06c7df'

--- a/Casks/uninstallpkg.rb
+++ b/Casks/uninstallpkg.rb
@@ -1,5 +1,6 @@
 class Uninstallpkg < Cask
   url 'http://www.corecode.at/downloads/uninstallpkg_1.0.5.zip'
+  appcast 'http://www.corecode.at/uninstallpkg/uninstallpkg.xml'
   homepage 'http://www.corecode.at/uninstallpkg/'
   version '1.0.5'
   sha256 '199cbae47644572aade93bb81a152934178016da7cf90f3c7136b36d4819e752'

--- a/Casks/unrarx.rb
+++ b/Casks/unrarx.rb
@@ -1,5 +1,6 @@
 class Unrarx < Cask
   url 'http://www.unrarx.com/files/UnRarX_2.2.zip'
+  appcast 'http://www.unrarx.com/update.xml'
   homepage 'http://www.unrarx.com'
   version '2.2'
   sha256 '616c5c536efb29a35fe45c8171874592cc28b269e5d7ed6947c19c8cbb686955'

--- a/Casks/vico.rb
+++ b/Casks/vico.rb
@@ -1,5 +1,6 @@
 class Vico < Cask
   url 'http://www.vicoapp.com/download/vico-r3132.dmg'
+  appcast 'http://www.vicoapp.com/appcast.xml'
   homepage 'http://www.vicoapp.com'
   version 'r3132'
   sha256 'f5c82f320a1e3929492ecb30ba6b50d48af413b33b8e14dac06c75cd06cb809f'

--- a/Casks/videomonkey.rb
+++ b/Casks/videomonkey.rb
@@ -1,5 +1,6 @@
 class Videomonkey < Cask
   url 'http://videomonkey.org/download/videomonkey-0.16.zip'
+  appcast 'http://videomonkey.org/releases/videomonkeycast.xml'
   homepage 'http://videomonkey.org/'
   version '0.16'
   sha256 'ab09a3bb98a78d32ae48c55b6572e4d1e10ead0f26d5ba895a9a2ee5c105088c'

--- a/Casks/videospec.rb
+++ b/Casks/videospec.rb
@@ -1,5 +1,6 @@
 class Videospec < Cask
   url 'http://videospec.free.fr/VideoSpec_0.9.8.dmg'
+  appcast 'http://videospec.free.fr/release/videospec.xml'
   homepage 'http://videospec.free.fr/english/'
   version '0.9.8'
   sha256 '3f1c0bee41512e1d728db693038c394fb2537ede64b79ece63fb7af6fa71676a'

--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,5 +1,6 @@
 class Vienna < Cask
   url 'http://downloads.sourceforge.net/vienna-rss/Vienna3.0.0_beta20.tgz'
+  appcast 'http://vienna-rss.org/changelog_beta.xml'
   homepage 'http://www.vienna-rss.org'
   version '3.0.0_beta20'
   sha256 '9d79e6697866b8a9403ec8e42d702a9eb927cb9757d47167aa474788c7ee7ac1'

--- a/Casks/visualack.rb
+++ b/Casks/visualack.rb
@@ -1,5 +1,6 @@
 class Visualack < Cask
   url 'https://kjkpub.s3.amazonaws.com/vack/VisualAck-0.3.3.zip'
+  appcast 'https://kjkpub.s3.amazonaws.com/vack/appcast.xml'
   homepage 'http://blog.kowalczyk.info/software/vack/'
   version '0.3.3'
   sha256 'bb9c9563003da7075deecc833546796a8da9abbadbde7600434c52c227da347b'

--- a/Casks/vocabulist.rb
+++ b/Casks/vocabulist.rb
@@ -1,5 +1,6 @@
 class Vocabulist < Cask
   url 'http://vocabulistapp.com/downloads/Vocabulist-2.2.dmg'
+  appcast 'http://vocabulistapp.com/downloads/appcast.xml'
   homepage 'http://vocabulistapp.com/'
   version '2.2'
   sha256 '414e77ea72c9caead1b5d7e389ed2541408350cd0a87d1e7e40c0d807ec577be'

--- a/Casks/weibox.rb
+++ b/Casks/weibox.rb
@@ -1,5 +1,6 @@
 class Weibox < Cask
   url 'http://weiboformac.sinaapp.com/downloads/2.6.1.release.zip'
+  appcast 'http://weiboformac.sinaapp.com/appcast/wm2.xml'
   homepage 'http://weiboformac.sinaapp.com'
   version '2.6.1'
   sha256 '60c023ba7cc9f93ac72a7b1a4e8a518595348f4f6d8c4fbef0af8822c318a908'

--- a/Casks/welly.rb
+++ b/Casks/welly.rb
@@ -1,5 +1,6 @@
 class Welly < Cask
   url 'http://welly.googlecode.com/files/Welly.v2.7.fix.zip'
+  appcast 'http://welly.googlecode.com/svn/wiki/WellyUpdate.xml'
   homepage 'https://code.google.com/p/welly/'
   version '2.7+'
   sha256 'cb24a26432d8927b1159a1865602c3f30b5190f628167c954e4d6cc723cfcb0f'

--- a/Casks/witgui.rb
+++ b/Casks/witgui.rb
@@ -1,5 +1,6 @@
 class Witgui < Cask
   url 'http://desairem.altervista.org/witgui/download.php?version=2.1.2'
+  appcast 'http://desairem.altervista.org/witgui/appcast.xml'
   homepage 'http://desairem.altervista.org/witgui/wordpress/'
   version '2.1.2'
   sha256 '4e108153a2cce9fede1358b265dfcd7d9f03c15658e2c9278ddad8a04260cf9b'

--- a/Casks/woodhouse.rb
+++ b/Casks/woodhouse.rb
@@ -1,5 +1,6 @@
 class Woodhouse < Cask
   url 'https://github.com/downloads/phinze/woodhouse/Woodhouse-0.5.0.dmg'
+  appcast 'http://phinze.github.com/woodhouse/appcast.xml'
   homepage 'https://github.com/phinze/woodhouse/'
   version '0.5.0'
   sha256 '3ed1b6711eb9ec862e34addc141d681d9b0fed2950b9d9b7189734087eeb7541'

--- a/Casks/wraparound.rb
+++ b/Casks/wraparound.rb
@@ -1,5 +1,6 @@
 class Wraparound < Cask
   url 'http://www.digicowsoftware.com/downloads/Wraparound2.0b2-2010.zip'
+  appcast 'http://www.digicowsoftware.com/appcast/'
   homepage 'http://www.digicowsoftware.com/detail?_app=Wraparound'
   version '2.0b2'
   sha256 'f156dfa65dad43d38cb3b0f8febd8de9711f4794bb166a293ced93860ebf7879'

--- a/Casks/xscope.rb
+++ b/Casks/xscope.rb
@@ -1,5 +1,6 @@
 class Xscope < Cask
   url 'http://iconfactory.com/assets/software/xscope/xScope-3.6.3.zip'
+  appcast 'http://iconfactory.com/appcasts/xScope/appcast.xml'
   homepage 'http://iconfactory.com/software/xscope'
   version '3.6.3'
   sha256 '1e5e46f50ecd81e35cf819fbd04b2c9726beddc24e86cdd2f6ae5dc60aeb4e4b'

--- a/Casks/xslimmer.rb
+++ b/Casks/xslimmer.rb
@@ -1,5 +1,6 @@
 class Xslimmer < Cask
   url 'http://latenitesoft.com/xslimmer/download/Xslimmer_1.9.dmg'
+  appcast 'http://www.xslimmer.com/releases.xml'
   homepage 'http://latenitesoft.com/xslimmer/'
   version '1.9.4'
   sha256 '3b496e1f51c10e48d6d0d4ac35f35f993a256044e8923936813363d5ef04b56a'

--- a/Casks/xtorrent.rb
+++ b/Casks/xtorrent.rb
@@ -1,5 +1,6 @@
 class Xtorrent < Cask
   url 'http://acquisition.dreamhosters.com/xtorrent/Xtorrent2.1(v171).dmg'
+  appcast 'http://xtorrent.s3.amazonaws.com/appcast.xml'
   homepage 'http://www.xtorrent.com'
   version '2.1 (v171)'
   sha256 '26ea235dcb827c6e58ab3409bec83396e86704d742d517e527016ecd44672379'

--- a/Casks/yemuzip.rb
+++ b/Casks/yemuzip.rb
@@ -1,5 +1,6 @@
 class Yemuzip < Cask
   url 'http://www.yellowmug.com/download/YemuZip.dmg'
+  appcast 'http://yellowmug.com/yemuzip/appcast.xml'
   homepage 'http://www.yellowmug.com/yemuzip'
   version 'latest'
   sha256 :no_check


### PR DESCRIPTION
Again focused on Casks which have version numbers.

This completes the first round of adding Sparkle-standard `appcast` stanzas for `link`-based Casks.

There are still more to be appcasts to be found:
- Casks that were added since I started this process
- Casks that use Sparkle with small modifications
- Casks that use non-Sparkle appcasts
- Casks that don't use `link` the link stanza
