### PR TITLE
Update to install Parallels Desktop 10

### DIFF
--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -10,17 +10,29 @@ class Parallels < Cask
 
   uninstall_preflight do
     # Need to change the ownership so that we can do the uninstall.  Running Parallels Desktop changes owner to root
+    # TODO: this should be moved to the core (see issue #6699)
     ohai "To uninstall Parallels Desktop 10, we need to change permissions, your password may be required."
-    system '/usr/bin/sudo', '-E', '--', 'chown', '-R', "#{ENV['USER']}", destination_path.join("Parallels Desktop.app")
+    system '/usr/bin/sudo', '-E', '--', 
+           '/usr/sbin/chown', '-R', Etc.getpwuid(Process.euid).name, destination_path.join("Parallels Desktop.app")
   end
-  uninstall_postflight do
-    # Need to remove these files that get symlinked into /usr/bin
-    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prl_convert'
-    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prl_disk_tool'
-    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prl_perf_ctl'
-    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prlctl'
-    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prlsrvctl'
-  end
+  
+  uninstall :delete => [ 
+                         '/usr/bin/prl_convert', 
+                         '/usr/bin/prl_disk_tool', 
+                         '/usr/bin/prl_perf_ctl',
+                         '/usr/bin/prlctl',
+                         '/usr/bin/prlsrvctl',
+                       ]
+  zap       :delete => [
+                         '~/.parallels_settings',
+                         '~/Library/Caches/com.parallels.desktop.console',
+                         '~/Library/Preferences/com.parallels.desktop.console.LSSharedFileList.plist',
+                         '~/Library/Preferences/com.parallels.desktop.console.plist',
+                         '~/Library/Preferences/com.parallels.Parallels Desktop Statistics.plist',
+                         '~/Library/Preferences/com.parallels.Parallels Desktop.plist',
+                         '~/Library/Preferences/com.parallels.Parallels.plist',
+                        ]
+  
   
   caveats <<-EOS.undent
     The first time you run Parallels Desktop, you will need to enter your

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -1,20 +1,31 @@
 class Parallels < Cask
-  version '9.0.24237.1028877'
-  sha256 'da71645ff1f0076ab5b2f8fa5eefb63bcd921e5f52161fd4dd85e6fb19ae2c57'
+  version '10.0.2-27712'
+  sha256 'be7f850b1bbe813c16521ff784d85d46fc01ebbb40b8e02352e38e2add704591'
 
-  url "http://download.parallels.com/desktop/v9/update2.hotfix2/ParallelsDesktop-#{version}.dmg"
+  url "http://download.parallels.com/desktop/v10/updates/#{version.gsub(/-.*$/, '')}/ParallelsDesktop-#{version}.dmg"
   homepage 'http://www.parallels.com/products/desktop/'
   license :commercial
 
-  pkg 'Install.mpkg'
+  app 'Parallels Desktop.app'
 
-  uninstall :pkgutil => 'com.parallels.pkg.virtualization.bundle',
-            :kext    => [
-                         'com.parallels.kext.usbconnect',
-                         'com.parallels.kext.hypervisor',
-                         'com.parallels.kext.hidhook',
-                         'com.parallels.kext.netbridge',
-                         'com.parallels.kext.vnic',
-                        ]
-  zap       :delete  => '~/.parallels_settings'
+  uninstall_preflight do
+    # Need to change the ownership so that we can do the uninstall.  Running Parallels Desktop changes owner to root
+    ohai "To uninstall Parallels Desktop 10, we need to change permissions, your password may be required."
+    system '/usr/bin/sudo', '-E', '--', 'chown', '-R', "#{ENV['USER']}", destination_path.join("Parallels Desktop.app")
+  end
+  uninstall_postflight do
+    # Need to remove these files that get symlinked into /usr/bin
+    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prl_convert'
+    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prl_disk_tool'
+    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prl_perf_ctl'
+    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prlctl'
+    system '/usr/bin/sudo', '-E', '--', 'rm', '-f', '/usr/bin/prlsrvctl'
+  end
+  
+  caveats <<-EOS.undent
+    The first time you run Parallels Desktop, you will need to enter your
+    password in order to complete the installation.
+    
+    EOS
+  
 end


### PR DESCRIPTION
Now that parallels9 exists in caskroom/homebrew-versions, it is possible to update parallels to install version 10 instead.  This cask handles the new way of installing Parallels Desktop 10.
