### PR TITLE
Update AutoDMG to v1.5.2

### DIFF
--- a/Casks/autodmg.rb
+++ b/Casks/autodmg.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'autodmg' do
-  version '1.5.1'
-  sha256 '574bbc8811ed39bf6751c76cba15cac789061f0032aadf205a906334e8970109'
+  version '1.5.2'
+  sha256 'a18cc5a840e56faaba133ab0cb3ea24e50b71a81cc87cd436ef71e739e62fea0'
 
   url "https://github.com/MagerValp/AutoDMG/releases/download/v#{version}/AutoDMG-#{version}.dmg"
   homepage 'https://github.com/MagerValp/AutoDMG'


### PR DESCRIPTION
AutoDMG v1.5.2 [released](https://github.com/MagerValp/AutoDMG/releases/tag/v1.5.2) 2014-11-13.
