### PR TITLE
Update vagrant-manager to v2.1.2

### DIFF
--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'vagrant-manager' do
-  version '2.1.1'
-  sha256 'bd4a44c82c4d2ffa2d9de3d9f924eb5eeb76ac133648de939668501a2deb021b'
+  version '2.1.2'
+  sha256 '8510664b4834c98ed9b72baa30aae611f640ca2292725a8cd6ae6d99d412dd4b'
 
   url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
   appcast 'http://api.lanayo.com/appcast/vagrant_manager.xml',
-          :sha256 => '9227c9784af8939aad0e7e0ddec0b748fbd463b464ece0f6dbb9c14240640b34'
+          :sha256 => '3dbe30121d4f32c4d600e30d58d6cfea142d9510823be7a125952aa2e05ea3af'
   homepage 'http://vagrantmanager.com/'
   license :mit
 


### PR DESCRIPTION
Update vagrant-manager to v2.1.2

Upgrade vagrant-manager to version 2.1.2. Latest version release 9th November 2014
