### PR TITLE
added TLD to host reference in 'official download host' comments

### DIFF
--- a/Casks/abgx360.rb
+++ b/Casks/abgx360.rb
@@ -2,7 +2,7 @@ cask :v1 => 'abgx360' do
   version '1.0.6'
   sha256 'b2b066d1500e6c6a64d103b2c1a9e1760be0a4e16df314b4868024c19df8c741'
 
-  # dropbox is the official download host per the vendor homepage
+  # dropbox.com is the official download host per the vendor homepage
   url "http://dl.dropbox.com/u/59058148/abgx360-#{version}.pkg"
   homepage 'http://abgx360.xecuter.com/'
   license :oss

--- a/Casks/actotracker.rb
+++ b/Casks/actotracker.rb
@@ -2,7 +2,7 @@ cask :v1 => 'actotracker' do
   version :latest
   sha256 :no_check
 
-  # dropbox is the official download host per the vendor homepage
+  # dropboxusercontent.com is the official download host per the vendor homepage
   url 'https://dl.dropboxusercontent.com/u/7614970/ActoTracker.zip'
   homepage 'http://onflapp.wordpress.com/actotracker'
   license :gratis

--- a/Casks/clipmenu.rb
+++ b/Casks/clipmenu.rb
@@ -2,7 +2,7 @@ cask :v1 => 'clipmenu' do
   version '0.4.3'
   sha256 'd0d7ca6c23f51b2dfe78c7bb40bf2f212c21b3304b3eacde86112d8ef3e6bfb9'
 
-  # dropbox is the official download host per the vendor homepage
+  # dropbox.com is the official download host per the vendor homepage
   url "https://dl.dropbox.com/u/1140644/clipmenu/ClipMenu_#{version}.dmg"
   appcast 'http://feeds.feedburner.com/clipmenu-appcast',
           :sha256 => 'e9f9df0e48aad4e00b8df26fd622f42a0218f5be662b6d2ee496664c5f45b4a3'

--- a/Casks/disconnect.rb
+++ b/Casks/disconnect.rb
@@ -2,7 +2,7 @@ cask :v1 => 'disconnect' do
   version :latest
   sha256 :no_check
 
-  # amazonaws is the official download host per the vendor homepage
+  # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/disconnect-desktop/Disconnect+Desktop.pkg'
   homepage 'https://disconnect.me'
 

--- a/Casks/giffun.rb
+++ b/Casks/giffun.rb
@@ -2,7 +2,7 @@ cask :v1 => 'giffun' do
   version '2008-03-13'
   sha256 '057e89ee3e5e39c82f40ea490f9f601a487bf688f55cd7e5e7e3b3f9ce812a4a'
 
-  # dropbox is the official download host per the vendor homepage
+  # dropbox.com is the official download host per the vendor homepage
   url "http://dl.dropbox.com/u/2000860/GIFfun-#{version}.dmg"
   homepage 'http://www.stone.com/GIFfun/'
   license :unknown

--- a/Casks/jsonlook.rb
+++ b/Casks/jsonlook.rb
@@ -2,7 +2,7 @@ cask :v1 => 'jsonlook' do
   version :latest
   sha256 :no_check
 
-  # dropbox is the official download host per the vendor homepage
+  # dropbox.com is the official download host per the vendor homepage
   url 'https://dl.dropbox.com/u/3878216/github/jsonlook.qlgenerator.zip'
   homepage 'https://github.com/rjregenold/jsonlook'
   license :oss

--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -2,7 +2,7 @@ cask :v1 => 'kicad' do
   version '2014-02-26'
   sha256 '066520f10e9646e88c2e1d7812adf54a73a331592076f394cb439a97c228410b'
 
-  # mdx4 is the official download host per the vendor homepage
+  # mdx4.org is the official download host per the vendor homepage
   url "http://www.mdx4.org/uploads/kicad/Kicad-product-#{version}.zip"
   homepage 'http://www.kicad-pcb.org/'
   license :gpl

--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -2,7 +2,7 @@ cask :v1 => 'lincastor' do
   version :latest
   sha256 :no_check
 
-  # dropbox is the official download host per the vendor homepage
+  # dropboxusercontent.com is the official download host per the vendor homepage
   url 'https://dl.dropboxusercontent.com/u/7614970/LinCastor.zip'
   homepage 'http://onflapp.wordpress.com/lincastor/'
   license :unknown

--- a/Casks/ninjablocks.rb
+++ b/Casks/ninjablocks.rb
@@ -2,7 +2,7 @@ cask :v1 => 'ninjablocks' do
   version '0.2'
   sha256 'f0ed94bc767a7f0059d08904f71c4266b6045ce4f7c194678e48b02a2d85eaeb'
 
-  # dropbox is the official download host per the vendor homepage
+  # dropboxusercontent.com is the official download host per the vendor homepage
   url "https://dl.dropboxusercontent.com/u/428557/NinjaBlocks-#{version}.dmg"
   homepage 'http://forums.ninjablocks.com/index.php?p=/discussion/1655/ninja-osx-client/p1'
   license :unknown

--- a/Casks/openlp.rb
+++ b/Casks/openlp.rb
@@ -2,7 +2,7 @@ cask :v1 => 'openlp' do
   version '2.0.5'
   sha256 '0ba5a37c359394c277e221f8ca74191d3425cf3cfbd70699d81346c77c93d746'
 
-  # sourceforge is the official download host per the vendor homepage
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/openlp/openlp/#{version}/OpenLP-#{version}.dmg"
   homepage 'http://openlp.org'
   license :gpl

--- a/Casks/pangu.rb
+++ b/Casks/pangu.rb
@@ -2,7 +2,7 @@ cask :v1 => 'pangu' do
   version '1.0.0'
   sha256 '910c2fcc6bbaea54f2944eb275de9674bc4613bf79f1f60dbf8ad0064269a252'
 
-  # 25pp is the official download host per the vendor homepage
+  # 25pp.com is the official download host per the vendor homepage
   url "http://dl.pangu.25pp.com/jb/Pangu8_v#{version}.dmg"
   homepage 'http://en.pangu.io/'
   license :unknown

--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -2,7 +2,7 @@ cask :v1 => 'redcine-x-pro' do
   version '31.0.0'
   sha256 '9393f84d839214ef4b692434ced8f4f9ecd12f8f49d8230d84c1bef9fe44d4db'
 
-  # amazonaws is the official download host per the vendor homepage
+  # amazonaws.com is the official download host per the vendor homepage
   url "http://s3.amazonaws.com/red_3/downloads/software/rcx/REDCINE-X_PRO_Build_#{version.to_i}_OSX.zip"
   homepage 'https://www.red.com/'
   license :commercial

--- a/Casks/shoes.rb
+++ b/Casks/shoes.rb
@@ -2,7 +2,7 @@ cask :v1 => 'shoes' do
   version '3.2.16'
   sha256 'dab8e717bc49e5c33654fde487cf1f0bef9dc6832df31dc54d084e8c5843532a'
 
-  # mvmanila is the official download host per the vendor homepage
+  # mvmanila.com is the official download host per the vendor homepage
   url "http://shoes.mvmanila.com/public/shoes/shoes-#{version}-osx-10.9.tgz"
   homepage 'http://shoesrb.com/'
   license :oss

--- a/Casks/sidekick.rb
+++ b/Casks/sidekick.rb
@@ -2,7 +2,7 @@ cask :v1 => 'sidekick' do
   version :latest
   sha256 :no_check
 
-  # amazonaws is the official download host per the vendor homepage
+  # amazonaws.com is the official download host per the vendor homepage
   url 'http://releases.oomphalot.com.s3-website-us-east-1.amazonaws.com/Sidekick/Sidekick.zip'
   appcast 'http://updates.oomphalot.com/?app=Sidekick'
   homepage 'http://oomphalot.com/sidekick/'

--- a/Casks/tagoman.rb
+++ b/Casks/tagoman.rb
@@ -2,7 +2,7 @@ cask :v1 => 'tagoman' do
   version :latest
   sha256 :no_check
 
-  # dropbox is the official download host per the vendor homepage
+  # dropboxusercontent.com is the official download host per the vendor homepage
   url 'https://dl.dropboxusercontent.com/u/7614970/TagoMan.zip'
   homepage 'http://onflapp.wordpress.com/tagoman'
   license :unknown

--- a/Casks/thaiwitter.rb
+++ b/Casks/thaiwitter.rb
@@ -2,7 +2,7 @@ cask :v1 => 'thaiwitter' do
   version :latest
   sha256 :no_check
 
-  # dropbox is the official download host per the vendor homepage
+  # dropbox.com is the official download host per the vendor homepage
   url 'https://dl.dropbox.com/u/25097375/thaiWitter/Builds/thaiWitter3.app.zip'
   homepage 'https://tw3.herokuapp.com/'
   license :unknown

--- a/Casks/uber-network-fuser.rb
+++ b/Casks/uber-network-fuser.rb
@@ -2,7 +2,7 @@ cask :v1 => 'uber-network-fuser' do
   version '1.701'
   sha256 'd2f919a466d093da30e66a664d716a96ea0e1167c887ace8fb30d2e55c6c3c7d'
 
-  # dropbox is the official download host per the vendor homepage
+  # dropbox.com is the official download host per the vendor homepage
   url "https://dl.dropbox.com/s/uytv8p2eljk6fez/ubernetfuser_#{version}.dmg"
   homepage 'http://nickapedia.com/2012/01/10/breaking-new-ground-an-uber-tool-for-the-mac/'
   license :unknown

--- a/Casks/workamajig.rb
+++ b/Casks/workamajig.rb
@@ -2,7 +2,7 @@ cask :v1 => 'workamajig' do
   version :latest
   sha256 :no_check
 
-  # amazonaws is the official download host per the vendor homepage
+  # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/Workamajig/AIR/Workamajig.air'
   homepage 'http://www.workamajig.com/'
   license :unknown


### PR DESCRIPTION
Just to make sure they exactly match what’s in the url, so even minor changes are likelier to be caught.
