### PR TITLE
Upgrade Vienna.app to v3.0.1 and add zap support

### DIFF
--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,12 +1,18 @@
 cask :v1 => 'vienna' do
-  version '3.0.0'
-  sha256 'e61f44b7be0f1f49cf6c735d8e03071141ddaca1d5ff65db29f786ee3dfeded3'
+  version '3.0.1'
+  sha256 'f6f89ebdf76b120fea7fa4b18ce26f2d79fd789492c98452ab3b6ab0f7939a19'
 
   url "https://downloads.sourceforge.net/vienna-rss/Vienna#{version}.tgz"
-  appcast 'http://vienna-rss.org/changelog_beta.xml',
-          :sha256 => '20ae887cd3d0f8b97cd133cd32454fdb8796e72f2de2a0e12fe288c7358f7e31'
+  appcast 'http://vienna-rss.org/changelog.xml',
+          :sha256 => 'e0b95e383d348a15e4e5fe806c99188983acd9bb92566f0b6277789fec7579b9'
   homepage 'http://www.vienna-rss.org'
-  license :oss
+  license :apache
 
   app 'Vienna.app'
+  
+  zap :delete => [
+                  '~/Library/Application Support/Vienna',
+                  '~/Library/Caches/uk.co.opencommunity.vienna2',
+                  '~/Library/Preferences/uk.co.opencommunity.vienna2.plist',
+                  ]
 end


### PR DESCRIPTION
Updated Vienna.app to version 3.0.1 and added zap support.
