### PR TITLE
Add Alarm Clock by Robbie Hanson

### DIFF
--- a/Casks/alarm-clock.rb
+++ b/Casks/alarm-clock.rb
@@ -1,0 +1,9 @@
+class AlarmClock < Cask
+  version '2.4.5'
+  sha256 '285d277572be83c632c696d565a8413c2d5149a460392177e9e1b601ffce8778'
+
+  url 'http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/downloads/Alarm%20Clock%20(2.4.5).dmg'
+  homepage 'http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/index.html'
+
+  link 'Alarm Clock.app'
+end


### PR DESCRIPTION
The app is no longer maintained, but still actively used judging by how often I hear it mentioned.

It feels decidedly silly to use the Internet Archive Wayback Machine for the .dmg. At the same time, I feel more inclined to trust them than MacUpdate or CNET to keep the link alive...

Let me know what you think.
