### PR TITLE
Refactor Homebrew's `Tty` class

### DIFF
--- a/lib/cask/artifact/symlinked.rb
+++ b/lib/cask/artifact/symlinked.rb
@@ -67,7 +67,7 @@ class Cask::Artifact::Symlinked < Cask::Artifact::Base
   def summarize_one_link(artifact_spec)
     load_specification artifact_spec
     if self.class.islink?(target)
-      link_description = target.exist? ? '' : "#{Tty.red}Broken Link#{Tty.reset}: "
+      link_description = target.exist? ? '' : "#{Tty.red.underline}Broken Link#{Tty.reset}: "
       printable_target = "'#{target}'"
       printable_target.sub!(%r{^'#{ENV['HOME']}/*}, %q{~/'})
       "#{link_description}#{printable_target} -> '#{target.readlink}'"

--- a/lib/cask/checkable.rb
+++ b/lib/cask/checkable.rb
@@ -27,9 +27,9 @@ module Cask::Checkable
 
   def result
     if errors?
-      "#{Tty.red}failed#{Tty.reset}"
+      "#{Tty.red.underline}failed#{Tty.reset}"
     elsif warnings?
-      "#{Tty.yellow}warning#{Tty.reset}"
+      "#{Tty.yellow.underline}warning#{Tty.reset}"
     else
       "#{Tty.green}passed#{Tty.reset}"
     end

--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -138,11 +138,11 @@ class Cask::CLI::Doctor < Cask::CLI::Base
   end
 
   def self.notfound_string
-    "#{Tty.red}Not Found - Unknown Error#{Tty.reset}"
+    "#{Tty.red.underline}Not Found - Unknown Error#{Tty.reset}"
   end
 
   def self.error_string(string='Error')
-    "#{Tty.red}(#{string})#{Tty.reset}"
+    "#{Tty.red.underline}(#{string})#{Tty.reset}"
   end
 
   def self.render_with_none(string)

--- a/lib/cask/cli/info.rb
+++ b/lib/cask/cli/info.rb
@@ -60,7 +60,7 @@ PURPOSE
     retval = ''
     Cask::DSL::ClassMethods.ordinary_artifact_types.each do |type|
       if cask.artifacts[type].length > 0
-        retval = "#{Tty.blue}==>#{Tty.white} Contents#{Tty.reset}\n" unless retval.length > 0
+        retval = "#{Tty.blue.bold}==>#{Tty.white} Contents#{Tty.reset}\n" unless retval.length > 0
         cask.artifacts[type].each do |artifact|
           activatable_item = type == :stage_only ? '<none>' : artifact.first
           retval.concat "  #{activatable_item} (#{type.to_s})\n"

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -73,7 +73,7 @@ class Cask::Installer
     s = if MacOS.version >= :lion and not ENV['HOMEBREW_NO_EMOJI']
       (ENV['HOMEBREW_INSTALL_BADGE'] || "\xf0\x9f\x8d\xba") + '  '
     else
-      "#{Tty.blue}==>#{Tty.white} Success!#{Tty.reset} "
+      "#{Tty.blue.bold}==>#{Tty.white} Success!#{Tty.reset} "
     end
     s << "#{@cask} staged at '#{@cask.staged_path}' (#{@cask.staged_path.cabv})"
   end

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -75,7 +75,7 @@ def odebug title, *sput
     if $stdout.tty? and title.to_s.length > width
       title = title.to_s[0, width - 3] + '...'
     end
-    puts "#{Tty.magenta}==>#{Tty.white} #{title}#{Tty.reset}"
+    puts "#{Tty.magenta.bold}==>#{Tty.white} #{title}#{Tty.reset}"
     puts sput unless sput.empty?
   end
 end
@@ -157,15 +157,15 @@ module Cask::Utils
 
   def self.error_message_with_suggestions
     <<-EOS.undent
-    #{ Tty.reset }
-      #{ Tty.white }Most likely, this means you have #{
-      }an outdated version of homebrew-cask. Please run:
+    #{ Tty.reset.white.bold }
+      Most likely, this means you have an outdated version of homebrew-cask.#{
+      } Please run:
 
-          #{ Tty.reset }#{ Tty.green }#{ UPDATE_CMD }#{ Tty.reset }
+          #{ Tty.green.normal }#{ UPDATE_CMD }
 
-      #{ Tty.white }If this doesn’t fix the problem, please report this bug:
+      #{ Tty.white.bold }If this doesn’t fix the problem, please report this bug:
 
-          #{ Tty.em }#{ Tty.white }#{ ISSUES_URL }#{ Tty.reset }
+          #{ Tty.underline }#{ ISSUES_URL }#{ Tty.reset }
 
     EOS
   end

--- a/lib/homebrew-fork/Library/Homebrew/utils.rb
+++ b/lib/homebrew-fork/Library/Homebrew/utils.rb
@@ -9,16 +9,16 @@ require 'open-uri'
 
 def ohai title, *sput
   title = Tty.truncate(title) if $stdout.tty? && !ARGV.verbose?
-  puts "#{Tty.blue}==>#{Tty.white} #{title}#{Tty.reset}"
+  puts "#{Tty.blue.bold}==>#{Tty.white} #{title}#{Tty.reset}"
   puts sput
 end
 
 def opoo warning
-  $stderr.puts "#{Tty.red}Warning#{Tty.reset}: #{warning}"
+  $stderr.puts "#{Tty.red.underline}Warning#{Tty.reset}: #{warning}"
 end
 
 def onoe error
-  $stderr.puts "#{Tty.red}Error#{Tty.reset}: #{error}"
+  $stderr.puts "#{Tty.red.underline}Error#{Tty.reset}: #{error}"
 end
 
 # :stopdoc:


### PR DESCRIPTION
which was incorporated into our codebase
- separate attributes from colors
- don't reset all attributes when setting a color
- allow chaining for multiple attributes
- cover all basic colors and attributes
- use more standard names _ie_ `Tty#underline` instead of `Tty#em`
- add `Tty#bg_red`, _etc._
- sanity checks
- style

This fixes some minor bugs such as the display of underline under single dash in audit output.
