### PR TITLE
array argument to `uninstall :script :input`

### DIFF
--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -8,5 +8,8 @@ class IntelHaxm < Cask
 
   container :nested => "haxm-macosx_r04/IntelHAXM_#{version}.dmg"
   pkg "IntelHAXM_#{version}.mpkg"
-  uninstall :script => { :executable => '/System/Library/Extensions/intelhaxm.kext/Contents/Resources/uninstall.sh', :input => 'y' }
+  uninstall :script => {
+                        :executable => '/System/Library/Extensions/intelhaxm.kext/Contents/Resources/uninstall.sh',
+                        :input      => ['y']
+                       }
 end

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -10,7 +10,7 @@ class Cask::SystemCommand
     raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(*command.map(&:to_s))
 
     if options[:input]
-      options[:input].each { |line| raw_stdin.puts line }
+      Array(options[:input]).each { |line| raw_stdin.puts line }
     end
     raw_stdin.close_write
 


### PR DESCRIPTION
Per #6589, `intel-haxm.rb` uninstall fails because the argument to `uninstall :script :input` must be an array.

This PR updates the Cask to match the docs, and (if there is no objection) changes the backend to implicitly coerce any single value to an array.
