### PR TITLE
remove homebrew-fork `MACOS_RELEASE` constants

### DIFF
--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -118,7 +118,7 @@ We recommend the following:
 	/<path>/<to>/<private>/<repo>/developer/bin/production_brew_cask
 	```
 
-#### Forcing a Ruby interpreter
+### Forcing a Ruby interpreter
 
 You can force a specific version of the Ruby interpreter, and/or an
 alternate version of the `brew-cask` subcommand, by invoking `brew cask`
@@ -128,7 +128,7 @@ with fully-qualified paths, like this:
 $ /System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby /usr/local/Library/Taps/caskroom/homebrew-cask/lib/brew-cask-cmd.rb help
 ```
 
-#### Forcing a Specific Homebrew-cask Subcommand
+### Forcing a Specific Homebrew-cask Subcommand
 
 If you are developing a subcommand, you can force `brew cask` to dispatch a
 specific file by giving a fully-qualified path to the file containing the
@@ -139,6 +139,18 @@ $ brew cask /usr/local/Cellar/brew-cask/0.37.0/rubylib/hbc/cli/info.rb google-ch
 ```
 
 This form can also be combined with a specific Ruby interpreter as above.
+
+### Forcing a Specific OS X Release
+
+The environment variable `$MACOS_RELEASE` can be overridden at the command
+line for test purposes:
+
+```bash
+$ MACOS_RELEASE=10.9 brew cask info <cask>
+```
+
+The environment variable `$MACOS_RELEASE_WITH_PATCHLEVEL` is also available,
+though not consulted directly.  Use `$MACOS_RELEASE` for testing.
 
 ### Target Ruby Versions
 

--- a/lib/hbc/cli/doctor.rb
+++ b/lib/hbc/cli/doctor.rb
@@ -1,7 +1,7 @@
 class Hbc::CLI::Doctor < Hbc::CLI::Base
   def self.run
-    ohai 'OS X Release:',                                    render_with_none_as_error( MACOS_RELEASE )
-    ohai 'OS X Point Release:',                              render_with_none_as_error( MACOS_POINT_RELEASE )
+    ohai 'OS X Release:',                                    render_with_none_as_error( MacOS.release )
+    ohai 'OS X Release with Patchlevel:',                    render_with_none_as_error( MacOS.release_with_patchlevel )
     ohai "Hardware Architecture:",                           render_with_none_as_error( "#{Hardware::CPU.type}-#{Hardware::CPU.bits}" )
     ohai 'Ruby Version:',                                    render_with_none_as_error( "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" )
     ohai 'Ruby Path:',                                       render_with_none_as_error( RbConfig.ruby )

--- a/lib/hbc/macos.rb
+++ b/lib/hbc/macos.rb
@@ -5,8 +5,14 @@ require 'hbc/macos/release'
 module Hbc::MacOS
   extend self
 
-  # This Comparable instance can be compared to numerics, strings, or symbols
+  # These Comparable instances can be compared to numerics, strings, or symbols
+  def release_with_patchlevel
+    @@release_with_patchlevel ||=
+      Release.new(ENV.fetch('MACOS_RELEASE_WITH_PATCHLEVEL',
+                            `/usr/bin/sw_vers -productVersion 2>/dev/null`.chomp))
+  end
+
   def release
-    @@release ||= Release.new(MACOS_RELEASE)
+    @@release ||= Release.new(ENV.fetch('MACOS_RELEASE', release_with_patchlevel.to_s[/10\.\d+/]))
   end
 end

--- a/lib/vendor/homebrew-fork/global.rb
+++ b/lib/vendor/homebrew-fork/global.rb
@@ -27,9 +27,5 @@ end
 HOMEBREW_CACHE = cache
 undef cache
 
-MACOS_POINT_RELEASE = `/usr/bin/sw_vers -productVersion`.chomp
-MACOS_RELEASE = MACOS_POINT_RELEASE[/10\.\d+/]
-
-HOMEBREW_USER_AGENT = "Homebrew-cask v0.51+ (Ruby #{RUBY_VERSION}-#{RUBY_PATCHLEVEL}; #{MACOS_RELEASE})"
-
+HOMEBREW_USER_AGENT = "Homebrew-cask v0.51+ (Ruby #{RUBY_VERSION}-#{RUBY_PATCHLEVEL})"
 HOMEBREW_CURL_ARGS = '-f#LA'

--- a/lib/vendor/homebrew-fork/testing_env.rb
+++ b/lib/vendor/homebrew-fork/testing_env.rb
@@ -11,6 +11,3 @@ at_exit { FileUtils.remove_entry(TEST_TMPDIR) }
 HOMEBREW_CACHE         = Pathname.new(TEST_TMPDIR).join('cache')
 HOMEBREW_USER_AGENT    = 'Homebrew'
 HOMEBREW_CURL_ARGS     = '-fsLA'
-
-MACOS_POINT_RELEASE = `/usr/bin/sw_vers -productVersion`.chomp
-MACOS_RELEASE = ENV.fetch('MACOS_RELEASE') { MACOS_POINT_RELEASE[/10\.\d+/] }


### PR DESCRIPTION
- contain logic within module `Hbc::MacOS`
- add `release_with_patchlevel` method
- allow `MACOS_RELEASE` and `MACOS_RELEASE_WITH_PATCHLEVEL` environment variables to override the determined release values regardless of whether under the test harness

cc @vitorgalvao I think you have wanted the ability to fake the OS X release in the past, which can be done after this PR via

``` bash
$ MACOS_RELEASE=10.9 brew cask <command>
```
