### PR TITLE
remove Homebrew internal method in `Cask::CLI::Update`

### DIFF
--- a/lib/cask/cli/update.rb
+++ b/lib/cask/cli/update.rb
@@ -1,8 +1,13 @@
 class Cask::CLI::Update < Cask::CLI::Base
   def self.run(*_ignored)
-    ARGV.clear
-    require HOMEBREW_REPOSITORY.join("Library/Homebrew/cmd/update")
-    Homebrew::update
+    result = Cask::SystemCommand.run(HOMEBREW_BREW_FILE,
+                                     :args => %w{update})
+    # todo: separating stderr/stdout is undesirable here.
+    # Cask::SystemCommand should have an option for plain
+    # unbuffered output.
+            print result.stdout
+    $stderr.print result.stderr
+    exit result.exit_status
   end
 
   def self.help


### PR DESCRIPTION
Invoke the `brew` command instead.

fixes #8153
