### PR TITLE
DSL: remove support for `after_install` and friends

### DIFF
--- a/lib/cask/artifact/after_block.rb
+++ b/lib/cask/artifact/after_block.rb
@@ -1,17 +1,17 @@
 class Cask::Artifact::AfterBlock < Cask::Artifact::Base
   def self.me?(cask)
-    cask.artifacts[:after_install].any? ||
-      cask.artifacts[:after_uninstall].any?
+    cask.artifacts[:postflight].any? ||
+      cask.artifacts[:uninstall_postflight].any?
   end
 
   def install_phase
-    @cask.artifacts[:after_install].each do |block|
+    @cask.artifacts[:postflight].each do |block|
       Cask::DSL::AfterInstall.new(@cask).instance_eval &block
     end
   end
 
   def uninstall_phase
-    @cask.artifacts[:after_uninstall].each do |block|
+    @cask.artifacts[:uninstall_postflight].each do |block|
       Cask::DSL::AfterUninstall.new(@cask).instance_eval &block
     end
   end

--- a/lib/cask/artifact/before_block.rb
+++ b/lib/cask/artifact/before_block.rb
@@ -1,17 +1,17 @@
 class Cask::Artifact::BeforeBlock < Cask::Artifact::Base
   def self.me?(cask)
-    cask.artifacts[:before_install].any? ||
-      cask.artifacts[:before_uninstall].any?
+    cask.artifacts[:preflight].any? ||
+      cask.artifacts[:uninstall_preflight].any?
   end
 
   def install_phase
-    @cask.artifacts[:before_install].each do |block|
+    @cask.artifacts[:preflight].each do |block|
       Cask::DSL::BeforeInstall.new(@cask).instance_eval &block
     end
   end
 
   def uninstall_phase
-    @cask.artifacts[:before_uninstall].each do |block|
+    @cask.artifacts[:uninstall_preflight].each do |block|
       Cask::DSL::BeforeUninstall.new(@cask).instance_eval &block
     end
   end

--- a/lib/cask/cli/internal_stanza.rb
+++ b/lib/cask/cli/internal_stanza.rb
@@ -39,10 +39,10 @@ class Cask::CLI::InternalStanza < Cask::CLI::InternalUseBase
                        :caskroom_only,
                        :nested_container,
                        :uninstall,
-                       :after_install,
-                       :after_uninstall,
-                       :before_install,
-                       :before_uninstall,
+                       :postflight,
+                       :uninstall_postflight,
+                       :preflight,
+                       :uninstall_postflight,
                        ])
 
   def self.run(*arguments)

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -209,16 +209,6 @@ module Cask::DSL
       end
     end
 
-    # Todo: this hash is transitional.  Each of these stanzas will
-    # ultimately either be removed or upgraded with its own unique
-    # semantics.
-    STANZA_ALIASES = {
-                       :preflight             => :before_install,   # todo remove
-                       :postflight            => :after_install,    # todo remove
-                       :uninstall_preflight   => :before_uninstall, # todo remove
-                       :uninstall_postflight  => :after_uninstall,  # todo remove
-                     }
-
     def self.ordinary_artifact_types
       @@ordinary_artifact_types ||= [
                                      :app,
@@ -242,9 +232,8 @@ module Cask::DSL
     installable_artifact_types.push :caskroom_only
 
     installable_artifact_types.each do |type|
-      resolved_type = STANZA_ALIASES.key?(type) ? STANZA_ALIASES[type] : type
       define_method(type) do |*args|
-        artifacts[resolved_type] << args
+        artifacts[type] << args
       end
     end
 
@@ -261,10 +250,6 @@ module Cask::DSL
     end
 
     ARTIFACT_BLOCK_TYPES = [
-      :after_install,           # todo remove
-      :after_uninstall,         # todo remove
-      :before_install,          # todo remove
-      :before_uninstall,        # todo remove
       :preflight,
       :postflight,
       :uninstall_preflight,
@@ -272,9 +257,8 @@ module Cask::DSL
     ]
 
     ARTIFACT_BLOCK_TYPES.each do |type|
-      resolved_type = STANZA_ALIASES.key?(type) ? STANZA_ALIASES[type] : type
       define_method(type) do |&block|
-        artifacts[resolved_type] << block
+        artifacts[type] << block
       end
     end
 


### PR DESCRIPTION
in favor of new-style `preflight`/`postflight` forms
