### PR TITLE
Upgrade Tower.app to v.2.1.3

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'tower' do
-  version :latest
-  sha256 :no_check
+  version '2.1.3'
+  sha256 'ee8826cbcbec2a20d9ddcd6819d607efa329ba6e574cb382caae2484049e9e19'
 
   url 'https://www.git-tower.com/download'
   appcast 'https://updates.fournova.com/updates/tower2-mac/stable'


### PR DESCRIPTION
Added version number to Tower. Hard to update otherwise, right? 
Thanks.
