### PR TITLE
Add uninstall stanza for TrueCrypt

### DIFF
--- a/Casks/truecrypt.rb
+++ b/Casks/truecrypt.rb
@@ -11,4 +11,5 @@ class Truecrypt < Cask
       http://truecrypt.sourceforge.net/
     EOS
   end
+  uninstall :pkgutil => 'org.TrueCryptFoundation.TrueCrypt'
 end


### PR DESCRIPTION
Did not find any `kext`s or launchjobs.

I would like to point out that I've only listed one bundle ID in the `:pkgutil` directive. The `mpkg` actually installs two other packages as well, `com.github.osxfuse.pkg.Core` and `com.google.macfuse.core`, which are OSXFuse and MacFuse, respectively. Because other applications may depend on these frameworks, I chose not to remove them from the system as it might break other apps. Should I add these bundle IDs into the `uninstall` stanza?
