### PR TITLE
recast `HOMEBREW_*` path constants as read/write location methods

### DIFF
--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -125,7 +125,7 @@ alternate version of the `brew-cask` subcommand, by invoking `brew cask`
 with fully-qualified paths, like this:
 
 ```bash
-$ HOMEBREW_BREW_FILE=/usr/local/bin/brew /System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby /usr/local/Library/brew.rb /usr/local/Library/Taps/caskroom/homebrew-cask/bin/brew-cask-cmd.rb help
+$ /System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby /usr/local/Library/Taps/caskroom/homebrew-cask/lib/brew-cask-cmd.rb help
 ```
 
 #### Forcing a Specific Homebrew-cask Subcommand

--- a/lib/hbc/caveats.rb
+++ b/lib/hbc/caveats.rb
@@ -67,7 +67,7 @@ class Hbc::CaveatsDSL
 
   def files_in_usr_local
     localpath = '/usr/local'
-    if HOMEBREW_PREFIX.to_s.downcase.index(localpath) == 0
+    if Hbc.homebrew_prefix.to_s.downcase.index(localpath) == 0
       puts <<-EOS.undent
       Cask #{@cask} installs files under "#{localpath}".  The presence of such
       files can cause warnings when running "brew doctor", which is considered

--- a/lib/hbc/cli/doctor.rb
+++ b/lib/hbc/cli/doctor.rb
@@ -7,7 +7,7 @@ class Hbc::CLI::Doctor < Hbc::CLI::Base
     ohai 'Ruby Path:',                                       render_with_none_as_error( RbConfig.ruby )
     # todo: consider removing most Homebrew constants from doctor output
     ohai 'Homebrew Version:',                                render_with_none_as_error( homebrew_version )
-    ohai 'Homebrew Executable Path:',                        render_with_none_as_error( HOMEBREW_BREW_FILE )
+    ohai 'Homebrew Executable Path:',                        render_with_none_as_error( Hbc.homebrew_executable )
     ohai 'Homebrew Cellar Path:',                            render_with_none_as_error( homebrew_cellar )
     ohai 'Homebrew Repository Path:',                        render_with_none_as_error( homebrew_repository )
     ohai 'Homebrew Origin:',                                 render_with_none_as_error( homebrew_origin )
@@ -104,9 +104,9 @@ class Hbc::CLI::Doctor < Hbc::CLI::Base
     return @homebrew_constants[name] if @homebrew_constants.key?(name)
     @homebrew_constants[name] = notfound_string
     begin
-      @homebrew_constants[name] = Hbc::SystemCommand.run!(HOMEBREW_BREW_FILE,
-                                                           :args => [ "--#{name}" ],
-                                                           :print_stderr => false).stdout.strip
+      @homebrew_constants[name] = Hbc::SystemCommand.run!(Hbc.homebrew_executable,
+                                                          :args => [ "--#{name}" ],
+                                                          :print_stderr => false).stdout.strip
       if @homebrew_constants[name] !~ %r{\S}
         @homebrew_constants[name] = "#{none_string} #{error_string}"
       end

--- a/lib/hbc/cli/update.rb
+++ b/lib/hbc/cli/update.rb
@@ -1,7 +1,7 @@
 class Hbc::CLI::Update < Hbc::CLI::Base
   def self.run(*_ignored)
-    result = Hbc::SystemCommand.run(HOMEBREW_BREW_FILE,
-                                     :args => %w{update})
+    result = Hbc::SystemCommand.run(Hbc.homebrew_executable,
+                                    :args => %w{update})
     # todo: separating stderr/stdout is undesirable here.
     # Hbc::SystemCommand should have an option for plain
     # unbuffered output.

--- a/lib/hbc/container/cab.rb
+++ b/lib/hbc/container/cab.rb
@@ -9,7 +9,7 @@ class Hbc::Container::Cab < Hbc::Container::Base
   end
 
   def extract
-    cabextract = HOMEBREW_PREFIX.join('bin/cabextract')
+    cabextract = Hbc.homebrew_prefix.join('bin/cabextract')
     if ! Pathname.new(cabextract).exist?
       raise Hbc::CaskError.new "Expected to find cabextract executable. Cask '#{@cask}' must add: depends_on :formula => 'cabextract'"
     end

--- a/lib/hbc/container/criteria.rb
+++ b/lib/hbc/container/criteria.rb
@@ -20,9 +20,9 @@ class Hbc::Container::Criteria
   end
 
   def cabextract
-    if HOMEBREW_PREFIX.join('bin/cabextract').exist?
+    if Hbc.homebrew_prefix.join('bin/cabextract').exist?
       @cabextract ||= @command.run(
-        HOMEBREW_PREFIX.join('bin/cabextract'),
+        Hbc.homebrew_prefix.join('bin/cabextract'),
         :args => ['-t', '--', path],
         :print_stderr => false
       ).stdout
@@ -30,9 +30,9 @@ class Hbc::Container::Criteria
   end
 
   def lsar
-    if HOMEBREW_PREFIX.join('bin/lsar').exist?
+    if Hbc.homebrew_prefix.join('bin/lsar').exist?
       @lsar ||= @command.run(
-        HOMEBREW_PREFIX.join('bin/lsar'),
+        Hbc.homebrew_prefix.join('bin/lsar'),
         :args => ['-l', '-t', '--', path],
         :print_stderr => false
       ).stdout

--- a/lib/hbc/container/generic_unar.rb
+++ b/lib/hbc/container/generic_unar.rb
@@ -7,7 +7,7 @@ class Hbc::Container::GenericUnar < Hbc::Container::Base
   end
 
   def extract
-    unar = HOMEBREW_PREFIX.join('bin/unar')
+    unar = Hbc.homebrew_prefix.join('bin/unar')
     if ! Pathname.new(unar).exist?
       raise Hbc::CaskError.new "Expected to find unar executable. Cask #{@cask} must add: depends_on :formula => 'unar'"
     end

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -170,13 +170,13 @@ class Hbc::Installer
     ohai 'Installing Formula dependencies from Homebrew'
     @cask.depends_on.formula.each do |dep_name|
       print "#{dep_name} ... "
-      installed = @command.run(HOMEBREW_BREW_FILE,
+      installed = @command.run(Hbc.homebrew_executable,
                                :args => ['list', '--versions', dep_name],
                                :print_stderr => false).stdout.include?(dep_name)
       if installed
         puts "already installed"
       else
-        @command.run!(HOMEBREW_BREW_FILE,
+        @command.run!(Hbc.homebrew_executable,
                       :args => ['install', dep_name])
         puts "done"
       end

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -4,10 +4,6 @@ module Hbc::Locations
   end
 
   module ClassMethods
-    def tapspath
-      HOMEBREW_REPOSITORY.join "Library", "Taps"
-    end
-
     def metadata_subdir
       '.metadata'
     end
@@ -130,9 +126,9 @@ module Hbc::Locations
         user, repo, token = token_with_tap.split('/')
         # bug/todo: handle old-style 1-slash form: phinze-cask/token
         repo = 'homebrew-' + repo unless repo.match(/^homebrew-/)
-        tapspath.join(user, repo, 'Casks', "#{token}.rb")
+        homebrew_tapspath.join(user, repo, 'Casks', "#{token}.rb")
       else
-        tapspath.join(default_tap, 'Casks', "#{query}.rb")
+        homebrew_tapspath.join(default_tap, 'Casks', "#{query}.rb")
       end
     end
 
@@ -150,6 +146,36 @@ module Hbc::Locations
 
     def x11_libpng
       @x11_libpng ||= [ Pathname.new('/opt/X11/lib/libpng.dylib'), Pathname.new('/usr/X11/lib/libpng.dylib') ]
+    end
+
+    def homebrew_executable
+      @homebrew_executable ||= Pathname(ENV['HOMEBREW_BREW_FILE'] || Hbc::Utils.which('brew') || '/usr/local/bin/brew')
+    end
+
+    def homebrew_prefix
+      # where Homebrew links
+      @homebrew_prefix ||= homebrew_executable.dirname.parent
+    end
+
+    def homebrew_prefix=(arg)
+      @homebrew_prefix = arg ? Pathname(arg) : arg
+    end
+
+    def homebrew_repository
+      # where Homebrew's .git dir is found
+      @homebrew_repository ||= homebrew_executable.realpath.dirname.parent
+    end
+
+    def homebrew_repository=(arg)
+      @homebrew_repository = arg ? Pathname(arg) : arg
+    end
+
+    def homebrew_tapspath
+      @homebrew_tapspath ||= homebrew_repository.join *%w{Library Taps}
+    end
+
+    def homebrew_tapspath=(arg)
+      @homebrew_tapspath = arg ? Pathname(arg) : arg
     end
   end
 end

--- a/lib/hbc/scopes.rb
+++ b/lib/hbc/scopes.rb
@@ -10,8 +10,8 @@ module Hbc::Scopes
 
     def all_tapped_cask_dirs
       return @all_tapped_cask_dirs unless @all_tapped_cask_dirs.nil?
-      fq_default_tap = tapspath.join(default_tap, 'Casks')
-      @all_tapped_cask_dirs = Dir.glob(tapspath.join('*', '*', 'Casks')).map { |d| Pathname.new(d) }
+      fq_default_tap = Hbc.homebrew_tapspath.join(default_tap, 'Casks')
+      @all_tapped_cask_dirs = Dir.glob(Hbc.homebrew_tapspath.join('*', '*', 'Casks')).map { |d| Pathname.new(d) }
       # optimization: place the default Tap first
       if @all_tapped_cask_dirs.include? fq_default_tap
         @all_tapped_cask_dirs = @all_tapped_cask_dirs - [ fq_default_tap ]

--- a/lib/hbc/source/tapped.rb
+++ b/lib/hbc/source/tapped.rb
@@ -11,9 +11,9 @@ class Hbc::Source::Tapped
     token_with_tap = Hbc.all_tokens.find { |t| t.split('/').last == query.sub(/\.rb$/i,'') }
     if token_with_tap
       user, repo, token = token_with_tap.split('/')
-      Hbc.tapspath.join(user, repo, 'Casks', "#{token}.rb")
+      Hbc.homebrew_tapspath.join(user, repo, 'Casks', "#{token}.rb")
     else
-      Hbc.tapspath.join(Hbc.default_tap, 'Casks', "#{query.sub(/\.rb$/i,'')}.rb")
+      Hbc.homebrew_tapspath.join(Hbc.default_tap, 'Casks', "#{query.sub(/\.rb$/i,'')}.rb")
     end
   end
 

--- a/lib/hbc/source/tapped_qualified.rb
+++ b/lib/hbc/source/tapped_qualified.rb
@@ -9,6 +9,6 @@ class Hbc::Source::TappedQualified < Hbc::Source::Tapped
     user, repo, token = Hbc::QualifiedToken::parse(query)
     token.sub!(/\.rb$/i,'')
     tap = "#{user}/homebrew-#{repo}"
-    Hbc.tapspath.join(tap, 'Casks', "#{token}.rb")
+    Hbc.homebrew_tapspath.join(tap, 'Casks', "#{token}.rb")
   end
 end

--- a/lib/hbc/source/untapped_qualified.rb
+++ b/lib/hbc/source/untapped_qualified.rb
@@ -5,13 +5,13 @@ class Hbc::Source::UntappedQualified < Hbc::Source::TappedQualified
     user, repo, token = Hbc::QualifiedToken::parse(query)
     token.sub!(/\.rb$/i,'')
     tap = "#{user}/homebrew-#{repo}"
-    unless Hbc.tapspath.join(tap).exist?
+    unless Hbc.homebrew_tapspath.join(tap).exist?
       ohai "Adding new tap '#{tap}'"
-      result = Hbc::SystemCommand.run!(HOMEBREW_BREW_FILE,
-                                        :args => ['tap', "#{user}/#{repo}"])
+      result = Hbc::SystemCommand.run!(Hbc.homebrew_executable,
+                                       :args => ['tap', "#{user}/#{repo}"])
               puts result.stdout
       $stderr.puts result.stderr
     end
-    Hbc.tapspath.join(tap, 'Casks', "#{token}.rb")
+    Hbc.homebrew_tapspath.join(tap, 'Casks', "#{token}.rb")
   end
 end

--- a/lib/vendor/homebrew-fork/global.rb
+++ b/lib/vendor/homebrew-fork/global.rb
@@ -27,16 +27,6 @@ end
 HOMEBREW_CACHE = cache
 undef cache
 
-if not defined? HOMEBREW_BREW_FILE
-  HOMEBREW_BREW_FILE = ENV['HOMEBREW_BREW_FILE'] || Hbc::Utils.which('brew').to_s
-end
-
-HOMEBREW_PREFIX = Pathname.new(HOMEBREW_BREW_FILE).dirname.parent # Where we link under
-HOMEBREW_REPOSITORY = Pathname.new(HOMEBREW_BREW_FILE).realpath.dirname.parent # Where .git is found
-HOMEBREW_LIBRARY = HOMEBREW_REPOSITORY.join('Library')
-
-HOMEBREW_TEMP = Pathname.new(ENV.fetch('HOMEBREW_TEMP', '/tmp'))
-
 MACOS_POINT_RELEASE = `/usr/bin/sw_vers -productVersion`.chomp
 MACOS_RELEASE = MACOS_POINT_RELEASE[/10\.\d+/]
 

--- a/lib/vendor/homebrew-fork/testing_env.rb
+++ b/lib/vendor/homebrew-fork/testing_env.rb
@@ -19,7 +19,3 @@ HOMEBREW_CURL_ARGS     = '-fsLA'
 
 MACOS_POINT_RELEASE = `/usr/bin/sw_vers -productVersion`.chomp
 MACOS_RELEASE = ENV.fetch('MACOS_RELEASE') { MACOS_POINT_RELEASE[/10\.\d+/] }
-
-# Test environment setup
-# needed to keep rspec from attempting to write outside test dir
-%w{ENV Formula}.each { |d| HOMEBREW_LIBRARY.join(d).mkpath }

--- a/lib/vendor/homebrew-fork/testing_env.rb
+++ b/lib/vendor/homebrew-fork/testing_env.rb
@@ -1,7 +1,5 @@
 # Require this file to build a testing environment.
 
-$:.push(File.expand_path(__FILE__+'/../..'))
-
 require 'vendor/homebrew-fork/monkeypatch_pathname'
 require 'vendor/homebrew-fork/utils'
 require 'tmpdir'

--- a/lib/vendor/homebrew-fork/testing_env.rb
+++ b/lib/vendor/homebrew-fork/testing_env.rb
@@ -8,10 +8,7 @@ TEST_TMPDIR = Dir.mktmpdir("homebrew_tests")
 at_exit { FileUtils.remove_entry(TEST_TMPDIR) }
 
 # Constants normally defined in global.rb
-HOMEBREW_PREFIX        = Pathname.new(TEST_TMPDIR).join("prefix")
-HOMEBREW_REPOSITORY    = HOMEBREW_PREFIX
-HOMEBREW_LIBRARY       = HOMEBREW_REPOSITORY+'Library'
-HOMEBREW_CACHE         = HOMEBREW_PREFIX.parent+'cache'
+HOMEBREW_CACHE         = Pathname.new(TEST_TMPDIR).join('cache')
 HOMEBREW_USER_AGENT    = 'Homebrew'
 HOMEBREW_CURL_ARGS     = '-fsLA'
 

--- a/spec/cask/cli_spec.rb
+++ b/spec/cask/cli_spec.rb
@@ -45,8 +45,10 @@ describe Hbc::CLI do
     it "exits with a status of 1 when something goes wrong" do
       Hbc::CLI.expects(:exit).with(1)
       Hbc::CLI.expects(:lookup_command).raises(Hbc::CaskError)
-      shutup {
-        Hbc::CLI.process('noop')
+      allow(Hbc).to receive(:init) {
+        shutup {
+          Hbc::CLI.process('noop')
+        }
       }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,12 +17,21 @@ $:.push(project_root.join('lib').to_s)
 
 require 'hbc'
 
+# override Homebrew locations
+Hbc.homebrew_prefix = Pathname.new(TEST_TMPDIR).join('prefix')
+Hbc.homebrew_repository = Hbc.homebrew_prefix
+Hbc.homebrew_tapspath = nil
+
+# making homebrew's cache dir allows us to actually download Casks in tests
+HOMEBREW_CACHE.mkpath
+HOMEBREW_CACHE.join('Casks').mkpath
+
 # Look for Casks in testcasks by default.  It is elsewhere required that
 # the string "test" appear in the directory name.
 Hbc.default_tap = 'caskroom/homebrew-testcasks'
 
 # our own testy caskroom
-Hbc.caskroom = HOMEBREW_PREFIX.join('TestCaskroom')
+Hbc.caskroom = Hbc.homebrew_prefix.join('TestCaskroom')
 
 RSpec.configure do |config|
   config.include ShutupHelper

--- a/spec/support/homebrew_testing_environment.rb
+++ b/spec/support/homebrew_testing_environment.rb
@@ -3,9 +3,6 @@ module HomebrewTestingEnvironment
     # force some environment variables
     ENV['HOMEBREW_NO_EMOJI']='1'
 
-    # set some Homebrew constants used in our code
-    base.const_set('HOMEBREW_BREW_FILE', '/usr/local/bin/brew')
-
     # require homebrew testing env
     with_disabled_at_exit do
       # todo: removeme, this is transitional

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -42,7 +42,7 @@ describe Hbc::Installer do
     end
 
     it "works with cab-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin/cabextract').exist?
+      skip unless Hbc.homebrew_prefix.join('bin/cabextract').exist?
       cab_container = Hbc.load('cab-container')
       empty = stub(:formula => [], :cask => [], :macos => nil, :arch => nil, :x11 => nil)
       cab_container.stubs(:depends_on).returns(empty)
@@ -70,7 +70,7 @@ describe Hbc::Installer do
     end
 
     it "works with 7z-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin','unar').exist?
+      skip unless Hbc.homebrew_prefix.join('bin','unar').exist?
       sevenzip_container = Hbc.load('sevenzip-container')
       empty = stub(:formula => [], :cask => [], :macos => nil, :arch => nil, :x11 => nil)
       sevenzip_container.stubs(:depends_on).returns(empty)
@@ -99,7 +99,7 @@ describe Hbc::Installer do
     end
 
     it "works with Stuffit-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin','unar').exist?
+      skip unless Hbc.homebrew_prefix.join('bin','unar').exist?
       stuffit_container = Hbc.load('stuffit-container')
       empty = stub(:formula => [], :cask => [], :macos => nil, :arch => nil, :x11 => nil)
       stuffit_container.stubs(:depends_on).returns(empty)
@@ -115,7 +115,7 @@ describe Hbc::Installer do
     end
 
     it "works with RAR-based Casks" do
-      skip unless HOMEBREW_PREFIX.join('bin','unar').exist?
+      skip unless Hbc.homebrew_prefix.join('bin','unar').exist?
       rar_container = Hbc.load('rar-container')
       empty = stub(:formula => [], :cask => [], :macos => nil, :arch => nil, :x11 => nil)
       rar_container.stubs(:depends_on).returns(empty)

--- a/test/support/fake_dirs.rb
+++ b/test/support/fake_dirs.rb
@@ -8,7 +8,7 @@ module FakeDirHooks
     @canned_dirs = {}
 
     DIRS.each do |dir_name|
-      dir = HOMEBREW_REPOSITORY.join("#{dir_name}-#{Time.now.to_i}-#{rand(1024)}")
+      dir = Hbc.homebrew_prefix.join("#{dir_name}-#{Time.now.to_i}-#{rand(1024)}")
       dir.mkpath
       Hbc.send("#{dir_name}=", dir)
       @canned_dirs[:dir_name] = dir

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,9 +9,6 @@ end
 # force some environment variables
 ENV['HOMEBREW_NO_EMOJI']='1'
 
-# set some Homebrew constants used in our code
-HOMEBREW_BREW_FILE = '/usr/local/bin/brew'
-
 # add homebrew-cask lib to load path
 brew_cask_path = Pathname.new(File.expand_path(__FILE__+'/../../'))
 casks_path = brew_cask_path.join('Casks')
@@ -57,12 +54,17 @@ Mocha::Integration::MiniTest.activate
 # our baby
 require 'hbc'
 
+# override Homebrew locations
+Hbc.homebrew_prefix = Pathname.new(TEST_TMPDIR).join('prefix')
+Hbc.homebrew_repository = Hbc.homebrew_prefix
+Hbc.homebrew_tapspath = nil
+
 # Look for Casks in testcasks by default.  It is elsewhere required that
 # the string "test" appear in the directory name.
 Hbc.default_tap = 'caskroom/homebrew-testcasks'
 
 # our own testy caskroom
-Hbc.caskroom = HOMEBREW_PREFIX.join('TestCaskroom')
+Hbc.caskroom = Hbc.homebrew_prefix.join('TestCaskroom')
 
 class TestHelper
   # helpers for test Casks to reference local files easily
@@ -123,11 +125,11 @@ require 'tempfile'
 
 # pretend like we installed the homebrew-cask tap
 project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
-taps_dest = HOMEBREW_LIBRARY.join('Taps/caskroom')
+taps_dest = Hbc.homebrew_prefix.join(*%w{Library Taps caskroom})
 
 # create directories
 FileUtils.mkdir_p taps_dest
-HOMEBREW_PREFIX.join('bin').mkdir
+FileUtils.mkdir_p Hbc.homebrew_prefix.join('bin')
 
 FileUtils.ln_s project_root, taps_dest.join('homebrew-cask')
 
@@ -135,9 +137,9 @@ FileUtils.ln_s project_root, taps_dest.join('homebrew-cask')
 class TestHbc < Hbc; end
 
 # jack in some optional utilities
-FileUtils.ln_s '/usr/local/bin/cabextract', HOMEBREW_PREFIX.join('bin/cabextract')
-FileUtils.ln_s '/usr/local/bin/unar', HOMEBREW_PREFIX.join('bin/unar')
-FileUtils.ln_s '/usr/local/bin/lsar', HOMEBREW_PREFIX.join('bin/lsar')
+FileUtils.ln_s '/usr/local/bin/cabextract', Hbc.homebrew_prefix.join('bin/cabextract')
+FileUtils.ln_s '/usr/local/bin/unar', Hbc.homebrew_prefix.join('bin/unar')
+FileUtils.ln_s '/usr/local/bin/lsar', Hbc.homebrew_prefix.join('bin/lsar')
 
 # also jack in some test Casks
 FileUtils.ln_s project_root.join('test', 'support'), taps_dest.join('homebrew-testcasks')


### PR DESCRIPTION
Fixes #8705
- strip constants from `homebrew-fork global.rb`  and corresponding `testing_env.rb`.
  - recast `HOMEBREW_BREW_FILE` as `Hbc.homebrew_executable`, defined in `Hbc::Locations`
  - recast `HOMEBREW_REPOSITORY` as `Hbc.homebrew_repository`
  - recast `HOMEBREW_PREFIX` as `Hbc.homebrew_prefix`
  - remove `HOMEBREW_LIBRARY`
  - recast existing `Hbc.tapspath` as `Hbc.homebrew_tapspath` to match new methods
- doc that brew-cask-cmd.rb can be invoked directly
- remove unneeded `$LOAD_PATH` manipulation
- cleaner way to allow Rspec to run without creating unwanted directories
