### PR TITLE
correct url for SubEthaEdit 3.5.4

### DIFF
--- a/Casks/subethaedit.rb
+++ b/Casks/subethaedit.rb
@@ -1,5 +1,5 @@
 class Subethaedit < Cask
-  url 'http://www.codingmonkeys.de/subethaedit/SubEthaEdit.zip'
+  url 'http://subethaedit.net/downloads/SubEthaEdit-354.zip'
   appcast 'http://www.codingmonkeys.de/subethaedit/appcast.rss'
   homepage 'http://www.codingmonkeys.de/subethaedit/'
   version '3.5.4'


### PR DESCRIPTION
former (unversioned) url was broken.

This Cask might need to move to `homebrew-versions`, as 3.5.4 will no longer be updated, and 4.x and above are only available on the Mac App Store.
