### PR TITLE
Add Lunchy (golang version) v0.1.4

### DIFF
--- a/Casks/lunchy-go.rb
+++ b/Casks/lunchy-go.rb
@@ -1,0 +1,10 @@
+class LunchyGo < Cask
+  version '0.1.4'
+  sha256 'b6f7d1efa33fe651ad2efba8ab24f8ba618f369bef872afa3ab6ae78a003b39a'
+
+  url "https://github.com/sosedoff/lunchy-go/releases/download/v#{version}/#{version}_darwin_amd64.zip"
+  homepage 'https://github.com/sosedoff/lunchy-go'
+  license :mit
+
+  binary "lunchy"
+end


### PR DESCRIPTION
This is a golang port of [Lunchy](https://github.com/eddiezane/lunchy), a 'friendly wrapper for launchctl'.
