### PR TITLE
Restore Xamarin Studio, as well as the Android and iOS platforms

### DIFF
--- a/Casks/xamarin-android.rb
+++ b/Casks/xamarin-android.rb
@@ -1,0 +1,12 @@
+class XamarinAndroid < Cask
+  version '4.12.5-2'
+  sha256 '4ca0cce28879f7db8cd5117c425212e2fab772ad1dbb3e2fc32ccefbc166e14e'
+
+  url 'http://download.xamarin.com/MonoforAndroid/Mac/mono-android-4.12.5-2.pkg'
+  # non-Sparkle appcast
+  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml'
+  homepage 'http://xamarin.com/android'
+
+  install 'mono-android-4.12.5-2.pkg'
+  uninstall :pkgutil => 'com.xamarin.android.pkg'
+end

--- a/Casks/xamarin-ios.rb
+++ b/Casks/xamarin-ios.rb
@@ -1,0 +1,12 @@
+class XamarinIos < Cask
+  version '7.2.4.4'
+  sha256 'd6056e2ab4e529d7a04e9bcca915d780e3d9a76593c14791040b29651f6f2e5d'
+
+  url 'http://download.xamarin.com/MonoTouch/Mac/monotouch-7.2.4.4.pkg'
+  # non-Sparkle appcast
+  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml'
+  homepage 'http://xamarin.com/ios'
+
+  install 'monotouch-7.2.4.4.pkg'
+  uninstall :pkgutil => 'com.xamarin.monotouch.pkg'
+end

--- a/Casks/xamarin-studio.rb
+++ b/Casks/xamarin-studio.rb
@@ -1,0 +1,11 @@
+class XamarinStudio < Cask
+  version '5.0.1.3-0'
+  sha256 '51e840a8b5e8679363290aee88af2cdadd9d99706ae346f787d07ecc27bdabe8'
+
+  url 'http://download.xamarin.com/studio/Mac/XamarinStudio-5.0.1.3-0.dmg'
+  # non-Sparkle appcast
+  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml'
+  homepage 'http://xamarin.com/studio'
+
+  link 'Xamarin Studio.app'
+end


### PR DESCRIPTION
#5099 (and later #5118) removed these three Casks because it was believed they couldn't be updated.

> @fapper: I originally created the XamarinPlatform cask because XamarinStudio is stuck at version 4.2.4, and seemingly will never be able to be updated past that because Xamarin have started to use this new installer that my cask uses, installing Xamarin Studio version 5 and above (I assume).

This isn't the case, so this PR restores the three individual Casks to allow direct installing of Xamarin Studio along with Xamarin.Android and Xamarin.iOS.

For the record, I use Charles (a web debugging proxy) to retrieve the direct download URLs for these three packages out of the general installer which Xamarin offer.

If any of this is unclear I'd be happy to clarify why I believe these Casks are the correct approach rather than the `Xamarin` one added in that other PR.
