### PR TITLE
made hydra easier to update

### DIFF
--- a/Casks/hydra.rb
+++ b/Casks/hydra.rb
@@ -1,8 +1,8 @@
 class Hydra < Cask
-  version '1.0 beta 9'
+  version '1.0.b9'
   sha256 '24e8c77e566253eafcb27e04045d236dc5f484c387c7897242eff42e5d08af13'
 
-  url 'https://github.com/sdegutis/hydra/releases/download/v1.0.b9/Hydra-v1.0.b9.app.zip'
+  url "https://github.com/sdegutis/hydra/releases/download/v#{version}/Hydra-v#{version}.app.zip"
   homepage 'https://github.com/sdegutis/hydra'
 
   link 'Hydra.app'


### PR DESCRIPTION
@sdegutis With this change, it should be easier to update (and script), as you’ll only need to worry about the first two lines in the cask.
