### PR TITLE
Metadata directory support

### DIFF
--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -8,6 +8,10 @@ module Cask::Locations
       HOMEBREW_REPOSITORY.join "Library", "Taps"
     end
 
+    def metadata_subdir
+      '.metadata'
+    end
+
     def caskroom
       @@caskroom ||= Pathname('/opt/homebrew-cask/Caskroom')
     end

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -274,6 +274,31 @@ describe Cask::Installer do
       dest_path = Cask.appdir/'MyNestedApp.app'
       TestHelper.valid_alias?(dest_path).must_equal true
     end
+
+    it "generates and finds a timestamped metadata directory for an installed Cask" do
+      caffeine = Cask.load('local-caffeine')
+
+      shutup do
+        Cask::Installer.new(caffeine).install
+      end
+
+      m_path = caffeine.metadata_path(:now, true)
+      caffeine.metadata_path(:now, false).must_equal(m_path)
+      caffeine.metadata_path(:latest).must_equal(m_path)
+    end
+
+    it "generates and finds a metadata subdirectory for an installed Cask" do
+      caffeine = Cask.load('local-caffeine')
+
+      shutup do
+        Cask::Installer.new(caffeine).install
+      end
+
+      subdir_name = 'Casks'
+      m_subdir = caffeine.metadata_subdir(subdir_name, :now, true)
+      caffeine.metadata_subdir(subdir_name, :now, false).must_equal(m_subdir)
+      caffeine.metadata_subdir(subdir_name, :latest).must_equal(m_subdir)
+    end
   end
 
   describe "uninstall" do

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -87,4 +87,13 @@ describe "Cask" do
       GamesXChange.title.must_equal 'games-x-change'
     end
   end
+
+  describe "metadata" do
+    it "proposes a versioned metadata directory name for each instance" do
+      cask_name = "adium"
+      c = Cask.load(cask_name)
+      metadata_path = Cask.caskroom.join(cask_name, '.metadata', c.version)
+      c.metadata_versioned_container_path.to_s.must_equal(metadata_path.to_s)
+    end
+  end
 end


### PR DESCRIPTION
This separates metadata directory support from Caskfile logging as in #3066,
and will conflict with #3066.

The immediate purpose is to provide persistent per-distribution locations to for GPG data.

Also
- incidentally adds defensive driving against null version number in method `destination_path`
- ~~increments Travis seed due to observed error in Ruby 1.8 build~~

**Update**: the Ruby 1.8 error looks real (not a Travis glitch).  This can't be merged until that is fixed.
