### PR TITLE
doc tweaks to CASK_LANGUAGE_REFERENCE.md

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -1,7 +1,7 @@
 # Cask Language Reference
 
-This document acts as a complete reference, and covers aspects of the Cask
-Domain-Specific Language (DSL) which are not needed in most cases.
+This document acts as a complete specification, and covers aspects of the
+Cask Domain-Specific Language (DSL) which are not needed in most cases.
 
  * [Casks Are Ruby Classes](#casks-are-ruby-classes)
  * [The Cask Language Is Declarative](#the-cask-language-is-declarative)
@@ -148,7 +148,7 @@ The following methods may be called to generate standard warning messages:
 | `assistive_devices`               | The user should grant the application access to assitive devices
 | `files_in_usr_local`              | The Cask installs files to `/usr/local`, which may confuse Homebrew
 | `arch_only(list)`                 | The Cask only supports certain architectures.  Currently valid elements of `list` are `intel-32` and `intel-64`
-| `os_version_only(list)`           | The Cask only supports certain OS X Versions.  Currently valid elements of `list` are `10.5`, `10.6`, `10.7`, `10.8`, and `10.9`
+| `os_version_only(list)`           | The Cask only supports certain OS X Versions.  Currently valid elements of `list` are `10.5`, `10.6`, `10.7`, `10.8`, `10.9`, and `10.10`
 | `x11_required`                    | The Cask requires X11 to run
 
 Example:
@@ -166,6 +166,15 @@ And the following methods may be useful for interpolation:
 | `title`            | the Cask title
 | `caskroom_path`    | eg `/opt/homebrew-cask/Caskroom`
 | `destination_path` | where this particular Cask is stored, including version number, eg `/opt/homebrew-cask/Caskroom/google-chrome/stable-channel`
+
+Any method from the main Cask DSL can be invoked from inside `caveats` via
+the `@cask` instance variable.  Example (see [sts.rb](../Casks/sts.rb)):
+
+```ruby
+caveats do
+  puts "You must obtain an API key at #{@cask.homepage}"
+end
+```
 
 
 ## Checksum Stanza Details
@@ -483,7 +492,8 @@ A fully manual method for finding bundle ids in a package file follows:
 ## Arbitrary Ruby Methods
 
 In the exceptional case that the Cask DSL is insufficient, it is possible to
-define arbitrary Ruby methods inside the Cask by creating a `Utils` namespace:
+define arbitrary Ruby methods inside the Cask by creating a `Utils` namespace.
+Example:
 
 ```ruby
 class Appname < Cask
@@ -499,9 +509,8 @@ class Appname < Cask
 end
 ```
 
-Example: [gpsbabel.rb](../Casks/gpsbabel.rb)
-
 This should be used sparingly: any method which is needed by two or more
-Casks should instead be rolled into the core.
+Casks should instead be rolled into the core.  Care must also be taken
+that such methods be very efficient.
 
 # <3 THANK YOU TO ALL CONTRIBUTORS! <3


### PR DESCRIPTION
- include OS X 10.10
- include the word "specification"
- clarify how to call out of the `caveats` mini-DSL
- reformat arbitrary methods example for consistency

References: #4921
