### PR TITLE
Update licenses for 53 casks

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -6,7 +6,7 @@ cask :v1 => 'carbon-copy-cloner' do
   appcast 'http://www.bombich.com/software/updates/ccc.php',
           :sha256 => 'ec02ebdd3e4bee0527d46e8256372249780fb1a4fb93ddb782e9da87787bbdff'
   homepage 'http://bombich.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Carbon Copy Cloner.app'
 end

--- a/Casks/chocolat.rb
+++ b/Casks/chocolat.rb
@@ -5,7 +5,7 @@ cask :v1 => 'chocolat' do
   url 'https://chocolatapp.com/download'
   appcast 'http://chocolatapp.com/userspace/appcast/appcast_alpha.php'
   homepage 'http://chocolatapp.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Chocolat.app'
 end

--- a/Casks/cloudpull.rb
+++ b/Casks/cloudpull.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cloudpull' do
   url 'http://downloads.goldenhillsoftware.com/cloudpull/CloudPull.zip'
   appcast 'https://secure.goldenhillsoftware.com/updates/cloudpull/appcast.xml'
   homepage 'http://www.goldenhillsoftware.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :freemium
 
   app 'CloudPull.app'
 end

--- a/Casks/colorpicker-skalacolor.rb
+++ b/Casks/colorpicker-skalacolor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'colorpicker-skalacolor' do
 
   url 'http://download.bjango.com/skalacolor/'
   homepage 'http://bjango.com/mac/skalacolor/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   colorpicker 'Skala Color Installer.app/Contents/Resources/SkalaColor.colorPicker'
 end

--- a/Casks/curb.rb
+++ b/Casks/curb.rb
@@ -6,7 +6,7 @@ cask :v1 => 'curb' do
   appcast 'http://www.mrrsoftware.com/Downloads/Curb/CurbSoftwareUpdates.xml',
           :sha256 => '2025c4fc40a80f7ca7fb4076deb357a133990ef0e9576ceb5a5dca5f03a7c500'
   homepage 'http://mrrsoftware.com/curb'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Curb.app'
 end

--- a/Casks/dragthing.rb
+++ b/Casks/dragthing.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dragthing' do
 
   url "https://s3.amazonaws.com/tlasystems/DragThing-#{version}.dmg"
   homepage 'http://www.dragthing.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :freemium
 
   app 'DragThing.app'
 end

--- a/Casks/elyse.rb
+++ b/Casks/elyse.rb
@@ -4,7 +4,7 @@ cask :v1 => 'elyse' do
 
   url "http://silkwoodsoftware.com/Elyse-#{version.gsub('.','')}.dmg"
   homepage 'http://silkwoodsoftware.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :freemium
 
   app 'Elyse.app'
 end

--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -5,7 +5,7 @@ cask :v1 => 'flux' do
   url 'https://justgetflux.com/mac/Flux.zip'
   appcast 'https://justgetflux.com/mac/macflux.xml'
   homepage 'http://justgetflux.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Flux.app'
 

--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -5,7 +5,7 @@ cask :v1 => 'folx' do
   url 'http://mac.eltima.com/download/downloader_mac.dmg'
   appcast 'http://mac.eltima.com/download/folx-update/folx3.xml'
   homepage 'http://mac.eltima.com/download-manager.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :freemium
 
   app 'Folx 3.app'
 end

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -4,7 +4,7 @@ cask :v1 => 'google-chrome' do
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
   homepage 'https://www.google.com/chrome/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
   tags :vendor => 'Google'
 
   app 'Google Chrome.app'

--- a/Casks/iannix.rb
+++ b/Casks/iannix.rb
@@ -4,7 +4,7 @@ cask :v1 => 'iannix' do
 
   url "http://www.iannix.org/download/iannix_mac_64__#{version.gsub('.','_')}.dmg"
   homepage 'http://www.iannix.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'IanniX/IanniX.app'
 end

--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -4,7 +4,7 @@ cask :v1 => 'itsycal' do
 
   url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
   homepage 'http://www.mowglii.com/itsycal/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app "Itsycal.app"
 end

--- a/Casks/jiggler.rb
+++ b/Casks/jiggler.rb
@@ -4,7 +4,7 @@ cask :v1 => 'jiggler' do
 
   url 'http://downloads.sticksoftware.com/Jiggler.dmg'
   homepage 'http://www.sticksoftware.com/software/Jiggler.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Jiggler.app'
 end

--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -4,7 +4,7 @@ cask :v1 => 'kitematic' do
 
   url "https://github.com/kitematic/kitematic/releases/download/v#{version}/Kitematic-#{version}.zip"
   homepage 'https://kitematic.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :affero
 
   app 'Kitematic.app'
 end

--- a/Casks/kivy.rb
+++ b/Casks/kivy.rb
@@ -4,7 +4,7 @@ cask :v1 => 'kivy' do
 
   url "http://kivy.org/downloads/#{version}/Kivy-#{version}-osx.dmg"
   homepage 'http://kivy.org'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'Kivy.app'
 end

--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -6,7 +6,7 @@ cask :v1 => 'latexit' do
   appcast 'http://pierre.chachatelier.fr/latexit/downloads/latexit-sparkle-en.rss',
           :sha256 => 'bc1bd88bf1d7a9770f0527652db2fc082214240a9b66684d9a95a0beaf2f260a'
   homepage 'http://www.chachatelier.fr/latexit'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   app 'LaTeXiT.app'
 

--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -4,7 +4,7 @@ cask :v1 => 'lilypond' do
 
   url "http://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   homepage 'http://lilypond.org'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'LilyPond.app'
 end

--- a/Casks/makehuman.rb
+++ b/Casks/makehuman.rb
@@ -4,7 +4,7 @@ cask :v1 => 'makehuman' do
 
   url "http://download.tuxfamily.org/makehuman/releases/#{version}/makehuman-#{version}-osx.dmg"
   homepage 'http://www.makehuman.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :affero
 
   app 'MakeHuman.app'
 end

--- a/Casks/manopen.rb
+++ b/Casks/manopen.rb
@@ -4,7 +4,7 @@ cask :v1 => 'manopen' do
 
   url "http://www.clindberg.org/projects/ManOpen-#{version}.dmg"
   homepage 'http://www.clindberg.org/projects/ManOpen.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   app 'ManOpen.app'
   binary 'openman'

--- a/Casks/marsedit.rb
+++ b/Casks/marsedit.rb
@@ -6,7 +6,7 @@ cask :v1 => 'marsedit' do
   appcast 'http://www.red-sweater.com/marsedit/appcast3.php',
           :sha256 => '3f45ba546de497b40ef88b7e6bea2b057a3935e71b4768ba626ea282edcef744'
   homepage 'http://www.red-sweater.com/marsedit/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'MarsEdit.app'
 end

--- a/Casks/matplotlib.rb
+++ b/Casks/matplotlib.rb
@@ -4,7 +4,7 @@ cask :v1 => 'matplotlib' do
 
   url "http://www.kyngchaos.com/files/software/python/matplotlib-#{version}.dmg"
   homepage 'http://www.kyngchaos.com/software/python'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   pkg 'matplotlib.pkg'
 

--- a/Casks/mauve.rb
+++ b/Casks/mauve.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mauve' do
 
   url "http://gel.ahabs.wisc.edu/mauve/downloads/Mauve-#{version}.dmg"
   homepage 'http://gel.ahabs.wisc.edu/mauve/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Mauve.app'
 end

--- a/Casks/multifirefox.rb
+++ b/Casks/multifirefox.rb
@@ -5,7 +5,7 @@ cask :v1 => 'multifirefox' do
   url 'https://mff.s3.amazonaws.com/MFF2_latest.dmg'
   appcast 'https://s3.amazonaws.com/mff_sparkle/MultiFirefoxAppcast2.xml'
   homepage 'http://davemartorana.com/multifirefox'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'MultiFirefox.app'
 end

--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -6,7 +6,7 @@ cask :v1 => 'namechanger' do
   appcast 'http://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
           :sha256 => 'f8e9f7e32a1402b6a1be71963ee33e79c86244ba2f6ca1fcf52e644b1c235192'
   homepage 'http://www.mrrsoftware.com/MRRSoftware/NameChanger.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'NameChanger.app'
 end

--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -4,7 +4,7 @@ cask :v1 => 'odrive' do
 
   url "http://cdn-mac.odrive.com/odrive.#{version}.dmg"
   homepage 'http://www.odrive.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   pkg "odrive.#{version}.pkg"
 

--- a/Casks/openarena.rb
+++ b/Casks/openarena.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openarena' do
 
   url 'http://openarena.ws/request.php?4'
   homepage 'http://openarena.ws'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app "openarena-#{version}/OpenArena.app"
 

--- a/Casks/openscad.rb
+++ b/Casks/openscad.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openscad' do
 
   url "http://files.openscad.org/OpenSCAD-#{version}.dmg"
   homepage 'http://www.openscad.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'OpenSCAD.app'
 end

--- a/Casks/openttd.rb
+++ b/Casks/openttd.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openttd' do
 
   url "http://binaries.openttd.org/releases/#{version}/openttd-#{version}-macosx-universal.zip"
   homepage 'http://openttd.org'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'OpenTTD.app'
 end

--- a/Casks/openvanilla.rb
+++ b/Casks/openvanilla.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openvanilla' do
 
   url "https://app.openvanilla.org/file/openvanilla/OpenVanilla-Installer-Mac-#{version}.zip"
   homepage 'http://openvanilla.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   input_method 'OpenVanillaInstaller.app/Contents/Resources/OpenVanilla.app'
   caveats do

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openzfs' do
 
   url "https://openzfsonosx.org/w/images/0/0d/OpenZFS_on_OS_X_#{version}.dmg"
   homepage 'https://openzfsonosx.org'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   pkg "OpenZFS on OS X #{version} Mavericks or higher.pkg"
 

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -4,7 +4,7 @@ cask :v1 => 'opera' do
 
   url "http://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   homepage 'http://www.opera.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Opera.app'
 end

--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pharo' do
 
   url "http://files.pharo.org/platform/Pharo#{version}-mac.zip"
   homepage 'http://www.pharo-project.org/home'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   app "Pharo#{version}.app"
 end

--- a/Casks/picasa.rb
+++ b/Casks/picasa.rb
@@ -4,7 +4,7 @@ cask :v1 => 'picasa' do
 
   url "https://dl.google.com/photos/picasamac#{version.gsub('.', '')}.dmg"
   homepage 'http://picasa.google.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Picasa.app'
 end

--- a/Casks/r-name.rb
+++ b/Casks/r-name.rb
@@ -4,7 +4,7 @@ cask :v1 => 'r-name' do
 
   url 'http://www.jacek-dom.net/software/R-Name/R-Name.app.zip'
   homepage 'http://www.jacek-dom.net/software/R-Name/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'R-Name.app'
 end

--- a/Casks/rcenvironment.rb
+++ b/Casks/rcenvironment.rb
@@ -4,7 +4,7 @@ cask :v1 => 'rcenvironment' do
 
   url "http://www.rubicode.com/Downloads/RCEnvironment-#{version}.X.dmg"
   homepage 'http://www.rubicode.com/Software/RCEnvironment/'
-  license :unknown    # todo: improve this machine-generated value
+  license :bsd
 
   prefpane 'RCEnvironment.prefPane'
 end

--- a/Casks/remonit.rb
+++ b/Casks/remonit.rb
@@ -4,7 +4,7 @@ cask :v1 => 'remonit' do
 
   url "http://874390f0461dc5bbf96b-8953e31051b5247f1143d89b1a42aa7d.r65.cf2.rackcdn.com/remonit-#{version}-mac.zip"
   homepage 'http://zef.io/remonit/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'Remonit.app'
 end

--- a/Casks/screenhero.rb
+++ b/Casks/screenhero.rb
@@ -5,7 +5,7 @@ cask :v1 => 'screenhero' do
   url 'http://dl.screenhero.com/update/screenhero/Screenhero.dmg'
   appcast 'http://dl.screenhero.com/update/screenhero/sparkle.xml'
   homepage 'http://screenhero.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Screenhero.app'
 end

--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -6,7 +6,7 @@ cask :v1 => 'simpholders' do
   appcast 'http://kfi-apps.com/appcasts/simpholders/',
           :sha256 => 'baa9148ebfb168d1c86480da0863b89a9eeb7b70e8d8e1e5806c7f7e1a0fdec2'
   homepage 'http://simpholders.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'SimPholders.app'
 end

--- a/Casks/simple-comic.rb
+++ b/Casks/simple-comic.rb
@@ -4,7 +4,7 @@ cask :v1 => 'simple-comic' do
 
   url "http://dancingtortoisedownload.s3.amazonaws.com/SimpleComic_#{version}.zip"
   homepage 'http://dancingtortoise.com/simplecomic/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'Simple Comic.app'
 end

--- a/Casks/simplesynth.rb
+++ b/Casks/simplesynth.rb
@@ -4,7 +4,7 @@ cask :v1 => 'simplesynth' do
 
   url "https://s3.amazonaws.com/notahat/SimpleSynth-#{version}.zip"
   homepage 'http://notahat.com/simplesynth/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'SimpleSynth.app'
 end

--- a/Casks/slingshot.rb
+++ b/Casks/slingshot.rb
@@ -5,7 +5,7 @@ cask :v1 => 'slingshot' do
   url 'http://download.airsquirrels.com/Slingshot/Mac/Slingshot.dmg'
   appcast 'https://updates.airsquirrels.com/Slingshot/Mac/Slingshot.xml'
   homepage 'http://www.airsquirrels.com/slingshot/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Slingshot.app'
 end

--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -4,7 +4,7 @@ cask :v1 => 'snes9x' do
 
   url "http://files.ipherswipsite.com/snes9x/snes9x-#{version}-macosx-113.dmg.gz"
   homepage 'http://www.snes9x.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :other
   container :nested => "snes9x-#{version}"
 
   app 'Snes9x.app'

--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sonic-pi' do
 
   url 'http://sonic-pi.net/files/sonic-pi-mac-latest.dmg'
   homepage 'http://sonic-pi.net/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   app 'Sonic Pi.app'
 end

--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -4,7 +4,7 @@ cask :v1 => 'subsurface' do
 
   url "https://subsurface.hohndel.org/downloads/Subsurface-#{version}.dmg"
   homepage 'http://subsurface.hohndel.org/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Subsurface.app'
 end

--- a/Casks/tau.rb
+++ b/Casks/tau.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tau' do
 
   url 'http://tau.uoregon.edu/tau.dmg'
   homepage 'http://tau.uoregon.edu/'
-  license :unknown    # todo: improve this machine-generated value
+  license :oss
 
   suite 'TAU'
 end

--- a/Casks/thong.rb
+++ b/Casks/thong.rb
@@ -4,7 +4,7 @@ cask :v1 => 'thong' do
 
   url "https://fousa-apps.s3.amazonaws.com/thong/thong-#{version}.dmg"
   homepage 'http://thong.fousa.be/'
-  license :unknown    # todo: improve this machine-generated value
+  license :mit
 
   qlplugin 'Thong.qlgenerator'
 end

--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -10,7 +10,7 @@ cask :v1 => 'time-out' do
 
   url "http://www.dejal.com/download/timeout-#{version}.zip"
   homepage 'http://www.dejal.com/timeout/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gratis
 
   app 'Time Out.app'
 end

--- a/Casks/uberpov.rb
+++ b/Casks/uberpov.rb
@@ -4,7 +4,7 @@ cask :v1 => 'uberpov' do
 
   url "http://megapov.inetart.net/uberpov_mac/downloads/Uberpov_Mac_r#{version.to_i}.zip"
   homepage 'http://megapov.inetart.net/uberpov_mac/index.html'
-  license :unknown    # todo: improve this machine-generated value
+  license :affero
 
   app 'Uberpov_Mac/UberPOV.app'
   caveats do

--- a/Casks/undercover.rb
+++ b/Casks/undercover.rb
@@ -4,7 +4,7 @@ cask :v1 => 'undercover' do
 
   url "http://assets.undercoverhq.com/client/#{version}/undercover_mac.pkg"
   homepage 'http://www.orbicule.com/undercover/mac/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   pkg 'undercover_mac.pkg'
 

--- a/Casks/xslimmer.rb
+++ b/Casks/xslimmer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'xslimmer' do
   appcast 'http://www.xslimmer.com/releases.xml',
           :sha256 => '7f27ccf84109291c59781abe74950f67d53cdb89365497c2925a5d1106f3a15a'
   homepage 'http://latenitesoft.com/xslimmer/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'Xslimmer.app'
 end

--- a/Casks/xtorrent.rb
+++ b/Casks/xtorrent.rb
@@ -6,7 +6,7 @@ cask :v1 => 'xtorrent' do
   appcast 'http://xtorrent.s3.amazonaws.com/appcast.xml',
           :sha256 => '21d8752a39782479a9f6f2485b0aba0af3f1f12d17ebc938c7526e5ca1a8b355'
   homepage 'http://www.xtorrent.com'
-  license :unknown    # todo: improve this machine-generated value
+  license :freemium
 
   app 'Xtorrent.app'
 end

--- a/Casks/yabumi.rb
+++ b/Casks/yabumi.rb
@@ -4,7 +4,7 @@ cask :v1 => 'yabumi' do
 
   url 'https://yabumi.cc/download/Yabumi.dmg'
   homepage 'https://yabumi.cc/'
-  license :unknown    # todo: improve this machine-generated value
+  license :gpl
 
   app 'Yabumi.app'
 end

--- a/Casks/zipcleaner.rb
+++ b/Casks/zipcleaner.rb
@@ -4,7 +4,7 @@ cask :v1 => 'zipcleaner' do
 
   url 'http://roger-jolly.nl/software/downloads/zipcleaner/ZipCleaner.zip'
   homepage 'http://roger-jolly.nl/software/#zipcleaner'
-  license :unknown    # todo: improve this machine-generated value
+  license :isc
 
   app 'ZipCleaner.app'
 end


### PR DESCRIPTION
A few notes:
- `tau` listed as `:oss` - Custom license, appears to be based on/similar to the MIT license
- `matplotlib` listed as `:oss` - Uses only BSD-compatible code, exact license is based on the Python Software Foundation license, see http://matplotlib.org/users/license.html
- `google-chrome` listed as `:gratis` - http://www.google.com/intl/en/chrome/browser/privacy/eula_text.html  To quote en.Wiki

> Chrome's WebKit & Blink layout engines and its V8 JavaScript engine are each free and open-source software, while its other components are each either open-source or proprietary. However, section 9 of Google Chrome's Terms of Service designates the whole package - Chrome itself - as proprietary freeware.
- `snes9x` listed as `:other` - Source is available, but not 'open' for the purposes of reusing.  snes9x is gratis for non-commercial purposes.  See the source for the full license but the relevant info:

> Snes9x is freeware for PERSONAL USE only. Commercial users should
> seek permission of the copyright holders first. Commercial use includes
> charging money for Snes9x or software derived from Snes9x.
- `chocolat` listed as `:commercial` - This could theoretically be billed as ':freemium' but after the trial period is over the app apparently forces you to use Comic Sans (http://gizmodo.com/5909063/how-to-make-sure-someone-will-buy-your-app).  Some may consider paying to avoid that a freemium, but I and many other would argue a Comic Sans-only texteditor is no texteditor at all.
