### PR TITLE
Upgrade ownCloud to 1.6.1.359

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -1,8 +1,8 @@
 class Owncloud < Cask
-  version '1.5.4.2580'
-  sha256 '2dd1b7cb5263a7cb5d5363290ec02d76305f6599941c1cd2f35399b319972503'
+  version '1.6.1.359'
+  sha256 '225ca73e3d57a56c68ba28cc9ea47aa7eb7f5abc00841528d5ee3f8a371fb0d3'
 
-  url 'https://download.owncloud.com/desktop/stable/ownCloud-1.5.4.2580.dmg'
+  url 'https://download.owncloud.com/desktop/stable/ownCloud-1.6.1.359.dmg'
   homepage 'http://owncloud.com'
 
   link 'owncloud.app'


### PR DESCRIPTION
https://download.owncloud.com/download/changelog-client

Release 1.6.1
Release Jun, 26th, 2014
- Fix 'precondition failed' bug with broken upload
- Fix openSSL problems for windows deployment
- Fix syncing a folder with '#' in the name
- Fix #1845: do not update parent directory etag before sub
  directories are removed
- Fix reappearing directories if dirs are removed during its
  upload
- Fix app version in settings dialog, General tab
- Fix crash in FolderWizard when going offline
- Shibboleth fixes
- More specific error messages (file remove during upload, open
  local sync file)
- Use QSet rather than QHash in SyncEngine (save memory)
- Fix some memory leaks
- Fix some thread race problems, ie. wait for neon thread to finish
  before the propagator is shut down
- Fix a lot of issues and warnings found by Coverity
- Fix Mac some settings dialog problems

Release 1.6.0
Released May, 30th, 2014
- Minor GUI improvements
- Qt5 compile issues fixed
- Ignore sync log file in filewatcher
- Install libocsync to private library dir and use rpath to localize
- Fix reconnect after server disconnect
- Fix "unknown action" display in Activity window
- Fix memory leaks
- Respect XDG_CONFIG_HOME environment var
- Handle empty fileids in the journal correctly
- Add abilility to compile libowncloudsync without GUI dependendy
- Fix SSL error with previously-expired CAs on Windows
- Fix incorrect folder pause state after start
- Fix a couple of actual potential crashes
- Improve Cookie support (e.g. for cookie-based load-balancers)
- Introduce a general timeout of 300s for network operations
- Improve error handling, blacklisting
- Job-based change propagation, enables faster parallel up/downloads 
  (right now only if no bandwidth limit is set and no proxy is used)
- Significantly reduced CPU load when checking for local and remote changes
- Speed up file stat code on Windows
- Enforce Qt5 for Windows and Mac OS X builds
- Improved owncloudcmd: SSL support, documentation
- Added advanced logging of operations (file .???.log in sync
  directory)
- Avoid creating a temporary copy of the sync database (.ctmp)
- Enable support for TLS 1.2 negotiation on platforms that use
  Qt 5.2 or later
- Forward server exception messages to client error messages
- Mac OS X: Support Notification Center in OS X 10.8+
- Mac OS X: Use native settings dialog 
- Mac OS X: Fix UI inconsistencies on Mavericks
- Shibboleth: Warn if authenticating with a different user
- Remove vio abstraction in csync
- Avoid data loss when a client file system is not case sensitive
