### PR TITLE
DSL: extend `appcast` stanza

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -8,6 +8,7 @@ require 'download_strategy'
 require 'cmd/update'
 require 'rubygems'
 
+require 'cask/appcast'
 require 'cask/artifact'
 require 'cask/audit'
 require 'cask/auditor'

--- a/lib/cask/appcast.rb
+++ b/lib/cask/appcast.rb
@@ -1,0 +1,33 @@
+class Cask::Appcast
+
+  # note  :latest_version is considered experimental
+  #       and may be removed
+
+  APPCAST_FORMATS = Set.new [
+                             :sparkle,     # first one is the default
+                             :plaintext,
+                             :unknown,
+                            ]
+
+  attr_reader :parameters, :sha256, :format, :latest_version
+
+  def initialize(uri, parameters={})
+    @parameters     = parameters
+    @uri            = Cask::UnderscoreSupportingURI.parse(uri)
+    @sha256         = @parameters[:sha256]
+    @latest_version = @parameters[:latest_version]
+    @format         = @parameters[:format]
+    @format         = APPCAST_FORMATS.first if @format.nil?
+    unless APPCAST_FORMATS.include?(@format)
+      raise "invalid appcast format: '#{@format.inspect}'"
+    end
+  end
+
+  def to_yaml
+    [@uri, @parameters].to_yaml
+  end
+
+  def to_s
+    @uri.to_s
+  end
+end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -46,7 +46,9 @@ module Cask::DSL
         raise CaskInvalidError.new(self.title, "'appcast' stanza may only appear once")
       end
       @appcast ||= begin
-        Cask::UnderscoreSupportingURI.parse(*args) unless args.empty?
+        Cask::Appcast.new(*args) unless args.empty?
+      rescue StandardError => e
+        raise CaskInvalidError.new(self.title, e)
       end
     end
 

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -8,17 +8,6 @@ describe Cask::DSL do
     test_cask.version.must_equal '1.2.3'
   end
 
-  it "lets you set checksum via sha256" do
-    ChecksumCask = Class.new(Cask)
-    ChecksumCask.class_eval do
-      sha256 'imasha2'
-    end
-    instance = ChecksumCask.new
-    instance.sums.must_equal [
-      Checksum.new(:sha2, 'imasha2')
-    ]
-  end
-
   it "prevents the entire world from crashing when a cask includes an unknown method" do
     UnexpectedMethodCask = Class.new(Cask)
     begin
@@ -43,73 +32,100 @@ describe Cask::DSL do
     end
   end
 
-  it "allows you to specify linkables" do
-    CaskWithLinkables = Class.new(Cask)
-    CaskWithLinkables.class_eval do
-      link 'Foo.app'
-      link 'Bar.app'
-    end
-
-    instance = CaskWithLinkables.new
-    Array(instance.artifacts[:link]).sort.must_equal [['Bar.app'], ['Foo.app']]
-  end
-
-  it "allow linkables to be set to empty" do
-    CaskWithNoLinkables = Class.new(Cask)
-
-    instance = CaskWithNoLinkables.new
-    Array(instance.artifacts[:link]).must_equal %w[]
-  end
-
-  it "allows caveats to be specified via a method define" do
-    PlainCask = Class.new(Cask)
-
-    instance = PlainCask.new
-
-    instance.caveats.must_be :empty?
-
-    CaskWithCaveats = Class.new(Cask)
-    CaskWithCaveats.class_eval do
-      def caveats; <<-EOS.undent
-        When you install this cask, you probably want to know this.
-        EOS
+  describe "sha256 stanza" do
+    it "lets you set checksum via sha256" do
+      ChecksumCask = Class.new(Cask)
+      ChecksumCask.class_eval do
+        sha256 'imasha2'
       end
+      instance = ChecksumCask.new
+      instance.sums.must_equal [
+                                Checksum.new(:sha2, 'imasha2')
+                               ]
+    end
+  end
+
+  describe "link stanza" do
+    it "allows you to specify linkables" do
+      CaskWithLinkables = Class.new(Cask)
+      CaskWithLinkables.class_eval do
+        link 'Foo.app'
+        link 'Bar.app'
+      end
+
+      instance = CaskWithLinkables.new
+      Array(instance.artifacts[:link]).sort.must_equal [['Bar.app'], ['Foo.app']]
     end
 
-    instance = CaskWithCaveats.new
+    it "allow linkables to be set to empty" do
+      CaskWithNoLinkables = Class.new(Cask)
 
-    instance.caveats.must_equal "When you install this cask, you probably want to know this.\n"
-  end
-
-  it "allows installable pkgs to be specified" do
-    CaskWithInstallables = Class.new(Cask)
-    CaskWithInstallables.class_eval do
-      install 'Foo.pkg'
-      install 'Bar.pkg'
+      instance = CaskWithNoLinkables.new
+      Array(instance.artifacts[:link]).must_equal %w[]
     end
-
-    instance = CaskWithInstallables.new
-    Array(instance.artifacts[:install]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
   end
 
-  it "prevents defining multiple urls" do
-    err = lambda {
-      invalid_cask = Cask.load('invalid/invalid-two-url')
-    }.must_raise(CaskInvalidError)
-    err.message.must_include "'url' stanza may only appear once"
+  describe "caveats stanza" do
+    it "allows caveats to be specified via a method define" do
+      PlainCask = Class.new(Cask)
+
+      instance = PlainCask.new
+
+      instance.caveats.must_be :empty?
+
+      CaskWithCaveats = Class.new(Cask)
+      CaskWithCaveats.class_eval do
+        def caveats; <<-EOS.undent
+          When you install this cask, you probably want to know this.
+          EOS
+        end
+      end
+
+      instance = CaskWithCaveats.new
+
+      instance.caveats.must_equal "When you install this cask, you probably want to know this.\n"
+    end
   end
 
-  it "prevents defining multiple homepages" do
-    err = lambda {
-      invalid_cask = Cask.load('invalid/invalid-two-homepage')
-    }.must_raise(CaskInvalidError)
-    err.message.must_include "'homepage' stanza may only appear once"
+  describe "pkg stanza" do
+    it "allows installable pkgs to be specified" do
+      CaskWithInstallables = Class.new(Cask)
+      CaskWithInstallables.class_eval do
+        install 'Foo.pkg'
+        install 'Bar.pkg'
+      end
+
+      instance = CaskWithInstallables.new
+      Array(instance.artifacts[:install]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
+    end
   end
 
-  it "prevents defining multiple versions" do
-    err = lambda {
-      invalid_cask = Cask.load('invalid/invalid-two-version')
-    }.must_raise(CaskInvalidError)
-    err.message.must_include "'version' stanza may only appear once"
+  describe "url stanza" do
+    it "prevents defining multiple urls" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-two-url')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include "'url' stanza may only appear once"
+    end
+  end
+
+  describe "homepage stanza" do
+    it "prevents defining multiple homepages" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-two-homepage')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include "'homepage' stanza may only appear once"
+    end
+  end
+
+  describe "version stanza" do
+    it "prevents defining multiple versions" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-two-version')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include "'version' stanza may only appear once"
+    end
+  end
+
   end
 end

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -127,5 +127,29 @@ describe Cask::DSL do
     end
   end
 
+  describe "appcast stanza" do
+    it "allows appcasts to be specified" do
+      cask = Cask.load('with-appcast')
+      cask.appcast.to_s.must_match %r{^http}
+    end
+
+    it "prevents defining multiple appcasts" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-appcast-multiple')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include "'appcast' stanza may only appear once"
+    end
+
+    it "refuses to load invalid appcast URLs" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-appcast-url')
+      }.must_raise(CaskInvalidError)
+    end
+
+    it "refuses to load if appcast :format is invalid" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-appcast-format')
+      }.must_raise(CaskInvalidError)
+    end
   end
 end

--- a/test/support/Casks/invalid/invalid-appcast-format.rb
+++ b/test/support/Casks/invalid/invalid-appcast-format.rb
@@ -1,0 +1,10 @@
+class InvalidAppcastFormat < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/invalid-appcast-format'
+  appcast 'http://example.com/appcast.xml',
+          :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
+          :format => :no_such_format
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  link 'Caffeine.app'
+end

--- a/test/support/Casks/invalid/invalid-appcast-multiple.rb
+++ b/test/support/Casks/invalid/invalid-appcast-multiple.rb
@@ -1,0 +1,13 @@
+class InvalidAppcastMultiple < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/invalid-appcast-multiple'
+  appcast 'http://example.com/appcast1.xml',
+          :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
+          :format => :sparkle
+  appcast 'http://example.com/appcast2.xml',
+          :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
+          :format => :sparkle
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  link 'Caffeine.app'
+end

--- a/test/support/Casks/invalid/invalid-appcast-url.rb
+++ b/test/support/Casks/invalid/invalid-appcast-url.rb
@@ -1,0 +1,10 @@
+class InvalidAppcastUrl < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/invalid-appcast-url'
+  appcast 1,
+          :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
+          :format => :sparkle
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  link 'Caffeine.app'
+end

--- a/test/support/Casks/with-appcast.rb
+++ b/test/support/Casks/with-appcast.rb
@@ -1,0 +1,10 @@
+class WithAppcast < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/with-appcast'
+  appcast 'http://example.com/appcast.xml',
+          :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
+          :format => :sparkle
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  link 'Caffeine.app'
+end


### PR DESCRIPTION
Extend `appcast` stanza to support multiple keys
- `:sha256`
- `:format` (default is `:sparkle`)
- `:latest_version` (experimental, may be removed)

add tests.

References: #4688
