### PR TITLE
Fix Dropzone app name in `link`

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -6,5 +6,5 @@ class Dropzone < Cask
   appcast 'https://aptonic.com/dropzone3/sparkle/updates.xml'
   homepage 'https://aptonic.com'
 
-  link 'Dropzone.app'
+  link 'Dropzone 3.app'
 end


### PR DESCRIPTION
The app name w/in the zip has changed.
