### PR TITLE
remove old-style header line from test Casks

### DIFF
--- a/lib/cask/source/path_base.rb
+++ b/lib/cask/source/path_base.rb
@@ -44,8 +44,11 @@ class Cask::Source::PathBase
 
       # munge text
       cask_string.sub!(%r{\A(\s*\#[^\n]*\n)+}, '');
-      if %r{\A\s*cask\s+:v[\d_]+\s+=>\s+([\'\"])(\S+?)\1(?:\s*,\s*|\s+)do\s*\n}.match(cask_string)
-        cask_string.sub!(%r{\A[^\n]+\n}, "class #{cask_class_name} < Cask\n")
+      if %r{\A\s*cask\s+:v([\d_]+)(test)?\s+=>\s+([\'\"])(\S+?)\3(?:\s*,\s*|\s+)do\s*\n}.match(cask_string)
+        dsl_version = $1
+        test_cask = ! $2.nil?
+        superclass_name = test_cask ? 'TestCask' : 'Cask'
+        cask_string.sub!(%r{\A[^\n]+\n}, "class #{cask_class_name} < #{superclass_name}\n")
       end
 
       # simulate "require"

--- a/test/cask/cli/cat_test.rb
+++ b/test/cask/cli/cat_test.rb
@@ -4,7 +4,7 @@ describe Cask::CLI::Cat do
   describe 'given a basic Cask' do
     before do
       @expected_output = <<-CLIOUTPUT.undent
-        class BasicCask < TestCask
+        cask :v1test => 'basic-cask' do
           version '1.2.3'
           sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/test/support/Casks/adobe-air-container.rb
+++ b/test/support/Casks/adobe-air-container.rb
@@ -1,4 +1,4 @@
-class AdobeAirContainer < TestCask
+cask :v1test => 'adobe-air-container' do
   version '1.0.1'
   sha256 '9b6e4174afa76f2af50238364fcf87525bc4ed2287acbe62925107ab6cda5c99'
 

--- a/test/support/Casks/bad-checksum.rb
+++ b/test/support/Casks/bad-checksum.rb
@@ -1,4 +1,4 @@
-class BadChecksum < TestCask
+cask :v1test => 'bad-checksum' do
   version '1.2.3'
   sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
 

--- a/test/support/Casks/basic-cask.rb
+++ b/test/support/Casks/basic-cask.rb
@@ -1,4 +1,4 @@
-class BasicCask < TestCask
+cask :v1test => 'basic-cask' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/test/support/Casks/bzipped-asset.rb
+++ b/test/support/Casks/bzipped-asset.rb
@@ -1,4 +1,4 @@
-class BzippedAsset < TestCask
+cask :v1test => 'bzipped-asset' do
   version '1.2.3'
   sha256 'eaf67b3a62cb9275f96e45d05c70b94bef9ef1dae344083e93eda6b0b388a61c'
 

--- a/test/support/Casks/cab-container.rb
+++ b/test/support/Casks/cab-container.rb
@@ -1,4 +1,4 @@
-class CabContainer < TestCask
+cask :v1test => 'cab-container' do
   version '1.2.3'
   sha256 '192d0cf6b727473f9ba0f55cec793ee2a8f7113c5cfe9d49e05a087436c5efe2'
 

--- a/test/support/Casks/gzipped-asset.rb
+++ b/test/support/Casks/gzipped-asset.rb
@@ -1,4 +1,4 @@
-class GzippedAsset < TestCask
+cask :v1test => 'gzipped-asset' do
   version '1.2.3'
   sha256 '832506ade94b3e41ecdf2162654eb75891a0749803229e82b2e0420fd1b9e8d2'
 

--- a/test/support/Casks/invalid/invalid-appcast-format.rb
+++ b/test/support/Casks/invalid/invalid-appcast-format.rb
@@ -1,4 +1,4 @@
-class InvalidAppcastFormat < TestCask
+cask :v1test => 'invalid-appcast-format' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-appcast-multiple.rb
+++ b/test/support/Casks/invalid/invalid-appcast-multiple.rb
@@ -1,4 +1,4 @@
-class InvalidAppcastMultiple < TestCask
+cask :v1test => 'invalid-appcast-multiple' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-appcast-url.rb
+++ b/test/support/Casks/invalid/invalid-appcast-url.rb
@@ -1,4 +1,4 @@
-class InvalidAppcastUrl < TestCask
+cask :v1test => 'invalid-appcast-url' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-conflicts-with-key.rb
+++ b/test/support/Casks/invalid/invalid-conflicts-with-key.rb
@@ -1,4 +1,4 @@
-class InvalidConflictsWithKey < TestCask
+cask :v1test => 'invalid-conflicts-with-key' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-depends-on-key.rb
+++ b/test/support/Casks/invalid/invalid-depends-on-key.rb
@@ -1,4 +1,4 @@
-class InvalidDependsOnKey < TestCask
+cask :v1test => 'invalid-depends-on-key' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
+++ b/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
@@ -1,4 +1,4 @@
-class InvalidGpgConflictingKeys < TestCask
+cask :v1test => 'invalid-gpg-conflicting-keys' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-key-id.rb
+++ b/test/support/Casks/invalid/invalid-gpg-key-id.rb
@@ -1,4 +1,4 @@
-class InvalidGpgKeyId < TestCask
+cask :v1test => 'invalid-gpg-key-id' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-key-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-key-url.rb
@@ -1,4 +1,4 @@
-class InvalidGpgKeyUrl < TestCask
+cask :v1test => 'invalid-gpg-key-url' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-missing-key.rb
+++ b/test/support/Casks/invalid/invalid-gpg-missing-key.rb
@@ -1,4 +1,4 @@
-class InvalidGpgMissingKeys < TestCask
+cask :v1test => 'invalid-gpg-missing-key' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
+++ b/test/support/Casks/invalid/invalid-gpg-multiple-stanzas.rb
@@ -1,4 +1,4 @@
-class InvalidGpgMultipleStanzas < TestCask
+cask :v1test => 'invalid-gpg-multiple-stanzas' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-parameter.rb
+++ b/test/support/Casks/invalid/invalid-gpg-parameter.rb
@@ -1,4 +1,4 @@
-class InvalidGpgParameter < TestCask
+cask :v1test => 'invalid-gpg-parameter' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-signature-url.rb
+++ b/test/support/Casks/invalid/invalid-gpg-signature-url.rb
@@ -1,4 +1,4 @@
-class InvalidGpgSignatureUrl < TestCask
+cask :v1test => 'invalid-gpg-signature-url' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-gpg-type.rb
+++ b/test/support/Casks/invalid/invalid-gpg-type.rb
@@ -1,4 +1,4 @@
-class InvalidGpgParameter < TestCask
+cask :v1test => 'invalid-gpg-type' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-license-multiple.rb
+++ b/test/support/Casks/invalid/invalid-license-multiple.rb
@@ -1,4 +1,4 @@
-class InvalidLicenseMultiple < TestCask
+cask :v1test => 'invalid-license-multiple' do
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
 

--- a/test/support/Casks/invalid/invalid-license-value.rb
+++ b/test/support/Casks/invalid/invalid-license-value.rb
@@ -1,4 +1,4 @@
-class InvalidLicenseValue < TestCask
+cask :v1test => 'invalid-license-value' do
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
 

--- a/test/support/Casks/invalid/invalid-stage-only-conflict.rb
+++ b/test/support/Casks/invalid/invalid-stage-only-conflict.rb
@@ -1,4 +1,4 @@
-class InvalidStageOnlyConflict < TestCask
+cask :v1test => 'invalid-stage-only-conflict' do
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
 

--- a/test/support/Casks/invalid/invalid-tags-key.rb
+++ b/test/support/Casks/invalid/invalid-tags-key.rb
@@ -1,4 +1,4 @@
-class InvalidTagsKey < TestCask
+cask :v1test => 'invalid-tags-key' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-tags-multiple.rb
+++ b/test/support/Casks/invalid/invalid-tags-multiple.rb
@@ -1,4 +1,4 @@
-class InvalidTagsMultiple < TestCask
+cask :v1test => 'invalid-tags-multiple' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-two-homepage.rb
+++ b/test/support/Casks/invalid/invalid-two-homepage.rb
@@ -1,4 +1,4 @@
-class InvalidTwoHomepage < TestCask
+cask :v1test => 'invalid-two-homepage' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-two-url.rb
+++ b/test/support/Casks/invalid/invalid-two-url.rb
@@ -1,4 +1,4 @@
-class InvalidTwoUrl < TestCask
+cask :v1test => 'invalid-two-url' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/invalid/invalid-two-version.rb
+++ b/test/support/Casks/invalid/invalid-two-version.rb
@@ -1,4 +1,4 @@
-class InvalidTwoVersion < TestCask
+cask :v1test => 'invalid-two-version' do
   version '1.2.3'
   version '2.0'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'

--- a/test/support/Casks/local-caffeine.rb
+++ b/test/support/Casks/local-caffeine.rb
@@ -1,4 +1,4 @@
-class LocalCaffeine < TestCask
+cask :v1test => 'local-caffeine' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/local-transmission.rb
+++ b/test/support/Casks/local-transmission.rb
@@ -1,4 +1,4 @@
-class LocalTransmission < TestCask
+cask :v1test => 'local-transmission' do
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
 

--- a/test/support/Casks/missing-checksum.rb
+++ b/test/support/Casks/missing-checksum.rb
@@ -1,4 +1,4 @@
-class MissingChecksum < TestCask
+cask :v1test => 'missing-checksum' do
   version '1.2.3'
 
   url TestHelper.local_binary_url('caffeine.zip')

--- a/test/support/Casks/naked-executable.rb
+++ b/test/support/Casks/naked-executable.rb
@@ -1,4 +1,4 @@
-class NakedExecutable < TestCask
+cask :v1test => 'naked-executable' do
   version '1.2.3'
   sha256 '306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb'
 

--- a/test/support/Casks/naked-pkg.rb
+++ b/test/support/Casks/naked-pkg.rb
@@ -1,4 +1,4 @@
-class NakedPkg < TestCask
+cask :v1test => 'naked-pkg' do
   version '1.2.3'
   sha256 '611c50c8a2a2098951d2cd0fd54787ed81b92cd97b4b08bd7cba17f1e1d8e40b'
 

--- a/test/support/Casks/nested-app.rb
+++ b/test/support/Casks/nested-app.rb
@@ -1,4 +1,4 @@
-class NestedApp < TestCask
+cask :v1test => 'nested-app' do
   version '1.2.3'
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
 

--- a/test/support/Casks/no-checksum.rb
+++ b/test/support/Casks/no-checksum.rb
@@ -1,4 +1,4 @@
-class NoChecksum < TestCask
+cask :v1test => 'no-checksum' do
   version '1.2.3'
   sha256 :no_check
 

--- a/test/support/Casks/rar-container.rb
+++ b/test/support/Casks/rar-container.rb
@@ -1,4 +1,4 @@
-class RarContainer < TestCask
+cask :v1test => 'rar-container' do
   version '1.2.3'
   sha256 '35fb13fb13e6aefc38b60486627eff6b6b55b2f99f64bf47938530c6cf9e0a0f'
 

--- a/test/support/Casks/sevenzip-container.rb
+++ b/test/support/Casks/sevenzip-container.rb
@@ -1,4 +1,4 @@
-class SevenzipContainer < TestCask
+cask :v1test => 'sevenzip-container' do
   version '1.2.3'
   sha256 '1550701e7848fcb94f5b0085cca527083a8662ddeb8c0a7bc5af6bd145797cc1'
 

--- a/test/support/Casks/stage-only.rb
+++ b/test/support/Casks/stage-only.rb
@@ -1,4 +1,4 @@
-class StageOnly < TestCask
+cask :v1test => 'stage-only' do
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
 

--- a/test/support/Casks/stuffit-container.rb
+++ b/test/support/Casks/stuffit-container.rb
@@ -1,4 +1,4 @@
-class StuffitContainer < TestCask
+cask :v1test => 'stuffit-container' do
   version '1.2.3'
   sha256 '892b6d49a98c546381d41dec9b0bbc04267ac008d72b99755968d357099993b7'
 

--- a/test/support/Casks/tarball.rb
+++ b/test/support/Casks/tarball.rb
@@ -1,4 +1,4 @@
-class Tarball < TestCask
+cask :v1test => 'tarball' do
   version '1.2.3'
   sha256 :no_check
 

--- a/test/support/Casks/test-opera-mail.rb
+++ b/test/support/Casks/test-opera-mail.rb
@@ -1,4 +1,4 @@
-class TestOperaMail < TestCask
+cask :v1test => 'test-opera-mail' do
   version '1.0'
   sha256 'afd192e308f8ea8ddb3d426fd6663d97078570417ee78b8e1fa15f515ae3d677'
 

--- a/test/support/Casks/test-opera.rb
+++ b/test/support/Casks/test-opera.rb
@@ -1,4 +1,4 @@
-class TestOpera < TestCask
+cask :v1test => 'test-opera' do
   version '19.0.1326.47'
   sha256 '7b91f20ab754f7b3fef8dc346e0393917e11676b74c8f577408841619f76040a'
 

--- a/test/support/Casks/with-alt-target.rb
+++ b/test/support/Casks/with-alt-target.rb
@@ -1,4 +1,4 @@
-class WithAltTarget < TestCask
+cask :v1test => 'with-alt-target' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-appcast.rb
+++ b/test/support/Casks/with-appcast.rb
@@ -1,4 +1,4 @@
-class WithAppcast < TestCask
+cask :v1test => 'with-appcast' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-binary.rb
+++ b/test/support/Casks/with-binary.rb
@@ -1,4 +1,4 @@
-class WithBinary < TestCask
+cask :v1test => 'with-binary' do
   version '1.2.3'
   sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
 

--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -1,4 +1,4 @@
-class WithCaveats < TestCask
+cask :v1test => 'with-caveats' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-conditional-caveats.rb
+++ b/test/support/Casks/with-conditional-caveats.rb
@@ -1,4 +1,4 @@
-class WithConditionalCaveats < TestCask
+cask :v1test => 'with-conditional-caveats' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-conflicts-with.rb
+++ b/test/support/Casks/with-conflicts-with.rb
@@ -1,4 +1,4 @@
-class WithConflictsWith < TestCask
+cask :v1test => 'with-conflicts-with' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-depends-on.rb
+++ b/test/support/Casks/with-depends-on.rb
@@ -1,4 +1,4 @@
-class WithDependsOn < TestCask
+cask :v1test => 'with-depends-on' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-generic-artifact.rb
+++ b/test/support/Casks/with-generic-artifact.rb
@@ -1,4 +1,4 @@
-class WithGenericArtifact < TestCask
+cask :v1test => 'with-generic-artifact' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-gpg-key-url.rb
+++ b/test/support/Casks/with-gpg-key-url.rb
@@ -1,4 +1,4 @@
-class WithGpgKeyUrl < TestCask
+cask :v1test => 'with-gpg-key-url' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-gpg.rb
+++ b/test/support/Casks/with-gpg.rb
@@ -1,4 +1,4 @@
-class WithGpg < TestCask
+cask :v1test => 'with-gpg' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-installable.rb
+++ b/test/support/Casks/with-installable.rb
@@ -1,4 +1,4 @@
-class WithInstallable < TestCask
+cask :v1test => 'with-installable' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/test/support/Casks/with-installer-manual.rb
+++ b/test/support/Casks/with-installer-manual.rb
@@ -1,4 +1,4 @@
-class WithInstallerManual < TestCask
+cask :v1test => 'with-installer-manual' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-installer-script.rb
+++ b/test/support/Casks/with-installer-script.rb
@@ -1,4 +1,4 @@
-class WithInstallerScript < TestCask
+cask :v1test => 'with-installer-script' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-license.rb
+++ b/test/support/Casks/with-license.rb
@@ -1,4 +1,4 @@
-class WithLicense < TestCask
+cask :v1test => 'with-license' do
   version '2.61'
   sha256 'd26d7481cf1229f879c05e11cbdf440d99db6d6342f26c73d8ba7861b975532f'
 

--- a/test/support/Casks/with-macosx-dir.rb
+++ b/test/support/Casks/with-macosx-dir.rb
@@ -1,4 +1,4 @@
-class WithMacosxDir < TestCask
+cask :v1test => 'with-macosx-dir' do
   version '1.2.3'
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
 

--- a/test/support/Casks/with-pkgutil-uninstall.rb
+++ b/test/support/Casks/with-pkgutil-uninstall.rb
@@ -1,4 +1,4 @@
-class WithPkgutilUninstall < TestCask
+cask :v1test => 'with-pkgutil-uninstall' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/test/support/Casks/with-pkgutil-zap.rb
+++ b/test/support/Casks/with-pkgutil-zap.rb
@@ -1,4 +1,4 @@
-class WithPkgutilZap < TestCask
+cask :v1test => 'with-pkgutil-zap' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/test/support/Casks/with-tags.rb
+++ b/test/support/Casks/with-tags.rb
@@ -1,4 +1,4 @@
-class WithTags < TestCask
+cask :v1test => 'with-tags' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-two-apps-correct.rb
+++ b/test/support/Casks/with-two-apps-correct.rb
@@ -1,4 +1,4 @@
-class WithTwoAppsCorrect < TestCask
+cask :v1test => 'with-two-apps-correct' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-two-apps-incorrect.rb
+++ b/test/support/Casks/with-two-apps-incorrect.rb
@@ -1,4 +1,4 @@
-class WithTwoAppsIncorrect < TestCask
+cask :v1test => 'with-two-apps-incorrect' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 

--- a/test/support/Casks/with-zap.rb
+++ b/test/support/Casks/with-zap.rb
@@ -1,4 +1,4 @@
-class WithZap < TestCask
+cask :v1test => 'with-zap' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/test/support/Casks/xar-container.rb
+++ b/test/support/Casks/xar-container.rb
@@ -1,4 +1,4 @@
-class XarContainer < TestCask
+cask :v1test => 'xar-container' do
   version '1.2.3'
   sha256 '1418752ac49e859f88590db245015cb2f8b459f619e0c50fd6ff87b902c72ee1'
 


### PR DESCRIPTION
This takes the form of a horrible hack: DSL version numbers may end with "test", _eg_ ":v1test". Such Casks are mapped to class `TestCask` instead of class `Cask`.

The intention is that all of this logic will be removed when Casks are migrated away from separate classes.

Tests driven by RSpec are still todo.  Since those tests don't read from a separate Cask file, they don't block removal of the legacy form on loads.
