### PR TITLE
renamed webp-quicklook to webpquicklook

### DIFF
--- a/Casks/webpquicklook.rb
+++ b/Casks/webpquicklook.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'webp-quicklook' do
+cask :v1 => 'webpquicklook' do
   version '2.1'
   sha256 '9efbdd2b3dcb44d41a53c1cb6ce64397fd00bd399189b1b742d2f4b2de28f437'
 


### PR DESCRIPTION
As stated by @rolandwalker in #3344, we should:

> try to avoid the case where a Cask name differs only by the placement of a hyphen.

However, it seems we forgot to change these (the other being [`emin-webpquicklook.rb`](https://github.com/caskroom/homebrew-cask/blob/1fc5bebf3f0aebd117e4a3065f85b5afec263f04/Casks/emin-webpquicklook.rb)), even though they were part of the rule’s mention. This PR addresses that.
