### PR TITLE
Subler update from 0.25 to 0.30

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,9 @@
 class Subler < Cask
-  version '0.25'
-  sha256 '7b93d8a6afc1db00ea86b3bb2f6f8927012e66f1d74d7bfc7293d87cc8565f86'
+  version '0.30'
+  sha256 'd0ab279f640c06ca6163144f2e11462d243bfeba32b64d258e5823cfd9386a7c'
 
-  url "https://subler.googlecode.com/files/Subler-#{version}.zip"
-  appcast 'http://subler.googlecode.com/svn/doc/appcast.xml',
-          :sha256 => 'b8d659a84089c8ebd4969c7e5393b0472d844c79d43bad33cbfbbe153f2dfb51'
-  homepage 'https://code.google.com/p/subler/'
+  url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
+  homepage 'https://bitbucket.org/galad87/subler'
   license :oss
 
   app 'Subler.app'


### PR DESCRIPTION
Subler version 0.25 to 0.30, changed to official bitbucket host.
