### PR TITLE
Add CAJViewerMac beta.

### DIFF
--- a/Casks/cajviewer.rb
+++ b/Casks/cajviewer.rb
@@ -1,0 +1,10 @@
+class Cajviewer < Cask
+  version 'latest'
+  sha256 :no_check
+
+  url 'http://cajviewer.cnki.net/download/CAJViewerMac.dmg'
+  homepage 'http://cajviewer.cnki.net/download.html'
+
+  pkg 'CAJViewerMac.pkg'
+  uninstall :pkgutil => 'com.TTKN.CAJViewerMac'
+end


### PR DESCRIPTION
CAJViewer is a document viewer widely used in the Chinese academic community. It is designed to view the CAJ format specifically. Only beta version is available at present.
