### PR TITLE
Enable new `accessibility_access` form in 4 Casks

### DIFF
--- a/Casks/arranger.rb
+++ b/Casks/arranger.rb
@@ -10,13 +10,5 @@ cask :v1 => 'arranger' do
 
   app 'Arranger.app'
 
-  # todo: replace with new assistive_devices stanza
-  caveats do
-    <<-EOS.undent
-      To use #{@cask}, you may need to give it access to assistive
-      devices (Accessibility).  For OS X Mavericks and Above:
-
-        System Preferences / Security & Privacy / Privacy / Accessibility
-    EOS
-  end
+  accessibility_access true
 end

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -9,13 +9,5 @@ cask :v1 => 'keycastr' do
 
   app 'KeyCastr.app'
 
-  # todo: replace with new assistive_devices stanza
-  caveats do
-    <<-EOS.undent
-      To use #{@cask}, you may need to give it access to assistive
-      devices (Accessibility).  For OS X Mavericks and Above:
-
-        System Preferences / Security & Privacy / Privacy / Accessibility
-    EOS
-  end
+  accessibility_access true
 end

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -8,13 +8,5 @@ cask :v1 => 'plover' do
 
   app 'plover.app'
 
-  # todo: replace with new assistive_devices stanza
-  caveats do
-    <<-EOS.undent
-      To use #{@cask}, you may need to give it access to assistive
-      devices (Accessibility).  For OS X Mavericks and Above:
-
-        System Preferences / Security & Privacy / Privacy / Accessibility
-    EOS
-  end
+  accessibility_access true
 end

--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -8,13 +8,5 @@ cask :v1 => 'typinator' do
 
   app 'Typinator.app'
 
-  # todo: replace with new assistive_devices stanza
-  caveats do
-    <<-EOS.undent
-      To use #{@cask}, you may need to give it access to assistive
-      devices (Accessibility).  For OS X Mavericks and Above:
-
-        System Preferences / Security & Privacy / Privacy / Accessibility
-    EOS
-  end
+  accessibility_access true
 end


### PR DESCRIPTION
We may as well enable recently-added forms, because the Homebrew glitch #7946 is going to require everyone to upgrade immediately.
