### PR TITLE
ignore non-XML hdiutil output preceding plists

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -66,7 +66,7 @@ class Cask::SystemCommand
     begin
       raise CaskError.new("Empty plist input") unless output =~ %r{\S}
       output.sub!(%r{\A(.*?)(<\?\s*xml)}m, '\2')
-      _warn_plist_garbage(command, $1)
+      _warn_plist_garbage(command, $1) if Cask.debug
       output.sub!(%r{(<\s*/\s*plist\s*>)(.*?)\Z}m, '\1')
       _warn_plist_garbage(command, $2)
       xml = Plist::parse_xml(output)


### PR DESCRIPTION
unless `--debug` is in effect.  This reverts to previous
behavior WRT DMG licenses.  Trailing non-XML garbage will
still be emitted.
