### PR TITLE
Update Bit-Slicer 1.7.3 sha256 hash

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,6 +1,6 @@
 class BitSlicer < Cask
   version '1.7.3'
-  sha256 'd1a2fa33852ec95f52070e6b4d9c16f4a8741b41d384f8d1aab7c501d5a78b24'
+  sha256 'be8e7638ef29b2fe85f4dc8d237176887c7de86debdb514ef4160d73597d99e7'
 
   url 'https://bitbucket.org/zorgiepoo/bit-slicer/downloads/Bit%20Slicer%201.7.3.zip'
   appcast 'http://zorg.tejat.net/bitslicer/update.php'


### PR DESCRIPTION
New version of 1.7.3 was uploaded.
