### PR TITLE
fix params for kextunload

### DIFF
--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -118,7 +118,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
         ohai "Unloading kernel extension #{kext}"
         is_loaded = @command.run!('/usr/sbin/kextstat', :args => ['-l', '-b', kext], :sudo => true).stdout
         if is_loaded.length > 1
-          @command.run!('/sbin/kextunload', :args => ['-b', '--', kext], :sudo => true)
+          @command.run!('/sbin/kextunload', :args => ['-b', kext], :sudo => true)
           sleep 1
         end
       end

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -131,7 +131,7 @@ describe Cask::Artifact::Uninstall do
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'unload', '-w', '--', 'my.fancy.package.service'])
 
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/kextstat', '-l', '-b', 'my.fancy.package.kernelextension'], 'loaded')
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', '--', 'my.fancy.package.kernelextension'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', 'my.fancy.package.kernelextension'])
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/pkgutil', '--forget', 'my.fancy.package.main'])
 
       Cask::FakeSystemCommand.stubs_command(

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -133,7 +133,7 @@ describe Cask::Artifact::Zap do
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'unload', '-w', '--', 'my.fancy.package.service'])
 
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/kextstat', '-l', '-b', 'my.fancy.package.kernelextension'], 'loaded')
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', '--', 'my.fancy.package.kernelextension'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', 'my.fancy.package.kernelextension'])
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/pkgutil', '--forget', 'my.fancy.package.main'])
 
       Cask::FakeSystemCommand.stubs_command(


### PR DESCRIPTION
use proper kextunload params
:kext in the cask realm is the bundle identifier (or bundle-id) and should be passed as `-b bundle-id`

to reproduce:

```
$ cask install karabiner
> run karabiner from spotlight and then quit (this loads/activates the kext)
$ cask uninstall karabiner
==> Removing Binary symlink: '/usr/local/bin/warp-mouse-cursor-position'
==> Removing Binary symlink: '/usr/local/bin/blueutil'
==> Running uninstall process for karabiner; your password may be necessary
==> Quitting application ID org.pqrs.Karabiner
==> Unloading kernel extension org.pqrs.driver.Karabiner
==> Can't create org.pqrs.driver.Karabiner.
==> (kernel) Kext -- not found for unload request.
==> Failed to unload -- - (libkern/kext) not found.
Error: Command failed to execute!

==> Failed command:
["/usr/bin/sudo", "-E", "--", "/sbin/kextunload", "-b", "--", "org.pqrs.driver.Karabiner"]

==> Output of failed command:


==> Exit status of failed command:
#<Process::Status: pid 97275 exit 1>
```
