### PR TITLE
Syntevo updates

### DIFF
--- a/Casks/smartgithg.rb
+++ b/Casks/smartgithg.rb
@@ -1,6 +1,6 @@
 class Smartgithg < Cask
-  version '6.0.6'
-  sha256 '25616f860cb03a9be9aa9ec21d2625673253c4dc702647d3c1f417f6b425fc96'
+  version '6.0.8'
+  sha256 '6540fe06e4a23438afd5d397af48bb95b7bf8befbc0d6809b7fe16d418b0e03b'
 
   url "http://www.syntevo.com/download/smartgithg/smartgithg-macosx-#{version.gsub('.', '_')}.dmg"
   homepage 'http://www.syntevo.com'

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -1,13 +1,13 @@
 class Smartsynchronize < Cask
-  version '3.3.4'
-  sha256 'dc3732ef768d06a610742b0e1cf562c3cfce973e378b4c2dead6bf6cff9966f8'
+  version '3.4'
+  sha256 'f7d30bae37c835ea208ff60b5b99c2668e3406c06f1321862495a425a9389322'
 
   url "http://www.syntevo.com/download/smartsynchronize/smartsynchronize-macosx-#{version.gsub('.','_')}.dmg"
   homepage 'http://www.syntevo.com'
   license :unknown
 
-  app "SmartSynchronize #{version.sub(%r{^(\d+\.\d+).*},'\1')}.app"
-  binary "SmartSynchronize #{version.sub(%r{^(\d+\.\d+).*},'\1')}.app/Contents/MacOS/SmartSynchronize"
+  app "SmartSynchronize.app"
+  binary "SmartSynchronize.app/Contents/MacOS/SmartSynchronize"
   caveats do
     files_in_usr_local
   end


### PR DESCRIPTION
Upgraded SmartGitHg and SmartSynchronize to the latest available versions.

The current SmartSynchronize cask points to a version that is no longer available. Also, the app no longer includes its version number in the name.
