### PR TITLE
add luminance-hdr 2.4.0

### DIFF
--- a/Casks/luminance-hdr.rb
+++ b/Casks/luminance-hdr.rb
@@ -1,0 +1,9 @@
+class LuminanceHdr < Cask
+  version '2.4.0'
+  sha256 '8b97a9bf902aba0249091a70637df5f6040cdc25f9522aaa25bbb73aa9e297b9'
+
+  url "http://downloads.sourceforge.net/sourceforge/qtpfsgui/Luminance%20HDR%20#{version}-MacOSX-10.8.dmg"
+  homepage 'http://qtpfsgui.sourceforge.net/'
+
+  link "Luminance HDR #{version}.app"
+end


### PR DESCRIPTION
new cask
ignored the sf url format warning that prefers the 'latest' version pattern. this app includes the version in the .app name, so will require an adjustment to the link directive each release.
