### PR TITLE
remove namespace workaround from homebrew-fork

### DIFF
--- a/lib/homebrew-fork/Library/Homebrew/utils/github.rb
+++ b/lib/homebrew-fork/Library/Homebrew/utils/github.rb
@@ -138,24 +138,4 @@ module GitHub extend self
     uri = URI.parse("https://api.github.com/repos/#{user}/#{repo}")
     open(uri) { |json| json["private"] }
   end
-
-  private
-
-  # If the zlib formula is loaded, TypeError will be raised when we try to load
-  # net/https. This monkeypatch prevents that and lets Net::HTTP fall back to
-  # the non-gzip codepath.
-  def safely_load_net_https
-    return if defined?(Net::HTTP)
-    if defined?(Zlib) && RUBY_VERSION >= "1.9"
-      require "net/protocol"
-      http = Class.new(Net::Protocol) do
-        def self.require(lib)
-          raise LoadError if lib == "zlib"
-          super
-        end
-      end
-      Net.const_set(:HTTP, http)
-    end
-    require "net/https"
-  end
 end


### PR DESCRIPTION
irrelevant since we don't load Formulae
