### PR TITLE
update git-annex.rb conditional to use fallthrough

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -17,8 +17,8 @@ cask :v1 => 'deeper' do
   elsif MacOS.release == :yosemite
     url 'http://www.titanium.free.fr/download/1010/Deeper.dmg'
   else
-    # Unusual case: there is no fall-through.  Each version of the software is
-    # specific to an OS X release, so define nothing when the release is unknown.
+    # Unusual case: there is no fall-through.  The software will stop
+    # working, or is dangerous to run, on the next OS X release.
   end
 
   homepage 'http://www.titanium.free.fr/downloaddeeper.php'

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -2,7 +2,7 @@ cask :v1 => 'git-annex' do
   version :latest
   sha256 :no_check
 
-  if MacOS.release == :lion
+  if MacOS.release <= :lion
     url 'https://downloads.kitenet.net/git-annex/OSX/current/10.7.5_Lion/git-annex.dmg'
   elsif MacOS.release == :mountain_lion
     url 'https://downloads.kitenet.net/git-annex/OSX/current/10.8.2_Mountain_Lion/git-annex.dmg.bz2'
@@ -15,11 +15,8 @@ cask :v1 => 'git-annex' do
     container :nested => 'git-annex-latest.dmg'
   elsif MacOS.release == :mavericks
     url 'https://downloads.kitenet.net/git-annex/OSX/current/10.9_Mavericks/git-annex.dmg'
-  elsif MacOS.release == :yosemite
-    url 'https://downloads.kitenet.net/git-annex/OSX/current/10.10_Yosemite/git-annex.dmg'
   else
-    # Unusual case: there is no fall-through.  Each version of the software is
-    # specific to an OS X release, so define nothing when the release is unknown.
+    url 'https://downloads.kitenet.net/git-annex/OSX/current/10.10_Yosemite/git-annex.dmg'
   end
 
   gpg "#{url}.sig",

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -17,8 +17,8 @@ cask :v1 => 'maintenance' do
   elsif MacOS.release == :yosemite
     url 'http://www.titanium.free.fr/download/1010/Maintenance.dmg'
   else
-    # Unusual case: there is no fall-through.  Each version of the software is
-    # specific to an OS X release, so define nothing when the release is unknown.
+    # Unusual case: there is no fall-through.  The software will stop
+    # working, or is dangerous to run, on the next OS X release.
   end
 
   homepage 'http://www.titanium.free.fr/downloadmaintenance.php'

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -17,8 +17,8 @@ cask :v1 => 'onyx' do
   elsif MacOS.release == :yosemite
     url 'http://www.titanium.free.fr/download/1010/OnyX.dmg'
   else
-    # Unusual case: there is no fall-through.  Each version of the software is
-    # specific to an OS X release, so define nothing when the release is unknown.
+    # Unusual case: there is no fall-through.  The software will stop
+    # working, or is dangerous to run, on the next OS X release.
   end
   homepage 'http://www.titanium.free.fr/downloadonyx.php'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
git-annex is not system-specific software, and should not stop working on a new release.  Also, attempt to install the Lion build on older releases.

Clarify fallthrough comments in the cases where software is expected to cease working under a new release.
