### PR TITLE
Bump version for path finder.

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -2,7 +2,7 @@ class PathFinder < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'http://get.cocoatech.com/PF6_LION.zip'
+  url 'http://get.cocoatech.com/PF7.zip'
   homepage 'http://www.cocoatech.com/pathfinder/'
 
   link 'Path Finder.app'


### PR DESCRIPTION
Bump major version for path finder. They don't track minor versions in the filename so you can't use a signature.
