### PR TITLE
Add depends_on OSX 10.9+ for Fog Burner cask

### DIFF
--- a/Casks/fog-burner.rb
+++ b/Casks/fog-burner.rb
@@ -7,4 +7,6 @@ cask :v1 => 'fog-burner' do
   license :oss
 
   app 'Fog Burner.app'
+
+  depends_on :macos => '>= 10.9'
 end


### PR DESCRIPTION
The `fog-burner` cask will only work on 10.9+ as stated [on the homepage](http://fogburner.tofumatt.com/).
