### PR TITLE
Add Fetch.app v5.7.3

### DIFF
--- a/Casks/fetch.rb
+++ b/Casks/fetch.rb
@@ -1,0 +1,9 @@
+class Fetch < Cask
+  version '5.7.3'
+  sha256 'fd75b4ab78211cc067906341576657e41e130080ce05a1f20947a6acbb816ea3'
+
+  url 'http://fetchsoftworks.com/fetch/download/Fetch_5.7.3.dmg?direct=1'
+  homepage 'http://fetchsoftworks.com/'
+
+  link 'Fetch.app'
+end


### PR DESCRIPTION
fetch is a non-free ftp client for macintosh. The education/charity license is
free.
