### PR TITLE
Make Rake test options consistent and documented

### DIFF
--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -172,6 +172,18 @@ If you're making changes - please write some tests for them! Also be sure to
 run the whole test suite using `rake test` before submitting (if you forget,
 Travis-CI will do that for you and embarrass you in front of all your friends). :)
 
+You may also use a set of environment variables to increase verbosity:
+
+ - `TESTOPTS`, `TEST` etc. for the old [minitest suites](http://www.ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/TestTask.html)
+ - `SPEC_OPTS`, `SPEC` etc. for [rspec suites](http://apidock.com/rspec/Spec/Rake/SpecTask)
+ - `VERBOSE_TESTS` to see the standard output from the actual code = ignore the `shutup` helper
+
+Example of a very verbose output:
+
+```shell
+TESTOPTS='-v' SPEC_OPTS='-fd' VERBOSE_TESTS=1 rake test
+```
+
 #### External Commands
 
 Advanced users may create their own external commands for homebrew-cask by

--- a/spec/support/shutup_helper.rb
+++ b/spec/support/shutup_helper.rb
@@ -1,6 +1,6 @@
 module ShutupHelper
   def shutup
-    if ARGV.verbose?
+    if ENV.has_key?('VERBOSE_TESTS')
       yield
     else
       begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,7 @@ require 'test/testing_env'
 
 # todo temporary, copied from old Homebrew, this method is now moved inside a class
 def shutup
-  if ARGV.verbose?
+  if ENV.has_key?('VERBOSE_TESTS')
     yield
   else
     begin


### PR DESCRIPTION
This fixes #8024 

It should be now much more obvious how to control verbosity and other options for both testing frameworks we use and and how to turn off the `shutup` helper.

I believe, that our own options should be separated from the framework variables which is why I'm introducing new one - `VERBOSE_TESTS`. I'm open for discussion about different name for this one.
