### PR TITLE
Update Intel Power Gadget's File URL

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -3,8 +3,8 @@ class IntelPowerGadget < Cask
   version '3.0.1'
   sha256 '538a792721604e2155b3a48caa4084db751a91b170e5fa62bf0331d3147f2239'
 
-  url 'https://software.intel.com/sites/default/files/IntelPowerGadget3.0.1.zip'
-  homepage 'http://software.intel.com/en-us/articles/intel-power-gadget-20'
+  url 'https://software.intel.com/sites/default/files/managed/59/39/IntelPowerGadgetMac3.0.1.zip'
+  homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
 
   # this bogus-looking character accurately reflects an upstream error
   nested_container 'IntelÆ Power Gadget.dmg'


### PR DESCRIPTION
Intel has just changed the location of the zip file.
