### PR TITLE
Add Java Legacy for OS X v2014-001

### DIFF
--- a/Casks/java-legacy.rb
+++ b/Casks/java-legacy.rb
@@ -1,0 +1,9 @@
+class JavaLegacy < Cask
+  version '2014-001'
+  sha256 '97bc9b3c47af1f303710c8b15f2bcaedd6b40963c711a18da8eac1e49690a8a0'
+
+  url 'http://support.apple.com/downloads/DL1572/en_US/JavaForOSX2014-001.dmg'
+  homepage 'http://support.apple.com/kb/DL1572'
+
+  pkg 'JavaForOSX.pkg'
+end


### PR DESCRIPTION
Adding Cask for Java for OS X 2014-001
