### PR TITLE
Add `uninstall_depends_on_default_install_location` caveat

### DIFF
--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -19,5 +19,7 @@ cask :v1 => 'battle-net' do
                   '/Users/Shared/Battle.net'
                  ]
 
-  caveats 'If you pick an installation directory other than /Applications when installing this cask, you will need to uninstall it manually'
+  caveats do
+    uninstall_depends_on_default_install_location
+  end
 end

--- a/Casks/blast2go.rb
+++ b/Casks/blast2go.rb
@@ -10,4 +10,8 @@ cask :v1 => 'blast2go' do
   installer :manual => 'Blast2GO Installer.app'
 
   uninstall :delete => '/Applications/Blast2GO'
+
+  caveats do
+    uninstall_depends_on_default_install_location
+  end
 end

--- a/Casks/vuze.rb
+++ b/Casks/vuze.rb
@@ -12,5 +12,7 @@ cask :v1 => 'vuze' do
 
   zap :delete => '~/Library/Application Support/Vuze'
 
-  caveats 'If you pick an installation directory other than /Applications when installing this cask, you will need to uninstall it manually'
+  caveats do
+    uninstall_depends_on_default_install_location
+  end
 end

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -240,13 +240,14 @@ There is a mini-DSL available within `caveats` blocks.
 
 The following methods may be called to generate standard warning messages:
 
-| method                            | description |
-| --------------------------------- | ----------- |
-| `path_environment_variable(path)` | users should make sure `path` is in their `$PATH` environment variable
-| `zsh_path_helper(path)`           | zsh users must take additional steps to make sure `path` is in their `$PATH` environment variable
-| `logout`                          | users should log out and log back in to complete installation
-| `reboot`                          | users should reboot to complete installation
-| `files_in_usr_local`              | the Cask installs files to `/usr/local`, which may confuse Homebrew
+| method                                                         | description |
+| -------------------------------------------------------------- | ----------- |
+| `path_environment_variable(path)`                              | users should make sure `path` is in their `$PATH` environment variable
+| `zsh_path_helper(path)`                                        | zsh users must take additional steps to make sure `path` is in their `$PATH` environment variable
+| `logout`                                                       | users should log out and log back in to complete installation
+| `reboot`                                                       | users should reboot to complete installation
+| `files_in_usr_local`                                           | the Cask installs files to `/usr/local`, which may confuse Homebrew
+| `uninstall_depends_on_default_install_location(optional_path)` | `uninstall` won't work if users picked an atypical location at install time
 
 Example:
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -143,6 +143,7 @@ For use in *eg* interpolation:
  * [`files_in_usr_local`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`logout`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`path_environment_variable(path)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
+ * [`uninstall_depends_on_default_install_location(optional_path)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`reboot`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`zsh_path_helper(path)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
 

--- a/lib/cask/caveats.rb
+++ b/lib/cask/caveats.rb
@@ -77,6 +77,13 @@ class Cask::CaveatsDSL
     end
   end
 
+  def uninstall_depends_on_default_install_location(default_install_path = '/Applications')
+    puts <<-EOS.undent
+    If you pick an installation directory other than #{default_install_path} when installing this cask, you will need to uninstall it manually
+
+    EOS
+  end
+
   def logout
     puts <<-EOS.undent
     You must log out and log back in for the installation of #{@cask}


### PR DESCRIPTION
This adds a `uninstall_depends_on_default_install_location` caveat, as well as changing three casks to use it. Thought descriptive, it is a verbose name, so ideas to make it shorter without losing clarity are very welcome.

This comes in the context of [`battle-net.rb`](https://github.com/caskroom/homebrew-cask/blob/67758531b7d688e304d68a85dbcd62886f7457ce/Casks/battle-net.rb) and [`vuze.rb`](https://github.com/caskroom/homebrew-cask/blob/67758531b7d688e304d68a85dbcd62886f7457ce/Casks/vuze.rb). Those casks use an installer via `installer :manual` that allows the user to pick an install location. To uninstall these, we need to delete files, but we cannot know where they are if the user picked an installation directory other than the default one. For that we currently use a caveat, but I bet there are many more casks that could benefit from it and do not yet have it, hence creating something specific should be beneficial.

``` ruby
caveats do
  uninstall_depends_on_default_install_location
end
```

should simply output `If you pick an installation directory other than {default_install_path} when installing this cask, you will need to uninstall it manually`, with `{default_install_path}` defaulting to `/Applications` if no argument is given. Maybe there aren’t cases where `/Applications` isn’t the default, but it doesn’t hurt to have the option there.

In a way, a better solution would be to automatically detect where an application is by their application bundle, but that would not work in cases like [`blast2go.rb`](https://github.com/caskroom/homebrew-cask/blob/67758531b7d688e304d68a85dbcd62886f7457ce/Casks/battle-net.rb) since it would still leave its directory (and possibly sibling files) intact. It would still be nice to be able to do this on the casks that need nothing more, but that is for another issue.

Naturally, this needs review from the more experienced Ruby developers among you.
