### PR TITLE
DSL: remove support for `container_type`

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -38,8 +38,6 @@ module Cask::DSL
 
   def conflicts_with; self.class.conflicts_with; end
 
-  def container_type; self.class.container_type; end
-
   def container; self.class.container; end
 
   def tags; self.class.tags; end
@@ -91,14 +89,6 @@ module Cask::DSL
       end
     end
 
-    # todo: remove this backwards compatibility element after 0.50.0
-    def container_type(type=nil)
-      if @container_type and !type.nil?
-        raise CaskInvalidError.new(self.title, "'container_type' stanza may only appear once")
-      end
-      @container_type ||= type
-    end
-
     def container(*args)
       if @container and !args.empty?
         # todo: remove this constraint, and instead merge multiple container stanzas
@@ -109,12 +99,8 @@ module Cask::DSL
       rescue StandardError => e
         raise CaskInvalidError.new(self.title, e)
       end
-      # todo: remove this backwards compatibility section after removing container_type
-      if @container.type
-        @container_type ||= @container.type
-      end
       # todo: remove this backwards compatibility section after removing nested_container
-      if @container.nested
+      if @container and @container.nested
         artifacts[:nested_container] << @container.nested
       end
       @container

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -77,8 +77,8 @@ class Cask::Installer
   def extract_primary_container
     odebug "Extracting primary container"
     FileUtils.mkdir_p @cask.staged_path
-    container = if @cask.container_type
-       Cask::Container.from_type(@cask.container_type)
+    container = if @cask.container and @cask.container.type
+       Cask::Container.from_type(@cask.container.type)
     else
        Cask::Container.for_path(@downloaded_path, @command)
     end

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -96,7 +96,7 @@ module Cask::Utils
        :caveats,
        :depends_on,
        :conflicts_with,
-       :container_type,
+       :container,
        :gpg,
       ].each do |method|
         odebug "Cask instance method '#{method}':", self.send(method).to_yaml

--- a/test/support/Casks/naked-executable.rb
+++ b/test/support/Casks/naked-executable.rb
@@ -5,5 +5,5 @@ class NakedExecutable < TestCask
   url TestHelper.local_binary_url('naked_executable')
   homepage 'http://example.com/naked-executable'
 
-  container_type :naked
+  container :type => :naked
 end


### PR DESCRIPTION
obsoleted by new form `container :type`
