### PR TITLE
Update scala-ide and add 32-bit version

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,8 +1,13 @@
 cask :v1 => 'scala-ide' do
-  version '3.0.3'
-  sha256 '74c0ed0a2ca9d5b7cad39142d436bf88db55e75f85f885c74a4b8a164e814ee1'
+  version '3.0.4'
 
-  url "http://downloads.typesafe.com/scalaide-pack/#{version}.vfinal-210-20140327/scala-SDK-#{version}-2.10-macosx.cocoa.x86_64.zip"
+  if Hardware::CPU.is_32_bit?
+    sha256 '01448e95f645955c0ab5e3461bc2a44104c01fcfb7f7355d317b1d6de11d2218'
+    url "http://downloads.typesafe.com/scalaide-pack/#{version}.vfinal-211-20140723/scala-SDK-#{version}-2.11-2.11-macosx.cocoa.x86.zip"
+  else
+    sha256 'a631e31a53bd7bda61ec579fe8013c7a7e22ab7e947e726cdc9efbe45a10bb3e'
+    url "http://downloads.typesafe.com/scalaide-pack/#{version}.vfinal-211-20140723/scala-SDK-#{version}-2.11-2.11-macosx.cocoa.x86_64.zip"
+  end
   homepage 'http://scala-ide.org/'
   license :bsd
 


### PR DESCRIPTION
Update to 3.0.4 and add download links for both 32-bit and 64-bit
architectures.
