### PR TITLE
Revert "qgis: Add gdal-framework, matplotlib Cask dependencies"

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -9,8 +9,15 @@ cask :v1 => 'qgis' do
 
   uninstall :pkgutil => 'org.qgis.qgis-*'
 
-  depends_on :cask => [
-                       'gdal-framework',
-                       'matplotlib'
-                      ]
+  caveats <<-EOS.undent
+    #{token} requires the GDAL framework and Matplotlib to be installed first,
+    otherwise the installation will fail. In case of problems, try installing
+    them:
+
+      brew cask install gdal-framework matplotlib
+
+    and then reinstall QGIS
+
+      brew cask uninstall qgis && brew cask install qgis
+  EOS
 end


### PR DESCRIPTION
`depends_on :cask` is not yet released; the dependency caveats must remain until then.
