### PR TITLE
Fix Armory 0.92.3 hashsum

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -1,6 +1,6 @@
 class Armory < Cask
   version '0.92.3'
-  sha256 '75d6b7566d6c40a93f7dcf995dfb778b577d0b4698cc52d1ecea8f6fadfdf460'
+  sha256 '25aac165bcdfc326ca36e630e9676dd1b116b246209e7bc9b646001977deb947'
 
   url "https://s3.amazonaws.com/bitcoinarmory-releases/armory_#{version}_osx.tar.gz"
   homepage 'https://bitcoinarmory.com/'


### PR DESCRIPTION
Closes #7192.
