### PR TITLE
rename gimp-lisanet.rb to lisanet-gimp.rb

### DIFF
--- a/Casks/lisanet-gimp.rb
+++ b/Casks/lisanet-gimp.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'gimp-lisanet' do
+cask :v1 => 'lisanet-gimp' do
   version '2.8.14p1'
   sha256 '2a755c08e50290b494c26c416b6dda6ad4151610f752216d0db126d479ed787e'
 


### PR DESCRIPTION
to conform with naming conventions: the string "lisanet"
refers to a vendor
