### PR TITLE
Update Typinator cask with URL, version, sha256, and caveat

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,8 +1,8 @@
 class Typinator < Cask
-  version 'latest'
-  sha256 :no_check
+  version '6.1'
+  sha256 'd08ad4595a3d1668ad5542030149ff7f9a9188eb5400b2fcda909c3ed4b36997'
 
-  url 'http://www.ergonis.com/downloads/typinator-install.dmg'
+  url 'http://www.ergonis.com/downloads/products/typinator/Typinator61-Install.dmg'
   homepage 'http://www.ergonis.com/'
 
   link 'Typinator.app'

--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -6,4 +6,5 @@ class Typinator < Cask
   homepage 'http://www.ergonis.com/'
 
   link 'Typinator.app'
+  caveats { assistive_devices }
 end


### PR DESCRIPTION
The URL for Typinator has been relocated, and the new location is
versioned, so changing the caskfile to be versioned.

Also adding the assistive devices caveat.
