### PR TITLE
Update p4v 2014.2.985932

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,7 +1,7 @@
 cask :v1 => 'p4v' do
-  version '2014.2-951414'
-  sha256 'cb8f210435de8186af92e5d376a64e6b5f48c67d1b4e892628de88d54ce4918e'
-
+  version '2014.2-985932'
+  sha256 '766b6f6b8669f889f1186dd96408b5b8af6b9dc6c602784d6d6ea25130007709'
+ 
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*},'\1')}/bin.macosx107x86_64/P4V.dmg"
   name 'P4V'
   name 'Perforce Visual Client'

--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -6,9 +6,15 @@ cask :v1 => 'p4v' do
   name 'P4V'
   name 'Perforce Visual Client'
   homepage 'http://www.perforce.com/product/components/perforce-visual-client'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
   tags :vendor => 'Perforce'
 
   app 'p4v.app'
   binary 'p4vc'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.perforce.p4v',
+                  '~/Library/Preferences/com.perforce.p4v.plist',
+                  '~/Library/Saved Application State/com.perforce.p4v.savedState'
+                 ]
 end


### PR DESCRIPTION
Perforce has released a new version of p4v even though the download webpage still refers to the last version 2014.2.951414.  The shasum no longer matches and the P4V.dmg/p4v.app/Contents/Info.plist has a property P4RevString <string>P4V/MACOSX107X86_64/2014.2/985932 (2015/01/14)</string>
