### PR TITLE
Add TodoTxtMac.app

### DIFF
--- a/Casks/todo-txt-mac.rb
+++ b/Casks/todo-txt-mac.rb
@@ -1,0 +1,10 @@
+class TodoTxtMac < Cask
+  version '1.2.3'
+  sha256 'f396ae24031a11c7371dfb187e958313a85cfd03b45b4f7d05f312cb944c5072'
+
+  url 'https://github.com/mjdescy/TodoTxtMac/releases/download/1.2.3/TodoTxtMac.app.zip'
+  homepage 'https://mjdescy.github.io/TodoTxtMac/'
+  license :mit
+
+  app 'TodoTxtMac.app'
+end


### PR DESCRIPTION
added cask for TodoTxtMac. It is a gui for todo-txt (available via brew as todo-txt).

Not sure about the Mac suffix. I read the naming guidelines, but found it to be important to distinguish the app from the todo-txt cli and other guis for todo.txt. Hope it's all right, it's my first contribution.
