### PR TITLE
Update adobe-air sha256

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,6 +1,6 @@
 class AdobeAir < Cask
   version '15.0'
-  sha256 '07f7ae83b9d9005c830ce7592d651c378e235a20f62da692410035a703af20c7'
+  sha256 '0fd04ae2ecb839a70b148a8194db1143fb3c2a8a2000d42e579c08aca65c0691'
 
   url "http://airdownload.adobe.com/air/mac/download/#{version}/AdobeAIR.dmg"
   homepage 'https://get.adobe.com/air/'


### PR DESCRIPTION
This updates adobe-air sha256
This PR becomes obsolete with #7168 
