### PR TITLE
Upgrade Terraform to v0.3.6

### DIFF
--- a/Casks/terraform.rb
+++ b/Casks/terraform.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'terraform' do
-  version '0.3.5'
-  sha256 'd583d58719951a5c3a06eec38390fe31bef7645af7fee3e915293aab7a910885'
+  version '0.3.6'
+  sha256 '65b4c5bfc34bb0464b691b31ac554132c87ac0c5d7acef936c039777a27dccad'
 
   url "https://dl.bintray.com/mitchellh/terraform/terraform_#{version}_darwin_amd64.zip"
   homepage 'http://www.terraform.io/'
@@ -10,6 +10,7 @@ cask :v1 => 'terraform' do
   binary 'terraform-provider-atlas'
   binary 'terraform-provider-aws'
   binary 'terraform-provider-cloudflare'
+  binary 'terraform-provider-cloudstack'
   binary 'terraform-provider-consul'
   binary 'terraform-provider-digitalocean'
   binary 'terraform-provider-dnsimple'


### PR DESCRIPTION
This upgrades Terraform to the latest version, which adds also adds the `terraform-provider-cloudstack` binary.
