### PR TITLE
remove unused constants/methods from hardware.rb

### DIFF
--- a/lib/homebrew-fork/Library/Homebrew/hardware.rb
+++ b/lib/homebrew-fork/Library/Homebrew/hardware.rb
@@ -1,26 +1,5 @@
 class Hardware
   module CPU extend self
-    INTEL_32BIT_ARCHS = [:i386].freeze
-    INTEL_64BIT_ARCHS = [:x86_64].freeze
-    PPC_32BIT_ARCHS   = [:ppc, :ppc7400, :ppc7450, :ppc970].freeze
-    PPC_64BIT_ARCHS   = [:ppc64].freeze
-
-    def type
-      @type || :dunno
-    end
-
-    def family
-      @family || :dunno
-    end
-
-    def cores
-      @cores || 1
-    end
-
-    def bits
-      @bits || 64
-    end
-
     def is_32_bit?
       bits == 32
     end


### PR DESCRIPTION
in homebrew-fork.
