### PR TITLE
Use 2.0 instead of latest for Semulov.app

### DIFF
--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -1,8 +1,8 @@
 class Semulov < Cask
-  version 'latest'
-  sha256 :no_check
+  version '2.0'
+  sha256 'de2b9d4e874885a6421c17fb716e2072827c4d111c946d15ada2b4d31392e803'
 
-  url 'http://www.kainjow.com/downloads/Semulov.zip'
+  url 'http://kainjow.com/downloads/Semulov_2.0.zip'
   homepage 'http://www.kainjow.com'
 
   link 'Semulov.app'


### PR DESCRIPTION
Updates the package to use a specific version now that the publisher has versioned urls: https://twitter.com/kainjow/status/509081101726261249.
