### PR TITLE
Fix SHA checksum for Texstudio

### DIFF
--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'texstudio' do
   version '2.8.8'
-  sha256 'cd9fd18b0147f43db64af0bb9bb468c9532a8967aa64d1b0aaa09ea98980e91e'
+  sha256 'bc0212fe6897128982cbd7227ec10562fdb421ba8e127e45d79e9c766896665a'
 
   url "http://downloads.sourceforge.net/sourceforge/texstudio/texstudio_#{version}_osx_qt5.zip"
   homepage 'http://texstudio.sourceforge.net/'


### PR DESCRIPTION
This fixes the checksum mismatch when installing Texstudio.
