### PR TITLE
method spelling error in pixelapse.rb

### DIFF
--- a/Casks/pixelapse.rb
+++ b/Casks/pixelapse.rb
@@ -2,7 +2,7 @@ class Pixelapse < Cask
   version '2.0.0'
   sha256 '6822de800b29b02f7ff6f94ef28bbbb3c38aef05fad0cf6c5cb293623227547c'
 
-  url "https://s3.amazonaws.com/download-pixelapse/Pixelapse%20#{vesion}.dmg"
+  url "https://s3.amazonaws.com/download-pixelapse/Pixelapse%20#{version}.dmg"
   homepage 'https://www.pixelapse.com'
 
   app 'Pixelapse.app'


### PR DESCRIPTION
refs: #6417, #6416 

This should be merged quickly to quiet the test suite.
