### PR TITLE
Fixed the sha256 hash for Vagrant 1.7.2

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vagrant' do
   version '1.7.2'
-  sha256 'b05c13675118a7c57ef78f932047f3db44456fff3edb408615fea0ba2cf7afe9'
+  sha256 '78d02afada2f066368bd0ce1883f900f89b6dc20f860463ce125e7cb295e347c'
 
   url "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{version}.dmg"
   homepage 'http://www.vagrantup.com'


### PR DESCRIPTION
brew cask install vagrant
==> Downloading https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.dmg
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: b05c13675118a7c57ef78f932047f3db44456fff3edb408615fea0ba2cf7afe9
Actual: 78d02afada2f066368bd0ce1883f900f89b6dc20f860463ce125e7cb295e347c
File: /Library/Caches/Homebrew/vagrant-1.7.2.dmg

Signed-off-by: Jachim Coudenys jachim@king-foo.be
