### PR TITLE
Remove Time Sink app capitalization question

### DIFF
--- a/Casks/time-sink.rb
+++ b/Casks/time-sink.rb
@@ -6,6 +6,5 @@ cask :v1 => 'time-sink' do
   homepage 'http://manytricks.com/timesink/'
   license :unknown    # todo: improve this machine-generated value
 
-  # todo: mistaken capital A in .app name?
   app 'Time Sink.App'
 end


### PR DESCRIPTION
Per discussion in #8202.

It seems as if this is how the dmg spits out the app.
