### PR TITLE
Renamed unity3d to unity

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,4 +1,4 @@
-class Unity3d < Cask
+class Unity < Cask
   version '4.5.4'
   sha256 '6fb72bfacf78df072559dd9a024a9d47e49b5717c8f17d53f05e2fc74a721876'
 


### PR DESCRIPTION
They don’t only do 3D anymore, and they brand themselves as just “Unity” throughout (it’s also the name of the `.pkg`.
