### PR TITLE
Updated anki to version 2.0.29

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -1,6 +1,6 @@
 class Anki < Cask
-  version '2.0.28'
-  sha256 '8071e6f1cdf661df6c8b9997e0618e8dc722ff8aeaf8b99390567204791f23cd'
+  version '2.0.29'
+  sha256 '2eea38eca7e4f720c01a10ffdbfe0b73c9ac06648483103ed034f9db6660c07a'
 
   url "http://ankisrs.net/download/mirror/anki-#{version}.dmg"
   homepage 'http://ankisrs.net/'


### PR DESCRIPTION
Upgrade Anki.app to version 2.0.29. :)
- Anki for Mac version 2.0.29
