### PR TITLE
Use the skype installer with version for old MacOS version

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,8 +1,13 @@
 class Skype < Cask
-  version 'latest'
-  sha256 :no_check
-
-  url 'https://www.skype.com/go/getskype-macosx.dmg'
+  if MacOS.version < :mavericks
+    version '6.15.0.335'
+    sha256 '592abdd157df12d718576a86c8f8e62fced55292fd7e6909d53aa5eaaa9218f4'
+    url 'http://download.skype.com/macosx/Skype_6.15.0.335.dmg'
+  else
+    version 'latest'
+    sha256 :no_check
+    url 'https://www.skype.com/go/getskype-macosx.dmg'
+  end
   homepage 'http://www.skype.com'
 
   link 'Skype.app'


### PR DESCRIPTION
I found the `getskype-macosx.dmg` installer cannot work on Mountain Lion.
When I tried to start Skype, the dialog like below opened:
![latest_skype_needs_mavericks_or_later](https://cloud.githubusercontent.com/assets/19299/4196064/1399d214-37cc-11e4-8616-8ccc5afcea15.png)
It says "This application needs OS X 10.9 or later".
So I modified this formula to use `getskype-macosx.dmg` for MacOS.version >= "10.9" and `Skype_6.15.0.335.dmg` otherwise.

Could you review this?
Thanks!
