### PR TITLE
updated libreoffice to version 4.3.2

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,11 +1,11 @@
 class Libreoffice < Cask
-  version '4.3.1'
+  version '4.3.2'
 
   if Hardware::CPU.is_32_bit? or MacOS.version < :mountain_lion
-    sha256 'a2d507f643b952282ff5ce90ac227bea9bd412748ffcb93050db75256b2f803c'
+    sha256 '5a41ebe0c09f663e2ba420e1ddd50601d0ba1c828b08eb8617e72bbeebe826a5'
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else
-    sha256 '9a212ca4b77770c57f8b7ac375b5a98824c93dabd6e238dc019dc1139b6d3b7f'
+    sha256 'e5246aa91a62fcb85596ecaa16ca608e34eca79caddf529750a8126f554f97cb'
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end
   gpg "#{url}.asc",


### PR DESCRIPTION
- http://download.documentfoundation.org/libreoffice/stable/4.3.2/mac/x86/LibreOffice_4.3.2_MacOS_x86.dmg
- http://download.documentfoundation.org/libreoffice/stable/4.3.2/mac/x86/LibreOffice_4.3.2_MacOS_x86.dmg.sha256
- http://download.documentfoundation.org/libreoffice/stable/4.3.2/mac/x86_64/LibreOffice_4.3.2_MacOS_x86-64.dmg
- http://download.documentfoundation.org/libreoffice/stable/4.3.2/mac/x86_64/LibreOffice_4.3.2_MacOS_x86-64.dmg.sha256
