### PR TITLE
Update slack symlink

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -6,5 +6,5 @@ class Slack < Cask
   appcast 'https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1'
   homepage 'http://slack.com'
 
-  link 'Slack.app'
+  link 'Slack 0.44.2.app'
 end


### PR DESCRIPTION
Similar to #4487

Seems that when Slack is unarchived it is named "Slack 0.44.2.app" instead of the "Slack.app" that is currently expected.

```
$ /usr/local/bin/brew cask install slack
==> Downloading http://slack.com/ssb/download-osx
Already downloaded: /Library/Caches/Homebrew/slack-latest
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/slack/latest/Slack.app'
```

```
$ /usr/local/bin/brew cask install test/slack.rb 
==> Downloading http://slack.com/ssb/download-osx
Already downloaded: /Library/Caches/Homebrew/slack-latest
==> Symlinking App 'Slack 0.44.2.app' to '/Users/jmaclean/Applications/Slack 0.44.2.app'
slack installed to '/opt/homebrew-cask/Caskroom/slack/latest' (181 files, 8.4M)
```
