### PR TITLE
Run RSpec tests along with minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,12 @@ require 'rake/testtask'
 require 'rspec/core/rake_task'
 
 Rake::TestTask.new do |t|
+  t.name = 'minitest'
   t.pattern = "test/**/*_test.rb"
   t.libs << 'test'
 end
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => [:test, :spec]
+task :test => [:minitest, :spec]
+task :default => :test


### PR DESCRIPTION
I like [the idea](https://github.com/caskroom/homebrew-cask/commit/58d4c745a9e160305236c3a561874035a3909660) of gradually rewriting tests to rspec, but we should also make sure to keep the new tests green and this change should help everyone to do so.

In fact [this change](https://github.com/caskroom/homebrew-cask/commit/db0b5aa9d9af6a8917508c4757bb26a0bf07253a) made ~1 month ago already caused 4 rspec tests to fail and apparently nobody noticed.

cc @phinze @rolandwalker 
