### PR TITLE
add binary in Skim.app Cask

### DIFF
--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -9,5 +9,8 @@ class Skim < Cask
   license :oss
 
   app 'Skim.app'
+  binary 'Skim.app/Contents/SharedSupport/displayline'
+  binary 'Skim.app/Contents/SharedSupport/skimnotes'
+  binary 'Skim.app/Contents/SharedSupport/skimpdf'
   zap :delete => '~/Library/Preferences/net.sourceforge.skim-app.skim.plist'
 end


### PR DESCRIPTION
Skim has three shared command line tools, displayline, skimnotes and
skimpdf. Other applications may need these binaries to interact with
Skim, for features like TeX-PDF Synchronization etc.
