### PR TITLE
logitech-control-center: new version 3.9.1.b20 and more

### DIFF
--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -1,6 +1,7 @@
 cask :v1 => 'logitech-control-center' do
   version '3.9.1.b20'
   sha256 'e2c938286c4044bc6b83a7455f659e99d5854572d308cd6a9befd39eaed57d6c'
+  depends_on :macos => %w(10.6 10.7 10.8 10.9)
 
   url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
   homepage 'http://support.logitech.com/en_us/product/3129'

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'logitech-control-center' do
-  version '3.9.0.60'
-  sha256 '1eab6118dc5ad0b3c790b9132b5968050dab0117b07d8f338c471aff00078df1'
+  version '3.9.1.b20'
+  sha256 'e2c938286c4044bc6b83a7455f659e99d5854572d308cd6a9befd39eaed57d6c'
 
   url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
   homepage 'http://support.logitech.com/en_us/product/3129'

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -1,9 +1,16 @@
 cask :v1 => 'logitech-control-center' do
-  version '3.9.1.b20'
-  sha256 'e2c938286c4044bc6b83a7455f659e99d5854572d308cd6a9befd39eaed57d6c'
-  depends_on :macos => %w(10.6 10.7 10.8 10.9)
+  depends_on :macos => '<= 10.9'
 
-  url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
+  if MacOS.version <= '10.5'
+    version '3.5.1.23'
+    sha256 'b0b944edcb7549ff94d150d7caf72fb662fe825e3c829642c242180f4478d1ca'
+    url 'http://www.logitech.com/pub/techsupport/mouse/mac/lcc351.zip'
+  else
+    version '3.9.1.b20'
+    sha256 'e2c938286c4044bc6b83a7455f659e99d5854572d308cd6a9befd39eaed57d6c'
+    url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
+  end
+
   homepage 'http://support.logitech.com/en_us/product/3129'
   license :unknown
 

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -3,7 +3,7 @@ cask :v1 => 'logitech-control-center' do
   sha256 '1eab6118dc5ad0b3c790b9132b5968050dab0117b07d8f338c471aff00078df1'
 
   url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
-  homepage 'http://www.logitech.com'
+  homepage 'http://support.logitech.com/en_us/product/3129'
   license :unknown
 
   pkg 'LCC Installer.app/Contents/Resources/Logitech Control Center.mpkg'


### PR DESCRIPTION
Changes included in this pull request:
- updated to version 3.9.1.b20 (not sure if the "b" is meant to be "beta" or "build", but the version has been out for a few months now and it is supposed to address a bug with Mavericks)
- added version 3.5.1 for Snow Leopard and older
- changed homepage to URL specific to this software
- added dependency on Mavericks or older (based on lack of Yosemite info on the homepage)
