### PR TITLE
change 6 Casks to use `container :type =>`

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -6,8 +6,8 @@ class AdobeArh < Cask
   homepage 'http://help.adobe.com/en_US/air/redist/WS485a42d56cd19641-70d979a8124ef20a34b-8000.html'
   license :unknown
 
+  container :type => :naked
   binary 'arh'
-  container_type :naked
 
   postflight do
     system '/bin/chmod', '--', '755', "#{destination_path}/arh"

--- a/Casks/bankid.rb
+++ b/Casks/bankid.rb
@@ -6,7 +6,7 @@ class Bankid < Cask
   homepage 'http://www.bankid.com/'
   license :unknown
 
-  container_type :naked
+  container :type => :naked
   preflight do
     system '/bin/mv', '--', destination_path.join('FileDownloader'), destination_path.join('bankid-latest.pkg')
   end

--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -6,8 +6,8 @@ class Parse < Cask
   homepage 'https://parse.com'
   license :unknown
 
+  container :type => :naked
   binary 'parse'
-  container_type :naked
 
   postflight do
     system "chmod", "755", "#{destination_path}/#{title}"

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -9,7 +9,7 @@ class Qlmarkdown < Cask
   # Fix broken zip file with no toplevel bundle directory.  This was
   # not needed for version 1.3.2.  We could add an option to the main
   # DSL to identify such containers and generate a target directory.
-  container_type :naked
+  container :type => :naked
   preflight do
     system '/usr/bin/ditto', '-xk', '--', "#{destination_path}/QLMarkdown.qlgenerator.zip", "#{destination_path}/QLMarkdown.qlgenerator"
   end

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -6,7 +6,7 @@ class Ridibooks < Cask
   homepage 'http://ridibooks.com/support/introduce_appdown'
   license :unknown
 
-  container_type :naked
+  container :type => :naked
   preflight do
     system '/bin/mv', '--', destination_path.join('getapp'), destination_path.join('ridibooks.pkg')
   end

--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -6,7 +6,7 @@ class TdToolbelt < Cask
   homepage 'http://toolbelt.treasuredata.com/'
   license :unknown
 
-  container_type :naked
+  container :type => :naked
   preflight do
     system '/bin/mv', '--', "#{destination_path}/mac", "#{destination_path}/td-toolbelt.pkg"
   end


### PR DESCRIPTION
Instead of `container_type`.  

This form was not supported until v0.40.0.  However, so few Casks are affected that it is unlikely we will see many bug reports.  Users will get a prompt to upgrade if attempting to use these Casks with an older version.
