### PR TITLE
DSL: add `artifact` stanza

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -89,7 +89,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 | `service`          | yes                           | relative path to a service that should be linked into the `~/Library/Services` folder on installation
 | `widget`           | yes                           | relative path to a widget that should be linked into the `~/Library/Widgets` folder on installation (ALPHA: DOES NOT WORK YET)
 | `suite`            | yes                           | relative path to a containing directory that should be linked into the `~/Applications` folder on installation (see also [Suite Stanza Details](#suite-stanza-details))
-| `link`             | yes                           | relative path to an arbitrary path that should be symlinked on installation.  This is an older form which is preserved only for unusual cases.  The `app` stanza is strongly preferred for linking `.app` bundles.
+| `artifact`         | yes                           | relative path to an arbitrary path that should be symlinked on installation.  This is only for unusual cases.  The `app` stanza is strongly preferred when linking `.app` bundles.
 
 ## Optional Stanzas
 
@@ -339,7 +339,7 @@ binary 'oclint-0.7-x86_64-apple-darwin-10/lib/oclint', :target => '/usr/local/li
 
 The `:target` key works similarly for other Cask artifacts, such as
 `binary`, `colorpicker`, `font`, `input_method`, `prefpane`, `qlplugin`,
-`service`, `widget`, `suite`, and `link`.
+`service`, `widget`, `suite`, and `artifact`.
 
 
 ## Suite Stanza Details

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -31,6 +31,7 @@ This notice will be removed for the final form.**
 
 ## Additions (1.0)
 
+ * `artifact`
  * `depends_on :cask`
    * stub - not yet functional
  * `depends_on :macos`
@@ -51,7 +52,7 @@ This notice will be removed for the final form.**
 | old form              | new form
 | --------------------- |----------------
 | `install`             | `pkg`
-| `link`                | `app`  (note: `link` is still available, with different semantics)
+| `link`                | `app` (or sometimes `suite` or `artifact`)
 | `before_install`      | `preflight`
 | `after_install`       | `postflight`
 | `before_uninstall`    | `uninstall_preflight`

--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -6,6 +6,7 @@ require 'cask/artifact/symlinked'
 require 'cask/artifact/hardlinked'
 
 require 'cask/artifact/app'
+require 'cask/artifact/artifact'        # generic 'artifact' stanza
 require 'cask/artifact/binary'
 require 'cask/artifact/after_block'
 require 'cask/artifact/before_block'
@@ -36,6 +37,7 @@ module Cask::Artifact
       Cask::Artifact::NestedContainer,
       Cask::Artifact::InstallScript,
       Cask::Artifact::App,
+      Cask::Artifact::Artifact,         # generic 'artifact' stanza
       Cask::Artifact::Colorpicker,
       Cask::Artifact::Pkg,
       Cask::Artifact::Prefpane,

--- a/lib/cask/artifact/app.rb
+++ b/lib/cask/artifact/app.rb
@@ -1,4 +1,5 @@
 class Cask::Artifact::App < Cask::Artifact::Symlinked
+  # todo remove this backward compatibility override
   def self.artifact_dsl_key
     :link
   end

--- a/lib/cask/artifact/artifact.rb
+++ b/lib/cask/artifact/artifact.rb
@@ -1,0 +1,20 @@
+class Cask::Artifact::Artifact < Cask::Artifact::Symlinked
+  def self.link_type_english_name
+    'Generic artifact'
+  end
+
+  # todo remove this backward compatibility override
+  def self.artifact_dsl_key
+    :link
+  end
+
+  # todo remove this backward compatibility override
+  def self.artifact_dirmethod
+    @artifact_dirmethod ||= :appdir
+  end
+
+  # todo remove this backward compatibility override
+  def summary
+    {}
+  end
+end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -206,24 +206,26 @@ module Cask::DSL
       end
     end
 
-    # This hash is transitional.  Each of these stanzas will
-    # ultimately either be removed or upgraded with its own
-    # unique semantics.
+    # Todo: this hash is transitional.  Each of these stanzas will
+    # ultimately either be removed or upgraded with its own unique
+    # semantics.
     STANZA_ALIASES = {
-                       :pkg                   => :install,          # to remove
-                       :app                   => :link,             # to upgrade
-                       :suite                 => :link,             # to upgrade
-                       :preflight             => :before_install,   # to remove
-                       :postflight            => :after_install,    # to remove
-                       :uninstall_preflight   => :before_uninstall, # to remove
-                       :uninstall_postflight  => :after_uninstall,  # to remove
+                       :pkg                   => :install,          # todo remove
+                       :app                   => :link,             # todo upgrade
+                       :suite                 => :link,             # todo upgrade
+                       :artifact              => :link,             # todo upgrade
+                       :preflight             => :before_install,   # todo remove
+                       :postflight            => :after_install,    # todo remove
+                       :uninstall_preflight   => :before_uninstall, # todo remove
+                       :uninstall_postflight  => :after_uninstall,  # todo remove
                      }
 
     def self.ordinary_artifact_types
       @@ordinary_artifact_types ||= [
-                                     :link,
+                                     :link,                         # todo remove
                                      :app,
                                      :suite,
+                                     :artifact,
                                      :prefpane,
                                      :qlplugin,
                                      :font,
@@ -234,7 +236,7 @@ module Cask::DSL
                                      :input_method,
                                      :internet_plugin,
                                      :screen_saver,
-                                     :install,      # deprecated
+                                     :install,                     # todo remove
                                      :pkg,
                                     ]
     end
@@ -262,10 +264,10 @@ module Cask::DSL
     end
 
     ARTIFACT_BLOCK_TYPES = [
-      :after_install,           # deprecated
-      :after_uninstall,         # deprecated
-      :before_install,          # deprecated
-      :before_uninstall,        # deprecated
+      :after_install,           # todo remove
+      :after_uninstall,         # todo remove
+      :before_install,          # todo remove
+      :before_uninstall,        # todo remove
       :preflight,
       :postflight,
       :uninstall_preflight,

--- a/test/cask/artifact/generic_artifact_test.rb
+++ b/test/cask/artifact/generic_artifact_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+describe Cask::Artifact::Artifact do
+  let(:cask) {
+    Cask.load('with-generic-artifact').tap do |cask|
+      TestHelper.install_without_artifacts(cask)
+    end
+  }
+  let(:expected_path) {
+    # todo 'artifact' should be changed to require a :target, in
+    #      which case it will no longer default to Cask.appdir
+    #      as below
+    Cask.appdir.join('Caffeine.app')
+  }
+
+  it "links the artifact to the proper directory" do
+    shutup do
+      Cask::Artifact::Artifact.new(cask).install_phase
+    end
+
+    TestHelper.valid_alias?(expected_path).must_equal true
+  end
+
+  it "avoids clobbering an existing artifact by linking over it" do
+    FileUtils.touch expected_path
+
+    shutup do
+      Cask::Artifact::Artifact.new(cask).install_phase
+    end
+
+    expected_path.wont_be :symlink?
+  end
+
+  it "clobbers an existing symlink" do
+    expected_path.make_symlink('/tmp')
+
+    shutup do
+      Cask::Artifact::Artifact.new(cask).install_phase
+    end
+
+    File.readlink(expected_path).wont_equal '/tmp'
+  end
+end

--- a/test/support/Casks/stuffit-container.rb
+++ b/test/support/Casks/stuffit-container.rb
@@ -4,5 +4,5 @@ class StuffitContainer < TestCask
   version '1.2.3'
   sha256 '892b6d49a98c546381d41dec9b0bbc04267ac008d72b99755968d357099993b7'
   depends_on :formula => 'unar'
-  link 'sheldonmac/v1.0'
+  artifact 'sheldonmac/v1.0'
 end

--- a/test/support/Casks/with-generic-artifact.rb
+++ b/test/support/Casks/with-generic-artifact.rb
@@ -1,0 +1,7 @@
+class WithGenericArtifact < TestCask
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/with-generic-artifact'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.2.3'
+  artifact 'Caffeine.app'
+end


### PR DESCRIPTION
Keeping the `link` stanza in the DSL is a mistake: it will be
confusing when combined with the ability to install by copying.

This PR retires `link` completely, and adds a generic artifact
stanza called `artifact`.  (`link` is removed from the docs, but
will still work for compatibility during transition.)

This only affects one current Cask (dwarf-fortress.rb), and that
Cask may be changed to use `suite` in the future.
