### PR TITLE
Add Cask for BitPim.App  (CDMA phone explorer) v1.0.7

### DIFF
--- a/Casks/bitpim.rb
+++ b/Casks/bitpim.rb
@@ -1,19 +1,16 @@
 cask :v1 => 'bitpim' do
   version '1.0.7'
   sha256 '567d41ececc8c416746c3aa9365182797b339001d255dc4da7acc285bb289880'
-  url 'http://downloads.sourceforge.net/project/bitpim/bitpim/1.0.7/LEOPARD-bitpim-1.0.7.dmg'
+
+  depends_on :macos => '>= :tiger' #BitPim actually runs in 10.3, but homebrew-cask doesn't go back that far.
 
   name 'BitPim'
-  homepage 'http://www.bitpim.org/'
   license :gpl
+  homepage 'http://www.bitpim.org/'
+  url 'http://downloads.sourceforge.net/project/bitpim/bitpim/#{version}/LEOPARD-bitpim-1.0.7.dmg'
+
   app 'BitPim.app'
-  depends_on :macos => '>= 10.3'
 
   uninstall :quit => 'org.bitpim.bitpim'
-
-  zap :quit => 'org.bitpim.bitpim'
-  zap :delete => [
-    '~/Library/Preferences/org.bitpim.bitpim.plist',
-    '~/Library/Preferences/LaunchpadCleaner/Local\ Store/applicattons/appicons/org.bitpim.bitpim.png',
-  ]
+  zap :delete => '~/Library/Preferences/org.bitpim.bitpim.plist'
 end

--- a/Casks/bitpim.rb
+++ b/Casks/bitpim.rb
@@ -1,0 +1,19 @@
+cask :v1 => 'bitpim' do
+  version '1.0.7'
+  sha256 '567d41ececc8c416746c3aa9365182797b339001d255dc4da7acc285bb289880'
+  url 'http://downloads.sourceforge.net/project/bitpim/bitpim/1.0.7/LEOPARD-bitpim-1.0.7.dmg'
+
+  name 'BitPim'
+  homepage 'http://www.bitpim.org/'
+  license :gpl
+  app 'BitPim.app'
+  depends_on :macos => '>= 10.3'
+
+  uninstall :quit => 'org.bitpim.bitpim'
+
+  zap :quit => 'org.bitpim.bitpim'
+  zap :delete => [
+    '~/Library/Preferences/org.bitpim.bitpim.plist',
+    '~/Library/Preferences/LaunchpadCleaner/Local\ Store/applicattons/appicons/org.bitpim.bitpim.png',
+  ]
+end

--- a/Casks/bitpim.rb
+++ b/Casks/bitpim.rb
@@ -1,19 +1,17 @@
 cask :v1 => 'bitpim' do
   version '1.0.7'
   sha256 '567d41ececc8c416746c3aa9365182797b339001d255dc4da7acc285bb289880'
-  url 'http://downloads.sourceforge.net/project/bitpim/bitpim/1.0.7/LEOPARD-bitpim-1.0.7.dmg'
 
+  url "http://downloads.sourceforge.net/project/bitpim/bitpim/#{version}/LEOPARD-bitpim-#{version}.dmg"
   name 'BitPim'
   homepage 'http://www.bitpim.org/'
   license :gpl
+
   app 'BitPim.app'
-  depends_on :macos => '>= 10.3'
 
   uninstall :quit => 'org.bitpim.bitpim'
 
-  zap :quit => 'org.bitpim.bitpim'
-  zap :delete => [
-    '~/Library/Preferences/org.bitpim.bitpim.plist',
-    '~/Library/Preferences/LaunchpadCleaner/Local\ Store/applicattons/appicons/org.bitpim.bitpim.png',
-  ]
+  zap :delete => '~/Library/Preferences/org.bitpim.bitpim.plist'
+
+  depends_on :macos => '>= :tiger' #BitPim actually supports 10.3, but Cask does not.
 end


### PR DESCRIPTION
This is my first commit to an open-source project, so please be kind. Constrictive criticism would be appreciated (please ELI5).

Not sure if I did the 'uninstall' and 'zap' stanzas correctly...  I figure that the 'quit' is needed for zap because you don't want those pref files being re-written if the app is still open. But does the 'quit' belong in the 'uninstall' stanza as well? 

FYI - Is one of the best GUI tools for pulling data from old phones. It hasn't been updated in a few years, but it still works on 10.9 (as tested by me), and probably 10.10.
