### PR TITLE
Add FreeDV.app v0.96.6

### DIFF
--- a/Casks/freedv.rb
+++ b/Casks/freedv.rb
@@ -1,0 +1,9 @@
+class Freedv < Cask
+  version '0.96.6'
+  sha256 'e8c42dbb7fc5b8dd88020aa000149185adc5f9583094617966008e5b39d54970'
+
+  url 'http://files.freedv.org/OSX/FreeDV-0.96.6.dmg'
+  homepage 'http://freedv.org/tiki-index.php'
+
+  link 'FreeDV.app'
+end


### PR DESCRIPTION
FreeDV is a GUI application for Windows, Linux and MacOS (BSD and Android in development) that allows any SSB radio to be used for low bit rate digital voice.
