### PR TITLE
replace ENV['HOME'] with Ruby stdlib in 2 Casks

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -7,10 +7,11 @@ class Gpgtools < Cask
   license :unknown
 
   pkg 'Install.pkg'
+  # todo, remove all ENV variables
   postflight do
     system '/usr/bin/sudo', '-E', '--',
            '/usr/local/MacGPG2/libexec/fixGpgHome', Etc.getpwuid(Process.euid).name,
-                                                    ENV['GNUPGHOME'] ? ENV['GNUPGHOME'] : "#{ENV['HOME']}/.gnupg"
+                                                    ENV['GNUPGHOME'] ? ENV['GNUPGHOME'] : Pathname.new(File.expand_path('~')).join('.gnupg')
   end
   uninstall :pkgutil => 'org.gpgtools.*',
             :quit => [

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -10,7 +10,7 @@ class PrivateInternetAccess < Cask
       system '/usr/bin/sudo', '-E', '--',
           "#{destination_path}/Private Internet Access Installer.app/Contents/MacOS/runner.sh"
       system '/usr/bin/sudo', '-E', '--',
-          '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", ENV['HOME'] + '/.pia_manager'
+          '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", Pathname.new(File.expand_path('~')).join('.pia_manager')
   end
 
   uninstall :delete => '/Applications/Private Internet Access.app'


### PR DESCRIPTION
Directly using environment variables in the Cask does not seem like a great idea in principle.

After this change, `gpgtools.rb` still uses `ENV['GNUPGHOME']`.
