### PR TITLE
convert 101 `:no_check` Casks to HTTPS URLs

### DIFF
--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -1,5 +1,5 @@
 class AmadeusPro < Cask
-  url 'http://s3.amazonaws.com/AmadeusPro2/AmadeusPro.dmg'
+  url 'https://s3.amazonaws.com/AmadeusPro2/AmadeusPro.dmg'
   homepage 'http://www.hairersoft.com/pro.html'
   version 'latest'
   sha256 :no_check

--- a/Casks/anvil.rb
+++ b/Casks/anvil.rb
@@ -1,5 +1,5 @@
 class Anvil < Cask
-  url 'http://sparkler.herokuapp.com/apps/3/download'
+  url 'https://sparkler.herokuapp.com/apps/3/download'
   appcast 'http://sparkler.herokuapp.com/apps/3/updates.xml'
   homepage 'http://anvilformac.com/'
   version 'latest'

--- a/Casks/appmenuboy.rb
+++ b/Casks/appmenuboy.rb
@@ -1,5 +1,5 @@
 class Appmenuboy < Cask
-  url 'http://appmenuboy.googlecode.com/svn/html/AppMenuBoy.zip'
+  url 'https://appmenuboy.googlecode.com/svn/html/AppMenuBoy.zip'
   homepage 'https://code.google.com/p/appmenuboy/'
   version 'latest'
   sha256 :no_check

--- a/Casks/archiver.rb
+++ b/Casks/archiver.rb
@@ -1,5 +1,5 @@
 class Archiver < Cask
-  url 'http://commondatastorage.googleapis.com/incrediblebee/apps/Archiver/Archiver.zip'
+  url 'https://commondatastorage.googleapis.com/incrediblebee/apps/Archiver/Archiver.zip'
   homepage 'http://archiverapp.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/arrsync.rb
+++ b/Casks/arrsync.rb
@@ -1,5 +1,5 @@
 class Arrsync < Cask
-  url 'http://sourceforge.net/projects/arrsync/files/latest/download'
+  url 'https://sourceforge.net/projects/arrsync/files/latest/download'
   homepage 'http://arrsync.sourceforge.net'
   version 'latest'
   sha256 :no_check

--- a/Casks/audio-hijack-pro.rb
+++ b/Casks/audio-hijack-pro.rb
@@ -1,5 +1,5 @@
 class AudioHijackPro < Cask
-  url 'http://rogueamoeba.com/audiohijackpro/download/AudioHijackPro.zip'
+  url 'https://rogueamoeba.com/audiohijackpro/download/AudioHijackPro.zip'
   homepage 'http://www.rogueamoeba.com/audiohijackpro/'
   version 'latest'
   sha256 :no_check

--- a/Casks/axure-rp-pro.rb
+++ b/Casks/axure-rp-pro.rb
@@ -1,5 +1,5 @@
 class AxureRpPro < Cask
-  url 'http://axure.cachefly.net/AxureRP-Pro-Setup.dmg'
+  url 'https://axure.cachefly.net/AxureRP-Pro-Setup.dmg'
   homepage 'http://www.axure.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/baygenie.rb
+++ b/Casks/baygenie.rb
@@ -1,5 +1,5 @@
 class Baygenie < Cask
-  url 'http://www.baygenie.com/Download/BayGenie4Mac.dmg'
+  url 'https://www.baygenie.com/Download/BayGenie4Mac.dmg'
   homepage 'http://www.baygenie.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -1,5 +1,5 @@
 class BbcIplayerDownloads < Cask
-  url 'http://www.bbc.co.uk/iplayer/dm/downloads/mac/latest'
+  url 'https://www.bbc.co.uk/iplayer/dm/downloads/mac/latest'
   homepage 'http://www.bbc.co.uk/iplayer/install'
   version 'latest'
   sha256 :no_check

--- a/Casks/box-sync.rb
+++ b/Casks/box-sync.rb
@@ -1,5 +1,5 @@
 class BoxSync < Cask
-  url 'http://box.com/sync4mac'
+  url 'https://box.com/sync4mac'
   homepage 'https://sites.box.com/sync4/'
   version 'latest'
   sha256 :no_check

--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,5 +1,5 @@
 class Chatology < Cask
-  url 'http://flexibits.com/chatology/download'
+  url 'https://flexibits.com/chatology/download'
   appcast 'https://flexibits.com/chatology/appcast.php'
   homepage 'http://flexibits.com/chatology'
   version 'latest'

--- a/Casks/chocolat.rb
+++ b/Casks/chocolat.rb
@@ -1,5 +1,5 @@
 class Chocolat < Cask
-  url 'http://chocolatapp.com/download'
+  url 'https://chocolatapp.com/download'
   appcast 'http://chocolatapp.com/userspace/appcast/appcast_alpha.php'
   homepage 'http://chocolatapp.com/'
   version 'latest'

--- a/Casks/cinch.rb
+++ b/Casks/cinch.rb
@@ -1,5 +1,5 @@
 class Cinch < Cask
-  url 'http://www.irradiatedsoftware.com/download/Cinch.zip'
+  url 'https://www.irradiatedsoftware.com/download/Cinch.zip'
   appcast 'https://www.irradiatedsoftware.com/updates/profiles/cinch.php'
   homepage 'http://www.irradiatedsoftware.com/cinch/'
   version 'latest'

--- a/Casks/color-picker-pro.rb
+++ b/Casks/color-picker-pro.rb
@@ -1,5 +1,5 @@
 class ColorPickerPro < Cask
-  url 'http://fructivity.s3.amazonaws.com/ColorPickerPro/Color%20Picker%20Pro.zip'
+  url 'https://fructivity.s3.amazonaws.com/ColorPickerPro/Color%20Picker%20Pro.zip'
   appcast 'http://fructivity.s3.amazonaws.com/ColorPickerPro/Appcast.xml'
   homepage 'https://github.com/oscardelben/Color-Picker-Pro'
   version 'latest'

--- a/Casks/colorschemer-studio.rb
+++ b/Casks/colorschemer-studio.rb
@@ -1,5 +1,5 @@
 class ColorschemerStudio < Cask
-  url 'http://www.colorschemer.com/colorschemerstudio.dmg'
+  url 'https://www.colorschemer.com/colorschemerstudio.dmg'
   appcast 'http://www.colorschemer.com/appcast/studio2_mac.xml'
   homepage 'http://www.colorschemer.com'
   version 'latest'

--- a/Casks/comicbooklover.rb
+++ b/Casks/comicbooklover.rb
@@ -1,5 +1,5 @@
 class Comicbooklover < Cask
-  url 'http://www.bitcartel.com/downloads/comicbooklover.zip'
+  url 'https://www.bitcartel.com/downloads/comicbooklover.zip'
   appcast 'http://www.bitcartel.com/appcast/comicbooklover-1.7-dsa.xml'
   homepage 'http://www.bitcartel.com/comicbooklover/'
   version 'latest'

--- a/Casks/comicbookloversync.rb
+++ b/Casks/comicbookloversync.rb
@@ -1,5 +1,5 @@
 class Comicbookloversync < Cask
-  url 'http://www.bitcartel.com/downloads/comicbookloversync.zip'
+  url 'https://www.bitcartel.com/downloads/comicbookloversync.zip'
   homepage 'http://www.bitcartel.com/comicbooklover'
   version 'latest'
   sha256 :no_check

--- a/Casks/commandq.rb
+++ b/Casks/commandq.rb
@@ -1,5 +1,5 @@
 class Commandq < Cask
-  url 'http://clickontyler.com/commandq/download/'
+  url 'https://clickontyler.com/commandq/download/'
   homepage 'http://clickontyler.com/commandq/'
   version 'latest'
   sha256 :no_check

--- a/Casks/crashlytics.rb
+++ b/Casks/crashlytics.rb
@@ -1,5 +1,5 @@
 class Crashlytics < Cask
-  url 'http://crashlytics.com/download/mac'
+  url 'https://crashlytics.com/download/mac'
   appcast 'https://ssl-download-crashlytics-com.s3.amazonaws.com/mac/version.xml'
   homepage 'http://crashlytics.com'
   version 'latest'

--- a/Casks/darteditor.rb
+++ b/Casks/darteditor.rb
@@ -1,5 +1,5 @@
 class Darteditor < Cask
-  url 'http://storage.googleapis.com/dart-archive/channels/stable/release/latest/editor/darteditor-macos-x64.zip'
+  url 'https://storage.googleapis.com/dart-archive/channels/stable/release/latest/editor/darteditor-macos-x64.zip'
   homepage 'https://www.dartlang.org/tools/editor/'
   version 'latest'
   sha256 :no_check

--- a/Casks/divvy.rb
+++ b/Casks/divvy.rb
@@ -1,5 +1,5 @@
 class Divvy < Cask
-  url 'http://mizage.com/downloads/Divvy.zip'
+  url 'https://mizage.com/downloads/Divvy.zip'
   appcast 'http://mizage.com/updates/profiles/divvy.php'
   homepage 'http://mizage.com/divvy/'
   version 'latest'

--- a/Casks/djay.rb
+++ b/Casks/djay.rb
@@ -1,5 +1,5 @@
 class Djay < Cask
-  url 'http://www.algoriddim.com/files/djay.zip'
+  url 'https://www.algoriddim.com/files/djay.zip'
   appcast 'http://www.algoriddim.com/djay-mac/releasenotes/appcast'
   homepage 'http://algoriddim.com/djay-mac'
   version 'latest'

--- a/Casks/dump-truck.rb
+++ b/Casks/dump-truck.rb
@@ -1,5 +1,5 @@
 class DumpTruck < Cask
-  url 'http://www.goldenfrog.com/downloads/dumptruck/dumptruck.dmg'
+  url 'https://www.goldenfrog.com/downloads/dumptruck/dumptruck.dmg'
   homepage 'http://www.goldenfrog.com/dumptruck'
   version 'latest'
   sha256 :no_check

--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,5 +1,5 @@
 class Espresso < Cask
-  url 'http://macrabbit.com/espresso/get/'
+  url 'https://macrabbit.com/espresso/get/'
   homepage 'http://macrabbit.com/espresso/'
   version 'latest'
   sha256 :no_check

--- a/Casks/filedrop.rb
+++ b/Casks/filedrop.rb
@@ -1,5 +1,5 @@
 class Filedrop < Cask
-  url 'http://commondatastorage.googleapis.com/filedropme/Filedrop.dmg'
+  url 'https://commondatastorage.googleapis.com/filedropme/Filedrop.dmg'
   homepage 'http://www.filedropme.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/foldit.rb
+++ b/Casks/foldit.rb
@@ -1,5 +1,5 @@
 class Foldit < Cask
-  url 'http://fold.it/portal/download/osx'
+  url 'https://fold.it/portal/download/osx'
   homepage 'http://fold.it'
   version 'latest'
   sha256 :no_check

--- a/Casks/gawker.rb
+++ b/Casks/gawker.rb
@@ -1,5 +1,5 @@
 class Gawker < Cask
-  url 'http://sourceforge.net/projects/gawker/files/latest/download'
+  url 'https://sourceforge.net/projects/gawker/files/latest/download'
   appcast 'http://gawker.sourceforge.net/appcast.xml'
   homepage 'http://gawker.sourceforge.net/Gawker.html'
   version 'latest'

--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -1,5 +1,5 @@
 class Harvest < Cask
-  url 'http://www.getharvest.com/harvest/mac/Harvest.zip'
+  url 'https://www.getharvest.com/harvest/mac/Harvest.zip'
   appcast 'https://www.getharvest.com/harvest/mac/appcast.xml'
   homepage 'http://www.getharvest.com/mac'
   version 'latest'

--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,5 +1,5 @@
 class Hostbuddy < Cask
-  url 'http://clickontyler.com/hostbuddy/download/'
+  url 'https://clickontyler.com/hostbuddy/download/'
   appcast 'http://shine.clickontyler.com/appcast.php?id=22'
   homepage 'http://clickontyler.com'
   version 'latest'

--- a/Casks/hyperswitch.rb
+++ b/Casks/hyperswitch.rb
@@ -1,5 +1,5 @@
 class Hyperswitch < Cask
-  url 'http://bahoom.com/hyperswitch/download'
+  url 'https://bahoom.com/hyperswitch/download'
   appcast 'http://hyperswitch.bahoom.com/appcast.xml'
   homepage 'http://bahoom.com/hyperswitch'
   version 'latest'

--- a/Casks/ibank.rb
+++ b/Casks/ibank.rb
@@ -1,5 +1,5 @@
 class Ibank < Cask
-  url 'http://www.iggsoft.com/ibank/iBank4_Web.dmg'
+  url 'https://www.iggsoft.com/ibank/iBank4_Web.dmg'
   homepage 'http://www.iggsoftware.com/ibank'
   version 'latest'
   sha256 :no_check

--- a/Casks/icompta.rb
+++ b/Casks/icompta.rb
@@ -1,5 +1,5 @@
 class Icompta < Cask
-  url 'http://www.lyricapps.fr/iCompta/downloads/iCompta.dmg'
+  url 'https://www.lyricapps.fr/iCompta/downloads/iCompta.dmg'
   homepage 'http://www.icompta-app.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/ideskcal.rb
+++ b/Casks/ideskcal.rb
@@ -1,5 +1,5 @@
 class Ideskcal < Cask
-  url 'http://www.hashbangind.com/files/iDeskCal-Latest.zip'
+  url 'https://www.hashbangind.com/files/iDeskCal-Latest.zip'
   appcast 'https://hashbangind.com/appcasts/iDeskCal-profileInfo.php'
   homepage 'http://www.hashbangind.com'
   version 'latest'

--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,5 +1,5 @@
 class Imageoptim < Cask
-  url 'http://imageoptim.com/ImageOptim.tbz2'
+  url 'https://imageoptim.com/ImageOptim.tbz2'
   appcast 'http://imageoptim.com/appcast.xml'
   homepage 'http://imageoptim.com/'
   version 'latest'

--- a/Casks/inky.rb
+++ b/Casks/inky.rb
@@ -1,5 +1,5 @@
 class Inky < Cask
-  url 'http://inky.com/mail/InkyInstall.pkg'
+  url 'https://inky.com/mail/InkyInstall.pkg'
   homepage 'http://inky.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/iupx.rb
+++ b/Casks/iupx.rb
@@ -1,5 +1,5 @@
 class Iupx < Cask
-  url 'http://sourceforge.net/projects/iupx/files/latest/download'
+  url 'https://sourceforge.net/projects/iupx/files/latest/download'
   appcast 'http://iupx.sourceforge.net/updates/appcast.xml'
   homepage 'http://iupx.sourceforge.net'
   version 'latest'

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,5 +1,5 @@
 class Josm < Cask
-  url 'http://josm.openstreetmap.de/download/macosx/josm-macosx.zip'
+  url 'https://josm.openstreetmap.de/download/macosx/josm-macosx.zip'
   homepage 'http://josm.openstreetmap.de'
   version 'latest'
   sha256 :no_check

--- a/Casks/jsonlook.rb
+++ b/Casks/jsonlook.rb
@@ -1,5 +1,5 @@
 class Jsonlook < Cask
-  url 'http://dl.dropbox.com/u/3878216/github/jsonlook.qlgenerator.zip'
+  url 'https://dl.dropbox.com/u/3878216/github/jsonlook.qlgenerator.zip'
   homepage 'https://github.com/rjregenold/jsonlook'
   version 'latest'
   sha256 :no_check

--- a/Casks/kindle-previewer.rb
+++ b/Casks/kindle-previewer.rb
@@ -1,5 +1,5 @@
 class KindlePreviewer < Cask
-  url 'http://kindlepreviewer.s3.amazonaws.com/KindlePreviewer.zip'
+  url 'https://kindlepreviewer.s3.amazonaws.com/KindlePreviewer.zip'
   homepage 'http://www.amazon.com/gp/feature.html/?docId=1000765261'
   version 'latest'
   sha256 :no_check

--- a/Casks/less.rb
+++ b/Casks/less.rb
@@ -1,5 +1,5 @@
 class Less < Cask
-  url 'http://incident57.com/less/files/Less.zip'
+  url 'https://incident57.com/less/files/Less.zip'
   homepage 'http://incident57.com/less/'
   version 'latest'
   sha256 :no_check

--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -1,5 +1,5 @@
 class Linein < Cask
-  url 'http://www.rogueamoeba.com/freebies/download/LineIn.zip'
+  url 'https://www.rogueamoeba.com/freebies/download/LineIn.zip'
   homepage 'http://www.rogueamoeba.com/freebies/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mac-linux-usb-loader.rb
+++ b/Casks/mac-linux-usb-loader.rb
@@ -1,5 +1,5 @@
 class MacLinuxUsbLoader < Cask
-  url 'http://sevenbits.github.io/downloads/Mac-Linux-USB-Loader.zip'
+  url 'https://sevenbits.github.io/downloads/Mac-Linux-USB-Loader.zip'
   appcast 'http://sevenbits.github.io/appcasts/mlul.xml'
   homepage 'http://sevenbits.github.io/Mac-Linux-USB-Loader/'
   version 'latest'

--- a/Casks/mediafire-desktop.rb
+++ b/Casks/mediafire-desktop.rb
@@ -1,5 +1,5 @@
 class MediafireDesktop < Cask
-  url 'http://www.mediafire.com/?4xcr491804ncktz/'
+  url 'https://www.mediafire.com/?4xcr491804ncktz/'
   homepage 'https://www.mediafire.com/software/desktop/'
   version 'latest'
   sha256 :no_check

--- a/Casks/mindnode-pro.rb
+++ b/Casks/mindnode-pro.rb
@@ -1,5 +1,5 @@
 class MindnodePro < Cask
-  url 'http://www.mindnode.com/download/MindNodePro.zip'
+  url 'https://www.mindnode.com/download/MindNodePro.zip'
   appcast 'https://www.mindnode.com/softwareupdate/mindnodepro.xml'
   homepage 'https://mindnode.com/'
   version 'latest'

--- a/Casks/multifirefox.rb
+++ b/Casks/multifirefox.rb
@@ -1,5 +1,5 @@
 class Multifirefox < Cask
-  url 'http://mff.s3.amazonaws.com/MFF2_latest.dmg'
+  url 'https://mff.s3.amazonaws.com/MFF2_latest.dmg'
   appcast 'https://s3.amazonaws.com/mff_sparkle/MultiFirefoxAppcast2.xml'
   homepage 'http://davemartorana.com/multifirefox'
   version 'latest'

--- a/Casks/nicecast.rb
+++ b/Casks/nicecast.rb
@@ -1,5 +1,5 @@
 class Nicecast < Cask
-  url 'http://rogueamoeba.com/nicecast/download/Nicecast.zip'
+  url 'https://rogueamoeba.com/nicecast/download/Nicecast.zip'
   homepage 'http://rogueamoeba.com/nicecast'
   version 'latest'
   sha256 :no_check

--- a/Casks/noisy.rb
+++ b/Casks/noisy.rb
@@ -1,5 +1,5 @@
 class Noisy < Cask
-  url 'http://github.com/downloads/jonshea/Noisy/Noisy.zip'
+  url 'https://github.com/downloads/jonshea/Noisy/Noisy.zip'
   homepage 'https://github.com/jonshea/Noisy'
   version 'latest'
   sha256 :no_check

--- a/Casks/nothing-to-hide.rb
+++ b/Casks/nothing-to-hide.rb
@@ -1,5 +1,5 @@
 class NothingToHide < Cask
-  url 'http://nothingtohide.s3.amazonaws.com/pc/Nothing_To_Hide_MAC.zip'
+  url 'https://nothingtohide.s3.amazonaws.com/pc/Nothing_To_Hide_MAC.zip'
   homepage 'https://back.nothingtohide.cc/'
   version 'latest'
   sha256 :no_check

--- a/Casks/omnidisksweeper.rb
+++ b/Casks/omnidisksweeper.rb
@@ -1,5 +1,5 @@
 class Omnidisksweeper < Cask
-  url 'http://www.omnigroup.com/download/latest/OmniDiskSweeper'
+  url 'https://www.omnigroup.com/download/latest/OmniDiskSweeper'
   homepage 'http://www.omnigroup.com/products/omnidisksweeper/'
   version 'latest'
   sha256 :no_check

--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -1,5 +1,5 @@
 class Omnifocus < Cask
-  url 'http://www.omnigroup.com/download/latest/omnifocus'
+  url 'https://www.omnigroup.com/download/latest/omnifocus'
   homepage 'http://www.omnigroup.com/products/omnifocus/'
   version 'latest'
   sha256 :no_check

--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -1,5 +1,5 @@
 class Omnigraffle < Cask
-  url 'http://www.omnigroup.com/download/latest/omnigraffle'
+  url 'https://www.omnigroup.com/download/latest/omnigraffle'
   homepage 'http://www.omnigroup.com/products/omnigraffle'
   version 'latest'
   sha256 :no_check

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,5 +1,5 @@
 class Omnioutliner < Cask
-  url 'http://www.omnigroup.com/download/latest/omnioutliner'
+  url 'https://www.omnigroup.com/download/latest/omnioutliner'
   homepage 'http://www.omnigroup.com/omnioutliner/'
   version 'latest'
   sha256 :no_check

--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,5 +1,5 @@
 class Omniplan < Cask
-  url 'http://www.omnigroup.com/download/latest/omniplan'
+  url 'https://www.omnigroup.com/download/latest/omniplan'
   homepage 'http://www.omnigroup.com/products/omniplan/'
   version 'latest'
   sha256 :no_check

--- a/Casks/onlive-client.rb
+++ b/Casks/onlive-client.rb
@@ -1,5 +1,5 @@
 class OnliveClient < Cask
-  url 'http://games.onlive.com/client/mac.pkg'
+  url 'https://games.onlive.com/client/mac.pkg'
   homepage 'http://games.onlive.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/outwit-hub.rb
+++ b/Casks/outwit-hub.rb
@@ -1,5 +1,5 @@
 class OutwitHub < Cask
-  url 'http://www.outwit.com/downloads/release/outwit-hub.en-US.mac64.dmg'
+  url 'https://www.outwit.com/downloads/release/outwit-hub.en-US.mac64.dmg'
   homepage 'http://www.outwit.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -1,5 +1,5 @@
 class Pacifist < Cask
-  url 'http://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg'
+  url 'https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg'
   appcast 'http://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi'
   homepage 'http://www.charlessoft.com/'
   version 'latest'

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -1,5 +1,5 @@
 class Parallels < Cask
-  url 'http://www.parallels.com/directdownload/pd9'
+  url 'https://www.parallels.com/directdownload/pd9'
   homepage 'http://www.parallels.com/products/desktop/'
   version 'latest'
   sha256 :no_check

--- a/Casks/pashua.rb
+++ b/Casks/pashua.rb
@@ -1,5 +1,5 @@
 class Pashua < Cask
-  url 'http://www.bluem.net/files/Pashua.dmg'
+  url 'https://www.bluem.net/files/Pashua.dmg'
   homepage 'http://www.bluem.net/en/mac/pashua/'
   version 'latest'
   sha256 :no_check

--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -1,5 +1,5 @@
 class Paw < Cask
-  url 'http://luckymarmot.com/paw/download'
+  url 'https://luckymarmot.com/paw/download'
   homepage 'http://luckymarmot.com/paw'
   version 'latest'
   sha256 :no_check

--- a/Casks/peepopen.rb
+++ b/Casks/peepopen.rb
@@ -1,5 +1,5 @@
 class Peepopen < Cask
-  url 'http://topfunky.github.io/PeepOpen/dl/PeepOpen.dmg'
+  url 'https://topfunky.github.io/PeepOpen/dl/PeepOpen.dmg'
   appcast 'https://peepcode.com/system/apps/PeepOpen/appcast.xml'
   homepage 'http://topfunky.github.io/PeepOpen/'
   version 'latest'

--- a/Casks/pentaho-data-integration.rb
+++ b/Casks/pentaho-data-integration.rb
@@ -1,5 +1,5 @@
 class PentahoDataIntegration < Cask
-  url 'http://sourceforge.net/projects/pentaho/files/latest/download'
+  url 'https://sourceforge.net/projects/pentaho/files/latest/download'
   homepage 'http://community.pentaho.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/pinegrow-web-designer.rb
+++ b/Casks/pinegrow-web-designer.rb
@@ -1,5 +1,5 @@
 class PinegrowWebDesigner < Cask
-  url 'http://pinegrow.s3.amazonaws.com/PinegrowMac.zip'
+  url 'https://pinegrow.s3.amazonaws.com/PinegrowMac.zip'
   homepage 'http://pinegrow.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/pixelpeeper.rb
+++ b/Casks/pixelpeeper.rb
@@ -1,5 +1,5 @@
 class Pixelpeeper < Cask
-  url 'http://www.irradiatedsoftware.com/download/PixelPeeper.zip'
+  url 'https://www.irradiatedsoftware.com/download/PixelPeeper.zip'
   appcast 'http://www.irradiatedsoftware.com/updates/profiles/pixelpeeper.php'
   homepage 'http://www.irradiatedsoftware.com/labs'
   version 'latest'

--- a/Casks/pixelstick.rb
+++ b/Casks/pixelstick.rb
@@ -1,5 +1,5 @@
 class Pixelstick < Cask
-  url 'http://plumamazing.com/bin/pixelstick/pixelstick.zip'
+  url 'https://plumamazing.com/bin/pixelstick/pixelstick.zip'
   appcast 'https://plumamazing.com/appcastSSL.php?pid=100'
   homepage 'http://plumamazing.com/mac/pixelstick'
   version 'latest'

--- a/Casks/plain-clip.rb
+++ b/Casks/plain-clip.rb
@@ -1,5 +1,5 @@
 class PlainClip < Cask
-  url 'http://www.bluem.net/files/Plain-Clip.dmg'
+  url 'https://www.bluem.net/files/Plain-Clip.dmg'
   homepage 'http://www.bluem.net/en/mac/plain-clip'
   version 'latest'
   sha256 :no_check

--- a/Casks/plycounter.rb
+++ b/Casks/plycounter.rb
@@ -1,5 +1,5 @@
 class Plycounter < Cask
-  url 'http://www.plycount.com/plycounter/downloads/PlyCounter.dmg'
+  url 'https://www.plycount.com/plycounter/downloads/PlyCounter.dmg'
   homepage 'http://www.plycount.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/propane.rb
+++ b/Casks/propane.rb
@@ -1,5 +1,5 @@
 class Propane < Cask
-  url 'http://propaneapp.com/appcast/Propane.zip'
+  url 'https://propaneapp.com/appcast/Propane.zip'
   appcast 'http://propaneapp.com/appcast/release.xml'
   homepage 'http://propaneapp.com/'
   version 'latest'

--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,5 +1,5 @@
 class Proxpn < Cask
-  url 'http://proxpn.com/mac.dmg'
+  url 'https://proxpn.com/mac.dmg'
   appcast 'http://www.proxpn.org/updater/appcast.rss'
   homepage 'http://proxpn.com'
   version 'latest'

--- a/Casks/puush.rb
+++ b/Casks/puush.rb
@@ -1,5 +1,5 @@
 class Puush < Cask
-  url 'http://puush.me/dl/puush.zip'
+  url 'https://puush.me/dl/puush.zip'
   appcast 'https://puush.me/dl/puush.xml?hax=jax'
   homepage 'http://puush.me/'
   version 'latest'

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -1,5 +1,5 @@
 class Qtspim < Cask
-  url 'http://sourceforge.net/projects/spimsimulator/files/latest/download'
+  url 'https://sourceforge.net/projects/spimsimulator/files/latest/download'
   homepage 'http://spimsimulator.sourceforge.net/'
   version 'latest'
   sha256 :no_check

--- a/Casks/quicklook-csv.rb
+++ b/Casks/quicklook-csv.rb
@@ -1,5 +1,5 @@
 class QuicklookCsv < Cask
-  url 'http://quicklook-csv.googlecode.com/files/QuickLookCSV.dmg'
+  url 'https://quicklook-csv.googlecode.com/files/QuickLookCSV.dmg'
   homepage 'https://github.com/p2/quicklook-csv'
   version 'latest'
   sha256 :no_check

--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,5 +1,5 @@
 class Rapidweaver < Cask
-  url 'http://realmacsoftware.com/redirects/rapidweaver/direct'
+  url 'https://realmacsoftware.com/redirects/rapidweaver/direct'
   appcast 'http://www.realmacsoftware.com/stats/rapidweaver5.php'
   homepage 'http://realmacsoftware.com/rapidweaver'
   version 'latest'

--- a/Casks/rdio.rb
+++ b/Casks/rdio.rb
@@ -1,5 +1,5 @@
 class Rdio < Cask
-  url 'http://www.rdio.com/media/static/desktop/mac/Rdio.dmg'
+  url 'https://www.rdio.com/media/static/desktop/mac/Rdio.dmg'
   appcast 'http://www.rdio.com/media/static/desktop/mac/appcast.xml'
   homepage 'http://www.rdio.com'
   version 'latest'

--- a/Casks/scapple.rb
+++ b/Casks/scapple.rb
@@ -1,5 +1,5 @@
 class Scapple < Cask
-  url 'http://scrivener.s3.amazonaws.com/Scapple.dmg'
+  url 'https://scrivener.s3.amazonaws.com/Scapple.dmg'
   appcast 'http://www.literatureandlatte.com/downloads/scapple/scapple.xml'
   homepage 'https://www.literatureandlatte.com/scapple.php'
   version 'latest'

--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,5 +1,5 @@
 class Scrivener < Cask
-  url 'http://scrivener.s3.amazonaws.com/Scrivener.dmg'
+  url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
   appcast 'http://www.literatureandlatte.com/downloads/scrivener-2.xml'
   homepage 'http://literatureandlatte.com/scrivener.php'
   version 'latest'

--- a/Casks/shadowsweeper.rb
+++ b/Casks/shadowsweeper.rb
@@ -1,5 +1,5 @@
 class Shadowsweeper < Cask
-  url 'http://www.irradiatedsoftware.com/download/ShadowSweeper.zip'
+  url 'https://www.irradiatedsoftware.com/download/ShadowSweeper.zip'
   homepage 'http://www.irradiatedsoftware.com/labs/'
   version 'latest'
   sha256 :no_check

--- a/Casks/silverback.rb
+++ b/Casks/silverback.rb
@@ -1,5 +1,5 @@
 class Silverback < Cask
-  url 'http://silverback.s3.amazonaws.com/silverback2.zip'
+  url 'https://silverback.s3.amazonaws.com/silverback2.zip'
   appcast 'http://silverback.s3.amazonaws.com/release/appcast.xml'
   homepage 'http://silverbackapp.com/'
   version 'latest'

--- a/Casks/simpletag.rb
+++ b/Casks/simpletag.rb
@@ -1,5 +1,5 @@
 class Simpletag < Cask
-  url 'http://sourceforge.net/projects/simpletag/files/latest/download'
+  url 'https://sourceforge.net/projects/simpletag/files/latest/download'
   homepage 'http://sourceforge.net/projects/simpletag/'
   version 'latest'
   sha256 :no_check

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -1,5 +1,5 @@
 class Sizeup < Cask
-  url 'http://www.irradiatedsoftware.com/download/SizeUp.zip'
+  url 'https://www.irradiatedsoftware.com/download/SizeUp.zip'
   appcast 'http://www.irradiatedsoftware.com/updates/profiles/sizeup.php'
   homepage 'http://www.irradiatedsoftware.com/sizeup/index.html'
   version 'latest'

--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,5 +1,5 @@
 class Skype < Cask
-  url 'http://www.skype.com/go/getskype-macosx.dmg'
+  url 'https://www.skype.com/go/getskype-macosx.dmg'
   homepage 'http://www.skype.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -1,5 +1,5 @@
 class Slicy < Cask
-  url 'http://macrabbit.com/slicy/get/'
+  url 'https://macrabbit.com/slicy/get/'
   appcast 'http://update.macrabbit.com/slicy/1.1.3.xml'
   homepage 'http://macrabbit.com/slicy/'
   version 'latest'

--- a/Casks/speedlimit.rb
+++ b/Casks/speedlimit.rb
@@ -1,5 +1,5 @@
 class Speedlimit < Cask
-  url 'http://mschrag.github.io/speedlimit/SpeedLimit.prefPane.zip'
+  url 'https://mschrag.github.io/speedlimit/SpeedLimit.prefPane.zip'
   homepage 'http://mschrag.github.io/'
   version 'latest'
   sha256 :no_check

--- a/Casks/spotdox.rb
+++ b/Casks/spotdox.rb
@@ -1,5 +1,5 @@
 class Spotdox < Cask
-  url 'http://spotdox.herokuapp.com/downloads/Spotdox.zip'
+  url 'https://spotdox.herokuapp.com/downloads/Spotdox.zip'
   appcast 'https://spotdox.herokuapp.com/downloads/appcast.xml'
   homepage 'http://spotdox.com/get-started/'
   version 'latest'

--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,5 +1,5 @@
 class Supersync < Cask
-  url 'http://supersync.com/downloads/SuperSync.app.zip'
+  url 'https://supersync.com/downloads/SuperSync.app.zip'
   homepage 'http://supersync.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,5 +1,5 @@
 class Swinsian < Cask
-  url 'http://swinsian.com/sparkle/Swinsian.zip'
+  url 'https://swinsian.com/sparkle/Swinsian.zip'
   appcast 'http://www.swinsian.com/sparkle/sparklecast.xml'
   homepage 'http://swinsian.com'
   version 'latest'

--- a/Casks/tag.rb
+++ b/Casks/tag.rb
@@ -1,5 +1,5 @@
 class Tag < Cask
-  url 'http://downloads.sourceforge.net/sourceforge/tagosx/Tag-0.4.1.zip'
+  url 'https://downloads.sourceforge.net/sourceforge/tagosx/Tag-0.4.1.zip'
   homepage 'http://sbooth.org/Tag/'
   version 'latest'
   sha256 :no_check

--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,5 +1,5 @@
 class Taskpaper < Cask
-  url 'http://taskpaper.s3.amazonaws.com/TaskPaper.dmg'
+  url 'https://taskpaper.s3.amazonaws.com/TaskPaper.dmg'
   appcast 'http://www.hogbaysoftware.com/products/taskpaper/releases.rss'
   homepage 'http://www.hogbaysoftware.com/products/taskpaper'
   version 'latest'

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,5 +1,5 @@
 class Teamviewer < Cask
-  url 'http://download.teamviewer.com/download/TeamViewer.dmg'
+  url 'https://download.teamviewer.com/download/TeamViewer.dmg'
   homepage 'http://www.teamviewer.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,5 +1,5 @@
 class Textmate < Cask
-  url 'http://api.textmate.org/downloads/release'
+  url 'https://api.textmate.org/downloads/release'
   homepage 'http://macromates.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/things.rb
+++ b/Casks/things.rb
@@ -1,5 +1,5 @@
 class Things < Cask
-  url 'http://culturedcode.com/things/download/'
+  url 'https://culturedcode.com/things/download/'
   appcast 'http://downloads.culturedcode.com/things/download/Things_Updates.php'
   homepage 'http://culturedcode.com/things/'
   version 'latest'

--- a/Casks/thinkorswim.rb
+++ b/Casks/thinkorswim.rb
@@ -1,5 +1,5 @@
 class Thinkorswim < Cask
-  url 'http://mediaserver.thinkorswim.com/installer/InstFiles/thinkorswim_installer.dmg'
+  url 'https://mediaserver.thinkorswim.com/installer/InstFiles/thinkorswim_installer.dmg'
   homepage 'http://mediaserver.thinkorswim.com/installer/install.html#macosx'
   version 'latest'
   sha256 :no_check

--- a/Casks/titanium-studio.rb
+++ b/Casks/titanium-studio.rb
@@ -1,5 +1,5 @@
 class TitaniumStudio < Cask
-  url 'http://titanium-studio.s3.amazonaws.com/latest/Titanium_Studio.dmg'
+  url 'https://titanium-studio.s3.amazonaws.com/latest/Titanium_Studio.dmg'
   homepage 'https://my.appcelerator.com/resources'
   version 'latest'
   sha256 :no_check

--- a/Casks/torpedo.rb
+++ b/Casks/torpedo.rb
@@ -1,5 +1,5 @@
 class Torpedo < Cask
-  url 'http://usetorpedo.com/app/mac/download'
+  url 'https://usetorpedo.com/app/mac/download'
   homepage 'https://usetorpedo.com'
   version 'latest'
   sha256 :no_check

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,5 +1,5 @@
 class Tower < Cask
-  url 'http://www.git-tower.com/download'
+  url 'https://www.git-tower.com/download'
   appcast 'https://macapps.fournova.com/tower1-1060/updates.xml'
   homepage 'http://www.git-tower.com/'
   version 'latest'

--- a/Casks/tunewiki.rb
+++ b/Casks/tunewiki.rb
@@ -1,5 +1,5 @@
 class Tunewiki < Cask
-  url 'http://www.tunewiki.com/download/desktop/TuneWiki_Installer.dmg'
+  url 'https://www.tunewiki.com/download/desktop/TuneWiki_Installer.dmg'
   homepage 'http://www.tunewiki.com/'
   version 'latest'
   sha256 :no_check

--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,5 +1,5 @@
 class Virtualhostx < Cask
-  url 'http://clickontyler.com/virtualhostx/download/'
+  url 'https://clickontyler.com/virtualhostx/download/'
   appcast 'http://shine.clickontyler.com/appcast.php?id=23'
   homepage 'http://clickontyler.com/virtualhostx/'
   version 'latest'

--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,5 +1,5 @@
 class Viscosity < Cask
-  url 'http://www.sparklabs.com/downloads/Viscosity.dmg'
+  url 'https://www.sparklabs.com/downloads/Viscosity.dmg'
   appcast 'http://www.viscosityvpn.com/update/viscosity.xml'
   homepage 'http://www.sparklabs.com/viscosity/'
   version 'latest'

--- a/Casks/web-sharing.rb
+++ b/Casks/web-sharing.rb
@@ -1,5 +1,5 @@
 class WebSharing < Cask
-  url 'http://clickontyler.com/web-sharing/download/'
+  url 'https://clickontyler.com/web-sharing/download/'
   homepage 'http://clickontyler.com/web-sharing/'
   version 'latest'
   sha256 :no_check

--- a/Casks/window-switch.rb
+++ b/Casks/window-switch.rb
@@ -1,5 +1,5 @@
 class WindowSwitch < Cask
-  url 'http://xpra.org/dists/osx/x86/Window-Switch.dmg'
+  url 'https://xpra.org/dists/osx/x86/Window-Switch.dmg'
   homepage 'http://xpra.org/'
   version 'latest'
   sha256 :no_check

--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,5 +1,5 @@
 class Xca < Cask
-  url 'http://sourceforge.net/projects/xca/files/latest/download',
+  url 'https://sourceforge.net/projects/xca/files/latest/download',
     :user_agent => :fake
   homepage 'http://xca.sourceforge.net/'
   version 'latest'

--- a/Casks/yandex.rb
+++ b/Casks/yandex.rb
@@ -1,5 +1,5 @@
 class Yandex < Cask
-  url 'http://download.cdn.yandex.net/browser/yandex/ru/Yandex.dmg'
+  url 'https://download.cdn.yandex.net/browser/yandex/ru/Yandex.dmg'
   homepage 'http://browser.yandex.com/'
   version 'latest'
   sha256 :no_check


### PR DESCRIPTION
These are a bit less tested than those in #4967, because they could not be checked against a Casked SHA-256.

However, the downloads from both the HTTP or HTTPS variants had the same checksum, and obvious errors such as empty responses were removed.

Spot-checking looked good.

So, while there may be a few broken links in here, such links are equally broken in both HTTP and HTTPS, so there should be no loss to the user.  Therefore I think it should be OK to merge _en masse_.

Testing this further would be a use case for `brew cask audit --stage`, which is mentioned in passing in #4678.
