### PR TITLE
Fix appcast url for Adium.

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -3,8 +3,8 @@ class Adium < Cask
   sha256 'bca3ac81d33265b71c95a3984be80715fbd98f38d7c463d0441d43a335ed399a'
 
   url "http://download.adium.im/Adium_#{version}.dmg"
-  appcast 'http://www.adium.im/sparkle/update.php',
-          :sha256 => 'cfb624cfa2f2526905ed7cb0eb39da98c73ef3c4633618348c00f12b2d44e19a'
+  appcast 'https://www.adium.im/sparkle/appcast-release.xml',
+          :sha256 => '5d05831689494b3059ddf31580438579dee1d1b2a34f24a018b86fcaadd46e53'
   homepage 'https://www.adium.im/'
   license :gpl
 


### PR DESCRIPTION
The old url is out-of-date and points to version 1.1.4 from 2007.
The new url is the correct one for stable releases.
