### PR TITLE
Improve version reuse in GDAL Framework

### DIFF
--- a/Casks/gdal-framework.rb
+++ b/Casks/gdal-framework.rb
@@ -1,8 +1,8 @@
 class GdalFramework < Cask
-  version '1.11'
-  sha256 'd8aa6d59236a75519e94a764dfc71d3122c8e88fa4f99072046c3a8a0bfb4124'
+  version '1.11.1-1'
+  sha256 'b5b3a62ead9e2bdff9b85eccf42dbc628f384f89eff33fe150933ddaa841d25b'
 
-  url "http://www.kyngchaos.com/files/software/frameworks/GDAL_Complete-#{version}.dmg"
+  url "http://www.kyngchaos.com/files/software/frameworks/GDAL_Complete-#{version.sub(%r{^(\d+\.\d+).*},'\1')}.dmg"
   homepage 'http://www.kyngchaos.com/software/frameworks'
   license :unknown
 


### PR DESCRIPTION
Closes #6330.

This cask will still break when the package found at the URL is updated again. An alternative would be to use `:latest`, which would only break if the URL itself changes.
