### PR TITLE
reformat test Casks to match layout conventions

### DIFF
--- a/test/cask/cli/cat_test.rb
+++ b/test/cask/cli/cat_test.rb
@@ -6,10 +6,12 @@ describe Cask::CLI::Cat do
       Cask::CLI::Cat.run('basic-cask')
     }.must_output <<-CLIOUTPUT.undent
       class BasicCask < TestCask
-        url 'http://example.com/TestCask.dmg'
-        homepage 'http://example.com/'
         version '1.2.3'
         sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+        url 'http://example.com/TestCask.dmg'
+        homepage 'http://example.com/'
+
         app 'TestCask.app'
       end
     CLIOUTPUT
@@ -20,10 +22,12 @@ describe Cask::CLI::Cat do
       Cask::CLI::Cat.run('basic-cask', 'local-caffeine')
     }.must_output <<-CLIOUTPUT.undent
       class BasicCask < TestCask
-        url 'http://example.com/TestCask.dmg'
-        homepage 'http://example.com/'
         version '1.2.3'
         sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+        url 'http://example.com/TestCask.dmg'
+        homepage 'http://example.com/'
+
         app 'TestCask.app'
       end
     CLIOUTPUT

--- a/test/support/Casks/adobe-air-container.rb
+++ b/test/support/Casks/adobe-air-container.rb
@@ -1,7 +1,9 @@
 class AdobeAirContainer < TestCask
-  url TestHelper.local_binary_url('GMDesk-1.01.air')
-  homepage 'http://robertnyman.com/gmdesk/'
   version '1.0.1'
   sha256 '9b6e4174afa76f2af50238364fcf87525bc4ed2287acbe62925107ab6cda5c99'
+
+  url TestHelper.local_binary_url('GMDesk-1.01.air')
+  homepage 'http://robertnyman.com/gmdesk/'
+
   app 'GMDesk.app'
 end

--- a/test/support/Casks/bad-checksum.rb
+++ b/test/support/Casks/bad-checksum.rb
@@ -1,7 +1,9 @@
 class BadChecksum < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/basic-cask.rb
+++ b/test/support/Casks/basic-cask.rb
@@ -1,7 +1,9 @@
 class BasicCask < TestCask
-  url 'http://example.com/TestCask.dmg'
-  homepage 'http://example.com/'
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url 'http://example.com/TestCask.dmg'
+  homepage 'http://example.com/'
+
   app 'TestCask.app'
 end

--- a/test/support/Casks/bzipped-asset.rb
+++ b/test/support/Casks/bzipped-asset.rb
@@ -1,7 +1,9 @@
 class BzippedAsset < TestCask
-  url TestHelper.local_binary_url('bzipped_asset.bz2')
-  homepage 'http://example.com/bzipped-asset'
   version '1.2.3'
   sha256 'eaf67b3a62cb9275f96e45d05c70b94bef9ef1dae344083e93eda6b0b388a61c'
+
+  url TestHelper.local_binary_url('bzipped_asset.bz2')
+  homepage 'http://example.com/bzipped-asset'
+
   app 'bzipped-asset-1.2.3'
 end

--- a/test/support/Casks/cab-container.rb
+++ b/test/support/Casks/cab-container.rb
@@ -1,8 +1,10 @@
 class CabContainer < TestCask
-  url TestHelper.local_binary_url('cabcontainer.cab')
-  homepage 'http://example.com/cab-container'
   version '1.2.3'
   sha256 '192d0cf6b727473f9ba0f55cec793ee2a8f7113c5cfe9d49e05a087436c5efe2'
+
+  url TestHelper.local_binary_url('cabcontainer.cab')
+  homepage 'http://example.com/cab-container'
+
   depends_on :formula => 'cabextract'
   app 'cabcontainer/Application.app'
 end

--- a/test/support/Casks/gzipped-asset.rb
+++ b/test/support/Casks/gzipped-asset.rb
@@ -1,7 +1,9 @@
 class GzippedAsset < TestCask
-  url TestHelper.local_binary_url('gzipped_asset.gz')
-  homepage 'http://example.com/gzipped-asset'
   version '1.2.3'
   sha256 '832506ade94b3e41ecdf2162654eb75891a0749803229e82b2e0420fd1b9e8d2'
+
+  url TestHelper.local_binary_url('gzipped_asset.gz')
+  homepage 'http://example.com/gzipped-asset'
+
   app 'gzipped-asset-1.2.3'
 end

--- a/test/support/Casks/invalid/invalid-appcast-format.rb
+++ b/test/support/Casks/invalid/invalid-appcast-format.rb
@@ -1,10 +1,13 @@
 class InvalidAppcastFormat < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-appcast-format'
   appcast 'http://example.com/appcast.xml',
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
           :format => :no_such_format
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-appcast-multiple.rb
+++ b/test/support/Casks/invalid/invalid-appcast-multiple.rb
@@ -1,4 +1,7 @@
 class InvalidAppcastMultiple < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-appcast-multiple'
   appcast 'http://example.com/appcast1.xml',
@@ -7,7 +10,6 @@ class InvalidAppcastMultiple < TestCask
   appcast 'http://example.com/appcast2.xml',
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
           :format => :sparkle
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-appcast-url.rb
+++ b/test/support/Casks/invalid/invalid-appcast-url.rb
@@ -1,10 +1,12 @@
 class InvalidAppcastUrl < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-appcast-url'
   appcast 1,
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
           :format => :sparkle
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-conflicts-with-key.rb
+++ b/test/support/Casks/invalid/invalid-conflicts-with-key.rb
@@ -1,8 +1,10 @@
 class InvalidConflictsWithKey < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-conflicts-with-key'
+
   conflicts_with :no_such_key => 'unar'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-depends-on-key.rb
+++ b/test/support/Casks/invalid/invalid-depends-on-key.rb
@@ -1,8 +1,10 @@
 class InvalidDependsOnKey < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-depends-on-key'
+
   depends_on :no_such_key => 'unar'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
+++ b/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
@@ -1,10 +1,12 @@
 class InvalidGpgConflictingKeys < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-conflicting-keys'
   gpg 'http://example.com/gpg-signature.asc',
       :key_id => 'ID',
       :key_url => 'http://example.com/gpg-key-url'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-key-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-key-url.rb
@@ -1,9 +1,11 @@
 class InvalidGpgKeyUrl < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-key-url'
   gpg 'http://example.com/gpg-signature.asc',
       :key_url => 1
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-missing-key.rb
+++ b/test/support/Casks/invalid/invalid-gpg-missing-key.rb
@@ -1,8 +1,10 @@
 class InvalidGpgMissingKeys < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-missing-keys'
   gpg 'http://example.com/gpg-signature.asc'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
+++ b/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
@@ -1,11 +1,13 @@
 class InvalidGpgMultipleStanzas < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-multiple-stanzas'
   gpg 'http://example.com/gpg-signature.asc',
       :key_id => 'ID'
   gpg 'http://example.com/gpg-signature.asc',
       :key_id => 'ID'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-parameter.rb
+++ b/test/support/Casks/invalid/invalid-gpg-parameter.rb
@@ -1,9 +1,11 @@
 class InvalidGpgParameter < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-type'
   gpg 'http://example.com/gpg-signature.asc',
       :no_such_parameter => :value
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-signature-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-signature-url.rb
@@ -1,9 +1,11 @@
 class InvalidGpgSignatureUrl < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-signature-url'
   gpg 1,
       :key_id => 'ID'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-type.rb
+++ b/test/support/Casks/invalid/invalid-gpg-type.rb
@@ -1,9 +1,11 @@
 class InvalidGpgParameter < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-type'
   gpg 'http://example.com/gpg-signature.asc',
       :no_such_parameter => :value
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-license-multiple.rb
+++ b/test/support/Casks/invalid/invalid-license-multiple.rb
@@ -1,9 +1,11 @@
 class InvalidLicenseMultiple < TestCask
+  version '2.61'
+  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
   url TestHelper.local_binary_url('transmission-2.61.dmg')
   homepage 'http://example.com/invalid-license-multiple'
   license :gpl
   license :gpl
-  version '2.61'
-  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
   app 'Transmission.app'
 end

--- a/test/support/Casks/invalid/invalid-license-value.rb
+++ b/test/support/Casks/invalid/invalid-license-value.rb
@@ -1,8 +1,10 @@
 class InvalidLicenseValue < TestCask
+  version '2.61'
+  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
   url TestHelper.local_binary_url('transmission-2.61.dmg')
   homepage 'http://example.com/invalid-license-value'
   license :no_such_license
-  version '2.61'
-  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
   app 'Transmission.app'
 end

--- a/test/support/Casks/invalid/invalid-tags-key.rb
+++ b/test/support/Casks/invalid/invalid-tags-key.rb
@@ -1,8 +1,10 @@
 class InvalidTagsKey < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-tags-key'
   tags :no_such_key => 'ExampleSoft'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-tags-multiple.rb
+++ b/test/support/Casks/invalid/invalid-tags-multiple.rb
@@ -1,9 +1,11 @@
 class InvalidTagsMultiple < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-tags-multiple'
   tags :vendor => 'ExampleSoft'
   tags :vendor => 'ExampleSoft'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-two-homepage.rb
+++ b/test/support/Casks/invalid/invalid-two-homepage.rb
@@ -1,9 +1,10 @@
 class InvalidTwoHomepage < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
   homepage 'http://www.example.com/local-caffeine'
-  version '1.2.3'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-two-url.rb
+++ b/test/support/Casks/invalid/invalid-two-url.rb
@@ -1,9 +1,10 @@
 class InvalidTwoUrl < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   url 'http://example.com/caffeine.zip'
   homepage 'http://example.com/local-caffeine'
-  version '1.2.3'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-two-version.rb
+++ b/test/support/Casks/invalid/invalid-two-version.rb
@@ -1,9 +1,10 @@
 class InvalidTwoVersion < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   version '2.0'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/local-caffeine.rb
+++ b/test/support/Casks/local-caffeine.rb
@@ -1,8 +1,9 @@
 class LocalCaffeine < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/local-transmission.rb
+++ b/test/support/Casks/local-transmission.rb
@@ -1,7 +1,9 @@
 class LocalTransmission < TestCask
-  url TestHelper.local_binary_url('transmission-2.61.dmg')
-  homepage 'http://example.com/local-transmission'
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
+  url TestHelper.local_binary_url('transmission-2.61.dmg')
+  homepage 'http://example.com/local-transmission'
+
   app 'Transmission.app'
 end

--- a/test/support/Casks/missing-checksum.rb
+++ b/test/support/Casks/missing-checksum.rb
@@ -1,6 +1,8 @@
 class MissingChecksum < TestCask
+  version '1.2.3'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/local-caffeine'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/naked-executable.rb
+++ b/test/support/Casks/naked-executable.rb
@@ -1,7 +1,9 @@
 class NakedExecutable < TestCask
-  url TestHelper.local_binary_url('naked_executable')
-  homepage 'http://example.com/naked-executable'
   version '1.2.3'
   sha256 '306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb'
-  container :type => :naked
+
+  url TestHelper.local_binary_url('naked_executable')
+  homepage 'http://example.com/naked-executable'
+
+  container_type :naked
 end

--- a/test/support/Casks/naked-pkg.rb
+++ b/test/support/Casks/naked-pkg.rb
@@ -1,6 +1,7 @@
 class NakedPkg < TestCask
-  url TestHelper.local_binary_url('Naked.pkg')
-  homepage 'http://example.com/naked-pkg'
   version '1.2.3'
   sha256 '611c50c8a2a2098951d2cd0fd54787ed81b92cd97b4b08bd7cba17f1e1d8e40b'
+
+  url TestHelper.local_binary_url('Naked.pkg')
+  homepage 'http://example.com/naked-pkg'
 end

--- a/test/support/Casks/nested-app-dsl-one.rb
+++ b/test/support/Casks/nested-app-dsl-one.rb
@@ -2,10 +2,12 @@ class NestedAppDslOne < TestCask
   # todo: This Cask can be removed after DSL 1.0 transition,
   #       b/c the main Cask nested-app.rb will be
   #       adopting this syntax.
-  url TestHelper.local_binary_url('NestedApp.dmg.zip')
-  homepage 'http://example.com/nested-app'
   version '1.2.3'
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
+
+  url TestHelper.local_binary_url('NestedApp.dmg.zip')
+  homepage 'http://example.com/nested-app'
+
   container :nested => 'NestedApp.dmg'
   app 'MyNestedApp.app'
 end

--- a/test/support/Casks/nested-app.rb
+++ b/test/support/Casks/nested-app.rb
@@ -1,8 +1,10 @@
 class NestedApp < TestCask
-  url TestHelper.local_binary_url('NestedApp.dmg.zip')
-  homepage 'http://example.com/nested-app'
   version '1.2.3'
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
+
+  url TestHelper.local_binary_url('NestedApp.dmg.zip')
+  homepage 'http://example.com/nested-app'
+
   nested_container 'NestedApp.dmg'
   app 'MyNestedApp.app'
 end

--- a/test/support/Casks/no-checksum.rb
+++ b/test/support/Casks/no-checksum.rb
@@ -1,7 +1,9 @@
 class NoChecksum < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 :no_check
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/rar-container.rb
+++ b/test/support/Casks/rar-container.rb
@@ -1,8 +1,10 @@
 class RarContainer < TestCask
-  url TestHelper.local_binary_url('rarcontainer.rar')
-  homepage 'http://example.com/rar-container'
   version '1.2.3'
   sha256 '35fb13fb13e6aefc38b60486627eff6b6b55b2f99f64bf47938530c6cf9e0a0f'
+
+  url TestHelper.local_binary_url('rarcontainer.rar')
+  homepage 'http://example.com/rar-container'
+
   depends_on :formula => 'unar'
   app 'rarcontainer/Application.app'
 end

--- a/test/support/Casks/sevenzip-container.rb
+++ b/test/support/Casks/sevenzip-container.rb
@@ -1,8 +1,10 @@
 class SevenzipContainer < TestCask
-  url TestHelper.local_binary_url('sevenzipcontainer.7z')
-  homepage 'http://example.com/sevenzip-container'
   version '1.2.3'
   sha256 '1550701e7848fcb94f5b0085cca527083a8662ddeb8c0a7bc5af6bd145797cc1'
+
+  url TestHelper.local_binary_url('sevenzipcontainer.7z')
+  homepage 'http://example.com/sevenzip-container'
+
   depends_on :formula => 'unar'
   app 'sevenzipcontainer/Application.app'
 end

--- a/test/support/Casks/stuffit-container.rb
+++ b/test/support/Casks/stuffit-container.rb
@@ -1,8 +1,10 @@
 class StuffitContainer < TestCask
-  url TestHelper.local_binary_url('sheldonmac.sit')
-  homepage 'http://www.tobias-jung.de/seekingprofont/'
   version '1.2.3'
   sha256 '892b6d49a98c546381d41dec9b0bbc04267ac008d72b99755968d357099993b7'
+
+  url TestHelper.local_binary_url('sheldonmac.sit')
+  homepage 'http://www.tobias-jung.de/seekingprofont/'
+
   depends_on :formula => 'unar'
   artifact 'sheldonmac/v1.0'
 end

--- a/test/support/Casks/tarball.rb
+++ b/test/support/Casks/tarball.rb
@@ -1,7 +1,9 @@
 class Tarball < TestCask
-  url TestHelper.local_binary_url('tarball.tgz')
-  homepage 'http://example.com/tarball'
   version '1.2.3'
   sha256 :no_check
+
+  url TestHelper.local_binary_url('tarball.tgz')
+  homepage 'http://example.com/tarball'
+
   app 'Tarball.app'
 end

--- a/test/support/Casks/test-opera-mail.rb
+++ b/test/support/Casks/test-opera-mail.rb
@@ -1,7 +1,9 @@
 class TestOperaMail < TestCask
-  url 'http://get-ash-1.opera.com/pub/opera/mail/1.0/mac/Opera-Mail-1.0-1040.i386.dmg'
-  homepage 'http://www.opera.com/computer/mail'
   version '1.0'
   sha256 'afd192e308f8ea8ddb3d426fd6663d97078570417ee78b8e1fa15f515ae3d677'
+
+  url 'http://get-ash-1.opera.com/pub/opera/mail/1.0/mac/Opera-Mail-1.0-1040.i386.dmg'
+  homepage 'http://www.opera.com/computer/mail'
+
   app 'Opera Mail.app'
 end

--- a/test/support/Casks/test-opera.rb
+++ b/test/support/Casks/test-opera.rb
@@ -1,7 +1,9 @@
 class TestOpera < TestCask
-  url 'http://get.geo.opera.com/pub/opera/desktop/19.0.1326.47/mac/Opera_19.0.1326.47_Setup.dmg'
-  homepage 'http://www.opera.com/'
   version '19.0.1326.47'
   sha256 '7b91f20ab754f7b3fef8dc346e0393917e11676b74c8f577408841619f76040a'
+
+  url 'http://get.geo.opera.com/pub/opera/desktop/19.0.1326.47/mac/Opera_19.0.1326.47_Setup.dmg'
+  homepage 'http://www.opera.com/'
+
   app 'Opera.app'
 end

--- a/test/support/Casks/with-alt-target.rb
+++ b/test/support/Casks/with-alt-target.rb
@@ -1,7 +1,9 @@
 class WithAltTarget < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app', :target => 'AnotherName.app'
 end

--- a/test/support/Casks/with-appcast.rb
+++ b/test/support/Casks/with-appcast.rb
@@ -1,10 +1,12 @@
 class WithAppcast < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-appcast'
   appcast 'http://example.com/appcast.xml',
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853',
           :format => :sparkle
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-binary.rb
+++ b/test/support/Casks/with-binary.rb
@@ -1,8 +1,10 @@
 class WithBinary < TestCask
+  version '1.2.3'
+  sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
+
   url TestHelper.local_binary_url('AppWithBinary.zip')
   homepage 'http://example.com/with-binary'
-  sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
-  version '1.2.3'
+
   app 'App.app'
   binary 'binary'
 end

--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -1,8 +1,10 @@
 class WithCaveats < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app'
   # simple string is evaluated at compile-time
   caveats <<-EOS.undent

--- a/test/support/Casks/with-conditional-caveats.rb
+++ b/test/support/Casks/with-conditional-caveats.rb
@@ -1,8 +1,10 @@
 class WithConditionalCaveats < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app'
   # a do block may print and use a DSL
   caveats do

--- a/test/support/Casks/with-conflicts-with.rb
+++ b/test/support/Casks/with-conflicts-with.rb
@@ -1,8 +1,10 @@
 class WithConflictsWith < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-conflicts-with'
+
   conflicts_with :formula => 'unar'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on.rb
+++ b/test/support/Casks/with-depends-on.rb
@@ -1,8 +1,10 @@
 class WithDependsOn < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-depends-on'
+
   depends_on :formula => 'unar'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-generic-artifact.rb
+++ b/test/support/Casks/with-generic-artifact.rb
@@ -1,7 +1,9 @@
 class WithGenericArtifact < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-generic-artifact'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   artifact 'Caffeine.app'
 end

--- a/test/support/Casks/with-gpg-key-url.rb
+++ b/test/support/Casks/with-gpg-key-url.rb
@@ -1,9 +1,10 @@
 class WithGpgKeyUrl < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-gpg-key-url'
   gpg 'http://example.com/gpg-signature.asc',
       :key_url => 'http://example.com/gpg-key-url'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-gpg.rb
+++ b/test/support/Casks/with-gpg.rb
@@ -1,9 +1,10 @@
 class WithGpg < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-gpg'
   gpg 'http://example.com/gpg-signature.asc',
       :key_id => 'ID'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-install-script.rb
+++ b/test/support/Casks/with-install-script.rb
@@ -1,8 +1,10 @@
 class WithInstallScript < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/with-install-script'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/with-install-script'
+
   install_script '/usr/bin/true',
                  :args => ['--flag']
   # acceptable alternate form

--- a/test/support/Casks/with-installable.rb
+++ b/test/support/Casks/with-installable.rb
@@ -1,8 +1,10 @@
 class WithInstallable < TestCask
-  url TestHelper.local_binary_url('MyFancyPkg.zip')
-  homepage 'http://example.com/fancy-pkg'
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url TestHelper.local_binary_url('MyFancyPkg.zip')
+  homepage 'http://example.com/fancy-pkg'
+
   pkg 'MyFancyPkg/Fancy.pkg'
   uninstall :script => { :executable => 'MyFancyPkg/FancyUninstaller.tool', :args => %w[--please] },
             :quit   => 'my.fancy.package.app',

--- a/test/support/Casks/with-license.rb
+++ b/test/support/Casks/with-license.rb
@@ -1,8 +1,10 @@
 class WithLicense < TestCask
+  version '2.61'
+  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
   url TestHelper.local_binary_url('transmission-2.61.dmg')
   homepage 'http://example.com/with-license'
   license :gpl
-  version '2.61'
-  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
   app 'Transmission.app'
 end

--- a/test/support/Casks/with-macosx-dir.rb
+++ b/test/support/Casks/with-macosx-dir.rb
@@ -1,7 +1,9 @@
 class WithMacosxDir < TestCask
-  url TestHelper.local_binary_url('MyFancyApp.zip')
-  homepage 'http://example.com/MyFancyApp'
   version '1.2.3'
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
+
+  url TestHelper.local_binary_url('MyFancyApp.zip')
+  homepage 'http://example.com/MyFancyApp'
+
   app 'MyFancyApp/MyFancyApp.app'
 end

--- a/test/support/Casks/with-pkgutil-uninstall.rb
+++ b/test/support/Casks/with-pkgutil-uninstall.rb
@@ -1,8 +1,10 @@
 class WithPkgutilUninstall < TestCask
-  url TestHelper.local_binary_url('MyFancyPkg.zip')
-  homepage 'http://example.com/fancy-pkg'
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url TestHelper.local_binary_url('MyFancyPkg.zip')
+  homepage 'http://example.com/fancy-pkg'
+
   pkg 'Fancy.pkg'
   uninstall :pkgutil => 'my.fancy.package.*',
             :kext => 'my.fancy.package.kernelextension',

--- a/test/support/Casks/with-pkgutil-zap.rb
+++ b/test/support/Casks/with-pkgutil-zap.rb
@@ -1,8 +1,10 @@
 class WithPkgutilZap < TestCask
-  url TestHelper.local_binary_url('MyFancyPkg.zip')
-  homepage 'http://example.com/fancy-pkg'
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url TestHelper.local_binary_url('MyFancyPkg.zip')
+  homepage 'http://example.com/fancy-pkg'
+
   pkg 'Fancy.pkg'
   zap :pkgutil => 'my.fancy.package.*',
       :kext => 'my.fancy.package.kernelextension',

--- a/test/support/Casks/with-tags.rb
+++ b/test/support/Casks/with-tags.rb
@@ -1,8 +1,10 @@
 class WithTags < TestCask
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-tags'
   tags :vendor => 'ExampleSoft'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
-  version '1.2.3'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-two-apps-correct.rb
+++ b/test/support/Casks/with-two-apps-correct.rb
@@ -1,8 +1,10 @@
 class WithTwoAppsCorrect < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app'
   app 'Caffeine.app', :target => 'AnotherName.app'
 end

--- a/test/support/Casks/with-two-apps-incorrect.rb
+++ b/test/support/Casks/with-two-apps-incorrect.rb
@@ -1,7 +1,9 @@
 class WithTwoAppsIncorrect < TestCask
-  url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/local-caffeine'
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
   app 'Caffeine.app', 'Caffeine.app/Contents/MacOS/Caffeine'
 end

--- a/test/support/Casks/with-zap.rb
+++ b/test/support/Casks/with-zap.rb
@@ -1,8 +1,10 @@
 class WithZap < TestCask
-  url TestHelper.local_binary_url('MyFancyPkg.zip')
-  homepage 'http://example.com/fancy-pkg'
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url TestHelper.local_binary_url('MyFancyPkg.zip')
+  homepage 'http://example.com/fancy-pkg'
+
   pkg 'MyFancyPkg/Fancy.pkg'
   uninstall :quit => 'my.fancy.package.app.from.uninstall'
   zap :script => {

--- a/test/support/Casks/xar-container.rb
+++ b/test/support/Casks/xar-container.rb
@@ -1,7 +1,9 @@
 class XarContainer < TestCask
-  url TestHelper.local_binary_url('xarcontainer.xar')
-  homepage 'http://example.com/xar-container'
   version '1.2.3'
   sha256 '1418752ac49e859f88590db245015cb2f8b459f619e0c50fd6ff87b902c72ee1'
+
+  url TestHelper.local_binary_url('xarcontainer.xar')
+  homepage 'http://example.com/xar-container'
+
   app 'xarcontainer/Application.app'
 end


### PR DESCRIPTION
In case a contributor uses a test Cask as a template

~~WIP.  This will conflict with  upcoming `container :type` PR~~ fixed
