### PR TITLE
refactor Cask::SystemCommand

### DIFF
--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -45,7 +45,7 @@ class Cask::Artifact::Base
     end
 
     # key sanity
-    permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print, :print_stderr]
+    permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print_stdout, :print_stderr]
     unknown_keys = arguments.keys - permitted_keys
     unless unknown_keys.empty?
       opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}

--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -45,7 +45,7 @@ class Cask::Artifact::Base
     end
 
     # key sanity
-    permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print]
+    permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print, :print_stderr]
     unknown_keys = arguments.keys - permitted_keys
     unless unknown_keys.empty?
       opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}

--- a/lib/cask/artifact/install_script.rb
+++ b/lib/cask/artifact/install_script.rb
@@ -16,7 +16,7 @@ class Cask::Artifact::InstallScript < Cask::Artifact::Base
                                                                       artifact,
                                                                       "#{self.class.artifact_dsl_key}",
                                                                       {:must_succeed => true},
-                                                                      {:print => true}
+                                                                      {:print_stdout => true}
                                                                       )
       ohai "Running #{self.class.artifact_dsl_key} script #{executable}"
       raise CaskInvalidError.new(@cask, "#{self.class.artifact_dsl_key} missing executable") if executable.nil?

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -48,6 +48,6 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     ]
     args << '-verboseR' if ARGV.verbose?
     args << '-allowUntrusted' if pkg_install_opts :allow_untrusted
-    @command.run!('/usr/sbin/installer', {:sudo => true, :args => args, :print => true})
+    @command.run!('/usr/sbin/installer', {:sudo => true, :args => args, :print_stdout => true})
   end
 end

--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -22,14 +22,14 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
     odebug "Adding #{attribute} metadata"
     altnames = @command.run('/usr/bin/xattr',
                             :args => ['-p', attribute, target],
-                            :stderr => :silence).sub(/\A\((.*)\)\Z/, "#{$1}")
+                            :print_stderr => false).sub(/\A\((.*)\)\Z/, "#{$1}")
     odebug "Existing metadata is: '#{altnames}'"
     altnames.concat(', ') if altnames.length > 0
     altnames.concat(%Q{"#{target.basename}"})
     altnames = %Q{(#{altnames})}
     @command.run!('/usr/bin/xattr',
                   :args => ['-w', attribute, altnames, target],
-                  :stderr => :silence)
+                  :print_stderr => false)
   end
 
   def summary

--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -22,7 +22,7 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
     odebug "Adding #{attribute} metadata"
     altnames = @command.run('/usr/bin/xattr',
                             :args => ['-p', attribute, target],
-                            :print_stderr => false).sub(/\A\((.*)\)\Z/, "#{$1}")
+                            :print_stderr => false).stdout.sub(/\A\((.*)\)\Z/, "#{$1}")
     odebug "Existing metadata is: '#{altnames}'"
     altnames.concat(', ') if altnames.length > 0
     altnames.concat(%Q{"#{target.basename}"})

--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -51,7 +51,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
       executable, script_arguments = self.class.read_script_arguments(directives,
                                                                       'uninstall',
                                                                       {:must_succeed => true},
-                                                                      {:sudo => true, :print => true},
+                                                                      {:sudo => true, :print_stdout => true},
                                                                       :early_script)
 
       ohai "Running uninstall script #{executable}"
@@ -129,7 +129,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
       executable, script_arguments = self.class.read_script_arguments(directives,
                                                                       'uninstall',
                                                                       {:must_succeed => true},
-                                                                      {:sudo => true, :print => true},
+                                                                      {:sudo => true, :print_stdout => true},
                                                                       :script)
       raise CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
       @command.run(@cask.destination_path.join(executable), script_arguments)

--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -185,10 +185,10 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
         next unless directory.exist?
         @command.run!('/bin/rm', :args => [ '-f', '--', directory.join('.DS_Store') ],
                                  :sudo => true,
-                                 :stderr => :silence)
+                                 :print_stderr => false)
         @command.run('/bin/rmdir', :args => [ '--', directory ],
                                    :sudo => true,
-                                   :stderr => :silence)
+                                   :print_stderr => false)
       end
     end
   end

--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -154,7 +154,7 @@ class Cask::CLI::Alfred < Cask::CLI::Base
       @system_command.run('/usr/bin/defaults', :args => ['write', PRIMARY_DOMAIN, key, value.to_s])
     else
       odebug 'Reading Alfred primary preferences'
-      @system_command.run('/usr/bin/defaults', :args => ['read', PRIMARY_DOMAIN, key])
+      @system_command.run('/usr/bin/defaults', :args => ['read', PRIMARY_DOMAIN, key]).stdout
     end
   end
 
@@ -168,7 +168,7 @@ class Cask::CLI::Alfred < Cask::CLI::Base
         @system_command.run('/usr/bin/defaults', :args => ['write', file, key, value.to_s])
       else
         odebug 'Reading Alfred local preferences'
-        @system_command.run('/usr/bin/defaults', :args => ['read', file, key])
+        @system_command.run('/usr/bin/defaults', :args => ['read', file, key]).stdout
       end
     # hack/limitation: if there happen to be multiple local preference
     # files, we only return the value from the first one.

--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -65,7 +65,7 @@ class Cask::CLI::Doctor < Cask::CLI::Base
       HOMEBREW_REPOSITORY.cd do
         homebrew_origin = Cask::SystemCommand.run('git',
                                                   :args => %w{config --get remote.origin.url},
-                                                  :stderr => :silence).strip
+                                                  :print_stderr => false).strip
       end
       if homebrew_origin !~ %r{\S}
         homebrew_origin = "#{none_string} #{error_string}"

--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -65,7 +65,7 @@ class Cask::CLI::Doctor < Cask::CLI::Base
       HOMEBREW_REPOSITORY.cd do
         homebrew_origin = Cask::SystemCommand.run('git',
                                                   :args => %w{config --get remote.origin.url},
-                                                  :print_stderr => false).strip
+                                                  :print_stderr => false).stdout.strip
       end
       if homebrew_origin !~ %r{\S}
         homebrew_origin = "#{none_string} #{error_string}"

--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -54,7 +54,7 @@ class Cask::CLI::List < Cask::CLI::Base
     if @options[:one]
       puts columns
     elsif @options[:long]
-      puts Cask::SystemCommand.run!("/bin/ls", :args => ["-l", Cask.caskroom])
+      puts Cask::SystemCommand.run!("/bin/ls", :args => ["-l", Cask.caskroom]).stdout
     else
       puts_columns columns
     end

--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -16,7 +16,7 @@ class Cask::Container::Criteria
       # realpath is a failsafe against unusual filenames
       :args => ['imageinfo', Pathname.new(path).realpath],
       :print_stderr => false,
-      :print => false
+      :print_stdout => false
     )
   end
 
@@ -26,7 +26,7 @@ class Cask::Container::Criteria
         HOMEBREW_PREFIX.join('bin/cabextract'),
         :args => ['-t', '--', path],
         :print_stderr => false,
-        :print => false
+        :print_stdout => false
       )
     end
   end
@@ -37,7 +37,7 @@ class Cask::Container::Criteria
         HOMEBREW_PREFIX.join('bin/lsar'),
         :args => ['-l', '-t', '--', path],
         :print_stderr => false,
-        :print => false
+        :print_stdout => false
       )
     end
   end

--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -15,8 +15,7 @@ class Cask::Container::Criteria
       '/usr/bin/hdiutil',
       # realpath is a failsafe against unusual filenames
       :args => ['imageinfo', Pathname.new(path).realpath],
-      :print_stderr => false,
-      :print_stdout => false
+      :print_stderr => false
     )
   end
 
@@ -25,8 +24,7 @@ class Cask::Container::Criteria
       @cabextract ||= @command.run(
         HOMEBREW_PREFIX.join('bin/cabextract'),
         :args => ['-t', '--', path],
-        :print_stderr => false,
-        :print_stdout => false
+        :print_stderr => false
       )
     end
   end
@@ -36,8 +34,7 @@ class Cask::Container::Criteria
       @lsar ||= @command.run(
         HOMEBREW_PREFIX.join('bin/lsar'),
         :args => ['-l', '-t', '--', path],
-        :print_stderr => false,
-        :print_stdout => false
+        :print_stderr => false
       )
     end
   end

--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -15,7 +15,7 @@ class Cask::Container::Criteria
       '/usr/bin/hdiutil',
       # realpath is a failsafe against unusual filenames
       :args => ['imageinfo', Pathname.new(path).realpath],
-      :stderr => :silence,
+      :print_stderr => false,
       :print => false
     )
   end
@@ -25,7 +25,7 @@ class Cask::Container::Criteria
       @cabextract ||= @command.run(
         HOMEBREW_PREFIX.join('bin/cabextract'),
         :args => ['-t', '--', path],
-        :stderr => :silence,
+        :print_stderr => false,
         :print => false
       )
     end
@@ -36,7 +36,7 @@ class Cask::Container::Criteria
       @lsar ||= @command.run(
         HOMEBREW_PREFIX.join('bin/lsar'),
         :args => ['-l', '-t', '--', path],
-        :stderr => :silence,
+        :print_stderr => false,
         :print => false
       )
     end

--- a/lib/cask/container/criteria.rb
+++ b/lib/cask/container/criteria.rb
@@ -7,7 +7,7 @@ class Cask::Container::Criteria
   end
 
   def file
-    @file ||= @command.run('/usr/bin/file', :args => ['-Izb', '--', path])
+    @file ||= @command.run('/usr/bin/file', :args => ['-Izb', '--', path]).stdout
   end
 
   def imageinfo
@@ -16,7 +16,7 @@ class Cask::Container::Criteria
       # realpath is a failsafe against unusual filenames
       :args => ['imageinfo', Pathname.new(path).realpath],
       :print_stderr => false
-    )
+    ).stdout
   end
 
   def cabextract
@@ -25,7 +25,7 @@ class Cask::Container::Criteria
         HOMEBREW_PREFIX.join('bin/cabextract'),
         :args => ['-t', '--', path],
         :print_stderr => false
-      )
+      ).stdout
     end
   end
 
@@ -35,7 +35,7 @@ class Cask::Container::Criteria
         HOMEBREW_PREFIX.join('bin/lsar'),
         :args => ['-l', '-t', '--', path],
         :print_stderr => false
-      )
+      ).stdout
     end
   end
 

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -38,7 +38,7 @@ class Cask::Container::Dmg < Cask::Container::Base
 
   def assert_mounts_found
     if @mounts.empty?
-      raise CaskError.new "No mounts found in '#{@path}'; perhaps it is a bad DMG?"
+      raise CaskError.new %Q{No mounts found in '#{@path}'; perhaps it is a bad DMG?}
     end
   end
 

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -49,12 +49,12 @@ class Cask::Container::Dmg < Cask::Container::Base
       next unless mountpath.exist?
       @command.run('/usr/sbin/diskutil',
                      :args => ['eject', mountpath],
-                     :stderr => :silence)
+                   :print_stderr => false)
       next unless mountpath.exist?
       sleep 1
       @command.run('/usr/sbin/diskutil',
                      :args => ['eject', mountpath],
-                     :stderr => :silence)
+                   :print_stderr => false)
       next unless mountpath.exist?
       raise CaskError.new "Failed to eject #{mountpath}"
     end

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -23,9 +23,8 @@ class Cask::Container::Dmg < Cask::Container::Base
     plist = @command.run('/usr/bin/hdiutil',
       # realpath is a failsafe against unusual filenames
       :args => %w[mount -plist -nobrowse -readonly -noidme -mountrandom /tmp] + [Pathname.new(@path).realpath],
-      :input => %w[y],
-      :plist => true
-    )
+      :input => %w[y]
+    ).plist
     @mounts = mounts_from_plist(plist)
   end
 
@@ -48,12 +47,12 @@ class Cask::Container::Dmg < Cask::Container::Base
       mountpath = Pathname.new(mount).realpath
       next unless mountpath.exist?
       @command.run('/usr/sbin/diskutil',
-                     :args => ['eject', mountpath],
+                   :args => ['eject', mountpath],
                    :print_stderr => false)
       next unless mountpath.exist?
       sleep 1
       @command.run('/usr/sbin/diskutil',
-                     :args => ['eject', mountpath],
+                   :args => ['eject', mountpath],
                    :print_stderr => false)
       next unless mountpath.exist?
       raise CaskError.new "Failed to eject #{mountpath}"

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -138,7 +138,7 @@ class Cask::SubversionDownloadStrategy < SubversionDownloadStrategy
     args << '--ignore-externals' if ignore_externals
     @command.run!('/usr/bin/svn',
                   :args => args,
-                  :stderr => :silence)
+                  :print_stderr => false)
   end
 
   def tarball_path
@@ -165,7 +165,7 @@ class Cask::SubversionDownloadStrategy < SubversionDownloadStrategy
   def compress
     Dir.chdir(cached_location) do
       @command.run!('/usr/bin/tar', :args => ['-s/^\.//', '--exclude', '.svn', '-cf', Pathname.new(tarball_path), '--', '.'],
-                                    :stderr => :silence)
+                                    :print_stderr => false)
     end
     clear_cache
   end

--- a/lib/cask/fetcher.rb
+++ b/lib/cask/fetcher.rb
@@ -8,7 +8,7 @@ class Cask::Fetcher
       googlecode_fake_head(url)
     else
       Cask::SystemCommand.run("curl",
-        :args => ["--max-time", TIMEOUT, "--silent", "--location", "--head", url])
+                              :args => ["--max-time", TIMEOUT, "--silent", "--location", "--head", url])
     end
   end
 

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -106,7 +106,7 @@ class Cask::Installer
         print "#{dep_name} ... "
         installed = @command.run(HOMEBREW_BREW_FILE,
                                  :args => ['list', '--versions', dep_name],
-                                 :stderr => :silence).include?(dep_name)
+                                 :print_stderr => false).include?(dep_name)
         if installed
           puts "already installed"
         else

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -106,7 +106,7 @@ class Cask::Installer
         print "#{dep_name} ... "
         installed = @command.run(HOMEBREW_BREW_FILE,
                                  :args => ['list', '--versions', dep_name],
-                                 :print_stderr => false).include?(dep_name)
+                                 :print_stderr => false).stdout.include?(dep_name)
         if installed
           puts "already installed"
         else

--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -227,7 +227,7 @@ class Cask::Pkg
                 ].map{|x| Pathname.new(x)}
 
   def self.all_matching(regexp, command)
-    command.run('/usr/sbin/pkgutil', :args => [%Q{--pkgs=#{regexp}}]).split("\n").map do |package_id|
+    command.run('/usr/sbin/pkgutil', :args => [%Q{--pkgs=#{regexp}}]).stdout.split("\n").map do |package_id|
       new(package_id.chomp, command)
     end
   end
@@ -269,19 +269,19 @@ class Cask::Pkg
   def pkgutil_bom_files
     @command.run!('/usr/sbin/pkgutil',
       :args => ['--only-files', '--files', package_id]
-    ).split("\n").map { |path| root.join(path) }
+    ).stdout.split("\n").map { |path| root.join(path) }
   end
 
   def pkgutil_bom_dirs
     @command.run!('/usr/sbin/pkgutil',
       :args => ['--only-dirs', '--files', package_id]
-    ).split("\n").map { |path| root.join(path) }
+    ).stdout.split("\n").map { |path| root.join(path) }
   end
 
   def pkgutil_bom_all
     @command.run!('/usr/sbin/pkgutil',
       :args => ['--files', package_id]
-    ).split("\n").map { |path| root.join(path) }
+    ).stdout.split("\n").map { |path| root.join(path) }
   end
 
   def pkgutil_bom_specials
@@ -294,9 +294,8 @@ class Cask::Pkg
 
   def info
     @command.run!('/usr/sbin/pkgutil',
-      :args => ['--pkg-info-plist', package_id],
-      :plist => true
-    )
+                  :args => ['--pkg-info-plist', package_id]
+                 ).plist
   end
 
   def _rmdir(path)

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -17,9 +17,9 @@ class Cask::SystemCommand
       ohai line.chomp if options[:print]
     end
     while line = ext_stderr.gets
-      next if options[:stderr] == :silence
+      next if ! options[:print_stderr]
       output << line
-      ohai line.chomp if options[:print]
+      ohai line.chomp if options[:print_stderr]
     end
     ext_stdout.close_read
     ext_stderr.close_read
@@ -40,10 +40,7 @@ class Cask::SystemCommand
   end
 
   def self._process_options(executable, options)
-    options.assert_valid_keys :input, :print, :stderr, :args, :must_succeed, :sudo, :plist
-    if options[:stderr] and options[:stderr] != :silence
-      raise CaskError.new "Unknown value #{options[:stderr]} for key :stderr"
-    end
+    options.assert_valid_keys :input, :print, :print_stderr, :args, :must_succeed, :sudo, :plist
     command = [executable]
     if options[:sudo]
       command.unshift('/usr/bin/sudo', '-E', '--')

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -14,7 +14,7 @@ class Cask::SystemCommand
     ext_stdin.close_write
     while line = ext_stdout.gets
       output << line
-      ohai line.chomp if options[:print]
+      ohai line.chomp if options[:print_stdout]
     end
     while line = ext_stderr.gets
       next if ! options[:print_stderr]
@@ -40,7 +40,7 @@ class Cask::SystemCommand
   end
 
   def self._process_options(executable, options)
-    options.assert_valid_keys :input, :print, :print_stderr, :args, :must_succeed, :sudo, :plist
+    options.assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo, :plist
     command = [executable]
     if options[:sudo]
       command.unshift('/usr/bin/sudo', '-E', '--')

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -4,35 +4,35 @@ class Cask::SystemCommand
   def self.run(executable, options={})
     command = _process_options(executable, options)
     odebug "Executing: #{command.utf8_inspect}"
-    output = ''
-    exit_status = nil
+    processed_stdout = ''
+    processed_stderr = ''
 
-    ext_stdin, ext_stdout, ext_stderr, wait_thr = Open3.popen3(*command.map(&:to_s))
+    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(*command.map(&:to_s))
+
     if options[:input]
-      options[:input].each { |line| ext_stdin.puts line }
+      options[:input].each { |line| raw_stdin.puts line }
     end
-    ext_stdin.close_write
-    while line = ext_stdout.gets
-      output << line
+    raw_stdin.close_write
+
+    while line = raw_stdout.gets
+      processed_stdout << line
       ohai line.chomp if options[:print_stdout]
     end
-    while line = ext_stderr.gets
-      next if ! options[:print_stderr]
-      output << line
+
+    while line = raw_stderr.gets
+      processed_stderr << line
       ohai line.chomp if options[:print_stderr]
     end
-    ext_stdout.close_read
-    ext_stderr.close_read
 
-    # Ruby 1.8 sets $?. Ruby 1.9+ has wait_thr, and does not set $?.
-    exit_status = wait_thr.nil? ? $? : wait_thr.value
+    raw_stdout.close_read
+    raw_stderr.close_read
 
-    _assert_success(exit_status, command, output) if options[:must_succeed]
-    if options[:plist]
-      _parse_plist(command, output)
-    else
-      output
-    end
+    # Ruby 1.8 sets $?. Ruby 1.9+ has raw_wait_thr, and does not set $?.
+    processed_exit_status = raw_wait_thr.nil? ? $? : raw_wait_thr.value
+
+    _assert_success(processed_exit_status, command, processed_stdout) if options[:must_succeed]
+
+    Cask::SystemCommand::Result.new(command, processed_stdout, processed_stderr, processed_exit_status)
   end
 
   def self.run!(command, options={})
@@ -40,15 +40,12 @@ class Cask::SystemCommand
   end
 
   def self._process_options(executable, options)
-    options.assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo, :plist
+    options.assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo
+    sudo_prefix = %w{/usr/bin/sudo -E --}
     command = [executable]
-    if options[:sudo]
-      command.unshift('/usr/bin/sudo', '-E', '--')
-    end
-    if options.key?(:args) and
-        ! options[:args].empty?
-      command.concat options[:args]
-    end
+    options[:print_stderr] = true  if !options.key?(:print_stderr)
+    command.unshift(*sudo_prefix)  if  options[:sudo]
+    command.concat(options[:args]) if  options.key?(:args) and !options[:args].empty?
     command
   end
 
@@ -57,12 +54,40 @@ class Cask::SystemCommand
       raise CaskCommandFailedError.new(command.utf8_inspect, output, status)
     end
   end
+end
+
+class Cask::SystemCommand::Result
+
+  attr_accessor :command, :stdout, :stderr, :exit_status
+
+  def initialize(command, stdout, stderr, exit_status)
+    @command     = command
+    @stdout      = stdout
+    @stderr      = stderr
+    @exit_status = exit_status
+  end
+
+  def plist
+    @plist ||= self.class._parse_plist(@command, @stdout)
+  end
+
+  def success?
+    @exit_status == 0
+  end
+
+  def merged_output
+    @merged_output ||= @stdout + @stderr
+  end
+
+  def to_s
+    @stdout
+  end
 
   def self._warn_plist_garbage(command, garbage)
     return true unless garbage =~ %r{\S}
     external = File.basename(command.first)
     lines = garbage.strip.split("\n")
-    opoo "Non-XML output from #{external}:"
+    opoo "Non-XML stdout from #{external}:"
     STDERR.puts lines.map {|l| "    #{l}"}
   end
 

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -47,11 +47,11 @@ class Pathname
     out=''
     n = Cask::SystemCommand.run!('/usr/bin/find',
                                  :args => [self.realpath, *%w[-type f ! -name .DS_Store]],
-                                 :stderr => :silence).count("\n")
+                                 :print_stderr => false).count("\n")
     out << "#{n} files, " if n > 1
     out << Cask::SystemCommand.run!('/usr/bin/du',
                                     :args => ['-hs', '--', self.to_s],
-                                    :stderr => :silence).split("\t").first.strip
+                                    :print_stderr => false).split("\t").first.strip
   end
 end
 

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -47,11 +47,11 @@ class Pathname
     out=''
     n = Cask::SystemCommand.run!('/usr/bin/find',
                                  :args => [self.realpath, *%w[-type f ! -name .DS_Store]],
-                                 :print_stderr => false).count("\n")
+                                 :print_stderr => false).stdout.count("\n")
     out << "#{n} files, " if n > 1
     out << Cask::SystemCommand.run!('/usr/bin/du',
                                     :args => ['-hs', '--', self.to_s],
-                                    :print_stderr => false).split("\t").first.strip
+                                    :print_stderr => false).stdout.split("\t").first.strip
   end
 end
 
@@ -114,7 +114,7 @@ module Cask::Utils
 
     if $stdout.tty?
       # determine the best width to display for different console sizes
-      console_width = Cask::SystemCommand.run("/bin/stty", :args => ["size"]).chomp.split(" ").last.to_i
+      console_width = Cask::SystemCommand.run("/bin/stty", :args => ["size"]).stdout.chomp.split(" ").last.to_i
       console_width = 80 if console_width <= 0
     else
       console_width = 80

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -29,7 +29,7 @@ describe Cask::Artifact::App do
                               :args => ['-p',
                                         'com.apple.metadata:kMDItemAlternateNames',
                                         Cask.appdir/'AnotherName.app'],
-                              :stderr => :silence).must_match(/AnotherName/)
+                              :print_stderr => false).must_match(/AnotherName/)
     end
 
     it "works with an application in a subdir" do

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -29,7 +29,7 @@ describe Cask::Artifact::App do
                               :args => ['-p',
                                         'com.apple.metadata:kMDItemAlternateNames',
                                         Cask.appdir/'AnotherName.app'],
-                              :print_stderr => false).must_match(/AnotherName/)
+                              :print_stderr => false).stdout.must_match(/AnotherName/)
     end
 
     it "works with an application in a subdir" do

--- a/test/cask/dsl/after_install_test.rb
+++ b/test/cask/dsl/after_install_test.rb
@@ -29,7 +29,7 @@ describe Cask::DSL::AfterInstall do
       ['/usr/libexec/PlistBuddy', '-c', 'Print CFBundleIdentifier', @dsl.info_plist],
       "com.example.BasicCask"
     )
-    @dsl.bundle_identifier.must_equal "com.example.BasicCask"
+    @dsl.bundle_identifier.stdout.must_equal "com.example.BasicCask"
   end
 
   it "can set a key in the Info.plist file" do

--- a/test/cask/pkg_test.rb
+++ b/test/cask/pkg_test.rb
@@ -78,7 +78,9 @@ describe Cask::Pkg do
       pkg.stubs(:pkgutil_bom_dirs).returns([fake_dir])
       pkg.stubs(:forget)
 
-      pkg.uninstall
+      shutup do
+        pkg.uninstall
+      end
 
       fake_dir.must_be :directory?
       fake_file.wont_be :file?

--- a/test/support/fake_system_command.rb
+++ b/test/support/fake_system_command.rb
@@ -40,11 +40,7 @@ class Cask::FakeSystemCommand
       fail("no response faked for #{command.inspect}, faked responses are: #{responses.inspect}")
     end
     system_calls[command] += 1
-    if options[:plist]
-      Plist::parse_xml(responses[command])
-    else
-      responses[command]
-    end
+    Cask::SystemCommand::Result.new(command, responses[command], '', 0)
   end
 
   def self.run!(command, options={})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,8 +105,10 @@ class TestHelper
 
   def self.install_without_artifacts(cask)
     Cask::Installer.new(cask).tap do |i|
-      shutup { i.download }
-      i.extract_primary_container
+      shutup do
+        i.download
+        i.extract_primary_container
+      end
     end
   end
 end


### PR DESCRIPTION
- return a `Cask::SystemCommand::Result` instance from `Cask::SystemCommand.run` instead of a string
- stderr and stdout are now separated, though both are available
- exit status can be read from the result object
- plist parsing is more naturally handled in the result object, rather than at invocation time.  The `:plist` argument to the `run` method was therefore removed, and replaced with a `plist` method on the result object.
- make the `:print` and `:stderr` parameters consistent: now `:print_stdout` and `:print_stderr`

The only functional change is that (as part of cleanly separating stderr and stdout) stderr is always returned to the console unless explicitly suppressed with `:print_stderr => false`.  As the previous behavior was somewhat inconsistent, this is a bugfix.  However, we may need to compensate if needless messages crop up.

~~**WIP** at least one commit message should be revised.~~ done.
