### PR TITLE
Upgrading Transporter Desktop.app to v2.8.1

### DIFF
--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -1,8 +1,8 @@
 class TransporterDesktop < Cask
-  version '2.6.10'
-  sha256 'ec56b51c08e6eb7442442b86ad6c8346bf1bf7e44680faf699e37f6111b7b722'
+  version '2.8.1'
+  sha256 '43d0f47993d233fee6209b040b77f42e1b909cfedcbe873b7fb4700782af4c75'
 
-  url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}_14167.dmg"
+  url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}_16078.dmg"
   homepage 'http://www.filetransporter.com/'
   license :unknown
 


### PR DESCRIPTION
The older 2.6.10 version would attempt to auto-update but has a bug
on Yosemite which would result in an endless loop and require a Force
Quit.
