### PR TITLE
rename faux-pas.rb to fauxpas.rb

### DIFF
--- a/Casks/fauxpas.rb
+++ b/Casks/fauxpas.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'faux-pas' do
+cask :v1 => 'fauxpas' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
to conform with naming conventions
