### PR TITLE
Update for Couchbase Server 3.0.0 versions

### DIFF
--- a/Casks/couchbase-server-community.rb
+++ b/Casks/couchbase-server-community.rb
@@ -1,8 +1,8 @@
 class CouchbaseServerCommunity < Cask
-  version '2.2.0'
-  sha256 'a5a99c09d405519e7dd7d28676004cf352356d932cee1f3638f8c9db9045f15a'
+  version '3.0.0'
+  sha256 'cf8f77cc3d5f164a8d49578af512f050afb515c7bd03b271f99110d31ac14ecd'
 
-  url "http://packages.couchbase.com/releases/#{version}/couchbase-server-community_#{version}_x86_64.zip"
+  url "http://packages.couchbase.com/releases/#{version}/couchbase-server-community_#{version}-macos_x86_64.zip"
   homepage 'http://www.couchbase.com/'
   license :unknown
 

--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -1,8 +1,8 @@
 class CouchbaseServerEnterprise < Cask
-  version '2.5.1'
-  sha256 'fce890b3c68893ad651da2103ae56d8be6a6310e607aa42b0376fea1a1ca1b41'
+  version '3.0.0'
+  sha256 'b3ea2d7dd10e97b51aa2492b4e1877f53d7ff3d45f401565dd117caf77e5f37d'
 
-  url "http://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}_x86_64.zip"
+  url "http://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"
   homepage 'http://www.couchbase.com/'
   license :unknown
 


### PR DESCRIPTION
Community and Enterprise versions of Couchbase Server are at 3.0.0 as of today.
