### PR TITLE
Update GURPS Character Sheet.app to v1.0.4

### DIFF
--- a/Casks/gurps-character-sheet.rb
+++ b/Casks/gurps-character-sheet.rb
@@ -1,7 +1,9 @@
 class GurpsCharacterSheet < Cask
-  url 'https://downloads.sourceforge.net/project/gcs-java/gcs-4.0.0-mac.zip'
+  version '4.0.1'
+  sha256 'ddff9b883b29be7dce0798cfedfe48c54d02a2adb16dc1e60cbcaa37d2ef902e'
+
+  url 'https://downloads.sourceforge.net/project/gcs-java/gcs-4.0.1-mac.zip'
   homepage 'http://gurpscharactersheet.com'
-  version '4.0.0'
-  sha256 '67ccecc44d28f8cf104094ae988779b8219f79a6e6fbe9c695828034d3307816'
-  link 'gcs-4.0.0-mac/GURPS Character Sheet.app'
+
+  link 'gcs-4.0.1-mac/GURPS Character Sheet.app'
 end


### PR DESCRIPTION
GCS updated and the old download link is dead, so the cask needs to be updated to the new version.
