### PR TITLE
Add pgweb binary v0.3.0

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,0 +1,10 @@
+class Pgweb < Cask
+  version '0.3.0'
+  sha256 'b871676c5c2fafa6deabcee8a72dd593e3562504dd32e38ea03840219ea60eba'
+
+  url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
+  homepage 'https://github.com/sosedoff/pgweb'
+  license :mit
+
+  binary 'pgweb_darwin_amd64', :target => 'pgweb'
+end


### PR DESCRIPTION
Add the [pgweb](https://github.com/sosedoff/pgweb) project to the homebrew-cask repository.

sosedoff/pgweb#9
