### PR TITLE
Add Audiobook Builder.app latest

### DIFF
--- a/Casks/audiobook-builder.rb
+++ b/Casks/audiobook-builder.rb
@@ -1,0 +1,10 @@
+class AudiobookBuilder < Cask
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.splasm.com/downloads/audiobookbuilder/Audiobook%20Builder.dmg'
+  homepage 'http://www.splasm.com/audiobookbuilder/'
+  license :commercial
+
+  app 'Audiobook Builder.app'
+end


### PR DESCRIPTION
The plain HTTP URL is used because the root certificate for the HTTPS URL has expired. The Download button on the app's homepage uses the plain URL.
