### PR TITLE
Upgrade Cloud Foundry CLI to 6.6.1

### DIFF
--- a/Casks/cloudfoundry-cli.rb
+++ b/Casks/cloudfoundry-cli.rb
@@ -1,6 +1,6 @@
 class CloudfoundryCli < Cask
-  version '6.2.0'
-  sha256 'c804b4245a194a1028b5ac2fe074755d18a8aa2eb37bfc9978a5a4e47e9e644d'
+  version '6.6.1'
+  sha256 '1a159944a447b4b321513cadd8c009477dc084ce22b6bfd2e5e20382d98bb5e5'
 
   url "http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v#{version}/installer-osx-amd64.pkg"
   homepage 'https://github.com/cloudfoundry/cli'


### PR DESCRIPTION
Latest is 6.6.2, but its package is broken (see
https://github.com/cloudfoundry/cli/issues/274),
so we're going with 6.6.1.
