### PR TITLE
Add RuntimeBrowser

### DIFF
--- a/Casks/runtimebrowser.rb
+++ b/Casks/runtimebrowser.rb
@@ -1,0 +1,7 @@
+class Runtimebrowser < Cask
+  url 'http://seriot.ch/temp/runtimebrowser.zip'
+  homepage 'https://github.com/nst/RuntimeBrowser'
+  version 'latest'
+  sha256 :no_check
+  link 'RuntimeBrowser.app'
+end


### PR DESCRIPTION
This is a class browser for the Objective-C runtime on iOS and OS X. It gives you full access to all classes loaded in the runtime; allows you to dynamically load new modules and their classes; shows every method implemented on each class; and displays information in a header (.h) file format.
