### PR TITLE
DSL: remove `manual_installer` from `caveats` mini-DSL

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -267,7 +267,7 @@ Example:
 
 ```ruby
 caveats do
-  manual_installer 'Little Snitch Installer.app'
+  path_environment_variable '/usr/texbin'
 end
 ```
 

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -49,17 +49,6 @@ class Cask::CaveatsDSL
   #   to the output by the caller, but that feature is only for the
   #   convenience of Cask authors. )
 
-  # todo: remove this method after DSL 1.0 transition
-  def manual_installer(path)
-    puts <<-EOS.undent
-    To complete the installation of Cask #{@cask}, you must also
-    run the installer at
-
-      '#{staged_path.join(path)}'
-
-    EOS
-  end
-
   def path_environment_variable(path)
     puts <<-EOS.undent
     To use #{@cask}, you may need to add the #{path} directory


### PR DESCRIPTION
obsoleted by new toplevel form `installer :manual`.

Also remove missed obsolete documentation item.
