### PR TITLE
Transfer SubEthaEdit 3 to `homebrew-versions` repo

### DIFF
--- a/Casks/subethaedit.rb
+++ b/Casks/subethaedit.rb
@@ -1,8 +1,0 @@
-class Subethaedit < Cask
-  url 'http://subethaedit.net/downloads/SubEthaEdit-354.zip'
-  appcast 'http://www.codingmonkeys.de/subethaedit/appcast.rss'
-  homepage 'http://www.codingmonkeys.de/subethaedit/'
-  version '3.5.4'
-  sha256 '72d3948e5da167ac3113ec8f56aa424965b0ec153df4ba8042ce5893a547e290'
-  link 'SubEthaEdit.app'
-end


### PR DESCRIPTION
SubEthaEdit 3 is EOL, vsn 4 is MAS-only

References: #4974, caskroom/homebrew-versions#301
