### PR TITLE
Add hub v2.2.0-rc1

### DIFF
--- a/Casks/hub.rb
+++ b/Casks/hub.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'hub' do
+  version '2.2.0-rc1'
+
+  if Hardware::CPU.is_32_bit?
+    sha256 '6e41b6e964e56caa9cc363411b4a54e22ece5613c0c425dbb755fce6928ba2db'
+    url "https://github.com/github/hub/releases/download/#{version}/hub_#{version}_mac_386.gz.tar"
+    binary "hub_#{version}_mac_386/hub"
+  else
+    sha256 '57e62305b983e4e292b0a503ab5e17701a5624ae640fd67c3d776415a85733f6'
+    url "https://github.com/github/hub/releases/download/v#{version}/hub_#{version}_mac_amd64.gz.tar"
+    binary "hub_#{version}_mac_amd64/hub"
+  end
+
+  name 'hub'
+  homepage 'https://github.com/github/hub'
+  license :mit
+end


### PR DESCRIPTION
Trying to add latest version of hub.
I'm getting the following error:

```
==> Creating directories
==> Loading Cask definitions
==> Translating 'hub' into a valid Cask source
==> Testing source class Hbc::Source::URI
==> Testing source class Hbc::Source::PathSlashRequired
==> Testing source class Hbc::Source::TappedQualified
==> Testing source class Hbc::Source::UntappedQualified
==> Testing source class Hbc::Source::Tapped
==> Success! Using source class Hbc::Source::Tapped
==> Resolved Cask URI or file source to '/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/Casks/hub.rb'
==> Cask instance dumps in YAML:
==> Cask instance toplevel:
--- !ruby/object:KlassPrefixHub
sourcefile_path: !ruby/object:Pathname
  path: /opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/Casks/hub.rb
token: hub
==> Cask instance method 'name':

---
- hub
==> Cask instance method 'homepage':
--- https://github.com/github/hub
...
==> Cask instance method 'url':
--- !ruby/object:Hbc::URL
uri: !ruby/object:URI::HTTPS
  scheme: https
  user: 
  password: 
  host: github.com
  port: 443
  path: /github/hub/releases/download/v2.2.0-rc1/hub_2.2.0-rc1_mac_amd64.gz.tar
  query: 
  opaque: 
  registry: 
  fragment: 
  parser: 
user_agent: 
cookies: 
referer: 
using: 
revision: 
trust_cert: 
data: 
==> Cask instance method 'appcast':
--- 
...
==> Cask instance method 'version':
--- 2.2.0-rc1
...
==> Cask instance method 'license':
--- !ruby/object:Hbc::DSL::License
value: :oss
==> Cask instance method 'tags':
--- 
...
==> Cask instance method 'sha256':
--- 57e62305b983e4e292b0a503ab5e17701a5624ae640fd67c3d776415a85733f6
...
==> Cask instance method 'artifacts':

---
:binary: !ruby/object:Set
  hash:
    ? - hub
    : true
==> Cask instance method 'caveats':
--- []
==> Cask instance method 'depends_on':
--- 
...
==> Cask instance method 'conflicts_with':
--- 
...
==> Cask instance method 'container':
--- 
...
==> Cask instance method 'gpg':
--- 
...
==> Cask instance method 'accessibility_access':
--- 
...
==> Hbc::Installer.install
==> Printing caveats
==> Downloading
==> Downloading https://github.com/github/hub/releases/download/v2.2.0-rc1/hub_2.2.0-rc1_mac_amd64.gz.tar
Already downloaded: /opt/boxen/cache/homebrew/hub-2.2.0-rc1.tar
==> SHA256 checksums match
==> Downloaded to -> /opt/boxen/cache/homebrew/hub-2.2.0-rc1.tar
==> Extracting primary container
==> Determining which containers to use based on filetype
==> Checking container class Hbc::Container::Pkg
==> Checking container class Hbc::Container::Ttf
==> Checking container class Hbc::Container::Otf
==> Checking container class Hbc::Container::Air
==> Checking container class Hbc::Container::Cab
==> Executing: ["/usr/bin/file", "-Izb", "--", "#<Pathname:/opt/boxen/cache/homebrew/hub-2.2.0-rc1.tar>"]
==> Checking container class Hbc::Container::Dmg
==> Executing: ["/usr/bin/hdiutil", "imageinfo", "#<Pathname:/opt/boxen/cache/homebrew/hub-2.2.0-rc1.tar>"]
==> Checking container class Hbc::Container::SevenZip
==> Checking container class Hbc::Container::Sit
==> Checking container class Hbc::Container::Tar
==> Using container class Hbc::Container::Tar for /opt/boxen/cache/homebrew/hub-2.2.0-rc1.tar
==> Executing: ["/usr/bin/tar", "xf", "#<Pathname:/opt/boxen/cache/homebrew/hub-2.2.0-rc1.tar>", "-C", "/var/folders/27/yjth92qs63g482k53zhr_hb80000gn/T/d20150118-14854-1w5hehq"]
==> Executing: ["/usr/bin/ditto", "--", "/var/folders/27/yjth92qs63g482k53zhr_hb80000gn/T/d20150118-14854-1w5hehq", "#<Pathname:/opt/homebrew-cask/Caskroom/hub/2.2.0-rc1>"]
==> Installing artifacts
==> Determining which artifacts are present in Cask hub
==> Checking for artifact class Hbc::Artifact::PreflightBlock
==> Checking for artifact class Hbc::Artifact::NestedContainer
==> Checking for artifact class Hbc::Artifact::Installer
==> Checking for artifact class Hbc::Artifact::App
==> Checking for artifact class Hbc::Artifact::Suite
==> Checking for artifact class Hbc::Artifact::Artifact
==> Checking for artifact class Hbc::Artifact::Colorpicker
==> Checking for artifact class Hbc::Artifact::Pkg
==> Checking for artifact class Hbc::Artifact::Prefpane
==> Checking for artifact class Hbc::Artifact::Qlplugin
==> Checking for artifact class Hbc::Artifact::Font
==> Checking for artifact class Hbc::Artifact::Service
==> Checking for artifact class Hbc::Artifact::StageOnly
==> Checking for artifact class Hbc::Artifact::Binary
==> Checking for artifact class Hbc::Artifact::InputMethod
==> Checking for artifact class Hbc::Artifact::InternetPlugin
==> Checking for artifact class Hbc::Artifact::ScreenSaver
==> Checking for artifact class Hbc::Artifact::Uninstall
==> Checking for artifact class Hbc::Artifact::PostflightBlock
==> Checking for artifact class Hbc::Artifact::Zap
==> 1 artifact/s defined
Hbc::Artifact::Binary
==> Installing artifact of class Hbc::Artifact::Binary
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/hub/2.2.0-rc1/hub'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/artifact/symlinked.rb:101:in `preflight_checks'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/artifact/symlinked.rb:62:in `link'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/artifact/symlinked.rb:87:in `block in install_phase'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/artifact/symlinked.rb:87:in `each'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/artifact/symlinked.rb:87:in `install_phase'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/artifact/binary.rb:3:in `install_phase'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/installer.rb:112:in `block in install_artifacts'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/installer.rb:110:in `each'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/installer.rb:110:in `install_artifacts'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/installer.rb:63:in `install'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/install.rb:20:in `block in install_casks'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/install.rb:17:in `each'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/install.rb:17:in `install_casks'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/install.rb:6:in `run'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli.rb:78:in `run_command'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli.rb:118:in `process'
/opt/boxen/homebrew/Library/Taps/caskroom/homebrew-cask/lib/brew-cask-cmd.rb:18:in `<main>'
==> Purging files for version 2.2.0-rc1 of Cask hub
```
