### PR TITLE
Add Krita.app v2.8.79.10

### DIFF
--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -9,4 +9,3 @@ cask :v1 => 'krita' do
 
   app 'Krita.app'
 end
-

--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'krita' do
+  version '2.8.79.10'
+  sha256 '2a80c2cf856fbbb799db8cea0ed8a43346e10cfb465bf8a4e181a1142bee62cd'
+
+  url "http://www.valdyas.org/~boud/Krita-#{version}.dmg"
+  name 'Krita'
+  homepage 'https://krita.org/'
+  license :gpl
+
+  app 'Krita.app'
+end
+


### PR DESCRIPTION
Krita is a free digital painting and illustration application.

As of this version, the Krita website states that OS X support is "very
experimental right now and unstable," but there are no immediately
noticable problems when running on Yosemite (10.10.1).
