### PR TITLE
document `license :abandoned`

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -367,6 +367,7 @@ open source.  Chromium licensing is described by the generic category [`:oss`](h
 | `:gratis`        | `:closed`        | free-to-use, closed source                                         | <none>
 | `:commercial`    | `:closed`        | not free to use                                                    | <none>
 | `:freemium`      | `:closed`        | free-to-use, payment required for full or additional functionality | <http://en.wikipedia.org/wiki/Freemium>
+| `:abandoned`     | `:closed`        | formerly commercial; vendor no longer accepts payment              | <none>
 | `:affero`        | `:oss`           | Affero General Public License                                      | <https://gnu.org/licenses/agpl.html>
 | `:apache`        | `:oss`           | Apache Public License                                              | <http://www.apache.org/licenses/>
 | `:arphic`        | `:oss`           | Arphic Public License                                              | <http://www.arphic.com/tw/download/public_license.rar>

--- a/lib/cask/dsl/license.rb
+++ b/lib/cask/dsl/license.rb
@@ -11,7 +11,7 @@ class Cask::DSL::License
                     :closed        => :closed,
                     :commercial    => :closed,
                     :gratis        => :closed,
-                    :abandoned     => :closed,  # undocumented, should not be used yet
+                    :abandoned     => :closed,
                     :freemium      => :closed,
                     :trial         => :closed,  # undocumented, should not be used yet
 


### PR DESCRIPTION
This is styled as a PR, but intended for discussion.

Is `license :abandoned` useful?
- does it cover many Casks?
- can it be clearly and objectively defined?

If yes, we can document it, as it [already exists](https://github.com/caskroom/homebrew-cask/blob/d4f52efd11eee8e7be68220998ca56d29b5cc092/lib/cask/dsl/license.rb#L14).  If no, we should delete it from the code.

The particular software I had in mind when adding this key was the font [Code2000](http://en.wikipedia.org/wiki/Code2000), and some related distributions by the same author.  They were and are quite popular, originally distributed as shareware and betas.  The author vanished completely.  The Code2000 binary is currently distributed by the FreeBSD project.

The relevant Casks are listed as [`:unknown`](https://github.com/caskroom/homebrew-fonts/blob/ed9fe45179124c82cc580058f781abfc64a6c4da/Casks/font-code2000.rb#L7) since this question is pending.  I suppose, if `:abandoned` is rejected, these should be set to `:closed` (the most-specific license everyone can agree is true).

Refs #8084, #8017, #6426, #7917, #7923, #5586
cc @Amorymeltzer, @vitorgalvao, @ndr-qef 
