### PR TITLE
refactor GenericUnar container class

### DIFF
--- a/lib/cask/container.rb
+++ b/lib/cask/container.rb
@@ -1,12 +1,12 @@
 class Cask::Container; end
 
 require 'cask/container/base'
-require 'cask/container/unarbase'
 require 'cask/container/air'
 require 'cask/container/bzip2'
 require 'cask/container/cab'
 require 'cask/container/criteria'
 require 'cask/container/dmg'
+require 'cask/container/generic_unar'
 require 'cask/container/gzip'
 require 'cask/container/naked'
 require 'cask/container/sevenzip'

--- a/lib/cask/container/generic_unar.rb
+++ b/lib/cask/container/generic_unar.rb
@@ -1,6 +1,6 @@
 require 'tmpdir'
 
-class Cask::Container::UnarBase < Cask::Container::Base
+class Cask::Container::GenericUnar < Cask::Container::Base
   def self.me?(criteria)
     ! criteria.lsar.nil? and
       criteria.lsar.include? 'passed, 0 failed'

--- a/lib/cask/container/rar.rb
+++ b/lib/cask/container/rar.rb
@@ -1,4 +1,4 @@
-class Cask::Container::Rar < Cask::Container::UnarBase
+class Cask::Container::Rar < Cask::Container::GenericUnar
   def self.me?(criteria)
     (criteria.file.include? 'application/x-rar;' or
      criteria.file.include? 'application/octet-stream;') and

--- a/lib/cask/container/sevenzip.rb
+++ b/lib/cask/container/sevenzip.rb
@@ -1,4 +1,4 @@
-class Cask::Container::SevenZip < Cask::Container::UnarBase
+class Cask::Container::SevenZip < Cask::Container::GenericUnar
   def self.me?(criteria)
     # todo: cover self-extracting archives
     criteria.extension '7z' and

--- a/lib/cask/container/sit.rb
+++ b/lib/cask/container/sit.rb
@@ -1,4 +1,4 @@
-class Cask::Container::Sit < Cask::Container::UnarBase
+class Cask::Container::Sit < Cask::Container::GenericUnar
   def self.me?(criteria)
     criteria.file.include? 'application/x-stuffit' and
       ! criteria.lsar.nil? and


### PR DESCRIPTION
This is just a matter of semantics: renaming the abstract base
class `Cask::Container::UnarBase` so that it makes sense when
referring to it in a `container_type` stanza.
