### PR TITLE
Add Cargo latest

### DIFF
--- a/Casks/cargo.rb
+++ b/Casks/cargo.rb
@@ -1,0 +1,18 @@
+class Cargo < Cask
+  version :latest
+  sha256 :no_check
+
+  target = 'cargo-nightly-x86_64-apple-darwin'
+
+  url "http://static.rust-lang.org/cargo-dist/#{target}.tar.gz"
+  homepage 'http://www.crates.io/'
+  license :oss
+
+
+  binary "#{target}/bin/cargo"
+
+  artifact "#{target}/share/man/man1/cargo.1", :target => '/usr/local/share/man/man1/cargo.1'
+  %w{LICENSE-APACHE LICENSE-MIT LICENSE-THIRD-PARTY README.md}.each do |doc_file|
+    artifact "#{target}/share/doc/cargo/#{doc_file}", :target => "/usr/local/share/doc/cargo/#{doc_file}"
+  end
+end


### PR DESCRIPTION
This is a nightly build of Cargo, the package manager for the Rust programming language. There is already a cask for the nightly build of Rust itself, so I think it makes sense to have its package manager in here as well.
