### PR TITLE
New QGIS 2.0.0 cask

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,0 +1,12 @@
+class Qgis < Cask
+  version '2.2.0-10'
+  sha256 '00ddf8511c11664600b680d569153a040bfd7579b40ccab53659d23999d4ad43'
+
+  url 'http://www.kyngchaos.com/files/software/qgis/QGIS-2.2.0-10.dmg'
+  homepage 'http://www.kyngchaos.com/software/qgis'
+  install 'Install QGIS.pkg'
+  uninstall :pkgutil => 'org.qgis.qgis-2.2'
+  caveats do
+    puts 'This app requires the GDAL framework and Matplotlib casks to be installed'
+  end
+end


### PR DESCRIPTION
- See issue #5074 - requires GDAL Framework and Matplotlib
- TODO: Add GDAL Framework and Matplotlib as Cask dependency once Caskroom supports it
