### PR TITLE
Changed link name to 'Marked 2.app'.

### DIFF
--- a/Casks/marked.rb
+++ b/Casks/marked.rb
@@ -6,5 +6,5 @@ class Marked < Cask
   appcast 'http://abyss.designheresy.com/marked/marked.xml'
   homepage 'http://marked2app.com'
 
-  link 'Marked.app'
+  link 'Marked 2.app'
 end


### PR DESCRIPTION
Fixed install error because application name is 'Marked 2.app', not 'Marked.app'.
