### PR TITLE
move growl-fork from macupdate to upstream vendor

### DIFF
--- a/Casks/growl-fork.rb
+++ b/Casks/growl-fork.rb
@@ -2,8 +2,8 @@ class GrowlFork < Cask
   version '1.2.2f1'
   sha256 'b57085eed9bafcafa75bdc2a4a482c77d33ebf2f1d9994bf5ff5a997c3958bcc'
 
-  url "https://www.macupdate.com/download/41038/Growl-#{version}.dmg"
-  homepage 'https://www.macupdate.com/app/mac/41038/growl-fork'
+  url "https://bitbucket.org/pmetzger/growl/downloads/Growl-#{version}.dmg"
+  homepage 'https://bitbucket.org/pmetzger/growl'
   license :unknown
 
   pkg 'Growl.pkg'


### PR DESCRIPTION
aggregators should be avoided when possible
