### PR TITLE
Upgrade EasySIMBL to v1.7.1

### DIFF
--- a/Casks/easysimbl.rb
+++ b/Casks/easysimbl.rb
@@ -1,10 +1,15 @@
 cask :v1 => 'easysimbl' do
-  version '1.6'
-  sha256 '42139885e35946f1b2decb9cdfa755b8df8c050134463d76b2e3e0f68e783e26'
+  version '1.7.1'
+  sha256 'd8afe8bfd7ea32f6d8ad1d4438ddc9ce2ad47e66942e6b6e900807daa59ddd50'
 
   url "https://github.com/norio-nomura/EasySIMBL/releases/download/EasySIMBL-#{version}/EasySIMBL-#{version}.zip"
-  homepage 'https://github.com/norio-nomura/EasySIMBL/'
-  license :oss
+  homepage 'https://github.com/norio-nomura/EasySIMBL'
+  license :gpl
 
   app 'EasySIMBL.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.github.norio-nomura.EasySIMBL.plist',
+                  '~/Library/Preferences/com.github.norio-nomura.SIMBL-Agent.plist',
+                 ]
 end


### PR DESCRIPTION
Hi! Let's give some love to EasySIMBL:
- Upgrade EasySIMBL to v1.7.1
- Remove unnecessary trailing slash from GitHub-hosted homepage url
  - Are there any style rules regarding urls normalization? It's a trifle but with so amazingly detailed DSL documentation only this prevents my inner perfectionist from being completely happy ;)
- Change license to GPL
  - https://github.com/norio-nomura/EasySIMBL#license
- Add zap stanza
  - We certainly shouldn't remove the app's Application Support folder as it contains user manually installed plugins

Thanks for all of your hard work!

EDIT:
Tests are failed because of some connectivity problems on the Travis' side. Audit test was OK locally.
