### PR TITLE
Doc: encourage programmatic versions in URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ class Alfred < Cask
   version '2.3_264'
   sha256 'a32565cdb1673f4071593d4cc9e1c26bc884218b62fef8abc450daa47ba8fa92'
 
-  url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
+  url 'https://cachefly.alfredapp.com/Alfred_#{version}.zip'
   homepage 'http://www.alfredapp.com/'
 
   link 'Alfred 2.app'
@@ -52,7 +52,7 @@ class Vagrant < Cask
   version '1.4.3'
   sha256 'e7ff13b01d3766829f3a0c325c1973d15b589fe1a892cf7f857da283a2cbaed1'
 
-  url 'https://dl.bintray.com/mitchellh/vagrant/Vagrant-1.4.3.dmg'
+  url 'https://dl.bintray.com/mitchellh/vagrant/Vagrant-#{version}.dmg'
   homepage 'http://www.vagrantup.com'
 
   install 'Vagrant.pkg'

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -29,7 +29,7 @@ class Alfred < Cask
   version '2.3_264'
   sha256 'a32565cdb1673f4071593d4cc9e1c26bc884218b62fef8abc450daa47ba8fa92'
 
-  url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
+  url 'https://cachefly.alfredapp.com/Alfred_#{version}.zip'
   homepage 'http://www.alfredapp.com/'
 
   link 'Alfred 2.app'
@@ -213,6 +213,22 @@ of key/value pairs appended to `url`:
 Example of using `:cookies`: [java.rb](../Casks/java.rb)
 
 Example of using `:referer`: [freefilesync.rb](../Casks/freefilesync.rb)
+
+### Version Numbers in URLs
+
+When the version number is part of the URL, try to incorporate it programmatically. For example:
+
+```ruby
+url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
+```
+
+becomes:
+
+```ruby
+url 'https://cachefly.alfredapp.com/Alfred_#{version}.zip'
+```
+
+as long as `version` is defined at the top of the Cask.
 
 ### Difficulty Finding a URL
 


### PR DESCRIPTION
Just a few documentation updates to help convey #4910 and the programmatic use of version numbers.

I could see benefit in having more creative examples to demonstrate using `#{version}` in other stanzas as well (i.e.: within the `link` stanza), but that is not addressed here. At the very least, this will nudge people in the right direction.
