### PR TITLE
Add JetPhoto Studio v5.5

### DIFF
--- a/Casks/jetphoto-studio.rb
+++ b/Casks/jetphoto-studio.rb
@@ -1,0 +1,10 @@
+class JetphotoStudio < Cask
+  version '5.5'
+  sha256 'c583a173d018696d613545acacba4c43f641d770de4e5d5bbb0964c1cb2e9f7f'
+
+  url 'http://www.jetphotosoft.com/web/download/JetPhoto_Studio_mac5.5.zip'
+  homepage 'http://www.jetphotosoft.com/web/home/'
+
+  nested_container 'JetPhoto Studio 5.5.dmg'
+  link 'JetPhoto Studio.app'
+end


### PR DESCRIPTION
JetPhoto Studio is a feature-rich and easy-to-use digital photography software.
- Organizes photos in albums
- Manage photos with the calendar and map
- Geotag photos with GPS
- Create Flash and Web galleries
- Publish web albums with JetPhoto Server
