### PR TITLE
Upgrade Apimac Timer formula to 8.0.2.

### DIFF
--- a/Casks/apimac-timer.rb
+++ b/Casks/apimac-timer.rb
@@ -2,7 +2,7 @@ cask :v1 => 'apimac-timer' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.apimac.com/download/timer.dmg'
+  url 'http://www.apimac.com/download/Timer.zip'
   homepage 'http://www.apimac.com/mac/timer/'
   license :gratis
 


### PR DESCRIPTION
Updates formula to reference the latest version of [Apimac Timer](http://www.apimac.com/downloads/), 8.0.2.
