### PR TITLE
Add Jameica.app

### DIFF
--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -1,0 +1,9 @@
+class Jameica < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'http://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64.zip'
+  homepage 'http://www.willuhn.de/products/jameica/'
+
+  link 'Jameica.app'
+end


### PR DESCRIPTION
Jameica is a free and open-source Java-Platform, which supports various plugins. It is mainly used for the Hibiscus plugin, which allows users to do home banking with mostly german banks.
