### PR TITLE
Update gitbook to use GitHub release

### DIFF
--- a/Casks/gitbook.rb
+++ b/Casks/gitbook.rb
@@ -1,9 +1,10 @@
 cask :v1 => 'gitbook' do
-  version :latest
-  sha256 :no_check
+  version '1.1.0'
+  sha256 'f8e2f7b28e7dfa18b3736f8d43d68068228774c0827fdc8c685846a129459c5f'
 
-  url 'https://www.gitbook.io/editor/download'
-  homepage 'https://www.gitbook.io/'
+  url "https://github.com/GitbookIO/editor/releases/download/#{version}/gitbook-mac.dmg"
+  name 'GitBook'
+  homepage 'https://github.com/GitbookIO/editor'
   license :apache
 
   app 'GitBook.app'


### PR DESCRIPTION
The maintainers of this app are no longer supporting the desktop
version, in favor of the web app. The latest desktop release is
no longer available from their website, but can be downloaded as
a GitHub release.

Closes #8540.
