### PR TITLE
Change iTerm2 license to GPL

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -7,7 +7,7 @@ cask :v1 => 'iterm2' do
   homepage 'http://www.iterm2.com/'
   appcast 'http://iterm2.com/appcasts/final.xml',
           :sha256 => 'd8e8c6f4990676b33c81d7b577b96ef5eed9f8f872c104d02f25e0290b0a8ee5'
-  license :oss
+  license :gpl
 
   app 'iTerm.app'
 


### PR DESCRIPTION
See: http://iterm2.com/ or https://github.com/gnachman/iTerm2/blob/master/README.license
