### PR TITLE
Apache license and Enterprise Edition 3.0.2

### DIFF
--- a/Casks/couchbase-server-community.rb
+++ b/Casks/couchbase-server-community.rb
@@ -4,7 +4,7 @@ cask :v1 => 'couchbase-server-community' do
 
   url "http://packages.couchbase.com/releases/#{version}/couchbase-server-community_#{version}-macos_x86_64.zip"
   homepage 'http://www.couchbase.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :apache
 
   app 'Couchbase Server.app'
 end

--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'couchbase-server-enterprise' do
-  version '3.0.1'
-  sha256 '1cbd844855102013b0b7afe129721900771f1069b550696a30fc639d78c4eca8'
+  version '3.0.2'
+  sha256 '6129bd810ed8d5a27cc5d25e82b998e90f7b6f283fca8841592e0e842c8578d9'
 
   url "http://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"
   homepage 'http://www.couchbase.com/'
-  license :unknown    # todo: improve this machine-generated value
+  license :apache
 
   app 'Couchbase Server.app'
 end


### PR DESCRIPTION
Updated Enterprise Edition to version 3.0.2 and applied Apache license to both editions.
