### PR TITLE
Fix Version typo in gulp.app Cask

### DIFF
--- a/Casks/gulp.rb
+++ b/Casks/gulp.rb
@@ -1,5 +1,5 @@
 class Gulp < Cask
-  version '0.10'
+  version '0.1.0'
   sha256 '59fed5d8c801c9302debf463f2d274404548e23433c965144e69a0b4a2e23851'
 
   url 'https://github.com/sindresorhus/gulp-app/releases/download/0.1.0/gulp.app.zip'


### PR DESCRIPTION
See https://github.com/sindresorhus/gulp-app/releases
