### PR TITLE
ensure more informative errors from `dmg.rb`

### DIFF
--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -30,6 +30,7 @@ class Cask::Container::Dmg < Cask::Container::Base
   end
 
   def mounts_from_plist(plist)
+    return [] unless plist.respond_to?(:fetch)
     plist.fetch('system-entities', []).map do |entity|
       entity['mount-point']
     end.compact


### PR DESCRIPTION
The logic for better errors was already there; this just makes
sure that another exceptional case is handled, and falls through
to the existing error-check.

References: #4857
