### PR TITLE
Paragon uninstall

### DIFF
--- a/Casks/paragon-extfs.rb
+++ b/Casks/paragon-extfs.rb
@@ -7,4 +7,10 @@ cask :v1 => 'paragon-extfs' do
   license :unknown
 
   pkg 'FSInstaller.app/Contents/Resources/Paragon ExtFS for Mac OS X.pkg'
+  uninstall :pkgutil => 'com.paragon-software.filesystems.ExtFS.pkg',
+            :script  => 'Uninstall.app/Contents/Resources/uninstall.sh',
+            :launchctl => [
+                           'com.paragon.extfs*',
+                           'com.paragon.updater'
+                          ]
 end

--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -10,7 +10,7 @@ cask :v1 => 'paragon-ntfs' do
   uninstall :pkgutil => 'com.paragon-software.filesystems.NTFS.pkg',
             :script => 'Uninstall.app/Contents/Resources/uninstall.sh',
             :launchctl => [
-                           'com.paragon.ntfs.trial',
+                           'com.paragon.ntfs*',
                            'com.paragon.updater'
                           ]
 end

--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -7,4 +7,10 @@ cask :v1 => 'paragon-ntfs' do
   license :unknown
 
   pkg 'FSInstaller.app/Contents/Resources/Paragon NTFS for Mac OS X.pkg'
+  uninstall :pkgutil => 'com.paragon-software.filesystems.NTFS.pkg',
+            :script => 'Uninstall.app/Contents/Resources/uninstall.sh',
+            :launchctl => [
+                           'com.paragon.ntfs.trial',
+                           'com.paragon.updater'
+                          ]
 end


### PR DESCRIPTION
References #3322.

`launchctl`s are actually `com.paragon.ntfs.trial` and `com.paragon.extfs.trial`. Since I do not own (or plan on buying) the software, I’m not sure those will change to remove the `trial` part. The wildcard should address that.

`com.paragon.updater` is also tricky. If we don’t include it, we’re not considering every case, but if we do, we might possibly break the other package.

The script should take care of everything, though, but the other options should not be neglected in its favour.
