### PR TITLE
Comment out `tags :name` in 5 Casks

### DIFF
--- a/Casks/cloud.rb
+++ b/Casks/cloud.rb
@@ -3,9 +3,10 @@ cask :v1 => 'cloud' do
   sha256 'f412e020c8307ef5872c0c5236f8bc1f1548c47d10b19315aba24ebd391cf293'
 
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
+  # todo
+  # name 'CloudApp'
   homepage 'http://getcloudapp.com/'
   license :unknown
-  tags :name => 'CloudApp'
 
   app 'CloudApp.app'
 

--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -3,10 +3,11 @@ cask :v1 => 'data-integration' do
   sha256 :no_check
 
   url 'https://sourceforge.net/projects/pentaho/files/latest/download'
+  # todo
+  # name 'Pentaho Data Integration'
   homepage 'http://community.pentaho.com'
   license :oss
-  tags :vendor => 'Pentaho',
-       :name   => 'Pentaho Data Integration'
+  tags :vendor => 'Pentaho'
 
   app 'data-integration/Data Integration.app'
 end

--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -3,6 +3,9 @@ cask :v1 => 'karabiner' do
   sha256 'b1e3ffb7cd10ec8651c68b184c236589f182a273dad4b1c68ab2c15d36a34248'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-#{version}.dmg"
+  # todo
+  # name 'Karabiner'
+  # name 'Keyremap4Macbook'
   homepage 'https://pqrs.org/osx/karabiner/'
   license :unknown
 

--- a/Casks/laullon-gitx.rb
+++ b/Casks/laullon-gitx.rb
@@ -3,11 +3,12 @@ cask :v1 => 'laullon-gitx' do
   sha256 'c5f4088497abf5a219bb7bde4fae643fec61647be25bf836fd679567dcabd7df'
 
   url "https://github.com/downloads/laullon/gitx/GitX-L_v#{version}.zip"
+  # todo
+  # name 'GitX (L)'
   appcast 'http://gitx.laullon.com/appcast.xml',
           :sha256 => '7ce5197de931145d75c57c2171fba559481e79e23bedd58ec107b476731f693b'
   homepage 'http://gitx.laullon.com/'
   license :oss
-  tags :name => 'GitX (L)'
 
   app 'GitX.app'
   binary 'GitX.app/Contents/Resources/gitx'

--- a/Casks/smlnj.rb
+++ b/Casks/smlnj.rb
@@ -3,9 +3,10 @@ cask :v1 => 'smlnj' do
   sha256 '77265ce1bdbca3e9c9b3053195503bf2bffafbba196596679fb64d9ceb4e25ee'
 
   url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-x86-#{version}.pkg"
+  # todo
+  # name 'Standard ML New Jersey'
   homepage 'http://www.smlnj.org/'
   license :oss
-  tags :name => 'Standard ML New Jersey'
 
   pkg "smlnj-x86-#{version}.pkg"
 

--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -3,9 +3,10 @@ cask :v1 => 'sqlitebrowser' do
   sha256 '8347deff7680fba86fcc21abb442a05a1526896d2701ed27d8aa8c38284a41ff'
 
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/sqlitebrowser-#{version}.dmg"
+  # todo
+  # name 'DB Browser for SQLite'
   homepage 'http://sqlitebrowser.org'
   license :mpl
-  tags :name => 'DB Browser for SQLite'
 
   app 'sqlitebrowser.app'
 end


### PR DESCRIPTION
I'm hoping to transition to `name` aggressively (in only one release).

To accomplish that, we should make sure `tags :name` is removed from Casks ahead of release.

Since the number of Casks is so small everything should be fine.
