### PR TITLE
Upgrade LyX to v2.1.1

### DIFF
--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -1,8 +1,8 @@
 class Lyx < Cask
-  version '2.1.0'
-  sha256 'b6a44dffb9692e450827c6e39b88b77480ec7c757c458cdbb9000cc751963ffc'
+  version '2.1.1'
+  sha256 '6e354ef25b2b4b0b46f1c95d048bef93917b794d227d841f03c0c5d1002ba923'
 
-  url 'ftp://ftp.lyx.org/pub/lyx/bin/2.1.0/LyX-2.1.0+qt4-cocoa.dmg'
+  url 'ftp://ftp.lyx.org/pub/lyx/bin/2.1.1/LyX-2.1.1+qt4-x86_64-cocoa.dmg'
   homepage 'http://www.lyx.org'
 
   link 'LyX.app'


### PR DESCRIPTION
Would prefer it if the .sig files was also verified against, see #164.
ftp://ftp.lyx.org/pub/lyx/bin/2.1.1/
ftp://ftp.lyx.org/pub/lyx/bin/2.1.1/LyX-2.1.1+qt4-x86_64-cocoa.dmg
ftp://ftp.lyx.org/pub/lyx/bin/2.1.1/LyX-2.1.1+qt4-x86_64-cocoa.dmg.sig

Edit: URL format has changed. Got a timeout during test installation, but thought it was temporary. Updating patch.
