### PR TITLE
mark `license :unknown` with explicit todo comment

### DIFF
--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -26,7 +26,7 @@ class Cask::CLI::Create < Cask::CLI::Base
         url 'https://'
         name ''
         homepage ''
-        license :unknown
+        license :unknown    # todo: improve this machine-generated value
 
         app ''
       end

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -43,7 +43,7 @@ describe Cask::CLI::Create do
         url 'https://'
         name ''
         homepage ''
-        license :unknown
+        license :unknown    # todo: improve this machine-generated value
 
         app ''
       end


### PR DESCRIPTION
In a [conversation elsewhere](https://github.com/Homebrew/homebrew/pull/34496#issuecomment-64772953), `license :unknown` was misinterpreted as meaning we don't care about licenses.

In fact the `license` stanza is just very new.  We have already annotated 36% of Casks in this repo with something more specific than `:unknown`.  I still feel strongly that we should continue accepting submissions that use `license :unknown`, but we should also keep moving forward toward filling in this information.

This comment seems like a reasonable step.  If accepted, I will mark up existing Casks as well.
