### PR TITLE
Update minimal clock cask to use package installer

### DIFF
--- a/Casks/minimalclock.rb
+++ b/Casks/minimalclock.rb
@@ -3,5 +3,6 @@ class Minimalclock < Cask
   homepage 'http://ilovecolorz.net/minimalclock/'
   version 'latest'
   sha256 :no_check
-  screen_saver 'MinimalClock.qtz'
+  install ' .pkg'
+  uninstall :pkgutil => 'com.ilovecolorz.minimalclockScreenSaver.*'
 end


### PR DESCRIPTION
Minimal Clock screensaver changed to a package installer, so update the
Cask accordingly and with @rolandwalker help.

Issue: #4989
