### PR TITLE
added 1Password caveat to Google Chrome

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -23,4 +23,11 @@ class GoogleChrome < Cask
                   '~/Library/Caches/Google',
                   '~/Library/Google',
                  ]
+
+  caveats <<-EOS.undent
+    The Mac App Store version of 1Password won't work with a Homebrew-Cask-linked Google Chrome. To bypass this limitation, you need to either:
+
+      + Move Google Chrome to your /Applications directory (the app itself, not a symlink).
+      + Install 1Password from outside the Mac App Store (licenses should transfer automatically, but you should contact AgileBits about it).
+  EOS
 end


### PR DESCRIPTION
@caskroom/maintainers [We’re frequently getting reports on this](https://github.com/caskroom/homebrew-cask/search?q=1password+chrome&type=Issues&utf8=%E2%9C%93), when it is nothing we can fix on our end.
