### PR TITLE
Add BBC iPlayer Downloads appcast

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -3,6 +3,7 @@ class BbcIplayerDownloads < Cask
   sha256 :no_check
 
   url 'https://www.bbc.co.uk/iplayer/dm/downloads/mac/latest'
+  appcast 'http://ipd-hq.cloud.bbc.co.uk/downloads/update.xml'
   homepage 'http://www.bbc.co.uk/iplayer/install'
   license :unknown
 


### PR DESCRIPTION
Set http://ipd-hq.cloud.bbc.co.uk/downloads/update.xml as BBC iPlayer Downloads' appcast.
