### PR TITLE
Update Jenkins Menu to 0.2.0

### DIFF
--- a/Casks/jenkins-menu.rb
+++ b/Casks/jenkins-menu.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'jenkins-menu' do
-  version '0.1.1'
-  sha256 'c53e72473ff1d64b0b63b28ebd6297553cd6045c383b48e15887041487b588fb'
+  version '0.2.0'
+  sha256 'dc2b69ab27b99ed0b0c165ade90b504b7c8201213b5334c6d927affd8cf106b4'
 
-  url "https://bitbucket.org/qvacua/qvacua/downloads/JenkinsMenu-#{version}.zip"
+  url  "https://github.com/qvacua/jenkins-menu/releases/download/v#{version}/Jenkins.Menu-#{version}.zip"
   appcast 'http://qvacua.com/jenkinsmenu/appcast.xml',
           :sha256 => '420aaafc9de36c174ba1b43d1dfd4719603808f1754da8b7bb2a4ef1e934429d'
   homepage 'http://qvacua.com'


### PR DESCRIPTION
Even though it is marked as "pre-release", Jenkins Menu 0.2 is linked
to by the app's update function and the appcast.
