### PR TITLE
Implement list -1

### DIFF
--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -1,5 +1,7 @@
 class Cask::CLI::List < Cask::CLI::Base
   def self.run(*arguments)
+    @options = Hash.new
+    @options[:one] = true if arguments.delete('-1')
     if arguments.any?
       retval = list_casks(*arguments)
     else
@@ -47,7 +49,11 @@ class Cask::CLI::List < Cask::CLI::Base
   def self.list_installed
     installed_casks = Cask.installed
     columns = installed_casks.map(&:to_s)
-    puts_columns columns
+    if @options[:one]
+      puts columns
+    else
+      puts_columns columns
+    end
     columns.empty? ? nil : installed_casks.length == columns.length
   end
 


### PR DESCRIPTION
I would like to use list option with `-1` like the brew command.

``` bash
$ brew list -1
ack
autoconf
...

$ brew list
ack             go              libpng              mysql               rbenv-default-gems
autoconf            groonga             libtool             openssl             readline
...
```

How about this?

``` bash
$ brew cask list -1
alfred
android-studio
appcleaner
vagrant
virtualbox

$ brew cask list
alfred      android-studio  appcleaner  vagrant     virtualbox
```
