### PR TITLE
Add Vox

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,0 +1,10 @@
+class Vox < Cask
+  version :latest
+  sha256 :no_check
+
+  url 'http://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
+  homepage 'http://coppertino.com/vox/osx/'
+  license :closed
+
+  app 'VOX.app'
+end


### PR DESCRIPTION
Vox was previously removed due to unavailability outside MAS. The vendor now promotes a direct download.
