### PR TITLE
add or expand zap stanzas in 53 Casks

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -8,8 +8,11 @@ class Adium < Cask
   license :oss
 
   app 'Adium.app'
+
   zap :delete => [
                   '~/Library/Application Support/Adium 2.0',
+                  '~/Library/Caches/Adium',
+                  '~/Library/Caches/com.adiumX.adiumX',
                   '~/Library/Preferences/com.adiumX.adiumX.plist',
                  ]
 end

--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -17,4 +17,9 @@ class AdobeAir < Cask
     :executable => 'Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer',
     :args => %w[-uninstall]
   }
+  zap :delete => [
+                  '~/Library/Application Support/Adobe/AIR',
+                  '~/Library/Caches/com.adobe.air.ApplicationInstaller',
+                 ],
+      :rmdir  => '~/Library/Application Support/Adobe/'
 end

--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -7,4 +7,7 @@ class AndroidFileTransfer < Cask
   license :unknown
 
   app 'Android File Transfer.app'
+
+  zap :delete => '~/Library/Application Support/Google/Android File Transfer',
+      :rmdir  => '~/Library/Application Support/Google/'
 end

--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -16,4 +16,6 @@ class Aquamacs < Cask
   license :oss
 
   app 'Aquamacs.app'
+
+  zap :delete => '~/Library/Caches/Aquamacs Emacs'
 end

--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -12,8 +12,8 @@ class Atom < Cask
   postflight do
     system '/usr/bin/defaults', 'write', 'com.github.atom', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+
   zap :delete => [
-                  '~/Library/Preferences/com.github.atom.plist',
                   '~/.atom/config.cson',
                   '~/.atom/init.coffee',
                   '~/.atom/keymap.cson',
@@ -21,5 +21,11 @@ class Atom < Cask
                   '~/.atom/packages',
                   '~/.atom/snippets.cson',
                   '~/.atom/styles.less',
-                 ]
+                  '~/Library/Application Support/ShipIt_stderr.log',
+                  '~/Library/Application Support/ShipIt_stdout.log',
+                  '~/Library/Application Support/com.github.atom.ShipIt',
+                  '~/Library/Caches/com.github.atom',
+                  '~/Library/Preferences/com.github.atom.plist',
+                 ],
+      :rmdir  => '~/.atom/'
 end

--- a/Casks/chainsaw.rb
+++ b/Casks/chainsaw.rb
@@ -7,4 +7,6 @@ class Chainsaw < Cask
   license :unknown
 
   app 'Chainsaw.app'
+
+  zap :delete => '~/.chainsaw'
 end

--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -12,6 +12,14 @@ class Clamxav < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'uk.co.markallan.clamxav', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+
+  zap :delete => [
+                  '~/Library/Caches/uk.co.markallan.clamxav',
+                  '~/Library/Logs/clamXav-scan.log',
+                  # todo glob/expand needed here
+                  '~/Library/Logs/clamXav-scan.log.0.bz2',
+                 ]
+
   caveats do
     # this happens sometime after installation, but still worth warning about
     files_in_usr_local

--- a/Casks/colloquy.rb
+++ b/Casks/colloquy.rb
@@ -8,8 +8,11 @@ class Colloquy < Cask
   license :unknown
 
   app 'Colloquy.app'
+
   zap :delete => [
-                  '~/Library/Preferences/info.colloquy.plist',
                   '~/Library/Application Support/Colloquy',
+                  '~/Library/Caches/info.colloquy',
+                  '~/Library/Preferences/info.colloquy.plist',
+                  '~/Library/Scripts/Applications/Colloquy',
                  ]
 end

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -7,6 +7,13 @@ class Controllermate < Cask
   license :unknown
 
   pkg 'ControllerMate.pkg'
+
   uninstall :script => 'ControllerMate Uninstaller.app/Contents/MacOS/ControllerMate Uninstaller',
             :pkgutil => 'com.orderedbytes.controllermate.*'
+  zap       :delete => [
+                        '~/Library/Application Support/ControllerMate',
+                        '~/Library/Caches/com.orderedbytes.ControllerMate4',
+                        '~/Library/Logs/ControllerMate MIDI',
+                        '~/Library/Logs/ControllerMate',
+                       ]
 end

--- a/Casks/cura.rb
+++ b/Casks/cura.rb
@@ -7,4 +7,6 @@ class Cura < Cask
   license :oss
 
   app 'Cura/Cura.app'
+
+  zap :delete => '~/.cura'
 end

--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -8,4 +8,10 @@ class DiskDrill < Cask
   license :unknown
 
   app 'Disk Drill.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/DiskDrill',
+                  '~/Library/Caches/com.cleverfiles.Disk_Drill',
+                  '~/Library/Logs/DiskDrill.log',
+                 ]
 end

--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -7,4 +7,6 @@ class Dropbox < Cask
   license :unknown
 
   app 'Dropbox.app'
+
+  zap :delete => '~/.dropbox'
 end

--- a/Casks/eloquent.rb
+++ b/Casks/eloquent.rb
@@ -7,4 +7,10 @@ class Eloquent < Cask
   license :unknown
 
   app 'Eloquent.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Eloquent',
+                  '~/Library/Caches/org.crosswire.Eloquent',
+                  '~/Library/Logs/Eloquent.log',
+                 ]
 end

--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -7,4 +7,9 @@ class Firefox < Cask
   license :oss
 
   app 'Firefox.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Firefox',
+                  '~/Library/Caches/Firefox',
+                 ]
 end

--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -8,4 +8,9 @@ class FlashPlayerDebugger < Cask
 
   # Renamed to avoid conflict with flash-player.
   app 'Flash Player.app', :target => 'Flash Player Debugger.app'
+
+  zap :delete => [
+                  '~/Library/Caches/Adobe/Flash Player',
+                  '~/Library/Logs/FlashPlayerInstallManager.log',
+                 ]
 end

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -7,4 +7,9 @@ class FlashPlayer < Cask
   license :unknown
 
   app 'Flash Player.app'
+
+  zap :delete => [
+                  '~/Library/Caches/Adobe/Flash Player',
+                  '~/Library/Logs/FlashPlayerInstallManager.log',
+                 ]
 end

--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -7,6 +7,11 @@ class Flash < Cask
   license :unknown
 
   pkg 'Install Adobe Flash Player.pkg'
+
   uninstall :pkgutil => 'com.adobe.pkg.FlashPlayer',
             :delete  => '/Library/Internet Plug-Ins/Flash Player.plugin'
+  zap       :delete => [
+                        '~/Library/Caches/Adobe/Flash Player',
+                        '~/Library/Logs/FlashPlayerInstallManager.log',
+                       ]
 end

--- a/Casks/gambit-c.rb
+++ b/Casks/gambit-c.rb
@@ -19,4 +19,5 @@ class GambitC < Cask
                         :executable => "/Library/Gambit-C/v#{version}/bin/uninstall-gambc",
                         :args => ["v#{version}"]
                        }
+  zap       :delete => '~/.gambc_history'
 end

--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -11,4 +11,15 @@ class Github < Cask
   postflight do
     system '/usr/bin/defaults', 'write', 'com.github.GitHub', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+
+  zap :delete => [
+                  '~/Library/Application Support/GitHub for Mac',
+                  '~/Library/Application Support/ShipIt_stderr.log',
+                  '~/Library/Application Support/ShipIt_stdout.log',
+                  '~/Library/Application Support/com.github.GitHub',
+                  '~/Library/Application Support/com.github.GitHub.ShipIt',
+                  '~/Library/Caches/GitHub for Mac',
+                  '~/Library/Caches/com.github.GitHub',
+                  '~/Library/Containers/com.github.GitHub.Conduit',
+                 ]
 end

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -8,4 +8,19 @@ class GoogleChrome < Cask
   tags :vendor => 'Google'
 
   app 'Google Chrome.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Google/Chrome',
+                  '~/Library/Caches/Google/Chrome',
+                  '~/Library/Caches/com.google.Chrome',
+                  '~/Library/Caches/com.google.Chrome.helper.EH',
+                  '~/Library/Caches/com.google.Keystone.Agent',
+                  '~/Library/Caches/com.google.SoftwareUpdate',
+                  '~/Library/Google/GoogleSoftwareUpdate',
+                  '~/Library/Logs/GoogleSoftwareUpdateAgent.log',
+                 ],
+      :rmdir  => [
+                  '~/Library/Caches/Google',
+                  '~/Library/Google',
+                 ]
 end

--- a/Casks/google-earth.rb
+++ b/Casks/google-earth.rb
@@ -7,4 +7,10 @@ class GoogleEarth < Cask
   license :unknown
 
   app 'Google Earth.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Google Earth',
+                  '~/Library/Caches/Google Earth',
+                  '~/Library/Caches/com.Google.GoogleEarthPlus',
+                 ]
 end

--- a/Casks/google-refine.rb
+++ b/Casks/google-refine.rb
@@ -7,4 +7,7 @@ class GoogleRefine < Cask
   license :oss
 
   app 'Google Refine.app'
+
+  zap :delete => '~/Library/Application Support/Google/Refine',
+      :rmdir  => '~/Library/Application Support/Google/'
 end

--- a/Casks/growl-fork.rb
+++ b/Casks/growl-fork.rb
@@ -7,5 +7,11 @@ class GrowlFork < Cask
   license :unknown
 
   pkg 'Growl.pkg'
+
   uninstall :delete => '/Library/PreferencePanes/Growl.prefPane'
+  zap       :delete => [
+                        '~/Library/Application Scripts/com.Growl.GrowlHelperApp',
+                        '~/Library/Containers/com.Growl.GrowlHelperApp',
+                        '~/Library/Containers/com.growl.GrowlLauncher',
+                       ]
 end

--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -13,4 +13,12 @@ class Hipchat < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.hipchat.HipChat', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+
+  zap :delete => [
+                  # todo expand/glob for '~/Library/<userid>/HipChat/',
+                  '~/Library/Caches/com.hipchat.HipChat',
+                  '~/Library/HipChat',
+                  '~/Library/Logs/HipChat',
+                  '~/Library/chat.hipchat.com',
+                 ]
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -8,6 +8,8 @@ class Inkscape < Cask
 
   app 'Inkscape.app'
 
+  zap :delete => '~/.inkscape-etc'
+
   caveats do
     x11_required
   end

--- a/Casks/inky.rb
+++ b/Casks/inky.rb
@@ -7,4 +7,9 @@ class Inky < Cask
   license :unknown
 
   app 'Inky.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Arcode',
+                  '~/Library/Caches/com.arcode.inky',
+                 ]
 end

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -50,6 +50,13 @@ class Java < Cask
                         '/Library/Java/Home',
                         '/usr/lib/java/libjdns_sd.jnilib',
                        ]
+  zap       :delete => [
+                        '~/Library/Application Support/Oracle/Java',
+                        '~/Library/Caches/com.oracle.java.Java-Updater',
+                        '~/Library/Caches/net.java.openjdk.cmd',
+                       ],
+            :rmdir  => '~/Library/Application Support/Oracle/'
+
   caveats <<-EOS.undent
     This Cask makes minor modifications to the JRE to prevent issues with
     packaged applications, as discussed here:

--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -7,4 +7,6 @@ class Julia < Cask
   license :unknown
 
   app "Julia-#{version}.app"
+
+  zap :delete => '~/.julia'
 end

--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -9,14 +9,16 @@ class Karabiner < Cask
   pkg 'Karabiner.pkg'
   binary '/Applications/Karabiner.app/Contents/Library/vendor/bin/blueutil'
   binary '/Applications/Karabiner.app/Contents/Library/utilities/bin/warp-mouse-cursor-position'
+
   uninstall :quit => 'org.pqrs.Karabiner',
             :pkgutil => 'org.pqrs.driver.Karabiner',
             :kext => 'org.pqrs.driver.Karabiner'
-  zap :delete => [
-                  '~/Library/Preferences/org.pqrs.Karabiner.plist',
-                  '~/Library/Preferences/org.pqrs.Karabiner-AXNotifier.plist',
-                  '~/Library/Preferences/org.pqrs.Karabiner.multitouchextension.plist',
-                 ]
-  # todo :rmdir not yet supported
-  #    :rmdir '~/Library/Application Support/Karabiner'
+  zap       :delete => [
+                        '~/Library/Application Support/Karabiner',
+                        '~/Library/Application Support/KeyRemap4MacBook',
+                        '~/Library/Caches/org.pqrs.KeyRemap4MacBook',
+                        '~/Library/Preferences/org.pqrs.Karabiner-AXNotifier.plist',
+                        '~/Library/Preferences/org.pqrs.Karabiner.multitouchextension.plist',
+                        '~/Library/Preferences/org.pqrs.Karabiner.plist',
+                       ]
 end

--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -9,4 +9,6 @@ class Kdiff3 < Cask
 
   app 'kdiff3.app'
   binary 'kdiff3.app/Contents/MacOS/kdiff3'
+
+  zap :delete => '~/.kdiff3rc'
 end

--- a/Casks/keepassx.rb
+++ b/Casks/keepassx.rb
@@ -7,4 +7,6 @@ class Keepassx < Cask
   license :unknown
 
   app 'KeePassX.app'
+
+  zap :delete => '~/.keepassx'
 end

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -17,4 +17,5 @@ class Macports < Cask
   license :unknown
 
   uninstall :pkgutil => 'org.macports.MacPorts'
+  zap       :delete  => '~/.macports'
 end

--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -8,4 +8,6 @@ class MplayerOsxExtended < Cask
   license :oss
 
   app 'MPlayer OSX Extended.app'
+
+  zap :delete => '~/.mplayer'
 end

--- a/Casks/mplayerx.rb
+++ b/Casks/mplayerx.rb
@@ -7,4 +7,6 @@ class Mplayerx < Cask
   license :oss
 
   app 'MPlayerX.app'
+
+  zap :delete => '~/.mplayer'
 end

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -8,13 +8,13 @@ class Mpv < Cask
 
   app 'mpv.app'
   binary 'mpv.app/Contents/MacOS/mpv'
+
   zap :delete => [
                   '~/.mpv/channels.conf',
                   '~/.mpv/config',
                   '~/.mpv/input.conf',
-                 ]
-  # todo :rmdir is not yet supported
-  #   :rmdir     '~/.mpv'
+                 ],
+      :rmdir  => '~/.mpv'
 
   caveats do
     files_in_usr_local

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -7,6 +7,7 @@ class Parallels < Cask
   license :unknown
 
   pkg 'Install.mpkg'
+
   uninstall :pkgutil => 'com.parallels.pkg.virtualization.bundle',
             :kext    => [
                          'com.parallels.kext.usbconnect',
@@ -15,4 +16,5 @@ class Parallels < Cask
                          'com.parallels.kext.netbridge',
                          'com.parallels.kext.vnic',
                         ]
+  zap       :delete  => '~/.parallels_settings'
 end

--- a/Casks/quick-search-box.rb
+++ b/Casks/quick-search-box.rb
@@ -10,4 +10,7 @@ class QuickSearchBox < Cask
   postflight do
     system '/bin/chmod', '-R', '--', 'u+w', destination_path
   end
+
+  zap :delete => '~/Library/Application Support/Google/Quick Search Box',
+      :rmdir  => '~/Library/Application Support/Google/'
 end

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -30,9 +30,13 @@ class R < Cask
                         # /Library/Frameworks/R.Framework/Versions/3.1/Resources/fontconfig/cache
                         '/Library/Frameworks/R.Framework/Versions/3.1',
                        ]
-  zap :delete => [
-                  '~/.R',
-                  '~/.Rhistory',
-                  '~/.Rprofile',
-                 ]
+  zap       :delete => [
+                        '~/.R',
+                        '~/.RData',
+                        '~/.Rapp.history',
+                        '~/.Rhistory',
+                        '~/.Rprofile',
+                        '~/Library/R',
+                        '~/Library/Caches/org.R-project.R',
+                       ]
 end

--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -7,4 +7,6 @@ class Razorsql < Cask
   license :unknown
 
   app 'RazorSQL.app'
+
+  zap :delete => '~/.razorsql'
 end

--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -7,4 +7,6 @@ class Rstudio < Cask
   license :unknown
 
   app 'RStudio.app'
+
+  zap :delete => '~/.rstudio-desktop'
 end

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -8,6 +8,12 @@ class Sage < Cask
 
   app "Sage-#{version}.app"
   binary "Sage-#{version}.app/Contents/Resources/sage/sage"
+
+  zap :delete => [
+                  '~/.sage',
+                  '~/Library/Logs/sage.log',
+                 ]
+
   caveats do
     files_in_usr_local
   end

--- a/Casks/seil.rb
+++ b/Casks/seil.rb
@@ -7,11 +7,14 @@ class Seil < Cask
   license :unknown
 
   pkg 'Seil.pkg'
+
   uninstall :quit => 'org.pqrs.Seil',
             :kext => 'org.pqrs.driver.Seil',
             :pkgutil => 'org.pqrs.driver.Seil'
-  zap :delete => [
-                  '~/Library/Preferences/org.pqrs.PCKeyboardHack.plist',
-                  '~/Library/Preferences/org.pqrs.Seil.plist',
-                 ]
+  zap       :delete => [
+                        '~/Library/Caches/org.pqrs.PCKeyboardHack',
+                        '~/Library/Caches/org.pqrs.Seil',
+                        '~/Library/Preferences/org.pqrs.PCKeyboardHack.plist',
+                        '~/Library/Preferences/org.pqrs.Seil.plist',
+                       ]
 end

--- a/Casks/send-to-kindle.rb
+++ b/Casks/send-to-kindle.rb
@@ -7,6 +7,11 @@ class SendToKindle < Cask
   license :unknown
 
   pkg "SendToKindleForMac-installer-v#{version}.pkg"
+
   uninstall :launchctl => 'com.amazon.sendtokindle.launcher',
             :pkgutil   => 'com.amazon.SendToKindleMacInstaller.pkg'
+  zap       :delete    => [
+                           '~/Library/Application Support/Amazon/SendToKindle',
+                           '~/Library/Logs/SendToKindleInstall.log',
+                          ]
 end

--- a/Casks/silverlight.rb
+++ b/Casks/silverlight.rb
@@ -7,5 +7,8 @@ class Silverlight < Cask
   license :unknown
 
   pkg 'Silverlight.pkg'
+
   uninstall :pkgutil => 'com.microsoft.SilverlightInstaller'
+  zap       :delete  => '~/Library/Application Support/Microsoft/Silverlight',
+            :rmdir   => '~/Library/Application Support/Microsoft/'
 end

--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -8,4 +8,9 @@ class Sketchup < Cask
   license :unknown
 
   suite 'SketchUp 2014'
+
+  zap :delete => [
+                  '~/Library/Application Support/Google SketchUp 8',
+                  '~/Library/Caches/com.google.sketchupfree8',
+                 ]
 end

--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -13,9 +13,13 @@ class Soulver < Cask
     # Don't ask to move the app bundle to /Applications
     system '/usr/bin/defaults', 'write', 'com.acqualia.soulver', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
   end
+
   zap :delete => [
                   # todo verify that this does not contain user-generated content
                   # '~/Library/Application Support/Soulver',
                   '~/Library/Preferences/com.acqualia.soulver.plist',
+                  '~/Library/Autosave Information/Unsaved Soulver Document.soulver',
+                  # todo glob/expand support
+                  # '~/Library/Autosave Information/Unsaved Soulver Document 2.soulver',
                  ]
 end

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -9,8 +9,10 @@ class Sourcetree < Cask
 
   app 'SourceTree.app'
   binary 'SourceTree.app/Contents/Resources/stree'
+
   zap :delete => [
                   '~/Library/Application Support/SourceTree',
+                  '~/Library/Caches/com.torusknot.SourceTreeNotMAS',
                  ]
 
   caveats do

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -9,13 +9,13 @@ class SublimeText < Cask
 
   app 'Sublime Text 2.app'
   binary 'Sublime Text 2.app/Contents/SharedSupport/bin/subl'
+
   zap :delete => [
                   '~/Library/Application Support/Sublime Text 2/Installed Packages',
                   '~/Library/Application Support/Sublime Text 2/Packages',
                   '~/Library/Application Support/Sublime Text 2/Pristine Packages',
-                 ]
-  # todo :rmdir not yet supported
-  #   :rmdir     '~/Library/Application Support/Sublime Text 2',
+                 ],
+      :rmdir  => '~/Library/Application Support/Sublime Text 2'
 
   caveats do
     files_in_usr_local

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -7,7 +7,12 @@ class Teamviewer < Cask
   license :unknown
 
   pkg 'Install TeamViewer.pkg'
+
   uninstall :pkgutil   => 'com.teamviewer.*',
             :launchctl => 'com.teamviewer.service',
             :delete    => '/Library/LaunchDaemons/com.teamviewer.teamviewer_service.plist'
+  zap       :delete    => [
+                           '~/Library/Caches/com.teamviewer.TeamViewer',
+                           '~/Library/Logs/TeamViewer',
+                          ]
 end

--- a/Casks/texmacs.rb
+++ b/Casks/texmacs.rb
@@ -7,4 +7,6 @@ class Texmacs < Cask
   license :unknown
 
   app "TeXmacs-#{version}.app"
+
+  zap :delete => '~/.TeXmacs'
 end

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -12,8 +12,16 @@ class VmwareFusion < Cask
   binary 'VMware Fusion.app/Contents/Library/vmware-vdiskmanager'
   binary 'VMware Fusion.app/Contents/Library/VMware OVF Tool/ovftool'
   app 'VMware Fusion.app'
+
   uninstall_preflight do
     system '/usr/bin/sudo', '-E', '--',
            '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "#{destination_path}/VMware Fusion.app"
   end
+  zap :delete => [
+                  # note: '~/Library/Application Support/VMware Fusion' is not safe
+                  # to delete.  In older versions, VM images were located there.
+                  '~/Library/Caches/com.vmware.fusion',
+                  '~/Library/Logs/VMware',
+                  '~/Library/Logs/VMware Fusion',
+                 ]
 end

--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -23,4 +23,10 @@ class Xquartz < Cask
             :launchctl => 'org.macosforge.xquartz.startx',
             :pkgutil => 'org.macosforge.xquartz.pkg',
             :delete => '/opt/X11/'
+  zap       :delete => [
+                        '~/Library/Caches/org.macosforge.xquartz.X11',
+                        '~/Library/Logs/X11',
+                        '~/Library/Logs/X11.org.macosforge.xquartz.log',
+                        '~/Library/Logs/X11.org.macosforge.xquartz.log.old',
+                       ]
 end

--- a/Casks/zeroxed.rb
+++ b/Casks/zeroxed.rb
@@ -7,4 +7,9 @@ class Zeroxed < Cask
   license :unknown
 
   app '0xED.app'
+
+  zap :delete => [
+                  '~/Library/Caches/com.suavetech.0xED',
+                  '~/Library/Logs/0xED.log',
+                 ]
 end


### PR DESCRIPTION
enables commented-out `:rmdir` directives
