### PR TITLE
convert 252 Casks to HTTPS URLs

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,5 +1,5 @@
 class AndroidStudio < Cask
-  url 'http://dl.google.com/dl/android/studio/ide-zips/0.6.1/android-studio-ide-135.1224218-mac.zip'
+  url 'https://dl.google.com/dl/android/studio/ide-zips/0.6.1/android-studio-ide-135.1224218-mac.zip'
   homepage 'https://developer.android.com/sdk/installing/studio.html'
   version '0.6.1 build-135.1224218'
   sha256 '64c395fd0e4a0d69ff6f8d5c06a5f7fc6f0f7a06096408b9849ce92d5d515182'

--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -1,5 +1,5 @@
 class AngryIpScanner < Cask
-  url 'http://github.com/angryziber/ipscan/releases/download/3.2.3/ipscan-mac-3.2.3.zip'
+  url 'https://github.com/angryziber/ipscan/releases/download/3.2.3/ipscan-mac-3.2.3.zip'
   homepage 'http://angryip.org'
   version '3.2.3'
   sha256 '3b9a9cc912b0817c09577835d094c74a61911213e0533f606f20a602ea3c1703'

--- a/Casks/aquaterm.rb
+++ b/Casks/aquaterm.rb
@@ -1,5 +1,5 @@
 class Aquaterm < Cask
-  url 'http://downloads.sourceforge.net/project/aquaterm/AquaTerm/v1.1.1/AquaTerm-1.1.1.dmg'
+  url 'https://downloads.sourceforge.net/project/aquaterm/AquaTerm/v1.1.1/AquaTerm-1.1.1.dmg'
   homepage 'http://aquaterm.sourceforge.net/'
   version '1.1.1'
   sha256 '94b33efea2ec037e6c06beef54b4b3cc48595453c874de863f25c26b3a7ffdb2'

--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -1,5 +1,5 @@
 class Arduino < Cask
-  url 'http://arduino.googlecode.com/files/arduino-1.0.5-macosx.zip'
+  url 'https://arduino.googlecode.com/files/arduino-1.0.5-macosx.zip'
   homepage 'http://arduino.cc/'
   version '1.0.5'
   sha256 '12f2d649b2cfd537317f63d9cb102dc052647c32a5b07c76d344ed959319c05e'

--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -1,5 +1,5 @@
 class AriaMaestosa < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/ariamaestosa/AriaMaestosa-osx-1.4.9.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/ariamaestosa/AriaMaestosa-osx-1.4.9.zip'
   homepage 'http://ariamaestosa.sourceforge.net'
   version '1.4.9'
   sha256 '3a8d8bc625a6e27b2312ff1c008e78b64c94faa5ef263c85c6005e72a98ec1bf'

--- a/Casks/aseprite.rb
+++ b/Casks/aseprite.rb
@@ -1,5 +1,5 @@
 class Aseprite < Cask
-  url 'http://aseprite.googlecode.com/files/ASEPRITE_0.9.5.dmg'
+  url 'https://aseprite.googlecode.com/files/ASEPRITE_0.9.5.dmg'
   homepage 'http://www.aseprite.org'
   version '0.9.5'
   sha256 '299eda3e5f11ae60d58bccdd26156169db6ebc01be8e806d7909f0b8f22e2928'

--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,5 +1,5 @@
 class Audacity < Cask
-  url 'http://audacity.googlecode.com/files/audacity-macosx-ub-2.0.5.dmg'
+  url 'https://audacity.googlecode.com/files/audacity-macosx-ub-2.0.5.dmg'
   homepage 'http://audacity.sourceforge.net/'
   version '2.0.5'
   sha256 'fb0e1c79159783e90403649c0c21fd067f709fd1d1c0f0f0b2a4b662617d8d90'

--- a/Casks/audioslicer.rb
+++ b/Casks/audioslicer.rb
@@ -1,5 +1,5 @@
 class Audioslicer < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/audioslicer/AudioSlicer-1.1.1.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/audioslicer/AudioSlicer-1.1.1.dmg'
   homepage 'http://audioslicer.sourceforge.net'
   version '1.1.1'
   sha256 'c0ef4d9b1690943def00ce4c7bb2838ff08cfe0d3ff85d39ca1e4ddc97593d01'

--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,5 +1,5 @@
 class Avidemux < Cask
-  url 'http://downloads.sourceforge.net/avidemux/Avidemux_2.6.8_ml_64bits.dmg'
+  url 'https://downloads.sourceforge.net/avidemux/Avidemux_2.6.8_ml_64bits.dmg'
   homepage 'http://www.avidemux.org/'
   version '2.6.8'
   sha256 '2478fbdf6e7bfc32dd98a53bb95e6a7d217d294d446910942c4904bf2094b90a'

--- a/Casks/avogadro.rb
+++ b/Casks/avogadro.rb
@@ -1,5 +1,5 @@
 class Avogadro < Cask
-  url 'http://downloads.sourceforge.net/avogadro/Avogadro-1.1.1.dmg.zip'
+  url 'https://downloads.sourceforge.net/avogadro/Avogadro-1.1.1.dmg.zip'
   homepage 'http://avogadro.openmolecules.net/'
   version '1.1.1'
   nested_container 'Avogadro-1.1.1.dmg'

--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -1,5 +1,5 @@
 class Bibdesk < Cask
-  url 'http://downloads.sourceforge.net/project/bibdesk/BibDesk/BibDesk-1.6.2/BibDesk-1.6.2.dmg'
+  url 'https://downloads.sourceforge.net/project/bibdesk/BibDesk/BibDesk-1.6.2/BibDesk-1.6.2.dmg'
   appcast 'http://bibdesk.sourceforge.net/bibdesk.xml'
   homepage 'http://bibdesk.sourceforge.net/'
   version '1.6.2'

--- a/Casks/black-ink.rb
+++ b/Casks/black-ink.rb
@@ -1,5 +1,5 @@
 class BlackInk < Cask
-  url 'http://www.red-sweater.com/blackink/BlackInk1.5.3.zip'
+  url 'https://www.red-sweater.com/blackink/BlackInk1.5.3.zip'
   appcast 'http://www.red-sweater.com/blackink/appcast1.php'
   homepage 'http://www.red-sweater.com/blackink/'
   version '1.5.3'

--- a/Casks/black-light.rb
+++ b/Casks/black-light.rb
@@ -1,5 +1,5 @@
 class BlackLight < Cask
-  url 'http://littoral.michelf.ca/apps/black-light/black-light-2.0.1.zip'
+  url 'https://littoral.michelf.ca/apps/black-light/black-light-2.0.1.zip'
   homepage 'http://michelf.ca/projects/black-light'
   version '2.0.1'
   sha256 '6f358e319427ddaf91343a05ffb662894502902875bd9b0703b17baaf0c30d10'

--- a/Casks/brain-workshop.rb
+++ b/Casks/brain-workshop.rb
@@ -1,5 +1,5 @@
 class BrainWorkshop < Cask
-  url 'http://downloads.sourceforge.net/project/brainworkshop/brainworkshop/Brain%20Workshop%204.8/brainworkshop-4.8.4-MacOSX.zip'
+  url 'https://downloads.sourceforge.net/project/brainworkshop/brainworkshop/Brain%20Workshop%204.8/brainworkshop-4.8.4-MacOSX.zip'
   homepage 'http://brainworkshop.sourceforge.net/'
   version '4.8.4'
   sha256 'b795220306862f55e79e3de9c8cf8b4e8667e7bb1b0e3f59604b4d5f29f3f623'

--- a/Casks/breakaway.rb
+++ b/Casks/breakaway.rb
@@ -1,5 +1,5 @@
 class Breakaway < Cask
-  url 'http://downloads.sourceforge.net/project/breakaway/breakaway-2.0.1.zip'
+  url 'https://downloads.sourceforge.net/project/breakaway/breakaway-2.0.1.zip'
   homepage 'http://mutablecode.com/apps/breakaway.html'
   version '2.0.1'
   sha256 'df5a3d42558f9cdc778c434f88f7e062032cf33dd751ef01e6109a9848a7f76a'

--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -1,5 +1,5 @@
 class Burn < Cask
-  url 'http://downloads.sourceforge.net/project/burn-osx/Burn/2.5.1/burn251.zip'
+  url 'https://downloads.sourceforge.net/project/burn-osx/Burn/2.5.1/burn251.zip'
   homepage 'http://burn-osx.sourceforge.net/'
   version '2.5.1'
   sha256 'e82d2b7ef6a99e5a139706ff4e360659830d618ab8743e4b55ec80cdcdc97596'

--- a/Casks/c3.rb
+++ b/Casks/c3.rb
@@ -1,5 +1,5 @@
 class C3 < Cask
-  url 'http://d2xj26462na9l3.cloudfront.net/c3/C3-FNF-0.5.2.2143.dmg'
+  url 'https://d2xj26462na9l3.cloudfront.net/c3/C3-FNF-0.5.2.2143.dmg'
   homepage 'http://www.downloadc3.com/'
   version '0.5.2.2143'
   sha256 '1f039168caf6487c4ded7fdec5ebf80f4400b03188a40b1bc06f0abc8bf3d3ff'

--- a/Casks/camed.rb
+++ b/Casks/camed.rb
@@ -1,5 +1,5 @@
 class Camed < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/camprocessor/CAMEd-3.1.1-macosx-cocoa-x86_64.tar.gz'
+  url 'https://downloads.sourceforge.net/sourceforge/camprocessor/CAMEd-3.1.1-macosx-cocoa-x86_64.tar.gz'
   homepage 'http://sourceforge.net/apps/mediawiki/camprocessor/index.php?title=Main_Page'
   version '3.1.1'
   sha256 'c9088796b6f5cee228341e2ec6c2ee0ff3e3a506ff0dde3643865ccbc9c4f744'

--- a/Casks/candybar.rb
+++ b/Casks/candybar.rb
@@ -1,5 +1,5 @@
 class Candybar < Cask
-  url 'http://panic.com/candybar/d/CandyBar%203.3.4.zip'
+  url 'https://panic.com/candybar/d/CandyBar%203.3.4.zip'
   homepage 'http://www.panic.com/blog/candybar-mountain-lion-and-beyond'
   version '3.3.4'
   sha256 'f305596f195445016b35c9d99a40789c6671195e9cbad0b6e92e808b6c633ad6'

--- a/Casks/capo.rb
+++ b/Casks/capo.rb
@@ -1,5 +1,5 @@
 class Capo < Cask
-  url 'http://s3.amazonaws.com/capo/Capo-3.0.3.zip'
+  url 'https://s3.amazonaws.com/capo/Capo-3.0.3.zip'
   homepage 'http://supermegaultragroovy.com/products/Capo/'
   version '3.0.3'
   sha256 'ab70d7ba4965cca146507ebbb3ad874b9f67efde11c2b84de58712d7e1c3391b'

--- a/Casks/carlson-minot.rb
+++ b/Casks/carlson-minot.rb
@@ -1,5 +1,5 @@
 class CarlsonMinot < Cask
-  url 'http://www.carlson-minot.com/downloads/arm-2013.05-24-arm-none-linux-gnueabi.osx.intelx86.bin.pkg'
+  url 'https://www.carlson-minot.com/downloads/arm-2013.05-24-arm-none-linux-gnueabi.osx.intelx86.bin.pkg'
   homepage 'http://www.carlson-minot.com'
   version '2013.05.24'
   sha256 '1c41265f1a61e8594e9bcd702de0a4e7ed786394c91764e4d7495a6220a95b51'

--- a/Casks/ccmenu.rb
+++ b/Casks/ccmenu.rb
@@ -1,5 +1,5 @@
 class Ccmenu < Cask
-  url 'http://downloads.sourceforge.net/project/ccmenu/CCMenu/1.7/ccmenu-1.7-b.dmg'
+  url 'https://downloads.sourceforge.net/project/ccmenu/CCMenu/1.7/ccmenu-1.7-b.dmg'
   appcast 'http://ccmenu.sourceforge.net/update-stable.xml'
   homepage 'http://ccmenu.sourceforge.net/'
   version '1.7'

--- a/Casks/celestia.rb
+++ b/Casks/celestia.rb
@@ -1,5 +1,5 @@
 class Celestia < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/celestia/celestia-osx-1.6.1.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/celestia/celestia-osx-1.6.1.dmg'
   homepage 'http://sourceforge.net/projects/celestia'
   version '1.6.1'
   sha256 'db09842a10b377038bedef87fda8d159549234b2e072fa22e096ade84aa3f52a'

--- a/Casks/cfxr.rb
+++ b/Casks/cfxr.rb
@@ -1,5 +1,5 @@
 class Cfxr < Cask
-  url 'http://github.com/downloads/nevyn/cfxr/cfxr%200.2.1.zip'
+  url 'https://github.com/downloads/nevyn/cfxr/cfxr%200.2.1.zip'
   homepage 'http://thirdcog.eu/apps/cfxr'
   version '0.2.1'
   sha256 '106e06fe1c76581ffb89b3f44419a1669526edb1609f54022390b22d0947a1f2'

--- a/Casks/chicken.rb
+++ b/Casks/chicken.rb
@@ -1,5 +1,5 @@
 class Chicken < Cask
-  url 'http://downloads.sourceforge.net/project/chicken/Chicken-2.2b2.dmg'
+  url 'https://downloads.sourceforge.net/project/chicken/Chicken-2.2b2.dmg'
   appcast 'http://chicken.sourceforge.net/chicken.xml'
   homepage 'http://sourceforge.net/projects/chicken/'
   version '2.2b2'

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,5 +1,5 @@
 class Chromium < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/osxportableapps/ChromiumOSX_35.0.1916.153.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/osxportableapps/ChromiumOSX_35.0.1916.153.dmg'
   appcast 'http://osxportableapps.sourceforge.net/chromium/chrcast.xml'
   homepage 'http://www.freesmug.org/chromium'
   version '35.0.1916.153'

--- a/Casks/chronomate.rb
+++ b/Casks/chronomate.rb
@@ -1,5 +1,5 @@
 class Chronomate < Cask
-  url 'http://studio-qb.com/sites/studio-qb.com/files/releases/chronomate_0.9.2.dmg'
+  url 'https://studio-qb.com/sites/studio-qb.com/files/releases/chronomate_0.9.2.dmg'
   appcast 'http://chronomateapp.com/update'
   homepage 'http://chronomateapp.com/'
   version '0.9.2'

--- a/Casks/clementine.rb
+++ b/Casks/clementine.rb
@@ -1,5 +1,5 @@
 class Clementine < Cask
-  url 'http://clementine-player.googlecode.com/files/clementine-1.2.1.dmg'
+  url 'https://clementine-player.googlecode.com/files/clementine-1.2.1.dmg'
   appcast 'https://clementine-data.appspot.com/sparkle'
   homepage 'http://www.clementine-player.org/'
   version '1.2.1'

--- a/Casks/clock.rb
+++ b/Casks/clock.rb
@@ -1,5 +1,5 @@
 class Clock < Cask
-  url 'http://github.com/downloads/zachwaugh/Clock.app/Clock-1.1.zip'
+  url 'https://github.com/downloads/zachwaugh/Clock.app/Clock-1.1.zip'
   homepage 'http://zachwaugh.me/clock/'
   version '1.1'
   sha256 'f2def6485626b4d10a535cb86eb7c877da8d59a2103f8da7b211970c88b96913'

--- a/Casks/coccinellida.rb
+++ b/Casks/coccinellida.rb
@@ -1,5 +1,5 @@
 class Coccinellida < Cask
-  url 'http://downloads.sourceforge.net/project/coccinellida/Coccinellida-0.6.1.zip'
+  url 'https://downloads.sourceforge.net/project/coccinellida/Coccinellida-0.6.1.zip'
   appcast 'http://coccinellida.sourceforge.net/sparkle.xml'
   homepage 'http://coccinellida.sourceforge.net/'
   version '0.6.1'

--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,5 +1,5 @@
 class Codekit < Cask
-  url 'http://incident57.com/codekit/files/codekit-17018.zip'
+  url 'https://incident57.com/codekit/files/codekit-17018.zip'
   appcast 'https://incident57.com/codekit/appcast/ck2appcast.xml'
   homepage 'http://incident57.com/codekit/'
   version '2.0.6 (17018)'

--- a/Casks/colors.rb
+++ b/Casks/colors.rb
@@ -1,5 +1,5 @@
 class Colors < Cask
-  url 'http://mattpatenaude.com/software/colors-1.9.zip'
+  url 'https://mattpatenaude.com/software/colors-1.9.zip'
   homepage 'http://mattpatenaude.com/'
   version '1.9'
   sha256 '60c8b53d0030624677dc500fd235e5ef41ba3b8a50d4d3ab68a8fba34de84e2c'

--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,5 +1,5 @@
 class Comictagger < Cask
-  url 'http://comictagger.googlecode.com/files/ComicTagger-1.1.9-beta.dmg'
+  url 'https://comictagger.googlecode.com/files/ComicTagger-1.1.9-beta.dmg'
   homepage 'http://code.google.com/p/comictagger/'
   version '1.1.9-beta'
   sha256 'd940b9fc5878f7d1e05e1b4e343ecf3e8ec5a5352180fc6c9792d58bb4469b89'

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,5 +1,5 @@
 class Controllermate < Cask
-  url 'http://s3.amazonaws.com/orderedbytes/ControllerMate482.dmg'
+  url 'https://s3.amazonaws.com/orderedbytes/ControllerMate482.dmg'
   homepage 'http://www.orderedbytes.com/controllermate/'
   version '4.8.2'
   sha256 '654096120355452f69de00f46c55ad295515a497255e035707ca195d1b17eac4'

--- a/Casks/cord.rb
+++ b/Casks/cord.rb
@@ -1,5 +1,5 @@
 class Cord < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/cord/CoRD_0.5.7.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/cord/CoRD_0.5.7.zip'
   appcast 'http://cord.sourceforge.net/sparkle.xml'
   homepage 'http://cord.sourceforge.net/'
   version '0.5.7'

--- a/Casks/cornerstone.rb
+++ b/Casks/cornerstone.rb
@@ -1,5 +1,5 @@
 class Cornerstone < Cask
-  url 'http://www.zennaware.com/cornerstone/downloads/Cornerstone-2.7.10.zip'
+  url 'https://www.zennaware.com/cornerstone/downloads/Cornerstone-2.7.10.zip'
   appcast 'http://www.zennaware.com/cornerstone/appcast/feed2.php'
   homepage 'http://www.zennaware.com/cornerstone/index.php'
   version '2.7.10'

--- a/Casks/cuda-z.rb
+++ b/Casks/cuda-z.rb
@@ -1,5 +1,5 @@
 class CudaZ < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/cuda-z/CUDA-Z-0.8.207.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/cuda-z/CUDA-Z-0.8.207.dmg'
   homepage 'http://cuda-z.sourceforge.net'
   version '0.8.207'
   sha256 '5dcb79ada1fe872cf849e050e5c60471fca9ba18178ecf5819859e6990e96196'

--- a/Casks/cutesdr.rb
+++ b/Casks/cutesdr.rb
@@ -1,5 +1,5 @@
 class Cutesdr < Cask
-  url 'http://downloads.sourceforge.net/project/cutesdr/CuteSdr111.dmg'
+  url 'https://downloads.sourceforge.net/project/cutesdr/CuteSdr111.dmg'
   homepage 'http://sourceforge.net/projects/cutesdr'
   version '1.11'
   sha256 'feabe63c84e0227c0bacbb4d5b22c6e269fe29f7ab834c28a656d9fb33cd10b3'

--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,5 +1,5 @@
 class Darktable < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/darktable/darktable-1.4.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/darktable/darktable-1.4.dmg'
   homepage 'http://www.darktable.org/'
   version '1.4'
   sha256 'c145772a7645da82a5bb8cabfb8fe44023b566135f60f3a93f9551312835234d'

--- a/Casks/desmume.rb
+++ b/Casks/desmume.rb
@@ -1,5 +1,5 @@
 class Desmume < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/desmume/desmume-0.9.10-mac.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/desmume/desmume-0.9.10-mac.dmg'
   homepage 'http://www.desmume.org'
   version '0.9.10'
   sha256 '5124a3ea2c64e55bf6b31bb8eb3408d3157e3fa739021dba16e39801388fbb2d'

--- a/Casks/dia.rb
+++ b/Casks/dia.rb
@@ -1,5 +1,5 @@
 class Dia < Cask
-  url 'http://downloads.sourceforge.net/dia-installer/dia/0.97.2/Dia-0.97.2-7.dmg'
+  url 'https://downloads.sourceforge.net/dia-installer/dia/0.97.2/Dia-0.97.2-7.dmg'
   homepage 'http://dia-installer.de/'
   version '0.97.2-7'
   sha256 '9d3038c01347716800688830eaf52204deb78affe74a5f0c6e0a48fd414d44be'

--- a/Casks/dictunifier.rb
+++ b/Casks/dictunifier.rb
@@ -1,5 +1,5 @@
 class Dictunifier < Cask
-  url 'http://mac-dictionary-kit.googlecode.com/files/DictUnifier-2.1.zip'
+  url 'https://mac-dictionary-kit.googlecode.com/files/DictUnifier-2.1.zip'
   homepage 'http://code.google.com/p/mac-dictionary-kit/'
   version '2.1'
   sha256 'ff80b354ebcbe7ddad0e01d64c667e6a026d92f6bac01d380ec009205679f14c'

--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -1,5 +1,5 @@
 class Djview < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/djvu/djvulibre-3.5.22%2Bdjview-4.5-intel-3.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/djvu/djvulibre-3.5.22%2Bdjview-4.5-intel-3.zip'
   homepage 'http://djvu.sourceforge.net/'
   version '4.5'
   sha256 'eec2efee86136725ae0a7164f80e2cea428c647fe987e3b6843b81280c7c7664'

--- a/Casks/dmm.rb
+++ b/Casks/dmm.rb
@@ -1,5 +1,5 @@
 class Dmm < Cask
-  url 'http://www.dmm.co.jp/transfer/-/dmmviewer/=/device=mac/'
+  url 'https://www.dmm.co.jp/transfer/-/dmmviewer/=/device=mac/'
   homepage 'http://www.dmm.com/dc/book/'
   version '1.1.3'
   sha256 'a903754cfa215bea8b041f67269525ba29a9fe34875f819c41d0bd65e5e1628f'

--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -1,5 +1,5 @@
 class Dosbox < Cask
-  url 'http://downloads.sourceforge.net/project/dosbox/dosbox/0.74/DOSBox-0.74-1_Universal.dmg'
+  url 'https://downloads.sourceforge.net/project/dosbox/dosbox/0.74/DOSBox-0.74-1_Universal.dmg'
   homepage 'http://www.dosbox.com'
   version '0.74'
   sha256 '99057370b478608a6f0167ef522ef59e0e1b876f8565622d3dbd707925d61f6c'

--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,5 +1,5 @@
 class DoubleCommander < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/doublecmd/doublecmd-0.5.8-5390.qt.x86_64.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/doublecmd/doublecmd-0.5.8-5390.qt.x86_64.dmg'
   homepage 'http://doublecmd.sourceforge.net/'
   version '0.5.8'
   sha256 'a4bf455f028783a4c14d600068d27556984bfc3357a80dc0715f047efbf6dbfe'

--- a/Casks/dragthing.rb
+++ b/Casks/dragthing.rb
@@ -1,5 +1,5 @@
 class Dragthing < Cask
-  url 'http://s3.amazonaws.com/tlasystems/DragThing-5.9.12.dmg'
+  url 'https://s3.amazonaws.com/tlasystems/DragThing-5.9.12.dmg'
   homepage 'http://www.dragthing.com'
   version '5.9.12'
   sha256 '4a351c593aff1c3214613d622a4e81f184e8ae238df6db921dd822efeefe27e6'

--- a/Casks/dvdstyler.rb
+++ b/Casks/dvdstyler.rb
@@ -1,5 +1,5 @@
 class Dvdstyler < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/dvdstyler/DVDStyler-2.6-MacOSX.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/dvdstyler/DVDStyler-2.6-MacOSX.zip'
   homepage 'http://dvdstyler.org'
   version '2.6'
   sha256 'fbb26aeb2ee50890b4a192d06d16ddc8a98a8465aa4eeff75d16fdc4de375ed6'

--- a/Casks/easysimbl.rb
+++ b/Casks/easysimbl.rb
@@ -1,5 +1,5 @@
 class Easysimbl < Cask
-  url 'http://github.com/norio-nomura/EasySIMBL/releases/download/EasySIMBL-1.6/EasySIMBL-1.6.zip'
+  url 'https://github.com/norio-nomura/EasySIMBL/releases/download/EasySIMBL-1.6/EasySIMBL-1.6.zip'
   homepage 'https://github.com/norio-nomura/EasySIMBL/'
   version '1.6'
   sha256 '42139885e35946f1b2decb9cdfa755b8df8c050134463d76b2e3e0f68e783e26'

--- a/Casks/electric-sheep.rb
+++ b/Casks/electric-sheep.rb
@@ -1,5 +1,5 @@
 class ElectricSheep < Cask
-  url 'http://electricsheep.googlecode.com/files/electricsheep-2.7b35b.dmg'
+  url 'https://electricsheep.googlecode.com/files/electricsheep-2.7b35b.dmg'
   homepage 'http://www.electricsheep.org'
   version '2.7b35b'
   sha256 '767062403cc93aa75192def84b509b4530caca3e271ba23267ffe79cb50da44f'

--- a/Casks/enjoyable.rb
+++ b/Casks/enjoyable.rb
@@ -1,5 +1,5 @@
 class Enjoyable < Cask
-  url 'http://yukkurigames.com/enjoyable/Enjoyable-1.1.zip'
+  url 'https://yukkurigames.com/enjoyable/Enjoyable-1.1.zip'
   appcast 'http://yukkurigames.com/enjoyable/appcast.xml'
   homepage 'http://yukkurigames.com/enjoyable/'
   version '1.1'

--- a/Casks/eye-fi.rb
+++ b/Casks/eye-fi.rb
@@ -1,5 +1,5 @@
 class EyeFi < Cask
-  url 'http://d2mje64xs0b9gu.cloudfront.net/3.4.35/Eye-Fi.dmg'
+  url 'https://d2mje64xs0b9gu.cloudfront.net/3.4.35/Eye-Fi.dmg'
   homepage 'http://support.eye.fi/downloads'
   version '3.4.35'
   sha256 '7de117d0ee443683ad5ca7b3ab4ef5fc9e96c1a3d226cf87358c46b1270fca4e'

--- a/Casks/fastscripts.rb
+++ b/Casks/fastscripts.rb
@@ -1,5 +1,5 @@
 class Fastscripts < Cask
-  url 'http://www.red-sweater.com/fastscripts/FastScripts2.6.5.zip'
+  url 'https://www.red-sweater.com/fastscripts/FastScripts2.6.5.zip'
   appcast 'http://www.red-sweater.com/fastscripts/appcast2.php'
   homepage 'http://www.red-sweater.com/fastscripts/'
   version '2.6.5'

--- a/Casks/fender-fuse.rb
+++ b/Casks/fender-fuse.rb
@@ -1,5 +1,5 @@
 class FenderFuse < Cask
-  url 'http://www.fmicassets.com/fender/support/software/fender_software/fender_fuse/mac/FenderFUSE_FULL_2.7.1.dmg'
+  url 'https://www.fmicassets.com/fender/support/software/fender_software/fender_fuse/mac/FenderFUSE_FULL_2.7.1.dmg'
   homepage 'https://fuse.fender.com/'
   version '2.7.1'
   sha256 'e68de1a1c1068d34dda354e2678ddac4a796b2ccdface95b034a438455442919'

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -1,5 +1,5 @@
 class Filebot < Cask
-  url 'http://downloads.sourceforge.net/project/filebot/filebot/FileBot_4.0/FileBot_4.0.app.tar.gz'
+  url 'https://downloads.sourceforge.net/project/filebot/filebot/FileBot_4.0/FileBot_4.0.app.tar.gz'
   homepage 'http://www.filebot.net/'
   version '4.0'
   sha256 '338c68789c1a3f96df760ca59143b801a851c4f0690a9b8a67f932e5a9d6d93d'

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,5 +1,5 @@
 class Filezilla < Cask
-  url 'http://downloads.sourceforge.net/project/filezilla/FileZilla_Client/3.8.1/FileZilla_3.8.1_macosx-x86.app.tar.bz2'
+  url 'https://downloads.sourceforge.net/project/filezilla/FileZilla_Client/3.8.1/FileZilla_3.8.1_macosx-x86.app.tar.bz2'
   homepage 'https://filezilla-project.org/'
   version '3.8.1'
   sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'

--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,5 +1,5 @@
 class FlashPlayerDebugger < Cask
-  url 'http://fpdownload.macromedia.com/pub/flashplayer/updaters/14/flashplayer_14_sa_debug.dmg'
+  url 'https://fpdownload.macromedia.com/pub/flashplayer/updaters/14/flashplayer_14_sa_debug.dmg'
   homepage 'https://www.adobe.com/support/flashplayer/downloads.html'
   version '14.0.0.125'
   sha256 'c10647ecb3c77d2f70437b5146add5785336b3e77f9b0e9ade53f7404f711d90'

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,5 +1,5 @@
 class FlashPlayer < Cask
-  url 'http://fpdownload.macromedia.com/pub/flashplayer/updaters/14/flashplayer_14_sa.dmg'
+  url 'https://fpdownload.macromedia.com/pub/flashplayer/updaters/14/flashplayer_14_sa.dmg'
   homepage 'https://www.adobe.com/support/flashplayer/downloads.html'
   version '14.0.0.125'
   sha256 'fa5eef90162516da0ba4de071abdff202f6bb5281d5a39b62169cad60d214a90'

--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -1,5 +1,5 @@
 class Flash < Cask
-  url 'http://download.macromedia.com/pub/flashplayer/installers/archive/fp_14.0.0.125_archive.zip'
+  url 'https://download.macromedia.com/pub/flashplayer/installers/archive/fp_14.0.0.125_archive.zip'
   homepage 'http://get.adobe.com/flashplayer/'
   version '14.0.0.125'
   sha256 '30fe1064b2b4864afd5adf26c08981c8d5351a507fbcc3fc5f2bb6ef7e352384'

--- a/Casks/fpc.rb
+++ b/Casks/fpc.rb
@@ -1,5 +1,5 @@
 class Fpc < Cask
-  url 'http://downloads.sourceforge.net/freepascal/fpc-2.6.2.intel-macosx.dmg'
+  url 'https://downloads.sourceforge.net/freepascal/fpc-2.6.2.intel-macosx.dmg'
   homepage 'http://www.freepascal.org/'
   version '2.6.2'
   sha256 '09b0964c6fb11eaa04e0fa065e479674384aab81e69e377bb1e030ec1d3398a6'

--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,5 +1,5 @@
 class Freecad < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/free-cad/FreeCAD_0.12_MacOSX10.7_20120110_x64.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/free-cad/FreeCAD_0.12_MacOSX10.7_20120110_x64.dmg'
   homepage 'http://sourceforge.net/projects/free-cad/'
   version '0.12'
   sha256 'aa27bafd7cf995d7e625007933dc4cb405dce6fcc7db3ba79c750153adf89969'

--- a/Casks/freecol.rb
+++ b/Casks/freecol.rb
@@ -1,5 +1,5 @@
 class Freecol < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/freecol/freecol-0.10.7-mac.tar.bz2'
+  url 'https://downloads.sourceforge.net/sourceforge/freecol/freecol-0.10.7-mac.tar.bz2'
   homepage 'http://freecol.org'
   version '0.10.7'
   sha256 'eb05ea179df6adc6bcf4234ce3809c48b8c2d5597da20a10910ded677f2b6a2d'

--- a/Casks/freemind.rb
+++ b/Casks/freemind.rb
@@ -1,5 +1,5 @@
 class Freemind < Cask
-  url 'http://downloads.sourceforge.net/project/freemind/freemind/1.0.1/FreeMind_1.0.1.dmg'
+  url 'https://downloads.sourceforge.net/project/freemind/freemind/1.0.1/FreeMind_1.0.1.dmg'
   homepage 'freemind.sourceforge.net'
   version '1.0.1'
   sha256 '0bd93317567f947e7fa3b3e8d2e0d908300642edc5e07f1929157469ffd14ea3'

--- a/Casks/fugu.rb
+++ b/Casks/fugu.rb
@@ -1,5 +1,5 @@
 class Fugu < Cask
-  url 'http://downloads.sourceforge.net/project/fugussh/Unstable/fugu-1.2.1pre1/Fugu-1.2.1pre1.zip'
+  url 'https://downloads.sourceforge.net/project/fugussh/Unstable/fugu-1.2.1pre1/Fugu-1.2.1pre1.zip'
   homepage 'http://rsug.itd.umich.edu/software/fugu/'
   version '1.2.1pre1'
   sha256 '3f96ac9c94516c100bab5fe03cc1571634955f15e1949d32d675b91f5058e328'

--- a/Casks/garmin-training-center.rb
+++ b/Casks/garmin-training-center.rb
@@ -1,5 +1,5 @@
 class GarminTrainingCenter < Cask
-  url 'http://www8.garmin.com/software/TrainingCenterforMac_321.dmg'
+  url 'https://www8.garmin.com/software/TrainingCenterforMac_321.dmg'
   homepage 'http://www.garmin.com/garmin/cms/intosports/training_center'
   version '3.2.1'
   sha256 '82bda2f40b3ad8402f1e88fd7750b2827dc8f8f17ea45165e0c85fe6dbd7dfb6'

--- a/Casks/geekbench.rb
+++ b/Casks/geekbench.rb
@@ -1,5 +1,5 @@
 class Geekbench < Cask
-  url 'http://d34wv75roto0rl.cloudfront.net/Geekbench-3.1.6-Mac.zip'
+  url 'https://d34wv75roto0rl.cloudfront.net/Geekbench-3.1.6-Mac.zip'
   appcast 'http://www.primatelabs.com/appcast/geekbench3.xml'
   homepage 'http://www.primatelabs.com/geekbench/'
   version '3.1.6'

--- a/Casks/gimp-lisanet.rb
+++ b/Casks/gimp-lisanet.rb
@@ -1,5 +1,5 @@
 class GimpLisanet < Cask
-  url 'http://downloads.sourceforge.net/gimponosx/Gimp-2.8.10p2-Mavericks.dmg'
+  url 'https://downloads.sourceforge.net/gimponosx/Gimp-2.8.10p2-Mavericks.dmg'
   homepage 'http://gimp.lisanet.de'
   version '2.8.10p2'
   sha256 'e44b78f67709bb9837236d80dc4d28ec5cb9f86dd0ab3d0d688f253f29546087'

--- a/Casks/gitbox.rb
+++ b/Casks/gitbox.rb
@@ -1,5 +1,5 @@
 class Gitbox < Cask
-  url 'http://d1oa71y4zxyi0a.cloudfront.net/gitbox-1.6.2-ml.zip'
+  url 'https://d1oa71y4zxyi0a.cloudfront.net/gitbox-1.6.2-ml.zip'
   appcast 'http://gitboxapp.com/updates.xml'
   homepage 'http://gitboxapp.com/'
   version '1.6.2'

--- a/Casks/gitifier.rb
+++ b/Casks/gitifier.rb
@@ -1,5 +1,5 @@
 class Gitifier < Cask
-  url 'http://github.com/downloads/jsuder/Gitifier/Gitifier-1.3.zip'
+  url 'https://github.com/downloads/jsuder/Gitifier/Gitifier-1.3.zip'
   appcast 'http://sparkle.psionides.eu/feed/gitifier'
   homepage 'http://psionides.github.io/Gitifier/'
   version '1.3'

--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,5 +1,5 @@
 class Gnucash < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-2.6.3-1.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-2.6.3-1.dmg'
   homepage 'http://www.gnucash.org'
   version '2.6.3-1'
   sha256 '58d0a9c95cd1835eeafc0b15b965d7aac9e71980b2ba7a7aac5707445fa17828'

--- a/Casks/google-notifier.rb
+++ b/Casks/google-notifier.rb
@@ -1,5 +1,5 @@
 class GoogleNotifier < Cask
-  url 'http://dl.google.com/mac/download/GoogleNotifier_1.10.7.dmg'
+  url 'https://dl.google.com/mac/download/GoogleNotifier_1.10.7.dmg'
   homepage 'http://toolbar.google.com/gmail-helper/notifier_mac.html'
   version '1.10.7'
   sha256 '055775cb02773e4ec0e133111c7720134d32bb8d3a1f747231dc0c7d4078f5f7'

--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,5 +1,5 @@
 class Gqrx < Cask
-  url 'http://downloads.sourceforge.net/project/gqrx/2.2.0/gqrx-2.2.0.dmg'
+  url 'https://downloads.sourceforge.net/project/gqrx/2.2.0/gqrx-2.2.0.dmg'
   homepage 'http://gqrx.dk/'
   version '2.2.0'
   sha256 'b4d81d542ea095bb882d465461d33f75ace2fca8806f8074464e9a586314ed07'

--- a/Casks/grandperspective.rb
+++ b/Casks/grandperspective.rb
@@ -1,5 +1,5 @@
 class Grandperspective < Cask
-  url 'http://downloads.sourceforge.net/project/grandperspectiv/grandperspective/1.5.1/GrandPerspective-1_5_1.dmg'
+  url 'https://downloads.sourceforge.net/project/grandperspectiv/grandperspective/1.5.1/GrandPerspective-1_5_1.dmg'
   homepage 'http://grandperspectiv.sourceforge.net/'
   version '1.5.1'
   sha256 '92204458042a337c1091879e167ea95e45cae33a7be16fa6c11e80572c54d135'

--- a/Casks/growlnotify.rb
+++ b/Casks/growlnotify.rb
@@ -1,5 +1,5 @@
 class Growlnotify < Cask
-  url 'http://growl.cachefly.net/GrowlNotify-2.1.zip'
+  url 'https://growl.cachefly.net/GrowlNotify-2.1.zip'
   homepage 'http://growl.info/downloads'
   version '2.1'
   sha256 'eec601488b19c9e9b9cb7f0081638436518bce782d079f6e43ddc195727c04ca'

--- a/Casks/gurps-character-sheet.rb
+++ b/Casks/gurps-character-sheet.rb
@@ -1,5 +1,5 @@
 class GurpsCharacterSheet < Cask
-  url 'http://downloads.sourceforge.net/project/gcs-java/gcs-4.0.0-mac.zip'
+  url 'https://downloads.sourceforge.net/project/gcs-java/gcs-4.0.0-mac.zip'
   homepage 'http://gurpscharactersheet.com'
   version '4.0.0'
   sha256 '67ccecc44d28f8cf104094ae988779b8219f79a6e6fbe9c695828034d3307816'

--- a/Casks/handbrake.rb
+++ b/Casks/handbrake.rb
@@ -1,5 +1,5 @@
 class Handbrake < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/handbrake/HandBrake-0.9.9-MacOSX.6_GUI_x86_64.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/handbrake/HandBrake-0.9.9-MacOSX.6_GUI_x86_64.dmg'
   appcast 'http://handbrake.fr/appcast.x86_64.xml'
   homepage 'http://handbrake.fr/'
   version '0.9.9'

--- a/Casks/hear.rb
+++ b/Casks/hear.rb
@@ -1,5 +1,5 @@
 class Hear < Cask
-  url 'http://s3.amazonaws.com/prosoft-engineering/hear/Hear_1.1.6.dmg'
+  url 'https://s3.amazonaws.com/prosoft-engineering/hear/Hear_1.1.6.dmg'
   appcast 'http://www.prosofteng.com/resources/sparkle/sparkle.php?psProduct=Hear'
   homepage 'http://www.prosofteng.com/products/hear.php'
   version '1.1.6'

--- a/Casks/historyhound.rb
+++ b/Casks/historyhound.rb
@@ -1,5 +1,5 @@
 class Historyhound < Cask
-  url 'http://www.stclairsoft.com/download/HistoryHound-1.9.9.dmg'
+  url 'https://www.stclairsoft.com/download/HistoryHound-1.9.9.dmg'
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?HH'
   homepage 'http://www.stclairsoft.com/HistoryHound/'
   version '1.9.9'

--- a/Casks/httpscoop.rb
+++ b/Casks/httpscoop.rb
@@ -1,5 +1,5 @@
 class Httpscoop < Cask
-  url 'http://s3.amazonaws.com/Trueridge/HTTPScoop_1.4.3.dmg'
+  url 'https://s3.amazonaws.com/Trueridge/HTTPScoop_1.4.3.dmg'
   appcast 'http://www.tuffcode.com/releases/httpscoop-appcast.xml'
   homepage 'http://www.tuffcode.com'
   version '1.4.3'

--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -1,5 +1,5 @@
 class Hugin < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/hugin/Hugin-2013.0.0.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/hugin/Hugin-2013.0.0.dmg'
   homepage 'http://hugin.sourceforge.net/'
   version '2013.0.0'
   sha256 '528cc2249d4cdf9267e85ab836ff36cc0e2450de6663661adfc5e2cc3ef1ec60'

--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -1,5 +1,5 @@
 class Hush < Cask
-  url 'http://coffitivity.com/hush/files/Hush.dmg.zip'
+  url 'https://coffitivity.com/hush/files/Hush.dmg.zip'
   homepage 'http://coffitivity.com/hush/'
   version '1.0'
   sha256 'da31f0abd7c531e87c9f171493d318535cb24f1335e7e2b1c0fa68eeed685b2e'

--- a/Casks/hyro.rb
+++ b/Casks/hyro.rb
@@ -1,5 +1,5 @@
 class Hyro < Cask
-  url 'http://jawerty.github.io/Hyro/apps/Hyro-0.0.3.dmg'
+  url 'https://jawerty.github.io/Hyro/apps/Hyro-0.0.3.dmg'
   homepage 'http://jawerty.github.io/Hyro/'
   version '0.0.3'
   sha256 '2a1fed542c0e9ecc148ac0e7241adf774762f06fc6bfbbf8b2e96437a4c915f7'

--- a/Casks/icolors.rb
+++ b/Casks/icolors.rb
@@ -1,5 +1,5 @@
 class Icolors < Cask
-  url 'http://www.fadingred.com/files/icolors/icolors_3.0.zip'
+  url 'https://www.fadingred.com/files/icolors/icolors_3.0.zip'
   homepage 'http://www.fadingred.com/icolors/'
   version '3.0'
   sha256 '92fab479c7916ee7c52efcc457d8d120acc555a05825b01ebca047f017c097b9'

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,5 +1,5 @@
 class Inkscape < Cask
-  url 'http://downloads.sourceforge.net/inkscape/Inkscape-0.48.2-1-SNOWLEOPARD.dmg'
+  url 'https://downloads.sourceforge.net/inkscape/Inkscape-0.48.2-1-SNOWLEOPARD.dmg'
   homepage 'http://inkscape.org'
   version '0.48.2-1'
   sha256 'dc45811c450687cf2a455decc047b27a53f79cc926cd3a3c57c60e757e5710f8'

--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,5 +1,5 @@
 class Instead < Cask
-  url 'http://downloads.sourceforge.net/project/instead/instead/2.0.3/Instead-2.0.3.dmg'
+  url 'https://downloads.sourceforge.net/project/instead/instead/2.0.3/Instead-2.0.3.dmg'
   homepage 'http://instead.syscall.ru/'
   version '2.0.3'
   sha256 'ccad05fce186df643c1312eb07f8b6e2c537df56de54f5a2f7059830822b5500'

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 class IntelPowerGadget < Cask
-  url 'http://software.intel.com/sites/default/files/IntelPowerGadget3.0.1.zip'
+  url 'https://software.intel.com/sites/default/files/IntelPowerGadget3.0.1.zip'
   homepage 'http://software.intel.com/en-us/articles/intel-power-gadget-20'
   version '3.0.1'
   sha256 '538a792721604e2155b3a48caa4084db751a91b170e5fa62bf0331d3147f2239'

--- a/Casks/intel-xdk.rb
+++ b/Casks/intel-xdk.rb
@@ -1,5 +1,5 @@
 class IntelXdk < Cask
-  url 'http://d2bnc8freht07j.cloudfront.net/xdk_web_mac_master_0769.dmg'
+  url 'https://d2bnc8freht07j.cloudfront.net/xdk_web_mac_master_0769.dmg'
   homepage 'http://xdk-software.intel.com/'
   version '0769'
   sha256 '365a1850ccbf52fb3f1946bb569c454ccd6ea1a72d43074a9e92d9a646881489'

--- a/Casks/invisiblix.rb
+++ b/Casks/invisiblix.rb
@@ -1,5 +1,5 @@
 class Invisiblix < Cask
-  url 'http://downloads.sourceforge.net/project/invisiblix/invisibliX-3.2.zip'
+  url 'https://downloads.sourceforge.net/project/invisiblix/invisibliX-3.2.zip'
   appcast 'http://www.read-write.fr/invisiblix/appcast.xml'
   homepage 'http://www.read-write.fr/invisiblix/'
   version '3.2'

--- a/Casks/ios7-screensaver.rb
+++ b/Casks/ios7-screensaver.rb
@@ -1,5 +1,5 @@
 class Ios7Screensaver < Cask
-  url 'http://www.weebly.com/uploads/2/5/7/9/25796706/ios_7_lockscreen_by_bodysoulspirit.dmg'
+  url 'https://www.weebly.com/uploads/2/5/7/9/25796706/ios_7_lockscreen_by_bodysoulspirit.dmg'
   homepage 'http://bodysoulspirit.weebly.com/ios-7-screensaver-for-mac-os-x-by-bodysoulspirit.html'
   version '2.8'
   sha256 '5b71814a11a701fc074994eba0af7f35533aa35acc6eaa78c2e70ce923e9f19d'

--- a/Casks/iphone-configuration-utility.rb
+++ b/Casks/iphone-configuration-utility.rb
@@ -1,5 +1,5 @@
 class IphoneConfigurationUtility < Cask
-  url 'http://support.apple.com/downloads/DL1465/en_US/iPhoneConfigUtility.dmg'
+  url 'https://support.apple.com/downloads/DL1465/en_US/iPhoneConfigUtility.dmg'
   homepage 'http://support.apple.com/kb/DL1465'
   version '3.5'
   sha256 '822204947ae5f7739bcb1e9694814f8e3ef65cd184952b76104f525d97a28163'

--- a/Casks/iphoney.rb
+++ b/Casks/iphoney.rb
@@ -1,5 +1,5 @@
 class Iphoney < Cask
-  url 'http://download.marketcircle.com/s3/iPhoney_1.2.zip'
+  url 'https://download.marketcircle.com/s3/iPhoney_1.2.zip'
   appcast 'http://www.marketcircle.com/iphoney/iPhoneyAppcast.xml'
   homepage 'https://www.marketcircle.com/iphoney'
   version '1.2'

--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,5 +1,5 @@
 class IstatMenus < Cask
-  url 'http://s3.amazonaws.com/bjango/files/istatmenus4/istatmenus4.21.zip'
+  url 'https://s3.amazonaws.com/bjango/files/istatmenus4/istatmenus4.21.zip'
   homepage 'http://bjango.com/mac/istatmenus/'
   version '4.21'
   sha256 'c0747dad57116f538d06c24bddbc962bd33f05320339f8884ac3f0e0cf04757a'

--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -1,5 +1,5 @@
 class Istumbler < Cask
-  url 'http://istumbler.net/beta/istumbler-100gmc5b.zip'
+  url 'https://istumbler.net/beta/istumbler-100gmc5b.zip'
   homepage 'http://istumbler.net/'
   version '100gmc5b'
   sha256 '867a62f891c8fdc31883f45c1a9d0a3bfef6786acbf0a0eec947c4efd8661eb3'

--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -1,5 +1,5 @@
 class Jabref < Cask
-  url 'http://downloads.sourceforge.net/project/jabref/jabref/2.10/JabRef-2.10-OSX.zip'
+  url 'https://downloads.sourceforge.net/project/jabref/jabref/2.10/JabRef-2.10-OSX.zip'
   homepage 'http://jabref.sourceforge.net/'
   version '2.10'
   sha256 'c63a49e47a43bdb026dde7fb695210d9a3f8c0e71445af7d6736c5379b23baa2'

--- a/Casks/jaspersoft-studio.rb
+++ b/Casks/jaspersoft-studio.rb
@@ -1,5 +1,5 @@
 class JaspersoftStudio < Cask
-  url 'http://downloads.sourceforge.net/project/jasperstudio/JaspersoftStudio-5.5.1/jaspersoftstudio-5.5.1.final-mac-x86_64.dmg'
+  url 'https://downloads.sourceforge.net/project/jasperstudio/JaspersoftStudio-5.5.1/jaspersoftstudio-5.5.1.final-mac-x86_64.dmg'
   homepage 'http://community.jaspersoft.com/project/jaspersoft-studio'
   version '5.5.1'
   sha256 '05294e98a9c11e0e5ffb03c68da5fab4e738c6060fcc8bcca674848d67c5dd7c'

--- a/Casks/jbidwatcher.rb
+++ b/Casks/jbidwatcher.rb
@@ -1,5 +1,5 @@
 class Jbidwatcher < Cask
-  url 'http://www.jbidwatcher.com/download/JBidwatcher-2.5.6.dmg'
+  url 'https://www.jbidwatcher.com/download/JBidwatcher-2.5.6.dmg'
   homepage 'http://www.jbidwatcher.com'
   version '2.5.6'
   sha256 '659de073d9e0d71fa86e21db1524b7df57b36ff7826600a01ed93da6df5f5c9f'

--- a/Casks/jedit.rb
+++ b/Casks/jedit.rb
@@ -1,5 +1,5 @@
 class Jedit < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/jedit/jedit5.1.0install.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/jedit/jedit5.1.0install.dmg'
   homepage 'http://www.jedit.org'
   version '5.1.0'
   sha256 '29922afea1411631436f5f1154e45ddf8d3f6db53c9e41b832cefe86f8b81446'

--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -1,5 +1,5 @@
 class Jubler < Cask
-  url 'http://jubler.googlecode.com/files/Jubler-4.6.1.dmg'
+  url 'https://jubler.googlecode.com/files/Jubler-4.6.1.dmg'
   homepage 'http://www.jubler.org/'
   version '4.6.1'
   sha256 '7a5d08d950ccd7869fedb25f6d0ed8b8e8277e99a9032601de641b3de6545a13'

--- a/Casks/jumpcut.rb
+++ b/Casks/jumpcut.rb
@@ -1,5 +1,5 @@
 class Jumpcut < Cask
-  url 'http://downloads.sourceforge.net/project/jumpcut/jumpcut/0.63/Jumpcut_0.63.tgz'
+  url 'https://downloads.sourceforge.net/project/jumpcut/jumpcut/0.63/Jumpcut_0.63.tgz'
   appcast 'http://jumpcut.sf.net/jumpcut.appcast.xml'
   homepage 'http://jumpcut.sourceforge.net/'
   version '0.63'

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -1,5 +1,5 @@
 class Jxplorer < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/jxplorer/jxplorer/version%203.3.1/jxplorer-3.3.1-osx.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/jxplorer/jxplorer/version%203.3.1/jxplorer-3.3.1-osx.zip'
   homepage 'http://jxplorer.org'
   version '3.3.1'
   sha256 'b51995a93203590e6690d8ad54f73cd7af1c9f2bef6219adca79c58eda71d860'

--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -1,6 +1,6 @@
 class Kdiff3 < Cask
   # note: "3" is not a version number, but an intrinsic part of the product name (3-way diff)
-  url 'http://downloads.sourceforge.net/sourceforge/kdiff3/kdiff3_0.9.97_MacOS_64bit.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/kdiff3/kdiff3_0.9.97_MacOS_64bit.dmg'
   homepage 'http://kdiff3.sourceforge.net/'
   version '0.9.97'
   sha256 '9be995cced9d3365d2f7f47f01a28bfc47172da7d049014617976e596756d5ee'

--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,5 +1,5 @@
 class KeystoreExplorer < Cask
-  url 'http://downloads.sourceforge.net/project/keystore-explorer/KSE%205.0.1/kse-501.dmg?r=&ts=1393234297&use_mirror=heanet'
+  url 'https://downloads.sourceforge.net/project/keystore-explorer/KSE%205.0.1/kse-501.dmg?r=&ts=1393234297&use_mirror=heanet'
   homepage 'http://keystore-explorer.sourceforge.net/index.php'
   version '5.0.1'
   sha256 '64932fc5a26bd4de32d952b73431307c9a7c3100c1b11e76ab9f55e2a2cf7d49'

--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,6 +1,6 @@
 class Kid3 < Cask
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  url 'http://downloads.sourceforge.net/sourceforge/kid3/kid3-3.0.2-Darwin.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/kid3/kid3-3.0.2-Darwin.dmg'
   homepage 'http://kid3.sourceforge.net/'
   version '3.0.2'
   sha256 'a1b60a4eea11ca62001365dd28d418c595ce2d073dd4e0ba07bd28a94cb5c260'

--- a/Casks/kindlegen.rb
+++ b/Casks/kindlegen.rb
@@ -1,5 +1,5 @@
 class Kindlegen < Cask
-  url 'http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip'
+  url 'https://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip'
   homepage 'http://www.amazon.com/gp/feature.html?docId=1000765211'
   version '2.9'
   sha256 'e09ad8f985c7096556f978df15903b71f9cf44d2e1f501139a420ff16931f980'

--- a/Casks/kiwi.rb
+++ b/Casks/kiwi.rb
@@ -1,5 +1,5 @@
 class Kiwi < Cask
-  url 'http://s3.amazonaws.com/Kiwi/Kiwi_3.1.0_1492.zip'
+  url 'https://s3.amazonaws.com/Kiwi/Kiwi_3.1.0_1492.zip'
   appcast 'http://yourhead.com/appcast/kiwi/appcast.xml'
   homepage 'http://kiwi-app.net/'
   version '3.1.0'

--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,5 +1,5 @@
 class KomodoEdit < Cask
-  url 'http://downloads.activestate.com/Komodo/releases/8.5.3/Komodo-Edit-8.5.3-14067-macosx-x86_64.dmg'
+  url 'https://downloads.activestate.com/Komodo/releases/8.5.3/Komodo-Edit-8.5.3-14067-macosx-x86_64.dmg'
   homepage 'http://www.activestate.com/komodo-edit'
   version '8.5.3'
   sha256 'baa1bea5942a762a749ce48bc1320f3fda3169655b7ed98b3b9dffe16c360146'

--- a/Casks/kompozer.rb
+++ b/Casks/kompozer.rb
@@ -1,5 +1,5 @@
 class Kompozer < Cask
-  url 'http://downloads.sourceforge.net/project/kompozer/current/0.8b3/macosx/kompozer-0.8b3.en-US.mac-universal.dmg'
+  url 'https://downloads.sourceforge.net/project/kompozer/current/0.8b3/macosx/kompozer-0.8b3.en-US.mac-universal.dmg'
   homepage 'http://www.kompozer.net/'
   version '0.8b3'
   sha256 '415e019c9b3ec1c76465bf4f561fa515f403e57ac6f92c76365d902241dc14ed'

--- a/Casks/kylo.rb
+++ b/Casks/kylo.rb
@@ -1,5 +1,5 @@
 class Kylo < Cask
-  url 'http://kylo.s3.amazonaws.com/update/public/kylo-setup-1_0_1_76141.dmg'
+  url 'https://kylo.s3.amazonaws.com/update/public/kylo-setup-1_0_1_76141.dmg'
   homepage 'http://kylo.tv'
   version '1.0.1.76141'
   sha256 '5c5f1c3aedba9aa2807cffbc3aec448f0f51e16e1039c0314cf6394ddbe391b1'

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -1,5 +1,5 @@
 class Lazarus < Cask
-  url 'http://downloads.sourceforge.net/lazarus/lazarus-1.0.14-20131116-i386-macosx.dmg'
+  url 'https://downloads.sourceforge.net/lazarus/lazarus-1.0.14-20131116-i386-macosx.dmg'
   homepage 'http://lazarus.freepascal.org/'
   version '1.0.14'
   sha256 'b371f073ae2b8b83c88c356aed8dd717811ba4d9adfee6623a9a48a9c341531a'

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,5 +1,5 @@
 class Liteide < Cask
-  url 'http://downloads.sourceforge.net/project/liteide/X22/liteidex22.macosx.zip'
+  url 'https://downloads.sourceforge.net/project/liteide/X22/liteidex22.macosx.zip'
   homepage 'https://code.google.com/p/golangide/'
   version 'x22'
   sha256 '994b2bf68bb7f99ef7ac8001546f437644e9751109e5bf207adee7fb6180c689'

--- a/Casks/logisim.rb
+++ b/Casks/logisim.rb
@@ -2,7 +2,7 @@ class Logisim < Cask
   version '2.7.1'
   sha256 '41c5555b8021794e268a3fc2c9c51301d919680ae780b000b99380fc492bae7c'
 
-  url "http://downloads.sourceforge.net/project/circuit/#{version.gsub(/\d$/, 'x')}/#{version}/logisim-macosx-#{version}.tar.gz"
+  url "https://downloads.sourceforge.net/project/circuit/#{version.gsub(/\d$/, 'x')}/#{version}/logisim-macosx-#{version}.tar.gz"
   homepage 'http://ozark.hendrix.edu/~burch/logisim/'
   link 'Logisim.app'
 end

--- a/Casks/mailfollowup.rb
+++ b/Casks/mailfollowup.rb
@@ -1,5 +1,5 @@
 class Mailfollowup < Cask
-  url 'http://www.cs.unc.edu/~welch/MailFollowup/media/MailFollowUp_1.6.2.dmg.zip'
+  url 'https://www.cs.unc.edu/~welch/MailFollowup/media/MailFollowUp_1.6.2.dmg.zip'
   homepage 'http://www.cs.unc.edu/~welch/MailFollowup/'
   version '1.6.2'
   sha256 'f656c121e04fac6185b24a96888613729c366275151c891258b634c71372b2af'

--- a/Casks/mame.rb
+++ b/Casks/mame.rb
@@ -1,5 +1,5 @@
 class Mame < Cask
-  url 'http://downloads.sourceforge.net/mameosx/MAMEOSX-0.135.dmg'
+  url 'https://downloads.sourceforge.net/mameosx/MAMEOSX-0.135.dmg'
   homepage 'http://mameosx.sourceforge.net/'
   version '0.135'
   sha256 'fce1a45e53e0f6bc2ef20e5b6fc84bd48806f1bc2a38acec57fd9fafe7e2af7e'

--- a/Casks/marble.rb
+++ b/Casks/marble.rb
@@ -1,5 +1,5 @@
 class Marble < Cask
-  url 'http://files.kde.org/marble/downloads/MacOSX/Marble-1.5.0.dmg'
+  url 'https://files.kde.org/marble/downloads/MacOSX/Marble-1.5.0.dmg'
   homepage 'http://www.marble.kde.org'
   version '1.5.0'
   sha256 '6d1bf3e02c34ef0df0d5d0311d580bfae1d5259e3db45036163a5330dc139c04'

--- a/Casks/marsedit.rb
+++ b/Casks/marsedit.rb
@@ -1,5 +1,5 @@
 class Marsedit < Cask
-  url 'http://www.red-sweater.com/marsedit/MarsEdit3.6.2.zip'
+  url 'https://www.red-sweater.com/marsedit/MarsEdit3.6.2.zip'
   appcast 'http://www.red-sweater.com/marsedit/appcast3.php'
   homepage 'http://www.red-sweater.com/marsedit/'
   version '3.6.2'

--- a/Casks/maxthon.rb
+++ b/Casks/maxthon.rb
@@ -1,5 +1,5 @@
 class Maxthon < Cask
-  url 'http://dl.maxthon.com/mac/Maxthon-4.1.3.4000.dmg'
+  url 'https://dl.maxthon.com/mac/Maxthon-4.1.3.4000.dmg'
   homepage 'http://www.maxthon.com/'
   version '4.1.3.4000'
   sha256 '6c9c5b3aa49827907d83b641fba816b0f9d8cb240e3afb6872f2bd9de203a31e'

--- a/Casks/media-converter.rb
+++ b/Casks/media-converter.rb
@@ -1,5 +1,5 @@
 class MediaConverter < Cask
-  url 'http://downloads.sourceforge.net/project/media-converter/media-converter/1.2/media-converter-1.2.zip'
+  url 'https://downloads.sourceforge.net/project/media-converter/media-converter/1.2/media-converter-1.2.zip'
   homepage 'http://media-converter.sourceforge.net/'
   version '1.2'
   sha256 '4893e6e5bc18b9cb0f0d8e1bcb861f92595314e4f9768ef638affdfc866f37e1'

--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,5 +1,5 @@
 class Mediainfo < Cask
-  url 'http://mediaarea.net/download/binary/mediainfo-gui/0.7.66/MediaInfo_GUI_0.7.66_Mac.dmg'
+  url 'https://mediaarea.net/download/binary/mediainfo-gui/0.7.66/MediaInfo_GUI_0.7.66_Mac.dmg'
   homepage 'http://mediaarea.net/en/MediaInfo'
   version '0.7.66'
   sha256 'c96dc8998fa323d04d82ee146a7aeee63b32a6e67c5750ba099f79900788a442'

--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,5 +1,5 @@
 class Mediathekview < Cask
-  url 'http://downloads.sourceforge.net/project/zdfmediathk/Mediathek/Mediathek%204/MediathekView_4_OSX.dmg'
+  url 'https://downloads.sourceforge.net/project/zdfmediathk/Mediathek/Mediathek%204/MediathekView_4_OSX.dmg'
   homepage 'http://sourceforge.net/projects/zdfmediathk/'
   version '4'
   sha256 '41f53b86b6475fa0d8e347e9430597a975fb4f7c13eae70e82b723dace5b7c8a'

--- a/Casks/menubar-countdown.rb
+++ b/Casks/menubar-countdown.rb
@@ -1,5 +1,5 @@
 class MenubarCountdown < Cask
-  url 'http://s3.amazonaws.com/capablehands/downloads/MenubarCountdown-1.2.zip'
+  url 'https://s3.amazonaws.com/capablehands/downloads/MenubarCountdown-1.2.zip'
   homepage 'http://capablehands.net/menubarcountdown'
   version '1.2'
   sha256 '4ee0a7a87dbd4013c461b59316c749a5f9a92160bdf6d90afb1ff029f9381c01'

--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -1,5 +1,5 @@
 class Meshlab < Cask
-  url 'http://downloads.sourceforge.net/project/meshlab/meshlab/MeshLab%20v1.3.2/MeshLabMac_v132.dmg'
+  url 'https://downloads.sourceforge.net/project/meshlab/meshlab/MeshLab%20v1.3.2/MeshLabMac_v132.dmg'
   homepage 'http://meshlab.sourceforge.net/'
   version '1.3.2'
   sha256 '4ea9f5d99bf1c55c870fe75919397e6788e441e0dcd564311089eb63f93ec989'

--- a/Casks/metanota.rb
+++ b/Casks/metanota.rb
@@ -1,5 +1,5 @@
 class Metanota < Cask
-  url 'http://j.mp/metanota-2-4-1'
+  url 'https://j.mp/metanota-2-4-1'
   appcast 'https://s3.amazonaws.com/sparkle.metanota.com/appcast.xml'
   homepage 'http://www.metanota.com/'
   version '2.4.1'

--- a/Casks/meteorologist.rb
+++ b/Casks/meteorologist.rb
@@ -1,5 +1,5 @@
 class Meteorologist < Cask
-  url 'http://downloads.sourceforge.net/heat-meteo/Meteorologist-1.6.1.dmg'
+  url 'https://downloads.sourceforge.net/heat-meteo/Meteorologist-1.6.1.dmg'
   homepage 'http://heat-meteo.sourceforge.net/'
   version '1.6.1'
   sha256 '15243a845062d87bf67e6a26b8da011e00c50a5f24def460cc685532d7d720a4'

--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -1,5 +1,5 @@
 class Mnemosyne < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/mnemosyne-proj/Mnemosyne-2.3-Mac.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/mnemosyne-proj/Mnemosyne-2.3-Mac.dmg'
   homepage 'http://mnemosyne-proj.org/'
   version '2.3'
   sha256 '094c4f6fb50de376a5190c3712b935089579717641ce90685aa48932bf0efa07'

--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -1,5 +1,5 @@
 class Mongodb < Cask
-  url 'http://github.com/orelord/mongodbx-app/releases/download/v1.2/MongoDBX-1.2-2.4.9.zip'
+  url 'https://github.com/orelord/mongodbx-app/releases/download/v1.2/MongoDBX-1.2-2.4.9.zip'
   homepage 'http://mongodbx-app.orelord.com/'
   version '1.2'
   sha256 '9b7f6e8988a3169bf5f234ee10f93823a16750b3c1d4de524cd2e2f09452fd02'

--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -1,5 +1,5 @@
 class Monolingual < Cask
-  url 'http://downloads.sourceforge.net/project/monolingual/monolingual/1.5.8/Monolingual-1.5.8.dmg'
+  url 'https://downloads.sourceforge.net/project/monolingual/monolingual/1.5.8/Monolingual-1.5.8.dmg'
   appcast 'http://monolingual.sourceforge.net/appcast.xml'
   homepage 'http://monolingual.sourceforge.net/'
   version '1.5.8'

--- a/Casks/moreamp.rb
+++ b/Casks/moreamp.rb
@@ -1,5 +1,5 @@
 class Moreamp < Cask
-  url 'http://downloads.sourceforge.net/project/moreamp/moreamp/MoreAmp-0.1.28/MoreAmp-0.1.28-binOSXintel.dmg'
+  url 'https://downloads.sourceforge.net/project/moreamp/moreamp/MoreAmp-0.1.28/MoreAmp-0.1.28-binOSXintel.dmg'
   homepage 'http://sourceforge.net/projects/moreamp/'
   version '0.1.28'
   sha256 '2f07c82bb5b29e12185cd35c3f3cd9c472e8cc837fe426af1c82af9428c89695'

--- a/Casks/mozart.rb
+++ b/Casks/mozart.rb
@@ -1,5 +1,5 @@
 class Mozart < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/mozart-oz/Mozart-1.4.0.20120201.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/mozart-oz/Mozart-1.4.0.20120201.zip'
   homepage 'http://www.mozart-oz.org'
   version '1.4.0.20120201'
   sha256 'df03e42ca0da5700f49d3ae036758bac762cbc3a95d4e69c4bc4aabb54e6f92b'

--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -1,5 +1,5 @@
 class Mumble < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/mumble/Mumble-1.2.7.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/mumble/Mumble-1.2.7.dmg'
   homepage 'http://mumble.sourceforge.net'
   version '1.2.7'
   sha256 '236c973a925309df696856bea63969cbf7fe82d1f88a93af0683407824e1430d'

--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -1,5 +1,5 @@
 class Mysqlworkbench < Cask
-  url 'http://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-6.1.6-osx-i686.dmg'
+  url 'https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-6.1.6-osx-i686.dmg'
   homepage 'http://www.mysql.com/products/workbench'
   version '6.1.6'
   sha256 '0d0a48a55947920406e4ea3d08226ed6477dd2e4027f41ec1c3042226a2a7f4a'

--- a/Casks/nally.rb
+++ b/Casks/nally.rb
@@ -1,5 +1,5 @@
 class Nally < Cask
-  url 'http://yllan.github.com/nally/download/Nally-1.4.9.app.zip'
+  url 'https://yllan.github.com/nally/download/Nally-1.4.9.app.zip'
   homepage 'http://yllan.org/app/Nally/'
   version '1.4.9'
   sha256 '5b7835f8842aa33d0f40eebddda2686a39f2106dfacd0bde04c3f0911da625d1'

--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,5 +1,5 @@
 class Netlogo < Cask
-  url 'http://ccl.northwestern.edu/netlogo/5.0.5/NetLogo%205.0.5.dmg'
+  url 'https://ccl.northwestern.edu/netlogo/5.0.5/NetLogo%205.0.5.dmg'
   homepage 'http://ccl.northwestern.edu/netlogo/'
   version '5.0.5'
   sha256 '317faad5fadff9bababce580d9c72d74a491ec81de5129529a5d2f4dd8241ebf'

--- a/Casks/nightingale.rb
+++ b/Casks/nightingale.rb
@@ -1,5 +1,5 @@
 class Nightingale < Cask
-  url 'http://downloads.sourceforge.net/ngale/Nightingale_1.12-2432_macosx-i686.dmg'
+  url 'https://downloads.sourceforge.net/ngale/Nightingale_1.12-2432_macosx-i686.dmg'
   homepage 'http://getnightingale.com/'
   version '1.12-2432'
   sha256 '854b02a22f2846284618dc8d3a64a766e8e7a34e65cf35934f6b357f4bc1000e'

--- a/Casks/no-ip-duc.rb
+++ b/Casks/no-ip-duc.rb
@@ -1,5 +1,5 @@
 class NoIpDuc < Cask
-  url 'http://www.noip.com/client/mac/noip3.1.5.dmg'
+  url 'https://www.noip.com/client/mac/noip3.1.5.dmg'
   homepage 'http://www.noip.com/download?page=mac'
   version '3.1.5'
   sha256 'a5c68a13188fd88f00c0588baa1b54a0ac2529a02b09dc436770183c059bfaf5'

--- a/Casks/nocturne.rb
+++ b/Casks/nocturne.rb
@@ -1,5 +1,5 @@
 class Nocturne < Cask
-  url 'http://blacktree-nocturne.googlecode.com/files/Nocturne.2.0.0.zip'
+  url 'https://blacktree-nocturne.googlecode.com/files/Nocturne.2.0.0.zip'
   homepage 'http://code.google.com/p/blacktree-nocturne/'
   version '2.0.0'
   sha256 '062ae6b4619ab518650b2f502aaeb7a864bf69e45ce08dec8b5a3f34a027a347'

--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -1,5 +1,5 @@
 class Nodeclipse < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/nodeclipse/Enide-Studio-2014-011-20140228-macosx-cocoa-x86_64.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/nodeclipse/Enide-Studio-2014-011-20140228-macosx-cocoa-x86_64.zip'
   homepage 'http://www.nodeclipse.org/'
   version '0.11-preview'
   sha256 '01f630446313cb981ce2ee9b934977cfdbf318e09761dee244a3256f9a559003'

--- a/Casks/nomacs.rb
+++ b/Casks/nomacs.rb
@@ -1,5 +1,5 @@
 class Nomacs < Cask
-  url 'http://downloads.sourceforge.net/nomacs/nomacs-1.0.0-x86_64.dmg'
+  url 'https://downloads.sourceforge.net/nomacs/nomacs-1.0.0-x86_64.dmg'
   homepage 'http://www.nomacs.org/'
   version '1.0.0'
   sha256 '2ec4bfd6390ab7c4b2a929a1e9d14f46f6f168608bf2aee8da67af797f73a54a'

--- a/Casks/ntfs-free.rb
+++ b/Casks/ntfs-free.rb
@@ -1,5 +1,5 @@
 class NtfsFree < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/ntfsfree/NTFS-free-10.8.2.pkg'
+  url 'https://downloads.sourceforge.net/sourceforge/ntfsfree/NTFS-free-10.8.2.pkg'
   homepage 'http://sourceforge.net/projects/ntfsfree/'
   version '10.8.2'
   sha256 '1bc7122a2d869b740a35e2dba1fe29c380f21ad07481fc0a46b2f55bf79c574e'

--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -1,5 +1,5 @@
 class Openoffice < Cask
-  url 'http://downloads.sourceforge.net/project/openofficeorg.mirror/4.1.0/binaries/en-US/Apache_OpenOffice_4.1.0_MacOS_x86-64_install_en-US.dmg'
+  url 'https://downloads.sourceforge.net/project/openofficeorg.mirror/4.1.0/binaries/en-US/Apache_OpenOffice_4.1.0_MacOS_x86-64_install_en-US.dmg'
   homepage 'http://www.openoffice.org/'
   version '4.1.0'
   sha256 'ac77ff69cbbd87523e019d3c68d839cba2f952b0b63c13fb948863c8f25eaa9a'

--- a/Casks/opensong.rb
+++ b/Casks/opensong.rb
@@ -1,5 +1,5 @@
 class Opensong < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/opensong/OpenSongOSX-V2.1.1.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/opensong/OpenSongOSX-V2.1.1.dmg'
   homepage 'http://www.opensong.org/'
   version '2.1.1'
   sha256 '7663e04a1ae46aec948fad9e80cd8966c5a006744b9da42bc85cca4bb4dda4bc'

--- a/Casks/opera-mail.rb
+++ b/Casks/opera-mail.rb
@@ -1,5 +1,5 @@
 class OperaMail < Cask
-  url 'http://get-ash-1.opera.com/pub/opera/mail/1.0/mac/Opera-Mail-1.0-1040.i386.dmg'
+  url 'https://get-ash-1.opera.com/pub/opera/mail/1.0/mac/Opera-Mail-1.0-1040.i386.dmg'
   homepage 'http://www.opera.com/computer/mail'
   version '1.0'
   sha256 'afd192e308f8ea8ddb3d426fd6663d97078570417ee78b8e1fa15f515ae3d677'

--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,5 +1,5 @@
 class Osxfuse < Cask
-  url 'http://downloads.sourceforge.net/project/osxfuse/osxfuse-2.6.4/osxfuse-2.6.4.dmg'
+  url 'https://downloads.sourceforge.net/project/osxfuse/osxfuse-2.6.4/osxfuse-2.6.4.dmg'
   homepage 'http://osxfuse.github.io/'
   version '2.6.4'
   sha256 '942ca4ac026e4545b915308b01e6706be04483d48e1257664add37564122e4ca'

--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -1,5 +1,5 @@
 class Owncloud < Cask
-  url 'http://download.owncloud.com/desktop/stable/ownCloud-1.5.4.2580.dmg'
+  url 'https://download.owncloud.com/desktop/stable/ownCloud-1.5.4.2580.dmg'
   homepage 'http://owncloud.com'
   version '1.5.4.2580'
   sha256 '2dd1b7cb5263a7cb5d5363290ec02d76305f6599941c1cd2f35399b319972503'

--- a/Casks/paintbrush.rb
+++ b/Casks/paintbrush.rb
@@ -1,5 +1,5 @@
 class Paintbrush < Cask
-  url 'http://downloads.sourceforge.net/project/paintbrush/Paintbrush%202.x/Paintbrush%202.1.1/Paintbrush-2.1.1.zip'
+  url 'https://downloads.sourceforge.net/project/paintbrush/Paintbrush%202.x/Paintbrush%202.1.1/Paintbrush-2.1.1.zip'
   appcast 'http://paintbrush.sourceforge.net/updates2x.xml'
   homepage 'http://paintbrush.sourceforge.net/'
   version '2.1.1'

--- a/Casks/pandora-one.rb
+++ b/Casks/pandora-one.rb
@@ -1,5 +1,5 @@
 class PandoraOne < Cask
-  url 'http://www.pandora.com/static/desktop_app/pandora_2_0_8.air'
+  url 'https://www.pandora.com/static/desktop_app/pandora_2_0_8.air'
   homepage 'http://www.pandora.com/'
   version '2.0.8'
   sha256 '9ac216fd51bb063f020a86c6f5d250989dfa033a2d6a3d703124c2f4bfa510d8'

--- a/Casks/panini.rb
+++ b/Casks/panini.rb
@@ -1,5 +1,5 @@
 class Panini < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/pvqt/Panini-0.71.104B-mac.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/pvqt/Panini-0.71.104B-mac.dmg'
   homepage 'http://sourceforge.net/projects/pvqt/'
   version '0.71.104'
   sha256 '2a2836b0035bc1be8ada1e07138c72276a89624321dbfaa475fc4cd88fffe544'

--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -1,5 +1,5 @@
 class Paparazzi < Cask
-  url 'http://derailer.org/paparazzi/Paparazzi!%200.6.7.dmg'
+  url 'https://derailer.org/paparazzi/Paparazzi!%200.6.7.dmg'
   appcast 'https://derailer.org/paparazzi/appcast/'
   homepage 'http://derailer.org/paparazzi/'
   version '0.6.7'

--- a/Casks/pastor.rb
+++ b/Casks/pastor.rb
@@ -1,5 +1,5 @@
 class Pastor < Cask
-  url 'http://mehlau.net/pastor/Pastor182-signed.dmg'
+  url 'https://mehlau.net/pastor/Pastor182-signed.dmg'
   homepage 'http://mehlau.net/pastor'
   version '1.8.2'
   sha256 'ac41e7f300d722fcd9733a4f13a984d211b20f95c94db4dc07ab537fd45f8370'

--- a/Casks/pcalc.rb
+++ b/Casks/pcalc.rb
@@ -1,5 +1,5 @@
 class Pcalc < Cask
-  url 'http://s3.amazonaws.com/tlasystems/PCalc-3.9.dmg'
+  url 'https://s3.amazonaws.com/tlasystems/PCalc-3.9.dmg'
   appcast 'http://www.pcalc.com/PCalcSUFeed.xml'
   homepage 'http://www.pcalc.com/index.html'
   version '3.9'

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -1,5 +1,5 @@
 class PdExtended < Cask
-  url 'http://downloads.sourceforge.net/project/pure-data/pd-extended/0.43.4/Pd-0.43.4-extended-macosx105-i386.dmg'
+  url 'https://downloads.sourceforge.net/project/pure-data/pd-extended/0.43.4/Pd-0.43.4-extended-macosx105-i386.dmg'
   homepage 'http://puredata.info/downloads/pd-extended'
   version '0.43.4'
   sha256 'abe7bd637b1495ad9d5a500f0a18550c1600e34ee17e60aa1a48e4dbdee59bb9'

--- a/Casks/pdfsam.rb
+++ b/Casks/pdfsam.rb
@@ -1,5 +1,5 @@
 class Pdfsam < Cask
-  url 'http://downloads.sourceforge.net/project/pdfsam/pdfsam/2.2.2/pdfsam-2.2.2.dmg'
+  url 'https://downloads.sourceforge.net/project/pdfsam/pdfsam/2.2.2/pdfsam-2.2.2.dmg'
   homepage 'http://www.pdfsam.org/'
   version '2.2.2'
   sha256 '235635231c0e2428e9da1b126075d4cafe6b43625645350ff1491033dfc461a8'

--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -1,5 +1,5 @@
 class Pencil < Cask
-  url 'http://evoluspencil.googlecode.com/files/Pencil-2.0.6-mac.tar.bz2'
+  url 'https://evoluspencil.googlecode.com/files/Pencil-2.0.6-mac.tar.bz2'
   homepage 'http://pencil.evolus.vn'
   version '2.0.6'
   sha256 'dacd76c658b12101457d17a4ade0b3f9c6a012f8eddacd379c41e372545ffac6'

--- a/Casks/perian.rb
+++ b/Casks/perian.rb
@@ -1,5 +1,5 @@
 class Perian < Cask
-  url 'http://perian.cachefly.net/Perian_1.2.3.dmg'
+  url 'https://perian.cachefly.net/Perian_1.2.3.dmg'
   homepage 'http://www.perian.org/'
   version '1.2.3'
   sha256 '4d1738104613ab4a7322637584ce7b851e4ef85888895360ad827a5f27c62e08'

--- a/Casks/photoninja.rb
+++ b/Casks/photoninja.rb
@@ -1,5 +1,5 @@
 class Photoninja < Cask
-  url 'http://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_1.2.1.dmg'
+  url 'https://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_1.2.1.dmg'
   homepage 'http://www.picturecode.com/index.php'
   version '1.2.1'
   sha256 '81f62282865c53d2ed653ea2494f44d9e4d82cce623e85c651bb9aa8ccb26794'

--- a/Casks/picasa.rb
+++ b/Casks/picasa.rb
@@ -1,5 +1,5 @@
 class Picasa < Cask
-  url 'http://dl.google.com/photos/picasamac39.dmg'
+  url 'https://dl.google.com/photos/picasamac39.dmg'
   homepage 'http://picasa.google.com/'
   version '3.9'
   sha256 'a3c4f0f0fdb94471e024469f83b29be333a8f3359aea1c5e0bfeca0d6b5c5d62'

--- a/Casks/plainview.rb
+++ b/Casks/plainview.rb
@@ -1,5 +1,5 @@
 class Plainview < Cask
-  url 'http://s3.amazonaws.com/plainviewapp/plainview_1.0.178.zip'
+  url 'https://s3.amazonaws.com/plainviewapp/plainview_1.0.178.zip'
   homepage 'http://barbariangroup.com/'
   version '1.0.178'
   sha256 'ff442b3e8995ab42c0908e2fafe07d14233bad72fff677a83cf9cf09b18a2e2c'

--- a/Casks/port-map.rb
+++ b/Casks/port-map.rb
@@ -1,5 +1,5 @@
 class PortMap < Cask
-  url 'http://tcmportmapper.googlecode.com/files/PortMap-1.3.1-r46.zip'
+  url 'https://tcmportmapper.googlecode.com/files/PortMap-1.3.1-r46.zip'
   appcast 'http://www.codingmonkeys.de/portmap/appcast.rss'
   homepage 'http://www.codingmonkeys.de/portmap'
   version '1.3.1-r46'

--- a/Casks/prey.rb
+++ b/Casks/prey.rb
@@ -1,5 +1,5 @@
 class Prey < Cask
-  url 'http://preyproject.com/releases/current/prey-0.6.3-mac-batch.mpkg.zip'
+  url 'https://preyproject.com/releases/current/prey-0.6.3-mac-batch.mpkg.zip'
   homepage 'https://preyproject.com'
   version '0.6.3'
   sha256 '7193cf76a776a015c7b533372506963c9ec2720966245dab1e0c02d149da1010'

--- a/Casks/projectlibre.rb
+++ b/Casks/projectlibre.rb
@@ -1,5 +1,5 @@
 class Projectlibre < Cask
-  url 'http://downloads.sourceforge.net/project/projectlibre/ProjectLibre/1.5.8/projectlibre-1.5.8.dmg'
+  url 'https://downloads.sourceforge.net/project/projectlibre/ProjectLibre/1.5.8/projectlibre-1.5.8.dmg'
   homepage 'http://www.projectlibre.org/'
   version '1.5.8'
   sha256 'efd7d228d2e71a2a5af185d2fe1ddcea4abc55af32188344e06e1871facd0c6b'

--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,5 +1,5 @@
 class Propresenter < Cask
-  url 'http://www.renewedvision.com/downloads/ProPresenter5_5.2.8_b11499.dmg'
+  url 'https://www.renewedvision.com/downloads/ProPresenter5_5.2.8_b11499.dmg'
   appcast 'https://www.renewedvision.com/update/ProPresenter5.php'
   homepage 'http://www.renewedvision.com/propresenter.php'
   version '5.2.8'

--- a/Casks/ps3-media-server.rb
+++ b/Casks/ps3-media-server.rb
@@ -1,5 +1,5 @@
 class Ps3MediaServer < Cask
-  url 'http://downloads.sourceforge.net/project/ps3mediaserver/pms-1.90.1-setup-macosx.tar.gz'
+  url 'https://downloads.sourceforge.net/project/ps3mediaserver/pms-1.90.1-setup-macosx.tar.gz'
   homepage 'http://www.ps3mediaserver.org/'
   version '1.90.1'
   sha256 '3ebe75ce0dbdc1313c10fb901f845564cc343dc3b7487f07e15db9d757850df5'

--- a/Casks/psi.rb
+++ b/Casks/psi.rb
@@ -1,5 +1,5 @@
 class Psi < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/psi/Psi-0.15.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/psi/Psi-0.15.dmg'
   homepage 'http://psi-im.org/'
   version '0.15'
   sha256 '76d50b5314d0a7d9f9a0a71d90e0f806f2da25436135dbd90bd1959286747742'

--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,5 +1,5 @@
 class Psychopy < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/psychpy/StandalonePsychoPy-1.79.01-OSX.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/psychpy/StandalonePsychoPy-1.79.01-OSX.dmg'
   homepage 'http://www.psychopy.org/'
   version '1.79.01'
   sha256 'a2b174aee30ca4a8858238404adfd9271da9ec14243aa30be0b7f9a6abb047b8'

--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,5 +1,5 @@
 class Qbittorrent < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/qbittorrent/qbittorrent-3.1.3.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/qbittorrent/qbittorrent-3.1.3.dmg'
   homepage 'http://www.qbittorrent.org'
   version '3.1.3'
   sha256 'eaa13313fd2f88b7cbc6dd9ad2c63871c2a58a8f0177349618bbc853e56783c7'

--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,5 +1,5 @@
 class QtCreator < Cask
-  url 'http://download.qt-project.org/official_releases/qtcreator/3.1/3.1.1/qt-creator-opensource-mac-x86_64-3.1.1.dmg'
+  url 'https://download.qt-project.org/official_releases/qtcreator/3.1/3.1.1/qt-creator-opensource-mac-x86_64-3.1.1.dmg'
   homepage 'http://qt-project.org/'
   version '3.1.1'
   sha256 '5d3219c155252d5364083c4395d326c274020b40c39d4148671d6839d20b369e'

--- a/Casks/quick-search-box.rb
+++ b/Casks/quick-search-box.rb
@@ -1,5 +1,5 @@
 class QuickSearchBox < Cask
-  url 'http://qsb-mac.googlecode.com/files/GoogleQuickSearchBox-2.0.0.1447.Release.dmg'
+  url 'https://qsb-mac.googlecode.com/files/GoogleQuickSearchBox-2.0.0.1447.Release.dmg'
   homepage 'http://www.google.com/quicksearchbox/'
   version '2.0.0.1447'
   sha256 '3fec80343c50a5b492e140fef13bd1bc4cce835beb3952591e8b4638e5940470'

--- a/Casks/recovery-disk-assistant.rb
+++ b/Casks/recovery-disk-assistant.rb
@@ -1,5 +1,5 @@
 class RecoveryDiskAssistant < Cask
-  url 'http://support.apple.com/downloads/DL1433/en_US/RecoveryDiskAssistant.dmg'
+  url 'https://support.apple.com/downloads/DL1433/en_US/RecoveryDiskAssistant.dmg'
   homepage 'http://support.apple.com/kb/HT4848'
   version '1.0'
   sha256 '4991086d733ceff060b1e2aedf7788c17be407db5f5a6bf6dde0c23f10db26c2'

--- a/Casks/reggy.rb
+++ b/Casks/reggy.rb
@@ -1,5 +1,5 @@
 class Reggy < Cask
-  url 'http://github.com/downloads/samsouder/reggy/Reggy_v1.3.tbz'
+  url 'https://github.com/downloads/samsouder/reggy/Reggy_v1.3.tbz'
   appcast 'http://reggyapp.com/appcast.xml'
   homepage 'http://reggyapp.com/'
   version '1.3'

--- a/Casks/retinizer.rb
+++ b/Casks/retinizer.rb
@@ -1,5 +1,5 @@
 class Retinizer < Cask
-  url 'http://sites.google.com/a/mikelpr.com/files/home/Retinizer050.zip'
+  url 'https://sites.google.com/a/mikelpr.com/files/home/Retinizer050.zip'
   homepage 'http://retinizer.mikelpr.com/'
   version '0.5'
   sha256 '34d82f6beeb934ebd73ac231c364298456374d8e52f5e3826077999507832922'

--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -1,5 +1,5 @@
 class Retroshare < Cask
-  url 'http://downloads.sourceforge.net/project/retroshare/RetroShare/0.5.5b/Retroshare-V0.5.5b-svn6877_OSX10.6u.dmg'
+  url 'https://downloads.sourceforge.net/project/retroshare/RetroShare/0.5.5b/Retroshare-V0.5.5b-svn6877_OSX10.6u.dmg'
   homepage 'http://retroshare.sourceforge.net/'
   version '0.5.5b'
   sha256 '24beb2e1087e7a93ba996030c0785cd9f3a575d3adc5dcfda0d58aab3b40aebe'

--- a/Casks/rftg.rb
+++ b/Casks/rftg.rb
@@ -1,5 +1,5 @@
 class Rftg < Cask
-  url 'http://dl.dropbox.com/u/51639697/rftg-osx-081.zip'
+  url 'https://dl.dropbox.com/u/51639697/rftg-osx-081.zip'
   homepage 'http://keldon.net/rftg/'
   version '0.8.1'
   sha256 '0cc507f0713d33aa7fdc5d26f86a7384d5b55d94506b2a8cfec994ac6882fab1'

--- a/Casks/riffworkst4.rb
+++ b/Casks/riffworkst4.rb
@@ -1,6 +1,6 @@
 class Riffworkst4 < Cask
   # note: "4" is not a version number, but an intrinsic part of product name "T4"
-  url 'http://www.sonomawireworks.com/accountManagerUI/files/RiffWorksT4.dmg'
+  url 'https://www.sonomawireworks.com/accountManagerUI/files/RiffWorksT4.dmg'
   homepage 'http://www.sonomawireworks.com/T4/'
   version '2.6'
   sha256 '83c51fa4a08ad19f92418572e11b09ebb33f9a0341ff9e0173d0eb0c7709cddb'

--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -1,5 +1,5 @@
 class Sabnzbd < Cask
-  url 'http://downloads.sourceforge.net/project/sabnzbdplus/sabnzbdplus/0.7.17/SABnzbd-0.7.17-osx.dmg'
+  url 'https://downloads.sourceforge.net/project/sabnzbdplus/sabnzbdplus/0.7.17/SABnzbd-0.7.17-osx.dmg'
   homepage 'http://sabnzbd.org/'
   version '0.7.17'
   sha256 '31cf257d951afbd0527f13969ba673808594f2b883c1aa8f532296db7b26d5e1'

--- a/Casks/satellite-eyes.rb
+++ b/Casks/satellite-eyes.rb
@@ -1,5 +1,5 @@
 class SatelliteEyes < Cask
-  url 'http://satellite-eyes.s3.amazonaws.com/satellite-eyes-1.2.4.zip'
+  url 'https://satellite-eyes.s3.amazonaws.com/satellite-eyes-1.2.4.zip'
   appcast 'https://satellite-eyes.s3.amazonaws.com/appcast.xml'
   homepage 'http://satelliteeyes.tomtaylor.co.uk/'
   version '1.2.4'

--- a/Casks/scansnap-manager.rb
+++ b/Casks/scansnap-manager.rb
@@ -1,5 +1,5 @@
 class ScansnapManager < Cask
-  url 'http://www.fujitsu.com/downloads/IMAGE/driver/ss/mgr/m-sv600/MacScanSnapV62L10WW.dmg'
+  url 'https://www.fujitsu.com/downloads/IMAGE/driver/ss/mgr/m-sv600/MacScanSnapV62L10WW.dmg'
   homepage 'http://www.fujitsu.com/global/support/computing/peripheral/scanners/software/'
   version '6.2L10'
   sha256 '7273034398e9a57eb0fa89167c9e801ad2bf9fe56b52b3d9591628e978168afb'

--- a/Casks/screenstagram.rb
+++ b/Casks/screenstagram.rb
@@ -1,5 +1,5 @@
 class Screenstagram < Cask
-  url 'http://screenstagram.s3.amazonaws.com/screenstagram_2.01.dmg'
+  url 'https://screenstagram.s3.amazonaws.com/screenstagram_2.01.dmg'
   homepage 'http://screenstagram.s3.amazonaws.com/download.html'
   version '2.01'
   sha256 '5cb9f7be247fdec897248f5091818bf7b25153fa99782e96f9d9b2c2431cdbb1'

--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,5 +1,5 @@
 class Scribus < Cask
-  url 'http://downloads.sourceforge.net/project/scribus/scribus/1.4.4/scribus-1.4.4.dmg'
+  url 'https://downloads.sourceforge.net/project/scribus/scribus/1.4.4/scribus-1.4.4.dmg'
   homepage 'http://www.scribus.net/canvas/Scribus'
   version '1.4.4'
   sha256 '57cdfacbfa6c60c035b746ac40ea8c46718fdfd4a9ac382b3b6c56a318fa162c'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -1,5 +1,5 @@
 class Scummvm < Cask
-  url 'http://downloads.sourceforge.net/project/scummvm/scummvm/1.6.0/scummvm-1.6.0-macosx.dmg'
+  url 'https://downloads.sourceforge.net/project/scummvm/scummvm/1.6.0/scummvm-1.6.0-macosx.dmg'
   appcast 'http://www.scummvm.org/appcasts/macosx/release.xml'
   homepage 'http://scummvm.org/'
   version '1.6.0'

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,5 +1,5 @@
 class Seashore < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/seashore/Seashore.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/seashore/Seashore.zip'
   homepage 'http://seashore.sourceforge.net/'
   version '0.5.1'
   sha256 '96463a3642f162a20b160d8df273e9b27a5fdbf9708bee6ebf6a6c8528047765'

--- a/Casks/secrets.rb
+++ b/Casks/secrets.rb
@@ -1,5 +1,5 @@
 class Secrets < Cask
-  url 'http://blacktree-secrets.googlecode.com/files/Secrets_1.0.6.zip'
+  url 'https://blacktree-secrets.googlecode.com/files/Secrets_1.0.6.zip'
   homepage 'http://secrets.blacktree.com'
   version '1.0.6'
   sha256 '9604bc37a52fe32cd5146715fe5f401512b214847284151155d28c43413e0d25'

--- a/Casks/send-to-kindle.rb
+++ b/Casks/send-to-kindle.rb
@@ -1,5 +1,5 @@
 class SendToKindle < Cask
-  url 'http://s3.amazonaws.com/sendtokindle/SendToKindleForMac-installer-v1.0.0.218.pkg'
+  url 'https://s3.amazonaws.com/sendtokindle/SendToKindleForMac-installer-v1.0.0.218.pkg'
   homepage 'http://www.amazon.com/gp/sendtokindle/mac'
   version '1.0.0.218'
   sha256 '9c3a9eca8fe9f09ff43dfb4132a8be163ef517008979075df3d947699c421494'

--- a/Casks/sente.rb
+++ b/Casks/sente.rb
@@ -1,5 +1,5 @@
 class Sente < Cask
-  url 'http://www.thirdstreetsoftware.com/downloads/Sente-6.7.6.11672.zip'
+  url 'https://www.thirdstreetsoftware.com/downloads/Sente-6.7.6.11672.zip'
   appcast 'http://www.thirdstreetsoftware.com/rss/Sente65.xml?v=6.6.0'
   homepage 'http://www.thirdstreetsoftware.com'
   version '6.7.6'

--- a/Casks/shadowsocksx.rb
+++ b/Casks/shadowsocksx.rb
@@ -1,5 +1,5 @@
 class Shadowsocksx < Cask
-  url 'http://downloads.sourceforge.net/project/shadowsocksgui/dist/ShadowsocksX-1.0.6.dmg'
+  url 'https://downloads.sourceforge.net/project/shadowsocksgui/dist/ShadowsocksX-1.0.6.dmg'
   homepage 'https://github.com/shadowsocks/shadowsocks-iOS/wiki/Shadowsocks-for-OSX-Help'
   version '1.0.6'
   sha256 '3b2d5289043f905897abc9ac395189201718acde79bd782c46a1e9ed6c32892d'

--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -1,5 +1,5 @@
 class Sketchup < Cask
-  url 'http://dl.trimble.com/sketchup/SketchUpMEN.dmg'
+  url 'https://dl.trimble.com/sketchup/SketchUpMEN.dmg'
   homepage 'http://www.sketchup.com/intl/en/'
   version '2013'
   sha256 '0a335e432eabafeaeed000c5471a0818fd5e92e65db4e3e145f99ea261a41844'

--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -1,5 +1,5 @@
 class Skim < Cask
-  url 'http://downloads.sourceforge.net/project/skim-app/Skim/Skim-1.4.8/Skim-1.4.8.dmg'
+  url 'https://downloads.sourceforge.net/project/skim-app/Skim/Skim-1.4.8/Skim-1.4.8.dmg'
   appcast 'http://skim-app.sourceforge.net/skim.xml'
   homepage 'http://skim-app.sourceforge.net/'
   version '1.4.8'

--- a/Casks/snippets.rb
+++ b/Casks/snippets.rb
@@ -1,5 +1,5 @@
 class Snippets < Cask
-  url 'http://snippets.me/download/mac/Snippets-468.zip'
+  url 'https://snippets.me/download/mac/Snippets-468.zip'
   appcast 'http://snippets.me/mac/appcast.xml'
   homepage 'http://snippets.me/'
   version '0.8.2'

--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -1,5 +1,5 @@
 class SonicVisualiser < Cask
-  url 'http://code.soundsoftware.ac.uk/attachments/download/907/Sonic%20Visualiser-2.3.dmg'
+  url 'https://code.soundsoftware.ac.uk/attachments/download/907/Sonic%20Visualiser-2.3.dmg'
   homepage 'http://www.sonicvisualiser.org/'
   version '2.3'
   sha256 '8a8c6c5268f10dd6614afeabd40a4fa962a31d55db0aed1ddf369c5a5b8b4981'

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -1,5 +1,5 @@
 class Sourcetree < Cask
-  url 'http://downloads.atlassian.com/software/sourcetree/SourceTree_1.9.4.1.dmg'
+  url 'https://downloads.atlassian.com/software/sourcetree/SourceTree_1.9.4.1.dmg'
   appcast 'http://www.sourcetreeapp.com/update/SparkleAppcast.xml'
   homepage 'http://www.sourcetreeapp.com/'
   version '1.9.4.1'

--- a/Casks/splashtop-personal.rb
+++ b/Casks/splashtop-personal.rb
@@ -1,5 +1,5 @@
 class SplashtopPersonal < Cask
-  url 'http://d17kmd0va0f0mp.cloudfront.net/macclient/STP/Splashtop_Personal_v2.4.3.1.dmg'
+  url 'https://d17kmd0va0f0mp.cloudfront.net/macclient/STP/Splashtop_Personal_v2.4.3.1.dmg'
   homepage 'http://www.splashtop.com/personal'
   version '2.4.3.1'
   sha256 'a0167ad134b3134e9b3e5e0a26238aed04ef230f3cabcddd7fd0fef9d82687aa'

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,5 +1,5 @@
 class SplashtopStreamer < Cask
-  url 'http://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_MAC_v2.4.5.3.dmg'
+  url 'https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_MAC_v2.4.5.3.dmg'
   homepage 'http://www.splashtop.com/downloads'
   version '2.4.5.3'
   sha256 '07fd11f7c19ce0c7c29e65d5182532940f74e6e4512b696c19e58389d5e86357'

--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,5 +1,5 @@
 class Sqleditor < Cask
-  url 'http://www.malcolmhardie.com/sqleditor/releases/2.7/SQLEditor-2-7.zip'
+  url 'https://www.malcolmhardie.com/sqleditor/releases/2.7/SQLEditor-2-7.zip'
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml'
   homepage 'http://www.malcolmhardie.com/sqleditor/'
   version '2.7'

--- a/Casks/sqlexplorer.rb
+++ b/Casks/sqlexplorer.rb
@@ -1,5 +1,5 @@
 class Sqlexplorer < Cask
-  url 'http://downloads.sourceforge.net/project/eclipsesql/SQL%20Explorer%20RCP%20%28exc%20JRE%29/3.6.1/sqlexplorer_rcp-3.6.1.macosx.cocoa.x86.tgz'
+  url 'https://downloads.sourceforge.net/project/eclipsesql/SQL%20Explorer%20RCP%20%28exc%20JRE%29/3.6.1/sqlexplorer_rcp-3.6.1.macosx.cocoa.x86.tgz'
   homepage 'http://eclipsesql.sourceforge.net/'
   version '3.6.1'
   sha256 '57b40bf7f06d8ea125126de9c370bbd0415f5d9c68ce5200765e146acac0b05e'

--- a/Casks/sqlite-database-browser.rb
+++ b/Casks/sqlite-database-browser.rb
@@ -1,5 +1,5 @@
 class SqliteDatabaseBrowser < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/sqlitebrowser/sqlitebrowser_200_b1_osx.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/sqlitebrowser/sqlitebrowser_200_b1_osx.zip'
   homepage 'http://sqlitebrowser.sourceforge.net/'
   version '2.0.0b1'
   sha256 '724d15c3958efc85f457278ba1a957b25b643f4e502e2b6ff3ba999354aadabd'

--- a/Casks/squirrel.rb
+++ b/Casks/squirrel.rb
@@ -1,5 +1,5 @@
 class Squirrel < Cask
-  url 'http://dl.bintray.com/lotem/rime/Squirrel-0.9.25.zip'
+  url 'https://dl.bintray.com/lotem/rime/Squirrel-0.9.25.zip'
   homepage 'https://github.com/lotem/squirrel'
   version '0.9.25'
   sha256 'ec9028e097ec5130c79c6e8353c88d50729cd3f8bb15832d498fc679c4391021'

--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -1,5 +1,5 @@
 class Stay < Cask
-  url 'http://cordlessdog.com/stay/versions/Stay%201.2.3.zip'
+  url 'https://cordlessdog.com/stay/versions/Stay%201.2.3.zip'
   appcast 'http://cordlessdog.com/stay/appcast.xml'
   homepage 'http://cordlessdog.com/stay/'
   version '1.2.3'

--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,5 +1,5 @@
 class Stella < Cask
-  url 'http://downloads.sourceforge.net/project/stella/stella/3.9.3/Stella-3.9.3_intel-macosx.dmg'
+  url 'https://downloads.sourceforge.net/project/stella/stella/3.9.3/Stella-3.9.3_intel-macosx.dmg'
   homepage 'http://stella.sourceforge.net'
   version '3.9.3'
   sha256 '83870088368be20224ed51f52e9babe53a75575495279adc596203f123e8477c'

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,5 +1,5 @@
 class Stellarium < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/stellarium/Stellarium-0.12.4.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/stellarium/Stellarium-0.12.4.dmg'
   homepage 'http://stellarium.org'
   version '0.12.4'
   sha256 'fe4f3c58a64780888d6ca6e28ec948fa1d885c7f0dd0a85beb4b5ec7339398db'

--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,5 +1,5 @@
 class Subsurface < Cask
-  url 'http://subsurface.hohndel.org/downloads/Subsurface-4.0.3.dmg'
+  url 'https://subsurface.hohndel.org/downloads/Subsurface-4.0.3.dmg'
   homepage 'http://subsurface.hohndel.org/'
   version '4.0.3'
   sha256 'bad56a7c6a1d99476b9361cd9de42adc458cc61eddcb519cefb049f2faf4a96d'

--- a/Casks/supercollider.rb
+++ b/Casks/supercollider.rb
@@ -1,5 +1,5 @@
 class Supercollider < Cask
-  url 'http://downloads.sourceforge.net/project/supercollider/Mac%20OS%20X/3.6/SuperCollider-3.6.5-OSX-universal.dmg'
+  url 'https://downloads.sourceforge.net/project/supercollider/Mac%20OS%20X/3.6/SuperCollider-3.6.5-OSX-universal.dmg'
   homepage 'http://supercollider.sourceforge.net/'
   version '3.6.5'
   sha256 '3a942aed9d28071bd8354b387d1e436205a1c21f55667e17689d9b361af3409b'

--- a/Casks/supertuxkart.rb
+++ b/Casks/supertuxkart.rb
@@ -1,5 +1,5 @@
 class Supertuxkart < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/supertuxkart/supertuxkart-0.8.1-osx.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/supertuxkart/supertuxkart-0.8.1-osx.dmg'
   homepage 'http://supertuxkart.sourceforge.net'
   version '0.8.1'
   sha256 'e3205788a42dd830cc1fb2deb100e305bd247d730ddd53bbd9e6601ea0e2a0d0'

--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -1,5 +1,5 @@
 class SweetHome3d < Cask
-  url 'http://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-4.3/SweetHome3D-4.3-macosx.dmg'
+  url 'https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-4.3/SweetHome3D-4.3-macosx.dmg'
   homepage 'http://www.sweethome3d.com/'
   version '4.3'
   sha256 'c8004cbcec8d587139751a7a39539903f0f555185ce41378056a4549d0f65962'

--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,5 +1,5 @@
 class Synergy < Cask
-  url 'http://synergy-project.org/files/packages/synergy-1.5.0-r2278-MacOSX109-x86_64.dmg'
+  url 'https://synergy-project.org/files/packages/synergy-1.5.0-r2278-MacOSX109-x86_64.dmg'
   homepage 'http://synergy-foss.org/'
   version '1.5.0'
   sha256 'b7f024720a3174ad68aa3489fa8674ca4bdc95a785b82044d57685325f60c913'

--- a/Casks/synology-assistant.rb
+++ b/Casks/synology-assistant.rb
@@ -1,5 +1,5 @@
 class SynologyAssistant < Cask
-  url 'http://global.download.synology.com/download/Tools/SynologyAssistant/4448/Mac/Synology-Assistant-5.0-4448.dmg'
+  url 'https://global.download.synology.com/download/Tools/SynologyAssistant/4448/Mac/Synology-Assistant-5.0-4448.dmg'
   homepage 'http://www.synology.com/'
   version '5.0-4448'
   sha256 'b4e23a43c2b11bd41596809fa84dfad1d17832140145ddf1b79cb8301f2f2014'

--- a/Casks/synology-cloud-station.rb
+++ b/Casks/synology-cloud-station.rb
@@ -1,5 +1,5 @@
 class SynologyCloudStation < Cask
-  url 'http://global.download.synology.com/download/Tools/CloudStation/3109/Mac/CloudStation-3109-Mac-Installer.dmg'
+  url 'https://global.download.synology.com/download/Tools/CloudStation/3109/Mac/CloudStation-3109-Mac-Installer.dmg'
   homepage 'http://www.synology.com/'
   version '3109'
   sha256 '32b3260a8da765840f602830dadfc95c2451e0d3eaded202ec8d315221a25d82'

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,5 +1,5 @@
 class SynologyPhotoStationUploader < Cask
-  url 'http://global.download.synology.com/download/Tools/PhotoStationUploader/046/Mac/PhotoStationUploader-046-Mac-Installer.dmg'
+  url 'https://global.download.synology.com/download/Tools/PhotoStationUploader/046/Mac/PhotoStationUploader-046-Mac-Installer.dmg'
   homepage 'http://www.synology.com/'
   version '046'
   sha256 'd8f3462c2590c9a302ec3ea091c779682f37bbacdae7c8038dcccddc9f920bc6'

--- a/Casks/teensy.rb
+++ b/Casks/teensy.rb
@@ -1,5 +1,5 @@
 class Teensy < Cask
-  url 'http://www.pjrc.com/teensy/teensy.dmg'
+  url 'https://www.pjrc.com/teensy/teensy.dmg'
   homepage 'http://pjrc.com/teensy/loader_mac.html'
   version '1.17'
   sha256 'da5a499303fb8f7ba95ff9f9a69b96f65280870ccff8f71d4dded00a5770f502'

--- a/Casks/teeworlds.rb
+++ b/Casks/teeworlds.rb
@@ -1,5 +1,5 @@
 class Teeworlds < Cask
-  url 'http://teeworlds.com/files/teeworlds-0.6.2-osx.dmg'
+  url 'https://teeworlds.com/files/teeworlds-0.6.2-osx.dmg'
   homepage 'https://www.teeworlds.com/'
   version '0.6.2'
   sha256 '954e8f213f22b0c47c529d6e4d92f5bc1008a6a1ee54229dc62e706ffd1cab64'

--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,5 +1,5 @@
 class Texpad < Cask
-  url 'http://cloud.texpadapp.com/bundles/Texpad_1_6_12.zip'
+  url 'https://cloud.texpadapp.com/bundles/Texpad_1_6_12.zip'
   appcast 'https://www.texpadapp.com/static-collected/upgrades/texpadappcast.xml'
   homepage 'https://www.texpadapp.com/osx'
   version '1.6.12'

--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -1,5 +1,5 @@
 class Texstudio < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/texstudio/texstudio_2.7.0_osx_qt5.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/texstudio/texstudio_2.7.0_osx_qt5.dmg'
   homepage 'http://texstudio.sourceforge.net/'
   version '2.7.0'
   sha256 '70a95e7602a790b71744ce84a649dfe5f7b597caa42007e3c34c3e631ffadb22'

--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -1,5 +1,5 @@
 class Texturepacker < Cask
-  url 'http://www.codeandweb.com/download/texturepacker/3.3.1/TexturePacker-3.3.1-uni.dmg'
+  url 'https://www.codeandweb.com/download/texturepacker/3.3.1/TexturePacker-3.3.1-uni.dmg'
   homepage 'http://www.codeandweb.com/texturepacker'
   version '3.3.1'
   sha256 '00f922d036bd7ec991bbe5ee5fcad1431c3c4884bc2b371fdff92cecdaa11339'

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,5 +1,5 @@
 class TheUnarchiver < Cask
-  url 'http://theunarchiver.googlecode.com/files/TheUnarchiver3.9.1.zip'
+  url 'https://theunarchiver.googlecode.com/files/TheUnarchiver3.9.1.zip'
   homepage 'http://unarchiver.c3.cx/'
   version '3.9.1'
   sha256 '34fa3410237e17b2cdceb801a84ed8db93c74ac0db551ffe65913c2134ebbf05'

--- a/Casks/thong.rb
+++ b/Casks/thong.rb
@@ -1,5 +1,5 @@
 class Thong < Cask
-  url 'http://fousa-apps.s3.amazonaws.com/thong/thong-1.1.dmg'
+  url 'https://fousa-apps.s3.amazonaws.com/thong/thong-1.1.dmg'
   homepage 'http://thong.fousa.be/'
   version '1.1'
   sha256 '87e5f3dc6fa85d039d761507aba13e5bc90578940412420d24fb621cfd4fc2b6'

--- a/Casks/thyme.rb
+++ b/Casks/thyme.rb
@@ -1,5 +1,5 @@
 class Thyme < Cask
-  url 'http://joaomoreno.github.io/thyme/dist/Thyme-0.4.2.dmg'
+  url 'https://joaomoreno.github.io/thyme/dist/Thyme-0.4.2.dmg'
   homepage 'http://joaomoreno.github.io/thyme/'
   version '0.4.2'
   sha256 '5963d199ff9d64f3cc6966ed532b949fa500c9887d391aef8eedba68ae469a45'

--- a/Casks/tickets.rb
+++ b/Casks/tickets.rb
@@ -1,5 +1,5 @@
 class Tickets < Cask
-  url 'http://www.irradiatedsoftware.com/download/Tickets.zip'
+  url 'https://www.irradiatedsoftware.com/download/Tickets.zip'
   appcast 'http://www.irradiatedsoftware.com/updates/profiles/tickets.php'
   homepage 'http://www.irradiatedsoftware.com/tickets/'
   version '2.5'

--- a/Casks/tikz-editor.rb
+++ b/Casks/tikz-editor.rb
@@ -1,5 +1,5 @@
 class TikzEditor < Cask
-  url 'http://github.com/downloads/fredokun/TikZ-Editor/TikZ%20Editor-1.0.dmg'
+  url 'https://github.com/downloads/fredokun/TikZ-Editor/TikZ%20Editor-1.0.dmg'
   homepage 'https://github.com/fredokun/TikZ-Editor'
   version '1.0'
   sha256 '0462af2994a5d2c3f495eb922e3cf989e3f4cff27bc545426ddc83da4a5f82db'

--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,5 +1,5 @@
 class Tiled < Cask
-  url 'http://downloads.sourceforge.net/project/tiled/tiled-qt/0.9.1/tiled-qt-0.9.1.dmg'
+  url 'https://downloads.sourceforge.net/project/tiled/tiled-qt/0.9.1/tiled-qt-0.9.1.dmg'
   homepage 'http://www.mapeditor.org/'
   version '0.9.1'
   sha256 '17560ca54389c077e80636ac96ddb905d2f5a3a1932562a0be6d91c76bf395a1'

--- a/Casks/tilemill.rb
+++ b/Casks/tilemill.rb
@@ -1,5 +1,5 @@
 class Tilemill < Cask
-  url 'http://tilemill.s3.amazonaws.com/latest/TileMill-0.10.1.zip'
+  url 'https://tilemill.s3.amazonaws.com/latest/TileMill-0.10.1.zip'
   appcast 'http://mapbox.com/tilemill/platforms/osx/appcast2.xml'
   homepage 'http://www.mapbox.com/tilemill/'
   version '0.10.1'

--- a/Casks/torustrooper.rb
+++ b/Casks/torustrooper.rb
@@ -1,5 +1,5 @@
 class Torustrooper < Cask
-  url 'http://workram.com/archives/TorusTrooperOSX0.22.2.dmg'
+  url 'https://workram.com/archives/TorusTrooperOSX0.22.2.dmg'
   homepage 'http://workram.com/games/'
   version '0.22.2'
   sha256 '39b188107620c58f4a60f2f24d01f39ab87d46655203f4bcfe97d3a6fa5b7b3e'

--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,5 +1,5 @@
 class Transmit < Cask
-  url 'http://www.panic.com/transmit/d/Transmit%204.4.6.zip'
+  url 'https://www.panic.com/transmit/d/Transmit%204.4.6.zip'
   appcast 'http://www.panic.com/updates/update.php'
   homepage 'http://panic.com/transmit'
   version '4.4.6'

--- a/Casks/truecrypt.rb
+++ b/Casks/truecrypt.rb
@@ -1,5 +1,5 @@
 class Truecrypt < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/truecrypt/TrueCrypt-7.2-Mac-OS-X.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/truecrypt/TrueCrypt-7.2-Mac-OS-X.dmg'
   homepage 'http://truecrypt.org/'
   version '7.2'
   sha256 '01acf85be9b23a1c718193c40f3ecaaf6551695e0dc67c28345e560cca56c94e'

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,5 +1,5 @@
 class Tunnelblick < Cask
-  url 'http://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_3.3.4.dmg'
+  url 'https://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_3.3.4.dmg'
   appcast 'https://www.tunnelblick.net/appcast.rss'
   homepage 'https://code.google.com/p/tunnelblick/'
   version '3.3.4'

--- a/Casks/tuxguitar.rb
+++ b/Casks/tuxguitar.rb
@@ -1,5 +1,5 @@
 class Tuxguitar < Cask
-  url 'http://downloads.sourceforge.net/project/tuxguitar/TuxGuitar/TuxGuitar-1.2/tuxguitar-1.2-macosx10.5-cocoa-64.dmg'
+  url 'https://downloads.sourceforge.net/project/tuxguitar/TuxGuitar/TuxGuitar-1.2/tuxguitar-1.2-macosx10.5-cocoa-64.dmg'
   homepage 'http://www.tuxguitar.com.ar/'
   version '1.2'
   sha256 '2d79ffdfdde9205073fdaa1c34701ea8f1961f822709b5270dc57555eb926d16'

--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -1,5 +1,5 @@
 class TvBrowser < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/tvbrowser/tvbrowser_3.3.3_mac.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/tvbrowser/tvbrowser_3.3.3_mac.dmg'
   homepage 'http://www.tvbrowser.org/index.php?setlang=en'
   version '3.3.3'
   sha256 '951fe8478fa2efa5f7784c23f153bcc8b0a6fcb8a7405c4990c44b3c967e73cc'

--- a/Casks/twitterrific.rb
+++ b/Casks/twitterrific.rb
@@ -1,5 +1,5 @@
 class Twitterrific < Cask
-  url 'http://iconfactory.com/assets/software/twitterrific/Twitterrific-4.5.1.zip'
+  url 'https://iconfactory.com/assets/software/twitterrific/Twitterrific-4.5.1.zip'
   appcast 'http://iconfactory.com/appcasts/Twitterrific/appcast.xml'
   homepage 'http://twitterrific.com/mac'
   version '4.5.1'

--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -1,5 +1,5 @@
 class Ukelele < Cask
-  url 'http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_2.2.8&filename=Ukelele_2.2.8.dmg'
+  url 'https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_2.2.8&filename=Ukelele_2.2.8.dmg'
   appcast 'http://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=ukelele_su_feed&filename=ukelele_su_feed.xml'
   homepage 'http://scripts.sil.org/ukelele'
   version '2.2.8'

--- a/Casks/ultrastardeluxe.rb
+++ b/Casks/ultrastardeluxe.rb
@@ -1,5 +1,5 @@
 class Ultrastardeluxe < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/ultrastardx/UltraStarDeluxe-1.1.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/ultrastardx/UltraStarDeluxe-1.1.dmg'
   homepage 'http://ultrastardx.sourceforge.net/'
   version '1.1'
   sha256 '18e36476ec6994b1dd54e6272c08ceb86b10abf4984a18d834003e696153ca9b'

--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -1,6 +1,6 @@
 class Unetbootin < Cask
   homepage 'http://unetbootin.sourceforge.net/'
-  url 'http://downloads.sourceforge.net/sourceforge/unetbootin/unetbootin-mac-585.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/unetbootin/unetbootin-mac-585.zip'
   version '585'
   sha256 '2a6cc88feb01b666710c094b49b4cbb4e33a301d699b1bd4dbd229bfa0b5572e'
   link 'unetbootin.app'

--- a/Casks/unpkg.rb
+++ b/Casks/unpkg.rb
@@ -1,5 +1,5 @@
 class Unpkg < Cask
-  url 'http://github.com/downloads/timdoug/unpkg/unpkg-4.5.zip'
+  url 'https://github.com/downloads/timdoug/unpkg/unpkg-4.5.zip'
   homepage 'http://www.timdoug.com/unpkg/'
   version '4.5'
   sha256 'e32754b07073b383320d2bc0ce4ba9bd83a3f352043bd6f500741901f00c8c17'

--- a/Casks/vassal.rb
+++ b/Casks/vassal.rb
@@ -1,5 +1,5 @@
 class Vassal < Cask
-  url 'http://downloads.sourceforge.net/project/vassalengine/VASSAL-current/VASSAL-3.2.11/VASSAL-3.2.11-macosx.dmg'
+  url 'https://downloads.sourceforge.net/project/vassalengine/VASSAL-current/VASSAL-3.2.11/VASSAL-3.2.11-macosx.dmg'
   homepage 'http://www.vassalengine.org'
   version '3.2.11'
   sha256 '30be0f5e7357ac7c39336604aaceef6d3d527e5db1733a8f1b1bfd99ba131ed3'

--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,5 +1,5 @@
 class Vienna < Cask
-  url 'http://downloads.sourceforge.net/vienna-rss/Vienna3.0.0_beta20.tgz'
+  url 'https://downloads.sourceforge.net/vienna-rss/Vienna3.0.0_beta20.tgz'
   appcast 'http://vienna-rss.org/changelog_beta.xml'
   homepage 'http://www.vienna-rss.org'
   version '3.0.0_beta20'

--- a/Casks/virtaal.rb
+++ b/Casks/virtaal.rb
@@ -1,5 +1,5 @@
 class Virtaal < Cask
-  url 'http://downloads.sourceforge.net/project/translate/Virtaal/0.7.1/Virtaal-0.7.1-Mac-Beta-2.dmg'
+  url 'https://downloads.sourceforge.net/project/translate/Virtaal/0.7.1/Virtaal-0.7.1-Mac-Beta-2.dmg'
   homepage 'http://virtaal.translatehouse.org/'
   version '0.7.1b2'
   sha256 '41fec069ca06eb627c75b8d66460110b7970b0894e19df4f41510ac7b91bdbd0'

--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,5 +1,5 @@
 class Visit < Cask
-  url 'http://portal.nersc.gov/svn/visit/trunk/releases/2.7.2/VisIt-2.7.2.dmg'
+  url 'https://portal.nersc.gov/svn/visit/trunk/releases/2.7.2/VisIt-2.7.2.dmg'
   homepage 'https://wci.llnl.gov/codes/visit/home.html'
   version '2.7.2'
   sha256 '3c1f1b201358876c1b23717a1b3a2c5a1777755e3fc7f242c08b53a033402fbc'

--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -1,5 +1,5 @@
 class Vistrails < Cask
-  url 'http://downloads.sourceforge.net/project/vistrails/vistrails/v2.1.1/vistrails-mac-10.6-intel-2.1.1-90975fc00211.dmg'
+  url 'https://downloads.sourceforge.net/project/vistrails/vistrails/v2.1.1/vistrails-mac-10.6-intel-2.1.1-90975fc00211.dmg'
   homepage 'http://www.vistrails.org/index.php/Main_Page'
   version '2.1.1'
   sha256 '38ac9da9af7a557cee6eb703517e38ea1bcc430706a436a182eec6f976275b02'

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,5 +1,5 @@
 class Vlc < Cask
-  url 'http://get.videolan.org/vlc/2.1.4/macosx/vlc-2.1.4.dmg'
+  url 'https://get.videolan.org/vlc/2.1.4/macosx/vlc-2.1.4.dmg'
   appcast 'http://update.videolan.org/vlc/sparkle/vlc-intel64.xml'
   homepage 'http://www.videolan.org/vlc/'
   version '2.1.4'

--- a/Casks/vyprvpn.rb
+++ b/Casks/vyprvpn.rb
@@ -1,5 +1,5 @@
 class Vyprvpn < Cask
-  url 'http://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/2.3.3.1851/VyprVPN_v2.3.3.1851.dmg'
+  url 'https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/2.3.3.1851/VyprVPN_v2.3.3.1851.dmg'
   homepage 'http://www.goldenfrog.com/vyprvpn'
   version '2.3.3.1851'
   sha256 '598967057d8e932bb4e2b332c0664ce31b708ceb36b89bae4a8c2a0c07ea03ec'

--- a/Casks/weibox.rb
+++ b/Casks/weibox.rb
@@ -1,5 +1,5 @@
 class Weibox < Cask
-  url 'http://weiboformac.sinaapp.com/downloads/2.6.1.release.zip'
+  url 'https://weiboformac.sinaapp.com/downloads/2.6.1.release.zip'
   appcast 'http://weiboformac.sinaapp.com/appcast/wm2.xml'
   homepage 'http://weiboformac.sinaapp.com'
   version '2.6.1'

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,5 +1,5 @@
 class Weka < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/weka/weka-3-6-11-oracle-jvm.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/weka/weka-3-6-11-oracle-jvm.dmg'
   homepage 'http://www.cs.waikato.ac.nz/ml/weka/'
   version '3.6.11'
   sha256 '51643edc349f46d76b96460ab16b97cf8e2d63ae6a4f6e5ba4c89dd404b56cea'

--- a/Casks/welly.rb
+++ b/Casks/welly.rb
@@ -1,5 +1,5 @@
 class Welly < Cask
-  url 'http://welly.googlecode.com/files/Welly.v2.7.fix.zip'
+  url 'https://welly.googlecode.com/files/Welly.v2.7.fix.zip'
   appcast 'http://welly.googlecode.com/svn/wiki/WellyUpdate.xml'
   homepage 'https://code.google.com/p/welly/'
   version '2.7+'

--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -1,5 +1,5 @@
 class Wesnoth < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/wesnoth/Wesnoth_1.10.7.dmg'
+  url 'https://downloads.sourceforge.net/sourceforge/wesnoth/Wesnoth_1.10.7.dmg'
   homepage 'http://wesnoth.org'
   version '1.10.7'
   sha256 'cdd7788e55e26c9d619b7c98b87db1b99c6a0fc9f525ddb63a6bd33923d94a6f'

--- a/Casks/wineskin-winery.rb
+++ b/Casks/wineskin-winery.rb
@@ -1,5 +1,5 @@
 class WineskinWinery < Cask
-  url 'http://downloads.sourceforge.net/project/wineskin/Wineskin%20Winery.app%20Version%201.7.zip'
+  url 'https://downloads.sourceforge.net/project/wineskin/Wineskin%20Winery.app%20Version%201.7.zip'
   homepage 'http://wineskin.urgesoftware.com/'
   version '1.7'
   sha256 'ef3ae1fe17a7bc622a59171985f304f506aea7ca0ad342281536dac8609eac32'

--- a/Casks/worksnaps-client.rb
+++ b/Casks/worksnaps-client.rb
@@ -1,5 +1,5 @@
 class WorksnapsClient < Cask
-  url 'http://www.worksnaps.net/download/WSClient-mac-1.1.20140328.dmg'
+  url 'https://www.worksnaps.net/download/WSClient-mac-1.1.20140328.dmg'
   homepage 'http://www.worksnaps.net/'
   version '1.1.20140328'
   sha256 '73800f9f5bf2dfb5c19fdffc96fc1c869e21118ef7ec25edda5be2d91335c5c3'

--- a/Casks/wowhead-client.rb
+++ b/Casks/wowhead-client.rb
@@ -1,5 +1,5 @@
 class WowheadClient < Cask
-  url 'http://static.wowhead.com/download/Wowhead_Client.dmg'
+  url 'https://static.wowhead.com/download/Wowhead_Client.dmg'
   appcast 'http://client.wowhead.com/files/wowhead-client-appcast.xml'
   homepage 'http://wowhead.com'
   version '1.2.2'

--- a/Casks/xampp.rb
+++ b/Casks/xampp.rb
@@ -1,5 +1,5 @@
 class Xampp < Cask
-  url 'http://downloads.sourceforge.net/project/xampp/XAMPP%20Mac%20OS%20X/1.8.3/xampp-osx-1.8.3-3-installer.dmg'
+  url 'https://downloads.sourceforge.net/project/xampp/XAMPP%20Mac%20OS%20X/1.8.3/xampp-osx-1.8.3-3-installer.dmg'
   homepage 'http://www.apachefriends.org/index.html'
   version '1.8.3.3'
   sha256 'b54cced0697caa418851a4bdb11ee1697b3f7f71130e1e6bce19582d60e41530'

--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -1,5 +1,5 @@
 class Xld < Cask
-  url 'http://downloads.sourceforge.net/project/xld/xld-20140504.dmg'
+  url 'https://downloads.sourceforge.net/project/xld/xld-20140504.dmg'
   appcast 'http://xld.googlecode.com/svn/appcast/xld-appcast_e.xml'
   homepage 'http://tmkk.undo.jp/xld/index_e.html'
   version '20140504'

--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -1,5 +1,5 @@
 class Xquartz < Cask
-  url 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg'
+  url 'https://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg'
   homepage 'http://xquartz.macosforge.org/'
   appcast 'http://xquartz-dl.macosforge.org/sparkle/release.xml'
   version '2.7.6'

--- a/Casks/xscope.rb
+++ b/Casks/xscope.rb
@@ -1,5 +1,5 @@
 class Xscope < Cask
-  url 'http://iconfactory.com/assets/software/xscope/xScope-3.6.3.zip'
+  url 'https://iconfactory.com/assets/software/xscope/xScope-3.6.3.zip'
   appcast 'http://iconfactory.com/appcasts/xScope/appcast.xml'
   homepage 'http://iconfactory.com/software/xscope'
   version '3.6.3'

--- a/Casks/ynab.rb
+++ b/Casks/ynab.rb
@@ -1,5 +1,5 @@
 class Ynab < Cask
-  url 'http://www.youneedabudget.com/CDNOrigin/download/ynab4/liveCaptive/Mac/YNAB4_LiveCaptive_4.3.451.dmg'
+  url 'https://www.youneedabudget.com/CDNOrigin/download/ynab4/liveCaptive/Mac/YNAB4_LiveCaptive_4.3.451.dmg'
   homepage 'http://www.youneedabudget.com/'
   version '4.3.451'
   sha256 '088f61e0e772193f6dac61e22067b1696246f214d7c9887f95d180cfabb57e25'

--- a/Casks/yubikey-personalization-gui.rb
+++ b/Casks/yubikey-personalization-gui.rb
@@ -1,5 +1,5 @@
 class YubikeyPersonalizationGui < Cask
-  url 'http://www.yubico.com/wp-content/uploads/2012/09/yubikey-personalization-gui-3.1.14.pkg'
+  url 'https://www.yubico.com/wp-content/uploads/2012/09/yubikey-personalization-gui-3.1.14.pkg'
   homepage 'http://www.yubico.com/products/services-software/personalization-tools/use/'
   version '3.1.14'
   sha256 'f0c3d016b90f54e69525d2fec4dee89df499862e4a8a1ad3323e0fca57287408'

--- a/Casks/zeroinstall.rb
+++ b/Casks/zeroinstall.rb
@@ -1,5 +1,5 @@
 class Zeroinstall < Cask
-  url 'http://downloads.sourceforge.net/project/zero-install/0install/2.7/ZeroInstall.pkg'
+  url 'https://downloads.sourceforge.net/project/zero-install/0install/2.7/ZeroInstall.pkg'
   homepage 'http://0install.net'
   version '2.7'
   sha256 '12246277e9d03fb1a083f6a0d7d088d7b90170dbd5fd8fb900b36d0470fb88e0'

--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,5 +1,5 @@
 class Zotero < Cask
-  url 'http://download.zotero.org/standalone/4.0.20/Zotero-4.0.20.dmg'
+  url 'https://download.zotero.org/standalone/4.0.20/Zotero-4.0.20.dmg'
   homepage 'http://www.zotero.org/'
   version '4.0.20'
   sha256 '5206accbc9324a5ca42d660dd1c74ca3bac2397ffa0d503819b4245820feea27'


### PR DESCRIPTION
From unencrypted HTTP.

The SHA-256 for each of these downloads matched that of the `sha256` stanza for both HTTP and HTTPS downloads.
