### PR TITLE
Add UTC Menu Clock cask

### DIFF
--- a/Casks/utc-menu-clock.rb
+++ b/Casks/utc-menu-clock.rb
@@ -1,0 +1,8 @@
+class UtcMenuClock < Cask
+  version '1.2'
+  sha256 '8a6d26228495aa802b3f9f80e43ee58bff92097e7de41de86dae994a9350d9b2'
+
+  url "https://github.com/downloads/netik/UTCMenuClock/UTCMenuClock_#{version}_installer.pkg"
+  homepage 'https://github.com/netik/UTCMenuClock'
+  install "UTCMenuClock_#{version}_installer.pkg"
+end


### PR DESCRIPTION
UTC Menu Clock is very simple program to add the UTC time to the MacOS Menu Status Bar.
