### PR TITLE
Add YourKit Java Profiler 2014 (build 14114)

### DIFF
--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'yourkit-java-profiler' do
+  version '2014-build-14114'
+  sha256 'd64d6496a7ae8e240ab5c32f6b1727898cd69a8f2e2716cf9901e3a9cc8a4c26'
+
+  url "http://www.yourkit.com/download/yjp-#{version}-mac.zip"
+  name 'YourKit Java Profiler'
+  homepage 'http://www.yourkit.com/overview/'
+  license :commercial
+  tags :vendor => 'YourKit'
+
+  app 'YourKit_Java_Profiler_2014_build_14114.app'
+end


### PR DESCRIPTION
Closes #8256.

`java-profiler` was kept as part of the name because it does not describe a software framework, but what the app it is used for, as part of its name. I believe we had a precedent on this when discussing token rules, @rolandwalker, but I’m not sure if this was the decision.
