### PR TITLE
Update ScreenFlow.app to v5.0.1

### DIFF
--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -1,10 +1,13 @@
 cask :v1 => 'screenflow' do
-  version '5.0'
-  sha256 'ee08bbf672d449e8c304b0b44d722a32d674d367725b7c6c8937254c50306f09'
+  version '5.0.1'
+  sha256 'd608763201157e0a92daf404f9d507dfe5f838bcf03b9e6d6eada6c8a60769c7'
 
   url "http://www.telestream.net/download-files/screenflow/5-0/ScreenFlow-#{version}.dmg"
+  appcast 'http://www.telestream.net/updater/screenflow/appcast.xml'
   homepage 'http://www.telestream.net/screenflow/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'ScreenFlow.app'
+
+  depends_on :macos => '>= :mavericks'
 end


### PR DESCRIPTION
ScreenFlow.app v5.0.1 released 2014-12-18.
