### PR TITLE
Nodeclipse: replace preflight stanza with target rename

### DIFF
--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -2,12 +2,13 @@ cask :v1 => 'nodeclipse' do
   version '0.11-preview'
   sha256 '01f630446313cb981ce2ee9b934977cfdbf318e09761dee244a3256f9a559003'
 
-  url 'https://downloads.sourceforge.net/sourceforge/nodeclipse/Enide-Studio-2014-011-20140228-macosx-cocoa-x86_64.zip'
+  url "http://downloads.sourceforge.net/project/nodeclipse/Enide-Studio-2014/#{version}/Enide-Studio-2014-011-20140228-macosx-cocoa-x86_64.zip"
+  name 'Nodeclipse'
   homepage 'http://www.nodeclipse.org/'
   license :oss
 
-  preflight do
-    system '/bin/mv', '--', staged_path.join('eclipse/Eclipse.app'), staged_path.join('eclipse/Nodeclipse.app')
-  end
-  app 'eclipse/Nodeclipse.app'
+  # Renamed for clarity: app name is inconsistent with its branding.
+  # Also renamed to avoid conflict with other eclipse Casks.
+  # Original discussion: https://github.com/caskroom/homebrew-cask/pull/8183
+  app 'eclipse/Eclipse.app', :target => 'Nodeclipse.app'
 end


### PR DESCRIPTION
Use `:target` key to rename app for `nodeclipse` to `Nodeclipse.app`
rather than making a system call to `/bin/mv` in preflight.

Also update url to use `version`.
