### PR TITLE
Refactor backend classes to match preflight/postflight

### DIFF
--- a/lib/cask/artifact.rb
+++ b/lib/cask/artifact.rb
@@ -8,23 +8,23 @@ require 'cask/artifact/hardlinked'
 require 'cask/artifact/app'
 require 'cask/artifact/artifact'        # generic 'artifact' stanza
 require 'cask/artifact/binary'
-require 'cask/artifact/after_block'
-require 'cask/artifact/before_block'
 require 'cask/artifact/colorpicker'
 require 'cask/artifact/font'
+require 'cask/artifact/input_method'
 require 'cask/artifact/installer'
+require 'cask/artifact/internet_plugin'
 require 'cask/artifact/nested_container'
 require 'cask/artifact/pkg'
+require 'cask/artifact/postflight_block'
+require 'cask/artifact/preflight_block'
 require 'cask/artifact/prefpane'
 require 'cask/artifact/qlplugin'
-require 'cask/artifact/widget'
-require 'cask/artifact/service'
-require 'cask/artifact/suite'
-require 'cask/artifact/stage_only'
-require 'cask/artifact/input_method'
-require 'cask/artifact/internet_plugin'
 require 'cask/artifact/screen_saver'
+require 'cask/artifact/service'
+require 'cask/artifact/stage_only'
+require 'cask/artifact/suite'
 require 'cask/artifact/uninstall'
+require 'cask/artifact/widget'
 require 'cask/artifact/zap'
 
 module Cask::Artifact
@@ -34,7 +34,7 @@ module Cask::Artifact
   #
   def self.artifacts
     [
-      Cask::Artifact::BeforeBlock,
+      Cask::Artifact::PreflightBlock,
       Cask::Artifact::NestedContainer,
       Cask::Artifact::Installer,
       Cask::Artifact::App,
@@ -53,7 +53,7 @@ module Cask::Artifact
       Cask::Artifact::InternetPlugin,
       Cask::Artifact::ScreenSaver,
       Cask::Artifact::Uninstall,
-      Cask::Artifact::AfterBlock,
+      Cask::Artifact::PostflightBlock,
       Cask::Artifact::Zap,
     ]
   end

--- a/lib/cask/artifact/postflight_block.rb
+++ b/lib/cask/artifact/postflight_block.rb
@@ -1,4 +1,4 @@
-class Cask::Artifact::AfterBlock < Cask::Artifact::Base
+class Cask::Artifact::PostflightBlock < Cask::Artifact::Base
   def self.me?(cask)
     cask.artifacts[:postflight].any? ||
       cask.artifacts[:uninstall_postflight].any?
@@ -6,13 +6,13 @@ class Cask::Artifact::AfterBlock < Cask::Artifact::Base
 
   def install_phase
     @cask.artifacts[:postflight].each do |block|
-      Cask::DSL::AfterInstall.new(@cask).instance_eval &block
+      Cask::DSL::Postflight.new(@cask).instance_eval &block
     end
   end
 
   def uninstall_phase
     @cask.artifacts[:uninstall_postflight].each do |block|
-      Cask::DSL::AfterUninstall.new(@cask).instance_eval &block
+      Cask::DSL::UninstallPostflight.new(@cask).instance_eval &block
     end
   end
 end

--- a/lib/cask/artifact/preflight_block.rb
+++ b/lib/cask/artifact/preflight_block.rb
@@ -1,4 +1,4 @@
-class Cask::Artifact::BeforeBlock < Cask::Artifact::Base
+class Cask::Artifact::PreflightBlock < Cask::Artifact::Base
   def self.me?(cask)
     cask.artifacts[:preflight].any? ||
       cask.artifacts[:uninstall_preflight].any?
@@ -6,13 +6,13 @@ class Cask::Artifact::BeforeBlock < Cask::Artifact::Base
 
   def install_phase
     @cask.artifacts[:preflight].each do |block|
-      Cask::DSL::BeforeInstall.new(@cask).instance_eval &block
+      Cask::DSL::Preflight.new(@cask).instance_eval &block
     end
   end
 
   def uninstall_phase
     @cask.artifacts[:uninstall_preflight].each do |block|
-      Cask::DSL::BeforeUninstall.new(@cask).instance_eval &block
+      Cask::DSL::UninstallPreflight.new(@cask).instance_eval &block
     end
   end
 end

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -165,19 +165,7 @@ class Cask::CaveatsDSL
   end
 
   def method_missing(method, *args)
-    poo = <<-EOPOO.undent
-      Unexpected method #{method} called on caveats in Cask #{@cask}.
-
-        If you are working on #{@cask}, this may point to a typo. Otherwise
-        it probably means this Cask is using a new feature. If that feature
-        has been released, running
-
-          brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
-
-        should fix it. Otherwise you should wait to use #{@cask} until the
-        new feature is released.
-    EOPOO
-    poo.split("\n").each { |line| opoo line }
+    Cask::Utils.method_missing_message(method, @cask.to_s, 'caveats')
     return nil
   end
 end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -3,19 +3,19 @@ require 'set'
 
 module Cask::DSL; end
 
-require 'cask/dsl/base'
-require 'cask/dsl/installer'
-require 'cask/dsl/after_install'
-require 'cask/dsl/after_uninstall'
-require 'cask/dsl/before_install'
-require 'cask/dsl/before_uninstall'
 require 'cask/dsl/appcast'
+require 'cask/dsl/base'
 require 'cask/dsl/conflicts_with'
 require 'cask/dsl/container'
 require 'cask/dsl/depends_on'
 require 'cask/dsl/gpg'
+require 'cask/dsl/installer'
 require 'cask/dsl/license'
+require 'cask/dsl/postflight'
+require 'cask/dsl/preflight'
 require 'cask/dsl/tags'
+require 'cask/dsl/uninstall_postflight'
+require 'cask/dsl/uninstall_preflight'
 
 module Cask::DSL
   def self.included(base)
@@ -275,19 +275,8 @@ module Cask::DSL
     end
 
     def method_missing(method, *args)
-      poo = <<-EOPOO.undent
-        Unexpected method '#{method}' called on #{self}.
-
-          If you are working on #{self}, this may point to a typo. Otherwise
-          it probably means this Cask is using a new feature. If that feature
-          has been released, running
-
-            brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
-
-          should fix it. Otherwise you should wait to use #{self} until the
-          new feature is released.
-      EOPOO
-      poo.split("\n").each { |line| opoo line }
+      Cask::Utils.method_missing_message(method, self.title)
+      return nil
     end
   end
 end

--- a/lib/cask/dsl/after_uninstall.rb
+++ b/lib/cask/dsl/after_uninstall.rb
@@ -1,1 +1,0 @@
-class Cask::DSL::AfterUninstall < Cask::DSL::Base; end

--- a/lib/cask/dsl/before_install.rb
+++ b/lib/cask/dsl/before_install.rb
@@ -1,1 +1,0 @@
-class Cask::DSL::BeforeInstall < Cask::DSL::Base; end

--- a/lib/cask/dsl/postflight.rb
+++ b/lib/cask/dsl/postflight.rb
@@ -1,6 +1,6 @@
 require 'cask/staged'
 
-class Cask::DSL::AfterInstall < Cask::DSL::Base
+class Cask::DSL::Postflight < Cask::DSL::Base
   include Cask::Staged
 
   def suppress_move_to_applications(options = {})
@@ -17,5 +17,10 @@ class Cask::DSL::AfterInstall < Cask::DSL::Base
         "INSERT INTO access VALUES('kTCCServiceAccessibility','#{bundle_identifier}',0,1,1,NULL);"
       ], :sudo => true)
     end
+  end
+
+  def method_missing(method, *args)
+    Cask::Utils.method_missing_message(method, @cask.to_s, 'postflight')
+    return nil
   end
 end

--- a/lib/cask/dsl/preflight.rb
+++ b/lib/cask/dsl/preflight.rb
@@ -1,0 +1,6 @@
+class Cask::DSL::Preflight < Cask::DSL::Base
+  def method_missing(method, *args)
+    Cask::Utils.method_missing_message(method, @cask.to_s, 'preflight')
+    return nil
+  end
+end

--- a/lib/cask/dsl/uninstall_postflight.rb
+++ b/lib/cask/dsl/uninstall_postflight.rb
@@ -1,0 +1,6 @@
+class Cask::DSL::UninstallPostflight < Cask::DSL::Base
+  def method_missing(method, *args)
+    Cask::Utils.method_missing_message(method, @cask.to_s, 'uninstall_postflight')
+    return nil
+  end
+end

--- a/lib/cask/dsl/uninstall_preflight.rb
+++ b/lib/cask/dsl/uninstall_preflight.rb
@@ -1,6 +1,6 @@
 require 'cask/staged'
 
-class Cask::DSL::BeforeUninstall < Cask::DSL::Base
+class Cask::DSL::UninstallPreflight < Cask::DSL::Base
   include Cask::Staged
 
   def remove_accessibility_access
@@ -10,5 +10,10 @@ class Cask::DSL::BeforeUninstall < Cask::DSL::Base
         "DELETE FROM access WHERE client='#{bundle_identifier}';"
       ], :sudo => true)
     end
+  end
+
+  def method_missing(method, *args)
+    Cask::Utils.method_missing_message(method, @cask.to_s, 'uninstall_preflight')
+    return nil
   end
 end

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -149,4 +149,21 @@ module Cask::Utils
     end
     return false
   end
+
+  def self.method_missing_message(method, cask_name, section=nil)
+    during = section ? "during #{section} " : '';
+    poo = <<-EOPOO.undent
+      Unexpected method '#{method}' called #{during}on Cask #{cask_name}.
+
+        If you are working on #{cask_name}, this may point to a typo. Otherwise
+        it probably means this Cask is using a new feature. If that feature
+        has been released, running
+
+          brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
+
+        should fix it. Otherwise you should wait to use #{cask_name} until the
+        new feature is released.
+    EOPOO
+    poo.split("\n").each { |line| opoo line }
+  end
 end

--- a/test/cask/artifact/postflight_block_test.rb
+++ b/test/cask/artifact/postflight_block_test.rb
@@ -1,24 +1,24 @@
 require 'test_helper'
 
-describe Cask::Artifact::AfterBlock do
+describe Cask::Artifact::PostflightBlock do
   describe 'install_phase' do
     it 'calls the specified block after installing, passing a Cask mini-dsl' do
       called      = false
       yielded_arg = nil
 
-      CaskWithAfterInstall = Class.new(Cask)
-      CaskWithAfterInstall.class_eval do
+      CaskWithPostflight = Class.new(Cask)
+      CaskWithPostflight.class_eval do
         postflight do |c|
           called = true
           yielded_arg = c
         end
       end
 
-      cask = CaskWithAfterInstall.new
-      Cask::Artifact::AfterBlock.new(cask).install_phase
+      cask = CaskWithPostflight.new
+      Cask::Artifact::PostflightBlock.new(cask).install_phase
 
       called.must_equal true
-      yielded_arg.must_be_kind_of Cask::DSL::AfterInstall
+      yielded_arg.must_be_kind_of Cask::DSL::Postflight
     end
   end
 
@@ -27,19 +27,19 @@ describe Cask::Artifact::AfterBlock do
       called      = false
       yielded_arg = nil
 
-      CaskWithAfterUninstall = Class.new(Cask)
-      CaskWithAfterUninstall.class_eval do
+      CaskWithUninstallPostflight = Class.new(Cask)
+      CaskWithUninstallPostflight.class_eval do
         uninstall_postflight do |c|
           called = true
           yielded_arg = c
         end
       end
 
-      cask = CaskWithAfterUninstall.new
-      Cask::Artifact::AfterBlock.new(cask).uninstall_phase
+      cask = CaskWithUninstallPostflight.new
+      Cask::Artifact::PostflightBlock.new(cask).uninstall_phase
 
       called.must_equal true
-      yielded_arg.must_be_kind_of Cask::DSL::AfterUninstall
+      yielded_arg.must_be_kind_of Cask::DSL::UninstallPostflight
     end
   end
 end

--- a/test/cask/artifact/preflight_block_test.rb
+++ b/test/cask/artifact/preflight_block_test.rb
@@ -1,24 +1,24 @@
 require 'test_helper'
 
-describe Cask::Artifact::BeforeBlock do
+describe Cask::Artifact::PreflightBlock do
   describe 'install_phase' do
     it 'calls the specified block before installing, passing a Cask mini-dsl' do
       called      = false
       yielded_arg = nil
 
-      CaskWithBeforeInstall = Class.new(Cask)
-      CaskWithBeforeInstall.class_eval do
+      CaskWithPreflight = Class.new(Cask)
+      CaskWithPreflight.class_eval do
         preflight do |c|
           called = true
           yielded_arg = c
         end
       end
 
-      cask = CaskWithBeforeInstall.new
-      Cask::Artifact::BeforeBlock.new(cask).install_phase
+      cask = CaskWithPreflight.new
+      Cask::Artifact::PreflightBlock.new(cask).install_phase
 
       called.must_equal true
-      yielded_arg.must_be_kind_of Cask::DSL::BeforeInstall
+      yielded_arg.must_be_kind_of Cask::DSL::Preflight
     end
   end
 
@@ -27,19 +27,19 @@ describe Cask::Artifact::BeforeBlock do
       called      = false
       yielded_arg = nil
 
-      CaskWithBeforeUninstall = Class.new(Cask)
-      CaskWithBeforeUninstall.class_eval do
+      CaskWithUninstallPreflight = Class.new(Cask)
+      CaskWithUninstallPreflight.class_eval do
         uninstall_preflight do |c|
           called = true
           yielded_arg = c
         end
       end
 
-      cask = CaskWithBeforeUninstall.new
-      Cask::Artifact::BeforeBlock.new(cask).uninstall_phase
+      cask = CaskWithUninstallPreflight.new
+      Cask::Artifact::PreflightBlock.new(cask).uninstall_phase
 
       called.must_equal true
-      yielded_arg.must_be_kind_of Cask::DSL::BeforeUninstall
+      yielded_arg.must_be_kind_of Cask::DSL::UninstallPreflight
     end
   end
 end

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
-describe Cask::DSL::AfterInstall do
+describe Cask::DSL::Postflight do
   before do
     cask = Cask.load('basic-cask')
-    @dsl = Cask::DSL::AfterInstall.new(cask, Cask::FakeSystemCommand)
+    @dsl = Cask::DSL::Postflight.new(cask, Cask::FakeSystemCommand)
   end
 
   it "can run system commands with list-form arguments" do

--- a/test/cask/dsl/uninstall_preflight_test.rb
+++ b/test/cask/dsl/uninstall_preflight_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
-describe Cask::DSL::BeforeUninstall do
+describe Cask::DSL::UninstallPreflight do
   before do
     cask = Cask.load('basic-cask')
-    @dsl = Cask::DSL::BeforeUninstall.new(cask, Cask::FakeSystemCommand)
+    @dsl = Cask::DSL::UninstallPreflight.new(cask, Cask::FakeSystemCommand)
   end
 
   it "can remove accessibility access" do

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -16,15 +16,15 @@ describe Cask::DSL do
           future_feature :not_yet_on_your_machine
         end
       }, <<-WARNING.undent.chomp)
-        Warning: Unexpected method 'future_feature' called on UnexpectedMethodCask.
+        Warning: Unexpected method 'future_feature' called on Cask unexpected-method-cask.
         Warning:#{' '}
-        Warning:   If you are working on UnexpectedMethodCask, this may point to a typo. Otherwise
+        Warning:   If you are working on unexpected-method-cask, this may point to a typo. Otherwise
         Warning:   it probably means this Cask is using a new feature. If that feature
         Warning:   has been released, running
         Warning:#{' '}
         Warning:     brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
         Warning:#{' '}
-        Warning:   should fix it. Otherwise you should wait to use UnexpectedMethodCask until the
+        Warning:   should fix it. Otherwise you should wait to use unexpected-method-cask until the
         Warning:   new feature is released.
       WARNING
     rescue Exception => e


### PR DESCRIPTION
From legacy forms `after_install`, `AfterInstall`, etc.
- abstract out `method_missing_message` to Cask::Utils
- provide `method_missing` coverage in pre/postflight blocks (fixes #7445)
- fix old-style rendering of Cask names as classnames in `method_missing` messages
