### PR TITLE
WIP "avoids clobbering" failure in test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
 # the test itself
 # path-quoting is different here due to YAML constraints
 script:
-  - /System/Library/Frameworks/Ruby.framework/Versions/"${CASK_RUBY_TEST_VERSION}"/usr/bin/bundle exec "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/rake" test
+  - /System/Library/Frameworks/Ruby.framework/Versions/"${CASK_RUBY_TEST_VERSION}"/usr/bin/bundle exec "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/rake" test TESTOPTS="--seed=11266"
 
 notifications:
   irc:


### PR DESCRIPTION
This commit preserves a random seed which makes a common "avoids clobbering"
failure in test `two_links_correct_test.rb` reproducible.

Therefore, this is expected to fail Travis, and should not be merged in
current form.

After the relevant bug is fixed on this branch, the `TESTOPTS` setting
in `.travis.yml` **must** be removed.
