### PR TITLE
Fix sha256 for pgweb 0.4.1

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pgweb' do
   version '0.4.1'
-  sha256 'd43493cf2d2255f9adc103fa88f9d714ff33ecc8988581d6b01425a395404eff'
+  sha256 '3c97605f1ac22f03a737a2d32a45b8f35988290123d593d0c21cb28010893fc7'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   homepage 'https://github.com/sosedoff/pgweb'


### PR DESCRIPTION
Source pulled from https://github.com/sosedoff/pgweb/releases/download/v0.4.1/pgweb_darwin_amd64.zip
