### PR TITLE
Update jitouch to the latest version, 2.6.

### DIFF
--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -2,9 +2,11 @@ cask :v1 => 'jitouch' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.jitouch.com/jitouch_mavericks.zip'
+  url 'http://www.jitouch.com/jitouch_yosemite.zip'
   homepage 'http://www.jitouch.com'
   license :unknown
 
   prefpane 'jitouch/Jitouch.prefPane'
+
+  zap :delete => '~/Library/Preferences/com.jitouch.Jitouch.plist'
 end


### PR DESCRIPTION
- Updates the jitouch formula to reference the latest version of jitouch, 2.6, which adds support for
  OS X Yosemite.
