### PR TITLE
Fix issues with Alfred's preferences syncing

### DIFF
--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -14,7 +14,8 @@ class Cask::CLI::Alfred < Cask::CLI::Base
   PRIMARY_SCOPES_KEY = 'features.defaultresults.scope'
 
   # http://www.alfredforum.com/topic/4810-alfred%E2%80%99s-scope-can-no-longer-be-changed-programatically/?p=29434
-  LOCALPREFS_SCOPES_FILEGLOB = '~/Library/Application Support/Alfred 2/Alfred.alfredpreferences/preferences/local/*/features/defaultresults/prefs.plist'
+  LOCALPREFS_SUBPATH = '/Alfred.alfredpreferences/preferences/local/*/features/defaultresults/prefs.plist'
+  LOCALPREFS_SYNCDIR_KEY = 'syncfolder'
   LOCALPREFS_SCOPES_KEY = 'scope'
 
   def self.run(*args)
@@ -137,7 +138,8 @@ class Cask::CLI::Alfred < Cask::CLI::Base
 
   def self.localprefs_scopes_files
     # local prefs file is used in Alfred 2.4 and above for Yosemite compatibility
-    Pathname.glob(Pathname.new(LOCALPREFS_SCOPES_FILEGLOB).expand_path)
+    prefs_path = alfred_primary_preference(LOCALPREFS_SYNCDIR_KEY).strip
+    Pathname.glob(Pathname.new(prefs_path + LOCALPREFS_SUBPATH).expand_path)
   end
 
   def self.alfred_preference(key, value=nil)

--- a/test/cask/cli/alfred_test.rb
+++ b/test/cask/cli/alfred_test.rb
@@ -11,6 +11,8 @@ DEFAULT_WRITE_SCOPE = %Q{(#{scope.join(',')})}
 scope               = (Cask::CLI::Alfred::DEFAULT_SCOPES + [Cask.caskroom.to_s]).map { |s| %Q{'#{s}'} }
 ALTERED_WRITE_SCOPE = %Q{(#{scope.join(',')})}
 
+DEFAULT_SYNCDIR     = '~/Library/Application Support/Alfred 2'
+
 def fake_alfred_read_primary_preference(key, response)
   Cask::FakeSystemCommand.stubs_command(['/usr/bin/defaults', 'read', 'com.runningwithcrayons.Alfred-Preferences', key], response)
 end
@@ -20,14 +22,14 @@ def fake_alfred_write_primary_preference(key, value)
 end
 
 def fake_alfred_read_local_preference(key, response)
-  local_files = Pathname.glob(Pathname.new(Cask::CLI::Alfred::LOCALPREFS_SCOPES_FILEGLOB).expand_path)
+  local_files = Pathname.glob(Pathname.new(DEFAULT_SYNCDIR + Cask::CLI::Alfred::LOCALPREFS_SUBPATH).expand_path)
   local_files.each do |file|
     Cask::FakeSystemCommand.stubs_command(['/usr/bin/defaults', 'read', file, key], response)
   end
 end
 
 def fake_alfred_write_local_preference(key, value)
-  local_files = Pathname.glob(Pathname.new(Cask::CLI::Alfred::LOCALPREFS_SCOPES_FILEGLOB).expand_path)
+  local_files = Pathname.glob(Pathname.new(DEFAULT_SYNCDIR + Cask::CLI::Alfred::LOCALPREFS_SUBPATH).expand_path)
   local_files.each do |file|
     Cask::FakeSystemCommand.stubs_command(['/usr/bin/defaults', 'write', file, key, value])
   end


### PR DESCRIPTION
This PR addresses #7216.

In case a custom Alfred syncing directory is used, you will get the following error if you try to link Alfred:
`Alfred 2.4+ detected, but local preferences file not found. Try running Alfred first.`

`LOCALPREFS_SCOPES_FILEGLOB` has been replaced with a method that looks up `syncfolder` in Alfred's preferences.
