### PR TITLE
fix checksum errors and upgrade to the latest download address.

### DIFF
--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -1,9 +1,9 @@
 # encoding: UTF-8
 class Baiduinput < Cask
-  url 'http://shouji.baidu.com/download/1000e/baiduinput_mac_v3.2_1000e.dmg'
+  url 'http://wuxian.baidu.com/download/1000e/baiduinput_mac_v3.2_1000e.dmg'
   homepage 'http://wuxian.baidu.com/input/mac.html'
-  version '3.2'
-  sha256 'a74ef75bee54e6d563f795a943d9328c3229205b273be38c6df144f49c9d67d5'
+  version '3.2_1000e'
+  sha256 'a8599116bb9248a06b7a26f7be73061cb00263263fe685cb0b7c6c99fce6cf56'
   install '安装百度输入法.pkg'
   uninstall :pkgutil  => 'com.baidu.inputmethod.*',
             :files    => [


### PR DESCRIPTION
Upgrade BaiduIM.app download address to http://wuxian.baidu.com/download/1000e/baiduinput_mac_v3.2_1000e.dmg

Fix checksum errors in baiduinput Cask.

Below is previous problem log:

```
# gba2z at Xiaotians-MacBook-Pro.local in ~ [0:10:24]
$ brew cask cleanup
==> Removing dead symlinks
==> Removing cached downloads
/Library/Caches/Homebrew/alfred-2.3_264.zip
/Library/Caches/Homebrew/aliwangwang-latest
/Library/Caches/Homebrew/baiduinput-3.2.dmg
/Library/Caches/Homebrew/caffeine-1.1.1.php
/Library/Caches/Homebrew/cheatsheet-latest.php
/Library/Caches/Homebrew/cleanmymac-latest.dmg
/Library/Caches/Homebrew/flash-14.0.0.125.zip
/Library/Caches/Homebrew/google-chrome-latest.dmg
/Library/Caches/Homebrew/reeder-2.0b7.zip
/Library/Caches/Homebrew/the-unarchiver-3.9.1.zip
/Library/Caches/Homebrew/thunder-2.6.3.1576.dmg
/Library/Caches/Homebrew/xiami-1.3.1-1821.dmg

# gba2z at Xiaotians-MacBook-Pro.local in ~ [0:10:42]
$ brew cask install baiduinput
==> Downloading http://shouji.baidu.com/download/1000e/baiduinput_mac_v3.2_1000e
######################################################################## 100.0%
==> Note: running "brew update" may fix checksum errors
Error: SHA2 mismatch
Expected: a74ef75bee54e6d563f795a943d9328c3229205b273be38c6df144f49c9d67d5
Actual: a8599116bb9248a06b7a26f7be73061cb00263263fe685cb0b7c6c99fce6cf56
Archive: /Library/Caches/Homebrew/baiduinput-3.2.dmg
To retry an incomplete download, remove the file above.

# gba2z at Xiaotians-MacBook-Pro.local in ~ [0:11:54]
$ brew cask doctor
==> OS X Version:
10.9.3
==> Hardware Architecture:
intel-64
==> Ruby Version:
2.0.0-p451
==> Ruby Path:
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby
==> Homebrew Version:
0.9.5
==> Homebrew Executable Path:
/usr/local/bin/brew
==> Homebrew Cellar Path:
/usr/local/Cellar
==> Homebrew Repository Path:
/usr/local
==> Homebrew Origin:
https://github.com/Homebrew/homebrew.git
==> Homebrew-cask Version:
0.36.2
==> Homebrew-cask Default Tap Path:
/usr/local/Library/Taps/caskroom/homebrew-cask
==> Homebrew-cask Alternate Cask Taps:
<NONE>
==> Homebrew-cask Default Tap Cask Count:
1608
==> Contents of $LOAD_PATH:
/usr/local/Cellar/brew-cask/0.36.2/rubylib
/usr/local/Library/Homebrew
/Library/Ruby/Site/2.0.0
/Library/Ruby/Site/2.0.0/x86_64-darwin13
/Library/Ruby/Site/2.0.0/universal-darwin13
/Library/Ruby/Site
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/vendor_ruby/2.0.0
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/vendor_ruby/2.0.0/x86_64-darwin13
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/vendor_ruby/2.0.0/universal-darwin13
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/vendor_ruby
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/x86_64-darwin13
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/universal-darwin13
==> Contents of $RUBYLIB Environment Variable:
<NONE>
==> Contents of $RUBYOPT Environment Variable:
<NONE>
==> Contents of $RUBYPATH Environment Variable:
<NONE>
==> Contents of $RBENV_VERSION Environment Variable:
<NONE>
==> Contents of $CHRUBY_VERSION Environment Variable:
<NONE>
==> Contents of $GEM_HOME Environment Variable:
<NONE>
==> Contents of $GEM_PATH Environment Variable:
<NONE>
==> Contents of $BUNDLE_PATH Environment Variable:
<NONE>
==> Contents of $PATH Environment Variable:
PATH="/usr/local/share/python:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/Library/Contributions/cmd"
==> Contents of $SHELL Environment Variable:
SHELL="/bin/zsh"
==> Contents of Locale Environment Variables:
LANG="en_US.UTF-8"
LC_CTYPE="en_US.UTF-8"
==> Running As Privileged User:
No
```
