### PR TITLE
Upgrade Cloak to v2.0.8

### DIFF
--- a/Casks/cloak.rb
+++ b/Casks/cloak.rb
@@ -1,6 +1,6 @@
 class Cloak < Cask
-  version '2.0.7'
-  sha256 '109b0d60d01fa2cf978bdf94e4108901816f689da95604c86ac7c520fda6fc92'
+  version '2.0.8'
+  sha256 '7c26d9d835b8d6d190581ac2fb3720d305e280cce916e0cbaba27c941ad66c01'
 
   url "https://s3.amazonaws.com/static.getcloak.com/osx/updates/Release/Cloak-#{version}.dmg"
   homepage 'https://www.getcloak.com'


### PR DESCRIPTION
Cloak v2.0.8 released 2014-10-16.
