### PR TITLE
return tarball_path from fetch method

### DIFF
--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -32,6 +32,11 @@ class Cask::CurlDownloadStrategy < CurlDownloadStrategy
     curl(*curl_args)
   end
 
+  def fetch
+    super
+    tarball_path
+  end
+
   private
 
   def curl_args


### PR DESCRIPTION
Compensate for a change in Homebrew.

Fixes #7946
