### PR TITLE
Reload QuickLook on plugin uninstall

### DIFF
--- a/lib/cask/artifact/qlplugin.rb
+++ b/lib/cask/artifact/qlplugin.rb
@@ -5,6 +5,15 @@ class Cask::Artifact::Qlplugin < Cask::Artifact::Symlinked
 
   def install_phase
     super
+    reload_quicklook
+  end
+
+  def uninstall_phase
+    super
+    reload_quicklook
+  end
+
+  def reload_quicklook
     @command.run!('/usr/bin/qlmanage', :args => ['-r'])
   end
 end


### PR DESCRIPTION
If we don't do this, QuickLook will still try to load the plugin but it will look completely broken.
