### PR TITLE
Add MenuCalendarClock 4.5.2

### DIFF
--- a/Casks/menucalendarclock-ical.rb
+++ b/Casks/menucalendarclock-ical.rb
@@ -1,0 +1,10 @@
+class MenucalendarclockIcal < Cask
+  version '4.5.2'
+  sha256 '7c78428fd22d0a3fa02e5df4c92fbb45dad881a7ba09205dc47c4bfaaf7f7f9e'
+
+  url 'http://www.objectpark.net/download/MenuCalendarClock-4.5.2.dmg.gz'
+  nested_container 'menucalendarclock-ical-4.5.2'
+  homepage 'http://www.objectpark.net/en/mcc.html'
+
+  link 'MenuCalendarClock iCal.app'
+end


### PR DESCRIPTION
``` ruby
class Menucalendarclock < Cask
  version '4.5.2'
  sha256 '7c78428fd22d0a3fa02e5df4c92fbb45dad881a7ba09205dc47c4bfaaf7f7f9e'

  url 'http://www.objectpark.net/download/MenuCalendarClock-4.5.2.dmg.gz'
  nested_container 'menucalendarclock-4.5.2'
  homepage 'http://www.objectpark.net/en/mcc.html'

  link 'MenuCalendarClock iCal.app'
end
```
