### PR TITLE
Add tests for new-style header lines

### DIFF
--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -40,6 +40,14 @@ describe Cask::DSL do
       err.message.must_include 'Bad header line: parse failed'
     end
 
+    it "requires the header name to match the file name" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-header-name-mismatch')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include 'Bad header line:'
+      err.message.must_include 'does not match file name'
+    end
+
     it "requires a valid minimum DSL version in the header" do
       err = lambda {
         invalid_cask = Cask.load('invalid/invalid-header-version')

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -33,6 +33,13 @@ describe Cask::DSL do
   end
 
   describe "header line" do
+    it "requires a valid header format" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-header-format')
+      }.must_raise(CaskInvalidError)
+      err.message.must_include 'Bad header line: parse failed'
+    end
+
     it "requires a valid minimum DSL version in the header" do
       err = lambda {
         invalid_cask = Cask.load('invalid/invalid-header-version')

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -52,7 +52,7 @@ describe Cask::DSL do
       err = lambda {
         invalid_cask = Cask.load('invalid/invalid-header-version')
       }.must_raise(CaskInvalidError)
-      err.message.must_include 'Bad header line'
+      err.message.must_include 'Bad header line:'
       err.message.must_include 'is less than required minimum version'
     end
   end

--- a/test/support/Casks/invalid/invalid-header-format.rb
+++ b/test/support/Casks/invalid/invalid-header-format.rb
@@ -1,0 +1,9 @@
+cask :v1test => => 'invalid-header-format' do
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
+  app 'Caffeine.app'
+end

--- a/test/support/Casks/invalid/invalid-header-name-mismatch.rb
+++ b/test/support/Casks/invalid/invalid-header-name-mismatch.rb
@@ -1,0 +1,9 @@
+cask :v1test => 'invalid-header-name-mismatch-this-text-does-not-belong' do
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/local-caffeine'
+
+  app 'Caffeine.app'
+end


### PR DESCRIPTION
Testing is needed because we now read and parse this line by hand.
