### PR TITLE
manopen 2.6: New formula

### DIFF
--- a/Casks/manopen.rb
+++ b/Casks/manopen.rb
@@ -1,0 +1,11 @@
+class Manopen < Cask
+  version '2.6'
+  sha256 '7b383ca493b0b360bb58e65f7e7ce0a92383ff38c5221cc410eaf03f1117a958'
+
+  url 'http://www.clindberg.org/projects/ManOpen-2.6.dmg'
+  homepage 'http://www.clindberg.org/projects/ManOpen.html'
+
+  app 'ManOpen.app'
+  binary 'openman'
+  artifact 'openman.1', :target => '/usr/local/share/man/man1/openman.1'
+end


### PR DESCRIPTION
ManOpen is a MacOS X GUI application for viewing Unix manual pages.
