### PR TITLE
permit `hdiutil` to exit with error code

### DIFF
--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -20,7 +20,7 @@ class Cask::Container::Dmg < Cask::Container::Base
   end
 
   def mount!
-    plist = @command.run!('/usr/bin/hdiutil',
+    plist = @command.run('/usr/bin/hdiutil',
       # realpath is a failsafe against unusual filenames
       :args => %w[mount -plist -nobrowse -readonly -noidme -mountrandom /tmp] + [Pathname.new(@path).realpath],
       :input => %w[y],


### PR DESCRIPTION
Mysterious `hdiutil` errors are a longtime problem with the
test suite, and the largest cause of false Travis failure
reports.

What appears to happen is that `hdiutil` returns a valid
plist output, but also exits with an error code.

Recently, user errors have been reported which seem to be
related to the same problem (#4857).

After #4892 and #4887, we have have more assurances that mount errors
will be caught elsewhere, if the XML is incorrect/missing, or if the
mounts are not returned.

So, for this special case, it should be safe to simply
ignore the error code from `hdiutil`.
