### PR TITLE
use "staged" instead of "installed" for Caskroom files in messages

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -78,7 +78,7 @@ more information.
 ## Other Commands
 
 * `info` -- displays information about the given Cask
-* `list` -- with no args, lists installed Casks; given installed Casks, lists installed files
+* `list` -- with no args, lists installed Casks; given installed Casks, lists staged files
 * `fetch` -- downloads Cask resources to local cache (with `--force`, re-download even if already cached)
 * `doctor` -- checks for configuration issues
 * `cleanup` -- cleans up cached downloads (with `--outdated`, only cleans old downloads)

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -85,7 +85,7 @@ names, and other aspects of this manual are still subject to change.
     format the output in a single column.  With `-l`, give a more detailed
     listing.
 
-    If <Casks> are given, list the installed files for <Casks>.
+    If <Casks> are given, list the staged files for <Casks>.
 
   * `uninstall [--force]` or `rm` or `remove` <Cask>:
     Uninstall <Cask>.  With `--force`, uninstall even if the Cask does

--- a/lib/cask/cli/list.rb
+++ b/lib/cask/cli/list.rb
@@ -62,6 +62,6 @@ class Cask::CLI::List < Cask::CLI::Base
   end
 
   def self.help
-    "with no args, lists installed Casks; given installed Casks, lists installed files"
+    "with no args, lists installed Casks; given installed Casks, lists staged files"
   end
 end

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -63,7 +63,7 @@ class Cask::Installer
     else
       "#{Tty.blue}==>#{Tty.white} Success!#{Tty.reset} "
     end
-    s << "#{@cask} installed to '#{@cask.staged_path}' (#{@cask.staged_path.cabv})"
+    s << "#{@cask} staged at '#{@cask.staged_path}' (#{@cask.staged_path.cabv})"
   end
 
   def download

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -29,7 +29,7 @@ describe Cask::CLI::Install do
 
     TestHelper.must_output(self, lambda {
       Cask::CLI::Install.run('local-transmission', '--force')
-    }, %r{==> Success! local-transmission installed to '#{Cask.caskroom}/local-transmission/2.61' \(487 files, 11M\)})
+    }, %r{==> Success! local-transmission staged at '#{Cask.caskroom}/local-transmission/2.61' \(487 files, 11M\)})
   end
 
   it "properly handles Casks that are not present" do


### PR DESCRIPTION
Following up on #6783.  This is imperfect and far from complete, as the "installed" terminology is used extensively in source, comments, messages, and documentation.

The intention is to clarify that there are two phases to `install`: staging and activation.
- Staging is the copying of the distribution to the Caskroom.  Clarifying the docs is a step toward exposing a separate `brew cask stage` verb.
- Activation is the creation of symlinks against the staged distribution.  Here we have an interest in clarifying the docs so that future versions can use copying, hardlinking, or symlinking for the activation phase.  A side benefit of exposing a `brew cask activate` verb would be enabling certain multi-user scenarios.

Homebrew uses `brew link` for the activation phase.  Since we specifically would like to support methods other than linking, we must diverge from the Homebrew interface and use a verb other than `link`.

Exposing these new verbs does not mean that `brew cask install` would need to change; `install` would continue to invoke all needed phases, up to and including "activation".
