### PR TITLE
Add Universal Media Server.app v4.0.2 for Java8

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,0 +1,9 @@
+class UniversalMediaServer < Cask
+  version '4.0.2'
+  sha256 '9fabc3561151aa256237cded007a25f776383bbcaf18d6bb58bb5a16c11e4e8c'
+
+  url 'http://downloads.sourceforge.net/sourceforge/unimediaserver/Official%20Releases/OS%20X/UMS-4.0.2-Java8.dmg'
+  homepage 'www.universalmediaserver.com'
+
+  link 'Universal Media Server.app'
+end


### PR DESCRIPTION
The authors of UMS decided to make 3 executables for each release, e.g. Java6, Java7 and Java8 for every host OS. Any ideas are welcome, I decided to go for Java8 since this is the default in "java.rb".
