### PR TITLE
Update node-webkit to 0.11.0

### DIFF
--- a/Casks/node-webkit.rb
+++ b/Casks/node-webkit.rb
@@ -1,6 +1,6 @@
 class NodeWebkit < Cask
-  version '0.10.5'
-  sha256 '37efb4629ee78b79c03122d8ff4176c08e9423e7f13482ab2b709615f9dbf0fe'
+  version '0.11.0'
+  sha256 'ada386b7d7531c565b6f4a48d90d1fc2cb075f838536df60fbb7730bd2487d72'
 
   url "http://dl.node-webkit.org/v#{version}/node-webkit-v#{version}-osx-x64.zip"
   homepage 'https://github.com/rogerwang/node-webkit'


### PR DESCRIPTION
Hi!

node-webkit 0.11.0 was released recently. I generated sha256 via `shasum -a 256 node-webkit-v0.11.0-osx-x64.zip`.
