### PR TITLE
P4V 2014.1-978848

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'p4v' do
-  version '2014.1-888424'
+  version '2014.1-978848'
 
   if Hardware::CPU.is_32_bit?
-    sha256 '03b716dde2c39f4214c1b9b016e151225d8830e2e555b30234c5f9c1d2940a78'
+    sha256 'a5af42fbab551e948de9dedf27f4605f5270e17ad4b9e2a42d252ea60e264f54'
     url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*},'\1')}/bin.macosx106x86/P4V.dmg"
   else
-    sha256 'c5d05d78596fe9b4f83193a11805a027b2652fdf87365de1321e671286fdca3f'
+    sha256 'a87fbc6d4eeaffa9547931a6c25a97c29efdbcc49728f38322a8ff532838ac5e'
     url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*},'\1')}/bin.macosx106x86_64/P4V.dmg"
   end
 


### PR DESCRIPTION
Similar to what happened for their command line clients (see pull request at https://github.com/Homebrew/homebrew-binary/pull/180), perforce has updated its client but is hosting it at the same URL.  This means that the signatures no longer match when trying to `brew cask install p4v`.
