### PR TITLE
Lots of formatting fixes for Adobe Reader Cask; Added Zap method

### DIFF
--- a/Casks/adobe-reader.rb
+++ b/Casks/adobe-reader.rb
@@ -2,10 +2,15 @@ cask :v1 => 'adobe-reader' do
   version '11.0.09'
   sha256 '259957f1434bcdf47dc6a7c12affc40dd3c17288009dc229aa51f20ec4e8b1c5'
 
-  url "http://ardownload.adobe.com/pub/adobe/reader/mac/11.x/#{version}/en_US/AdbeRdr11009_en_US.dmg"
+  url "http://ardownload.adobe.com/pub/adobe/reader/mac/#{version.to_i}.x/#{version}/en_US/AdbeRdr#{version.gsub('.', '')}_en_US.dmg"
   homepage 'http://www.adobe.com/products/reader.html'
   license :unknown
 
   pkg 'Adobe Reader XI Installer.pkg'
-  uninstall :pkgutil => 'com.adobe.acrobat.reader.11009.*'
+  uninstall :pkgutil => "com.adobe.acrobat.reader.#{version.gsub('.', '')}.*",
+            :delete => '/Applications/Adobe Reader.app'
+  zap       :delete => [
+                        "~/Library/Application Support/Adobe/Acrobat/#{version.sub(%r{(\d+)\.(\d+).*},'\1.\2')}",
+                        '~/Library/Preferences/com.adobe.Reader.plist',
+                       ]
 end


### PR DESCRIPTION
Trying to simplify updating the Adobe Reader Cask by automatically determining the version number in download URL

Also added "zap" method for Adobe Reader => "Adobe Reader.app" is now deleted after uninstalling. (It was left there before, but could not be started)

Also, might it be possible to implement something like "version.to_roman" in homebrew-cask, which would result in "XI" for version 11? Adobe uses a lot of roman numbering for their products. I think having a method like this would help simplifying the update process :) 
