### PR TITLE
update license comment in brew cask create

### DIFF
--- a/lib/cask/cli/create.rb
+++ b/lib/cask/cli/create.rb
@@ -26,7 +26,7 @@ class Cask::CLI::Create < Cask::CLI::Base
         url 'https://'
         name ''
         homepage ''
-        license :unknown    # todo: improve this machine-generated value
+        license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
         app ''
       end

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -43,7 +43,7 @@ describe Cask::CLI::Create do
         url 'https://'
         name ''
         homepage ''
-        license :unknown    # todo: improve this machine-generated value
+        license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
         app ''
       end


### PR DESCRIPTION
refs: #8309

When we get past say 85% coverage we can remove the comment from the template.
