### PR TITLE
mikogo: correct artifact, specify license

### DIFF
--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mikogo' do
 
   url 'http://download.mikogo4.com/mikogo.dmg'
   homepage 'http://www.mikogo.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Mikogo.app'
 end

--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -6,5 +6,6 @@ cask :v1 => 'mikogo' do
   homepage 'http://www.mikogo.com/'
   license :gratis
 
-  app 'Mikogo.app'
+  # Renamed for clarity: app name is inconsistent with its branding
+  app 'Mikogo-host.app', :target => 'Mikogo.app'
 end


### PR DESCRIPTION
Closes #8824.

Note that the name of the app bundle is not only inconsistent with the branding, but also with the [installation instructions](https://www.mikogo.com/wp-content/uploads/2013/10/mac-step2.png) offered by the website.
