### PR TITLE
remove homebrew-fork `Pathname#/` monkeypatch

### DIFF
--- a/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
+++ b/lib/homebrew-fork/Library/Homebrew/extend/pathname.rb
@@ -20,12 +20,4 @@ class Pathname
 
   # FIXME eliminate the places where we rely on this method
   alias_method :to_str, :to_s unless method_defined?(:to_str)
-
-  def /(other)
-    unless other.respond_to?(:to_str) || other.respond_to?(:to_path)
-      opoo "Pathname#/ called on #{inspect} with #{other.inspect} as an argument"
-      puts "This behavior is deprecated, please pass either a String or a Pathname"
-    end
-    self + other.to_s
-  end unless method_defined?(:/)
 end

--- a/lib/homebrew-fork/Library/Homebrew/global.rb
+++ b/lib/homebrew-fork/Library/Homebrew/global.rb
@@ -36,7 +36,7 @@ end
 
 HOMEBREW_PREFIX = Pathname.new(HOMEBREW_BREW_FILE).dirname.parent # Where we link under
 HOMEBREW_REPOSITORY = Pathname.new(HOMEBREW_BREW_FILE).realpath.dirname.parent # Where .git is found
-HOMEBREW_LIBRARY = HOMEBREW_REPOSITORY/"Library"
+HOMEBREW_LIBRARY = HOMEBREW_REPOSITORY.join('Library')
 
 HOMEBREW_TEMP = Pathname.new(ENV.fetch('HOMEBREW_TEMP', '/tmp'))
 

--- a/lib/homebrew-fork/Library/Homebrew/os/mac/xquartz.rb
+++ b/lib/homebrew-fork/Library/Homebrew/os/mac/xquartz.rb
@@ -105,11 +105,11 @@ module OS
       end
 
       def bin
-        prefix/"bin"
+        prefix.join("bin")
       end
 
       def share
-        prefix/"share"
+        prefix.join("share")
       end
     end
   end

--- a/test/cask/artifact/alt_target_test.rb
+++ b/test/cask/artifact/alt_target_test.rb
@@ -15,7 +15,7 @@ describe Cask::Artifact::App do
         Cask::Artifact::App.new(cask).install_phase
       end
 
-      TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
+      TestHelper.valid_alias?(Cask.appdir.join('AnotherName.app')).must_equal true
     end
 
     it "creates metadata containing the alternate target name" do
@@ -28,7 +28,7 @@ describe Cask::Artifact::App do
       Cask::SystemCommand.run('/usr/bin/xattr',
                               :args => ['-p',
                                         'com.apple.metadata:kMDItemAlternateNames',
-                                        Cask.appdir/'AnotherName.app'],
+                                        Cask.appdir.join('AnotherName.app')],
                               :print_stderr => false).stdout.must_match(/AnotherName/)
     end
 
@@ -47,14 +47,14 @@ describe Cask::Artifact::App do
           TestHelper.install_without_artifacts(cask)
         end
 
-        appsubdir = (subdir_cask.staged_path/'subdir').tap(&:mkpath)
-        FileUtils.mv((subdir_cask.staged_path/'Caffeine.app'), appsubdir)
+        appsubdir = subdir_cask.staged_path.join('subdir').tap(&:mkpath)
+        FileUtils.mv(subdir_cask.staged_path.join('Caffeine.app'), appsubdir)
 
         shutup do
           Cask::Artifact::App.new(subdir_cask).install_phase
         end
 
-        TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
+        TestHelper.valid_alias?(Cask.appdir.join('AnotherName.app')).must_equal true
       ensure
         if defined?(subdir_cask)
           shutup do
@@ -74,32 +74,32 @@ describe Cask::Artifact::App do
         Cask::Artifact::App.new(cask).install_phase
       end
 
-      TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
-      TestHelper.valid_alias?(Cask.appdir/'AnotherNameAgain.app').must_equal false
+      TestHelper.valid_alias?(Cask.appdir.join('AnotherName.app')).must_equal true
+      TestHelper.valid_alias?(Cask.appdir.join('AnotherNameAgain.app')).must_equal false
     end
 
     it "avoids clobbering an existing app by linking over it" do
       cask = local_alt_caffeine
 
-      (Cask.appdir/'AnotherName.app').mkpath
+      Cask.appdir.join('AnotherName.app').mkpath
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
       }, "==> It seems there is already an App at '#{Cask.appdir.join('AnotherName.app')}'; not linking.")
 
-      (Cask.appdir/'AnotherName.app').wont_be :symlink?
+      Cask.appdir.join('AnotherName.app').wont_be :symlink?
     end
 
     it "happily clobbers an existing symlink" do
       cask = local_alt_caffeine
 
-      (Cask.appdir/'AnotherName.app').make_symlink('/tmp')
+      Cask.appdir.join('AnotherName.app').make_symlink('/tmp')
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
       }, "==> Symlinking App 'Caffeine.app' to '#{Cask.appdir.join('AnotherName.app')}'")
 
-      File.readlink(Cask.appdir/'AnotherName.app').wont_equal '/tmp'
+      File.readlink(Cask.appdir.join('AnotherName.app')).wont_equal '/tmp'
     end
   end
 end

--- a/test/cask/artifact/app_test.rb
+++ b/test/cask/artifact/app_test.rb
@@ -15,7 +15,7 @@ describe Cask::Artifact::App do
         Cask::Artifact::App.new(cask).install_phase
       end
 
-      TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
+      TestHelper.valid_alias?(Cask.appdir.join('Caffeine.app')).must_equal true
     end
 
     it "works with an application in a subdir" do
@@ -33,14 +33,14 @@ describe Cask::Artifact::App do
           TestHelper.install_without_artifacts(cask)
         end
 
-        appsubdir = (subdir_cask.staged_path/'subdir').tap(&:mkpath)
-        FileUtils.mv((subdir_cask.staged_path/'Caffeine.app'), appsubdir)
+        appsubdir = subdir_cask.staged_path.join('subdir').tap(&:mkpath)
+        FileUtils.mv(subdir_cask.staged_path.join('Caffeine.app'), appsubdir)
 
         shutup do
           Cask::Artifact::App.new(subdir_cask).install_phase
         end
 
-        TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
+        TestHelper.valid_alias?(Cask.appdir.join('Caffeine.app')).must_equal true
       ensure
         if defined?(subdir_cask)
           shutup do
@@ -60,32 +60,32 @@ describe Cask::Artifact::App do
         Cask::Artifact::App.new(cask).install_phase
       end
 
-      TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
-      TestHelper.valid_alias?(Cask.appdir/'CaffeineAgain.app').must_equal false
+      TestHelper.valid_alias?(Cask.appdir.join('Caffeine.app')).must_equal true
+      TestHelper.valid_alias?(Cask.appdir.join('CaffeineAgain.app')).must_equal false
     end
 
     it "avoids clobbering an existing app by linking over it" do
       cask = local_caffeine
 
-      (Cask.appdir/'Caffeine.app').mkpath
+      Cask.appdir.join('Caffeine.app').mkpath
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
       }, "==> It seems there is already an App at '#{Cask.appdir.join('Caffeine.app')}'; not linking.")
 
-      (Cask.appdir/'Caffeine.app').wont_be :symlink?
+      Cask.appdir.join('Caffeine.app').wont_be :symlink?
     end
 
     it "happily clobbers an existing symlink" do
       cask = local_caffeine
 
-      (Cask.appdir/'Caffeine.app').make_symlink('/tmp')
+      Cask.appdir.join('Caffeine.app').make_symlink('/tmp')
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
       }, "==> Symlinking App 'Caffeine.app' to '#{Cask.appdir.join('Caffeine.app')}'")
 
-      File.readlink(Cask.appdir/'Caffeine.app').wont_equal '/tmp'
+      File.readlink(Cask.appdir.join('Caffeine.app')).wont_equal '/tmp'
     end
   end
 end

--- a/test/cask/artifact/binary_test.rb
+++ b/test/cask/artifact/binary_test.rb
@@ -7,7 +7,7 @@ describe Cask::Artifact::App do
     end
   }
   let(:expected_path) {
-    Cask.binarydir/'binary'
+    Cask.binarydir.join('binary')
   }
 
   it "links the binary to the proper directory" do

--- a/test/cask/artifact/pkg_test.rb
+++ b/test/cask/artifact/pkg_test.rb
@@ -12,7 +12,7 @@ describe Cask::Artifact::Pkg do
     it 'runs the system installer on the specified pkgs' do
       pkg = Cask::Artifact::Pkg.new(@cask, Cask::FakeSystemCommand)
 
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/installer', '-pkg', @cask.staged_path/'MyFancyPkg'/'Fancy.pkg', '-target', '/'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/installer', '-pkg', @cask.staged_path.join('MyFancyPkg','Fancy.pkg'), '-target', '/'])
 
       shutup do
         pkg.install_phase

--- a/test/cask/artifact/suite_test.rb
+++ b/test/cask/artifact/suite_test.rb
@@ -7,7 +7,7 @@ describe Cask::Artifact::Suite do
     end
   }
   let(:expected_path) {
-    Cask.appdir/'caffeine_suite'
+    Cask.appdir.join('caffeine_suite')
   }
 
   it "links the suite to the proper directory" do

--- a/test/cask/artifact/two_apps_correct_test.rb
+++ b/test/cask/artifact/two_apps_correct_test.rb
@@ -15,8 +15,8 @@ describe Cask::Artifact::App do
         Cask::Artifact::App.new(cask).install_phase
       end
 
-      TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
-      TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
+      TestHelper.valid_alias?(Cask.appdir.join('Caffeine.app')).must_equal true
+      TestHelper.valid_alias?(Cask.appdir.join('AnotherName.app')).must_equal true
     end
 
     it "works with an application in a subdir" do
@@ -35,15 +35,15 @@ describe Cask::Artifact::App do
           TestHelper.install_without_artifacts(cask)
         end
 
-        appsubdir = (subdir_cask.staged_path/'subdir').tap(&:mkpath)
-        FileUtils.mv((subdir_cask.staged_path/'Caffeine.app'), appsubdir)
+        appsubdir = subdir_cask.staged_path.join('subdir').tap(&:mkpath)
+        FileUtils.mv(subdir_cask.staged_path.join('Caffeine.app'), appsubdir)
 
         shutup do
           Cask::Artifact::App.new(subdir_cask).install_phase
         end
 
-        TestHelper.valid_alias?(Cask.appdir/'Caffeine.app').must_equal true
-        TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
+        TestHelper.valid_alias?(Cask.appdir.join('Caffeine.app')).must_equal true
+        TestHelper.valid_alias?(Cask.appdir.join('AnotherName.app')).must_equal true
       ensure
         if defined?(subdir_cask)
           shutup do
@@ -64,14 +64,14 @@ describe Cask::Artifact::App do
     #     Cask::Artifact::App.new(cask).install_phase
     #   end
     #
-    #   TestHelper.valid_alias?(Cask.appdir/'AnotherName.app').must_equal true
-    #   TestHelper.valid_alias?(Cask.appdir/'AnotherNameAgain.app').must_equal false
+    #   TestHelper.valid_alias?(Cask.appdir.join('AnotherName.app')).must_equal true
+    #   TestHelper.valid_alias?(Cask.appdir.join('AnotherNameAgain.app').must_equal false
     # end
 
     it "avoids clobbering an existing app by linking over it (link 1)" do
       cask = local_two_apps_caffeine
 
-      (Cask.appdir/'Caffeine.app').mkpath
+      Cask.appdir.join('Caffeine.app').mkpath
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
@@ -80,13 +80,13 @@ describe Cask::Artifact::App do
          ==> Symlinking App 'Caffeine.app' to '#{Cask.appdir.join('AnotherName.app')}'
          MESSAGE
 
-      (Cask.appdir/'Caffeine.app').wont_be :symlink?
+      Cask.appdir.join('Caffeine.app').wont_be :symlink?
     end
 
     it "avoids clobbering an existing app by linking over it (link 2)" do
       cask = local_two_apps_caffeine
 
-      (Cask.appdir/'AnotherName.app').mkpath
+      Cask.appdir.join('AnotherName.app').mkpath
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
@@ -95,13 +95,13 @@ describe Cask::Artifact::App do
          ==> It seems there is already an App at '#{Cask.appdir.join('AnotherName.app')}'; not linking.
          MESSAGE
 
-      (Cask.appdir/'AnotherName.app').wont_be :symlink?
+      Cask.appdir.join('AnotherName.app').wont_be :symlink?
     end
 
     it "happily clobbers an existing symlink (link 1)" do
       cask = local_two_apps_caffeine
 
-      (Cask.appdir/'Caffeine.app').make_symlink('/tmp')
+      Cask.appdir.join('Caffeine.app').make_symlink('/tmp')
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
@@ -110,13 +110,13 @@ describe Cask::Artifact::App do
          ==> Symlinking App 'Caffeine.app' to '#{Cask.appdir.join('AnotherName.app')}'
          MESSAGE
 
-      File.readlink(Cask.appdir/'Caffeine.app').wont_equal '/tmp'
+      File.readlink(Cask.appdir.join('Caffeine.app')).wont_equal '/tmp'
     end
 
     it "happily clobbers an existing symlink (link 2)" do
       cask = local_two_apps_caffeine
 
-      (Cask.appdir/'AnotherName.app').make_symlink('/tmp')
+      Cask.appdir.join('AnotherName.app').make_symlink('/tmp')
 
       TestHelper.must_output(self, lambda {
         Cask::Artifact::App.new(cask).install_phase
@@ -125,7 +125,7 @@ describe Cask::Artifact::App do
          ==> Symlinking App 'Caffeine.app' to '#{Cask.appdir.join('AnotherName.app')}'
          MESSAGE
 
-      File.readlink(Cask.appdir/'AnotherName.app').wont_equal '/tmp'
+      File.readlink(Cask.appdir.join('AnotherName.app')).wont_equal '/tmp'
     end
   end
 end

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -34,7 +34,7 @@ describe Cask::Artifact::Uninstall do
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--', '/permissible/absolute/path'])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-f', '--', Pathname.new(TestHelper.local_binary_path('empty_directory')).join('.DS_Store')])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rmdir', '--', Pathname.new(TestHelper.local_binary_path('empty_directory'))])
@@ -105,14 +105,14 @@ describe Cask::Artifact::Uninstall do
         ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', 'my.fancy.package.service'],
         <<-"PLIST"
 {
-	"LimitLoadToSessionType" = "Aqua";
-	"Label" = "my.fancy.package.service";
-	"TimeOut" = 30;
-	"OnDemand" = true;
-	"LastExitStatus" = 0;
-	"ProgramArguments" = (
-		"argument";
-	);
+        "LimitLoadToSessionType" = "Aqua";
+        "Label" = "my.fancy.package.service";
+        "TimeOut" = 30;
+        "OnDemand" = true;
+        "LastExitStatus" = 0;
+        "ProgramArguments" = (
+                "argument";
+        );
 };
         PLIST
       )

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -37,7 +37,7 @@ describe Cask::Artifact::Zap do
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
-      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+      Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'])
       Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
                                                Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])
 
@@ -107,14 +107,14 @@ describe Cask::Artifact::Zap do
         ['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'list', 'my.fancy.package.service'],
         <<-"PLIST"
 {
-	"LimitLoadToSessionType" = "Aqua";
-	"Label" = "my.fancy.package.service";
-	"TimeOut" = 30;
-	"OnDemand" = true;
-	"LastExitStatus" = 0;
-	"ProgramArguments" = (
-		"argument";
-	);
+        "LimitLoadToSessionType" = "Aqua";
+        "Label" = "my.fancy.package.service";
+        "TimeOut" = 30;
+        "OnDemand" = true;
+        "LastExitStatus" = 0;
+        "ProgramArguments" = (
+                "argument";
+        );
 };
         PLIST
       )

--- a/test/cask/cli/zap_test.rb
+++ b/test/cask/cli/zap_test.rb
@@ -48,7 +48,7 @@ describe Cask::CLI::Zap do
   #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app.from.uninstall"'], '1')
   #   Cask::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app.from.uninstall" to quit'])
   #
-  #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', with_zap.staged_path/'MyFancyPkg'/'FancyUninstaller.tool', '--please'])
+  #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', with_zap.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'])
   #   Cask::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
   #                                             Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])
   #

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -9,9 +9,9 @@ describe Cask::Installer do
         Cask::Installer.new(caffeine).install
       end
 
-      dest_path = Cask.caskroom/'local-caffeine'/caffeine.version
+      dest_path = Cask.caskroom.join('local-caffeine',caffeine.version)
       dest_path.must_be :directory?
-      application = dest_path/'Caffeine.app'
+      application = dest_path.join('Caffeine.app')
       application.must_be :directory?
     end
 
@@ -22,9 +22,9 @@ describe Cask::Installer do
         Cask::Installer.new(transmission).install
       end
 
-      dest_path = Cask.caskroom/'local-transmission'/transmission.version
+      dest_path = Cask.caskroom.join('local-transmission',transmission.version)
       dest_path.must_be :directory?
-      application = dest_path/'Transmission.app'
+      application = dest_path.join('Transmission.app')
       application.must_be :directory?
     end
 
@@ -35,9 +35,9 @@ describe Cask::Installer do
         Cask::Installer.new(tarball).install
       end
 
-      dest_path = Cask.caskroom/'tarball'/tarball.version
+      dest_path = Cask.caskroom.join('tarball',tarball.version)
       dest_path.must_be :directory?
-      application = dest_path/'Tarball.app'
+      application = dest_path.join('Tarball.app')
       application.must_be :directory?
     end
 
@@ -51,9 +51,9 @@ describe Cask::Installer do
         Cask::Installer.new(cab_container).install
       end
 
-      dest_path = Cask.caskroom/'cab-container'/cab_container.version
+      dest_path = Cask.caskroom.join('cab-container',cab_container.version)
       dest_path.must_be :directory?
-      application = dest_path/'cabcontainer/Application.app'
+      application = dest_path.join('cabcontainer','Application.app')
       application.must_be :directory?
     end
 
@@ -63,14 +63,14 @@ describe Cask::Installer do
       shutup do
         Cask::Installer.new(air_container).install
       end
-      dest_path = Cask.caskroom/'adobe-air-container'/air_container.version
+      dest_path = Cask.caskroom.join('adobe-air-container',air_container.version)
       dest_path.must_be :directory?
-      application = dest_path/'GMDesk.app'
+      application = dest_path.join('GMDesk.app')
       application.must_be :directory?
     end
 
     it "works with 7z-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
+      skip unless HOMEBREW_PREFIX.join('bin','unar').exist?
       sevenzip_container = Cask.load('sevenzip-container')
       empty = stub(:formula => [], :macos => nil, :arch => nil, :x11 => nil)
       sevenzip_container.stubs(:depends_on).returns(empty)
@@ -79,9 +79,9 @@ describe Cask::Installer do
         Cask::Installer.new(sevenzip_container).install
       end
 
-      dest_path = Cask.caskroom/'sevenzip-container'/sevenzip_container.version
+      dest_path = Cask.caskroom.join('sevenzip-container',sevenzip_container.version)
       dest_path.must_be :directory?
-      application = dest_path/'sevenzipcontainer/Application.app'
+      application = dest_path.join('sevenzipcontainer','Application.app')
       application.must_be :directory?
     end
 
@@ -92,14 +92,14 @@ describe Cask::Installer do
         Cask::Installer.new(xar_container).install
       end
 
-      dest_path = Cask.caskroom/'xar-container'/xar_container.version
+      dest_path = Cask.caskroom.join('xar-container',xar_container.version)
       dest_path.must_be :directory?
-      application = dest_path/'xarcontainer/Application.app'
+      application = dest_path.join('xarcontainer','Application.app')
       application.must_be :directory?
     end
 
     it "works with Stuffit-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
+      skip unless HOMEBREW_PREFIX.join('bin','unar').exist?
       stuffit_container = Cask.load('stuffit-container')
       empty = stub(:formula => [], :macos => nil, :arch => nil, :x11 => nil)
       stuffit_container.stubs(:depends_on).returns(empty)
@@ -108,14 +108,14 @@ describe Cask::Installer do
         Cask::Installer.new(stuffit_container).install
       end
 
-      dest_path = Cask.caskroom/'stuffit-container'/stuffit_container.version
+      dest_path = Cask.caskroom.join('stuffit-container',stuffit_container.version)
       dest_path.must_be :directory?
-      application = dest_path/'sheldonmac/v1.0'
+      application = dest_path.join('sheldonmac','v1.0')
       application.must_be :directory?
     end
 
     it "works with RAR-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin/unar').exist?
+      skip unless HOMEBREW_PREFIX.join('bin','unar').exist?
       rar_container = Cask.load('rar-container')
       empty = stub(:formula => [], :macos => nil, :arch => nil, :x11 => nil)
       rar_container.stubs(:depends_on).returns(empty)
@@ -124,9 +124,9 @@ describe Cask::Installer do
         Cask::Installer.new(rar_container).install
       end
 
-      dest_path = Cask.caskroom/'rar-container'/rar_container.version
+      dest_path = Cask.caskroom.join('rar-container',rar_container.version)
       dest_path.must_be :directory?
-      application = dest_path/'rarcontainer/Application.app'
+      application = dest_path.join('rarcontainer','Application.app')
       application.must_be :directory?
     end
 
@@ -137,9 +137,9 @@ describe Cask::Installer do
         Cask::Installer.new(asset).install
       end
 
-      dest_path = Cask.caskroom/'bzipped-asset'/asset.version
+      dest_path = Cask.caskroom.join('bzipped-asset',asset.version)
       dest_path.must_be :directory?
-      file = dest_path/"bzipped-asset-#{asset.version}"
+      file = dest_path.join("bzipped-asset-#{asset.version}")
       file.must_be :file?
     end
 
@@ -150,9 +150,9 @@ describe Cask::Installer do
         Cask::Installer.new(asset).install
       end
 
-      dest_path = Cask.caskroom/'gzipped-asset'/asset.version
+      dest_path = Cask.caskroom.join('gzipped-asset',asset.version)
       dest_path.must_be :directory?
-      file = dest_path/"gzipped-asset-#{asset.version}"
+      file = dest_path.join("gzipped-asset-#{asset.version}")
       file.must_be :file?
     end
 
@@ -236,8 +236,8 @@ describe Cask::Installer do
         Cask::Installer.new(naked_pkg).install
       end
 
-      dest_path = Cask.caskroom/'naked-pkg'/naked_pkg.version
-      pkg = dest_path/'Naked.pkg'
+      dest_path = Cask.caskroom.join('naked-pkg',naked_pkg.version)
+      pkg = dest_path.join('Naked.pkg')
       pkg.must_be :file?
     end
 
@@ -248,8 +248,8 @@ describe Cask::Installer do
         Cask::Installer.new(naked_executable).install
       end
 
-      dest_path = Cask.caskroom/'naked-executable'/naked_executable.version
-      executable = dest_path/'naked_executable'
+      dest_path = Cask.caskroom.join('naked-executable',naked_executable.version)
+      executable = dest_path.join('naked_executable')
       executable.must_be :file?
     end
 
@@ -260,7 +260,7 @@ describe Cask::Installer do
         Cask::Installer.new(nested_app).install
       end
 
-      dest_path = Cask.appdir/'MyNestedApp.app'
+      dest_path = Cask.appdir.join('MyNestedApp.app')
       TestHelper.valid_alias?(dest_path).must_equal true
     end
 
@@ -300,9 +300,9 @@ describe Cask::Installer do
         installer.uninstall
       end
 
-      (Cask.caskroom/'local-caffeine'/caffeine.version/'Caffeine.app').wont_be :directory?
-      (Cask.caskroom/'local-caffeine'/caffeine.version).wont_be :directory?
-      (Cask.caskroom/'local-caffeine').wont_be :directory?
+      Cask.caskroom.join('local-caffeine',caffeine.version,'Caffeine.app').wont_be :directory?
+      Cask.caskroom.join('local-caffeine',caffeine.version).wont_be :directory?
+      Cask.caskroom.join('local-caffeine').wont_be :directory?
     end
 
     it "uninstalls all versions if force is set" do
@@ -314,19 +314,19 @@ describe Cask::Installer do
         installer.install
       end
 
-      (Cask.caskroom/'local-caffeine'/caffeine.version).must_be :directory?
-      (Cask.caskroom/'local-caffeine'/mutated_version).wont_be  :directory?
-      FileUtils.mv(Cask.caskroom/'local-caffeine'/caffeine.version, Cask.caskroom/'local-caffeine'/mutated_version)
-      (Cask.caskroom/'local-caffeine'/caffeine.version).wont_be :directory?
-      (Cask.caskroom/'local-caffeine'/mutated_version).must_be  :directory?
+      Cask.caskroom.join('local-caffeine',caffeine.version).must_be :directory?
+      Cask.caskroom.join('local-caffeine',mutated_version).wont_be  :directory?
+      FileUtils.mv(Cask.caskroom.join('local-caffeine',caffeine.version), Cask.caskroom.join('local-caffeine',mutated_version))
+      Cask.caskroom.join('local-caffeine',caffeine.version).wont_be :directory?
+      Cask.caskroom.join('local-caffeine',mutated_version).must_be  :directory?
 
       shutup do
         installer.uninstall(true)
       end
 
-      (Cask.caskroom/'local-caffeine'/caffeine.version).wont_be :directory?
-      (Cask.caskroom/'local-caffeine'/mutated_version).wont_be  :directory?
-      (Cask.caskroom/'local-caffeine').wont_be :directory?
+      Cask.caskroom.join('local-caffeine',caffeine.version).wont_be :directory?
+      Cask.caskroom.join('local-caffeine',mutated_version).wont_be  :directory?
+      Cask.caskroom.join('local-caffeine').wont_be :directory?
     end
   end
 end

--- a/test/support/fake_dirs.rb
+++ b/test/support/fake_dirs.rb
@@ -8,7 +8,7 @@ module FakeDirHooks
     @canned_dirs = {}
 
     DIRS.each do |dir_name|
-      dir = HOMEBREW_REPOSITORY/"#{dir_name}-#{Time.now.to_i}-#{rand(1024)}"
+      dir = HOMEBREW_REPOSITORY.join("#{dir_name}-#{Time.now.to_i}-#{rand(1024)}")
       dir.mkpath
       Cask.send("#{dir_name}=", dir)
       @canned_dirs[:dir_name] = dir

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -126,13 +126,13 @@ require 'tempfile'
 
 # pretend like we installed the homebrew-cask tap
 project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
-taps_dest = HOMEBREW_LIBRARY/"Taps/caskroom"
+taps_dest = HOMEBREW_LIBRARY.join('Taps/caskroom')
 
 # create directories
 FileUtils.mkdir_p taps_dest
 HOMEBREW_PREFIX.join('bin').mkdir
 
-FileUtils.ln_s project_root, taps_dest/"homebrew-cask"
+FileUtils.ln_s project_root, taps_dest.join('homebrew-cask')
 
 # Common superclass for test Casks for when we need to filter them out
 class TestCask < Cask; end
@@ -143,4 +143,4 @@ FileUtils.ln_s '/usr/local/bin/unar', HOMEBREW_PREFIX.join('bin/unar')
 FileUtils.ln_s '/usr/local/bin/lsar', HOMEBREW_PREFIX.join('bin/lsar')
 
 # also jack in some test Casks
-FileUtils.ln_s project_root/'test'/'support', taps_dest/"homebrew-testcasks"
+FileUtils.ln_s project_root.join('test', 'support'), taps_dest.join('homebrew-testcasks')


### PR DESCRIPTION
in favor of ordinary `Pathname#join`.  This was already the rule for our codebase except for some areas of the test suite.

refs: #8113
cc: @radeksimko 
