### PR TITLE
Adding cask for iPhone Backup Extractor v1.2.4

### DIFF
--- a/Casks/iphone-backup-extractor.rb
+++ b/Casks/iphone-backup-extractor.rb
@@ -1,0 +1,9 @@
+class IphoneBackupExtractor < Cask
+  version :latest
+  sha256 :no_check
+
+  url 'http://supercrazyawesome.com/downloads/iPhone%20Backup%20Extractor.app.zip'
+  homepage 'http://supercrazyawesome.com/'
+
+  app 'iPhone Backup Extractor.app'
+end


### PR DESCRIPTION
This is an unversioned download.

Please note: I grepped the current casks directory to see if the domain from the download URL already existed, but couldn’t find anything. Hopefully that means this PR isn’t a dupe.
