### PR TITLE
add `version` helper method to `caveats` mini-DSL

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -164,6 +164,7 @@ And the following methods may be useful for interpolation:
 | method             | description |
 | ------------------ | ----------- |
 | `title`            | the Cask title
+| `version`          | the Cask version
 | `caskroom_path`    | eg `/opt/homebrew-cask/Caskroom`
 | `destination_path` | where this particular Cask is stored, including version number, eg `/opt/homebrew-cask/Caskroom/google-chrome/stable-channel`
 

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -24,6 +24,10 @@ class Cask::CaveatsDSL
     @cask.title
   end
 
+  def version
+    @cask.version
+  end
+
   def caskroom_path
     @cask.class.caskroom.join(title)
   end


### PR DESCRIPTION
As was already done (for convenience) for `title`.

References: #4921 .

This is somewhat contradictory with #4926, where an example was given using
`@cask.version` within the `caveats` mini-DSL.  But even if this PR is merged,
I think `CASK_LANGUAGE_REFERENCE.md` still needs a similar section,
explaining how to use the `@cask` instance variable.

Edit: #4926 was revised to correct the problem.
