### PR TITLE
change docs/tests to use `version :latest`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,11 @@ class Unity < Cask
 end
 ```
 
-And here is one for `Firefox.app`. Note that it has an unversioned download (the download `url` does not contain the version number, unlike the example above). It also suppresses the checksum with `sha256 :no_check` (necessary since the checksum will change when a new version is available). This combination of `version 'latest'` and `sha256 :no_check` is currently the preferred mechanism when an unversioned download link is available:
+And here is one for `Firefox.app`. Note that it has an unversioned download (the download `url` does not contain the version number, unlike the example above). It also suppresses the checksum with `sha256 :no_check` (necessary since the checksum will change when a new version is available). This combination of `version :latest` and `sha256 :no_check` is currently the preferred mechanism when an unversioned download link is available:
 
 ```ruby
 class Firefox < Cask
-  version 'latest'
+  version :latest
   sha256 :no_check
 
   url 'https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US'
@@ -133,7 +133,7 @@ Fill in the following stanzas for your Cask:
 | __cask metadata__  | information about the Cask (required)
 | `url`              | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application (see also [URL Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#url-stanza-details))
 | `homepage`         | application homepage; used for the `brew cask home` command
-| `version`          | application version; give the value `'latest'` if an unversioned download is available
+| `version`          | application version; give the value `:latest` if an unversioned download is available
 | `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be suppressed for unversioned downloads by using the special value `:no_check`. (see also [Checksum Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#checksum-stanza-details))
 | __artifact info__  | information about artifacts inside the Cask (can be specified multiple times)
 | `app`              | relative path to an `.app` bundle that should be linked into the `~/Applications` folder on installation (see also [App Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#app-stanza-details))
@@ -338,7 +338,7 @@ the key info in the first line will help us respond faster to
 your pull.
 
 For Cask commits in the homebrew-cask project, we like to include
-the Application name, version number (or `'latest'`), and purpose of
+the Application name, version number (or `:latest`), and purpose of
 the commit in the first line.
 
 Examples of good, clear commit summaries:

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -66,7 +66,7 @@ Each of the following stanzas is required for every Cask.
 | ------------------ |------------------------------ | ----------- |
 | `url`              | No                            | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application (see also [URL Stanza Details](#url-stanza-details))
 | `homepage`         | No                            | application homepage; used for the `brew cask home` command
-| `version`          | No                            | application version; give value of `'latest'` if versioned downloads are not offered
+| `version`          | No                            | application version; give value of `:latest`  if versioned downloads are not offered
 | `sha256`           | No                            | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`.  Can be suppressed for unversioned downloads by using the special value `:no_check`. (see also [Checksum Stanza Details](#checksum-stanza-details))
 
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -57,6 +57,7 @@ This notice will be removed for the final form.**
 | `before_uninstall`    | `uninstall_preflight`
 | `after_uninstall`     | `uninstall_postflight`
 | `depends_on_formula`  | `depends_on :formula`
+| `version 'latest'`    | `version :latest`
 
 
 ## All Supported Stanzas (1.0)

--- a/lib/cask/audit.rb
+++ b/lib/cask/audit.rb
@@ -12,6 +12,8 @@ class Cask::Audit
 
   def run!(download = false)
     _check_required_fields
+    # todo: enable this test before 0.50.0
+    # _check_no_string_version_latest
     _check_checksums
     _check_sha256_no_check_if_latest
     _check_sha256_if_versioned
@@ -38,17 +40,26 @@ class Cask::Audit
     add_error "sha256 is required" unless cask.sums.is_a?(Array) && cask.sums.length > 0
   end
 
+  def _check_no_string_version_latest
+    odebug "Verifying version :latest does not appear as a string ('latest')"
+    if (cask.version == 'latest')
+      add_error "you should use version :latest instead of version 'latest'"
+    end
+  end
+
   def _check_sha256_no_check_if_latest
-    odebug "Verifying sha256 :no_check with version 'latest'"
-    if ((cask.version == "latest" or cask.version == :latest) and cask.sums.is_a?(Array))
-      add_error "you should use sha256 :no_check when version is 'latest'"
+    odebug "Verifying sha256 :no_check with version :latest"
+    # todo: remove this string test before 0.50.0
+    if ((cask.version == 'latest' or cask.version == :latest) and cask.sums.is_a?(Array))
+      add_error "you should use sha256 :no_check when version is :latest"
     end
   end
 
   def _check_sha256_if_versioned
     odebug "Verifying a sha256 is present when versioned"
-    if ((cask.version != "latest" and cask.version != :latest) and cask.sums == :no_check)
-      add_error "you must include a sha256 when version is not 'latest'"
+    # todo: remove this string test before 0.50.0
+    if ((cask.version != 'latest' and cask.version != :latest) and cask.sums == :no_check)
+      add_error "you must include a sha256 when version is not :latest"
     end
   end
 

--- a/spec/cask/audit_spec.rb
+++ b/spec/cask/audit_spec.rb
@@ -28,13 +28,13 @@ class CaskSourceForgeCorrectURLFormat < Cask
 end
 
 class CaskSourceForgeOtherCorrectURLFormat < Cask
-  version 'latest'
+  version :latest
   homepage 'http://sourceforge.net/projects/something/'
   url 'http://sourceforge.net/projects/something/files/latest/download'
 end
 
 class CaskVersionLatestWithChecksum < Cask
-  version 'latest'
+  version :latest
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 end
 
@@ -87,13 +87,13 @@ describe Cask::Audit do
       it "adds an error if version is latest and using sha256" do
         audit = Cask::Audit.new(CaskVersionLatestWithChecksum.new)
         audit.run!
-        expect(audit.errors).to include(%q{you should use sha256 :no_check when version is 'latest'})
+        expect(audit.errors).to include(%q{you should use sha256 :no_check when version is :latest})
       end
 
       it "adds an error if versioned and has no checksum" do
         audit = Cask::Audit.new(CaskWithVersionNoChecksum.new)
         audit.run!
-        expect(audit.errors).to include(%q{you must include a sha256 when version is not 'latest'})
+        expect(audit.errors).to include(%q{you must include a sha256 when version is not :latest})
       end
     end
 


### PR DESCRIPTION
Instead of `version 'latest'` (value as string).  The string
form is still permitted during a transitional period.
