### PR TITLE
Update and Fix itsycal

### DIFF
--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'itsycal' do
-  version '0.8.10'
-  sha256 '2cfa08066722a13b994559f45b9d01bba1ff02e98c6797f2fc7c93344747093b'
+  version '0.8.12'
+  sha256 '1b138d7ddce1ac725c7fd0146225dd50f1bad90b62cf727fe89c636c4281e697'
 
   url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
   homepage 'http://www.mowglii.com/itsycal/'
   license :unknown
 
-  app "Itsycal #{version}/Itsycal.app"
+  app "Itsycal.app"
 end


### PR DESCRIPTION
updates itsycal to new version
fixes "Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/itsycal/0.8.10/Itsycal 0.8.10/Itsycal.app'" when installing
