### PR TITLE
don't check error code of diskutil eject

### DIFF
--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -45,7 +45,18 @@ class Cask::Container::Dmg < Cask::Container::Base
   def eject!
     @mounts.each do |mount|
       # realpath is a failsafe against unusual filenames
-      @command.run!('/usr/sbin/diskutil', :args => ['eject', Pathname.new(mount).realpath])
+      mountpath = Pathname.new(mount).realpath
+      next unless mountpath.exist?
+      @command.run('/usr/sbin/diskutil',
+                     :args => ['eject', mountpath],
+                     :stderr => :silence)
+      next unless mountpath.exist?
+      sleep 1
+      @command.run('/usr/sbin/diskutil',
+                     :args => ['eject', mountpath],
+                     :stderr => :silence)
+      next unless mountpath.exist?
+      raise CaskError.new "Failed to eject #{mountpath}"
     end
   end
 end


### PR DESCRIPTION
Instead, check the result: does the mount path still exist?
This is intended to help with unpredictable problems with the
test suite that manifest frequently on Travis.

References: #4975, #4900, #4857
