### PR TITLE
Switch 3 Casks to `depends_on :x11`

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -10,7 +10,5 @@ cask :v1 => 'inkscape' do
 
   zap :delete => '~/.inkscape-etc'
 
-  caveats do
-    x11_required
-  end
+  depends_on :x11 => true
 end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -39,7 +39,5 @@ cask :v1 => 'wireshark' do
                          '/usr/local/bin/wireshark',
                         ]
 
-  caveats do
-    x11_required
-  end
+  depends_on :x11 => true
 end

--- a/Casks/x48.rb
+++ b/Casks/x48.rb
@@ -8,7 +8,6 @@ cask :v1 => 'x48' do
   license :unknown
 
   app "x48-#{version} osx/x48.app"
-  caveats do
-    x11_required
-  end
+
+  depends_on :x11 => true
 end


### PR DESCRIPTION
Users in release already have a forward-compatibility stub, making this function like a comment for a brief period until the next release and upgrade.
