### PR TITLE
update cockatrice.rb

### DIFF
--- a/Casks/cockatrice.rb
+++ b/Casks/cockatrice.rb
@@ -1,11 +1,11 @@
 class Cockatrice < Cask
-  version '0.20120624-14-g7938171'
-  sha256 '7549af19fba0c5a634f4c9f732201c143bbf237aa4ad2a790a1709043b93fb7a'
+  version :latest
+  sha256 :no_check
 
-  url 'http://www.woogerworks.com/files/cockatrice_weeklybuilds/Cockatrice-osx_git-59b8d70.dmg'
+  url 'http://www.woogerworks.com/files/cockatrice_weeklybuilds/Cockatrice-MacClient.dmg'
   homepage 'http://www.woogerworks.com/'
-  license :unknown
+  license :gpl
 
-  app 'cockatrice.app', :target => 'Cockatrice.app'
-  app 'oracle.app', :target => 'Oracle.app'
+  app 'cockatrice.app'
+  app 'oracle.app'
 end


### PR DESCRIPTION
- update URL and switch to `:latest` version scheme
- more specific license
- remove `:target` used to change case, per #6375

This is a weekly build.  Perhaps it belongs in the versions
repo with nightlies.
