### PR TITLE
Remove constraint that Cask tokens cannot start with digits

### DIFF
--- a/Casks/ax88179.rb
+++ b/Casks/ax88179.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ax88179' do
 
   module Utils
     def self.basename
-      "AX88179_178A_Macintosh_10.6_to_10.10_Driver_Installer_v#{Ax88179.version}"
+      "AX88179_178A_Macintosh_10.6_to_10.10_Driver_Installer_v#{Module.nesting.last.version}"
     end
   end
 

--- a/Casks/ax88772.rb
+++ b/Casks/ax88772.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ax88772' do
 
   module Utils
     def self.basename
-      "AX88772C_772B_772A_760_772_Macintosh_10.5_to_10.10_Driver_Installer_v#{Ax88772.version}"
+      "AX88772C_772B_772A_760_772_Macintosh_10.5_to_10.10_Driver_Installer_v#{Module.nesting.last.version}"
     end
   end
 

--- a/Casks/mcs783x.rb
+++ b/Casks/mcs783x.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mcs783x' do
 
   module Utils
     def self.basename
-      "MCS783x_Mac_OSX_10.5_to_10.7_driver_v#{Mcs783x.version}_Binary"
+      "MCS783x_Mac_OSX_10.5_to_10.7_driver_v#{Module.nesting.last.version}_Binary"
     end
   end
 

--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -24,19 +24,6 @@ end
 ### configurable constants
 ###
 
-EXPANDED_NUMBERS = {
-                     '0' => 'zero',
-                     '1' => 'one',
-                     '2' => 'two',
-                     '3' => 'three',
-                     '4' => 'four',
-                     '5' => 'five',
-                     '6' => 'six',
-                     '7' => 'seven',
-                     '8' => 'eight',
-                     '9' => 'nine',
-                   }
-
 EXPANDED_SYMBOLS = {
                     '+' => 'plus',
                    }
@@ -302,14 +289,6 @@ class CaskFileName < String
     self.gsub(/-([0-9])/, '\1')
   end
 
-  def spell_out_leading_numbers
-    cask_file_name = self
-    EXPANDED_NUMBERS.each do |k, v|
-      cask_file_name.sub!(/^#{k}/, v)
-    end
-    cask_file_name
-  end
-
   def spell_out_symbols
     cask_file_name = self
     EXPANDED_SYMBOLS.each do |k, v|
@@ -339,7 +318,6 @@ class CaskFileName < String
           .collapse_multiple_hyphens
           .delete_leading_hyphens
           .delete_hyphens_before_numbers
-          .spell_out_leading_numbers
     end
     raise "Could not determine Simplified App name" unless @from_simplified_app_name.length > 0
     @from_simplified_app_name.add_extension

--- a/doc/cask_token_reference.md
+++ b/doc/cask_token_reference.md
@@ -68,8 +68,6 @@ distribution, use [`tags :name`](CASK_LANGUAGE_REFERENCE.md#tags-stanza-details)
 
   * Remove from the end: localization strings such as "en-US"
 
-  * Pay attention to details, for example: `"Git Hub" != "git_hub" != "GitHub"`
-
   * If the result of that process is a generic term, such as "Macintosh Installer",
     try prepending the name of the vendor or developer, followed by a hyphen.
     If that doesn't work, then just create the best name you can, based on the
@@ -142,7 +140,6 @@ To convert the App's Simplified Name (above) to a token:
   * delete any character which is not alphanumeric or hyphen
   * collapse a series of multiple hyphens into one hyphen
   * delete a leading or trailing hyphen
-  * a leading number gets spelled out into English: `1password` becomes `onepassword`
 
 We avoid defining Cask tokens in the repository which differ only by the
 placement of hyphens.  Prepend the vendor name if needed to disambiguate
@@ -168,7 +165,6 @@ App Name on Disk       | Simplified App Name | Cask Token       | Filename
 `BetterTouchTool.app`  | BetterTouchTool     | bettertouchtool  | `bettertouchtool.rb`
 `LPK25 Editor.app`     | LPK25 Editor        | lpk25-editor     | `lpk25-editor.rb`
 `Sublime Text 2.app`   | Sublime Text        | sublime-text     | `sublime-text.rb`
-`1Password.app`        | 1Password           | onepassword      | `onepassword.rb`
 
 
 # <3 THANK YOU TO ALL CONTRIBUTORS! <3

--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -81,7 +81,8 @@ class Cask
   end
 
   def self.token
-    self.name.gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase
+    # todo removeme: prepending KlassPrefix is transitional as we move away from representing Casks as classes
+    self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase
   end
 
   # todo removeme transitional backward-compatibility
@@ -114,6 +115,7 @@ class Cask
     self.class.caskroom.join(token)
   end
 
+  # todo: move to staged.rb ?
   def staged_path
     cask_version = version ? version : :unknown
     caskroom_path.join(cask_version.to_s)

--- a/lib/cask/source/path_base.rb
+++ b/lib/cask/source/path_base.rb
@@ -91,7 +91,8 @@ class Cask::Source::PathBase
   end
 
   def cask_class_name
-    cask_token.split('-').map(&:capitalize).join
+    # todo removeme: prepending KlassPrefix is transitional as we move away from representing Casks as classes
+    'KlassPrefix'.concat cask_token.split('-').map(&:capitalize).join
   end
 
   def to_s

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -5,26 +5,26 @@ describe "Cask" do
     it "returns an instance of the Cask for the given token" do
       c = Cask.load("adium")
       c.must_be_kind_of(Cask)
-      c.must_be_instance_of(Adium)
+      c.must_be_instance_of(KlassPrefixAdium)
     end
 
     it "returns an instance of the Cask from a specific file location" do
       # defensive constant cleanup is required because Cask
       # classes may already be loaded due to audit test
       begin
-        Object.class_eval{remove_const :Dia}
+        Object.class_eval{remove_const :KlassPrefixDia}
       rescue
       end
       location = File.expand_path('./Casks/dia.rb')
       c = Cask.load(location)
       c.must_be_kind_of(Cask)
-      c.must_be_instance_of(Dia)
-      Object.class_eval{remove_const :Dia}
+      c.must_be_instance_of(KlassPrefixDia)
+      Object.class_eval{remove_const :KlassPrefixDia}
     end
 
     it "returns an instance of the Cask from a url" do
       begin
-        Object.class_eval{remove_const :Dia}
+        Object.class_eval{remove_const :KlassPrefixDia}
       rescue
       end
       url = "file://" + File.expand_path('./Casks/dia.rb')
@@ -32,8 +32,8 @@ describe "Cask" do
         Cask.load(url)
       end
       c.must_be_kind_of(Cask)
-      c.must_be_instance_of(Dia)
-      Object.class_eval{remove_const :Dia}
+      c.must_be_instance_of(KlassPrefixDia)
+      Object.class_eval{remove_const :KlassPrefixDia}
     end
 
     it "raises an error when failing to download a Cask from a url" do
@@ -47,18 +47,18 @@ describe "Cask" do
 
     it "returns an instance of the Cask from a relative file location" do
       begin
-        Object.class_eval{remove_const :Bbedit}
+        Object.class_eval{remove_const :KlassPrefixBbedit}
       rescue
       end
       c = Cask.load("./Casks/bbedit.rb")
       c.must_be_kind_of(Cask)
-      c.must_be_instance_of(Bbedit)
-      Object.class_eval{remove_const :Bbedit}
+      c.must_be_instance_of(KlassPrefixBbedit)
+      Object.class_eval{remove_const :KlassPrefixBbedit}
     end
 
     it "uses exact match when loading by token" do
-      Cask.load('test-opera').must_be_instance_of(TestOpera)
-      Cask.load('test-opera-mail').must_be_instance_of(TestOperaMail)
+      Cask.load('test-opera').must_be_instance_of(KlassPrefixTestOpera)
+      Cask.load('test-opera-mail').must_be_instance_of(KlassPrefixTestOperaMail)
     end
 
     it "raises an error when attempting to load a Cask that doesn't exist" do
@@ -78,13 +78,13 @@ describe "Cask" do
 
   describe "token" do
     it "converts a class constant to a token-style dashed string" do
-      PascalCasedConstant = Class.new(Cask)
-      PascalCasedConstant.token.must_equal 'pascal-cased-constant'
+      KlassPrefixPascalCasedConstant = Class.new(Cask)
+      KlassPrefixPascalCasedConstant.token.must_equal 'pascal-cased-constant'
     end
 
     it "properly dasherizes constants with single letters in the middle" do
-      GamesXChange = Class.new(Cask)
-      GamesXChange.token.must_equal 'games-x-change'
+      KlassPrefixGamesXChange = Class.new(Cask)
+      KlassPrefixGamesXChange.token.must_equal 'games-x-change'
     end
   end
 


### PR DESCRIPTION
This PR works by adding an internal prefix to all Cask class names.  Since the class names are now completely hidden from the user, the prefix is never seen.

This trick is considered to be an ugly transitional hack on the way to representing individual Casks as instances instead of classes.

Three Casks are also altered, but the change is backward-compatible and does not need to be coordinated with a code release.
