### PR TITLE
Add MyPhotostream.app version 1.1.0

### DIFF
--- a/Casks/myphotostream.rb
+++ b/Casks/myphotostream.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'myphotostream' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.weareyeah.com/MyPhotostream/download'
+  homepage 'http://www.weareyeah.com/MyPhotostream/'
+  license :unknown
+
+  app 'MyPhotostream.app'
+end


### PR DESCRIPTION
iCloud's Photo Stream feature works great on iOS, but on the Mac it is kind of broken. We think your Photo Stream deserves a dedicated application in your Dock. http://www.weareyeah.com/MyPhotostream/
