### PR TITLE
Add CodeRunner at latest version

### DIFF
--- a/Casks/coderunner.rb
+++ b/Casks/coderunner.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'coderunner' do
+  version :latest
+  sha256 :no_check
+
+  url "https://coderunnerapp.com/download"
+  name 'CodeRunner'
+  homepage 'https://coderunnerapp.com/'
+  license :unknown
+
+  app 'CodeRunner.app'
+end


### PR DESCRIPTION
I've set up this new cask to use the :latest as the main download
URL will redirect to the appropriately versioned file. If it is
preferable to use an explicit version I can change it to do so.
