### PR TITLE
add requires removed during homebrew-fork cleanups

### DIFF
--- a/lib/cask/artifact/uninstall_base.rb
+++ b/lib/cask/artifact/uninstall_base.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 class Cask::Artifact::UninstallBase < Cask::Artifact::Base
 
   # todo: 500 is also hardcoded in cask/pkg.rb, but much of

--- a/lib/homebrew-fork/Library/Homebrew/global.rb
+++ b/lib/homebrew-fork/Library/Homebrew/global.rb
@@ -2,6 +2,7 @@ require 'extend/pathname'
 require 'extend/ARGV'
 require 'extend/string'
 require 'exceptions'
+require 'utils'
 
 ARGV.extend(HomebrewForkArgvExtension)
 


### PR DESCRIPTION
Recent deletions in homebrew-fork allowed tests to pass,
but HEAD was actually broken for interactive use.
