### PR TITLE
Update yubikey-neo-manager to 1.1.0

### DIFF
--- a/Casks/yubikey-neo-manager.rb
+++ b/Casks/yubikey-neo-manager.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'yubikey-neo-manager' do
-  version '1.0.0'
-  sha256 '9e2bad45d2138d72040ef4fba8d377196d630afa1d07779217c5a9684a96df45'
+  version '1.1.0'
+  sha256 '3af16efa1ac02ea4244cf906d8d63d98e4b867b3f4ceaed668d405bd6d2b809e'
 
   url "https://developers.yubico.com/yubikey-neo-manager/Releases/yubikey-neo-manager-#{version}-mac.pkg"
   homepage 'https://developers.yubico.com/yubikey-neo-manager/'


### PR DESCRIPTION
Like the title said. Sha sum was generated with shasum -a 256 on the downloaded file. URL was checked as correct.
