### PR TITLE
Add Spectacle 0.8.6 for older (<Mavericks) Macs.

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -1,6 +1,11 @@
 class Spectacle < Cask
-  version '0.8.8'
-  sha256 '7c7386e526cbabedb1e16f2e3366c7842712f590985fe9d4f57ff9c0a7854bcf'
+  if MacOS.version < :mavericks
+    version '0.8.6'
+    sha256 '3e367d2d7e6fe7d5f41d717d49cb087ba7432624b71ddd91c0cfa9d5a5459b7c'
+  else
+    version '0.8.8'
+    sha256 '7c7386e526cbabedb1e16f2e3366c7842712f590985fe9d4f57ff9c0a7854bcf'
+  end
 
   url "https://s3.amazonaws.com/spectacle/downloads/Spectacle+#{version}.zip"
   appcast 'http://spectacleapp.com/updates/appcast.xml',


### PR DESCRIPTION
The new Spectacle version is only compatible with Mac OS X 10.9 onwards.
