### PR TITLE
Update Mou URLs

### DIFF
--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -2,9 +2,9 @@ cask :v1 => 'mou' do
   version :latest
   sha256 :no_check
 
-  url 'http://mouapp.com/download/Mou.zip'
-  appcast 'http://mouapp.com/up/updates.xml'
-  homepage 'http://mouapp.com/'
+  url 'http://25.io/mou/download/Mou.zip'
+  appcast 'http://25.io/mou/up/updates.xml'
+  homepage 'http://25.io/mou/'
   license :unknown
 
   app 'Mou.app'


### PR DESCRIPTION
The homepage and download URLs for Mou.app have changed now that the project is under a
software studio called 25.io
