### PR TITLE
Remove `#{title}` in 24 Casks (transitional)

### DIFF
--- a/Casks/alib1.rb
+++ b/Casks/alib1.rb
@@ -13,8 +13,9 @@ cask :v1 => 'alib1' do
     system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName ALib1 (Presstube)', "#{staged_path}/presstube-alib1.app/Contents/Resources/Presstube - ALib1.saver/Contents/Info.plist"
   end
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires Adobe Air, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/ap-grapher.rb
+++ b/Casks/ap-grapher.rb
@@ -10,8 +10,9 @@ cask :v1 => 'ap-grapher' do
 
   app 'AP Grapher.app'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Warning: #{title} has been abandoned by its author, and the
+    Warning: #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} has been abandoned by its author, and the
     vendor homepage is defunct.  This Cask downloads an untrusted
     copy from an alternative source.
   EOS

--- a/Casks/cacoo-ninja.rb
+++ b/Casks/cacoo-ninja.rb
@@ -12,8 +12,9 @@ cask :v1 => 'cacoo-ninja' do
 
   uninstall :script => { :executable => 'Install Cacoo Ninja.app/Contents/MacOS/Install Cacoo Ninja' }
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires Adobe Air, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/cdock.rb
+++ b/Casks/cdock.rb
@@ -7,8 +7,10 @@ cask :v1 => 'cdock' do
   license :oss
 
   app 'cDock.app'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires easysimbl, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires easysimbl, available via
 
       brew cask install easysimbl
   EOS

--- a/Casks/chirp.rb
+++ b/Casks/chirp.rb
@@ -8,8 +8,9 @@ cask :v1 => 'chirp' do
 
   app "chirp-#{version}.app"
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} also requires the KK7DS Python Runtime as described at
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} also requires the KK7DS Python Runtime as described at
 
       http://chirp.danplanet.com/projects/chirp/wiki/Download#CHIRP-Downloads
   EOS

--- a/Casks/chunkulus.rb
+++ b/Casks/chunkulus.rb
@@ -12,8 +12,9 @@ cask :v1 => 'chunkulus' do
     system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Chunkulus (Presstube)', "#{staged_path}/presstube-chunkulus.app/Contents/Resources/Presstube - Chunkulus.saver/Contents/Info.plist"
   end
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires Adobe Air, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/craftstudio.rb
+++ b/Casks/craftstudio.rb
@@ -12,8 +12,9 @@ cask :v1 => 'craftstudio' do
             :pkgutil => 'com.sparklinlabs.CraftStudioLauncher'
   zap       :delete => '~/Library/CraftStudio'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires mono-mre, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires mono-mre, available via
 
       brew cask install mono-mre
   EOS

--- a/Casks/delivery-status.rb
+++ b/Casks/delivery-status.rb
@@ -7,8 +7,10 @@ cask :v1 => 'delivery-status' do
   license :oss
 
   widget 'Delivery Status.wdgt'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Currently, Dashboard Widgets such as '#{title}' do NOT work correctly
+    Currently, Dashboard Widgets such as '#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
       https://github.com/caskroom/homebrew-cask/issues/2206

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -10,15 +10,16 @@ cask :v1 => 'google-cloud-sdk' do
             :args => %w{--usage-reporting false --bash-completion false --path-update false --rc-path false},
             :sudo => false
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats do
-    "#{title} is installed at #{staged_path}/#{title}. Add your profile:
+    "#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} is installed at #{staged_path}/#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}. Add your profile:
 
       for bash users
-        source '#{staged_path}/#{title}/path.bash.inc'
-        source '#{staged_path}/#{title}/completion.bash.inc'
+        source '#{staged_path}/#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}/path.bash.inc'
+        source '#{staged_path}/#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}/completion.bash.inc'
 
       for zsh users
-        source '#{staged_path}/#{title}/path.zsh.inc'
-        source '#{staged_path}/#{title}/completion.zsh.inc'"
+        source '#{staged_path}/#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}/path.zsh.inc'
+        source '#{staged_path}/#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}/completion.zsh.inc'"
   end
 end

--- a/Casks/grooveshark.rb
+++ b/Casks/grooveshark.rb
@@ -7,8 +7,10 @@ cask :v1 => 'grooveshark' do
   license :unknown
 
   app 'Grooveshark.app'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires Adobe Flash, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires Adobe Flash, available via
 
       brew cask install flash
   EOS

--- a/Casks/heart.rb
+++ b/Casks/heart.rb
@@ -12,8 +12,9 @@ cask :v1 => 'heart' do
     system '/usr/libexec/PlistBuddy', '-c', 'Set :CFBundleName Heart (Presstube)', "#{staged_path}/presstube-heart.app/Contents/Resources/Presstube - Heart.saver/Contents/Info.plist"
   end
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires Adobe Air, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS

--- a/Casks/icursor.rb
+++ b/Casks/icursor.rb
@@ -10,8 +10,9 @@ cask :v1 => 'icursor' do
 
   app 'iCursor.app'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Warning: #{title} has been abandoned by its author, and the
+    Warning: #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} has been abandoned by its author, and the
     vendor homepage is defunct.  This Cask downloads an untrusted
     copy from an alternative source.
   EOS

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -19,13 +19,14 @@ cask :v1 => 'intellij-idea-ce' do
                   '~/Library/Logs/IdeaIC14',
                  ]
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} may require Java 7 (an older version), available from the
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} may require Java 7 (an older version), available from the
     caskroom-versions repository via
 
       brew cask install caskroom/versions/java7
 
-    Alternatively, #{title} can be modified to use Java 8 as described in
+    Alternatively, #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} can be modified to use Java 8 as described in
 
       https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
   EOS

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -17,13 +17,14 @@ cask :v1 => 'intellij-idea' do
                   '~/Library/Preferences/IntelliJIdea14',
                  ]
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} may require Java 7 (an older version) available from the
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} may require Java 7 (an older version) available from the
     caskroom-versions repository via
 
       brew cask install caskroom/versions/java7
 
-    Alternatively, #{title} can be modified to use Java 8 as described in
+    Alternatively, #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} can be modified to use Java 8 as described in
 
       https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
   EOS

--- a/Casks/ioquake3.rb
+++ b/Casks/ioquake3.rb
@@ -8,8 +8,10 @@ cask :v1 => 'ioquake3' do
   license :unknown
 
   suite 'ioquake3'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    To complete the installation of #{title}, you will have to copy the file
+    To complete the installation of #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}, you will have to copy the file
     'pak0.pk3' from your Quake 3 Arena installation support directory into
     ~/Applications/ioquake3/baseq3/.
   EOS

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -9,8 +9,9 @@ cask :v1 => 'keycastr' do
 
   app 'KeyCastr.app'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    For OSX 10.9 or later, #{title} requires that you "Enable access for assistive devices".
+    For OSX 10.9 or later, #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires that you "Enable access for assistive devices".
     The app must be dragged into the Accessibility list in System Preferences.
     See https://github.com/sdeken/keycastr/issues/5
   EOS

--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -9,9 +9,12 @@ cask :v1 => 'ksdiff' do
   pkg 'Install ksdiff.pkg'
 
   uninstall :pkgutil => 'com.blackpixel.kaleidoscope.ksdiff.installer.pkg'
-  # todo: conflicts_with_cask kaleidoscope
+  # todo
+  # conflicts_with :cask => 'kaleidoscope'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    The #{title} Cask is not needed when installing Kaleidoscope via Cask. It
+    The #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} Cask is not needed when installing Kaleidoscope via Cask. It
     is provided for users who have purchased Kaleidoscope via the App Store.
   EOS
 end

--- a/Casks/multibrowser.rb
+++ b/Casks/multibrowser.rb
@@ -9,8 +9,9 @@ cask :v1 => 'multibrowser' do
 
   app 'MultiBrowser.app'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Warning: #{title} has been abandoned by its author, and the
+    Warning: #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} has been abandoned by its author, and the
     vendor homepage is defunct.  This Cask downloads an untrusted
     copy from an alternative source.
   EOS

--- a/Casks/pemdas-widget.rb
+++ b/Casks/pemdas-widget.rb
@@ -7,8 +7,10 @@ cask :v1 => 'pemdas-widget' do
   license :oss
 
   widget 'PEMDAS.wdgt'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Currently, Dashboard Widgets such as '#{title}' do NOT work correctly
+    Currently, Dashboard Widgets such as '#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
       https://github.com/caskroom/homebrew-cask/issues/2206

--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -8,8 +8,10 @@ cask :v1 => 'qgis' do
   pkg 'Install QGIS.pkg'
 
   uninstall :pkgutil => 'org.qgis.qgis-*'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires the GDAL framework and Matplotlib to be installed first,
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires the GDAL framework and Matplotlib to be installed first,
     otherwise the installation will fail. In case of problems, try installing
     them:
 

--- a/Casks/sevenzx.rb
+++ b/Casks/sevenzx.rb
@@ -12,8 +12,9 @@ cask :v1 => 'sevenzx' do
 
   app '7zX.app'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Warning: #{title} has been abandoned by its author, and the
+    Warning: #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} has been abandoned by its author, and the
     vendor homepage is defunct.  This Cask downloads an untrusted
     copy from an alternative source.
   EOS

--- a/Casks/tv-show-tracker.rb
+++ b/Casks/tv-show-tracker.rb
@@ -7,8 +7,10 @@ cask :v1 => 'tv-show-tracker' do
   license :oss
 
   widget 'TV Show Tracker.wdgt'
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    Currently, Dashboard Widgets such as '#{title}' do NOT work correctly
+    Currently, Dashboard Widgets such as '#{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase}' do NOT work correctly
     when installed via brew-cask.  The bug is being tracked here:
 
       https://github.com/caskroom/homebrew-cask/issues/2206

--- a/Casks/tvrenamer.rb
+++ b/Casks/tvrenamer.rb
@@ -7,8 +7,10 @@ cask :v1 => 'tvrenamer' do
   license :gpl
 
   app "TVRenamer-#{version}.app"
+
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires a Java JRE to be installed. You should be prompted to install
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires a Java JRE to be installed. You should be prompted to install
     Java on the first execution if it is not already present.
   EOS
 end

--- a/Casks/workamajig.rb
+++ b/Casks/workamajig.rb
@@ -9,8 +9,9 @@ cask :v1 => 'workamajig' do
 
   app 'Workamajig.app'
 
+  # todo: transitional, replace #{self.name...} with #{token}
   caveats <<-EOS.undent
-    #{title} requires Adobe Air, available via
+    #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires Adobe Air, available via
 
       brew cask install adobe-air
   EOS


### PR DESCRIPTION
This is super ugly, but allows us to speed up the transition to `#{token}`.

The backward compatibility `title` method can be removed from the backend once `title` is no longer used in Casks.  But the `token` method has not really been in release long enough to transition Casks to `token`.
