### PR TITLE
Update Racket to 6.1

### DIFF
--- a/Casks/racket.rb
+++ b/Casks/racket.rb
@@ -1,9 +1,9 @@
 class Racket < Cask
-  version '6.0.1'
-  sha256 '92cc13955a70ee6f350bfb0d639072b2b1e0504184102660429f5404bc14785b'
+  version '6.1'
+  sha256 'b7f12dcc2d60770e7da7e8268d4ac46db2c666302cd5472d414d5b4b30cd529b'
 
-  url 'http://mirror.racket-lang.org/installers/6.0.1/racket-6.0.1-x86_64-macosx.dmg'
+  url "http://mirror.racket-lang.org/installers/#{version}/racket-#{version}-x86_64-macosx.dmg"
   homepage 'http://racket-lang.org/'
 
-  link 'Racket v6.0.1'
+  link "Racket v#{version}"
 end


### PR DESCRIPTION
Additionally, reuse `version` value in `url` and `link` stanzas.

Closes #5630.
