### PR TITLE
zap stanza for onepassword

### DIFF
--- a/Casks/onepassword.rb
+++ b/Casks/onepassword.rb
@@ -13,4 +13,11 @@ class Onepassword < Cask
   url "http://i.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   homepage 'https://agilebits.com/onepassword'
   license :commercial
+
+  zap :delete => [
+                  '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',
+                  '~/Library/Containers/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',
+                  '~/Library/Containers/com.agilebits.onepassword-osx',
+                  '~/Library/Group Containers/2BUA8C4S2C.com.agilebits',
+                 ]
 end


### PR DESCRIPTION
I have 1password installed via the App Store.

Could someone who uses 1password installed via Homebrew-cask please review this zap stanza? I suppose the container stuff may be specific to the App Store, and that the Homebrew-cask installation might use different locations.

In addition, (when using the App Store version) I haven't checked whether the UID "2BUA8C4S2C" is unique to the 1password app, or whether it might be specific to my user/machine.
