### PR TITLE
Add cask for Avast Mac Security

### DIFF
--- a/Casks/avast.rb
+++ b/Casks/avast.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'avast' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://download.ff.avast.com/mac/avast_free_antivirus_mac_setup.dmg'
+  homepage 'http://www.avast.com/'
+  license :commercial
+
+  pkg 'Avast Mac Security.pkg'
+
+  uninstall :script => '/Library/Application Support/Avast/hub/uninstall.sh'
+end


### PR DESCRIPTION
Create a cask for Avast Mac Security. Not entirely sure if the
uninstall stanza is correct. The dmg comes with an uninstaller
with the filename 'com.avast.uninstall.app', but I can't find
anything in the docs about using a pre-packaged uninstaller.
