### PR TITLE
Add Rekordbox v3.0.0

### DIFF
--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -1,0 +1,11 @@
+class Rekordbox < Cask
+  version '3.0.0_2369'
+  sha256 '5e3887ab45ea780307e6fabb6ff84cb836d60ad42ed1030df3e91010d994ba31'
+
+  url 'http://dl.pioneer.jp/dl/rekordbox/mac/Install_rekordbox_3_0_0_2369.pkg.zip'
+  homepage 'http://rekordbox.com/en/'
+
+  install 'Install_rekordbox_3_0_0_2369.pkg'
+  uninstall :pkgutil => 'com.pioneer.rekordbox.3.*',
+    :files => '/Applications/rekordbox 3/'
+end


### PR DESCRIPTION
App to manage music for Pioneer CDJs.

The installer has a `postinstall` script, that moves files from `/tmp` to `/Applications`, so `pkgutil` cannot remove the files properly. Therefore we need to delete them manually.

This is only my second cask, so if you find a better way for uninstall, please share! 
