### PR TITLE
minor amendments to release process/changelog

### DIFF
--- a/developer/bin/generate_changelog
+++ b/developer/bin/generate_changelog
@@ -245,7 +245,7 @@ end
 
 def footer
   @footer ||= Set.new
-  @footer.to_a
+  @footer.to_a.sort
 end
 
 def add_to_footer(line)

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -97,13 +97,13 @@ written down than floating in a brain somewhere.
 13. Push that commit and the tag:
 
 	```bash
-	$ git push --follow-tags
+	$ git push && git push --follow-tags
 	```
     Or, depending on your git configuration, you might need to append
     `<repository> <refspec>` to the above command, for example:
 
 	```bash
-	$ git push --follow-tags upstream master
+	$ git push upstream master && git push --follow-tags upstream master
 	```
 
 14. Unset the shell variable `$NEW_RELEASE_TAG`; you don't need it anymore.


### PR DESCRIPTION
based on lessons learned from failed release v0.39.0,
`git push && git push --follow-tags` is smarter because
it reduces the chance of an unreleasable tag being pushed.
(git pushes the tags before it pushes the commits).
