### PR TITLE
rename mass-replace-it.rb to massreplaceit.rb

### DIFF
--- a/Casks/massreplaceit.rb
+++ b/Casks/massreplaceit.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'mass-replace-it' do
+cask :v1 => 'massreplaceit' do
   version '2.9.1'
   sha256 '1ab3482f7568953899474397fa401342daec56d4efe4a856de8e387294f7c667'
   container :nested => 'MassReplaceIt.dmg'


### PR DESCRIPTION
to conform with naming conventions
