### PR TITLE
Colloquy: suppress move to applications

### DIFF
--- a/Casks/colloquy.rb
+++ b/Casks/colloquy.rb
@@ -10,10 +10,15 @@ cask :v1 => 'colloquy' do
 
   app 'Colloquy.app'
 
+  postflight do
+    suppress_move_to_applications
+  end
+
   zap :delete => [
                   '~/Library/Application Support/Colloquy',
                   '~/Library/Caches/info.colloquy',
                   '~/Library/Preferences/info.colloquy.plist',
-                  '~/Library/Scripts/Applications/Colloquy',
+                  '~/Library/Saved Application State/info.colloquy.savedState',
+                  '~/Library/Scripts/Applications/Colloquy'
                  ]
 end


### PR DESCRIPTION
Add postflight stanza to `colloquy` Cask to suppress the prompt
to move the app to `/Applications`.

Also zap `~/Library/Saved Application State/info.colloquy.savedState`
