### PR TITLE
use `Utils` namespace in 4 Casks

### DIFF
--- a/Casks/ax88179.rb
+++ b/Casks/ax88179.rb
@@ -1,14 +1,18 @@
 class Ax88179 < Cask
+  version '2.2.0_20140724'
+  sha256 '075cdf5cb5a6ed0e8a4d59ff470a32f5e869f3b2f2b08f268120cbae30c61329'
+
+  module Utils
+    def self.basename
+      "AX88179_178A_Macintosh_10.6_to_10.10_Driver_Installer_v#{Ax88179.version}"
+    end
+  end
+
+  url "http://www.asix.com.tw/FrootAttach/driver/#{Utils.basename}.zip"
   homepage 'http://www.asix.com.tw/products.php?op=pItemdetail&PItemID=131;71;112&PLine=71'
   license :unknown
 
-  version '2.2.0_20140724'
-  basename = "AX88179_178A_Macintosh_10.6_to_10.10_Driver_Installer_v#{version}"
-
-  url "http://www.asix.com.tw/FrootAttach/driver/#{basename}.zip"
-  sha256 '075cdf5cb5a6ed0e8a4d59ff470a32f5e869f3b2f2b08f268120cbae30c61329'
-
-  nested_container "#{basename}/AX88179_178A.dmg"
+  nested_container "#{Utils.basename}/AX88179_178A.dmg"
   pkg "AX88179_178A_v#{version[0..-10]}.pkg"
   uninstall :script => { :executable => 'AX88179_178A_Uninstall_v140' }
 end

--- a/Casks/ax88772.rb
+++ b/Casks/ax88772.rb
@@ -1,14 +1,18 @@
 class Ax88772 < Cask
+  version '2.1.0_20140428'
+  sha256 'ea7b2c401855c991cfd9d147632d5bf0478c99a4be034575301eb8549404391f'
+
+  module Utils
+    def self.basename
+      "AX88772C_772B_772A_760_772_Macintosh_10.5_to_10.9_Driver_Installer_v#{Ax88772.version}"
+    end
+  end
+
+  url "http://www.asix.com.tw/FrootAttach/driver/#{Utils.basename}.zip"
   homepage 'http://www.asix.com.tw/products.php?op=pItemdetail&PItemID=86;71;101&PLine=71'
   license :unknown
 
-  version '2.1.0_20140428'
-  basename = "AX88772C_772B_772A_760_772_Macintosh_10.5_to_10.9_Driver_Installer_v#{version}"
-
-  url "http://www.asix.com.tw/FrootAttach/driver/#{basename}.zip"
-  sha256 'ea7b2c401855c991cfd9d147632d5bf0478c99a4be034575301eb8549404391f'
-
-  nested_container "#{basename}/AX88772.dmg"
+  nested_container "#{Utils.basename}/AX88772.dmg"
   pkg "AX88772_v#{version[0..-10]}.pkg"
   uninstall :script => { :executable => 'AX88772C_772B_772A_760_772_Uninstall_v130' }
 end

--- a/Casks/mcs783x.rb
+++ b/Casks/mcs783x.rb
@@ -1,15 +1,21 @@
 class Mcs783x < Cask
+  version '1.1.0'
+  sha256 'ea1d6245b5accabf041060886f16cc00b43d3e6e7e032f4154b487e96ab05569'
+
+  module Utils
+    def self.basename
+      "MCS783x_Mac_OSX_10.5_to_10.7_driver_v#{Mcs783x.version}_Binary"
+    end
+  end
+
+  url "http://www.asix.com.tw/FrootAttach/driver/#{Utils.basename}.zip"
   homepage 'http://www.asix.com.tw/products.php?op=ProductList&PLine=74&PSeries=109'
   license :unknown
 
-  version '1.1.0'
-  basename = "MCS783x_Mac_OSX_10.5_to_10.7_driver_v#{version}_Binary"
-
-  url "http://www.asix.com.tw/FrootAttach/driver/#{basename}.zip"
-  sha256 'ea1d6245b5accabf041060886f16cc00b43d3e6e7e032f4154b487e96ab05569'
-
-  nested_container "#{basename}/MCS7830_v#{version}.dmg"
+  nested_container "#{Utils.basename}/MCS7830_v#{version}.dmg"
   pkg "MCS7830 v#{version}.pkg"
+  # todo, is "uninstal" below (one "l") a typo, or is that really the
+  # file in the package?
   uninstall :script => { :executable => 'uninstal driver' },
             :pkgutil => 'asix.com.moschipUsbEthernet.pkg'
 end

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -1,10 +1,14 @@
 class Sts < Cask
   version '3.5.1'
   sha256 'f71274c9f946d2af6bbd12e811d7c8d371d3031415839b9aa6ed35347d2980f8'
-  # find eclise version at http://spring.io/tools/sts/all
-  based_on_eclipse = '4.3.2'
 
-  url "http://download.springsource.com/release/STS/#{version}/dist/e#{based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{based_on_eclipse}-macosx-cocoa-x86_64-installer.dmg"
+  module Utils
+    def self.based_on_eclipse
+      '4.3.2'   # find eclipse version at http://spring.io/tools/sts/all
+    end
+  end
+
+  url "http://download.springsource.com/release/STS/#{version}/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64-installer.dmg"
   homepage 'http://spring.io/tools/sts'
   license :unknown
 


### PR DESCRIPTION
Per [CASK_LANGUAGE_REFERENCE.md](https://github.com/caskroom/homebrew-cask/blob/1ff7c99d9bd196f53c7994954248a848d8f57476/doc/CASK_LANGUAGE_REFERENCE.md#arbitrary-ruby-methods), best practice is to use a separate `Utils` namespace instead of defining any variables or methods at the top level of a Cask.

This keeps our own code from colliding with user code.  (We guarantee not to use the Utils namespace inside a Cask.)
