### PR TITLE
dogecoin 1.8.1

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'dogecoin' do
-  version '1.8.0'
-  sha256 '905ae1eba55294dfd32b6e3ffb357010d04b564455434d918c863fe55c2be968'
+  version '1.8.1'
+  sha256 '03c10d6523689d8597933d3b3751830d9cd518f1477cd6da40804b22da0b234b'
 
   url "https://github.com/dogecoin/dogecoin/releases/download/v#{version}/dogecoin-#{version}-mac.zip"
   homepage 'http://dogecoin.com/'
-  license :oss
+  license :mit
 
   app 'Dogecoin-Qt.app'
 end


### PR DESCRIPTION
Version bump, and updated the license note as per the MIT license at https://github.com/dogecoin/dogecoin/blob/master/doc/README.md
