### PR TITLE
Add `brew cask --repository` command

### DIFF
--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -16,6 +16,7 @@ require 'hbc/cli/home'
 require 'hbc/cli/info'
 require 'hbc/cli/install'
 require 'hbc/cli/list'
+require 'hbc/cli/repository'
 require 'hbc/cli/search'
 require 'hbc/cli/uninstall'
 require 'hbc/cli/update'
@@ -39,10 +40,10 @@ class Hbc::CLI
              'remove'         => 'uninstall',
              'abv'            => 'info',
              'dr'             => 'doctor',
+             '--repo'         => '--repository'
              # aliases from Homebrew that we don't (yet) support
              # 'ln'           => 'link',
              # 'configure'    => 'diy',
-             # '--repo'       => '--repository',
              # 'environment'  => '--env',
              # '-c1'          => '--config',
             }

--- a/lib/hbc/cli/repository.rb
+++ b/lib/hbc/cli/repository.rb
@@ -1,0 +1,13 @@
+class Hbc::CLI::Repository < Hbc::CLI::Base
+  def self.run(*args)
+    puts Hbc.tapspath.join Hbc.default_tap
+  end
+
+  def self.command_name
+    @command_name ||= "--repository"
+  end
+
+  def self.help
+    "displays where Homebrew-cask's .git directory is located"
+  end
+end

--- a/test/cask/cli/repository_test.rb
+++ b/test/cask/cli/repository_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+describe Hbc::CLI::Repository do
+  before do
+    @expected_output = "#{HOMEBREW_REPOSITORY}/Library/Taps/caskroom/homebrew-testcasks\n"
+  end
+
+  it 'displays the location of the .git repository' do
+    lambda {
+      Hbc::CLI::Repository.run
+    }.must_output(@expected_output)
+  end
+
+  it 'ignores any arguments' do
+    lambda {
+      Hbc::CLI::Repository.run('--anoption')
+    }.must_output(@expected_output)
+  end
+end


### PR DESCRIPTION
Displays where Homebrew-cask's .git directory is located.
