### PR TITLE
Add uninstall stanza for TVMobili

### DIFF
--- a/Casks/tvmobili.rb
+++ b/Casks/tvmobili.rb
@@ -4,4 +4,9 @@ class Tvmobili < Cask
   version 'latest'
   sha256 :no_check
   install 'tvmobili-mountainlion-universal.2.1.4481.pkg'
+  uninstall :pkgutil   => 'com.tvmobili.tvmobilisvcd',
+            :launchctl => [
+                           'com.tvmobili.artwork',
+                           'com.tvmobili.tvmobilisvcd',
+                          ]
 end


### PR DESCRIPTION
After a disproportionate amount of effort, sweat, and tears, this is the result. This installation leaves behind a dock icon (that this `uninstall` stanza doesn't remove - I'm don't think there's a way to unpin stuff from Dock within Cask, but the capability to do so programmatically probably exists somewhere).
