### PR TITLE
Fix checksum in Pharo.app Cask

### DIFF
--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -1,6 +1,6 @@
 class Pharo < Cask
   version '3.0'
-  sha256 'f811c7ab77240c680ac74f0d50390101cd61007f027045a9c68322f7dadc6c38'
+  sha256 '2aae5efd2d6e93df29ca5e04f2ad95c22494ff3d0e27c50276c25c298c0a58b1'
 
   url "http://files.pharo.org/platform/Pharo#{version}-mac.zip"
   homepage 'http://www.pharo-project.org/home'


### PR DESCRIPTION
Sha256 checksum was wrong and it has been fixed.
