### PR TITLE
Update node-webkit to 0.10.0 and remove `link` stanza

### DIFF
--- a/Casks/node-webkit.rb
+++ b/Casks/node-webkit.rb
@@ -1,9 +1,9 @@
 class NodeWebkit < Cask
-  version '0.9.2'
-  sha256 '2133f498d2607e02a1af1b1988fb191ed0467a268afffabbeb3b99ee62384407'
+  version '0.10.0'
+  sha256 '37e2000b5bbc9a96c55ab15c86b21aeb38de2aa7d373c04c5f820d5bae07dc54'
 
-  url 'http://dl.node-webkit.org/v0.9.2/node-webkit-v0.9.2-osx-ia32.zip'
+  url "http://dl.node-webkit.org/v#{version}/node-webkit-v#{version}-osx-ia32.zip"
   homepage 'https://github.com/rogerwang/node-webkit'
 
-  link 'node-webkit.app'
+  caskroom_only true
 end


### PR DESCRIPTION
[node-webkit](https://github.com/rogerwang/node-webkit) has recently reached version 10, but I think we should either remove the `link` stanza, or the cask altogether.

node-webkit is, effectively, a runtime. It works as a binary with which the application developer launches or bundles their code. As such, symlinking it anywhere provides very little utility.
