### PR TITLE
fix sha mismatch for istumbler

### DIFF
--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -1,6 +1,6 @@
 class Istumbler < Cask
   version '100'
-  sha256 'bc260060dd2d2ccff122e523aa3b9d610bea2d158bb8b0a18eb14c304e49ff67'
+  sha256 '19fb21209669683ad5419643c65fb457245ce076805f2ec022edde0cb7e161b4'
 
   url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   homepage 'http://istumbler.net/'


### PR DESCRIPTION
I tried installing just now and it fails due to a SHA mismatch. I tried with this updated formula and it worked.
