### PR TITLE
remove quotes around 'external command'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ installation and management of GUI Mac applications such as Google Chrome and Ad
 Homebrew-cask provides a friendly homebrew-style CLI workflow for the
 administration of Mac applications distributed as binaries.
 
-It's implemented as a `homebrew` "[external command](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/External-Commands.md)"
+It's implemented as a `homebrew` [external command](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/External-Commands.md)
 called `cask`.
 
 ## Let's try it!


### PR DESCRIPTION
Why are we quoting this?
