### PR TITLE
Update parallels.rb

### DIFF
--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -1,8 +1,8 @@
 class Parallels < Cask
-  version 'latest'
-  sha256 :no_check
+  version '9.0.24237.1028877'
+  sha256 'da71645ff1f0076ab5b2f8fa5eefb63bcd921e5f52161fd4dd85e6fb19ae2c57'
 
-  url 'https://www.parallels.com/directdownload/pd9'
+  url 'http://download.parallels.com/desktop/v9/update2.hotfix2/ParallelsDesktop-9.0.24237.1028877.dmg'
   homepage 'http://www.parallels.com/products/desktop/'
 
   install 'Install.mpkg'


### PR DESCRIPTION
The 'latest' url does not appear to be working any longer
