### PR TITLE
remove manual_installer from league_of_legends

### DIFF
--- a/Casks/league-of-legends.rb
+++ b/Casks/league-of-legends.rb
@@ -7,7 +7,4 @@ class LeagueOfLegends < Cask
   license :unknown
 
   app 'League of Legends.app'
-  caveats do
-    manual_installer 'League of Legends.app'
-  end
 end


### PR DESCRIPTION
From what I can tell by reading, this is an ordinary `app`
artifact.  It cannot be both `app` and `installer :manual`.

closes #6870
