### PR TITLE
Upgrade packer to version 0.7.5

### DIFF
--- a/Casks/packer.rb
+++ b/Casks/packer.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'packer' do
-  version '0.7.2'
-  sha256 'bed7ddc255b5b71b139de5e30d4221926cd314a87baf0b937ba7a97c196b1286'
+  version '0.7.5'
+  sha256 'c0e149c4515fe548c1daeafabec3b4a091f2aa0c6936723382b3f6fe5a617880'
 
   url "https://dl.bintray.com/mitchellh/packer/packer_#{version}_darwin_amd64.zip"
   homepage 'http://www.packer.io/'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   binary 'packer'
   binary 'packer-builder-amazon-chroot'


### PR DESCRIPTION
This updates to 0.7.5 - which adds Atlas deployment support - and also sets the license to Open Source (which packer is).
