### PR TITLE
Change app to "Timer.app"

### DIFF
--- a/Casks/apimac-timer.rb
+++ b/Casks/apimac-timer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'apimac-timer' do
   homepage 'http://www.apimac.com/mac/timer/'
   license :commercial
 
-  app 'Apimac Timer.app'
+  app 'Timer.app'
 
   zap :delete => [
                   '~/Library/Preferences/Apimac',


### PR DESCRIPTION
Application was renamed from "Apimac Timer.app" to "Timer.app" in the zip file by the developer
