### PR TITLE
Add PFLists 1.0.1

### DIFF
--- a/Casks/pflists.rb
+++ b/Casks/pflists.rb
@@ -1,0 +1,9 @@
+class Pflists < Cask
+  version '1.0.1'
+  sha256 '024cd972503df8b7b01602e092a9b900b6758b33ba040860fd46af3bb53f2856'
+
+  url "http://www.hanynet.com/pflists-#{version}.zip"
+  homepage 'http://www.hanynet.com/pflists/index.html'
+
+  link 'PFLists.app'
+end


### PR DESCRIPTION
PFLists is a basic PF firewall frontend for OS X 10.7 and newer. PFLists is inspired by the old Server Admin's firewall tool shipped with Mac OS X Server 10.7 but uses PF firewall instead of the old and deprecated IPFW.
