### PR TITLE
Remove remaining uses of `destination_path`

### DIFF
--- a/Casks/bankid.rb
+++ b/Casks/bankid.rb
@@ -8,7 +8,7 @@ cask :v1 => 'bankid' do
 
   container :type => :naked
   preflight do
-    system '/bin/mv', '--', staged_path.join('FileDownloader'), destination_path.join('bankid-latest.pkg')
+    system '/bin/mv', '--', staged_path.join('FileDownloader'), staged_path.join('bankid-latest.pkg')
   end
 
   pkg 'bankid-latest.pkg'

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -8,7 +8,7 @@ cask :v1 => 'git-annex' do
     # This is a horrible hack to force the file extension.  The
     # backend code should be fixed so that this is not needed.
     preflight do
-      system '/bin/mv', '--', staged_path.join('git-annex-latest'), destination_path.join('git-annex-latest.dmg')
+      system '/bin/mv', '--', staged_path.join('git-annex-latest'), staged_path.join('git-annex-latest.dmg')
     end
     container :nested => 'git-annex-latest.dmg'
   else

--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -7,7 +7,7 @@ cask :v1 => 'nodeclipse' do
   license :oss
 
   preflight do
-    system '/bin/mv', '--', staged_path.join('eclipse/Eclipse.app'), destination_path.join('eclipse/Nodeclipse.app')
+    system '/bin/mv', '--', staged_path.join('eclipse/Eclipse.app'), staged_path.join('eclipse/Nodeclipse.app')
   end
   app 'eclipse/Nodeclipse.app'
 end

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -11,7 +11,7 @@ cask :v1 => 'qlmarkdown' do
   # DSL to identify such containers and generate a target directory.
   container :type => :naked
   preflight do
-    system '/usr/bin/ditto', '-xk', '--', "#{staged_path}/QLMarkdown.qlgenerator.zip", "#{destination_path}/QLMarkdown.qlgenerator"
+    system '/usr/bin/ditto', '-xk', '--', "#{staged_path}/QLMarkdown.qlgenerator.zip", "#{staged_path}/QLMarkdown.qlgenerator"
   end
 
   qlplugin 'QLMarkdown.qlgenerator'

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -8,7 +8,7 @@ cask :v1 => 'ridibooks' do
 
   container :type => :naked
   preflight do
-    system '/bin/mv', '--', staged_path.join('getapp'), destination_path.join('ridibooks.pkg')
+    system '/bin/mv', '--', staged_path.join('getapp'), staged_path.join('ridibooks.pkg')
   end
   pkg 'ridibooks.pkg'
   uninstall :pkgutil => 'com.ridibooks.Ridibooks'

--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -8,7 +8,7 @@ cask :v1 => 'td-toolbelt' do
 
   container :type => :naked
   preflight do
-    system '/bin/mv', '--', "#{staged_path}/mac", "#{destination_path}/td-toolbelt.pkg"
+    system '/bin/mv', '--', "#{staged_path}/mac", "#{staged_path}/td-toolbelt.pkg"
   end
 
   pkg 'td-toolbelt.pkg'


### PR DESCRIPTION
#7297 was incomplete; in some cases only the first usage of `destination_path` was changed to `staged_path`
