### PR TITLE
Rename lastpass

### DIFF
--- a/Casks/lastpass-universal.rb
+++ b/Casks/lastpass-universal.rb
@@ -2,11 +2,11 @@ cask :v1 => 'lastpass-universal' do
   version :latest
   sha256 :no_check
 
-  url 'https://lastpass.com/lpmacosx.dmg'
+  url 'https://lastpass.com/download/cdn/lpmacosx.zip'
   homepage 'https://lastpass.com/'
   license :unknown
 
-  pkg 'lpmacosx.pkg'
+  installer :manual => 'LastPass Installer.app'
 
-  uninstall :pkgutil => 'com.lastpass.lpmacosx'
+  uninstall :script => 'Uninstaller.app/Contents/Resources/uninstall.sh'
 end

--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'lastpass-universal' do
+cask :v1 => 'lastpass' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
On top of (but unrelated to) PR #7702, I feel that the `-universal` suffix should be abandoned to conform with our naming conventions.

Renamed to `lastpass`.
