### PR TITLE
Add Atlantis.app v0.9.9.4

### DIFF
--- a/Casks/atlantis.rb
+++ b/Casks/atlantis.rb
@@ -1,0 +1,9 @@
+class Atlantis < Cask
+  version '0.9.9.4'
+  sha256 '52957a5b92b1fd3612aa7a3a07f5238236dad4397a6a256a03355c331433e540'
+
+  url 'http://www.riverdark.net/atlantis/downloads/Atlantis-0.9.9.4.dmg'
+  homepage 'http://www.riverdark.net/atlantis/'
+
+  link 'Atlantis.app'
+end


### PR DESCRIPTION
Atlantis is an OS X MUD/MUSH client. It hasn't been updated in a while but is still one of the better MU\* clients on the platform.

Plain app bundle, no install/uninstall process needed.
