### PR TITLE
Add td-toolbelt

### DIFF
--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -1,0 +1,20 @@
+class TdToolbelt < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'http://toolbelt.treasuredata.com/mac'
+  homepage 'http://toolbelt.treasuredata.com/'
+
+  caskroom_only true
+  container_type :pkg
+
+  before_install do
+    system 'mv', "#{caskroom_path}/#{version}/mac", "#{caskroom_path}/#{version}/#{title}.pkg"
+  end
+
+  install "#{title}.pkg"
+
+  uninstall :files => [
+    '/usr/local/td',
+  ]
+end


### PR DESCRIPTION
the Treasure Data CLI (td-toolbelt)
http://docs.treasuredata.com/articles/installing-the-cli#mac-osx-or-windows
td-toolbelt download file is not .pkg extension, so manually rename and install pkg it.
