### PR TITLE
add Mapbox Studio

### DIFF
--- a/Casks/mapbox-studio.rb
+++ b/Casks/mapbox-studio.rb
@@ -1,0 +1,9 @@
+class MapboxStudio < Cask
+  version '0.1.0'
+  sha256 'c36455cfa938c957cb08acd04281a5104702ab3b6ba0c76ae38bb6a55910296d'
+
+  url 'https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-v0.1.0.zip'
+  homepage 'https://www.mapbox.com/mapbox-studio/#darwin'
+
+  link 'Mapbox Studio.app'
+end


### PR DESCRIPTION
This PR adds Mapbox Studio; however, I'm also looking for assistance as to how to resolve the following error before getting this merged:

```
==> Downloading https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-v0.1.0.zip
Already downloaded: /Library/Caches/Homebrew/mapbox-studio-0.1.0.zip
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/mapbox-studio/0.1.0/Mapbox Studio.app'
```
