### PR TITLE
set unetbootin to latest

### DIFF
--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -1,8 +1,8 @@
 class Unetbootin < Cask
-  version '585'
-  sha256 '2a6cc88feb01b666710c094b49b4cbb4e33a301d699b1bd4dbd229bfa0b5572e'
+  version 'latest'
+  sha256 :no_check
 
-  url 'https://downloads.sourceforge.net/sourceforge/unetbootin/unetbootin-mac-585.zip'
+  url 'http://sourceforge.net/projects/unetbootin/files/latest/download'
   homepage 'http://unetbootin.sourceforge.net/'
 
   link 'unetbootin.app'


### PR DESCRIPTION
This is many times needed in a pinch, and only then. Being something you use sporadically, it means it’s rarely updated, making more sense to set it as “latest”.
