### PR TITLE
Update licenses for a few casks

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cleanmymac' do
   url 'http://dl.devmate.com/com.macpaw.CleanMyMac2/CleanMyMac2.dmg'
   appcast 'http://updates.devmate.com/com.macpaw.CleanMyMac2.xml'
   homepage 'http://macpaw.com/cleanmymac'
-  license :unknown
+  license :commercial
 
   app 'CleanMyMac 2.app'
 end

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -20,7 +20,7 @@ cask :v1 => 'cocktail' do
   end
 
   homepage 'http://www.maintain.se/cocktail'
-  license :unknown
+  license :commercial
 
   app 'Cocktail.app'
 end

--- a/Casks/colloquy.rb
+++ b/Casks/colloquy.rb
@@ -6,7 +6,7 @@ cask :v1 => 'colloquy' do
   appcast 'http://colloquy.info/update.php?rss',
           :sha256 => 'd1eb727b05c5146585aa249354f016cc29a0ee1a71102c4c25fcdf56bc207f92'
   homepage 'http://colloquy.info/'
-  license :unknown
+  license :gpl
 
   app 'Colloquy.app'
 

--- a/Casks/controlplane.rb
+++ b/Casks/controlplane.rb
@@ -6,7 +6,7 @@ cask :v1 => 'controlplane' do
   appcast 'http://www.controlplaneapp.com/appcast.xml',
           :sha256 => 'bc5bd3a27e1e12f09fc1d5089af79535992473d361030ae50993e7c0135ad287'
   homepage 'http://www.controlplaneapp.com/'
-  license :unknown
+  license :gpl
 
   app 'ControlPlane.app'
 

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -12,7 +12,7 @@ cask :v1 => 'libreoffice' do
       :key_id => 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
   homepage 'https://www.libreoffice.org/'
-  license :unknown
+  license :oss
 
   app 'LibreOffice.app'
 end

--- a/Casks/multibit.rb
+++ b/Casks/multibit.rb
@@ -6,7 +6,7 @@ cask :v1 => 'multibit' do
   gpg "#{url}.asc",
       :key_id => '23f7fb7b'
   homepage 'https://multibit.org/'
-  license :unknown
+  license :mit
 
   app 'MultiBit.app'
 end

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -12,7 +12,7 @@ cask :v1 => 'r' do
   end
 
   homepage 'http://www.r-project.org/'
-  license :unknown
+  license :gpl
 
   uninstall :pkgutil => [
                          # eg org.r-project.R.maverics.fw.pkg

--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -4,7 +4,7 @@ cask :v1 => 'rstudio' do
 
   url "http://download1.rstudio.org/RStudio-#{version}.dmg"
   homepage 'http://www.rstudio.com/'
-  license :unknown
+  license :affero
 
   app 'RStudio.app'
 

--- a/Casks/sloth.rb
+++ b/Casks/sloth.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sloth' do
 
   url 'http://sveinbjorn.org/files/software/sloth.zip'
   homepage 'http://sveinbjorn.org/sloth'
-  license :unknown
+  license :gpl
 
   app "Sloth-#{version}/Sloth.app"
 end


### PR DESCRIPTION
Gets rid of unknown and adds licenses for sloth, rstudio, r, multibit, controlplane, colloquy, cocktail, cleanmymac, and libreoffice.  I'd especially welcome a check on libreoffice - I listed it as `:oss` rather than `:mpl` given that it includes other software under other licenses.
