### PR TITLE
Link the mate command line tool during install

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -6,6 +6,7 @@ class Textmate < Cask
   homepage 'http://macromates.com/'
 
   app 'TextMate.app'
+  binary 'TextMate.app/Contents/Resources/mate'
   zap :delete => [
                   '~/Library/Application Support/TextMate',
                   '~/Library/Preferences/com.macromates.textmate.plist',


### PR DESCRIPTION
The "mate" command line tool is distributed within the TextMate.app bundle, and we can link the binary so that it is picked up during installation.
