### PR TITLE
Downgrade teamspeak-client to 3.0.14

### DIFF
--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -1,8 +1,9 @@
 class TeamspeakClient < Cask
-  version '3.0.15'
-  sha256 '69fe499b38e3ebd53339cb1ce571ea8f012b3de1553ab3fab95a04d4b3cb131a'
+  # note: version 3.0.15 causes hdiutil to segfault
+  version '3.0.14'
+  sha256 '305f1d33df4bff324c232811253dd65b0caca477fc9196a1e82cbc6c6796e680'
 
-  url 'http://dl.4players.de/ts/releases/3.0.15/TeamSpeak3-Client-macosx-3.0.15.dmg'
+  url 'http://dl.4players.de/ts/releases/3.0.14/TeamSpeak3-Client-macosx-3.0.14.dmg'
   homepage 'http://www.teamspeak.com/'
 
   link 'TeamSpeak 3 Client.app'


### PR DESCRIPTION
To work around segfault on mounting DMG.  Fixes #5160.
