### PR TITLE
Add Bookends.app latest

### DIFF
--- a/Casks/bookends.rb
+++ b/Casks/bookends.rb
@@ -1,0 +1,10 @@
+class Bookends < Cask
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.sonnysoftware.com/Bookends.dmg'
+  homepage 'http://www.sonnysoftware.com'
+  license :closed
+
+  app 'Bookends.app'
+end


### PR DESCRIPTION
Using plain HTTP download URL because HTTPS URL is unavailable.
