### PR TITLE
add `MacOS.release` alias for `MacOS.version`

### DIFF
--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -22,6 +22,13 @@ class Object
   end
 end
 
+# monkeypatch MacOS
+module MacOS
+  def release
+    version
+  end
+end
+
 # monkeypatch Tty
 class Tty
   class << self


### PR DESCRIPTION
- to match phrasing in our documentation
- to distinguish against the Cask `version` (of which there may be more than one in the future)
- better fit with symbolic release names _eg_ `:yosemite`
- `MacOS.release` itself is intentionally undocumented pending the next code release
