### PR TITLE
Delete special files (eg symlinks) from pkg BOMs

### DIFF
--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -60,6 +60,16 @@ describe Cask::Artifact::Uninstall do
         ].join("\n")
       )
       Cask::FakeSystemCommand.stubs_command(
+        ['/usr/sbin/pkgutil', '--files', 'my.fancy.package.main'],
+        [
+          'fancy',
+          'fancy/bin',
+          'fancy/var',
+          'fancy/bin/fancy.exe',
+          'fancy/var/fancy.data',
+        ].join("\n")
+      )
+      Cask::FakeSystemCommand.stubs_command(
         ['/usr/sbin/pkgutil', '--pkg-info-plist', 'my.fancy.package.main'],
         <<-PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -125,6 +135,16 @@ describe Cask::Artifact::Uninstall do
         [
           'fancy',
           'fancy/agent',
+        ].join("\n")
+      )
+      Cask::FakeSystemCommand.stubs_command(
+        ['/usr/sbin/pkgutil', '--files', 'my.fancy.package.agent'],
+        [
+          'fancy',
+          'fancy/agent',
+          'fancy/agent/fancy-agent.exe',
+          'fancy/agent/fancy-agent.pid',
+          'fancy/agent/fancy-agent.log',
         ].join("\n")
       )
       Cask::FakeSystemCommand.stubs_command(

--- a/test/cask/pkg_test.rb
+++ b/test/cask/pkg_test.rb
@@ -6,10 +6,13 @@ describe Cask::Pkg do
       pkg = Cask::Pkg.new('my.fake.pkg', Cask::NeverSudoSystemCommand)
 
       some_files = Array.new(3) { Pathname(Tempfile.new('testfile').path) }
-      pkg.stubs(:list).with('files').returns some_files
+      pkg.stubs(:pkgutil_bom_files).returns some_files
+
+      some_specials = Array.new(3) { Pathname(Tempfile.new('testfile').path) }
+      pkg.stubs(:pkgutil_bom_specials).returns some_specials
 
       some_dirs = Array.new(3) { Pathname(Dir.mktmpdir) }
-      pkg.stubs(:list).with('dirs').returns some_dirs
+      pkg.stubs(:pkgutil_bom_dirs).returns some_dirs
 
       pkg.stubs(:forget)
 
@@ -27,6 +30,9 @@ describe Cask::Pkg do
       )
       Cask::FakeSystemCommand.stubs_command(
         ['/usr/sbin/pkgutil', '--only-dirs', '--files', 'my.fake.pkg']
+                                            )
+      Cask::FakeSystemCommand.stubs_command(
+        ['/usr/sbin/pkgutil',                '--files', 'my.fake.pkg']
       )
 
       Cask::FakeSystemCommand.expects_command(
@@ -45,8 +51,9 @@ describe Cask::Pkg do
       intact_symlink = fake_dir.join('intact_symlink').tap { |path| path.make_symlink(fake_file) }
       broken_symlink = fake_dir.join('broken_symlink').tap { |path| path.make_symlink('im_nota_file') }
 
-      pkg.stubs(:list).with('files').returns([])
-      pkg.stubs(:list).with('dirs').returns([fake_dir])
+      pkg.stubs(:pkgutil_bom_specials).returns([])
+      pkg.stubs(:pkgutil_bom_files).returns([])
+      pkg.stubs(:pkgutil_bom_dirs).returns([fake_dir])
       pkg.stubs(:forget)
 
       pkg.uninstall
@@ -66,8 +73,9 @@ describe Cask::Pkg do
 
       fake_dir.chmod(0000)
 
-      pkg.stubs(:list).with('files').returns([fake_file])
-      pkg.stubs(:list).with('dirs').returns([fake_dir])
+      pkg.stubs(:pkgutil_bom_specials).returns([])
+      pkg.stubs(:pkgutil_bom_files).returns([fake_file])
+      pkg.stubs(:pkgutil_bom_dirs).returns([fake_dir])
       pkg.stubs(:forget)
 
       pkg.uninstall


### PR DESCRIPTION
`pkgutil --only-files` plus `pkgutil --only-dirs` does not
cover all files in the BOM.

Closes #5491
