### PR TITLE
Bring the repo layout test back in sync with `.gitignore`

### DIFF
--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -14,6 +14,8 @@ describe "Repo layout" do
                     ..
                     .DS_Store
                     .bundle
+                    .ruby-version
+                    coverage
                    }
 
   # the developer has hopefully gitignored these


### PR DESCRIPTION
This keeps the tests from failing, e. g. when developers use `rbenv` to run the 1.8-based tests.
