### PR TITLE
Tunnelblick 3.4.2 (and other changes)

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'tunnelblick' do
-  version '3.4.1_r3054'
-  sha256 '44a9b1986c100698c82186c4ce404d5acf34f292d08c5f8528c33e22646f955a'
+  version '3.4.2_build_4055.4161'
+  sha256 '19cd879009d8f6989abd1f7e1ed1feb5dc68995f3146e08c547d4b64d3679c5b'
 
   url "https://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_#{version}.dmg"
+
   appcast 'https://www.tunnelblick.net/appcast.rss',
           :sha256 => '7fa119cda4d782dc61cb75895c70b3572652df737c908270c48a09d67a874592'
   homepage 'https://code.google.com/p/tunnelblick/'

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -3,7 +3,6 @@ cask :v1 => 'tunnelblick' do
   sha256 '19cd879009d8f6989abd1f7e1ed1feb5dc68995f3146e08c547d4b64d3679c5b'
 
   url "https://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_#{version}.dmg"
-
   appcast 'https://www.tunnelblick.net/appcast.rss',
           :sha256 => '7fa119cda4d782dc61cb75895c70b3572652df737c908270c48a09d67a874592'
   homepage 'https://code.google.com/p/tunnelblick/'

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -9,5 +9,8 @@ cask :v1 => 'tunnelblick' do
   license :oss
 
   app 'Tunnelblick.app'
+  uninstall :launchctl => 'net.tunnelblick.tunnelblick.LaunchAtLogin',
+            :quit      => 'net.tunnelblick.tunnelblick'
+
   caveats 'For security reasons, Tunnelblick must be installed to /Applications and will request to be moved at launch.'
 end

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tunnelblick' do
   appcast 'https://www.tunnelblick.net/appcast.rss',
           :sha256 => '7fa119cda4d782dc61cb75895c70b3572652df737c908270c48a09d67a874592'
   homepage 'https://code.google.com/p/tunnelblick/'
-  license :oss
+  license :gpl
 
   app 'Tunnelblick.app'
   uninstall :launchctl => 'net.tunnelblick.tunnelblick.LaunchAtLogin',

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -13,5 +13,9 @@ cask :v1 => 'tunnelblick' do
   uninstall :launchctl => 'net.tunnelblick.tunnelblick.LaunchAtLogin',
             :quit      => 'net.tunnelblick.tunnelblick'
 
-  caveats 'For security reasons, Tunnelblick must be installed to /Applications and will request to be moved at launch.'
+  caveats do
+    os_version_only *%w(10.4 10.5 10.6 10.7 10.8 10.9 10.10)
+    'For security reasons, Tunnelblick must be installed to /Applications '\
+      'and will request to be moved at launch.'
+  end
 end


### PR DESCRIPTION
Tunnelblick 3.4.2 was released today.  I've made changes to the cask file that:
- update to the latest version;
- specify the supported Mac OS X versions;
- specify the GPL; and
- add an uninstall stanza to remove a launchctl item and quit the app if running.

I don't really like the verbose version number.  I was tempted to change it to SemVer.org style
("3.4.2+4055.4161") or just omit the build specifier completely.
