### PR TITLE
Add PreForm.app 1.6.5

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,0 +1,9 @@
+class Preform < Cask
+  version '1.6.5'
+  sha256 '465bd7f85a44d66d0e0bf160ed744f9d014e1acf11478e1c884a72414b7053ab'
+
+  url 'https://s3.amazonaws.com/FormlabsReleases/Release/1.6/PreForm_1.6_5.dmg'
+  homepage 'http://formlabs.com/en/products/preform/'
+
+  app 'PreForm.app'
+end


### PR DESCRIPTION
This is the first cask file submission for PreForm,
a desktop application to help prepare models
for Formlabs 3D printers.
