### PR TITLE
Added new Cask for SublerCLI (Subler Command Line Interface)

### DIFF
--- a/Casks/sublercli.rb
+++ b/Casks/sublercli.rb
@@ -1,0 +1,9 @@
+class Sublercli < Cask
+  version '0.19'
+  sha256 '968c6c0ff530ee603a5a3deec93911cc1c5c1fd8b100883cb485278fccc79104'
+
+  url 'https://subler.googlecode.com/files/SublerCLI-0.19.zip'
+  homepage 'https://code.google.com/p/subler/'
+
+  binary 'SublerCLI'
+end


### PR DESCRIPTION
Added a new Cask to be able to install SublerCLI which is the CLI for Subler, this is not included in the Subler binary distribution and it is distributed as a separate package
