### PR TITLE
rename temperature-monitor.rb

### DIFF
--- a/Casks/temperaturemonitor.rb
+++ b/Casks/temperaturemonitor.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'temperature-monitor' do
+cask :v1 => 'temperaturemonitor' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
to temperaturemonitor.rb, to conform with naming conventions
