### PR TITLE
enable `installer` artifact in `_stanza` verb

### DIFF
--- a/lib/cask/cli/internal_stanza.rb
+++ b/lib/cask/cli/internal_stanza.rb
@@ -36,6 +36,7 @@ class Cask::CLI::InternalStanza < Cask::CLI::InternalUseBase
                        :internet_plugin,
                        :screen_saver,
                        :pkg,
+                       :installer,
                        :stage_only,
                        :nested_container,
                        :uninstall,


### PR DESCRIPTION
Since `installer` is a type of artifact, it must be enabled explicitly, though this repetition indicates poor design.

refs: #7893
