### PR TITLE
standardize Cask (capitalized) when used as noun

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -7,7 +7,7 @@ class ScalaIde < Cask
   license :unknown
 
   # Renamed for clarity: app name is inconsistent with its branding.
-  # Also renamed to avoid conflict with other eclipse casks.
+  # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/2731
   app 'eclipse/Eclipse.app', :target => 'Scala IDE.app'
 end

--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -11,7 +11,7 @@ class Soundflower < Cask
     system '/usr/bin/sudo', '-E', '--',
       '/sbin/kextload', '-b', 'com.Cycling74.driver.Soundflower'
   end
-  # early_script is a workaround for a slowly unloading kext, see private-eye cask
+  # early_script is a workaround for a slowly unloading kext, see private-eye Cask
   uninstall :early_script => {
               :executable => '/sbin/kextunload',
               :args => ['-b', 'com.Cycling74.driver.Soundflower'],

--- a/doc/AUTOMATION.md
+++ b/doc/AUTOMATION.md
@@ -1,5 +1,5 @@
-# Automating with Homebrew Cask
-Homebrew Cask allows you to install several applications at once. Calling `cask install` with multiple arguments works as you would expect:
+# Automating with Homebrew-cask
+Homebrew-cask allows you to install several applications at once. Calling `brew cask install` with multiple arguments works as you would expect:
 
 ```
 brew cask install vagrant virtualbox
@@ -11,14 +11,14 @@ brew cask install vagrant virtualbox
 ==> Success! virtualbox installed to /opt/homebrew-cask/Caskroom/virtualbox/4.3.8
 ```
 
-However, this approach doesn't scale very well. For large numbers of applications, you want a list that's easy to organize and a way to use it when needed. In Homebrew Cask, the `Caskfile` is one such list, and `brew bundle` is the way to use it.
+However, this approach doesn't scale very well. For large numbers of applications, you want a list that's easy to organize and a way to use it when needed. In Homebrew-cask, the `Caskfile` is one such list, and `brew bundle` is the way to use it.
 
 ## `brew bundle Caskfile`
 A Caskfile is a plain text document containing a set of Homebrew commands, one per line. `brew bundle` will read it and execute all instructions in the order they appear.
 
-For example, on a freshly installed OS X, you could `brew bundle` the following `Caskfile` to set up Homebrew Cask and a few basic tools:
+For example, on a freshly installed OS X, you could `brew bundle` the following `Caskfile` to set up Homebrew-cask and a few basic tools:
 ```bash
-# Install Cask
+# Install Homebrew-cask
 install caskroom/cask/brew-cask
 
 # Productivity tools
@@ -44,7 +44,7 @@ cask install iterm2
 ## Dotfiles
 [Dotfiles](http://dotfiles.github.io/) are a popular way to configure OS X. They are easy to use, backup, move around, and share.
 
-Integrating Homebrew Cask in your dotfiles is immediate; indeed, the `Caskfile` is most commonly used as a dotfiles module, to provision machines with binary apps and precompiled software.
+Integrating Homebrew-cask in your dotfiles is immediate; indeed, the `Caskfile` is most commonly used as a dotfiles module, to provision machines with binary apps and precompiled software.
 
 If you want to fully automate the deployment process by scripting the execution of `brew bundle`, it is sufficient to ensure that the following steps happen in the correct order:
 

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -432,7 +432,7 @@ The `:target` key works similarly for most Cask artifacts, such as
 
 Don’t use `:target` for aesthetic reasons, like removing version numbers
 (`app "Slack #{version}.app", :target => 'Slack.app'`). With `app`, use it
-when it makes sense functionally and document your reason cleary in the cask:
+when it makes sense functionally and document your reason cleary in the Cask:
 was it [for clarity](../Cask/imagemin.rb); [for consistency](devonthink-pro-office.rb);
 [to prevent conflicts](flash-player-debugger.rb)? With `binary` you can
 take some extra liberties to be consistent with other command-line tools,

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -7,7 +7,7 @@ under the organizational umbrella at https://github.com/caskroom/homebrew-cask .
 
 Web redirection happens automatically.
 
-The location of the Cask Tap on disk has also changed, which should be
+The location of the Homebrew-cask Tap on disk has also changed, which should be
 handled automatically upon upgrading.  If you have technical difficulties,
 please see [TAP_MIGRATION.md](TAP_MIGRATION.md).
 

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -65,13 +65,13 @@ include arbitrary Ruby code.
 used by apps, pkg installers, and so on, making them suitable for a
 [declarative DSL](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md).
 
-We encourage cask authors to use the DSL as much as possible, since
+We encourage Cask authors to use the DSL as much as possible, since
 that makes things easier for everyone: from maintainers who review
 pull requests, to first-time contributors, to people who are unfamiliar
 with Ruby but would like to help.
 
 For software with unusual needs that are not covered by the DSL, we
-generally accept casks containing small hacks or arbitrary code.
+generally accept Casks containing small hacks or arbitrary code.
 If the hack becomes common enough, we extend the DSL with a simple
 shorthand that offers the same (or better) functionality.
 

--- a/doc/TAP_MIGRATION.md
+++ b/doc/TAP_MIGRATION.md
@@ -37,7 +37,7 @@ should happen for you automatically.
 
 ## Uncommitted Casks May Be Deleted
 
-If you have recently created a Cask using "brew cask create", and have not
+If you have recently created a Cask using `brew cask create`, and have not
 submitted that Cask to the main GitHub repository (meaning that your local
 repository is dirty), you should be aware that Homebrew may delete your
 uncommited Casks during the process of Tap migration.  See

--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -177,9 +177,9 @@ class Cask::CLI::Alfred < Cask::CLI::Base
 
   def self.usage
     ohai 'brew cask alfred', <<-ALFREDHELP.undent
-      manages integration with Alfred; allows applications installed with
-      homebrew cask to be launched by Alfred by adding the Caskroom to Alfreds
-      search paths
+      manages integration with Alfred; allows applications installed via
+      homebrew-cask to be launched by Alfred, by adding the Caskroom
+      directory to Alfred's search paths
 
       subcommands:
         status - reports whether Alfred is linked

--- a/lib/cask/cli/audit.rb
+++ b/lib/cask/cli/audit.rb
@@ -1,6 +1,6 @@
 class Cask::CLI::Audit < Cask::CLI::Base
   def self.help
-    'verifies installability of casks'
+    'verifies installability of Casks'
   end
 
   def self.run(*args)

--- a/lib/cask/cli/checklinks.rb
+++ b/lib/cask/cli/checklinks.rb
@@ -10,6 +10,6 @@ class Cask::CLI::Checklinks < Cask::CLI::Base
   end
 
   def self.help
-    "checks for bad cask links"
+    "checks for bad Cask links"
   end
 end

--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -34,6 +34,6 @@ class Cask::CLI::Create < Cask::CLI::Base
   end
 
   def self.help
-    "creates a cask of the given name and opens it in an editor"
+    "creates a Cask of the given name and opens it in an editor"
   end
 end

--- a/lib/cask/cli/edit.rb
+++ b/lib/cask/cli/edit.rb
@@ -7,12 +7,12 @@ class Cask::CLI::Edit < Cask::CLI::Base
     cask_path = Cask.path(cask_name)
     odebug "Opening editor for Cask #{cask_name}"
     unless cask_path.exist?
-      raise CaskUnavailableError, %Q{#{cask_name}, run "brew cask create #{cask_name}" to create a new cask with this name}
+      raise CaskUnavailableError, %Q{#{cask_name}, run "brew cask create #{cask_name}" to create a new Cask with this name}
     end
     exec_editor cask_path
   end
 
   def self.help
-    "edits the cask of the given name"
+    "edits the Cask of the given name"
   end
 end

--- a/lib/cask/cli/home.rb
+++ b/lib/cask/cli/home.rb
@@ -13,6 +13,6 @@ class Cask::CLI::Home < Cask::CLI::Base
   end
 
   def self.help
-    "opens the homepage of the cask of the given name"
+    "opens the homepage of the Cask of the given name"
   end
 end

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -11,7 +11,7 @@ class Cask::CLI::Info < Cask::CLI::Base
   end
 
   def self.help
-    "displays information about the cask of the given name"
+    "displays information about the Cask of the given name"
   end
 
   def self.info(cask)

--- a/lib/cask/cli/install.rb
+++ b/lib/cask/cli/install.rb
@@ -44,6 +44,6 @@ class Cask::CLI::Install < Cask::CLI::Base
   end
 
   def self.help
-    "installs the cask of the given name"
+    "installs the Cask of the given name"
   end
 end

--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -62,6 +62,6 @@ class Cask::CLI::List < Cask::CLI::Base
   end
 
   def self.help
-    "with no args, lists installed casks; given installed casks, lists installed files"
+    "with no args, lists installed Casks; given installed Casks, lists installed files"
   end
 end

--- a/lib/cask/cli/search.rb
+++ b/lib/cask/cli/search.rb
@@ -33,7 +33,7 @@ class Cask::CLI::Search < Cask::CLI::Base
 
   def self.render_results(exact_match, partial_matches, search_term)
     if ! exact_match and partial_matches.empty?
-      puts "No cask found for \"#{search_term}\"."
+      puts "No Cask found for \"#{search_term}\"."
       return
     end
     if exact_match
@@ -51,6 +51,6 @@ class Cask::CLI::Search < Cask::CLI::Base
   end
 
   def self.help
-    "searches all known casks"
+    "searches all known Casks"
   end
 end

--- a/lib/cask/cli/uninstall.rb
+++ b/lib/cask/cli/uninstall.rb
@@ -12,6 +12,6 @@ class Cask::CLI::Uninstall < Cask::CLI::Base
   end
 
   def self.help
-    "uninstalls the cask of the given name"
+    "uninstalls the Cask of the given name"
   end
 end

--- a/lib/cask/cli/zap.rb
+++ b/lib/cask/cli/zap.rb
@@ -10,6 +10,6 @@ class Cask::CLI::Zap < Cask::CLI::Base
   end
 
   def self.help
-    "zaps all files associated with the cask of the given name"
+    "zaps all files associated with the Cask of the given name"
   end
 end

--- a/lib/cask/exceptions.rb
+++ b/lib/cask/exceptions.rb
@@ -18,7 +18,7 @@ class CaskUnavailableError < CaskError
   end
 
   def to_s
-    "No available cask for #{name}"
+    "No available Cask for #{name}"
   end
 end
 
@@ -29,7 +29,7 @@ class CaskAlreadyCreatedError < CaskError
   end
 
   def to_s
-    %Q{Cask for #{name} already exists. Run "brew cask cat #{name}" to see it.}
+    %Q{A Cask for #{name} already exists. Run "brew cask cat #{name}" to see it.}
   end
 end
 
@@ -40,7 +40,7 @@ class CaskAlreadyInstalledError < CaskError
   end
 
   def to_s
-    %Q{Cask for #{name} is already installed. Add the "--force" option to force re-install.}
+    %Q{A Cask for #{name} is already installed. Add the "--force" option to force re-install.}
   end
 end
 
@@ -69,7 +69,7 @@ end
 
 class CaskUnspecifiedError < CaskError
   def to_s
-    "This command requires a cask's name"
+    "This command requires a Cask name"
   end
 end
 

--- a/spec/cask/cli_spec.rb
+++ b/spec/cask/cli_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Cask::CLI do
-  it "lists the taps for casks that show up in two taps" do
+  it "lists the taps for Casks that show up in two taps" do
     listing = Cask::CLI.nice_listing(%w[
       caskroom/cask/adium
       caskroom/cask/google-chrome

--- a/spec/cask/download_strategy_spec.rb
+++ b/spec/cask/download_strategy_spec.rb
@@ -18,14 +18,14 @@ describe 'download strategies' do
       allow(downloader.temporary_path).to receive(:rename)
     end
 
-    it 'properly assigns a name and Resource based on the cask' do
+    it 'properly assigns a name and Resource based on the Cask' do
       expect(downloader.name).to eq('some-cask')
       expect(downloader.resource.name).to eq('some-cask')
       expect(downloader.resource.url).to eq('http://example.com/cask.dmg')
       expect(downloader.resource.version.to_s).to eq('1.2.3.4')
     end
 
-    it 'calls curl with default arguments for a simple cask' do
+    it 'calls curl with default arguments for a simple Cask' do
       allow(downloader).to receive(:curl)
 
       shutup do

--- a/spec/cask/scopes_spec.rb
+++ b/spec/cask/scopes_spec.rb
@@ -9,7 +9,7 @@ describe Cask::Scopes do
     end
     after { fake_caskroom.rmtree }
 
-    it 'returns a list installed casks by loading casks for all the dirs that exist in the caskroom' do
+    it 'returns a list installed Casks by loading Casks for all the dirs that exist in the caskroom' do
       allow(Cask).to receive(:load) { |name| "loaded-#{name}" }
 
       fake_caskroom.join('cask-bar').mkdir

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,12 @@ Dir["#{project_root}/spec/support/**/*.rb"].each { |f| require f }
 
 include HomebrewTestingEnvironment
 
-# add cask lib to load path
+# add homebrew-cask lib to load path
 $:.push(project_root.join('lib').to_s)
 
 require 'cask'
 
-# Look for casks in testcasks by default.  It is elsewhere required that
+# Look for Casks in testcasks by default.  It is elsewhere required that
 # the string "test" appear in the directory name.
 Cask.default_tap = 'caskroom/homebrew-testcasks'
 

--- a/test/cask/artifact/after_block_test.rb
+++ b/test/cask/artifact/after_block_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Cask::Artifact::AfterBlock do
   describe 'install_phase' do
-    it 'calls the specified block after installing, passing a cask mini-dsl' do
+    it 'calls the specified block after installing, passing a Cask mini-dsl' do
       called      = false
       yielded_arg = nil
 
@@ -23,7 +23,7 @@ describe Cask::Artifact::AfterBlock do
   end
 
   describe 'uninstall_phase' do
-    it 'calls the specified block after uninstalling, passing a cask mini-dsl' do
+    it 'calls the specified block after uninstalling, passing a Cask mini-dsl' do
       called      = false
       yielded_arg = nil
 

--- a/test/cask/artifact/before_block_test.rb
+++ b/test/cask/artifact/before_block_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Cask::Artifact::BeforeBlock do
   describe 'install_phase' do
-    it 'calls the specified block before installing, passing a cask mini-dsl' do
+    it 'calls the specified block before installing, passing a Cask mini-dsl' do
       called      = false
       yielded_arg = nil
 
@@ -23,7 +23,7 @@ describe Cask::Artifact::BeforeBlock do
   end
 
   describe 'uninstall_phase' do
-    it 'calls the specified block before uninstalling, passing a cask mini-dsl' do
+    it 'calls the specified block before uninstalling, passing a Cask mini-dsl' do
       called      = false
       yielded_arg = nil
 

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -28,7 +28,7 @@ describe Cask::Artifact::Uninstall do
 
   describe 'uninstall_phase' do
     # todo: uninstall tests for :signal (implementation does not use SystemCommand)
-    it 'runs the specified uninstaller for the cask' do
+    it 'runs the specified uninstaller for the Cask' do
       uninstall_artifact = Cask::Artifact::Uninstall.new(@cask, Cask::FakeSystemCommand)
 
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -31,7 +31,7 @@ describe Cask::Artifact::Zap do
 
   describe 'zap_phase' do
     # todo: zap tests for :signal (implementation does not use SystemCommand)
-    it 'runs the specified zap procedures for the cask' do
+    it 'runs the specified zap procedures for the Cask' do
       zap_artifact = Cask::Artifact::Zap.new(@cask, Cask::FakeSystemCommand)
 
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')

--- a/test/cask/cli/audit_test.rb
+++ b/test/cask/cli/audit_test.rb
@@ -4,15 +4,15 @@ describe Cask::CLI::Audit do
   let(:auditor) { mock() }
   let(:cask) { mock() }
 
-  describe 'selection of casks to audit' do
-    it 'audits all casks if no names are given' do
+  describe 'selection of Casks to audit' do
+    it 'audits all Casks if no names are given' do
       Cask.stubs(:all => [cask, cask])
       auditor.expects(:audit).times(2)
 
       run_audit([], auditor)
     end
 
-    it 'audits specified casks if names are given' do
+    it 'audits specified Casks if names are given' do
       cask_name = 'nice-app'
       Cask.expects(:load).with(cask_name).returns(cask)
       auditor.expects(:audit).with(cask, :audit_download => false)
@@ -21,8 +21,8 @@ describe Cask::CLI::Audit do
     end
   end
 
-  describe 'rules for downloading a cask' do
-    it 'does not download the cask per default' do
+  describe 'rules for downloading a Cask' do
+    it 'does not download the Cask per default' do
       Cask.stubs(:load => cask)
 
       auditor.expects(:audit).with(cask, :audit_download => false)
@@ -30,7 +30,7 @@ describe Cask::CLI::Audit do
       run_audit(['caskname'], auditor)
     end
 
-    it 'download a cask if --download flag is set' do
+    it 'download a Cask if --download flag is set' do
       Cask.stubs(:load => cask)
 
       auditor.expects(:audit).with(cask, :audit_download => true)

--- a/test/cask/cli/cat_test.rb
+++ b/test/cask/cli/cat_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Cask::CLI::Cat do
-  describe 'given a basic cask' do
+  describe 'given a basic Cask' do
     before do
       @expected_output = <<-CLIOUTPUT.undent
         class BasicCask < TestCask
@@ -16,13 +16,13 @@ describe Cask::CLI::Cat do
       CLIOUTPUT
     end
 
-    it 'displays the cask file content about the specified cask' do
+    it 'displays the Cask file content about the specified Cask' do
       lambda {
         Cask::CLI::Cat.run('basic-cask')
       }.must_output(@expected_output)
     end
 
-    it 'throws away additional casks and uses the first' do
+    it 'throws away additional Cask arguments and uses the first' do
       lambda{
         Cask::CLI::Cat.run('basic-cask', 'local-caffeine')
       }.must_output(@expected_output)
@@ -35,13 +35,13 @@ describe Cask::CLI::Cat do
     end
   end
 
-  it %q{raises an exception when the cask doesn't exist} do
+  it %q{raises an exception when the Cask doesn't exist} do
     lambda {
       Cask::CLI::Cat.run('notacask')
     }.must_raise CaskUnavailableError
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Cat.run()
@@ -49,7 +49,7 @@ describe Cask::CLI::Cat do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Cat.run('--notavalidoption')

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -25,14 +25,14 @@ describe Cask::CLI::Create do
     end
   }
 
-  it 'opens the editor for the specified cask' do
+  it 'opens the editor for the specified Cask' do
     Cask::CLI::Create.run('new-cask')
     Cask::CLI::Create.editor_commands.must_equal [
       [Cask.path('new-cask')]
     ]
   end
 
-  it 'drops a template down for the specified cask' do
+  it 'drops a template down for the specified Cask' do
     Cask::CLI::Create.run('new-cask')
     template = File.read(Cask.path('new-cask'))
     template.must_equal <<-TEMPLATE.undent
@@ -49,7 +49,7 @@ describe Cask::CLI::Create do
     TEMPLATE
   end
 
-  it 'throws away additional casks and uses the first' do
+  it 'throws away additional Cask arguments and uses the first' do
     Cask::CLI::Create.run('additional-cask', 'another-cask')
     Cask::CLI::Create.editor_commands.must_equal [
       [Cask.path('additional-cask')]
@@ -63,20 +63,20 @@ describe Cask::CLI::Create do
     ]
   end
 
-  it 'raises an exception when the cask already exists' do
+  it 'raises an exception when the Cask already exists' do
     lambda {
       Cask::CLI::Create.run('caffeine')
     }.must_raise CaskAlreadyCreatedError
   end
 
-  it 'allows creating casks that are substrings of existing casks' do
+  it 'allows creating Casks that are substrings of existing Casks' do
     Cask::CLI::Create.run('feine')
     Cask::CLI::Create.editor_commands.must_equal [
       [Cask.path('feine')]
     ]
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Create.run()
@@ -84,7 +84,7 @@ describe Cask::CLI::Create do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Create.run('--notavalidoption')

--- a/test/cask/cli/edit_test.rb
+++ b/test/cask/cli/edit_test.rb
@@ -20,7 +20,7 @@ describe Cask::CLI::Edit do
     Cask::CLI::Edit.reset!
   end
 
-  it 'opens the editor for the specified cask' do
+  it 'opens the editor for the specified Cask' do
     Cask::CLI::Edit.run('alfred')
     Cask::CLI::Edit.editor_commands.must_equal [
       [Cask.path('alfred')]
@@ -34,13 +34,13 @@ describe Cask::CLI::Edit do
     ]
   end
 
-  it 'raises an exception when the cask doesnt exist' do
+  it 'raises an exception when the Cask doesnt exist' do
     lambda {
       Cask::CLI::Edit.run('notacask')
     }.must_raise CaskUnavailableError
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Edit.run()
@@ -48,7 +48,7 @@ describe Cask::CLI::Edit do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Edit.run('--notavalidoption')

--- a/test/cask/cli/fetch_test.rb
+++ b/test/cask/cli/fetch_test.rb
@@ -9,7 +9,7 @@ describe Cask::CLI::Fetch do
     Cask.load('local-caffeine')
   end
 
-  it "allows download the installer of a cask" do
+  it "allows download the installer of a Cask" do
     shutup do
       Cask::CLI::Fetch.run('local-transmission', 'local-caffeine')
     end
@@ -53,7 +53,7 @@ describe Cask::CLI::Fetch do
     new_ctime.to_i.must_be :>, old_ctime.to_i
   end
 
-  it "properly handles casks that are not present" do
+  it "properly handles Casks that are not present" do
     lambda {
       shutup do
         Cask::CLI::Fetch.run('notacask')
@@ -61,7 +61,7 @@ describe Cask::CLI::Fetch do
     }.must_raise CaskUnavailableError
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Fetch.run()
@@ -69,7 +69,7 @@ describe Cask::CLI::Fetch do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Fetch.run('--notavalidoption')

--- a/test/cask/cli/home_test.rb
+++ b/test/cask/cli/home_test.rb
@@ -20,14 +20,14 @@ describe Cask::CLI::Home do
     Cask::CLI::Home.reset!
   end
 
-  it 'opens the homepage for the specified cask' do
+  it 'opens the homepage for the specified Cask' do
     Cask::CLI::Home.run('alfred')
     Cask::CLI::Home.system_commands.must_equal [
       ['/usr/bin/open', '--', 'http://www.alfredapp.com/']
     ]
   end
 
-  it 'works for multiple casks' do
+  it 'works for multiple Casks' do
     Cask::CLI::Home.run('alfred', 'adium')
     Cask::CLI::Home.system_commands.must_equal [
       ['/usr/bin/open', '--', 'http://www.alfredapp.com/'],
@@ -35,7 +35,7 @@ describe Cask::CLI::Home do
     ]
   end
 
-  it "opens the project page when no cask is specified" do
+  it "opens the project page when no Cask is specified" do
     Cask::CLI::Home.run
     Cask::CLI::Home.system_commands.must_equal [
       ['/usr/bin/open', '--', 'http://caskroom.io/'],

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Cask::CLI::Info do
-  it 'displays some nice info about the specified cask' do
+  it 'displays some nice info about the specified Cask' do
     lambda {
       Cask::CLI::Info.run('local-caffeine')
     }.must_output <<-CLIOUTPUT.undent
@@ -14,7 +14,7 @@ describe Cask::CLI::Info do
     CLIOUTPUT
   end
 
-  describe 'given multiple casks' do
+  describe 'given multiple Casks' do
     before do
       @expected_output = <<-CLIOUTPUT.undent
         local-caffeine: 1.2.3
@@ -45,7 +45,7 @@ describe Cask::CLI::Info do
     end
   end
 
-  it 'should print caveats if the cask provided one' do
+  it 'should print caveats if the Cask provided one' do
     lambda {
       Cask::CLI::Info.run('with-caveats')
     }.must_output <<-CLIOUTPUT.undent
@@ -82,7 +82,7 @@ describe Cask::CLI::Info do
     CLIOUTPUT
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Info.run()
@@ -90,7 +90,7 @@ describe Cask::CLI::Info do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Info.run('--notavalidoption')

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Cask::CLI::Install do
-  it "allows install and link of multiple casks at once" do
+  it "allows install and link of multiple Casks at once" do
     shutup do
       Cask::CLI::Install.run('local-transmission', 'local-caffeine')
     end
@@ -32,7 +32,7 @@ describe Cask::CLI::Install do
     }, %r{==> Success! local-transmission installed to '#{Cask.caskroom}/local-transmission/2.61' \(487 files, 11M\)})
   end
 
-  it "properly handles casks that are not present" do
+  it "properly handles Casks that are not present" do
     lambda {
       shutup do
         Cask::CLI::Install.run('notacask')
@@ -46,7 +46,7 @@ describe Cask::CLI::Install do
         Cask::CLI::Install.run('googlechrome')
       rescue CaskError; end
     end
-    err.must_match %r{No available cask for googlechrome\. Did you mean:\ngoogle-chrome}
+    err.must_match %r{No available Cask for googlechrome\. Did you mean:\ngoogle-chrome}
   end
 
   it "returns multiple suggestions for a Cask fragment" do
@@ -55,10 +55,10 @@ describe Cask::CLI::Install do
       Cask::CLI::Install.run('google')
       rescue CaskError; end
     end
-    err.must_match %r{No available cask for google\. Did you mean one of:\ngoogle}
+    err.must_match %r{No available Cask for google\. Did you mean one of:\ngoogle}
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     with_options = lambda do |options|
       it "raises an exception" do
         lambda {

--- a/test/cask/cli/list_test.rb
+++ b/test/cask/cli/list_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Cask::CLI::List do
-  it 'lists the installed casks in a pretty fashion' do
+  it 'lists the installed Casks in a pretty fashion' do
     casks = %w[local-caffeine local-transmission].map { |c| Cask.load(c) }
 
     casks.each { |c| TestHelper.install_without_artifacts(c) }
@@ -14,7 +14,7 @@ describe Cask::CLI::List do
     OUTPUT
   end
 
-  describe 'when casks have been renamed' do
+  describe 'when Casks have been renamed' do
     before do
       @renamed_path = Cask.caskroom.join('ive-been-renamed','latest','Renamed.app').tap(&:mkpath)
       @renamed_path.join('Info.plist').open('w') { |f| f.puts "Oh plist" }
@@ -24,7 +24,7 @@ describe Cask::CLI::List do
       @renamed_path.rmtree if @renamed_path.exist?
     end
 
-    it 'lists installed casks without backing ruby files (due to renames or otherwise)' do
+    it 'lists installed Casks without backing ruby files (due to renames or otherwise)' do
       lambda {
         Cask::CLI::List.run
       }.must_output <<-OUTPUT.gsub(/^ */, '')
@@ -34,7 +34,7 @@ describe Cask::CLI::List do
   end
 
 
-  it 'given a set of installed casks, lists the installed files for those casks' do
+  it 'given a set of installed Casks, lists the installed files for those Casks' do
     casks = %w[local-caffeine local-transmission].map { |c| Cask.load(c) }
 
     casks.each { |c| TestHelper.install_without_artifacts(c) }

--- a/test/cask/cli/search_test.rb
+++ b/test/cask/cli/search_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Cask::CLI::Search do
-  it "lists the available casks that match the search term" do
+  it "lists the available Casks that match the search term" do
     lambda {
       Cask::CLI::Search.run('intellij')
     }.must_output <<-OUTPUT.gsub(/^ */, '')
@@ -11,10 +11,10 @@ describe Cask::CLI::Search do
     OUTPUT
   end
 
-  it "shows that there are no casks matching a search term that did not result in anything" do
+  it "shows that there are no Casks matching a search term that did not result in anything" do
     lambda {
       Cask::CLI::Search.run('foo-bar-baz')
-    }.must_output("No cask found for \"foo-bar-baz\".\n")
+    }.must_output("No Cask found for \"foo-bar-baz\".\n")
   end
 
   it "lists all available Casks with no search term" do
@@ -66,6 +66,6 @@ describe Cask::CLI::Search do
     out, err = capture_io do
       Cask::CLI::Search.run('caskroom')
     end
-    out.must_match(/^No cask found for "caskroom"\.\n/)
+    out.must_match(/^No Cask found for "caskroom"\.\n/)
   end
 end

--- a/test/cask/cli/uninstall_test.rb
+++ b/test/cask/cli/uninstall_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 describe Cask::CLI::Uninstall do
-  it "shows an error when a bad cask is provided" do
+  it "shows an error when a bad Cask is provided" do
     lambda {
       Cask::CLI::Uninstall.run('notacask')
     }.must_raise CaskUnavailableError
   end
 
-  it "shows an error when a cask is provided that's not installed" do
+  it "shows an error when a Cask is provided that's not installed" do
     lambda {
       Cask::CLI::Uninstall.run('anvil')
     }.must_raise CaskNotInstalledError
@@ -19,7 +19,7 @@ describe Cask::CLI::Uninstall do
     } # wont_raise
   end
 
-  it "can uninstall and unlink multiple casks at once" do
+  it "can uninstall and unlink multiple Casks at once" do
     caffeine = Cask.load('local-caffeine')
     transmission = Cask.load('local-transmission')
 
@@ -41,7 +41,7 @@ describe Cask::CLI::Uninstall do
     Cask.appdir.join('Caffeine.app').wont_be :symlink?
   end
 
-  describe "when casks have been renamed" do
+  describe "when Casks have been renamed" do
     before do
       @renamed_path = Cask.caskroom.join('ive-been-renamed','latest','Renamed.app').tap(&:mkpath)
       @renamed_path.join('Info.plist').open('w') { |f| f.puts "Oh plist" }
@@ -51,7 +51,7 @@ describe Cask::CLI::Uninstall do
       @renamed_path.rmtree if @renamed_path.exist?
     end
 
-    it "can uninstall non-ruby-backed casks" do
+    it "can uninstall non-ruby-backed Casks" do
       shutup do
         Cask::CLI::Uninstall.run('ive-been-renamed')
       end
@@ -60,7 +60,7 @@ describe Cask::CLI::Uninstall do
     end
   end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Uninstall.run()
@@ -68,7 +68,7 @@ describe Cask::CLI::Uninstall do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Uninstall.run('--notavalidoption')

--- a/test/cask/cli/zap_test.rb
+++ b/test/cask/cli/zap_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 describe Cask::CLI::Zap do
-  it "shows an error when a bad cask is provided" do
+  it "shows an error when a bad Cask is provided" do
     lambda {
       Cask::CLI::Zap.run('notacask')
     }.must_raise CaskUnavailableError
   end
 
-  it "can zap and unlink multiple casks at once" do
+  it "can zap and unlink multiple Casks at once" do
     caffeine = Cask.load('local-caffeine')
     transmission = Cask.load('local-transmission')
 
@@ -58,7 +58,7 @@ describe Cask::CLI::Zap do
   #   with_zap.wont_be :installed?
   # end
 
-  describe "when no cask is specified" do
+  describe "when no Cask is specified" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Zap.run()
@@ -66,7 +66,7 @@ describe Cask::CLI::Zap do
     end
   end
 
-  describe "when no cask is specified, but an invalid option" do
+  describe "when no Cask is specified, but an invalid option" do
     it "raises an exception" do
       lambda {
         Cask::CLI::Zap.run('--notavalidoption')

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -8,7 +8,7 @@ describe Cask::DSL do
     test_cask.version.must_equal '1.2.3'
   end
 
-  it "prevents the entire world from crashing when a cask includes an unknown method" do
+  it "prevents the entire world from crashing when a Cask includes an unknown method" do
     UnexpectedMethodCask = Class.new(Cask)
     begin
       TestHelper.must_output(self, lambda {
@@ -76,14 +76,14 @@ describe Cask::DSL do
       CaskWithCaveats = Class.new(Cask)
       CaskWithCaveats.class_eval do
         def caveats; <<-EOS.undent
-          When you install this cask, you probably want to know this.
+          When you install this Cask, you probably want to know this.
           EOS
         end
       end
 
       instance = CaskWithCaveats.new
 
-      instance.caveats.must_equal "When you install this cask, you probably want to know this.\n"
+      instance.caveats.must_equal "When you install this Cask, you probably want to know this.\n"
     end
   end
 

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -15,7 +15,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with dmg-based casks" do
+    it "works with dmg-based Casks" do
       transmission = Cask.load('local-transmission')
 
       shutup do
@@ -28,7 +28,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with tar-based casks" do
+    it "works with tar-based Casks" do
       tarball = Cask.load('tarball')
 
       shutup do
@@ -41,7 +41,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with cab-based casks" do
+    it "works with cab-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/cabextract').exist?
       cab_container = Cask.load('cab-container')
       cab_container.stubs(:depends_on_formula).returns([])
@@ -68,7 +68,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with 7z-based casks" do
+    it "works with 7z-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       sevenzip_container = Cask.load('sevenzip-container')
       sevenzip_container.stubs(:depends_on_formula).returns([])
@@ -83,7 +83,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with xar-based casks" do
+    it "works with xar-based Casks" do
       xar_container = Cask.load('xar-container')
 
       shutup do
@@ -111,7 +111,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with RAR-based casks" do
+    it "works with RAR-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       rar_container = Cask.load('rar-container')
       rar_container.stubs(:depends_on_formula).returns([])
@@ -126,7 +126,7 @@ describe Cask::Installer do
       application.must_be :directory?
     end
 
-    it "works with bz2-based casks" do
+    it "works with bz2-based Casks" do
       asset = Cask.load('bzipped-asset')
 
       shutup do
@@ -139,7 +139,7 @@ describe Cask::Installer do
       file.must_be :file?
     end
 
-    it "works with pure gz-based casks" do
+    it "works with pure gz-based Casks" do
       asset = Cask.load('gzipped-asset')
 
       shutup do
@@ -195,7 +195,7 @@ describe Cask::Installer do
     end
 
     # unlike the CLI, the internal interface throws exception on double-install
-    it "installer method raises an exception when already-installed casks are attempted" do
+    it "installer method raises an exception when already-installed Casks are attempted" do
       transmission = Cask.load('local-transmission')
       transmission.installed?.must_equal false
       installer = Cask::Installer.new(transmission)
@@ -206,7 +206,7 @@ describe Cask::Installer do
       }.must_raise(CaskAlreadyInstalledError)
     end
 
-    it "allows already-installed casks to be installed if force is provided" do
+    it "allows already-installed Casks to be installed if force is provided" do
       transmission = Cask.load('local-transmission')
       transmission.installed?.must_equal false
       installer = Cask::Installer.new(transmission)
@@ -290,7 +290,7 @@ describe Cask::Installer do
   end
 
   describe "uninstall" do
-    it "fully uninstalls a cask" do
+    it "fully uninstalls a Cask" do
       caffeine = Cask.load('local-caffeine')
       installer = Cask::Installer.new(caffeine)
 

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 describe "Cask" do
   describe "load" do
-    it "returns an instance of the cask with the given name" do
+    it "returns an instance of the Cask with the given name" do
       c = Cask.load("adium")
       c.must_be_kind_of(Cask)
       c.must_be_instance_of(Adium)
     end
 
-    it "returns an instance of the cask from a specific file location" do
+    it "returns an instance of the Cask from a specific file location" do
       # defensive constant cleanup is required because Cask
       # classes may already be loaded due to audit test
       begin
@@ -22,7 +22,7 @@ describe "Cask" do
       Object.class_eval{remove_const :Dia}
     end
 
-    it "returns an instance of the cask from a url" do
+    it "returns an instance of the Cask from a url" do
       begin
         Object.class_eval{remove_const :Dia}
       rescue
@@ -36,7 +36,7 @@ describe "Cask" do
       Object.class_eval{remove_const :Dia}
     end
 
-    it "raises an error when failing to download a cask from a url" do
+    it "raises an error when failing to download a Cask from a url" do
       lambda {
         url = "file://" + File.expand_path('./Casks/notacask.rb')
         shutup do
@@ -45,7 +45,7 @@ describe "Cask" do
       }.must_raise(CaskUnavailableError)
     end
 
-    it "returns an instance of the cask from a relative file location" do
+    it "returns an instance of the Cask from a relative file location" do
       begin
         Object.class_eval{remove_const :Bbedit}
       rescue
@@ -61,7 +61,7 @@ describe "Cask" do
       Cask.load('test-opera-mail').must_be_instance_of(TestOperaMail)
     end
 
-    it "raises an error when attempting to load a cask that doesn't exist" do
+    it "raises an error when attempting to load a Cask that doesn't exist" do
       lambda {
         Cask.load("notacask")
       }.must_raise(CaskUnavailableError)
@@ -69,7 +69,7 @@ describe "Cask" do
   end
 
   describe "all_titles" do
-    it "returns every cask that there is as a string" do
+    it "returns every Cask that there is as a string" do
       all_casks = Cask.all_titles
       all_casks.count.must_be :>, 20
       all_casks.each { |cask| cask.must_be_kind_of String }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV['HOMEBREW_NO_EMOJI']='1'
 # set some Homebrew constants used in our code
 HOMEBREW_BREW_FILE = '/usr/local/bin/brew'
 
-# add cask lib to load path
+# add homebrew-cask lib to load path
 brew_cask_path = Pathname.new(File.expand_path(__FILE__+'/../../'))
 casks_path = brew_cask_path.join('Casks')
 lib_path = brew_cask_path.join('lib')
@@ -40,7 +40,7 @@ def shutup
   end
 end
 
-# making homebrew's cache dir allows us to actually download casks in tests
+# making homebrew's cache dir allows us to actually download Casks in tests
 HOMEBREW_CACHE.mkpath
 HOMEBREW_CACHE.join('Casks').mkpath
 
@@ -57,7 +57,7 @@ Mocha::Integration::MiniTest.activate
 # our baby
 require 'cask'
 
-# Look for casks in testcasks by default.  It is elsewhere required that
+# Look for Casks in testcasks by default.  It is elsewhere required that
 # the string "test" appear in the directory name.
 Cask.default_tap = 'caskroom/homebrew-testcasks'
 
@@ -65,7 +65,7 @@ Cask.default_tap = 'caskroom/homebrew-testcasks'
 Cask.caskroom = HOMEBREW_PREFIX.join('TestCaskroom')
 
 class TestHelper
-  # helpers for test casks to reference local files easily
+  # helpers for test Casks to reference local files easily
   def self.local_binary_path(name)
     File.expand_path(File.join(File.dirname(__FILE__), 'support', 'binaries', name))
   end
@@ -121,7 +121,7 @@ require 'support/never_sudo_system_command'
 require 'tmpdir'
 require 'tempfile'
 
-# pretend like we installed the cask tap
+# pretend like we installed the homebrew-cask tap
 project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
 taps_dest = HOMEBREW_LIBRARY/"Taps/caskroom"
 
@@ -131,7 +131,7 @@ HOMEBREW_PREFIX.join('bin').mkdir
 
 FileUtils.ln_s project_root, taps_dest/"homebrew-cask"
 
-# Common superclass for tests casks for when we need to filter them out
+# Common superclass for test Casks for when we need to filter them out
 class TestCask < Cask; end
 
 # jack in some optional utilities
@@ -139,5 +139,5 @@ FileUtils.ln_s '/usr/local/bin/cabextract', HOMEBREW_PREFIX.join('bin/cabextract
 FileUtils.ln_s '/usr/local/bin/unar', HOMEBREW_PREFIX.join('bin/unar')
 FileUtils.ln_s '/usr/local/bin/lsar', HOMEBREW_PREFIX.join('bin/lsar')
 
-# also jack in some test casks
+# also jack in some test Casks
 FileUtils.ln_s project_root/'test'/'support', taps_dest/"homebrew-testcasks"


### PR DESCRIPTION
- was already done, but inconsistently
- this style follows homebrew Formula
- covers user-facing messages, test titles, comments
- some related minor orthography is included, such
  as the consistent spelling of our project name as
  "homebrew-cask"
- grammar nits
