### PR TITLE
don't monkeypatch `MacOS#release`

### DIFF
--- a/lib/cask/cli/doctor.rb
+++ b/lib/cask/cli/doctor.rb
@@ -1,6 +1,7 @@
 class Cask::CLI::Doctor < Cask::CLI::Base
   def self.run
-    ohai 'OS X Version:',                                    render_with_none_as_error( MACOS_FULL_VERSION )
+    ohai 'OS X Release:',                                    render_with_none_as_error( MACOS_RELEASE )
+    ohai 'OS X Point Release:',                              render_with_none_as_error( MACOS_POINT_RELEASE )
     ohai "Hardware Architecture:",                           render_with_none_as_error( "#{Hardware::CPU.type}-#{Hardware::CPU.bits}" )
     ohai 'Ruby Version:',                                    render_with_none_as_error( "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" )
     ohai 'Ruby Path:',                                       render_with_none_as_error( RbConfig.ruby )

--- a/lib/cask/download_strategy.rb
+++ b/lib/cask/download_strategy.rb
@@ -127,7 +127,7 @@ class Cask::SubversionDownloadStrategy < SubversionDownloadStrategy
     args = [svncommand]
 
     # SVN shipped with XCode 3.1.4 can't force a checkout.
-    args << '--force' unless MacOS.version == :leopard
+    args << '--force' unless MacOS.release == :leopard
 
     # make timestamps consistent for checksumming
     args.concat(%w[--config-option config:miscellany:use-commit-times=yes])

--- a/lib/cask/installer.rb
+++ b/lib/cask/installer.rb
@@ -70,7 +70,7 @@ class Cask::Installer
   end
 
   def summary
-    s = if MacOS.version >= :lion and not ENV['HOMEBREW_NO_EMOJI']
+    s = if MacOS.release >= :lion and not ENV['HOMEBREW_NO_EMOJI']
       (ENV['HOMEBREW_INSTALL_BADGE'] || "\xf0\x9f\x8d\xba") + '  '
     else
       "#{Tty.blue.bold}==>#{Tty.white} Success!#{Tty.reset} "
@@ -129,16 +129,16 @@ class Cask::Installer
     return unless @cask.depends_on.macos
     if @cask.depends_on.macos.first.is_a?(Array)
       operator, release = @cask.depends_on.macos.first
-      unless MacOS.version.send(operator, release)
-        raise CaskError.new "Cask #{@cask} depends on OS X release #{operator} #{release}, but you are running release #{MacOS.version}."
+      unless MacOS.release.send(operator, release)
+        raise CaskError.new "Cask #{@cask} depends on OS X release #{operator} #{release}, but you are running release #{MacOS.release}."
       end
     elsif @cask.depends_on.macos.length > 1
-      unless @cask.depends_on.macos.include?(Gem::Version.new(MacOS.version.to_s))
-        raise CaskError.new "Cask #{@cask} depends on OS X release being one of: #{@cask.depends_on.macos(&:to_s).inspect}, but you are running release #{MacOS.version}."
+      unless @cask.depends_on.macos.include?(Gem::Version.new(MacOS.release.to_s))
+        raise CaskError.new "Cask #{@cask} depends on OS X release being one of: #{@cask.depends_on.macos(&:to_s).inspect}, but you are running release #{MacOS.release}."
       end
     else
-      unless MacOS.version == @cask.depends_on.macos.first
-        raise CaskError.new "Cask #{@cask} depends on OS X release #{@cask.depends_on.macos.first}, but you are running release #{MacOS.version}."
+      unless MacOS.release == @cask.depends_on.macos.first
+        raise CaskError.new "Cask #{@cask} depends on OS X release #{@cask.depends_on.macos.first}, but you are running release #{MacOS.release}."
       end
     end
   end
@@ -186,7 +186,7 @@ class Cask::Installer
   def enable_accessibility_access
     return unless @cask.accessibility_access
     ohai 'Enabling accessibility access'
-    if MacOS.version >= :mavericks
+    if MacOS.release >= :mavericks
       @command.run!('/usr/bin/sqlite3',
                     :args => [
                               Cask.tcc_db,
@@ -202,7 +202,7 @@ class Cask::Installer
 
   def disable_accessibility_access
     return unless @cask.accessibility_access
-    if MacOS.version >= :mavericks
+    if MacOS.release >= :mavericks
       ohai 'Disabling accessibility access'
       @command.run!('/usr/bin/sqlite3',
                     :args => [

--- a/lib/cask/utils.rb
+++ b/lib/cask/utils.rb
@@ -23,13 +23,6 @@ class Object
   end
 end
 
-# monkeypatch MacOS
-module MacOS
-  def release
-    version
-  end
-end
-
 # monkeypatch Hash
 class Hash
   def assert_valid_keys(*valid_keys)

--- a/lib/homebrew-fork/Library/Homebrew/download_strategy.rb
+++ b/lib/homebrew-fork/Library/Homebrew/download_strategy.rb
@@ -217,7 +217,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     svncommand = target.directory? ? 'up' : 'checkout'
     args = ['svn', svncommand]
     # SVN shipped with XCode 3.1.4 can't force a checkout.
-    args << '--force' unless MacOS.version == :leopard
+    args << '--force' unless MacOS.release == :leopard
     args << url unless target.directory?
     args << target
     args << '-r' << revision if revision

--- a/lib/homebrew-fork/Library/Homebrew/global.rb
+++ b/lib/homebrew-fork/Library/Homebrew/global.rb
@@ -37,9 +37,9 @@ HOMEBREW_LIBRARY = HOMEBREW_REPOSITORY.join('Library')
 
 HOMEBREW_TEMP = Pathname.new(ENV.fetch('HOMEBREW_TEMP', '/tmp'))
 
-MACOS_FULL_VERSION = `/usr/bin/sw_vers -productVersion`.chomp
-MACOS_VERSION = MACOS_FULL_VERSION[/10\.\d+/]
+MACOS_POINT_RELEASE = `/usr/bin/sw_vers -productVersion`.chomp
+MACOS_RELEASE = MACOS_POINT_RELEASE[/10\.\d+/]
 
-HOMEBREW_USER_AGENT = "Homebrew-cask v0.51+ (Ruby #{RUBY_VERSION}-#{RUBY_PATCHLEVEL}; #{MACOS_VERSION})"
+HOMEBREW_USER_AGENT = "Homebrew-cask v0.51+ (Ruby #{RUBY_VERSION}-#{RUBY_PATCHLEVEL}; #{MACOS_RELEASE})"
 
 HOMEBREW_CURL_ARGS = '-f#LA'

--- a/lib/homebrew-fork/Library/Homebrew/os/mac.rb
+++ b/lib/homebrew-fork/Library/Homebrew/os/mac.rb
@@ -10,8 +10,8 @@ module OS
 
     # This can be compared to numerics, strings, or symbols
     # using the standard Ruby Comparable methods.
-    def version
-      @version ||= Version.new(MACOS_VERSION)
+    def release
+      @release ||= Version.new(MACOS_RELEASE)
     end
 
     def prefer_64_bit?

--- a/lib/homebrew-fork/Library/Homebrew/os/mac/hardware.rb
+++ b/lib/homebrew-fork/Library/Homebrew/os/mac/hardware.rb
@@ -89,7 +89,7 @@ module MacCPUs
   def universal_archs
     # Building 64-bit is a no-go on Tiger, and pretty hit or miss on Leopard.
     # Don't even try unless Tigerbrew's experimental 64-bit Leopard support is enabled.
-    if MacOS.version <= :leopard and !MacOS.prefer_64_bit?
+    if MacOS.release <= :leopard and !MacOS.prefer_64_bit?
       [arch_32_bit].extend ArchitectureListExtension
     else
       [arch_32_bit, arch_64_bit].extend ArchitectureListExtension

--- a/lib/homebrew-fork/Library/Homebrew/os/mac/xquartz.rb
+++ b/lib/homebrew-fork/Library/Homebrew/os/mac/xquartz.rb
@@ -45,7 +45,7 @@ module OS
       # http://xquartz.macosforge.org/trac/wiki
       # http://xquartz.macosforge.org/trac/wiki/Releases
       def latest_version
-        case MacOS.version
+        case MacOS.release
         when "10.5"
           "2.6.3"
         else
@@ -68,7 +68,7 @@ module OS
       # pkg-util entry, so if Spotlight indexing is disabled we must make an
       # educated guess as to what version is installed.
       def guess_system_version
-        case MacOS.version
+        case MacOS.release
         when '10.5' then '2.1.6'
         when '10.6' then '2.3.6'
         when '10.7' then '2.6.3'

--- a/lib/homebrew-fork/Library/Homebrew/test/testing_env.rb
+++ b/lib/homebrew-fork/Library/Homebrew/test/testing_env.rb
@@ -17,8 +17,8 @@ HOMEBREW_CACHE         = HOMEBREW_PREFIX.parent+'cache'
 HOMEBREW_USER_AGENT    = 'Homebrew'
 HOMEBREW_CURL_ARGS     = '-fsLA'
 
-MACOS_FULL_VERSION = `/usr/bin/sw_vers -productVersion`.chomp
-MACOS_VERSION = ENV.fetch('MACOS_VERSION') { MACOS_FULL_VERSION[/10\.\d+/] }
+MACOS_POINT_RELEASE = `/usr/bin/sw_vers -productVersion`.chomp
+MACOS_RELEASE = ENV.fetch('MACOS_RELEASE') { MACOS_POINT_RELEASE[/10\.\d+/] }
 
 # Test environment setup
 # needed to keep rspec from attempting to write outside test dir

--- a/lib/homebrew-fork/Library/Homebrew/utils.rb
+++ b/lib/homebrew-fork/Library/Homebrew/utils.rb
@@ -39,7 +39,7 @@ def curl *args
 
   args = [flags, HOMEBREW_USER_AGENT, *args]
   # See https://github.com/Homebrew/homebrew/issues/6103
-  args << "--insecure" if MacOS.version < "10.6"
+  args << "--insecure" if MacOS.release < "10.6"
   args << "--verbose" if ENV['HOMEBREW_CURL_VERBOSE']
   args << "--silent" unless $stdout.tty?
 

--- a/test/cask/accessibility_test.rb
+++ b/test/cask/accessibility_test.rb
@@ -10,7 +10,7 @@ describe "Accessibility Access" do
 
   describe "install" do
     it "can enable accessibility access" do
-      MacOS.stubs(:version => OS::Mac::Version.new('10.9'))
+      MacOS.stubs(:release => OS::Mac::Version.new('10.9'))
 
       @installer.stubs(:bundle_identifier => 'com.example.BasicCask')
 
@@ -22,8 +22,8 @@ describe "Accessibility Access" do
       end
     end
 
-    it "can enable accessibility access in OS X versions prior to Mavericks" do
-      MacOS.stubs(:version => OS::Mac::Version.new('10.8'))
+    it "can enable accessibility access in OS X releases prior to Mavericks" do
+      MacOS.stubs(:release => OS::Mac::Version.new('10.8'))
 
       Cask::FakeSystemCommand.expects_command(
         ['/usr/bin/sudo', '-E', '--', '/usr/bin/touch', Cask.pre_mavericks_accessibility_dotfile]
@@ -36,7 +36,7 @@ describe "Accessibility Access" do
 
   describe "uninstall" do
     it "can disable accessibility access" do
-      MacOS.stubs(:version => OS::Mac::Version.new('10.9'))
+      MacOS.stubs(:release => OS::Mac::Version.new('10.9'))
 
       @installer.stubs(:bundle_identifier => 'com.example.BasicCask')
 
@@ -47,8 +47,8 @@ describe "Accessibility Access" do
         @installer.disable_accessibility_access
       end
     end
-    it "warns about disabling accessibility access on old OS X versions" do
-      MacOS.stubs(:version => OS::Mac::Version.new('10.8'))
+    it "warns about disabling accessibility access on old OS X releases" do
+      MacOS.stubs(:release => OS::Mac::Version.new('10.8'))
 
       @installer.stubs(:bundle_identifier => 'com.example.BasicCask')
 

--- a/test/cask/cli/doctor_test.rb
+++ b/test/cask/cli/doctor_test.rb
@@ -7,7 +7,7 @@ describe Cask::CLI::Doctor do
       Cask::CLI::Doctor.run
     end
     # no point in trying to match more of this environment-specific info
-    out.must_match /\A==> OS X Version:/
+    out.must_match /\A==> OS X Release:/
   end
 
   it "raises an exception when arguments are given" do

--- a/test/support/Casks/with-depends-on-macos-array.rb
+++ b/test/support/Casks/with-depends-on-macos-array.rb
@@ -5,8 +5,8 @@ cask :v1test => 'with-depends-on-macos-array' do
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-depends-on-macos-array'
 
-  # since all OS versions are included, this should always pass
-  depends_on :macos => [ '10.0', '10.1', '10.2', '10.3', '10.3', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10', MacOS.version.to_s ]
+  # since all OS releases are included, this should always pass
+  depends_on :macos => [ '10.0', '10.1', '10.2', '10.3', '10.3', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10', MacOS.release.to_s ]
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on-macos-failure.rb
+++ b/test/support/Casks/with-depends-on-macos-failure.rb
@@ -5,8 +5,8 @@ cask :v1test => 'with-depends-on-macos-failure' do
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-depends-on-macos-failure'
 
-  # guarantee a mismatched version
-  depends_on :macos => MacOS.version.to_s == '10.0' ? '10.1' : '10.0'
+  # guarantee a mismatched release
+  depends_on :macos => MacOS.release.to_s == '10.0' ? '10.1' : '10.0'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on-macos-string.rb
+++ b/test/support/Casks/with-depends-on-macos-string.rb
@@ -5,7 +5,7 @@ cask :v1test => 'with-depends-on-macos-string' do
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-depends-on-macos-string'
 
-  depends_on :macos => MacOS.version.to_s
+  depends_on :macos => MacOS.release.to_s
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on-macos-symbol.rb
+++ b/test/support/Casks/with-depends-on-macos-symbol.rb
@@ -5,7 +5,7 @@ cask :v1test => 'with-depends-on-macos-symbol' do
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/with-depends-on-macos-symbol'
 
-  depends_on :macos => MacOS.version.to_sym
+  depends_on :macos => MacOS.release.to_sym
 
   app 'Caffeine.app'
 end


### PR DESCRIPTION
- complete transition from `MacOS#version` to `MacOS#release` throughout backend code
- recast related constants and comments as "release" instead of "version", and "point release" instead of "full version"
- show point release in doctor output
