### PR TITLE
slic3r: upgrade to 1.1.6

### DIFF
--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -1,8 +1,8 @@
 class Slic3r < Cask
-  version '1.1.5'
-  sha256 '5257d3481cae658cc61353a0582b3e28a351b2a4aad6e5c2240458a1fa4637ec'
+  version '1.1.6'
+  sha256 '544cb36ff905d32790f66c3872b0806e6854f5214fa38fd705afbb610a5f718f'
 
-  url 'http://dl.slic3r.org/mac/slic3r-osx-uni-1-1-5-stable.dmg'
+  url 'http://dl.slic3r.org/mac/slic3r-osx-uni-1-1-6-stable.dmg'
   homepage 'http://slic3r.org/'
 
   link 'Slic3r.app'


### PR DESCRIPTION
Upgrade slic3r to 1.1.6 stable version.
Signed-off-by: coldnew coldnew.tw@gmail.com
