### PR TITLE
Suggest `brew update && …` when handling errors or missing methods

### DIFF
--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -29,8 +29,6 @@ require 'cask/cli/internal_stanza'
 
 class Cask::CLI
 
-  ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
-
   ALIASES = {
              'ls'             => 'list',
              'homepage'       => 'home',
@@ -125,8 +123,7 @@ class Cask::CLI
     exit 1
   rescue StandardError, ScriptError, NoMemoryError => e
     onoe e
-    puts "#{Tty.white}Please report this bug:"
-    puts "    #{Tty.em}#{ISSUES_URL}#{Tty.reset}"
+    puts Cask::Utils.error_message_with_suggestions
     puts e.backtrace
     exit 1
   end


### PR DESCRIPTION
As @ndr-qef and @rolandwalker suggested on IRC.

This is supposed to help cut trivial issues that would be easily fixable by doing `brew update && …` etc.
Also, splitting unit tests in two to keep one from triggering the other.
