### PR TITLE
update slack to official download URL

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -2,8 +2,8 @@ class Slack < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'https://rink.hockeyapp.net/api/2/apps/89dc0a9e3d01fb65e383b13c9ce0d3ac?format=zip'
-  appcast 'https://rink.hockeyapp.net/api/2/apps/89dc0a9e3d01fb65e383b13c9ce0d3ac'
+  url 'http://slack.com/ssb/download-osx'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1'
   homepage 'http://slack.com'
 
   link 'Slack.app'


### PR DESCRIPTION
URL was retrieved by asking via their support channel, so it should
remain good for awhile

also update appcast based on new url found in latest download
