### PR TITLE
rename readefine-desktop.rb to readefine.rb

### DIFF
--- a/Casks/readefine.rb
+++ b/Casks/readefine.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'readefine-desktop' do
+cask :v1 => 'readefine' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
to conform with naming conventions
