### PR TITLE
Add gpg stanza to compatible casks

### DIFF
--- a/Casks/cryptol.rb
+++ b/Casks/cryptol.rb
@@ -3,6 +3,8 @@ class Cryptol < Cask
   sha256 '19b3c24390ccb66584f42f34fed91cefc12f667879ab0228cdf806016bcd53c4'
 
   url "https://github.com/GaloisInc/cryptol/releases/download/v#{version}/cryptol-#{version}-MacOSX-64.tar.gz"
+  gpg "#{url}.sig",
+      :key_url => 'http://cryptol.net/files/Galois.asc'
   homepage 'http://cryptol.net/'
   license :oss
 

--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -3,6 +3,8 @@ class ElectrumLtc < Cask
   sha256 'db5a36d7c4dca249fd6c4fee2dec04f88d9778e35b02a7e1df992327d0a66944'
 
   url "https://electrum-ltc.org/download/Electrum-LTC-#{version}.dmg"
+  gpg "#{url}.asc",
+      :key_id => '9914864dfc33499c6ca2beea22453004695506fd'
   homepage 'http://electrum-ltc.org'
   license :unknown
 

--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -3,6 +3,8 @@ class Electrum < Cask
   sha256 'ad3818e34a9b3a292257377e337603ed362ff928f2054e92f764d771f0e49ec0'
 
   url "https://download.electrum.org/electrum-#{version}.dmg"
+  gpg "#{url}.asc",
+      :key_id => '9914864dfc33499c6ca2beea22453004695506fd'
   homepage 'http://electrum.org/'
   license :unknown
 

--- a/Casks/espionage.rb
+++ b/Casks/espionage.rb
@@ -3,6 +3,8 @@ class Espionage < Cask
   sha256 :no_check
 
   url 'https://www.espionageapp.com/Espionage.dmg'
+  gpg "#{url}.sig",
+      :key_url => 'https://www.taoeffect.com/other/A884B988.asc'
   homepage 'https://www.espionageapp.com/'
   license :unknown
 

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -15,6 +15,8 @@ class GitAnnex < Cask
     url 'http://downloads.kitenet.net/git-annex/OSX/current/10.9_Mavericks/git-annex.dmg'
   end
 
+  gpg "#{url}.sig",
+      :key_url => 'https://downloads.kitenet.net/git-annex/gpg-pubkey.asc'
   homepage 'http://git-annex.branchable.com/'
   license :unknown
 

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -3,6 +3,8 @@ class Gpgtools < Cask
   sha256 'd37ccf01e5ddd07dd84b76574e99b605ca9ead89cb0c6c126f4045e271eb3841'
 
   url "https://releases.gpgtools.org/GPG%20Suite%20-%20#{version}.dmg"
+  gpg "#{url}.sig",
+      :key_url => 'https://gpgtools.org/GPGTools%2000D026C4.asc'
   homepage 'https://gpgtools.org/index.html'
   license :unknown
 

--- a/Casks/horndis.rb
+++ b/Casks/horndis.rb
@@ -3,6 +3,8 @@ class Horndis < Cask
   sha256 'd183b8613b7e3811580afa9f1a8691163c36745cea3b8531bf1a50aba180565d'
 
   url "http://joshuawise.com/downloads/HoRNDIS-rel#{version}.pkg"
+  gpg "#{url}.sig",
+      :key_id => '3e7f6d58ea80e0b3'
   homepage 'http://joshuawise.com/horndis'
   license :unknown
 

--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -3,6 +3,8 @@ class Jameica < Cask
   sha256 :no_check
 
   url 'http://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64.zip'
+  gpg "#{url}.asc",
+      :key_id => '5a8ed9cfc0db6c70'
   homepage 'http://www.willuhn.de/products/jameica/'
   license :unknown
 

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -8,6 +8,8 @@ class Libreoffice < Cask
     sha256 '9a212ca4b77770c57f8b7ac375b5a98824c93dabd6e238dc019dc1139b6d3b7f'
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end
+  gpg "#{url}.asc",
+      :key_id => 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
   homepage 'https://www.libreoffice.org/'
   license :unknown

--- a/Casks/linphone.rb
+++ b/Casks/linphone.rb
@@ -3,6 +3,8 @@ class Linphone < Cask
   sha256 '4d4a01354a7b5cd011746d3477a93ffb6e531ff8e2afccd2b9bb031f06cc42cc'
 
   url "http://download-mirror.savannah.gnu.org/releases/linphone/3.7.x/macos/linphone-#{version}.dmg"
+  gpg "#{url}.sig",
+      :key_id => '3ecd52dee2f56985'
   homepage 'http://www.linphone.org/'
   license :unknown
 

--- a/Casks/litecoin.rb
+++ b/Casks/litecoin.rb
@@ -3,6 +3,8 @@ class Litecoin < Cask
   sha256 'c5931a4b7b4ca16ba1a7f7f23994f30e47d530f44f70de8a72e24345f04bed2d'
 
   url "https://download.litecoin.org/litecoin-#{version}/macosx/Litecoin-Qt-#{version}.dmg"
+  gpg "#{url}.asc",
+      :key_id => 'c37e4723969276f5'
   homepage 'https://litecoin.org/'
   license :unknown
 

--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -3,6 +3,8 @@ class Lyx < Cask
   sha256 '2230c29e1ac0334b2c58bf072c28bbd9a9e2c98eaab90adf04d25f9e12dd3730'
 
   url "ftp://ftp.lyx.org/pub/lyx/bin/#{version}/LyX-#{version}+qt4-x86_64-cocoa.dmg"
+  gpg "#{url}.sig",
+      :key_id => 'de7a44fac7fb382d'
   homepage 'http://www.lyx.org'
   license :unknown
 

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -11,6 +11,8 @@ class Macports < Cask
     pkg "MacPorts-#{version}-10.9-Mavericks.pkg"
   end
 
+  gpg "#{url}.asc",
+      :key_id => '01ff673fb4aae6cd'
   homepage 'http://www.macports.org'
   license :unknown
 

--- a/Casks/multibit.rb
+++ b/Casks/multibit.rb
@@ -3,6 +3,8 @@ class Multibit < Cask
   sha256 '0d2fe6fa68385c1ca964d9588272787dabffbc2061f29ebaab422317d0972257'
 
   url "https://multibit.org/releases/multibit-#{version}/multibit-#{version}.dmg"
+  gpg "#{url}.asc",
+      :key_id => '23f7fb7b'
   homepage 'https://multibit.org/'
   license :unknown
 

--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -3,6 +3,8 @@ class Mumble < Cask
   sha256 '19ea209ed4a589ad0959f4c8b4af47f479efbf63d5efb0b170c3b31f98979e2f'
 
   url "https://downloads.sourceforge.net/sourceforge/mumble/Mumble-#{version}.dmg"
+  gpg "#{url}.sig",
+      :key_url => 'http://mumble.info/gpg/mumble-auto-build-2014.asc'
   homepage 'http://mumble.sourceforge.net'
   license :oss
 

--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -3,6 +3,8 @@ class Mysqlworkbench < Cask
   sha256 '0a66707a03d83a70f1ced521ac0954ee56ff9a6e86f81e01d03df723755e9186'
 
   url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-osx-i686.dmg"
+  gpg "#{url}.asc",
+      :key_id => '8c718d3b5072e1f5'
   homepage 'http://www.mysql.com/products/workbench'
   license :unknown
 

--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -3,6 +3,8 @@ class Onionshare < Cask
   sha256 '80c583f1dc280f08c11dc60b308e2f6d8fe31c554d59f795ccf0f3252733a6ce'
 
   url "https://onionshare.org/files/#{version}/OnionShare-#{version}.dmg"
+  gpg "#{url}.sig",
+      :key_url => 'https://onionshare.org/signing-key.asc'
   homepage 'https://onionshare.org/'
   license :unknown
 

--- a/Casks/pgadmin3.rb
+++ b/Casks/pgadmin3.rb
@@ -4,6 +4,8 @@ class Pgadmin3 < Cask
   sha256 '6fe924168c7a8ee9224527fcafc3e612de60c011a27dc44b8293401ff346627d'
 
   url "http://ftp.postgresql.org/pub/pgadmin3/release/v#{version}/osx/pgadmin3-#{version}.dmg"
+  gpg "#{url}.sig",
+      :key_id => '96020e041a19643b'
   homepage 'http://pgadmin.org'
   license :unknown
 

--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -3,6 +3,8 @@ class Ricochet < Cask
   sha256 '089e8b8d177ee2b5aeb50b62447a27994a432ffd8fe1893e071c4df4bc5e1993'
 
   url "https://ricochet.im/releases/#{version}/Ricochet-#{version}.dmg"
+  gpg "#{url}.asc",
+      :key_id => '9032cae4cbfa933a5a2145d5ff97c53f183c045d'
   homepage 'https://ricochet.im/'
   license :unknown
 

--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -3,6 +3,8 @@ class Torbrowser < Cask
   sha256 '45843982df1c339f3aa165bf09b96b27306749c38aaf669a13cc9c508b679141'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_en-US.dmg"
+  gpg "#{url}.asc",
+      :key_id => '416f061063fee659'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :unknown
 

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -3,6 +3,8 @@ class Vlc < Cask
   sha256 '923504e296829f4253af8276b992636f72e56232ecdbdcf6003647ee662257f2'
 
   url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
+  gpg "#{url}.asc",
+      :key_id => '65f7c6b4206bd057a7eb73787180713be58d1adc'
   appcast 'http://update.videolan.org/vlc/sparkle/vlc-intel64.xml'
   homepage 'http://www.videolan.org/vlc/'
   license :oss


### PR DESCRIPTION
Add `gpg` stanza to casks for which keys and detached signatures are available. Feel free to add entries to the list.

Known compatible:  
- [x] cryptol
- [x] electrum
- [x] electrum-ltc
- [x] espionage
- [x] git-annex
- [x] gpgtools
- [x] horndis
- [x] jameica
- [x] libreoffice
- [x] linphone
- [x] litecoin
- [x] lyx
- [x] macports
- [x] multibit
- [x] mumble
- [x] mysqlworkbench
- [x] onionshare
- [x] pgadmin3
- [x] ricochet
- [x] torbrowser
- [x] vlc
- ~~armory~~ — no detached signature
- ~~bitcoin~~ — no detached signature
- ~~wireshark~~ — no detached signature
