### PR TITLE
Updated download url for supersync.rb

### DIFF
--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'supersync' do
-  version :latest
-  sha256 :no_check
+  version '6.1'
+  sha256 'c97191ea844a581bbafc8382cac6449be577c1c8b5639c64033fb200fc3a79dc'
 
-  url 'https://supersync.com/downloads/SuperSync.app.zip'
+  url 'http://supersync.com/downloads/SuperSync-6.1.dmg'
   homepage 'http://supersync.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 


### PR DESCRIPTION
supersync no longer supports downloading the latest version, so I replaced the url with the latest version url
