### PR TITLE
Bump Slack to v1.0

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -1,12 +1,12 @@
 class Slack < Cask
-  version '0.44.2'
-  sha256 '2b24fa40d0c928bd1cba82263dbb34b12cf9486e7b6dfff5d24216a6b89d4584'
+  version '1.0'
+  sha256 '3cb5c52077388042006104d18ec1b7c230ededcf9f9691df2a42687e86f3b40c'
 
-  url 'https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1/app_versions/2?format=zip&amp;avtoken=b79aac107b7fda6c56fc5af6052bbc1713da870e'
+  url 'https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1/app_versions/4?format=zip&avtoken=826b2af93e6b167a3571c3823019254f0352efd3'
   appcast 'https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1',
           :sha256 => '0bfbef89c2b420d7485baf482cdd82d84f5e529c92cca653996e15ca5e6ba3c6'
   homepage 'http://slack.com'
   license :unknown
 
-  app "Slack #{version}.app"
+  app 'Slack.app'
 end


### PR DESCRIPTION
Slack pushed the 1.0 download to their stable channel appcast.

Does the appcast's checksum need to be updated?
