### PR TITLE
[vmware-fusion] fix broken sha256 sum of package

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,6 +1,6 @@
 class VmwareFusion < Cask
   version '7.0.0-2103067'
-  sha256 'f5b4bd80a2b8f6538ff24780998f73876acee1b65c1e38df0323734fa86d9e80'
+  sha256 'eb0656024f65d53a29e82a957610b5d47cfbf07cdbe90d1a273a948b7cf24213'
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   homepage 'http://www.vmware.com/products/fusion/'


### PR DESCRIPTION
I tried to install vmware-fusion and it failed because the checksum failed. 
