### PR TITLE
Updated Mac Linux USB Loader cask to version 2.0.2

### DIFF
--- a/Casks/mac-linux-usb-loader.rb
+++ b/Casks/mac-linux-usb-loader.rb
@@ -1,11 +1,11 @@
 class MacLinuxUsbLoader < Cask
-  version :latest
+  version '2.0.2'
   sha256 :no_check
 
-  url 'https://sevenbits.github.io/downloads/Mac-Linux-USB-Loader.zip'
+  url 'https://github.com/SevenBits/Mac-Linux-USB-Loader/releases/download/v2.0.2/Mac.Linux.USB.Loader.zip'
   appcast 'http://sevenbits.github.io/appcasts/mlul.xml'
   homepage 'http://sevenbits.github.io/Mac-Linux-USB-Loader/'
-  license :oss
+  license :bsd
 
   app 'Mac Linux USB Loader.app'
 end


### PR DESCRIPTION
This updates the cask to reflect Mac Linux USB Loader version 2.0.2. Note that it is now using a versioned download URL.

Also sets the license to BSD license.
