### PR TITLE
suggested (not enforced) order for Cask stanzas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,12 @@ the `link` stanza as many times as you need, to create multiple links:
 
 ```ruby
 class Alfred < Cask
-  url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
-  homepage 'http://www.alfredapp.com/'
   version '2.3_264'
   sha256 'a32565cdb1673f4071593d4cc9e1c26bc884218b62fef8abc450daa47ba8fa92'
+
+  url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
+  homepage 'http://www.alfredapp.com/'
+
   link 'Alfred 2.app'
   link 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
 end
@@ -47,10 +49,12 @@ Here is another Cask for `Vagrant.pkg`:
 
 ```ruby
 class Vagrant < Cask
-  url 'https://dl.bintray.com/mitchellh/vagrant/Vagrant-1.4.3.dmg'
-  homepage 'http://www.vagrantup.com'
   version '1.4.3'
   sha256 'e7ff13b01d3766829f3a0c325c1973d15b589fe1a892cf7f857da283a2cbaed1'
+
+  url 'https://dl.bintray.com/mitchellh/vagrant/Vagrant-1.4.3.dmg'
+  homepage 'http://www.vagrantup.com'
+
   install 'Vagrant.pkg'
   uninstall :script => { :executable => 'uninstall.tool', :input => %w[Yes] }
 end
@@ -96,10 +100,12 @@ this:
 
 ```ruby
 class MyNewCask < Cask
-  url ''
-  homepage ''
   version ''
   sha256 ''
+
+  url ''
+  homepage ''
+
   link ''
 end
 ```

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -26,10 +26,12 @@ is always enclosed in a `class ... end` block.  Example:
 
 ```ruby
 class Alfred < Cask
-  url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
-  homepage 'http://www.alfredapp.com/'
   version '2.3_264'
   sha256 'a32565cdb1673f4071593d4cc9e1c26bc884218b62fef8abc450daa47ba8fa92'
+
+  url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
+  homepage 'http://www.alfredapp.com/'
+
   link 'Alfred 2.app'
   link 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
 end
@@ -40,8 +42,12 @@ end
 
 Each Cask contains a series of stanzas (or "fields") which *declare* how the
 software is to be obtained and installed.  In a declarative language, the
-author does not need to worry about order.  As long as all the needed fields
-are present, homebrew-cask will figure out what needs to be done.
+author does not need to worry about **order**.  As long as all the needed fields
+are present, homebrew-cask will figure out what needs to be done at install
+time.
+
+To make maintenance easier, the most-frequently-updated stanzas are usually
+placed at the top.  But that's a convention, not a rule.
 
 Exception: `do` blocks such as `after_install` may enclose a block of
 pure Ruby code.  Lines within that block follow a procedural (order-dependent)
@@ -493,13 +499,14 @@ class Appname < Cask
     end
   end
 
+  version '1.0'
+  sha256 'a32565cdb1673f4071593d4cc9e1c26bc884218b62fef8abc450daa47ba8fa92'
+
   url "https://#{Utils.arbitrary_method}"
   homepage 'http://www.example.com/'
   ...
 end
 ```
-
-Example: [gpsbabel.rb](../Casks/gpsbabel.rb)
 
 This should be used sparingly: any method which is needed by two or more
 Casks should instead be rolled into the core.

--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -20,10 +20,12 @@ module Cask::CLI::Create
     cask_class = cask_name.split('-').map(&:capitalize).join
     <<-EOS.undent
       class #{cask_class} < Cask
-        url 'https://'
-        homepage ''
         version ''
         sha256 ''
+
+        url 'https://'
+        homepage ''
+
         link ''
       end
     EOS

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -40,10 +40,12 @@ describe Cask::CLI::Create do
     template = File.read(Cask.path('new-cask'))
     template.must_equal <<-TEMPLATE.undent
       class NewCask < Cask
-        url 'https://'
-        homepage ''
         version ''
         sha256 ''
+
+        url 'https://'
+        homepage ''
+
         link ''
       end
     TEMPLATE


### PR DESCRIPTION
References: #4914

This is mostly documentation, but it also changes the template used by
`brew cask create`.

Based on the suggestions from @vitorgalvao in #4914 — but I went one farther
(since I like whitespace) and added another blank line before the start of the
artifacts "section" of the Cask.

Comments welcomed.
