### PR TITLE
gitx-rowanj: Version and checksum

### DIFF
--- a/Casks/gitx-rowanj.rb
+++ b/Casks/gitx-rowanj.rb
@@ -1,8 +1,8 @@
 class GitxRowanj < Cask
-  version 'latest'
-  sha256 :no_check
+  version '0.15.1949'
+  sha256 '17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a'
 
-  url 'http://builds.phere.net/GitX/development/GitX-dev.dmg'
+  url 'http://builds.phere.net/GitX/development/GitX-dev-1949.dmg'
   appcast 'https://s3.amazonaws.com/builds.phere.net/GitX/development/GitX-dev.xml'
   homepage 'http://rowanj.github.io/gitx/'
 


### PR DESCRIPTION
According to #1021, versioned/checksummed downloads should be preferred when available and the URL contains the version number. This is the case with [gitx-rowanj](https://github.com/caskroom/homebrew-cask/blob/master/Casks/gitx-rowanj.rb)—in fact, the appcast referenced links to the versioned downloads, not the unversioned one.
