### PR TITLE
Update Audiobookbinder to v2.0

### DIFF
--- a/Casks/audiobookbinder.rb
+++ b/Casks/audiobookbinder.rb
@@ -1,8 +1,8 @@
 class Audiobookbinder < Cask
-  version '1.18'
-  sha256 'b6b8ad12378710fb73c0db990f6fb471f0bba163ad83c84958992d62c106e588'
+  version '2.0'
+  sha256 '7f66fab2041666b2b4d2f4547035804ee9fa7cc5487d6a428f5354e0a793064b'
 
-  url 'http://bluezbox.com/audiobookbinder/AudiobookBinder-1.18.dmg'
+  url 'http://bluezbox.com/audiobookbinder/AudiobookBinder-2.0.dmg'
   appcast 'http://bluezbox.com/audiobookbinder/appcast.xml'
   homepage 'http://bluezbox.com/audiobookbinder.html'
 


### PR DESCRIPTION
Release: http://git.io/ZBO0lA
Homepage: http://bluezbox.com/audiobookbinder.html
