### PR TITLE
added note for sourceforge.jp urls in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,12 @@ fall back to this format:
 http://downloads.sourceforge.net/sourceforge/$PROJECTNAME/$FILENAME.$EXT
 ```
 
+Or, if it’s from [SourceForge.JP](http://sourceforge.jp/):
+
+```
+http://dl.sourceforge.jp/$PROJECTNAME/$RELEASEID/$FILENAME.$EXT
+```
+
 ### Personal Hosting Such as Dropbox
 
 URLs from dropbox.com or cl.ly/cloudapp.com are not readily distinguishable


### PR DESCRIPTION
Does anyone have an idea what that `$NUMBER` (refraining from calling it `$INTEGER` for less technical users) part is? It seems to be in all urls of this type, and fairly specific to each download (meaning there’s no logical way to describe it, as it’s just something that increments on sourceforge’s servers).

@troter You were the one to add this exception. Any idea if it’s something we can be more descriptive about?
