### PR TITLE
Add depends_on and caveats clauses for onyx

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -21,4 +21,20 @@ cask :v1 => 'onyx' do
   license :unknown
 
   app 'OnyX.app'
+
+  depends_on :macos => %w{
+                          :tiger
+                          :leopard
+                          :snow_leopard
+                          :lion
+                          :mountain_lion
+                          :mavericks
+                          :yosemite
+                         }
+
+  caveats do
+    if [:leopard, :tiger].include?(MacOS.version.to_sym)
+      puts 'OnyX only runs from an Administrator account on this version of OS X.'
+    end
+  end
 end


### PR DESCRIPTION
Add MacOS version dependencies in the style of #7760.
Also add caveat for OS 10.4-5 as in the casks for Deeper
and Maintenance.
