### PR TITLE
Adobe Digital Editions: Disable sha256 check, update homepage and license

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'adobe-digital-editions' do
   version '4.0'
-  sha256 '00b846565da5962993bf3d9f4e629764d439da8269e4c84da49b441fa48d0e86'
+  sha256 :no_check    # required as upstream package is updated in-place
 
   url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version}_Installer.dmg"
   name 'Adobe Digital Editions'
-  homepage 'http://www.adobe.com/pt/products/digital-editions.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
+  license :gratis
 
   pkg "Digital Editions #{version} Installer.pkg"
 


### PR DESCRIPTION
Following recommendations in #8717, disable sha256 check due to package
being updated in place. Corrected homepage and set proper license.
