### PR TITLE
revisions to td-toolbelt

### DIFF
--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -5,16 +5,12 @@ class TdToolbelt < Cask
   url 'http://toolbelt.treasuredata.com/mac'
   homepage 'http://toolbelt.treasuredata.com/'
 
-  caskroom_only true
-  container_type :pkg
-
+  container_type :naked
   before_install do
-    system 'mv', "#{destination_path}/mac", "#{destination_path}/#{title}.pkg"
+    system '/bin/mv', '--', "#{destination_path}/mac", "#{destination_path}/td-toolbelt.pkg"
   end
 
-  install "#{title}.pkg"
-
-  uninstall :files => [
-    '/usr/local/td',
-  ]
+  install 'td-toolbelt.pkg'
+  uninstall :pkgutil => 'com.td.toolbelt'
+  # zap :pkgutil => 'org.ruby-lang.installer'
 end


### PR DESCRIPTION
- `caskroom_only true` is not needed
- uninstall via `:pkgutil` instead of `:files`
- commented-out future `zap` stanza
- `container_type :naked` since no action is taken on the container
- full path to `mv`
- use `--` after `mv` to disambiguate files
- don't recycle `title` for the filename
