### PR TITLE
Updated ADE's sha256 stanza

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'adobe-digital-editions' do
   version '4.0'
-  sha256 '00b846565da5962993bf3d9f4e629764d439da8269e4c84da49b441fa48d0e86'
+  sha256 :no_check
 
   url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version}_Installer.dmg"
   homepage 'http://www.adobe.com/pt/products/digital-editions.html'


### PR DESCRIPTION
Adobe does change ADE's downloadable filename for minor upgrades and new
new builds, thus regularly changing the file and its checksum while
retaining the name (here ADE_4.0_Installer.dmg). This consequently
breaks the cask formula that relies on a specific precalculated
checksum. I removed the checksum verification for this download in order
to be treated like in version-independent Cask forumals.
