### PR TITLE
Update sidekick to not prompt for moving to /Applications

### DIFF
--- a/Casks/sidekick.rb
+++ b/Casks/sidekick.rb
@@ -7,4 +7,10 @@ class Sidekick < Cask
   homepage 'http://oomphalot.com/sidekick/'
 
   app 'Sidekick.app'
+  
+  postflight do
+    # Don't ask to move the app bundle to /Applications
+    system '/usr/bin/defaults', 'write', 'com.oomphalot.Sidekick', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
+  end
+
 end


### PR DESCRIPTION
Sidekick currently prompts the user if they want to move it into /Applications.  This patch will prevent that from being asked.
