### PR TITLE
rename messenger-for-telegram.rb to telegram.rb

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,4 +1,4 @@
-class MessengerForTelegram < Cask
+class Telegram < Cask
   version 'latest'
   sha256 :no_check
 


### PR DESCRIPTION
Apparently upstream has changed the application name.

References: #5585
