### PR TITLE
Add Maintenance Latest

### DIFF
--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -1,0 +1,29 @@
+class Maintenance < Cask
+  version :latest
+  sha256 :no_check
+  homepage 'http://www.titanium.free.fr/downloadmaintenance.php'
+  license :closed
+  app 'Maintenance.app'
+
+  if MacOS.version == :mavericks
+    url 'http://joel.barriere.pagesperso-orange.fr/dl/109/Maintenance.dmg'
+  elsif MacOS.version == :mountain_lion
+    url 'http://joel.barriere.pagesperso-orange.fr/dl/108/Maintenance.dmg'
+  elsif MacOS.version == :lion
+    url 'http://www.titanium.free.fr/download/107/Maintenance.dmg'
+  elsif MacOS.version == :snow_leopard
+    url 'http://www.titanium.free.fr/download/106/Maintenance.dmg'
+  elsif MacOS.version == :leopard
+    url 'http://www.titanium.free.fr/download/105/Maintenance.dmg'
+  elsif MacOS.version == :tiger
+    url 'http://www.titanium.free.fr/download/104/Maintenance.dmg'
+  end
+
+  caveats do
+    os_version_only('10.4', '10.5', '10.6', '10.7', '10.8', '10.9')
+
+    if [:leopard, :tiger].include? MacOS.version
+      puts 'Maintenance only runs from an Administrator account.'
+    end
+  end
+end


### PR DESCRIPTION
Cask added for [Titanium Software's](http://www.titanium.free.fr/) freeware utility [Maintenance](http://www.titanium.free.fr/downloadmaintenance.php).

**N.B.:** requires [this PR](https://github.com/caskroom/homebrew-cask/pull/6487) to be deployed prior otherwise [line 23](https://github.com/alexcruice/homebrew-cask/blob/be9fe59bd83d584c2d5d71cdcbda6830fc22f03c/Casks/maintenance.rb#L23) will cause an issue.

> Maintenance is a system maintenance and cleaning utility for OS X which allows you to run miscellaneous tasks of system maintenance: repair permissions, run periodic scripts, reset Spotlight’s Index, rebuild the LaunchServices database, delete Application, Font and System cache, check the status of the hard disk, and more.

![6_10_2014_7_15_am](https://cloud.githubusercontent.com/assets/3786095/4519982/b5c16904-4cd4-11e4-8725-28630b6d5d39.png)
