### PR TITLE
Add Clip-O-Tron

### DIFF
--- a/Casks/omnifocus-clip-o-tron.rb
+++ b/Casks/omnifocus-clip-o-tron.rb
@@ -1,0 +1,13 @@
+class OmnifocusClipOTron < Cask
+  version '1.0'
+  sha256 '904e808ca65d1f2db4c1356255200ec73364ff7f23528fd4ff857edead39a312'
+
+  url "http://www.omnigroup.com/ftp/pub/software/MacOSX/10.9/OmniFocus-Clip-o-Tron-Installer-#{version}.dmg"
+  homepage 'http://support.omnigroup.com/omnifocus-clip-o-tron'
+
+  app 'OmniFocus Clip-o-Tron.app'
+
+  caveats do
+    manual_installer 'OmniFocus Clip-o-Tron.app'
+  end
+end


### PR DESCRIPTION
> The OmniFocus Clip-o-Tron is a handy tool for extending OmniFocus’s interaction with Mail for Mac OS X. It lets use your Clippings shortcut to copy Mail messages in whole cloth – subject, contents, and all – and add them to Quick Entry.

I think I got everything right with the new format, but let me know if I need to add/fix anything.
