### PR TITLE
brew-cask.rb: fix `brew audit --strict brew-cask`.

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,22 +1,22 @@
-require 'pathname'
-require 'formula'
-
-require Pathname(__FILE__).realpath.dirname.join('lib', 'cask', 'version')
+require Pathname(__FILE__).realpath.dirname.join("lib", "cask", "version")
 
 class BrewCask < Formula
-  homepage 'https://github.com/caskroom/homebrew-cask/'
-  url 'https://github.com/caskroom/homebrew-cask.git', :tag => "v#{HOMEBREW_CASK_VERSION}"
+  homepage "https://github.com/caskroom/homebrew-cask/"
+  url "https://github.com/caskroom/homebrew-cask.git", :tag => "v#{HOMEBREW_CASK_VERSION}"
+  head "https://github.com/caskroom/homebrew-cask.git", :branch => "master"
 
-  head 'https://github.com/caskroom/homebrew-cask.git', :branch => 'master'
-
-  skip_clean 'bin'
+  skip_clean "bin"
 
   def install
-    man1.install 'doc/man/brew-cask.1'
-    prefix.install 'lib' => 'rubylib'
-    inreplace 'bin/brew-cask', '/lib', '/rubylib'
+    man1.install "doc/man/brew-cask.1"
+    prefix.install "lib" => "rubylib"
+    inreplace "bin/brew-cask", "/lib", "/rubylib"
 
-    prefix.install 'Casks', 'bin'
-    (bin+'brew-cask').chmod 0755
+    prefix.install "Casks", "bin"
+    (bin+"brew-cask").chmod 0755
+  end
+
+  test do
+    system "#{bin}/brew-cask", "cask", "info", "google-chrome"
   end
 end


### PR DESCRIPTION
We added a few more warnings so fix them up.
