### PR TITLE
generate_cask_token Ruby 2.0 shebang line

### DIFF
--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -1,10 +1,14 @@
-#!/usr/bin/env ruby
+#!/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby
 #
 # generate_cask_token
 #
 # todo:
 #
+# remove Ruby 2.0 dependency and change shebang line
+#
 # detect Cask files which differ only by the placement of hyphens.
+#
+# merge entirely into "brew cask create" command
 #
 
 ###


### PR DESCRIPTION
It was just carelessness that this script was written in a way limited to Ruby 2.0, but we may as well be explicit about that pending a fix.

closes #8021
