### PR TITLE
don't redirect tput STDERR

### DIFF
--- a/lib/cask/utils/tty.rb
+++ b/lib/cask/utils/tty.rb
@@ -47,7 +47,7 @@ class Tty
     end
 
     def width
-      `/usr/bin/tput cols 2>/dev/null`.strip.to_i
+      `/usr/bin/tput cols`.strip.to_i
     end
 
     def truncate(str)


### PR DESCRIPTION
when both outputs are redirected, it always returns 80
