### PR TITLE
Update brackets.rb

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,5 +1,5 @@
 class Brackets < Cask
-  version '0.44'
+  version '1.0'
   sha256 '3619f01dddc55f47be87306909b7264cbdad9fb43be8c88661bec0a087b0f8a6'
 
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"


### PR DESCRIPTION
Brackets released V 1.0 and the cask version needed to be updated.
