### PR TITLE
Legacy keepassx

### DIFF
--- a/Casks/legacy-keepassx.rb
+++ b/Casks/legacy-keepassx.rb
@@ -1,0 +1,12 @@
+class LegacyKeepassx < Cask
+  version '0.4.3'
+  sha256 '15ce2e950ab78ccb6956de985c1fcbf11d27df6a58ab7bf19e106f0a1dc2fedd'
+
+  url 'https://www.keepassx.org/releases/KeePassX-0.4.3.dmg'
+  homepage 'https://www.keepassx.org/'
+
+  link 'KeePassX.app'
+    caveats <<-EOS.undent
+    This is legacy KeePassX that only supports KeePass 1 databases
+  EOS
+end

--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -1,8 +1,8 @@
 class Slic3r < Cask
-  version '1.0.1'
-  sha256 '2c1b07f41f392b5b111307e796158fe21038bca0a296c4d93756a902586c8629'
+  version '1.1.5'
+  sha256 '5257d3481cae658cc61353a0582b3e28a351b2a4aad6e5c2240458a1fa4637ec'
 
-  url 'http://dl.slic3r.org/mac/slic3r-osx-uni-1-0-1-stable.dmg'
+  url 'http://dl.slic3r.org/mac/slic3r-osx-uni-1-1-5-stable.dmg'
   homepage 'http://slic3r.org/'
 
   link 'Slic3r.app'


### PR DESCRIPTION
Installs KeePassX 0.4. This supports KeePassX 1 databases which has better cross platform support.

Cask name is legacy-keepassx
