### PR TITLE
virtualbox: change license to GPL

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -4,7 +4,7 @@ cask :v1 => 'virtualbox' do
 
   url "http://download.virtualbox.org/virtualbox/#{version.gsub(/-.*/, '')}/VirtualBox-#{version}-OSX.dmg"
   homepage 'http://www.virtualbox.org'
-  license :unknown
+  license :gpl
 
   pkg 'VirtualBox.pkg'
 


### PR DESCRIPTION
From the [VirtualBox download page](https://www.virtualbox.org/wiki/Downloads): "The binaries are released under the terms of the GPL version 2."
