### PR TITLE
recast method `destination_path` as `staged_path`

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -205,8 +205,8 @@ position at the end of the Cask:
 | `title`            | the Cask title
 | `version`          | the Cask version
 | `homepage`         | the Cask homepage
-| `caskroom_path`    | eg `/opt/homebrew-cask/Caskroom`
-| `destination_path` | the staging location for this Cask, including version number, *eg* `/opt/homebrew-cask/Caskroom/adium/1.5.10`
+| `caskroom_path`    | the containing directory for all staged Casks, typically `/opt/homebrew-cask/Caskroom`
+| `staged_path`      | the staged location for this Cask, including version number, *eg* `/opt/homebrew-cask/Caskroom/adium/1.5.10`
 
 Example:
 

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -150,9 +150,14 @@ class Cask
     self.class.caskroom.join(title)
   end
 
-  def destination_path
+  def staged_path
     cask_version = version ? version : :unknown
     caskroom_path.join(cask_version.to_s)
+  end
+
+  # todo transitional method, removeme after DSL 1.0
+  def destination_path
+    staged_path
   end
 
   def metadata_master_container_path
@@ -201,7 +206,7 @@ class Cask
   end
 
   def installed?
-    destination_path.exist?
+    staged_path.exist?
   end
 
   def to_s

--- a/lib/cask/artifact/installer.rb
+++ b/lib/cask/artifact/installer.rb
@@ -17,7 +17,7 @@ class Cask::Artifact::Installer < Cask::Artifact::Base
           To complete the installation of Cask #{@cask}, you must also
           run the installer at
 
-            '#{@cask.destination_path.join(artifact.manual)}'
+            '#{@cask.staged_path.join(artifact.manual)}'
 
         EOS
       else
@@ -29,7 +29,7 @@ class Cask::Artifact::Installer < Cask::Artifact::Base
                                                                         )
         ohai "Running #{self.class.artifact_dsl_key} script #{executable}"
         raise CaskInvalidError.new(@cask, "#{self.class.artifact_dsl_key} missing executable") if executable.nil?
-        @command.run(@cask.destination_path.join(executable), script_arguments)
+        @command.run(@cask.staged_path.join(executable), script_arguments)
       end
     end
   end

--- a/lib/cask/artifact/nested_container.rb
+++ b/lib/cask/artifact/nested_container.rb
@@ -8,7 +8,7 @@ class Cask::Artifact::NestedContainer < Cask::Artifact::Base
   end
 
   def extract(container_relative_path)
-    source = @cask.destination_path.join(container_relative_path)
+    source = @cask.staged_path.join(container_relative_path)
     container = Cask::Container.for_path(source, @command)
     unless container
       raise CaskError.new "Aw dang, could not identify nested container at '#{source}'"

--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -38,7 +38,7 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
     load_pkg_description pkg_description
     ohai "Running installer for #{@cask}; your password may be necessary."
     ohai "Package installers may write to any location; options such as --appdir are ignored."
-    source = @cask.destination_path.join(pkg_relative_path)
+    source = @cask.staged_path.join(pkg_relative_path)
     unless source.exist?
       raise CaskError.new "pkg source file not found: '#{source}'"
     end

--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -47,7 +47,7 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
   def load_specification(artifact_spec)
     source_string, target_hash = artifact_spec
     raise CaskInvalidError if source_string.nil?
-    @source = @cask.destination_path.join(source_string)
+    @source = @cask.staged_path.join(source_string)
     if target_hash
       raise CaskInvalidError unless target_hash.respond_to?(:keys)
       target_hash.assert_valid_keys(:target)

--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -198,7 +198,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
 
       ohai "Running uninstall script #{executable}"
       raise CaskInvalidError.new(@cask, "#{stanza} :early_script without :executable") if executable.nil?
-      @command.run(@cask.destination_path.join(executable), script_arguments)
+      @command.run(@cask.staged_path.join(executable), script_arguments)
       sleep 1
     end
 
@@ -274,7 +274,7 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
                                                                       {:sudo => true, :print_stdout => true},
                                                                       :script)
       raise CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
-      @command.run(@cask.destination_path.join(executable), script_arguments)
+      @command.run(@cask.staged_path.join(executable), script_arguments)
       sleep 1
     end
 

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -32,8 +32,13 @@ class Cask::CaveatsDSL
     @cask.class.caskroom.join(title)
   end
 
-  def destination_path
+  def staged_path
     caskroom_path.join(@cask.version.to_s)
+  end
+
+  # todo transitional method, removeme after DSL 1.0
+  def destination_path
+    staged_path
   end
 
   # DSL. Each method should handle output, following the convention of
@@ -50,7 +55,7 @@ class Cask::CaveatsDSL
     To complete the installation of Cask #{@cask}, you must also
     run the installer at
 
-      '#{destination_path.join(path)}'
+      '#{staged_path.join(path)}'
 
     EOS
   end

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -16,7 +16,7 @@ class Cask::CLI::Info < Cask::CLI::Base
 
   def self.info(cask)
     installation = if cask.installed?
-                     "#{cask.destination_path} (#{cask.destination_path.cabv})"
+                     "#{cask.staged_path} (#{cask.staged_path.cabv})"
                    else
                      "Not installed"
                    end

--- a/lib/cask/container/air.rb
+++ b/lib/cask/container/air.rb
@@ -26,6 +26,6 @@ class Cask::Container::Air < Cask::Container::Base
 
   def extract
     @command.run!(self.class.installer_cmd,
-                  :args => ['-silent', '-location', @cask.destination_path, Pathname.new(@path).realpath])
+                  :args => ['-silent', '-location', @cask.staged_path, Pathname.new(@path).realpath])
   end
 end

--- a/lib/cask/container/bzip2.rb
+++ b/lib/cask/container/bzip2.rb
@@ -6,10 +6,10 @@ class Cask::Container::Bzip2 < Cask::Container::Base
   end
 
   def extract
-    Dir.mktmpdir do |staging_dir|
-      @command.run!('/usr/bin/ditto',   :args => ['--', @path, staging_dir])
-      @command.run!('/usr/bin/bunzip2', :args => ['-q', '--', Pathname(staging_dir).join(@path.basename)])
-      @command.run!('/usr/bin/ditto',   :args => ['--', staging_dir, @cask.destination_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!('/usr/bin/ditto',   :args => ['--', @path, unpack_dir])
+      @command.run!('/usr/bin/bunzip2', :args => ['-q', '--', Pathname(unpack_dir).join(@path.basename)])
+      @command.run!('/usr/bin/ditto',   :args => ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/cask/container/cab.rb
+++ b/lib/cask/container/cab.rb
@@ -13,9 +13,9 @@ class Cask::Container::Cab < Cask::Container::Base
     if ! Pathname.new(cabextract).exist?
       raise CaskError.new "Expected to find cabextract executable. Cask '#{@cask}' must add: depends_on :formula => 'cabextract'"
     end
-    Dir.mktmpdir do |staging_dir|
-      @command.run!(cabextract, :args => ['-d', staging_dir, '--', @path])
-      @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!(cabextract, :args => ['-d', unpack_dir, '--', @path])
+      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -24,7 +24,7 @@ class Cask::Container::Dmg < Cask::Container::Base
                    # - or support some type of text filter to be passed to
                    #   :print_stderr instead of true/false
                    :print_stderr => false,
-                   :args => ['--', mount, @cask.destination_path])
+                   :args => ['--', mount, @cask.staged_path])
     end
   ensure
     eject!

--- a/lib/cask/container/generic_unar.rb
+++ b/lib/cask/container/generic_unar.rb
@@ -11,9 +11,9 @@ class Cask::Container::GenericUnar < Cask::Container::Base
     if ! Pathname.new(unar).exist?
       raise CaskError.new "Expected to find unar executable. Cask #{@cask} must add: depends_on :formula => 'unar'"
     end
-    Dir.mktmpdir do |staging_dir|
-      @command.run!(unar, :args => ['-q', '-D', '-o', staging_dir, '--', @path])
-      @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!(unar, :args => ['-q', '-D', '-o', unpack_dir, '--', @path])
+      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/cask/container/gzip.rb
+++ b/lib/cask/container/gzip.rb
@@ -9,10 +9,10 @@ class Cask::Container::Gzip < Cask::Container::Base
   end
 
   def extract
-    Dir.mktmpdir do |staging_dir|
-      @command.run!('/usr/bin/ditto',  :args => ['--', @path, staging_dir])
-      @command.run!('/usr/bin/gunzip', :args => ['-q', '--', Pathname(staging_dir).join(@path.basename)])
-      @command.run!('/usr/bin/ditto',  :args => ['--', staging_dir, @cask.destination_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!('/usr/bin/ditto',  :args => ['--', @path, unpack_dir])
+      @command.run!('/usr/bin/gunzip', :args => ['-q', '--', Pathname(unpack_dir).join(@path.basename)])
+      @command.run!('/usr/bin/ditto',  :args => ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/cask/container/naked.rb
+++ b/lib/cask/container/naked.rb
@@ -7,7 +7,7 @@ class Cask::Container::Naked < Cask::Container::Base
   end
 
   def extract
-    @command.run!('/usr/bin/ditto', :args => ['--', @path, @cask.destination_path.join(target_file)])
+    @command.run!('/usr/bin/ditto', :args => ['--', @path, @cask.staged_path.join(target_file)])
   end
 
   def target_file

--- a/lib/cask/container/tar.rb
+++ b/lib/cask/container/tar.rb
@@ -6,9 +6,9 @@ class Cask::Container::Tar < Cask::Container::Base
   end
 
   def extract
-    Dir.mktmpdir do |staging_dir|
-      @command.run!('/usr/bin/tar', :args => ['xf', @path, '-C', staging_dir])
-      @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!('/usr/bin/tar', :args => ['xf', @path, '-C', unpack_dir])
+      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/cask/container/xar.rb
+++ b/lib/cask/container/xar.rb
@@ -6,9 +6,9 @@ class Cask::Container::Xar < Cask::Container::Base
   end
 
   def extract
-    Dir.mktmpdir do |staging_dir|
-      @command.run!('/usr/bin/xar', :args => ['-xf', @path, '-C', staging_dir])
-      @command.run!('/usr/bin/ditto', :args => ['--', staging_dir, @cask.destination_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!('/usr/bin/xar', :args => ['-xf', @path, '-C', unpack_dir])
+      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/cask/container/zip.rb
+++ b/lib/cask/container/zip.rb
@@ -4,6 +4,6 @@ class Cask::Container::Zip < Cask::Container::Base
   end
 
   def extract
-    @command.run!('/usr/bin/ditto', :args => ['-xk', '--', @path, @cask.destination_path])
+    @command.run!('/usr/bin/ditto', :args => ['-xk', '--', @path, @cask.staged_path])
   end
 end

--- a/lib/cask/dsl/base.rb
+++ b/lib/cask/dsl/base.rb
@@ -20,7 +20,12 @@ class Cask::DSL::Base
     @cask.class.caskroom.join(title)
   end
 
-  def destination_path
+  def staged_path
     caskroom_path.join(@cask.version.to_s)
+  end
+
+  # todo transitional method, removeme after DSL 1.0
+  def destination_path
+    staged_path
   end
 end

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -63,7 +63,7 @@ class Cask::Installer
     else
       "#{Tty.blue}==>#{Tty.white} Success!#{Tty.reset} "
     end
-    s << "#{@cask} installed to '#{@cask.destination_path}' (#{@cask.destination_path.cabv})"
+    s << "#{@cask} installed to '#{@cask.staged_path}' (#{@cask.staged_path.cabv})"
   end
 
   def download
@@ -76,7 +76,7 @@ class Cask::Installer
 
   def extract_primary_container
     odebug "Extracting primary container"
-    FileUtils.mkdir_p @cask.destination_path
+    FileUtils.mkdir_p @cask.staged_path
     container = if @cask.container_type
        Cask::Container.from_type(@cask.container_type)
     else
@@ -172,7 +172,7 @@ class Cask::Installer
     odebug "Purging files for version #{@cask.version} of Cask #{@cask}"
 
     # versioned staged distribution
-    permissions_rmtree(@cask.destination_path)
+    permissions_rmtree(@cask.staged_path)
 
     # Homebrew-cask metadata
     if @cask.metadata_versioned_container_path.respond_to?(:children) and

--- a/lib/cask/pretty_listing.rb
+++ b/lib/cask/pretty_listing.rb
@@ -7,6 +7,6 @@ class Cask::PrettyListing
   end
 
   def print
-    ::PrettyListing.new(cask.destination_path)
+    ::PrettyListing.new(cask.staged_path)
   end
 end

--- a/lib/cask/staged.rb
+++ b/lib/cask/staged.rb
@@ -1,6 +1,6 @@
 module Cask::Staged
   def info_plist
-    "#{destination_path}/#{@cask.artifacts[:link].first.first}/Contents/Info.plist"
+    "#{staged_path}/#{@cask.artifacts[:link].first.first}/Contents/Info.plist"
   end
 
   def plist_exec(cmd)

--- a/lib/cask/without_source.rb
+++ b/lib/cask/without_source.rb
@@ -1,6 +1,11 @@
 class Cask::WithoutSource < Cask
-  def destination_path
+  def staged_path
     caskroom_path.children.first
+  end
+
+  # todo transitional method, removeme after DSL 1.0
+  def destination_path
+    staged_path
   end
 
   def to_s

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -47,8 +47,8 @@ describe Cask::Artifact::App do
           TestHelper.install_without_artifacts(cask)
         end
 
-        appsubdir = (subdir_cask.destination_path/'subdir').tap(&:mkpath)
-        FileUtils.mv((subdir_cask.destination_path/'Caffeine.app'), appsubdir)
+        appsubdir = (subdir_cask.staged_path/'subdir').tap(&:mkpath)
+        FileUtils.mv((subdir_cask.staged_path/'Caffeine.app'), appsubdir)
 
         shutup do
           Cask::Artifact::App.new(subdir_cask).install_phase
@@ -67,7 +67,7 @@ describe Cask::Artifact::App do
     it "only uses linkables when they are specified" do
       cask = local_alt_caffeine
 
-      app_path = cask.destination_path.join('Caffeine.app')
+      app_path = cask.staged_path.join('Caffeine.app')
       FileUtils.cp_r app_path, app_path.sub('Caffeine.app', 'CaffeineAgain.app')
 
       shutup do

--- a/test/cask/artifact/app_test.rb
+++ b/test/cask/artifact/app_test.rb
@@ -33,8 +33,8 @@ describe Cask::Artifact::App do
           TestHelper.install_without_artifacts(cask)
         end
 
-        appsubdir = (subdir_cask.destination_path/'subdir').tap(&:mkpath)
-        FileUtils.mv((subdir_cask.destination_path/'Caffeine.app'), appsubdir)
+        appsubdir = (subdir_cask.staged_path/'subdir').tap(&:mkpath)
+        FileUtils.mv((subdir_cask.staged_path/'Caffeine.app'), appsubdir)
 
         shutup do
           Cask::Artifact::App.new(subdir_cask).install_phase
@@ -53,7 +53,7 @@ describe Cask::Artifact::App do
     it "only uses linkables when they are specified" do
       cask = local_caffeine
 
-      app_path = cask.destination_path.join('Caffeine.app')
+      app_path = cask.staged_path.join('Caffeine.app')
       FileUtils.cp_r app_path, app_path.sub('Caffeine.app', 'CaffeineAgain.app')
 
       shutup do

--- a/test/cask/artifact/nested_container_test.rb
+++ b/test/cask/artifact/nested_container_test.rb
@@ -11,7 +11,7 @@ describe Cask::Artifact::NestedContainer do
         Cask::Artifact::NestedContainer.new(cask).install_phase
       end
 
-      cask.destination_path.join('MyNestedApp.app').must_be :directory?
+      cask.staged_path.join('MyNestedApp.app').must_be :directory?
     end
   end
 end

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -12,7 +12,7 @@ describe Cask::Artifact::Pkg do
     it 'runs the system installer on the specified pkgs' do
       pkg = Cask::Artifact::Pkg.new(@cask, Cask::FakeSystemCommand)
 
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/installer', '-pkg', @cask.destination_path/'MyFancyPkg'/'Fancy.pkg', '-target', '/'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/installer', '-pkg', @cask.staged_path/'MyFancyPkg'/'Fancy.pkg', '-target', '/'])
 
       shutup do
         pkg.install_phase

--- a/test/cask/artifact/two_apps_correct_test.rb
+++ b/test/cask/artifact/two_apps_correct_test.rb
@@ -35,8 +35,8 @@ describe Cask::Artifact::App do
           TestHelper.install_without_artifacts(cask)
         end
 
-        appsubdir = (subdir_cask.destination_path/'subdir').tap(&:mkpath)
-        FileUtils.mv((subdir_cask.destination_path/'Caffeine.app'), appsubdir)
+        appsubdir = (subdir_cask.staged_path/'subdir').tap(&:mkpath)
+        FileUtils.mv((subdir_cask.staged_path/'Caffeine.app'), appsubdir)
 
         shutup do
           Cask::Artifact::App.new(subdir_cask).install_phase
@@ -57,7 +57,7 @@ describe Cask::Artifact::App do
     # it "only uses linkables when they are specified" do
     #   cask = local_two_apps_caffeine
     #
-    #   app_path = cask.destination_path.join('Caffeine.app')
+    #   app_path = cask.staged_path.join('Caffeine.app')
     #   FileUtils.cp_r app_path, app_path.sub('Caffeine.app', 'CaffeineAgain.app')
     #
     #   shutup do

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -34,7 +34,7 @@ describe Cask::Artifact::Uninstall do
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--', '/permissible/absolute/path'])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-f', '--', Pathname.new(TestHelper.local_binary_path('empty_directory')).join('.DS_Store')])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rmdir', '--', Pathname.new(TestHelper.local_binary_path('empty_directory'))])

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -37,7 +37,7 @@ describe Cask::Artifact::Zap do
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.destination_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
                                                Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])
 

--- a/test/cask/cli/list_test.rb
+++ b/test/cask/cli/list_test.rb
@@ -49,10 +49,10 @@ describe Cask::CLI::List do
     }.must_output <<-OUTPUT.gsub(/^ */, '')
       ==> App Symlinks managed by brew-cask:
       ==> Raw contents of Cask directory:
-      #{transmission.destination_path}/Transmission.app/Contents/ (489 files)
+      #{transmission.staged_path}/Transmission.app/Contents/ (489 files)
       ==> App Symlinks managed by brew-cask:
       ==> Raw contents of Cask directory:
-      #{caffeine.destination_path}/Caffeine.app/Contents/ (13 files)
+      #{caffeine.staged_path}/Caffeine.app/Contents/ (13 files)
     OUTPUT
   end
 end

--- a/test/cask/cli/zap_test.rb
+++ b/test/cask/cli/zap_test.rb
@@ -48,7 +48,7 @@ describe Cask::CLI::Zap do
   #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app.from.uninstall"'], '1')
   #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app.from.uninstall" to quit'])
   #
-  #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', with_zap.destination_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+  #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', with_zap.staged_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
   #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
   #                                             Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])
   #

--- a/test/cask/container/naked_test.rb
+++ b/test/cask/container/naked_test.rb
@@ -10,7 +10,7 @@ describe Cask::Container::Naked do
 
     cask                 = SpaceyCask.new
     path                 = '/tmp/downloads/kevin-spacey-1.2.pkg'
-    expected_destination = cask.destination_path.join('kevin spacey.pkg')
+    expected_destination = cask.staged_path.join('kevin spacey.pkg')
     expected_command     = ['/usr/bin/ditto', '--', path, expected_destination]
     Cask::FakeSystemCommand.stubs_command(expected_command)
 

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -190,7 +190,7 @@ describe Cask::Installer do
       with_installer_manual = Cask.load('with-installer-manual')
       TestHelper.must_output(self, lambda {
         Cask::Installer.new(with_installer_manual).install
-      }, /To complete the installation of Cask with-installer-manual, you must also\nrun the installer at\n\n  '#{with_installer_manual.destination_path.join(%Q{Caffeine.app})}'/)
+      }, /To complete the installation of Cask with-installer-manual, you must also\nrun the installer at\n\n  '#{with_installer_manual.staged_path.join(%Q{Caffeine.app})}'/)
       with_installer_manual.must_be :installed?
     end
 
@@ -199,7 +199,7 @@ describe Cask::Installer do
       shutup do
         Cask::Installer.new(with_macosx_dir).install
       end
-      with_macosx_dir.destination_path.join('__MACOSX').wont_be :directory?
+      with_macosx_dir.staged_path.join('__MACOSX').wont_be :directory?
     end
 
     # unlike the CLI, the internal interface throws exception on double-install


### PR DESCRIPTION
- part of DSL 1.0 review
- `destination_path` was always a bit vague (it refers to the Cask-specific, version-specific location under  `/opt/homebrew-cask/Caskroom`)
- here renamed `staged_path` to match upcoming command verb `brew cask stage`
- rename also intended to reduce confusion when we implement copying as a configurable alternative to symlinking
- transitional `destination_path` methods to remain while Casks are converted (this was documented as a part of the DSL, and used by 39 Casks in main repo)
- unrelated variables containing "stage" recast for clarity
