### PR TITLE
Remove assistive_devices caveat in 4 Casks

### DIFF
--- a/Casks/arranger.rb
+++ b/Casks/arranger.rb
@@ -9,5 +9,14 @@ cask :v1 => 'arranger' do
   license :unknown
 
   app 'Arranger.app'
-  caveats 'Note that Arranger also needs access for assistive devices (Accessibility)'
+
+  # todo: replace with new assistive_devices stanza
+  caveats do
+    <<-EOS.undent
+      To use #{@cask}, you may need to give it access to assistive
+      devices (Accessibility).  For OS X Mavericks and Above:
+
+        System Preferences / Security & Privacy / Privacy / Accessibility
+    EOS
+  end
 end

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -9,10 +9,13 @@ cask :v1 => 'keycastr' do
 
   app 'KeyCastr.app'
 
-  # todo: transitional, replace #{self.name...} with #{token}
-  caveats <<-EOS.undent
-    For OSX 10.9 or later, #{self.name.sub(/^KlassPrefix/,'').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').gsub(/([a-zA-Z\d])([A-Z])/,'\1-\2').downcase} requires that you "Enable access for assistive devices".
-    The app must be dragged into the Accessibility list in System Preferences.
-    See https://github.com/sdeken/keycastr/issues/5
-  EOS
+  # todo: replace with new assistive_devices stanza
+  caveats do
+    <<-EOS.undent
+      To use #{@cask}, you may need to give it access to assistive
+      devices (Accessibility).  For OS X Mavericks and Above:
+
+        System Preferences / Security & Privacy / Privacy / Accessibility
+    EOS
+  end
 end

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -8,7 +8,13 @@ cask :v1 => 'plover' do
 
   app 'plover.app'
 
+  # todo: replace with new assistive_devices stanza
   caveats do
-    assistive_devices
+    <<-EOS.undent
+      To use #{@cask}, you may need to give it access to assistive
+      devices (Accessibility).  For OS X Mavericks and Above:
+
+        System Preferences / Security & Privacy / Privacy / Accessibility
+    EOS
   end
 end

--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -7,7 +7,14 @@ cask :v1 => 'typinator' do
   license :unknown
 
   app 'Typinator.app'
+
+  # todo: replace with new assistive_devices stanza
   caveats do
-    assistive_devices
+    <<-EOS.undent
+      To use #{@cask}, you may need to give it access to assistive
+      devices (Accessibility).  For OS X Mavericks and Above:
+
+        System Preferences / Security & Privacy / Privacy / Accessibility
+    EOS
   end
 end


### PR DESCRIPTION
In DSL 1.0 or immediately after, there is going to be a new form for `assistive_devices`, which will no longer be part of `caveats`

The easiest way to transition these Casks is to inline the literal `caveats` text with a todo comment.
