### PR TITLE
Homepage, Download URL, and Version Updates for Adobe Digital Editions

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'adobe-digital-editions' do
-  version '4.0'
-  sha256 '00b846565da5962993bf3d9f4e629764d439da8269e4c84da49b441fa48d0e86'
+  version '4.0.2'
+  sha256 'd91535d8ca1cb4d7cdbb96c2820cf9c79524369acffa3d4e97f53e30812ae98a'
 
-  url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version}_Installer.dmg"
+  url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_4.0_Installer.dmg"
   name 'Adobe Digital Editions'
-  homepage 'http://www.adobe.com/pt/products/digital-editions.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
+  license :proprietary
 
   pkg "Digital Editions #{version} Installer.pkg"
 


### PR DESCRIPTION
Corrected homepage. Download URL apparently does not change for minor releases,
uncoupled 'url' from 'version'. Updated version to 4.0.2 and fixed sha256
fingerprint.
