### PR TITLE
audioscrobbler 0.9.15

### DIFF
--- a/Casks/audioscrobbler.rb
+++ b/Casks/audioscrobbler.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'audioscrobbler' do
-  version '0.9.14'
-  sha256 'e7b37abcdb01f0e888a7135395b9369ed47edb37ab669f778dc96d674e83ed1c'
+  version '0.9.15'
+  sha256 'd14bd947f32a5e6c17645d9378b69b0aded91b95dd87a9a8971e013a8fff5063'
 
   url "https://github.com/mxcl/Audioscrobbler.app/releases/download/#{version}/Audioscrobbler-#{version}.zip"
   homepage 'https://github.com/mxcl/Audioscrobbler.app'


### PR DESCRIPTION
Supports OS X Yosemite dark menu bar.

Long-time Homebrew contributor, first-time Cask contributor. Be gentle and shout if there's anything else needed here.

Thanks!
