### PR TITLE
Upgrade iTerm2 to version 2.0

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,9 +1,9 @@
 class Iterm2 < Cask
   # note: "2" is not a version number, but indicates a different vendor
-  version '1.0.0'
-  sha256 '2afad022b1e1f08b3ed40f0c2bde7bf7cce003852c83f85948c7f57a5578d9c5'
+  version '2.0.0'
+  sha256 '6a59e1b96d9037b6ff1b8aaaf7aed5cff572d74d6e58390db16028433769c058'
 
-  url 'http://www.iterm2.com/downloads/stable/iTerm2_v1_0_0.zip'
+  url 'http://www.iterm2.com/downloads/stable/iTerm2_v2_0.zip'
   homepage 'http://www.iterm2.com/'
 
   link 'iTerm.app'


### PR DESCRIPTION
iTerm2 has been updated to version 2.0. This commit increments the
version number, the SHA, and the download URL.
