### PR TITLE
Remove Mangao

### DIFF
--- a/Casks/mangao.rb
+++ b/Casks/mangao.rb
@@ -1,9 +1,0 @@
-class Mangao < Cask
-  version 'latest'
-  sha256 :no_check
-
-  url 'https://dl.dropboxusercontent.com/u/262366138/mangao/Mangao.app.zip'
-  homepage 'http://ryotaminami93.appspot.com/mangao.html'
-
-  link 'Mangao.app'
-end


### PR DESCRIPTION
Application was discontinued. No official package or homepage could be found.

Closes #5889.
