### PR TITLE
rename hockeyapp.rb to hockey.rb

### DIFF
--- a/Casks/hockey.rb
+++ b/Casks/hockey.rb
@@ -1,10 +1,12 @@
-cask :v1 => 'hockeyapp' do
+cask :v1 => 'hockey' do
   version :latest
   sha256 :no_check
 
   url 'https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1?format=zip'
-  appcast 'https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1'
+  # todo transitional enable name
+  # name 'HockeyApp'
   homepage 'http://hockeyapp.net/releases/mac/'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1'
   license :unknown
 
   app 'HockeyApp.app'


### PR DESCRIPTION
to conform with naming conventions.

It seems we have visited the naming here before in #4286, but not covered [Remove the term "app" from the end, if the developer styles the name like "Software App.app"](https://github.com/caskroom/homebrew-cask/blob/163e52aa853c623345bf2398b3e0ea5bce0dff4e/doc/CASK_NAMING_REFERENCE.md#canonical-names-of-apps).
