### PR TITLE
Add Skii 2.1.5.1

### DIFF
--- a/Casks/skii.rb
+++ b/Casks/skii.rb
@@ -1,0 +1,9 @@
+class Skii < Cask
+  version '2.1.6.1'
+  sha256 'f523b9a7f58592103529813a79d95424f8025e8d0c033d6d32cb4f355aecc63a'
+
+  url 'http://f.cl.ly/items/1C0f162Q0l450s0F2H26/Skii_2.1.6.1.dmg'
+  homepage 'https://www.macupdate.com/app/mac/36677/skii'
+
+  link 'Skii.app'
+end


### PR DESCRIPTION
This (old) app was running fine for the first time before I created the cask. Having quit the app, created the cask, and reinstalled via cask, it now just crashes. I'm not sure what the problem is, but since the cask is already created, perhaps it's worth sharing for someone else to test/use.

Skii lets you create a push-to-talk mapping for Skype.
