### PR TITLE
HOLD: Add tests for `brew cask search` when casks have the same token

### DIFF
--- a/test/cask/cli/search_test.rb
+++ b/test/cask/cli/search_test.rb
@@ -68,4 +68,28 @@ describe Cask::CLI::Search do
     end
     out.must_match(/^No Cask found for "caskroom"\.\n/)
   end
+
+  describe "multiple Casks with the same token in different taps" do
+    describe "when the search term exactly matches the token" do
+      it "finds multiple matches" do
+        out, err = capture_io do
+          Cask::CLI::Search.run('firefox')
+        end
+        out.must_match(/caskroom\/cask\/firefox/)
+        out.must_match(/caskroom\/testcasks\/firefox/)
+        out.length.must_be :<, 1000
+      end
+    end
+
+    describe "when the search term partially matches the token" do
+      it "finds multiple matches" do
+        out, err = capture_io do
+          Cask::CLI::Search.run('fire')
+        end
+        out.must_match(/caskroom\/cask\/firefox/)
+        out.must_match(/caskroom\/testcasks\/firefox/)
+        out.length.must_be :<, 1000
+      end
+    end
+  end
 end

--- a/test/support/Casks/firefox.rb
+++ b/test/support/Casks/firefox.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'firefox' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://example.com/duplicate-firefox/latest.dmg'
+  homepage 'https://example.com/duplicate-firefox/'
+  license :oss
+
+  app 'Duplicate Firefox.app'
+end


### PR DESCRIPTION
This PR adds failing tests for just one more edge case I’ve encountered.
### Issue

When two or more Casks (from separate repos) have the same token, the `brew cask search` command can get a bit confused.

I’m not really sure if we’re committed to supporting this in the first place. However, we have a method `Cask::CLI::nice_listing` which [suggests that we are](https://github.com/caskroom/homebrew-cask/blob/a335d3b06d49e4a30c8ab013cae2962704f89b1e/lib/cask/cli.rb#L146-L147).

For this discussion, let’s suppose a user has tapped into a repo called `other/repo` which happens to carry another `firefox`. (This PR includes a Cask like this in case you want to have a look.)
### Current behavior

Now that either repo has a `firefox`, the command `brew cask search fire` yields:

``` md
==> Partial matches
caskroom/cask/firefox  caskroom/cask/firefox   mediafire-desktop   multifirefox
```

with `caskroom/cask/firefox` listed twice while `other/repo/firefox` is missing.

Similarly, `brew cask search firefox` yields:

``` md
==> Exact match
caskroom/cask/firefox
==> Partial matches
multifirefox
```

with only one match, but `other/repo/firefox` still missing.
### Proposed behavior

Instead, I’d expect `brew cask search fire` to yield:

``` md
==> Partial matches
caskroom/cask/firefox  other/repo/firefox      mediafire-desktop   multifirefox
```

and `brew cask search firefox` to yield something like this:

``` md
==> Exact match
caskroom/cask/firefox
==> Partial matches
other/repo/firefox     multifirefox
```
### Please do NOT merge

I only created this PR to have a place for the failing tests … and to kindly ask for your thoughts about them.

The [upcoming version](https://github.com/claui/homebrew-cask/commit/3b4c9faae1c8d0f7fbcf1256931e69828471eaa0) of `brew cask search` already implements what the _Proposed_ section says. Still, I’d love some feedback from the @caskroom/maintainers … does the proposed behavior make sense?
