### PR TITLE
Add ColorPort.app v2.0.5

### DIFF
--- a/Casks/colorport.rb
+++ b/Casks/colorport.rb
@@ -1,0 +1,15 @@
+class Colorport < Cask
+  version '2.0.5'
+  sha256 'ae176e3118ba55b4dd8a0716707d149a4e13827b30cdc3f1d29bc329a0ef4bd0'
+
+  url 'http://www.xrite.com/downloader.aspx?FileID=1168&Type=M&returnurl=%2fcolorport-utility-software%2fsupport%2fd1168'
+  homepage 'http://www.xrite.com/colorport-utility-software/support/d1168'
+  license :unknown
+
+  pkg 'ColorPort20Distribution.mpkg'
+  uninstall :pkgutil => 'com.xrite.colorport'
+  
+  caveats do
+    reboot
+  end
+end


### PR DESCRIPTION
- Add ColorPort v2.0.5 from X-Rite.
- Include XRD drivers.
- Uninstall will not remove XRD drivers because of other program dependencies.
