### PR TITLE
Cask dependency stanzas, caveats for 2 casks

### DIFF
--- a/Casks/cryptol.rb
+++ b/Casks/cryptol.rb
@@ -15,9 +15,5 @@ cask :v1 => 'cryptol' do
 
   caveats do
     files_in_usr_local
-    <<-EOS.undent
-      Cryptol depends on CVC4 (http://cvc4.cs.nyu.edu/).
-      The CVC4 binary must be in your PATH.
-    EOS
   end
 end

--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -9,15 +9,6 @@ cask :v1 => 'qgis' do
 
   uninstall :pkgutil => 'org.qgis.qgis-*'
 
-  caveats <<-EOS.undent
-    #{token} requires the GDAL framework and Matplotlib to be installed first,
-    otherwise the installation will fail. In case of problems, try installing
-    them:
-
-      brew cask install gdal-framework matplotlib
-
-    and then reinstall QGIS
-
-      brew cask uninstall qgis && brew cask install qgis
-  EOS
+  depends_on :cask => 'gdal-framework'
+  depends_on :cask => 'matplotlib'
 end


### PR DESCRIPTION
- Add `depends_on :cask` to qgis; remove caveats.
- Remove caveat from cryptol.

Refer to #8492.
