### PR TITLE
removed airmail

### DIFF
--- a/Casks/airmail.rb
+++ b/Casks/airmail.rb
@@ -1,9 +1,0 @@
-class Airmail < Cask
-  version 'latest'
-  sha256 :no_check
-
-  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
-  homepage 'http://airmailapp.com/'
-
-  link 'AirMail Beta.app'
-end


### PR DESCRIPTION
Like [vox, this is a beta of an app that has a stable version on the MAS](https://github.com/caskroom/homebrew-cask/pull/5319). As such, it should be in [caskroom versions](https://github.com/caskroom/homebrew-versions).

Not merging yet, to allow for possible discussion.
