### PR TITLE
Added CactusVPN Client

### DIFF
--- a/Casks/cactusvpn.rb
+++ b/Casks/cactusvpn.rb
@@ -1,0 +1,13 @@
+class Cactusvpn < Cask
+  version '2.0.1'
+  sha256 '819dd58b260257e29e1b8773a75227c6b54b1ba974e120a2d8e7d3dd61ac8012'
+
+  url 'https://files.oliverconzen.de/brew/CactusVPN-Mac-OS-v.2.0.1.pkg'
+  homepage 'http://cactusvon.com'
+  license :commercial
+
+  pkg 'CactusVPN-Mac-OS-v.2.0.1.pkg'
+
+  uninstall :pkgutil => 'com.logicnet.CactusVPN.cactusvpn.CactusVPN.pkg'
+  uninstall :pkgutil => 'com.logicnet.CactusVPN.cactusvpn.hide.pkg'
+end


### PR DESCRIPTION
A software provided by CactusVPN to use their service.
I tested it and the only thing that seems to persist across installs/uninstalls are the -configuration files/login cookie/whatever it is they use for authentication- so you are still logged in when you reinstall the application.

Everything else is working:
- Install
- Uninstall

Problem I was facing was the incredibly stupid and file damaging download php they were using. I therefore hosted a downloaded pkg on my own server. SHA Hash is the same as the dl they provide(but doesn't work as a cask).
