### PR TITLE
Update compatability of TotalSpaces.app to exclude Mavericks

### DIFF
--- a/Casks/totalspaces.rb
+++ b/Casks/totalspaces.rb
@@ -10,4 +10,7 @@ class Totalspaces < Cask
                          ['INT', 'com.binaryage.totalspacescrashwatcher'],
                          ['KILL', 'com.binaryage.totalspacescrashwatcher'],
                         ]
+  caveats do
+    os_version_only '10.8', '10.7'
+  end
 end


### PR DESCRIPTION
Total Spaces is only compatible with OSX 10.7 and 10.8

http://totalspaces.binaryage.com/faq
