### PR TITLE
Add GPL license for licecap

### DIFF
--- a/Casks/licecap.rb
+++ b/Casks/licecap.rb
@@ -4,7 +4,7 @@ cask :v1 => 'licecap' do
 
   url "http://www.cockos.com/licecap/licecap#{version.gsub('.','')}.dmg"
   homepage 'http://www.cockos.com/licecap/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'LICEcap.app'
 end


### PR DESCRIPTION
Their license text is located inside http://www-dev.cockos.com/licecap/licecap.git
