### PR TITLE
Tower 2 doesn't have an appcast url right now

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -3,7 +3,6 @@ class Tower < Cask
   sha256 :no_check
 
   url 'https://www.git-tower.com/download'
-  appcast 'https://macapps.fournova.com/tower1-1060/updates.xml'
   homepage 'http://www.git-tower.com/'
 
   link 'Tower.app'


### PR DESCRIPTION
I removed the appcast url from Tower because there's no appcast url in the Info.plist (reads `NULL` right now). Current appcast points to Tower 1, which is now PR'd in the versions repo.
