### PR TITLE
update HoRNDIS to rel7

### DIFF
--- a/Casks/horndis.rb
+++ b/Casks/horndis.rb
@@ -1,12 +1,12 @@
 class Horndis < Cask
-  version '5'
-  sha256 'd183b8613b7e3811580afa9f1a8691163c36745cea3b8531bf1a50aba180565d'
+  version '7'
+  sha256 '6e12e75a07ed729986cc0d7a25faa1aa1171c2e4a8ddf3ccf819a35a20c6e98d'
 
   url "http://joshuawise.com/downloads/HoRNDIS-rel#{version}.pkg"
   gpg "#{url}.sig",
       :key_id => '3e7f6d58ea80e0b3'
   homepage 'http://joshuawise.com/horndis'
-  license :unknown
+  license :gpl
 
   pkg "HoRNDIS-rel#{version}.pkg"
   uninstall :kext => 'com.joshuawise.kexts.HoRNDIS',


### PR DESCRIPTION
Update to latest version which includes a variety of improvements and 10.10 support; add license (technically GPLv3 but don't see that in the spec).
