### PR TITLE
Add Cloud Foundry's CLI (`cf`) v6.2.0

### DIFF
--- a/Casks/cloudfoundry-cli.rb
+++ b/Casks/cloudfoundry-cli.rb
@@ -1,0 +1,13 @@
+class CloudfoundryCli < Cask
+  version '6.2.0'
+  sha256 'c804b4245a194a1028b5ac2fe074755d18a8aa2eb37bfc9978a5a4e47e9e644d'
+
+  url 'http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.2.0/installer-osx-amd64.pkg'
+  homepage 'https://github.com/cloudfoundry/cli'
+
+  install 'installer-osx-amd64.pkg'
+  uninstall :pkgutil => 'com.pivotal.cloudfoundry.pkg'
+  caveats do
+    files_in_usr_local
+  end
+end


### PR DESCRIPTION
The Cloud Foundry CLI is one command:  `cf`

The command enables the user to log into a Cloud Foundry
deployment and to make changes to services, brokers,
quotas, organizations, routes, etc....

The Cloud Foundry CLI is open source and written in Go.
