### PR TITLE
Add karabiner

### DIFF
--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -1,0 +1,9 @@
+class Karabiner < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'https://pqrs.org/osx/karabiner/files/Karabiner-10.0.0.dmg'
+  homepage 'https://pqrs.org/osx/karabiner/'
+
+  install 'Karabiner.pkg'
+end


### PR DESCRIPTION
KeyRemap4MacBook is renamed to Karabiner from v10.0
