### PR TITLE
Update download URL for Balsamiq Mockups

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -2,7 +2,8 @@ class BalsamiqMockups < Cask
   version :latest
   sha256 :no_check
 
-  url 'http://builds.balsamiq.com/b/mockups-desktop/MockupsForDesktop.dmg'
+  # amazonaws is the official download host per the vendor homepage
+  url 'http://s3.amazonaws.com/build_production/mockups-desktop/MockupsForDesktop.dmg'
   homepage 'http://balsamiq.com/'
   license :commercial
 


### PR DESCRIPTION
Closes #6944.
