### PR TITLE
add uninstall stanza for epub-quicklook and rename

### DIFF
--- a/Casks/epubquicklook.rb
+++ b/Casks/epubquicklook.rb
@@ -1,4 +1,4 @@
-class EpubQuicklook < Cask
+class Epubquicklook < Cask
   version 'latest'
   sha256 :no_check
 
@@ -6,4 +6,5 @@ class EpubQuicklook < Cask
   homepage 'http://people.ict.usc.edu/~leuski/programming/epub-quickview.php'
 
   install 'EpubQuickLook.pkg'
+  uninstall :pkgutil => 'net.leuski.epubQuicklookPlugin.epub.pkg'
 end


### PR DESCRIPTION
References: #5928

@federicobond I didn't test uninstalling, but maybe we should eventually expose `reload_quicklook` in `after_uninstall`.
