### PR TITLE
Upgrade Transporter Desktop.app to v3.0.15

### DIFF
--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'transporter-desktop' do
-  version '2.8.1_16078'
-  sha256 '43d0f47993d233fee6209b040b77f42e1b909cfedcbe873b7fb4700782af4c75'
+  version '3.0.15_16791'
+  sha256 'a30e41afe1be4c0a3b10b2a61a059aee36da173d021ea25e3d73ba3a39d85d25'
 
   url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}.dmg"
   homepage 'http://www.filetransporter.com/'


### PR DESCRIPTION
This PR updates the transporter-desktop cask to v3.0.15 and includes
the new SHA.
