### PR TITLE
fixed binary link in rowanj-gitx.rb

### DIFF
--- a/Casks/rowanj-gitx.rb
+++ b/Casks/rowanj-gitx.rb
@@ -8,5 +8,5 @@ cask :v1 => 'rowanj-gitx' do
   license :oss
 
   app 'GitX.app'
-  binary 'GitX.app/Contents/Resources/GitX', :target => 'gitx'
+  binary 'GitX.app/Contents/Resources/gitx'
 end


### PR DESCRIPTION
Original problem was misdiagnosed. Though the previous change did still work and didn’t introduce breaking changes, this is more correct.
