### PR TITLE
remove numerous unused methods from homebrew-fork

### DIFF
--- a/lib/homebrew-fork/Library/Homebrew/extend/fileutils.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/fileutils.rb
@@ -83,21 +83,4 @@ module FileUtils
       end
     end
   end
-
-  private
-
-  # Run scons using a Homebrew-installed version, instead of whatever
-  # is in the user's PATH
-  def scons *args
-    system Formulary.factory("scons").opt_bin/"scons", *args
-  end
-
-  def rake *args
-    system RUBY_BIN/'rake', *args
-  end
-
-  alias_method :old_ruby, :ruby if method_defined?(:ruby)
-  def ruby *args
-    system RUBY_PATH, *args
-  end
 end

--- a/lib/homebrew-fork/Library/Homebrew/hardware.rb
+++ b/lib/homebrew-fork/Library/Homebrew/hardware.rb
@@ -40,26 +40,4 @@ class Hardware
 
   require 'os/mac/hardware'
   CPU.extend MacCPUs
-
-  def self.cores_as_words
-    case Hardware::CPU.cores
-    when 1 then 'single'
-    when 2 then 'dual'
-    when 4 then 'quad'
-    else
-      Hardware::CPU.cores
-    end
-  end
-
-  def self.oldest_cpu
-    if Hardware::CPU.intel?
-      if Hardware::CPU.is_64_bit?
-        :core2
-      else
-        :core
-      end
-    else
-      Hardware::CPU.family
-    end
-  end
 end


### PR DESCRIPTION
Covering files:
- extend/fileutils.rb
- hardware.rb
- utils.rb
