### PR TITLE
don't undent CaskError exception text

### DIFF
--- a/lib/cask/exceptions.rb
+++ b/lib/cask/exceptions.rb
@@ -51,14 +51,14 @@ class CaskCommandFailedError < CaskError
   end
 
   def to_s;
-    <<-EOS.undent
-      Command failed to execute!
+    <<-EOS
+Command failed to execute!
 
-      ==> Failed command:
-      #{@cmd}
+==> Failed command:
+#{@cmd}
 
-      ==> Output of failed command:
-      #{@output}
+==> Output of failed command:
+#{@output}
     EOS
   end
 end


### PR DESCRIPTION
The content of `output` is probably not indented, and will be
left-truncated if it is multi-line.  This happens often with
Travis `hdiutil` errors
