### PR TITLE
User-friendly error messages for invalid options/arguments; fixes #5997

### DIFF
--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -212,6 +212,11 @@ class Cask::CLI
       rescue OptionParser::InvalidOption
         remaining << head
         retry
+      rescue OptionParser::MissingArgument
+        raise CaskError.new("The option '#{head}' requires an argument")
+      rescue OptionParser::AmbiguousOption
+        raise CaskError.new(
+          "There is more than one possible option that starts with '#{head}'")
       end
     end
     remaining

--- a/lib/cask/cli/base.rb
+++ b/lib/cask/cli/base.rb
@@ -7,6 +7,10 @@ class Cask::CLI::Base
     true
   end
 
+  def self.cask_names_from(args)
+    args.reject { |a| a.chars.first == '-' }
+  end
+
   def self.help
     "No help available for the #{command_name} command"
   end

--- a/lib/cask/cli/cat.rb
+++ b/lib/cask/cli/cat.rb
@@ -1,8 +1,9 @@
 class Cask::CLI::Cat < Cask::CLI::Base
-  def self.run(*arguments)
+  def self.run(*args)
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
     # only respects the first argument
-    raise CaskUnspecifiedError if arguments.empty?
-    cask_name = arguments.first.sub(/\.rb$/i, '')
+    cask_name = cask_names.first.sub(/\.rb$/i, '')
     cask_path = Cask.path(cask_name)
     raise CaskUnavailableError, cask_name.to_s unless cask_path.exist?
     puts File.open(cask_path) { |f| f.read }

--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -1,7 +1,8 @@
 class Cask::CLI::Create < Cask::CLI::Base
-  def self.run(*arguments)
-    raise CaskUnspecifiedError if arguments.empty?
-    cask_name = arguments.first.sub(/\.rb$/i,'')
+  def self.run(*args)
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
+    cask_name = cask_names.first.sub(/\.rb$/i,'')
     cask_path = Cask.path(cask_name)
     odebug "Creating Cask #{cask_name}"
 

--- a/lib/cask/cli/edit.rb
+++ b/lib/cask/cli/edit.rb
@@ -1,7 +1,9 @@
 class Cask::CLI::Edit < Cask::CLI::Base
-  def self.run(*arguments)
-    raise CaskUnspecifiedError if arguments.empty?
-    cask_name = arguments.first.sub(/\.rb$/i,'')
+  def self.run(*args)
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
+    # only respects the first argument
+    cask_name = cask_names.first.sub(/\.rb$/i, '')
     cask_path = Cask.path(cask_name)
     odebug "Opening editor for Cask #{cask_name}"
     unless cask_path.exist?

--- a/lib/cask/cli/fetch.rb
+++ b/lib/cask/cli/fetch.rb
@@ -1,7 +1,7 @@
 class Cask::CLI::Fetch < Cask::CLI::Base
   def self.run(*args)
-    raise CaskUnspecifiedError if args.empty?
-    cask_names = args.reject { |a| a.chars.first == '-' }
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
     force = args.include? '--force'
 
     cask_names.each do |cask_name|

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -1,5 +1,6 @@
 class Cask::CLI::Info < Cask::CLI::Base
-  def self.run(*cask_names)
+  def self.run(*args)
+    cask_names = cask_names_from(args)
     raise CaskUnspecifiedError if cask_names.empty?
     cask_names.each do |cask_name|
       odebug "Getting info for Cask #{cask_name}"

--- a/lib/cask/cli/install.rb
+++ b/lib/cask/cli/install.rb
@@ -1,7 +1,7 @@
 class Cask::CLI::Install < Cask::CLI::Base
   def self.run(*args)
-    raise CaskUnspecifiedError if args.empty?
-    cask_names = args.reject { |a| a.chars.first == '-' }
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
     force = args.include? '--force'
     retval = install_casks cask_names, force
     # retval is ternary: true/false/nil

--- a/lib/cask/cli/uninstall.rb
+++ b/lib/cask/cli/uninstall.rb
@@ -1,7 +1,7 @@
 class Cask::CLI::Uninstall < Cask::CLI::Base
   def self.run(*args)
-    raise CaskUnspecifiedError if args.empty?
-    cask_names = args.reject { |a| a.chars.first == '-' }
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
     force = args.include? '--force'
     cask_names.each do |cask_name|
       odebug "Uninstalling Cask #{cask_name}"

--- a/lib/cask/cli/zap.rb
+++ b/lib/cask/cli/zap.rb
@@ -1,7 +1,7 @@
 class Cask::CLI::Zap < Cask::CLI::Base
   def self.run(*args)
-    raise CaskUnspecifiedError if args.empty?
-    cask_names = args.reject { |a| a.chars.first == '-' }
+    cask_names = cask_names_from(args)
+    raise CaskUnspecifiedError if cask_names.empty?
     cask_names.each do |cask_name|
       odebug "Zapping Cask #{cask_name}"
       cask = Cask.load(cask_name)

--- a/test/cask/cli/cat_test.rb
+++ b/test/cask/cli/cat_test.rb
@@ -1,36 +1,38 @@
 require 'test_helper'
 
 describe Cask::CLI::Cat do
-  it 'displays the cask file content about the specified cask' do
-    lambda {
-      Cask::CLI::Cat.run('basic-cask')
-    }.must_output <<-CLIOUTPUT.undent
-      class BasicCask < TestCask
-        version '1.2.3'
-        sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+  describe 'given a basic cask' do
+    before do
+      @expected_output = <<-CLIOUTPUT.undent
+        class BasicCask < TestCask
+          version '1.2.3'
+          sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
-        url 'http://example.com/TestCask.dmg'
-        homepage 'http://example.com/'
+          url 'http://example.com/TestCask.dmg'
+          homepage 'http://example.com/'
 
-        app 'TestCask.app'
-      end
-    CLIOUTPUT
-  end
+          app 'TestCask.app'
+        end
+      CLIOUTPUT
+    end
 
-  it 'throws away additional arguments and uses the first' do
-    lambda{
-      Cask::CLI::Cat.run('basic-cask', 'local-caffeine')
-    }.must_output <<-CLIOUTPUT.undent
-      class BasicCask < TestCask
-        version '1.2.3'
-        sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+    it 'displays the cask file content about the specified cask' do
+      lambda {
+        Cask::CLI::Cat.run('basic-cask')
+      }.must_output(@expected_output)
+    end
 
-        url 'http://example.com/TestCask.dmg'
-        homepage 'http://example.com/'
+    it 'throws away additional casks and uses the first' do
+      lambda{
+        Cask::CLI::Cat.run('basic-cask', 'local-caffeine')
+      }.must_output(@expected_output)
+    end
 
-        app 'TestCask.app'
-      end
-    CLIOUTPUT
+    it 'throws away stray options' do
+      lambda{
+        Cask::CLI::Cat.run('--notavalidoption', 'basic-cask')
+      }.must_output(@expected_output)
+    end
   end
 
   it %q{raises an exception when the cask doesn't exist} do
@@ -39,9 +41,19 @@ describe Cask::CLI::Cat do
     }.must_raise CaskUnavailableError
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Cat.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Cat.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Cat.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -19,7 +19,7 @@ describe Cask::CLI::Create do
   before { Cask::CLI::Create.reset! }
 
   after {
-    %w[ new-cask additional-cask another-cask feine ].each do |cask|
+    %w[ new-cask additional-cask another-cask yet-another-cask feine ].each do |cask|
       path = Cask.path(cask)
       path.delete if path.exist?
     end
@@ -49,10 +49,17 @@ describe Cask::CLI::Create do
     TEMPLATE
   end
 
-  it 'throws away additional arguments and uses the first' do
+  it 'throws away additional casks and uses the first' do
     Cask::CLI::Create.run('additional-cask', 'another-cask')
     Cask::CLI::Create.editor_commands.must_equal [
       [Cask.path('additional-cask')]
+    ]
+  end
+
+  it 'throws away stray options' do
+    Cask::CLI::Create.run('--notavalidoption', 'yet-another-cask')
+    Cask::CLI::Create.editor_commands.must_equal [
+      [Cask.path('yet-another-cask')]
     ]
   end
 
@@ -69,9 +76,19 @@ describe Cask::CLI::Create do
     ]
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Create.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Create.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Create.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end

--- a/test/cask/cli/edit_test.rb
+++ b/test/cask/cli/edit_test.rb
@@ -40,9 +40,19 @@ describe Cask::CLI::Edit do
     }.must_raise CaskUnavailableError
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Edit.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Edit.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Edit.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end

--- a/test/cask/cli/fetch_test.rb
+++ b/test/cask/cli/fetch_test.rb
@@ -61,11 +61,19 @@ describe Cask::CLI::Fetch do
     }.must_raise CaskUnavailableError
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      shutup do
-        Cask::CLI::Fetch.run
-      end
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Fetch.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Fetch.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -14,23 +14,35 @@ describe Cask::CLI::Info do
     CLIOUTPUT
   end
 
-  it 'works for multiple casks' do
-    lambda {
-      Cask::CLI::Info.run('local-caffeine', 'local-transmission')
-    }.must_output <<-CLIOUTPUT.undent
-      local-caffeine: 1.2.3
-      http://example.com/local-caffeine
-      Not installed
-      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
-      ==> Contents
-        Caffeine.app (link)
-      local-transmission: 2.61
-      http://example.com/local-transmission
-      Not installed
-      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
-      ==> Contents
-        Transmission.app (link)
-    CLIOUTPUT
+  describe 'given multiple casks' do
+    before do
+      @expected_output = <<-CLIOUTPUT.undent
+        local-caffeine: 1.2.3
+        http://example.com/local-caffeine
+        Not installed
+        https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+        ==> Contents
+          Caffeine.app (link)
+        local-transmission: 2.61
+        http://example.com/local-transmission
+        Not installed
+        https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
+        ==> Contents
+          Transmission.app (link)
+      CLIOUTPUT
+    end
+
+    it 'displays the info' do
+      lambda {
+        Cask::CLI::Info.run('local-caffeine', 'local-transmission')
+      }.must_output(@expected_output)
+    end
+
+    it 'throws away stray options' do
+      lambda {
+        Cask::CLI::Info.run('--notavalidoption', 'local-caffeine', 'local-transmission')
+      }.must_output(@expected_output)
+    end
   end
 
   it 'should print caveats if the cask provided one' do
@@ -70,9 +82,19 @@ describe Cask::CLI::Info do
     CLIOUTPUT
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Info.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Info.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Info.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -68,15 +68,15 @@ describe Cask::CLI::Install do
     end
 
     describe "without options" do
-      with_options.([])
+      with_options.call([])
     end
 
     describe "with --force" do
-      with_options.(['--force'])
+      with_options.call(['--force'])
     end
 
     describe "with an invalid option" do
-      with_options.(['--notavalidoption'])
+      with_options.call(['--notavalidoption'])
     end
   end
 end

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -58,9 +58,25 @@ describe Cask::CLI::Install do
     err.must_match %r{No available cask for google\. Did you mean one of:\ngoogle}
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Install.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    with_options = lambda do |options|
+      it "raises an exception" do
+        lambda {
+          Cask::CLI::Install.run(*options)
+        }.must_raise CaskUnspecifiedError
+      end
+    end
+
+    describe "without options" do
+      with_options.([])
+    end
+
+    describe "with --force" do
+      with_options.(['--force'])
+    end
+
+    describe "with an invalid option" do
+      with_options.(['--notavalidoption'])
+    end
   end
 end

--- a/test/cask/cli/options_test.rb
+++ b/test/cask/cli/options_test.rb
@@ -106,6 +106,22 @@ describe Cask::CLI do
     rest.must_equal %w{edit foo --create}
   end
 
+  describe "when a mandatory argument is missing" do
+    it "shows a user-friendly error message" do
+      lambda {
+        Cask::CLI.process_options %w{install -f}
+      }.must_raise CaskError
+    end
+  end
+
+  describe "given an ambiguous option" do
+    it "shows a user-friendly error message" do
+      lambda {
+        Cask::CLI.process_options %w{edit -c}
+      }.must_raise CaskError
+    end
+  end
+
   describe "--debug" do
     it "sets the Cask debug method to true" do
       Cask::CLI.process_options %w{help --debug}

--- a/test/cask/cli/uninstall_test.rb
+++ b/test/cask/cli/uninstall_test.rb
@@ -60,9 +60,19 @@ describe Cask::CLI::Uninstall do
     end
   end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Uninstall.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Uninstall.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Uninstall.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end

--- a/test/cask/cli/zap_test.rb
+++ b/test/cask/cli/zap_test.rb
@@ -20,7 +20,8 @@ describe Cask::CLI::Zap do
     transmission.must_be :installed?
 
     shutup do
-      Cask::CLI::Zap.run('local-caffeine', 'local-transmission')
+      Cask::CLI::Zap.run('--notavalidoption',
+        'local-caffeine', 'local-transmission')
     end
 
     caffeine.wont_be :installed?
@@ -57,9 +58,19 @@ describe Cask::CLI::Zap do
   #   with_zap.wont_be :installed?
   # end
 
-  it "raises an exception when no cask is specified" do
-    lambda {
-      Cask::CLI::Uninstall.run
-    }.must_raise CaskUnspecifiedError
+  describe "when no cask is specified" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Zap.run()
+      }.must_raise CaskUnspecifiedError
+    end
+  end
+
+  describe "when no cask is specified, but an invalid option" do
+    it "raises an exception" do
+      lambda {
+        Cask::CLI::Zap.run('--notavalidoption')
+      }.must_raise CaskUnspecifiedError
+    end
   end
 end


### PR DESCRIPTION
- Show a more user-friendly error message when dealing with an option whose (mandatory) argument is missing.
- Likewise, we show a more user-friendly error message when a given option is ambiguous. Examples:
  - Given `-f`, the parser successfully expands to `--fontdir`.
  - Given `-c`, we fail to expand because the parser can’t tell if the user means `--caskroom` or rather `--colorpickerdir`. This exception now results in a nicer error message.
- Some commands now result in a consistent error message when a required cask name is missing.  
  This affects all stable commands which require one or more cask names as arguments, i. e. `cat`, `create`, `edit`, `fetch`, `info`, `install`, `uninstall`, and `zap`.
- Up to now, the commands `cat`, `create`, `edit`, and `info` used to treat any unknown option as a cask name. This commit changes that behaviour to make it consistent to the rest of the commands (like `fetch`, `install`, `uninstall`, and `zap`), who have silently discarded any unknown option in the past, and continue to do so.
