### PR TITLE
devscript: check ruby version before execution

### DIFF
--- a/developer/bin/list_running_app_ids
+++ b/developer/bin/list_running_app_ids
@@ -20,6 +20,13 @@ $opt_test = nil
 ### methods
 ###
 
+def check_ruby
+  if RUBY_VERSION.to_f < 1.9
+    print "You are currently using Ruby ", RUBY_VERSION, ", but version 1.9 or above is required."
+    exit 1
+  end
+end
+
 def usage
   <<-EOS
 list_running_app_ids [ -t <bundle-id> ]
@@ -97,6 +104,7 @@ end
 ### main
 ###
 
+check_ruby
 process_args
 load_apps
 


### PR DESCRIPTION
When `developer/bin/list_running_app_ids` is run with `ruby < 1.9`, the following error will occur:

``` bash
developer/bin/list_running_app_ids:58:in `load_apps': undefined method `capture3' for Open3:Module (NoMethodError)
    from developer/bin/list_running_app_ids:101
```

For Ruby-illterate people (such as myself for the most part), that error doesn't really describe how to fix the error (yes, a problem lies in the `open3` module, but most Cask authors, especially first time devscript users, would not know how to fix the issue or, even worse, not bother using the devscript/give up on making a Cask). This pull request places a small check at the beginning of execution to make sure the script is compatible. Now the error returned is:

``` bash
You are currently using Ruby 1.8.7, but version 1.9 or above is required.
```
