### PR TITLE
Specify various licenses

### DIFF
--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -4,7 +4,7 @@ class AdobeCreativeCloud < Cask
 
   url 'https://ccmdls.adobe.com/AdobeProducts/KCCC/1/osx10/CreativeCloudInstaller.dmg'
   homepage 'https://creative.adobe.com/products/creative-cloud'
-  license :unknown
+  license :commercial
 
   caveats do
     manual_installer 'Creative Cloud Installer.app'

--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -5,7 +5,7 @@ class Appzapper < Cask
   url 'http://www.appzapper.com/downloads/appzapper.dmg'
   appcast 'http://www.appzapper.com/az2appcast.xml'
   homepage 'http://www.appzapper.com/'
-  license :unknown
+  license :commercial
 
   app 'AppZapper.app'
 end

--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -5,7 +5,7 @@ class Cyberduck < Cask
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss'
   homepage 'http://cyberduck.io/'
-  license :unknown
+  license :gpl
 
   app 'Cyberduck.app'
   zap :delete => [

--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -4,7 +4,7 @@ class HexFiend < Cask
 
   url 'http://ridiculousfish.com/hexfiend/files/HexFiend.zip'
   homepage 'http://ridiculousfish.com/hexfiend/'
-  license :unknown
+  license :bsd
 
   app 'Hex Fiend.app'
 end

--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -5,7 +5,7 @@ class Imageoptim < Cask
   url 'https://imageoptim.com/ImageOptim.tbz2'
   appcast 'http://imageoptim.com/appcast.xml'
   homepage 'http://imageoptim.com/'
-  license :unknown
+  license :gpl
 
   app 'ImageOptim.app'
 end

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -7,7 +7,7 @@ class Java < Cask
                     'oraclelicense' => 'accept-securebackup-cookie'
                   }
   homepage 'http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html'
-  license :unknown
+  license :gratis
 
   pkg 'JDK 8 Update 20.pkg'
   postflight do

--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -5,7 +5,7 @@ class Kaleidoscope < Cask
   url 'http://cdn.kaleidoscopeapp.com/releases/Kaleidoscope-2.1.0-134.zip'
   appcast 'https://updates.blackpixel.com/updates?app=ks'
   homepage 'http://www.kaleidoscopeapp.com/'
-  license :unknown
+  license :commercial
 
   app 'Kaleidoscope.app'
   binary 'Kaleidoscope.app/Contents/Resources/bin/ksdiff'

--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -5,7 +5,7 @@ class Moom < Cask
   url 'http://manytricks.com/download/moom'
   appcast 'http://manytricks.com/moom/appcast.xml'
   homepage 'http://manytricks.com/moom/'
-  license :unknown
+  license :commercial
 
   app 'Moom.app'
   zap :delete => [

--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -5,7 +5,7 @@ class Netnewswire < Cask
   url "http://cdn.netnewswireapp.com/releases/NetNewsWire-#{version}.zip"
   appcast 'https://updates.blackpixel.com/updates?app=nnw'
   homepage 'http://netnewswireapp.com/'
-  license :unknown
+  license :commercial
 
   app 'NetNewsWire.app'
 end

--- a/Casks/notational-velocity.rb
+++ b/Casks/notational-velocity.rb
@@ -5,7 +5,7 @@ class NotationalVelocity < Cask
   url 'http://notational.net/NotationalVelocity.zip'
   appcast 'http://notational.net/nvupdates.xml'
   homepage 'http://notational.net'
-  license :unknown
+  license :gpl
 
   app 'Notational Velocity.app'
 end

--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -4,7 +4,7 @@ class Omnifocus < Cask
 
   url 'http://www.omnigroup.com/download/latest/omnifocus'
   homepage 'http://www.omnigroup.com/products/omnifocus/'
-  license :unknown
+  license :commercial
 
   app 'OmniFocus.app'
   zap :delete => [

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -4,7 +4,7 @@ class Parallels < Cask
 
   url "http://download.parallels.com/desktop/v9/update2.hotfix2/ParallelsDesktop-#{version}.dmg"
   homepage 'http://www.parallels.com/products/desktop/'
-  license :unknown
+  license :commercial
 
   pkg 'Install.mpkg'
 

--- a/Casks/seil.rb
+++ b/Casks/seil.rb
@@ -4,7 +4,7 @@ class Seil < Cask
 
   url "https://pqrs.org/macosx/keyremap4macbook/files/Seil-#{version}.dmg"
   homepage 'https://pqrs.org/macosx/keyremap4macbook/seil.html.en'
-  license :unknown
+  license :public_domain
 
   pkg 'Seil.pkg'
 

--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -11,7 +11,7 @@ class Skype < Cask
   end
 
   homepage 'http://www.skype.com'
-  license :unknown
+  license :gratis
 
   app 'Skype.app'
 

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -4,7 +4,7 @@ class Spotify < Cask
 
   url 'http://download.spotify.com/Spotify.dmg'
   homepage 'https://www.spotify.com'
-  license :unknown
+  license :gratis
 
   app 'Spotify.app'
   zap :delete => '~/Library/Preferences/com.spotify.client.plist'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -5,7 +5,7 @@ class Transmission < Cask
   url "https://transmission.cachefly.net/Transmission-#{version}.dmg"
   appcast 'http://update.transmissionbt.com/appcast.xml'
   homepage 'http://www.transmissionbt.com/'
-  license :unknown
+  license :gpl
 
   app 'Transmission.app'
   zap :delete => [

--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -5,7 +5,7 @@ class Viscosity < Cask
   url 'https://www.sparklabs.com/downloads/Viscosity.dmg'
   appcast 'http://www.viscosityvpn.com/update/viscosity.xml'
   homepage 'http://www.sparklabs.com/viscosity/'
-  license :unknown
+  license :commercial
 
   app 'Viscosity.app'
   zap :delete => [

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -4,7 +4,7 @@ class VmwareFusion < Cask
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   homepage 'http://www.vmware.com/products/fusion/'
-  license :unknown
+  license :commercial
 
   binary 'VMware Fusion.app/Contents/Library/vmnet-cfgcli'
   binary 'VMware Fusion.app/Contents/Library/vmnet-cli'


### PR DESCRIPTION
This PR adds license specifications to these casks:
- `vmware-fusion`
- `moom`
- `parallels`
- `omnifocus`
- `kaleidoscope`
- `skype`
- `adobe-creative-cloud`
- `notational-velocity`
- `spotify`
- `transmission`
- `seil`
- `hex-fiend`
- `imageoptim`
- `cyberduck`
- `java`
- `appzapper`
- `viscosity`
- `netnewswire`

Source, when appropriate, is specified in detailed description of a commit.
