### PR TITLE
Upgrade Clarify.app to v2.0.1

### DIFF
--- a/Casks/clarify.rb
+++ b/Casks/clarify.rb
@@ -2,7 +2,7 @@ class Clarify < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'http://www.bluemangolearning.com/download/clarify/1_0/release/clarify.dmg'
+  url 'http://www.clarify-it.com/download/mac/Clarify.dmg'
   homepage 'http://www.clarify-it.com/'
 
   link 'Clarify.app'


### PR DESCRIPTION
Clarify 2 recently launched, so I updated the URL to pull the new DMG.
