### PR TITLE
bartender rejects hotlinking. refs #4202

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -2,7 +2,7 @@ cask :v1 => 'bartender' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.macbartender.com/Demo/Bartender.zip'
+  url 'http://www.macbartender.com/Demo/Bartender.zip', :referer => 'http://www.macbartender.com'
   appcast 'http://www.macbartender.com/updates/updates.php'
   homepage 'http://www.macbartender.com/'
   license :commercial


### PR DESCRIPTION
_Test_

this fails

`````` shell
$ curl -v -o bar.zip http://www.macbartender.com/Demo/Bartender.zip
* Hostname was NOT found in DNS cache
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 104.28.20.52...
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to www.macbartender.com (104.28.20.52) port 80 (#0)
> GET /Demo/Bartender.zip HTTP/1.1
> User-Agent: curl/7.37.1
> Host: www.macbartender.com
> Accept: */*
> Referer:
>
< HTTP/1.1 403 Forbidden
< Date: Sat, 17 Jan 2015 18:31:13 GMT
< Content-Type: text/html; charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Set-Cookie: __cfduid=d8eea3513bd6eed636a350098b55bbb4b1421519473; expires=Sun, 17-Jan-16 18:31:13 GMT; path=/; domain=.macbartender.com; HttpOnly
< Cache-Control: max-age=10
< Expires: Sat, 17 Jan 2015 18:31:23 GMT
< X-Frame-Options: SAMEORIGIN
* Server cloudflare-nginx is not blacklisted
< Server: cloudflare-nginx
< CF-RAY: 1aa4a0e320ae0a60-ARN
<
{ [data not shown]
100  3246    0  3246    0     0  17272      0 --:--:-- --:--:-- --:--:-- 17265
* Connection #0 to host www.macbartender.com left intact
`
``

but this works
```shell
$ curl -H"Referer: http://www.macbartender.com" -v -o bar.zip http://www.macbartender.com/Demo/Bartender.zip
* Hostname was NOT found in DNS cache
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 104.28.21.52...
* Connected to www.macbartender.com (104.28.21.52) port 80 (#0)
> GET /Demo/Bartender.zip HTTP/1.1
> User-Agent: curl/7.37.1
> Host: www.macbartender.com
> Accept: */*
> Referer: http://www.macbartender.com
>
< HTTP/1.1 200 OK
< Date: Sat, 17 Jan 2015 18:31:58 GMT
< Content-Type: application/zip
< Content-Length: 3968222
< Connection: keep-alive
< Set-Cookie: __cfduid=d3ad95d95fb65f7cf5d05c7fd4bf739be1421519518; expires=Sun, 17-Jan-16 18:31:58 GMT; path=/; domain=.macbartender.com; HttpOnly
< Last-Modified: Mon, 15 Dec 2014 09:46:47 GMT
< ETag: "7e55e47-3c8cde-50a3e1efc3e06"
< Accept-Ranges: bytes
< Vary: User-Agent
* Server cloudflare-nginx is not blacklisted
< Server: cloudflare-nginx
< CF-RAY: 1aa4a1fd6e94168e-ARN
<
{ [data not shown]
``````
