### PR TITLE
Add qrq v0.3.1

### DIFF
--- a/Casks/qrq.rb
+++ b/Casks/qrq.rb
@@ -1,0 +1,9 @@
+class Qrq < Cask
+  version '0.3.1'
+  sha256 '76712d07f2d61b5d382c4c0c02a0c067e752c745db6b931717b3eb1e42e5076a'
+
+  url 'http://fkurz.net/ham/qrq/qrq-0.3.1.dmg'
+  homepage 'http://fkurz.net/ham/qrq.html'
+
+  link 'qrq.app'
+end


### PR DESCRIPTION
qrq is an open source Morse telegraphy trainer.
