### PR TITLE
Update LastPass universal installer

### DIFF
--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -2,11 +2,11 @@ cask :v1 => 'lastpass-universal' do
   version :latest
   sha256 :no_check
 
-  url 'https://lastpass.com/lpmacosx.dmg'
+  url 'https://lastpass.com/download/cdn/lpmacosx.zip'
   homepage 'https://lastpass.com/'
   license :unknown
 
-  pkg 'lpmacosx.pkg'
+  installer :manual => 'LastPass Installer.app'
 
-  uninstall :pkgutil => 'com.lastpass.lpmacosx'
+  uninstall :script => 'Uninstaller.app/Contents/Resources/uninstall.sh'
 end


### PR DESCRIPTION
LastPass now uses a .zip file with an installer app rather than
a .dmg with a .pkg installer. Addresses #1994
