### PR TITLE
fix yEd cask

### DIFF
--- a/Casks/yed.rb
+++ b/Casks/yed.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'yed' do
-  version '3.13'
-  sha256 'b597d7468cef6981ed364a17c525a8b83d0818fd016c21f3efc6e3ea99922d1d'
+  version '3.14'
+  sha256 '6978e180d6063e22ab0460742915b20d1f3419d284a7815041d28e318764f8ad'
 
-  url "http://www.yworks.com/products/yed/demo/yEd-#{version}.dmg"
+  url "http://live.yworks.com/yed-downloads/yEd-#{version}_with-JRE8.dmg"
   homepage 'http://www.yworks.com/en/products_yed_about.html'
   license :unknown # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 


### PR DESCRIPTION
currently, the yEd cask gives this behavior

```
$ brew cask install yEd
==> Downloading http://www.yworks.com/products/yed/demo/yEd-3.13.dmg
######################################################################## 100.0%
curl: (7) Failed to connect to 127.0.0.1 port 80: Connection refused
Error: Download failed on Cask 'yed' with message: Download failed: http://www.yworks.com/products/yed/demo/yEd-3.13.dmg
```

This happens because the yEd folk have a bogus redirect at that url:

```
$ curl http://www.yworks.com/products/yed/demo/yEd-3.13.dmg
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="http://127.0.0.1/yEd-3.13.dmg">here</a>.</p>
</body></html>
```
