### PR TITLE
Upgrade Trailer.app to 1.1.2

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,10 @@
 class Trailer < Cask
-  version '1.1.1'
-  sha256 'a24bd6bb40fdafc638732fa1eb5f44b7e333ea1986e792c367f5e7632f184983'
+  version '1.1.2'
+  sha256 'b3c19fa0f15176b1b4244a0572d9488618854de54889b5d40bbb36e73692b357'
 
   url "http://dev.housetrip.com/trailer/trailer#{version.gsub('.','')}.zip"
   appcast 'http://dev.housetrip.com/trailer/appcast.xml',
-          :sha256 => '18944eb95afa0c9627d1682a3b8afb7f4a4f72d35a721e7379d7e0ba2623e619'
+          :sha256 => 'e4f8d3bf70078922985b48e9f9b8f291c583b14a214abc6789d2467b8afc2957'
   homepage 'http://dev.housetrip.com/trailer/'
   license :mit
 


### PR DESCRIPTION
Upgraded to the latest version of Trailer (1.1.2) from 1.1.1
