### PR TITLE
corrected fuze.rb

### DIFF
--- a/Casks/fuze.rb
+++ b/Casks/fuze.rb
@@ -2,9 +2,10 @@ cask :v1 => 'fuze' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.fuzemeeting.com/downloads/fuze/Fuze.dmg'
-  homepage 'https://www.fuzemeeting.com'
+  # fuzemeeting.com is the official download host per the vendor homepage
+  url 'https://www.fuzemeeting.com/fuze/mac_download'
+  homepage 'https://www.fuze.com/'
   license :commercial
 
-  app 'Fuze.app'
+  installer :manual => 'Fuze_39e32182.app'
 end


### PR DESCRIPTION
Due to the installer’s name, this cask may need to become versioned (we’ll see on the next update).
