### PR TITLE
functionality and docs for zap stanza and verb

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -76,6 +76,7 @@ This will both uninstall the Cask and remove symlinks which were created in
 * `home` -- opens the homepage of the given Cask; or with no arguments, the homebrew-cask project page
 * `alfred` -- modifies Alfred's scope to include the Caskroom
 * `update` -- a synonym for `brew update`
+* `zap` -- try to remove *all* files associated with a Cask (including resources which may be shared with other applications)
 
 The following commands are for Cask authors:
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -41,6 +41,7 @@ This notice will be removed for the final form.**
    * stub - not yet functional
  * `depends_on :java`
    * stub - not yet functional
+ * `zap`
 
 
 ## Renames (1.0)

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -89,6 +89,22 @@ names, and other aspects of this manual are still subject to change.
   * `uninstall` or `rm` or `remove` <Cask>:
     Uninstall <Cask>.
 
+  * `zap` <Cask>:
+    Unconditionally remove _all_ files associated with <Cask>.
+
+    Implicitly performs all actions associated with `uninstall`, even if
+    the Cask does not appear to be currently installed.
+
+    Removes all staged versions of the Cask distribution found under
+    `/opt/homebrew-cask/Caskroom/<Cask>`
+
+    If the Cask definition contains a `zap` stanza, performs additional
+    `zap` actions as defined there, such as removing local preference
+    files.  `zap` actions are variable, depending on the level of detail
+    defined by the Cask author.
+
+    **`zap` may remove resources which are shared between applications.**
+
   * `search` or `-S`:
     Display all Casks available for install.
 

--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -24,6 +24,10 @@ class Cask::Artifact::Base
      cask.artifacts[self.artifact_dsl_key].any?
   end
 
+  def zap_phase
+    odebug "Nothing to do. The #{self.class.artifact_name} artifact has no zap phase."
+  end
+
   # todo: this sort of logic would make more sense in dsl.rb, or a
   # constructor called from dsl.rb, so long as that isn't slow.
   def self.read_script_arguments(arguments, stanza, default_arguments={}, override_arguments={}, key=nil)

--- a/lib/cask/artifact/zap.rb
+++ b/lib/cask/artifact/zap.rb
@@ -8,6 +8,7 @@ class Cask::Artifact::Zap < Cask::Artifact::UninstallBase
   end
 
   def zap_phase
-    dispatch_uninstall_directives(self.class.artifact_dsl_key)
+    expand_tilde = true
+    dispatch_uninstall_directives(self.class.artifact_dsl_key, expand_tilde)
   end
 end

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -20,6 +20,7 @@ require 'cask/cli/list'
 require 'cask/cli/search'
 require 'cask/cli/uninstall'
 require 'cask/cli/update'
+require 'cask/cli/zap'
 
 require 'cask/cli/internal_use_base'
 require 'cask/cli/internal_dump'

--- a/lib/cask/cli/zap.rb
+++ b/lib/cask/cli/zap.rb
@@ -1,0 +1,15 @@
+class Cask::CLI::Zap < Cask::CLI::Base
+  def self.run(*args)
+    raise CaskUnspecifiedError if args.empty?
+    cask_names = args.reject { |a| a.chars.first == '-' }
+    cask_names.each do |cask_name|
+      odebug "Zapping Cask #{cask_name}"
+      cask = Cask.load(cask_name)
+      Cask::Installer.new(cask).zap
+    end
+  end
+
+  def self.help
+    "zaps all files associated with the cask of the given name"
+  end
+end

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -1,8 +1,11 @@
 require 'test_helper'
 
-describe Cask::Artifact::Uninstall do
+# todo
+# - test that zap removes an alternate version of the same Cask
+
+describe Cask::Artifact::Zap do
   before {
-    @cask = Cask.load('with-installable')
+    @cask = Cask.load('with-zap')
     shutup do
       TestHelper.install_without_artifacts(@cask)
     end
@@ -10,41 +13,42 @@ describe Cask::Artifact::Uninstall do
 
   describe 'install_phase' do
     it 'does nothing, because the install_phase method is a no-op' do
-      uninstall_artifact = Cask::Artifact::Uninstall.new(@cask, Cask::FakeSystemCommand)
+      zap_artifact = Cask::Artifact::Zap.new(@cask, Cask::FakeSystemCommand)
       shutup do
-        uninstall_artifact.install_phase
-      end
-    end
-  end
-
-  describe 'zap_phase' do
-    it 'does nothing, because the zap_phase method is a no-op' do
-      uninstall_artifact = Cask::Artifact::Uninstall.new(@cask, Cask::FakeSystemCommand)
-      shutup do
-        uninstall_artifact.zap_phase
+        zap_artifact.install_phase
       end
     end
   end
 
   describe 'uninstall_phase' do
-    # todo: uninstall tests for :signal (implementation does not use SystemCommand)
-    it 'runs the specified uninstaller for the cask' do
-      uninstall_artifact = Cask::Artifact::Uninstall.new(@cask, Cask::FakeSystemCommand)
+    it 'does nothing, because the uninstall_phase method is a no-op' do
+      zap_artifact = Cask::Artifact::Zap.new(@cask, Cask::FakeSystemCommand)
+      shutup do
+        zap_artifact.uninstall_phase
+      end
+    end
+  end
+
+  describe 'zap_phase' do
+    # todo: zap tests for :signal (implementation does not use SystemCommand)
+    it 'runs the specified zap procedures for the cask' do
+      zap_artifact = Cask::Artifact::Zap.new(@cask, Cask::FakeSystemCommand)
 
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--', '/permissible/absolute/path'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
+                                               Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])
 
       shutup do
-        uninstall_artifact.uninstall_phase
+        zap_artifact.zap_phase
       end
     end
 
-    it 'can uninstall using pkgutil, launchctl, and file lists' do
-      cask = Cask.load('with-pkgutil-uninstall')
-      uninstall_artifact = Cask::Artifact::Uninstall.new(cask, Cask::FakeSystemCommand)
+    it 'can zap using pkgutil, launchctl, and file lists' do
+      cask = Cask.load('with-pkgutil-zap')
+      zap_artifact = Cask::Artifact::Zap.new(cask, Cask::FakeSystemCommand)
 
       Cask::FakeSystemCommand.stubs_command(
         ['/usr/sbin/pkgutil', '--pkgs=my.fancy.package.*'],
@@ -195,7 +199,7 @@ describe Cask::Artifact::Uninstall do
       # No assertions after call since all assertions are implicit from the interactions setup above.
       # TODO: verify rmdir commands (requires setting up actual file tree or faking out .exists?
       shutup do
-        uninstall_artifact.uninstall_phase
+        zap_artifact.zap_phase
       end
     end
   end

--- a/test/cask/cli/zap_test.rb
+++ b/test/cask/cli/zap_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+describe Cask::CLI::Zap do
+  it "shows an error when a bad cask is provided" do
+    lambda {
+      Cask::CLI::Zap.run('notacask')
+    }.must_raise CaskUnavailableError
+  end
+
+  it "can zap and unlink multiple casks at once" do
+    caffeine = Cask.load('local-caffeine')
+    transmission = Cask.load('local-transmission')
+
+    shutup do
+      Cask::Installer.new(caffeine).install
+      Cask::Installer.new(transmission).install
+    end
+
+    caffeine.must_be :installed?
+    transmission.must_be :installed?
+
+    shutup do
+      Cask::CLI::Zap.run('local-caffeine', 'local-transmission')
+    end
+
+    caffeine.wont_be :installed?
+    Cask.appdir.join('Transmission.app').wont_be :symlink?
+    transmission.wont_be :installed?
+    Cask.appdir.join('Caffeine.app').wont_be :symlink?
+  end
+
+  # todo
+  # Explicit test that both zap and uninstall directives get dispatched.
+  # The above tests that implicitly.
+  #
+  # it "dispatches both uninstall and zap stanzas" do
+  #   with_zap = Cask.load('with-zap')
+  #
+  #   shutup do
+  #     Cask::Installer.new(with_zap).install
+  #   end
+  #
+  #   with_zap.must_be :installed?
+  #
+  #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
+  #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
+  #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app.from.uninstall"'], '1')
+  #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app.from.uninstall" to quit'])
+  #
+  #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', with_zap.destination_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+  #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
+  #                                             Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])
+  #
+  #   shutup do
+  #     Cask::CLI::Zap.run('with-zap')
+  #   end
+  #   with_zap.wont_be :installed?
+  # end
+
+  it "raises an exception when no cask is specified" do
+    lambda {
+      Cask::CLI::Uninstall.run
+    }.must_raise CaskUnspecifiedError
+  end
+end

--- a/test/support/Casks/with-installable.rb
+++ b/test/support/Casks/with-installable.rb
@@ -5,5 +5,10 @@ class WithInstallable < TestCask
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
   pkg 'MyFancyPkg/Fancy.pkg'
   uninstall :script => { :executable => 'MyFancyPkg/FancyUninstaller.tool', :args => %w[--please] },
-            :quit => 'my.fancy.package.app'
+            :quit   => 'my.fancy.package.app',
+            :files  => [
+                        '/permissible/absolute/path',
+                        '~/impermissible/path/with/tilde',
+                        'impermissible/relative/path',
+                       ]
 end

--- a/test/support/Casks/with-pkgutil-zap.rb
+++ b/test/support/Casks/with-pkgutil-zap.rb
@@ -1,0 +1,10 @@
+class WithPkgutilZap < TestCask
+  url TestHelper.local_binary('MyFancyPkg.zip')
+  homepage 'http://example.com/fancy-pkg'
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+  pkg 'Fancy.pkg'
+  zap :pkgutil => 'my.fancy.package.*',
+      :kext => 'my.fancy.package.kernelextension',
+      :launchctl => 'my.fancy.package.service'
+end

--- a/test/support/Casks/with-zap.rb
+++ b/test/support/Casks/with-zap.rb
@@ -1,0 +1,14 @@
+class WithZap < TestCask
+  url TestHelper.local_binary('MyFancyPkg.zip')
+  homepage 'http://example.com/fancy-pkg'
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+  pkg 'MyFancyPkg/Fancy.pkg'
+  uninstall :quit => 'my.fancy.package.app.from.uninstall'
+  zap :script => {
+                  :executable => 'MyFancyPkg/FancyUninstaller.tool',
+                  :args => %w[--please]
+                  },
+      :quit => 'my.fancy.package.app',
+      :files => '~/Library/Preferences/my.fancy.app.plist'
+end

--- a/test/support/cleanup.rb
+++ b/test/support/cleanup.rb
@@ -3,7 +3,7 @@ module Cask::CleanupHooks
     super
     Cask.installed.each do |cask|
       Cask::Installer.new(cask).tap do |installer|
-        installer.purge_files
+        installer.purge_versioned_files
       end
     end
   end


### PR DESCRIPTION
- `zap` was previously supported as a noop for forward-compatibility
- Also adds restrictions against relative paths in `uninstall :files`
