### PR TITLE
Fix OpenLP.app & upgrade to 2.0.5

### DIFF
--- a/Casks/openlp.rb
+++ b/Casks/openlp.rb
@@ -1,10 +1,10 @@
 class Openlp < Cask
-  version '2.0.4'
-  sha256 '24850da1e2d75b17d76cf102721d4c5e56d8faaa97ce1194577264c8edc6cc70'
+  version '2.0.5'
+  sha256 '0ba5a37c359394c277e221f8ca74191d3425cf3cfbd70699d81346c77c93d746'
 
-  url "http://builds.openlp.org/OpenLP-#{version}.dmg"
+  url "http://downloads.sourceforge.net/project/openlp/openlp/#{version}/OpenLP-#{version}.dmg"
   homepage 'http://openlp.org'
-  license :unknown
+  license :gpl
 
   app 'OpenLP.app'
 end


### PR DESCRIPTION
The old download from http://builds.openlp.org/ now 404s. The developers suggested using SourceForge instead.

I hope the SourceForge URL is acceptable!
