### PR TITLE
X11/XQuartz should work right after installation

### DIFF
--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -8,8 +8,15 @@ class Xquartz < Cask
 
   after_install do
     Pathname.new(Dir.home).join('Library', 'Logs').mkpath
+
+    # Set default path to X11 = avoid the need of manual setup
+    system '/usr/bin/defaults', 'write', 'com.apple.applescript', 'ApplicationMap', '-dict-add', 'X11', 'file://localhost/Applications/Utilities/XQuartz.app/'
+
+    # Load & start XServer = avoid the need of relogin
+    system '/bin/launchctl', 'load', '/Library/LaunchAgents/org.macosforge.xquartz.startx.plist'
   end
 
   uninstall :quit => 'org.macosforge.xquartz.X11',
+            :launchctl => 'org.macosforge.xquartz.startx',
             :pkgutil => 'org.macosforge.xquartz.pkg'
 end


### PR DESCRIPTION
When I take any of the X11 app - Inkscape or Wireshark or x48, none of them will work right after installing XQuartz without some extra bits of work:
1. User would have to **relogin** to activate & start the XServer daemon
2. User would have to manually **choose the location of X11**

![screen-x11-dialog](https://cloud.githubusercontent.com/assets/287584/3279447/06a849f0-f3fc-11e3-884c-136367ea6f8e.png)

This will free user's hands completely, well almost completely. The only bit left is this:

![screen-wireshark](https://cloud.githubusercontent.com/assets/287584/3279452/34585854-f3fc-11e3-921e-b30bd9249462.png)

but I was not trying to find out how to build the font cache and I'm not even convinced we should be doing that on behalf of the user.
#### Feel free to test it on a fresh OSX:

```
brew cask install xquartz wireshark inkscape x48
```
