### PR TITLE
Pointing homepage to ChefDK home instead of Chef home

### DIFF
--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -4,7 +4,7 @@ cask :v1 => 'chefdk' do
 
   # amazonaws is the official download host per the vendor homepage
   url "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-#{version}.dmg"
-  homepage 'https://getchef.com/'
+  homepage 'https://downloads.getchef.com/chef-dk/'
   license :apache
 
   pkg "chefdk-#{version}.pkg"


### PR DESCRIPTION
043ef5ec8a26d621aebad90db4f9acdc50b2d4dd changed the homepage to the Chef homepage. This cask is for ChefDK. Chef != ChefDK. The proper homepage is https://downloads.getchef.com/chef-dk/ which actually introduces the ChefDK toolkit.
