### PR TITLE
Update node-webkit to 0.10.1

### DIFF
--- a/Casks/node-webkit.rb
+++ b/Casks/node-webkit.rb
@@ -1,8 +1,8 @@
 class NodeWebkit < Cask
-  version '0.10.0'
-  sha256 '37e2000b5bbc9a96c55ab15c86b21aeb38de2aa7d373c04c5f820d5bae07dc54'
+  version '0.10.1'
+  sha256 '8842b014d4c1719dbdbb4a6d5f5172c77375b068c44720f5b7166d7acbdeaf2a'
 
-  url "http://dl.node-webkit.org/v#{version}/node-webkit-v#{version}-osx-ia32.zip"
+  url "http://dl.node-webkit.org/v#{version}/node-webkit-v#{version}-osx-x64.zip"
   homepage 'https://github.com/rogerwang/node-webkit'
 
   caskroom_only true


### PR DESCRIPTION
The node-webkit cask now installs the 64-bit release. The 32-bit release will be available in the Versions repository.
