### PR TITLE
restore `pkg` to cask_language_deltas.md

### DIFF
--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -47,11 +47,13 @@ This notice will be removed for the final form.**
 
 | old form              | new form
 | --------------------- |----------------
+| `install`             | `pkg`
 | `before_install`      | `preflight`
 | `after_install`       | `postflight`
 | `before_uninstall`    | `uninstall_preflight`
 | `after_uninstall`     | `uninstall_postflight`
 | `depends_on_formula`  | `depends_on :formula`
+
 
 ## All Supported Stanzas (1.0)
 


### PR DESCRIPTION
was deleted due to merge error in #6138
