### PR TITLE
removed caveat from the-archive-browser

### DIFF
--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -7,8 +7,4 @@ cask :v1 => 'the-archive-browser' do
   license :commercial
 
   app 'The Archive Browser.app'
-  caveats <<-EOS.undent
-    The Archive Browser is a commercial app. Only a trial version will be
-    installed.  A full license may be purchased from the developer website.
-  EOS
 end


### PR DESCRIPTION
No longer makes sense, with license
