### PR TITLE
Cask::SystemCommand refactor followups

### DIFF
--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -13,7 +13,18 @@ class Cask::Container::Dmg < Cask::Container::Base
     mount!
     assert_mounts_found
     @mounts.each do |mount|
-      @command.run('/usr/bin/ditto', :args => ['--', mount, @cask.destination_path])
+      @command.run('/usr/bin/ditto',
+                   # todo
+                   # per https://github.com/caskroom/homebrew-cask/issues/6382, ditto
+                   # complains to stderr about unreadable .Trashes directories, so all
+                   # stderr output is silenced for now.  But better solutions would be
+                   # - use the --bom option to ditto to selectively avoid certain files
+                   #   - .Trashes
+                   #   - symlinks to Applications
+                   # - or support some type of text filter to be passed to
+                   #   :print_stderr instead of true/false
+                   :print_stderr => false,
+                   :args => ['--', mount, @cask.destination_path])
     end
   ensure
     eject!

--- a/lib/cask/fetcher.rb
+++ b/lib/cask/fetcher.rb
@@ -8,7 +8,7 @@ class Cask::Fetcher
       googlecode_fake_head(url)
     else
       Cask::SystemCommand.run("curl",
-                              :args => ["--max-time", TIMEOUT, "--silent", "--location", "--head", url])
+                              :args => ["--max-time", TIMEOUT, "--silent", "--location", "--head", url]).stdout
     end
   end
 


### PR DESCRIPTION
- hide stderr messages from `ditto` when copying mounted DMG
- fix `Cask::LinkChecker` to return string

fixes #6382
fixes #6385
refs #6329
