### PR TITLE
Adding cask task for go-agent and go-server

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,0 +1,9 @@
+class GoAgent < Cask
+  version '14.2.0-377'
+  sha256 'b3886afe748bbba3dccd0f3282af4e1860ca93223a5a70bf22a3b132adeb3701'
+
+  url "http://download.go.cd/gocd/go-agent-#{version}-osx.zip"
+  homepage 'http://www.go.cd'
+
+  link 'Go Agent.app'
+end

--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,0 +1,9 @@
+class GoServer < Cask
+  version '14.2.0-377'
+  sha256 '19fd85946f838a647dba5de75aff4a63eb0c03f6b0c2f619e42705936053d493'
+
+  url "http://download.go.cd/gocd/go-server-#{version}-osx.zip"
+  homepage 'http://www.go.cd/'
+
+  link 'Go Server.app'
+end


### PR DESCRIPTION
Closes #5352. Commits are squashed. The new preferred syntax is added.
