### PR TITLE
Update whatsize.app to v6.

### DIFF
--- a/Casks/whatsize.rb
+++ b/Casks/whatsize.rb
@@ -2,7 +2,7 @@ class Whatsize < Cask
   version :latest
   sha256 :no_check
 
-  url 'http://whatsizemac.com/software/whatsize/whatsize.dmg'
+  url 'http://www.whatsizemac.com/software/whatsize6/whatsize.dmg'
   appcast 'http://www.id-design.com/software/whatsize/release/notes.xml'
   homepage 'http://whatsizemac.com/'
   license :unknown


### PR DESCRIPTION
Whatsize.app has jumped to a new major version. This is a paid upgrade from previous versions.
