### PR TITLE
XQuartz: Create Logs dir if it does not exist

### DIFF
--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -5,6 +5,11 @@ class Xquartz < Cask
   version '2.7.6'
   sha256 '02aa3268af0bd7dcd5dfbc10d673f5c6834bba6371a928d2a3fc44a8039b194e'
   install 'XQuartz.pkg'
+
+  after_install do
+    Pathname.new(Dir.home).join('Library', 'Logs').mkpath
+  end
+
   uninstall :quit => 'org.macosforge.xquartz.X11',
             :pkgutil => 'org.macosforge.xquartz.pkg'
 end


### PR DESCRIPTION
Apparently Apple devs just rely on other apps to create the `~/Library/Logs` directory.

This error came up when installing XQuartz on a fresh OSX VM (with XCode CLI tools + Homebrew + Homebrew Cask):
![screenshot](https://cloud.githubusercontent.com/assets/287584/3278643/bb47f83c-f3cb-11e3-8ef9-7aabea211362.png)

I have many other apps using that directory on my "host" OSX, any of them theoretically could have the same problem, but at least one of these have managed to create the directory (I haven't created the directory manually).

```
$ ls ~/Library/Logs
ACC.log             MusicManager
AMRestoreLog.txt        NELog.log
Adobe               PDApp.log
Adobe Illustrator CS6       ScreenRecycler.log
AdobeDownload           SparkleUpdateLog.log
AdobeIPCBroker.log      Spotify
AdobeIPCBrokerCustomHook.log    Ubiquity
AndroidStudioPreview        Unity
CleanMyMac 2.log        VMware
DiagnosticReports       VMware Fusion
DiscRecording.log       WebIde50
DiskUtility.log         X11
FaceTime            appstore.log
FlashPlayerInstallManager.log   com.macpaw.CleanMyMac2
Garmin              fsck_hfs.log
GoogleSoftwareUpdateAgent.log   iOS Simulator
Homebrew            iStatMenus.log
ICDM                iStatMenus2.log
Last.fm             pip.log
Last.fm Twiddly.log     storeagent
Last.fm iTunes Plugin.log   talagent.log
Last.fm.log         vnc
MTPViewer
```
