### PR TITLE
bug: use `install_phase` in `caskroom_only` and `qlplugin`

### DIFF
--- a/lib/cask/artifact/caskroom_only.rb
+++ b/lib/cask/artifact/caskroom_only.rb
@@ -3,7 +3,7 @@ class Cask::Artifact::CaskroomOnly < Cask::Artifact::Base
     :caskroom_only
   end
 
-  def install
+  def install_phase
     # do nothing
   end
 end

--- a/lib/cask/artifact/qlplugin.rb
+++ b/lib/cask/artifact/qlplugin.rb
@@ -3,7 +3,7 @@ class Cask::Artifact::Qlplugin < Cask::Artifact::Symlinked
     'QuickLook Plugin'
   end
 
-  def install
+  def install_phase
     super
     @command.run!('/usr/bin/qlmanage', :args => ['-r'])
   end


### PR DESCRIPTION
Missed in #4865.  `install` method was renamed.
Bug exercised by Cask `amazon_music.rb`.
