### PR TITLE
Simplified homepage on 54 casks

### DIFF
--- a/Casks/adventure.rb
+++ b/Casks/adventure.rb
@@ -4,7 +4,7 @@ cask :v1 => 'adventure' do
 
   url 'http://www.lobotomo.com/products/downloads/Adventure.dmg'
   appcast 'http://www.lobotomo.com/products/Adventure/profileInfo.php'
-  homepage 'http://www.lobotomo.com/products/Adventure/index.html'
+  homepage 'http://www.lobotomo.com/products/Adventure/'
   license :gratis
 
   app 'Adventure.app'

--- a/Casks/alarm-clock.rb
+++ b/Casks/alarm-clock.rb
@@ -3,7 +3,7 @@ cask :v1 => 'alarm-clock' do
   sha256 '285d277572be83c632c696d565a8413c2d5149a460392177e9e1b601ffce8778'
 
   url "http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/downloads/Alarm%20Clock%20(#{version}).dmg"
-  homepage 'http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/index.html'
+  homepage 'http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Alarm Clock.app'

--- a/Casks/alinof-timer.rb
+++ b/Casks/alinof-timer.rb
@@ -3,7 +3,7 @@ cask :v1 => 'alinof-timer' do
   sha256 :no_check
 
   url 'http://www.alinofsoftware.ch/resources/AlinofTimer.pkg'
-  homepage 'http://www.alinofsoftware.ch/en/products/products-timer/index.html'
+  homepage 'http://www.alinofsoftware.ch/en/products/products-timer/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'AlinofTimer.pkg', :allow_untrusted => true

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -3,7 +3,7 @@ cask :v1 => 'android-studio' do
   sha256 '2bb8f2ed4f904c71a1d4a4b46eb76e492791f17bf6926a51d7c94ea0e22fc0f5'
 
   url "https://dl.google.com/dl/android/studio/install/#{version}/android-studio-ide-1641136.dmg"
-  homepage 'https://developer.android.com/sdk/index.html'
+  homepage 'https://developer.android.com/sdk/'
   license :apache
 
   app 'Android Studio.app'

--- a/Casks/anonym.rb
+++ b/Casks/anonym.rb
@@ -3,7 +3,7 @@ cask :v1 => 'anonym' do
   sha256 '696ac1cf173976b26e2fdd8f8f087df16437e237cf271fae6dcbcc403148a0d4'
 
   url "http://www.hanynet.com/anonym-#{version}.zip"
-  homepage 'http://www.hanynet.com/anonym/index.html'
+  homepage 'http://www.hanynet.com/anonym/'
   license :oss
 
   container :nested => "Anonym #{version}.dmg"

--- a/Casks/audio-editor.rb
+++ b/Casks/audio-editor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'audio-editor' do
 
   url 'http://www.macsome.com/AudioEditor.dmg'
   appcast 'http://www.macsome.com/audio-editor-mac/su_feed.xml'
-  homepage 'http://www.macsome.com/audio-editor-mac/index.html'
+  homepage 'http://www.macsome.com/audio-editor-mac/'
   license :gratis
 
   app 'Audio Editor.app'

--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -3,7 +3,7 @@ cask :v1 => 'beyond-compare' do
   sha256 'cb9987b62ac68a2493b7bc5678125fbf1b8919796bc82718ddd23958768fd457'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
-  homepage 'http://www.scootersoftware.com/index.php'
+  homepage 'http://www.scootersoftware.com/'
   license :commercial
 
   app 'Beyond Compare.app'

--- a/Casks/buddi.rb
+++ b/Casks/buddi.rb
@@ -3,7 +3,7 @@ cask :v1 => 'buddi' do
   sha256 :no_check
 
   url 'http://buddi.digitalcave.ca/buddi.dmg'
-  homepage 'http://buddi.digitalcave.ca/index.jsp'
+  homepage 'http://buddi.digitalcave.ca/'
   license :gpl
 
   app 'Buddi.app'

--- a/Casks/camed.rb
+++ b/Casks/camed.rb
@@ -3,7 +3,7 @@ cask :v1 => 'camed' do
   sha256 'c9088796b6f5cee228341e2ec6c2ee0ff3e3a506ff0dde3643865ccbc9c4f744'
 
   url "http://downloads.sourceforge.net/sourceforge/camprocessor/CAMEd-#{version}-macosx-cocoa-x86_64.tar.gz"
-  homepage 'http://sourceforge.net/apps/mediawiki/camprocessor/index.php?title=Main_Page'
+  homepage 'http://camprocessor.sourceforge.net/'
   license :oss
 
   app "CAMEd-#{version}/CAMed.app"

--- a/Casks/catch.rb
+++ b/Casks/catch.rb
@@ -5,7 +5,7 @@ cask :v1 => 'catch' do
   url "https://github.com/mipstian/catch/releases/download/#{version}/Catch-#{version}.zip"
   appcast 'https://raw.github.com/mipstian/catch/master/update/appcast.xml',
           :sha256 => 'd559363812ead3090bf597711821d4e47dd281e7695f4e377767fffd56637a2d'
-  homepage 'http://www.giorgiocalderolla.com/index.html'
+  homepage 'http://www.giorgiocalderolla.com/'
   license :oss
 
   app 'Catch.app'

--- a/Casks/clix.rb
+++ b/Casks/clix.rb
@@ -3,7 +3,7 @@ cask :v1 => 'clix' do
   sha256 'a4f9d270792e9da698326924e4c899c7a5f13f157c7793b82187688f8c189008'
 
   url 'ftp://rixstep.com/CLIX.tar.bz2'
-  homepage 'http://rixstep.com/4/0/clix/index.shtml'
+  homepage 'http://rixstep.com/4/0/clix/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app "CLIX#{version}/CLIX.app"

--- a/Casks/cornerstone.rb
+++ b/Casks/cornerstone.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cornerstone' do
   url "https://www.zennaware.com/cornerstone/downloads/Cornerstone-#{version}.zip"
   appcast 'http://www.zennaware.com/cornerstone/appcast/feed2.php',
           :sha256 => '333fee9fc2c478a0d5305ad2d9faecdb2c44e5554e8d43762c0917a7531fb145'
-  homepage 'http://www.zennaware.com/cornerstone/index.php'
+  homepage 'http://www.zennaware.com/cornerstone/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Cornerstone.app'

--- a/Casks/doxygen.rb
+++ b/Casks/doxygen.rb
@@ -3,7 +3,7 @@ cask :v1 => 'doxygen' do
   sha256 'd4d23df0372362358d26ab3c3c13d701b1f1751a7b80d427742665739a4f49c0'
 
   url "ftp://ftp.stack.nl/pub/users/dimitri/Doxygen-#{version}.dmg"
-  homepage 'http://www.stack.nl/~dimitri/doxygen/index.html'
+  homepage 'http://www.stack.nl/~dimitri/doxygen/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Doxygen.app'

--- a/Casks/dupscanub.rb
+++ b/Casks/dupscanub.rb
@@ -3,7 +3,7 @@ cask :v1 => 'dupscanub' do
   sha256 'd9c318d017012266461c8705bb9f9ebe23f052b4e794ace950f7edee8836f614'
 
   url "http://www5.wind.ne.jp/miko/mac_soft/dup_scan/hqx/DupScanUB_#{version.gsub('.','')}.dmg.zip"
-  homepage 'http://www5.wind.ne.jp/miko/mac_soft/dup_scan/index.html'
+  homepage 'http://www5.wind.ne.jp/miko/mac_soft/dup_scan/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   container :nested => 'DupScanUB_241.dmg'

--- a/Casks/freedv.rb
+++ b/Casks/freedv.rb
@@ -3,7 +3,7 @@ cask :v1 => 'freedv' do
   sha256 'e8c42dbb7fc5b8dd88020aa000149185adc5f9583094617966008e5b39d54970'
 
   url "http://files.freedv.org/OSX/FreeDV-#{version}.dmg"
-  homepage 'http://freedv.org/tiki-index.php'
+  homepage 'http://freedv.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'FreeDV.app'

--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -5,7 +5,7 @@ cask :v1 => 'garagesale' do
   url "http://www.iwascoding.de/downloads/GarageSale_#{version}.dmg"
   appcast 'http://www.iwascoding.com/GarageSale/AppCast.php',
           :sha256 => '3bc0ac9ead57616b1261263671045ca70cedc5061047da72e536c266cc6a2f4d'
-  homepage 'http://www.iwascoding.com/GarageSale/index.html'
+  homepage 'http://www.iwascoding.com/GarageSale/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'GarageSale.app'

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gpgtools' do
   url "https://releases.gpgtools.org/GPG%20Suite%20-%20#{version}.dmg"
   gpg "#{url}.sig",
       :key_url => 'https://gpgtools.org/GPGTools%2000D026C4.asc'
-  homepage 'https://gpgtools.org/index.html'
+  homepage 'https://gpgtools.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install.pkg'

--- a/Casks/hoppergdbserver.rb
+++ b/Casks/hoppergdbserver.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hoppergdbserver' do
   url "http://www.hopperapp.com/HopperGDBServer/HopperGDBServer-#{version}.zip"
   appcast 'http://www.hopperapp.com/HopperGDBServer/appcast.xml',
           :sha256 => 'b554d3f681960d00d94bdce4db2efe1cc6addc69db9441e359839d6f2379924b'
-  homepage 'http://www.hopperapp.com/HopperGDBServer/index.html'
+  homepage 'http://www.hopperapp.com/HopperGDBServer/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'HopperGDBServer.app'

--- a/Casks/ifilex.rb
+++ b/Casks/ifilex.rb
@@ -3,7 +3,7 @@ cask :v1 => 'ifilex' do
   sha256 :no_check
 
   url 'http://www.osxbytes.com/iFileX.dmg'
-  homepage 'http://www.osxbytes.com/page3/index.html'
+  homepage 'http://www.osxbytes.com/page3/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iFileX.app'

--- a/Casks/indigo.rb
+++ b/Casks/indigo.rb
@@ -3,7 +3,7 @@ cask :v1 => 'indigo' do
   sha256 :no_check
 
   url 'http://cloud.goprism.com/download/Indigo.dmg'
-  homepage 'http://www.perceptiveautomation.com/indigo/index.html'
+  homepage 'http://www.perceptiveautomation.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Indigo Installer.pkg'

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -3,7 +3,7 @@ cask :v1 => 'intellij-idea' do
   sha256 'cfab01c2b5b7265f0cf7b365872180261154a5e3ff1fc710c545d36e1f936a7b'
 
   url "http://download.jetbrains.com/idea/ideaIU-#{version}.dmg"
-  homepage 'https://www.jetbrains.com/idea/index.html'
+  homepage 'https://www.jetbrains.com/idea/'
   license :commercial
 
   app 'IntelliJ IDEA 14.app'

--- a/Casks/ireadfast.rb
+++ b/Casks/ireadfast.rb
@@ -3,7 +3,7 @@ cask :v1 => 'ireadfast' do
   sha256 '0bc213c6da72a7917ceba8a9de46e307933608cd6d2bf397770517401ab3d98c'
 
   url "http://www.gengis.net/downloads/iReadFast%20#{version}.dmg"
-  homepage 'http://www.gengis.net/prodotti/iReadFast_Mac/en/index.php'
+  homepage 'http://www.gengis.net/prodotti/iReadFast_Mac/en/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iReadFast.app'

--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -3,7 +3,7 @@ cask :v1 => 'keystore-explorer' do
   sha256 '64932fc5a26bd4de32d952b73431307c9a7c3100c1b11e76ab9f55e2a2cf7d49'
 
   url "http://downloads.sourceforge.net/project/keystore-explorer/KSE%20#{version}/kse-#{version.gsub('.','')}.dmg"
-  homepage 'http://keystore-explorer.sourceforge.net/index.php'
+  homepage 'http://keystore-explorer.sourceforge.net/'
   license :oss
 
   app "KeyStore Explorer #{version}.app"

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -3,7 +3,7 @@ cask :v1 => 'klayout' do
   sha256 '96ce3fdead710248ed2ed4f25c9a94859949466d42eaa4f87881c17567dc1f15'
 
   url "http://178.77.72.242/downloads/klayout.#{version}.pkg"
-  homepage 'http://www.klayout.de/index.html'
+  homepage 'http://www.klayout.de/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "klayout.#{version}.pkg"

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -3,7 +3,7 @@ cask :v1 => 'little-snitch' do
   sha256 '42e0e8009af01ff8050a5c42e49f67b2e0e3424562b21de4648a73062bd2e735'
 
   url "http://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
-  homepage 'http://www.obdev.at/products/littlesnitch/index.html'
+  homepage 'http://www.obdev.at/products/littlesnitch/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   installer :manual => 'Little Snitch Installer.app'

--- a/Casks/machacha.rb
+++ b/Casks/machacha.rb
@@ -3,7 +3,7 @@ cask :v1 => 'machacha' do
   sha256 :no_check
 
   url 'http://www.julifos.com/soft/machacha/machacha.dmg'
-  homepage 'http://www.julifos.com/soft/machacha/index.html'
+  homepage 'http://www.julifos.com/soft/machacha/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'MacHacha.app'

--- a/Casks/mactubes.rb
+++ b/Casks/mactubes.rb
@@ -3,7 +3,7 @@ cask :v1 => 'mactubes' do
   sha256 'd3fbe0ee7fb95c1eea0f70b84140a816561601f0a1f36ba2b16ba63bfa57cd19'
 
   url "http://macapps.sakura.ne.jp/mactubes/archives/MacTubes_v#{version}.zip"
-  homepage 'http://macapps.sakura.ne.jp/mactubes/index_en.html'
+  homepage 'http://macapps.sakura.ne.jp/mactubes/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app "MacTubes_v#{version}/MacTubes.app"

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -3,7 +3,7 @@ cask :v1 => 'mamp' do
   sha256 '840877041af7a06d50a3ddc67030ae4f193f70add473ebad0f7418daf80cd553'
 
   url "http://downloads4.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"
-  homepage 'http://www.mamp.info/en/index.html'
+  homepage 'http://www.mamp.info/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "MAMP_MAMP_PRO_#{version}.pkg"

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -3,7 +3,7 @@ cask :v1 => 'mucommander' do
   sha256 '24665a248bd0f027b399277c2e7096a57e75120048302f3ac2f89ce4f7f1acae'
 
   url "http://www.mucommander.com/download/mucommander-#{version.gsub('.','_')}.dmg"
-  homepage 'http://www.mucommander.com/index.php'
+  homepage 'http://www.mucommander.com/'
   license :gpl
 
   app 'muCommander.app'

--- a/Casks/murasaki.rb
+++ b/Casks/murasaki.rb
@@ -3,7 +3,7 @@ cask :v1 => 'murasaki' do
   sha256 '2dd07c47d59aff053b8be804e08b087ce8d9e127365de43a206011a63ba42966'
 
   url "http://genjiapp.com/mac/murasaki/downloads/murasaki_v#{version}.zip"
-  homepage 'http://genjiapp.com/mac/murasaki/index_en.html'
+  homepage 'http://genjiapp.com/mac/murasaki/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Murasaki.app'

--- a/Casks/ninjablocks.rb
+++ b/Casks/ninjablocks.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ninjablocks' do
 
   # dropboxusercontent.com is the official download host per the vendor homepage
   url "https://dl.dropboxusercontent.com/u/428557/NinjaBlocks-#{version}.dmg"
-  homepage 'http://forums.ninjablocks.com/index.php?p=/discussion/1655/ninja-osx-client/p1'
+  homepage 'https://discuss.ninjablocks.com/t/ninja-osx-client/1449'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'NinjaBlocks.app'

--- a/Casks/noobproof.rb
+++ b/Casks/noobproof.rb
@@ -3,7 +3,7 @@ cask :v1 => 'noobproof' do
   sha256 '6e74a5aec8e9cf9102c160019990e90ae46486358959fa0d22517b4171f8209a'
 
   url "http://www.hanynet.com/noobproof-#{version}.zip"
-  homepage 'http://www.hanynet.com/noobproof/index.html'
+  homepage 'http://www.hanynet.com/noobproof/'
   license :oss
 
   app 'NoobProof.app'

--- a/Casks/pcalc.rb
+++ b/Casks/pcalc.rb
@@ -5,7 +5,7 @@ cask :v1 => 'pcalc' do
   url "https://s3.amazonaws.com/tlasystems/PCalc-#{version}.dmg"
   appcast 'http://www.pcalc.com/PCalcSUFeed.xml',
           :sha256 => '5e84c3bd2c0cfa56ff20dffd5106d761d3073d9d1ea61062524cb4d0e6f369f5'
-  homepage 'http://www.pcalc.com/index.html'
+  homepage 'http://www.pcalc.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PCalc.app'

--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -3,7 +3,7 @@ cask :v1 => 'pdfpen' do
   sha256 :no_check
 
   url 'http://dl.smilesoftware.com/com.smileonmymac.PDFpen/PDFpen.zip'
-  homepage 'http://smilesoftware.com/PDFpen/index.html'
+  homepage 'http://smilesoftware.com/PDFpen/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PDFpen.app'

--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -3,7 +3,7 @@ cask :v1 => 'pdfpenpro' do
   sha256 :no_check
 
   url 'http://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/PDFpenPro.zip'
-  homepage 'http://www.smilesoftware.com/PDFpenPro/index.html'
+  homepage 'http://www.smilesoftware.com/PDFpenPro/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PDFpenPro.app'

--- a/Casks/pflists.rb
+++ b/Casks/pflists.rb
@@ -3,7 +3,7 @@ cask :v1 => 'pflists' do
   sha256 '024cd972503df8b7b01602e092a9b900b6758b33ba040860fd46af3bb53f2856'
 
   url "http://www.hanynet.com/pflists-#{version}.zip"
-  homepage 'http://www.hanynet.com/pflists/index.html'
+  homepage 'http://www.hanynet.com/pflists/'
   license :oss
 
   app 'PFLists.app'

--- a/Casks/photoninja.rb
+++ b/Casks/photoninja.rb
@@ -3,7 +3,7 @@ cask :v1 => 'photoninja' do
   sha256 '81f62282865c53d2ed653ea2494f44d9e4d82cce623e85c651bb9aa8ccb26794'
 
   url "https://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_#{version}.dmg"
-  homepage 'http://www.picturecode.com/index.php'
+  homepage 'http://www.picturecode.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PhotoNinja.app'

--- a/Casks/pikopixel.rb
+++ b/Casks/pikopixel.rb
@@ -3,7 +3,7 @@ cask :v1 => 'pikopixel' do
   sha256 'bf024db394bfd6031f02f75313a591f949decea0cad80ec07357c0f32e34fa92'
 
   url "http://twilightedge.com/downloads/PikoPixel#{version}.dmg"
-  homepage 'http://twilightedge.com/mac/pikopixel/index.html'
+  homepage 'http://twilightedge.com/mac/pikopixel/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PikoPixel.app'

--- a/Casks/qq.rb
+++ b/Casks/qq.rb
@@ -3,7 +3,7 @@ cask :v1 => 'qq' do
   sha256 'dc206b856dda0ef3db8420d7678ddaefafd1e6919a9dc3d3115fc926b20bce35'
 
   url "http://dldir1.qq.com/qqfile/QQforMac/QQ_V#{version}.dmg"
-  homepage 'http://im.qq.com/macqq/index.shtml'
+  homepage 'http://im.qq.com/macqq/'
   license :commercial
 
   app 'QQ.app'

--- a/Casks/sharemouse.rb
+++ b/Casks/sharemouse.rb
@@ -3,7 +3,7 @@ cask :v1 => 'sharemouse' do
   sha256 :no_check
 
   url 'http://www.keyboard-and-mouse-sharing.com/ShareMouseSetup.dmg'
-  homepage 'http://www.keyboard-and-mouse-sharing.com/index.html'
+  homepage 'http://www.keyboard-and-mouse-sharing.com/'
   license :closed
 
   app 'ShareMouse.app'

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sizeup' do
 
   url 'https://www.irradiatedsoftware.com/download/SizeUp.zip'
   appcast 'http://www.irradiatedsoftware.com/updates/profiles/sizeup.php'
-  homepage 'http://www.irradiatedsoftware.com/sizeup/index.html'
+  homepage 'http://www.irradiatedsoftware.com/sizeup/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'SizeUp.app'

--- a/Casks/ssx.rb
+++ b/Casks/ssx.rb
@@ -3,7 +3,7 @@ cask :v1 => 'ssx' do
   sha256 '34d904e909191e60e0b84ea43f177871ac4310c91af53e5c4cbff28c5dd29fcb'
 
   url "http://chris.schleifer.net/ssX/builds/ssX-#{version}.dmg"
-  homepage 'http://chris.schleifer.net/ssX/index.cgi/index.html'
+  homepage 'http://chris.schleifer.net/ssX/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ssX.app'

--- a/Casks/stackato.rb
+++ b/Casks/stackato.rb
@@ -3,7 +3,7 @@ cask :v1 => 'stackato' do
   sha256 '79b34288416e2adac24c30c8eacd0b1177f8c3985d355af16e13b7b9dd17259d'
 
   url "http://downloads.activestate.com/stackato/client/v#{version}/stackato-#{version}-macosx10.5-i386-x86_64.zip"
-  homepage 'http://docs.stackato.com/user/client/index.html'
+  homepage 'http://docs.stackato.com/user/client/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   binary "stackato-#{version}-macosx10.5-i386-x86_64/stackato"

--- a/Casks/stackroom.rb
+++ b/Casks/stackroom.rb
@@ -3,7 +3,7 @@ cask :v1 => 'stackroom' do
   sha256 'b5904f8c39a3941a827cea31e77dc9c62b12025cccddc5b42869615392a543ce'
 
   url "http://www.geocities.jp/aromaticssoft/stackroom/download/stackroom_#{version}.zip"
-  homepage 'http://www.geocities.jp/aromaticssoft/stackroom/index.html'
+  homepage 'http://www.geocities.jp/aromaticssoft/stackroom/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Stackroom.app'

--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -10,7 +10,7 @@ cask :v1 => 'textexpander' do
   end
 
   url "http://cdn.smilesoftware.com/TextExpander_#{version}.zip"
-  homepage 'http://www.smilesoftware.com/TextExpander/index.html'
+  homepage 'http://www.smilesoftware.com/TextExpander/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TextExpander.app'

--- a/Casks/thetube.rb
+++ b/Casks/thetube.rb
@@ -3,7 +3,7 @@ cask :v1 => 'thetube' do
   sha256 '8ca81ca68d5ddca04a9fa8d53e9b8ba542e1b3c9806b3cd500172abd316bf277'
 
   url "http://download2.equinux.com/files/other/TheTube_#{version}_Web.zip"
-  homepage 'http://www.equinux.com/us/products/thetube/index.html'
+  homepage 'http://www.equinux.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TheTube.app'

--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -3,7 +3,7 @@ cask :v1 => 'tv-browser' do
   sha256 '951fe8478fa2efa5f7784c23f153bcc8b0a6fcb8a7405c4990c44b3c967e73cc'
 
   url "http://downloads.sourceforge.net/sourceforge/tvbrowser/tvbrowser_#{version}_mac.dmg"
-  homepage 'http://www.tvbrowser.org/index.php?setlang=en'
+  homepage 'http://www.tvbrowser.org/'
   license :oss
 
   app 'TV-Browser.app'

--- a/Casks/uberpov.rb
+++ b/Casks/uberpov.rb
@@ -3,7 +3,7 @@ cask :v1 => 'uberpov' do
   sha256 '5e3e8ba5b257ad4e058c2f7735776e271f32c02e9cc02f71b1ece6b8c950c8d0'
 
   url "http://megapov.inetart.net/uberpov_mac/downloads/Uberpov_Mac_r#{version.to_i}.zip"
-  homepage 'http://megapov.inetart.net/uberpov_mac/index.html'
+  homepage 'http://megapov.inetart.net/uberpov_mac/'
   license :affero
 
   app 'Uberpov_Mac/UberPOV.app'

--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -3,7 +3,7 @@ cask :v1 => 'vistrails' do
   sha256 '38ac9da9af7a557cee6eb703517e38ea1bcc430706a436a182eec6f976275b02'
 
   url "http://downloads.sourceforge.net/project/vistrails/vistrails/v#{version}/vistrails-mac-10.6-intel-#{version}-90975fc00211.dmg"
-  homepage 'http://www.vistrails.org/index.php/Main_Page'
+  homepage 'http://www.vistrails.org/'
   license :oss
 
   suite 'VisTrails'

--- a/Casks/waterroof.rb
+++ b/Casks/waterroof.rb
@@ -3,7 +3,7 @@ cask :v1 => 'waterroof' do
   sha256 '30c5794bab61ad30a019b0f1a2cf798dcc6f3bc83a867fde1b3a4f71019c48ee'
 
   url "http://www.hanynet.com/waterroof-#{version}.zip"
-  homepage 'http://www.hanynet.com/waterroof/index.html'
+  homepage 'http://www.hanynet.com/waterroof/'
   license :oss
 
   container :nested => "WaterRoof #{version}.dmg"

--- a/Casks/windownaut.rb
+++ b/Casks/windownaut.rb
@@ -3,7 +3,7 @@ cask :v1 => 'windownaut' do
   sha256 :no_check
 
   url 'http://www.binarybakery.com/products/Windownaut.dmg'
-  homepage 'http://www.binarybakery.com/aprod/index.html'
+  homepage 'http://www.binarybakery.com/aprod/windownaut.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Windownaut.app'

--- a/Casks/xampp.rb
+++ b/Casks/xampp.rb
@@ -4,7 +4,7 @@ cask :v1 => 'xampp' do
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/xampp/XAMPP%20Mac%20OS%20X/#{version.sub(%r{-\d+$},'')}/xampp-osx-#{version}-installer.dmg"
-  homepage 'http://www.apachefriends.org/index.html'
+  homepage 'http://www.apachefriends.org/'
   license :oss
 
   installer :manual => 'XAMPP.app'

--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -5,7 +5,7 @@ cask :v1 => 'xld' do
   url "http://downloads.sourceforge.net/project/xld/xld-#{version}.dmg"
   appcast 'http://xld.googlecode.com/svn/appcast/xld-appcast_e.xml',
           :sha256 => '16420b367df9b64870bd2a38ee20e688d17b065783b93371065ac7094ab93cb0'
-  homepage 'http://tmkk.undo.jp/xld/index_e.html'
+  homepage 'http://tmkk.undo.jp/xld/'
   license :oss
 
   app 'XLD.app'

--- a/Casks/younited.rb
+++ b/Casks/younited.rb
@@ -3,7 +3,7 @@ cask :v1 => 'younited' do
   sha256 :no_check
 
   url 'https://download.sp.f-secure.com/younited/younited.dmg'
-  homepage 'http://www.younited.com/index.html'
+  homepage 'http://www.younited.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'younited.app'


### PR DESCRIPTION
Most of the time this means simply removing `index.*` variants from the end of the url. All of them were manually tested.
