### PR TITLE
Update Bit Slicer to 1.7.4

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,10 +1,10 @@
 class BitSlicer < Cask
-  version '1.7.3'
-  sha256 'be8e7638ef29b2fe85f4dc8d237176887c7de86debdb514ef4160d73597d99e7'
+  version '1.7.4'
+  sha256 '02766dcb88e21b39b78c91718eff5547904ad121e55b89b5bc11846a0c7e6ed4'
 
   url "https://bitbucket.org/zorgiepoo/bit-slicer/downloads/Bit%20Slicer%20#{version}.zip"
   appcast 'http://zorg.tejat.net/bitslicer/update.php',
-          :sha256 => '89a252d7d8606a2a1929562fe9060999088729a6c602c8742515c2877bf9b29d'
+          :sha256 => '11d0afe33a4cbf65a8df4c4d323b150853a62b0cbfe77d36dc70b5113aeca631'
   homepage 'https://github.com/zorgiepoo/bit-slicer/'
   license :oss
 


### PR DESCRIPTION
I assumed the sha256 for the app cast was for the appcast.xml file.
