### PR TITLE
make relative `Pathname`s absolute in `system_command`

### DIFF
--- a/lib/cask/system_command.rb
+++ b/lib/cask/system_command.rb
@@ -7,7 +7,8 @@ class Cask::SystemCommand
     processed_stdout = ''
     processed_stderr = ''
 
-    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(*command.map(&:to_s))
+    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr =
+      Open3.popen3(*command.map { |arg| arg.respond_to?(:to_path) ? File.absolute_path(arg) : arg.to_s })
 
     if options[:input]
       Array(options[:input]).each { |line| raw_stdin.puts line }


### PR DESCRIPTION
This was the original intention as mentioned in some comments elsewhere.
This may occasionally produce a surprising result, in which case the argument should be explicitly stringified.
