### PR TITLE
Add binary stanza to praat

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -13,4 +13,5 @@ class Praat < Cask
   license :gpl
 
   app 'Praat.app'
+  binary 'Praat.app/Contents/MacOS/Praat', :target => 'praat'
 end


### PR DESCRIPTION
- For shell scripts to execute praat scripts, `praat` should be on the path and link to `/Applications/Praat.app/Contents/MacOS/Praat`
- For consistency across platforms (specifically linux), the target link should be named `praat` (lower-case for case-sensitive file systems)
