### PR TITLE
Add the Mailpile beta

### DIFF
--- a/Casks/mailpile.rb
+++ b/Casks/mailpile.rb
@@ -1,0 +1,9 @@
+class Mailpile < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'https://www.mailpile.is/files/releases/Mailpile-Installer-Beta.dmg'
+  homepage 'https://www.mailpile.is/'
+
+  app 'Mailpile.app'
+end


### PR DESCRIPTION
See the [release annoucement](https://www.mailpile.is/blog/2014-09-13_Mailpile_Beta_Release.html) for more info.

This replaces caskroom/homebrew-versions#421 since Mailpile [doesn't currently have a stable version](https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#but-there-is-no-stable-version).
