### PR TITLE
Allow invocation of subcommand with full paths

### DIFF
--- a/bin/brew-cask.rb
+++ b/bin/brew-cask.rb
@@ -40,3 +40,4 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', Pathname.new(__FILE__).realpath
 require 'cask'
 
 Cask::CLI.process(ARGV)
+exit 0

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -133,6 +133,16 @@ We recommend the following:
 	/<path>/<to>/<private>/<repo>/developer/bin/production_brew_cask
 	```
 
+## How Can I Force a Specific Ruby Interpreter?
+
+You can force a specific version of the Ruby interpreter, and/or an
+alternate version of the `brew-cask` subcommand, by invoking `brew cask`
+with fully-qualified paths, like this:
+
+```bash
+$ HOMEBREW_BREW_FILE=/usr/local/bin/brew /System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby /usr/local/Library/brew.rb /usr/local/bin/brew-cask.rb help
+```
+
 ## Hanging out on IRC
 
 We're on IRC at `#homebrew-cask` on Freenode. If you are going to develop for


### PR DESCRIPTION
Full paths to subcommand source and Ruby may be given,
which is helpful in troubleshooting, particularly for
forcing a specific Ruby version.

Example usage:

``` bash
$ HOMEBREW_BREW_FILE=/usr/local/bin/brew /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby /usr/local/Library/brew.rb /usr/local/bin/brew-cask.rb help
```

Previously, this would work, but throw an odd error when
returning to Homebrew.  Fix: we unconditionally do not
return to Homebrew.
