### PR TITLE
Update boot2docker to v1.1.2

### DIFF
--- a/Casks/boot2docker.rb
+++ b/Casks/boot2docker.rb
@@ -1,10 +1,10 @@
 class Boot2docker < Cask
-  version '1.1.1'
-  sha256 'cde211e758737d290d927afc8167c55ebb490c5569998332fb0a524d5f7a02eb'
+  version '1.1.2'
+  sha256 'd85b77ac181987fa4b41b5e50d54b05e47165b675242abd20170a460e6797e7a'
 
-  url 'https://github.com/boot2docker/osx-installer/releases/download/v1.1.1/Boot2Docker-1.1.1.pkg'
+  url 'https://github.com/boot2docker/osx-installer/releases/download/v1.1.2/Boot2Docker-1.1.2.pkg'
   homepage 'https://github.com/boot2docker/osx-installer'
 
-  install 'Boot2Docker-1.1.1.pkg'
+  install 'Boot2Docker-1.1.2.pkg'
   uninstall :pkgutil => ['io.boot2docker.pkg.boot2docker', 'io.boot2docker.pkg.boot2dockerapp', 'io.boot2dockeriso.pkg.boot2dockeriso', 'io.docker.pkg.docker']
 end


### PR DESCRIPTION
Release details: http://git.io/vHbTaQ
