### PR TITLE
Revert "gitx-rowanj: Version and checksum"

### DIFF
--- a/Casks/gitx-rowanj.rb
+++ b/Casks/gitx-rowanj.rb
@@ -1,8 +1,8 @@
 class GitxRowanj < Cask
-  version '0.15.1949'
-  sha256 '17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a'
+  version 'latest'
+  sha256 :no_check
 
-  url 'http://builds.phere.net/GitX/development/GitX-dev-1949.dmg'
+  url 'http://builds.phere.net/GitX/development/GitX-dev.dmg'
   appcast 'https://s3.amazonaws.com/builds.phere.net/GitX/development/GitX-dev.xml'
   homepage 'http://rowanj.github.io/gitx/'
 


### PR DESCRIPTION
Reverts caskroom/homebrew-cask#6126

See #6126 for reasoning as why this PR has been reverted.
