### PR TITLE
added d235j-xbox360-controller-driver (0.13.1)

### DIFF
--- a/Casks/d235j-xbox360-controller-driver.rb
+++ b/Casks/d235j-xbox360-controller-driver.rb
@@ -1,0 +1,11 @@
+class D235jXbox360ControllerDriver < Cask
+  version '0.13.1'
+  sha256 'f324341a11ba5588b71fd246e5b6d79189abb886cf641d96650133cadbc293f9'
+
+  url "https://github.com/d235j/360Controller/releases/download/v#{version}-unofficial/360ControllerInstall_#{version}_unofficial.dmg"
+  homepage 'https://github.com/d235j/360Controller'
+  license :gpl
+
+  pkg 'Install360Controller.pkg'
+  uninstall :pkgutil => 'com.mice.pkg.Xbox360controller'
+end


### PR DESCRIPTION
Similarly to [growl-fork](https://github.com/caskroom/homebrew-cask/pull/6568), this is the continuation of a software piece that is possibly no longer in development. The original one stopped working in Yosemite (since kexts now need to be signed), and this one [should solve the issue soon](https://github.com/d235j/360Controller/issues/9#issuecomment-60189347).
