### PR TITLE
Add EarthCoin-Qt.app v1.3.2

### DIFF
--- a/Casks/earthcoin.rb
+++ b/Casks/earthcoin.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'earthcoin' do
+  version '1.3.2'
+  sha256 '5e5c52e1d5d27af5de0d544d95426477be31dc47df1b7ab834f0c57b27e8d16b'
+
+  url "https://earthcoin.s3.amazonaws.com/releases/#{version}/macosx/EarthCoin-Qt-#{version}.dmg"
+  homepage 'http://getearthcoin.com/'
+  license :oss
+
+  app 'EarthCoin-Qt.app'
+end


### PR DESCRIPTION
Hi,

this PR adds EarthCoin's official Qt Wallet to the Cask Library :-)

Download link is pointing to an amazon bucket we use for quite a while now.
It's the same that's used on the homepage: http://getearthcoin.com/earthcoin-wallets

Best Regards,
Linki
