### PR TITLE
DSL Remove support for old-style header lines

### DIFF
--- a/lib/cask/source/path_base.rb
+++ b/lib/cask/source/path_base.rb
@@ -47,8 +47,15 @@ class Cask::Source::PathBase
       if %r{\A\s*cask\s+:v([\d_]+)(test)?\s+=>\s+([\'\"])(\S+?)\3(?:\s*,\s*|\s+)do\s*\n}.match(cask_string)
         dsl_version = $1
         test_cask = ! $2.nil?
+        header_name = $4
         superclass_name = test_cask ? 'TestCask' : 'Cask'
         cask_string.sub!(%r{\A[^\n]+\n}, "class #{cask_class_name} < #{superclass_name}\n")
+        # todo enforce valid DSL version
+        if header_name != cask_name
+          raise CaskInvalidError.new(cask_name, "Bad header line: '#{header_name}' does not match file name")
+        end
+      else
+        raise CaskInvalidError.new(cask_name, "Bad header line: parse failed")
       end
 
       # simulate "require"
@@ -72,8 +79,12 @@ class Cask::Source::PathBase
     end
   end
 
+  def cask_name
+    path.basename.to_s.sub(/\.rb/, '')
+  end
+
   def cask_class_name
-    path.basename.to_s.sub(/\.rb/, '').split('-').map(&:capitalize).join
+    cask_name.split('-').map(&:capitalize).join
   end
 
   def to_s

--- a/test/support/Casks/with-suite.rb
+++ b/test/support/Casks/with-suite.rb
@@ -1,4 +1,4 @@
-class WithSuite < TestCask
+cask :v1 => 'with-suite' do
   version '1.2.3'
   sha256 'd1302a0dc25aff72ad395ed01a830468b92253ffd28269574f3ac0b5eb8aad54'
 


### PR DESCRIPTION
- require the new form
- enforce that the cask name (per the header) must match the filename
- fix old-style header line in test suite introduced in #7432
