### PR TITLE
Update PhpStorm to 8.0.2

### DIFF
--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'phpstorm' do
-  version '8.0.1'
-  sha256 'ff8af437d96befd475744e08b1d663df778db8711e2671551fc797cd30b0cdc7'
+  version '8.0.2'
+  sha256 'd6c6ee8c84edcdbd7da7c8af33185ecb7a1d9ddb4e5d97b035c9a30d07c8d073'
 
   url "http://download.jetbrains.com/webide/PhpStorm-#{version}.dmg"
   homepage 'http://www.jetbrains.com/phpstorm/'


### PR DESCRIPTION
PhpStorm 8.0.2 released.
http://blog.jetbrains.com/phpstorm/2014/12/phpstorm-8-0-2-bug-fix-update-is-available/
