### PR TITLE
enforce a valid minimum DSL version in headers

### DIFF
--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -32,6 +32,16 @@ describe Cask::DSL do
     end
   end
 
+  describe "header line" do
+    it "requires a valid minimum DSL version in the header" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-header-version')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include 'Bad header line'
+      err.message.must_include 'is less than required minimum version'
+    end
+  end
+
   describe "sha256 stanza" do
     it "lets you set checksum via sha256" do
       ChecksumCask = Class.new(Cask)

--- a/test/support/Casks/invalid/invalid-header-version.rb
+++ b/test/support/Casks/invalid/invalid-header-version.rb
@@ -1,0 +1,9 @@
+cask :v0_9test => 'invalid-header-version' do
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
+  app 'Caffeine.app'
+end


### PR DESCRIPTION
currently, "1" aka "1.0"
