### PR TITLE
tiddlywiki update to 0.0.4

### DIFF
--- a/Casks/tiddlywiki.rb
+++ b/Casks/tiddlywiki.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'tiddlywiki' do
-  version '0.0.3'
-  sha256 'b96e44b88d6ff421b0d35644862c4e474ba7099f597f0dc8d530f467d31abd5c'
+  version '0.0.4'
+  sha256 'e7ec36897c60c40f56ac0e1c66395e1c517ca403d9d1c0188738be6a7a0b8400'
 
-  url "https://github.com/Jermolene/TiddlyDesktop/releases/download/v#{version}/tiddlydesktop-mac-#{version}.zip"
+  url "https://github.com/Jermolene/TiddlyDesktop/releases/download/v#{version}/tiddlydesktop-mac64-#{version}.zip"
   homepage 'https://github.com/Jermolene/TiddlyDesktop'
   license :oss
 


### PR DESCRIPTION
link changed to:
mac32 or mac64

I chose 64.
