### PR TITLE
cloud.app artifact rename

### DIFF
--- a/Casks/cloud.rb
+++ b/Casks/cloud.rb
@@ -5,7 +5,8 @@ class Cloud < Cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   homepage 'http://getcloudapp.com/'
   license :unknown
+  tags :name => 'CloudApp'
 
-  app 'Cloud.app'
+  app 'CloudApp.app'
   zap :delete => '~/Library/Preferences/com.linebreak.CloudAppMacOSX.plist'
 end


### PR DESCRIPTION
fixes #7019 

Upstream is amending their branding.

This situation ("NameApp.app") was anticipated by the naming rules, which declares that "App.app" disappears and the file name stays as `cloud.rb`.  I have included `tags :name` to match the orthography of the branding.
