### PR TITLE
Add ios-lockscreen

### DIFF
--- a/Casks/ios-lockscreen.rb
+++ b/Casks/ios-lockscreen.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'ios-lockscreen' do
+  version :latest
+  sha256 :no_check
+
+  name 'iOS Lockscreen'
+  homepage 'http://littleendiangamestudios.com/project/ios-7-screen-saver/'
+  url 'http://dlstatsios7.site90.net/download.php', :referer => "#{homepage}"
+  license :unknown    # todo: improve this machine-generated value
+
+  screen_saver 'iOS Lockscreen.saver'
+end


### PR DESCRIPTION
This is a continuation of the ios7-screensaver project, which was
archived by the original maintainer.

The url doesn't include the filename, and the referer needs to be
spoofed. Not sure if this is acceptable.
