### PR TITLE
Update Screens Connect to v3.2.3

### DIFF
--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -1,16 +1,25 @@
 cask :v1 => 'screens-connect' do
-  version :latest
-  sha256 :no_check
+  version '3.2.3'
+  sha256 'bdffd7b7e750d5bcb23d2895588b5d14c8d0cdd5211391d537ee781b43321afc'
 
-  url 'https://screensconnect.com/downloads/screensconnect.dmg'
+  # edovia.com is the official download host per the appcast
+  # Original discussion: https://github.com/caskroom/homebrew-cask/pull/8816
+  url "http://download.edovia.com/screensconnect/screensconnect_#{version}.dmg"
+  appcast 'https://screensconnect.com/sparkle/appcast.xml'
   homepage 'https://screensconnect.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   pkg 'Screens Connect.pkg'
 
-  uninstall :script => 'Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool',
-            :pkgutil => 'com.edovia.pkg.screens.connect.*'
+  depends_on :macos => '>= :mountain_lion'
 
+  # Uninstall script can fail when trying to remove legacy PKGIDS
+  # Original discussion: https://github.com/caskroom/homebrew-cask/pull/8833
+  uninstall :script => {
+              :executable => 'Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool',
+              :must_succeed => false
+              },
+            :pkgutil => 'com.edovia.pkg.screens.connect.*'
   uninstall_preflight do
     system '/bin/chmod', '+x', "#{staged_path}/Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool"
   end


### PR DESCRIPTION
Screens Connect v3.2.3 released 2014-11-04.
Previous URL was not the ':latest'.
Also added minimum OS X version (10.8).
