### PR TITLE
review/revise plist methods in postflight mini-DSL

### DIFF
--- a/lib/cask/staged.rb
+++ b/lib/cask/staged.rb
@@ -1,11 +1,13 @@
 module Cask::Staged
-  def info_plist
-    "#{staged_path}/#{@cask.artifacts[:app].first.first}/Contents/Info.plist"
+  def info_plist(index = 0)
+    index =  0 if index == :first
+    index =  1 if index == :second
+    index = -1 if index == :last
+    staged_path.join(@cask.artifacts[:app].to_a.at(index).first, 'Contents', 'Info.plist')
   end
 
   def plist_exec(cmd)
-    # todo: don't use external interface system_command
-    system_command("/usr/libexec/PlistBuddy", :args => ["-c", cmd, info_plist])
+    @command.run!('/usr/libexec/PlistBuddy', :args => ['-c', cmd, info_plist])
   end
 
   def plist_set(key, value)
@@ -13,6 +15,6 @@ module Cask::Staged
   end
 
   def bundle_identifier
-    plist_exec("Print CFBundleIdentifier")
+    plist_exec('Print CFBundleIdentifier')
   end
 end

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -14,7 +14,7 @@ describe Cask::DSL::Postflight do
   end
 
   it "can get the Info.plist file for the primary app" do
-    @dsl.info_plist.must_include "basic-cask/1.2.3/TestCask.app/Contents/Info.plist"
+    @dsl.info_plist.to_s.must_include 'basic-cask/1.2.3/TestCask.app/Contents/Info.plist'
   end
 
   it "can execute commands on the Info.plist file" do
@@ -27,9 +27,9 @@ describe Cask::DSL::Postflight do
   it "can retrieve the bundle identifier for the primary app" do
     Cask::FakeSystemCommand.stubs_command(
       ['/usr/libexec/PlistBuddy', '-c', 'Print CFBundleIdentifier', @dsl.info_plist],
-      "com.example.BasicCask"
+      'com.example.BasicCask'
     )
-    @dsl.bundle_identifier.stdout.must_equal "com.example.BasicCask"
+    @dsl.bundle_identifier.stdout.must_equal 'com.example.BasicCask'
   end
 
   it "can set a key in the Info.plist file" do


### PR DESCRIPTION
- accept index argument to `info_plist` in case of multiple `app` artifacts, defaulting to first
- return `Pathname` object from `info_plist`
- use `@command.run` instead of `system_command` which is intended as an external interface
- quoting
