### PR TITLE
Add Fiery Software Manager.app v2.0.0.15

### DIFF
--- a/Casks/fiery-software-manager.rb
+++ b/Casks/fiery-software-manager.rb
@@ -1,0 +1,10 @@
+class FierySoftwareManager < Cask
+  version :latest
+  sha256 :no_check
+
+  url 'https://d1umxs9ckzarso.cloudfront.net/Products/FSM/Fiery-Software-Manager.dmg'
+  homepage 'http://w3.efi.com/Fiery/Products/CWS5/Download/thank-you'
+  license :unknown
+
+  installer :manual => 'Fiery Software Manager.app'
+end


### PR DESCRIPTION
Download latest at URL.
Manual install probably necessary but may review at later date.
