### PR TITLE
update texshop to version 3.45.2

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'texshop' do
-  version '3.45'
-  sha256 '63afb1141ae41277dc40c3f6f8130e104d89cac2be85c21373a2087aaa25a4eb'
+  version '3.45.2'
+  sha256 '2d42e2b6601ece337aafbc57acca148c3a9f066c8ecb5807c82e4e67bf4c82e5'
 
-  url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.gsub('.','')}.zip"
+  url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.sub(%r{^(\d+)\.(\d+)},'\1\2')}.zip"
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
-          :sha256 => '2ac3386dd338df8178ee8a007ebf9f9db649120307b71c35f5a1b3eeedaa92c6'
+          :sha256 => 'c40ae2cd48a38ab90fb5e3e9ec92e8769be03e13dfc2a6246c63ab8f94f51b10'
   homepage 'http://pages.uoregon.edu/koch/texshop'
-  license :unknown
+  license :gpl
 
   app 'TexShop.app'
 end


### PR DESCRIPTION
- URL was broken
- change version munging to accomodate sub-version in URL
- update license to `:gpl`
- checksum
- `appcast` checksum
