### PR TITLE
Binaries should install to HOMEBREW_PREFIX

### DIFF
--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -77,7 +77,7 @@ module Cask::Locations
     end
 
     def binarydir
-      @binarydir ||= Pathname.new('/usr/local/bin').expand_path
+      @binarydir ||= HOMEBREW_PREFIX.join 'bin'
     end
 
     def binarydir=(_binarydir)


### PR DESCRIPTION
I was trying to use brew cask to install apps with boxen. Sublime Text fails to install as boxen uses a custom HOMEBREW_PREFIX (`/opt/boxen/homebrew`) which brew cask ignores when linking the `subl` binary.

Installation fails with `Error: Permission denied - /usr/local` because `/usr/local` does not exist.

This minor patch returns the correct binary directory based on the current prefix.
