### PR TITLE
Add additional GitHub launchctl service

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -13,7 +13,10 @@ cask :v1 => 'github' do
     suppress_move_to_applications
   end
 
-  uninstall :launchctl => 'com.github.GitHub.GHInstallCLI'
+  uninstall :launchctl => [
+                           'com.github.GitHub.Conduit',
+                           'com.github.GitHub.GHInstallCLI'
+                          ]
 
   zap :delete => [
                   '~/Library/Application Support/GitHub for Mac',


### PR DESCRIPTION
This one showed up in the output of `list_loaded_launchjob_ids`, but not `list_installed_launchjob_ids`. Weird.
