### PR TITLE
bug: fix container :type => <type>

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -109,8 +109,8 @@ module Cask::DSL
         raise CaskInvalidError.new(self.title, e)
       end
       # todo: remove this backwards compatibility section after removing container_type
-      if @container.formula
-        @container_type ||= @container.formula
+      if @container.type
+        @container_type ||= @container.type
       end
       @container
     end

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -241,6 +241,18 @@ describe Cask::Installer do
       executable.must_be :file?
     end
 
+    it "works properly with the new form container :type => <type>" do
+      naked_executable_dsl_one = Cask.load('naked-executable-dsl-one')
+
+      shutup do
+        Cask::Installer.new(naked_executable_dsl_one).install
+      end
+
+      dest_path = Cask.caskroom/'naked-executable-dsl-one'/naked_executable_dsl_one.version
+      executable = dest_path/'naked_executable'
+      executable.must_be :file?
+    end
+
     it "works fine with a nested container" do
       nested_app = Cask.load('nested-app')
 

--- a/test/support/Casks/naked-executable-dsl-one.rb
+++ b/test/support/Casks/naked-executable-dsl-one.rb
@@ -1,0 +1,10 @@
+class NakedExecutableDslOne < TestCask
+  # todo: This Cask can be removed after DSL 1.0 transition,
+  #       b/c the main Cask naked-executable.rb will be
+  #       adopting this syntax.
+  url TestHelper.local_binary('naked_executable')
+  homepage 'http://example.com/naked-executable'
+  version '1.2.3'
+  sha256 '306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb'
+  container :type => :naked
+end


### PR DESCRIPTION
Copypasta error in #6068 means that `container :type => <type>`
never worked, because it looked for nonexistent method `container.formula`
in `lib/cask/dsl.rb`

This happened because I recklessly pushed through the new `container`
stanza to make 0.40.0 on 8 Sep for inclusion in DSL 1.0.

This PR adds a test.
