### PR TITLE
Update OmniFocus to use versioned downloads

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -1,16 +1,30 @@
 cask :v1 => 'omnifocus' do
-  version :latest
-  sha256 :no_check
+  if MacOS.release <= :mountain_lion
+    version '1.10.6'
+    sha256 'bd3aa44dced86fc3921c01f4467422a7b87a92afbd4be642ea4d4bb8b14b728c'
+    url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.6/OmniFocus-#{version}.dmg"
 
-  url 'http://www.omnigroup.com/download/latest/omnifocus'
-  homepage 'http://www.omnigroup.com/products/omnifocus/'
+    zap :delete => [
+      '~/Library/Application Support/OmniFocus/Plug-Ins',
+      '~/Library/Application Support/OmniFocus/Themes',
+      '~/Library/Preferences/com.omnigroup.OmniFocus.plist'
+    ]
+  else
+    version '2.0.4'
+    sha256 'c5667f950147cbc33387ab45267b15666eef558391aeaf8d6df543a65edaa799'
+    url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.9/OmniFocus-#{version}.dmg"
+
+    zap :delete => [
+      '~/Library/containers/com.omnigroup.omnifocus2',
+      '~/Library/Preferences/com.omnigroup.OmniFocus2.LSSharedFileList.plist',
+      '~/Library/Preferences/com.omnigroup.OmniSoftwareUpdate.plist',
+      '~/Library/Caches/Metadata/com.omnigroup.OmniFocus2'
+    ]
+  end
+
+  name 'OmniFocus'
+  homepage 'https://www.omnigroup.com/omnifocus/'
   license :commercial
 
   app 'OmniFocus.app'
-
-  zap :delete => [
-                  '~/Library/Application Support/OmniFocus/Plug-Ins',
-                  '~/Library/Application Support/OmniFocus/Themes',
-                  '~/Library/Preferences/com.omnigroup.OmniFocus.plist',
-                 ]
 end

--- a/lib/cask/cli.rb
+++ b/lib/cask/cli.rb
@@ -29,8 +29,6 @@ require 'cask/cli/internal_stanza'
 
 class Cask::CLI
 
-  ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
-
   ALIASES = {
              'ls'             => 'list',
              'homepage'       => 'home',
@@ -125,8 +123,7 @@ class Cask::CLI
     exit 1
   rescue StandardError, ScriptError, NoMemoryError => e
     onoe e
-    puts "#{Tty.white}Please report this bug:"
-    puts "    #{Tty.em}#{ISSUES_URL}#{Tty.reset}"
+    puts Cask::Utils.error_message_with_suggestions
     puts e.backtrace
     exit 1
   end


### PR DESCRIPTION
Update OmniFocus Cask to use versioned downloads, and add support for older versions.
