### PR TITLE
Add TeamPostgreSQL Cask

### DIFF
--- a/Casks/teampostgresql.rb
+++ b/Casks/teampostgresql.rb
@@ -1,0 +1,27 @@
+cask :v1 => 'teampostgresql' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://cdn.webworks.dk/download/teampostgresql_multiplatform.zip'
+  name 'TeamPostgreSQL'
+  homepage 'http://www.teampostgresql.com/'
+  license :gratis
+
+  preflight do
+    File.open(staged_path.join('teampostgresql.sh'), "w") do |f|
+      f.write <<-EOS.undent
+        #!/bin/sh
+        cd "#{staged_path.join('teampostgresql')}"
+        ./teampostgresql-run.sh
+      EOS
+    end
+  end
+
+  binary 'teampostgresql.sh', :target => 'teampostgresql'
+
+  postflight do
+    system '/bin/chmod', '--', 'a+x', "#{staged_path}/teampostgresql.sh"
+  end
+
+  zap :delete => '~/teampostgresql_rev_20130612'
+end


### PR DESCRIPTION
This is a weird one. It uses a graphical installer, and a graphical uninstaller which is found in the install directory.

Since there's no support for graphical uninstallers yet, I'm not entirely sure what to use for the `uninstall` stanza.

Also, the graphical uninstaller removes the install directory contents but not the directory itself, which is why I added `"#{Cask.appdir}/teampostgresql"` to the `zap` stanza. This won't work if the user selects a different location in the graphical installer, but I figured it would cover most cases. Is there a better way to handle this?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caskroom/homebrew-cask/8279)

<!-- Reviewable:end -->
