### PR TITLE
Update to Dogecoin-Qt 1.7

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -1,7 +1,7 @@
 class Dogecoin < Cask
-  url 'https://github.com/dogecoin/dogecoin/releases/download/1.6/dogecoin-qt-1_6_0-mac.zip'
+  url 'https://github.com/dogecoin/dogecoin/releases/download/v1.7.1/dogecoin-core-1.7.1-mac.zip'
   homepage 'http://dogecoin.com/'
-  version '1.6.0'
+  version '1.7.1'
   sha256 '087fc6c8d0ab0715144434b147659649417d21901d4dda3024d8712fcc23bf06'
   link 'Dogecoin-Qt.app'
 end


### PR DESCRIPTION
This commit updates the link from version 1.6.0 to 1.7.1.
