### PR TITLE
Updated Yasu Formula

### DIFF
--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -1,10 +1,33 @@
 cask :v1 => 'yasu' do
-  version :latest
-  sha256 :no_check
 
-  url 'http://yasuapp.net/files/Yasu.zip'
+  if MacOS.release <= :snow_leopard
+    version '2.8.2'
+    sha256 '427672a45b8315c2f38d968ea5e0c35c21b91091a1fe0e750fcd2b0078644336'
+    url "http://yasuapp.net/files/yasu_#{version}.zip"
+  else
+    version '2.9.1'
+    sha256 '597385cec59650cf5f5c9b54e22df5c0a87e4298e2164ceb09cf446b83646547'
+    url "http://yasuapp.net/files/yasu_#{version}.zip"
+  end
+
   homepage 'http://yasuapp.net'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Yasu.app'
+
+  zap :delete => [
+                  '~/Library/Caches/com.apple.helpd/Generated/net.yasuapp.yasu.help',
+                  '~/Library/Caches/net.yasuapp.yasu',
+                  '~/Library/Logs/Yasu.log',
+                  '~/Library/Preferences/net.yasuapp.yasu.plist',
+                  '~/Library/Preferences/org.jimmitchell.yasu.plist',
+                 ]
+
+  caveats <<-EOS.undent
+    Yasu is no longer maintained and updated. There is no support for any Yasu downloads. Yasu may not work with OS X beyond Yosemite.
+    Use at your own risk.
+
+    Official announcement can be found on the Yasu homepage.
+  EOS
+
 end


### PR DESCRIPTION
Yasu download url is broken, and without shasum check, it is not caught until installation. The developer has decided to stop maintaining Yasu and has released the last working version various OS X versions, but not supporting the software. This has been noted in the Caveats for user awareness. Added the zap stanza to cleanup cruft left behind.
