### PR TITLE
Fix download protocol in OmniFocus.app Cask

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -2,7 +2,7 @@ class Omnifocus < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'https://www.omnigroup.com/download/latest/omnifocus'
+  url 'http://www.omnigroup.com/download/latest/omnifocus'
   homepage 'http://www.omnigroup.com/products/omnifocus/'
 
   link 'OmniFocus.app'


### PR DESCRIPTION
Changed https to http because the former has stopped working
