### PR TITLE
sqlite-database-browser Fix checksum and link for 3.2.0

### DIFF
--- a/Casks/sqlite-database-browser.rb
+++ b/Casks/sqlite-database-browser.rb
@@ -1,9 +1,9 @@
 class SqliteDatabaseBrowser < Cask
   version '3.2.0'
-  sha256 '77ff563d108dc2bf224b3628172df31238fe2d74d7a2e1954b120463a865c4d8'
+  sha256 '4f89640ffecf6e663554e07987dc6d555929f9e8c0db55b22824d7025fdc8b97'
 
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/sqlb-#{version}/sqlitebrowser-#{version}.dmg"
   homepage 'http://sqlitebrowser.org'
 
-  link "SQLite Database Browser #{version}.app"
+  link "sqlitebrowser.app"
 end


### PR DESCRIPTION
Changed sha-2 checksum and symlink name so install works correctly
