### PR TITLE
DSL: add `zap` stanza

### DIFF
--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -21,7 +21,7 @@ require 'cask/artifact/caskroom_only'
 require 'cask/artifact/input_method'
 require 'cask/artifact/screen_saver'
 require 'cask/artifact/uninstall'
-
+require 'cask/artifact/zap'
 
 module Cask::Artifact
   #
@@ -46,6 +46,7 @@ module Cask::Artifact
       Cask::Artifact::ScreenSaver,
       Cask::Artifact::Uninstall,
       Cask::Artifact::AfterBlock,
+      Cask::Artifact::Zap,
     ]
   end
 

--- a/lib/cask/artifact/zap.rb
+++ b/lib/cask/artifact/zap.rb
@@ -1,0 +1,13 @@
+class Cask::Artifact::Zap < Cask::Artifact::UninstallBase
+  def install_phase
+    odebug "Nothing to do. The zap artifact has no install phase."
+  end
+
+  def uninstall_phase
+    odebug "Nothing to do. The zap artifact has no uninstall phase."
+  end
+
+  def zap_phase
+    dispatch_uninstall_directives(self.class.artifact_dsl_key)
+  end
+end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -121,7 +121,8 @@ module Cask::DSL
 
     SPECIAL_ARTIFACT_TYPES = [
       :nested_container,
-      :uninstall
+      :uninstall,
+      :zap,
     ]
 
     SPECIAL_ARTIFACT_TYPES.each do |type|


### PR DESCRIPTION
HOLD until #4865.  Tests will fail until #4865.  Will also MERGE CONFLICT
after #4865, and require minor cleanup.

The zap functionality here is in working form, but there is not a
corresponding `brew cask zap` command verb, which is to be supplied
in a separate PR.

Like other forward-compatible DSL extensions, it is intentionally
undocumented.

References: #4688
