### PR TITLE
Add ZOC terminal emulator - zoc6.app v6.59

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,0 +1,9 @@
+class Zoc < Cask
+  version '6.59'
+  sha256 'e5bab1efba9920129e7e829f255a73bf6abea443533c428ec797b787379b7827'
+
+  url 'http://www.emtec.com/downloads/zoc/zoc659.dmg'
+  homepage 'http://www.emtec.com/zoc/'
+
+  link 'zoc6.app'
+end


### PR DESCRIPTION
Zoc is a terminal emulator. It has arcane features like AT&T 4410 emulation, which is useful for managing avaya phone systems.

It 'requires' a license to use after 30 days, but continues to work as nagware.
