### PR TITLE
rename folding-text.rb to foldingtext.rb

### DIFF
--- a/Casks/foldingtext.rb
+++ b/Casks/foldingtext.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'folding-text' do
+cask :v1 => 'foldingtext' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
to conform with naming conventions
