### PR TITLE
update Adobe Air checksum

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,6 +1,6 @@
 class AdobeAir < Cask
   version '15.0'
-  sha256 '07f7ae83b9d9005c830ce7592d651c378e235a20f62da692410035a703af20c7'
+  sha256 'd0b82ca3c266034b9bc3029e3bb2e69e1a242af5012e6eebafb68cc489609f2d'
 
   url "http://airdownload.adobe.com/air/mac/download/#{version}/AdobeAIR.dmg"
   homepage 'https://get.adobe.com/air/'


### PR DESCRIPTION
upstream seems to have changed the binary in-place
