### PR TITLE
Bump terraform to 0.3.5

### DIFF
--- a/Casks/terraform.rb
+++ b/Casks/terraform.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'terraform' do
-  version '0.3.1'
-  sha256 'dda41425c7eb06c5e8b3f5ad4904e993aa8a9ab6b61f954ee2e259667cb6ff57'
+  version '0.3.5'
+  sha256 'd583d58719951a5c3a06eec38390fe31bef7645af7fee3e915293aab7a910885'
 
   url "https://dl.bintray.com/mitchellh/terraform/terraform_#{version}_darwin_amd64.zip"
   homepage 'http://www.terraform.io/'


### PR DESCRIPTION
Bumping terraform to the latest version available: https://dl.bintray.com/mitchellh/terraform/terraform_0.3.5_darwin_amd64.zip
