### PR TITLE
Update NoSleep to 1.4.0

### DIFF
--- a/Casks/nosleep.rb
+++ b/Casks/nosleep.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'nosleep' do
-  version '1.3.3'
-  sha256 '5fe90c54e975d3f1de9f7fdb66def0188c571eab083b18a7e94abaa5f0d41ba9'
+  version '1.4.0'
+  sha256 '29e7f771970dce41936372687a5160700e2208357ef1ce37d81ac95c9188efe8'
 
-  url "https://macosx-nosleep-extension.googlecode.com/files/NoSleep-#{version}.dmg"
+  url "https://github.com/integralpro/nosleep/releases/download/v#{version}/NoSleep-#{version}.dmg"
   homepage 'https://code.google.com/p/macosx-nosleep-extension/'
   license :oss
 
-  pkg 'NoSleep.mpkg'
+  pkg 'NoSleep.pkg'
 
   uninstall :script => 'Uninstall.command',
             :pkgutil => 'com.protech.pkg.NoSleep'


### PR DESCRIPTION
Update to the latest version.  Also includes the new url, as the old download location is deprecated.   ([see google code](https://code.google.com/p/macosx-nosleep-extension/wiki/ExternalDownloads?tm=2))
