### PR TITLE
Readme: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ command](https://github.com/mxcl/homebrew/wiki/External-Commands)" called
 
 ## Let's try it!
 ```sh
-$ brew tap caskroom/cask
-$ brew install brew-cask
+$ brew install caskroom/cask/brew-cask
 $ brew cask install google-chrome
 => Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
 => Success! google-chrome installed to /opt/homebrew-cask/Caskroom/google-chrome/stable-channel


### PR DESCRIPTION
USAGE.md tells us to use `brew install caskroom/cask/brew-cask` instead of using `brew tap && brew install`. This updates the README.md file to be consistent with USAGE.md.
