### PR TITLE
updated googleappenginelauncher (1.9.6)

### DIFF
--- a/Casks/googleappenginelauncher.rb
+++ b/Casks/googleappenginelauncher.rb
@@ -1,8 +1,8 @@
 class Googleappenginelauncher < Cask
-  version '1.9.5'
-  sha256 '7e5f765ea89193b0d1176b059a6100c546ff9aea4ad1df8e1dd894f15b81a0bc'
+  version '1.9.6'
+  sha256 '82b97a2d02be6834a87783a76d88d1c9fc436e1ee0832476df30d4f5ea938d7a'
 
-  url 'https://storage.googleapis.com/appengine-sdks/featured/GoogleAppEngineLauncher-1.9.5.dmg'
+  url "https://storage.googleapis.com/appengine-sdks/featured/GoogleAppEngineLauncher-#{version}.dmg"
   homepage 'https://developers.google.com/appengine/'
 
   link 'GoogleAppEngineLauncher.app'


### PR DESCRIPTION
Closes #5252.
