### PR TITLE
Add :bsexec option to command.run

### DIFF
--- a/lib/cask/artifact/base.rb
+++ b/lib/cask/artifact/base.rb
@@ -45,7 +45,7 @@ class Cask::Artifact::Base
     end
 
     # key sanity
-    permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print_stdout, :print_stderr]
+    permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :bsexec, :print_stdout, :print_stderr]
     unknown_keys = arguments.keys - permitted_keys
     unless unknown_keys.empty?
       opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}

--- a/lib/cask/container/dmg.rb
+++ b/lib/cask/container/dmg.rb
@@ -33,6 +33,7 @@ class Cask::Container::Dmg < Cask::Container::Base
   def mount!
     plist = @command.run('/usr/bin/hdiutil',
       # realpath is a failsafe against unusual filenames
+      :bsexec => '/',
       :args => %w[mount -plist -nobrowse -readonly -noidme -mountrandom /tmp] + [Pathname.new(@path).realpath],
       :input => %w[y]
     ).plist
@@ -58,11 +59,13 @@ class Cask::Container::Dmg < Cask::Container::Base
       mountpath = Pathname.new(mount).realpath
       next unless mountpath.exist?
       @command.run('/usr/sbin/diskutil',
+                   :bsexec => '/',
                    :args => ['eject', mountpath],
                    :print_stderr => false)
       next unless mountpath.exist?
       sleep 1
       @command.run('/usr/sbin/diskutil',
+                   :bsexec => '/',
                    :args => ['eject', mountpath],
                    :print_stderr => false)
       next unless mountpath.exist?

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -39,12 +39,14 @@ class Cask::SystemCommand
     run(command, options.merge(:must_succeed => true))
   end
 
-  def self._process_options(executable, options)
-    options.assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo
+    def self._process_options(executable, options)
+    options.assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo, :bsexec
     sudo_prefix = %w{/usr/bin/sudo -E --}
+    bsexec_prefix = [ 'launchctl', 'bsexec',  options[:bsexec] ]
     command = [executable]
     options[:print_stderr] = true  if !options.key?(:print_stderr)
     command.unshift(*sudo_prefix)  if  options[:sudo]
+    command.unshift(*bsexec_prefix)  if  options[:bsexec]
     command.concat(options[:args]) if  options.key?(:args) and !options[:args].empty?
     command
   end


### PR DESCRIPTION
This should fix #7132: mount dmg image fails if user does not have
StartupItemContext(8).
