### PR TITLE
Use :freemium license symbol for sixtyforce, daisydisk, iexplorer

### DIFF
--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -12,7 +12,7 @@ cask :v1 => 'daisydisk' do
 
   appcast 'http://www.daisydiskapp.com/downloads/appcastFeed.php'
   homepage 'http://www.daisydiskapp.com'
-  license :closed
+  license :freemium
 
   app 'DaisyDisk.app'
 

--- a/Casks/iexplorer.rb
+++ b/Casks/iexplorer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'iexplorer' do
   appcast 'http://www.macroplant.com/iexplorer/ie3-appcast.xml',
           :sha256 => '50a537b61eec96833d145abfe25affc972579f4e01cf3876aa6596ba5320db26'
   homepage 'http://www.macroplant.com/iexplorer/'
-  license :closed
+  license :freemium
 
   app 'iExplorer.app'
 end

--- a/Casks/sixtyforce.rb
+++ b/Casks/sixtyforce.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sixtyforce' do
 
   url 'http://sixtyforce.com/download/sixtyforce.zip'
   homepage 'http://sixtyforce.com/'
-  license :closed
+  license :freemium
 
   app 'sixtyforce.app'
 end


### PR DESCRIPTION
These three were changed recently by me in #7999, stylized as `:closed` before #8017 and `:freemium` kicked in; just tidying up after myself.
