### PR TITLE
update hashcat.rb to use depends_on :formula

### DIFF
--- a/Casks/hashcat.rb
+++ b/Casks/hashcat.rb
@@ -5,7 +5,7 @@ class Hashcat < Cask
   url 'https://hashcat.net/files/hashcat-0.47.7z'
   homepage 'https://hashcat.net/hashcat/'
 
-  depends_on_formula 'unar'
+  depends_on :formula => 'unar'
 
   binary 'hashcat-0.47/hashcat-cli64.app', :target => 'hashcat'
 end


### PR DESCRIPTION
This is the only Cask with `depends_on_formula` in the main repo.
