### PR TITLE
Show file contents instead of commits

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -109,7 +109,7 @@ $ brew cask info caffeine
 caffeine: 1.1.1
 http://lightheadsw.com/caffeine/
 Not installed
-https://github.com/caskroom/homebrew-cask/commits/master/Casks/caffeine.rb
+https://github.com/caskroom/homebrew-cask/blob/master/Casks/caffeine.rb
 ```
 
 ## Updating/Upgrading Casks

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -46,7 +46,7 @@ PURPOSE
       user, repo, name = path_elements
     end
     repo.sub!(/^homebrew-/i, '')
-    "https://github.com/#{user}/homebrew-#{repo}/commits/master/Casks/#{name}.rb"
+    "https://github.com/#{user}/homebrew-#{repo}/blob/master/Casks/#{name}.rb"
   end
 
   def self.artifact_info(cask)

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -8,7 +8,7 @@ describe Cask::CLI::Info do
       local-caffeine: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
+      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
       ==> Contents
         Caffeine.app (link)
     CLIOUTPUT
@@ -21,13 +21,13 @@ describe Cask::CLI::Info do
       local-caffeine: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/local-caffeine.rb
+      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
       ==> Contents
         Caffeine.app (link)
       local-transmission: 2.61
       http://example.com/local-transmission
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/local-transmission.rb
+      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
       ==> Contents
         Transmission.app (link)
     CLIOUTPUT
@@ -40,7 +40,7 @@ describe Cask::CLI::Info do
       with-caveats: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/commits/master/Casks/with-caveats.rb
+      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-caveats.rb
       ==> Contents
         Caffeine.app (link)
       ==> Caveats


### PR DESCRIPTION
It's better to display Github's link to entire file instead of link to commits.
