### PR TITLE
Update selfcontrol license

### DIFF
--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -6,7 +6,7 @@ cask :v1 => 'selfcontrol' do
   appcast 'http://selfcontrolapp.com/SelfControlAppcast.xml',
           :sha256 => '05d48c097c072ffd92d4d938b6984c8a09f446a556dc30acf25e3896cc3e0826'
   homepage 'http://selfcontrolapp.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'SelfControl.app'
 


### PR DESCRIPTION
SelfControl is licensed under GPL3. See https://github.com/SelfControlApp/selfcontrol
