### PR TITLE
use `installer :manual` in 21 Casks

### DIFF
--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -6,7 +6,5 @@ class AdobeCreativeCloud < Cask
   homepage 'https://creative.adobe.com/products/creative-cloud'
   license :commercial
 
-  caveats do
-    manual_installer 'Creative Cloud Installer.app'
-  end
+  installer :manual => 'Creative Cloud Installer.app'
 end

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -6,7 +6,5 @@ class Backblaze < Cask
   homepage 'https://www.backblaze.com/'
   license :commercial
 
-  caveats do
-    manual_installer 'Backblaze Installer.app'
-  end
+  installer :manual => 'Backblaze Installer.app'
 end

--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -7,10 +7,8 @@ class Baiduinput < Cask
   homepage 'http://wuxian.baidu.com/input/mac.html'
   license :gratis
 
+  installer :manual => '安装百度输入法.app'
+
   uninstall :pkgutil  => 'com.baidu.inputmethod.*',
             :delete   => '/Library/Input Methods/BaiduIM.app'
-
-  caveats do
-    manual_installer '安装百度输入法.app'
-  end
 end

--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -6,7 +6,5 @@ class Dbvisualizer < Cask
   homepage 'http://www.dbvis.com/'
   license :commercial
 
-  caveats do
-    manual_installer('DbVisualizer Installer.app')
-  end
+  installer :manual => 'DbVisualizer Installer.app'
 end

--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -6,13 +6,11 @@ class DefaultFolderX < Cask
   homepage 'http://www.stclairsoft.com/DefaultFolderX'
   license :unknown
 
+  installer :manual => 'Default Folder X Installer.app'
+
   zap :delete => [
                   '~/Library/Preferences/com.stclairsoft.DefaultFolderX.favorites.plist',
                   '~/Library/Preferences/com.stclairsoft.DefaultFolderX.plist',
                   '~/Library/Preferences/com.stclairsoft.DefaultFolderX.settings.plist',
                  ]
-
-  caveats do
-    manual_installer 'Default Folder X Installer.app'
-  end
 end

--- a/Casks/google-nik-collection.rb
+++ b/Casks/google-nik-collection.rb
@@ -6,7 +6,5 @@ class GoogleNikCollection < Cask
   homepage 'https://www.google.com/nikcollection/'
   license :unknown
 
-  caveats do
-    manual_installer 'Nik Collection.app'
-  end
+  installer :manual => 'Nik Collection.app'
 end

--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -6,7 +6,5 @@ class Jdownloader < Cask
   homepage 'http://jdownloader.org/'
   license :unknown
 
-  caveats do
-    manual_installer 'JDownloader Installer.app'
-  end
+  installer :manual => 'JDownloader Installer.app'
 end

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -6,14 +6,12 @@ class LittleSnitch < Cask
   homepage 'http://www.obdev.at/products/littlesnitch/index.html'
   license :unknown
 
+  installer :manual => 'Little Snitch Installer.app'
+
   zap :delete => [
                   '~/Library/Preferences/at.obdev.LittleSnitchNetworkMonitor.plist',
                   '~/Library/Application Support/Little Snitch/rules.usr.xpl',
                   '~/Library/Application Support/Little Snitch/configuration.xpl',
                   '~/Library/Application Support/Little Snitch/configuration.user.xpl',
                  ]
-
-  caveats do
-    manual_installer 'Little Snitch Installer.app'
-  end
 end

--- a/Casks/logmein-hamachi.rb
+++ b/Casks/logmein-hamachi.rb
@@ -6,7 +6,5 @@ class LogmeinHamachi < Cask
   homepage 'http://vpn.net'
   license :unknown
 
-  caveats do
-    manual_installer 'LogMeInHamachiInstaller.app'
-  end
+  installer :manual => 'LogMeInHamachiInstaller.app'
 end

--- a/Casks/omnifocus-clip-o-tron.rb
+++ b/Casks/omnifocus-clip-o-tron.rb
@@ -6,9 +6,5 @@ class OmnifocusClipOTron < Cask
   homepage 'http://support.omnigroup.com/omnifocus-clip-o-tron'
   license :unknown
 
-  app 'OmniFocus Clip-o-Tron.app'
-
-  caveats do
-    manual_installer 'OmniFocus Clip-o-Tron.app'
-  end
+  installer :manual => 'OmniFocus Clip-o-Tron.app'
 end

--- a/Casks/paye-tools.rb
+++ b/Casks/paye-tools.rb
@@ -6,7 +6,5 @@ class PayeTools < Cask
   homepage 'http://www.hmrc.gov.uk/payerti/payroll/bpt/paye-tools.htm'
   license :unknown
 
-  caveats do
-    manual_installer "payetools-rti-#{version}-osx.app"
-  end
+  installer :manual => "payetools-rti-#{version}-osx.app"
 end

--- a/Casks/ps3-media-server.rb
+++ b/Casks/ps3-media-server.rb
@@ -6,7 +6,5 @@ class Ps3MediaServer < Cask
   homepage 'http://www.ps3mediaserver.org/'
   license :oss
 
-  caveats do
-    manual_installer 'PS3 Media Server Setup.app'
-  end
+  installer :manual => 'PS3 Media Server Setup.app'
 end

--- a/Casks/scout.rb
+++ b/Casks/scout.rb
@@ -6,7 +6,5 @@ class Scout < Cask
   homepage 'http://mhs.github.io/scout-app/'
   license :oss
 
-  caveats do
-    manual_installer 'Install Scout.app'
-  end
+  installer :manual => 'Install Scout.app'
 end

--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -7,9 +7,7 @@ class Sogouinput < Cask
   homepage 'http://pinyin.sogou.com/mac/'
   license :unknown
 
-  uninstall :delete => '/Library/Input Methods/SogouInput.app'
+  installer :manual => '安装搜狗输入法.app'
 
-  caveats do
-    manual_installer '安装搜狗输入法.app'
-  end
+  uninstall :delete => '/Library/Input Methods/SogouInput.app'
 end

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -12,7 +12,5 @@ class Sts < Cask
   homepage 'http://spring.io/tools/sts'
   license :unknown
 
-  caveats do
-    manual_installer "Installer - Spring Tool Suite #{version}.RELEASE.app"
-  end
+  installer :manual => "Installer - Spring Tool Suite #{version}.RELEASE.app"
 end

--- a/Casks/thinkorswim.rb
+++ b/Casks/thinkorswim.rb
@@ -6,7 +6,5 @@ class Thinkorswim < Cask
   homepage 'http://mediaserver.thinkorswim.com/installer/install.html#macosx'
   license :unknown
 
-  caveats do
-    manual_installer 'thinkorswim Installer.app'
-  end
+  installer :manual => 'thinkorswim Installer.app'
 end

--- a/Casks/titanium-studio.rb
+++ b/Casks/titanium-studio.rb
@@ -6,7 +6,5 @@ class TitaniumStudio < Cask
   homepage 'https://my.appcelerator.com/resources'
   license :unknown
 
-  caveats do
-    manual_installer 'Titanium Studio.app'
-  end
+  installer :manual => 'Titanium Studio.app'
 end

--- a/Casks/utorrent.rb
+++ b/Casks/utorrent.rb
@@ -7,7 +7,5 @@ class Utorrent < Cask
   homepage 'http://www.utorrent.com/'
   license :unknown
 
-  caveats do
-    manual_installer 'uTorrent-Installer.app'
-  end
+  installer :manual => 'uTorrent-Installer.app'
 end

--- a/Casks/vlc-remote.rb
+++ b/Casks/vlc-remote.rb
@@ -7,7 +7,5 @@ class VlcRemote < Cask
   homepage 'http://hobbyistsoftware.com/vlc'
   license :unknown
 
-  caveats do
-    manual_installer 'VLC Setup.app'
-  end
+  installer :manual => 'VLC Setup.app'
 end

--- a/Casks/xamarin.rb
+++ b/Casks/xamarin.rb
@@ -6,11 +6,12 @@ class Xamarin < Cask
   homepage 'http://xamarin.com/platform'
   license :unknown
 
+  installer :manual => 'Install Xamarin.app'
+
   uninstall :delete => '/Applications/Xamarin Studio.app'
   zap       :delete => '~/Library/Developer/Xamarin'
 
   caveats do
     puts 'This app requires the JRE (Java Runtime Environment) to be installed'
-    manual_installer 'Install Xamarin.app'
   end
 end

--- a/Casks/xampp.rb
+++ b/Casks/xampp.rb
@@ -6,7 +6,5 @@ class Xampp < Cask
   homepage 'http://www.apachefriends.org/index.html'
   license :oss
 
-  caveats do
-    manual_installer 'xampp-osx-1.8.3-3-installer.app'
-  end
+  installer :manual => 'xampp-osx-1.8.3-3-installer.app'
 end


### PR DESCRIPTION
As mentioned elsewhere, `installer` is a very late addition to the DSL (#6660, only available in the latest release 0.45.0).

This PR is the most-disruptive change put forward so far during the DSL transition, as >20 Casks are touched, and the relevant backend support is recent.  However, 20 Casks seems reasonably small, and the `method_missing` warning will guide users to upgrade.
