### PR TITLE
info: add requires_sudo? and --machine-readable

### DIFF
--- a/doc/man/brew-cask.1
+++ b/doc/man/brew-cask.1
@@ -74,8 +74,8 @@ Display the homepage associated with a given Cask in a browser\.
 With no arguments, display the project page \fIhttp://caskroom\.io\fR\.
 .
 .TP
-\fBinfo\fR or \fBabv\fR \fItoken\fR [ \fItoken\fR \.\.\. ]
-Display information about the given Cask\.
+\fBinfo\fR or \fBabv\fR \fItoken\fR [ \fItoken\fR \.\.\. ] [\-\-machine\-readable] 
+Display information about the given Cask\. With \fB\-\-machine-readable\fR, output in JSON format\.
 .
 .TP
 \fBinstall [\-\-force]\fR \fItoken\fR [ \fItoken\fR \.\.\. ]

--- a/lib/hbc.rb
+++ b/lib/hbc.rb
@@ -168,6 +168,10 @@ class Hbc
     staged_path.exist?
   end
 
+  def requires_sudo?
+    artifacts[:pkg].any?
+  end
+
   def to_s
     @token
   end

--- a/lib/hbc/cli/info.rb
+++ b/lib/hbc/cli/info.rb
@@ -1,7 +1,21 @@
+require 'json'
+
 class Hbc::CLI::Info < Hbc::CLI::Base
   def self.run(*args)
     cask_tokens = cask_tokens_from(args)
     raise Hbc::CaskUnspecifiedError if cask_tokens.empty?
+    if args.include?('--machine-readable')
+      machine_readable_info(cask_tokens)
+    else
+      human_readable_info(cask_tokens)
+    end
+  end
+
+  def self.help
+    "displays information about the given Cask"
+  end
+
+  def self.human_readable_info(cask_tokens)
     cask_tokens.each do |cask_token|
       odebug "Getting info for Cask #{cask_token}"
       cask = Hbc.load(cask_token)
@@ -10,8 +24,18 @@ class Hbc::CLI::Info < Hbc::CLI::Base
     end
   end
 
-  def self.help
-    "displays information about the given Cask"
+  def self.machine_readable_info(cask_tokens)
+    cask_tokens.each do |cask_token|
+      cask = Hbc.load(cask_token)
+      puts JSON.pretty_generate(
+        name: cask.to_s,
+        full_name: formatted_full_name(cask),
+        installed: cask.installed?,
+        homepage: cask.homepage,
+        github_url: github_url(cask),
+        requires_sudo: cask.requires_sudo?,
+      )
+    end
   end
 
   def self.info(cask)
@@ -26,17 +50,19 @@ class Hbc::CLI::Info < Hbc::CLI::Base
 #{formatted_full_name(cask) }
 #{cask.homepage or 'No Homepage'}
 #{installation}
-#{github_info(cask) or 'No GitHub URL'}
+#{github_url(cask) or 'No GitHub URL'}
+#{requires_sudo(cask)}
 #{artifact_info(cask) or 'No Artifact Info'}
 PURPOSE
   end
+
 
   def self.formatted_full_name(cask)
     # todo transitional: make name a required stanza, and then stop substituting cask.token here
     cask.full_name.empty? ? cask.token : cask.full_name.join(', ')
   end
 
-  def self.github_info(cask)
+  def self.github_url(cask)
     cask_token = cask.token
     cask_token = cask.class.all_tokens.detect { |t| t.split("/").last == cask_token } unless cask_token =~ /\//
     return nil unless cask_token.respond_to?(:length) and cask_token.length > 0
@@ -60,7 +86,7 @@ PURPOSE
     retval = ''
     Hbc::DSL::ClassMethods.ordinary_artifact_types.each do |type|
       if cask.artifacts[type].length > 0
-        retval = "#{Tty.blue.bold}==>#{Tty.white} Contents#{Tty.reset}\n" unless retval.length > 0
+        retval = heading("Contents") unless retval.length > 0
         cask.artifacts[type].each do |artifact|
           activatable_item = type == :stage_only ? '<none>' : artifact.first
           retval.concat "  #{activatable_item} (#{type.to_s})\n"
@@ -68,5 +94,13 @@ PURPOSE
       end
     end
     retval.sub!(/\n\Z/, '')
+  end
+
+  def self.requires_sudo(cask)
+    heading("Needs sudo to install?") + cask.requires_sudo?.to_s
+  end
+
+  def self.heading(message)
+    "#{Tty.blue.bold}==>#{Tty.white} #{message}#{Tty.reset}\n"
   end
 end

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -10,6 +10,8 @@ describe Hbc::CLI::Info do
       http://example.com/local-caffeine
       Not installed
       https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+      ==> Needs sudo to install?
+      false
       ==> Contents
         Caffeine.app (app)
     CLIOUTPUT
@@ -23,6 +25,8 @@ describe Hbc::CLI::Info do
         http://example.com/local-caffeine
         Not installed
         https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+        ==> Needs sudo to install?
+        false
         ==> Contents
           Caffeine.app (app)
         local-transmission: 2.61
@@ -30,6 +34,8 @@ describe Hbc::CLI::Info do
         http://example.com/local-transmission
         Not installed
         https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
+        ==> Needs sudo to install?
+        false
         ==> Contents
           Transmission.app (app)
       CLIOUTPUT
@@ -57,6 +63,8 @@ describe Hbc::CLI::Info do
       http://example.com/local-caffeine
       Not installed
       https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-caveats.rb
+      ==> Needs sudo to install?
+      false
       ==> Contents
         Caffeine.app (app)
       ==> Caveats
@@ -82,6 +90,8 @@ describe Hbc::CLI::Info do
       http://example.com/local-caffeine
       Not installed
       https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-conditional-caveats.rb
+      ==> Needs sudo to install?
+      false
       ==> Contents
         Caffeine.app (app)
     CLIOUTPUT
@@ -100,6 +110,22 @@ describe Hbc::CLI::Info do
       lambda {
         Hbc::CLI::Info.run('--notavalidoption')
       }.must_raise Hbc::CaskUnspecifiedError
+    end
+  end
+
+  describe 'with --machine-readable' do
+    it 'outputs JSON' do
+      out, err = capture_io do
+        Hbc::CLI::Info.run('local-caffeine', '--machine-readable')
+      end
+
+      parsed_info = JSON.parse(out)
+      parsed_info['name'].must_equal 'local-caffeine'
+      parsed_info['full_name'].must_equal 'local-caffeine'
+      parsed_info['installed'].must_equal false
+      parsed_info['homepage'].must_equal 'http://example.com/local-caffeine'
+      parsed_info['github_url'].must_equal 'https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb'
+      parsed_info['requires_sudo'].must_equal false
     end
   end
 end

--- a/test/cask_test.rb
+++ b/test/cask_test.rb
@@ -96,4 +96,18 @@ describe "Cask" do
       c.metadata_versioned_container_path.to_s.must_equal(metadata_path.to_s)
     end
   end
+
+  describe "requires_sudo?" do
+    it "is true with a cask that has pkg artifacts" do
+      cask = Hbc.load('with-installable')
+
+      cask.requires_sudo?.must_equal true
+    end
+
+    it "is false when there are no pkg artifacts" do
+      cask = Hbc.load('tarball')
+
+      cask.requires_sudo?.must_equal false
+    end
+  end
 end

--- a/test/support/Casks/Casks
+++ b/test/support/Casks/Casks
@@ -1,0 +1,1 @@
+/Users/vagrant/homebrew-cask/test/support/Casks


### PR DESCRIPTION
- requires_sudo reports whether we can detect that the cask
  install will need sudo privileges
- the `--machine-readable` option for `brew cask info` changes the
  output format to JSON, which is more suitable for parsing from
  external tools

I didn't attempt to include artifact details in the JSON output just
yet, since the first goal of this feature is just to tell
puppet-brewcask (in boxen) whether it need sudo for a given Cask.

refs #8817
