### PR TITLE
defensive driving against errors running `hdiutil`

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -57,7 +57,12 @@ class Cask::SystemCommand
 
   def self._parse_plist(command, output)
     begin
-      Plist::parse_xml(output)
+      raise Plist::ParseError "Empty XML input" unless output =~ %r{\S}
+      xml = Plist::parse_xml(output)
+      unless xml.respond_to?(:keys) and xml.keys.size > 0
+        raise Plist::ParseError "Empty XML output"
+      end
+      xml
     rescue Plist::ParseError
       raise CaskError.new(<<-ERRMSG)
 Error parsing plist output from command.


### PR DESCRIPTION
This may not be strictly necessary.  But it should help track
down the `hdiutil` errors, which are persistent, but occasional,
and hard to reproduce. (We pass a flag to `hdiutil` to make
respond in XML.)

References: #4857.
