### PR TITLE
Upgrade TotalSpaces to 2.2.9

### DIFF
--- a/Casks/totalspaces.rb
+++ b/Casks/totalspaces.rb
@@ -21,7 +21,10 @@ class Totalspaces < Cask
 
     app 'TotalSpaces2.app'
 
-    uninstall :pkgutil => 'com.binaryage.TotalSpaces2',
+    uninstall :script  => {
+                           :executable => 'TotalSpaces2 Uninstaller.app/Contents/MacOS/TotalSpaces2 Uninstaller',
+                           :args       => %w[--headless],
+                          },
               :quit    => 'com.binaryage.TotalSpaces2',
               :signal  => [
                            ['INT', 'com.binaryage.totalspacescrashwatcher'],

--- a/Casks/totalspaces.rb
+++ b/Casks/totalspaces.rb
@@ -14,12 +14,13 @@ class Totalspaces < Cask
                            ['KILL', 'com.binaryage.totalspacescrashwatcher'],
                           ]
   else
-    version '2.2.6'
-    sha256 '900ece3f5ceae479b4019f854e1875eb402edf3ef1b17f813a70fe42290a0a12'
+    version '2.2.9'
+    sha256 '66656dab328455906fd6e757bd966efac7d3a364b66155c847de55bfc57d8f14'
 
-    url "http://downloads.binaryage.com/TotalSpaces-#{version}.zip"
+    url "http://downloads.binaryage.com/TotalSpaces2-#{version}.dmg"
 
-    pkg 'TotalSpaces2.pkg'
+    app 'TotalSpaces2.app'
+
     uninstall :pkgutil => 'com.binaryage.TotalSpaces2',
               :quit    => 'com.binaryage.TotalSpaces2',
               :signal  => [


### PR DESCRIPTION
- Fixed URL as it now differentiates between v1 and v2
- App is now distributed in a dmg instead of a pkg
