### PR TITLE
Improve Box Sync Cask

### DIFF
--- a/Casks/box-sync.rb
+++ b/Casks/box-sync.rb
@@ -7,4 +7,16 @@ cask :v1 => 'box-sync' do
   license :gratis
 
   app 'Box Sync.app'
+
+  uninstall :quit => 'com.box.sync',
+            :delete =>  [
+                          '/Library/PrivilegedHelperTools/com.box.sync.iconhelper',
+                          '/Library/PrivilegedHelperTools/com.box.sync.bootstrapper'
+                        ]
+
+  zap :delete =>  [
+                    '~/Library/Application Support/Box/Box Sync',
+                    '~/Library/Logs/Box/Box Sync'
+                  ],
+      :rmdir => '~/Library/Application Support/Box'
 end


### PR DESCRIPTION
Add uninstall and zap stanzas

Add uninstall_preflight to change ownership of Box Sync.app to user

Box Sync changes ownership of the application upon first run to root.
This makes the uninstall hang.
