### PR TITLE
Adjust to Homebrew's test environment changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-  gem 'minitest', '4.7.0'
+  gem 'minitest', '5.3'
   gem 'minitest-colorize'
   gem 'mocha', '0.14.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     metaclass (0.0.1)
-    minitest (4.7.0)
+    minitest (5.3)
     minitest-colorize (0.0.5)
       minitest (>= 2.0)
     mocha (0.14.0)
@@ -13,7 +13,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (= 4.7.0)
+  minitest (= 5.3)
   minitest-colorize
   mocha (= 0.14.0)
   rake

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,8 @@ HOMEBREW_CACHE.join('Casks').mkpath
 
 # must be called after testing_env so at_exit hooks are in proper order
 require 'minitest/autorun'
-require 'minitest-colorize'
+# todo, re-enable minitest-colorize, broken under current test environment for unknown reasons
+# require 'minitest-colorize'
 
 # Force mocha to patch MiniTest since we have both loaded thanks to homebrew's testing_env
 require 'mocha/api'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,24 @@ $:.push(homebrew_path.join('Library', 'Homebrew'))
 # require homebrew testing env
 require 'test/testing_env'
 
+# todo temporary, copied from old Homebrew, this method is now moved inside a class
+def shutup
+  if ARGV.verbose?
+    yield
+  else
+    begin
+      tmperr = $stderr.clone
+      tmpout = $stdout.clone
+      $stderr.reopen '/dev/null', 'w'
+      $stdout.reopen '/dev/null', 'w'
+      yield
+    ensure
+      $stderr.reopen tmperr
+      $stdout.reopen tmpout
+    end
+  end
+end
+
 # making homebrew's cache dir allows us to actually download casks in tests
 HOMEBREW_CACHE.mkpath
 HOMEBREW_CACHE.join('Casks').mkpath


### PR DESCRIPTION
Homebrew has been changing their test infrastructure quite a bit.

The logs say they are switching to Minitest, and a refactor seems to be happening.

These changes are imperfect, but without them, Travis is going to start reporting
failures 100% of the time.
- minitest-colorize disabled, should find a way to re-enable it
- global `shutup` method defined, should use Homebrew's new version instead
