### PR TITLE
DSL: add `install_script` stanza

### DIFF
--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -11,6 +11,7 @@ require 'cask/artifact/after_block'
 require 'cask/artifact/before_block'
 require 'cask/artifact/colorpicker'
 require 'cask/artifact/font'
+require 'cask/artifact/install_script'
 require 'cask/artifact/nested_container'
 require 'cask/artifact/pkg'
 require 'cask/artifact/prefpane'
@@ -32,6 +33,7 @@ module Cask::Artifact
     [
       Cask::Artifact::BeforeBlock,
       Cask::Artifact::NestedContainer,
+      Cask::Artifact::InstallScript,
       Cask::Artifact::App,
       Cask::Artifact::Colorpicker,
       Cask::Artifact::Pkg,

--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -44,7 +44,7 @@ class Cask::Artifact::Base
     permitted_keys = [:args, :input, :executable, :must_succeed]
     unknown_keys = arguments.keys - permitted_keys
     unless unknown_keys.empty?
-      opoo "Unknown arguments to #{description} -- :#{unknown_keys.join(", :")} (ignored). Running `brew update; brew upgrade brew-cask` will likely fix it.'"
+      opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}
     end
     arguments.reject! {|k,v| ! permitted_keys.include?(k)}
 

--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -24,6 +24,37 @@ class Cask::Artifact::Base
      cask.artifacts[self.artifact_dsl_key].any?
   end
 
+  def self.read_script_arguments(uninstall_options, key)
+    script_arguments = uninstall_options[key]
+
+    # backwards-compatible string value
+    if script_arguments.kind_of?(String)
+      script_arguments = { :executable => script_arguments }
+    end
+
+    # key sanity
+    permitted_keys = [:args, :input, :executable, :must_succeed]
+    unknown_keys = script_arguments.keys - permitted_keys
+    unless unknown_keys.empty?
+      opoo "Unknown arguments to uninstall :#{key} -- :#{unknown_keys.join(", :")} (ignored). Running `brew update; brew upgrade brew-cask` will likely fix it.'"
+    end
+    script_arguments.reject! {|k,v| ! permitted_keys.include?(k)}
+
+    # extract executable
+    if script_arguments.key?(:executable)
+      executable = script_arguments.delete(:executable)
+    else
+      executable = nil
+    end
+
+    unless script_arguments.key?(:must_succeed)
+      script_arguments[:must_succeed] = true
+    end
+
+    script_arguments.merge!(:sudo => true, :print => true)
+    return executable, script_arguments
+  end
+
   def summary
     {}
   end

--- a/lib/cask/artifact/install_script.rb
+++ b/lib/cask/artifact/install_script.rb
@@ -1,0 +1,30 @@
+class Cask::Artifact::InstallScript < Cask::Artifact::Base
+
+  # todo: for backward compatibility, removeme
+  def install
+    install_phase
+  end
+
+  # todo: for backward compatibility, removeme
+  def uninstall
+    uninstall_phase
+  end
+
+  def install_phase
+    @cask.artifacts[self.class.artifact_dsl_key].each do |artifact|
+      executable, script_arguments = self.class.read_script_arguments(
+                                                                      artifact,
+                                                                      "#{self.class.artifact_dsl_key}",
+                                                                      {:must_succeed => true},
+                                                                      {:print => true}
+                                                                      )
+      ohai "Running #{self.class.artifact_dsl_key} script #{executable}"
+      raise CaskInvalidError.new(@cask, "#{self.class.artifact_dsl_key} missing executable") if executable.nil?
+      @command.run(@cask.destination_path.join(executable), script_arguments)
+    end
+  end
+
+  def uninstall_phase
+    odebug "Nothing to do. The #{self.class.artifact_dsl_key} artifact has no uninstall phase."
+  end
+end

--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -11,37 +11,6 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
     dispatch_uninstall_directives(self.class.artifact_dsl_key)
   end
 
-  def self.read_script_arguments(uninstall_options, key)
-    script_arguments = uninstall_options[key]
-
-    # backwards-compatible string value
-    if script_arguments.kind_of?(String)
-      script_arguments = { :executable => script_arguments }
-    end
-
-    # key sanity
-    permitted_keys = [:args, :input, :executable, :must_succeed]
-    unknown_keys = script_arguments.keys - permitted_keys
-    unless unknown_keys.empty?
-      opoo %Q{Unknown arguments to #{stanza} #{key.inspect} -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}
-    end
-    script_arguments.reject! {|k,v| ! permitted_keys.include?(k)}
-
-    # extract executable
-    if script_arguments.key?(:executable)
-      executable = script_arguments.delete(:executable)
-    else
-      executable = nil
-    end
-
-    unless script_arguments.key?(:must_succeed)
-      script_arguments[:must_succeed] = true
-    end
-
-    script_arguments.merge!(:sudo => true, :print => true)
-    return executable, script_arguments
-  end
-
   def dispatch_uninstall_directives(stanza)
     directives_set = @cask.artifacts[stanza]
     ohai "Running #{stanza} process for #{@cask}; your password may be necessary"

--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -26,7 +26,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
     # :early_script should not delete files, better defer that to :script.
     # If Cask writers never need :early_script it may be removed in the future.
     directives_set.select{ |h| h.key?(:early_script) }.each do |directives|
-      executable, script_arguments = self.class.read_script_arguments(directives, :early_script)
+      executable, script_arguments = self.class.read_script_arguments(directives, 'uninstall', :early_script)
       ohai "Running uninstall script #{executable}"
       raise CaskInvalidError.new(@cask, "#{stanza} :early_script without :executable") if executable.nil?
       @command.run(@cask.destination_path.join(executable), script_arguments)
@@ -99,7 +99,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
 
     # :script must come before :pkgutil or :files so that the script file is not already deleted
     directives_set.select{ |h| h.key?(:script) }.each do |directives|
-      executable, script_arguments = self.class.read_script_arguments(directives, :script)
+      executable, script_arguments = self.class.read_script_arguments(directives, 'uninstall', :script)
       raise CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
       @command.run(@cask.destination_path.join(executable), script_arguments)
       sleep 1

--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -26,7 +26,12 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
     # :early_script should not delete files, better defer that to :script.
     # If Cask writers never need :early_script it may be removed in the future.
     directives_set.select{ |h| h.key?(:early_script) }.each do |directives|
-      executable, script_arguments = self.class.read_script_arguments(directives, 'uninstall', :early_script)
+      executable, script_arguments = self.class.read_script_arguments(directives,
+                                                                      'uninstall',
+                                                                      {:must_succeed => true},
+                                                                      {:sudo => true, :print => true},
+                                                                      :early_script)
+
       ohai "Running uninstall script #{executable}"
       raise CaskInvalidError.new(@cask, "#{stanza} :early_script without :executable") if executable.nil?
       @command.run(@cask.destination_path.join(executable), script_arguments)
@@ -99,7 +104,11 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
 
     # :script must come before :pkgutil or :files so that the script file is not already deleted
     directives_set.select{ |h| h.key?(:script) }.each do |directives|
-      executable, script_arguments = self.class.read_script_arguments(directives, 'uninstall', :script)
+      executable, script_arguments = self.class.read_script_arguments(directives,
+                                                                      'uninstall',
+                                                                      {:must_succeed => true},
+                                                                      {:sudo => true, :print => true},
+                                                                      :script)
       raise CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
       @command.run(@cask.destination_path.join(executable), script_arguments)
       sleep 1

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -211,6 +211,13 @@ module Cask::DSL
       end
     end
 
+    def install_script(*args)
+      executable = args.shift
+      args = Hash.new(*args)
+      args.merge!({ :executable => executable })
+      artifacts[:install_script] << args
+    end
+
     attr_reader :sums
 
     def hash_name(hash_type)

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -222,4 +222,11 @@ describe Cask::DSL do
       }.must_raise(CaskInvalidError)
     end
   end
+
+  describe "install_script stanza" do
+    it "allows install_script to be specified" do
+      cask = Cask.load('with-install-script')
+      cask.artifacts[:install_script].first[:executable].must_equal '/usr/bin/true'
+    end
+  end
 end

--- a/test/support/Casks/with-install-script.rb
+++ b/test/support/Casks/with-install-script.rb
@@ -1,0 +1,7 @@
+class WithInstallScript < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/with-install-script'
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  install_script '/usr/bin/true'
+end


### PR DESCRIPTION
The purpose is to run an installation script, providing cleaner syntax than
the current method, which is to use `caskroom_only` followed by `after_install`.
(example [adobe-air.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/adobe-air.rb)).

~~This PR is in almost working form.  It is marked WIP because~~
- ~~tests are failing~~ FIXED?
- ~~`installer` doesn't seem like the right name for the stanza~~ 
  - **Settled on `install_script` for consistency with `uninstall :script`**
  - `install :script` would be even more consistent, but the overlap with an existing stanza name would make a transition difficult
  - ~~we are changing `install` to `pkg`, so that would reduce one source of confusion.  But the Apple-provided CLI tool for installing `pkg` files is also called `installer`.~~
  - ~~what is a better name?~~
    - **`install_script`  <----- consistent with `uninstall :script`**
    - ~~`install_command` ?~~
    - ~~`installer_script` ?~~
    - ~~`installer_command` ?~~
    - ~~`custom_installer` ?~~
    - ~~`cli_installer` ?~~

References: #4688
