### PR TITLE
Downgrade CaskAlreadyInstalledError to a warning

### DIFF
--- a/lib/cask/cli/install.rb
+++ b/lib/cask/cli/install.rb
@@ -19,12 +19,9 @@ class Cask::CLI::Install < Cask::CLI::Base
         cask = Cask.load(cask_name)
         Cask::Installer.new(cask).install(force)
         count += 1
-      rescue CaskAlreadyInstalledError => e
-        # todo: downgrade this message from Error to Warning
-        #       possibly get rid of the CaskAlreadyInstalledError exception
-        #       and simply test cask.installed? in this loop
-        onoe e.message
-        count += 1
+       rescue CaskAlreadyInstalledError => e
+         opoo e.message
+         count += 1
       rescue CaskUnavailableError => e
         warn_unavailable_with_suggestion cask_name, e
       end

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -22,6 +22,16 @@ describe Cask::CLI::Install do
     Cask.load('local-transmission').must_be :installed?
   end
 
+  it "prints a warning message on double install" do
+    shutup do
+      Cask::CLI::Install.run('local-transmission')
+    end
+
+    TestHelper.must_output(self, lambda {
+      Cask::CLI::Install.run('local-transmission', '')
+    }, %r{Warning: A Cask for local-transmission is already installed. Add the "--force" option to force re-install.})
+  end
+
   it "allows double install with --force" do
     shutup do
       Cask::CLI::Install.run('local-transmission')


### PR DESCRIPTION
Automatic installs - like thoughtbot's laptop script - fail when we
use Homebrew's onoe method.  Using opoo (to warn) will let the
scripts complete successfully when they try to install packages that
have already been installed.

Test for downgrading AlreadyInstalledError to warning

Output of unit tests:

```
Finished in 79.407864s, 36.8603 runs/s, 79.6269 assertions/s.

2927 runs, 6323 assertions, 0 failures, 0 errors, 181 skips
```

Output of rspec:

```
Finished in 0.19466 seconds (files took 0.48031 seconds to load)
32 examples, 0 failures

Randomized with seed 17284
```
