### PR TITLE
DSL: forward-compatible synonyms

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -84,9 +84,24 @@ module Cask::DSL
       end
     end
 
+    # This hash is transitional.  Each of these stanzas will
+    # ultimately either be removed or upgraded with its own
+    # unique semantics.
+    STANZA_ALIASES = {
+                       :pkg                   => :install,          # to remove
+                       :app                   => :link,             # to upgrade
+                       :suite                 => :link,             # to upgrade
+                       :preflight             => :before_install,   # to remove
+                       :postflight            => :after_install,    # to remove
+                       :uninstall_preflight   => :before_uninstall, # to remove
+                       :uninstall_postflight  => :after_uninstall,  # to remove
+                     }
+
     def self.ordinary_artifact_types
       @@ordinary_artifact_types ||= [
                                      :link,
+                                     :app,
+                                     :suite,
                                      :prefpane,
                                      :qlplugin,
                                      :font,
@@ -96,7 +111,8 @@ module Cask::DSL
                                      :binary,
                                      :input_method,
                                      :screen_saver,
-                                     :install,
+                                     :install,      # deprecated
+                                     :pkg,
                                     ]
     end
 
@@ -104,8 +120,9 @@ module Cask::DSL
     installable_artifact_types.push :caskroom_only
 
     installable_artifact_types.each do |type|
+      resolved_type = STANZA_ALIASES.key?(type) ? STANZA_ALIASES[type] : type
       define_method(type) do |*args|
-        artifacts[type] << args
+        artifacts[resolved_type] << args
       end
     end
 
@@ -121,15 +138,20 @@ module Cask::DSL
     end
 
     ARTIFACT_BLOCK_TYPES = [
-      :after_install,
-      :after_uninstall,
-      :before_install,
-      :before_uninstall,
+      :after_install,           # deprecated
+      :after_uninstall,         # deprecated
+      :before_install,          # deprecated
+      :before_uninstall,        # deprecated
+      :preflight,
+      :postflight,
+      :uninstall_preflight,
+      :uninstall_postflight,
     ]
 
     ARTIFACT_BLOCK_TYPES.each do |type|
+      resolved_type = STANZA_ALIASES.key?(type) ? STANZA_ALIASES[type] : type
       define_method(type) do |&block|
-        artifacts[type] << block
+        artifacts[resolved_type] << block
       end
     end
 


### PR DESCRIPTION
This makes the following stanzas available in the DSL as
synonyms to existing stanzas, with no change to existing
functionality:
- pkg for `install`
- app for `link`
- suite for `link`
- preflight for `before_install`
- postflight for `before_uninstall`
- uninstall_preflight for `before_uninstall`
- uninstall_postflight for `after_uninstall`

References #4688

This works, but is marked WIP because we are not in a hurry,
and because I intend to add tests.
