### PR TITLE
Add TimeTracker.app v0.4.5

### DIFF
--- a/Casks/charlessoft-timetracker.rb
+++ b/Casks/charlessoft-timetracker.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'charlessoft-timetracker' do
+  version '0.4.5'
+  sha256 '6d1b4dd29b2866afa195d7fd18df7868e8c329781e15246f6b1e200451914c04'
+
+  url 'http://charlessoft.com/TimeTracker.zip'
+  name 'TimeTracker'
+  homepage 'http://charlessoft.com/'
+  license :unknown
+
+  app 'TimeTracker.app'
+end


### PR DESCRIPTION
Only thing I'm not 100% sure on is there's currently a time-tracker cask. Just so happens author always refers to it as TimeTracker (one word) so there's no conflict.
