### PR TITLE
Minor fixes in PlexHomeTheater and PlexMediaServer

### DIFF
--- a/Casks/plex-home-theater.rb
+++ b/Casks/plex-home-theater.rb
@@ -3,10 +3,10 @@ class PlexHomeTheater < Cask
 
   if Hardware::CPU.is_32_bit?
     sha256 '7c2fd9541104346478fd7fa1e34c609bc6494202e82dcb91533b1e3931add232'
-    url "http://downloads.plex.tv/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-i386.zip"
+    url "https://downloads.plex.tv/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-i386.zip"
   else
     sha256 '329011165014f20110c258049ab5de6c84a2957065e7dd01dfa68599ae9d4810'
-    url "http://downloads.plex.tv/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-x86_64.zip"
+    url "https://downloads.plex.tv/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-x86_64.zip"
   end
 
   homepage 'https://plex.tv'

--- a/Casks/plex-home-theater.rb
+++ b/Casks/plex-home-theater.rb
@@ -3,10 +3,10 @@ class PlexHomeTheater < Cask
 
   if Hardware::CPU.is_32_bit?
     sha256 '7c2fd9541104346478fd7fa1e34c609bc6494202e82dcb91533b1e3931add232'
-    url "http://downloads.plexapp.com/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-i386.zip"
+    url "http://downloads.plex.tv/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-i386.zip"
   else
     sha256 '329011165014f20110c258049ab5de6c84a2957065e7dd01dfa68599ae9d4810'
-    url "http://downloads.plexapp.com/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-x86_64.zip"
+    url "http://downloads.plex.tv/plex-home-theater/#{version}/PlexHomeTheater-#{version}-macosx-x86_64.zip"
   end
 
   homepage 'https://plex.tv'

--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -2,7 +2,7 @@ class PlexMediaServer < Cask
   version '0.9.9.14.531-7eef8c6'
   sha256 '7cd91e89f74569409b12f8151d66c731ca8658e6df61aaaac41accf6e6cba337'
 
-  url "http://downloads.plexapp.com/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
+  url "http://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   homepage 'https://plex.tv/'
   license :unknown
 

--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -2,7 +2,7 @@ class PlexMediaServer < Cask
   version '0.9.9.14.531-7eef8c6'
   sha256 '7cd91e89f74569409b12f8151d66c731ca8658e6df61aaaac41accf6e6cba337'
 
-  url "http://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
+  url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   homepage 'https://plex.tv/'
   license :unknown
 


### PR DESCRIPTION
- Change from [downloads.plexapp.com](downloads.plexapp.com) to [downloads.plex.tv](downloads.plex.tv)
- Use secure download URLs
