### PR TITLE
Fix rftg cask app name / installation failure.

### DIFF
--- a/Casks/rftg.rb
+++ b/Casks/rftg.rb
@@ -6,5 +6,5 @@ class Rftg < Cask
   homepage 'http://keldon.net/rftg/'
   license :unknown
 
-  app 'RFTG.app'
+  app 'Race for the Galaxy.app'
 end


### PR DESCRIPTION
This fixes the following problem:

``` bash
$ brew cask install rftg
==> Downloading http://keldon.net/rftg/rftg-osx-0.9.4.zip
Already downloaded: /Library/Caches/Homebrew/rftg-0.9.4.zip
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/rftg/0.9.4/RFTG.app'
```

Like so:

``` bash
$ brew tap cowboy/homebrew-cask
Cloning into '/usr/local/Library/Taps/cowboy/homebrew-cask'...
remote: Counting objects: 80634, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 80634 (delta 6), reused 3 (delta 0)
Receiving objects: 100% (80634/80634), 23.16 MiB | 3.61 MiB/s, done.
Resolving deltas: 100% (52453/52453), done.
Checking connectivity... done.
Warning: Could not create link for cowboy/cask/brew-cask, as it
conflicts with caskroom/cask/brew-cask. You will need to use the
fully-qualified name when referring this formula, e.g.
  brew install cowboy/cask/brew-cask
Tapped 1 formula

$ cd /usr/local/Library/Taps/cowboy/homebrew-cask && git checkout patch-1
Branch patch-1 set up to track remote branch patch-1 from origin.
Switched to a new branch 'patch-1'

$ brew cask install cowboy/homebrew-cask/rftg
==> Downloading http://keldon.net/rftg/rftg-osx-0.9.4.zip
Already downloaded: /Library/Caches/Homebrew/rftg-0.9.4.zip
==> Symlinking App 'Race for the Galaxy.app' to '/Users/cowboy/Applications/Race for t
==> Generic artifacting Artifact 'Race for the Galaxy.app' to '/Users/cowboy/Applicati
🍺  rftg installed to '/opt/homebrew-cask/Caskroom/rftg/0.9.4' (224 files, 108M)
```
