### PR TITLE
DSL: remove support for `depends_on_formula`

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -34,8 +34,6 @@ module Cask::DSL
 
   def license; self.class.license; end
 
-  def depends_on_formula; self.class.depends_on_formula; end
-
   def depends_on; self.class.depends_on; end
 
   def conflicts_with; self.class.conflicts_with; end
@@ -160,10 +158,6 @@ module Cask::DSL
       end
     end
 
-    def depends_on_formula(*args)
-      @depends_on_formula ||= args
-    end
-
     def depends_on(*args)
       if @depends_on and !args.empty?
         # todo: remove this constraint, and instead merge multiple depends_on stanzas
@@ -173,10 +167,6 @@ module Cask::DSL
         Cask::DSL::DependsOn.new(*args) unless args.empty?
       rescue StandardError => e
         raise CaskInvalidError.new(self.title, e)
-      end
-      # todo: remove this backwards compatibility section after removing depends_on_formula
-      if @depends_on.formula
-        @depends_on_formula ||= [ @depends_on.formula ]
       end
       @depends_on
     end

--- a/lib/cask/dsl/depends_on.rb
+++ b/lib/cask/dsl/depends_on.rb
@@ -17,6 +17,7 @@ class Cask::DSL::DependsOn
     pairs.each do |key, value|
       raise "invalid depends_on key: '#{key.inspect}'" unless VALID_KEYS.include?(key)
       writer_method = "#{key}=".to_sym
+      value = Array(value) if [:formula, :cask].include?(key)
       send(writer_method, value)
     end
   end

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -100,9 +100,12 @@ class Cask::Installer
   end
 
   def formula_dependencies
-    unless @cask.depends_on_formula.empty?
+    # todo The Cask::DependsOn object needs to be more friendly.
+    #      Currently @cask.depends_on.formula raises an exception
+    #      if :formula was not set.
+    if @cask.depends_on and not @cask.depends_on.formula.empty?
       ohai 'Installing Formula dependencies from Homebrew'
-      @cask.depends_on_formula.each do |dep_name|
+      @cask.depends_on.formula.each do |dep_name|
         print "#{dep_name} ... "
         installed = @command.run(HOMEBREW_BREW_FILE,
                                  :args => ['list', '--versions', dep_name],

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -94,7 +94,7 @@ module Cask::Utils
        :sums,
        :artifacts,
        :caveats,
-       :depends_on_formula,
+       :depends_on,
        :conflicts_with,
        :container_type,
        :gpg,

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -44,7 +44,8 @@ describe Cask::Installer do
     it "works with cab-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/cabextract').exist?
       cab_container = Cask.load('cab-container')
-      cab_container.stubs(:depends_on_formula).returns([])
+      empty = stub(:formula => [])
+      cab_container.stubs(:depends_on).returns(empty)
 
       shutup do
         Cask::Installer.new(cab_container).install
@@ -71,7 +72,8 @@ describe Cask::Installer do
     it "works with 7z-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       sevenzip_container = Cask.load('sevenzip-container')
-      sevenzip_container.stubs(:depends_on_formula).returns([])
+      empty = stub(:formula => [])
+      sevenzip_container.stubs(:depends_on).returns(empty)
 
       shutup do
         Cask::Installer.new(sevenzip_container).install
@@ -99,7 +101,8 @@ describe Cask::Installer do
     it "works with Stuffit-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       stuffit_container = Cask.load('stuffit-container')
-      stuffit_container.stubs(:depends_on_formula).returns([])
+      empty = stub(:formula => [])
+      stuffit_container.stubs(:depends_on).returns(empty)
 
       shutup do
         Cask::Installer.new(stuffit_container).install
@@ -114,7 +117,8 @@ describe Cask::Installer do
     it "works with RAR-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       rar_container = Cask.load('rar-container')
-      rar_container.stubs(:depends_on_formula).returns([])
+      empty = stub(:formula => [])
+      rar_container.stubs(:depends_on).returns(empty)
 
       shutup do
         Cask::Installer.new(rar_container).install


### PR DESCRIPTION
obsoleted by `depends_on :formula`
