### PR TITLE
Update Qt-Creator to 3.2.2

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 class QtCreator < Cask
-  version '3.2.1'
-  sha256 'cfe2c0b3f40306397637182f86d0d26d954569baeec556b76804da1bfe403f10'
+  version '3.2.2'
+  sha256 'ca3cca6ed88bdec0eac48e0fa0005702e9924498b0fbb9ad2250978384f24f7a'
 
   url "https://download.qt-project.org/official_releases/qtcreator/3.2/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   homepage 'http://qt-project.org/'


### PR DESCRIPTION
Hi,

a new Qt-Creator version is out, and I simply changed the version and hash according to [the download page](http://download.qt-project.org/official_releases/qtcreator/3.2/3.2.2/qt-creator-opensource-mac-x86_64-3.2.2.dmg.mirrorlist).

Best regards,
  Fabian
