### PR TITLE
DSL: change container_type to extensible container

### DIFF
--- a/lib/cask/dsl/container.rb
+++ b/lib/cask/dsl/container.rb
@@ -1,0 +1,26 @@
+class Cask::DSL::Container
+
+  VALID_KEYS = Set.new [
+                        :type,
+                       ]
+
+  attr_accessor *VALID_KEYS
+  attr_accessor :pairs
+
+  def initialize(pairs={})
+    @pairs = pairs
+    pairs.each do |key, value|
+      raise "invalid container key: '#{key.inspect}'" unless VALID_KEYS.include?(key)
+      writer_method = "#{key}=".to_sym
+      send(writer_method, value)
+    end
+  end
+
+  def to_yaml
+    @pairs.to_yaml
+  end
+
+  def to_s
+    @pairs.inspect
+  end
+end


### PR DESCRIPTION
Late addition to DSL 1.0 (oversight in the roadmap)

References: #4688 

New syntax:

``` ruby
container :type => :naked
```

This is obviously more extensible than `container_type`, but I simply forgot to make
this amendment in #4688.

An example of what else might possibly be added in this stanza is renaming:

``` ruby
container :rename => 'bankid-latest.pkg'
```

So that we wouldn't need this [hack](https://github.com/caskroom/homebrew-cask/pull/6002#issuecomment-54649885).  No sure yet; just an example.

@caskroom/maintainers, as this only affects 5 Casks in the main repo, I am comfortable
pushing in this change at the last minute and including it in DSL 1.0.  The chance that
a user will actually be inconvenienced is very small.
