### PR TITLE
the lastest is now v2.3.0.

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'hex-fiend' do
-  version :latest
-  sha256 :no_check
+  version '2.3.0'
+  sha256 '0e0a683971c872ee734af2a3440f1f2abb8d442609077bd5c3e212ab3b5439f7'
 
-  url 'http://ridiculousfish.com/hexfiend/files/HexFiend.zip'
+  # github.com is the official download host per the vendor homepage.
+  url 'https://github.com/ridiculousfish/HexFiend/releases/download/v2.3.0/Hex.Fiend.app.zip'
   homepage 'http://ridiculousfish.com/hexfiend/'
   license :bsd
 


### PR DESCRIPTION
Hello,

I updated the cask because a more recent version is available on the hex-fiend's github repository.
Could you say if it's a good idea to alter the :latest param by the effective version ?

Thank a lot,
