### PR TITLE
sanity checks and error handling in postflight mini-DSL

### DIFF
--- a/lib/cask/dsl/postflight.rb
+++ b/lib/cask/dsl/postflight.rb
@@ -4,8 +4,17 @@ class Cask::DSL::Postflight < Cask::DSL::Base
   include Cask::Staged
 
   def suppress_move_to_applications(options = {})
+    permitted_keys = [:key]
+    unknown_keys = options.keys - permitted_keys
+    unless unknown_keys.empty?
+      opoo %Q{Unknown arguments to suppress_move_to_applications -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}
+    end
     key = options[:key] || 'moveToApplicationsFolderAlertSuppress'
-    @command.run!('/usr/bin/defaults', :args => ['write', bundle_identifier, key, '-bool', 'true'])
+    begin
+      @command.run!('/usr/bin/defaults', :args => ['write', bundle_identifier, key, '-bool', 'true'])
+    rescue StandardError => e
+      raise CaskError.new("#{@cask.token}: 'suppress_move_to_applications' failed with: #{e}")
+    end
   end
 
   def method_missing(method, *args)

--- a/lib/cask/staged.rb
+++ b/lib/cask/staged.rb
@@ -11,10 +11,18 @@ module Cask::Staged
   end
 
   def plist_set(key, value)
-    plist_exec("Set #{key} #{value}")
+    begin
+      plist_exec("Set #{key} #{value}")
+    rescue StandardError => e
+      raise CaskError.new("#{@cask.token}: 'plist_set' failed with: #{e}")
+    end
   end
 
   def bundle_identifier
-    plist_exec('Print CFBundleIdentifier').stdout.chomp
+    begin
+      plist_exec('Print CFBundleIdentifier').stdout.chomp
+    rescue StandardError => e
+      raise CaskError.new("#{@cask.token}: 'bundle_identifier' failed with: #{e}")
+    end
   end
 end

--- a/lib/cask/staged.rb
+++ b/lib/cask/staged.rb
@@ -1,5 +1,5 @@
 module Cask::Staged
-  def info_plist(index = 0)
+  def info_plist_file(index = 0)
     index =  0 if index == :first
     index =  1 if index == :second
     index = -1 if index == :last
@@ -7,7 +7,7 @@ module Cask::Staged
   end
 
   def plist_exec(cmd)
-    @command.run!('/usr/libexec/PlistBuddy', :args => ['-c', cmd, info_plist])
+    @command.run!('/usr/libexec/PlistBuddy', :args => ['-c', cmd, info_plist_file])
   end
 
   def plist_set(key, value)

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -14,14 +14,14 @@ describe Cask::DSL::Postflight do
   end
 
   it "can get the Info.plist file for the primary app" do
-    @dsl.info_plist.to_s.must_include 'basic-cask/1.2.3/TestCask.app/Contents/Info.plist'
+    @dsl.info_plist_file.to_s.must_include 'basic-cask/1.2.3/TestCask.app/Contents/Info.plist'
   end
 
   it "can execute commands on the Info.plist file" do
     @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
 
     Cask::FakeSystemCommand.expects_command(
-      ['/usr/libexec/PlistBuddy', '-c', 'Print CFBundleIdentifier', @dsl.info_plist]
+      ['/usr/libexec/PlistBuddy', '-c', 'Print CFBundleIdentifier', @dsl.info_plist_file]
     )
     @dsl.plist_exec('Print CFBundleIdentifier')
   end
@@ -30,7 +30,7 @@ describe Cask::DSL::Postflight do
     @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
 
     Cask::FakeSystemCommand.expects_command(
-      ['/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', @dsl.info_plist]
+      ['/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', @dsl.info_plist_file]
     )
     @dsl.plist_set(':JVMOptions:JVMVersion', '1.6+')
   end


### PR DESCRIPTION
- report errors in all user-facing methods
- validate arguments
- incidentally recast `info_plist` as `info_plist_file`
