### PR TITLE
steer away from using `@cask` instance variable in `caveats` interpolation

### DIFF
--- a/Casks/alib1.rb
+++ b/Casks/alib1.rb
@@ -14,7 +14,7 @@ class Alib1 < Cask
   end
 
   caveats <<-EOS.undent
-    #{@cask} requires Adobe Air, available via
+    #{title} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -7,9 +7,10 @@ class Baiduinput < Cask
   homepage 'http://wuxian.baidu.com/input/mac.html'
   license :unknown
 
+  uninstall :pkgutil  => 'com.baidu.inputmethod.*',
+            :delete   => '/Library/Input Methods/BaiduIM.app'
+
   caveats do
     manual_installer '安装百度输入法.app'
   end
-  uninstall :pkgutil  => 'com.baidu.inputmethod.*',
-            :delete   => '/Library/Input Methods/BaiduIM.app'
 end

--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -20,14 +20,14 @@ class Bassjump < Cask
   homepage 'http://www.twelvesouth.com/product/bassjump-2-for-macbook'
   license :unknown
 
-  caveats do
-    reboot
-  end
-
   uninstall :pkgutil => [
                          'com.twelvesouth.bassjump.installer.halplugin',
                          'com.twelvesouth.bassjump.installer.overridekext',
                          'com.twelvesouth.bassjump.installer.prefpane',
                         ],
             :kext => 'com.twelvesouth.driver.BassJumpOverrideDriver'
+
+  caveats do
+    reboot
+  end
 end

--- a/Casks/cdock.rb
+++ b/Casks/cdock.rb
@@ -8,7 +8,7 @@ class Cdock < Cask
 
   app 'cDock.app'
   caveats <<-EOS.undent
-    #{@cask} requires easysimbl, available via
+    #{title} requires easysimbl, available via
 
       brew cask install easysimbl
   EOS

--- a/Casks/chunkulus.rb
+++ b/Casks/chunkulus.rb
@@ -13,7 +13,7 @@ class Chunkulus < Cask
   end
 
   caveats <<-EOS.undent
-    #{@cask} requires Adobe Air, available via
+    #{title} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -12,11 +12,6 @@ class Cocoaspell < Cask
                          '/Application Support/cocoAspell/aspell6-en-6.0-0',
                          '/Library/PreferencePanes/Spelling.prefPane',
                         ]
-  caveats <<-EOS.undent
-    Non-English dictionaries must be installed separately.  For more information, see
-
-      http://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php
-  EOS
   zap :delete => [
                  '~/.aspell.conf',
                  '~/.aspell.en.prepl',
@@ -25,4 +20,10 @@ class Cocoaspell < Cask
                  # of this particular file.
                  # '~/.aspell.en.pws',
                 ]
+
+  caveats <<-EOS.undent
+    Non-English dictionaries must be installed separately.  For more information, see
+
+      http://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php
+  EOS
 end

--- a/Casks/craftstudio.rb
+++ b/Casks/craftstudio.rb
@@ -13,7 +13,7 @@ class Craftstudio < Cask
   zap       :delete => '~/Library/CraftStudio'
 
   caveats <<-EOS.undent
-    #{@cask} requires mono-mre, available via
+    #{title} requires mono-mre, available via
 
       brew cask install mono-mre
   EOS

--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -6,12 +6,13 @@ class DefaultFolderX < Cask
   homepage 'http://www.stclairsoft.com/DefaultFolderX'
   license :unknown
 
-  caveats do
-    manual_installer 'Default Folder X Installer.app'
-  end
   zap :delete => [
                   '~/Library/Preferences/com.stclairsoft.DefaultFolderX.favorites.plist',
                   '~/Library/Preferences/com.stclairsoft.DefaultFolderX.plist',
                   '~/Library/Preferences/com.stclairsoft.DefaultFolderX.settings.plist',
                  ]
+
+  caveats do
+    manual_installer 'Default Folder X Installer.app'
+  end
 end

--- a/Casks/delivery-status.rb
+++ b/Casks/delivery-status.rb
@@ -8,7 +8,7 @@ class DeliveryStatus < Cask
 
   widget 'Delivery Status.wdgt'
   caveats <<-EOS.undent
-    Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
+    Currently, Dashboard Widgets such as '#{title}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
       https://github.com/caskroom/homebrew-cask/issues/2206

--- a/Casks/fenics.rb
+++ b/Casks/fenics.rb
@@ -17,13 +17,13 @@ class Fenics < Cask
       available when you start your shell by adding the following to the .profile
       file in your home directory:
 
-        source #{@cask.destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
+        source #{destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
 
       If you are using an alternate shell (e.g., zsh, csh) or a modified or brewed Python,
       be sure to launch FEniCS using a clean (bash) shell.
       Creating a new shell using the following command works well:
 
-        /bin/bash --rcfile #{@cask.destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
+        /bin/bash --rcfile #{destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
     EOS
   end
 end

--- a/Casks/flavours.rb
+++ b/Casks/flavours.rb
@@ -8,9 +8,6 @@ class Flavours < Cask
   license :unknown
 
   app 'Flavours.app'
-  caveats do
-    files_in_usr_local
-  end
 
   uninstall :launchctl => 'net.interacto.flavours.helper',
             :quit  => 'net.interacto.Flavours',
@@ -21,4 +18,8 @@ class Flavours < Cask
                         '/usr/local/lib/libflavours.dylib',
                         '/usr/local/lib/libflavoursui.dylib',
                        ]
+
+  caveats do
+    files_in_usr_local
+  end
 end

--- a/Casks/grooveshark.rb
+++ b/Casks/grooveshark.rb
@@ -8,7 +8,7 @@ class Grooveshark < Cask
 
   app 'Grooveshark.app'
   caveats <<-EOS.undent
-    #{@cask} requires Adobe Flash, available via
+    #{title} requires Adobe Flash, available via
 
       brew cask install flash
   EOS

--- a/Casks/heart.rb
+++ b/Casks/heart.rb
@@ -13,7 +13,7 @@ class Heart < Cask
   end
 
   caveats <<-EOS.undent
-    #{@cask} requires Adobe Air, available via
+    #{title} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -13,12 +13,12 @@ class IntellijIdeaCe < Cask
   end
 
   caveats <<-EOS.undent
-    #{@cask} may require Java 7 (an older version), available from the
+    #{title} may require Java 7 (an older version), available from the
     caskroom-versions repository via
 
       brew cask install caskroom/versions/java7
 
-    Alternatively, #{@cask} can be modified to use Java 8 as described in
+    Alternatively, #{title} can be modified to use Java 8 as described in
 
       https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
   EOS

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -13,12 +13,12 @@ class IntellijIdea < Cask
   end
 
   caveats <<-EOS.undent
-    #{@cask} may require Java 7 (an older version) available from the
+    #{title} may require Java 7 (an older version) available from the
     caskroom-versions repository via
 
       brew cask install caskroom/versions/java7
 
-    Alternatively, #{@cask} can be modified to use Java 8 as described in
+    Alternatively, #{title} can be modified to use Java 8 as described in
 
       https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
   EOS

--- a/Casks/ioquake3.rb
+++ b/Casks/ioquake3.rb
@@ -8,7 +8,7 @@ class Ioquake3 < Cask
 
   suite 'ioquake3'
   caveats <<-EOS.undent
-    To complete the installation of #{@cask}, you will have to copy the file
+    To complete the installation of #{title}, you will have to copy the file
     'pak0.pk3' from your Quake 3 Arena installation support directory into
     ~/Applications/ioquake3/baseq3/.
   EOS

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -9,7 +9,7 @@ class Keycastr < Cask
   app 'KeyCastr.app'
 
   caveats <<-EOS.undent
-    For OSX 10.9 or later, #{@cask} requires that you "Enable access for assistive devices".
+    For OSX 10.9 or later, #{title} requires that you "Enable access for assistive devices".
     See https://github.com/sdeken/keycastr/issues/5
   EOS
 end

--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -10,7 +10,7 @@ class Ksdiff < Cask
   uninstall :pkgutil => 'com.blackpixel.kaleidoscope.ksdiff.installer.pkg'
   # todo: conflicts_with_cask kaleidoscope
   caveats <<-EOS.undent
-    The #{@cask} Cask is not needed when installing Kaleidoscope via Cask. It
+    The #{title} Cask is not needed when installing Kaleidoscope via Cask. It
     is provided for users who have purchased Kaleidoscope via the App Store.
   EOS
 end

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -6,13 +6,14 @@ class LittleSnitch < Cask
   homepage 'http://www.obdev.at/products/littlesnitch/index.html'
   license :unknown
 
-  caveats do
-    manual_installer 'Little Snitch Installer.app'
-  end
   zap :delete => [
                   '~/Library/Preferences/at.obdev.LittleSnitchNetworkMonitor.plist',
                   '~/Library/Application Support/Little Snitch/rules.usr.xpl',
                   '~/Library/Application Support/Little Snitch/configuration.xpl',
                   '~/Library/Application Support/Little Snitch/configuration.user.xpl',
                  ]
+
+  caveats do
+    manual_installer 'Little Snitch Installer.app'
+  end
 end

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -15,6 +15,11 @@ class Macvim < Cask
 
   app 'MacVim-snapshot-73/MacVim.app'
   binary 'MacVim-snapshot-73/mvim'
+  zap :delete => [
+                  '~/Library/Preferences/org.vim.MacVim.LSSharedFileList.plist',
+                  '~/Library/Preferences/org.vim.MacVim.plist',
+                 ]
+
   caveats do
     files_in_usr_local
     <<-EOS.undent
@@ -23,8 +28,4 @@ class Macvim < Cask
       Cask and the Formula of MacVim.
     EOS
   end
-  zap :delete => [
-                  '~/Library/Preferences/org.vim.MacVim.LSSharedFileList.plist',
-                  '~/Library/Preferences/org.vim.MacVim.plist',
-                 ]
 end

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -8,9 +8,6 @@ class Mpv < Cask
 
   app 'mpv.app'
   binary 'mpv.app/Contents/MacOS/mpv'
-  caveats do
-    files_in_usr_local
-  end
   zap :delete => [
                   '~/.mpv/channels.conf',
                   '~/.mpv/config',
@@ -18,4 +15,8 @@ class Mpv < Cask
                  ]
   # todo :rmdir is not yet supported
   #   :rmdir     '~/.mpv'
+
+  caveats do
+    files_in_usr_local
+  end
 end

--- a/Casks/pemdas-widget.rb
+++ b/Casks/pemdas-widget.rb
@@ -8,7 +8,7 @@ class PemdasWidget < Cask
 
   widget 'PEMDAS.wdgt'
   caveats <<-EOS.undent
-    Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
+    Currently, Dashboard Widgets such as '#{title}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
       https://github.com/caskroom/homebrew-cask/issues/2206

--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -8,7 +8,7 @@ class Qgis < Cask
   pkg 'Install QGIS.pkg'
   uninstall :pkgutil => 'org.qgis.qgis-*'
   caveats <<-EOS.undent
-    #{@cask} requires the GDAL framework and Matplotlib to be installed first,
+    #{title} requires the GDAL framework and Matplotlib to be installed first,
     otherwise the installation will fail. In case of problems, try installing
     them:
 

--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -7,8 +7,9 @@ class Sogouinput < Cask
   homepage 'http://pinyin.sogou.com/mac/'
   license :unknown
 
+  uninstall :delete => '/Library/Input Methods/SogouInput.app'
+
   caveats do
     manual_installer '安装搜狗输入法.app'
   end
-  uninstall :delete => '/Library/Input Methods/SogouInput.app'
 end

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -9,10 +9,11 @@ class Sourcetree < Cask
 
   app 'SourceTree.app'
   binary 'SourceTree.app/Contents/Resources/stree'
-  caveats do
-    files_in_usr_local
-  end
   zap :delete => [
                   '~/Library/Application Support/SourceTree',
                  ]
+
+  caveats do
+    files_in_usr_local
+  end
 end

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -13,6 +13,6 @@ class Sts < Cask
   license :unknown
 
   caveats do
-    manual_installer "Installer - Spring Tool Suite #{@cask.version}.RELEASE.app"
+    manual_installer "Installer - Spring Tool Suite #{version}.RELEASE.app"
   end
 end

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -9,9 +9,6 @@ class SublimeText < Cask
 
   app 'Sublime Text 2.app'
   binary 'Sublime Text 2.app/Contents/SharedSupport/bin/subl'
-  caveats do
-    files_in_usr_local
-  end
   zap :delete => [
                   '~/Library/Application Support/Sublime Text 2/Installed Packages',
                   '~/Library/Application Support/Sublime Text 2/Packages',
@@ -19,4 +16,8 @@ class SublimeText < Cask
                  ]
   # todo :rmdir not yet supported
   #   :rmdir     '~/Library/Application Support/Sublime Text 2',
+
+  caveats do
+    files_in_usr_local
+  end
 end

--- a/Casks/truecrypt.rb
+++ b/Casks/truecrypt.rb
@@ -7,6 +7,8 @@ class Truecrypt < Cask
   license :oss
 
   pkg "TrueCrypt #{version}.mpkg"
+  uninstall :pkgutil => 'org.TrueCryptFoundation.TrueCrypt'
+
   caveats do
     files_in_usr_local
     <<-EOS.undent
@@ -15,5 +17,4 @@ class Truecrypt < Cask
       http://truecrypt.sourceforge.net/
     EOS
   end
-  uninstall :pkgutil => 'org.TrueCryptFoundation.TrueCrypt'
 end

--- a/Casks/tv-show-tracker.rb
+++ b/Casks/tv-show-tracker.rb
@@ -8,7 +8,7 @@ class TvShowTracker < Cask
 
   widget 'TV Show Tracker.wdgt'
   caveats <<-EOS.undent
-    Currently, Dashboard Widgets such as '#{@cask}' do NOT work correctly
+    Currently, Dashboard Widgets such as '#{title}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
       https://github.com/caskroom/homebrew-cask/issues/2206

--- a/Casks/tvrenamer.rb
+++ b/Casks/tvrenamer.rb
@@ -8,7 +8,7 @@ class Tvrenamer < Cask
 
   app "TVRenamer-#{version}.app"
   caveats <<-EOS.undent
-    #{@cask} requires a Java JRE to be installed. You should be prompted to install
+    #{title} requires a Java JRE to be installed. You should be prompted to install
     Java on the first execution if it is not already present.
   EOS
 end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -7,11 +7,6 @@ class Wireshark < Cask
   license :unknown
 
   pkg "Wireshark #{version} Intel 64.pkg"
-
-  caveats do
-    x11_required
-  end
-
   postflight do
     if Process.euid == 0 then
       ohai 'Note:'
@@ -43,4 +38,8 @@ class Wireshark < Cask
                          '/usr/local/bin/tshark',
                          '/usr/local/bin/wireshark',
                         ]
+
+  caveats do
+    x11_required
+  end
 end

--- a/Casks/xamarin.rb
+++ b/Casks/xamarin.rb
@@ -6,11 +6,11 @@ class Xamarin < Cask
   homepage 'http://xamarin.com/platform'
   license :unknown
 
+  uninstall :delete => '/Applications/Xamarin Studio.app'
+  zap       :delete => '~/Library/Developer/Xamarin'
+
   caveats do
     puts 'This app requires the JRE (Java Runtime Environment) to be installed'
     manual_installer 'Install Xamarin.app'
   end
-
-  uninstall :delete => '/Applications/Xamarin Studio.app'
-  zap       :delete => '~/Library/Developer/Xamarin'
 end

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -191,23 +191,29 @@ end
 
 ### Caveats as a String
 
-When `caveats` is a string, it is evaluated at compile time. Use this only for a static
-message in which you don't need to interpolate any runtime variables.  Example:
+When `caveats` is a string, it is evaluated at compile time.  The following
+methods are available for interpolation if `caveats` is placed in its customary
+position at the end of the Cask:
+
+| method             | description |
+| ------------------ | ----------- |
+| `title`            | the Cask title
+| `version`          | the Cask version
+| `homepage`         | the Cask homepage
+| `caskroom_path`    | eg `/opt/homebrew-cask/Caskroom`
+| `destination_path` | the staging location for this Cask, including version number, *eg* `/opt/homebrew-cask/Caskroom/adium/1.5.10`
+
+Example:
 
 ```ruby
-caveats 'Using this software is hazardous to your health.'
+caveats "Using #{title} is hazardous to your health."
 ```
 
 ### Caveats as a Block
 
-When `caveats` is a Ruby block, evaluation is deferred until install time. Here you may
-refer to the Cask instance in your message to the user:
-
-```ruby
-caveats do
-  puts "Using #{@cask} is hazardous to your health."
-end
-```
+When `caveats` is a Ruby block, evaluation is deferred until install time.
+Within a block you may refer to the `@cask` instance variable, and invoke
+any method available on `@cask`.
 
 ### Caveats Mini-DSL
 
@@ -222,10 +228,10 @@ The following methods may be called to generate standard warning messages:
 | `zsh_path_helper(path)`           | Zsh users must take additional steps to make sure `path` is in their `$PATH` environment variable
 | `logout`                          | The user should log out and log back in to complete installation
 | `reboot`                          | The user should reboot to complete installation
-| `assistive_devices`               | The user should grant the application access to assitive devices
+| `assistive_devices`               | The user should grant the application access to assistive devices
 | `files_in_usr_local`              | The Cask installs files to `/usr/local`, which may confuse Homebrew
 | `arch_only(list)`                 | The Cask only supports certain architectures.  Currently valid elements of `list` are `intel-32` and `intel-64`
-| `os_version_only(list)`           | The Cask only supports certain OS X Versions.  Currently valid elements of `list` are `10.5`, `10.6`, `10.7`, `10.8`, `10.9`, and `10.10`
+| `os_version_only(list)`           | The Cask only supports certain OS X Versions.  Currently valid elements of `list` are all major releases: `10.0`, `10.1`, … `10.10`
 | `x11_required`                    | The Cask requires X11 to run
 
 Example:
@@ -233,24 +239,6 @@ Example:
 ```ruby
 caveats do
   manual_installer 'Little Snitch Installer.app'
-end
-```
-
-And the following methods may be useful for interpolation:
-
-| method             | description |
-| ------------------ | ----------- |
-| `title`            | the Cask title
-| `version`          | the Cask version
-| `caskroom_path`    | eg `/opt/homebrew-cask/Caskroom`
-| `destination_path` | where this particular Cask is stored, including version number, eg `/opt/homebrew-cask/Caskroom/google-chrome/stable-channel`
-
-Any method from the main Cask DSL can be invoked from inside `caveats` via
-the `@cask` instance variable.  Example (see [sts.rb](../Casks/sts.rb)):
-
-```ruby
-caveats do
-  puts "You must obtain an API key at #{@cask.homepage}"
 end
 ```
 


### PR DESCRIPTION
Several Casks were damaged in #6533 as I changed `caveats` to the simpler string form, but forgot the fine points of how interpolation works at evaluation time _vs_ install time.  This PR addresses that by
- changing `#{@cask}` interpolations to `#{title}` in 16 damaged Casks
- removing needless references to `@cask` such as `#{@cask.version}` interpolation in 2 Casks (just `#{version}` will do)
- updating docs to
  - steer away from install-time method interpolations (this form was previously featured first)
  - suggest placing `caveats` last so that info is filled in at evaluation time
  - update list of available interpolations
  - incidental updates to caveats section
- moving `caveats` to last position in 13 Casks

In many cases where `caveats` was not already in the last position, `manual_installer` was used, reinforcing the recent decision that `manual_installer` is actually a pseudo-artifact which must be hoisted out of `caveats` entirely.
