### PR TITLE
Fix broken container in qlmarkdown.rb

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -5,5 +5,13 @@ class Qlmarkdown < Cask
   url 'https://github.com/toland/qlmarkdown/releases/download/v1.3.3/QLMarkdown.qlgenerator.zip'
   homepage 'https://github.com/toland/qlmarkdown'
 
+  # Fix broken zip file with no toplevel bundle directory.  This was
+  # not needed for version 1.3.2.  We could add an option to the main
+  # DSL to identify such containers and generate a target directory.
+  container_type :naked
+  before_install do
+    system '/usr/bin/ditto', '-xk', '--', "#{destination_path}/QLMarkdown.qlgenerator.zip", "#{destination_path}/QLMarkdown.qlgenerator"
+  end
+
   qlplugin 'QLMarkdown.qlgenerator'
 end


### PR DESCRIPTION
This is something of a hack.  Upstream has an atypical
file format.

References: #5885
