### PR TITLE
Add PCSXR cask

### DIFF
--- a/Casks/pcsxr.rb
+++ b/Casks/pcsxr.rb
@@ -1,0 +1,9 @@
+class Pcsxr < Cask
+  url 'http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=pcsxr&DownloadId=722115&Build=20919'
+  sha256 'e7361ceb8dc9089cae084ce119a5dc4119cab22bb5d79ebf55af596b7e7eb916'
+
+  homepage 'https://pcsxr.codeplex.com'
+  version '1.9.93'
+
+  link 'PCSXR.app'
+end


### PR DESCRIPTION
PCSXR is a PS1 emulator (the only one which works out of the box).
http://pcsxr.codeplex.com
