### PR TITLE
Add Scribbleton version 1.0.1

### DIFF
--- a/Casks/scribbleton.rb
+++ b/Casks/scribbleton.rb
@@ -1,0 +1,9 @@
+class Scribbleton < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'http://scribbleton.com/download/mac'
+  homepage 'http://scribbleton.com/'
+
+  link 'Scribbleton.app'
+end


### PR DESCRIPTION
The little personal wiki http://scribbleton.com.

This cask works to install, though, it has an agreement modal box popping up before opening the `dmg`. In the terminal it just ouputs the text and installes the app. Is there anything I can add to prevent the text from showing?
