### PR TITLE
SourceTree 2.0.4

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -4,8 +4,8 @@ cask :v1 => 'sourcetree' do
     version '1.8.1'
     sha256 '37a42f2d83940cc7e1fbd573a70c3c74a44134c956ac3305f6b153935dc01b80'
   else
-    version '2.0.3'
-    sha256 '66f7f8186ff8afa1e8d26fc26bd55ad73380de3d5d9aa5985dfa6b7d143dd0ec'
+    version '2.0.4'
+    sha256 'fe1477ad902c2965a25560331778ec0b99eeed8e6871b88cb552910abe9e067e'
   end
 
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.dmg"


### PR DESCRIPTION
Updated to address the vulnerability in embedded hg and git
