### PR TITLE
Sourceforge URL format updates

### DIFF
--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -68,6 +68,8 @@ class Cask::Audit
       %r{https?://sourceforge\.net/projects/.*/files/latest/download},
       %r{https?://downloads\.sourceforge\.net/},
       %r{https?://dl\.sourceforge\.jp/},
+      # special case: cannot find canonical format URL
+      %r{https?://brushviewer\.sourceforge\.net/brushviewql\.zip},
     ]
     valid_url_formats.none? { |format| cask.url.to_s =~ format }
   end

--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -65,9 +65,9 @@ class Cask::Audit
   def _bad_sourceforge_url?
     return false unless cask.url.to_s =~ /sourceforge/
     valid_url_formats = [
-      %r{https?://sourceforge.net/projects/.*/files/latest/download},
-      %r{https?://downloads.sourceforge.net/},
-      %r{https?://dl.sourceforge.jp/},
+      %r{https?://sourceforge\.net/projects/.*/files/latest/download},
+      %r{https?://downloads\.sourceforge\.net/},
+      %r{https?://dl\.sourceforge\.jp/},
     ]
     valid_url_formats.none? { |format| cask.url.to_s =~ format }
   end


### PR DESCRIPTION
- special-case brushviewql sourceforge URL
  - No alternative for this binary was found matching the standard URL patterns.
- fix unescape regexp metacharacters

References: #4751
