### PR TITLE
Modify splayerx url

### DIFF
--- a/Casks/splayerx.rb
+++ b/Casks/splayerx.rb
@@ -2,7 +2,7 @@ class Splayerx < Cask
   version '1.1.8'
   sha256 '75a3decacd5a8efe5b6f5638999281159cb7ddf598d158a89f3d6e157c276433'
 
-  url "http://cdn.bitbucket.org/Tomasen/splayerx/downloads/SPlayerX_#{version}.zip"
+  url "http://bitbucket.org/Tomasen/splayerx/downloads/SPlayerX_#{version}.zip"
   homepage 'https://bitbucket.org/Tomasen/splayerx/wiki/Home'
   license :oss
 


### PR DESCRIPTION
bitbucket use cloudfront cdn.
cloudfront.net  can not be accessed in China because of DNS cache pollution.
When I use proxy to access download url, 403 forbidden occurs.
New url is ok!
