### PR TITLE
Update homepages for spotdox and folx

### DIFF
--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -4,7 +4,7 @@ cask :v1 => 'folx' do
 
   url 'http://mac.eltima.com/download/downloader_mac.dmg'
   appcast 'http://mac.eltima.com/download/folx-update/folx3.xml'
-  homepage 'http://mac.eltima.com/de/download-manager.html'
+  homepage 'http://mac.eltima.com/download-manager.html'
   license :unknown    # todo: improve this machine-generated value
 
   app 'Folx 3.app'

--- a/Casks/spotdox.rb
+++ b/Casks/spotdox.rb
@@ -4,7 +4,7 @@ cask :v1 => 'spotdox' do
 
   url 'https://spotdox.herokuapp.com/downloads/Spotdox.zip'
   appcast 'https://spotdox.herokuapp.com/downloads/appcast.xml'
-  homepage 'http://spotdox.com/get-started/'
+  homepage 'http://spotdox.com/'
   license :unknown    # todo: improve this machine-generated value
 
   app 'Spotdox.app'


### PR DESCRIPTION
`spotdox` - Use the homepage https://spotdox.com/ instead of the infopage http://spotdox.com/get-started/

`folx` - Use English instead of German
