### PR TITLE
Strip "launcher" strings from end of Cask names

### DIFF
--- a/Casks/googleappengine.rb
+++ b/Casks/googleappengine.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'googleappenginelauncher' do
+cask :v1 => 'googleappengine' do
   version '1.9.15'
   sha256 '403a1df731537de41307a6245e3265b921c058c0c3ccc6dcedf0dd93439eff47'
 

--- a/developer/bin/cask_namer
+++ b/developer/bin/cask_namer
@@ -79,8 +79,7 @@ REMOVE_TRAILING_PATS = [
 
                         # generic terms
                         %r{\bapp}i,
-                        # idea, but never discussed
-                        # %r{\blauncher}i,
+                        %r{\b(?:quick[\s-]*)?launcher}i,
 
                         # "mac", "for mac", "for OS X".
                         %r{\b(?:for)?[\s-]*mac(?:intosh)?}i,

--- a/doc/CASK_NAMING_REFERENCE.md
+++ b/doc/CASK_NAMING_REFERENCE.md
@@ -26,6 +26,7 @@ most cases.
     differentiator for a different product from a different vendor: [pgadmin3.rb](../Casks/pgadmin3.rb).
   * If the version number is arranged to occur in the middle of the App name,
     it should also be removed.  Example: [IntelliJ IDEA 13 CE.app](../Casks/intellij-idea-ce.rb).
+  * Remove from the end: "Launcher", "Quick Launcher".
   * Remove from the end: "mac", "for mac", "for OS X".  These terms are generally
     added to ports such as "MAME OS X.app".  Exception: when the software is not
     a port, but "Mac" is an inseparable part of the name or branding, as in


### PR DESCRIPTION
There is a small inconsistency present naming practice: whether to remove trailing "launcher" strings.  [readytalk.rb](https://github.com/caskroom/homebrew-cask/blob/163e52aa853c623345bf2398b3e0ea5bce0dff4e/Casks/readytalk.rb) does so, [googleappenginelauncher.rb](https://github.com/caskroom/homebrew-cask/blob/163e52aa853c623345bf2398b3e0ea5bce0dff4e/Casks/googleappenginelauncher.rb) does not.

At 50/50 we don't have a prevailing practice, which is unusual.  This PR resolves in favor of removing "launcher" strings on the theory that they are generic and thus not helpful in search.
