### PR TITLE
explicitly require Ruby 2.0 at all entry points

### DIFF
--- a/lib/brew-cask-cmd.rb
+++ b/lib/brew-cask-cmd.rb
@@ -1,6 +1,11 @@
 #!/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -W0 -EUTF-8:UTF-8
 # encoding: UTF-8
 
+# just in case
+if RUBY_VERSION.to_i < 2
+  raise 'brew-cask: Ruby 2.0 or greater is required.'
+end
+
 require 'pathname'
 
 # todo remove internal Homebrew dependencies and remove this line

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
+
+# just in case
+if RUBY_VERSION.to_i < 2
+  raise 'brew-cask: Ruby 2.0 or greater is required.'
+end
+
 project_root = Pathname(File.expand_path("../..", __FILE__))
 
 Dir["#{project_root}/spec/support/**/*.rb"].each { |f| require f }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,11 @@
 require 'bundler'
 require 'bundler/setup'
 
+# just in case
+if RUBY_VERSION.to_i < 2
+  raise 'brew-cask: Ruby 2.0 or greater is required.'
+end
+
 # force some environment variables
 ENV['HOMEBREW_NO_EMOJI']='1'
 


### PR DESCRIPTION
to give a more informative error
