### PR TITLE
Update Doxie.app to latest

### DIFF
--- a/Casks/doxie.rb
+++ b/Casks/doxie.rb
@@ -1,8 +1,8 @@
 class Doxie < Cask
-  version '2.6'
-  sha256 '4d00f1aee0db17fb60859b0f81dd8dc17342d85988f1ada69a23ed69a0e00934'
+  version 'latest'
+  sha256 :no_check
 
-  url 'http://cdn.getdoxie.com/resources/files/Doxie_2_6.dmg'
+  url 'http://www.getdoxie.com/resources/files/download_current_mac.php'
   homepage 'http://www.getdoxie.com/'
 
   link 'Doxie.app'


### PR DESCRIPTION
The previous link to 2.6 no longer works as it’s now http://cdn.getdoxie.com/resources/files/Doxie_2_6_1523.dmg — but I think it’s more robust to go through their PHP redirect script.
