### PR TITLE
remove abandoned skii.rb

### DIFF
--- a/Casks/skii.rb
+++ b/Casks/skii.rb
@@ -1,9 +1,0 @@
-class Skii < Cask
-  version '2.1.6.1'
-  sha256 'f523b9a7f58592103529813a79d95424f8025e8d0c033d6d32cb4f355aecc63a'
-
-  url "http://f.cl.ly/items/1C0f162Q0l450s0F2H26/Skii_#{version}.dmg"
-  homepage 'https://www.macupdate.com/app/mac/36677/skii'
-
-  link 'Skii.app'
-end


### PR DESCRIPTION
- Original homepage (http://www.awesome-studio.tk/) taken over by squatters.
  I get various redirections, including one which generated a malware warning.
- The `url` points to an anonymous cloud.app user.
- The macupdate page referenced as `homepage` points to the same cloud.app
  download.

It seems that nobody is vouching for this binary.  Historical awesome-studio.tk
is also blocked from the Wayback Machine.  We have no information about the
provenance of this app, and should not include it.
