### PR TITLE
Casks/thunderbird.rb - bump Thunderbird to 31.4.0

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'thunderbird' do
-  version '31.3.0'
-  sha256 'b420b7b04cde0c57645bf2ae0f8b9fc507e854f82690b26551a54c17518885a6'
+  version '31.4.0'
+  sha256 '6de56ad6d215e3505afa376834cf251e1a1d0d4d4d1d570cfb507afefd164490'
 
   url "https://download.mozilla.org/?product=thunderbird-#{version}&os=osx&lang=en-US"
   homepage 'http://www.mozilla.org/en-US/thunderbird/'


### PR DESCRIPTION
Reflects release on 13 January 2015.

https://www.mozilla.org/en-US/thunderbird/31.4.0/releasenotes/
