### PR TITLE
Fix SHA sum for Julia 0.3.4

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'julia' do
   version '0.3.4'
-  sha256 '34cf0b928f20994a087c0cc550576992bc7abd4cc4e8db206125bb5d04c2ae47'
+  sha256 'eba64c0f2788ab39565541498fcd3c76625ebdfb9564e3f3ca023e022754c91b'
 
   url "https://s3.amazonaws.com/julialang/bin/osx/x64/0.3/julia-#{version}-osx10.7+.dmg"
   homepage 'http://julialang.org/'


### PR DESCRIPTION
My apologies, I somehow used the wrong SHA sum for Julia 0.3.4 in #8482, resulting in failed installations due to a mismatch. I’ve double-checked, and this is the correct expected checksum.
