### PR TITLE
added Radius Networks RadBeacon beacon configuration app

### DIFF
--- a/Casks/rad-beacon.rb
+++ b/Casks/rad-beacon.rb
@@ -1,0 +1,7 @@
+class RadBeacon < Cask
+  url 'https://s3.amazonaws.com/downloads.radiusnetworks.com/cc3cef5f-fd6f-4789-8030-cf82d13bf487/RadBeacon.zip'
+  homepage 'http://store.radiusnetworks.com/collections/all/products/radbeacon-config'
+  version '1.0'
+  sha256 'bebe84b18ec732ca68277f8c1f0dbdf27dc09cf2d3b1acb9bef4a1ce69d5f2fa'
+  link 'RadBeacon.app'
+end


### PR DESCRIPTION
I prepared this recipe a while ago. Radius Networks changed the website since then, the link still works. The app is free so I guess it is still okay to download it from the s3 location...
