### PR TITLE
fixed checksum error in carbon-copy-cloner

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,12 +1,11 @@
 class CarbonCopyCloner < Cask
-  version '4.0.3274'
-  sha256 '7d6479cd68ba9e8f9e0a74b2426d38c99ad3dea1c3a29dd7aaad8d8854d8a753'
+  version 'latest'
+  sha256 :no_check
 
-  url "http://bombich.com/software/files/ccc-#{version}.zip"
-  appcast 'http://www.bombich.com/software/updates/ccc.php',
-          :sha256 => 'ec02ebdd3e4bee0527d46e8256372249780fb1a4fb93ddb782e9da87787bbdff'
+  url "http://www.bombich.com/software/download_ccc.php?v=latest&l=alternate"
   homepage 'http://bombich.com/'
   license :unknown
 
   app 'Carbon Copy Cloner.app'
+
 end


### PR DESCRIPTION
changed version flag to 'latest' to remedy sha256 error; changed url field because the previous one was nonfunctional
