### PR TITLE
dterm: add caveat and uninstall

### DIFF
--- a/Casks/dterm.rb
+++ b/Casks/dterm.rb
@@ -8,4 +8,8 @@ cask :v1 => 'dterm' do
   license :unknown
 
   app 'DTerm.app'
+  uninstall :quit => 'net.decimus.dterm'
+  caveats do
+    assistive_devices
+  end
 end


### PR DESCRIPTION
This adds a `caveats` stanza to highlight the need for accessibility permissions and an `uninstall` stanza to quit the app upon removal.
