### PR TITLE
Version substitution cleanups in 10 Casks

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -2,7 +2,7 @@ cask :v1 => 'eagle' do
   version '7.2.0'
   sha256 '9cae311072d8be5a16631ce08d9e0653bdc21e336cc90df2463d7df35521ff2a'
 
-  url "ftp://ftp.cadsoft.de/eagle/program/#{version.gsub(/\.\d$/, '')}/eagle-mac-#{version}.zip"
+  url "ftp://ftp.cadsoft.de/eagle/program/#{version.sub(/\.\d+$/, '')}/eagle-mac-#{version}.zip"
   homepage 'http://www.cadsoftusa.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/komanda.rb
+++ b/Casks/komanda.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'komanda' do
-  version '1.0.0 beta'
+  version '1.0.0.beta'
   sha256 'e54f195185d92b0b4a9e9be3b1db4b2cbd99723c93e9b6e57feb0df90b27a5d1'
 
-  url "https://github.com/mephux/komanda/releases/download/#{version.gsub(' ','.')}/Komanda-macosx.zip"
+  url "https://github.com/mephux/komanda/releases/download/#{version}/Komanda-macosx.zip"
   homepage 'https://github.com/mephux/komanda'
   license :mit
 

--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -2,7 +2,7 @@ cask :v1 => 'komodo-ide' do
   version '8.5.4-86985'
   sha256 'dde427a79aa17f5404b15bb286c075857fe5407f98395cc97f3e0e9c8b27851c'
 
-  url "http://downloads.activestate.com/Komodo/releases/#{version.gsub(/-.*/, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
+  url "http://downloads.activestate.com/Komodo/releases/#{version.sub(/-.*$/, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
   homepage 'http://komodoide.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/logisim.rb
+++ b/Casks/logisim.rb
@@ -2,7 +2,7 @@ cask :v1 => 'logisim' do
   version '2.7.1'
   sha256 '41c5555b8021794e268a3fc2c9c51301d919680ae780b000b99380fc492bae7c'
 
-  url "http://downloads.sourceforge.net/project/circuit/#{version.gsub(/\d$/, 'x')}/#{version}/logisim-macosx-#{version}.tar.gz"
+  url "http://downloads.sourceforge.net/project/circuit/#{version.sub(/\d+$/, 'x')}/#{version}/logisim-macosx-#{version}.tar.gz"
   homepage 'http://ozark.hendrix.edu/~burch/logisim/'
   license :oss
 

--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -2,7 +2,7 @@ cask :v1 => 'parallels-desktop' do
   version '10.1.1-28614'
   sha256 'd39780b42640c5de6198fb7434e24ac1cc983cc13b131c73cdba775964ec4e0d'
 
-  url "http://download.parallels.com/desktop/v10/updates/#{version.gsub(/-.*$/, '')}/ParallelsDesktop-#{version}.dmg"
+  url "http://download.parallels.com/desktop/v10/updates/#{version.sub(/-.*$/, '')}/ParallelsDesktop-#{version}.dmg"
   homepage 'http://www.parallels.com/products/desktop/'
   license :commercial
 

--- a/Casks/selflanguage-self-control.rb
+++ b/Casks/selflanguage-self-control.rb
@@ -2,7 +2,7 @@ cask :v1 => 'selflanguage-self-control' do
   version '4.5.0'
   sha256 'fa5edc50ec517c06547e8c57246075f1fcd4ad98b5b9c681b9a60e357f4d3f04'
 
-  url "http://files.selflanguage.org/releases/#{version.gsub(/\.\d$/, '')}/Self-#{version}.dmg"
+  url "http://files.selflanguage.org/releases/#{version.sub(/\.\d+$/, '')}/Self-#{version}.dmg"
   homepage 'http://selflanguage.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -2,7 +2,7 @@ cask :v1 => 'shotcut' do
   version '14.11.01'
   sha256 'f364c8849ed79376006209bfb0146d1449461bb3b18a1548c55b3c8fb93f00ba'
 
-  url "https://github.com/mltframework/shotcut/releases/download/v#{version.gsub(/\.\d{2}$/, '')}/shotcut-osx-x86_64-#{version.gsub('.', '')}.dmg"
+  url "https://github.com/mltframework/shotcut/releases/download/v#{version.sub(/\.\d+$/, '')}/shotcut-osx-x86_64-#{version.gsub('.', '')}.dmg"
   homepage 'http://www.shotcut.org/'
   license :oss
 

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -2,7 +2,7 @@ cask :v1 => 'vimr' do
   version '0.5.1-25'
   sha256 'b316e879b546a89f5339a510a7168801c98e3180759ca76c3c8272be22f4ad62'
 
-  url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-#{version.gsub(/-.*/, '')}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-#{version.sub(/-.*$/, '')}.tar.bz2"
   homepage 'http://vimr.org/'
   license :gpl
 

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -2,7 +2,7 @@ cask :v1 => 'virtualbox' do
   version '4.3.20-96996'
   sha256 '744e77119a640a5974160213c9912568a3d88dbd06a2fc6b6970070941732705'
 
-  url "http://download.virtualbox.org/virtualbox/#{version.gsub(/-.*/, '')}/VirtualBox-#{version}-OSX.dmg"
+  url "http://download.virtualbox.org/virtualbox/#{version.sub(/-.*$/, '')}/VirtualBox-#{version}-OSX.dmg"
   homepage 'http://www.virtualbox.org'
   license :gpl
 

--- a/Casks/xtorrent.rb
+++ b/Casks/xtorrent.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'xtorrent' do
-  version '2.1 (v171)'
+  version '2.1(v171)'
   sha256 '26ea235dcb827c6e58ab3409bec83396e86704d742d517e527016ecd44672379'
 
-  url "http://acquisition.dreamhosters.com/xtorrent/Xtorrent#{version.gsub(' ','')}.dmg"
+  url "http://acquisition.dreamhosters.com/xtorrent/Xtorrent#{version}.dmg"
   appcast 'http://xtorrent.s3.amazonaws.com/appcast.xml',
           :sha256 => '21d8752a39782479a9f6f2485b0aba0af3f1f12d17ebc938c7526e5ca1a8b355'
   homepage 'http://www.xtorrent.com'


### PR DESCRIPTION
Principally replacing `version.gsub` with `version.sub` when that is what is meant.
