### PR TITLE
fixed shasum for p4merge

### DIFF
--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -1,6 +1,6 @@
 class P4merge < Cask
   version '2014.1'
-  sha256 'ff643c91069cb952d35146be5aa3be519119d4abce2a585d6ff307ab42e59d70'
+  sha256 'c5d05d78596fe9b4f83193a11805a027b2652fdf87365de1321e671286fdca3f'
 
   url 'http://filehost.perforce.com/perforce/r14.1/bin.macosx106x86_64/P4V.dmg'
   homepage 'http://www.perforce.com/product/components/perforce-visual-merge-and-diff-tools'


### PR DESCRIPTION
The cask couldn't be installed because of a checksum error. Fixed the shasum for the cask.
