### PR TITLE
Mass update 36 Casks to use `staged_path` instead of `destination_path`

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -10,7 +10,7 @@ class AdobeArh < Cask
   binary 'arh'
 
   postflight do
-    system '/bin/chmod', '--', '755', "#{destination_path}/arh"
+    system '/bin/chmod', '--', '755', "#{staged_path}/arh"
   end
 
   caveats "Please refer to the documentation at #{homepage}"

--- a/Casks/alib1.rb
+++ b/Casks/alib1.rb
@@ -10,7 +10,7 @@ class Alib1 < Cask
   screen_saver 'Presstube-ALib1.app/Contents/Resources/Presstube - ALib1.saver'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName ALib1 (Presstube)', "#{destination_path}/presstube-alib1.app/Contents/Resources/Presstube - ALib1.saver/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName ALib1 (Presstube)', "#{staged_path}/presstube-alib1.app/Contents/Resources/Presstube - ALib1.saver/Contents/Info.plist"
   end
 
   caveats <<-EOS.undent

--- a/Casks/alice.rb
+++ b/Casks/alice.rb
@@ -9,6 +9,6 @@ class Alice < Cask
   app 'Alice.app'
 
   caveats do
-    path_environment_variable("#{destination_path}/Alice.app/Contents/Resources/bin")
+    path_environment_variable("#{staged_path}/Alice.app/Contents/Resources/bin")
   end
 end

--- a/Casks/android-studio-bundle.rb
+++ b/Casks/android-studio-bundle.rb
@@ -9,6 +9,6 @@ class AndroidStudioBundle < Cask
   app 'Android Studio.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/Android Studio.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/Android Studio.app/Contents/Info.plist"
   end
 end

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -9,6 +9,6 @@ class AndroidStudio < Cask
   app 'Android Studio.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/Android Studio.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/Android Studio.app/Contents/Info.plist"
   end
 end

--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -9,6 +9,6 @@ class Appcode < Cask
   app 'AppCode.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/AppCode.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/AppCode.app/Contents/Info.plist"
   end
 end

--- a/Casks/bankid.rb
+++ b/Casks/bankid.rb
@@ -8,7 +8,7 @@ class Bankid < Cask
 
   container :type => :naked
   preflight do
-    system '/bin/mv', '--', destination_path.join('FileDownloader'), destination_path.join('bankid-latest.pkg')
+    system '/bin/mv', '--', staged_path.join('FileDownloader'), destination_path.join('bankid-latest.pkg')
   end
 
   pkg 'bankid-latest.pkg'

--- a/Casks/chunkulus.rb
+++ b/Casks/chunkulus.rb
@@ -9,7 +9,7 @@ class Chunkulus < Cask
   screen_saver 'presstube-chunkulus.app/Contents/Resources/Presstube - Chunkulus.saver'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Chunkulus (Presstube)', "#{destination_path}/presstube-chunkulus.app/Contents/Resources/Presstube - Chunkulus.saver/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Chunkulus (Presstube)', "#{staged_path}/presstube-chunkulus.app/Contents/Resources/Presstube - Chunkulus.saver/Contents/Info.plist"
   end
 
   caveats <<-EOS.undent

--- a/Casks/decitime.rb
+++ b/Casks/decitime.rb
@@ -13,6 +13,6 @@ class Decitime < Cask
   # https://github.com/caskroom/homebrew-cask/pull/2654
   preflight do
     # todo the nested_container hack must be revised when container :nested stops being an alias around 0.50.0
-    system %Q{/usr/bin/hdiutil eject "$(/usr/bin/hdiutil mount -readwrite -noidme -nobrowse -mountrandom /tmp #{destination_path.join(artifacts[:nested_container].first)} | /usr/bin/cut -f3 -- - | /usr/bin/grep -- '.' -)" >/dev/null 2>&1}
+    system %Q{/usr/bin/hdiutil eject "$(/usr/bin/hdiutil mount -readwrite -noidme -nobrowse -mountrandom /tmp #{staged_path.join(artifacts[:nested_container].first)} | /usr/bin/cut -f3 -- - | /usr/bin/grep -- '.' -)" >/dev/null 2>&1}
   end
 end

--- a/Casks/fenics.rb
+++ b/Casks/fenics.rb
@@ -17,13 +17,13 @@ class Fenics < Cask
       available when you start your shell by adding the following to the .profile
       file in your home directory:
 
-        source #{destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
+        source #{staged_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
 
       If you are using an alternate shell (e.g., zsh, csh) or a modified or brewed Python,
       be sure to launch FEniCS using a clean (bash) shell.
       Creating a new shell using the following command works well:
 
-        /bin/bash --rcfile #{destination_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
+        /bin/bash --rcfile #{staged_path}/FEniCS.app/Contents/Resources/share/fenics/fenics.conf
     EOS
   end
 end

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -8,7 +8,7 @@ class GitAnnex < Cask
     # This is a horrible hack to force the file extension.  The
     # backend code should be fixed so that this is not needed.
     preflight do
-      system '/bin/mv', '--', destination_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
+      system '/bin/mv', '--', staged_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
     end
     container :nested => 'git-annex-latest.dmg'
   else

--- a/Casks/heart.rb
+++ b/Casks/heart.rb
@@ -9,7 +9,7 @@ class Heart < Cask
   screen_saver 'presstube-heart.app/Contents/Resources/Presstube - Heart.saver'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Heart (Presstube)', "#{destination_path}/presstube-heart.app/Contents/Resources/Presstube - Heart.saver/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Heart (Presstube)', "#{staged_path}/presstube-heart.app/Contents/Resources/Presstube - Heart.saver/Contents/Info.plist"
   end
 
   caveats <<-EOS.undent

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -9,7 +9,7 @@ class IntellijIdeaCe < Cask
   app 'IntelliJ IDEA 14 CE.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/IntelliJ IDEA 14 CE.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/IntelliJ IDEA 14 CE.app/Contents/Info.plist"
   end
 
   zap :delete => [

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -9,7 +9,7 @@ class IntellijIdea < Cask
   app 'IntelliJ IDEA 14.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/IntelliJ IDEA 14.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/IntelliJ IDEA 14.app/Contents/Info.plist"
   end
 
   zap :delete => [

--- a/Casks/jabber-video.rb
+++ b/Casks/jabber-video.rb
@@ -10,6 +10,6 @@ class JabberVideo < Cask
 
   # todo what is the reason for this?
   postflight do
-    system '/bin/rm', '--', "#{destination_path}/Jabber Video.app/Contents/Resources/ForcedConfig.plist"
+    system '/bin/rm', '--', "#{staged_path}/Jabber Video.app/Contents/Resources/ForcedConfig.plist"
   end
 end

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -8,6 +8,6 @@ class Jxplorer < Cask
 
   app "jxplorer-#{version}.app"
   postflight do
-    system '/bin/chmod', '--', 'a+x', "#{destination_path}/jxplorer-#{version}.app/Contents/MacOS/jxplorer"
+    system '/bin/chmod', '--', 'a+x', "#{staged_path}/jxplorer-#{version}.app/Contents/MacOS/jxplorer"
   end
 end

--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -7,7 +7,7 @@ class Nodeclipse < Cask
   license :oss
 
   preflight do
-    system '/bin/mv', '--', destination_path.join('eclipse/Eclipse.app'), destination_path.join('eclipse/Nodeclipse.app')
+    system '/bin/mv', '--', staged_path.join('eclipse/Eclipse.app'), destination_path.join('eclipse/Nodeclipse.app')
   end
   app 'eclipse/Nodeclipse.app'
 end

--- a/Casks/openarena.rb
+++ b/Casks/openarena.rb
@@ -9,6 +9,6 @@ class Openarena < Cask
   app "openarena-#{version}/OpenArena.app"
 
   postflight do
-    system '/bin/chmod', '--', '755', "#{destination_path}/openarena-#{version}/OpenArena.app/Contents/MacOS/openarena.ub"
+    system '/bin/chmod', '--', '755', "#{staged_path}/openarena-#{version}/OpenArena.app/Contents/MacOS/openarena.ub"
   end
 end

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -10,7 +10,7 @@ class Parallels < Cask
 
   postflight do
     # Set the file to visible, since it was hidden in the dmg
-    system '/usr/bin/SetFile', '-a', 'v', destination_path.join("Parallels Desktop.app")
+    system '/usr/bin/SetFile', '-a', 'v', staged_path.join("Parallels Desktop.app")
   end
 
   uninstall :delete => [

--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -10,6 +10,6 @@ class Parse < Cask
   binary 'parse'
 
   postflight do
-    system '/bin/chmod', '--', '0755', "#{destination_path}/parse"
+    system '/bin/chmod', '--', '0755', "#{staged_path}/parse"
   end
 end

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -9,6 +9,6 @@ class PdExtended < Cask
   app 'Pd-extended.app'
 
   uninstall_preflight do
-    system '/bin/chmod', '-R', '--', 'u+w', "#{destination_path}/Pd-extended.app"
+    system '/bin/chmod', '-R', '--', 'u+w', "#{staged_path}/Pd-extended.app"
   end
 end

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -9,7 +9,7 @@ class Phpstorm < Cask
   app 'PhpStorm.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/PhpStorm.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/PhpStorm.app/Contents/Info.plist"
   end
 
   zap :delete => [

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -9,6 +9,6 @@ class PycharmCe < Cask
   app 'PyCharm CE.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/PyCharm CE.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/PyCharm CE.app/Contents/Info.plist"
   end
 end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -9,6 +9,6 @@ class Pycharm < Cask
   app 'PyCharm.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/PyCharm.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/PyCharm.app/Contents/Info.plist"
   end
 end

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -11,7 +11,7 @@ class Qlmarkdown < Cask
   # DSL to identify such containers and generate a target directory.
   container :type => :naked
   preflight do
-    system '/usr/bin/ditto', '-xk', '--', "#{destination_path}/QLMarkdown.qlgenerator.zip", "#{destination_path}/QLMarkdown.qlgenerator"
+    system '/usr/bin/ditto', '-xk', '--', "#{staged_path}/QLMarkdown.qlgenerator.zip", "#{destination_path}/QLMarkdown.qlgenerator"
   end
 
   qlplugin 'QLMarkdown.qlgenerator'

--- a/Casks/quick-search-box.rb
+++ b/Casks/quick-search-box.rb
@@ -8,7 +8,7 @@ class QuickSearchBox < Cask
 
   app 'Quick Search Box.app'
   postflight do
-    system '/bin/chmod', '-R', '--', 'u+w', destination_path
+    system '/bin/chmod', '-R', '--', 'u+w', staged_path
   end
 
   zap :delete => '~/Library/Application Support/Google/Quick Search Box',

--- a/Casks/quotefixformac.rb
+++ b/Casks/quotefixformac.rb
@@ -14,7 +14,7 @@ class Quotefixformac < Cask
         defaults write com.apple.mail BundleCompatibilityVersion -string 3
 
         mkdir -p ~/Library/Mail/Bundles
-        cp -R #{destination_path}/QuoteFix.mailbundle ~/Library/Mail/Bundles/
+        cp -R #{staged_path}/QuoteFix.mailbundle ~/Library/Mail/Bundles/
         killall Mail; open -a Mail
     EOS
   end

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -8,7 +8,7 @@ class Ridibooks < Cask
 
   container :type => :naked
   preflight do
-    system '/bin/mv', '--', destination_path.join('getapp'), destination_path.join('ridibooks.pkg')
+    system '/bin/mv', '--', staged_path.join('getapp'), destination_path.join('ridibooks.pkg')
   end
   pkg 'ridibooks.pkg'
   uninstall :pkgutil => 'com.ridibooks.Ridibooks'

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -9,7 +9,7 @@ class Rubymine < Cask
   app 'RubyMine.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/RubyMine.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/RubyMine.app/Contents/Info.plist"
   end
   zap :delete => [
                   '~/Library/Application Support/RubyMine40',

--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -11,6 +11,6 @@ class ScreensConnect < Cask
             :pkgutil => 'com.edovia.pkg.screens.connect.*'
 
   uninstall_preflight do
-    system '/bin/chmod', '+x', "#{destination_path}/Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool"
+    system '/bin/chmod', '+x', "#{staged_path}/Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool"
   end
 end

--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -8,7 +8,7 @@ class TdToolbelt < Cask
 
   container :type => :naked
   preflight do
-    system '/bin/mv', '--', "#{destination_path}/mac", "#{destination_path}/td-toolbelt.pkg"
+    system '/bin/mv', '--', "#{staged_path}/mac", "#{destination_path}/td-toolbelt.pkg"
   end
 
   pkg 'td-toolbelt.pkg'

--- a/Casks/uberpov.rb
+++ b/Casks/uberpov.rb
@@ -11,7 +11,7 @@ class Uberpov < Cask
     <<-EOS.undent
       The standard UberPOV include path is:
 
-        #{destination_path}/Uberpov_Mac/include/
+        #{staged_path}/Uberpov_Mac/include/
 
       Before starting any renders, you may want to set the include path in
       UberPOV's preferences under
@@ -20,7 +20,7 @@ class Uberpov < Cask
 
       Sample scenes will be installed at:
 
-        #{destination_path}/Uberpov_Mac/scenes/
+        #{staged_path}/Uberpov_Mac/scenes/
     EOS
   end
 end

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -15,7 +15,7 @@ class VmwareFusion < Cask
 
   uninstall_preflight do
     system '/usr/bin/sudo', '-E', '--',
-           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "#{destination_path}/VMware Fusion.app"
+           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "#{staged_path}/VMware Fusion.app"
   end
   zap :delete => [
                   # note: '~/Library/Application Support/VMware Fusion' is not safe

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -9,6 +9,6 @@ class Voicemac < Cask
 
   app 'VoiceMac/VoiceMac.app'
   postflight do
-    system '/bin/chmod', '--', 'a+r', "#{destination_path}/VoiceMac/VoiceMac.app/Contents/Info.plist"
+    system '/bin/chmod', '--', 'a+r', "#{staged_path}/VoiceMac/VoiceMac.app/Contents/Info.plist"
   end
 end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -9,6 +9,6 @@ class Webstorm < Cask
   app 'WebStorm.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/WebStorm.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/WebStorm.app/Contents/Info.plist"
   end
 end

--- a/Casks/zeroxdbe-eap.rb
+++ b/Casks/zeroxdbe-eap.rb
@@ -9,6 +9,6 @@ class ZeroxdbeEap < Cask
   app '0xDBE EAP.app'
 
   postflight do
-    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{destination_path}/0xDBE\ EAP.app/Contents/Info.plist"
+    system '/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', "#{staged_path}/0xDBE\ EAP.app/Contents/Info.plist"
   end
 end


### PR DESCRIPTION
This is relatively disruptive, affecting 43 Casks, and requiring upgrade to 0.46.0
