### PR TITLE
"Downgrade" rust to alpha version

### DIFF
--- a/Casks/rust.rb
+++ b/Casks/rust.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'rust' do
-  version :latest
-  sha256 :no_check
+  version '1.0.0-alpha'
+  sha256 'b38eb92599249368a8b5ac87e2a47bcec4e57cd5557bd4869e848a16f1e16d23'
 
-  url 'http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg'
+  url "https://static.rust-lang.org/dist/rust-#{version}-x86_64-apple-darwin.pkg"
   homepage 'http://www.rust-lang.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :mit
 
-  pkg 'rust-nightly-x86_64-apple-darwin.pkg'
+  pkg "rust-#{version}-x86_64-apple-darwin.pkg"
 
   uninstall :pkgutil => 'org.rust-lang.rust'
 end


### PR DESCRIPTION
The Rust team released the first "stable" release of the Rust compiler. The rationale for this PR is to have the "rust" cask follow the latest stable release (alpha for now, beta in six weeks and 1.0 proper after that, hopefully). Nightly builds are moved to the rust-nightly cask in caskroom/homebrew-versions.

See also https://github.com/caskroom/homebrew-versions/pull/677
