### PR TITLE
video-transcoding-scripts (separate casks)

### DIFF
--- a/Casks/convert-video.rb
+++ b/Casks/convert-video.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'convert-video' do
+  version '5.3'
+  sha256 '077a789a9198f56bb7cb15017c418032f255b00a239ada71562927b9893908bb'
+
+  url 'https://github.com/donmelton/video-transcoding-scripts/archive/master.zip'
+  name 'Video Transcoding Scripts'
+  homepage 'https://github.com/donmelton/video-transcoding-scripts/'
+  license :mit
+
+  binary 'video-transcoding-scripts-master/convert-video.sh', :target => 'convert-video'
+
+  depends_on :formula => %w{
+                            ffmpeg
+                            mkvtoolnix
+                            mp4v2
+                           }
+end

--- a/Casks/detect-crop.rb
+++ b/Casks/detect-crop.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'detect-crop' do
+  version '5.3'
+  sha256 '077a789a9198f56bb7cb15017c418032f255b00a239ada71562927b9893908bb'
+
+  url 'https://github.com/donmelton/video-transcoding-scripts/archive/master.zip'
+  name 'Video Transcoding Scripts'
+  homepage 'https://github.com/donmelton/video-transcoding-scripts/'
+  license :mit
+
+  binary 'video-transcoding-scripts-master/detect-crop.sh', :target => 'detect-crop'
+
+  depends_on :cask => 'caskroom/versions/handbrakecli-nightly',
+             :formula => 'mplayer'
+end

--- a/Casks/query-handbrake-log.rb
+++ b/Casks/query-handbrake-log.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'query-handbrake-log' do
+  version '5.3'
+  sha256 '077a789a9198f56bb7cb15017c418032f255b00a239ada71562927b9893908bb'
+
+  url 'https://github.com/donmelton/video-transcoding-scripts/archive/master.zip'
+  name 'Video Transcoding Scripts'
+  homepage 'https://github.com/donmelton/video-transcoding-scripts/'
+  license :mit
+
+  binary 'video-transcoding-scripts-master/query-handbrake-log.sh', :target => 'query-handbrake-log'
+end

--- a/Casks/transcode-video.rb
+++ b/Casks/transcode-video.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'transcode-video' do
+  version '5.3'
+  sha256 '077a789a9198f56bb7cb15017c418032f255b00a239ada71562927b9893908bb'
+
+  url 'https://github.com/donmelton/video-transcoding-scripts/archive/master.zip'
+  name 'Video Transcoding Scripts'
+  homepage 'https://github.com/donmelton/video-transcoding-scripts/'
+  license :mit
+
+  binary 'video-transcoding-scripts-master/transcode-video.sh', :target => 'transcode-video'
+
+  depends_on :cask => 'caskroom/versions/handbrakecli-nightly',
+             :formula => %w{
+                            mkvtoolnix
+                            mp4v2
+                           }
+end


### PR DESCRIPTION
Was waiting on `depends_on :cask` to land to be able to build these. Initially I had a single cask for all of them

``` ruby
cask :v1 => 'video-transcoding-scripts' do
  version '5.3'
  sha256 '077a789a9198f56bb7cb15017c418032f255b00a239ada71562927b9893908bb'

  url 'https://github.com/donmelton/video-transcoding-scripts/archive/master.zip'
  name 'Video Transcoding Scripts'
  homepage 'https://github.com/donmelton/video-transcoding-scripts/'
  license :mit

  binary 'video-transcoding-scripts-master/convert-video.sh', :target => 'convert-video'
  binary 'video-transcoding-scripts-master/detect-crop.sh', :target => 'detect-crop'
  binary 'video-transcoding-scripts-master/query-handbrake-log.sh', :target => 'query-handbrake-log'
  binary 'video-transcoding-scripts-master/transcode-video.sh', :target => 'transcode-video'

  depends_on :cask => 'caskroom/versions/handbrakecli-nightly',
             :formula => %w{
                            ffmpeg
                            mkvtoolnix
                            mp4v2
                            mplayer
                           }
end
```

but even if they live in the same repo and are complementary, they are different tools that can live on their own. It’s a different approach from what we took with [batch-rip-actions-for-automator.rb](https://github.com/caskroom/homebrew-unofficial/pull/31/files), and I’d like to see how it works in practice. `video-transcoding-scripts` would then become an ideal case for a [metacask](https://github.com/caskroom/homebrew-cask/issues/2001).
