### PR TITLE
Improve handbrake URLs

### DIFF
--- a/Casks/handbrake.rb
+++ b/Casks/handbrake.rb
@@ -5,7 +5,7 @@ cask :v1 => 'handbrake' do
   url "http://download.handbrake.fr/releases/#{version}/HandBrake-#{version}-MacOSX.6_GUI_x86_64.dmg"
   appcast 'http://handbrake.fr/appcast.x86_64.xml',
           :sha256 => 'f0e700c39b76c16dba12ff8b931ae75ae4d764f1e8d1f5b2deb9231e5a445390'
-  homepage 'http://handbrake.fr/'
+  homepage 'https://handbrake.fr'
   license :oss
 
   app 'HandBrake.app'

--- a/Casks/handbrake.rb
+++ b/Casks/handbrake.rb
@@ -2,7 +2,7 @@ cask :v1 => 'handbrake' do
   version '0.10.0'
   sha256 'c26a1a37d03c977e0296f0198ce11bf74ee5da8aa410ea3b5eef6449e0aa3c9c'
 
-  url "http://handbrake.fr/rotation.php?file=HandBrake-#{version}-MacOSX.6_GUI_x86_64.dmg"
+  url "http://download.handbrake.fr/releases/#{version}/HandBrake-#{version}-MacOSX.6_GUI_x86_64.dmg"
   appcast 'http://handbrake.fr/appcast.x86_64.xml',
           :sha256 => 'f0e700c39b76c16dba12ff8b931ae75ae4d764f1e8d1f5b2deb9231e5a445390'
   homepage 'http://handbrake.fr/'

--- a/Casks/handbrakecli.rb
+++ b/Casks/handbrakecli.rb
@@ -2,7 +2,7 @@ cask :v1 => 'handbrakecli' do
   version '0.10.0'
   sha256 '84dcc20cffd2cbbe1d7804dbb8dfdb4ce7ce78b2f44ae25a998f18771a9c05f9'
 
-  url "https://handbrake.fr/rotation.php?file=HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
+  url "http://download.handbrake.fr/releases/#{version}/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'
   license :oss
 

--- a/Casks/handbrakecli.rb
+++ b/Casks/handbrakecli.rb
@@ -3,7 +3,7 @@ cask :v1 => 'handbrakecli' do
   sha256 '84dcc20cffd2cbbe1d7804dbb8dfdb4ce7ce78b2f44ae25a998f18771a9c05f9'
 
   url "http://download.handbrake.fr/releases/#{version}/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
-  homepage 'http://handbrake.fr'
+  homepage 'https://handbrake.fr'
   license :oss
 
   binary 'HandBrakeCLI'


### PR DESCRIPTION
Closes #7553.

Note that the downloadable packages are not available via HTTPS.
