### PR TITLE
expand tilde in `$PATH` for internal `which` method

### DIFF
--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -106,13 +106,13 @@ module Hbc::Utils
 
   def self.which(cmd, path=ENV['PATH'])
     unless File.basename(cmd) == cmd.to_s
-      # path contains a directory element
+      # cmd contains a directory element
       cmd_pn = Pathname(cmd)
       return nil unless cmd_pn.absolute?
       return resolve_executable(cmd_pn)
     end
     path.split(File::PATH_SEPARATOR).each do |elt|
-      fq_cmd = Pathname(elt).join(cmd)
+      fq_cmd = Pathname(elt).expand_path.join(cmd)
       resolved = resolve_executable fq_cmd
       return resolved if resolved
     end


### PR DESCRIPTION
restores Homebrew's behavior with regard to external commands
fixes #8889

Not all software supports literal `~` in `$PATH`.  On OS X, `/usr/bin/which` and `/usr/bin/type` differ on this point.  However, Homebrew does so, and consistency is good.
