### PR TITLE
Delete reeder.rb

### DIFF
--- a/Casks/reeder.rb
+++ b/Casks/reeder.rb
@@ -1,7 +1,0 @@
-class Reeder < Cask
-  url 'http://reederapp.com/beta-reeder-for-mac/Reeder2.0b7.zip'
-  homepage 'http://reederapp.com/mac/'
-  version '2.0b7'
-  sha256 '6778fe2747d907e153666c01b3ee8700ed31b05e128c8433fb24f429a62dfdd2'
-  link 'Reeder.app'
-end


### PR DESCRIPTION
Reeder is now only available for purchase in Mac App Store
