### PR TITLE
Add X11 support to the `caveats` mini-DSL

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -4,4 +4,8 @@ class Inkscape < Cask
   version '0.48.2-1'
   sha256 'dc45811c450687cf2a455decc047b27a53f79cc926cd3a3c57c60e757e5710f8'
   link 'Inkscape.app'
+
+  caveats do
+    x11_required
+  end
 end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -5,6 +5,10 @@ class Wireshark < Cask
   sha256 'dad35fa72d763b19cbd11ae9d339144d3b205c1b3575d51368d9b81c43f1b527'
   install 'Wireshark 1.10.8 Intel 64.pkg'
 
+  caveats do
+    x11_required
+  end
+
   after_install do
     if Process.euid == 0 then
       ohai "Note:"

--- a/Casks/x48.rb
+++ b/Casks/x48.rb
@@ -5,10 +5,8 @@ class X48 < Cask
   version '0.6.4'
   sha256 '21184fceec8fd471d034932ac9b49f41c98cd5d730fa3fb02ccf0bcf02951f70'
   link 'x48-0.6.4 osx/x48.app'
-  caveats <<-EOS.undent
-    x48 requires XQuartz/X11, which can be installed via homebrew-cask by
-        brew cask install xquartz
-    or manually, by downloading the package from
-        http://xquartz.macosforge.org
-    EOS
+
+  caveats do
+    x11_required
+  end
 end

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -158,6 +158,17 @@ class Cask::CaveatsDSL
     end
   end
 
+  def x11_required
+    unless File.exist?('/usr/X11/bin/X')
+      puts <<-EOS.undent
+      #{@cask} requires XQuartz/X11, which can be installed via homebrew-cask by
+          brew cask install xquartz
+      or manually, by downloading the package from
+          http://xquartz.macosforge.org
+      EOS
+    end
+  end
+
   def method_missing(method, *args)
     poo = <<-EOPOO.undent
       Unexpected method #{method} called on caveats in Cask #{@cask}.


### PR DESCRIPTION
Since this applies to a few different Casks, and is easy to add.

References: #4861 .
