### PR TITLE
document `license :trial`

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -367,6 +367,7 @@ open source.  Chromium licensing is described by the generic category [`:oss`](h
 | `:gratis`        | `:closed`        | free-to-use, closed source                                         | <none>
 | `:commercial`    | `:closed`        | not free to use                                                    | <none>
 | `:freemium`      | `:closed`        | free-to-use, payment required for full or additional functionality | <http://en.wikipedia.org/wiki/Freemium>
+| `:trial`         | `:closed`        | free to use for a limited time                                     | <none>
 | `:affero`        | `:oss`           | Affero General Public License                                      | <https://gnu.org/licenses/agpl.html>
 | `:apache`        | `:oss`           | Apache Public License                                              | <http://www.apache.org/licenses/>
 | `:arphic`        | `:oss`           | Arphic Public License                                              | <http://www.arphic.com/tw/download/public_license.rar>

--- a/lib/cask/dsl/license.rb
+++ b/lib/cask/dsl/license.rb
@@ -13,7 +13,7 @@ class Cask::DSL::License
                     :gratis        => :closed,
                     :abandoned     => :closed,  # undocumented, should not be used yet
                     :freemium      => :closed,
-                    :trial         => :closed,  # undocumented, should not be used yet
+                    :trial         => :closed,
 
                     :oss           => :oss,
                     :affero        => :oss,


### PR DESCRIPTION
This is styled as a PR, but intended for discussion.

Is `license :trial` useful?
- does it cover many Casks?
- can it be clearly and objectively defined?
- if clearly defined, is it also fully distinct from `:freemium`

If yes, we can document it, as it [already exists](https://github.com/caskroom/homebrew-cask/blob/d4f52efd11eee8e7be68220998ca56d29b5cc092/lib/cask/dsl/license.rb#L16).  If no, we should delete it from the code.

There is a third possible answer, that the name `:trial` was badly chosen, and that something else like `:limited` would be useful.  `:trial` could be considered part of DSL 1.0, as the forward-compatibility code is already present.  `:limited` or some other substitute would have to wait.

In any case, my priority is to maximize discussion here, and minimize decision-making per-Cask.

Refs #8017, #6426, #7917, #7923, #5586
cc @Amorymeltzer, @vitorgalvao, @ndr-qef 
