### PR TITLE
DSL: add stanza `stage_only` (new spelling of `caskroom_only`)

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -119,6 +119,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 | `container :type =>`   | no                            | a symbol to override container-type autodetect. may be one of: `:air`, `:bz2`, `:cab`, `:dmg`, `:generic_unar`, `:gzip`, `:otf`, `:pkg`, `:rar`, `:seven_zip`, `:sit`, `:tar`, `:ttf`, `:xar`, `:zip`, `:naked`.  (example [parse.rb](../Casks/parse.rb))
 | `tags`                 | no                            | a list of key-value pairs for Cask annotation.  Not free-form.  (see also [Tags Stanza Details](#tags-stanza-details))
 | `gpg`                  | no                            | *stub: not yet functional.*  (see also [GPG Stanza Details](#gpg-stanza-details))
+| `stage_only`           | no                            | `true`.  Assert that the Cask contains no activatable artifacts.
 
 
 ## Legacy Stanzas
@@ -136,6 +137,7 @@ The following stanzas are no longer in use.
 | `install`                 | an obsolete alternative to `pkg`
 | `link`                    | an obsolete alternative to `artifact`
 | `no_checksum`             | an obsolete alternative to `sha256 :no_check`
+| `caskroom_only`           | an obsolete alternative to `stage_only`
 
 
 ## Legacy Forms

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -50,6 +50,7 @@ This notice will be removed for the final form.**
  * `installer :script`
  * `license`
  * `suite`
+ * `stage_only`
  * `tags`
  * `uninstall :rmdir`
  * `uninstall :trash`

--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -20,7 +20,7 @@ require 'cask/artifact/qlplugin'
 require 'cask/artifact/widget'
 require 'cask/artifact/service'
 require 'cask/artifact/suite'
-require 'cask/artifact/caskroom_only'
+require 'cask/artifact/stage_only'
 require 'cask/artifact/input_method'
 require 'cask/artifact/internet_plugin'
 require 'cask/artifact/screen_saver'
@@ -46,7 +46,7 @@ module Cask::Artifact
       Cask::Artifact::Font,
       Cask::Artifact::Widget,
       Cask::Artifact::Service,
-      Cask::Artifact::CaskroomOnly,
+      Cask::Artifact::StageOnly,
       Cask::Artifact::Binary,
       Cask::Artifact::InputMethod,
       Cask::Artifact::InternetPlugin,

--- a/lib/cask/artifact/stage_only.rb
+++ b/lib/cask/artifact/stage_only.rb
@@ -1,6 +1,6 @@
-class Cask::Artifact::CaskroomOnly < Cask::Artifact::Base
+class Cask::Artifact::StageOnly < Cask::Artifact::Base
   def self.artifact_dsl_key
-    :caskroom_only
+    :stage_only
   end
 
   def install_phase

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -56,7 +56,8 @@ PURPOSE
       if cask.artifacts[type].length > 0
         retval = "#{Tty.blue}==>#{Tty.white} Contents#{Tty.reset}\n" unless retval.length > 0
         cask.artifacts[type].each do |artifact|
-          retval.concat "  #{artifact.first} (#{type.to_s})\n"
+          activatable_item = type == :stage_only ? '<none>' : artifact.first
+          retval.concat "  #{activatable_item} (#{type.to_s})\n"
         end
       end
     end

--- a/lib/cask/cli/internal_stanza.rb
+++ b/lib/cask/cli/internal_stanza.rb
@@ -36,7 +36,7 @@ class Cask::CLI::InternalStanza < Cask::CLI::InternalUseBase
                        :internet_plugin,
                        :screen_saver,
                        :pkg,
-                       :caskroom_only,
+                       :stage_only,
                        :nested_container,
                        :uninstall,
                        :postflight,

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -295,4 +295,18 @@ describe Cask::DSL do
       }.must_raise(CaskInvalidError)
     end
   end
+
+  describe "stage_only stanza" do
+    it "allows stage_only stanza to be specified" do
+      cask = Cask.load('stage-only')
+      cask.artifacts[:stage_only].first.must_equal [true]
+    end
+
+    it "prevents specifying stage_only with other activatables" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-stage-only-conflict')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include "'stage_only' must be the only activatable artifact"
+    end
+  end
 end

--- a/test/support/Casks/invalid/invalid-stage-only-conflict.rb
+++ b/test/support/Casks/invalid/invalid-stage-only-conflict.rb
@@ -1,0 +1,10 @@
+class InvalidStageOnlyConflict < TestCask
+  version '2.61'
+  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
+  url TestHelper.local_binary_url('transmission-2.61.dmg')
+  homepage 'http://example.com/invalid-stage-only-conflict'
+
+  stage_only true
+  app 'Transmission.app'
+end

--- a/test/support/Casks/stage-only.rb
+++ b/test/support/Casks/stage-only.rb
@@ -1,0 +1,9 @@
+class StageOnly < TestCask
+  version '2.61'
+  sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
+
+  url TestHelper.local_binary_url('transmission-2.61.dmg')
+  homepage 'http://example.com/stage-only'
+
+  stage_only true
+end


### PR DESCRIPTION
`caskroom_only` was never documented.  Its original purpose was obsoleted in #4865, and its use has been recently been reduced to two Casks.

This PR
- continues the rationalization of naming by changing `caskroom_only` to `stage_only`. "stage" is the verb for "make a copy under the caskroom directory"
- documents `stage_only`
- adds tests for `stage_only`
- validates the argument to `stage_only`
- gives sensible output in `brew cask info` for `stage_only` Casks
- enforces that `stage_only` cannot coexist with any activatable artifacts

`caskroom_only` is still supported for backward compatibility, but should be removed before 0.50.0.
