### PR TITLE
doc: first changes for DSL 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# NOTICE: The Cask syntax is changing! (8 Sep 2014)
+
+There will be a period of transition while we update the Cask DSL to use
+new forms described in #4688.
+
+The Cask DSL 1.0 will be documented in [CASK_LANGUAGE_REFERENCE.md](doc/CASK_LANGUAGE_REFERENCE.md)
+and [cask_language_delta_1.0.md](doc/cask_language_delta_1.0.md).
+
+Code to support most of the new DSL forms has been in release for several
+weeks; most users are already running forward compatible code<sup>1</sup>.
+
+The transition officially begins with version 0.40.0, released today, 8
+Sep 2014.  Cask definitions will also be changing.  If you experience an
+error when running Homebrew-cask, please run
+
+```bash
+$ brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
+```
+
+<sup>1</sup> forward compatibility began with [v0.38.0](https://github.com/caskroom/homebrew-cask/releases/tag/v0.38.0), released 28 Jul 2014
+
+---------------------------------------
+
+
 # "To install, drag this icon..." no more!
 
 [![Build Status](https://travis-ci.org/caskroom/homebrew-cask.png?branch=master)](https://travis-ci.org/caskroom/homebrew-cask)
@@ -11,9 +35,8 @@ installation and management of GUI Mac applications such as Google Chrome and Ad
 Homebrew-cask provides a friendly homebrew-style CLI workflow for the
 administration of Mac applications distributed as binaries.
 
-It's implemented as a `homebrew` "[external
-command](https://github.com/mxcl/homebrew/wiki/External-Commands)" called
-`cask`.
+It's implemented as a `homebrew` "[external command](https://github.com/mxcl/homebrew/wiki/External-Commands)"
+called `cask`.
 
 ## Let's try it!
 ```sh

--- a/doc/cask_language_delta_1.0.md
+++ b/doc/cask_language_delta_1.0.md
@@ -1,0 +1,21 @@
+# Cask Language Delta 1.0
+
+This document lists changes to the Cask language from the pre-existing
+(unversioned) conventions to the Cask DSL 1.0 standard.
+
+ * [Stub](#stub)
+ * [References](#references)
+
+## Stub
+
+**This is only a stub! Future documentation will appear here.**
+
+## References
+
+ * [DSL 1.0 Transition Notice](https://github.com/caskroom/homebrew-cask/issues/5890)
+ * [DSL 1.0 Roadmap](https://github.com/caskroom/homebrew-cask/issues/4688)
+ * [DSL 1.1 Roadmap](https://github.com/caskroom/homebrew-cask/issues/5586)
+ * [DSL 2.0 Roadmap](https://github.com/caskroom/homebrew-cask/issues/5592)
+ * [`brew cask upgrade` Roadmap](https://github.com/caskroom/homebrew-cask/issues/4678)
+
+# <3 THANK YOU TO ALL CONTRIBUTORS! <3


### PR DESCRIPTION
Do not revert this PR after the transition period.  It contains
a README banner which needs to be deleted later, but also a
persistent doc file and an unrelated whitespace nit.
