### PR TITLE
Fix Breakaway cask

### DIFF
--- a/Casks/breakaway.rb
+++ b/Casks/breakaway.rb
@@ -6,5 +6,5 @@ class Breakaway < Cask
   homepage 'http://mutablecode.com/apps/breakaway.html'
   license :gpl
 
-  app 'Breakaway.app'
+  app "breakaway-#{version}/Breakaway.app"
 end


### PR DESCRIPTION
The Breakaway zip file creates a top-level directory, so the app needs to be found inside that directory.
