### PR TITLE
Add uninstall stanza for TotalSpaces

### DIFF
--- a/Casks/totalspaces.rb
+++ b/Casks/totalspaces.rb
@@ -4,4 +4,10 @@ class Totalspaces < Cask
   version '1.2.11'
   sha256 'fd54c6ea092f6fae2035745959ff6e080953e77ec6c76715e532b4b0352235d4'
   install 'TotalSpaces.pkg'
+  uninstall :pkgutil => 'com.switchstep.totalspaces',
+            :quit    => 'com.binaryage.TotalSpaces',
+            :signal  => [
+                         ['INT', 'com.binaryage.totalspacescrashwatcher'],
+                         ['KILL', 'com.binaryage.totalspacescrashwatcher'],
+                        ]
 end


### PR DESCRIPTION
Upon installation, two processes are started. One is resilient to the `:quit` directive, so I do believe this is the first usage of the `:signal` directive here. I tried using the `:signal` directive with only an `INT` signal, i.e.:

```
:signal    => ['INT', 'com.binaryage.totalspacescrashwatcher'],
```

but I got this error on uninstall:

```
Error: Cask 'totalspaces' definition is invalid: Each uninstall :signal must have 2 elements.
```

So, I added the `KILL` signal in an array, as shown in the example on the docs, and have the form seen in this PR, which works well enough.
