### PR TITLE
re-use version number in android-studio.rb

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -2,7 +2,7 @@ class AndroidStudio < Cask
   version '0.8.9'
   sha256 'ee89cc544829cb62611ac7686254c4fc2eff00fdb6ab9a49330c97b8e8e952ac'
 
-  url 'http://dl.google.com/dl/android/studio/ide-zips/0.8.9/android-studio-ide-135.1404660-mac.zip'
+  url "http://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-ide-135.1404660-mac.zip"
   homepage 'http://tools.android.com/download/studio'
   license :unknown
 


### PR DESCRIPTION
this might not work completely, due to other revision strings
in the url
