### PR TITLE
doc new `app` stanza and update tests to use it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Making a Cask is easy: a Cask is a small Ruby file.
 ### Examples
 
 Here's a Cask for `Alfred.app` as an example.  Note that you may repeat
-the `link` stanza as many times as you need, to create multiple links:
+the `app` stanza as many times as you need, to define multiple apps:
 
 ```ruby
 class Alfred < Cask
@@ -40,8 +40,8 @@ class Alfred < Cask
   url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
   homepage 'http://www.alfredapp.com/'
 
-  link 'Alfred 2.app'
-  link 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
+  app 'Alfred 2.app'
+  app 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
 end
 ```
 
@@ -70,7 +70,7 @@ class Firefox < Cask
   url 'https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US'
   homepage 'https://www.mozilla.org/en-US/firefox/'
 
-  link 'Firefox.app'
+  app 'Firefox.app'
 end
 ```
 
@@ -120,7 +120,7 @@ class MyNewCask < Cask
   url ''
   homepage ''
 
-  link ''
+  app ''
 end
 ```
 
@@ -136,7 +136,7 @@ Fill in the following stanzas for your Cask:
 | `version`          | application version; give the value `'latest'` if an unversioned download is available
 | `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be suppressed for unversioned downloads by using the special value `:no_check`. (see also [Checksum Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#checksum-stanza-details))
 | __artifact info__  | information about artifacts inside the Cask (can be specified multiple times)
-| `link`             | relative path to a file that should be linked into the `Applications` folder on installation (see also [Link Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#link-stanza-details))
+| `app`              | relative path to an `.app` bundle that should be linked into the `Applications` folder on installation (see also [App Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#app-stanza-details))
 | `pkg`              | relative path to a `.pkg` file containing the distribution (see also [Pkg Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#pkg-stanza-details))
 | `uninstall`        | procedures to uninstall a Cask. Optional unless the `pkg` stanza is used. (see also [Uninstall Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details))
 
@@ -218,17 +218,17 @@ To name a Cask manually, or to learn about exceptions for unusual cases, see [CA
 ### Archives With Subfolders
 
 When a downloaded archive expands to a subfolder, the subfolder name must be
-included in the `link` value.
+included in the `app` value.
 
 Example:
 
  * Texmaker is downloaded to the file `TexmakerMacosxLion.zip`.
  * `TexmakerMacosxLion.zip` unzips to a folder called `TexmakerMacosxLion`.
  * The folder `TexmakerMacosxLion` contains the application `texmaker.app`.
- * So, the `link` stanza should include the subfolder as a relative path:
+ * So, the `app` stanza should include the subfolder as a relative path:
 
 	```ruby
-	link 'TexmakerMacosxLion/texmaker.app'
+	app 'TexmakerMacosxLion/texmaker.app'
 	```
 
 ### Indenting

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -13,7 +13,7 @@ Cask Domain-Specific Language (DSL) which are not needed in most cases.
  * [Caveats Stanza Details](#caveats-stanza-details)
  * [Checksum Stanza Details](#checksum-stanza-details)
  * [URL Stanza Details](#url-stanza-details)
- * [Link Stanza Details](#link-stanza-details)
+ * [App Stanza Details](#app-stanza-details)
  * [Pkg Stanza Details](#pkg-stanza-details)
  * [Depends_on Stanza Details](#depends_on-stanza-details)
  * [Uninstall Stanza Details](#uninstall-stanza-details)
@@ -35,8 +35,8 @@ class Alfred < Cask
   url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
   homepage 'http://www.alfredapp.com/'
 
-  link 'Alfred 2.app'
-  link 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
+  app 'Alfred 2.app'
+  app 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
 end
 ```
 
@@ -75,19 +75,19 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 
 | name               | multiple occurrences allowed? | value       |
 | ------------------ |------------------------------ | ----------- |
-| `link`             | yes                           |  relative path to a file that should be linked into the `Applications` folder on installation (see also [Link Stanza Details](#link-stanza-details))
-| `pkg`              | yes                           |  relative path to a `.pkg` file containing the distribution (see also [Pkg Stanza Details](#pkg-stanza-details))
-| `binary`           | yes                           |  relative path to a binary that should be linked into the `/usr/local/bin` folder on installation
-| `colorpicker`      | yes                           |  relative path to a ColorPicker plugin that should be linked into the `~/Library/ColorPickers` folder on installation
-| `font`             | yes                           |  relative path to a font that should be linked into the `~/Library/Fonts` folder on installation
-| `input_method`     | yes                           |  relative path to a input method that should be linked into the `~/Library/Input Methods` folder on installation
-| `internet_plugin`  | yes                           |  relative path to a service that should be linked into the `~/Library/Internet Plug-Ins` folder on installation
-| `prefpane`         | yes                           |  relative path to a preference pane that should be linked into the `~/Library/PreferencePanes` folder on installation
-| `qlplugin`         | yes                           |  relative path to a QuickLook plugin that should be linked into the `~/Library/QuickLook` folder on installation
-| `screen_saver`     | yes                           |  relative path to a Screen Saver that should be linked into the `~/Library/Screen Savers` folder on installation
-| `service`          | yes                           |  relative path to a service that should be linked into the `~/Library/Services` folder on installation
-| `widget`           | yes                           |  relative path to a widget that should be linked into the `~/Library/Widgets` folder on installation (ALPHA: DOES NOT WORK YET)
-
+| `app`              | yes                           | relative path to an `.app` that should be linked into the `~/Applications` folder on installation (see also [App Stanza Details](#app-stanza-details))
+| `pkg`              | yes                           | relative path to a `.pkg` file containing the distribution (see also [Pkg Stanza Details](#pkg-stanza-details))
+| `binary`           | yes                           | relative path to a binary that should be linked into the `/usr/local/bin` folder on installation
+| `colorpicker`      | yes                           | relative path to a ColorPicker plugin that should be linked into the `~/Library/ColorPickers` folder on installation
+| `font`             | yes                           | relative path to a font that should be linked into the `~/Library/Fonts` folder on installation
+| `input_method`     | yes                           | relative path to a input method that should be linked into the `~/Library/Input Methods` folder on installation
+| `internet_plugin`  | yes                           | relative path to a service that should be linked into the `~/Library/Internet Plug-Ins` folder on installation
+| `prefpane`         | yes                           | relative path to a preference pane that should be linked into the `~/Library/PreferencePanes` folder on installation
+| `qlplugin`         | yes                           | relative path to a QuickLook plugin that should be linked into the `~/Library/QuickLook` folder on installation
+| `screen_saver`     | yes                           | relative path to a Screen Saver that should be linked into the `~/Library/Screen Savers` folder on installation
+| `service`          | yes                           | relative path to a service that should be linked into the `~/Library/Services` folder on installation
+| `widget`           | yes                           | relative path to a widget that should be linked into the `~/Library/Widgets` folder on installation (ALPHA: DOES NOT WORK YET)
+| `link`             | yes                           | relative path to an arbitrary path that should be symlinked on installation.  This is an older form which is preserved only for unusual cases.  The `app` stanza is strongly preferred for linking `.app` bundles.
 
 ## Optional Stanzas
 
@@ -292,14 +292,14 @@ following key/value pairs to `url`:
 | `:trust_cert`      | set to `true` to automatically trust the certificate presented by the server (avoiding an interactive prompt)
 
 
-## Link Stanza Details
+## App Stanza Details
 
-In the simple case of a string argument to `link`, a symlink is created in
+In the simple case of a string argument to `app`, a symlink is created in
 the target `~/Applications` directory using the same basename as the source
 file.  For example:
 
 ```ruby
-link 'Alfred 2.app'
+app 'Alfred 2.app'
 ```
 
 causes the creation of this symlink
@@ -317,10 +317,10 @@ which points to a source file such as
 ### Renaming the Target
 
 You can rename the target link which appears in your `~/Applications`
-directory by adding a `:target` key to `link`, like this:
+directory by adding a `:target` key to `app`, like this:
 
 ```ruby
-link 'Alfred 2.app', :target => 'Jeeves.app'
+app 'Alfred 2.app', :target => 'Jeeves.app'
 ```
 
 ### :target May Contain an Absolute Path

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -49,6 +49,7 @@ This notice will be removed for the final form.**
 | old form              | new form
 | --------------------- |----------------
 | `install`             | `pkg`
+| `link`                | `app`  (note: `link` is still available, with different semantics)
 | `before_install`      | `preflight`
 | `after_install`       | `postflight`
 | `before_uninstall`    | `uninstall_preflight`

--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -26,7 +26,7 @@ class Cask::CLI::Create < Cask::CLI::Base
         url 'https://'
         homepage ''
 
-        link ''
+        app ''
       end
     EOS
   end

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -39,7 +39,7 @@ describe Cask::Artifact::App do
         homepage 'http://example.com/local-caffeine'
         version '1.2.3'
         sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-        link 'subdir/Caffeine.app', :target => 'AnotherName.app'
+        app 'subdir/Caffeine.app', :target => 'AnotherName.app'
       end
 
       begin

--- a/test/cask/artifact/app_test.rb
+++ b/test/cask/artifact/app_test.rb
@@ -25,7 +25,7 @@ describe Cask::Artifact::App do
         homepage 'http://example.com/local-caffeine'
         version '1.2.3'
         sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-        link 'subdir/Caffeine.app'
+        app 'subdir/Caffeine.app'
       end
 
       begin

--- a/test/cask/artifact/two_apps_correct_test.rb
+++ b/test/cask/artifact/two_apps_correct_test.rb
@@ -1,15 +1,15 @@
 require 'test_helper'
 
 describe Cask::Artifact::App do
-  let(:local_two_links_caffeine) {
-    Cask.load('with-two-links-correct').tap do |cask|
+  let(:local_two_apps_caffeine) {
+    Cask.load('with-two-apps-correct').tap do |cask|
       TestHelper.install_without_artifacts(cask)
     end
   }
 
-  describe 'install multiple links' do
+  describe 'install multiple apps' do
     it "links both noted applications to the proper directory" do
-      cask = local_two_links_caffeine
+      cask = local_two_apps_caffeine
 
       shutup do
         Cask::Artifact::App.new(cask).install_phase
@@ -20,18 +20,18 @@ describe Cask::Artifact::App do
     end
 
     it "works with an application in a subdir" do
-      AltSubDirTwoLinksCask = Class.new(Cask)
-      AltSubDirTwoLinksCask.class_eval do
+      AltSubDirTwoAppsCask = Class.new(Cask)
+      AltSubDirTwoAppsCask.class_eval do
         url TestHelper.local_binary('caffeine.zip')
         homepage 'http://example.com/local-caffeine'
         version '1.2.3'
         sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-        link 'subdir/Caffeine.app'
-        link 'subdir/Caffeine.app', :target => 'AnotherName.app'
+        app 'subdir/Caffeine.app'
+        app 'subdir/Caffeine.app', :target => 'AnotherName.app'
       end
 
       begin
-        subdir_cask = AltSubDirTwoLinksCask.new.tap do |cask|
+        subdir_cask = AltSubDirTwoAppsCask.new.tap do |cask|
           TestHelper.install_without_artifacts(cask)
         end
 
@@ -55,7 +55,7 @@ describe Cask::Artifact::App do
 
     # @@@ todo
     # it "only uses linkables when they are specified" do
-    #   cask = local_two_links_caffeine
+    #   cask = local_two_apps_caffeine
     #
     #   app_path = cask.destination_path.join('Caffeine.app')
     #   FileUtils.cp_r app_path, app_path.sub('Caffeine.app', 'CaffeineAgain.app')
@@ -69,7 +69,7 @@ describe Cask::Artifact::App do
     # end
 
     it "avoids clobbering an existing app by linking over it (link 1)" do
-      cask = local_two_links_caffeine
+      cask = local_two_apps_caffeine
 
       (Cask.appdir/'Caffeine.app').mkpath
 
@@ -84,7 +84,7 @@ describe Cask::Artifact::App do
     end
 
     it "avoids clobbering an existing app by linking over it (link 2)" do
-      cask = local_two_links_caffeine
+      cask = local_two_apps_caffeine
 
       (Cask.appdir/'AnotherName.app').mkpath
 
@@ -99,7 +99,7 @@ describe Cask::Artifact::App do
     end
 
     it "happily clobbers an existing symlink (link 1)" do
-      cask = local_two_links_caffeine
+      cask = local_two_apps_caffeine
 
       (Cask.appdir/'Caffeine.app').make_symlink('/tmp')
 
@@ -114,7 +114,7 @@ describe Cask::Artifact::App do
     end
 
     it "happily clobbers an existing symlink (link 2)" do
-      cask = local_two_links_caffeine
+      cask = local_two_apps_caffeine
 
       (Cask.appdir/'AnotherName.app').make_symlink('/tmp')
 

--- a/test/cask/artifact/two_apps_incorrect_test.rb
+++ b/test/cask/artifact/two_apps_incorrect_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Cask::Artifact::App do
   it 'must raise' do
    begin
-     Cask.load('two-links-incorrect')
+     Cask.load('two-apps-incorrect')
    rescue => e
    end
     # todo: later give the user a nice exception for this case and check for it here

--- a/test/cask/cli/cat_test.rb
+++ b/test/cask/cli/cat_test.rb
@@ -10,7 +10,7 @@ describe Cask::CLI::Cat do
         homepage 'http://example.com/'
         version '1.2.3'
         sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
-        link 'TestCask.app'
+        app 'TestCask.app'
       end
     CLIOUTPUT
   end
@@ -24,7 +24,7 @@ describe Cask::CLI::Cat do
         homepage 'http://example.com/'
         version '1.2.3'
         sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
-        link 'TestCask.app'
+        app 'TestCask.app'
       end
     CLIOUTPUT
   end

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -43,7 +43,7 @@ describe Cask::CLI::Create do
         url 'https://'
         homepage ''
 
-        link ''
+        app ''
       end
     TEMPLATE
   end

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -45,19 +45,19 @@ describe Cask::DSL do
     end
   end
 
-  describe "link stanza" do
-    it "allows you to specify linkables" do
+  describe "app stanza" do
+    it "allows you to specify app stanzas" do
       CaskWithLinkables = Class.new(Cask)
       CaskWithLinkables.class_eval do
-        link 'Foo.app'
-        link 'Bar.app'
+        app 'Foo.app'
+        app 'Bar.app'
       end
 
       instance = CaskWithLinkables.new
       Array(instance.artifacts[:link]).sort.must_equal [['Bar.app'], ['Foo.app']]
     end
 
-    it "allow linkables to be set to empty" do
+    it "allow app stanzas to be set to empty" do
       CaskWithNoLinkables = Class.new(Cask)
 
       instance = CaskWithNoLinkables.new

--- a/test/support/Casks/adobe-air-container.rb
+++ b/test/support/Casks/adobe-air-container.rb
@@ -3,5 +3,5 @@ class AdobeAirContainer < TestCask
   homepage 'http://robertnyman.com/gmdesk/'
   version '1.0.1'
   sha256 '9b6e4174afa76f2af50238364fcf87525bc4ed2287acbe62925107ab6cda5c99'
-  link 'GMDesk.app'
+  app 'GMDesk.app'
 end

--- a/test/support/Casks/bad-checksum.rb
+++ b/test/support/Casks/bad-checksum.rb
@@ -3,5 +3,5 @@ class BadChecksum < TestCask
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/basic-cask.rb
+++ b/test/support/Casks/basic-cask.rb
@@ -3,5 +3,5 @@ class BasicCask < TestCask
   homepage 'http://example.com/'
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
-  link 'TestCask.app'
+  app 'TestCask.app'
 end

--- a/test/support/Casks/bzipped-asset.rb
+++ b/test/support/Casks/bzipped-asset.rb
@@ -3,5 +3,5 @@ class BzippedAsset < TestCask
   homepage 'http://example.com/bzipped-asset'
   version '1.2.3'
   sha256 'eaf67b3a62cb9275f96e45d05c70b94bef9ef1dae344083e93eda6b0b388a61c'
-  link 'bzipped-asset-1.2.3'
+  app 'bzipped-asset-1.2.3'
 end

--- a/test/support/Casks/cab-container.rb
+++ b/test/support/Casks/cab-container.rb
@@ -4,5 +4,5 @@ class CabContainer < TestCask
   version '1.2.3'
   sha256 '192d0cf6b727473f9ba0f55cec793ee2a8f7113c5cfe9d49e05a087436c5efe2'
   depends_on :formula => 'cabextract'
-  link 'cabcontainer/Application.app'
+  app 'cabcontainer/Application.app'
 end

--- a/test/support/Casks/gzipped-asset.rb
+++ b/test/support/Casks/gzipped-asset.rb
@@ -3,5 +3,5 @@ class GzippedAsset < TestCask
   homepage 'http://example.com/gzipped-asset'
   version '1.2.3'
   sha256 '832506ade94b3e41ecdf2162654eb75891a0749803229e82b2e0420fd1b9e8d2'
-  link 'gzipped-asset-1.2.3'
+  app 'gzipped-asset-1.2.3'
 end

--- a/test/support/Casks/invalid/invalid-appcast-format.rb
+++ b/test/support/Casks/invalid/invalid-appcast-format.rb
@@ -6,5 +6,5 @@ class InvalidAppcastFormat < TestCask
           :format => :no_such_format
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-appcast-multiple.rb
+++ b/test/support/Casks/invalid/invalid-appcast-multiple.rb
@@ -9,5 +9,5 @@ class InvalidAppcastMultiple < TestCask
           :format => :sparkle
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-appcast-url.rb
+++ b/test/support/Casks/invalid/invalid-appcast-url.rb
@@ -6,5 +6,5 @@ class InvalidAppcastUrl < TestCask
           :format => :sparkle
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-conflicts-with-key.rb
+++ b/test/support/Casks/invalid/invalid-conflicts-with-key.rb
@@ -4,5 +4,5 @@ class InvalidConflictsWithKey < TestCask
   conflicts_with :no_such_key => 'unar'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-depends-on-key.rb
+++ b/test/support/Casks/invalid/invalid-depends-on-key.rb
@@ -4,5 +4,5 @@ class InvalidDependsOnKey < TestCask
   depends_on :no_such_key => 'unar'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
+++ b/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
@@ -6,5 +6,5 @@ class InvalidGpgConflictingKeys < TestCask
       :key_url => 'http://example.com/gpg-key-url'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-key-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-key-url.rb
@@ -5,5 +5,5 @@ class InvalidGpgKeyUrl < TestCask
       :key_url => 1
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-missing-key.rb
+++ b/test/support/Casks/invalid/invalid-gpg-missing-key.rb
@@ -4,5 +4,5 @@ class InvalidGpgMissingKeys < TestCask
   gpg 'http://example.com/gpg-signature.asc'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
+++ b/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
@@ -7,5 +7,5 @@ class InvalidGpgMultipleStanzas < TestCask
       :key_id => 'ID'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-parameter.rb
+++ b/test/support/Casks/invalid/invalid-gpg-parameter.rb
@@ -5,5 +5,5 @@ class InvalidGpgParameter < TestCask
       :no_such_parameter => :value
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-signature-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-signature-url.rb
@@ -5,5 +5,5 @@ class InvalidGpgSignatureUrl < TestCask
       :key_id => 'ID'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-type.rb
+++ b/test/support/Casks/invalid/invalid-gpg-type.rb
@@ -5,5 +5,5 @@ class InvalidGpgParameter < TestCask
       :no_such_parameter => :value
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-license-multiple.rb
+++ b/test/support/Casks/invalid/invalid-license-multiple.rb
@@ -5,5 +5,5 @@ class InvalidLicenseMultiple < TestCask
   license :gpl
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
-  link 'Transmission.app'
+  app 'Transmission.app'
 end

--- a/test/support/Casks/invalid/invalid-license-value.rb
+++ b/test/support/Casks/invalid/invalid-license-value.rb
@@ -4,5 +4,5 @@ class InvalidLicenseValue < TestCask
   license :no_such_license
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
-  link 'Transmission.app'
+  app 'Transmission.app'
 end

--- a/test/support/Casks/invalid/invalid-tags-key.rb
+++ b/test/support/Casks/invalid/invalid-tags-key.rb
@@ -4,5 +4,5 @@ class InvalidTagsKey < TestCask
   tags :no_such_key => 'ExampleSoft'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-tags-multiple.rb
+++ b/test/support/Casks/invalid/invalid-tags-multiple.rb
@@ -5,5 +5,5 @@ class InvalidTagsMultiple < TestCask
   tags :vendor => 'ExampleSoft'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-two-homepage.rb
+++ b/test/support/Casks/invalid/invalid-two-homepage.rb
@@ -5,5 +5,5 @@ class InvalidTwoHomepage < TestCask
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-two-url.rb
+++ b/test/support/Casks/invalid/invalid-two-url.rb
@@ -5,5 +5,5 @@ class InvalidTwoUrl < TestCask
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-two-version.rb
+++ b/test/support/Casks/invalid/invalid-two-version.rb
@@ -5,5 +5,5 @@ class InvalidTwoVersion < TestCask
   version '2.0'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/local-caffeine.rb
+++ b/test/support/Casks/local-caffeine.rb
@@ -4,5 +4,5 @@ class LocalCaffeine < TestCask
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/local-transmission.rb
+++ b/test/support/Casks/local-transmission.rb
@@ -3,5 +3,5 @@ class LocalTransmission < TestCask
   homepage 'http://example.com/local-transmission'
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
-  link 'Transmission.app'
+  app 'Transmission.app'
 end

--- a/test/support/Casks/missing-checksum.rb
+++ b/test/support/Casks/missing-checksum.rb
@@ -2,5 +2,5 @@ class MissingChecksum < TestCask
   url TestHelper.local_binary('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/nested-app-dsl-one.rb
+++ b/test/support/Casks/nested-app-dsl-one.rb
@@ -7,5 +7,5 @@ class NestedAppDslOne < TestCask
   version '1.2.3'
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
   container :nested => 'NestedApp.dmg'
-  link 'MyNestedApp.app'
+  app 'MyNestedApp.app'
 end

--- a/test/support/Casks/nested-app.rb
+++ b/test/support/Casks/nested-app.rb
@@ -4,5 +4,5 @@ class NestedApp < TestCask
   version '1.2.3'
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
   nested_container 'NestedApp.dmg'
-  link 'MyNestedApp.app'
+  app 'MyNestedApp.app'
 end

--- a/test/support/Casks/no-checksum.rb
+++ b/test/support/Casks/no-checksum.rb
@@ -3,5 +3,5 @@ class NoChecksum < TestCask
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 :no_check
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/rar-container.rb
+++ b/test/support/Casks/rar-container.rb
@@ -4,5 +4,5 @@ class RarContainer < TestCask
   version '1.2.3'
   sha256 '35fb13fb13e6aefc38b60486627eff6b6b55b2f99f64bf47938530c6cf9e0a0f'
   depends_on :formula => 'unar'
-  link 'rarcontainer/Application.app'
+  app 'rarcontainer/Application.app'
 end

--- a/test/support/Casks/sevenzip-container.rb
+++ b/test/support/Casks/sevenzip-container.rb
@@ -4,5 +4,5 @@ class SevenzipContainer < TestCask
   version '1.2.3'
   sha256 '1550701e7848fcb94f5b0085cca527083a8662ddeb8c0a7bc5af6bd145797cc1'
   depends_on :formula => 'unar'
-  link 'sevenzipcontainer/Application.app'
+  app 'sevenzipcontainer/Application.app'
 end

--- a/test/support/Casks/tarball.rb
+++ b/test/support/Casks/tarball.rb
@@ -3,5 +3,5 @@ class Tarball < TestCask
   homepage 'http://example.com/tarball'
   version '1.2.3'
   sha256 :no_check
-  link 'Tarball.app'
+  app 'Tarball.app'
 end

--- a/test/support/Casks/test-opera-mail.rb
+++ b/test/support/Casks/test-opera-mail.rb
@@ -3,5 +3,5 @@ class TestOperaMail < TestCask
   homepage 'http://www.opera.com/computer/mail'
   version '1.0'
   sha256 'afd192e308f8ea8ddb3d426fd6663d97078570417ee78b8e1fa15f515ae3d677'
-  link 'Opera Mail.app'
+  app 'Opera Mail.app'
 end

--- a/test/support/Casks/test-opera.rb
+++ b/test/support/Casks/test-opera.rb
@@ -3,5 +3,5 @@ class TestOpera < TestCask
   homepage 'http://www.opera.com/'
   version '19.0.1326.47'
   sha256 '7b91f20ab754f7b3fef8dc346e0393917e11676b74c8f577408841619f76040a'
-  link 'Opera.app'
+  app 'Opera.app'
 end

--- a/test/support/Casks/with-alt-target.rb
+++ b/test/support/Casks/with-alt-target.rb
@@ -3,5 +3,5 @@ class WithAltTarget < TestCask
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  link 'Caffeine.app', :target => 'AnotherName.app'
+  app 'Caffeine.app', :target => 'AnotherName.app'
 end

--- a/test/support/Casks/with-appcast.rb
+++ b/test/support/Casks/with-appcast.rb
@@ -6,5 +6,5 @@ class WithAppcast < TestCask
           :format => :sparkle
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/with-binary.rb
+++ b/test/support/Casks/with-binary.rb
@@ -3,6 +3,6 @@ class WithBinary < TestCask
   homepage 'http://example.com/with-binary'
   sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
   version '1.2.3'
-  link 'App.app'
+  app 'App.app'
   binary 'binary'
 end

--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -3,7 +3,7 @@ class WithCaveats < TestCask
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
   # simple string is evaluated at compile-time
   caveats <<-EOS.undent
     Here are some things you might want to know.

--- a/test/support/Casks/with-conditional-caveats.rb
+++ b/test/support/Casks/with-conditional-caveats.rb
@@ -3,7 +3,7 @@ class WithConditionalCaveats < TestCask
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
   # a do block may print and use a DSL
   caveats do
     puts 'This caveat is conditional' if false

--- a/test/support/Casks/with-conflicts-with.rb
+++ b/test/support/Casks/with-conflicts-with.rb
@@ -4,5 +4,5 @@ class WithConflictsWith < TestCask
   conflicts_with :formula => 'unar'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on.rb
+++ b/test/support/Casks/with-depends-on.rb
@@ -4,5 +4,5 @@ class WithDependsOn < TestCask
   depends_on :formula => 'unar'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/with-gpg-key-url.rb
+++ b/test/support/Casks/with-gpg-key-url.rb
@@ -5,5 +5,5 @@ class WithGpgKeyUrl < TestCask
       :key_url => 'http://example.com/gpg-key-url'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/with-gpg.rb
+++ b/test/support/Casks/with-gpg.rb
@@ -5,5 +5,5 @@ class WithGpg < TestCask
       :key_id => 'ID'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/with-license.rb
+++ b/test/support/Casks/with-license.rb
@@ -4,5 +4,5 @@ class WithLicense < TestCask
   license :gpl
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
-  link 'Transmission.app'
+  app 'Transmission.app'
 end

--- a/test/support/Casks/with-macosx-dir.rb
+++ b/test/support/Casks/with-macosx-dir.rb
@@ -3,5 +3,5 @@ class WithMacosxDir < TestCask
   homepage 'http://example.com/MyFancyApp'
   version '1.2.3'
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
-  link 'MyFancyApp/MyFancyApp.app'
+  app 'MyFancyApp/MyFancyApp.app'
 end

--- a/test/support/Casks/with-tags.rb
+++ b/test/support/Casks/with-tags.rb
@@ -4,5 +4,5 @@ class WithTags < TestCask
   tags :vendor => 'ExampleSoft'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   version '1.2.3'
-  link 'Caffeine.app'
+  app 'Caffeine.app'
 end

--- a/test/support/Casks/with-two-apps-correct.rb
+++ b/test/support/Casks/with-two-apps-correct.rb
@@ -1,7 +1,8 @@
-class WithTwoLinksIncorrect < TestCask
+class WithTwoAppsCorrect < TestCask
   url TestHelper.local_binary('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  link 'Caffeine.app', 'Caffeine.app/Contents/MacOS/Caffeine'
+  app 'Caffeine.app'
+  app 'Caffeine.app', :target => 'AnotherName.app'
 end

--- a/test/support/Casks/with-two-apps-incorrect.rb
+++ b/test/support/Casks/with-two-apps-incorrect.rb
@@ -1,8 +1,7 @@
-class WithTwoLinksCorrect < TestCask
+class WithTwoAppsIncorrect < TestCask
   url TestHelper.local_binary('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  link 'Caffeine.app'
-  link 'Caffeine.app', :target => 'AnotherName.app'
+  app 'Caffeine.app', 'Caffeine.app/Contents/MacOS/Caffeine'
 end

--- a/test/support/Casks/xar-container.rb
+++ b/test/support/Casks/xar-container.rb
@@ -3,5 +3,5 @@ class XarContainer < TestCask
   homepage 'http://example.com/xar-container'
   version '1.2.3'
   sha256 '1418752ac49e859f88590db245015cb2f8b459f619e0c50fd6ff87b902c72ee1'
-  link 'xarcontainer/Application.app'
+  app 'xarcontainer/Application.app'
 end


### PR DESCRIPTION
Replacing `link` for almost all cases.

The `link` stanza can still appear in error messages, because
under the hood, `app` is still implemented as a pure synonym
for the `link` artifact.  That will change automatically when
we factor into separate artifacts.
