### PR TITLE
Upgrade Vagrant Manager.app to v2.0.1

### DIFF
--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -1,6 +1,6 @@
 class VagrantManager < Cask
-  version '1.5.5'
-  sha256 '778815d9b5a41e30363f8ca652fc5964beb4fbca0691feaad2595e1382870762'
+  version '2.0.1'
+  sha256 '690cdc1649255b0d4c54636548f834c77d0b9f1705383380a99bbc46b9e7b3f3'
 
   url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
   appcast 'http://api.lanayo.com/appcast/vagrant_manager.xml'


### PR DESCRIPTION
Upgraded from v1.5.5
shasum confirm locally and via [online-convert.com](http://www.online-convert.com/result/5b387868fb961aee30ae8d028df05f04)
