### PR TITLE
devscript + doc: "cocoa" is a framework to remove from the end of Cask names

### DIFF
--- a/developer/bin/cask_namer
+++ b/developer/bin/cask_namer
@@ -96,6 +96,7 @@ REMOVE_TRAILING_PATS = [
                         %r{\bgtk}i,
                         %r{\bqt}i,
                         %r{\bwx}i,
+                        %r{\bcocoa}i,
 
                         # localizations
                         %r{en\s*-\s*us}i,

--- a/doc/CASK_NAMING_REFERENCE.md
+++ b/doc/CASK_NAMING_REFERENCE.md
@@ -31,7 +31,7 @@ most cases.
     a port, but "Mac" is an inseparable part of the name or branding, as in
     'PlayForMac.app'
   * Remove from the end: hardware designations such as "for x86", "32-bit", "ppc".
-  * Remove from the end: software framework names such as "Qt", "Gtk", "Wx", "Java", "Oracle JVM", etc.
+  * Remove from the end: software framework names such as "Cocoa", "Qt", "Gtk", "Wx", "Java", "Oracle JVM", etc.
     Exception: the framework is the product being Casked: [java.rb](../Casks/java.rb).
   * Remove from the end: localization strings such as "en-US"
   * Pay attention to details, for example: `"Git Hub" != "git_hub" != "GitHub"`


### PR DESCRIPTION
Example: https://github.com/caskroom/homebrew-cask/blob/163e52aa853c623345bf2398b3e0ea5bce0dff4e/Casks/opensong.rb#L9
