### PR TITLE
vagrant: update to version 1.7.1

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vagrant' do
-  version '1.7.0'
-  sha256 '1b228d79066938f879335ddb4dce69eb8954e7337a117104004854dc39c135b0'
+  version '1.7.1'
+  sha256 'eaeb3ad6624ccaeaefa6fc7a77a2f5d9640ef9385c5eeebdb90602d5f2011176'
 
   url "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{version}.dmg"
   homepage 'http://www.vagrantup.com'


### PR DESCRIPTION
Nothing changed in the cask but the version number and hash.
