### PR TITLE
Add explicit conversion Pathname -> String

### DIFF
--- a/lib/cask.rb
+++ b/lib/cask.rb
@@ -67,7 +67,7 @@ class Cask
         # sudo in system is rude.
         system '/usr/bin/sudo', '--', '/bin/mkdir', '-p', '--', caskroom
         unless caskroom.parent == toplevel_dir
-          system '/usr/bin/sudo', '--', '/usr/sbin/chown', '-R', '--', "#{current_user}:staff", caskroom.parent
+          system '/usr/bin/sudo', '--', '/usr/sbin/chown', '-R', '--', "#{current_user}:staff", caskroom.parent.to_s
         end
       end
     end


### PR DESCRIPTION
This is related to https://github.com/caskroom/homebrew-cask/pull/8022 and some of our rspec tests (after adding fakefs bootstrap) will fail while calling this code because it relies on automatic conversion from object to String (via `to_str`).

I first thought I'm gonna send a PR to fakefs to implement the `to_str` method, but after doing a quick search I rather decided to do explicit conversion here and here's why:
https://www.ruby-forum.com/topic/4405700

I'm actually surprised that the tests are still green on Ruby 2.0.0+.

I was also thinking that we could add it elsewhere where we work with Pathname as String, but this is currently the one place which is heavily covered with tests and which bothers me most + I want to see your feedback on suggested approach first.

Feel free to run the tests with fakefs to see the failures:
https://github.com/radeksimko/homebrew-cask/commit/fe1095b5c81992aaa1e6c39a6afb0931d1191b30

It is only problem when ignoring the `shutup` helper, so you will need to use the environment variable from here:
https://github.com/caskroom/homebrew-cask/pull/8101
