### PR TITLE
Add Tower2 appcast url

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -3,6 +3,7 @@ class Tower < Cask
   sha256 :no_check
 
   url 'https://www.git-tower.com/download'
+  appcast 'https://updates.fournova.com/updates/tower2-mac/stable'
   homepage 'http://www.git-tower.com/'
 
   link 'Tower.app'


### PR DESCRIPTION
Hi,

I've sent an email to Tower and they answered me with the new appcast url.

Stable: https://updates.fournova.com/updates/tower2-mac/stable
Beta: https://updates.fournova.com/updates/tower2-mac/beta

So I've added the new appcast url to the Tower cast.
