### PR TITLE
Update cocktail to 8.0 (Yosemite edition)

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -2,8 +2,8 @@ class Cocktail < Cask
   version :latest
   sha256 :no_check
 
-  url 'http://usa.maintain.se/CocktailME.dmg'
-  appcast 'http://www.maintain.se/downloads/sparkle/mavericks/mavericks.xml'
+  url 'http://usa.maintain.se/CocktailYE.dmg'
+  appcast 'http://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml'
   homepage 'http://maintain.se/cocktail'
   license :unknown
 
@@ -11,8 +11,8 @@ class Cocktail < Cask
 
   # todo replace this with a conditional
   caveats <<-EOS.undent
-    This version of Cocktail is for OS X Mavericks only. If you are using other versions of
+    This version of Cocktail is for OS X Yosemite only. If you are using other versions of
     OS X, please run 'brew tap caskroom/versions' and install cocktail-mountainlion /
-    cocktail-lion / cocktail-snowleopard
+    cocktail-lion / cocktail-snowleopard / cocktail-mavericks
   EOS
 end


### PR DESCRIPTION
Update Cocktail from Mavericks (v7.6.1) to Yosemite (v8.0) edition. Will also add a Mavericks cask to versions repository.
