### PR TITLE
Upgrade iBank to v5

### DIFF
--- a/Casks/ibank.rb
+++ b/Casks/ibank.rb
@@ -2,8 +2,8 @@ class Ibank < Cask
   version 'latest'
   sha256 :no_check
 
-  url 'https://www.iggsoft.com/ibank/iBank4_Web.dmg'
+  url 'https://www.iggsoft.com/ibank/iBank5_Web.dmg'
   homepage 'http://www.iggsoftware.com/ibank'
 
-  app 'iBank.app'
+  app 'iBank 5.app'
 end


### PR DESCRIPTION
In moving to v5 Igg Software changed the download URL and app name. This
PR addresses both those issues.

When I decided to make this change I considered whether this should actually
be submitted as a different cask. Igg Software still offer iBank 4 (and 3) for 
download, and the application name has changed to “iBank 5.app”.

However, I decided to proceed with modifying the existing cask as I feel the 
`ibank` cask should point to the latest version. I was initially confused as to 
why `brew cask install ibank` resulted in an old version being installed. I’m 
happy to create a new cask if you disagree, or to supply a PR for an 
`ibank4` cask as well.
