### PR TITLE
Add OpenArena.app v0.8.8

### DIFF
--- a/Casks/open-arena.rb
+++ b/Casks/open-arena.rb
@@ -1,0 +1,13 @@
+class OpenArena < Cask
+  version '0.8.8'
+  sha256 '5a8faf7f5b51f351b0a1618c06b6b98a5f1a6758f1d39818de2c87df2a0bac4a'
+
+  url 'http://openarena.ws/request.php?4'
+  homepage 'http://openarena.ws'
+
+  link 'openarena-0.8.8/OpenArena.app'
+
+  after_install do
+    system '/bin/chmod', '--', '755', "#{destination_path}/openarena-0.8.8/OpenArena.app/Contents/MacOS/openarena.ub"
+  end
+end


### PR DESCRIPTION
> OpenArena is a community-produced deathmatch FPS based on GPL idTech3 technology.
> 
> There are many game types supported including Free For All, Capture The Flag, Domination, Overload, Harvester, and more. 

What more can I say? This game = awesome :bomb: :gun: 

The game requires a `chmod +x` to work. I added that as an `caveat`, but not sure there's a better way around it.

Thanks!
