### PR TITLE
Remove comment recommending :silence_stderr

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -34,7 +34,6 @@ class Cask::SystemCommand
 
   def self._process_options(executable, options)
     options.assert_valid_keys :input, :print, :stderr, :args, :must_succeed, :sudo, :plist
-    # would probably be better to change :stderr to boolean :silence_stderr
     if options[:stderr] and options[:stderr] != :silence
       raise CaskError.new "Unknown value #{options[:stderr]} for key :stderr"
     end


### PR DESCRIPTION
As parameter to the `run` method, but also exposed as interface to Cask authors
in eg `uninstall` `:script`.  The existing DSL design: `:stderr => :silence`
is more flexible/extensible.

References: #4688
