### PR TITLE
update valid license values

### DIFF
--- a/lib/cask/dsl/license.rb
+++ b/lib/cask/dsl/license.rb
@@ -11,7 +11,8 @@ class Cask::DSL::License
                     :closed        => :closed,
                     :abandoned     => :closed,
                     :commercial    => :closed,
-                    :free          => :closed,
+                    :freemium      => :closed,
+                    :gratis        => :closed,
                     :trial         => :closed,
 
                     :oss           => :oss,
@@ -24,12 +25,13 @@ class Cask::DSL::License
                     :eclipse       => :oss,
                     :gpl           => :oss,
                     :isc           => :oss,
+                    :lppl          => :oss,
                     :ncsa          => :oss,
                     :mit           => :oss,
                     :mpl           => :oss,
                     :ofl           => :oss,
                     :public_domain => :oss,
-                    :ubuntu        => :oss,
+                    :ubuntu_font   => :oss,
                     :x11           => :oss,
                    }
 


### PR DESCRIPTION
- change `:free` (closed source) to `:gratis` for clarity
- add `:freemium` (_eg_ Alfred)
- add `:lppl` (LaTeX)
- change `:ubuntu` to `:ubuntu_font`

~~**WIP** pending discussion here and/or in IRC.   In particular, I think `:free` is a poor name, and would lead to confusion.~~ After some discussion on IRC, these changes seem OK — good enough to move forward.

There will always be rough points.  `license` is intended for search/filtering, not annotation.  The most accurate information is always the distribution's home page.

In IRC, we also discussed whether all licenses under `:closed` should be eliminated in favor of just `:closed`.  For the record, I am open to that, if licensing distinctions inspire a too much argument and absorb non-trivial maintainer time.
