### PR TITLE
Review and revise accessibility methods in postflight mini-DSL

### DIFF
--- a/lib/cask/dsl/postflight.rb
+++ b/lib/cask/dsl/postflight.rb
@@ -9,13 +9,17 @@ class Cask::DSL::Postflight < Cask::DSL::Base
   end
 
   def enable_accessibility_access
-    if MacOS.version < :mavericks
-      system_command("touch", :args => ["/private/var/db/.AccessibilityAPIEnabled"])
+    if MacOS.version >= :mavericks
+      @command.run!('/usr/bin/sqlite3',
+                    :args => [
+                              Cask.tcc_db,
+                              "INSERT INTO access VALUES('kTCCServiceAccessibility','#{bundle_identifier}',0,1,1,NULL);",
+                             ],
+                    :sudo => true)
     else
-      system_command("sqlite3", :args => [
-        "/Library/Application\ Support/com.apple.TCC/TCC.db",
-        "INSERT INTO access VALUES('kTCCServiceAccessibility','#{bundle_identifier}',0,1,1,NULL);"
-      ], :sudo => true)
+      @command.run!('/usr/bin/touch',
+                    :args => [Cask.pre_mavericks_accessibility_dotfile],
+                    :sudo => true)
     end
   end
 

--- a/lib/cask/dsl/uninstall_preflight.rb
+++ b/lib/cask/dsl/uninstall_preflight.rb
@@ -3,12 +3,19 @@ require 'cask/staged'
 class Cask::DSL::UninstallPreflight < Cask::DSL::Base
   include Cask::Staged
 
-  def remove_accessibility_access
+  def disable_accessibility_access
     if MacOS.version >= :mavericks
-      system_command("sqlite3", :args => [
-        "/Library/Application\ Support/com.apple.TCC/TCC.db",
-        "DELETE FROM access WHERE client='#{bundle_identifier}';"
-      ], :sudo => true)
+      @command.run!('/usr/bin/sqlite3',
+                    :args => [
+                              Cask.tcc_db,
+                              "DELETE FROM access WHERE client='#{bundle_identifier}';",
+                             ],
+                    :sudo => true)
+    else
+      opoo <<-EOS.undent
+        Accessibility access was enabled for #{@cask}, but it is not safe to disable
+        automatically on this version of OS X.  See System Preferences.
+      EOS
     end
   end
 

--- a/lib/cask/locations.rb
+++ b/lib/cask/locations.rb
@@ -135,5 +135,13 @@ module Cask::Locations
         tapspath.join(default_tap, 'Casks', "#{cask_title}.rb")
       end
     end
+
+    def tcc_db
+      @tcc_db ||= Pathname.new('/Library/Application Support/com.apple.TCC/TCC.db')
+    end
+
+    def pre_mavericks_accessibility_dotfile
+      @pre_mavericks_accessibility_dotfile ||= Pathname.new('/private/var/db/.AccessibilityAPIEnabled')
+    end
   end
 end

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -63,7 +63,7 @@ describe Cask::DSL::Postflight do
     @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
 
     Cask::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "sqlite3", "/Library/Application Support/com.apple.TCC/TCC.db", "INSERT INTO access VALUES('kTCCServiceAccessibility','com.example.BasicCask',0,1,1,NULL);"]
+      ['/usr/bin/sudo', '-E', '--', '/usr/bin/sqlite3', Cask.tcc_db, %q{INSERT INTO access VALUES('kTCCServiceAccessibility','com.example.BasicCask',0,1,1,NULL);}]
     )
     @dsl.enable_accessibility_access
   end
@@ -72,7 +72,7 @@ describe Cask::DSL::Postflight do
     MacOS.stubs(:version => OS::Mac::Version.new('10.8'))
 
     Cask::FakeSystemCommand.expects_command(
-      ['touch', '/private/var/db/.AccessibilityAPIEnabled']
+      ['/usr/bin/sudo', '-E', '--', '/usr/bin/touch', Cask.pre_mavericks_accessibility_dotfile]
     )
     @dsl.enable_accessibility_access
   end

--- a/test/cask/dsl/uninstall_preflight_test.rb
+++ b/test/cask/dsl/uninstall_preflight_test.rb
@@ -6,14 +6,25 @@ describe Cask::DSL::UninstallPreflight do
     @dsl = Cask::DSL::UninstallPreflight.new(cask, Cask::FakeSystemCommand)
   end
 
-  it "can remove accessibility access" do
+  it "can disable accessibility access" do
     MacOS.stubs(:version => OS::Mac::Version.new('10.9'))
 
     @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
 
     Cask::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "sqlite3", "/Library/Application Support/com.apple.TCC/TCC.db", "DELETE FROM access WHERE client='com.example.BasicCask';"]
+      ['/usr/bin/sudo', '-E', '--', '/usr/bin/sqlite3', Cask.tcc_db, %q{DELETE FROM access WHERE client='com.example.BasicCask';}]
     )
-    @dsl.remove_accessibility_access
+    @dsl.disable_accessibility_access
+  end
+
+  it "warns about disabling accessibility access on old OS X versions" do
+    MacOS.stubs(:version => OS::Mac::Version.new('10.8'))
+
+    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
+
+    out, err = capture_io do
+      @dsl.disable_accessibility_access
+    end
+    err.must_match('Warning: Accessibility access was enabled for basic-cask, but it is not safe to disable')
   end
 end


### PR DESCRIPTION
- rename `remove_accessibility_access` to `disable_accessibility_access` to match corresponding method `enable_accessibility_access`
- move `TCC.db` and `.AccessibilityAPIEnabled` paths to `Cask::Locations`
- remove unneeded backslash from `TCC.db` path
- use full paths to `touch` and `sqlite3` utilities
- reverse conditional so enable/disable logic is consistent
- `sudo` is needed when creating `.AccessibilityAPIEnabled`
- instead of silent fail, warn that access cannot be safely disabled on Mountain Lion and earlier (it could, but might affect other apps)
- quoting/whitespace

Todo: the relevant methods are only available in either `postflight` or `preflight`, but they should be in both.

Edit:
- use `@command.run` instead of `system_command` which is intended as an  external interface

cc @federicobond 
