### PR TITLE
Remove unsupported -x option in launchctl command

### DIFF
--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -207,12 +207,13 @@ class Cask::Artifact::UninstallBase < Cask::Artifact::Base
       Array(directives[:launchctl]).each do |service|
         ohai "Removing launchctl service #{service}"
         [false, true].each do |with_sudo|
-          xml_status = @command.run('/bin/launchctl', :args => ['list', '-x', service], :sudo => with_sudo).stdout
-          if %r{^<\?xml}.match(xml_status)
+          plist_status = @command.run('/bin/launchctl', :args => ['list', service], :sudo => with_sudo).stdout
+          if %r{^\{}.match(plist_status)
             @command.run('/bin/launchctl',  :args => ['unload', '-w', '--', service], :sudo => with_sudo)
             sleep 1
             @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
             sleep 1
+            break
           end
         end
       end

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -98,32 +98,22 @@ describe Cask::Artifact::Uninstall do
       )
 
       Cask::FakeSystemCommand.stubs_command(
-        ['/bin/launchctl', 'list', '-x', 'my.fancy.package.service'],
+        ['/bin/launchctl', 'list', 'my.fancy.package.service'],
         "launchctl list returned unknown response\n"
       )
       Cask::FakeSystemCommand.stubs_command(
-        ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', '-x', 'my.fancy.package.service'],
+        ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', 'my.fancy.package.service'],
         <<-"PLIST"
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-\t<key>Label</key>
-\t<string>my.fancy.package.service</string>
-\t<key>LastExitStatus</key>
-\t<integer>0</integer>
-\t<key>LimitLoadToSessionType</key>
-\t<string>System</string>
-\t<key>OnDemand</key>
-\t<true/>
-\t<key>ProgramArguments</key>
-\t<array>
-\t\t<string>argument</string>
-\t</array>
-\t<key>TimeOut</key>
-\t<integer>30</integer>
-</dict>
-</plist>
+{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "my.fancy.package.service";
+	"TimeOut" = 30;
+	"OnDemand" = true;
+	"LastExitStatus" = 0;
+	"ProgramArguments" = (
+		"argument";
+	);
+};
         PLIST
       )
 

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -100,32 +100,22 @@ describe Cask::Artifact::Zap do
       )
 
       Cask::FakeSystemCommand.stubs_command(
-        ['/bin/launchctl', 'list', '-x', 'my.fancy.package.service'],
+        ['/bin/launchctl', 'list', 'my.fancy.package.service'],
         "launchctl list returned unknown response\n"
       )
       Cask::FakeSystemCommand.stubs_command(
-        ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', '-x', 'my.fancy.package.service'],
+        ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', 'my.fancy.package.service'],
         <<-"PLIST"
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-\t<key>Label</key>
-\t<string>my.fancy.package.service</string>
-\t<key>LastExitStatus</key>
-\t<integer>0</integer>
-\t<key>LimitLoadToSessionType</key>
-\t<string>System</string>
-\t<key>OnDemand</key>
-\t<true/>
-\t<key>ProgramArguments</key>
-\t<array>
-\t\t<string>argument</string>
-\t</array>
-\t<key>TimeOut</key>
-\t<integer>30</integer>
-</dict>
-</plist>
+{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "my.fancy.package.service";
+	"TimeOut" = 30;
+	"OnDemand" = true;
+	"LastExitStatus" = 0;
+	"ProgramArguments" = (
+		"argument";
+	);
+};
         PLIST
       )
 


### PR DESCRIPTION
Also added a break statement to prevent redundant second call.

Works on Yosemite but have not tested this on earlier versions. Feedback welcome.

Fixes #7154 
