### PR TITLE
Update pgweb to 0.5.0

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pgweb' do
-  version '0.4.1'
-  sha256 '3c97605f1ac22f03a737a2d32a45b8f35988290123d593d0c21cb28010893fc7'
+  version '0.5.0'
+  sha256 'b96e0383bf0981ad0dfeab0aabd878e4a5599c327e213986e1e63e2700b12934'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   name 'pgweb'


### PR DESCRIPTION
New release 0.5.0: https://github.com/sosedoff/pgweb/releases/tag/v0.5.0
