### PR TITLE
Update Arduino URL

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -2,7 +2,7 @@ class Arduino < Cask
   version '1.0.6'
   sha256 '11838fe58cd366561cb1868378269da959bf67518cc2b88eee3f010c9c1c072d'
 
-  url "http://downloads.arduino.cc/arduino-#{version}-macosx.zip"
+  url "http://arduino.cc/download.php?f=/arduino-#{version}-macosx.zip"
   homepage 'http://arduino.cc/'
   license :oss
 


### PR DESCRIPTION
Arduino download link has changed. It seems that now the URL is `arduino.cc/download.php?f=/arduino-1.0.6-macosx.zip`
