### PR TITLE
boxcryptor classic 1.4

### DIFF
--- a/Casks/boxcryptor-classic.rb
+++ b/Casks/boxcryptor-classic.rb
@@ -5,6 +5,5 @@ class BoxcryptorClassic < Cask
   url 'https://www.boxcryptor.com/download/Boxcryptor_Installer.dmg'
   homepage 'https://www.boxcryptor.com/en/boxcryptor-classic'
 
-  pkg 'Install Boxcryptor Classic.pkg'
-  uninstall :script => { :executable => 'Uninstall.command', :args => %w[--unattended] }
+  app 'Boxcryptor Classic.app'
 end


### PR DESCRIPTION
using new DSL.  BC 1.4 no longer uses an install package so linking to
app directly.  Prior versions also depended on OSXFuse.  This is no longer necessary as BC now utilizes its own file system
