### PR TITLE
rename grafx2.rb to grafx.rb

### DIFF
--- a/Casks/grafx.rb
+++ b/Casks/grafx.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'grafx2' do
+cask :v1 => 'grafx' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
to conform with naming conventions: "2" refers to a version
series
