### PR TITLE
Specify most licenses for letter B

### DIFF
--- a/Casks/back-in-time.rb
+++ b/Casks/back-in-time.rb
@@ -4,7 +4,7 @@ class BackInTime < Cask
 
   url 'http://www.tri-edre.fr/pub/files/backintime3.dmg'
   homepage 'http://www.tri-edre.fr/english/backintime.html'
-  license :unknown
+  license :commercial
 
   app 'Back-In-Time 3.app'
 end

--- a/Casks/backblaze-downloader.rb
+++ b/Casks/backblaze-downloader.rb
@@ -4,7 +4,7 @@ class BackblazeDownloader < Cask
 
   url 'https://secure.backblaze.com/mac_restore_downloader'
   homepage 'http://www.backblaze.com/'
-  license :unknown
+  license :commercial
 
   app 'Backblaze Downloader.app'
 end

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -4,7 +4,7 @@ class Backblaze < Cask
 
   url 'https://secure.backblaze.com/mac/install_backblaze.dmg'
   homepage 'https://www.backblaze.com/'
-  license :unknown
+  license :commercial
 
   caveats do
     manual_installer 'Backblaze Installer.app'

--- a/Casks/backtobed.rb
+++ b/Casks/backtobed.rb
@@ -2,9 +2,9 @@ class Backtobed < Cask
   version :latest
   sha256 :no_check
 
-  url 'http://backtobed.dadiugames.dk/backtobed_osx.zip'
+  url 'http://backtobed.dadiugames.dk/studentversion/backtobed_osx.zip'
   homepage 'http://backtobed.dadiugames.dk/'
-  license :unknown
+  license :gratis
 
   app 'BackToBed.app'
 end

--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -5,7 +5,7 @@ class Backuploupe < Cask
   url "http://www.soma-zone.com/download/files/BackupLoupe_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/BackupLoupe/a/appcast.xml'
   homepage 'http://www.soma-zone.com/BackupLoupe/'
-  license :unknown
+  license :commercial
 
   app 'BackupLoupe.app'
 end

--- a/Casks/bahamut.rb
+++ b/Casks/bahamut.rb
@@ -5,7 +5,7 @@ class Bahamut < Cask
   url 'https://raw.github.com/sdegutis/bahamut/master/Builds/Bahamut-LATEST.app.tar.gz'
   appcast 'https://raw.github.com/sdegutis/bahamut/master/appcast.xml'
   homepage 'https://github.com/sdegutis/bahamut'
-  license :oss
+  license :mit
 
   app 'Bahamut.app'
 end

--- a/Casks/baiducloud.rb
+++ b/Casks/baiducloud.rb
@@ -5,7 +5,7 @@ class Baiducloud < Cask
 
   url "http://bcscdn.baidu.com/netdisk/BaiduYun_#{version}.dmg"
   homepage 'http://pan.baidu.com'
-  license :unknown
+  license :gratis
 
   app '百度云同步盘.app'
 end

--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -5,7 +5,7 @@ class Baiduinput < Cask
 
   url "http://wuxian.baidu.com/download/1000e/baiduinput_mac_v#{version}.dmg"
   homepage 'http://wuxian.baidu.com/input/mac.html'
-  license :unknown
+  license :gratis
 
   uninstall :pkgutil  => 'com.baidu.inputmethod.*',
             :delete   => '/Library/Input Methods/BaiduIM.app'

--- a/Casks/baidumusic.rb
+++ b/Casks/baidumusic.rb
@@ -4,7 +4,7 @@ class Baidumusic < Cask
 
   url 'http://music.baidu.com/player/mac/baidumusic_mac.dmg'
   homepage 'http://music.baidu.com/'
-  license :unknown
+  license :gratis
 
   app '百度音乐.app'
 end

--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -4,7 +4,7 @@ class BalsamiqMockups < Cask
 
   url 'http://builds.balsamiq.com/b/mockups-desktop/MockupsForDesktop.dmg'
   homepage 'http://balsamiq.com/'
-  license :unknown
+  license :commercial
 
   app 'Balsamiq Mockups.app'
 end

--- a/Casks/banshee.rb
+++ b/Casks/banshee.rb
@@ -4,7 +4,7 @@ class Banshee < Cask
 
   url "http://ftp.gnome.org/pub/GNOME/binaries/mac/banshee/banshee-#{version}.macosx.intel.dmg"
   homepage 'http://banshee.fm'
-  license :unknown
+  license :mit
 
   app 'Banshee.app'
 end

--- a/Casks/bar-magnet.rb
+++ b/Casks/bar-magnet.rb
@@ -3,8 +3,9 @@ class BarMagnet < Cask
   sha256 'b8242cbef4ecf537770e53ae3e7a750e6241f4185898476b021f356d9328567c'
 
   url "http://qata.cc/app/Bar%20Magnet%20#{version}.zip"
+  appcast 'http://qata.cc/app/appcast.xml'
   homepage 'http://qata.cc/Site/Bar_Magnet.html'
-  license :unknown
+  license :gratis
 
   app 'Bar Magnet.app'
 end

--- a/Casks/baretorrent.rb
+++ b/Casks/baretorrent.rb
@@ -4,7 +4,7 @@ class Baretorrent < Cask
 
   url "https://launchpad.net/baretorrent/trunk/#{version}/+download/baretorrent-#{version}-osx-x64.dmg"
   homepage 'http://baretorrent.org'
-  license :unknown
+  license :public_domain
 
   app 'baretorrent.app'
 end

--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -5,7 +5,7 @@ class Bartender < Cask
   url 'http://www.macbartender.com/Demo/Bartender.zip'
   appcast 'http://www.macbartender.com/updates/updates.php'
   homepage 'http://www.macbartender.com/'
-  license :unknown
+  license :commercial
 
   app 'Bartender.app'
 

--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -5,7 +5,7 @@ class Base < Cask
   url 'http://menial.co.uk/base/download/'
   appcast 'http://update.menial.co.uk/software/base/'
   homepage 'http://menial.co.uk/base/'
-  license :unknown
+  license :commercial
 
   app 'Base.app'
 end

--- a/Casks/basecamp.rb
+++ b/Casks/basecamp.rb
@@ -4,7 +4,7 @@ class Basecamp < Cask
 
   url "http://download.garmin.com/software/BaseCampforMac_#{version.gsub('.', '')}.dmg"
   homepage 'http://www.garmin.com/en-US/shop/downloads/basecamp'
-  license :unknown
+  license :gratis
 
   pkg 'Install BaseCamp.pkg'
   uninstall :pkgutil => 'com.garmin.BaseCamp'

--- a/Casks/basex.rb
+++ b/Casks/basex.rb
@@ -4,7 +4,7 @@ class Basex < Cask
 
   url "http://files.basex.org/releases/#{version}/BaseX781.app.zip"
   homepage 'http://basex.org/home/'
-  license :unknown
+  license :bsd
 
   app 'BaseX.app'
 end

--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -4,7 +4,7 @@ class Basictex < Cask
 
   url "http://mirror.ctan.org/systems/mac/mactex/basictex#{version}.pkg"
   homepage 'http://www.tug.org/mactex/morepackages.html'
-  license :unknown
+  license :oss
 
   pkg "basictex#{version}.pkg"
   uninstall :pkgutil => 'org.tug.mactex.basictex2014'

--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -18,7 +18,7 @@ class Bassjump < Cask
   end
 
   homepage 'http://www.twelvesouth.com/product/bassjump-2-for-macbook'
-  license :unknown
+  license :gratis
 
   uninstall :pkgutil => [
                          'com.twelvesouth.bassjump.installer.halplugin',

--- a/Casks/bassshapes.rb
+++ b/Casks/bassshapes.rb
@@ -4,7 +4,7 @@ class Bassshapes < Cask
 
   url "http://yellquietly.com/downloads/BassShapes_v#{version.gsub('.', '')}.zip"
   homepage 'http://yellquietly.com/bass-shapes/'
-  license :unknown
+  license :gratis
 
   app "BassShapes_v#{version.gsub('.', '')}/BassShapes.app"
 end

--- a/Casks/battery-guardian.rb
+++ b/Casks/battery-guardian.rb
@@ -5,7 +5,7 @@ class BatteryGuardian < Cask
   url 'https://www.dssw.co.uk/batteryguardian/dsswbatteryguardian.dmg'
   appcast 'http://version.dssw.co.uk/batteryguardian/standard'
   homepage 'https://www.dssw.co.uk/batteryguardian'
-  license :unknown
+  license :gratis
 
   app 'Battery Guardian.app'
 end

--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -5,7 +5,7 @@ class BatteryReport < Cask
   url 'https://www.dssw.co.uk/batteryreport/dsswbatteryreport.dmg'
   appcast 'http://version.dssw.co.uk/batteryreport/standard'
   homepage 'https://www.dssw.co.uk/batteryreport'
-  license :unknown
+  license :commercial
 
   app 'Battery Report.app'
 end

--- a/Casks/battery-time-remaining.rb
+++ b/Casks/battery-time-remaining.rb
@@ -4,7 +4,7 @@ class BatteryTimeRemaining < Cask
 
   url "http://yap.nu/battery-time-remaining/download/Battery%20Time%20Remaining%202-#{version}.zip"
   homepage 'http://yap.nu/battery-time-remaining/'
-  license :unknown
+  license :apache
 
   app 'Battery Time Remaining 2.app'
 end

--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -5,7 +5,7 @@ class BbcIplayerDownloads < Cask
   url 'https://www.bbc.co.uk/iplayer/dm/downloads/mac/latest'
   appcast 'http://ipd-hq.cloud.bbc.co.uk/downloads/update.xml'
   homepage 'http://www.bbc.co.uk/iplayer/install'
-  license :unknown
+  license :gratis
 
   app 'BBC iPlayer Downloads.app'
 end

--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -5,7 +5,7 @@ class Bbedit < Cask
   url "http://pine.barebones.com/files/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml'
   homepage 'http://www.barebones.com/products/bbedit/'
-  license :unknown
+  license :commercial
 
   app 'BBEdit.app'
 end

--- a/Casks/bean.rb
+++ b/Casks/bean.rb
@@ -4,7 +4,7 @@ class Bean < Cask
 
   url 'http://www.bean-osx.com/releases/Bean-Install.zip'
   homepage 'http://www.bean-osx.com'
-  license :unknown
+  license :gratis
 
   app 'Bean-Install/Bean.app'
 end

--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -5,7 +5,7 @@ class Bee < Cask
   url 'http://neat.io/bee/download.html'
   appcast 'http://neat.io/appcasts/bee-appcast.xml'
   homepage 'http://neat.io/bee/'
-  license :unknown
+  license :commercial
 
   app 'Bee.app'
 end

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -5,7 +5,7 @@ class Bettertouchtool < Cask
   url 'http://www.boastr.de/BetterTouchTool.zip'
   appcast 'http://appcast.boastr.net'
   homepage 'http://blog.boastr.net/'
-  license :unknown
+  license :commercial
 
   app 'BetterTouchTool.app'
   zap :delete => [

--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -5,7 +5,7 @@ class Betterzip < Cask
   url 'http://macitbetter.com/BetterZip.zip'
   appcast 'http://macitbetter.com/BetterZip2.rss'
   homepage 'http://macitbetter.com'
-  license :unknown
+  license :commercial
 
   app 'BetterZip.app'
 end

--- a/Casks/big-mean-folder-machine.rb
+++ b/Casks/big-mean-folder-machine.rb
@@ -5,7 +5,7 @@ class BigMeanFolderMachine < Cask
   url 'http://www.publicspace.net/download/BMFM.dmg'
   appcast 'http://www.publicspace.net/app/bmfm2.xml'
   homepage 'http://www.publicspace.net/BigMeanFolderMachine/'
-  license :unknown
+  license :commercial
 
   app 'Big Mean Folder Machine 2.app'
 end

--- a/Casks/bino.rb
+++ b/Casks/bino.rb
@@ -4,7 +4,7 @@ class Bino < Cask
 
   url "http://devernay.free.fr/hacks/bino/Bino-#{version}-OSX-SnowLeopard-GPL.zip"
   homepage 'http://bino3d.org'
-  license :unknown
+  license :gpl
 
   app 'Bino.app'
 end

--- a/Casks/bitcasa.rb
+++ b/Casks/bitcasa.rb
@@ -4,7 +4,7 @@ class Bitcasa < Cask
 
   url "https://d1kbf262vwnlmm.cloudfront.net/Bitcasa_#{version}.dmg"
   homepage 'https://www.bitcasa.com'
-  license :unknown
+  license :gratis
 
   pkg 'InstallBitcasa.pkg'
   uninstall :pkgutil => 'com.bitcasa.AutoLaunch|com.bitcasa.Bitcasa'

--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -4,7 +4,7 @@ class BitcoinCore < Cask
 
   url "https://bitcoin.org/bin/#{version}/bitcoin-#{version}-macosx.dmg"
   homepage 'https://bitcoin.org/'
-  license :unknown
+  license :mit
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/3634

--- a/Casks/bitlord.rb
+++ b/Casks/bitlord.rb
@@ -4,7 +4,7 @@ class Bitlord < Cask
 
   url "http://www.bitlord.com/osx/BitLord-Lion-#{version}.dmg"
   homepage 'http://www.bitlord.com'
-  license :unknown
+  license :gpl
 
   app 'BitLord.app'
 end

--- a/Casks/bitmessage.rb
+++ b/Casks/bitmessage.rb
@@ -4,7 +4,7 @@ class Bitmessage < Cask
 
   url "https://bitmessage.org/download/osx/Archive/bitmessage-v#{version}.dmg"
   homepage 'https://bitmessage.org/'
-  license :unknown
+  license :mit
 
   app 'Bitmessage.app'
 end

--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -6,7 +6,7 @@ class BittorrentSync < Cask
   # todo: response was not XML
   # appcast 'http://www.usyncapp.com/cfu.php'
   homepage 'http://www.bittorrent.com/sync'
-  license :unknown
+  license :gratis
 
   app 'BitTorrent Sync.app'
 end

--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -4,7 +4,7 @@ class BitwigStudio < Cask
 
   url 'http://packs.bitwig.com/downloads/Bitwig%20Studio%201.0.14.dmg'
   homepage 'https://www.bitwig.com'
-  license :unknown
+  license :commercial
 
   app 'Bitwig Studio.app'
 end

--- a/Casks/black-ink.rb
+++ b/Casks/black-ink.rb
@@ -5,7 +5,7 @@ class BlackInk < Cask
   url "http://www.red-sweater.com/blackink/BlackInk#{version}.zip"
   appcast 'http://www.red-sweater.com/blackink/appcast1.php'
   homepage 'http://www.red-sweater.com/blackink/'
-  license :unknown
+  license :commercial
 
   app 'Black Ink.app'
 end

--- a/Casks/black-light.rb
+++ b/Casks/black-light.rb
@@ -4,7 +4,7 @@ class BlackLight < Cask
 
   url "https://littoral.michelf.ca/apps/black-light/black-light-#{version}.zip"
   homepage 'http://michelf.ca/projects/black-light'
-  license :unknown
+  license :commercial
 
   app 'Black Light.app'
 end

--- a/Casks/bleep.rb
+++ b/Casks/bleep.rb
@@ -4,7 +4,7 @@ class Bleep < Cask
 
   url 'https://download-new.utorrent.com/endpoint/bleep/os/osx/track/stable/'
   homepage 'http://labs.bittorrent.com/bleep/'
-  license :unknown
+  license :gratis
 
   app 'Bleep.app'
 end

--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -4,7 +4,7 @@ class Blender < Cask
 
   url "http://download.blender.org/release/Blender#{version}/blender-#{version}-OSX_10.6-x86_64.zip"
   homepage 'http://www.blender.org/'
-  license :unknown
+  license :gpl
 
   app 'Blender/blender.app'
   app 'Blender/blenderplayer.app'

--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -4,7 +4,7 @@ class Bluegriffon < Cask
 
   url "http://bluegriffon.org/freshmeat/#{version}/bluegriffon-#{version}.mac.dmg"
   homepage 'http://bluegriffon.org'
-  license :unknown
+  license :oss
 
   app 'BlueGriffon.app'
 end

--- a/Casks/blueharvest.rb
+++ b/Casks/blueharvest.rb
@@ -5,7 +5,7 @@ class Blueharvest < Cask
   url 'http://zeroonetwenty.com/downloads/BlueHarvest559.dmg'
   appcast 'https://cp37.ezyreg.com/~zeroonet/downloads/versioninfo/sparkle/blueharvest.xml'
   homepage 'http://zeroonetwenty.com/blueharvest/'
-  license :unknown
+  license :commercial
 
   app 'BlueHarvest.app'
 end

--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -4,7 +4,7 @@ class Bluej < Cask
 
   url "http://www.bluej.org/download/files/BlueJ-#{version.gsub('.', '')}.zip"
   homepage 'http://www.bluej.org'
-  license :unknown
+  license :gpl
 
   app "BlueJ #{version}/BlueJ.app"
 end

--- a/Casks/bonjour-browser.rb
+++ b/Casks/bonjour-browser.rb
@@ -4,7 +4,7 @@ class BonjourBrowser < Cask
 
   url 'http://www.tildesoft.com/files/BonjourBrowser.dmg'
   homepage 'http://www.tildesoft.com/'
-  license :unknown
+  license :gratis
 
   app 'Bonjour Browser.app'
 end

--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -4,7 +4,7 @@ class Boom < Cask
 
   url 'http://www.globaldelight.com/boom/download/1.1x/boom.dmg'
   homepage 'http://www.globaldelight.com/boom/'
-  license :unknown
+  license :commercial
 
   app 'Boom.app'
 end

--- a/Casks/bootchamp.rb
+++ b/Casks/bootchamp.rb
@@ -5,7 +5,7 @@ class Bootchamp < Cask
   url 'http://www.kainjow.com/downloads/BootChamp.zip'
   appcast 'http://kainjow.com/updates/bootchamp.xml'
   homepage 'http://www.kainjow.com/'
-  license :unknown
+  license :oss
 
   app 'BootChamp.app'
 end

--- a/Casks/bootxchanger.rb
+++ b/Casks/bootxchanger.rb
@@ -5,7 +5,7 @@ class Bootxchanger < Cask
   url "http://namedfork.net/_media/bootxchanger_#{version}.dmg"
   appcast 'http://swupdate.namedfork.net/bootxchanger.xml'
   homepage 'http://namedfork.net/bootxchanger'
-  license :unknown
+  license :gpl
 
   app 'BootXChanger.app'
 end

--- a/Casks/bowtie.rb
+++ b/Casks/bowtie.rb
@@ -5,7 +5,7 @@ class Bowtie < Cask
   url "http://bowtieapp.com/bowtie-#{version}.zip"
   appcast 'http://updates.13bold.com/appcasts/bowtie'
   homepage 'http://bowtieapp.com/'
-  license :unknown
+  license :gratis
 
   app "Bowtie #{version}/Bowtie.app"
 end

--- a/Casks/box-sync.rb
+++ b/Casks/box-sync.rb
@@ -4,7 +4,7 @@ class BoxSync < Cask
 
   url 'https://box.com/sync4mac'
   homepage 'https://sites.box.com/sync4/'
-  license :unknown
+  license :gratis
 
   app 'Box Sync.app'
 end

--- a/Casks/boxcryptor-classic.rb
+++ b/Casks/boxcryptor-classic.rb
@@ -4,7 +4,7 @@ class BoxcryptorClassic < Cask
 
   url 'https://www.boxcryptor.com/download/Boxcryptor_Installer.dmg'
   homepage 'https://www.boxcryptor.com/en/boxcryptor-classic'
-  license :unknown
+  license :commercial
 
   app 'Boxcryptor Classic.app'
 end

--- a/Casks/boxer.rb
+++ b/Casks/boxer.rb
@@ -5,7 +5,7 @@ class Boxer < Cask
   url 'http://boxerapp.com/download/latest'
   appcast 'http://boxerapp.com/appcast'
   homepage 'http://boxerapp.com/'
-  license :unknown
+  license :gpl
 
   app 'Boxer.app'
 end

--- a/Casks/breach.rb
+++ b/Casks/breach.rb
@@ -4,7 +4,7 @@ class Breach < Cask
 
   url "https://raw.githubusercontent.com/breach/releases/master/v#{version}/breach-v#{version}-darwin-ia32.tar.gz"
   homepage 'http://breach.cc'
-  license :unknown
+  license :mit
 
   app "breach-v#{version}-darwin-ia32/Breach.app"
 end

--- a/Casks/breakaway.rb
+++ b/Casks/breakaway.rb
@@ -4,7 +4,7 @@ class Breakaway < Cask
 
   url "https://downloads.sourceforge.net/project/breakaway/breakaway-#{version}.zip"
   homepage 'http://mutablecode.com/apps/breakaway.html'
-  license :oss
+  license :gpl
 
   app 'Breakaway.app'
 end

--- a/Casks/brightness.rb
+++ b/Casks/brightness.rb
@@ -4,7 +4,7 @@ class Brightness < Cask
 
   url "http://www.bergdesign.com/resources/Brightness/Brightness_#{version}.dmg"
   homepage 'http://www.bergdesign.com/brightness/'
-  license :unknown
+  license :gratis
 
   app 'Brightness.app'
 end

--- a/Casks/brogue.rb
+++ b/Casks/brogue.rb
@@ -4,7 +4,7 @@ class Brogue < Cask
 
   url "https://sites.google.com/site/broguegame/Brogue%20OS%20X%2010.6%2B%20v#{version}.zip?attredirects=0&d=1"
   homepage 'https://sites.google.com/site/broguegame/'
-  license :unknown
+  license :affero
 
   app "Brogue v#{version}/Brogue.app"
 end

--- a/Casks/brow.rb
+++ b/Casks/brow.rb
@@ -4,7 +4,7 @@ class Brow < Cask
 
   url 'http://www.timschroeder.net/brow/brow.zip'
   homepage 'http://www.timschroeder.net/brow/'
-  license :unknown
+  license :gratis
 
   app 'Brow.app'
 end

--- a/Casks/browserstacklocal.rb
+++ b/Casks/browserstacklocal.rb
@@ -4,7 +4,7 @@ class Browserstacklocal < Cask
 
   url 'https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip'
   homepage 'http://www.browserstack.com/'
-  license :unknown
+  license :commercial
 
   binary 'BrowserStackLocal'
 end

--- a/Casks/buddi.rb
+++ b/Casks/buddi.rb
@@ -4,7 +4,7 @@ class Buddi < Cask
 
   url 'http://buddi.digitalcave.ca/buddi.dmg'
   homepage 'http://buddi.digitalcave.ca/index.jsp'
-  license :unknown
+  license :gpl
 
   app 'Buddi.app'
 end

--- a/Casks/budget.rb
+++ b/Casks/budget.rb
@@ -4,7 +4,7 @@ class Budget < Cask
 
   url 'http://www.snowmintcs.com/downloads/budget.dmg'
   homepage 'http://www.snowmintcs.com/products/budgetmac/'
-  license :unknown
+  license :commercial
 
   app 'Budget.app'
 end

--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -4,7 +4,7 @@ class Burn < Cask
 
   url "https://downloads.sourceforge.net/project/burn-osx/Burn/#{version}/burn251.zip"
   homepage 'http://burn-osx.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Burn.localized/Burn.app'
 end

--- a/Casks/butter.rb
+++ b/Casks/butter.rb
@@ -3,8 +3,8 @@ class Butter < Cask
   sha256 '98cdd021f1c940ac1066600bef344400c3f932747882e971096152397f19b350'
 
   url "https://github.com/harukasan/butter/releases/download/v#{version}/Butter_#{version}.dmg"
-  homepage 'http://harukasan.jp'
-  license :oss
+  homepage 'https://github.com/harukasan/butter'
+  license :mit
 
   app 'Butter.app'
 end

--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -4,7 +4,7 @@ class Bzflag < Cask
 
   url "http://downloads.sourceforge.net/project/bzflag/bzflag%20Mac%20OS%20X/#{version}/BZFlag-#{version}.zip"
   homepage 'http://bzflag.org/'
-  license :oss
+  license :gpl
 
   app "BZFlag-#{version}.app"
 end

--- a/Casks/c3.rb
+++ b/Casks/c3.rb
@@ -4,7 +4,7 @@ class C3 < Cask
 
   url "https://d2xj26462na9l3.cloudfront.net/c3/C3-FNF-#{version}.dmg"
   homepage 'http://www.downloadc3.com/'
-  license :unknown
+  license :gratis
 
   app 'c3.app'
 end

--- a/Casks/caffeine.rb
+++ b/Casks/caffeine.rb
@@ -4,7 +4,7 @@ class Caffeine < Cask
 
   url 'http://download.lightheadsw.com/download.php?software=caffeine'
   homepage 'http://lightheadsw.com/caffeine/'
-  license :unknown
+  license :gratis
 
   app 'Caffeine.app'
   zap :delete => '~/Library/Preferences/com.lightheadsw.Caffeine.plist'

--- a/Casks/cakebrew.rb
+++ b/Casks/cakebrew.rb
@@ -5,7 +5,7 @@ class Cakebrew < Cask
   url "https://www.cakebrew.com/files/cakebrew-#{version}.dmg"
   appcast 'http://www.cakebrew.com/appcast/profileInfo.php'
   homepage 'http://www.cakebrew.com'
-  license :unknown
+  license :gpl
 
   app 'Cakebrew.app'
 end

--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -4,7 +4,7 @@ class Calibre < Cask
 
   url 'http://status.calibre-ebook.com/dist/osx32'
   homepage 'http://calibre-ebook.com/'
-  license :unknown
+  license :gpl
 
   app 'calibre.app'
 end


### PR DESCRIPTION
It is missing one or two casks starting with letter B though, due to lack of related information.
Detailed license info is included in git message's body, where appropriate.
