### PR TITLE
followups on `depends_on` `:macos`/`:arch`

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -107,7 +107,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 | `uninstall`            | yes                           | procedures to uninstall a Cask. Optional unless the `pkg` stanza is used. (see also [Uninstall Stanza Details](#uninstall-stanza-details))
 | `zap`                  | yes                           | additional procedures for a more complete uninstall, including user files and shared resources. (see also [Zap Stanza Details](#zap-stanza-details))
 | `appcast`              | no                            | a URL providing an appcast feed to find updates for this Cask.  (see also [Appcast Stanza Details](#appcast-stanza-details))
-| `depends_on`           | yes                           | a list of dependencies required by this Cask (see also [Depends_on Stanza Details](#depends_on-stanza-details))
+| `depends_on`           | yes                           | a list of dependencies and requirements for this Cask (see also [Depends_on Stanza Details](#depends_on-stanza-details))
 | `conflicts_with`       | yes                           | a list of conflicts with this Cask (*not yet functional* see also [Conflicts_with Stanza Details](#conflicts_with-stanza-details))
 | `caveats`              | yes                           | a string or Ruby block providing the user with Cask-specific information at install time (see also [Caveats Stanza Details](#caveats-stanza-details))
 | `preflight`            | yes                           | a Ruby block containing preflight install operations (needed only in very rare cases)
@@ -538,12 +538,12 @@ installer :script => 'Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer
 
 ## Depends_on Stanza Details
 
-`depends_on` is used to declare dependencies required to install a Cask
-or to execute its contents.
+`depends_on` is used to declare dependencies and requirements for a Cask.
+`depends_on` is not consulted until `install` is attempted.
 
 ### Depends_on :formula
 
-The value should name a Homebrew formula needed by the Cask.
+The value should name a Homebrew Formula needed by the Cask.
 
 Example use: some distributions are contained in archive formats such as
 `7z` which are not supported by stock Apple tools.  For these cases, a more
@@ -558,14 +558,24 @@ depends_on :formula => 'unar'
 
 #### Requiring an Exact OS X Release
 
-The value for `depends_on :macos` may be a string, symbol or an array of
-strings or symbols, listing the exact compatible OS X releases.
+The value for `depends_on :macos` may be a symbol, string, or an array,
+listing the exact compatible OS X releases.
 
-The available symbols for OS X releases are: `:tiger`, `:leopard`,
-`:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, and `:yosemite`.
-These correspond to strings `'10.4'`, `'10.5'`, … `'10.10'` (major releases
-containing a single dot.  The following are all valid ways to enumerate the
-exact OS X version requirements for a Cask:
+The available values for OS X releases are:
+
+| symbol             | corresponding string
+| -------------------|----------------------
+| `:tiger`           | `'10.4'`
+| `:leopard`         | `'10.5'`
+| `:snow_leopard`    | `'10.6'`
+| `:lion`            | `'10.7'`
+| `:mountain_lion`   | `'10.8'`
+| `:mavericks`       | `'10.9'`
+| `:yosemite`        | `'10.10'`
+
+Only major releases are covered (version numbers containing a single dot).
+The symbol form is preferred for readability.  The following are all valid
+ways to enumerate the exact OS X release requirements for a Cask:
 
 ```ruby
 depends_on :macos => :yosemite
@@ -577,7 +587,7 @@ depends_on :macos => ['10.9', '10.10']
 #### Setting a Minimum OS X Release
 
 `depends_on :macos` can also accept a string starting with a comparison
-operator such as `>=`, followed by an OS X version in the form above.  The
+operator such as `>=`, followed by an OS X release in the form above.  The
 following are both valid expressions meaning "at least OS X 10.9":
 
 ```ruby
@@ -628,7 +638,7 @@ functionality:
 | ---------- | ----------- |
 | `:formula` | a Homebrew Formula
 | `:cask`    | *stub - not yet functional*
-| `:macos`   | a string, symbol, array, or expression defining OS X version requirements.
+| `:macos`   | a symbol, string, array, or comparison expression defining OS X release requirements.
 | `:arch`    | a symbol or array defining hardware requirements.
 | `:x11`     | *stub - not yet functional*
 | `:java`    | *stub - not yet functional*

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -61,14 +61,14 @@ features which are available for the current Cask.
  * [`conflicts_with`](CASK_LANGUAGE_REFERENCE.md#conflicts_with-stanza-details)
    * *stub* - not yet functional
  * [`gpg`](CASK_LANGUAGE_REFERENCE.md#gpg-stanza-details) *stub: not yet functional.*
- * [`installer :script`](CASK_LANGUAGE_REFERENCE.md#installer-stanza-details)
+ * [`installer :script`](CASK_LANGUAGE_REFERENCE.md#installer-script)
  * [`license`](CASK_LANGUAGE_REFERENCE.md#license-stanza-details)
  * [`stage_only`](CASK_LANGUAGE_REFERENCE.md#at-least-one-artifact-stanza-is-also-required)
    * replaced undocumented `caskroom_only`
  * [`suite`](CASK_LANGUAGE_REFERENCE.md#suite-stanza-details)
  * [`tags`](CASK_LANGUAGE_REFERENCE.md#tags-stanza-details)
  * [`uninstall :rmdir`](CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details)
- * [`uninstall :trash`](CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details)
+ * [`uninstall :trash`](CASK_LANGUAGE_REFERENCE.md#uninstall-key-trash)
    * *stub* - currently just a synonym for `uninstall :delete`
  * [`zap`](CASK_LANGUAGE_REFERENCE.md#zap-stanza-details)
 
@@ -82,15 +82,15 @@ features which are available for the current Cask.
 | `before_install`                      | [`preflight`](CASK_LANGUAGE_REFERENCE.md#optional-stanzas)
 | `before_uninstall`                    | [`uninstall_preflight`](CASK_LANGUAGE_REFERENCE.md#optional-stanzas)
 | `container_type`                      | [`container :type`](CASK_LANGUAGE_REFERENCE.md#optional-stanzas)
-| `depends_on_formula`                  | [`depends_on :formula`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
+| `depends_on_formula`                  | [`depends_on :formula`](CASK_LANGUAGE_REFERENCE.md#depends_on-formula)
 | `destination_path`                    | [`staged_path`](CASK_LANGUAGE_REFERENCE.md#caveats-as-a-string)
 | `install`                             | [`pkg`](CASK_LANGUAGE_REFERENCE.md#pkg-stanza-details)
 | `link`                                | [`app`](CASK_LANGUAGE_REFERENCE.md#app-stanza-details) (or sometimes `suite` or `artifact`)
-| `manual_installer` (within `caveats`) | [`installer :manual`](CASK_LANGUAGE_REFERENCE.md#installer-stanza-details)
+| `manual_installer` (within `caveats`) | [`installer :manual`](CASK_LANGUAGE_REFERENCE.md#installer-manual)
 | `os_version_only` (within `caveats`)  | [`depends_on :macos`](CASK_LANGUAGE_REFERENCE.md#depends_on-macos)
 | `nested_container`                    | [`container :nested =>`](CASK_LANGUAGE_REFERENCE.md#optional-stanzas)
 | `title` (in interpolations)           | [`token`](CASK_LANGUAGE_REFERENCE.md#caveats-as-a-string)
-| `uninstall :files`                    | [`uninstall :delete`](CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details)
+| `uninstall :files`                    | [`uninstall :delete`](CASK_LANGUAGE_REFERENCE.md#uninstall-key-delete)
 | `version 'latest'`                    | [`version :latest`](CASK_LANGUAGE_REFERENCE.md#required-stanzas)
 | `arch_only` (within `caveats`)        | [`depends_on :arch`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
 
@@ -147,7 +147,6 @@ For use in *eg* interpolation:
  * [`assistive_devices`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`files_in_usr_local`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`logout`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
- * [`os_version_only(list)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`path_environment_variable(path)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`reboot`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`x11_required`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -49,8 +49,8 @@ so we try to match semantics wherever possible. That means that similar
 functionality should have similar flags and parameters.
 
 However, very little backend code is shared between the two projects.
-The Homebrew codebase is based on how Homebrew *formulae* work, and our
-*casks* are very much unlike that.
+The Homebrew codebase is based on how Homebrew Formulae work, and our
+Casks are very much unlike Formulae.
 
 Because our backend needs are so different, we are discussing whether
 we should completely separate our codebase from Homebrew's
@@ -58,10 +58,10 @@ we should completely separate our codebase from Homebrew's
 
 ### Casks and Formulae
 
-Homebrew *formulae* deal with many different build processes, and often
+Homebrew Formulae deal with many different build processes, and often
 include arbitrary Ruby code.
 
-*Casks*, by contrast, only need to support the few installation methods
+Casks, by contrast, only need to support the few installation methods
 used by apps, pkg installers, and so on, making them suitable for a
 [declarative DSL](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md).
 

--- a/lib/cask/dsl/depends_on.rb
+++ b/lib/cask/dsl/depends_on.rb
@@ -52,7 +52,7 @@ class Cask::DSL::DependsOn
     end
   end
 
-  def self.coerce_os_version(arg)
+  def self.coerce_os_release(arg)
 
     # supplement Homebrew's table
     @osx_symbols ||= OS::Mac::Version::SYMBOLS.merge!(
@@ -83,16 +83,15 @@ class Cask::DSL::DependsOn
   end
 
   def macos=(arg)
-    @macos = if arg.kind_of?(Array)
-      arg.map do |elt|
-        self.class.coerce_os_version(elt)
-      end.sort
-    elsif arg =~ %r{^\s*(<|>|[=<>]=)\s*(\S+)\s*$}
+    @macos = if not arg.kind_of?(Array) and
+      arg =~ %r{^\s*(<|>|[=<>]=)\s*(\S+)\s*$}
       operator = $1.to_sym
-      version = self.class.coerce_os_version($2)
-      [ operator, version ]
+      release = self.class.coerce_os_release($2)
+      [ operator, release ]
     else
-      self.class.coerce_os_version(arg)
+      Array(arg).map do |elt|
+        self.class.coerce_os_release(elt)
+      end.sort
     end
     @pairs[:macos] = @macos
   end

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -111,32 +111,26 @@ class Cask::Installer
   end
 
   def macos_dependencies
-    # todo The Cask::DependsOn object needs to be more friendly.
-    #      Currently @cask.depends_on.macos raises an exception
-    #      if :macos was not set.
-    if @cask.depends_on and
-       @cask.depends_on.macos
-      if @cask.depends_on.macos.kind_of?(Array) and
-         @cask.depends_on.macos.first.is_a?(Symbol)
-        operator, version = @cask.depends_on.macos
-        unless MacOS.version.send(operator, version)
-          raise CaskError.new "Cask #{@cask} depends on OS X version #{operator} #{version}, but you are running version #{MacOS.version}."
+    if @cask.depends_on and @cask.depends_on.macos
+      if @cask.depends_on.macos.first.is_a?(Symbol)
+        operator, release = @cask.depends_on.macos
+        unless MacOS.version.send(operator, release)
+          raise CaskError.new "Cask #{@cask} depends on OS X release #{operator} #{release}, but you are running release #{MacOS.version}."
         end
-      elsif @cask.depends_on.macos.kind_of?(Array)
+      elsif @cask.depends_on.macos.length > 1
         unless @cask.depends_on.macos.include?(Gem::Version.new(MacOS.version.to_s))
-          raise CaskError.new "Cask #{@cask} depends on OS X version being one of: #{@cask.depends_on.macos(&:to_s).inspect}, but you are running version #{MacOS.version}."
+          raise CaskError.new "Cask #{@cask} depends on OS X release being one of: #{@cask.depends_on.macos(&:to_s).inspect}, but you are running release #{MacOS.version}."
         end
       else
-        unless MacOS.version == @cask.depends_on.macos
-          raise CaskError.new "Cask #{@cask} depends on OS X version #{@cask.depends_on.macos}, but you are running version #{MacOS.version}."
+        unless MacOS.version == @cask.depends_on.macos.first
+          raise CaskError.new "Cask #{@cask} depends on OS X release #{@cask.depends_on.macos.first}, but you are running release #{MacOS.version}."
         end
       end
     end
   end
 
   def arch_dependencies
-    if @cask.depends_on and
-       @cask.depends_on.arch
+    if @cask.depends_on and @cask.depends_on.arch
       @current_arch ||= [
                          Hardware::CPU.type,
                          Hardware::CPU.is_32_bit? ?

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -257,7 +257,7 @@ describe Cask::DSL do
     end
     it "refuses to load with an invalid depends_on :macos value" do
       err = lambda {
-        invalid_cask = Cask.load('invalid/invalid-depends-on-macos-version')
+        invalid_cask = Cask.load('invalid/invalid-depends-on-macos-bad-release')
       }.must_raise(CaskInvalidError)
     end
   end

--- a/test/support/Casks/invalid/invalid-depends-on-macos-bad-release.rb
+++ b/test/support/Casks/invalid/invalid-depends-on-macos-bad-release.rb
@@ -1,11 +1,11 @@
-cask :v1test => 'invalid-depends-on-macos-version' do
+cask :v1test => 'invalid-depends-on-macos-bad-release' do
   version '1.2.3'
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
   url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/invalid-depends-on-macos-version'
+  homepage 'http://example.com/invalid-depends-on-macos-bad-release'
 
-  depends_on :macos => :no_such_version
+  depends_on :macos => :no_such_release
 
   app 'Caffeine.app'
 end


### PR DESCRIPTION
- always coerce `:macos` value to array; simplify code
- remove warning comments about unset values
- doc explicitly that requirements are covered as well as dependencies
- doc that `depends_on` is not consulted until `install` time
- in docs and code, say "release" instead of "version" for the :macos release
  - todo: provide our own variable styled "release" to use in Casks, instead of Homebrew's `MacOS.Version`
- doc that symbols are preferred for `:macos` over strings in Casks (interally, all are converted to idential `Gem::Version` objects) refs: https://github.com/caskroom/homebrew-cask/pull/7760#discussion_r21234042
- doc: remove `os_version_only` from `cask_language_deltas.md`
- doc: improve internal links
- doc: recast OS X release symbol list as table
- doc: (incidental) regularize orthography of Formula and Cask
