### PR TITLE
Use "latest" URL for recordit

### DIFF
--- a/Casks/recordit.rb
+++ b/Casks/recordit.rb
@@ -2,7 +2,7 @@ class Recordit < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'https://rink.hockeyapp.net/api/2/apps/5fcda0b48f1dcf0c938b289b9ab57790/app_versions/7?format=zip'
+  url 'http://recordit.co/latest'
   appcast 'https://rink.hockeyapp.net/api/2/apps/5fcda0b48f1dcf0c938b289b9ab57790'
   homepage 'http://recordit.co/'
 


### PR DESCRIPTION
because otherwise we're getting _Version 1.0 Build 02141_ instead of the latest, _Version 1.4.1_.
