### PR TITLE
DSL: validate value of GPG key ID

### DIFF
--- a/lib/cask/dsl/gpg.rb
+++ b/lib/cask/dsl/gpg.rb
@@ -18,11 +18,20 @@ class Cask::DSL::Gpg
       raise "invalid 'gpg' parameter: '#{hkey.inspect}'" unless VALID_PARAMETERS.include?(hkey)
       writer_method = "#{hkey}=".to_sym
       hvalue = Cask::UnderscoreSupportingURI.parse(hvalue) if hkey == :key_url
+      valid_id?(hvalue) if hkey == :key_id
       send(writer_method, hvalue)
     end
     unless KEY_PARAMETERS.intersection(parameters.keys).length == 1
       raise "'gpg' stanza must include exactly one of: '#{KEY_PARAMETERS.to_a}'"
     end
+  end
+
+  def valid_id?(id)
+    legal_lengths = Set.new [8, 16, 40]
+    is_valid = id.kind_of?(String) && legal_lengths.include?(id.length) && id[/^[0-9a-f]+$/i]
+    raise "invalid ':key_id' value: '#{id.inspect}'" unless is_valid
+
+    is_valid
   end
 
   def to_yaml

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -197,6 +197,12 @@ describe Cask::DSL do
       }.must_raise(CaskInvalidError)
     end
 
+    it "refuses to load invalid gpg key IDs" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-gpg-key-id')
+      }.must_raise(CaskInvalidError)
+    end
+
     it "refuses to load if gpg parameter is unknown" do
       err = lambda {
         invalid_cask = Cask.load('invalid/invalid-gpg-parameter')

--- a/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
+++ b/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
@@ -5,7 +5,7 @@ class InvalidGpgConflictingKeys < TestCask
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-conflicting-keys'
   gpg 'http://example.com/gpg-signature.asc',
-      :key_id => 'ID',
+      :key_id => '01234567',
       :key_url => 'http://example.com/gpg-key-url'
 
   app 'Caffeine.app'

--- a/test/support/Casks/invalid/invalid-gpg-key-id.rb
+++ b/test/support/Casks/invalid/invalid-gpg-key-id.rb
@@ -1,0 +1,11 @@
+class InvalidGpgKeyId < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/invalid-gpg-key-id'
+  gpg 'http://example.com/gpg-signature.asc',
+      :key_id => '012'
+
+  app 'Caffeine.app'
+end

--- a/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
+++ b/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
@@ -5,9 +5,9 @@ class InvalidGpgMultipleStanzas < TestCask
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-multiple-stanzas'
   gpg 'http://example.com/gpg-signature.asc',
-      :key_id => 'ID'
+      :key_id => '01234567'
   gpg 'http://example.com/gpg-signature.asc',
-      :key_id => 'ID'
+      :key_id => '01234567'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-signature-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-signature-url.rb
@@ -5,7 +5,7 @@ class InvalidGpgSignatureUrl < TestCask
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-signature-url'
   gpg 1,
-      :key_id => 'ID'
+      :key_id => '01234567'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-gpg.rb
+++ b/test/support/Casks/with-gpg.rb
@@ -5,6 +5,7 @@ class WithGpg < TestCask
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-gpg'
   gpg 'http://example.com/gpg-signature.asc',
-      :key_id => 'ID'
+      :key_id => '01234567'
+
   app 'Caffeine.app'
 end


### PR DESCRIPTION
The `gpg` CLI can recover keys from hexadecimal identifiers in three formats: fingerprint, ID, short ID. The latter two are merely substrings (length of 16, 8) of the full fingerprint (length of 40).

Ref. #6184
