### PR TITLE
Update mpv

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -9,13 +9,25 @@ cask :v1 => 'mpv' do
   app 'mpv.app'
   binary 'mpv.app/Contents/MacOS/mpv'
 
+  # Symlink fonts.conf to user dir so mpv doesn’t show errors while used as CLI app
+  postflight do
+    system '/bin/ln', '-nsf', staged_path.join("mpv.app/Contents/Resources/fonts.conf"), File.expand_path('~/.config/mpv/fonts.conf')
+  end
+
   zap :delete => [
                   '~/.mpv/channels.conf',
                   '~/.mpv/config',
                   '~/.mpv/input.conf',
+                  '~/.mpv/fonts.conf',
+                  '~/.config/mpv/channels.conf',
                   '~/.config/mpv/mpv.conf',
+                  '~/.config/mpv/input.conf',
+                  '~/.config/mpv/fonts.conf',
                  ],
-      :rmdir  => '~/.mpv'
+      :rmdir  => [
+                  '~/.mpv',
+                  '~/.config/mpv'
+                 ]
 
   caveats do
     files_in_usr_local


### PR DESCRIPTION
- Symlink `fonts.conf` to user dir so mpv doesn’t show errors while used as CLI app (ref. https://github.com/mpv-player/mpv/issues/1391)
- Zap additional user config files
