### PR TITLE
In `SystemCommand`, fix `success?` and `exit_status`

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -28,11 +28,11 @@ class Cask::SystemCommand
     raw_stderr.close_read
 
     # Ruby 1.8 sets $?. Ruby 1.9+ has raw_wait_thr, and does not set $?.
-    processed_exit_status = raw_wait_thr.nil? ? $? : raw_wait_thr.value
+    processed_status = raw_wait_thr.nil? ? $? : raw_wait_thr.value
 
-    _assert_success(processed_exit_status, command, processed_stdout) if options[:must_succeed]
+    _assert_success(processed_status, command, processed_stdout) if options[:must_succeed]
 
-    Cask::SystemCommand::Result.new(command, processed_stdout, processed_stderr, processed_exit_status)
+    Cask::SystemCommand::Result.new(command, processed_stdout, processed_stderr, processed_status.exitstatus)
   end
 
   def self.run!(command, options={})

--- a/test/cask/system_command_test.rb
+++ b/test/cask/system_command_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+describe Cask::SystemCommand do
+  describe "when the exit code is 0" do
+    result = nil
+
+    before do
+      command = '/usr/bin/true'
+      options = {
+        :must_succeed => false
+      }
+      result = Cask::SystemCommand.run(command, options)
+    end
+
+    it "says the command was successful" do
+      result.success?.must_equal(true)
+    end
+
+    it "says the exit status is 0" do
+      result.exit_status.must_equal(0)
+    end
+  end
+
+  describe "when the exit code is 1" do
+    before do
+      # See: https://bugs.ruby-lang.org/issues/1287
+      skip("Ruby 1.8.7 doesn’t see exit statuses") if TestHelper.ruby18?
+    end
+
+    describe "and the command must succeed" do
+      it "throws an error" do
+        lambda {
+          command = '/usr/bin/false'
+          options = {
+            :must_succeed => true
+          }
+          result = Cask::SystemCommand.run(command, options)
+        }.must_raise(CaskCommandFailedError)
+      end
+    end
+
+    describe "and the command does not have to succeed" do
+      result = nil
+
+      before do
+        command = '/usr/bin/false'
+        options = {
+          :must_succeed => false
+        }
+        result = Cask::SystemCommand.run(command, options)
+      end
+
+      it "says the command failed" do
+        result.success?.must_equal(false)
+      end
+
+      it "says the exit status is 1" do
+        result.exit_status.must_equal(1)
+      end
+    end
+  end
+end

--- a/test/cask/system_command_test.rb
+++ b/test/cask/system_command_test.rb
@@ -24,7 +24,7 @@ describe Cask::SystemCommand do
   describe "when the exit code is 1" do
     before do
       # See: https://bugs.ruby-lang.org/issues/1287
-      skip("Ruby 1.8.7 doesn’t see exit statuses") if TestHelper.ruby18?
+      skip("Ruby 1.8.7 doesn't see exit statuses") if TestHelper.ruby18?
     end
 
     describe "and the command must succeed" do

--- a/test/syntax_test.rb
+++ b/test/syntax_test.rb
@@ -18,8 +18,7 @@ describe "Syntax check" do
 
           # Reason for this hack is unknown. Travis appears to freeze,
           # but only in one section of the build matrix.
-          skip if ENV.key?('TRAVIS_JOB_ID')     and
-                  RUBY_VERSION.match(%r{^1\.8})
+          skip if ENV.key?('TRAVIS_JOB_ID') and TestHelper.ruby18?
 
           args = flags + [ '--', file ]
           shutup do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -111,6 +111,10 @@ class TestHelper
       end
     end
   end
+
+  def self.ruby18?
+    RUBY_VERSION.match(%r{^1\.8})
+  end
 end
 
 require 'support/fake_fetcher'


### PR DESCRIPTION
For the upcoming `brew cask search` by `name`, I’m going to have to invoke a `Cask::SystemCommand` with the option `:must_succeed => false` and then look at the exit status.

Like this:

``` rb
result = Cask::SystemCommand.run(command, :must_succeed => false)
if (result.exit_status >= 2)
  # …
else
  # …
end
```

The issue is that the [`SystemCommand::Result#exit_status`](https://github.com/caskroom/homebrew-cask/blob/d2f041d9d4224c6ef4f087fd571146dc461eb601/lib/cask/system_command.rb#L61) method returns the whole [`Process::Status`](http://ruby-doc.org/core-1.8.7/Process/Status.html) object instead of a `Fixnum`.

As a workaround, I could have done `result.exit_status.exitstatus` but I think this would be very ugly.
### Cause

When invoking a `SystemCommand` with the option `:must_succeed => false`, the code in `SystemCommand` [feeds](https://github.com/caskroom/homebrew-cask/blob/d2f041d9d4224c6ef4f087fd571146dc461eb601/lib/cask/system_command.rb#L35) a `Process.Status` object to `SystemCommand::Result.new` instead of the `Fixnum` it expects.
### Impact

Apart from the usage in the upcoming PR, why didn’t this issue ever come up?

I think this is because:
1. Usually, everyone uses `:must_succeed => true` so there is no need to care about `exit_status`, and
2. In the rare usages of `:must_succeed => false` (only the Casks `private-eye` and `soundflower` do this), no one cares about `exit_status`.
### Please review

Pinging @federicobond @ndr-qef @phinze @rolandwalker to ask if one of you could please have a look. Thanks! :blush:
