### PR TITLE
Add Snapped for Mac Beta v0.1.5

### DIFF
--- a/Casks/snapped.rb
+++ b/Casks/snapped.rb
@@ -1,0 +1,10 @@
+class Snapped < Cask
+  version '0.1.5'
+  sha256 '8cec22bd0c88b1fb0680e018a6706aeaf925688b84bdd2c7a2e5fdb99d20bd52'
+
+  url 'http://cl.ly/2J3L2r2h0A1l/download/Snapped%20Beta.app.zip'
+  homepage 'http://www.thnkdev.com/Snapped/'
+  license :closed
+
+  app 'Snapped Beta.app'
+end


### PR DESCRIPTION
There is no stable version of this software yet.
