### PR TITLE
Comment out arch_only in 2 Casks

### DIFF
--- a/Casks/jaspersoft-studio.rb
+++ b/Casks/jaspersoft-studio.rb
@@ -7,7 +7,7 @@ cask :v1 => 'jaspersoft-studio' do
   license :oss
 
   app "Jaspersoft Studio #{version}.final/Jaspersoft Studio.app"
-  caveats do
-    arch_only 'intel-64'
-  end
+
+  # todo
+  # depends_on :arch => :x86_64
 end

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -13,7 +13,7 @@ cask :v1 => 'paraview' do
   license :unknown
 
   app 'paraview.app'
-  caveats do
-    arch_only 'intel-64'
-  end
+
+  # todo
+  # depends_on :arch => :x86_64
 end


### PR DESCRIPTION
These will be switched to `depends_on :arch` after the next release
