### PR TITLE
Removing `foreman` installed by heroku-toolbelt's setup.

### DIFF
--- a/Casks/heroku-toolbelt.rb
+++ b/Casks/heroku-toolbelt.rb
@@ -13,6 +13,8 @@ cask :v1 => 'heroku-toolbelt' do
             :delete  => [
                          '/usr/local/heroku',
                          '/usr/bin/heroku',
+                         '/usr/local/foreman',
+                         '/usr/bin/foreman'
                         ]
   zap       :delete => '~/.heroku'
 


### PR DESCRIPTION
The heroku-toolbelt setup install the tool `foreman` used to simulate an heroku app on a local workstation. In order to cleanly delete this cask we need to remove it.
