### PR TITLE
update darktable to 1.6.1

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'darktable' do
-  version '1.6.0'
-  sha256 'f45fda7a7ac9648f26687b1b51f258493c73da592248ab2f0fa4b9bc79f0f3b4'
+  version '1.6.1'
+  sha256 'fcb45835f703bc394072fd5ee1f043f44097e2f48843da1cbfc414c3103606d0'
 
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
   homepage 'http://www.darktable.org/'


### PR DESCRIPTION
Update to darktable 1.6.1 https://github.com/darktable-org/darktable/releases/tag/release-1.6.1
