### PR TITLE
Remove encoding cookies from 13 Casks

### DIFF
--- a/Casks/aliedit.rb
+++ b/Casks/aliedit.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'aliedit' do
   version :latest
   sha256 :no_check

--- a/Casks/baiducloud.rb
+++ b/Casks/baiducloud.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'baiducloud' do
   version '2.4.3'
   sha256 'f8e1f5afa3e1cbdac4d3d859f2f8da41093e37afbb51959ab6ee6b2dc91fc069'

--- a/Casks/baiduinput.rb
+++ b/Casks/baiduinput.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'baiduinput' do
   version '3.3_1000e'
   sha256 '7fbfd7270ce5c8d3a7e801ce67b4e858089299ef3ba96b3c0feb110d87da24e2'

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'intel-power-gadget' do
   version '3.0.1'
   sha256 '538a792721604e2155b3a48caa4084db751a91b170e5fa62bf0331d3147f2239'

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'neteasemusic' do
   version :latest
   sha256 :no_check

--- a/Casks/powerword.rb
+++ b/Casks/powerword.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'powerword' do
   version '1.0.0'
   sha256 '8bee28fa52bc967f91f6700d9642e00fc5e275cc41e0c15e5bf288fcac537c07'

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'qiyimedia' do
   version '3.1.14'
   sha256 'bab6c18060eabb2ae3326c562de6e33041ab6a0476817ae7fc1f39d2265734b5'

--- a/Casks/qqinput.rb
+++ b/Casks/qqinput.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'qqinput' do
   version '2.8.86.400'
   sha256 '5b90cf604230013d5afa974b5b4835c0d6faf55da932cebce4f72478b5665a4d'

--- a/Casks/qqmusic.rb
+++ b/Casks/qqmusic.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'qqmusic' do
   version '1.3.0'
   sha256 '2f1198f9b3e1407822a771fcdfdd643b65f35f6b51cc0af8c6b11fa11fc30a0d'

--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'sogouinput' do
   version '3.0.2.59116'
   sha256 '51df347ed60ea13bb39dd89ec5fc9eb6cd549f0080d9f94d97a7e0502b0edb0c'

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'tuneinstructor' do
   version '3.4'
 

--- a/Casks/xee.rb
+++ b/Casks/xee.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'xee' do
   version '3.4'
   sha256 'e9d47feb6fd1365333958e04372bbc02d3bc098ba7a14695a0c91957dfb1fb99'

--- a/Casks/youdao.rb
+++ b/Casks/youdao.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'youdao' do
   version :latest
   sha256 :no_check


### PR DESCRIPTION
These UTF-8 encoding cookies were intended to help Ruby 1.9, and should not have had an effect for users running Ruby 2.0.  We no longer need them.

Since #8089 (requiring Ruby 2.0) was only just merged, we should HOLD until 15 Jan.

Sorry if this long-term PR is considered clutter.
