### PR TITLE
upgrade boot2docker to v1.0.1

### DIFF
--- a/Casks/boot2docker.rb
+++ b/Casks/boot2docker.rb
@@ -1,10 +1,10 @@
 class Boot2docker < Cask
-  version '1.0.0'
-  sha256 '4bcdc3b4f309c7957aa8b91768f9c59d23f63258bc83d22cbdf268f5bbf2785f'
+  version '1.0.1'
+  sha256 '9f03f3eca0d3645d082bf249ad0a1ce3feb60134bdad6fcfbb47aa67a30c5e79'
 
-  url 'https://github.com/boot2docker/osx-installer/releases/download/v1.0.0/Boot2Docker-1.0.0.pkg'
+  url 'https://github.com/boot2docker/osx-installer/releases/download/v1.0.1/Boot2Docker-1.0.1.pkg'
   homepage 'https://github.com/boot2docker/osx-installer'
 
-  install 'Boot2Docker-1.0.0.pkg'
+  install 'Boot2Docker-1.0.1.pkg'
   uninstall :pkgutil => ['io.boot2docker.pkg.boot2docker', 'io.boot2docker.pkg.boot2dockerapp', 'io.boot2dockeriso.pkg.boot2dockeriso', 'io.docker.pkg.docker']
 end


### PR DESCRIPTION
https://github.com/boot2docker/osx-installer/releases/tag/v1.0.1
