### PR TITLE
remove support for `title` method in Casks

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -84,11 +84,6 @@ class Cask
     self.name.gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase
   end
 
-  # todo removeme transitional backward-compatibility
-  def self.title
-    self.token
-  end
-
   def self.nowstamp_metadata_path(container_path)
     @timenow ||= Time.now.gmtime
     if container_path.respond_to?(:join)
@@ -103,11 +98,6 @@ class Cask
   attr_reader :token
   def initialize(token=self.class.token)
     @token = token
-  end
-
-  # todo removeme transitional backward-compatibility
-  def title
-    @token
   end
 
   def caskroom_path

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -24,11 +24,6 @@ class Cask::CaveatsDSL
     @cask.token
   end
 
-  # todo removeme transitional backward compatibility
-  def title
-    @cask.token
-  end
-
   def version
     @cask.version
   end

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -275,7 +275,7 @@ module Cask::DSL
     end
 
     def method_missing(method, *args)
-      Cask::Utils.method_missing_message(method, self.title)
+      Cask::Utils.method_missing_message(method, self.token)
       return nil
     end
   end

--- a/lib/cask/dsl/base.rb
+++ b/lib/cask/dsl/base.rb
@@ -12,11 +12,6 @@ class Cask::DSL::Base
     @cask.token
   end
 
-  # todo removeme transitional backward compatibility
-  def title
-    @cask.token
-  end
-
   def version
     @cask.version
   end

--- a/lib/cask/source/tapped.rb
+++ b/lib/cask/source/tapped.rb
@@ -23,11 +23,6 @@ class Cask::Source::Tapped
     @token = token
   end
 
-  # todo removeme transitional backward-compatibility
-  def title
-    @token
-  end
-
   def load
     path = self.class.path_for_query(token)
     Cask::Source::PathSlashOptional.new(path).load

--- a/spec/cask/download_strategy_spec.rb
+++ b/spec/cask/download_strategy_spec.rb
@@ -5,7 +5,7 @@ describe 'download strategies' do
   let(:url_options) { Hash.new }
   let(:cask) {
     class_double(Cask,
-      :title => 'some-cask',
+      :token => 'some-cask',
       :url => Cask::URL.new(url, url_options),
       :version => '1.2.3.4'
     )


### PR DESCRIPTION
obsoleted by `token`

HOLD until #7820 and caskroom/homebrew-versions#589
