### PR TITLE
Add qgroundcontrol.app

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,0 +1,9 @@
+class Qgroundcontrol < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'http://latestfiasco.com/ftp/qgroundcontrol-pixhawk.dmg'
+  homepage 'http://qgroundcontrol.org'
+
+  link 'qgroundcontrol.app'
+end


### PR DESCRIPTION
Add a cask for the popular unmanned system ground control station software.
Not versioned, as upstream always link to latest build.
