### PR TITLE
Fix app name for the 'djay Pro.app' Cask

### DIFF
--- a/Casks/djay.rb
+++ b/Casks/djay.rb
@@ -7,5 +7,5 @@ cask :v1 => 'djay' do
   homepage 'http://algoriddim.com/djay-mac'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  app 'djay.app'
+  app 'djay Pro.app'
 end


### PR DESCRIPTION
The app name in the downloaded zip file has changed from 'djay.app' to 'djay Pro.app'.
