### PR TITLE
Add SimpleCov for test coverage reporting

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,6 @@
+SimpleCov.start do
+  add_filter 'spec/'
+  add_filter 'test/'
+end
+
+# vim:ft=ruby:

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :test do
   gem 'minitest-colorize'
   gem 'mocha', '1.1.0', :require => false
   gem 'rspec', '~> 3.0.0'
+  gem 'simplecov', '~> 0.6.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       minitest (>= 2.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
+    multi_json (1.3.6)
     rake (10.0.4)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
@@ -21,6 +22,10 @@ GEM
     rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
+    simplecov (0.6.4)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.5.3)
+    simplecov-html (0.5.3)
 
 PLATFORMS
   ruby
@@ -31,3 +36,4 @@ DEPENDENCIES
   mocha (= 1.1.0)
   rake
   rspec (~> 3.0.0)
+  simplecov (~> 0.6.4)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+
 project_root = Pathname(File.expand_path("../..", __FILE__))
 
 Dir["#{project_root}/spec/support/**/*.rb"].each { |f| require f }

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -37,6 +37,7 @@ describe "Repo layout" do
   TOPLEVEL_FILES = %w{
                       .gitignore
                       .rspec
+                      .simplecov
                       .travis.yml
                       CONDUCT.md
                       CONTRIBUTING.md

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler'
 require 'bundler/setup'
+require 'simplecov'
 
 # force some environment variables
 ENV['HOMEBREW_NO_EMOJI']='1'


### PR DESCRIPTION
This SimpleCov configuration will work transparently whenever "rake test" or "rake spec" are run. Results from both kinds of tests are cached and combined.
