### PR TITLE
Apply proper symlink for 'Messenger for Telegram'

### DIFF
--- a/Casks/messenger-for-telegram.rb
+++ b/Casks/messenger-for-telegram.rb
@@ -6,5 +6,5 @@ class MessengerForTelegram < Cask
   appcast 'https://rink.hockeyapp.net/api/2/apps/c55f5e74ae5d0ad254df29f71a1b5f0e'
   homepage 'https://vk.com/telegram_osx'
 
-  link 'Messenger for Telegram.app'
+  link 'Telegram.app'
 end


### PR DESCRIPTION
Fix for #5584 
