### PR TITLE
Update Kext Wizard to new download location

### DIFF
--- a/Casks/kext-wizard.rb
+++ b/Casks/kext-wizard.rb
@@ -2,8 +2,8 @@ class KextWizard < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'https://dl.dropboxusercontent.com/u/7085278/Kext_Wizard/KextWizard.zip'
-  appcast 'http://dl.dropbox.com/u/7085278/Kext_Wizard/update.xml'
+  url 'http://wizards.osxlatitude.com/kext/kw.zip'
+  appcast 'http://wizards.osxlatitude.com/kext/update.xml'
   homepage 'http://www.insanelymac.com/forum/topic/253395-kext-wizard-easy-to-use-kext-installer-and-more/'
 
   link 'Kext Wizard.app'


### PR DESCRIPTION
Kext Wizard is no longer served from a Dropbox location but now has a website. For whatever reason, the project "homepage" is still the forum thread:

http://www.osxlatitude.com/ -> Projects -> Kext Wizard points to the thread, so that's what I left it as. Let me know if you think I should change to osxlatititude on its own.
