### PR TITLE
Upgrade Android Studio to 0.8.9

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,9 +1,9 @@
 class AndroidStudio < Cask
-  version '0.8.6 build-135.1339820'
-  sha256 '3a9f65434a2381019f4487481331f539a69b09b8ea81a8b4dfff9c6a126423f0'
+  version '0.8.9'
+  sha256 'ee89cc544829cb62611ac7686254c4fc2eff00fdb6ab9a49330c97b8e8e952ac'
 
-  url 'http://dl.google.com/android/studio/install/0.8.6/android-studio-bundle-135.1339820-mac.dmg'
-  homepage 'https://developer.android.com/sdk/installing/studio.html'
+  url 'http://dl.google.com/dl/android/studio/ide-zips/0.8.9/android-studio-ide-135.1404660-mac.zip'
+  homepage 'http://tools.android.com/download/studio'
   license :unknown
 
   app 'Android Studio.app'


### PR DESCRIPTION
the version 0.8.9 comes from http://tools.android.com/download/studio/canary/0-8-9 and offical doesn't include the build number in version
the homepage url also changed to a more accurate place
