### PR TITLE
Fixed sha256 to match 1.7.1 release.

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -2,6 +2,6 @@ class Dogecoin < Cask
   url 'https://github.com/dogecoin/dogecoin/releases/download/v1.7.1/dogecoin-core-1.7.1-mac.zip'
   homepage 'http://dogecoin.com/'
   version '1.7.1'
-  sha256 '087fc6c8d0ab0715144434b147659649417d21901d4dda3024d8712fcc23bf06'
+  sha256 '04fe6443e5541c9c1d5a94ebdf2418e8dfe91a013322229c93e91090bda822bb'
   link 'Dogecoin-Qt.app'
 end


### PR DESCRIPTION
The sha256 hash in #5079 is still set to the 1.6 release, which is blocking installation using Cask. This updates it to the correct hash so updates/installs can succeed.
