### PR TITLE
Add Xamarin Platform v5.0.1 (build 3)

### DIFF
--- a/Casks/xamarin-platform.rb
+++ b/Casks/xamarin-platform.rb
@@ -1,0 +1,16 @@
+class XamarinPlatform < Cask
+  url 'http://download.xamarin.com/Installer/Mac/XamarinInstaller.dmg'
+  homepage 'http://xamarin.com/platform'
+  version '5.0.1-build-3'
+  sha256 '063935ac9c5c5726946614d382c0b412093a961d1473436dfac8b1969e7b7c31'
+
+  after_install do
+    system '/usr/bin/sudo', '-E', '--',
+      "#{destination_path}/Install Xamarin.app/Contents/MacOS/Install_Xamarin"
+  end
+
+  #uninstall :files => [
+  #  '/Applications/Xamarin Studio.app',
+  #  '~/Library/Developer/Xamarin'
+  #]
+end

--- a/Casks/xamarin-platform.rb
+++ b/Casks/xamarin-platform.rb
@@ -1,8 +1,8 @@
 class XamarinPlatform < Cask
   url 'http://download.xamarin.com/Installer/Mac/XamarinInstaller.dmg'
   homepage 'http://xamarin.com/platform'
-  version '5.0.1-build-3'
-  sha256 '063935ac9c5c5726946614d382c0b412093a961d1473436dfac8b1969e7b7c31'
+  version 'latest'
+  sha256 :no_check
 
   after_install do
     system '/usr/bin/sudo', '-E', '--',


### PR DESCRIPTION
Xamarin's new app installer to install version 5 (and above) of Xamarin Studio with Xamarin iOS,
Xamarin Android, and Xamarin Mac. This is meant as a replacement for the current Xamarin casks: `xamarin-android`, `xamarin-ios`, and `xamarin-studio`, locked at version 4.

I need help with the uninstall logic. I need to remove folders `/Applications/Xamarin Studio.app` and `~/Library/Developer/Xamarin`. It's currently giving an error upon running `brew cask uninstall xamarin-platform`
