### PR TITLE
Add Fog Burner.app version 1.0

### DIFF
--- a/Casks/fog-burner.rb
+++ b/Casks/fog-burner.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'fog-burner' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://fogburner.tofumatt.com/FogBurner.zip'
+  homepage 'http://fogburner.tofumatt.com/'
+  license :oss
+
+  app 'Fog Burner.app'
+end


### PR DESCRIPTION
Fog Burner is a simple status bar application for Mac OS X (10.9+) that prevents your Mac from going to sleep or dimming its screen. http://fogburner.tofumatt.com/
