### PR TITLE
merge version `utorrent-ppc.rb` into `utorrent.rb`

### DIFF
--- a/Casks/utorrent.rb
+++ b/Casks/utorrent.rb
@@ -2,10 +2,17 @@ cask :v1 => 'utorrent' do
   version :latest
   sha256 :no_check
 
-  url 'http://download-new.utorrent.com/endpoint/utmac/os/osx/track/stable/'
-  appcast 'http://update.utorrent.com/checkupdate.php'
-  homepage 'http://www.utorrent.com/'
-  license :unknown    # todo: improve this machine-generated value
+  if Hardware::CPU.type == :ppc
+    url 'http://download-new.utorrent.com/endpoint/utmac/os/osx-ppc/track/stable/'
+    app 'uTorrent.app'
+  else
+    url 'http://download-new.utorrent.com/endpoint/utmac/os/osx/track/stable/'
+    appcast 'http://update.utorrent.com/checkupdate.php'
+    installer :manual => 'uTorrent-Installer.app'
+  end
 
-  installer :manual => 'uTorrent-Installer.app'
+  homepage 'http://www.utorrent.com/'
+  license :freemium
+
+  zap :delete => '~/Library/Application Support/uTorrent'
 end


### PR DESCRIPTION
and update license.

Intention: to delete `utorrent-ppc.rb` from versions.

I was surprised to find any PPC-requiring Casks at all.  However, this is a good example of why merging is better, as the PPC Cask had acquired a `zap` stanza which was missing in the main Cask.

@vitorgalvao since Rosetta was discontinued in Lion, the to-be-deleted versions Cask in practice required <= Snow Leopard.
