### PR TITLE
Fix SHA 256 hash for MacDown 0.2.4

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -1,6 +1,6 @@
 class Macdown < Cask
   version '0.2.4'
-  sha256 '8720bb9644b391a9a6fa06af50a57f7fff495c2da80573fc0077445d9ca67367'
+  sha256 'd8bdec9c696a70ca88a885fad0d5f1804501921d48ea875ac08e3f5b0a9fe859'
 
   url "http://macdown.uranusjr.com/download/v#{version}/"
   appcast 'http://macdown.uranusjr.com/sparkle/macdown/appcast.xml'


### PR DESCRIPTION
The previous build had some packaging issues; this is the hash for the updated package. The URL stays unchanged.
