### PR TITLE
Update licenses for a bunch of casks

### DIFF
--- a/Casks/cactus.rb
+++ b/Casks/cactus.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cactus' do
 
   url "http://update.cactusformac.com/static/downloads/Cactus-#{version}.zip"
   homepage 'http://cactusformac.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   app 'Cactus.app'
 

--- a/Casks/candybar.rb
+++ b/Casks/candybar.rb
@@ -4,7 +4,7 @@ cask :v1 => 'candybar' do
 
   url "https://panic.com/candybar/d/CandyBar%20#{version}.zip"
   homepage 'http://www.panic.com/blog/candybar-mountain-lion-and-beyond'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'CandyBar.app'
   caveats <<-EOS.undent

--- a/Casks/chromatic.rb
+++ b/Casks/chromatic.rb
@@ -5,7 +5,7 @@ cask :v1 => 'chromatic' do
   url 'http://download.mrgeckosmedia.com/Chromatic.zip'
   appcast 'http://mrgeckosmedia.com/applications/appcast/Chromatic'
   homepage 'https://mrgeckosmedia.com/applications/info/Chromatic'
-  license :unknown    # todo: improve this machine-generated value
+  license :isc
 
   app 'Chromatic.app'
 end

--- a/Casks/clarify.rb
+++ b/Casks/clarify.rb
@@ -4,7 +4,7 @@ cask :v1 => 'clarify' do
 
   url 'http://www.clarify-it.com/download/mac/Clarify.dmg'
   homepage 'http://www.clarify-it.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Clarify.app'
 end

--- a/Casks/consul.rb
+++ b/Casks/consul.rb
@@ -4,7 +4,7 @@ cask :v1 => 'consul' do
 
   url "https://dl.bintray.com/mitchellh/consul/#{version}_darwin_amd64.zip"
   homepage 'http://www.consul.io/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mpl
 
   binary 'consul'
 end

--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -12,7 +12,7 @@ cask :v1 => 'daisydisk' do
 
   appcast 'http://www.daisydiskapp.com/downloads/appcastFeed.php'
   homepage 'http://www.daisydiskapp.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :closed
 
   app 'DaisyDisk.app'
 

--- a/Casks/darteditor.rb
+++ b/Casks/darteditor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'darteditor' do
 
   url 'https://storage.googleapis.com/dart-archive/channels/stable/release/latest/editor/darteditor-macos-x64.zip'
   homepage 'https://www.dartlang.org/tools/editor/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   app 'dart/DartEditor.app'
 end

--- a/Casks/day-o.rb
+++ b/Casks/day-o.rb
@@ -4,7 +4,7 @@ cask :v1 => 'day-o' do
 
   url 'http://shauninman.com/assets/downloads/Day-O.zip'
   homepage 'http://www.shauninman.com/archive/2011/10/20/day_o_mac_menu_bar_clock'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Day-O/Day-O.app'
 end

--- a/Casks/deathtodsstore.rb
+++ b/Casks/deathtodsstore.rb
@@ -4,7 +4,7 @@ cask :v1 => 'deathtodsstore' do
 
   url 'http://www.aorensoftware.com/Downloads/Files/DeathToDSStore.zip'
   homepage 'http://www.aorensoftware.com/blog/2011/12/24/death-to-ds_store/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'DeathToDSStore.app'
 end

--- a/Casks/displaperture.rb
+++ b/Casks/displaperture.rb
@@ -4,7 +4,7 @@ cask :v1 => 'displaperture' do
 
   url 'http://manytricks.com/download/displaperture'
   homepage 'http://manytricks.com/displaperture'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Displaperture.app'
 end

--- a/Casks/e-tax2014.rb
+++ b/Casks/e-tax2014.rb
@@ -4,7 +4,7 @@ cask :v1 => 'e-tax2014' do
 
   url "https://www.ato.gov.au/misc/downloads/etax2014/etax2014_#{version}.dmg"
   homepage 'https://www.ato.gov.au/individuals/lodging-your-tax-return/lodge-online/e-tax/downloading-and-installing-e-tax/#Mac'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   pkg 'etax2014_1.pkg'
 

--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -6,7 +6,7 @@ cask :v1 => 'electrum-ltc' do
   gpg "#{url}.asc",
       :key_id => '9914864dfc33499c6ca2beea22453004695506fd'
   homepage 'http://electrum-ltc.org'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Electrum-LTC.app'
 end

--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -6,7 +6,7 @@ cask :v1 => 'electrum' do
   gpg "#{url}.asc",
       :key_id => '9914864dfc33499c6ca2beea22453004695506fd'
   homepage 'http://electrum.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Electrum.app'
 end

--- a/Casks/exhaust.rb
+++ b/Casks/exhaust.rb
@@ -5,7 +5,7 @@ cask :v1 => 'exhaust' do
   url 'http://download.mrgeckosmedia.com/Exhaust.zip'
   appcast 'http://mrgeckosmedia.com/applications/appcast/Exhaust'
   homepage 'https://mrgeckosmedia.com/applications/info/Exhaust'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   app 'Exhaust/Exhaust.app'
 end

--- a/Casks/facter.rb
+++ b/Casks/facter.rb
@@ -4,7 +4,7 @@ cask :v1 => 'facter' do
 
   url "https://downloads.puppetlabs.com/mac/facter-#{version}.dmg"
   homepage 'https://puppetlabs.com/facter'
-  license :unknown    # todo: improve this machine-generated value
+  license :apache
 
   pkg "facter-#{version}.pkg"
 

--- a/Casks/fakethunder.rb
+++ b/Casks/fakethunder.rb
@@ -6,7 +6,7 @@ cask :v1 => 'fakethunder' do
   appcast 'http://martianlaboratory.com/fakethunder/update.xml',
           :sha256 => '71c38833d0f6e1fb929d6914e2cbaa3978a5155cde21353eae7a73d046b10731'
   homepage 'http://martianz.cn/fakethunder/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'fakeThunder.app'
 end

--- a/Casks/fetch.rb
+++ b/Casks/fetch.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fetch' do
 
   url "http://fetchsoftworks.com/fetch/download/Fetch_#{version}.dmg?direct=1"
   homepage 'http://fetchsoftworks.com/fetch/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Fetch.app'
 end

--- a/Casks/fiji.rb
+++ b/Casks/fiji.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fiji' do
 
   url 'http://jenkins.imagej.net/job/Stable-Fiji-MacOSX/lastSuccessfulBuild/artifact/fiji-macosx.dmg'
   homepage 'http://fiji.sc'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   app 'Fiji.app'
 end

--- a/Casks/fission.rb
+++ b/Casks/fission.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fission' do
 
   url 'http://neutral.rogueamoeba.com/mirror/files/Fission.zip'
   homepage 'http://rogueamoeba.com/fission/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Fission.app'
 end

--- a/Casks/fliqlo.rb
+++ b/Casks/fliqlo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fliqlo' do
 
   url "http://fliqlo.com/download/fliqlo_#{version.gsub('.','')}.dmg", :referer => 'http://fliqlo.com/#about'
   homepage 'http://fliqlo.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   screen_saver 'Fliqlo.saver'
 end

--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -4,7 +4,7 @@ cask :v1 => 'frostwire' do
 
   url "http://dl.frostwire.com/frostwire/#{version}/frostwire-#{version}.dmg"
   homepage 'http://www.frostwire.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'FrostWire.app'
 end

--- a/Casks/functionflip.rb
+++ b/Casks/functionflip.rb
@@ -4,7 +4,7 @@ cask :v1 => 'functionflip' do
 
   url "http://kevingessner.com/public/downloads/FunctionFlip/#{version}/FunctionFlip.prefPane.zip"
   homepage 'http://kevingessner.com/software/functionflip/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   prefpane 'FunctionFlip.prefPane'
 end

--- a/Casks/gas-mask.rb
+++ b/Casks/gas-mask.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gas-mask' do
   appcast 'http://gmask.clockwise.ee/check_update/',
           :sha256 => '2e4f5292999bddfc25245a9c10f98d7ac23d0717a1dd45436a00cf09be7f8d9b'
   homepage 'http://www.clockwise.ee/gasmask/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Gas Mask.app'
 end

--- a/Casks/gitbook.rb
+++ b/Casks/gitbook.rb
@@ -4,7 +4,7 @@ cask :v1 => 'gitbook' do
 
   url 'https://www.gitbook.io/editor/download'
   homepage 'https://www.gitbook.io/'
-  license :unknown    # todo: improve this machine-generated value
+  license :apache
 
   app 'GitBook.app'
 end

--- a/Casks/glueprint.rb
+++ b/Casks/glueprint.rb
@@ -4,7 +4,7 @@ cask :v1 => 'glueprint' do
 
   url "http://glueprintapp.com/static/download/GluePrint-#{version}.app.zip"
   homepage 'http://glueprintapp.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'GluePrint.app'
 end

--- a/Casks/gmail-notifr.rb
+++ b/Casks/gmail-notifr.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gmail-notifr' do
   appcast 'https://s3.amazonaws.com/assets.ashchan.com/gmailnotifr/update.xml',
           :sha256 => '20876c0cef8d54463a5189948259e7ad268a28424b96e7fa2fbad860b0ec9554'
   homepage 'http://ashchan.com/projects/gmail-notifr'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'Gmail Notifr.app'
 

--- a/Casks/goagentx.rb
+++ b/Casks/goagentx.rb
@@ -5,7 +5,7 @@ cask :v1 => 'goagentx' do
   url 'https://goagentx.com/files/GoAgentX.dmg'
   appcast 'https://goagentx.com/update/SUAppcast.xml'
   homepage 'http://goagentx.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   app 'GoAgentX.app'
 end

--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hostbuddy' do
   url 'https://clickontyler.com/hostbuddy/download/'
   appcast 'http://shine.clickontyler.com/appcast.php?id=22'
   homepage 'http://clickontyler.com/hostbuddy/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Hostbuddy.app'
 end

--- a/Casks/houdahgeo.rb
+++ b/Casks/houdahgeo.rb
@@ -5,7 +5,7 @@ cask :v1 => 'houdahgeo' do
   url 'http://houdah.com/houdahGeo/download_assets/HoudahGeo_latest.zip'
   appcast 'http://www.houdah.com/houdahGeo/updates3/profileInfo.php'
   homepage 'http://houdah.com/houdahGeo/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'HoudahGeo.app'
 end

--- a/Casks/hyperdither.rb
+++ b/Casks/hyperdither.rb
@@ -4,7 +4,7 @@ cask :v1 => 'hyperdither' do
 
   url 'http://www.tinrocket.com/wp-content/plugins/download-monitor/download.php?id=1'
   homepage 'http://www.tinrocket.com/hyperdither/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app "HyperDither #{version}/HyperDither.app"
 end

--- a/Casks/ibabel.rb
+++ b/Casks/ibabel.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ibabel' do
 
   url 'http://macinchem.org/ibabel/ibabel3_files/iBabel.zip'
   homepage 'http://www.macinchem.org/ibabel/ibabel3.php'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'iBabel.app'
 end

--- a/Casks/iexplorer.rb
+++ b/Casks/iexplorer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'iexplorer' do
   appcast 'http://www.macroplant.com/iexplorer/ie3-appcast.xml',
           :sha256 => '50a537b61eec96833d145abfe25affc972579f4e01cf3876aa6596ba5320db26'
   homepage 'http://www.macroplant.com/iexplorer/'
-  license :unknown    # todo: improve this machine-generated value
+  license :closed
 
   app 'iExplorer.app'
 end

--- a/Casks/intermission.rb
+++ b/Casks/intermission.rb
@@ -4,7 +4,7 @@ cask :v1 => 'intermission' do
 
   url 'http://dm.rogueamoeba.com/mirror/files/Intermission.zip'
   homepage 'http://rogueamoeba.com/intermission/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Intermission.app'
 end

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -4,7 +4,7 @@ cask :v1 => 'j' do
 
   url "http://www.jsoftware.com/download/j#{version}/install/j#{version}_mac64.zip"
   homepage 'http://www.jsoftware.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   %w<jbrk jcon jhs jqt>.each do |a|
     app "j64-#{version}/#{a}.app"

--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -7,7 +7,7 @@ cask :v1 => 'karabiner' do
   # name 'Karabiner'
   # name 'Keyremap4Macbook'
   homepage 'https://pqrs.org/osx/karabiner/'
-  license :unknown    # todo: improve this machine-generated value
+  license :public_domain
 
   pkg 'Karabiner.pkg'
   binary '/Applications/Karabiner.app/Contents/Library/vendor/bin/blueutil'

--- a/Casks/kylo.rb
+++ b/Casks/kylo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'kylo' do
 
   url "https://kylo.s3.amazonaws.com/update/public/kylo-setup-#{version.gsub('.','_')}.dmg"
   homepage 'http://kylo.tv'
-  license :unknown    # todo: improve this machine-generated value
+  license :mpl
 
   app 'Kylo.app'
 end

--- a/Casks/launchy.rb
+++ b/Casks/launchy.rb
@@ -4,7 +4,7 @@ cask :v1 => 'launchy' do
 
   url "http://www.launchy.net/downloads/mac/Launchy#{version}.dmg"
   homepage 'http://www.launchy.net'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Launchy.app'
 end

--- a/Casks/licensed.rb
+++ b/Casks/licensed.rb
@@ -4,7 +4,7 @@ cask :v1 => 'licensed' do
 
   url 'http://amarsagoo.info/licensed/Licensed.dmg'
   homepage 'http://amarsagoo.info/licensed'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Licensed.app'
 end

--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -4,7 +4,7 @@ cask :v1 => 'linein' do
 
   url 'https://www.rogueamoeba.com/freebies/download/LineIn.zip'
   homepage 'http://www.rogueamoeba.com/freebies/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'LineIn.app'
 end

--- a/Casks/mac-informer.rb
+++ b/Casks/mac-informer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mac-informer' do
 
   url 'http://files.informer.com/simac.dmg'
   homepage 'http://macdownload.informer.com/landing/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Mac Informer.app'
 end

--- a/Casks/macgdbp.rb
+++ b/Casks/macgdbp.rb
@@ -6,7 +6,7 @@ cask :v1 => 'macgdbp' do
   appcast 'https://www.bluestatic.org/versioncast.php/macgdbp',
           :sha256 => '5c1c3548e8e993df1bd38d0d0c5149e8e4312566da858bbfdbbe83ca93793048'
   homepage 'https://www.bluestatic.org/software/macgdbp/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'MacGDBp.app'
 end

--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -4,7 +4,7 @@ cask :v1 => 'macpilot' do
 
   url 'http://www.koingo.com/downloads/macintosh/mac_pilot.dmg'
   homepage 'http://www.koingosw.com/products/macpilot.php'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'MacPilot.app'
 end

--- a/Casks/mailpile.rb
+++ b/Casks/mailpile.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mailpile' do
 
   url 'https://www.mailpile.is/files/releases/Mailpile-Installer-Beta.dmg'
   homepage 'https://www.mailpile.is/'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   app 'Mailpile.app'
 end

--- a/Casks/memorytamer.rb
+++ b/Casks/memorytamer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'memorytamer' do
 
   url "https://memorytamer.s3.amazonaws.com/MemoryTamer-#{version}.zip"
   homepage 'http://www.memorytamer.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'MemoryTamer.app'
 end

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -10,7 +10,7 @@ cask :v1 => 'middleclick' do
     url 'http://clement.beffa.org/labs/downloads/MiddleClick-maverick.zip'
   end
   homepage 'http://clement.beffa.org/labs/projects/middleclick'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'MiddleClick.app'
 end

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mucommander' do
 
   url "http://www.mucommander.com/download/mucommander-#{version.gsub('.','_')}.dmg"
   homepage 'http://www.mucommander.com/index.php'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'muCommander.app'
 end

--- a/Casks/namely.rb
+++ b/Casks/namely.rb
@@ -4,7 +4,7 @@ cask :v1 => 'namely' do
 
   url 'http://amarsagoo.info/namely/Namely.dmg'
   homepage 'http://amarsagoo.info/namely'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Namely.app'
 end

--- a/Casks/nicecast.rb
+++ b/Casks/nicecast.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nicecast' do
 
   url 'https://rogueamoeba.com/nicecast/download/Nicecast.zip'
   homepage 'http://rogueamoeba.com/nicecast'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Nicecast.app'
 end

--- a/Casks/nitroshare.rb
+++ b/Casks/nitroshare.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nitroshare' do
 
   url "https://launchpad.net/nitroshare/#{version}/#{version}/+download/nitroshare_#{version}.app.dmg"
   homepage 'https://launchpad.net/nitroshare'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'NitroShare.app'
 end

--- a/Casks/nmap.rb
+++ b/Casks/nmap.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nmap' do
 
   url "http://nmap.org/dist/nmap-#{version}.dmg"
   homepage 'http://nmap.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   pkg "nmap-#{version}.mpkg"
 

--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -4,7 +4,7 @@ cask :v1 => 'noejectdelay' do
 
   url "https://pqrs.org/macosx/keyremap4macbook/files/NoEjectDelay-#{version}.dmg"
   homepage 'https://pqrs.org/macosx/keyremap4macbook/noejectdelay.html.en'
-  license :unknown    # todo: improve this machine-generated value
+  license :public_domain
 
   pkg 'NoEjectDelay.pkg'
 

--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -11,7 +11,7 @@ cask :v1 => 'opensesame' do
   end
 
   homepage 'http://osdoc.cogsci.nl/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'opensesame.app'
 end

--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -5,7 +5,7 @@ cask :v1 => 'papers' do
   url 'http://papersapp.com/papers/download'
   appcast 'http://www.papersapp.com/papers/appcast_v3.xml'
   homepage 'http://www.papersapp.com/papers/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Papers.app'
 end

--- a/Casks/password-practice.rb
+++ b/Casks/password-practice.rb
@@ -4,7 +4,7 @@ cask :v1 => 'password-practice' do
 
   url 'https://mrgeckosmedia.com/applications/download/PasswordPractice'
   homepage 'https://mrgeckosmedia.com/applications/info/PasswordPractice'
-  license :unknown    # todo: improve this machine-generated value
+  license :public_domain
 
   app 'Password Practice.app'
 end

--- a/Casks/piezo.rb
+++ b/Casks/piezo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'piezo' do
 
   url 'http://neutral.rogueamoeba.com/mirror/files/Piezo.zip'
   homepage 'http://rogueamoeba.com/piezo/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Piezo.app'
 end

--- a/Casks/pokertracker.rb
+++ b/Casks/pokertracker.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pokertracker' do
 
   url "http://s3-us1.ptrackupdate.com/releases/PT-Install-v#{version}.dmg"
   homepage 'https://www.pokertracker.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'PokerTracker 4.app'
 end

--- a/Casks/power-manager-pro.rb
+++ b/Casks/power-manager-pro.rb
@@ -5,7 +5,7 @@ cask :v1 => 'power-manager-pro' do
   url 'https://www.dssw.co.uk/powermanager/dsswpowermanagerpro.dmg'
   appcast 'http://version.dssw.co.uk/powermanager/professional'
   homepage 'https://www.dssw.co.uk/powermanager'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Power Manager Pro.app'
 end

--- a/Casks/power-manager.rb
+++ b/Casks/power-manager.rb
@@ -4,7 +4,7 @@ cask :v1 => 'power-manager' do
 
   url 'https://www.dssw.co.uk/powermanager/dsswpowermanager.dmg'
   homepage 'https://www.dssw.co.uk/powermanager'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   pkg 'DssW Power Manager.pkg'
 

--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -6,7 +6,7 @@ cask :v1 => 'propresenter' do
   appcast 'https://www.renewedvision.com/update/ProPresenter5.php',
           :sha256 => 'f70029136ad0273f64bdbe6eff1d838e18dba1a1e0c3fe6e85c88909fe4cbf64'
   homepage 'http://www.renewedvision.com/propresenter.php'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'ProPresenter 5.app'
 end

--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -4,7 +4,7 @@ cask :v1 => 'protege' do
 
   url "http://protege.stanford.edu/download/protege/4.3/osx/protege-#{version}-304.zip"
   homepage 'http://protege.stanford.edu/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   app 'protege-4.3.app'
 end

--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'renamer' do
 
   url 'http://creativebe.com/download/renamer'
   homepage 'http://renamer.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Renamer.app'
 end

--- a/Casks/satellite-eyes.rb
+++ b/Casks/satellite-eyes.rb
@@ -6,7 +6,7 @@ cask :v1 => 'satellite-eyes' do
   appcast 'https://satellite-eyes.s3.amazonaws.com/appcast.xml',
           :sha256 => '5853ce38284dd959729ea64a423c359d6f2e383be3f062b38825762dfb97860b'
   homepage 'http://satelliteeyes.tomtaylor.co.uk/'
-  license :unknown    # todo: improve this machine-generated value
+  license :apache
 
   app 'Satellite Eyes.app'
 end

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -4,7 +4,7 @@ cask :v1 => 'scala-ide' do
 
   url "http://downloads.typesafe.com/scalaide-pack/#{version}.vfinal-210-20140327/scala-SDK-#{version}-2.10-macosx.cocoa.x86_64.zip"
   homepage 'http://scala-ide.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.

--- a/Casks/shady.rb
+++ b/Casks/shady.rb
@@ -4,7 +4,7 @@ cask :v1 => 'shady' do
 
   url "http://instinctivecode.com/shady/shady_#{version}.zip"
   homepage 'http://instinctivecode.com/shady/'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   app 'Shady.app'
 end

--- a/Casks/sickbeard-anime.rb
+++ b/Casks/sickbeard-anime.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sickbeard-anime' do
 
   url "http://sickbeard.lad1337.de/download.php?f=SickBeard-OSX-anime-#{version}.dmg"
   homepage 'http://sickbeard.lad1337.de/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'SickBeard.app'
 end

--- a/Casks/sickbeard.rb
+++ b/Casks/sickbeard.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sickbeard' do
 
   url "http://sickbeard.lad1337.de/download.php?f=SickBeard-OSX-master-#{version}.dmg"
   homepage 'http://sickbeard.lad1337.de/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'SickBeard.app'
 end

--- a/Casks/silverlight.rb
+++ b/Casks/silverlight.rb
@@ -4,7 +4,7 @@ cask :v1 => 'silverlight' do
 
   url 'http://silverlight.dlservice.microsoft.com/download/F/8/C/F8C0EACB-92D0-4722-9B18-965DD2A681E9/30514.00/Silverlight.dmg'
   homepage 'http://www.microsoft.com/silverlight/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   pkg 'Silverlight.pkg'
 

--- a/Casks/sixtyforce.rb
+++ b/Casks/sixtyforce.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sixtyforce' do
 
   url 'http://sixtyforce.com/download/sixtyforce.zip'
   homepage 'http://sixtyforce.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :closed
 
   app 'sixtyforce.app'
 end

--- a/Casks/sketch-toolbox.rb
+++ b/Casks/sketch-toolbox.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sketch-toolbox' do
 
   url 'http://sketchtoolbox.com/Sketch%20Toolbox.zip'
   homepage 'http://sketchtoolbox.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'Sketch Toolbox.app'
 end

--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -5,7 +5,7 @@ cask :v1 => 'slicy' do
   url 'https://macrabbit.com/slicy/get/'
   appcast 'http://update.macrabbit.com/slicy/1.1.3.xml'
   homepage 'http://macrabbit.com/slicy/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Slicy.app'
 end

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -5,7 +5,7 @@ cask :v1 => 'snagit' do
   url 'http://download.techsmith.com/snagitmac/enu/Snagit.dmg'
   appcast 'http://techsmithredirect.appspot.com/'
   homepage 'http://www.techsmith.com/snagit.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Snagit.app'
 end

--- a/Casks/soundnote.rb
+++ b/Casks/soundnote.rb
@@ -5,7 +5,7 @@ cask :v1 => 'soundnote' do
   url 'http://download.mrgeckosmedia.com/SoundNote.zip'
   appcast 'http://mrgeckosmedia.com/applications/appcast/SoundNote'
   homepage 'https://mrgeckosmedia.com/applications/info/SoundNote'
-  license :unknown    # todo: improve this machine-generated value
+  license :isc
 
   app 'SoundNote.app'
 end

--- a/Casks/stockbarjp.rb
+++ b/Casks/stockbarjp.rb
@@ -4,7 +4,7 @@ cask :v1 => 'stockbarjp' do
 
   url 'http://midnightsuyama.org/download/StockBarJP.zip'
   homepage 'http://midnightsuyama.org/blog/articles/stockbarjp/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'StockBarJP.app'
 end

--- a/Casks/subnetcalc.rb
+++ b/Casks/subnetcalc.rb
@@ -4,7 +4,7 @@ cask :v1 => 'subnetcalc' do
 
   url "http://subnetcalc.free.fr/download/subnetcalc-#{version}.dmg"
   homepage 'http://subnetcalc.free.fr/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'SubnetCalc.app'
 end

--- a/Casks/subsmarine.rb
+++ b/Casks/subsmarine.rb
@@ -6,7 +6,7 @@ cask :v1 => 'subsmarine' do
   appcast 'http://www.cocoawithchurros.com/shine/appcast.php?id=7',
           :sha256 => '9659830b134ac12326639e1b3f7ba06945cc18db343890e06a4c7f9d9dce8912'
   homepage 'http://www.cocoawithchurros.com/subsmarine.php'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'SubsMarine.app'
 end

--- a/Casks/sumbolon.rb
+++ b/Casks/sumbolon.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sumbolon' do
 
   url "http://www.rwe-uk.com/uploads/updates/Sumbolon%20#{version}.zip"
   homepage 'http://www.rwe-uk.com/app/sumbolon'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Sumbolon.app'
 end

--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -5,7 +5,7 @@ cask :v1 => 'swinsian' do
   url 'https://swinsian.com/sparkle/Swinsian.zip'
   appcast 'http://www.swinsian.com/sparkle/sparklecast.xml'
   homepage 'http://swinsian.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Swinsian.app'
 end

--- a/Casks/teleport.rb
+++ b/Casks/teleport.rb
@@ -4,7 +4,7 @@ cask :v1 => 'teleport' do
 
   url 'http://www.abyssoft.com/software/teleport/downloads/teleport.zip'
   homepage 'http://www.abyssoft.com/software/teleport/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   prefpane 'teleport/teleport.prefPane'
 end

--- a/Casks/tinkertool.rb
+++ b/Casks/tinkertool.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tinkertool' do
 
   url 'http://dl.macupdate.com/prod/TinkerTool.dmg'
   homepage 'http://www.bresink.com/osx/TinkerTool.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'TinkerTool.app'
 end

--- a/Casks/tofu.rb
+++ b/Casks/tofu.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tofu' do
 
   url 'http://amarsagoo.info/tofu/Tofu.dmg'
   homepage 'http://amarsagoo.info/tofu/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Tofu.app'
 end

--- a/Casks/totalterminal.rb
+++ b/Casks/totalterminal.rb
@@ -4,7 +4,7 @@ cask :v1 => 'totalterminal' do
 
   url "http://downloads.binaryage.com/TotalTerminal-#{version}.dmg"
   homepage 'http://totalterminal.binaryage.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   pkg 'TotalTerminal.pkg'
 

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -4,7 +4,7 @@ cask :v1 => 'twine' do
 
   url "http://twinery.org/downloads/twine_#{version}_osx.zip"
   homepage 'http://twinery.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Twine.app'
 end

--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -4,7 +4,7 @@ cask :v1 => 'unison' do
 
   url "http://alan.petitepomme.net/unison/assets/Unison-#{version}_x64.dmg"
   homepage 'http://www.cis.upenn.edu/~bcpierce/unison/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Unison.app'
 end

--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -4,7 +4,7 @@ cask :v1 => 'visit' do
 
   url "https://portal.nersc.gov/svn/visit/trunk/releases/#{version}/VisIt-#{version}.dmg"
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   app 'VisIt.app'
 end

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -5,7 +5,7 @@ cask :v1 => 'voicemac' do
   url 'http://download.mrgeckosmedia.com/VoiceMac.zip'
   appcast 'https://mrgeckosmedia.com/applications/appcast/VoiceMac'
   homepage 'https://mrgeckosmedia.com/applications/info/VoiceMac'
-  license :unknown    # todo: improve this machine-generated value
+  license :isc
 
   app 'VoiceMac/VoiceMac.app'
   postflight do

--- a/Casks/x-moto.rb
+++ b/Casks/x-moto.rb
@@ -4,7 +4,7 @@ cask :v1 => 'x-moto' do
 
   url "http://download.tuxfamily.org/xmoto/xmoto/#{version}/xmoto-#{version}-macosx.zip"
   homepage 'http://xmoto.tuxfamily.org'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'X-Moto.app'
 end

--- a/Casks/x48.rb
+++ b/Casks/x48.rb
@@ -5,7 +5,7 @@ cask :v1 => 'x48' do
 
   url "https://sites.google.com/a/sharkus.com/sharkus-com/Home/x48-#{version}%20osx.zip"
   homepage 'http://blog.sharkus.com/2012/08/osx-hp48-emulators.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app "x48-#{version} osx/x48.app"
 

--- a/Casks/xnconvert.rb
+++ b/Casks/xnconvert.rb
@@ -4,7 +4,7 @@ cask :v1 => 'xnconvert' do
 
   url 'http://download.xnview.com/XnConvert-mac-x64.tgz'
   homepage 'http://www.xnview.com/en/xnconvert/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'XnConvert.app'
 end

--- a/Casks/yubikey-personalization-gui.rb
+++ b/Casks/yubikey-personalization-gui.rb
@@ -4,7 +4,7 @@ cask :v1 => 'yubikey-personalization-gui' do
 
   url "https://www.yubico.com/wp-content/uploads/2012/09/yubikey-personalization-gui-#{version}.pkg"
   homepage 'http://www.yubico.com/products/services-software/personalization-tools/use/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   pkg "yubikey-personalization-gui-#{version}.pkg"
 

--- a/Casks/zeroxed.rb
+++ b/Casks/zeroxed.rb
@@ -4,7 +4,7 @@ cask :v1 => 'zeroxed' do
 
   url 'http://www.suavetech.com/cgi-bin/download.cgi?0xED.tar.bz2'
   homepage 'http://www.suavetech.com/0xed/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app '0xED.app'
 


### PR DESCRIPTION
`git status` tells me it's 90 so I believe it.  Failed rebase should be fixed now.  Some notes:
- `mailpile` listed as `:oss` since it's either `:affero` or `:apache`
- `exhaust` listed as `:oss` since it's a custom license
- `shady` listed as `:oss` - Original creator indicates his software is licensed under a 'version' of the new BSD (see http://mattgemmell.com/license/), and is willing to license under BSD or GPL if desired.  The website (http://instinctivecode.com/shady/) claims to be open source but the link is dead (http://svn.cocoasourcecode.com/Shady/).  Github repo here: https://github.com/mattgemmell/Shady
- `gmail-notifr` listed as `:mit` - v0.9 is the last open version (https://github.com/ashchan/gmail-notifr-objc), but since v1.0 onward will only be offered through the App Store, this is open as far as we're concerned
