### PR TITLE
Upgrading ChefDK to 0.3.4

### DIFF
--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'chefdk' do
-  version '0.3.2-1'
-  sha256 'ffef287a9eba71eec8ee3f47044d351f6e679ed77b022f8be8bed3b76a912d44'
+  version '0.3.4-1'
+  sha256 'f4647e69df4bb3a4e66a82f24ff8f6ee253904e0655608dc102e215c4409db04'
 
   url "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-#{version}.dmg"
   homepage 'http://downloads.getchef.com/chef-dk/mac/'

--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -3,7 +3,7 @@ cask :v1 => 'chefdk' do
   sha256 'f4647e69df4bb3a4e66a82f24ff8f6ee253904e0655608dc102e215c4409db04'
 
   url "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-#{version}.dmg"
-  homepage 'http://downloads.getchef.com/chef-dk/mac/'
+  homepage 'https://downloads.getchef.com/chef-dk/mac/'
   license :apache
 
   pkg "chefdk-#{version}.pkg"


### PR DESCRIPTION
``` bash
$ brew cask audit chefdk --download
==> Downloading https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-0.3.4-1.dmg
######################################################################## 100.0%
audit for chefdk: passed
```
