### PR TITLE
Update shuttle to version 1.2.2

### DIFF
--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'shuttle' do
-  version '1.2.0'
+  version '1.2.2'
   sha256 'a6a20b461556e54c99f14eaaaa4ee8e41cb0250561525be87340f0fda635d2b3'
 
-  url "https://github.com/fitztrev/shuttle/releases/download/v#{version}/Shuttle.dmg"
+  url "https://github.com/fitztrev/shuttle/releases/download/#{version}/Shuttle.zip"
   homepage 'http://fitztrev.github.io/shuttle/'
   license :mit
 


### PR DESCRIPTION
Use the zip file now, instead of the dmg.
