### PR TITLE
[HOLD until #6356] :no_check in versioned casks

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'adobe-air' do
   version '15.0'
-  sha256 '0fd04ae2ecb839a70b148a8194db1143fb3c2a8a2000d42e579c08aca65c0691'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "http://airdownload.adobe.com/air/mac/download/#{version}/AdobeAIR.dmg"
   homepage 'https://get.adobe.com/air/'


### PR DESCRIPTION
Refs #6356.

As per discussion in the mentioned issue, adding this with a comment to ensure this is only used in specific cases. Other apps, as they’re discovered, shall be added to this PR.
