### PR TITLE
don't use Markdown-style backtick in error msgs

### DIFF
--- a/lib/cask/cli/edit.rb
+++ b/lib/cask/cli/edit.rb
@@ -5,7 +5,7 @@ module Cask::CLI::Edit
     cask_path = Cask.path(cask_name)
     odebug "Opening editor for Cask #{cask_name}"
     unless cask_path.exist?
-      raise CaskUnavailableError, "#{cask_name}, use `brew cask create #{cask_name}` to make a new cask with this name"
+      raise CaskUnavailableError, %Q{#{cask_name}, run "brew cask create #{cask_name}" to create a new cask with this name}
     end
     exec_editor cask_path
   end

--- a/lib/cask/exceptions.rb
+++ b/lib/cask/exceptions.rb
@@ -29,7 +29,7 @@ class CaskAlreadyCreatedError < CaskError
   end
 
   def to_s
-    "Cask for #{name} already exists. Use `brew cask edit #{name}` to see it."
+    %Q{Cask for #{name} already exists. Run "brew cask cat #{name}" to see it.}
   end
 end
 
@@ -40,7 +40,7 @@ class CaskAlreadyInstalledError < CaskError
   end
 
   def to_s
-    "Cask for #{name} is already installed. Use `--force` to force re-install."
+    %Q{Cask for #{name} is already installed. Add the "--force" option to force re-install.}
   end
 end
 


### PR DESCRIPTION
Because backtick has a different meaning in the shell, and the user
may copy-and-paste such text.

Some light re-wording included as well, and a reference to "brew cask edit"
changed to "brew cask cat" for simplicity.
