### PR TITLE
Add 0xDBE EAP 138.1400.3

### DIFF
--- a/Casks/zeroxdbe-eap.rb
+++ b/Casks/zeroxdbe-eap.rb
@@ -1,0 +1,13 @@
+class ZeroxdbeEap < Cask
+  version '138.1400.3'
+  sha256 '1f16618a29f004e5e846d6a7ccfa3afa2115886b94294b71c28781427a9589b5'
+
+  url 'http://download.jetbrains.com/dbe/0xdbe-138.1400.3.dmg'
+  homepage 'http://www.jetbrains.com/dbe/'
+
+  link '0xDBE EAP.app'
+
+  after_install do
+    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/0xDBE\ EAP.app/Contents/Info.plist"
+  end
+end


### PR DESCRIPTION
As titled. Since Ruby class couldn't be started with '0', I used abbreviation 'DBE' for cask name which is also used in JetBrain website.
