### PR TITLE
Improve error message for AIR app reinstallation

### DIFF
--- a/lib/hbc/container/air.rb
+++ b/lib/hbc/container/air.rb
@@ -25,7 +25,11 @@ class Hbc::Container::Air < Hbc::Container::Base
   end
 
   def extract
-    @command.run!(self.class.installer_cmd,
-                  :args => ['-silent', '-location', @cask.staged_path, Pathname.new(@path).realpath])
+    install = @command.run(self.class.installer_cmd,
+                           :args => ['-silent', '-location', @cask.staged_path, Pathname.new(@path).realpath])
+
+    if install.exit_status == 9 then
+      raise Hbc::CaskError.new "Adobe AIR application #{@cask} already exists on the system, and cannot be reinstalled."
+    end
   end
 end


### PR DESCRIPTION
Closes #8606. This patch merely presents a readable error message to the user; the underlying problem persists, but there is little we can do.

Note: every other attempt to reinstall with `brew cask` will succeed. The most likely cause is that launching an AIR installer with `-silent -location installer_path destination_path` nukes any preexisting package at `destination_path`.
