### PR TITLE
Update Lightpaper to 0.9.0.

### DIFF
--- a/Casks/lightpaper.rb
+++ b/Casks/lightpaper.rb
@@ -1,8 +1,8 @@
 class Lightpaper < Cask
-  version '0.8.7'
-  sha256 'e4ec5c87f8e35b9688f25808def9efa610923858d60c26917315422094f0108a'
+  version '0.9.0'
+  sha256 'e90ad6d7052573a8048b65c590f9227f75a55690731ccf6986ded5982fc02afe'
 
-  url 'http://cl.ly/3c370B2o0J2A/download/LightPaper_v0.8.7.dmg'
+  url 'http://f.cl.ly/items/3q1Q3C472c3G2L2l2X0m/LightPaper_v0.0.9.dmg'
   appcast 'http://links.clockworkengine.com/lp-mac-update-feed'
   homepage 'http://clockworkengine.com/lightpaper-mac/'
 


### PR DESCRIPTION
Updated Lightpaper to version 0.9.0.

For some reason, the instalation file for this version is called Lightpaper_v0.0.9.dmg, but it contains correct latest version 0.9.0 - check download on [Lightpaper homepage](http://clockworkengine.com/lightpaper-mac/).
