### PR TITLE
Update to NEW sha256 checksum of Vagrant 1.7.0

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vagrant' do
   version '1.7.0'
-  sha256 '2b3d7cf0d2490e1f1d4f7ad13e2caf44a50cec33419a6ea281f3e5c693da7e8d'
+  sha256 '1b228d79066938f879335ddb4dce69eb8954e7337a117104004854dc39c135b0'
 
   url "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{version}.dmg"
   homepage 'http://www.vagrantup.com'


### PR DESCRIPTION
There were some problems with the initial packages, and Vagrant 1.7.0 has
been re-packaged with same version number.

See https://github.com/mitchellh/vagrant/issues/4918.

Fix https://github.com/caskroom/homebrew-cask/pull/7969#issuecomment-66505058
