### PR TITLE
Add Atraci.app v0.5.2

### DIFF
--- a/Casks/atraci.rb
+++ b/Casks/atraci.rb
@@ -1,0 +1,9 @@
+class Atraci < Cask
+  version '0.5.2'
+  sha256 '13746212a40c2402482feda2ac70aa5016f435f8b3abaa1982965d5f4738006a'
+
+  url "https://github.com/Atraci/Atraci/raw/gh-pages/releases/#{version}/mac/Atraci.zip"
+  homepage 'https://github.com/Atraci/Atraci'
+
+  link 'Atraci.app'
+end


### PR DESCRIPTION
Atraci is an application for Windows, Mac and Linux that lets you listen instantly to more than 60 million songs. [https://github.com/Atraci/Atraci](https://github.com/Atraci/Atraci)

Closes #5410.
