### PR TITLE
blast2go.rb: add uninstall

### DIFF
--- a/Casks/blast2go.rb
+++ b/Casks/blast2go.rb
@@ -8,4 +8,6 @@ cask :v1 => 'blast2go' do
   license :unknown
 
   installer :manual => 'Blast2GO Installer.app'
+
+  uninstall :delete => '/Applications/Blast2GO'
 end


### PR DESCRIPTION
As per https://github.com/caskroom/homebrew-cask/pull/8145#issuecomment-67410938, though it may not suffice, but it is a first step.
