### PR TITLE
Pedantic tweaks for 104 Casks

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -13,5 +13,5 @@ class AdobeArh < Cask
     system '/bin/chmod', '--', '755', "#{destination_path}/arh"
   end
 
-  caveats "Please refer to the documention at #{homepage}"
+  caveats "Please refer to the documentation at #{homepage}"
 end

--- a/Casks/airstream.rb
+++ b/Casks/airstream.rb
@@ -7,11 +7,10 @@ class Airstream < Cask
   license :unknown
   app 'AirStream.app'
 
-  caveats do
-    puts <<-EOS.undent
-      If you have Java 7 or above installed, you may have to run the following commands:
-        sudo mkdir -p /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/bundle/Libraries/
-        sudo ln -s /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/jre/lib/server/libjvm.dylib /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/bundle/Libraries/libserver.dylib
-    EOS
-  end
+  caveats <<-EOS.undent
+    If you have Java 7 or above installed, you may have to run the following:
+
+      sudo mkdir -p /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/bundle/Libraries/
+      sudo ln -s /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/jre/lib/server/libjvm.dylib /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/bundle/Libraries/libserver.dylib
+  EOS
 end

--- a/Casks/alib1.rb
+++ b/Casks/alib1.rb
@@ -13,12 +13,9 @@ class Alib1 < Cask
     system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName ALib1 (Presstube)', "#{destination_path}/presstube-alib1.app/Contents/Resources/Presstube - ALib1.saver/Contents/Info.plist"
   end
 
-  caveats do
-    <<-EOS.undent
-    If you have issue running #{@cask}, try installing Adobe Air with
+  caveats <<-EOS.undent
+    #{@cask} requires Adobe Air, available via
 
-        brew cask install adobe-air
-
-    EOS
-  end
+      brew cask install adobe-air
+  EOS
 end

--- a/Casks/android-studio-bundle.rb
+++ b/Casks/android-studio-bundle.rb
@@ -9,6 +9,6 @@ class AndroidStudioBundle < Cask
   app 'Android Studio.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/Android Studio.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/Android Studio.app/Contents/Info.plist"
   end
 end

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -9,6 +9,6 @@ class AndroidStudio < Cask
   app 'Android Studio.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/Android Studio.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/Android Studio.app/Contents/Info.plist"
   end
 end

--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -9,6 +9,6 @@ class Appcode < Cask
   app 'AppCode.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/AppCode.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/AppCode.app/Contents/Info.plist"
   end
 end

--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,14 +1,19 @@
 class Aquamacs < Cask
+
   if Hardware::CPU.is_32_bit?
-    url 'http://braeburn.aquamacs.org/releases/Aquamacs-Emacs-2.5.dmg'
     version '2.5'
     sha256 '5857848d8d46bba43d160c02393b098a370e2156608be24b288419f668210be9'
+
+    url "http://braeburn.aquamacs.org/releases/Aquamacs-Emacs-#{version}.dmg"
   else
-    url 'https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-3.0a/Aquamacs-Emacs-3.0a.dmg'
     version '3.0a'
     sha256 '1d833cb2e40c1af96713badc4efa7c1c9259317b91edcfe17059c73e989f9e07'
+
+    url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-3.0a/Aquamacs-Emacs-#{version}.dmg"
   end
+
   homepage 'http://aquamacs.org/'
   license :oss
+
   app 'Aquamacs.app'
 end

--- a/Casks/avogadro.rb
+++ b/Casks/avogadro.rb
@@ -1,9 +1,11 @@
 class Avogadro < Cask
-  url 'https://downloads.sourceforge.net/avogadro/Avogadro-1.1.1.dmg.zip'
+  version '1.1.1'
+  sha256 '8e63b7ec07555fd30ea2c22ed7f070e1b692fd2c9fbb60a3c8e0ddd411bb6477'
+
+  url "https://downloads.sourceforge.net/avogadro/Avogadro-#{version}.dmg.zip"
   homepage 'http://avogadro.openmolecules.net/'
   license :oss
-  version '1.1.1'
+
   nested_container "Avogadro-#{version}.dmg"
-  sha256 '8e63b7ec07555fd30ea2c22ed7f070e1b692fd2c9fbb60a3c8e0ddd411bb6477'
   app 'Avogadro.app'
 end

--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -1,14 +1,18 @@
 class Bassjump < Cask
 
   if MacOS.version < :mavericks
-    url 'http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpSoundSystem-2.0.3-249-ML.mpkg.zip'
     version '2.0.3'
     sha256 '8e4dffa6bb3b532b994f379d19d70903f59fc019916f10cba9d01b8075d69a7f'
+
+    url "http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpSoundSystem-#{version}-249-ML.mpkg.zip"
+
     pkg "BassJump Sound System-#{version}-249-ML.mpkg"
   else
-    url 'http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpInstaller_2.5.1.dmg.zip'
     version '2.5.1'
     sha256 '14408480cded51f6334753639e973ebbf2fc40f34ff64e1c35d2f32507d88afd'
+
+    url "http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpInstaller_#{version}.dmg.zip"
+
     nested_container "BassJumpInstaller_#{version}.dmg"
     pkg 'BassJumpInstaller.pkg'
   end

--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -2,9 +2,9 @@ class Blink1control < Cask
   version '1.91'
   sha256 'fc3624a041f561f086cdce95bd70470b072c9b586e9ee1247d88b78e6abce094'
 
+  url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
   homepage 'http://blink1.thingm.com/'
   license :oss
-  url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
 
   app 'Blink1Control.app'
 end

--- a/Casks/candybar.rb
+++ b/Casks/candybar.rb
@@ -9,6 +9,7 @@ class Candybar < Cask
   app 'CandyBar.app'
   caveats <<-EOS.undent
     Candybar is free of charge.  Visit the following link for a license
-    http://panic.com/bin/setup.php/cb3/PPQA-YAMA-E3KP-VHXG-B6AL-L
+
+      http://panic.com/bin/setup.php/cb3/PPQA-YAMA-E3KP-VHXG-B6AL-L
   EOS
 end

--- a/Casks/cdock.rb
+++ b/Casks/cdock.rb
@@ -7,10 +7,9 @@ class Cdock < Cask
   license :oss
 
   app 'cDock.app'
-  caveats do
-    puts <<-EOS.undent
-    Currently the cask '#{@cask}' depends on the cask easysimbl so
-    in order to use '#{@cask}' do 'brew cask install easysimbl'
-    EOS
-  end
+  caveats <<-EOS.undent
+    #{@cask} requires easysimbl, available via
+
+      brew cask install easysimbl
+  EOS
 end

--- a/Casks/chunkulus.rb
+++ b/Casks/chunkulus.rb
@@ -12,12 +12,9 @@ class Chunkulus < Cask
     system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Chunkulus (Presstube)', "#{destination_path}/presstube-chunkulus.app/Contents/Resources/Presstube - Chunkulus.saver/Contents/Info.plist"
   end
 
-  caveats do
-    <<-EOS.undent
-    If you have issue running #{@cask}, try installing Adobe Air with
+  caveats <<-EOS.undent
+    #{@cask} requires Adobe Air, available via
 
-        brew cask install adobe-air
-
-    EOS
-  end
+      brew cask install adobe-air
+  EOS
 end

--- a/Casks/cloudera-hive-odbc.rb
+++ b/Casks/cloudera-hive-odbc.rb
@@ -8,9 +8,9 @@ class ClouderaHiveOdbc < Cask
 
   pkg 'ClouderaHiveODBC.pkg'
   uninstall :pkgutil => 'cloudera.hiveodbc'
-  caveats do
-    <<-EOS.undent
-    See /opt/cloudera/hiveodbc/Readme.txt for configuration instructions.
-    EOS
-  end
+  caveats <<-EOS.undent
+    For configuration instructions, see
+
+      /opt/cloudera/hiveodbc/Readme.txt
+  EOS
 end

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -8,9 +8,11 @@ class Cocktail < Cask
   license :unknown
 
   app 'Cocktail.app'
+
+  # todo replace this with a conditional
   caveats <<-EOS.undent
     This version of Cocktail is for OS X Mavericks only. If you are using other versions of
     OS X, please run 'brew tap caskroom/versions' and install cocktail-mountainlion /
     cocktail-lion / cocktail-snowleopard
-    EOS
+  EOS
 end

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -13,9 +13,10 @@ class Cocoaspell < Cask
                          '/Library/PreferencePanes/Spelling.prefPane',
                         ]
   caveats <<-EOS.undent
-    Non-English dictionaries must be installed separately.  For more information,
-    see http://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php .
-    EOS
+    Non-English dictionaries must be installed separately.  For more information, see
+
+      http://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php
+  EOS
   zap :delete => [
                  '~/.aspell.conf',
                  '~/.aspell.en.prepl',

--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -1,19 +1,20 @@
 class Coconutbattery < Cask
+
   if MacOS.version < :leopard
-    url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.6.6.zip'
     version '2.6.6'
     sha256 '8d235b237e42754ceda26af2babc160fd23f890d0fe6d7780b86a8e9c6effe42'
   elsif MacOS.version < :lion
-    url 'http://www.coconut-flavour.com/downloads/coconutBattery_2.8.zip'
     version '2.8'
     sha256 'fcfc81214ff26afff9f5c6c7cdc455b23ac898b6918f864b641a9e31526692d4'
   else
-    url 'http://www.coconut-flavour.com/downloads/coconutBattery_3_1_1.zip'
-    appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml'
     version '3.1.1'
     sha256 'd95951e14b77a3deff5503fd8ff7098d1a38fabe5c38764f4c9f5bd20d9bea16'
+    appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml'
   end
+
+  url "http://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
   homepage 'http://www.coconut-flavour.com/coconutbattery/'
   license :unknown
+
   app 'coconutBattery.app'
 end

--- a/Casks/colorpicker-propicker.rb
+++ b/Casks/colorpicker-propicker.rb
@@ -2,6 +2,7 @@ class ColorpickerPropicker < Cask
   version '1.0'
   sha256 'd1c07c116fee22dbbaea86c285327b5468b82863ba575e8fe462a2dcec023891'
 
+  # todo, the URL indicates there is an appcast
   url "http://www.irradiated.net/appcasts/pro-picker/releases/#{version}/ProPicker.zip"
   homepage 'http://www.irradiated.net/?page=pro-picker'
   license :unknown

--- a/Casks/craftstudio.rb
+++ b/Casks/craftstudio.rb
@@ -12,7 +12,9 @@ class Craftstudio < Cask
             :pkgutil => 'com.sparklinlabs.CraftStudioLauncher'
   zap       :delete => '~/Library/CraftStudio'
 
-  caveats do
-    "Requires mono-mre. You can install this by running brew cask install mono-mre."
-  end
+  caveats <<-EOS.undent
+    #{@cask} requires mono-mre, available via
+
+      brew cask install mono-mre
+  EOS
 end

--- a/Casks/crosspack-avr.rb
+++ b/Casks/crosspack-avr.rb
@@ -17,7 +17,8 @@ class CrosspackAvr < Cask
   end
 
   caveats do
-    puts <<-EOS.undent
+    files_in_usr_local
+    <<-EOS.undent
       CrossPack-AVR can normally install multiple versions side-by-side.
       Therefore, running install will typically install multiple versions
       of the tools in /usr/local/ (e.g. /usr/local/CrossPack-AVR-20131216).
@@ -25,6 +26,5 @@ class CrosspackAvr < Cask
       This cask will invoke the CrossPack-AVR uninstall script when it is
       uninstalled, removing the most recent version of the tools.
     EOS
-    files_in_usr_local
   end
 end

--- a/Casks/cryptol.rb
+++ b/Casks/cryptol.rb
@@ -11,7 +11,9 @@ class Cryptol < Cask
 
   caveats do
     files_in_usr_local
-    puts "Cryptol depends on CVC4 (http://cvc4.cs.nyu.edu/)."
-         "The CVC4 binary must be in your PATH."
+    <<-EOS.undent
+      Cryptol depends on CVC4 (http://cvc4.cs.nyu.edu/).
+      The CVC4 binary must be in your PATH.
+    EOS
   end
 end

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -7,7 +7,9 @@ class Deeper < Cask
   license :unknown
 
   app 'Deeper.app'
+
+  # todo replace this with a conditional
   caveats <<-EOS.undent
     This version of Deeper is for OS X Mavericks only. If you are using other versions of OS X, please run 'brew tap caskroom/versions' and install deeper-mountainlion / deeper-lion / deeper-snowleopard
-    EOS
+  EOS
 end

--- a/Casks/delivery-status.rb
+++ b/Casks/delivery-status.rb
@@ -7,16 +7,13 @@ class DeliveryStatus < Cask
   license :oss
 
   widget 'Delivery Status.wdgt'
-  caveats do
-    puts <<-EOS.undent
+  caveats <<-EOS.undent
     Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
-        https://github.com/caskroom/homebrew-cask/issues/2206
+      https://github.com/caskroom/homebrew-cask/issues/2206
 
     It is recommended that you do not install this Cask unless you are
     a developer working on the problem.
-
-    EOS
-    end
+  EOS
 end

--- a/Casks/dewdrop.rb
+++ b/Casks/dewdrop.rb
@@ -9,20 +9,17 @@ class Dewdrop < Cask
 
   app 'Dewdrop.app'
 
-  caveats do
-    <<-EOF.undent
-    Available server implementations:
+  caveats <<-EOS.undent
+    Available server implementations
 
-      * https://github.com/dewdrop-org/Server-PHP
-      * https://github.com/dewdrop-org/Server-Node.js
+      https://github.com/dewdrop-org/Server-PHP
+      https://github.com/dewdrop-org/Server-Node.js
 
-    You may wish to script your preferences using `defaults` ... e.g.:
+    You may wish to script your preferences using "defaults", eg
 
       defaults write dangelov.Dewdrop ddUsername "$USER"
       defaults write dangelov.Dewdrop ddPassword "secret"
       defaults write dangelov.Dewdrop ddServer "https://dewdrop.example.org"
       defaults write dangelov.Dewdrop automaticallyUploadScreenshots 1
-
-    EOF
-  end
+  EOS
 end

--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -10,7 +10,7 @@ class Diffmerge < Cask
   binary 'DiffMerge.app/Contents/MacOS/DiffMerge', :target => 'diffmerge'
 
   caveats <<-EOS.undent
-    Use `diffmerge --nosplash` when configuring external tools such
-    as git to use diffmerge. This will squlech the splash screen.
-    EOS
+    Use "diffmerge --nosplash" to hide the splash screen when using
+    diffmerge with external tools such as git.
+  EOS
 end

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,15 +1,17 @@
 class Displaylink < Cask
+  version '2.2'
+  sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
+
   url 'http://www.displaylink.com/support/file.php',
       :data => {
-        'file' => 'DisplayLink_Mac_2.2.dmg',
+        'file' => "DisplayLink_Mac_#{version}.dmg",
         'folder' => 'publicsoftware',
         'id' => '330'
       },
       :using => :post
   homepage 'http://www.displaylink.com'
   license :unknown
-  version '2.2'
-  sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
+
   pkg 'DisplayLink Software Installer.pkg'
   uninstall :pkgutil => ['com.displaylink.displaylinkdriversigned',
                          'com.displaylink.displaylinkdriverunsigned']
@@ -27,6 +29,6 @@ class Displaylink < Cask
     Installing this Cask means you have AGREED to the DisplayLink
     Software License Agreement at
 
-        http://www.displaylink.com/support/sla.php?fileid=102
+      http://www.displaylink.com/support/sla.php?fileid=102
   EOS
 end

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,13 +1,16 @@
 class EclipseIde < Cask
-  if Hardware::CPU.is_32_bit?
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa.tar.gz'
-    sha256 'c902ee4d9f753b2bc48f7194ea9f5bb98a264a984f6aaead710f8b601c574505'
-  else
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa-x86_64.tar.gz'
-    sha256 'c902ee4d9f753b2bc48f7194ea9f5bb98a264a984f6aaead710f8b601c574505'
-  end
   version '4.4.0'
+
+  if Hardware::CPU.is_32_bit?
+    sha256 'c902ee4d9f753b2bc48f7194ea9f5bb98a264a984f6aaead710f8b601c574505'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa.tar.gz'
+  else
+    sha256 'c902ee4d9f753b2bc48f7194ea9f5bb98a264a984f6aaead710f8b601c574505'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-standard-luna-R-macosx-cocoa-x86_64.tar.gz'
+  end
+
   homepage 'http://eclipse.org/'
   license :unknown
+
   app 'eclipse/Eclipse.app'
 end

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,13 +1,16 @@
 class EclipseJava < Cask
-  if Hardware::CPU.is_32_bit?
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa.tar.gz'
-    sha256 '11ebf6c2deb9d0f656ddf0ced4b65e340a2ec80426786440f687f164bd973b1e'
-  else
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa-x86_64.tar.gz'
-    sha256 '4902bdb5eb64dbcef86b10838a3734c1148d3d85ae8454f71a6929292de43784'
-  end
   version '4.4.0'
+
+  if Hardware::CPU.is_32_bit?
+    sha256 '11ebf6c2deb9d0f656ddf0ced4b65e340a2ec80426786440f687f164bd973b1e'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa.tar.gz'
+  else
+    sha256 '4902bdb5eb64dbcef86b10838a3734c1148d3d85ae8454f71a6929292de43784'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-macosx-cocoa-x86_64.tar.gz'
+  end
+
   homepage 'http://eclipse.org/'
   license :unknown
+
   app 'eclipse/Eclipse.app'
 end

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -7,7 +7,6 @@ class EclipseJee < Cask
   else
     url 'http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-jee-luna-R-macosx-cocoa-x86_64.tar.gz'
   end
-
   homepage 'http://eclipse.org/'
   license :unknown
 

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,13 +1,16 @@
 class EclipsePlatform < Cask
-  if Hardware::CPU.is_32_bit?
-    url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa.tar.gz'
-    sha256 '28e873cc4e575bbf3abb364ccd7dec59394891f5ca80ee7b591a7982345d0ab9'
-  else
-    url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa-x86_64.tar.gz'
-    sha256 '09e127b85b136f60bec18c4c823596c145dbc5fbcfe6af0e4fe2a27590ffa5a0'
-  end
   version '4.4.0'
+
+  if Hardware::CPU.is_32_bit?
+    sha256 '28e873cc4e575bbf3abb364ccd7dec59394891f5ca80ee7b591a7982345d0ab9'
+    url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa.tar.gz'
+  else
+    sha256 '09e127b85b136f60bec18c4c823596c145dbc5fbcfe6af0e4fe2a27590ffa5a0'
+    url 'http://download.eclipse.org/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-macosx-cocoa-x86_64.tar.gz'
+  end
+
   homepage 'http://eclipse.org'
   license :unknown
+
   app 'eclipse/Eclipse.app'
 end

--- a/Casks/fenics.rb
+++ b/Casks/fenics.rb
@@ -9,23 +9,21 @@ class Fenics < Cask
   app 'FEniCS.app'
 
   caveats do
-  "  FEniCS is designed to work with the OS X system Python (v. 2.7.5 in OS X 10.9).
+    os_version_only '10.9', '10.10'
+    <<-EOS.undent
+      FEniCS is designed to work with the OS X system Python (v. 2.7.5 in OS X 10.9).
 
-  If you are using a standard bash shell and system Python, you can make FEniCS
-  available when you start your shell by adding the following to the .profile
-  file in your home directory:
+      If you are using a standard bash shell and system Python, you can make FEniCS
+      available when you start your shell by adding the following to the .profile
+      file in your home directory:
 
-    source #{@cask.destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
+        source #{@cask.destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
 
+      If you are using an alternate shell (e.g., zsh, csh) or a modified or brewed Python,
+      be sure to launch FEniCS using a clean (bash) shell.
+      Creating a new shell using the following command works well:
 
-  If you are using an alternate shell (e.g., zsh, csh) or a modified or brewed Python,
-  be sure to launch FEniCS using a clean (bash) shell.
-  Creating a new shell using the following command works well:
-
-    /bin/bash --rcfile #{@cask.destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf"
-  end
-
-  caveats do
-    os_version_only("10.9", "10.10")
+        /bin/bash --rcfile #{@cask.destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
+    EOS
   end
 end

--- a/Casks/fenics.rb
+++ b/Casks/fenics.rb
@@ -2,7 +2,7 @@ class Fenics < Cask
   version '1.4.0'
   sha256 'b0071fa25759fcef124e418c202cc81d297d12633b24385b70b9408af76c2bb5'
 
-  url 'http://www.fenicsproject.org/pub/software/fenics/fenics-1.4.0-osx10.9.dmg'
+  url "http://www.fenicsproject.org/pub/software/fenics/fenics-#{version}-osx10.9.dmg"
   homepage 'http://fenicsproject.org/'
   license :unknown
 

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -2,9 +2,9 @@ class Filebot < Cask
   version '4.5'
   sha256 '389e663588f241c1aa97a2797f54d4e52e7c4fe47d394cd70cb5b2c7395a6761'
 
+  url "https://downloads.sourceforge.net/project/filebot/filebot/FileBot_#{version}/FileBot_#{version}.app.tar.gz"
   homepage 'http://www.filebot.net/'
   license :oss
-  url "https://downloads.sourceforge.net/project/filebot/filebot/FileBot_#{version}/FileBot_#{version}.app.tar.gz"
 
   app 'FileBot.app'
   binary 'FileBot.app/Contents/MacOS/filebot.sh', :target => 'filebot'

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -8,5 +8,5 @@ class Filebot < Cask
 
   app 'FileBot.app'
   binary 'FileBot.app/Contents/MacOS/filebot.sh', :target => 'filebot'
-  caveats 'FileBot requires Java 8. Run `java -version` to verify.'
+  caveats 'FileBot requires Java 8. Run "java -version" to verify.'
 end

--- a/Casks/gambit-c.rb
+++ b/Casks/gambit-c.rb
@@ -2,12 +2,12 @@ class GambitC < Cask
   version '4.7.3'
 
   if Hardware::CPU.is_32_bit?
-    url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel32.dmg"
     sha256 '002ea1d272a4328a0448eab69e6256e104d888bc3c98133d072092457f842bbf'
+    url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel32.dmg"
     pkg "gambc-v#{version.gsub('.', '_')}-macosx-intel32.pkg"
   else
-    url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel64.dmg"
     sha256 'bfdad5d4c5025b3ab21926554d870cb37a68607534b78912f81c62db29054a02'
+    url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel64.dmg"
     pkg "gambc-v#{version.gsub('.', '_')}-macosx-intel64.pkg"
   end
 

--- a/Casks/geppetto.rb
+++ b/Casks/geppetto.rb
@@ -1,13 +1,15 @@
 class Geppetto < Cask
+  version '4.2.0'
+
   if Hardware::CPU.is_32_bit?
-    url 'https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86-4.2.0-R201407250959.zip'
     sha256 '78f578ff4cf0a9eadf85cc5a821e55125ee98ab4a8e1d4f0f5d1607487314804'
+    url "https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86-#{version}-R201407250959.zip"
   else
-    url 'https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86_64-4.2.0-R201407250959.zip'
     sha256 '7a09c823cea9900cb51d009f47fab69569e1d8115c6326f3e91db62714480d69'
+    url "https://downloads.puppetlabs.com/geppetto/4.x/geppetto-macosx.cocoa.x86_64-#{version}-R201407250959.zip"
   end
   homepage 'http://puppetlabs.github.io/geppetto/'
   license :oss
-  version '4.2.0'
+
   app 'geppetto/Geppetto.app'
 end

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -1,6 +1,10 @@
 class GitAnnex < Cask
+  version :latest
+  sha256 :no_check
+
   if MacOS.version < :mavericks
     url 'http://downloads.kitenet.net/git-annex/OSX/current/10.8.2_Mountain_Lion/git-annex.dmg.bz2'
+
     # This is a horrible hack to force the file extension.  The
     # backend code should be fixed so that this is not needed.
     preflight do
@@ -10,10 +14,10 @@ class GitAnnex < Cask
   else
     url 'http://downloads.kitenet.net/git-annex/OSX/current/10.9_Mavericks/git-annex.dmg'
   end
+
   homepage 'http://git-annex.branchable.com/'
   license :unknown
-  version :latest
-  sha256 :no_check
+
   app 'git-annex.app'
   binary 'git-annex.app/Contents/MacOS/git-annex'
   binary 'git-annex.app/Contents/MacOS/git-annex-shell'

--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -2,19 +2,24 @@ class Golly < Cask
   version '2.6'
 
   if MacOS.version < :mavericks
-    url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac106.zip/"
     sha256 '6fee35e8e4f63ee2c1b0913b7e8009b2548c4e4469050f9c31791900e1e97f16'
+
+    url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac106.zip/"
+
     app "golly-#{version}-mac106/Golly.app"
     binary "golly-#{version}-mac106/bgolly"
   else
-    url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac109.zip"
     sha256 '360c1e279d89fc3a19bed9c75dfe5b1085a67672490f17fe38941cab3680b983'
+
+    url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac109.zip"
+
     app "golly-#{version}-mac109/Golly.app"
     binary "golly-#{version}-mac109/bgolly"
   end
 
   homepage 'http://golly.sourceforge.net/'
   license :oss
+
   caveats do
     files_in_usr_local
   end

--- a/Casks/googleappenginelauncher.rb
+++ b/Casks/googleappenginelauncher.rb
@@ -1,6 +1,7 @@
 class Googleappenginelauncher < Cask
   version '1.9.11'
   sha256 'e198b384760686012438d3a4b2890e682e39e16007b22fc12693d16323bdf5ed'
+
   url "https://storage.googleapis.com/appengine-sdks/featured/GoogleAppEngineLauncher-#{version}.dmg"
   homepage 'https://developers.google.com/appengine/'
   license :unknown

--- a/Casks/grooveshark.rb
+++ b/Casks/grooveshark.rb
@@ -8,7 +8,8 @@ class Grooveshark < Cask
 
   app 'Grooveshark.app'
   caveats <<-EOS.undent
-    Grooveshark requires Adobe Flash.  Flash can be installed via:
+    #{@cask} requires Adobe Flash, available via
+
       brew cask install flash
-    EOS
+  EOS
 end

--- a/Casks/hear.rb
+++ b/Casks/hear.rb
@@ -8,7 +8,9 @@ class Hear < Cask
   license :unknown
 
   app 'Hear.app'
+
+  # todo: an uninstall stanza should be provided, and this message removed
   caveats <<-EOS.undent
-    To uninstall open Hear.app and go to the menu Hear > Uninstall...
+    To uninstall, open Hear.app and choose the menu item "Hear > Uninstall"
   EOS
 end

--- a/Casks/heart.rb
+++ b/Casks/heart.rb
@@ -12,12 +12,9 @@ class Heart < Cask
     system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Heart (Presstube)', "#{destination_path}/presstube-heart.app/Contents/Resources/Presstube - Heart.saver/Contents/Info.plist"
   end
 
-  caveats do
-    <<-EOS.undent
-    If you have issue running #{@cask}, try installing Adobe Air with
+  caveats <<-EOS.undent
+    #{@cask} requires Adobe Air, available via
 
-        brew cask install adobe-air
-
-    EOS
-  end
+      brew cask install adobe-air
+  EOS
 end

--- a/Casks/iexplorer.rb
+++ b/Casks/iexplorer.rb
@@ -2,10 +2,10 @@ class Iexplorer < Cask
   version '3.5.0.6'
   sha256 'a189663121ba78d2927cb113e56bfb6235045ccd6e54e453f9aee389af61be43'
 
+  url "http://cdn.macroplant.com/release/iExplorer-#{version}.dmg"
+  appcast 'http://www.macroplant.com/iexplorer/ie3-appcast.xml'
   homepage 'http://www.macroplant.com/'
   license :unknown
-  appcast 'http://www.macroplant.com/iexplorer/ie3-appcast.xml'
-  url "http://cdn.macroplant.com/release/iExplorer-#{version}.dmg"
 
   app 'iExplorer.app'
 end

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -9,20 +9,17 @@ class IntellijIdeaCe < Cask
   app 'IntelliJ IDEA 13 CE.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/IntelliJ IDEA 13 CE.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/IntelliJ IDEA 13 CE.app/Contents/Info.plist"
   end
 
-  caveats do
-    <<-EOS.undent
-    #{@cask} may require Java 7 (an older version) available from the
-    caskroom-versions repo via
+  caveats <<-EOS.undent
+    #{@cask} may require Java 7 (an older version), available from the
+    caskroom-versions repository via
 
-        brew cask install caskroom/versions/java7
+      brew cask install caskroom/versions/java7
 
     Alternatively, #{@cask} can be modified to use Java 8 as described in
 
-        https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
-
-    EOS
-  end
+      https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
+  EOS
 end

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -9,20 +9,17 @@ class IntellijIdea < Cask
   app 'IntelliJ IDEA 13.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/IntelliJ IDEA 13.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/IntelliJ IDEA 13.app/Contents/Info.plist"
   end
 
-  caveats do
-    <<-EOS.undent
+  caveats <<-EOS.undent
     #{@cask} may require Java 7 (an older version) available from the
-    caskroom-versions repo via
+    caskroom-versions repository via
 
-        brew cask install caskroom/versions/java7
+      brew cask install caskroom/versions/java7
 
     Alternatively, #{@cask} can be modified to use Java 8 as described in
 
-        https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
-
-    EOS
-  end
+      https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
+  EOS
 end

--- a/Casks/ioquake3.rb
+++ b/Casks/ioquake3.rb
@@ -8,8 +8,8 @@ class Ioquake3 < Cask
 
   suite 'ioquake3'
   caveats <<-EOS.undent
-    To complete the installation of #{title}, you will have to copy the file
+    To complete the installation of #{@cask}, you will have to copy the file
     'pak0.pk3' from your Quake 3 Arena installation support directory into
-    ~/Applications/ioquake3/baseq3.
-    EOS
+    ~/Applications/ioquake3/baseq3/.
+  EOS
 end

--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -2,7 +2,7 @@ class IstatMenus < Cask
   version :latest
   sha256 :no_check
 
-  url "http://download.bjango.com/istatmenus/"
+  url 'http://download.bjango.com/istatmenus/'
   homepage 'http://bjango.com/mac/istatmenus/'
   license :unknown
 

--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -7,6 +7,6 @@ class Isyncr < Cask
 
   pkg "iSyncr #{version}.pkg"
 
-  uninstall :pkgutil => "com.test.iSyncr.pkg",
-  			:quit => "com.JRTStudio.iSyncrWiFi"
+  uninstall :pkgutil => 'com.test.iSyncr.pkg',
+            :quit    => 'com.JRTStudio.iSyncrWiFi'
 end

--- a/Casks/jabber-video.rb
+++ b/Casks/jabber-video.rb
@@ -8,7 +8,8 @@ class JabberVideo < Cask
 
   app 'Jabber Video.app'
 
+  # todo what is the reason for this?
   postflight do
-    system "/bin/rm", "#{destination_path}/Jabber Video.app/Contents/Resources/ForcedConfig.plist"
+    system '/bin/rm', '--', "#{destination_path}/Jabber Video.app/Contents/Resources/ForcedConfig.plist"
   end
 end

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -54,7 +54,7 @@ class Java < Cask
     This Cask makes minor modifications to the JRE to prevent issues with
     packaged applications, as discussed here:
 
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
+      https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
 
     If your Java application still asks for JRE installation, you might need
     to reboot or logout/login.
@@ -62,7 +62,6 @@ class Java < Cask
     Installing this Cask means you have AGREED to the Oracle Binary Code
     License Agreement for Java SE at
 
-        http://www.oracle.com/technetwork/java/javase/terms/license/index.html
-
-    EOS
+      http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
 end

--- a/Casks/javafx-scene-builder.rb
+++ b/Casks/javafx-scene-builder.rb
@@ -15,6 +15,6 @@ class JavafxSceneBuilder < Cask
     Installing this Cask means you have AGREED to the Oracle BSD License
     Agreement for JavaFX Scene Builder at
 
-        http://www.oracle.com/technetwork/java/javase/terms/license/oraclebsd-1603217.txt
-    EOS
+      http://www.oracle.com/technetwork/java/javase/terms/license/oraclebsd-1603217.txt
+  EOS
 end

--- a/Casks/jotta.rb
+++ b/Casks/jotta.rb
@@ -6,6 +6,5 @@ class Jotta < Cask
   homepage 'https://www.jottacloud.com/'
   license :closed
 
-
   app 'Jotta.app'
 end

--- a/Casks/juliastudio.rb
+++ b/Casks/juliastudio.rb
@@ -2,11 +2,11 @@ class Juliastudio < Cask
   version '0.4.4'
 
   if MacOS.version < '10.7'
-    url "https://s3.amazonaws.com/cdn-common.forio.com/julia-studio/#{version}/julia-studio-mac10.6-installer-#{version}.dmg"
     sha256 '380006f00db5b19ab1a68b25b72dba669d7ff8f109c68d6ecf1fcc34dbfe485f'
+    url "https://s3.amazonaws.com/cdn-common.forio.com/julia-studio/#{version}/julia-studio-mac10.6-installer-#{version}.dmg"
   else
-    url "https://s3.amazonaws.com/cdn-common.forio.com/julia-studio/#{version}/julia-studio-macx-installer-#{version}.dmg"
     sha256 'ce165f2ff8b1fd76ad3d1f4cb822dbf23c4d87390e6b4089b0ea17ab18bfd3ed'
+    url "https://s3.amazonaws.com/cdn-common.forio.com/julia-studio/#{version}/julia-studio-macx-installer-#{version}.dmg"
   end
 
   homepage 'http://forio.com/labs/julia-studio/'

--- a/Casks/keepassx.rb
+++ b/Casks/keepassx.rb
@@ -7,7 +7,7 @@ class Keepassx < Cask
   license :unknown
 
   app 'KeePassX.app'
-  # This caveat added Mar 2014.  OK to delete it after 3-4 months.
+  # This caveat added Mar 2014.  todo OK to delete it after 3-4 months.
   caveats <<-EOS.undent
     If you are upgrading from an older version of KeePassX, you must
     manually import the old-format database via menu item

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -8,7 +8,8 @@ class Keycastr < Cask
 
   app 'KeyCastr.app'
 
-  caveats do
-    puts "For OSX 10.9 or later, you need to setup in \"Enable access for assistive devices\", see https://github.com/sdeken/keycastr/issues/5"
-  end
+  caveats <<-EOS.undent
+    For OSX 10.9 or later, #{@cask} requires that you "Enable access for assistive devices".
+    See https://github.com/sdeken/keycastr/issues/5
+  EOS
 end

--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -10,7 +10,7 @@ class Ksdiff < Cask
   uninstall :pkgutil => 'com.blackpixel.kaleidoscope.ksdiff.installer.pkg'
   # todo: conflicts_with_cask kaleidoscope
   caveats <<-EOS.undent
-    The #{title} Cask is not needed when installing Kaleidoscope via Cask. It
+    The #{@cask} Cask is not needed when installing Kaleidoscope via Cask. It
     is provided for users who have purchased Kaleidoscope via the App Store.
-    EOS
+  EOS
 end

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,15 +1,16 @@
 class Libreoffice < Cask
-  homepage 'https://www.libreoffice.org/'
-  license :unknown
   version '4.3.1'
 
   if Hardware::CPU.is_32_bit? or MacOS.version < :mountain_lion
-    url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
     sha256 'a2d507f643b952282ff5ce90ac227bea9bd412748ffcb93050db75256b2f803c'
+    url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else
-    url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
     sha256 '9a212ca4b77770c57f8b7ac375b5a98824c93dabd6e238dc019dc1139b6d3b7f'
+    url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end
+
+  homepage 'https://www.libreoffice.org/'
+  license :unknown
 
   app 'LibreOffice.app'
 end

--- a/Casks/limechat.rb
+++ b/Casks/limechat.rb
@@ -1,15 +1,14 @@
 class Limechat < Cask
 
   if MacOS.version < :mountain_lion
-    url "https://downloads.sourceforge.net/project/limechat/limechat/LimeChat_2.38.tbz"
-    sha256 "1d7bf505ce60f1bfeb809de67d9f07c996a19eaa6d43b3c5e9df3fcc76077e11"
-    version "2.38"
+    version '2.38'
+    sha256 '1d7bf505ce60f1bfeb809de67d9f07c996a19eaa6d43b3c5e9df3fcc76077e11'
   else
-    url 'https://downloads.sourceforge.net/project/limechat/limechat/LimeChat_2.42.tbz'
-    sha256 '708d10591784e5beb7ed80236d809d5cd4f992c133483bc2a82775acdc6f1f0f'
     version '2.42'
+    sha256 '708d10591784e5beb7ed80236d809d5cd4f992c133483bc2a82775acdc6f1f0f'
   end
 
+  url "https://downloads.sourceforge.net/project/limechat/limechat/LimeChat_#{version}.tbz"
   appcast 'http://limechat.net/mac/appcast.xml'
   homepage 'http://limechat.net/mac/'
   license :oss

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -1,15 +1,18 @@
 class Macports < Cask
+  version '2.2.1'
+
   if MacOS.version < :mavericks
-    url 'https://distfiles.macports.org/MacPorts/MacPorts-2.2.1-10.8-MountainLion.pkg'
     sha256 'd10bf4a27f89709501e1370d7d80f415eaf16bae23fd9ff3d4e96f86afdf8cd6'
-    pkg 'MacPorts-2.2.1-10.8-MountainLion.pkg'
+    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.8-MountainLion.pkg"
+    pkg "MacPorts-#{version}-10.8-MountainLion.pkg"
   else
-    url 'https://distfiles.macports.org/MacPorts/MacPorts-2.2.1-10.9-Mavericks.pkg'
     sha256 '2df01bf88e1e3de32ada0f42a8a46fb992093baee62f9d911fa3ae3ee895d471'
-    pkg 'MacPorts-2.2.1-10.9-Mavericks.pkg'
+    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.9-Mavericks.pkg"
+    pkg "MacPorts-#{version}-10.9-Mavericks.pkg"
   end
+
   homepage 'http://www.macports.org'
   license :unknown
-  version '2.2.1'
+
   uninstall :pkgutil => 'org.macports.MacPorts'
 end

--- a/Casks/macupdate-desktop.rb
+++ b/Casks/macupdate-desktop.rb
@@ -2,10 +2,10 @@ class MacupdateDesktop < Cask
   version '6.0.2'
   sha256 '1aa04e0bec920f28af5417a2b875e40af832d5303a29dca27e527e30c4db42f5'
 
-  homepage 'https://www.macupdate.com/desktop'
-  license :unknown
   url "http://dl.macupdate.com/MacUpdateDesktop#{version}.zip"
   appcast 'https://www.macupdate.com/desktop/updates.xml'
+  homepage 'https://www.macupdate.com/desktop'
+  license :unknown
 
   app 'MacUpdate Desktop.app'
   postflight do

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,25 +1,27 @@
 class Macvim < Cask
+  version '7.4-73'
+
   if MacOS.version < :mavericks
-    url 'https://github.com/eee19/macvim/releases/download/snapshot-73/MacVim-snapshot-73-Mountain-Lion.tbz'
     sha256 '7f573fb9693052a86845c0a9cbb0b3c3c33ee23294f9d8111187377e4d89f72c'
+    url 'https://github.com/eee19/macvim/releases/download/snapshot-73/MacVim-snapshot-73-Mountain-Lion.tbz'
   else
+    sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
     url 'https://github.com/b4winckler/macvim/releases/download/snapshot-73/MacVim-snapshot-73-Mavericks.tbz'
     appcast 'http://b4winckler.github.com/macvim/appcast/stable.xml'
-    sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
   end
+
   homepage 'http://code.google.com/p/macvim/'
   license :oss
-  version '7.4-73'
+
   app 'MacVim-snapshot-73/MacVim.app'
   binary 'MacVim-snapshot-73/mvim'
   caveats do
-    puts <<-EOS.undent
-    Note that homebrew also provides a compiled macvim Formula that links its
-    binary to /usr/local/bin/mvim. It's not recommended to install both the
-    Cask and the Formula of MacVim.
-
-    EOS
     files_in_usr_local
+    <<-EOS.undent
+      Note that homebrew also provides a compiled macvim Formula that links its
+      binary to /usr/local/bin/mvim. It's not recommended to install both the
+      Cask and the Formula of MacVim.
+    EOS
   end
   zap :delete => [
                   '~/Library/Preferences/org.vim.MacVim.LSSharedFileList.plist',

--- a/Casks/matplotlib.rb
+++ b/Casks/matplotlib.rb
@@ -1,6 +1,7 @@
 class Matplotlib < Cask
   version '1.3.1-2'
   sha256 'e90bef08b03c2526b85b669705fdc6b1ba95099e7524fdc52a79ab2081466b2d'
+
   url "http://www.kyngchaos.com/files/software/python/matplotlib-#{version}.dmg"
   homepage 'http://www.kyngchaos.com/software/python'
   license :unknown

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,4 +1,7 @@
 class Middleclick < Cask
+  version :latest
+  sha256 :no_check
+
   if MacOS.version < :mountain_lion
     url 'http://clement.beffa.org/labs/downloads/MiddleClick.zip'
   elsif MacOS.version == :mountain_lion
@@ -8,7 +11,6 @@ class Middleclick < Cask
   end
   homepage 'http://clement.beffa.org/labs/projects/middleclick'
   license :unknown
-  version :latest
-  sha256 :no_check
+
   app 'MiddleClick.app'
 end

--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -25,7 +25,7 @@ class Netbeans < Cask
   #
   # The NetBeans installer does some postflight unpacking of paths installed by
   # the OS X installer, so it's insufficient to just delete the paths exposed
-  # by pkgutil, hence the additional `:delete` option below.
+  # by pkgutil, hence the additional ":delete" option below.
   uninstall :pkgutil => 'org.netbeans.ide.*|glassfish-.*',
             :delete => '/Applications/NetBeans'
 end

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -1,4 +1,7 @@
 class Onyx < Cask
+  version :latest
+  sha256 :no_check
+
   if MacOS.version == :snow_leopard
     url 'http://www.titanium.free.fr/download/106/OnyX.dmg'
   elsif MacOS.version == :lion
@@ -10,7 +13,6 @@ class Onyx < Cask
   end
   homepage 'http://www.titanium.free.fr/downloadonyx.php'
   license :unknown
-  version :latest
-  sha256 :no_check
+
   app 'OnyX.app'
 end

--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,14 +1,17 @@
 class Opensesame < Cask
+
   if MacOS.version < :lion
-    url 'http://files.cogsci.nl/software/opensesame/opensesame_0.26-macos-2.zip'
     version '0.26'
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'
+    url "http://files.cogsci.nl/software/opensesame/opensesame_#{version}-macos-2.zip"
   else
-    url 'http://www.cogsci.nl/dschreij/opensesame-mac/opensesame-0.27.4-macos-x86_64-1.dmg'
     version '0.27.4'
     sha256 '8814da8fe5e638cb7db18b4e8188fc97028bd98f1603ceae006aff13745fc739'
+    url "http://www.cogsci.nl/dschreij/opensesame-mac/opensesame-#{version}-macos-x86_64-1.dmg"
   end
+
   homepage 'http://osdoc.cogsci.nl/'
   license :unknown
+
   app 'opensesame.app'
 end

--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -8,7 +8,8 @@ class P4merge < Cask
 
   app 'p4merge.app'
   caveats <<-EOS.undent
-    You can set up git to use p4merge as a merge tool by following the instructions available here:
+    git can be configured to use p4merge as a merge tool via
+
       https://gist.github.com/henrik242/1510148
-    EOS
+  EOS
 end

--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,5 +1,6 @@
 class P4v < Cask
   version '2014.1-888424'
+
   if Hardware::CPU.is_32_bit?
     sha256 '03b716dde2c39f4214c1b9b016e151225d8830e2e555b30234c5f9c1d2940a78'
     url 'http://filehost.perforce.com/perforce/r14.1/bin.macosx106x86/P4V.dmg'
@@ -14,7 +15,5 @@ class P4v < Cask
   app 'p4v.app'
   binary 'p4vc'
 
-  caveats do
-    puts "p4merge has its own cask. Run 'brew cask install p4merge.'"
-  end
+  caveats 'p4merge is in a separate Cask'
 end

--- a/Casks/pandoc.rb
+++ b/Casks/pandoc.rb
@@ -8,11 +8,9 @@ class Pandoc < Cask
 
   pkg "pandoc-#{version}-osx.pkg"
   uninstall :pkgutil => 'net.johnmacfarlane.pandoc'
-  caveats do
-    puts <<-EOS.undent
+  caveats <<-EOS.undent
     Note that homebrew also provides a compiled pandoc Formula that links its
     binary to /usr/local/bin/pandoc. It's not recommended to install both the
     Cask and the Formula of Pandoc.
-    EOS
-  end
+  EOS
 end

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,14 +1,17 @@
 class Paraview < Cask
+  version '4.1.0'
+
   if MacOS.version < :mavericks
-    url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit-Lion-Python27.dmg'
     sha256 '8784481c90b58b0c6158e21b7f978a7d78caa67c63d28d6d5d770ef43f0ad890'
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit-Lion-Python27.dmg"
   else
-    url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit.dmg'
     sha256 '1eef4a2ee155049059967733e40010e86cc6cd05458de676217af5c276995817'
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit.dmg"
   end
+
   homepage 'http://www.paraview.org/'
   license :unknown
-  version '4.1.0'
+
   app 'paraview.app'
   caveats do
     arch_only 'intel-64'

--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -10,6 +10,6 @@ class Parse < Cask
   binary 'parse'
 
   postflight do
-    system "chmod", "755", "#{destination_path}/#{title}"
+    system '/bin/chmod', '--', '0755', "#{destination_path}/parse"
   end
 end

--- a/Casks/pemdas-widget.rb
+++ b/Casks/pemdas-widget.rb
@@ -7,16 +7,13 @@ class PemdasWidget < Cask
   license :oss
 
   widget 'PEMDAS.wdgt'
-  caveats do
-    puts <<-EOS.undent
+  caveats <<-EOS.undent
     Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
-        https://github.com/caskroom/homebrew-cask/issues/2206
+      https://github.com/caskroom/homebrew-cask/issues/2206
 
     It is recommended that you do not install this Cask unless you are
     a developer working on the problem.
-
-    EOS
-    end
+  EOS
 end

--- a/Casks/perian.rb
+++ b/Casks/perian.rb
@@ -10,6 +10,6 @@ class Perian < Cask
   caveats <<-EOS.undent
     Perian development officially stopped as of 2012, and 1.2.3 was the final released version.
 
-    See the Perian homepage for the full message from the development team, which points to some alternatives.
-    EOS
+    See the Perian homepage for more information.
+  EOS
 end

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -9,6 +9,6 @@ class Phpstorm < Cask
   app 'PhpStorm.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/PhpStorm.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/PhpStorm.app/Contents/Info.plist"
   end
 end

--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -2,11 +2,11 @@ class Praat < Cask
   version '5.3.82'
 
   if Hardware::CPU.is_32_bit?
-    url 'http://www.fon.hum.uva.nl/praat/praat5382_mac32.dmg'
     sha256 'c1ef06ed8fd9e36d5eb96699daf5fba3e04e2c32edcda0c2981d8f817c019371'
+    url 'http://www.fon.hum.uva.nl/praat/praat5382_mac32.dmg'
   else
-    url 'http://www.fon.hum.uva.nl/praat/praat5382_mac64.dmg'
     sha256 'c02aa1ae0e896325cbc8a917e5cfef37a0f6e38e78d2b71757134158f7e563f3'
+    url 'http://www.fon.hum.uva.nl/praat/praat5382_mac64.dmg'
   end
 
   homepage 'http://www.fon.hum.uva.nl/praat/'

--- a/Casks/prey.rb
+++ b/Casks/prey.rb
@@ -9,12 +9,9 @@ class Prey < Cask
   pkg "prey-#{version}-mac-batch.mpkg"
   uninstall :pkgutil => 'com.forkhq.prey'
   caveats <<-EOS.undent
-    Prey requires an API key during installation. If none is found,
-    installation will fail.  To install using your API key, set it
-    as an environment variable during installation like this:
+    To complete installation, Prey requires an API key. It may be set
+    as an environment variable as follows:
 
-      brew cask uninstall prey
       API_KEY="abcdef123456" brew cask install prey
-
-    EOS
+  EOS
 end

--- a/Casks/programmer-dvorak.rb
+++ b/Casks/programmer-dvorak.rb
@@ -10,7 +10,7 @@ class ProgrammerDvorak < Cask
   uninstall :pkgutil => 'com.apple.keyboardlayout.Programmer Dvorak',
             :delete => [
                         '/Library/Keyboard Layouts/Programmer Dvorak.bundle/',
-                        # note: these will not work because the glob will not be expanded
+                        # todo these will not work because the glob will not be expanded
                         '/Library/Caches/com.apple.IntlDataCache*',
                         '/System/Library/Caches/com.apple.IntlDataCache.le*',
                         '/private/var/folders/*/*/-Caches-/com.apple.IntlDataCache.le*',
@@ -18,7 +18,7 @@ class ProgrammerDvorak < Cask
   if MacOS.version >= :mavericks
     postflight do
       # clear the layout cache before new layouts are recognized
-      # note: this will not work because the glob will not be expanded
+      # todo this will not work because the glob will not be expanded
       system '/bin/rm', '-f', '--', '/System/Library/Caches/com.apple.IntlDataCache.le*'
     end
   end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -9,6 +9,6 @@ class PycharmCe < Cask
   app 'PyCharm CE.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/PyCharm CE.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/PyCharm CE.app/Contents/Info.plist"
   end
 end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -9,6 +9,6 @@ class Pycharm < Cask
   app 'PyCharm.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/PyCharm.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/PyCharm.app/Contents/Info.plist"
   end
 end

--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -7,17 +7,15 @@ class Qgis < Cask
   license :unknown
   pkg 'Install QGIS.pkg'
   uninstall :pkgutil => 'org.qgis.qgis-*'
-  caveats do
-    <<-EOS.undent
+  caveats <<-EOS.undent
     #{@cask} requires the GDAL framework and Matplotlib to be installed first,
-    otherwise the installation will fail. In case of issues, try installing it
+    otherwise the installation will fail. In case of problems, try installing
+    them:
 
-        brew cask install gdal-framework matplotlib
+      brew cask install gdal-framework matplotlib
 
     and then reinstall QGIS
 
-        brew cask uninstall qgis
-        brew cask install qgis
-    EOS
-  end
+      brew cask uninstall qgis && brew cask install qgis
+  EOS
 end

--- a/Casks/quotefixformac.rb
+++ b/Casks/quotefixformac.rb
@@ -8,15 +8,14 @@ class Quotefixformac < Cask
 
   caveats do
     <<-EOS.undent
-    Follow these instructions to enable mail plugins and link QuoteFix:
+      To enable mail plugins and link QuoteFix:
 
-      defaults write com.apple.mail EnableBundles -bool true
-      defaults write com.apple.mail BundleCompatibilityVersion -string 3
+        defaults write com.apple.mail EnableBundles -bool true
+        defaults write com.apple.mail BundleCompatibilityVersion -string 3
 
-      mkdir -p ~/Library/Mail/Bundles
-      cp -R #{destination_path}/QuoteFix.mailbundle ~/Library/Mail/Bundles/
-      killall Mail; open -a Mail
-
+        mkdir -p ~/Library/Mail/Bundles
+        cp -R #{destination_path}/QuoteFix.mailbundle ~/Library/Mail/Bundles/
+        killall Mail; open -a Mail
     EOS
   end
 end

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,16 +1,19 @@
 class R < Cask
+  version '3.1.1'
+
   if MacOS.version < :mavericks
-    url 'http://cran.rstudio.com/bin/macosx/R-3.1.1-snowleopard.pkg'
     sha256 '4db95d2bffdaa342a89d01088f47cfe6575ed7e953c31ea4dea629a0942b56b6'
-    pkg 'R-3.1.1-snowleopard.pkg'
+    url "http://cran.rstudio.com/bin/macosx/R-#{version}-snowleopard.pkg"
+    pkg "R-#{version}-snowleopard.pkg"
   else
-    url 'http://cran.rstudio.com/bin/macosx/R-3.1.1-mavericks.pkg'
     sha256 'd2f4e4f68628d998f81146eacd929ef6fb9bc01ca93d968e6562a3a6372c4d93'
-    pkg 'R-3.1.1-mavericks.pkg'
+    url "http://cran.rstudio.com/bin/macosx/R-#{version}-mavericks.pkg"
+    pkg "R-#{version}-mavericks.pkg"
   end
+
   homepage 'http://www.r-project.org/'
   license :unknown
-  version '3.1.1'
+
   uninstall :pkgutil => [
                          # eg org.r-project.R.maverics.fw.pkg
                          #   org.r-project.R.mavericks.GUI.pkg

--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -1,12 +1,12 @@
 class RawPhotoProcessor < Cask
+  version '4.7.2'
+  sha256 'ce003b7c78916baaf51b39e26633f9ac069e78b7e5bf8904b966c4c409c06f39'
 
   url 'http://www.raw-photo-processor.com/RPP/RPP_64.zip'
   appcast 'http://www.raw-photo-processor.com/rpp_updates.xml'
   homepage 'http://www.raw-photo-processor.com/RPP/Overview.html'
   license :unknown
 
-  version '4.7.2'
   nested_container 'RPP472_1672_64.dmg'
-  sha256 'ce003b7c78916baaf51b39e26633f9ac069e78b7e5bf8904b966c4c409c06f39'
   app 'Raw Photo Processor 64.app'
 end

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,17 +1,18 @@
 class Reaper < Cask
-  homepage 'http://www.reaper.fm/'
-  license :unknown
   version '4.71'
 
   if Hardware::CPU.is_32_bit?
-    url 'http://www.reaper.fm/files/4.x/reaper471_i386.dmg'
     sha256 '1a670d5afb5956e1486c1fdef008ccfb4faa7987cc4d5ea8171a2794ff86ffca'
+    url 'http://www.reaper.fm/files/4.x/reaper471_i386.dmg'
     app 'REAPER.app'
     app 'ReaMote.app'
   else
-    url 'http://www.reaper.fm/files/4.x/reaper471_x86_64.dmg'
     sha256 '3045fd59189bd0fe398b50f511d014a5e385c8cfb88f8a188a8437050f783d71'
+    url 'http://www.reaper.fm/files/4.x/reaper471_x86_64.dmg'
     app 'REAPER64.app'
     app 'ReaMote64.app'
   end
+
+  homepage 'http://www.reaper.fm/'
+  license :unknown
 end

--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -8,6 +8,7 @@ class Retroarch < Cask
     sha256 '8a528e6b954d614e86c5a3cfa8608008f60b593ef9a5bb12be3a834ebac9177a'
     url "http://www.libretro.com/wp-content/plugins/cip4-folder-download-widget/cip4-download.php?target=wp-content/releases/OSX/RetroArch-OSX10.7-x86_64-v#{version}.zip"
   end
+
   homepage 'http://www.libretro.com/'
 
   app 'RetroArch.app'

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -9,7 +9,7 @@ class Rubymine < Cask
   app 'RubyMine.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/RubyMine.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/RubyMine.app/Contents/Info.plist"
   end
   zap :delete => [
                   '~/Library/Application Support/RubyMine40',

--- a/Casks/rust.rb
+++ b/Casks/rust.rb
@@ -2,7 +2,7 @@ class Rust < Cask
   version :latest
   sha256 :no_check
 
-  url "http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg"
+  url 'http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg'
   homepage 'http://www.rust-lang.org/'
   license :unknown
 

--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,4 +1,5 @@
 class Skype < Cask
+
   if MacOS.version < :mavericks
     version '6.15.0.335'
     sha256 '592abdd157df12d718576a86c8f8e62fced55292fd7e6909d53aa5eaaa9218f4'

--- a/Casks/sqlite-database-browser.rb
+++ b/Casks/sqlite-database-browser.rb
@@ -6,5 +6,5 @@ class SqliteDatabaseBrowser < Cask
   homepage 'http://sqlitebrowser.org'
   license :oss
 
-  app "sqlitebrowser.app"
+  app 'sqlitebrowser.app'
 end

--- a/Casks/streamtools.rb
+++ b/Casks/streamtools.rb
@@ -1,14 +1,16 @@
 class Streamtools < Cask
+  version '0.2.8'
+
   if Hardware::CPU.is_32_bit?
-    url 'https://github.com/nytlabs/streamtools/releases/download/0.2.8/st_darwin_386-0.2.8.tar.gz'
     sha256 'de5763ffcd6689d2157ab115e1a3d8a34e85e1e4de7b186f7f5079fe01a5f004'
-    binary 'st_darwin_386-0.2.8/st'
+    url "https://github.com/nytlabs/streamtools/releases/download/#{version}/st_darwin_386-#{version}.tar.gz"
+    binary "st_darwin_386-#{version}/st"
   else
-    url 'https://github.com/nytlabs/streamtools/releases/download/0.2.8/st_darwin_amd64-0.2.8.tar.gz'
     sha256 '5ca21f4c4c2091c96c508bb277cb5c022f18a8cd3c53abb1ceb11ca0f6454309'
-    binary 'st_darwin_amd64-0.2.8/st'
+    url "https://github.com/nytlabs/streamtools/releases/download/#{version}/st_darwin_amd64-#{version}.tar.gz"
+    binary "st_darwin_amd64-#{version}/st"
   end
+
   homepage 'https://github.com/nytlabs/streamtools'
   license :oss
-  version '0.2.8'
 end

--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -1,6 +1,6 @@
 class Switchresx < Cask
   version '4.4.1'
-  sha256 "a7fd24312ab65a1d3da00da4fc9fb1d15a463f5d93c922bffa4ecfbe87b8e3cf"
+  sha256 'a7fd24312ab65a1d3da00da4fc9fb1d15a463f5d93c922bffa4ecfbe87b8e3cf'
 
   url 'http://www.madrau.com/data/switchresx/SwitchResX4.zip'
   homepage 'http://www.madrau.com'

--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -10,5 +10,5 @@ class TheArchiveBrowser < Cask
   caveats <<-EOS.undent
     The Archive Browser is a commercial app. Only a trial version will be
     installed.  A full license may be purchased from the developer website.
-    EOS
+  EOS
 end

--- a/Casks/totalspaces.rb
+++ b/Casks/totalspaces.rb
@@ -1,9 +1,12 @@
 class Totalspaces < Cask
+
   if MacOS.version < :mavericks
-    url 'http://downloads.binaryage.com/TotalSpaces-1.2.11.zip'
     version '1.2.11'
-    pkg 'TotalSpaces.pkg'
     sha256 'fd54c6ea092f6fae2035745959ff6e080953e77ec6c76715e532b4b0352235d4'
+
+    url "http://downloads.binaryage.com/TotalSpaces-#{version}.zip"
+
+    pkg 'TotalSpaces.pkg'
     uninstall :pkgutil => 'com.switchstep.totalspaces',
               :quit    => 'com.binaryage.TotalSpaces',
               :signal  => [
@@ -11,10 +14,12 @@ class Totalspaces < Cask
                            ['KILL', 'com.binaryage.totalspacescrashwatcher'],
                           ]
   else
-    url "http://downloads.binaryage.com/TotalSpaces2-2.2.6.zip"
     version '2.2.6'
-    pkg 'TotalSpaces2.pkg'
     sha256 '900ece3f5ceae479b4019f854e1875eb402edf3ef1b17f813a70fe42290a0a12'
+
+    url "http://downloads.binaryage.com/TotalSpaces-#{version}.zip"
+
+    pkg 'TotalSpaces2.pkg'
     uninstall :pkgutil => 'com.binaryage.TotalSpaces2',
               :quit    => 'com.binaryage.TotalSpaces2',
               :signal  => [
@@ -22,6 +27,7 @@ class Totalspaces < Cask
                            ['KILL', 'com.binaryage.totalspacescrashwatcher'],
                           ]
   end
+
   homepage 'http://totalspaces.binaryage.com/'
   license :unknown
 end

--- a/Casks/truecrypt.rb
+++ b/Casks/truecrypt.rb
@@ -10,7 +10,8 @@ class Truecrypt < Cask
   caveats do
     files_in_usr_local
     <<-EOS.undent
-    Warning: TrueCrypt IS NOT SECURE and the development was ended, see more:
+    Warning: TrueCrypt IS NOT SECURE.  Development has been halted, see
+
       http://truecrypt.sourceforge.net/
     EOS
   end

--- a/Casks/tv-show-tracker.rb
+++ b/Casks/tv-show-tracker.rb
@@ -7,16 +7,13 @@ class TvShowTracker < Cask
   license :oss
 
   widget 'TV Show Tracker.wdgt'
-  caveats do
-    puts <<-EOS.undent
+  caveats <<-EOS.undent
     Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
-        https://github.com/caskroom/homebrew-cask/issues/2206
+      https://github.com/caskroom/homebrew-cask/issues/2206
 
     It is recommended that you do not install this Cask unless you are
     a developer working on the problem.
-
-    EOS
-    end
+  EOS
 end

--- a/Casks/tvrenamer.rb
+++ b/Casks/tvrenamer.rb
@@ -7,10 +7,8 @@ class Tvrenamer < Cask
   license :oss
 
   app "TVRenamer-#{version}.app"
-  caveats do
-    <<-EOS.undent
-      #{@cask} requires a Java JRE to be installed. Mac OS X should prompt you to install
-      Java on the first run if you don't already have it installed.
-    EOS
-  end
+  caveats <<-EOS.undent
+    #{@cask} requires a Java JRE to be installed. You should be prompted to install
+    Java on the first execution if it is not already present.
+  EOS
 end

--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -7,5 +7,7 @@ class Typinator < Cask
   license :unknown
 
   app 'Typinator.app'
-  caveats { assistive_devices }
+  caveats do
+    assistive_devices
+  end
 end

--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -8,6 +8,6 @@ class Ubar < Cask
 
   app 'uBar.app'
   caveats do
-    os_version_only("10.9", "10.10")
+    os_version_only '10.9', '10.10'
   end
 end

--- a/Casks/uberpov.rb
+++ b/Casks/uberpov.rb
@@ -7,20 +7,20 @@ class Uberpov < Cask
   license :unknown
 
   app 'Uberpov_Mac/UberPOV.app'
-  caveats do <<-EOS.undent
-    The standard UberPOV include path is:
+  caveats do
+    <<-EOS.undent
+      The standard UberPOV include path is:
 
         #{destination_path}/Uberpov_Mac/include/
 
-    Before starting any renders, you may want to set the include path in
-    UberPOV's preferences under
+      Before starting any renders, you may want to set the include path in
+      UberPOV's preferences under
 
         "Files & Paths" > "Set search Paths for additional include files".
 
-    Sample scenes will be installed at:
+      Sample scenes will be installed at:
 
         #{destination_path}/Uberpov_Mac/scenes/
-
     EOS
   end
 end

--- a/Casks/utorrent.rb
+++ b/Casks/utorrent.rb
@@ -1,12 +1,11 @@
 class Utorrent < Cask
+  version :latest
+  sha256 :no_check
 
   url 'http://download-new.utorrent.com/endpoint/utmac/os/osx/track/stable/'
   appcast 'http://update.utorrent.com/checkupdate.php'
   homepage 'http://www.utorrent.com/'
   license :unknown
-
-  version :latest
-  sha256 :no_check
 
   caveats do
     manual_installer 'uTorrent-Installer.app'

--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,13 +1,16 @@
 class Vuescan < Cask
+  version '9.4.37'
+
   if Hardware::CPU.is_32_bit?
-    url 'http://www.hamrick.com/files/vuex3294.dmg'
     sha256 '9f12d5a180a79c9d297913cdfb793382b512f25388de66f007cb621f4d69f461'
+    url 'http://www.hamrick.com/files/vuex3294.dmg'
   else
-    url 'http://www.hamrick.com/files/vuex6494.dmg'
     sha256 'a6e82863f7d6fc34400f678fb4de3cf5af6cbde9a20693ff4bfb5d95ad59f398'
+    url 'http://www.hamrick.com/files/vuex6494.dmg'
   end
+
   homepage 'http://www.hamrick.com'
   license :unknown
-  version '9.4.37'
+
   app 'VueScan.app'
 end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -9,6 +9,6 @@ class Webstorm < Cask
   app 'WebStorm.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/WebStorm.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/WebStorm.app/Contents/Info.plist"
   end
 end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -14,13 +14,12 @@ class Wireshark < Cask
 
   postflight do
     if Process.euid == 0 then
-      ohai "Note:"
+      ohai 'Note:'
       puts <<-EOS.undent
-              You executed 'brew cask' as the superuser.
+        You executed 'brew cask' as the superuser.
 
-              You must manually add users to group 'access_bpf' in order to use Wireshark
-
-              EOS
+        You must manually add users to group 'access_bpf' in order to use Wireshark
+      EOS
     else
       system '/usr/bin/sudo', '-E', '--',
              '/usr/sbin/dseditgroup', '-o', 'edit', '-a', Etc.getpwuid(Process.euid).name, '-t', 'user', '--', 'access_bpf'

--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -12,10 +12,10 @@ class Xquartz < Cask
   postflight do
     Pathname.new(File.expand_path('~')).join('Library', 'Logs').mkpath
 
-    # Set default path to X11 = avoid the need of manual setup
+    # Set default path to X11 to avoid the need of manual setup
     system '/usr/bin/defaults', 'write', 'com.apple.applescript', 'ApplicationMap', '-dict-add', 'X11', 'file://localhost/Applications/Utilities/XQuartz.app/'
 
-    # Load & start XServer = avoid the need of relogin
+    # Load & start XServer to avoid the need of relogin
     system '/bin/launchctl', 'load', '/Library/LaunchAgents/org.macosforge.xquartz.startx.plist'
   end
 

--- a/Casks/zeroxdbe-eap.rb
+++ b/Casks/zeroxdbe-eap.rb
@@ -9,6 +9,6 @@ class ZeroxdbeEap < Cask
   app '0xDBE EAP.app'
 
   postflight do
-    system "/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", "#{destination_path}/0xDBE\ EAP.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/0xDBE\ EAP.app/Contents/Info.plist"
   end
 end

--- a/Casks/zooom.rb
+++ b/Casks/zooom.rb
@@ -8,6 +8,6 @@ class Zooom < Cask
 
   pkg 'Zooom2.pkg'
   caveats do
-    os_version_only '10.10', '10.9'
+    os_version_only '10.9', '10.10'
   end
 end


### PR DESCRIPTION
- Most of these are utterly trivial changes to quoting, order or whitespace, which I noticed during the course of making mass updates.
- `caveats` is converted to string form where possible, and needless explicit `puts` are removed
- `caveats` texts were simplified and grammar-checked
- some re-uses of `version` are added

No functional changes.
