### PR TITLE
Add Beyond Compare 4

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,0 +1,15 @@
+class BeyondCompare < Cask
+  version '4.0.0.18847'
+  sha256 'cb9987b62ac68a2493b7bc5678125fbf1b8919796bc82718ddd23958768fd457'
+
+  url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
+  homepage 'http://www.scootersoftware.com/index.php'
+  license :commercial
+
+  app 'Beyond Compare.app'
+
+  postflight do
+    # Don't ask to move the app bundle to /Applications
+    system '/usr/bin/defaults', 'write', 'com.ScooterSoftware.BeyondCompare', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true'
+  end
+end


### PR DESCRIPTION
Scooter Software released officially on 1 Sept, 2014 (http://www.scootersoftware.com/download.php?zz=v4changelog).

I am going remove caskroom/homebrew-versions@f38393671ec1879372ace49e16104fc43314c75e since it is no longer beta.
