### PR TITLE
mono-mdk: Cask is updated in-place, use sha256 :no_check

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'mono-mdk' do
   version '3.10.0'
-  sha256 'e71b558c2b7857c124ccbb5e73bc622733e1cd5da494a7b5d9d14a90f555c1b8'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "http://download.mono-project.com/archive/#{version}/macos-10-x86/MonoFramework-MDK-#{version}.macos10.xamarin.x86.pkg"
   homepage 'http://mono-project.com/'


### PR DESCRIPTION
Closes #8610.
