### PR TITLE
Update Skim from 1.4.8 to 1.4.9

### DIFF
--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -1,8 +1,8 @@
 class Skim < Cask
-  url 'https://downloads.sourceforge.net/project/skim-app/Skim/Skim-1.4.8/Skim-1.4.8.dmg'
+  url 'https://downloads.sourceforge.net/project/skim-app/Skim/Skim-1.4.9/Skim-1.4.9.dmg'
   appcast 'http://skim-app.sourceforge.net/skim.xml'
   homepage 'http://skim-app.sourceforge.net/'
-  version '1.4.8'
-  sha256 '664e2e3dae52758ccff84f1205da85022c041cf92273002979e7aa16d51277ff'
+  version '1.4.9'
+  sha256 'b8964263e06b37b81443659d4c96385866d5b0af6e65ce393095b46e95591546'
   link 'Skim.app'
 end


### PR DESCRIPTION
This commit updates the cask for Skim from version 1.4.8 to version 1.4.9.
