### PR TITLE
Add Baudline v1.08

### DIFF
--- a/Casks/baudline.rb
+++ b/Casks/baudline.rb
@@ -1,0 +1,9 @@
+class Baudline < Cask
+  version '1.08'
+  sha256 'f47201069812333c36715beaacb17de93bc8fa5f7e68952fe51296f04df69f83'
+
+  url 'http://www.baudline.com/baudline_1.08_macosx_universal.dmg'
+  homepage 'http://www.baudline.com/'
+
+  app 'baudline.app'
+end


### PR DESCRIPTION
Baudline is a time-frequency browser designed for scientific visualization of the spectral domain.
