### PR TITLE
leave stdout intact when parsing plists

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -69,7 +69,7 @@ class Cask::SystemCommand::Result
   end
 
   def plist
-    @plist ||= self.class._parse_plist(@command, @stdout)
+    @plist ||= self.class._parse_plist(@command, @stdout.dup)
   end
 
   def success?


### PR DESCRIPTION
from a `Cask::SystemCommand::Result` instance
