### PR TITLE
Split arguments on whitespace when executing editors

### DIFF
--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -135,7 +135,7 @@ module Hbc::Utils
   def self.exec_editor(*args)
     editor = [ *ENV.values_at('HOMEBREW_EDITOR', 'VISUAL', 'EDITOR'),
                *%w{mate edit vim /usr/bin/vim} ].compact.first
-    exec(editor, *args)
+    exec(*editor.split.concat(args))
   end
 
   # originally from Homebrew puts_columns


### PR DESCRIPTION
The `safe_exec` method was previously removed in #8611, leading to the failure of `brew cask edit` and `brew cask create` in scenarios where the editor ENV included any flag.

Fixes #8788. @phinze, if you prefer, feel free to revert the original PR (which included a few other changes) and close this one.
