### PR TITLE
Add Sony Homestream v1.1 cask

### DIFF
--- a/Casks/homestream.rb
+++ b/Casks/homestream.rb
@@ -1,0 +1,10 @@
+class Homestream < Cask
+  version '1.1'
+  sha256 '193dd9fb3488dfb754057b9c216e09fe2f0528b20a95bbe9b7d5f4b0556a4e2b'
+
+  url 'http://homestreamdownload.sony-europe.com/homestream-1.1-osx.tar.gz'
+  homepage 'http://www.sony.co.uk/hub/1237485339460'
+
+  link 'Homestream.app'
+  link 'Homestream-Console.app'
+end


### PR DESCRIPTION
This pull requests adds the Sony Homestream app used for media sharing with Sony network-enabled devices such as their TVs, Playstation 3/4, and other media centers produced by Sony.
