### PR TITLE
WIP re-enable minitest-colorize

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,8 +46,7 @@ HOMEBREW_CACHE.join('Casks').mkpath
 
 # must be called after testing_env so at_exit hooks are in proper order
 require 'minitest/autorun'
-# todo, re-enable minitest-colorize, broken under current test environment for unknown reasons
-# require 'minitest-colorize'
+require 'minitest-colorize'
 
 # Force mocha to patch MiniTest since we have both loaded thanks to homebrew's testing_env
 require 'mocha/api'


### PR DESCRIPTION
Travis expected to fail.  Local tests fail.

It is possible that minitest-colorize is broken for newer Minitest versions, per sobrinho/minitest-colorize#10 .
