### PR TITLE
Update Hive to 1.3.3

### DIFF
--- a/Casks/hive.rb
+++ b/Casks/hive.rb
@@ -1,8 +1,8 @@
 class Hive < Cask
-  version '1.3.2'
-  sha256 '1a903d177315bbd9268bb9202a30c3a7b929a74b0afb8f271fd13e9c955f74f7'
+  version '1.3.3'
+  sha256 '62d10ca58f11b984221fdf04d4d1fd307f191275f04815a8f6ed1ec65c51a7cc'
 
-  url 'https://github.com/hivewallet/hive-osx/releases/download/1.3.2/Hive-1.3.2.zip'
+  url "https://github.com/hivewallet/hive-osx/releases/download/#{version}/Hive-#{version}.zip"
   appcast 'https://hivewallet.com/hive-osx-appcast.xml'
   homepage 'http://www.hivewallet.com'
 


### PR DESCRIPTION
Additionally, reuse `version` value in `url` stanza.
