### PR TITLE
New cask: track-o-bot

### DIFF
--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -1,0 +1,10 @@
+class TrackOBot < Cask
+  version '0.4.2'
+  sha256 '3746f662cda62047c8b9e870997bfc8d4f04040b72e1573177c4da2cfc5e8cb3'
+
+  url 'https://github.com/stevschmid/track-o-bot/releases/download/0.4.2/Track-o-Bot_0.4.2.dmg'
+  homepage 'https://trackobot.com/'
+  license :gpl
+
+  app 'Track-o-Bot.app'
+end


### PR DESCRIPTION
Track-o-Bot is a small, easy-to-use app which automatically tracks your
Hearthstones matches. Install, launch and you are ready to go.
