### PR TITLE
use `installer :script` in 3 Casks

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -6,17 +6,14 @@ class AdobeAir < Cask
   homepage 'https://get.adobe.com/air/'
   license :gratis
 
-  caskroom_only true
-
-  postflight do
-    system '/usr/bin/sudo', '-E', '--',
-      "#{destination_path}/Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer", '-silent'
-  end
+  installer :script => 'Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer',
+            :args   => %w[-silent],
+            :sudo   => true
 
   uninstall :script => {
-    :executable => 'Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer',
-    :args => %w[-uninstall]
-  }
+                        :executable => 'Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer',
+                        :args       => %w[-uninstall]
+                       }
   zap :delete => [
                   '~/Library/Application Support/Adobe/AIR',
                   '~/Library/Caches/com.adobe.air.ApplicationInstaller',

--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -6,10 +6,6 @@ class AmazonMusic < Cask
   homepage 'https://www.amazon.com/gp/feature.html/ref=dm_mo_cpw_fb_lm?docId=1001067901'
   license :unknown
 
-  caskroom_only true
-
-  postflight do
-    system '/usr/bin/sudo', '-E', '--',
-      "#{destination_path}/Amazon Music Installer.app/Contents/MacOS/osx-intel"
-  end
+  installer :script => 'Amazon Music Installer.app/Contents/MacOS/osx-intel',
+            :sudo   => true
 end

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -6,11 +6,11 @@ class PrivateInternetAccess < Cask
   homepage 'https://www.privateinternetaccess.com'
   license :unknown
 
+  installer :script => 'Private Internet Access Installer.app/Contents/MacOS/runner.sh'
+
   postflight do
-      system '/usr/bin/sudo', '-E', '--',
-          "#{destination_path}/Private Internet Access Installer.app/Contents/MacOS/runner.sh"
-      system '/usr/bin/sudo', '-E', '--',
-          '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", Pathname.new(File.expand_path('~')).join('.pia_manager')
+    system '/usr/bin/sudo', '-E', '--',
+           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", Pathname.new(File.expand_path('~')).join('.pia_manager')
   end
 
   uninstall :delete => '/Applications/Private Internet Access.app'


### PR DESCRIPTION
`installer` is a very late addition to the DSL because the form was changed from the original proposal (#6660, only available in the latest release 0.45.0).

However, `installer :script` is unlikely to be disruptive, as the change only touches 3 Casks, and the `method_missing` warning will be generated for anyone who tries to use these Casks without updating.

Part of the purpose here was to get rid of the old `caskroom_only`/`postflight` hack.  After this change, `caskroom_only` is used only once ([node-webkit.rb](https://github.com/caskroom/homebrew-cask/blob/c093d9df6abb1ebae4c999c56521142668665eba/Casks/node-webkit.rb#L9)).

Enforcing that `caskroom_only` may not be used in combination with other artifacts is still todo.
