### PR TITLE
Update licenses for pycharm, pycharm-ce, and lynxlet

### DIFF
--- a/Casks/lynxlet.rb
+++ b/Casks/lynxlet.rb
@@ -4,7 +4,7 @@ cask :v1 => 'lynxlet' do
 
   url "http://habilis.net/lynxlet/Lynxlet_#{version}.dmg"
   homepage 'http://habilis.net/lynxlet/'
-  license :unknown    # todo: improve this machine-generated value
+  license :closed
 
   app 'Lynxlet.app'
 end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pycharm-ce' do
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"
   homepage 'http://www.jetbrains.com/pycharm'
-  license :unknown    # todo: improve this machine-generated value
+  license :apache
 
   app 'PyCharm CE.app'
 

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pycharm' do
 
   url "https://download.jetbrains.com/python/pycharm-professional-#{version}.dmg"
   homepage 'http://www.jetbrains.com/pycharm/'
-  license :unknown    # todo: improve this machine-generated value
+  license :commercial
 
   app 'PyCharm.app'
 


### PR DESCRIPTION
- `lynxlet` as `:closed` since source is not available for redistribution/modification
- `pycharm-ce` as `:apache`
- `pycharm` as `:commercial` since 30-day trial
