### PR TITLE
Updated to new .dmg revision of Database Browser 3.3.1 for SQLite

### DIFF
--- a/Casks/sqlite-database-browser.rb
+++ b/Casks/sqlite-database-browser.rb
@@ -1,8 +1,8 @@
 class SqliteDatabaseBrowser < Cask
   version '3.3.1'
-  sha256 '0f326309c283a460b28f437d780e05bee8a40d6dc95a32e393f531493d3e8aff'
+  sha256 '14fce5d0df8c06e355aba526f256fd69c7f32e277506add4406c66e4714325eb'
 
-  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/sqlitebrowser-#{version}.dmg"
+  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/sqlitebrowser-#{version}v2.dmg"
   homepage 'http://sqlitebrowser.org'
 
   link "sqlitebrowser.app"


### PR DESCRIPTION
The previous v3.3.1 .dmg accidentally included an old version of
SQLite. :( This new .dmg has the correct (latest) version of
SQLite in it. :)
