### PR TITLE
convert old-style `link` stanza to `app` or `artifact` in 3 Casks

### DIFF
--- a/Casks/bleep.rb
+++ b/Casks/bleep.rb
@@ -6,5 +6,5 @@ class Bleep < Cask
   homepage 'http://labs.bittorrent.com/bleep/'
   license :unknown
 
-  link 'Bleep.app'
+  app 'Bleep.app'
 end

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -11,5 +11,5 @@ class DwarfFortress < Cask
   #    suite 'df_osx', :target => 'Dwarf Fortress'
   #
   # ?
-  link 'df_osx/df', :target => 'Dwarf Fortress/df'
+  artifact 'df_osx/df', :target => 'Dwarf Fortress/df'
 end

--- a/Casks/ip-in-menu-bar.rb
+++ b/Casks/ip-in-menu-bar.rb
@@ -5,5 +5,5 @@ class IpInMenuBar < Cask
   url 'http://www.monkeybreadsoftware.de/Software/IPinmenubar.dmg'
   homepage 'http://www.monkeybreadsoftware.de/Software/IPinmenubar.shtml'
 
-  link 'IP in menu bar.app'
+  app 'IP in menu bar.app'
 end


### PR DESCRIPTION
`link` currently works fine, but is due to expire in version 0.50.0
