### PR TITLE
Update GnuCash to 2.6.4-5

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 class Gnucash < Cask
-  version '2.6.4-4'
-  sha256 'd80385c30f7e647b6f8af711cf9f34cd1de8c7dc49794f94d15aa63d82cefc56'
+  version '2.6.4-5'
+  sha256 '8c9701cbc6acf191b682d80c5e2eedd5dc4099ccaacacef3f89cecd967ca8651'
 
   url "https://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-#{version}.dmg"
   homepage 'http://www.gnucash.org'


### PR DESCRIPTION
The GnuCash development team is pleased to announce that we've fixed bug Bug 738375 - Cannot start aqbanking Wizard, which was due to a Mac-only bug in a dependent library.
