### PR TITLE
Upgrade ksdiff to 2.1.0 (122)

### DIFF
--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -1,8 +1,8 @@
 class Ksdiff < Cask
-  version '2.0.1 (111)'
-  sha256 '59f1f090135148a0ab6f04df503a5bb229c3ecd0ea5c96da19a1bf6bb1a4c930'
+  version '2.1.0 (122)'
+  sha256 '9570f53dcbeb558c53f4808ba58e8c9f394a3026e8bdd122277200a1cdf11e52'
 
-  url 'http://cdn.kaleidoscopeapp.com/releases/ksdiff-111.zip'
+  url 'http://cdn.kaleidoscopeapp.com/releases/ksdiff-122.zip'
   homepage 'http://www.kaleidoscopeapp.com/ksdiff2'
 
   install 'Install ksdiff.pkg'


### PR DESCRIPTION
Just upgrading the ksdiff tool for Kaleidoscope to latest version as of today: 2.1.0 (122)
