### PR TITLE
Add Folding

### DIFF
--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -1,0 +1,19 @@
+cask :v1 => 'folding-at-home' do
+  version '7.4.4'
+  sha256 'c0de525eef498c2c4befc0b719ffd50d8fe4494ced64ee3bc4d60e8b919306a0'
+
+  url "https://fah.stanford.edu/file-releases/public/release/fah-installer/osx-10.6.4-64bit/v#{version.sub(/\.\d+$/, '')}/fah-installer_#{version}_x86_64.mpkg.zip"
+  name 'Folding@Home'
+  homepage 'http://folding.stanford.edu'
+  license :closed
+
+  pkg "fah-installer_#{version}_x86_64.pkg"
+
+  uninstall :pkgutil   => [
+                         'edu.stanford.folding.fahclient.pkg',
+                         'edu.stanford.folding.fahcontrol.pkg',
+                         'edu.stanford.folding.fahviewer.pkg',
+                         'edu.stanford.folding.uninstaller.pkg'
+                        ],
+            :launchctl => 'edu.stanford.folding.fahclient'
+end


### PR DESCRIPTION
Folding is a project by Stanford University to perform complex protien folding simulations on remote computers for scientific work.  The results are sent back (and obviously verified) and points awarded.

Now this is going to be a strange case.  The version is 7.4.4 - but the URL is https://fah.stanford.edu/file-releases/public/release/fah-installer/osx-10.6.4-64bit/v7.4/fah-installer_7.4.4_x86_64.mpkg.zip.  Both 7.4 and 7.4.4 make an appearance in the URL path.  In the PR I only replaced 7.4.4 and left 7.4 alone, but that's obviously not the best solution.

Should I add a "major_version" stanza with 7.4 (or would that even be possible)?  Or should this just be left as-is, with a notice to update part of the URL when the minor/major version changes as opposed to the patch?
