### PR TITLE
always default to latest hardware/OS in conditionals

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,12 +1,12 @@
 class Aquamacs < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-3.0a/Aquamacs-Emacs-3.0a.dmg'
-    version '3.0a'
-    sha256 '1d833cb2e40c1af96713badc4efa7c1c9259317b91edcfe17059c73e989f9e07'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://braeburn.aquamacs.org/releases/Aquamacs-Emacs-2.5.dmg'
     version '2.5'
     sha256 '5857848d8d46bba43d160c02393b098a370e2156608be24b288419f668210be9'
+  else
+    url 'https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-3.0a/Aquamacs-Emacs-3.0a.dmg'
+    version '3.0a'
+    sha256 '1d833cb2e40c1af96713badc4efa7c1c9259317b91edcfe17059c73e989f9e07'
   end
   homepage 'http://aquamacs.org/'
   link 'Aquamacs.app'

--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -1,15 +1,15 @@
 class Bassjump < Cask
-  if MacOS.version == :mavericks
+  if MacOS.version < :mavericks
+    url 'http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpSoundSystem-2.0.3-249-ML.mpkg.zip'
+    version '2.0.3'
+    sha256 '8e4dffa6bb3b532b994f379d19d70903f59fc019916f10cba9d01b8075d69a7f'
+    install 'BassJump Sound System-2.0.3-249-ML.mpkg'
+  else
     url 'http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpInstaller_2.5.1.dmg.zip'
     version '2.5.1'
     sha256 '14408480cded51f6334753639e973ebbf2fc40f34ff64e1c35d2f32507d88afd'
     nested_container 'BassJumpInstaller_2.5.1.dmg'
     install 'BassJumpInstaller.pkg'
-  else
-    url 'http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpSoundSystem-2.0.3-249-ML.mpkg.zip'
-    version '2.0.3'
-    sha256 '8e4dffa6bb3b532b994f379d19d70903f59fc019916f10cba9d01b8075d69a7f'
-    install 'BassJump Sound System-2.0.3-249-ML.mpkg'
   end
   homepage 'http://www.twelvesouth.com/product/bassjump-2-for-macbook'
   caveats do

--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -1,17 +1,17 @@
 class Coconutbattery < Cask
-  if MacOS.version == :lion or MacOS.version == :mountain_lion or MacOS.version == :mavericks
-    url 'http://www.coconut-flavour.com/downloads/coconutBattery_3_1.zip'
-    appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml'
-    version '3.1'
-    sha256 'fee4c3e0ccc9c6ea1acc0dc7b3191ff6bf727df03cb9cb269a9347cd0e931618'
-  elsif MacOS.version == :leopard or MacOS.version == :snow_leopard
+  if MacOS.version < :leopard
+    url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.6.6.zip'
+    version '2.6.6'
+    sha256 '8d235b237e42754ceda26af2babc160fd23f890d0fe6d7780b86a8e9c6effe42'
+  elsif MacOS.version < :lion
     url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.8.zip'
     version '2.8'
     sha256 'fcfc81214ff26afff9f5c6c7cdc455b23ac898b6918f864b641a9e31526692d4'
   else
-    url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.6.6.zip'
-    version '2.6.6'
-    sha256 '8d235b237e42754ceda26af2babc160fd23f890d0fe6d7780b86a8e9c6effe42'
+    url 'http://www.coconut-flavour.com/downloads/coconutBattery_3_1.zip'
+    appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml'
+    version '3.1'
+    sha256 'fee4c3e0ccc9c6ea1acc0dc7b3191ff6bf727df03cb9cb269a9347cd0e931618'
   end
   homepage 'http://www.coconut-flavour.com/coconutbattery/'
   link 'coconutBattery.app'

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,9 +1,9 @@
 class EclipseIde < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa-x86_64.tar.gz'
+  if Hardware::CPU.is_32_bit?
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa.tar.gz'
     sha256 'c902ee4d9f753b2bc48f7194ea9f5bb98a264a984f6aaead710f8b601c574505'
   else
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa.tar.gz'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa-x86_64.tar.gz'
     sha256 'c902ee4d9f753b2bc48f7194ea9f5bb98a264a984f6aaead710f8b601c574505'
   end
   version '4.4.0'

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,10 +1,10 @@
 class EclipseJava < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa-x86_64.tar.gz'
-    sha256 '4902bdb5eb64dbcef86b10838a3734c1148d3d85ae8454f71a6929292de43784'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa.tar.gz'
     sha256 '11ebf6c2deb9d0f656ddf0ced4b65e340a2ec80426786440f687f164bd973b1e'
+  else
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa-x86_64.tar.gz'
+    sha256 '4902bdb5eb64dbcef86b10838a3734c1148d3d85ae8454f71a6929292de43784'
   end
   version '4.4.0'
   homepage 'http://eclipse.org/'

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -2,10 +2,10 @@ class EclipseJee < Cask
   version 'latest'
   sha256 :no_check
 
-  if Hardware::CPU.is_64_bit?
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-jee-luna-R-macosx-cocoa-x86_64.tar.gz'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-jee-luna-R-macosx-cocoa.tar.gz'
+  else
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-jee-luna-R-macosx-cocoa-x86_64.tar.gz'
   end
 
   homepage 'http://eclipse.org/'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,10 +1,10 @@
 class EclipsePlatform < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa-x86_64.tar.gz'
-    sha256 '09e127b85b136f60bec18c4c823596c145dbc5fbcfe6af0e4fe2a27590ffa5a0'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa.tar.gz'
     sha256 '28e873cc4e575bbf3abb364ccd7dec59394891f5ca80ee7b591a7982345d0ab9'
+  else
+    url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa-x86_64.tar.gz'
+    sha256 '09e127b85b136f60bec18c4c823596c145dbc5fbcfe6af0e4fe2a27590ffa5a0'
   end
   version '4.4.0'
   homepage 'http://eclipse.org'

--- a/Casks/gambit-c.rb
+++ b/Casks/gambit-c.rb
@@ -1,12 +1,12 @@
 class GambitC < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v4_7_2-macosx-intel64.dmg'
-    sha256 '2be0b846bb469fad9c4501efa3d34ed7aab6cc2d2fdc5acbe4eb39c4dc39b4bd'
-    install 'gambc-v4_7_2-macosx-intel64.pkg'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v4_7_2-macosx-intel32.dmg'
     sha256 'fb19aceeeac5e7ce4ae7e1a07dbf8ab81906d372fbea56493171aa0bfe47899c'
     install 'gambc-v4_7_2-macosx-intel32.pkg'
+  else
+    url 'http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v4_7_2-macosx-intel64.dmg'
+    sha256 '2be0b846bb469fad9c4501efa3d34ed7aab6cc2d2fdc5acbe4eb39c4dc39b4bd'
+    install 'gambc-v4_7_2-macosx-intel64.pkg'
   end
   homepage 'http://gambitscheme.org/wiki/index.php/Main_Page'
   version '4.7.2'

--- a/Casks/geppetto.rb
+++ b/Casks/geppetto.rb
@@ -1,10 +1,10 @@
 class Geppetto < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86_64-4.2.0-R201407250959.zip'
-    sha256 '7a09c823cea9900cb51d009f47fab69569e1d8115c6326f3e91db62714480d69'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86-4.2.0-R201407250959.zip'
     sha256 '78f578ff4cf0a9eadf85cc5a821e55125ee98ab4a8e1d4f0f5d1607487314804'
+  else
+    url 'https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86_64-4.2.0-R201407250959.zip'
+    sha256 '7a09c823cea9900cb51d009f47fab69569e1d8115c6326f3e91db62714480d69'
   end
   homepage 'http://puppetlabs.github.io/geppetto/'
   version '4.2.0'

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -1,7 +1,5 @@
 class GitAnnex < Cask
-  if MacOS.version == :mavericks
-    url 'http://downloads.kitenet.net/git-annex/OSX/current/10.9_Mavericks/git-annex.dmg'
-  else
+  if MacOS.version < :mavericks
     url 'http://downloads.kitenet.net/git-annex/OSX/current/10.8.2_Mountain_Lion/git-annex.dmg.bz2'
     # This is a horrible hack to force the file extension.  The
     # backend code should be fixed so that this is not needed.
@@ -9,6 +7,8 @@ class GitAnnex < Cask
       system '/bin/mv', '--', destination_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
     end
     nested_container 'git-annex-latest.dmg'
+  else
+    url 'http://downloads.kitenet.net/git-annex/OSX/current/10.9_Mavericks/git-annex.dmg'
   end
   homepage 'http://git-annex.branchable.com/'
   version 'latest'

--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -1,16 +1,16 @@
 class Golly < Cask
   version '2.6'
 
-  if MacOS.version == :mavericks
-    url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac109.zip"
-    sha256 '360c1e279d89fc3a19bed9c75dfe5b1085a67672490f17fe38941cab3680b983'
-    link "golly-#{version}-mac109/Golly.app"
-    binary "golly-#{version}-mac109/bgolly"
-  else
+  if MacOS.version < :mavericks
     url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac106.zip/"
     sha256 '6fee35e8e4f63ee2c1b0913b7e8009b2548c4e4469050f9c31791900e1e97f16'
     link "golly-#{version}-mac106/Golly.app"
     binary "golly-#{version}-mac106/bgolly"
+  else
+    url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac109.zip"
+    sha256 '360c1e279d89fc3a19bed9c75dfe5b1085a67672490f17fe38941cab3680b983'
+    link "golly-#{version}-mac109/Golly.app"
+    binary "golly-#{version}-mac109/bgolly"
   end
 
   homepage 'http://golly.sourceforge.net/'

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -2,12 +2,12 @@ class Libreoffice < Cask
   homepage 'https://www.libreoffice.org/'
   version '4.3.0'
 
-  if Hardware::CPU.is_64_bit? && OS::Mac.version >= '10.8'
-    url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
-    sha256 '80772ed238b2033233aa2867962cfbb6f701ae81b3f592971149f8e3e54504bf'
-  else
+  if Hardware::CPU.is_32_bit? or MacOS.version < :mountain_lion
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
     sha256 '31b84237db80f655aabcc3962c4a5e4fd84318adb6db1b3b311a883f16af1164'
+  else
+    url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
+    sha256 '80772ed238b2033233aa2867962cfbb6f701ae81b3f592971149f8e3e54504bf'
   end
 
   link 'LibreOffice.app'

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -1,12 +1,12 @@
 class Macports < Cask
-  if MacOS.version == :mavericks
-    url 'https://distfiles.macports.org/MacPorts/MacPorts-2.2.1-10.9-Mavericks.pkg'
-    sha256 '2df01bf88e1e3de32ada0f42a8a46fb992093baee62f9d911fa3ae3ee895d471'
-    install 'MacPorts-2.2.1-10.9-Mavericks.pkg'
-  else
+  if MacOS.version < :mavericks
     url 'https://distfiles.macports.org/MacPorts/MacPorts-2.2.1-10.8-MountainLion.pkg'
     sha256 'd10bf4a27f89709501e1370d7d80f415eaf16bae23fd9ff3d4e96f86afdf8cd6'
     install 'MacPorts-2.2.1-10.8-MountainLion.pkg'
+  else
+    url 'https://distfiles.macports.org/MacPorts/MacPorts-2.2.1-10.9-Mavericks.pkg'
+    sha256 '2df01bf88e1e3de32ada0f42a8a46fb992093baee62f9d911fa3ae3ee895d471'
+    install 'MacPorts-2.2.1-10.9-Mavericks.pkg'
   end
   homepage 'http://www.macports.org'
   version '2.2.1'

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,11 +1,11 @@
 class Macvim < Cask
-  if MacOS.version >= :mavericks
-    url 'https://github.com/b4winckler/macvim/releases/download/snapshot-73/MacVim-snapshot-73-Mavericks.tbz'
-  appcast 'http://b4winckler.github.com/macvim/appcast/stable.xml'
-    sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
-  else
+  if MacOS.version < :mavericks
     url 'https://github.com/eee19/macvim/releases/download/snapshot-73/MacVim-snapshot-73-Mountain-Lion.tbz'
     sha256 '7f573fb9693052a86845c0a9cbb0b3c3c33ee23294f9d8111187377e4d89f72c'
+  else
+    url 'https://github.com/b4winckler/macvim/releases/download/snapshot-73/MacVim-snapshot-73-Mavericks.tbz'
+    appcast 'http://b4winckler.github.com/macvim/appcast/stable.xml'
+    sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
   end
   homepage 'http://code.google.com/p/macvim/'
   version '7.4-73'

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,5 +1,5 @@
 class Middleclick < Cask
-  if MacOS.version == :snow_leopard or MacOS.version == :lion
+  if MacOS.version < :mountain_lion
     url 'http://clement.beffa.org/labs/downloads/MiddleClick.zip'
   elsif MacOS.version == :mountain_lion
     url 'http://clement.beffa.org/labs/downloads/MiddleClick_ml.zip'

--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,5 +1,5 @@
 class Opensesame < Cask
-  if MacOS.version == :snow_leopard
+  if MacOS.version < :lion
     url 'http://files.cogsci.nl/software/opensesame/opensesame_0.26-macos-2.zip'
     version '0.26'
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'

--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,11 +1,11 @@
 class P4v < Cask
   version '2014.1-888424'
-  if Hardware::CPU.is_64_bit?
+  if Hardware::CPU.is_32_bit?
+    sha256 '03b716dde2c39f4214c1b9b016e151225d8830e2e555b30234c5f9c1d2940a78'
+    url 'http://filehost.perforce.com/perforce/r14.1/bin.macosx106x86/P4V.dmg'
+  else
     sha256 'c5d05d78596fe9b4f83193a11805a027b2652fdf87365de1321e671286fdca3f'
     url 'http://filehost.perforce.com/perforce/r14.1/bin.macosx106x86_64/P4V.dmg'
-  else
-    sha256 '03b716dde2c39f4214c1b9b016e151225d8830e2e555b30234c5f9c1d2940a78'
-    url 'http://filehost.perforce.com/perforce/r14.1/bin.macosx106x86/P4V.dmg'  
   end
 
   homepage 'http://www.perforce.com/product/components/perforce-visual-client'

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,10 +1,10 @@
 class Paraview < Cask
-  if MacOS.version == :mavericks
-    url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit.dmg'
-    sha256 '1eef4a2ee155049059967733e40010e86cc6cd05458de676217af5c276995817'
-  else
+  if MacOS.version < :mavericks
     url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit-Lion-Python27.dmg'
     sha256 '8784481c90b58b0c6158e21b7f978a7d78caa67c63d28d6d5d770ef43f0ad890'
+  else
+    url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit.dmg'
+    sha256 '1eef4a2ee155049059967733e40010e86cc6cd05458de676217af5c276995817'
   end
   homepage 'http://www.paraview.org/'
   version '4.1.0'

--- a/Casks/plex-home-theater.rb
+++ b/Casks/plex-home-theater.rb
@@ -1,12 +1,12 @@
 class PlexHomeTheater < Cask
   version '1.2.1.314'
 
-  if MacOS.prefer_64_bit?
-    sha256 '0e243ca7112cccd11f75bf799ff21a69413dc1eca6652f934ed456ac54fab5ae'
-    url 'http://downloads.plexapp.com/plex-home-theater/1.2.1.314-7cb0133e/PlexHomeTheater-1.2.1.314-7cb0133e-macosx-x86_64.zip'
-  else
+  if Hardware::CPU.is_32_bit?
     sha256 '87954578b4aa1ec93876115967b0da61d6fa47f3f1125743a55f688366d56860'
     url 'http://downloads.plexapp.com/plex-home-theater/1.2.1.314-7cb0133e/PlexHomeTheater-1.2.1.314-7cb0133e-macosx-i386.zip'
+  else
+    sha256 '0e243ca7112cccd11f75bf799ff21a69413dc1eca6652f934ed456ac54fab5ae'
+    url 'http://downloads.plexapp.com/plex-home-theater/1.2.1.314-7cb0133e/PlexHomeTheater-1.2.1.314-7cb0133e-macosx-x86_64.zip'
   end
 
   homepage 'https://plex.tv'

--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,12 +1,12 @@
 class Praat < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'http://www.fon.hum.uva.nl/praat/praat5382_mac64.dmg'
-    version '5.3.82'
-    sha256 'c02aa1ae0e896325cbc8a917e5cfef37a0f6e38e78d2b71757134158f7e563f3'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://www.fon.hum.uva.nl/praat/praat5382_mac32.dmg'
     version '5.3.82'
     sha256 'c1ef06ed8fd9e36d5eb96699daf5fba3e04e2c32edcda0c2981d8f817c019371'
+  else
+    url 'http://www.fon.hum.uva.nl/praat/praat5382_mac64.dmg'
+    version '5.3.82'
+    sha256 'c02aa1ae0e896325cbc8a917e5cfef37a0f6e38e78d2b71757134158f7e563f3'
   end
   homepage 'http://www.fon.hum.uva.nl/praat/'
   link 'Praat.app'

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,12 +1,12 @@
 class R < Cask
-  if MacOS.version == :mavericks
-    url 'http://cran.rstudio.com/bin/macosx/R-3.1.1-mavericks.pkg'
-    sha256 'd2f4e4f68628d998f81146eacd929ef6fb9bc01ca93d968e6562a3a6372c4d93'
-    install 'R-3.1.1-mavericks.pkg'
-  else
+  if MacOS.version < :mavericks
     url 'http://cran.rstudio.com/bin/macosx/R-3.1.1-snowleopard.pkg'
     sha256 '4db95d2bffdaa342a89d01088f47cfe6575ed7e953c31ea4dea629a0942b56b6'
     install 'R-3.1.1-snowleopard.pkg'
+  else
+    url 'http://cran.rstudio.com/bin/macosx/R-3.1.1-mavericks.pkg'
+    sha256 'd2f4e4f68628d998f81146eacd929ef6fb9bc01ca93d968e6562a3a6372c4d93'
+    install 'R-3.1.1-mavericks.pkg'
   end
   homepage 'http://www.r-project.org/'
   version '3.1.1'

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -2,15 +2,15 @@ class Reaper < Cask
   homepage 'http://www.reaper.fm/'
   version '4.71'
 
-  if Hardware::CPU.is_64_bit?
-    url 'http://www.reaper.fm/files/4.x/reaper471_x86_64.dmg'
-    sha256 '3045fd59189bd0fe398b50f511d014a5e385c8cfb88f8a188a8437050f783d71'
-    link 'REAPER64.app'
-    link 'ReaMote64.app'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://www.reaper.fm/files/4.x/reaper471_i386.dmg'
     sha256 '1a670d5afb5956e1486c1fdef008ccfb4faa7987cc4d5ea8171a2794ff86ffca'
     link 'REAPER.app'
     link 'ReaMote.app'
+  else
+    url 'http://www.reaper.fm/files/4.x/reaper471_x86_64.dmg'
+    sha256 '3045fd59189bd0fe398b50f511d014a5e385c8cfb88f8a188a8437050f783d71'
+    link 'REAPER64.app'
+    link 'ReaMote64.app'
   end
 end

--- a/Casks/streamtools.rb
+++ b/Casks/streamtools.rb
@@ -1,12 +1,12 @@
 class Streamtools < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'https://github.com/nytlabs/streamtools/releases/download/v0.2.3/st_darwin_amd64-0.2.3.tar.gz'
-    sha256 'dd8a2d82b018ad283fbdea8bb2427814e87f6bbe070367ba07b4c054d758d75c'
-    binary 'st_darwin_amd64-0.2.3/st'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'https://github.com/nytlabs/streamtools/releases/download/v0.2.3/st_darwin_386-0.2.3.tar.gz'
     sha256 'dd69376923570ea12846bcd75b3a9a46a621cb8882de81e93e71f67308b1d723'
     binary 'st_darwin_386-0.2.3/st'
+  else
+    url 'https://github.com/nytlabs/streamtools/releases/download/v0.2.3/st_darwin_amd64-0.2.3.tar.gz'
+    sha256 'dd8a2d82b018ad283fbdea8bb2427814e87f6bbe070367ba07b4c054d758d75c'
+    binary 'st_darwin_amd64-0.2.3/st'
   end
   homepage 'https://github.com/nytlabs/streamtools'
   version '0.2.3'

--- a/Casks/totalspaces.rb
+++ b/Casks/totalspaces.rb
@@ -1,22 +1,22 @@
 class Totalspaces < Cask
-  if MacOS.version == :mavericks
-    url "http://downloads.binaryage.com/TotalSpaces2-2.2.6.zip"
-    version '2.2.6'
-    install 'TotalSpaces2.pkg'
-    sha256 '900ece3f5ceae479b4019f854e1875eb402edf3ef1b17f813a70fe42290a0a12'
-    uninstall :pkgutil => 'com.binaryage.TotalSpaces2',
-              :quit    => 'com.binaryage.TotalSpaces2',
-              :signal  => [
-                           ['INT', 'com.binaryage.totalspacescrashwatcher'],
-                           ['KILL', 'com.binaryage.totalspacescrashwatcher'],
-                          ]
-  else
+  if MacOS.version < :mavericks
     url 'http://downloads.binaryage.com/TotalSpaces-1.2.11.zip'
     version '1.2.11'
     install 'TotalSpaces.pkg'
     sha256 'fd54c6ea092f6fae2035745959ff6e080953e77ec6c76715e532b4b0352235d4'
     uninstall :pkgutil => 'com.switchstep.totalspaces',
               :quit    => 'com.binaryage.TotalSpaces',
+              :signal  => [
+                           ['INT', 'com.binaryage.totalspacescrashwatcher'],
+                           ['KILL', 'com.binaryage.totalspacescrashwatcher'],
+                          ]
+  else
+    url "http://downloads.binaryage.com/TotalSpaces2-2.2.6.zip"
+    version '2.2.6'
+    install 'TotalSpaces2.pkg'
+    sha256 '900ece3f5ceae479b4019f854e1875eb402edf3ef1b17f813a70fe42290a0a12'
+    uninstall :pkgutil => 'com.binaryage.TotalSpaces2',
+              :quit    => 'com.binaryage.TotalSpaces2',
               :signal  => [
                            ['INT', 'com.binaryage.totalspacescrashwatcher'],
                            ['KILL', 'com.binaryage.totalspacescrashwatcher'],

--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 class Vuescan < Cask
-  if Hardware::CPU.is_64_bit?
-    url 'http://www.hamrick.com/files/vuex6494.dmg'
-    sha256 'a6e82863f7d6fc34400f678fb4de3cf5af6cbde9a20693ff4bfb5d95ad59f398'
-  else
+  if Hardware::CPU.is_32_bit?
     url 'http://www.hamrick.com/files/vuex3294.dmg'
     sha256 '9f12d5a180a79c9d297913cdfb793382b512f25388de66f007cb621f4d69f461'
+  else
+    url 'http://www.hamrick.com/files/vuex6494.dmg'
+    sha256 'a6e82863f7d6fc34400f678fb4de3cf5af6cbde9a20693ff4bfb5d95ad59f398'
   end
   homepage 'http://www.hamrick.com'
   version '9.4.37'

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -111,12 +111,50 @@ The following stanzas are no longer in use.
 
 ## Conditional Statements
 
+### Efficiency
+
 Conditional statements are permitted, but only if they are very efficient.
 Tests on the following values are known to be acceptable:
 
- * `MacOS.version`      (example: see [macports.rb](../Casks/macports.rb))
- * `Hardware::CPU.is_64_bit?`
- * `Hardware::CPU.is_32_bit?`
+| value                       | examples
+| ----------------------------|--------------------------------------
+| `MacOS.version`             | [macports.rb](../Casks/macports.rb), [coconutbattery.rb](../Casks/coconutbattery.rb)
+| `Hardware::CPU.is_32_bit?`  | [vuescan.rb](../Casks/vuescan.rb)
+| `Hardware::CPU.is_64_bit?`  | none, see [Always Fall Through to the Newest Case](#always-fall-through-to-the-newest-case)
+
+### Version Comparisons
+
+Tests against `MacOS.version` may use either symbolic names or version
+strings with numeric comparison operators:
+
+```ruby
+if MacOS.version < :mavericks     # symbolic name
+```
+
+```ruby
+if MacOS.version < '10.9'         # version string
+```
+
+The available symbols for OS versions are: `:tiger`, `:leopard`,
+`:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, and `:yosemite`.
+
+### Always Fall Through to the Newest Case
+
+Conditionals should be constructed so that the default is the newest OS
+version or hardware type.  When using an `if` statement, test for older
+versions, and then let the `else` statement hold the latest and greatest.
+This makes it more likely that the Cask will work without alteration when
+a new OS is released.  Example (from [coconutbattery.rb](../Casks/coconutbattery.rb)):
+
+```ruby
+if MacOS.version < :leopard
+  # ...
+elsif MacOS.version < :lion
+  # ...
+else
+  # ...
+end
+```
 
 ## Caveats Stanza Details
 


### PR DESCRIPTION
This makes it more likely that Casks will work automatically for Yosemite.

Hardware tests were also reordered for consistency, though these should not
work any differently, as there is only a binary choice between 32/64 bit.

Amended 24 Casks, plus docs.  One related change to come in homebrew-versions.
