### PR TITLE
Add gPodder.app v3.8.3

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,0 +1,13 @@
+cask :v1 => "gpodder" do
+  version "3.8.3_0"
+  sha256 "57fe1f006a691487452f80d924fa60fbadd865dbfb4cde2000aaf46db76d3065"
+
+  url "https://downloads.sourceforge.net/sourceforge/gpodder/gPodder-#{version}.zip"
+  name "gPodder"
+  homepage "http://gpodder.org/"
+  license :gpl
+
+  depends_on :x11 => true
+
+  app "gPodder.app"
+end


### PR DESCRIPTION
Added new cask for gPodder, which is byte-compiled
and bundled specifically for OS X.
