### PR TITLE
Add DoubleCommand v1.7

### DIFF
--- a/Casks/doublecommand.rb
+++ b/Casks/doublecommand.rb
@@ -1,0 +1,10 @@
+class Doublecommand < Cask
+  version '1.7'
+  sha256 '312aaf1a60517c694b24131bf502945dc23a22c917971c3e7a3adca163560503'
+
+  url 'http://doublecommand.sourceforge.net/files/DoubleCommand-1.7.dmg'
+  homepage 'http://doublecommand.sourceforge.net'
+
+  install 'DoubleCommand-1.7.pkg'
+  uninstall :script => '/Library/StartupItems/DoubleCommand/uninstall.command'
+end


### PR DESCRIPTION
DoubleCommand is software for Mac OS X (a kernel extension) that lets you remap keys.
For uninstallation purposes I used the bundled script as explained in DoubleCommand's help page http://doublecommand.sourceforge.net/help.html
