### PR TITLE
Solve issues with Java for all IntelliJ based IDEs

### DIFF
--- a/Casks/android-studio-bundle.rb
+++ b/Casks/android-studio-bundle.rb
@@ -6,4 +6,8 @@ class AndroidStudioBundle < Cask
   homepage 'http://developer.android.com/sdk/installing/studio.html'
 
   link 'Android Studio.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/Android Studio.app/Contents/Info.plist"
+  end
 end

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -6,4 +6,8 @@ class AndroidStudio < Cask
   homepage 'https://developer.android.com/sdk/installing/studio.html'
 
   link 'Android Studio.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/Android Studio.app/Contents/Info.plist"
+  end
 end

--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -6,4 +6,8 @@ class Appcode < Cask
   homepage 'http://www.jetbrains.com/objc/'
 
   link 'AppCode.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/AppCode.app/Contents/Info.plist"
+  end
 end

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -6,6 +6,11 @@ class IntellijIdeaCe < Cask
   homepage 'https://www.jetbrains.com/idea/index.html'
 
   link 'IntelliJ IDEA 13 CE.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/IntelliJ IDEA 13 CE.app/Contents/Info.plist"
+  end
+
   caveats do
     <<-EOS.undent
     #{@cask} may require Java 7 (an older version) available from the

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -6,6 +6,11 @@ class IntellijIdea < Cask
   homepage 'https://www.jetbrains.com/idea/index.html'
 
   link 'IntelliJ IDEA 13.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/IntelliJ IDEA 13.app/Contents/Info.plist"
+  end
+
   caveats do
     <<-EOS.undent
     #{@cask} may require Java 7 (an older version) available from the

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -6,4 +6,8 @@ class Phpstorm < Cask
   homepage 'http://www.jetbrains.com/phpstorm/'
 
   link 'PhpStorm.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/PhpStorm.app/Contents/Info.plist"
+  end
 end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -6,4 +6,8 @@ class PycharmCe < Cask
   homepage 'http://www.jetbrains.com/pycharm'
 
   link 'PyCharm CE.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/PyCharm CE.app/Contents/Info.plist"
+  end
 end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -6,4 +6,8 @@ class Pycharm < Cask
   homepage 'http://www.jetbrains.com/pycharm/'
 
   link 'PyCharm.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/PyCharm.app/Contents/Info.plist"
+  end
 end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -6,4 +6,8 @@ class Rubymine < Cask
   homepage 'http://www.jetbrains.com/ruby/'
 
   link 'RubyMine.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/RubyMine.app/Contents/Info.plist"
+  end
 end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -6,4 +6,8 @@ class Webstorm < Cask
   homepage 'http://www.jetbrains.com/webstorm/'
 
   link 'WebStorm.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/WebStorm.app/Contents/Info.plist"
+  end
 end


### PR DESCRIPTION
See #4524 for details and reasons behind this solution which is upgrade-proof and will also work in case user has multiple Java installations.

The list of all IntelliJ IDEs (affected casks) can be obtained from http://www.jetbrains.com/products.html

There will be another PR for adding/correcting the Java caveats for all of these casks (all should support Java 6+ which also includes 8).

btw. I was not digging deeper for reason, but it would really help if `link` could be reused in the DSL as there's usually version present too.

I will welcome any feedback, especially from @zwaldowski @thesamet @alebelcor @ashishb @justmao945
