### PR TITLE
Fix typo in list_apps_in_pkg script

### DIFF
--- a/developer/bin/list_apps_in_pkg
+++ b/developer/bin/list_apps_in_pkg
@@ -138,7 +138,7 @@ _list_apps_in_pkg () {
     if [[ -d "$opt_pkg" ]]; then
         pkgdir="$opt_pkg"
     else
-        local tmpdir="$(usr/bin/mktemp -d -t list_ids_in_pkg)"
+        local tmpdir="$(/usr/bin/mktemp -d -t list_ids_in_pkg)"
         trap "/bin/rm -rf -- '$tmpdir'" EXIT
         pkgdir="$tmpdir/unpack"
         /usr/sbin/pkgutil --expand "$opt_pkg" "$tmpdir/unpack" "$pkgdir"


### PR DESCRIPTION
Without the fix, I get this error:

```
./developer/bin/list_apps_in_pkg: line 141: usr/bin/mktemp: No such file or directory
```
