### PR TITLE
rename pentaho-data-integration.rb

### DIFF
--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -1,10 +1,12 @@
-cask :v1 => 'pentaho-data-integration' do
+cask :v1 => 'data-integration' do
   version :latest
   sha256 :no_check
 
   url 'https://sourceforge.net/projects/pentaho/files/latest/download'
   homepage 'http://community.pentaho.com'
   license :oss
+  tags :vendor => 'Pentaho',
+       :name   => 'Pentaho Data Integration'
 
   app 'data-integration/Data Integration.app'
 end


### PR DESCRIPTION
to data-integration.rb, to conform with naming conventions.

Add `:vendor` and `:name` tags to maintain discoverability.
