### PR TITLE
Upgrade dbeaver to 3.1.1 - Prioritize 64-bit ver.

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'dbeaver-community' do
   version '3.1.1'
 
-  if Hardware::CPU.is_64_bit?
-    sha256 '77eff21ec2b49cf7473aa1fff3b7ccf99ddf93c48470414376f002263f324ef7'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86_64.zip"
-  else
+  if Hardware::CPU.is_32_bit?
     sha256 '0e1eef7f80d880a895fdd8bc205edfa3c82b2d4165de25cfd5c6bd8292682707'
     url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86.zip"
+  else
+    sha256 '77eff21ec2b49cf7473aa1fff3b7ccf99ddf93c48470414376f002263f324ef7'
+    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86_64.zip"
   end
 
   homepage 'http://dbeaver.jkiss.org/'

--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'dbeaver-community' do
-  version '3.0.2'
+  version '3.1.1'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 'fa4b332756aaba3ee8bd2b07ef52b5b4dc5cb679ad8ac29a1f54d00f2c867bbf'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86.zip"
-  else
-    sha256 'b32c6f5fb64f1bdeab9683b62b7a685e022ba7f61c00e4b04d7ef8e62c75d61d'
+  if Hardware::CPU.is_64_bit?
+    sha256 '77eff21ec2b49cf7473aa1fff3b7ccf99ddf93c48470414376f002263f324ef7'
     url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86_64.zip"
+  else
+    sha256 '0e1eef7f80d880a895fdd8bc205edfa3c82b2d4165de25cfd5c6bd8292682707'
+    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86.zip"
   end
 
   homepage 'http://dbeaver.jkiss.org/'

--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'dbeaver-enterprise' do
-  version '3.0.2'
+  version '3.1.1'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '8943411eff3074ff7f986fa2f9db4ab185519c4ba20abef67f8fa18d9e270e5b'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86.zip"
-  else
-    sha256 '7751a5a97de1f78735eaba3d69486cc39b8bddb1f4b2fb81173d111a6ee2b8c8'
+  if Hardware::CPU.is_64_bit?
+    sha256 '27564968a4fd27dcaca5a9639cd787f63f006cab844017c7d094f922d506922d'
     url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86_64.zip"
+  else
+    sha256 '692bf7ab300f0876ab3dac996e61f0b7c367db307c8190754fbf798dbb38daeb'
+    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86.zip"
   end
 
   homepage 'http://dbeaver.jkiss.org/'

--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'dbeaver-enterprise' do
   version '3.1.1'
 
-  if Hardware::CPU.is_64_bit?
-    sha256 '27564968a4fd27dcaca5a9639cd787f63f006cab844017c7d094f922d506922d'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86_64.zip"
-  else
+  if Hardware::CPU.is_32_bit?
     sha256 '692bf7ab300f0876ab3dac996e61f0b7c367db307c8190754fbf798dbb38daeb'
     url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86.zip"
+  else
+    sha256 '27564968a4fd27dcaca5a9639cd787f63f006cab844017c7d094f922d506922d'
+    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86_64.zip"
   end
 
   homepage 'http://dbeaver.jkiss.org/'


### PR DESCRIPTION
Upgraded both dbeaver-enterprise and dbeaver-community casks to
3.1.1. Also fixed a bug that checked for 32-bit architecture first
rather than checking for 64-bit version, hence always installing
the 32-bit version.
