### PR TITLE
Upgrade VirtualBox to v4.3.14

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,8 +1,8 @@
 class Virtualbox < Cask
-  version '4.3.12-93733'
-  sha256 'a9d9e3b3217177bc175839747de663ba25886f71e97a9c35ad802f618f11e23e'
+  version '4.3.14-95030'
+  sha256 'c89b22f3e5ba5d93ccf762c5922c1f21d2c4e7c21b9487d892ac0516d6f4d55a'
 
-  url 'http://download.virtualbox.org/virtualbox/4.3.12/VirtualBox-4.3.12-93733-OSX.dmg'
+  url "http://download.virtualbox.org/virtualbox/#{version.gsub(/-.*/, '')}/VirtualBox-#{version}-OSX.dmg"
   homepage 'http://www.virtualbox.org'
 
   install 'VirtualBox.pkg'


### PR DESCRIPTION
How can we set this cask up with the new conventions? The version number differs in the URL, setting up 
`#{version}` would still mean that you need to update the URL with a key (in this case `95030`). 

Maybe we can add an extra parameter just below version number?

``` ruby
class Virtualbox < Cask
  version '4.3.14'
  key '95030'

  sha256 'c89b22f3e5ba5d93ccf762c5922c1f21d2c4e7c21b9487d892ac0516d6f4d55a'

  url "http://download.virtualbox.org/virtualbox/#{version}/VirtualBox-#{version}-#{key}-OSX.dmg"
  homepage 'http://www.virtualbox.org'

  install 'VirtualBox.pkg'
  uninstall :script => { :executable => 'VirtualBox_Uninstall.tool', :args => %w[--unattended] }
end
```
