### PR TITLE
DSL: remove special properties of `caskroom_only` stanza

### DIFF
--- a/lib/cask/artifact/caskroom_only.rb
+++ b/lib/cask/artifact/caskroom_only.rb
@@ -1,4 +1,4 @@
-class Cask::Artifact::CaskroomOnly < Cask::Artifact::Pkg
+class Cask::Artifact::CaskroomOnly < Cask::Artifact::Base
   def self.artifact_dsl_key
     :caskroom_only
   end


### PR DESCRIPTION
HOLD until #4865 is merged.  The test suite passes, but this would actually
break some unusual Casks without #4865.

After #4865, `caskroom_only` can be subclassed from `Cask::Artifact::Base`
like any other artifact.  It no longer has the special property of making
`uninstall` stanzas work.

This stanza has never been documented.  It is possible that it will no longer
be needed, after #4865 and subsequent cleanup on Casks that use this form.

References: #4688
