### PR TITLE
Add jenkins 1.596

### DIFF
--- a/Casks/jenkins.rb
+++ b/Casks/jenkins.rb
@@ -1,0 +1,29 @@
+cask :v1 => 'jenkins' do
+  version '1.596'
+  sha256 'eb7be5bd1e350b71ec8fb66721c28abbe0912e7062bc4f93ce61750467dfde4e'
+
+  url "http://mirrors.jenkins-ci.org/osx/jenkins-#{version}.pkg"
+  name 'Jenkins'
+  homepage 'http://jenkins-ci.org/'
+  license :cc
+
+  pkg "jenkins-#{version}.pkg"
+  binary '/Library/Application Support/Jenkins/jenkins-runner.sh', :target => 'jenkins'
+
+  uninstall :script    => '/Library/Application Support/Jenkins/Uninstall.command',
+            :pkgutil   => 'org.jenkins-ci.*pkg',
+            :launchctl => 'org.jenkins-ci'
+
+  zap :delete => '/Library/Preferences/org.jenkins-ci.plist'
+
+  conflicts_with :formula => %w{
+                                jenkins
+                                homebrew/versions/jenkins-lts
+                               },
+                 :cask    => 'caskroom/versions/jenkins-lts'
+
+  caveats <<-EOS.undent
+    #{token} requires Java. You can install the latest version with
+      brew cask install java
+  EOS
+end


### PR DESCRIPTION
Jenkins installer for Mac.

The `preflight`, `binary` and `postflight` stanzas are certainly up for discussion. The intent is to provide a CLI equivalent to the one provided through `brew install jenkins`. I did something similar in #8279.

The `pkg` does install a script `/Library/Application Support/Jenkins/jenkins-runner.sh`, which the `launchctl` job calls, but it reads arguments from `/Library/Preferences/org.jenkins-ci.plist` rather than allowing the user to pass them in.
