### PR TITLE
Re-add Vox.app

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,0 +1,9 @@
+class Vox < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'http://coppertino.com/getVox/'
+  homepage 'http://coppertino.com/vox/'
+
+  link 'Vox.app'
+end


### PR DESCRIPTION
See discussion in comments of #2644.

Caveats: the link that was the official link before is not linked from the homepage, and it's also a beta, different from the (free) version offered on the App Store. But since `vox-preference-pane` is offered as a cask, it feels like `vox` itself ought to be too.
