### PR TITLE
Add NoobProof 1.5

### DIFF
--- a/Casks/noobproof.rb
+++ b/Casks/noobproof.rb
@@ -1,0 +1,9 @@
+class Noobproof < Cask
+  version '1.5'
+  sha256 '6e74a5aec8e9cf9102c160019990e90ae46486358959fa0d22517b4171f8209a'
+
+  url "http://www.hanynet.com/noobproof-#{version}.zip"
+  homepage 'http://www.hanynet.com/noobproof/index.html'
+
+  link 'NoobProof.app'
+end


### PR DESCRIPTION
NoobProof is a IPFW firewall configuration tool for Mac OS X.   Very easy, just follow the 5 steps how-to in the application help. You can also tune bandwidth, manage black lists and create self-configuration tools called injectors. The first time you launch NoobProof the Wizard will help you configuring the Mac OS X firewall. 
