### PR TITLE
make `install_script` stanza more robust

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -282,9 +282,16 @@ module Cask::DSL
     end
 
     def install_script(*args)
-      executable = args.shift
-      args = Hash.new(*args)
-      args.merge!({ :executable => executable })
+      unless args.length > 0
+        raise CaskInvalidError.new(self.title, "'install_script' stanza requires an argument")
+      end
+      executable = args.shift if args[0].kind_of? String
+      if args.length > 0
+        args = Hash.new().merge(*args)
+      else
+        args = Hash.new()
+      end
+      args.merge!({ :executable => executable }) if executable
       artifacts[:install_script] << args
     end
 

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -258,7 +258,11 @@ describe Cask::DSL do
   describe "install_script stanza" do
     it "allows install_script to be specified" do
       cask = Cask.load('with-install-script')
-      cask.artifacts[:install_script].first[:executable].must_equal '/usr/bin/true'
+      # the sorts are needed to force the order for Ruby 1.8
+      cask.artifacts[:install_script].sort{ |a,b| a[:executable] <=> b[:executable] }.first[:executable].must_equal '/usr/bin/false'
+      cask.artifacts[:install_script].sort{ |a,b| a[:executable] <=> b[:executable] }.first[:args].must_equal ['--flag']
+      cask.artifacts[:install_script].sort{ |a,b| a[:executable] <=> b[:executable] }.to_a[1][:executable].must_equal '/usr/bin/true'
+      cask.artifacts[:install_script].sort{ |a,b| a[:executable] <=> b[:executable] }.to_a[1][:args].must_equal ['--flag']
     end
   end
 

--- a/test/support/Casks/with-install-script.rb
+++ b/test/support/Casks/with-install-script.rb
@@ -3,5 +3,9 @@ class WithInstallScript < TestCask
   homepage 'http://example.com/with-install-script'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  install_script '/usr/bin/true'
+  install_script '/usr/bin/true',
+                 :args => ['--flag']
+  # acceptable alternate form
+  install_script :executable => '/usr/bin/false',
+                 :args       => ['--flag']
 end


### PR DESCRIPTION
- correctly (and leniently) parse values
- add test

~~This PR has an issue with Ruby 1.8~~ Fixed
