### PR TITLE
Add Videobox.app 4.1.2

### DIFF
--- a/Casks/videobox.rb
+++ b/Casks/videobox.rb
@@ -1,0 +1,10 @@
+class Videobox < Cask
+  version '4.1.2'
+  sha256 'bd9e6ae942b729b02c40ad076814be7c5e2f966325c9c5e982070d03443408c5'
+
+  url 'http://download.tastyapps.com/videobox_4.1.2.dmg'
+  homepage 'http://www.tastyapps.com/videobox/'
+  license :closed
+
+  app 'Videobox.app'
+end


### PR DESCRIPTION
Added cask for [TastyApps Videbox](http://www.tastyapps.com/videobox/) v4.1.2.

![22_10_2014_5_00_pm](https://cloud.githubusercontent.com/assets/3786095/4732246/0f807156-59b9-11e4-9d99-a3a7e4d8f70c.png)

> Videobox allows you to quickly and easily download Flash video from most all of the popular video sites on the internet. Videobox will convert the video into a native Quicktime format so it's ready to view on your Mac, iPod, iPhone or iTunes.

Initial download is a 7 day trial version. Can be upgraded from within the app without an additional download.
