### PR TITLE
DSL: `depends_on :arch` functionality/tests/doc

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -232,7 +232,6 @@ The following methods may be called to generate standard warning messages:
 | `reboot`                          | users should reboot to complete installation
 | `assistive_devices`               | users should grant the application access to assistive devices
 | `files_in_usr_local`              | the Cask installs files to `/usr/local`, which may confuse Homebrew
-| `arch_only(list)`                 | the Cask only supports certain architectures.  Currently valid elements of `list` are `intel-32` and `intel-64`
 | `x11_required`                    | the Cask requires X11 to run
 
 Example:
@@ -586,6 +585,40 @@ depends_on :macos => '>= :mavericks'
 depends_on :macos => '>= 10.9'
 ```
 
+### Depends_on :arch
+
+The value for `depends_on :arch` may be a symbol or an array of symbols,
+listing the hardware compatibility requirements for a Cask.  The requirement
+is satisfied at install time if any one of multiple `:arch` value matches
+the user's hardware.
+
+The available symbols for hardware are:
+
+| symbol     | meaning        |
+| ---------- | -------------- |
+| `:i386`    | 32-bit Intel   |
+| `:x86_64`  | 64-bit Intel   |
+| `:ppc_7400`| 32-bit PowerPC |
+| `:ppc_64`  | 64-bit PowerPC |
+| `:intel`   | Any Intel      |
+| `:ppc`     | Any PowerPC    |
+
+The following are all valid expressions:
+
+```ruby
+depends_on :arch => :x86_64
+depends_on :arch => [:x86_64]          # same meaning as above
+depends_on :arch => :intel
+depends_on :arch => [:i386, :x86_64]   # same meaning as above
+```
+
+Since PowerPC hardware is no longer common, the expression most
+frequently needed will be:
+
+```ruby
+depends_on :arch => :x86_64
+```
+
 ### All Depends_on Keys
 
 Several other keys are accepted by `depends_on`, in anticipation of future
@@ -596,7 +629,7 @@ functionality:
 | `:formula` | a Homebrew Formula
 | `:cask`    | *stub - not yet functional*
 | `:macos`   | a string, symbol, array, or expression defining OS X version requirements.
-| `:arch`    | *stub - not yet functional*
+| `:arch`    | a symbol or array defining hardware requirements.
 | `:x11`     | *stub - not yet functional*
 | `:java`    | *stub - not yet functional*
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -54,8 +54,6 @@ features which are available for the current Cask.
  * [`artifact`](CASK_LANGUAGE_REFERENCE.md#at-least-one-artifact-stanza-is-also-required)
  * [`depends_on :cask`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
    * *stub* - not yet functional
- * [`depends_on :arch`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
-   * *stub* - not yet functional
  * [`depends_on :x11`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
    * *stub* - not yet functional
  * [`depends_on :java`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
@@ -94,6 +92,7 @@ features which are available for the current Cask.
 | `title` (in interpolations)           | [`token`](CASK_LANGUAGE_REFERENCE.md#caveats-as-a-string)
 | `uninstall :files`                    | [`uninstall :delete`](CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details)
 | `version 'latest'`                    | [`version :latest`](CASK_LANGUAGE_REFERENCE.md#required-stanzas)
+| `arch_only` (within `caveats`)        | [`depends_on :arch`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
 
 
 ## All Supported Stanzas (1.0)
@@ -145,7 +144,6 @@ For use in *eg* interpolation:
 
 ## Caveats Mini-DSL (1.0)
 
- * [`arch_only(list)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`assistive_devices`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`files_in_usr_local`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`logout`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -106,6 +106,7 @@ class Cask::Installer
   #      override dependencies with --force or perhaps --force-deps
   def satisfy_dependencies
     macos_dependencies
+    arch_dependencies
     formula_dependencies
   end
 
@@ -129,6 +130,21 @@ class Cask::Installer
         unless MacOS.version == @cask.depends_on.macos
           raise CaskError.new "Cask #{@cask} depends on OS X version #{@cask.depends_on.macos}, but you are running version #{MacOS.version}."
         end
+      end
+    end
+  end
+
+  def arch_dependencies
+    if @cask.depends_on and
+       @cask.depends_on.arch
+      @current_arch ||= [
+                         Hardware::CPU.type,
+                         Hardware::CPU.is_32_bit? ?
+                           (Hardware::CPU.intel? ? :i386   : :ppc_7400) :
+                           (Hardware::CPU.intel? ? :x86_64 : :ppc_64)
+                        ]
+      if Array(@cask.depends_on.arch & @current_arch).count == 0
+        raise CaskError.new "Cask #{@cask} depends on hardware architecture being one of #{@cask.depends_on.arch.inspect}, but you are running #{@current_arch.inspect}"
       end
     end
   end

--- a/test/cask/depends_on_test.rb
+++ b/test/cask/depends_on_test.rb
@@ -50,4 +50,22 @@ describe "Satisfy Dependencies and Requirements" do
       }.must_raise(CaskError)
     end
   end
+
+  describe "depends_on :arch" do
+    it "succeeds when depends_on :arch is satisfied" do
+      arch_cask = Cask.load('with-depends-on-arch')
+      shutup do
+        Cask::Installer.new(arch_cask).install
+      end
+    end
+
+    it "raises an exception when depends_on :arch is not satisfied" do
+      arch_cask = Cask.load('with-depends-on-arch-failure')
+      lambda {
+        shutup do
+          Cask::Installer.new(arch_cask).install
+        end
+      }.must_raise(CaskError)
+    end
+  end
 end

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -262,6 +262,18 @@ describe Cask::DSL do
     end
   end
 
+  describe "depends_on :arch" do
+    it "allows depends_on :arch to be specified" do
+      cask = Cask.load('with-depends-on-arch')
+      cask.depends_on.arch.wont_be_nil
+    end
+    it "refuses to load with an invalid depends_on :arch value" do
+      err = lambda {
+        invalid_cask = Cask.load('invalid/invalid-depends-on-arch-value')
+      }.must_raise(CaskInvalidError)
+    end
+  end
+
   describe "conflicts_with stanza" do
     it "allows conflicts_with stanza to be specified" do
       cask = Cask.load('with-conflicts-with')

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -44,7 +44,7 @@ describe Cask::Installer do
     it "works with cab-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/cabextract').exist?
       cab_container = Cask.load('cab-container')
-      empty = stub(:formula => [], :macos => nil)
+      empty = stub(:formula => [], :macos => nil, :arch => nil)
       cab_container.stubs(:depends_on).returns(empty)
 
       shutup do
@@ -72,7 +72,7 @@ describe Cask::Installer do
     it "works with 7z-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       sevenzip_container = Cask.load('sevenzip-container')
-      empty = stub(:formula => [], :macos => nil)
+      empty = stub(:formula => [], :macos => nil, :arch => nil)
       sevenzip_container.stubs(:depends_on).returns(empty)
 
       shutup do
@@ -101,7 +101,7 @@ describe Cask::Installer do
     it "works with Stuffit-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       stuffit_container = Cask.load('stuffit-container')
-      empty = stub(:formula => [], :macos => nil)
+      empty = stub(:formula => [], :macos => nil, :arch => nil)
       stuffit_container.stubs(:depends_on).returns(empty)
 
       shutup do
@@ -117,7 +117,7 @@ describe Cask::Installer do
     it "works with RAR-based Casks" do
       skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
       rar_container = Cask.load('rar-container')
-      empty = stub(:formula => [], :macos => nil)
+      empty = stub(:formula => [], :macos => nil, :arch => nil)
       rar_container.stubs(:depends_on).returns(empty)
 
       shutup do

--- a/test/support/Casks/invalid/invalid-depends-on-arch-value.rb
+++ b/test/support/Casks/invalid/invalid-depends-on-arch-value.rb
@@ -1,0 +1,11 @@
+cask :v1test => 'invalid-depends-on-arch-value' do
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/invalid-depends-on-arch-value'
+
+  depends_on :arch => :no_such_arch
+
+  app 'Caffeine.app'
+end

--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -19,9 +19,4 @@ cask :v1test => 'with-caveats' do
     puts 'Custom text via puts followed by DSL-generated text:'
     path_environment_variable('/custom/path/bin')
   end
-  caveats do
-    # since both valid arches are specified, no output should be
-    # generated here during the test
-    arch_only('intel-32', 'intel-64')
-  end
 end

--- a/test/support/Casks/with-conditional-caveats.rb
+++ b/test/support/Casks/with-conditional-caveats.rb
@@ -10,9 +10,4 @@ cask :v1test => 'with-conditional-caveats' do
   caveats do
     puts 'This caveat is conditional' if false
   end
-  caveats do
-    # since both valid arches are specified, no output should be
-    # generated here during the test
-    arch_only('intel-32', 'intel-64')
-  end
 end

--- a/test/support/Casks/with-depends-on-arch-failure.rb
+++ b/test/support/Casks/with-depends-on-arch-failure.rb
@@ -1,0 +1,12 @@
+cask :v1test => 'with-depends-on-arch-failure' do
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/with-depends-on-arch-failure'
+
+  # guarantee mismatched hardware
+  depends_on :arch => Hardware::CPU.intel? ? :ppc : :intel
+
+  app 'Caffeine.app'
+end

--- a/test/support/Casks/with-depends-on-arch.rb
+++ b/test/support/Casks/with-depends-on-arch.rb
@@ -1,0 +1,12 @@
+cask :v1test => 'with-depends-on-arch' do
+  version '1.2.3'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+
+  url TestHelper.local_binary_url('caffeine.zip')
+  homepage 'http://example.com/with-depends-on-arch'
+
+  # covers all known hardware; always succeeds
+  depends_on :arch => [:ppc, :intel]
+
+  app 'Caffeine.app'
+end


### PR DESCRIPTION
- fill in functionality for the `depends_on :arch` stub
- de-document `caveats` method `arch_only`
