### PR TITLE
Add Dbvisualizer.app v9.1.11

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -1,0 +1,10 @@
+class Dbvisualizer < Cask
+  version '9.1.11'
+  sha256 '066e63bfda0032dde126a64e51cfe037f5c8dfd226b43b069d09a2ff7df3d17b'
+
+  url 'http://www.dbvis.com/product_download/dbvis-9.1.11/media/dbvis_macos_9_1_11.dmg'
+  homepage 'http://www.dbvis.com/'
+  license :commercial
+
+  app 'DbVisualizer Installer.app'
+end

--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -6,5 +6,7 @@ class Dbvisualizer < Cask
   homepage 'http://www.dbvis.com/'
   license :commercial
 
-  app 'DbVisualizer Installer.app'
+  caveats do
+    manual_installer('DbVisualizer Installer.app')
+  end
 end


### PR DESCRIPTION
Adding a cask for DbVisualizer universal database tool. It was made for developers,  DBAs and analysts. It is the perfect solution since the same tool can be used on all major operating systems accessing a wide range of databases.
