### PR TITLE
WIP Gemfile: Update Rake and Mocha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-  gem 'minitest', '5.3'
+  gem 'minitest', '~> 5.3'
   gem 'minitest-colorize'
-  gem 'mocha', '0.14.0'
+  gem 'mocha', '~> 1.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    metaclass (0.0.1)
-    minitest (5.3)
+    metaclass (0.0.4)
+    minitest (5.3.0)
     minitest-colorize (0.0.5)
       minitest (>= 2.0)
-    mocha (0.14.0)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
-    rake (10.0.4)
+    rake (10.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (= 5.3)
+  minitest (~> 5.3)
   minitest-colorize
-  mocha (= 0.14.0)
+  mocha (~> 1.1.0)
   rake


### PR DESCRIPTION
All gems are now up to date. The following changes were copied from the
gem's respective changelog that may pertain to us:

```
Rake changes:

* The rake task arguments can contain escaped commas (10.1)
* Restored Ruby 1.8.7 compatibility (10.2)

Mocha changes:

* Consider stubs on superclasses if none exist on primary receiver. Largely based
  on changes suggested by @ccutrer in #145. Note: this may break existing tests
  which rely on the old behavior
```
- Remove minitest-colorize in favor of minitest-reporter.
- Use twiddle-waka for Minitest's version to ensure safe version updates

On my local machine, I was able to shave 6 seconds off the test suite. I was also not able to encounter the `ln` issue from #4990

![1 _tmux__usersnanodevelopercodenanofiles_tmux_2014-06-19_17-26-57_2014-06-19_17-27-00](https://cloud.githubusercontent.com/assets/1889575/3335469/8176ba5a-f815-11e3-9ba0-b8110f6d6e0e.jpg)

Refs: #4984 #4990 
