### PR TITLE
new DSL form container :nested => <inner>

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -112,6 +112,10 @@ module Cask::DSL
       if @container.type
         @container_type ||= @container.type
       end
+      # todo: remove this backwards compatibility section after removing nested_container
+      if @container.nested
+        artifacts[:nested_container] << @container.nested
+      end
       @container
     end
 

--- a/lib/cask/dsl/container.rb
+++ b/lib/cask/dsl/container.rb
@@ -2,6 +2,7 @@ class Cask::DSL::Container
 
   VALID_KEYS = Set.new [
                         :type,
+                        :nested,
                        ]
 
   attr_accessor *VALID_KEYS

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -263,6 +263,17 @@ describe Cask::Installer do
       dest_path = Cask.appdir/'MyNestedApp.app'
       TestHelper.valid_alias?(dest_path).must_equal true
     end
+
+    it "supports new DSL form container :nested => <inner-container>" do
+      nested_app_dsl_one = Cask.load('nested-app-dsl-one')
+
+      shutup do
+        Cask::Installer.new(nested_app_dsl_one).install
+      end
+
+      dest_path = Cask.appdir/'MyNestedApp.app'
+      TestHelper.valid_alias?(dest_path).must_equal true
+    end
   end
 
   describe "uninstall" do

--- a/test/support/Casks/nested-app-dsl-one.rb
+++ b/test/support/Casks/nested-app-dsl-one.rb
@@ -1,0 +1,11 @@
+class NestedAppDslOne < TestCask
+  # todo: This Cask can be removed after DSL 1.0 transition,
+  #       b/c the main Cask nested-app.rb will be
+  #       adopting this syntax.
+  url TestHelper.local_binary('NestedApp.dmg.zip')
+  homepage 'http://example.com/nested-app'
+  version '1.2.3'
+  sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
+  container :nested => 'NestedApp.dmg'
+  link 'MyNestedApp.app'
+end


### PR DESCRIPTION
Note: tests will probably not pass until #6118 is merged, and may conflict with that PR.

Like #6068, this is a new form intended for inclusion in DSL 1.0, but which was
overlooked during planning in #4688.

As with #6068, implementing `container :nested` now means we would not have the
benefit of the forward-compatibility transition code.  However, `nested_container` is
only used in 38 Casks in the main repo, so that is unlikely to cause a problem in practice.

The gain is consolidating two stanzas: `container_type` and `nested_container` are both
handled by `container`.  For a first-time Cask author, that seems more logical and regular.

We do lose the extensibility of `nested_container`, since `:nested` can only take a single
value.  However, it is unlikely that extensibility is needed, and there are workarounds.
