### PR TITLE
[HOLD UNTIL 2/1] Remove the begin/rescue logic

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,12 +1,3 @@
-begin
-  require Pathname(__FILE__).realpath.dirname.join("lib", "hbc", "version")
-rescue
-  # todo: transitional, defensive, should not be needed.
-  # remove the begin/rescue logic after 1 Feb 2015
-  require Pathname(__FILE__).realpath.dirname.join("lib", "cask", "version")
-  HBC_VERSION = HOMEBREW_CASK_VERSION
-end
-
 class BrewCask < Formula
   homepage "https://github.com/caskroom/homebrew-cask/"
   url "https://github.com/caskroom/homebrew-cask.git", :tag => "v#{HBC_VERSION}"


### PR DESCRIPTION
See https://github.com/caskroom/homebrew-cask/blob/19d784799dbee0d2c8e6ddf15dfb08fc6e9cae3e/brew-cask.rb#L5 - per #8575.

I'll rebase this onto master as we get closer to the first of the month (inb4 a breaking change comes at 11:59 PM on January 31st).

You can merge this or don't - I don't really care.  Just trying to make this easier for you because you've done such an awesome job making this! :D
