### PR TITLE
Updated version of Tagspaces 1.9.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,8 +1,17 @@
 cask :v1 => 'tagspaces' do
-  version '1.8.1'
-  sha256 '1a6d63598b5689b7fee4cb0c469a5f87251f43008f208c08020ded64c8fbcf66'
 
-  url "https://github.com/uggrock/tagspaces/releases/download/v#{version}/tagspaces-#{version}-osx.zip"
+  version '1.9.0'
+
+  if Hardware::CPU.is_32_bit?
+    sha256 'ca127150d07d45b7b77beefe32df22441504c4de070468996372aed523341264'
+
+    url "https://github.com/uggrock/tagspaces/releases/download/#{version}/tagspaces-#{version}-osx32.zip"
+  else
+    sha256 '42f115adb5ea7eb687c5b5b07d8843e895a8ed492a46800120e46f1c1f450aa2'
+
+    url "https://github.com/uggrock/tagspaces/releases/download/#{version}/tagspaces-#{version}-osx64.zip"
+  end
+
   homepage 'http://www.tagspaces.org'
   license :affero
 


### PR DESCRIPTION
This PR updates the version for Tagspaces, which was at 1.8.1, though the current version is 1.9.0

Also adds support for the 32 and 64 bit versions of Tagspaces for OSX.
