### PR TITLE
Fixed license description

### DIFF
--- a/Casks/caffeine.rb
+++ b/Casks/caffeine.rb
@@ -4,7 +4,7 @@ class Caffeine < Cask
 
   url 'http://download.lightheadsw.com/download.php?software=caffeine'
   homepage 'http://lightheadsw.com/caffeine/'
-  license :gratis
+  license :closed
 
   app 'Caffeine.app'
   zap :delete => '~/Library/Preferences/com.lightheadsw.Caffeine.plist'


### PR DESCRIPTION
Since `:gratis` is no valid license categroy as required by the [license stanza details](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#license-stanza-details).
