### PR TITLE
Add Lingon X.app v2.0

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -2,10 +2,12 @@ cask :v1 => 'lingon-x' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.peterborgapps.com/downloads/LingonX.zip'
-  appcast 'http://www.peterborgapps.com/updates/lingonx-appcast.xml'
+  url 'http://www.peterborgapps.com/downloads/LingonX2.zip'
+  appcast 'http://www.peterborgapps.com/updates/lingonx2-appcast.xml'
   homepage 'http://www.peterborgapps.com/lingon/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Lingon X.app'
+
+  depends_on :macos => '>= :yosemite'
 end


### PR DESCRIPTION
Lingon X version 1.0 already exists as lingon-x but Lingon X 2.0 is an
entirely new version of Lingon X which only runs on Yosemite 10.10 or
higher. In my opinion, Lingon X 1.0 is still a valid Cask for this very
reason, and I think including 2.0 as lingon-x2 is the best way to handle
this updated version.
