### PR TITLE
Add `name` stanza for proper name

### DIFF
--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -24,6 +24,7 @@ class Cask::CLI::Create < Cask::CLI::Base
         sha256 ''
 
         url 'https://'
+        name ''
         homepage ''
         license :unknown
 

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -20,14 +20,20 @@ class Cask::CLI::Info < Cask::CLI::Base
                    else
                      "Not installed"
                    end
-
+    # todo completely reformat the info report
     <<-PURPOSE
 #{cask}: #{cask.version}
+#{formatted_full_name(cask) }
 #{cask.homepage or 'No Homepage'}
 #{installation}
 #{github_info(cask) or 'No GitHub URL'}
 #{artifact_info(cask) or 'No Artifact Info'}
 PURPOSE
+  end
+
+  def self.formatted_full_name(cask)
+    # todo transitional: make name a required stanza, and then stop substituting cask.token here
+    cask.full_name.empty? ? cask.token : cask.full_name.join(', ')
   end
 
   def self.github_info(cask)

--- a/lib/cask/cli/internal_stanza.rb
+++ b/lib/cask/cli/internal_stanza.rb
@@ -69,7 +69,8 @@ class Cask::CLI::InternalStanza < Cask::CLI::InternalUseBase
 
   def self.print_stanzas(stanza, format=nil, table=nil, quiet=nil, *cask_tokens)
     count = 0
-    stanza = :sums if stanza == :sha256
+    stanza = :sums      if stanza == :sha256
+    stanza = :full_name if stanza == :name
     if ARTIFACTS.include?(stanza)
       artifact_name = stanza
       stanza = :artifacts

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -22,6 +22,8 @@ module Cask::DSL
     base.extend(ClassMethods)
   end
 
+  def full_name; self.class.full_name; end
+
   def homepage; self.class.homepage; end
 
   def url; self.class.url; end
@@ -49,6 +51,27 @@ module Cask::DSL
   def caveats; self.class.caveats; end
 
   module ClassMethods
+
+    # A quite fragile shim to allow "full_name" be exposed as simply "name"
+    # in the DSL.  We detect the difference with the already-existing "name"
+    # method by arity, and use "full_name" exclusively in backend code.
+    def name(*args)
+      if args.empty?
+        super
+      else
+        self.full_name(args)
+      end
+    end
+
+    def full_name(_full_name=nil)
+      @full_name ||= []
+      if _full_name
+        # todo this idiom may be preferred to << if it behaves the same on Ruby 1.8 and 2.x
+        @full_name.concat(Array(*_full_name))
+      end
+      @full_name
+    end
+
     def homepage(homepage=nil)
       if @homepage and !homepage.nil?
         raise CaskInvalidError.new(self.token, "'homepage' stanza may only appear once")

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -85,6 +85,7 @@ module Cask::Utils
       odebug "Cask instance dumps in YAML:"
       odebug "Cask instance toplevel:", self.to_yaml
       [
+       :full_name,
        :homepage,
        :url,
        :appcast,
@@ -99,7 +100,9 @@ module Cask::Utils
        :container,
        :gpg,
       ].each do |method|
-        odebug "Cask instance method '#{method}':", self.send(method).to_yaml
+        printable_method = method.to_s
+        printable_method = "name" if printable_method == "full_name"
+        odebug "Cask instance method '#{printable_method}':", self.send(method).to_yaml
       end
     end
   end

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -41,6 +41,7 @@ describe Cask::CLI::Create do
         sha256 ''
 
         url 'https://'
+        name ''
         homepage ''
         license :unknown
 

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -6,6 +6,7 @@ describe Cask::CLI::Info do
       Cask::CLI::Info.run('local-caffeine')
     }.must_output <<-CLIOUTPUT.undent
       local-caffeine: 1.2.3
+      local-caffeine
       http://example.com/local-caffeine
       Not installed
       https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
@@ -18,12 +19,14 @@ describe Cask::CLI::Info do
     before do
       @expected_output = <<-CLIOUTPUT.undent
         local-caffeine: 1.2.3
+        local-caffeine
         http://example.com/local-caffeine
         Not installed
         https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
         ==> Contents
           Caffeine.app (app)
         local-transmission: 2.61
+        local-transmission
         http://example.com/local-transmission
         Not installed
         https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
@@ -50,6 +53,7 @@ describe Cask::CLI::Info do
       Cask::CLI::Info.run('with-caveats')
     }.must_output <<-CLIOUTPUT.undent
       with-caveats: 1.2.3
+      with-caveats
       http://example.com/local-caffeine
       Not installed
       https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-caveats.rb
@@ -74,6 +78,7 @@ describe Cask::CLI::Info do
       Cask::CLI::Info.run('with-conditional-caveats')
     }.must_output <<-CLIOUTPUT.undent
       with-conditional-caveats: 1.2.3
+      with-conditional-caveats
       http://example.com/local-caffeine
       Not installed
       https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-conditional-caveats.rb

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -57,6 +57,45 @@ describe Cask::DSL do
     end
   end
 
+  describe "name stanza" do
+    it "lets you set the full name via a name stanza" do
+      NameCask = Class.new(Cask)
+      NameCask.class_eval do
+        name 'Proper Name'
+      end
+      instance = NameCask.new
+      instance.full_name.must_equal [
+                                     'Proper Name',
+                                    ]
+    end
+
+    it "Accepts an array value to the name stanza" do
+      ArrayNameCask = Class.new(Cask)
+      ArrayNameCask.class_eval do
+        name ['Proper Name', 'Alternate Name']
+      end
+      instance = ArrayNameCask.new
+      instance.full_name.must_equal [
+                                     'Proper Name',
+                                     'Alternate Name',
+                                    ]
+    end
+
+    it "Accepts multiple name stanzas" do
+      MultiNameCask = Class.new(Cask)
+      MultiNameCask.class_eval do
+        name 'Proper Name'
+        name 'Alternate Name'
+      end
+      instance = MultiNameCask.new
+      # the sort is a hack to deal with Ruby 1.8 oddities
+      instance.full_name.sort.must_equal [
+                                          'Proper Name',
+                                          'Alternate Name',
+                                         ].sort
+    end
+  end
+
   describe "sha256 stanza" do
     it "lets you set checksum via sha256" do
       ChecksumCask = Class.new(Cask)


### PR DESCRIPTION
Following up on #7673, add a `name` stanza
- This will obsolete `tags :name` (before it ever really gets started)
- Documentation will be in a separate PR so that authors don't start using the feature before code release
- Future plan would be to make this mandatory
- Proposed placement in create template is high, which may warrant discussion

There is a bit of hackery needed to expose `name` in the DSL, because Ruby has already defined a `name` method.  On the backend, this is everywhere referred to as `full_name`.

Exposing simply `name` has the virtue of clearly directing all naming activities away from the token, which cannot bear the weight.
