### PR TITLE
Amend valid values for tags stanza

### DIFF
--- a/lib/cask/tags.rb
+++ b/lib/cask/tags.rb
@@ -5,10 +5,7 @@ class Cask::Tags
   # So far, we only check the keys.
   VALID_TAGS = Set.new [
                         :vendor,
-                        :font_pitch,
-                        :font_serif,
-                        :font_weight,
-                        :font_slant,
+                        :name,
                        ]
 
   attr_accessor *VALID_TAGS


### PR DESCRIPTION
- remove font tags (per earlier discussion in #4953 — font tags were 
  left in by mistake)
- add tag `:name` for corner cases where the Cask name cannot
  adequately follow the product name.  Examples: non-English apps,
  App bundles which do not match publicized names.
