### PR TITLE
DSL add NCSA OSS license type

### DIFF
--- a/lib/cask/dsl/license.rb
+++ b/lib/cask/dsl/license.rb
@@ -24,6 +24,7 @@ class Cask::DSL::License
                     :eclipse       => :oss,
                     :gpl           => :oss,
                     :isc           => :oss,
+                    :ncsa          => :oss,
                     :mit           => :oss,
                     :mpl           => :oss,
                     :ofl           => :oss,


### PR DESCRIPTION
Used for example by LLVM.
