### PR TITLE
Add PingMenu

### DIFF
--- a/Casks/pingmenu.rb
+++ b/Casks/pingmenu.rb
@@ -1,0 +1,9 @@
+class Pingmenu < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'https://github.com/kalleboo/PingMenu/raw/master/PingMenu.app.zip'
+  homepage 'https://github.com/kalleboo/PingMenu'
+
+  link 'PingMenu.app'
+end


### PR DESCRIPTION
Adds a status menu to the OS X menu bar showing the current ping time to google.com
