### PR TITLE
Update Postgres to 9.3.5.2

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,6 +1,6 @@
 class Postgres < Cask
-  version '9.3.5.1'
-  sha256 '0dd20b941a4b356f3d0845e76a220a22f5d07ed047c0029b997829a0f44800d9'
+  version '9.3.5.2'
+  sha256 '8b7ddc0e721960fa0f50903d5f7d47a29de308d981e93ee3af0664547e3f322d'
 
   url "https://github.com/PostgresApp/PostgresApp/releases/download/#{version}/Postgres-#{version}.zip"
   homepage 'http://postgresapp.com/'


### PR DESCRIPTION
Fixes an issue with [Yosemite](https://github.com/PostgresApp/PostgresApp/releases/tag/9.3.5.2).
