### PR TITLE
Convert 7 Casks to `depends_on :macos`

### DIFF
--- a/Casks/couleurs.rb
+++ b/Casks/couleurs.rb
@@ -8,7 +8,5 @@ cask :v1 => 'couleurs' do
 
   app 'Couleurs.app'
 
-  caveats do
-    os_version_only '10.10'
-  end
+  depends_on :macos => '>= :yosemite'
 end

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -23,11 +23,19 @@ cask :v1 => 'deeper' do
 
   app 'Deeper.app'
 
-  caveats do
-    os_version_only('10.4', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10')
+  depends_on :macos => %w{
+                          :tiger
+                          :leopard
+                          :snow_leopard
+                          :lion
+                          :mountain_lion
+                          :mavericks
+                          :yosemite
+                         }
 
-    if [:leopard, :tiger].include? MacOS.version
-      puts 'Deeper only runs from an Administrator account.'
+  caveats do
+    if [:leopard, :tiger].include?(MacOS.version.to_sym)
+      puts 'Deeper only runs from an Administrator account on this version of OS X.'
     end
   end
 end

--- a/Casks/fenics.rb
+++ b/Casks/fenics.rb
@@ -8,8 +8,9 @@ cask :v1 => 'fenics' do
 
   app 'FEniCS.app'
 
+  depends_on :macos => '>= :mavericks'
+
   caveats do
-    os_version_only '10.9', '10.10'
     <<-EOS.undent
       FEniCS is designed to work with the OS X system Python (v. 2.7.5 in OS X 10.9).
 

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -23,11 +23,19 @@ cask :v1 => 'maintenance' do
 
   app 'Maintenance.app'
 
-  caveats do
-    os_version_only('10.4', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10')
+  depends_on :macos => %w{
+                          :tiger
+                          :leopard
+                          :snow_leopard
+                          :lion
+                          :mountain_lion
+                          :mavericks
+                          :yosemite
+                         }
 
-    if [:leopard, :tiger].include? MacOS.version
-      puts 'Maintenance only runs from an Administrator account.'
+  caveats do
+    if [:leopard, :tiger].include?(MacOS.version.to_sym)
+      puts 'Maintenance only runs from an Administrator account on this version of OS X.'
     end
   end
 end

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -12,8 +12,9 @@ cask :v1 => 'tunnelblick' do
   uninstall :launchctl => 'net.tunnelblick.tunnelblick.LaunchAtLogin',
             :quit      => 'net.tunnelblick.tunnelblick'
 
+  depends_on :macos => '>= :tiger'
+
   caveats do
-    os_version_only *%w(10.4 10.5 10.6 10.7 10.8 10.9 10.10)
     <<-EOS.undent
     For security reasons, Tunnelblick must be installed to /Applications,
     and will request to be moved at launch.

--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -7,7 +7,6 @@ cask :v1 => 'ubar' do
   license :unknown
 
   app 'uBar.app'
-  caveats do
-    os_version_only '10.9', '10.10'
-  end
+
+  depends_on :macos => '>= :mavericks'
 end

--- a/Casks/zooom.rb
+++ b/Casks/zooom.rb
@@ -10,7 +10,5 @@ cask :v1 => 'zooom' do
 
   uninstall :pkgutil => 'com.coderage.pkg.Zooom2'
 
-  caveats do
-    os_version_only '10.9', '10.10'
-  end
+  depends_on :macos => '>= :mavericks'
 end


### PR DESCRIPTION
It is OK to use this feature, even though it is very new, because forward-compatibility code has been in release for some time.
