### PR TITLE
Make staged_path work in installer stanzas

### DIFF
--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -47,6 +47,10 @@ module Hbc::DSL
 
   def artifacts; self.class.artifacts; end
 
+  def caskroom_path; self.class.caskroom_path; end
+
+  def staged_path; self.class.staged_path; end
+
   def caveats; self.class.caveats; end
 
   def accessibility_access; self.class.accessibility_access; end
@@ -215,6 +219,14 @@ module Hbc::DSL
 
     def artifacts
       @artifacts ||= Hash.new { |hash, key| hash[key] = Set.new }
+    end
+
+    def caskroom_path
+      @caskroom_path ||= self.caskroom
+    end
+
+    def staged_path
+      @staged_path ||= self.caskroom.join(self.name, self.version)
     end
 
     def caveats(*string, &block)


### PR DESCRIPTION
This should add support for using staged_path in installer stanzas. It also did work just fine two weeks ago, but now suddenly self.name is always returning KlassPrefixActualname instead of Actualname. Setting name at the start of the recipe doesn't fix it either. How do I get the actual name?
