### PR TITLE
Add blackmagic davinci resolve

### DIFF
--- a/Casks/davinci-resolve-lite.rb
+++ b/Casks/davinci-resolve-lite.rb
@@ -1,0 +1,34 @@
+cask :v1 => 'davinci-resolve-lite' do
+  module Utils
+    def self.blackmagick_url(url, data)
+      info = {
+        'country'   => 'us',
+        'platform'  => 'Mac OS X',
+        'firstname' => 'Homebrew',
+        'lastname'  => 'Cask',
+        'company'   => 'Hombrew Cask',
+        'email'     => 'N/A',
+        'phone'     => 'N/A',
+        'city'      => 'N/A',
+        'state'     => 'N/A'
+      }
+
+      require 'net/http'
+      Net::HTTP.post_form(URI(url), info.merge(data)).body
+    end
+  end
+
+  version '11.1.3'
+  sha256 '09b51ce4e962a525f3c13c03c50c0bbe77f5cf73411833209402d9ce9be75f44'
+
+  url Utils.blackmagick_url('https://www.blackmagicdesign.com/api/register/us/download/15061',
+                            'product' => { 'name' => 'DaVinci Resolve Lite' })
+
+  homepage 'https://www.blackmagicdesign.com/products/davinciresolve'
+  license :gratis
+
+  container :nested => "DaVinci_Resolve_Lite_#{version}_Mac.dmg"
+  pkg "Install Resolve #{version} Lite.pkg"
+
+  uninstall :script => { :executable => '/usr/bin/open', :args => ['/Applications/DaVinci Resolve/Uninstall Resolve.app'] }
+end

--- a/Casks/davinci-resolve-lite.rb
+++ b/Casks/davinci-resolve-lite.rb
@@ -30,5 +30,5 @@ cask :v1 => 'davinci-resolve-lite' do
   container :nested => "DaVinci_Resolve_Lite_#{version}_Mac.dmg"
   pkg "Install Resolve #{version} Lite.pkg"
 
-  uninstall :script => { :executable => '/usr/bin/open', :args => ['/Applications/DaVinci Resolve/Uninstall Resolve.app'] }
+  uninstall :script => '/Applications/DaVinci Resolve/Uninstall Resolve.app/Contents/MacOS/Uninstall Resolve'
 end

--- a/Casks/davinci-resolve.rb
+++ b/Casks/davinci-resolve.rb
@@ -1,0 +1,34 @@
+cask :v1 => 'davinci-resolve' do
+  module Utils
+    def self.blackmagick_url(url, data)
+      info = {
+        'country'   => 'us',
+        'platform'  => 'Mac OS X',
+        'firstname' => 'Homebrew',
+        'lastname'  => 'Cask',
+        'company'   => 'Hombrew Cask',
+        'email'     => 'N/A',
+        'phone'     => 'N/A',
+        'city'      => 'N/A',
+        'state'     => 'N/A'
+      }
+
+      require 'net/http'
+      Net::HTTP.post_form(URI(url), info.merge(data)).body
+    end
+  end
+
+  version '11.1.3'
+  sha256 '33b229a79cf431d957f8ca0870b4bda4775e1fcd1bd7f3a008cc0ab02c416d63'
+
+  url Utils.blackmagick_url('https://www.blackmagicdesign.com/api/register/us/download/15055',
+                            'product' => { 'name' => 'DaVinci Resolve' })
+
+  homepage 'https://www.blackmagicdesign.com/products/davinciresolve'
+  license :commercial
+
+  container :nested => "DaVinci_Resolve_#{version}_Mac.dmg"
+  pkg "Install Resolve #{version}.pkg"
+
+  uninstall :script => { :executable => '/usr/bin/open', :args => ['/Applications/DaVinci Resolve/Uninstall Resolve.app'] }
+end

--- a/Casks/davinci-resolve.rb
+++ b/Casks/davinci-resolve.rb
@@ -3,14 +3,7 @@ cask :v1 => 'davinci-resolve' do
     def self.blackmagick_url(url, data)
       info = {
         'country'   => 'us',
-        'platform'  => 'Mac OS X',
-        'firstname' => 'Homebrew',
-        'lastname'  => 'Cask',
-        'company'   => 'Hombrew Cask',
-        'email'     => 'N/A',
-        'phone'     => 'N/A',
-        'city'      => 'N/A',
-        'state'     => 'N/A'
+        'platform'  => 'Mac OS X'
       }
 
       require 'net/http'

--- a/Casks/davinci-resolve.rb
+++ b/Casks/davinci-resolve.rb
@@ -23,5 +23,5 @@ cask :v1 => 'davinci-resolve' do
   container :nested => "DaVinci_Resolve_#{version}_Mac.dmg"
   pkg "Install Resolve #{version}.pkg"
 
-  uninstall :script => { :executable => '/usr/bin/open', :args => ['/Applications/DaVinci Resolve/Uninstall Resolve.app'] }
+  uninstall :script => '/Applications/DaVinci Resolve/Uninstall Resolve.app/Contents/MacOS/Uninstall Resolve'
 end


### PR DESCRIPTION
Add cask for Blackmagic Davinci Resolve - one of the most powerful video production tool.
There are two versions of Davinci Resolve:
- Normal - works only with special usb dongle :moneybag::moneybag::moneybag:.
- Lite - absolutely free, but without some features

What version should place here? I add casks for both.

There is a problem with uninstaller: To uninstall davinci resolve you should execute special app ["Uninstall Resolve.app"](http://content.screencast.com/users/donbobka/folders/Snagit/media/4a2122f3-baea-49ea-a3a7-104bdac0f89c/2015-01-09_03-29-45.png). I implemented uninstall through `uninstall :script`, but when script executed, uninstaller asks user input. Is there something like `installer :manual` for uninstaller?

P.S.: Check Utils.blackmagick_url, please. Is there a more beautiful way?
P.P.S.: Is there way to prevent installation of cask if another cask already installed? For example: if davinci-resolve installed, then you can't install davinci-resolve-lite and vice-versa
