### PR TITLE
Fix SHA2 mismatch on droplr cask

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 class Droplr < Cask
   version '4.1.2'
-  sha256 '60e45c4ea0e4658f78a0a78a36fd3f6e1c5d37efca1984f19f46e12ef6024f15'
+  sha256 '495537ae3b18f79d85a45b8e83244e7c906e2f4871119c120d2dff2693ce15d1'
 
   url 'http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+35.zip'
   appcast 'https://droplr.com/appcast/appcast.xml'


### PR DESCRIPTION
Sorry, forgot the checksum in my last pull request (b8bc05f1aa1d2fff5a7ca53eab5a9c6fbbc326e1).
