### PR TITLE
Enable `depends_on :arch` in 2 Casks

### DIFF
--- a/Casks/jaspersoft-studio.rb
+++ b/Casks/jaspersoft-studio.rb
@@ -8,6 +8,5 @@ cask :v1 => 'jaspersoft-studio' do
 
   app "Jaspersoft Studio #{version}.final/Jaspersoft Studio.app"
 
-  # todo
-  # depends_on :arch => :x86_64
+  depends_on :arch => :x86_64
 end

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -14,6 +14,5 @@ cask :v1 => 'paraview' do
 
   app 'paraview.app'
 
-  # todo
-  # depends_on :arch => :x86_64
+  depends_on :arch => :x86_64
 end


### PR DESCRIPTION
In #7811, I forgot that there have been forward-compatibility stubs for `depends_on :arch` for some time.

Therefore, enabling it has the same effect as a comment, and the functionality will kick in with the next release.
