### PR TITLE
Update julia to v0.3.4

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'julia' do
-  version '0.3.3'
-  sha256 '24df35408e83d38bcf95fcaeefd613beeafe00e2b6d8435f760289c158adc7b9'
+  version '0.3.4'
+  sha256 '34cf0b928f20994a087c0cc550576992bc7abd4cc4e8db206125bb5d04c2ae47'
 
   url "https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-#{version}-osx10.7+.dmg"
   homepage 'http://julialang.org/'


### PR DESCRIPTION
Updates Julia to the latest stable version listed at http://julialang.org/downloads/
