### PR TITLE
rename sqlite-database-browser.rb

### DIFF
--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -1,10 +1,11 @@
-cask :v1 => 'sqlite-database-browser' do
+cask :v1 => 'sqlitebrowser' do
   version '3.4.0'
   sha256 '8347deff7680fba86fcc21abb442a05a1526896d2701ed27d8aa8c38284a41ff'
 
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/sqlitebrowser-#{version}.dmg"
   homepage 'http://sqlitebrowser.org'
   license :mpl
+  tags :name => 'DB Browser for SQLite'
 
   app 'sqlitebrowser.app'
 end


### PR DESCRIPTION
to sqlitebrowser.rb, according to the naming conventions.

This one is messy.  Upstream announced that the project branding had changed (twice).  However, a new  release was made a month later, and the name of the app bundle is unchanged.

The Cask name we have is neither the announced project name, nor the actual app bundle name, so it ought to change.

This PR resolves in favor of the app bundle name.  Another way to resolve would be to use the new project name with a `:target` on `app` as was done for `bitcoin-core.rb`.

I picked this direction based on the guess that upstream is not going to change the app bundle name in the future.  More info would be helpful.
