### PR TITLE
reformat maintenance.rb, provide `else` in `if`

### DIFF
--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -1,23 +1,25 @@
 class Maintenance < Cask
   version :latest
   sha256 :no_check
-  homepage 'http://www.titanium.free.fr/downloadmaintenance.php'
-  license :closed
-  app 'Maintenance.app'
 
-  if MacOS.version == :mavericks
-    url 'http://joel.barriere.pagesperso-orange.fr/dl/109/Maintenance.dmg'
-  elsif MacOS.version == :mountain_lion
-    url 'http://joel.barriere.pagesperso-orange.fr/dl/108/Maintenance.dmg'
-  elsif MacOS.version == :lion
-    url 'http://www.titanium.free.fr/download/107/Maintenance.dmg'
-  elsif MacOS.version == :snow_leopard
-    url 'http://www.titanium.free.fr/download/106/Maintenance.dmg'
+  if MacOS.version == :tiger
+    url 'http://www.titanium.free.fr/download/104/Maintenance.dmg'
   elsif MacOS.version == :leopard
     url 'http://www.titanium.free.fr/download/105/Maintenance.dmg'
-  elsif MacOS.version == :tiger
-    url 'http://www.titanium.free.fr/download/104/Maintenance.dmg'
+  elsif MacOS.version == :snow_leopard
+    url 'http://www.titanium.free.fr/download/106/Maintenance.dmg'
+  elsif MacOS.version == :lion
+    url 'http://www.titanium.free.fr/download/107/Maintenance.dmg'
+  elsif MacOS.version == :mountain_lion
+    url 'http://joel.barriere.pagesperso-orange.fr/dl/108/Maintenance.dmg'
+  else
+    url 'http://joel.barriere.pagesperso-orange.fr/dl/109/Maintenance.dmg'
   end
+
+  homepage 'http://www.titanium.free.fr/downloadmaintenance.php'
+  license :closed
+
+  app 'Maintenance.app'
 
   caveats do
     os_version_only('10.4', '10.5', '10.6', '10.7', '10.8', '10.9')


### PR DESCRIPTION
Per [CASK_LANGUAGE_REFERENCE.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#always-fall-through-to-the-newest-case) an `if` should have an `else`.

This Cask is an unusual case, as the vendor has a different version for every OS revision.  So, it is likely that a Yosemite user does not want to download the Mavericks version of the software, as this `else` directs.

However, we bump up against a limitation of our code here: leaving the `url` field blank is illegal in the DSL. Any command which merely _evaluated_ this Cask would die under Yosemite, because the `url` field would be empty.

A better resolution would be to accept `:unknown` in the `url` field (see #5248).  We should consider accepting `:unknown` for all stanzas in anticipation of such corner cases.

cc @alexcruice
