### PR TITLE
Add MEGAsync.app latest

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'megasync' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://mega.nz/MEGAsyncSetup.dmg'
+  name 'MEGAsync'
+  homepage 'https://mega.co.nz'
+  license :gratis
+
+  app 'MEGAsync.app'
+end


### PR DESCRIPTION
This is a follow-up to #5338. I had no issues installing and running 
the MEGAsync client using this caskfile.
