### PR TITLE
disable RSpec test which writes outside test directories

### DIFF
--- a/spec/cask/cli_spec.rb
+++ b/spec/cask/cli_spec.rb
@@ -31,14 +31,16 @@ describe Cask::CLI do
       end
     end
 
-    it "respects the ENV variable when choosing a non-default Caskroom location" do
-      with_env_var 'HOMEBREW_CASK_OPTS', "--caskroom=/custom/caskdir" do
-        allow(Cask).to receive(:init) {
-          expect(Cask.caskroom.to_s).to eq('/custom/caskdir')
-        }
-        Cask::CLI.process('noop')
-      end
-    end
+    # todo: merely invoking init causes an attempt to create the caskroom directory
+    #
+    # it "respects the ENV variable when choosing a non-default Caskroom location" do
+    #   with_env_var 'HOMEBREW_CASK_OPTS', "--caskroom=/custom/caskdir" do
+    #     allow(Cask).to receive(:init) {
+    #       expect(Cask.caskroom.to_s).to eq('/custom/caskdir')
+    #     }
+    #     Cask::CLI.process('noop')
+    #   end
+    # end
 
     it "exits with a status of 1 when something goes wrong" do
       Cask::CLI.expects(:exit).with(1)


### PR DESCRIPTION
invoking `Cask.init` attempts to actually `mkdir /custom/caskdir`

Per https://github.com/caskroom/homebrew-cask/blob/2db68b6bfa7c380db4c9ac5883bafc408c561195/lib/cask.rb#L57

which is really a bug in `Cask.init`.

cc @radeksimko 
