### PR TITLE
Update Synergy to 1.5.1

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,8 +1,8 @@
 class Synergy < Cask
-  version '1.5.0'
-  sha256 'b7f024720a3174ad68aa3489fa8674ca4bdc95a785b82044d57685325f60c913'
+  version '1.5.1'
+  sha256 'd787031705b0123d36f07e7639fd8882d1969bc8f7ddad25a3326c873385dfe2'
 
-  url 'https://synergy-project.org/files/packages/synergy-1.5.0-r2278-MacOSX109-x86_64.dmg'
+  url 'https://synergy-project.org/files/packages/synergy-1.5.1-r2398-MacOSX109-x86_64.dmg'
   homepage 'http://synergy-foss.org/'
 
   link 'Synergy.app'


### PR DESCRIPTION
SHA256 calculated with:

``` bash
$ openssl dgst -sha256 synergy-1.5.1-r2398-MacOSX109-x86_64.dmg
SHA256(synergy-1.5.1-r2398-MacOSX109-x86_64.dmg)= d787031705b0123d36f07e7639fd8882d1969bc8f7ddad25a3326c873385dfe2
```
