### PR TITLE
Updated Yasu formula

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -2,13 +2,15 @@ cask :v1 => 'aquamacs' do
 
   if Hardware::CPU.is_32_bit?
     version '2.5'
-    sha256 '5857848d8d46bba43d160c02393b098a370e2156608be24b288419f668210be9'
+    sha256 '04835075a0c2db072bc974b0e01876e4c95e89deed0485755354f2bbffc8481a'
 
-    url "http://braeburn.aquamacs.org/releases/Aquamacs-Emacs-#{version}.dmg"
+    # github.com is the official download host per the vendor homepage
+    url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}-final/Aquamacs-Emacs-#{version}final.tar.bz2"
   else
     version '3.2'
     sha256 '0bdbbe20afd1d2f2bc23fd583de9475a8826493fcf9fe0e4d2717353cf5f04b2'
 
+    # github.com is the official download host per the vendor homepage
     url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}/Aquamacs-Emacs-#{version}.dmg"
   end
 

--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -1,10 +1,37 @@
 cask :v1 => 'yasu' do
-  version :latest
-  sha256 :no_check
 
-  url 'http://yasuapp.net/files/Yasu.zip'
+  if MacOS.release <= '10.3'
+    version '1.0.3'
+    sha256 'f2c25505848e0de41f783f31e2c6a465741249e904b13d824eb586a9ed2a69af'
+    url 'http://yasuapp.net/files/Yasu_PE.dmg.gz'
+  elseif MacOS.release <= '10.6'
+    version '2.8.2'
+    sha256 '427672a45b8315c2f38d968ea5e0c35c21b91091a1fe0e750fcd2b0078644336'
+    url "http://yasuapp.net/files/yasu_#{version}.zip"
+  else
+    version '2.9.1'
+    sha256 '597385cec59650cf5f5c9b54e22df5c0a87e4298e2164ceb09cf446b83646547'
+    url "http://yasuapp.net/files/yasu_#{version}.zip"
+  end
+
   homepage 'http://yasuapp.net'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Yasu.app'
+
+  zap :delete => [
+                  '~/Library/Caches/com.apple.helpd/Generated/net.yasuapp.yasu.help',
+                  '~/Library/Caches/net.yasuapp.yasu',
+                  '~/Library/Logs/Yasu.log',
+                  '~/Library/Preferences/net.yasuapp.yasu.plist',
+                  '~/Library/Preferences/org.jimmitchell.yasu.plist',
+                 ]
+
+  caveats <<-EOS.undent
+    Yasu is no longer maintained and updated. There is no support for any Yasu downloads. Yasu may not work with OS X beyond Yosemite.
+    Use at your own risk.
+
+    Official announcement can be found on the Yasu homepage.
+  EOS
+
 end


### PR DESCRIPTION
Yasu cask download url is broken, and without shasum check, it is only caught upon installation. The developer had decided to stop maintaining Yasu and has released the last versions free for use, but without support. This has been noted in the Caveats for user awareness. Added the zap stanza to cleanup cruft left behind.
