### PR TITLE
Fix an issue with `--debug` and `_dump` on Ruby 1.8.7

### DIFF
--- a/lib/cask/dsl/installer.rb
+++ b/lib/cask/dsl/installer.rb
@@ -28,12 +28,4 @@ class Cask::DSL::Installer
     writer_method = "#{key}=".to_sym
     send(writer_method, parameters[key])
   end
-
-  def to_yaml
-    @pairs.to_yaml
-  end
-
-  def to_s
-    @pairs.inspect
-  end
 end


### PR DESCRIPTION
This is a very minor issue I bumped into while working on `brew cask search`. For casks that have an `installer` stanza, the internal command `brew cask _dump` would fail on Ruby 1.8.7. One example where this occurs is the Cask `adobe-air`.

Assuming both `rbenv` and `1.8.7-p375` installed, the issue can be reproduced like so:

``` sh
RBENV_VERSION=1.8.7-p375 HOMEBREW_BREW_FILE=/usr/local/bin/brew ruby /usr/local/Library/brew.rb /usr/local/bin/brew-cask _dump adobe-air
```

This would result in the following error:

``` md
Warning: adobe-air was not found or would not load: wrong number of arguments (1 for 0)
Error: nothing to dump
/usr/local/Cellar/brew-cask/0.49.0/rubylib/cask/cli/internal_dump.rb:8:in `run'
/usr/local/Cellar/brew-cask/0.49.0/rubylib/cask/cli.rb:81:in `run_command'
/usr/local/Cellar/brew-cask/0.49.0/rubylib/cask/cli.rb:121:in `process'
/usr/local/bin/brew-cask.rb:42
/usr/local/Library/brew.rb:59:in `require'
/usr/local/Library/brew.rb:59:in `require?'
/usr/local/Library/brew.rb:118
```
