### PR TITLE
be explicit: no fallthrough for apps from titantium.free.fr

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -14,8 +14,11 @@ cask :v1 => 'deeper' do
     url 'http://www.titanium.free.fr/download/108/Deeper.dmg'
   elsif MacOS.version == :mavericks
     url 'http://www.titanium.free.fr/download/109/Deeper.dmg'
-  else
+  elsif MacOS.version == :yosemite
     url 'http://www.titanium.free.fr/download/1010/Deeper.dmg'
+  else
+    # Unusual case: there is no fall-through.  Each version of the software is
+    # specific to an OS X release, so define nothing when the release is unknown.
   end
 
   homepage 'http://www.titanium.free.fr/downloaddeeper.php'

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -14,8 +14,11 @@ cask :v1 => 'maintenance' do
     url 'http://www.titanium.free.fr/download/108/Maintenance.dmg'
   elsif MacOS.version == :mavericks
     url 'http://www.titanium.free.fr/download/109/Maintenance.dmg'
-  else
+  elsif MacOS.version == :yosemite
     url 'http://www.titanium.free.fr/download/1010/Maintenance.dmg'
+  else
+    # Unusual case: there is no fall-through.  Each version of the software is
+    # specific to an OS X release, so define nothing when the release is unknown.
   end
 
   homepage 'http://www.titanium.free.fr/downloadmaintenance.php'

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -14,8 +14,11 @@ cask :v1 => 'onyx' do
     url 'http://www.titanium.free.fr/download/108/OnyX.dmg'
   elsif MacOS.version == :mavericks
     url 'http://www.titanium.free.fr/download/109/OnyX.dmg'
-  else
+  elsif MacOS.version == :yosemite
     url 'http://www.titanium.free.fr/download/1010/OnyX.dmg'
+  else
+    # Unusual case: there is no fall-through.  Each version of the software is
+    # specific to an OS X release, so define nothing when the release is unknown.
   end
   homepage 'http://www.titanium.free.fr/downloadonyx.php'
   license :unknown


### PR DESCRIPTION
Each version is specific to an OS X release.

This is already more or less in effect due to `depends_on :macos`, but the `else` clause contradicted that meaning.  This syncs the conditional and the `depends_on`.
