### PR TITLE
Add IntelliJ IDEA CE with bundled JDK

### DIFF
--- a/Casks/intellij-idea-ce-bundled-jdk.rb
+++ b/Casks/intellij-idea-ce-bundled-jdk.rb
@@ -1,0 +1,17 @@
+class IntellijIdeaCeBundledJdk < Cask
+  version "14"
+  sha256 "09bb078252e2f6af6b58605ad3a380a71c8cc53f8e697e31fe03fcadb2152b07"
+
+  url "http://download.jetbrains.com/idea/ideaIC-#{version}-jdk-bundled.dmg"
+  homepage "https://www.jetbrains.com/idea/"
+  license :oss
+
+  app "IntelliJ IDEA #{version} CE.app"
+  
+  zap :delete => [
+                  "~/Library/Application Support/IdeaIC#{version}",
+                  "~/Library/Preferences/IdeaIC#{version}",
+                  "~/Library/Caches/IdeaIC#{version}",
+                  "~/Library/Logs/IdeaIC#{version}",
+                 ]
+end


### PR DESCRIPTION
IntelliJ offers a version with a bundled JDK for it to run when one is not present, or there is no java version installed (as with yosemite not having a jdk)
