### PR TITLE
doc: tracker symlinks are in download cache

### DIFF
--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -49,8 +49,8 @@ names, and other aspects of this manual are still subject to change.
     Check for bad Cask links.
 
   * `cleanup` [--outdated]:
-    Clean up cached downloads.  With `--outdated`, only clean up cached
-    downloads older than 10 days old.
+    Clean up cached downloads and tracker symlinks.  With `--outdated`, only
+    clean up cached downloads older than 10 days old.
 
   * `create` <Cask>:
     Generate a Cask definition file for the Cask named <Cask> and open a

--- a/lib/cask/cli/cleanup.rb
+++ b/lib/cask/cli/cleanup.rb
@@ -77,6 +77,6 @@ class Cask::CLI::Cleanup
   end
 
   def self.help
-    "cleans up cached downloads"
+    "cleans up cached downloads and tracker symlinks"
   end
 end


### PR DESCRIPTION
At least mention tracker symlinks in the docs, since they
are displayed in the feedback messages.

References: #4995
