### PR TITLE
Blender to 2.71 and MakeHuman to 1.0.1

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -1,8 +1,8 @@
 class Blender < Cask
-  version '2.70a'
-  sha256 '590461502fe257883c78be3d6cf0eb329bced07c9aeea499bb812e2d55c3e8ba'
+  version '2.71'
+  sha256 'facd97d6d4c6ff9088c1ee994468d35342435054fb5d02c3ae7eee38045d0bc6'
 
-  url 'http://download.blender.org/release/Blender2.70/blender-2.70a-OSX_10.6-x86_64.zip'
+  url 'http://download.blender.org/release/Blender2.71/blender-2.71-OSX_10.6-x86_64.zip'
   homepage 'http://www.blender.org/'
 
   link 'Blender/blender.app'

--- a/Casks/makehuman.rb
+++ b/Casks/makehuman.rb
@@ -1,8 +1,8 @@
 class Makehuman < Cask
-  version '1.0.0'
-  sha256 'f104963fc5fcf627069324cc3d3b9dc7bae65608fd9b7354fb914a1f3c755e70'
+  version '1.0.1'
+  sha256 'c3a4d693a23aff5e4f6dd93c0452d7d753703d48b9d3600d210c436b6dc756f4'
 
-  url 'http://download.tuxfamily.org/makehuman/releases/1.0.0/makehuman-1.0.0-osx.dmg'
+  url 'http://download.tuxfamily.org/makehuman/releases/1.0.1/makehuman-1.0.1-osx.dmg'
   homepage 'http://www.makehuman.org/'
 
   link 'MakeHuman.app'


### PR DESCRIPTION
Simple version bump to move Blender from 2.70 alpha to stable 2.71 and MakeHuman to latest version (1.0.1)
