### PR TITLE
enable `license :freemium`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ cask :v1 => 'alfred' do
   url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
   name 'Alfred'
   homepage 'http://www.alfredapp.com/'
-  license :commercial
+  license :freemium
 
   app 'Alfred 2.app'
   app 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -44,7 +44,7 @@ cask :v1 => 'alfred' do
   url 'https://cachefly.alfredapp.com/Alfred_2.3_264.zip'
   name 'Alfred'
   homepage 'http://www.alfredapp.com/'
-  license :commercial
+  license :freemium
 
   app 'Alfred 2.app'
   app 'Alfred 2.app/Contents/Preferences/Alfred Preferences.app'
@@ -362,27 +362,28 @@ open source.  Chromium licensing is described by the generic category [`:oss`](h
 
 ### Valid Licenses
 
-| symbol           | generic category | meaning                                         | URL         |
-| ---------------- | ---------------- | ----------------------------------------------- | ----------- |
-| `:gratis`        | `:closed`        | free-to-use, closed source                      | <none>
-| `:commercial`    | `:closed`        | not free to use                                 | <none>
-| `:affero`        | `:oss`           | Affero General Public License                   | <https://gnu.org/licenses/agpl.html>
-| `:apache`        | `:oss`           | Apache Public License                           | <http://www.apache.org/licenses/>
-| `:arphic`        | `:oss`           | Arphic Public License                           | <http://www.arphic.com/tw/download/public_license.rar>
-| `:artistic`      | `:oss`           | Artistic License                                | <http://dev.perl.org/licenses/artistic.html>
-| `:bsd`           | `:oss`           | BSD License                                     | <http://www.linfo.org/bsdlicense.html>
-| `:cc`            | `:oss`           | Creative Commons License                        | <http://creativecommons.org/licenses/>
-| `:eclipse`       | `:oss`           | Eclipse Public License                          | <https://www.eclipse.org/legal/eplfaq.php>
-| `:gpl`           | `:oss`           | GNU Public License                              | <http://www.gnu.org/copyleft/gpl.html>
-| `:isc`           | `:oss`           | Internet Systems Consortium License             | <http://www.isc.org/downloads/software-support-policy/isc-license/>
-| `:lppl`          | `:oss`           | LaTeX Project Public License                    | <http://latex-project.org/lppl/>
-| `:ncsa`          | `:oss`           | University of Illinois/NCSA Open Source License | <http://otm.illinois.edu/uiuc_openSource>
-| `:mit`           | `:oss`           | MIT License                                     | <http://opensource.org/licenses/MIT>
-| `:mpl`           | `:oss`           | Mozilla Public License                          | <https://www.mozilla.org/MPL/>
-| `:ofl`           | `:oss`           | SIL Open Font License                           | <http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL>
-| `:public_domain` | `:oss`           | not copyrighted                                 | <http://creativecommons.org/publicdomain/zero/1.0/legalcode>
-| `:ubuntu_font`   | `:oss`           | Ubuntu Font License                             | <http://font.ubuntu.com/licence/>
-| `:x11`           | `:oss`           | X Consortium License                            | <http://www.xfree86.org/3.3.6/COPYRIGHT2.html>
+| symbol           | generic category | meaning                                                            | URL         |
+| ---------------- | ---------------- | ------------------------------------------------------------------ | ----------- |
+| `:gratis`        | `:closed`        | free-to-use, closed source                                         | <none>
+| `:commercial`    | `:closed`        | not free to use                                                    | <none>
+| `:freemium`      | `:closed`        | free-to-use, payment required for full or additional functionality | <http://en.wikipedia.org/wiki/Freemium>
+| `:affero`        | `:oss`           | Affero General Public License                                      | <https://gnu.org/licenses/agpl.html>
+| `:apache`        | `:oss`           | Apache Public License                                              | <http://www.apache.org/licenses/>
+| `:arphic`        | `:oss`           | Arphic Public License                                              | <http://www.arphic.com/tw/download/public_license.rar>
+| `:artistic`      | `:oss`           | Artistic License                                                   | <http://dev.perl.org/licenses/artistic.html>
+| `:bsd`           | `:oss`           | BSD License                                                        | <http://www.linfo.org/bsdlicense.html>
+| `:cc`            | `:oss`           | Creative Commons License                                           | <http://creativecommons.org/licenses/>
+| `:eclipse`       | `:oss`           | Eclipse Public License                                             | <https://www.eclipse.org/legal/eplfaq.php>
+| `:gpl`           | `:oss`           | GNU Public License                                                 | <http://www.gnu.org/copyleft/gpl.html>
+| `:isc`           | `:oss`           | Internet Systems Consortium License                                | <http://www.isc.org/downloads/software-support-policy/isc-license/>
+| `:lppl`          | `:oss`           | LaTeX Project Public License                                       | <http://latex-project.org/lppl/>
+| `:ncsa`          | `:oss`           | University of Illinois/NCSA Open Source License                    | <http://otm.illinois.edu/uiuc_openSource>
+| `:mit`           | `:oss`           | MIT License                                                        | <http://opensource.org/licenses/MIT>
+| `:mpl`           | `:oss`           | Mozilla Public License                                             | <https://www.mozilla.org/MPL/>
+| `:ofl`           | `:oss`           | SIL Open Font License                                              | <http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL>
+| `:public_domain` | `:oss`           | not copyrighted                                                    | <http://creativecommons.org/publicdomain/zero/1.0/legalcode>
+| `:ubuntu_font`   | `:oss`           | Ubuntu Font License                                                | <http://font.ubuntu.com/licence/>
+| `:x11`           | `:oss`           | X Consortium License                                               | <http://www.xfree86.org/3.3.6/COPYRIGHT2.html>
 
 
 ## Tags Stanza Details

--- a/lib/cask/dsl/license.rb
+++ b/lib/cask/dsl/license.rb
@@ -12,7 +12,7 @@ class Cask::DSL::License
                     :commercial    => :closed,
                     :gratis        => :closed,
                     :abandoned     => :closed,  # undocumented, should not be used yet
-                    :freemium      => :closed,  # undocumented, should not be used yet
+                    :freemium      => :closed,
                     :trial         => :closed,  # undocumented, should not be used yet
 
                     :oss           => :oss,


### PR DESCRIPTION
This is styled as a PR, but intended for discussion.

Some of our previous license discussions have been too broad; it is hard to figure out four things at once.  Let's approach one point here:  is `:freemium` useful?
- does it cover many Casks?
- can it be clearly and objectively defined?

If yes, we can document it, as it [already exists](https://github.com/caskroom/homebrew-cask/blob/2db68b6bfa7c380db4c9ac5883bafc408c561195/lib/cask/dsl/license.rb#L15).  If no, we should delete it from the code.

As a point of discussion, there is a lengthy Wikipedia page defining [Freemium](http://en.wikipedia.org/wiki/Freemium), which might be considered in favor or against.  It does mean that the term is commonly used.  On the other hand, we are not like Wikipedia.  Their [detailed breakdown of   software distribution models](http://en.wikipedia.org/wiki/Software_distribution#References) is exactly the sort of tarpit we don't want to step into.

(Incidentally `license :freemium` is a special case in that we wouldn't need to do extra bookkeeping and define it into DSL 1.1.  Because it already exists as an undocumented form, it won't break code that assumes DSL 1.0.)

Refs #6426, #7917, #7923, #5586
cc @Amorymeltzer, @vitorgalvao, @ndr-qef 
