### PR TITLE
Upgrade Mapbox Studio to v0.1.5

### DIFF
--- a/Casks/mapbox-studio.rb
+++ b/Casks/mapbox-studio.rb
@@ -1,10 +1,10 @@
 class MapboxStudio < Cask
-  version '0.1.0'
-  sha256 'c36455cfa938c957cb08acd04281a5104702ab3b6ba0c76ae38bb6a55910296d'
+  version '0.1.5'
+  sha256 '5da396ebd7bde39d211d0edf2de1b27bfe974c33e7edd0c27966053df6055ab0'
 
   url "https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-v#{version}.zip"
   homepage 'https://www.mapbox.com/mapbox-studio/'
-  license :unknown
+  license :bsd
 
   app "mapbox-studio-darwin-x64-v#{version}/Mapbox Studio.app"
 end


### PR DESCRIPTION
The latest version addresses bugs
related to atom-shell integration.

For a full list of changes, see
https://github.com/mapbox/mapbox-studio/blob/mb-pages/CHANGELOG.md#changelog
