### PR TITLE
Upgrade BibDesk to v1.6.3

### DIFF
--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -1,8 +1,8 @@
 class Bibdesk < Cask
-  version '1.6.2'
-  sha256 'f06b15290f57c95418fd1441d6dd7b61ce9b95a6953d3a231dcb390f64bfcce0'
+  version '1.6.3'
+  sha256 '30dcf97dbf1256fbc49e98ff67b7e510ea8b90bcefb4f919d0b2ac8aa8f695a8'
 
-  url 'https://downloads.sourceforge.net/project/bibdesk/BibDesk/BibDesk-1.6.2/BibDesk-1.6.2.dmg'
+  url "https://downloads.sourceforge.net/project/bibdesk/BibDesk/BibDesk-#{version}/BibDesk-#{version}.dmg"
   appcast 'http://bibdesk.sourceforge.net/bibdesk.xml'
   homepage 'http://bibdesk.sourceforge.net/'
 


### PR DESCRIPTION
Closes #5726.
