### PR TITLE
Update NetNewsWire to 4.0.0-166

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,10 +1,10 @@
 class Netnewswire < Cask
-  version '4.0.0-152'
-  sha256 'f82539a4a53f6b3b05a6d63f459fee705bd28b83034bd0fc7e20be76e4592945'
+  version '4.0.0-166'
+  sha256 '94bbf93cc820be06f32fc80ff1ce065e5e5e219a0587fee948355a72140d05f3'
 
   url "http://cdn.netnewswireapp.com/releases/NetNewsWire-#{version}.zip"
   appcast 'https://updates.blackpixel.com/updates?app=nnw',
-          :sha256 => '33564e80110c0e5bc562bf65f09046d95afcbab79d0e9c49617c2b8548a64cc2'
+          :sha256 => '1ad06240a769ed639d5c0e0a9a139ef498915f17e3d069c90f7d5555f9954034'
   homepage 'http://netnewswireapp.com/'
   license :commercial
 


### PR DESCRIPTION
Update NetNewsWire to 4.0.0-166 (aka Public Beta 18)
