### PR TITLE
Symlinks libserver.dylib to the correct lib for Java

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -24,6 +24,10 @@ class Java < Cask
       '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'
     system '/usr/bin/sudo', '-E', '--',
       '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home", '/Library/Java/Home'
+    system '/usr/bin/sudo', '-E', '--',
+      '/bin/mkdir', '-p', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home/bundle/Libraries"
+    system '/usr/bin/sudo', '-E', '--',
+      '/bin/ln', '-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home/jre/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"
   end
   uninstall :pkgutil => [
                          'com.oracle.jdk8u5',         # manually update this for each version


### PR DESCRIPTION
Fixes #5332.
This fixes issues where applications using java were unable to start because this lib could not be found.
