### PR TITLE
Move the Tap Migration banner from README.md to FAQ.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# NOTICE: Homebrew-cask has moved!
-
-The original repo at https://github.com/phinze/homebrew-cask has moved
-under the organizational umbrella at https://github.com/caskroom/homebrew-cask .
-
-Web redirection happens automatically.
-
-The location of the Cask Tap on disk has also changed, which should be
-handled automatically upon upgrading.  If you have technical difficulties,
-please see [TAP_MIGRATION.md](doc/TAP_MIGRATION.md).
-
 # "To install, drag this icon..." no more!
 
 [![Build Status](https://travis-ci.org/caskroom/homebrew-cask.png?branch=master)](https://travis-ci.org/caskroom/homebrew-cask)

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,5 +1,16 @@
 # Frequently Asked Questions
 
+# NOTICE: Homebrew-cask has moved!
+
+The original repo at https://github.com/phinze/homebrew-cask has moved
+under the organizational umbrella at https://github.com/caskroom/homebrew-cask .
+
+Web redirection happens automatically.
+
+The location of the Cask Tap on disk has also changed, which should be
+handled automatically upon upgrading.  If you have technical difficulties,
+please see [TAP_MIGRATION.md](TAP_MIGRATION.md).
+
 ## What is a Cask?
 
 A `Cask` is like a `Formula` in Homebrew except it describes how to download


### PR DESCRIPTION
We have not seen an issue filed on this in some time.
