### PR TITLE
cryptol: Add cvc4 Cask dependency

### DIFF
--- a/Casks/cryptol.rb
+++ b/Casks/cryptol.rb
@@ -11,6 +11,8 @@ cask :v1 => 'cryptol' do
   binary "cryptol-#{version}-MacOSX-64/bin/cryptol"
   binary "cryptol-#{version}-MacOSX-64/lib/Cryptol.cry", :target => '/usr/local/lib/Cryptol.cry'
 
+  depends_on :cask => 'cvc4'
+
   caveats do
     files_in_usr_local
     <<-EOS.undent


### PR DESCRIPTION
Left the caveats alone, since it's still important that the CVC4 binary is in your PATH (installed to /opt/local/bin by default).

Per discussion in #8492.
