### PR TITLE
Fix regression where some CLI commands break on Ruby 1.8

### DIFF
--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -1,3 +1,5 @@
+require 'rubygems'
+
 class Cask::CLI::Alfred < Cask::CLI::Base
   DEFAULT_SCOPES = [
     '/Applications',

--- a/lib/cask/source/path_base.rb
+++ b/lib/cask/source/path_base.rb
@@ -1,3 +1,5 @@
+require 'rubygems'
+
 class Cask::Source::PathBase
 
   # derived classes must define method self.me?


### PR DESCRIPTION
This fixes a regression where for example, `brew cask list` would break on Ruby 1.8.7.
### Cause

I feel the regression might have been introduced in the merge commit 62c1ce5, which adds code to `path_base.rb` which depends on `Gem::Version`, but doesn’t require the `rubygems` gem.

A Google search showed that `rubygems` is [built into 1.9 and later](http://guides.rubygems.org/rubygems-basics/) but not into 1.8 (I learn something new every day!). This seems to cause `brew cask list` (and other commands) to break under Ruby 1.8 since 62c1ce5.
### Steps to reproduce

Assuming `rbenv` and Ruby 1.8.7-p375 are installed, follow these steps:
1. Make sure homebrew-cask is in development mode.
2. In case you don’t have 1.8.7-p375 installed, change the command below to the patch level you have.
3. Run `brew cask list` under Ruby 1.8 like so:

``` sh
RBENV_VERSION=1.8.7-p375 HOMEBREW_BREW_FILE=/usr/local/bin/brew ruby /usr/local/Library/brew.rb /usr/local/bin/brew-cask list
```
### Result

``` md
Error: uninitialized constant Cask::Source::PathBase::Gem while loading '/usr/local/Library/Taps/caskroom/homebrew-cask/Casks/clarify.rb'
Please report this bug:
    https://github.com/caskroom/homebrew-cask/issues
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/source/path_base.rb:51:in `load'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask.rb:78:in `load'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/scopes.rb:87:in `installed'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/scopes.rb:81:in `map'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/scopes.rb:81:in `installed'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/cli/list.rb:52:in `list_installed'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/cli/list.rb:10:in `run'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/cli.rb:81:in `run_command'
/usr/local/Cellar/brew-cask/0.48.0/rubylib/cask/cli.rb:121:in `process'
/usr/local/bin/brew-cask.rb:42
/usr/local/Library/brew.rb:59:in `require'
/usr/local/Library/brew.rb:59:in `require?'
/usr/local/Library/brew.rb:118
```
### CLI::Alfred
- There appears to be a similar constellation in the `CLI::Alfred` class (since 0f664ca). That commit has been around since 0.41.1 so I guess it doesn’t cause any issues after all. I couldn’t produce any problem with this either but I added the missing `require` here as well just in case. 
### Test coverage

Given that `brew cask list` breaks, I would have expected `list_test.rb` to break as well. However, for some strange reason all **the unit tests are still green:**

``` sh
cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask/lib/..

RBENV_VERSION=1.8.7-p375 bundle exec rake test TEST=test/cask/cli/list_test.rb
```

Strangely, the result is:

``` md
...

Finished in 7.214952s, 0.4158 runs/s, 0.4158 assertions/s.

3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```
### Please review

Pinging one of @federicobond @ndr-qef @phinze @rolandwalker to please have a look. :blush:

Thank you!
