### PR TITLE
Upgrade Zooom to 2.6.0

### DIFF
--- a/Casks/zooom.rb
+++ b/Casks/zooom.rb
@@ -1,12 +1,12 @@
 class Zooom < Cask
-  version '2.5.0'
-  sha256 '944d8c6f0869963ea0c0b11491d05eaa4357953072c43519f674fa81216e9e34'
+  version '2.6.0'
+  sha256 'eda52f42d06a6cd32c2fc419358a4a589087a1592a38e717577e3ae9a656036f'
 
-  url 'http://software.coderage-software.com/zooom/Zooom_2.5.0.dmg'
+  url 'http://software.coderage-software.com/zooom/Zooom_2.6.0.dmg'
   homepage 'http://coderage-software.com/zooom'
 
   install 'Zooom2.pkg'
   caveats do
-    os_version_only '10.8', '10.7', '10.6', '10.5'
+    os_version_only '10.10', '10.9'
   end
 end


### PR DESCRIPTION
Zooom 2.6 has been released and now supports 10.9 (technically 2.5.x never supported 10.9, though it did seem to work) and enables beta support for 10.10.
