### PR TITLE
rename audio-mate.rb to audiomate.rb

### DIFF
--- a/Casks/audiomate.rb
+++ b/Casks/audiomate.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'audio-mate' do
+cask :v1 => 'audiomate' do
   version '2.1.2'
   sha256 'c9cbd426d2d8f011f99250eac1bb76651f4c53c58a009edceca946b6179f1771'
 


### PR DESCRIPTION
to conform with naming conventions
