### PR TITLE
DSL: remove support for `nested_container`

### DIFF
--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -249,7 +249,6 @@ module Cask::DSL
     end
 
     SPECIAL_ARTIFACT_TYPES = [
-      :nested_container,
       :uninstall,
       :zap,
     ]


### PR DESCRIPTION
Obsoleted by new form `container :nested`.

This PR only removes DSL support; the job is incomplete.  Internally, `container :nested` is still implemented as a pseudo-artifact named `nested_container`.  The intention is to factor nested containers out of artifacts.
