### PR TITLE
Update diffmerge

### DIFF
--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -6,5 +6,10 @@ class Diffmerge < Cask
   homepage 'http://www.sourcegear.com/diffmerge'
 
   link 'DiffMerge.app'
-  binary 'Extras/diffmerge.sh', :target => 'diffmerge'
+  binary 'DiffMerge.app/Contents/MacOS/DiffMerge', :target => 'diffmerge'
+  
+  caveats <<-EOS.undent
+    Use `diffmerge --nosplash` when configuring external tools such
+    as git to use diffmerge. This will squlech the splash screen.
+    EOS
 end


### PR DESCRIPTION
In reference to #5133, this update to `diffmerge` symlinks the `DiffMerge` binary, instead of the devloper provided shell script. This has the advantage of working (the developer provided shell script assumes DiffMerge.app lives in /Applications) but the disadvantage of causing a wxWidgets Debug alert to appear when launching `diffmerge` from the command line. This method also misses out on a `--nosplash` option from the developer provided shell script.

Unfortunately I don't know why this method causes the wxWidgets debug alert when the previous one doesn't. 
