### PR TITLE
put gpsbabel.rb utility function inside namespace

### DIFF
--- a/Casks/gpsbabel.rb
+++ b/Casks/gpsbabel.rb
@@ -1,18 +1,21 @@
-def get_token(unix_timestamp)
-  _hour_in_sec = 60 * 60
-  _constant = 1480813383
-
-  unix_hours = unix_timestamp / _hour_in_sec
-  token = _constant + unix_hours
-
-  token.to_s(16)
-end
-
 class Gpsbabel < Cask
+
+  module Utils
+    def self.get_token(unix_timestamp)
+      _hour_in_sec = 60 * 60
+      _constant = 1480813383
+
+      unix_hours = unix_timestamp / _hour_in_sec
+      token = _constant + unix_hours
+
+      token.to_s(16)
+    end
+  end
+
   url 'http://www.gpsbabel.org/plan9.php',
     :data => {
       'dl' => 'GPSBabel-1.5.1.dmg',
-      'token' => get_token(Time.now.utc.to_i)
+      'token' => Utils.get_token(Time.now.utc.to_i)
     },
     :using => :post
   homepage 'http://www.gpsbabel.org'

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -16,6 +16,7 @@ Domain-Specific Language (DSL) which are not needed in most cases.
  * [Link Stanza Details](#link-stanza-details)
  * [Install Stanza Details](#install-stanza-details)
  * [Uninstall Stanza Details](#uninstall-stanza-details)
+ * [Arbitrary Ruby Methods](#arbitrary-ruby-methods)
 
 
 ## Casks Are Ruby Classes
@@ -476,5 +477,30 @@ A fully manual method for finding bundle ids in a package file follows:
      `find /tmp/expanded.unpkg -name PackageInfo -print0 | xargs -0 grep -i kext` should return a `<bundle id>` tag with a `path`
      attribute that contains a `.kext` extension, for example `<bundle id="com.wavtap.driver.WavTap" ... path="./WavTap.kext" ... />`.
   5. Once bundle ids have been identified, the unpacked package directory can be deleted.
+
+
+## Arbitrary Ruby Methods
+
+In the exceptional case that the Cask DSL is insufficient, it is possible to
+define arbitrary Ruby methods inside the Cask by creating a `Utils` namespace:
+
+```ruby
+class Appname < Cask
+  Module Utils
+    def self.arbitrary_method
+      ...
+    end
+  end
+
+  url "https://#{Utils.arbitrary_method}"
+  homepage 'http://www.example.com/'
+  ...
+end
+```
+
+Example: [gpsbabel.rb](../Casks/gpsbabel.rb)
+
+This should be used sparingly: any method which is needed by two or more
+Casks should instead be rolled into the core.
 
 # <3 THANK YOU TO ALL CONTRIBUTORS! <3


### PR DESCRIPTION
Although, @radeksimko, the trick itself seems to have stopped working.

@phinze, soliciting your advice on whether this is the best way to do such namespacing in principle.
