### PR TITLE
Upgrade Wireshark to v1.12.2

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'wireshark' do
-  version '1.12.1'
-  sha256 '3ce749efbcf89dd72b4e1c2336f4edd7111e05ce9cad8da2df189ac4e56fa1b7'
+  version '1.12.2'
+  sha256 '39a94d55dfa3b27ea9a672df12d98509150bf022da2e581817374274215a0f9a'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   homepage 'http://www.wireshark.org'


### PR DESCRIPTION
Just noticed that wireshark wasn't downloading on cask 'cause they bumped the version number. Not sure if someone has submitted already but didn't see it with a quick search so... here's a pull request... The sha256 was calculated locally after downloading on my computer -- not sure if that fits security protocol or not.

Release notes: https://www.wireshark.org/docs/relnotes/wireshark-1.12.2.html
