### PR TITLE
Add casks for Python.org Pythons

### DIFF
--- a/Casks/python.rb
+++ b/Casks/python.rb
@@ -1,0 +1,19 @@
+class Python < Cask
+  version '2.7.8'
+  sha256 '8411ce3ce0172c1f2a05e86eb10931e88900b58bf80b0c6adc64a520ce20b494'
+
+  url "https://www.python.org/ftp/python/#{version}/python-#{version}-macosx10.6.dmg"
+  pkg "Python.mpkg"
+  homepage "http://www.python.org/"
+  license :oss
+
+  uninstall :delete => [
+                       "/Library/Receipts/Python*-#{version.slice(/\d+\.\d+/)}.pkg",
+                       "/Applications/Python #{version.slice(/\d+\.\d+/)}",
+                       "/Library/Frameworks/Python.Framework/Versions/#{version.slice(/\d+\.\d+/)}",
+                       ]
+  zap :delete => [
+                 "/Library/Python/#{version.slice(/\d+\.\d+/)}",
+                 "~/Library/Python/#{version.slice(/\d+\.\d+/)}",
+                 ]
+end

--- a/Casks/python3.rb
+++ b/Casks/python3.rb
@@ -1,0 +1,25 @@
+class Python3 < Cask
+  version '3.4.2'
+  sha256 '5a4edfac31efd4ecd2efb4cb7203c0c36e488f1d0a20755b674b04dcb3c21e1b'
+
+  url "https://www.python.org/ftp/python/#{version}/python-#{version}-macosx10.6.pkg"
+  pkg "python-#{version}-macosx10.6.pkg"
+  homepage "http://www.python.org/"
+  license :oss
+
+  uninstall :pkgutil => [
+                        "org.python.Python.PythonApplications-#{version.slice(/\d+\.\d+/)}",
+                        "org.python.Python.PythonDocumentation-#{version.slice(/\d+\.\d+/)}",
+                        "org.python.Python.PythonFramework-#{version.slice(/\d+\.\d+/)}",
+                        "org.python.Python.PythonUnixTools-#{version.slice(/\d+\.\d+/)}",
+                        ],
+            :delete => [
+                       "/Library/Receipts/PythonInstallPip-#{version.slice(/\d+\.\d+/)}",
+                       "/Applications/Python #{version.slice(/\d+\.\d+/)}",
+                       "/Library/Frameworks/Python.Framework/Versions/#{version.slice(/\d+\.\d+/)}",
+                       ]
+  zap :delete => [
+                 "/Library/Python/#{version.slice(/\d+\.\d+/)}",
+                 "~/Library/Python/#{version.slice(/\d+\.\d+/)}",
+                 ]
+end


### PR DESCRIPTION
current: 2.7, 3.4

2.6, 3.2, 3.3 added in caskroom/homebrew-versions#517
