### PR TITLE
Strip homebrew-fork `extend/pathname.rb`

### DIFF
--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -64,7 +64,7 @@ class Cask::CLI::Doctor < Cask::CLI::Base
   def self.homebrew_origin
     homebrew_origin = notfound_string
     begin
-      homebrew_repository.cd do
+      Dir.chdir(homebrew_repository) do
         homebrew_origin = Cask::SystemCommand.run('git',
                                                   :args => %w{config --get remote.origin.url},
                                                   :print_stderr => false).stdout.strip

--- a/lib/cask/extend.rb
+++ b/lib/cask/extend.rb
@@ -1,1 +1,3 @@
+# monkeypatching
 require 'cask/extend/string'
+require 'cask/extend/pathname'

--- a/lib/cask/extend/pathname.rb
+++ b/lib/cask/extend/pathname.rb
@@ -1,0 +1,12 @@
+require 'pathname'
+
+class Pathname
+  # https://bugs.ruby-lang.org/issues/9915
+  if RUBY_VERSION == "2.0.0"
+    prepend Module.new {
+      def inspect
+        super.force_encoding(@path.encoding)
+      end
+    }
+  end
+end

--- a/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
@@ -1,17 +1,7 @@
 require 'pathname'
 require 'resource'
 
-# we enhance pathname to make our code more readable
 class Pathname
-
-  # we assume this pathname object is a file obviously
-  alias_method :old_write, :write if method_defined?(:write)
-  def write(content, *open_args)
-    raise "Will not overwrite #{to_s}" if exist?
-    dirname.mkpath
-    open("w", *open_args) { |f| f.write(content) }
-  end
-
   # extended to support common double extensions
   alias extname_old extname
   def extname(path=to_s)

--- a/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
@@ -2,11 +2,6 @@ require 'pathname'
 require 'resource'
 
 class Pathname
-  # for filetypes we support, basename without extension
-  def stem
-    File.basename((path = to_s), extname(path))
-  end
-
   # I don't trust the children.length == 0 check particularly, not to mention
   # it is slow to enumerate the whole directory just to see if it is empty,
   # instead rely on good ol' libc and the filesystem
@@ -27,10 +22,6 @@ class Pathname
   def version
     require 'version'
     Version.parse(self)
-  end
-
-  def text_executable?
-    %r[^#!\s*\S+] === open('r') { |f| f.read(1024) }
   end
 
   # FIXME eliminate the places where we rely on this method

--- a/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
@@ -38,13 +38,4 @@ class Pathname
     end
     self + other.to_s
   end unless method_defined?(:/)
-
-  if RUBY_VERSION == "2.0.0"
-    # https://bugs.ruby-lang.org/issues/9915
-    prepend Module.new {
-      def inspect
-        super.force_encoding(@path.encoding)
-      end
-    }
-  end
 end

--- a/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
@@ -27,10 +27,6 @@ class Pathname
   # FIXME eliminate the places where we rely on this method
   alias_method :to_str, :to_s unless method_defined?(:to_str)
 
-  def cd
-    Dir.chdir(self){ yield }
-  end
-
   def /(other)
     unless other.respond_to?(:to_str) || other.respond_to?(:to_path)
       opoo "Pathname#/ called on #{inspect} with #{other.inspect} as an argument"

--- a/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
@@ -2,14 +2,6 @@ require 'pathname'
 require 'resource'
 
 class Pathname
-  # extended to support common double extensions
-  alias extname_old extname
-  def extname(path=to_s)
-    /(\.(tar|cpio|pax)\.(gz|bz2|lz|xz|Z))$/.match(path)
-    return $1 if $1
-    return File.extname(path)
-  end
-
   # for filetypes we support, basename without extension
   def stem
     File.basename((path = to_s), extname(path))


### PR DESCRIPTION
Remove and adapt several methods from Homebrew-fork's `Pathname` monkeypatching
- remove replacement methods
- remove unused methods
- adopt Ruby 2.0.0 `Pathname` rendering fix
