### PR TITLE
use app instead of suite in sketchup

### DIFF
--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -8,8 +8,10 @@ cask :v1 => 'sketchup' do
   homepage 'http://www.sketchup.com/intl/en/'
   license :unknown
 
-  suite 'SketchUp 2015'
-  
+  app 'Sketchup 2015/LayOut.app'
+  app 'Sketchup 2015/SketchUp.app'
+  app 'Sketchup 2015/Style Builder.app'
+
   zap :delete => [
                   '~/Library/Application Support/SketchUp 2015',
                   '~/Library/Caches/com.sketchup.SketchUp.2015',


### PR DESCRIPTION
Only three apps and nothing else in the directory. No reason why `suite` should be used.
