### PR TITLE
Update OpenRA to 20141029

### DIFF
--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'openra' do
-  version '20140722'
-  sha256 '0f9bc52de1e4569371ae643d505c66d5196a73537f6810fad2a1c49baad37995'
+  version '20141029'
+  sha256 '421f341d324e2e360cf17facc1379b19036f7459516b84685037a041d5020e64'
 
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
   homepage 'http://www.openra.net/'


### PR DESCRIPTION
[Official release!](https://github.com/OpenRA/OpenRA/releases/tag/release-20141029)
