### PR TITLE
Mackup zap stanza import

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -7,4 +7,8 @@ class Adium < Cask
   homepage 'https://www.adium.im/'
 
   app 'Adium.app'
+  zap :files => [
+                 '~/Library/Application Support/Adium 2.0',
+                 '~/Library/Preferences/com.adiumX.adiumX.plist',
+                ]
 end

--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -11,4 +11,14 @@ class Atom < Cask
   postflight do
     system '/usr/bin/defaults', 'write', 'com.github.atom', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => [
+                 '~/Library/Preferences/com.github.atom.plist',
+                 '~/.atom/config.cson',
+                 '~/.atom/init.coffee',
+                 '~/.atom/keymap.cson',
+                 '~/.atom/keymaps',
+                 '~/.atom/packages',
+                 '~/.atom/snippets.cson',
+                 '~/.atom/styles.less',
+                ]
 end

--- a/Casks/awareness.rb
+++ b/Casks/awareness.rb
@@ -6,4 +6,5 @@ class Awareness < Cask
   homepage 'http://iamfutureproof.com/tools/awareness/'
 
   app 'Awareness.app'
+  zap :files => '~/Library/Preferences/com.futureproof.awareness.plist'
 end

--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -12,4 +12,5 @@ class Bartender < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.surteesstudios.Bartender', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => '~/Library/Preferences/com.surteesstudios.Bartender.plist'
 end

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -7,4 +7,8 @@ class Bettertouchtool < Cask
   homepage 'http://blog.boastr.net/'
 
   app 'BetterTouchTool.app'
+  zap :files => [
+                 '~/Library/Preferences/com.hegenberg.BetterTouchTool.plist',
+                 '~/Library/Application Support/BetterTouchTool',
+                ]
 end

--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -7,4 +7,8 @@ class Bibdesk < Cask
   homepage 'http://bibdesk.sourceforge.net/'
 
   app 'BibDesk.app'
+  zap :files => [
+                 '~/Library/Preferences/edu.ucsd.cs.mmccrack.bibdesk.plist',
+                 '~/Library/Application Support/BibDesk',
+                ]
 end

--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -6,4 +6,8 @@ class Brackets < Cask
   homepage 'http://brackets.io'
 
   app 'Brackets.app'
+  zap :files => [
+                 '~/Library/Application Support/Brackets',
+                 '~/Library/Preferences/io.brackets.appshell.plist',
+                ]
 end

--- a/Casks/caffeine.rb
+++ b/Casks/caffeine.rb
@@ -6,4 +6,5 @@ class Caffeine < Cask
   homepage 'http://lightheadsw.com/caffeine/'
 
   app 'Caffeine.app'
+  zap :files => '~/Library/Preferences/com.lightheadsw.Caffeine.plist'
 end

--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -6,4 +6,8 @@ class Charles < Cask
   homepage 'http://www.charlesproxy.com/'
 
   app 'Charles.app'
+  zap :files => [
+                 '~/Library/Application Support/Charles',
+                 '~/Library/Preferences/com.xk72.charles.config',
+                ]
 end

--- a/Casks/chicken.rb
+++ b/Casks/chicken.rb
@@ -7,4 +7,5 @@ class Chicken < Cask
   homepage 'http://sourceforge.net/projects/chicken/'
 
   app 'Chicken.app'
+  zap :files => '~/Library/Preferences/net.sourceforge.chicken.plist'
 end

--- a/Casks/clementine.rb
+++ b/Casks/clementine.rb
@@ -7,4 +7,5 @@ class Clementine < Cask
   homepage 'http://www.clementine-player.org/'
 
   app 'clementine.app'
+  zap :files => '~/Library/Preferences/org.clementine-player.Clementine.plist'
 end

--- a/Casks/clipmenu.rb
+++ b/Casks/clipmenu.rb
@@ -7,4 +7,8 @@ class Clipmenu < Cask
   homepage 'http://www.clipmenu.com/'
 
   app 'ClipMenu.app'
+  zap :files => [
+                 '~/Library/Application Support/ClipMenu',
+                 '~/Library/Preferences/com.naotaka.ClipMenu.plist',
+                ]
 end

--- a/Casks/cloud.rb
+++ b/Casks/cloud.rb
@@ -6,4 +6,5 @@ class Cloud < Cask
   homepage 'http://getcloudapp.com/'
 
   app 'Cloud.app'
+  zap :files => '~/Library/Preferences/com.linebreak.CloudAppMacOSX.plist'
 end

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -15,4 +15,12 @@ class Cocoaspell < Cask
     Non-English dictionaries must be installed separately.  For more information,
     see http://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php .
     EOS
+  zap :files => [
+                 '~/.aspell.conf',
+                 '~/.aspell.en.prepl',
+                 # Debatable. The Pws holds user-created content, though typically
+                 # created through the application, and the user is not likely aware
+                 # of this particular file.
+                 # '~/.aspell.en.pws',
+                ]
 end

--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -7,4 +7,8 @@ class Coda < Cask
   homepage 'https://panic.com/Coda/'
 
   app 'Coda 2.app'
+  zap :files => [
+                 '~/Library/Application Support/Coda 2',
+                 '~/Library/Preferences/com.panic.Coda2.plist',
+                ]
 end

--- a/Casks/colloquy.rb
+++ b/Casks/colloquy.rb
@@ -7,4 +7,8 @@ class Colloquy < Cask
   homepage 'http://colloquy.info/'
 
   app 'Colloquy.app'
+  zap :files => [
+                 '~/Library/Preferences/info.colloquy.plist',
+                 '~/Library/Application Support/Colloquy',
+                ]
 end

--- a/Casks/concentrate.rb
+++ b/Casks/concentrate.rb
@@ -7,4 +7,5 @@ class Concentrate < Cask
   homepage 'http://www.getconcentrating.com/'
 
   app 'Concentrate.app'
+  zap :files => '~/Library/Application Support/Concentrate/Concentrate.sqlite3'
 end

--- a/Casks/controlplane.rb
+++ b/Casks/controlplane.rb
@@ -7,4 +7,5 @@ class Controlplane < Cask
   homepage 'http://www.controlplaneapp.com/'
 
   app 'ControlPlane.app'
+  zap :files => '~/Library/Preferences/com.dustinrue.ControlPlane.plist'
 end

--- a/Casks/cord.rb
+++ b/Casks/cord.rb
@@ -7,4 +7,5 @@ class Cord < Cask
   homepage 'http://cord.sourceforge.net/'
 
   app 'CoRD.app'
+  zap :files => '~/Library/Application Support/CoRD'
 end

--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -7,4 +7,8 @@ class Cyberduck < Cask
   homepage 'http://cyberduck.io/'
 
   app 'Cyberduck.app'
+  zap :files => [
+                 '~/Library/Application Support/Cyberduck',
+                 '~/Library/Preferences/ch.sudo.cyberduck.plist',
+                ]
 end

--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -12,4 +12,8 @@ class Dash < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.kapeli.dash', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => [
+                 '~/Library/Application Support/Dash/library.dash',
+                 '~/Library/Preferences/com.kapeli.dash.plist',
+                ]
 end

--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -9,4 +9,9 @@ class DefaultFolderX < Cask
   caveats do
     manual_installer 'Default Folder X Installer.app'
   end
+  zap :files => [
+                 '~/Library/Preferences/com.stclairsoft.DefaultFolderX.favorites.plist',
+                 '~/Library/Preferences/com.stclairsoft.DefaultFolderX.plist',
+                 '~/Library/Preferences/com.stclairsoft.DefaultFolderX.settings.plist',
+                ]
 end

--- a/Casks/divvy.rb
+++ b/Casks/divvy.rb
@@ -7,4 +7,8 @@ class Divvy < Cask
   homepage 'http://mizage.com/divvy/'
 
   app 'Divvy.app'
+  zap :files => [
+                 '~/Library/Preferences/com.mizage.direct.Divvy.plist',
+                 '~/Library/Preferences/com.mizage.Divvy.plist',
+                ]
 end

--- a/Casks/dolphin.rb
+++ b/Casks/dolphin.rb
@@ -6,4 +6,8 @@ class Dolphin < Cask
   homepage 'http://www.dolphin-emu.org/'
 
   app 'Dolphin.app'
+  zap :files => [
+                 '~/Library/Application Support/Dolphin',
+                 '~/Library/Preferences/org.dolphin-emu.dolphin.plist',
+                ]
 end

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -7,4 +7,5 @@ class Droplr < Cask
   homepage 'https://www.droplr.com/'
 
   app 'Droplr.app'
+  zap :files => '~/Library/Preferences/com.droplr.droplr-mac.plist'
 end

--- a/Casks/enjoyable.rb
+++ b/Casks/enjoyable.rb
@@ -7,4 +7,5 @@ class Enjoyable < Cask
   homepage 'http://yukkurigames.com/enjoyable/'
 
   app 'Enjoyable.app'
+  zap :files => '~/Library/Preferences/com.yukkurigames.Enjoyable.plist'
 end

--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -7,4 +7,9 @@ class Expandrive < Cask
   homepage 'http://www.expandrive.com/expandrive'
 
   app 'ExpanDrive.app'
+  zap :files => [
+                 '~/Library/Application Support/ExpanDrive',
+                 '~/Preferences/com.expandrive.ExpanDrive2.plist',
+                 '~/Preferences/com.expandrive.ExpanDrive3.plist',
+                ]
 end

--- a/Casks/fantastical.rb
+++ b/Casks/fantastical.rb
@@ -12,4 +12,5 @@ class Fantastical < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.flexibits.fantastical', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => '~/Library/Preferences/com.flexibits.fantastical.plist'
 end

--- a/Casks/feeds.rb
+++ b/Casks/feeds.rb
@@ -7,4 +7,5 @@ class Feeds < Cask
   homepage 'http://www.feedsapp.com/'
 
   app 'Feeds.app'
+  zap :files => '~/Library/Preferences/com.feedsapp.Feeds.plist'
 end

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -6,4 +6,6 @@ class Filezilla < Cask
   homepage 'https://filezilla-project.org/'
 
   app 'FileZilla.app'
+  # todo verify that this does not contain user-generate content
+  # zap :files => '~/.filezilla'
 end

--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -12,4 +12,5 @@ class Flux < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'org.herf.Flux', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => '~/Library/Preferences/org.herf.Flux.plist'
 end

--- a/Casks/geektool.rb
+++ b/Casks/geektool.rb
@@ -1,10 +1,17 @@
 class Geektool < Cask
-    version '3.1.1-311'
+  version '3.1.1-311'
   sha256 'ef1a7439d91f0de9e459a4677c6f95fe35bd7e02c300adc9ce315b5590cbbfc9'
 
   url 'http://download.tynsoe.org/GeekTool-3.1.1-311.zip'
   appcast 'http://dl.dropboxusercontent.com/u/1760713/appcast/appcast.xml'
   homepage 'http://projects.tynsoe.org/en/geektool/'
 
-    app 'GeekTool.app'
+  app 'GeekTool.app'
+  zap :files => [
+                 '~/Library/Preferences/org.tynsoe.GeekTool.plist',
+                 '~/Library/Preferences/org.tynsoe.geeklet.file.plist',
+                 '~/Library/Preferences/org.tynsoe.geeklet.image.plist',
+                 '~/Library/Preferences/org.tynsoe.geeklet.shell.plist',
+                 '~/Library/Preferences/org.tynsoe.geektool3.plist',
+                ]
 end

--- a/Casks/gitbox.rb
+++ b/Casks/gitbox.rb
@@ -7,4 +7,5 @@ class Gitbox < Cask
   homepage 'http://gitboxapp.com/'
 
   app 'Gitbox.app'
+  zap :files => '~/Library/Preferences/com.oleganza.gitbox.plist'
 end

--- a/Casks/gmail-notifr.rb
+++ b/Casks/gmail-notifr.rb
@@ -7,4 +7,5 @@ class GmailNotifr < Cask
   homepage 'http://ashchan.com/projects/gmail-notifr'
 
   app 'Gmail Notifr.app'
+  zap :files => '~/Library/Preferences/com.ashchan.GmailNotifr.plist'
 end

--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -7,4 +7,5 @@ class HandsOff < Cask
   homepage 'http://www.metakine.com/products/handsoff/'
 
   app 'Hands Off!.app'
+  zap :files => '~/Library/Preferences/com.metakine.handsoff.plist'
 end

--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -6,4 +6,8 @@ class Hazel < Cask
   homepage 'http://www.noodlesoft.com/hazel.php'
 
   prefpane 'Hazel.prefPane'
+  zap :files => [
+                 '~/Library/Application Support/Hazel',
+                 '~/Library/Preferences/com.noodlesoft.Hazel.plist',
+                ]
 end

--- a/Casks/hexels.rb
+++ b/Casks/hexels.rb
@@ -6,4 +6,5 @@ class Hexels < Cask
   homepage 'http://hexraystudios.com/hexels/'
 
   app 'Hexels.app'
+  zap :files => '~/Library/Preferences/com.hex-ray.hexels.plist'
 end

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -7,4 +7,5 @@ class Iterm2 < Cask
   homepage 'http://www.iterm2.com/'
 
   app 'iTerm.app'
+  zap :files => '~/Library/Preferences/com.googlecode.iterm2.plist'
 end

--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -11,4 +11,11 @@ class Karabiner < Cask
   uninstall :quit => 'org.pqrs.Karabiner',
             :pkgutil => 'org.pqrs.driver.Karabiner',
             :kext => 'org.pqrs.driver.Karabiner'
+  zap :files => [
+                 '~/Library/Preferences/org.pqrs.Karabiner.plist',
+                 '~/Library/Preferences/org.pqrs.Karabiner-AXNotifier.plist',
+                 '~/Library/Preferences/org.pqrs.Karabiner.multitouchextension.plist',
+                ]
+  # todo :rmdir not yet supported
+  #    :rmdir '~/Library/Application Support/Karabiner'
 end

--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -7,4 +7,5 @@ class Keka < Cask
   homepage 'http://kekaosx.com/'
 
   app 'Keka.app'
+  zap :files => '~/Library/Preferences/com.aone.keka.plist'
 end

--- a/Casks/keymo.rb
+++ b/Casks/keymo.rb
@@ -7,4 +7,5 @@ class Keymo < Cask
   homepage 'http://manytricks.com/keymo'
 
   app 'Keymo.app'
+  zap :files => '~/Library/Preferences/com.manytricks.Keymo.plist'
 end

--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -7,4 +7,5 @@ class Latexit < Cask
   homepage 'http://www.chachatelier.fr/latexit'
 
   app 'LaTeXiT.app'
+  zap :files => '~/Library/Preferences/fr.chachatelier.pierre.LaTeXiT.plist'
 end

--- a/Casks/launchbar.rb
+++ b/Casks/launchbar.rb
@@ -6,4 +6,12 @@ class Launchbar < Cask
   homepage 'http://www.obdev.at/products/launchbar/'
 
   app 'LaunchBar.app'
+  zap :files => [
+                 '~/Library/Preferences/at.obdev.LaunchBar.plist',
+                 '~/Library/Application Support/LaunchBar/Configuration.plist',
+                 '~/Library/Application Support/LaunchBar/CustomShortcuts.plist',
+                 # todo unsure if these contain user-created content
+                 # '~/Library/Application Support/LaunchBar/Actions',
+                 # '~/Library/Application Support/LaunchBar/Snippets',
+                ]
 end

--- a/Casks/lighttable.rb
+++ b/Casks/lighttable.rb
@@ -7,4 +7,9 @@ class Lighttable < Cask
 
   app 'LightTable/LightTable.app'
   binary 'LightTable/light'
+  zap :files => [
+                 '~/Library/Application Support/LightTable/plugins',
+                 '~/Library/Application Support/LightTable/settings',
+                 '~/Library/Preferences/com.kodowa.LightTable.plist',
+                ]
 end

--- a/Casks/limechat.rb
+++ b/Casks/limechat.rb
@@ -14,4 +14,5 @@ class Limechat < Cask
   homepage 'http://limechat.net/mac/'
 
   app 'LimeChat.app'
+  zap :files => '~/Library/Preferences/net.limechat.LimeChat-AppStore.plist'
 end

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -8,4 +8,10 @@ class LittleSnitch < Cask
   caveats do
     manual_installer 'Little Snitch Installer.app'
   end
+  zap :files => [
+                 '~/Library/Preferences/at.obdev.LittleSnitchNetworkMonitor.plist',
+                 '~/Library/Application Support/Little Snitch/rules.usr.xpl',
+                 '~/Library/Application Support/Little Snitch/configuration.xpl',
+                 '~/Library/Application Support/Little Snitch/configuration.user.xpl',
+                ]
 end

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -20,4 +20,8 @@ class Macvim < Cask
     EOS
     files_in_usr_local
   end
+  zap :files => [
+                 '~/Library/Preferences/org.vim.MacVim.LSSharedFileList.plist',
+                 '~/Library/Preferences/org.vim.MacVim.plist',
+                ]
 end

--- a/Casks/magic-launch.rb
+++ b/Casks/magic-launch.rb
@@ -6,4 +6,5 @@ class MagicLaunch < Cask
   homepage 'http://www.oneperiodic.com/products/magiclaunch/'
 
   prefpane 'Magic Launch.prefPane'
+  zap :files => '~/Library/Preferences/com.metakine.magic-launch.agent.plist'
 end

--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -6,4 +6,5 @@ class Mailplane < Cask
   homepage 'http://mailplaneapp.com'
 
   app 'Mailplane 3.app'
+  zap :files => '~/Library/Preferences/com.mailplaneapp.Mailplane.plist'
 end

--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -6,4 +6,5 @@ class Menumeters < Cask
   homepage 'http://www.ragingmenace.com/software/menumeters/'
 
   prefpane 'MenuMeters Installer.app/Contents/Resources/MenuMeters.prefPane'
+  zap :files => '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'
 end

--- a/Casks/mercurymover.rb
+++ b/Casks/mercurymover.rb
@@ -6,4 +6,5 @@ class Mercurymover < Cask
   homepage 'http://www.heliumfoot.com/mercurymover'
 
   prefpane 'MercuryMover.prefPane'
+  zap :files => '~/Library/Preferences/com.heliumfoot.MyWiAgent.plist'
 end

--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -7,4 +7,8 @@ class Moom < Cask
   homepage 'http://manytricks.com/moom/'
 
   app 'Moom.app'
+  zap :files => [
+                 '~/Library/Preferences/com.manytricks.Moom.plist',
+                 '~/Library/Application Support/Many Tricks',
+                ]
 end

--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -7,4 +7,9 @@ class Mou < Cask
   homepage 'http://mouapp.com/'
 
   app 'Mou.app'
+  zap :files => [
+                 '~/Library/Preferences/com.mouapp.Mou.plist',
+                 '~/Library/Preferences/com.mouapp.Mou.LSSharedFileList.plist',
+                 '~/Library/Application Support/Mou',
+                ]
 end

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -10,4 +10,11 @@ class Mpv < Cask
   caveats do
     files_in_usr_local
   end
+  zap :files => [
+                 '~/.mpv/channels.conf',
+                 '~/.mpv/config',
+                 '~/.mpv/input.conf',
+                ]
+  # todo :rmdir is not yet supported
+  #   :rmdir     '~/.mpv'
 end

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -6,4 +6,7 @@ class Ngrok < Cask
   homepage 'https://ngrok.com/'
 
   binary 'ngrok'
+
+  # todo verify that this does not contain user-created content
+  # zap :files => '~/.ngrok'
 end

--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -6,4 +6,8 @@ class Nvalt < Cask
   homepage 'http://brettterpstra.com/project/nvalt/'
 
   app 'nvALT.app'
+  zap :files => [
+                 '~/Library/Preferences/net.elasticthreads.nv.plist',
+                 '~/Library/Application Support/Notational Velocity',
+                ]
 end

--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -6,4 +6,9 @@ class Omnifocus < Cask
   homepage 'http://www.omnigroup.com/products/omnifocus/'
 
   app 'OmniFocus.app'
+  zap :files => [
+                 '~/Library/Application Support/OmniFocus/Plug-Ins',
+                 '~/Library/Application Support/OmniFocus/Themes',
+                 '~/Library/Preferences/com.omnigroup.OmniFocus.plist',
+                ]
 end

--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -6,4 +6,5 @@ class Omnigraffle < Cask
   homepage 'http://www.omnigroup.com/products/omnigraffle'
 
   app 'OmniGraffle.app'
+  zap :files => '~/Library/Application Support/The Omni Group/OmniGraffle'
 end

--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -11,4 +11,8 @@ class PathFinder < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.cocoatech.PathFinder', 'kNTMoveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => [
+                 '~/Library/Preferences/com.cocoatech.PathFinder.plist',
+                 '~/Library/Application Support/Path Finder',
+                ]
 end

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -6,4 +6,8 @@ class Pokerstars < Cask
   homepage 'http://www.pokerstars.com/'
 
   app 'PokerStars.app'
+  zap :files => [
+                 '~/Library/Preferences/com.pokerstars.user.ini',
+                 '~/Library/Preferences/com.pokerstars.PokerStars.plist',
+                ]
 end

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -6,4 +6,5 @@ class Processing < Cask
   homepage 'http://processing.org/'
 
   app 'Processing.app'
+  zap :files => '~/Library/Processing/preferences.txt'
 end

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -6,4 +6,8 @@ class Quicksilver < Cask
   homepage 'http://qsapp.com/'
 
   app 'Quicksilver.app'
+  zap :files => [
+                 '~/Library/Preferences/com.blacktree.Quicksilver.plist',
+                 '~/Library/Application Support/Quicksilver',
+                ]
 end

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -26,4 +26,9 @@ class R < Cask
                        # /Library/Frameworks/R.Framework/Versions/3.1/Resources/fontconfig/cache
                        '/Library/Frameworks/R.Framework/Versions/3.1',
                       ]
+  zap :files => [
+                 '~/.R',
+                 '~/.Rhistory',
+                 '~/.Rprofile',
+                ]
 end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -10,4 +10,12 @@ class Rubymine < Cask
   postflight do
     system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/RubyMine.app/Contents/Info.plist"
   end
+  zap :files => [
+                 '~/Library/Application Support/RubyMine40',
+                 '~/Library/Preferences/RubyMine40',
+                 '~/Library/Application Support/RubyMine50',
+                 '~/Library/Preferences/RubyMine50',
+                 '~/Library/Application Support/RubyMine60',
+                 '~/Library/Preferences/RubyMine60',
+                ]
 end

--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -6,4 +6,8 @@ class Sabnzbd < Cask
   homepage 'http://sabnzbd.org/'
 
   app '10.8 (M-Lion) 10.9 (Mavericks)/SABnzbd.app'
+  zap :files => [
+                 '~/Library/Application Support/SABnzbd/sabnzbd.ini',
+                 '~/Library/Application Support/SABnzbd/admin/rss_data.sab',
+                ]
 end

--- a/Casks/seil.rb
+++ b/Casks/seil.rb
@@ -9,4 +9,8 @@ class Seil < Cask
   uninstall :quit => 'org.pqrs.Seil',
             :kext => 'org.pqrs.driver.Seil',
             :pkgutil => 'org.pqrs.driver.Seil'
+  zap :files => [
+                 '~/Library/Preferences/org.pqrs.PCKeyboardHack.plist',
+                 '~/Library/Preferences/org.pqrs.Seil.plist',
+                ]
 end

--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -7,4 +7,5 @@ class Selfcontrol < Cask
   homepage 'http://selfcontrolapp.com/'
 
   app 'SelfControl.app'
+  zap :files => '~/Library/Preferences/org.eyebeam.SelfControl.plist'
 end

--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -7,4 +7,5 @@ class SequelPro < Cask
   homepage 'http://www.sequelpro.com/'
 
   app 'Sequel Pro.app'
+  zap :files => '~/Library/Application Support/Sequel Pro/Data'
 end

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -7,4 +7,8 @@ class Sizeup < Cask
   homepage 'http://www.irradiatedsoftware.com/sizeup/index.html'
 
   app 'SizeUp.app'
+  zap :files => [
+                 '~/Library/Preferences/com.irradiatedsoftware.SizeUp.plist',
+                 '~/Library/Application Support/SizeUp',
+                ]
 end

--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -7,4 +7,5 @@ class Skim < Cask
   homepage 'http://skim-app.sourceforge.net/'
 
   app 'Skim.app'
+  zap :files => '~/Library/Preferences/net.sourceforge.skim-app.skim.plist'
 end

--- a/Casks/skitch.rb
+++ b/Casks/skitch.rb
@@ -6,4 +6,8 @@ class Skitch < Cask
   homepage 'http://evernote.com/skitch/'
 
   app 'Skitch.app'
+  zap :files => [
+                 '~/Library/Preferences/com.plasq.skitch.plist',
+                 '~/Library/Preferences/com.plasq.skitch.history',
+                ]
 end

--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -11,4 +11,5 @@ class Skype < Cask
   homepage 'http://www.skype.com'
 
   app 'Skype.app'
+  zap :files => '~/Library/Application Support/Skype'
 end

--- a/Casks/slate.rb
+++ b/Casks/slate.rb
@@ -7,4 +7,9 @@ class Slate < Cask
   homepage 'https://github.com/jigish/slate'
 
   app 'Slate.app'
+  zap :files => [
+                 '~/.slate',
+                 '~/.slate.js',
+                 '~/Library/Application Support/com.slate.Slate',
+                ]
 end

--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -12,4 +12,9 @@ class Soulver < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.acqualia.soulver', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+  zap :files => [
+                 # todo verify that this does not contain user-generated content
+                 # '~/Library/Application Support/Soulver',
+                 '~/Library/Preferences/com.acqualia.soulver.plist',
+                ]
 end

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -11,4 +11,7 @@ class Sourcetree < Cask
   caveats do
     files_in_usr_local
   end
+  zap :files => [
+                 '~/Library/Application Support/SourceTree',
+                ]
 end

--- a/Casks/spark.rb
+++ b/Casks/spark.rb
@@ -6,4 +6,5 @@ class Spark < Cask
   homepage 'http://www.shadowlab.org/softwares/spark.php'
 
   app 'Spark.app'
+  zap :files => '~/Library/Application Support/Spark'
 end

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -7,4 +7,5 @@ class Spectacle < Cask
   homepage 'http://spectacleapp.com/'
 
   app 'Spectacle.app'
+  zap :files => '~/Library/Preferences/com.divisiblebyzero.Spectacle.plist'
 end

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -6,4 +6,5 @@ class Spotify < Cask
   homepage 'https://www.spotify.com'
 
   app 'Spotify.app'
+  zap :files => '~/Library/Preferences/com.spotify.client.plist'
 end

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -11,4 +11,11 @@ class SublimeText < Cask
   caveats do
     files_in_usr_local
   end
+  zap :files => [
+                 '~/Library/Application Support/Sublime Text 2/Installed Packages',
+                 '~/Library/Application Support/Sublime Text 2/Packages',
+                 '~/Library/Application Support/Sublime Text 2/Pristine Packages',
+                ]
+  # todo :rmdir not yet supported
+  #   :rmdir     '~/Library/Application Support/Sublime Text 2',
 end

--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -6,4 +6,5 @@ class Superduper < Cask
   homepage 'http://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html'
 
   app 'SuperDuper!.app'
+  zap :files => '~/Library/Application Support/SuperDuper!'
 end

--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -6,4 +6,9 @@ class Textmate < Cask
   homepage 'http://macromates.com/'
 
   app 'TextMate.app'
+  zap :files => [
+                 '~/Library/Application Support/TextMate',
+                 '~/Library/Preferences/com.macromates.textmate.plist',
+                 '~/Library/Preferences/com.macromates.textmate.latex_config.plist',
+                ]
 end

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -7,4 +7,8 @@ class Tower < Cask
   homepage 'http://www.git-tower.com/'
 
   app 'Tower.app'
+  zap :files => [
+                 '~/Library/Application Support/com.fournova.Tower2',
+                 '~/Library/Preferences/com.fournova.Tower2.plist',
+                ]
 end

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -7,4 +7,8 @@ class Transmission < Cask
   homepage 'http://www.transmissionbt.com/'
 
   app 'Transmission.app'
+  zap :files => [
+                 '~/Library/Preferences/org.m0k.transmission.plist',
+                 '~/Library/Application Support/Transmission/blocklists',
+                ]
 end

--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -7,4 +7,8 @@ class Transmit < Cask
   homepage 'http://panic.com/transmit'
 
   app 'Transmit.app'
+  zap :files => [
+                 '~/Library/Preferences/com.panic.Transmit.plist',
+                 '~/Library/Application Support/Transmit',
+                ]
 end

--- a/Casks/twitterrific.rb
+++ b/Casks/twitterrific.rb
@@ -7,4 +7,5 @@ class Twitterrific < Cask
   homepage 'http://twitterrific.com/mac'
 
   app 'Twitterrific.app'
+  zap :files => '~/Library/Application Support/Twitterrific'
 end

--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -7,4 +7,8 @@ class Viscosity < Cask
   homepage 'http://www.sparklabs.com/viscosity/'
 
   app 'Viscosity.app'
+  zap :files => [
+                 '~/Library/Application Support/Viscosity',
+                 '~/Library/Preferences/com.viscosityvpn.Viscosity.plist',
+                ]
 end

--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -6,4 +6,5 @@ class Witch < Cask
   homepage 'http://manytricks.com/witch/'
 
   prefpane 'Witch.prefPane'
+  zap :files => '~/Library/Preferences/com.manytricks.Witch.plist'
 end

--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -7,4 +7,8 @@ class Xld < Cask
   homepage 'http://tmkk.undo.jp/xld/index_e.html'
 
   app 'XLD.app'
+  zap :files => [
+                 '~/Library/Application Support/XLD',
+                 '~/Library/Preferences/jp.tmkk.XLD.plist',
+                ]
 end


### PR DESCRIPTION
Add `zap` stanzas to 88 Casks based on data from the wonderful [mackup](https://github.com/lra/mackup).

I couldn't come up a clever way to leverage the mackup repo, given our current Homebrew-based infrastructure, so am importing some of the relevant data into the Cask DSL, now that we support `zap`.

Note that the `brew cask zap` verb is merged now but not yet in release.

cc @lra
