### PR TITLE
Add Cloud.app v2.0.2

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,0 +1,9 @@
+class Cloudapp < Cask
+  version '2.0.2'
+  sha256 'e9d638c0ee25b5269c1c9bd48f031ebfddd5997ec6543c1d4e202627cf5e28d4'
+
+  url 'http://downloads.getcloudapp.com/mac/CloudApp-2.0.2.zip'
+  homepage 'http://www.getcloudapp.com/download'
+
+  link 'Cloud.app'
+end


### PR DESCRIPTION
Naming this app was challenging. The public/marketing name of the app and related service is [CloudApp](http://www.getcloudapp.com/), but the developer named its Mac OS X application bundle simply `Cloud.app`.

I realize that in the [Cask Naming Reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_NAMING_REFERENCE.md#canonical-names-of-apps) documentation, both

> - Remove `.app` from the end

and

> - Remove the term "app" from the end, if the developer styles the name like "Software App.app". Exception: if the term "app" describes functionality, as in [rcdefaultapp.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/rcdefaultapp.rb).

seem indicate that the application's collection of names should generally be:

| App Name on Disk | Canonical App Name | Cask Name | Cask File | Cask Class |
| --- | --- | --- | --- | --- |
| `Cloud.app` | Cloud | `cloud` | `cloud.rb` | `Cloud` |

However, the app and service are just simply never referenced, marketed, or themed (in the app's UI) as _Cloud_, and the use of this term alone seems very ambiguous. One might even be able to argue, albeit utterly pedantic, that the "app" does indeed describe functionality as it's a desktop app companion to a cloud service.

I think it may be advised to except this app from the "letter" of the naming rules in order to better follow their spirit and intent.  Instead, I've suggested (in this pull request) to use the following collection of names:

| App Name on Disk | Canonical App Name | Cask Name | Cask File | Cask Class |
| --- | --- | --- | --- | --- |
| `Cloud.app` | CloudApp | `cloudapp` | `cloudapp.rb` | `Cloudapp` |

I think making this adjustment better relates to and identifies the app, and using `cloudapp` will certainly increase its utility and findability as a cask to `homebrew-cask` users.

Thank you for your amazingly useful contribution! ...And, thanks in advance, for taking a look at this pull request.
