### PR TITLE
Correct name positions

### DIFF
--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -3,8 +3,8 @@ cask :v1 => 'base' do
   sha256 :no_check
 
   url 'http://menial.co.uk/base/download/'
-  name 'Base'
   appcast 'http://update.menial.co.uk/software/base/'
+  name 'Base'
   homepage 'http://menial.co.uk/base/'
   license :commercial
   tags :vendor => 'Menial'

--- a/Casks/big-mean-folder-machine.rb
+++ b/Casks/big-mean-folder-machine.rb
@@ -3,8 +3,8 @@ cask :v1 => 'big-mean-folder-machine' do
   sha256 :no_check
 
   url 'http://www.publicspace.net/download/BMFM.dmg'
-  name 'Big Mean Folder Machine'
   appcast 'http://www.publicspace.net/app/bmfm2.xml'
+  name 'Big Mean Folder Machine'
   homepage 'http://www.publicspace.net/BigMeanFolderMachine/'
   license :commercial
 

--- a/Casks/bootxchanger.rb
+++ b/Casks/bootxchanger.rb
@@ -3,9 +3,9 @@ cask :v1 => 'bootxchanger' do
   sha256 'cfb05680ab6a7d0b1793a33135dd15562a7b5fd59bb1ebf3ad6067c2c9fad6c1'
 
   url "http://namedfork.net/_media/bootxchanger_#{version}.dmg"
-  name 'BootXChanger'
   appcast 'http://swupdate.namedfork.net/bootxchanger.xml',
           :sha256 => 'afbae3b2a378ebb18f1668c062ba48436e956cad840fcc86cba610d351931187'
+  name 'BootXChanger'
   homepage 'http://namedfork.net/bootxchanger'
   license :gpl
 

--- a/Casks/bowtie.rb
+++ b/Casks/bowtie.rb
@@ -3,9 +3,9 @@ cask :v1 => 'bowtie' do
   sha256 'd8406b066851c0730ca052036bedd5ded82019403de1fd58b579da34cfa4a948'
 
   url "http://bowtieapp.com/bowtie-#{version}.zip"
-  name 'Bowtie'
   appcast 'http://updates.13bold.com/appcasts/bowtie',
           :sha256 => '006ab04ddddeb487b3b16807d58508549e067baf601656f1f95740791d1cca66'
+  name 'Bowtie'
   homepage 'http://bowtieapp.com/'
   license :gratis
 

--- a/Casks/ccmenu.rb
+++ b/Casks/ccmenu.rb
@@ -3,9 +3,9 @@ cask :v1 => 'ccmenu' do
   sha256 'e2d36083388b4c68c1dff396393f4d3b2df614ff09deca1fdd9bbba286f7faa5'
 
   url "http://downloads.sourceforge.net/project/ccmenu/CCMenu/#{version}/ccmenu-#{version}-b.dmg"
-  name 'CCMenu'
   appcast 'http://ccmenu.sourceforge.net/update-stable.xml',
           :sha256 => 'a72951f416906d309cb7ec8d233bf5546540641efa99332e0f1bdde119b51cac'
+  name 'CCMenu'
   homepage 'http://ccmenu.sourceforge.net/'
   license :oss
 

--- a/Casks/colorschemer-studio.rb
+++ b/Casks/colorschemer-studio.rb
@@ -3,8 +3,8 @@ cask :v1 => 'colorschemer-studio' do
   sha256 :no_check
 
   url 'https://www.colorschemer.com/colorschemerstudio.dmg'
-  name 'ColorSchemer Studio'
   appcast 'http://www.colorschemer.com/appcast/studio2_mac.xml'
+  name 'ColorSchemer Studio'
   homepage 'http://www.colorschemer.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/contexts.rb
+++ b/Casks/contexts.rb
@@ -3,8 +3,8 @@ cask :v1 => 'contexts' do
   sha256 :no_check
 
   url 'http://contextsformac.com/releases/Contexts.zip'
-  name 'Contexts'
   appcast 'http://www.contextsformac.com/releases/appcast.xml'
+  name 'Contexts'
   homepage 'http://contextsformac.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -3,9 +3,9 @@ cask :v1 => 'coteditor' do
   sha256 'b656aa0b6526c89d7d52cf12b715cf529f8e5048c7e13720673c3e32318a26d8'
 
   url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
-  name 'CotEditor'
   appcast 'http://coteditor.com/appcast.xml',
           :sha256 => '86c24c497701e51df3e0b35e72be5f1cc1d2e3b307a8deb0a188c3443ccd553f'
+  name 'CotEditor'
   homepage 'http://coteditor.com/'
   license :gpl
 

--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -3,9 +3,9 @@ cask :v1 => 'electrum-ltc' do
   sha256 '6e6cee192fc4485d8ba0850fc07eab6d58b0abd55b92209a2076aa3d12c10801'
 
   url "https://electrum-ltc.org/download/Electrum-LTC-#{version}.dmg"
-  name 'Electrum-LTC'
   gpg "#{url}.asc",
       :key_id => '9914864dfc33499c6ca2beea22453004695506fd'
+  name 'Electrum-LTC'
   homepage 'http://electrum-ltc.org'
   license :gpl
 

--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -3,8 +3,8 @@ cask :v1 => 'flux' do
   sha256 :no_check
 
   url 'https://justgetflux.com/mac/Flux.zip'
-  name 'f.lux'
   appcast 'https://justgetflux.com/mac/macflux.xml'
+  name 'f.lux'
   homepage 'http://justgetflux.com'
   license :gratis
 

--- a/Casks/freezer.rb
+++ b/Casks/freezer.rb
@@ -3,8 +3,8 @@ cask :v1 => 'freezer' do
   sha256 :no_check
 
   url 'http://download.mrgeckosmedia.com/Freezer.zip'
-  name 'Freezer'
   appcast 'https://mrgeckosmedia.com/applications/appcast/Freezer'
+  name 'Freezer'
   homepage 'https://mrgeckosmedia.com/applications/info/Freezer'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/hear.rb
+++ b/Casks/hear.rb
@@ -3,9 +3,9 @@ cask :v1 => 'hear' do
   sha256 '6acd179b108283a51debac3c6a4f7cf20220d4129a702ce702f06cc7e2884649'
 
   url "https://s3.amazonaws.com/prosoft-engineering/hear/Hear_#{version}.dmg"
-  name 'Hear'
   appcast 'http://www.prosofteng.com/resources/sparkle/sparkle.php?psProduct=Hear',
           :sha256 => '48edc9b03ce5d9709b27fb5099dc3cce25cc8920656b9cdb9a066ae7999c8d9d'
+  name 'Hear'
   homepage 'http://www.prosofteng.com/products/hear.php'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/houdahgeo.rb
+++ b/Casks/houdahgeo.rb
@@ -3,8 +3,8 @@ cask :v1 => 'houdahgeo' do
   sha256 :no_check
 
   url 'http://houdah.com/houdahGeo/download_assets/HoudahGeo_latest.zip'
-  name 'HoudahGeo'
   appcast 'http://www.houdah.com/houdahGeo/updates3/profileInfo.php'
+  name 'HoudahGeo'
   homepage 'http://houdah.com/houdahGeo/'
   license :commercial
 

--- a/Casks/inboard.rb
+++ b/Casks/inboard.rb
@@ -3,9 +3,9 @@ cask :v1 => 'inboard' do
   sha256 '3bb602cde63f0b3401fc681cd50a3545c5a47c2326ea81cf66844039fb100522'
 
   url "http://dl.devmate.com/com.ideabits.Inboard/#{version}/1390822305/Inboard-#{version}.dmg"
-  name 'Inboard'
   appcast 'http://updates.devmate.com/com.ideabits.Inboard.xml',
           :sha256 => '3bde9bcd42058928757ce5b3edc9de1ef4f488b190b8efec40e6c7e4fd69a020'
+  name 'Inboard'
   homepage 'http://inboardapp.com/beta'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -3,9 +3,9 @@ cask :v1 => 'jameica' do
   sha256 :no_check
 
   url 'http://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64.zip'
-  name 'Jameica'
   gpg "#{url}.asc",
       :key_id => '5a8ed9cfc0db6c70'
+  name 'Jameica'
   homepage 'http://www.willuhn.de/products/jameica/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/jumpcut.rb
+++ b/Casks/jumpcut.rb
@@ -3,9 +3,9 @@ cask :v1 => 'jumpcut' do
   sha256 '19c84eefbc7f173af45affe3a9ca6fd9ec58d9bdf6bacef165085e63e82d54e1'
 
   url "http://downloads.sourceforge.net/project/jumpcut/jumpcut/#{version}/Jumpcut_#{version}.tgz"
-  name 'Jumpcut'
   appcast 'http://jumpcut.sf.net/jumpcut.appcast.xml',
           :sha256 => '908a13b8cf3ef67128d6bd1a09ef6f7e70a60e7c39f67e36d1a178fcb30bb38c'
+  name 'Jumpcut'
   homepage 'http://jumpcut.sourceforge.net/'
   license :oss
 

--- a/Casks/meerkat.rb
+++ b/Casks/meerkat.rb
@@ -3,9 +3,9 @@ cask :v1 => 'meerkat' do
   sha256 'bf5a5e492463a7ec1c3e959a55227dd6fcec5bb902124f9bde819bf4f5933982'
 
   url "http://codesorcery.net/downloads/Meerkat_#{version}.dmg"
-  name 'Meerkat'
   appcast 'http://codesorcery.net/appcasts/Meerkat.xml',
           :sha256 => 'ef91167a375342e078f147e20477056552bef06ea9e306a93ffb8a17ad4e654c'
+  name 'Meerkat'
   homepage 'http://codesorcery.net/meerkat'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/mongohub.rb
+++ b/Casks/mongohub.rb
@@ -3,8 +3,8 @@ cask :v1 => 'mongohub' do
   sha256 :no_check
 
   url 'https://mongohub.s3.amazonaws.com/MongoHub.zip'
-  name 'MongoHub'
   appcast 'https://mongohub.s3.amazonaws.com/mongohub_su_feed.xml'
+  name 'MongoHub'
   homepage 'https://github.com/fotonauts/MongoHub-Mac'
   license :oss
 

--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -3,8 +3,8 @@ cask :v1 => 'moom' do
   sha256 :no_check
 
   url 'http://manytricks.com/download/moom'
-  name 'Moom'
   appcast 'http://manytricks.com/moom/appcast.xml'
+  name 'Moom'
   homepage 'http://manytricks.com/moom/'
   license :commercial
 

--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -3,9 +3,9 @@ cask :v1 => 'onionshare' do
   sha256 '80c583f1dc280f08c11dc60b308e2f6d8fe31c554d59f795ccf0f3252733a6ce'
 
   url "https://onionshare.org/files/#{version}/OnionShare-#{version}.dmg"
-  name 'OnionShare'
   gpg "#{url}.sig",
       :key_url => 'https://onionshare.org/signing-key.asc'
+  name 'OnionShare'
   homepage 'https://onionshare.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/optimal-layout.rb
+++ b/Casks/optimal-layout.rb
@@ -3,8 +3,8 @@ cask :v1 => 'optimal-layout' do
   sha256 :no_check
 
   url 'http://files.windowflow.com/OptimalLayout2.zip'
-  name 'Optimal Layout'
   appcast 'http://most-advantageous.com/sparkle/OL-AppCast.cfm'
+  name 'Optimal Layout'
   homepage 'http://most-advantageous.com/optimal-layout/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -3,8 +3,8 @@ cask :v1 => 'pacifist' do
   sha256 :no_check
 
   url 'https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg'
-  name 'Pacifist'
   appcast 'http://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi'
+  name 'Pacifist'
   homepage 'http://www.charlessoft.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -3,8 +3,8 @@ cask :v1 => 'rapidweaver' do
   sha256 'e30a85f337d846a44feb902f0214b6cd49c2ff375db81a7197704fd57aae0442'
 
   url "http://realmacsoftware.com/redirects/rapidweaver#{version.to_i}/direct"
-  name 'RapidWeaver'
   appcast "http://www.realmacsoftware.com/stats/rapidweaver#{version.to_i}.php"
+  name 'RapidWeaver'
   homepage 'http://realmacsoftware.com/rapidweaver'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/scapple.rb
+++ b/Casks/scapple.rb
@@ -3,8 +3,8 @@ cask :v1 => 'scapple' do
   sha256 :no_check
 
   url 'https://scrivener.s3.amazonaws.com/Scapple.dmg'
-  name 'Scapple'
   appcast 'http://www.literatureandlatte.com/downloads/scapple/scapple.xml'
+  name 'Scapple'
   homepage 'https://www.literatureandlatte.com/scapple.php'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/scrup.rb
+++ b/Casks/scrup.rb
@@ -3,9 +3,9 @@ cask :v1 => 'scrup' do
   sha256 '5004222db9a6ddd4e6cb525d00e95f8a38e9fb623bc1397e5258b2ef2c4bd3b0'
 
   url "http://data.hunch.se/scrup/Scrup-#{version}-bd23160.zip"
-  name 'Scrup'
   appcast 'https://s.rsms.me/scrup/appcast.xml',
           :sha256 => '140f4487d00bb157286f261bfddb8f7a8c29a4fc2e53a63119bdbe1c828a6d00'
+  name 'Scrup'
   homepage 'https://github.com/rsms/scrup'
   license :oss
 

--- a/Casks/snippet-edit.rb
+++ b/Casks/snippet-edit.rb
@@ -3,9 +3,9 @@ cask :v1 => 'snippet-edit' do
   sha256 '2a6ee1b3ecd5d5d84743be9d81b36e969f05fe40209d8877008dc6f60d95d37c'
 
   url "http://cocoaholic.com/downloads/snippet_edit/Snippet_Edit_#{version}.zip"
-  name 'Snippet Edit'
   appcast 'http://cocoaholic.com/sparkle/snippet_edit/sparkle.xml',
           :sha256 => 'a32af024b5e43f5bd6fef837808d8130359000c2f7f975f38abc46aecf17e113'
+  name 'Snippet Edit'
   homepage 'http://cocoaholic.com/snippet_edit/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/switchup.rb
+++ b/Casks/switchup.rb
@@ -3,9 +3,9 @@ cask :v1 => 'switchup' do
   sha256 'dd269749385090bec6bbf30e917b78f07cf0424c5e94c3602a41dbf7718597b3'
 
   url "http://www.irradiatedsoftware.com/downloads/SwitchUp_#{version}.zip"
-  name 'SwitchUp'
   appcast 'http://www.irradiatedsoftware.com/updates/profiles/switchup.php',
           :sha256 => 'a9feeb5f7dcb832042ad2d8083844e6f26c0537628820870b27e1d8a8d5abb82'
+  name 'SwitchUp'
   homepage 'http://www.irradiatedsoftware.com/switchup/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/time-tracker.rb
+++ b/Casks/time-tracker.rb
@@ -3,9 +3,9 @@ cask :v1 => 'time-tracker' do
   sha256 'a6c982ee82f8babcf0f42d49950e5b3a1d613946736a7ee4a272b05916271aeb'
 
   url "https://time-tracker-mac.googlecode.com/files/Time%20Tracker-#{version}.zip"
-  name 'TimeTracker'
   appcast 'http://time-tracker-mac.googlecode.com/svn/appcast/timetracker-test.xml',
           :sha256 => '8737634f2e43e4eaf63d2ab603b47e46c13f3c322e2484b407f45776905777aa'
+  name 'TimeTracker'
   homepage 'https://code.google.com/p/time-tracker-mac'
   license :oss
 

--- a/Casks/tunnelbear.rb
+++ b/Casks/tunnelbear.rb
@@ -3,9 +3,9 @@ cask :v1 => 'tunnelbear' do
   sha256 '39d39d8f7801ef5d13787647919fb78f4f4669164002d9299b4b0fc7b2e4ccf5'
 
   url "https://tunnelbear.s3.amazonaws.com/downloads/mac/TunnelBear-#{version}.zip"
-  name 'TunnelBear'
   appcast 'https://s3.amazonaws.com/tunnelbear/downloads/mac/appcast.xml',
           :sha256 => '69e4bf8982ecc871fd701062b35c7de265ebd76b8676256923cf7c6e1b1249a0'
+  name 'TunnelBear'
   homepage 'https://www.tunnelbear.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/twentytwo.rb
+++ b/Casks/twentytwo.rb
@@ -3,8 +3,8 @@ cask :v1 => 'twentytwo' do
   sha256 :no_check
 
   url 'https://github.com/marcw/twentytwo/raw/master/dist/TwentyTwo.dmg'
-  name 'TwentyTwo'
   appcast 'https://raw.github.com/marcw/soundcleod/master/appcast.xml'
+  name 'TwentyTwo'
   homepage 'https://github.com/marcw/twentytwo'
   license :mit
 

--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -3,8 +3,8 @@ cask :v1 => 'virtualhostx' do
   sha256 :no_check
 
   url 'https://clickontyler.com/virtualhostx/download/v6/'
-  name 'VirtualHostX'
   appcast 'http://shine.clickontyler.com/appcast.php?id=30'
+  name 'VirtualHostX'
   homepage 'http://clickontyler.com/virtualhostx/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 


### PR DESCRIPTION
Had to change my strategy. While getting and verifying names is a manual process (has to be), adding it to the cask is semi-automated. Should be adding them above `homepage`, instead of under `url`. This corrects the already merged mistakes.
