### PR TITLE
Update version to 2.84

### DIFF
--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -1,5 +1,5 @@
 class Transmission < Cask
-  version '2.83'
+  version '2.84'
   sha256 '78c90b0cdc4a37064d66bba5976a4e46a778acfd4bf97d5bc18b9aeb21e36a64'
 
   url "https://transmission.cachefly.net/Transmission-#{version}.dmg"


### PR DESCRIPTION
Attempting `brew cask install transmission` produces the following error:

```
✓ → brew cask install transmission
==> Downloading https://transmission.cachefly.net/Transmission-2.83.dmg

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'transmission' with message: Download failed: https://transmission.cachefly.net/Transmission-2.83.dmg
```
