### PR TITLE
WIP DSL: add `:glob` key to expand fileglobs

### DIFF
--- a/test/cask/artifact/glob_test.rb
+++ b/test/cask/artifact/glob_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+describe ":glob key on link" do
+  describe 'install a link artifact using the :glob key' do
+    it "links the application to the proper directory" do
+      cask = Cask.load('with-glob').tap do |c|
+        TestHelper.install_without_artifacts(c)
+      end
+
+      shutup do
+        Cask::Artifact::App.new(cask).install
+      end
+
+      TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
+    end
+  end
+
+  describe "bad :glob value on link" do
+    it "refuses to install" do
+      invalid_cask = Cask.load('invalid/invalid-glob-value').tap do |c|
+        TestHelper.install_without_artifacts(c)
+      end
+
+      err = lambda {
+        Cask::Artifact::App.new(invalid_cask).install
+      }.must_raise(CaskError)
+      err.message.must_include ':glob expansion does not respond'
+    end
+  end
+
+  describe "no match for :glob expansion on link" do
+    it "refuses to install" do
+      invalid_cask = Cask.load('invalid/invalid-glob-no-match').tap do |c|
+        TestHelper.install_without_artifacts(c)
+      end
+
+      err = lambda {
+        Cask::Artifact::App.new(invalid_cask).install
+      }.must_raise(CaskError)
+      err.message.must_include 'Failed to perform :glob expansion'
+    end
+  end
+end

--- a/test/support/Casks/invalid/invalid-glob-no-match.rb
+++ b/test/support/Casks/invalid/invalid-glob-no-match.rb
@@ -1,0 +1,7 @@
+class InvalidGlobNoMatch < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/invalid-glob-no-match'
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  link 'NO_SUCH_FILE*.app', :glob => :first
+end

--- a/test/support/Casks/invalid/invalid-glob-value.rb
+++ b/test/support/Casks/invalid/invalid-glob-value.rb
@@ -1,0 +1,7 @@
+class InvalidGlobValue < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/invalid-glob-value'
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  link 'Caff*.app', :glob => :no_such_method
+end

--- a/test/support/Casks/with-glob.rb
+++ b/test/support/Casks/with-glob.rb
@@ -1,0 +1,7 @@
+class WithGlob < TestCask
+  url TestHelper.local_binary('caffeine.zip')
+  homepage 'http://example.com/with-glob'
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  link 'Caff*.app', :glob => :first
+end


### PR DESCRIPTION
This is a very rough/quick implementation, and is intended mostly for discussion,
as this is the DSL proposal in #4688 which has no associated PR.

Problems here include:
1. This was implemented alongside `:target` in `artifact/symlinked.rb`, which also
    contains installation logic for artifacts.  A smarter implementation would improve
    separation of concerns by moving the logic for interpreting both `:glob` and `:target`
    keys into `dsl.rb` (or some class called from `dsl.rb`)
2. Only artifact sources such as `link` can be expanded.  Similar functionality would
    also be useful (for example) in `uninstall :files`.
3. This interface seems clunky.  It might be cleaner to have an `expand` method in
    the DSL for wrapping filenames:
   
   ``` ruby
     link expand('*/VLC.app')
   ```
   
   The `expand` method would actually call a constructor, because the action of expansion
   must be deferred until install-time.  However, I think Expander.new('*') is needlessly
   verbose for Cask authors, and not necessarily more self-documenting.
   - The `expand` interface might also help address problem 2 above.

References: https://github.com/caskroom/homebrew-versions/pull/293#issuecomment-46166969
