### PR TITLE
Add Twelf, version 1.7.1

### DIFF
--- a/Casks/twelf.rb
+++ b/Casks/twelf.rb
@@ -1,0 +1,9 @@
+class Twelf < Cask
+  version '1.7.1'
+  sha256 'be9e638d0c1dca17d70b06218084b6012fe74aecae09183db457c1c25f7cf3a0'
+
+  url "http://twelf.plparty.org/releases/twelf-osx-#{version}.dmg"
+  homepage 'http://www.twelf.org'
+
+  app 'Twelf'
+end


### PR DESCRIPTION
Note that Twelf is not actually packaged as an .app, but the developers suggest to treat it like one, i.e. the user is instructed to move `Twelf` to `/Applications`.
