### PR TITLE
Add my KeePassX (0.4.x-svn) retina fork

### DIFF
--- a/Casks/dwihn0r-keepassx.rb
+++ b/Casks/dwihn0r-keepassx.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'dwihn0r-keepassx' do
+  version '0.4.4'
+  sha256 '53ae446d458ef0ab6dae268ba17b0eb9779959f3f821552de89122bd434769e2'
+
+  url "https://github.com/dwihn0r/keepassx/releases/download/v#{version}/KeePassX-#{version}-OSX.zip"
+  homepage 'https://github.com/dwihn0r/keepassx/'
+  license :oss
+
+  app 'KeePassX.app'
+end


### PR DESCRIPTION
There's basically two versions of KeePassX:
- New: version 2 alpha for which there's already a cask.
- Old: version 0.4.3 (plus some svn code - approx 3 years old - for which there's no official build yet). The official repo has been "closed" with a reference to the new client.

I've forked the old repo, added some retina glue and produced a binary that works with retina screens. The old 0.4.3 build looks excessively blurry on a rMBP.
