### PR TITLE
Add Backblaze cask

### DIFF
--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,0 +1,11 @@
+class Backblaze < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'https://secure.backblaze.com/mac/install_backblaze.dmg'
+  homepage 'https://www.backblaze.com/'
+
+  caveats do
+    manual_installer 'Backblaze Installer.app'
+  end
+end


### PR DESCRIPTION
This cask works as-is by downloading a DMG and caveating the user that they need to run `/opt/homebrew-cask/Caskroom/backblaze/latest/Backblaze\ Installer.app`. 

I personally find the caveat clunky and after a little digging, found a binary inside Blackblaze Installer.app at `/opt/homebrew-cask/Caskroom/backblaze/latest/Backblaze\ Installer.app/Contents/MacOS/bzdoinstall` that just opens the installer app for you. You still have to execute the install manually, but at least you don't have to go find and launch the installer app in the Finder. 

It appears that currently the only way to execute an installer is if it is a .pkg file. Are there any plans to support executing binaries if the result of installation is not an actual binary, but rather the installation of an app or merely the opening of an installer app?
