### PR TITLE
Update Zotero to 4.0.21.5

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,8 +1,8 @@
 class Zotero < Cask
-  version '4.0.20'
-  sha256 '5206accbc9324a5ca42d660dd1c74ca3bac2397ffa0d503819b4245820feea27'
+  version '4.0.21.5'
+  sha256 '0c5b7fd612f44e6efdcec7d9dc050ddcb2586373e93c5fb40f846cc45df87a30'
 
-  url 'https://download.zotero.org/standalone/4.0.20/Zotero-4.0.20.dmg'
+  url "https://download.zotero.org/standalone/#{version}/Zotero-#{version}.dmg"
   homepage 'http://www.zotero.org/'
 
   link 'Zotero.app'


### PR DESCRIPTION
Value of `version` stanza now reused in `url`, ref. #4910.
