### PR TITLE
review/revise `suppress_move_to_applications` method in postflight mini-DSL

### DIFF
--- a/lib/cask/dsl/postflight.rb
+++ b/lib/cask/dsl/postflight.rb
@@ -4,8 +4,8 @@ class Cask::DSL::Postflight < Cask::DSL::Base
   include Cask::Staged
 
   def suppress_move_to_applications(options = {})
-    key = options[:key] || "moveToApplicationsFolderAlertSuppress"
-    system_command("/usr/bin/defaults", :args => ["write", bundle_identifier, key, "-bool", "true"])
+    key = options[:key] || 'moveToApplicationsFolderAlertSuppress'
+    @command.run!('/usr/bin/defaults', :args => ['write', bundle_identifier, key, '-bool', 'true'])
   end
 
   def enable_accessibility_access


### PR DESCRIPTION
- use `@command.run` instead of `system_command` which is intended as an external interface
- quoting

Here I considered always setting multiple variants of `:key` to simplify Casks, but the each of the alternative keys only appear once in the repo.

Todo: as with all of these, it makes sense for this to be exposed symmetrically in `preflight` as well as `postflight`.

cc @federicobond 
