### PR TITLE
DSL: add `dsl` stanza, defining DSL specification version for a Cask

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -6,6 +6,12 @@ module Cask::DSL
     base.extend(ClassMethods)
   end
 
+  # Slightly confusing: there is a method  "dsl" inside the
+  # namespace Cask::DSL.  Lowercase "dsl" follows the Cask
+  # stanza "dsl", which is nothing more than a version number
+  # for the Cask language spec.
+  def dsl; self.class.dsl; end
+
   def homepage; self.class.homepage; end
 
   def url; self.class.url; end
@@ -25,6 +31,13 @@ module Cask::DSL
   def caveats; self.class.caveats; end
 
   module ClassMethods
+    def dsl(arg=nil)
+      if @dsl and !arg.nil?
+        raise CaskInvalidError.new(self.title, "'dsl' stanza may only appear once")
+      end
+      @dsl ||= arg
+    end
+
     def homepage(homepage=nil)
       if @homepage and !homepage.nil?
         raise CaskInvalidError.new(self.title, "'homepage' stanza may only appear once")

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -73,6 +73,7 @@ module Cask::Utils
       odebug "Cask instance dumps in YAML:"
       odebug "Cask instance toplevel:", self.to_yaml
       [
+       :dsl,
        :homepage,
        :url,
        :appcast,

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -112,4 +112,18 @@ describe Cask::DSL do
     }.must_raise(CaskInvalidError)
     err.message.must_include "'version' stanza may only appear once"
   end
+
+  describe "dsl stanza" do
+    it "allows dsl version to be defined" do
+      cask = Cask.load('with-dsl-stanza')
+      cask.dsl.to_s.must_match %r{\S}
+    end
+
+    it "prevents defining dsl version multiple times" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-dsl-stanza-multiple')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include "'dsl' stanza may only appear once"
+    end
+  end
 end

--- a/test/support/Casks/invalid/invalid-dsl-stanza-multiple.rb
+++ b/test/support/Casks/invalid/invalid-dsl-stanza-multiple.rb
@@ -1,0 +1,9 @@
+class InvalidDslStanzaMultiple < TestCask
+  dsl '1.0'
+  dsl '1.0'
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/invalid-dsl-stanza-multiple'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  link 'Caffeine.app'
+end

--- a/test/support/Casks/with-dsl-stanza.rb
+++ b/test/support/Casks/with-dsl-stanza.rb
@@ -1,0 +1,8 @@
+class WithDslStanza < TestCask
+  dsl '1.0'
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/with-dsl-stanza'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  link 'Caffeine.app'
+end


### PR DESCRIPTION
References: #4688

Renamed `dsl` from earlier proposed stanza `spec`.

I remain conflicted about adding boilerplate to the Cask language.  Simplicity is
what makes Casks amenable to first-time authors, and first-time authors are the
principal drivers of this project.

However, the technical advantage of specifying the DSL version is pretty hard to deny
if we merge #3066 — which is also seeking simplicity, in the form of very straightforward
bookkeeping.

The alternatives to #3066 are: binary serialization (which will break), or creating
a new log format which largely duplicates the info in the Cask DSL — which requires
much more new code.  Also, both alternatives would reduce transparency to the
user.
