### PR TITLE
DSL: remove support for `install` stanza

### DIFF
--- a/lib/cask/artifact/pkg.rb
+++ b/lib/cask/artifact/pkg.rb
@@ -1,6 +1,6 @@
 class Cask::Artifact::Pkg < Cask::Artifact::Base
   def self.artifact_dsl_key
-    :install
+    :pkg
   end
 
   def load_pkg_description(pkg_description)
@@ -27,7 +27,7 @@ class Cask::Artifact::Pkg < Cask::Artifact::Base
   end
 
   def install_phase
-    @cask.artifacts[:install].each { |pkg_description| run_installer(pkg_description) }
+    @cask.artifacts[:pkg].each { |pkg_description| run_installer(pkg_description) }
   end
 
   def uninstall_phase

--- a/lib/cask/cli/internal_stanza.rb
+++ b/lib/cask/cli/internal_stanza.rb
@@ -35,7 +35,7 @@ class Cask::CLI::InternalStanza < Cask::CLI::InternalUseBase
                        :input_method,
                        :internet_plugin,
                        :screen_saver,
-                       :install,
+                       :pkg,
                        :caskroom_only,
                        :nested_container,
                        :uninstall,

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -213,7 +213,6 @@ module Cask::DSL
     # ultimately either be removed or upgraded with its own unique
     # semantics.
     STANZA_ALIASES = {
-                       :pkg                   => :install,          # todo remove
                        :preflight             => :before_install,   # todo remove
                        :postflight            => :after_install,    # todo remove
                        :uninstall_preflight   => :before_uninstall, # todo remove
@@ -235,7 +234,6 @@ module Cask::DSL
                                      :input_method,
                                      :internet_plugin,
                                      :screen_saver,
-                                     :install,                     # todo remove
                                      :pkg,
                                     ]
     end

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -7,7 +7,7 @@ describe Cask::Artifact::App do
     end
   }
 
-  describe 'install to alternate target' do
+  describe 'activate to alternate target' do
     it "activates the given apps using the proper target directory" do
       cask = local_alt_caffeine
 

--- a/test/cask/artifact/two_apps_correct_test.rb
+++ b/test/cask/artifact/two_apps_correct_test.rb
@@ -7,7 +7,7 @@ describe Cask::Artifact::App do
     end
   }
 
-  describe 'install multiple apps' do
+  describe 'multiple apps' do
     it "activates both apps using the proper target directory" do
       cask = local_two_apps_caffeine
 

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Cask::CLI::Install do
-  it "allows install and activation of multiple Casks at once" do
+  it "allows staging and activation of multiple Casks at once" do
     shutup do
       Cask::CLI::Install.run('local-transmission', 'local-caffeine')
     end

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -96,7 +96,7 @@ describe Cask::DSL do
       end
 
       instance = CaskWithPkgs.new
-      Array(instance.artifacts[:install]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
+      Array(instance.artifacts[:pkg]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
     end
   end
 


### PR DESCRIPTION
now replaced by `pkg`
