### PR TITLE
remove docs and code relevant to Ruby 1.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: objective-c
 # test with Ruby 2.1, but allow failure
 #
 
-# "Current" is dependent on OS release.  At the time of writing, it is always
-# either 1.8 or 2.0
+# "Current" is dependent on OS X release.  At the time of writing, it
+# is always either 1.8 or 2.0
 env:
   matrix:
     - CASK_RUBY_TEST_VERSION="2.0"

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -142,17 +142,8 @@ This form can also be combined with a specific Ruby interpreter as above.
 
 ### Target Ruby Versions
 
-Homebrew-cask is `require`d from within the Ruby environment of the parent
-Homebrew command (`brew`).
-
-Therefore, Homebrew-cask uses whichever Ruby interpreter chosen by Homebrew.
-This is generally an Apple-supplied Ruby, though it may change according to
-OS version.  At the time of writing, Homebrew targets Ruby 2.0 on OS X
-Mavericks (10.9) and Yosemite (10.10), and Ruby 1.8.7 on older OS revisions.
-
-So, our code must currently maintain compatibility across Ruby 1.8.7 and
-2.0.  The automated testing provided by Travis-CI will ensure that any pull
-request will be tested under both versions.
+Homebrew-cask requires a Ruby interpreter version 2.0 or above.  This
+is the default system Ruby on Mavericks (10.9) and Yosemite (10.10).
 
 ### Submitting Your Changes
 

--- a/lib/cask/cli/alfred.rb
+++ b/lib/cask/cli/alfred.rb
@@ -59,8 +59,7 @@ class Cask::CLI::Alfred < Cask::CLI::Base
       opoo "Alfred appears to be already linked. Updating defaults anyway."
     end
     odebug 'Linking Alfred scopes'
-    # this silly ternary operation is for precise compat with Ruby 1.8
-    save_alfred_scopes( alfred_scopes.include?(Cask.caskroom.to_s) ? alfred_scopes : alfred_scopes + [ Cask.caskroom.to_s ])
+    save_alfred_scopes(linked? ? alfred_scopes : alfred_scopes + [ Cask.caskroom.to_s ])
     ohai "Successfully linked Alfred to homebrew-cask."
   end
 

--- a/lib/cask/dsl.rb
+++ b/lib/cask/dsl.rb
@@ -68,7 +68,6 @@ module Cask::DSL
     def full_name(_full_name=nil)
       @full_name ||= []
       if _full_name
-        # todo this idiom may be preferred to << if it behaves the same on Ruby 1.8 and 2.x
         @full_name.concat(Array(*_full_name))
       end
       @full_name

--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -27,8 +27,7 @@ class Cask::SystemCommand
     raw_stdout.close_read
     raw_stderr.close_read
 
-    # Ruby 1.8 sets $?. Ruby 1.9+ has raw_wait_thr, and does not set $?.
-    processed_status = raw_wait_thr.nil? ? $? : raw_wait_thr.value
+    processed_status = raw_wait_thr.value
 
     _assert_success(processed_status, command, processed_stdout) if options[:must_succeed]
 

--- a/spec/cask/scopes_spec.rb
+++ b/spec/cask/scopes_spec.rb
@@ -19,7 +19,7 @@ describe Cask::Scopes do
 
       expect(Cask).to have_received(:load).with('cask-bar')
       expect(Cask).to have_received(:load).with('cask-foo')
-      expect(installed_casks.sort).to eq(%w[
+      expect(installed_casks).to eq(%w[
         loaded-cask-bar
         loaded-cask-foo
       ])

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -100,11 +100,10 @@ describe Cask::DSL do
         name 'Alternate Name'
       end
       instance = MultiNameCask.new
-      # the sort is a hack to deal with Ruby 1.8 oddities
-      instance.full_name.sort.must_equal [
-                                          'Proper Name',
-                                          'Alternate Name',
-                                         ].sort
+      instance.full_name.must_equal [
+                                     'Proper Name',
+                                     'Alternate Name',
+                                    ]
     end
   end
 
@@ -130,7 +129,7 @@ describe Cask::DSL do
       end
 
       instance = CaskWithApps.new
-      Array(instance.artifacts[:app]).sort.must_equal [['Bar.app'], ['Foo.app']]
+      Array(instance.artifacts[:app]).must_equal [['Foo.app'], ['Bar.app']]
     end
 
     it "allow app stanzas to be empty" do
@@ -172,7 +171,7 @@ describe Cask::DSL do
       end
 
       instance = CaskWithPkgs.new
-      Array(instance.artifacts[:pkg]).sort.must_equal [['Bar.pkg'], ['Foo.pkg']]
+      Array(instance.artifacts[:pkg]).must_equal [['Foo.pkg'], ['Bar.pkg']]
     end
   end
 
@@ -388,11 +387,10 @@ describe Cask::DSL do
   describe "installer stanza" do
     it "allows installer :script to be specified" do
       cask = Cask.load('with-installer-script')
-      # the sorts are needed to force the order for Ruby 1.8
-      cask.artifacts[:installer].sort{ |a,b| a.script[:executable] <=> b.script[:executable] }.first.script[:executable].must_equal '/usr/bin/false'
-      cask.artifacts[:installer].sort{ |a,b| a.script[:executable] <=> b.script[:executable] }.first.script[:args].must_equal ['--flag']
-      cask.artifacts[:installer].sort{ |a,b| a.script[:executable] <=> b.script[:executable] }.to_a[1].script[:executable].must_equal '/usr/bin/true'
-      cask.artifacts[:installer].sort{ |a,b| a.script[:executable] <=> b.script[:executable] }.to_a[1].script[:args].must_equal ['--flag']
+      cask.artifacts[:installer].first.script[:executable].must_equal '/usr/bin/true'
+      cask.artifacts[:installer].first.script[:args].must_equal ['--flag']
+      cask.artifacts[:installer].to_a[1].script[:executable].must_equal '/usr/bin/false'
+      cask.artifacts[:installer].to_a[1].script[:args].must_equal ['--flag']
     end
     it "allows installer :manual to be specified" do
       cask = Cask.load('with-installer-manual')

--- a/test/cask/system_command_test.rb
+++ b/test/cask/system_command_test.rb
@@ -22,11 +22,6 @@ describe Cask::SystemCommand do
   end
 
   describe "when the exit code is 1" do
-    before do
-      # See: https://bugs.ruby-lang.org/issues/1287
-      skip("Ruby 1.8.7 doesn't see exit statuses") if TestHelper.ruby18?
-    end
-
     describe "and the command must succeed" do
       it "throws an error" do
         lambda {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -109,10 +109,6 @@ class TestHelper
       end
     end
   end
-
-  def self.ruby18?
-    RUBY_VERSION.match(%r{^1\.8})
-  end
 end
 
 require 'support/fake_fetcher'


### PR DESCRIPTION
We now require Ruby 2.0+.

refs: #8089
