### PR TITLE
remove `Homebrew` namespaces in homebrew-fork

### DIFF
--- a/lib/homebrew-fork/Library/Homebrew/extend/ARGV.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/ARGV.rb
@@ -1,4 +1,4 @@
-module HomebrewArgvExtension
+module HomebrewForkArgvExtension
   def verbose?
     flag? '--verbose' or !ENV['VERBOSE'].nil? or !ENV['HOMEBREW_VERBOSE'].nil?
   end

--- a/lib/homebrew-fork/Library/Homebrew/global.rb
+++ b/lib/homebrew-fork/Library/Homebrew/global.rb
@@ -1,12 +1,9 @@
 require 'extend/pathname'
 require 'extend/ARGV'
 require 'extend/string'
-require 'utils'
 require 'exceptions'
-require 'set'
-require 'rbconfig'
 
-ARGV.extend(HomebrewArgvExtension)
+ARGV.extend(HomebrewForkArgvExtension)
 
 def cache
   if ENV['HOMEBREW_CACHE']
@@ -50,10 +47,3 @@ HOMEBREW_GITHUB_API_TOKEN = ENV["HOMEBREW_GITHUB_API_TOKEN"]
 HOMEBREW_USER_AGENT = "Homebrew-cask v0.51+ (Ruby #{RUBY_VERSION}-#{RUBY_PATCHLEVEL}; #{MACOS_VERSION})"
 
 HOMEBREW_CURL_ARGS = '-f#LA'
-
-module Homebrew
-  extend self
-
-  attr_accessor :failed
-  alias_method :failed?, :failed
-end

--- a/lib/homebrew-fork/Library/Homebrew/test/testing_env.rb
+++ b/lib/homebrew-fork/Library/Homebrew/test/testing_env.rb
@@ -28,4 +28,4 @@ MACOS_VERSION = ENV.fetch('MACOS_VERSION') { MACOS_FULL_VERSION[/10\.\d+/] }
 
 # required for many tests
 # eg: undefined method `verbose?' for []:Array
-ARGV.extend(HomebrewArgvExtension)
+ARGV.extend(HomebrewForkArgvExtension)


### PR DESCRIPTION
- remove two `Homebrew` modules
- rename method `Homebrew.system`
- rename class `HomebrewArgvExtension`
- remove some unused `require`s

still todo: constants starting with `HOMEBREW_`
