### PR TITLE
Add iSteg 1.62

### DIFF
--- a/Casks/isteg.rb
+++ b/Casks/isteg.rb
@@ -1,0 +1,9 @@
+class Isteg < Cask
+  version '1.6.2'
+  sha256 '5f385efce3416c9df75c6d97a35de82b76d9c829c2956461dd2fc95ca843702d'
+
+  url "http://www.hanynet.com/isteg-#{version}.zip"
+  homepage 'http://www.hanynet.com/isteg/'
+
+  link 'iSteg.app'
+end


### PR DESCRIPTION
iSteg is an encryption tool used to hide a file (for example a zip archive) inside a jpeg picture. This encryption technology is called steganography. iSteg is a frontend for the opensource tool outguess 2.0.
iSteg can be used to both encode and decode a hidden file. 
