### PR TITLE
correct sha for happygrep

### DIFF
--- a/Casks/happygrep.rb
+++ b/Casks/happygrep.rb
@@ -1,6 +1,6 @@
 class Happygrep < Cask
   version '1.0'
-  sha256 '572c3eaa6b0609c05b85c6934155b8e8943d28464438d9ec2838efbf6e29e863'
+  sha256 '05c5f33142c9ea4559b20ca421c76fa0b081ae3edc0d6e3b8f7c3dd8ba21a518'
 
   url 'https://github.com/happypeter/happygrep/releases/download/v1.0/happygrep.zip'
   homepage 'https://github.com/happypeter/happygrep'


### PR DESCRIPTION
installation failed because of wrong sha. Sorry guys, my fault.
