### PR TITLE
Handle permissions corner cases on uninstall

### DIFF
--- a/lib/cask/pkg.rb
+++ b/lib/cask/pkg.rb
@@ -306,6 +306,7 @@ class Cask::Pkg
 
   def _with_full_permissions(path, &block)
     original_mode = (path.stat.mode % 01000).to_s(8)
+    # todo: similarly read and restore OS X flags (qv man chflags)
     @command.run!('/bin/chmod', :args => ['--', '777', path], :sudo => true)
     block.call
   ensure


### PR DESCRIPTION
- unset BSD file flags if present
- attempt ownership change if permissions changes fail

fixes #6699
fixes #6752
