### PR TITLE
DSL: allow `version :latest` (symbol not string)

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -135,7 +135,7 @@ class Cask
   end
 
   def destination_path
-    caskroom_path.join(version)
+    caskroom_path.join(version.to_s)
   end
 
   def installed?

--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -40,12 +40,16 @@ class Cask::Audit
 
   def _check_sha256_no_check_if_latest
     odebug "Verifying sha256 :no_check with version 'latest'"
-    add_error "you should use sha256 :no_check when version is 'latest'" if cask.version == "latest" && cask.sums.is_a?(Array)
+    if ((cask.version == "latest" or cask.version == :latest) and cask.sums.is_a?(Array))
+      add_error "you should use sha256 :no_check when version is 'latest'"
+    end
   end
 
   def _check_sha256_if_versioned
     odebug "Verifying a sha256 is present when versioned"
-    add_error "you must include a sha256 when version is not 'latest'" if cask.version != "latest" && cask.sums == :no_check
+    if ((cask.version != "latest" and cask.version != :latest) and cask.sums == :no_check)
+      add_error "you must include a sha256 when version is not 'latest'"
+    end
   end
 
   def _check_download(download)

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -29,7 +29,7 @@ class Cask::CaveatsDSL
   end
 
   def destination_path
-    caskroom_path.join(@cask.version)
+    caskroom_path.join(@cask.version.to_s)
   end
 
   # DSL. Each method should handle output, following the convention of

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -17,7 +17,7 @@ module Cask::DownloadStrategy
       cask.title,
       ::Resource.new(cask.title) do |r|
         r.url     cask.url.to_s
-        r.version cask.version
+        r.version cask.version.to_s
       end
     )
   end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -57,11 +57,19 @@ module Cask::DSL
       @container_type ||= type
     end
 
-    def version(version=nil)
-      if @version and !version.nil?
+    SYMBOLIC_VERSIONS = Set.new [
+      :latest,
+    ]
+
+    def version(arg=nil)
+      if arg.nil?
+        @version
+      elsif @version
         raise CaskInvalidError.new(self.title, "'version' stanza may only appear once")
+      elsif !arg.is_a?(String) and !SYMBOLIC_VERSIONS.include?(arg)
+        raise CaskInvalidError.new(self.title, "invalid 'version' value: '#{arg.inspect}'")
       end
-      @version ||= version
+      @version ||= arg
     end
 
     def depends_on_formula(*args)


### PR DESCRIPTION
Forward-compatibility. Intentionally not documented.  When
version is a symbol, it may only be `:latest`.

References: #4688
