### PR TITLE
Added vendor download comment to 197 casks

### DIFF
--- a/Casks/invisiblix.rb
+++ b/Casks/invisiblix.rb
@@ -2,6 +2,7 @@ cask :v1 => 'invisiblix' do
   version '3.2'
   sha256 '528328a0e7c3f0a72e763ea766324d491dfe20d6f18a2882eefda1a5a2c4d68e'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/invisiblix/invisibliX-#{version}.zip"
   appcast 'http://www.read-write.fr/invisiblix/appcast.xml',
           :sha256 => '35040c896c24cd6299de79f3a977584af0bdc29de72f1c4f4023ae41e17b0d6c'

--- a/Casks/ios-lockscreen.rb
+++ b/Casks/ios-lockscreen.rb
@@ -4,6 +4,7 @@ cask :v1 => 'ios-lockscreen' do
 
   name 'iOS Lockscreen'
   homepage 'http://littleendiangamestudios.com/project/ios-7-screen-saver/'
+  # site90.net is the official download host per the vendor homepage
   url 'http://dlstatsios7.site90.net/download.php', :referer => "#{homepage}"
   license :unknown    # todo: improve this machine-generated value
 

--- a/Casks/iphoto-library-manager.rb
+++ b/Casks/iphoto-library-manager.rb
@@ -2,6 +2,7 @@ cask :v1 => 'iphoto-library-manager' do
   version '4.1.10'
   sha256 '2ab9ec177b2c6ee94847ea6c2164a51f86e2c9e288433f9f7a4f20ab175be519'
 
+  # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/fatcatsoftware/iplm/iPhotoLibraryManager_#{version.gsub('.', '')}.zip"
   name 'iPhoto Library Manager'
   homepage 'http://www.fatcatsoftware.com/iplm/'

--- a/Casks/itools.rb
+++ b/Casks/itools.rb
@@ -2,6 +2,7 @@ cask :v1 => 'itools' do
   version '2.4.4'
   sha256 '4ea6717d78d8e782fcd41fe10ff0e44d6a6cac5dfa1fcfd08176889b2f55334a'
 
+  # itools.hk is the official download host per the vendor homepage
   url "http://dl2.itools.hk/dl/iTools_#{version}.dmg"
   name 'iTools'
   homepage 'http://pro.itools.cn/mac'

--- a/Casks/jenkins-menu.rb
+++ b/Casks/jenkins-menu.rb
@@ -2,6 +2,7 @@ cask :v1 => 'jenkins-menu' do
   version '0.2.0'
   sha256 'dc2b69ab27b99ed0b0c165ade90b504b7c8201213b5334c6d927affd8cf106b4'
 
+  # github.com is the official download host per the vendor homepage
   url  "https://github.com/qvacua/jenkins-menu/releases/download/v#{version}/Jenkins.Menu-#{version}.zip"
   appcast 'http://qvacua.com/jenkinsmenu/appcast.xml',
           :sha256 => '420aaafc9de36c174ba1b43d1dfd4719603808f1754da8b7bb2a4ef1e934429d'

--- a/Casks/jin.rb
+++ b/Casks/jin.rb
@@ -2,6 +2,7 @@ cask :v1 => 'jin' do
   version '2.14.1'
   sha256 'd5592e35bc1e1bb6cf8337d0adaf883c7f5964e9e6f378f66f3fa29979d653aa'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/jin/jin/jin-#{version}/jin-#{version}-macosx-lion.dmg"
   name 'Jin'
   homepage 'http://www.jinchess.com/'

--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -2,6 +2,7 @@ cask :v1 => 'jubler' do
   version '5.0.5'
   sha256 '363f272cc1e15e02cf3e28935b9b2fdd91c43b93b2d1afef281e500c158b8bcd'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/jubler/Jubler-#{version}.dmg"
   homepage 'http://www.jubler.org/'
   license :oss

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'jxplorer' do
   version '3.3.1'
   sha256 'b51995a93203590e6690d8ad54f73cd7af1c9f2bef6219adca79c58eda71d860'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/jxplorer/jxplorer/version%20#{version}/jxplorer-#{version}-osx.zip"
   homepage 'http://jxplorer.org'
   license :oss

--- a/Casks/kensington-trackball-works.rb
+++ b/Casks/kensington-trackball-works.rb
@@ -2,6 +2,7 @@ cask :v1 => 'kensington-trackball-works' do
   version '1.1.2'
   sha256 '02e3fed2fe01c234206d3fcf2c85f71f10aa2a3bc3d3dd6f4694ac41b725e3df'
 
+  # windows.net is the official download host per the vendor homepage
   url 'http://accoblobstorageus.blob.core.windows.net/software/38c5e777-b2ef-4434-8091-6290cb41fc16.dmg'
   homepage 'http://www.kensington.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/kismac.rb
+++ b/Casks/kismac.rb
@@ -2,6 +2,7 @@ cask :v1 => 'kismac' do
   version '0.3.3'
   sha256 'd48f307c1c46a1d1a6b4465d653cf417e583bc09b7ea76d21183068066bc49bb'
 
+  # kismacmirror.com is the official download host per the vendor homepage
   url "http://update.kismacmirror.com/binaries/KisMAC-#{version}.dmg"
   appcast 'http://update.kismac-ng.org/sparkle/profileInfo.php',
           :sha256 => '18095f38358d65f5cbaa2a876745c7b1213d56893bc26c182138f51a2d3fa8df'

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -2,6 +2,7 @@ cask :v1 => 'klayout' do
   version '0.23.2'
   sha256 '96ce3fdead710248ed2ed4f25c9a94859949466d42eaa4f87881c17567dc1f15'
 
+  # 178.77.72.242 is the official download host per the vendor homepage
   url "http://178.77.72.242/downloads/klayout.#{version}.pkg"
   name 'KLayout'
   homepage 'http://www.klayout.de/'

--- a/Casks/klystrack.rb
+++ b/Casks/klystrack.rb
@@ -2,6 +2,7 @@ cask :v1 => 'klystrack' do
   version '1.6.0-1270'
   sha256 '32121c17df528c780384d235f91da3bd0552ac3b20a4e3538e6627d8255ff30c'
 
+  # dropboxusercontent.com is the official download host per the vendor homepage
   url 'https://dl.dropboxusercontent.com/u/1190319/Klystrack_1.6.0-1270.dmg'
   name 'Klystrack'
   homepage 'https://code.google.com/p/klystrack/'

--- a/Casks/knox.rb
+++ b/Casks/knox.rb
@@ -2,6 +2,7 @@ cask :v1 => 'knox' do
   version '2.2.0'
   sha256 'c19c56a35d299a2cd85c612e1e99009bff9d7536ddd24f9d565910702be9742a'
 
+  # cloudfront.net is the official download host per the vendor homepage
   url "https://d13itkw33a7sus.cloudfront.net/dist/K/Knox-#{version}.zip"
   name 'Knox'
   homepage 'https://agilebits.com/knox'

--- a/Casks/kod.rb
+++ b/Casks/kod.rb
@@ -2,6 +2,7 @@ cask :v1 => 'kod' do
   version '0.0.3'
   sha256 'bbc645f03e3aa49438606f2c874b6773c648e8409a395149492ec000b10d4ddb'
 
+  # hunch.se is the official download host per the vendor homepage
   url "http://data.hunch.se/kod/kod-#{version}.zip"
   homepage 'https://github.com/rsms/kod/'
   license :oss

--- a/Casks/kodi.rb
+++ b/Casks/kodi.rb
@@ -2,9 +2,10 @@ cask :v1 => 'kodi' do
   version '14.0'
   sha256 'bf0f5b836a517edeb78b75424b929c9d42067463232e6f62a2df327a947d9d35'
 
+  # xbmc.org is the official download host per the vendor homepage
   url "http://mirrors.xbmc.org/releases/osx/x86_64/kodi-#{version}-Helix-x86_64.dmg"
   name 'Kodi'
-  name 'XBMC'    # former
+  name 'XBMC' # former
   homepage 'http://kodi.tv/'
   license :gpl
 

--- a/Casks/kompozer.rb
+++ b/Casks/kompozer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'kompozer' do
   version '0.8b3'
   sha256 '415e019c9b3ec1c76465bf4f561fa515f403e57ac6f92c76365d902241dc14ed'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/kompozer/current/#{version}/macosx/kompozer-#{version}.en-US.mac-universal.dmg"
   homepage 'http://www.kompozer.net/'
   license :oss

--- a/Casks/kvirc.rb
+++ b/Casks/kvirc.rb
@@ -2,6 +2,7 @@ cask :v1 => 'kvirc' do
   version '4.2.0'
   sha256 'bb450b5abc2012cfc6c3f2cce3c8b13239acad4553cdd73d48f8d47dd8cf61c2'
 
+  # tradebit.com is the official download host per the vendor homepage
   url "http://kvirc.tradebit.com/#{version}/binary/osx/KVIrc-#{version}-Equilibrium.dmg"
   homepage 'http://www.kvirc.net'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/laullon-gitx.rb
+++ b/Casks/laullon-gitx.rb
@@ -2,6 +2,7 @@ cask :v1 => 'laullon-gitx' do
   version '0.8.4'
   sha256 'c5f4088497abf5a219bb7bde4fae643fec61647be25bf836fd679567dcabd7df'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/downloads/laullon/gitx/GitX-L_v#{version}.zip"
   name 'GitX (L)'
   appcast 'http://gitx.laullon.com/appcast.xml',

--- a/Casks/league-of-legends.rb
+++ b/Casks/league-of-legends.rb
@@ -2,9 +2,10 @@ cask :v1 => 'league-of-legends' do
   version :latest
   sha256 :no_check
 
+  # riotgames.com is the official download host per the vendor homepage
   url 'http://l3cdn.riotgames.com/Installer/NA_Mac_Installer/League%20of%20Legends%20NA.dmg'
-  homepage 'http://signup.leagueoflegends.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'http://leagueoflegends.com/'
+  license :gratis
 
   app 'League of Legends.app'
 end

--- a/Casks/librecad.rb
+++ b/Casks/librecad.rb
@@ -2,9 +2,11 @@ cask :v1 => 'librecad' do
   version '2.0.5'
 
   if MacOS.release <= :mountain_lion
+    # sourceforge.net is the official download host per the vendor homepage
     url "http://downloads.sourceforge.net/project/librecad/OSX/#{version}/LibreCAD-#{version}-MountainLion.dmg"
     sha256 '6f1f1fe3f49ac404608965c1d40e7a109b7f416b7b0624c4d8e11e72f01c7ef6'
   else
+    # sourceforge.net is the official download host per the vendor homepage
     url "http://downloads.sourceforge.net/project/librecad/OSX/#{version}/LibreCAD-#{version}-Mavericks.dmg"
     sha256 'ab8ccd20cb1f80b038e2aa471981d4e3e63a38ff632eba6382ef5904c4d3f2dd'
   end

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -3,9 +3,11 @@ cask :v1 => 'libreoffice' do
 
   if Hardware::CPU.is_32_bit? or MacOS.release < :mountain_lion
     sha256 '0121e87396a880884a6fac02e7799fe5bc4cbfe0e346a60aa21176acbd44602f'
+    # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else
     sha256 '46d33f40207fcdc8737e44ee951432727ed19788721746ea44e59cc14da15553'
+    # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end
   gpg "#{url}.asc",

--- a/Casks/lifeslice.rb
+++ b/Casks/lifeslice.rb
@@ -2,6 +2,7 @@ cask :v1 => 'lifeslice' do
   version :latest
   sha256 :no_check
 
+  # wanderingstan.com is the official download host per the vendor homepage
   url 'http://wanderingstan.com/apps/lifeslice/LifeSlice.dmg'
   name 'LifeSlice'
   homepage 'http://wanderingstan.github.io/Lifeslice/'

--- a/Casks/lightpaper.rb
+++ b/Casks/lightpaper.rb
@@ -2,7 +2,7 @@ cask :v1 => 'lightpaper' do
   version '0.9.0'
   sha256 'e90ad6d7052573a8048b65c590f9227f75a55690731ccf6986ded5982fc02afe'
 
-  # The cl.ly url is from the official vendor homepage (redirected from goo.gl/xiOgxx)
+  # cl.ly is the official download host per the vendor homepage
   url 'http://f.cl.ly/items/3q1Q3C472c3G2L2l2X0m/LightPaper_v0.0.9.dmg'
   appcast 'http://links.clockworkengine.com/lp-mac-update-feed',
           :sha256 => '88b4051a4255b9d82534f3fc502ecab5fa2d7df73a94ef563e02bec7848276c2'

--- a/Casks/lighttable.rb
+++ b/Casks/lighttable.rb
@@ -2,6 +2,7 @@ cask :v1 => 'lighttable' do
   version '0.7.2'
   sha256 '236bb18d6715ce3095c975871b7c7f495f306a086dce8a50ff35f267a25c5163'
 
+  # cloudfront.net is the official download host per the vendor homepage
   url "https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/#{version}/LightTableMac.zip"
   homepage 'http://www.lighttable.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -2,6 +2,7 @@ cask :v1 => 'lilypond' do
   version '2.18.2-1'
   sha256 '0009bf234db6a598e30940ae9a5cef50ffe939992c9bf0c7959ecd9c0d179c80'
 
+  # linuxaudio.org is the official download host per the vendor homepage
   url "http://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   name 'LilyPond'
   homepage 'http://lilypond.org'

--- a/Casks/limechat.rb
+++ b/Casks/limechat.rb
@@ -8,6 +8,7 @@ cask :v1 => 'limechat' do
     sha256 '708d10591784e5beb7ed80236d809d5cd4f992c133483bc2a82775acdc6f1f0f'
   end
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/limechat/limechat/LimeChat_#{version}.tbz"
   appcast 'http://limechat.net/mac/appcast.xml',
           :sha256 => '32dd2f6795c4f19940a8bb8a093b5b297167c28a4b6712cb94d6de14f1002e4f'

--- a/Casks/linphone.rb
+++ b/Casks/linphone.rb
@@ -2,6 +2,7 @@ cask :v1 => 'linphone' do
   version '3.7.0'
   sha256 '4d4a01354a7b5cd011746d3477a93ffb6e531ff8e2afccd2b9bb031f06cc42cc'
 
+  # gnu.org is the official download host per the vendor homepage
   url "http://download-mirror.savannah.gnu.org/releases/linphone/3.7.x/macos/linphone-#{version}.dmg"
   gpg "#{url}.sig",
       :key_id => '3ecd52dee2f56985'

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -2,6 +2,7 @@ cask :v1 => 'liteide' do
   version '25.2'
   sha256 '92cb684a4832cf32d06ca0fa60f1155d64bd63fb9af708277bd57b70f5eb2cf8'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/liteide/X#{version}/liteidex#{version}.macosx.zip"
   homepage 'https://github.com/visualfc/liteide'
   license :oss

--- a/Casks/lmms.rb
+++ b/Casks/lmms.rb
@@ -2,6 +2,7 @@ cask :v1 => 'lmms' do
   version '1.0.99'
   sha256 '2ce390337a2ee372f76812b5c308ac8f3faad6981d99f0eb3b843149e3ebc98c'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}.dmg"
   homepage 'https://lmms.io'
   license :gpl

--- a/Casks/logitech-harmony.rb
+++ b/Casks/logitech-harmony.rb
@@ -2,6 +2,7 @@ cask :v1 => 'logitech-harmony' do
   version '7.8.1'
   sha256 '13a100211fb18569563c9d9bbe6c231cbfaa50989df0b471703ec942be2ecafb'
 
+  # navisite.net is the official download host per the vendor homepage
   url "http://logitech-sjca.navisite.net/web/ftp/pub/techsupport/harmony/LogitechHarmonyRemoteSoftware#{version}-OSX.dmg"
   homepage 'http://www.logitech.com/en-us/support/universal-remotes'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/logmein-hamachi.rb
+++ b/Casks/logmein-hamachi.rb
@@ -2,6 +2,7 @@ cask :v1 => 'logmein-hamachi' do
   version :latest
   sha256 :no_check
 
+  # logmein.com is the official download host per the vendor homepage
   url 'https://secure.logmein.com/LogMeInHamachi.zip'
   name 'Hamachi'
   homepage 'http://vpn.net'

--- a/Casks/love.rb
+++ b/Casks/love.rb
@@ -2,6 +2,7 @@ cask :v1 => 'love' do
   version '0.9.1'
   sha256 '40dfeb1069f6c056b06d0e87c64f3950fd1b1523a9e19af2b03912a5d5c03b13'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/rude/love/downloads/love-#{version}-macosx-x64.zip"
   name 'LÖVE'
   homepage 'http://love2d.org'

--- a/Casks/lpk25-editor.rb
+++ b/Casks/lpk25-editor.rb
@@ -2,6 +2,7 @@ cask :v1 => 'lpk25-editor' do
   version :latest
   sha256 :no_check
 
+  # rackcdn.com is the official download host per the vendor homepage
   url 'http://6be54c364949b623a3c0-4409a68c214f3a9eeca8d0265e9266c0.r0.cf2.rackcdn.com/453/downloads/lpk25_editor_mac_00.zip'
   homepage 'http://www.akaipro.com/index.php/product/lpk25'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/ltspice.rb
+++ b/Casks/ltspice.rb
@@ -2,6 +2,7 @@ cask :v1 => 'ltspice' do
   version :latest
   sha256 :no_check
 
+  # tech.com is the official download host per the vendor homepage
   url 'http://ltspice.linear-tech.com/LTspiceIV.dmg'
   homepage 'http://www.linear.com/designtools/software/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/macpaw-gemini.rb
+++ b/Casks/macpaw-gemini.rb
@@ -2,6 +2,7 @@ cask :v1 => 'macpaw-gemini' do
   version :latest
   sha256 :no_check
 
+  # devmate.com is the official download host per the vendor homepage
   url 'http://dl.devmate.com/download/com.macpaw.site.Gemini/macpaw%20gemini.dmg'
   appcast 'http://updates.devmate.com/com.macpaw.site.Gemini.xml'
   homepage 'http://macpaw.com/gemini'

--- a/Casks/macscale.rb
+++ b/Casks/macscale.rb
@@ -2,6 +2,7 @@ cask :v1 => 'macscale' do
   version :latest
   sha256 :no_check
 
+  # brinscall.com is the official download host per the vendor homepage
   url 'http://www.brinscall.com/MacScale.zip'
   homepage 'http://www.macscale.com'
   license :closed

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mactex' do
   version '20140525'
   sha256 '4e7fc21dbddae436f604dbeb3db2dc13c44aa9e2dd827a669a170418e84fc7e6'
 
+  # ctan.org is the official download host per the vendor homepage
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   name 'MacTeX'
   homepage 'http://www.tug.org/mactex/'

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -3,9 +3,11 @@ cask :v1 => 'macvim' do
 
   if MacOS.release <= :mountain_lion
     sha256 '7f573fb9693052a86845c0a9cbb0b3c3c33ee23294f9d8111187377e4d89f72c'
+    # github.com is the official download host per the vendor homepage
     url "https://github.com/eee19/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Mountain-Lion.tbz"
   else
     sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
+    # github.com is the official download host per the vendor homepage
     url "https://github.com/b4winckler/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Mavericks.tbz"
     appcast 'http://b4winckler.github.com/macvim/appcast/stable.xml',
             :sha256 => '1408f192fe672eb99d7032eff37bd93537d65499fa9b4502eb0ae1365a73d056'

--- a/Casks/mailmate.rb
+++ b/Casks/mailmate.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mailmate' do
   version :latest
   sha256 :no_check
 
+  # app.com is the official download host per the vendor homepage
   url 'http://dl.mailmate-app.com/MailMate.tbz'
   homepage 'http://freron.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/makehuman.rb
+++ b/Casks/makehuman.rb
@@ -2,6 +2,7 @@ cask :v1 => 'makehuman' do
   version '1.0.2'
   sha256 'ea74381b1fd9c0f699b2cf1a3476d7cf9447fad3beb3c48de0a4017032c44de9'
 
+  # tuxfamily.org is the official download host per the vendor homepage
   url "http://download.tuxfamily.org/makehuman/releases/#{version}/makehuman-#{version}-osx.dmg"
   homepage 'http://www.makehuman.org/'
   license :affero

--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -2,6 +2,7 @@ cask :v1 => 'megasync' do
   version :latest
   sha256 :no_check
 
+  # mega.nz is the official download host per the vendor homepage
   url 'https://mega.nz/MEGAsyncSetup.dmg'
   name 'MEGAsync'
   homepage 'https://mega.co.nz'

--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mikogo' do
   version :latest
   sha256 :no_check
 
+  # mikogo4.com is the official download host per the vendor homepage
   url 'http://download.mikogo4.com/mikogo.dmg'
   homepage 'http://www.mikogo.com/'
   license :gratis

--- a/Casks/mirador.rb
+++ b/Casks/mirador.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mirador' do
   version '1.3beta'
   sha256 'c2c4e2b5c9a9723c99c65894db97fa008fa49def3ede3a2d32426877b5b89351'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/mirador/mirador/releases/download/#{version}/mirador-macosx-#{version}.zip"
   homepage 'http://fathom.info/mirador/'
   license :gpl

--- a/Casks/miro-video-converter.rb
+++ b/Casks/miro-video-converter.rb
@@ -2,6 +2,7 @@ cask :v1 => 'miro-video-converter' do
   version :latest
   sha256 :no_check
 
+  # osuosl.org is the official download host per the vendor homepage
   url 'http://ftp.osuosl.org/pub/pculture.org/mirovideoconverter/mac/Miro%20Video%20Converter.dmg'
   appcast 'http://miro-updates.participatoryculture.org/mvc-appcast-osx.xml'
   homepage 'http://www.mirovideoconverter.com/'

--- a/Casks/miro.rb
+++ b/Casks/miro.rb
@@ -2,6 +2,7 @@ cask :v1 => 'miro' do
   version :latest
   sha256 :no_check
 
+  # osuosl.org is the official download host per the vendor homepage
   url 'http://ftp.osuosl.org/pub/pculture.org/miro/osx/Miro.dmg'
   name 'Miro'
   homepage 'http://www.getmiro.com/'

--- a/Casks/mmex.rb
+++ b/Casks/mmex.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mmex' do
   version '1.1.0'
   sha256 '37042d0255e4bf89aecab1373e8c27597ad654f9164a1ee1d2773f021c79a925'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/moneymanagerex/Version%20#{version}/mmex_#{version}_mac.dmg"
   homepage 'http://www.moneymanagerex.org'
   license :gpl

--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mnemosyne' do
   version '2.3'
   sha256 '094c4f6fb50de376a5190c3712b935089579717641ce90685aa48932bf0efa07'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/mnemosyne-proj/Mnemosyne-#{version}-Mac.dmg"
   homepage 'http://mnemosyne-proj.org/'
   license :oss

--- a/Casks/moneyplex.rb
+++ b/Casks/moneyplex.rb
@@ -2,6 +2,7 @@ cask :v1 => 'moneyplex' do
   version :latest
   sha256 :no_check
 
+  # matrica.com is the official download host per the vendor homepage
   url 'http://www.matrica.com/download/mac/moneyplex.dmg'
   homepage 'http://www.matrica.de/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mongodb' do
   version '1.2'
   sha256 '9b7f6e8988a3169bf5f234ee10f93823a16750b3c1d4de524cd2e2f09452fd02'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/orelord/mongodbx-app/releases/download/v#{version}/MongoDBX-#{version}-2.4.9.zip"
   homepage 'http://mongodbx-app.orelord.com/'
   license :oss

--- a/Casks/monotype-skyfonts.rb
+++ b/Casks/monotype-skyfonts.rb
@@ -2,6 +2,7 @@ cask :v1 => 'monotype-skyfonts' do
   version '4.6.0.0'
   sha256 '211f8f386c0ed84a19235a1cc64478c5f24d1cb0bbfb3947fa5cb5633f36484d'
 
+  # skyfonts.com is the official download host per the vendor homepage
   url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
   homepage 'http://www.fonts.com/web-fonts/google'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/moscow-ml.rb
+++ b/Casks/moscow-ml.rb
@@ -2,6 +2,7 @@ cask :v1 => 'moscow-ml' do
   version '2.10.1'
   sha256 '4b3e2035b106c688e43e7d415ca74ca8970f74656cc2c17326c5fb7d1f948ca0'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/kfl/mosml/releases/download/ver-#{version}/mosml-#{version}.pkg"
   name 'Moscow ML'
   homepage 'http://mosml.org/'

--- a/Casks/mozart.rb
+++ b/Casks/mozart.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mozart' do
   version '1.4.0.20120201'
   sha256 'df03e42ca0da5700f49d3ae036758bac762cbc3a95d4e69c4bc4aabb54e6f92b'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/mozart-oz/Mozart-#{version}.zip"
   name 'Mozart'
   homepage 'http://www.mozart-oz.org'

--- a/Casks/mpeg-streamclip.rb
+++ b/Casks/mpeg-streamclip.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mpeg-streamclip' do
   version '1.9.2'
   sha256 'f539e527a7232a9ac4398c0d3e7730010058b300c8d7fd33c4baf8c9ac232b85'
 
+  # alfanet.it is the official download host per the vendor homepage
   url "http://www.alfanet.it/squared5/MPEG_Streamclip_#{version}.dmg"
   homepage 'http://www.squared5.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mplayer-osx-extended' do
   version 'rev15'
   sha256 '7979f2369730d389ceb4ec3082c65ffa3ec70f812f0699a2ef8acbae958a5c93'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/sttz/MPlayer-OSX-Extended/releases/download/#{version}/MPlayer-OSX-Extended_#{version}.zip"
   appcast 'http://mplayerosx.ch/updates.xml',
           :sha256 => '2c74b034df3d97edc5748201d35cb5dec7c3715212d6cf4bd7f8bdd1a087e3cc'

--- a/Casks/mplayerx.rb
+++ b/Casks/mplayerx.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mplayerx' do
   version '1.0.22.1'
   sha256 '08ce85671814e65b8c7ec8438b85be593b6deaf7d5c3b242e686a6b0176a2c77'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/mplayerx-osx/MPlayerX-#{version}.zip"
   name 'MPlayerX'
   homepage 'http://mplayerx.org/'

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -2,6 +2,7 @@ cask :v1 => 'mpv' do
   version '0.7.2'
   sha256 'a73392d6c9cc998442a0dc3323caa90a1ef24258026c18da66fa21921d234f43'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/mpv-player/mpv/releases/download/v#{version}/mpv_#{version}_mac.tar.bz2"
   homepage 'http://mpv.io/'
   license :gpl

--- a/Casks/multidoge.rb
+++ b/Casks/multidoge.rb
@@ -2,6 +2,7 @@ cask :v1 => 'multidoge' do
   version '0.1.2'
   sha256 'e6639dac77df7a6ea34ce086d68dedda98d8537bd31d32b17598243e26122bcc'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/langerhans/multidoge/releases/download/v#{version}/multidoge-#{version}.dmg"
   name 'MultiDoge'
   homepage 'http://multidoge.org/'

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -2,6 +2,7 @@ cask :v1 => 'musescore' do
   version '1.3'
   sha256 'fcd106ec700f14053c9b4f3fd411d2335915c040f9071ea6da8d109e6827c3a5'
 
+  # osuosl.org is the official download host per the vendor homepage
   url "http://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version}/MuseScore-#{version}.dmg"
   homepage 'http://musescore.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/nally.rb
+++ b/Casks/nally.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nally' do
   version '1.4.9'
   sha256 '5b7835f8842aa33d0f40eebddda2686a39f2106dfacd0bde04c3f0911da625d1'
 
+  # github.com is the official download host per the vendor homepage
   url "https://yllan.github.com/nally/download/Nally-#{version}.app.zip"
   homepage 'http://yllan.org/app/Nally/'
   license :oss

--- a/Casks/nightingale.rb
+++ b/Casks/nightingale.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nightingale' do
   version '1.12-2432'
   sha256 '854b02a22f2846284618dc8d3a64a766e8e7a34e65cf35934f6b357f4bc1000e'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/ngale/Nightingale_#{version}_macosx-i686.dmg"
   name 'Nightingale'
   homepage 'http://getnightingale.com/'

--- a/Casks/node-webkit.rb
+++ b/Casks/node-webkit.rb
@@ -2,6 +2,7 @@ cask :v1 => 'node-webkit' do
   version '0.11.5'
   sha256 '94af5cd1a77ef72ab04c5af3c132e6402289aad602587202a3d08f014e863943'
 
+  # webkit.org is the official download host per the vendor homepage
   url "http://dl.node-webkit.org/v#{version}/node-webkit-v#{version}-osx-x64.zip"
   homepage 'https://github.com/rogerwang/node-webkit'
   license :mit

--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nodeclipse' do
   version '0.11-preview'
   sha256 '01f630446313cb981ce2ee9b934977cfdbf318e09761dee244a3256f9a559003'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/nodeclipse/Enide-Studio-2014/#{version}/Enide-Studio-2014-011-20140228-macosx-cocoa-x86_64.zip"
   name 'Nodeclipse'
   homepage 'http://www.nodeclipse.org/'

--- a/Casks/nomacs.rb
+++ b/Casks/nomacs.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nomacs' do
   version '1.0.0'
   sha256 '2ec4bfd6390ab7c4b2a929a1e9d14f46f6f168608bf2aee8da67af797f73a54a'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/nomacs/nomacs-#{version}-x86_64.dmg"
   homepage 'http://www.nomacs.org/'
   license :oss

--- a/Casks/nosleep.rb
+++ b/Casks/nosleep.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nosleep' do
   version '1.4.0'
   sha256 '29e7f771970dce41936372687a5160700e2208357ef1ce37d81ac95c9188efe8'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/integralpro/nosleep/releases/download/v#{version}/NoSleep-#{version}.dmg"
   name 'NoSleep'
   homepage 'https://code.google.com/p/macosx-nosleep-extension/'

--- a/Casks/nsregextester.rb
+++ b/Casks/nsregextester.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nsregextester' do
   version :latest
   sha256 :no_check
 
+  # vegh.ca is the official download host per the vendor homepage
   url 'http://vegh.ca/nsregextester/NSRegexTester.zip'
   homepage 'https://github.com/aaronvegh/nsregextester'
   license :oss

--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -2,6 +2,7 @@ cask :v1 => 'nvalt' do
   version '2.2b111'
   sha256 'd787ddf92730bb03ba084e72bc6fb5f4fbd42731fa3531476af9eb3ce39e1cd0'
 
+  # designheresy.com is the official download host per the vendor homepage
   url "http://abyss.designheresy.com/nvaltb/nvalt#{version}.zip"
   homepage 'http://brettterpstra.com/project/nvalt/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/objektiv.rb
+++ b/Casks/objektiv.rb
@@ -2,6 +2,7 @@ cask :v1 => 'objektiv' do
   version :latest
   sha256 :no_check
 
+  # nthloop.com is the official download host per the vendor homepage
   url 'http://nthloop.com/objektiv/objektiv-latest.zip'
   appcast 'http://nthloop.com/objektiv/appcast.xml'
   name 'Objektiv'

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -2,6 +2,7 @@ cask :v1 => 'obs' do
   version '0.6.2'
   sha256 '871b73509008c3df1c3ba005ff290395d19e494266571fc0f7b14d73f813d605'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-#{version}-installer.dmg"
   homepage 'http://obsproject.com/'
   license :oss

--- a/Casks/octave.rb
+++ b/Casks/octave.rb
@@ -2,6 +2,7 @@ cask :v1 => 'octave' do
   version '3.8.0-6'
   sha256 'b51c20b109e15928350624011885e658b45009da0acb8872a1347688f8f62963'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/octave/Octave%20MacOSX%20Binary/2013-12-30%20binary%20installer%20of%20Octave%203.8.0%20for%20OSX%2010.9.1%20%28beta%29/GNU_Octave_#{version}.dmg"
   homepage 'https://gnu.org/software/octave/'
   license :oss

--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -2,6 +2,7 @@ cask :v1 => 'openemu' do
   version '1.0.4'
   sha256 'c9c3abc2acea4ed4c1e2b62fd6868feae1719251428a79803d9aa8a0de4474ef'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}.zip"
   appcast 'https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast.xml',
           :sha256 => '0bc7baf23728b6c53a7d3c502fff9ccb0df150446a1164dc9e8ebcefc1c5a619'

--- a/Casks/opennx.rb
+++ b/Casks/opennx.rb
@@ -2,6 +2,7 @@ cask :v1 => 'opennx' do
   version '0.16.0.729'
   sha256 '65dde1a3504a17ac58ed2a7178536347d829ee8c27cc90bebdae3e98c36fc6c6'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/opennx/OpenNX-#{version}.dmg"
   homepage 'http://opennx.net/'
   license :oss

--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -2,6 +2,7 @@ cask :v1 => 'openoffice' do
   version '4.1.1'
   sha256 '7becbdbe2abbcfd9d27953d2e11dc07da308d80f208b5f27f6213d225dc95e64'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_en-US.dmg"
   name 'OpenOffice'
   homepage 'http://www.openoffice.org/'

--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -2,6 +2,7 @@ cask :v1 => 'openra' do
   version '20141029'
   sha256 '421f341d324e2e360cf17facc1379b19036f7459516b84685037a041d5020e64'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
   homepage 'http://www.openra.net/'
   license :oss

--- a/Casks/optimal-layout.rb
+++ b/Casks/optimal-layout.rb
@@ -2,6 +2,7 @@ cask :v1 => 'optimal-layout' do
   version :latest
   sha256 :no_check
 
+  # windowflow.com is the official download host per the vendor homepage
   url 'http://files.windowflow.com/OptimalLayout2.zip'
   appcast 'http://most-advantageous.com/sparkle/OL-AppCast.cfm'
   name 'Optimal Layout'

--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -2,6 +2,7 @@ cask :v1 => 'origin' do
   version :latest
   sha256 :no_check
 
+  # akamaihd.net is the official download host per the vendor homepage
   url 'https://eaassets-a.akamaihd.net/Origin-Client-Download/origin/mac/Origin.dmg'
   homepage 'http://origin.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -2,6 +2,7 @@ cask :v1 => 'osxfuse' do
   version '2.7.4'
   sha256 'e5f43f673062725d76b6c10d379d576f6148f32fab42f6d18455b11f41e92969'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"
   homepage 'https://osxfuse.github.io/'
   license :oss

--- a/Casks/p5.rb
+++ b/Casks/p5.rb
@@ -3,6 +3,7 @@ cask :v1 => 'p5' do
   version '0.1.8'
   sha256 '3a46a98995b43e792d7e7f7407aba1503084cf37339064711abcfad54dd5c094'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/antiboredom/jside/releases/download/v#{version}/p5.zip"
   homepage 'http://p5js.org/download/#editor'
   license :mit

--- a/Casks/packer.rb
+++ b/Casks/packer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'packer' do
   version '0.7.5'
   sha256 'c0e149c4515fe548c1daeafabec3b4a091f2aa0c6936723382b3f6fe5a617880'
 
+  # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/packer/packer_#{version}_darwin_amd64.zip"
   homepage 'http://www.packer.io/'
   license :oss

--- a/Casks/padre.rb
+++ b/Casks/padre.rb
@@ -2,6 +2,7 @@ cask :v1 => 'padre' do
   version '0.92.0'
   sha256 '481088a40bc71bd62d13ac23ed8fbfa3b8fc651587b9e47461795a9a78032d87'
 
+  # wildperl.com is the official download host per the vendor homepage
   url "http://wildperl.com/wp-content/uploads/Padre/padre-osx-uni-#{version.gsub('.','-')}.dmg"
   homepage 'http://padre.perlide.org'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/pandoc.rb
+++ b/Casks/pandoc.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pandoc' do
   version '1.13.2'
   sha256 '02455fba5353568b19d8b0bebbda9b99ba2c943b3f01b11b185f25c7db111b50'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/jgm/pandoc/releases/download/#{version}/pandoc-#{version}-osx.pkg"
   name 'Pandoc'
   homepage 'http://johnmacfarlane.net/pandoc'

--- a/Casks/pastebotsync-pane.rb
+++ b/Casks/pastebotsync-pane.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pastebotsync-pane' do
   version :latest
   sha256 :no_check
 
+  # tapbots.net is the official download host per the vendor homepage
   url 'http://tapbots.net/pastebot/PastebotSync.dmg'
   homepage 'http://tapbots.com/software/pastebot/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pd-extended' do
   version '0.43.4'
   sha256 'abe7bd637b1495ad9d5a500f0a18550c1600e34ee17e60aa1a48e4dbdee59bb9'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/pure-data/pd-extended/#{version}/Pd-#{version}-extended-macosx105-i386.dmg"
   name 'Pd-extended'
   homepage 'http://puredata.info/downloads/pd-extended'

--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pencil' do
   version '2.0.6'
   sha256 'dacd76c658b12101457d17a4ade0b3f9c6a012f8eddacd379c41e372545ffac6'
 
+  # googlecode.com is the official download host per the vendor homepage
   url "https://evoluspencil.googlecode.com/files/Pencil-#{version}-mac.tar.bz2"
   homepage 'http://pencil.evolus.vn'
   license :oss

--- a/Casks/perian.rb
+++ b/Casks/perian.rb
@@ -2,6 +2,7 @@ cask :v1 => 'perian' do
   version '1.2.3'
   sha256 '4d1738104613ab4a7322637584ce7b851e4ef85888895360ad827a5f27c62e08'
 
+  # cachefly.net is the official download host per the vendor homepage
   url "https://perian.cachefly.net/Perian_#{version}.dmg"
   name 'Perian'
   homepage 'http://www.perian.org/'

--- a/Casks/pgadmin3.rb
+++ b/Casks/pgadmin3.rb
@@ -3,6 +3,7 @@ cask :v1 => 'pgadmin3' do
   version '1.20.0'
   sha256 '0712106cca16240db9962214384874c108fe8397d0c418a79dfb3639f8f140da'
 
+  # postgresql.org is the official download host per the vendor homepage
   url "http://ftp.postgresql.org/pub/pgadmin3/release/v#{version}/osx/pgadmin3-#{version}.dmg"
   gpg "#{url}.sig",
       :key_id => 'e0c4ceeb826b1fda4fb468e024adfaaf698f1519'

--- a/Casks/phantomjs.rb
+++ b/Casks/phantomjs.rb
@@ -2,6 +2,7 @@ cask :v1 => 'phantomjs' do
   version '1.9.8'
   sha256 '8f15043ae3031815dc5f884ea6ffa053d365491b1bc0dc3a0862d5ff1ac20a48'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{version}-macosx.zip"
   homepage 'http://phantomjs.org/'
   license :oss

--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pharo' do
   version '3.0'
   sha256 'a13577159336d3de7e71d71c0e0f58985060d2455bc8d40d501c81e97a75b5e7'
 
+  # pharo.org is the official download host per the vendor homepage
   url "http://files.pharo.org/platform/Pharo#{version}-mac.zip"
   name 'Pharo'
   homepage 'http://www.pharo-project.org/home'

--- a/Casks/pinta.rb
+++ b/Casks/pinta.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pinta' do
   version '1.4'
   sha256 'ebe9e8c271e5c445144ecbbce62d0e5bb20a27b75f34b90bf1a898e1cc452edf'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/downloads/PintaProject/Pinta/pinta-#{version}.app.zip"
   name 'Pinta'
   homepage 'http://pinta-project.com/'

--- a/Casks/pixi-paint.rb
+++ b/Casks/pixi-paint.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pixi-paint' do
   version :latest
   sha256 :no_check
 
+  # pixiecdn.com is the official download host per the vendor homepage
   url 'http://0.pixiecdn.com/PixiePaint-osx.zip'
   name 'Pixi Paint'
   homepage 'http://www.danielx.net/pixel-editor/docs/download'

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -2,6 +2,7 @@ cask :v1 => 'plover' do
   version '2.5.8'
   sha256 'a8bbeddb5d6fb8d4499844257035edd62e431a4f1eb7959bdf17a15c1cbe12de'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/openstenoproject/plover/releases/download/v#{version}/Plover.dmg"
   name 'Plover'
   homepage 'http://stenoknight.com/wiki/Main_Page'

--- a/Casks/polyphone.rb
+++ b/Casks/polyphone.rb
@@ -2,6 +2,7 @@ cask :v1 => 'polyphone' do
   version '1.5'
   sha256 '2eab21617a7cd35252ded1ae0d25404dab8d03a865f6495b61f8990747d1ea20'
   
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/polyphone/polyphone-#{version}.dmg"
   name 'Polyphone'
   homepage 'http://polyphone.fr'

--- a/Casks/port-map.rb
+++ b/Casks/port-map.rb
@@ -2,6 +2,7 @@ cask :v1 => 'port-map' do
   version '1.3.1-r46'
   sha256 '50e29f121139ee2f68ad978cb3921ef52f2dbfb5a0131c417516e4e5f1fa64af'
 
+  # googlecode.com is the official download host per the vendor homepage
   url "https://tcmportmapper.googlecode.com/files/PortMap-#{version}.zip"
   appcast 'http://www.codingmonkeys.de/portmap/appcast.rss',
           :sha256 => 'c74b6bc407fe3a5daea1f3be09deabef3590fa5dc63c8ed32062f97d8bf5aa79'

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -2,6 +2,7 @@ cask :v1 => 'printrun' do
   version '1.2'
   sha256 'b270edb951cbee3e957eab3ecd3bbd4fe25e93ce478393c61f029bfff4e3b902'
 
+  # kapsi.fi is the official download host per the vendor homepage
   url 'http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-10Mar2014.zip'
   homepage 'https://github.com/kliment/Printrun'
   license :oss

--- a/Casks/prismatik.rb
+++ b/Casks/prismatik.rb
@@ -2,6 +2,7 @@ cask :v1 => 'prismatik' do
   version '5.11.1'
   sha256 '178ea51c143c2cb005199f5cfaf24695324b951ba98c55cec83c7882e6420903'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/woodenshark/Lightpack/releases/download/#{version}/Prismatik.#{version}.dmg"
   name 'Prismatik'
   homepage 'http://lightpack.tv/'

--- a/Casks/projectlibre.rb
+++ b/Casks/projectlibre.rb
@@ -2,6 +2,7 @@ cask :v1 => 'projectlibre' do
   version '1.5.8'
   sha256 'efd7d228d2e71a2a5af185d2fe1ddcea4abc55af32188344e06e1871facd0c6b'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/projectlibre/ProjectLibre/#{version}/projectlibre-#{version}.dmg"
   homepage 'http://www.projectlibre.org/'
   license :oss

--- a/Casks/ps3-media-server.rb
+++ b/Casks/ps3-media-server.rb
@@ -2,6 +2,7 @@ cask :v1 => 'ps3-media-server' do
   version '1.90.1'
   sha256 '3ebe75ce0dbdc1313c10fb901f845564cc343dc3b7487f07e15db9d757850df5'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/ps3mediaserver/pms-#{version}-setup-macosx.tar.gz"
   name 'PS3 Media Server'
   homepage 'http://www.ps3mediaserver.org/'

--- a/Casks/psi.rb
+++ b/Casks/psi.rb
@@ -2,6 +2,7 @@ cask :v1 => 'psi' do
   version '0.15'
   sha256 '76d50b5314d0a7d9f9a0a71d90e0f806f2da25436135dbd90bd1959286747742'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/psi/Psi-#{version}.dmg"
   name 'Psi'
   homepage 'http://psi-im.org/'

--- a/Casks/purescript.rb
+++ b/Casks/purescript.rb
@@ -2,6 +2,7 @@ cask :v1 => 'purescript' do
   version '0.6.3'
   sha256 'f2b2281b2db1d66570b16bbe6d104ba36787ed7d684b640917e673ea0cc5cdc2'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/purescript/purescript/releases/download/v#{version}/macos.tar.gz"
   name 'PureScript'
   homepage 'http://purescript.org'

--- a/Casks/pwnagetool.rb
+++ b/Casks/pwnagetool.rb
@@ -2,6 +2,7 @@ cask :v1 => 'pwnagetool' do
   version '5.1.1'
   sha256 '84262734ad9f9186bce14a4f939d7ea290ed187782fdfa549a82c28bf837c808'
 
+  # google.com is the official download host per the vendor homepage
   url "https://sites.google.com/a/ipad-dev.com/files/pwnagetool/PwnageTool_#{version}.dmg"
   appcast 'http://www.iphone-dev.org/appcast/PwnageTool2.xml',
           :sha256 => '83d334e863f2a0ab58615cbc03805b9ed6a83daf496c0ce315285fbe635e35ce'

--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -2,6 +2,7 @@ cask :v1 => 'qdesktop' do
   version '0.1.1'
   sha256 '1eddd3513cca892fb8e53452d79d4589ef5b1e3cd885a1f52748b6df64588094'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/qvacua/qvacua/downloads/Qdesktop-#{version}.zip"
   appcast 'http://qvacua.com/qdesktop/appcast.xml',
           :sha256 => '9714a19fae1e50cfdc06a1f300dae791d400b4c64a0f679b29d633ea8a59b46b'

--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -2,6 +2,7 @@ cask :v1 => 'qlimagesize' do
   version :latest
   sha256 :no_check
 
+  # whine.fr is the official download host per the vendor homepage
   url 'http://repo.whine.fr/qlImageSize.pkg'
   name 'qlImageSize'
   homepage 'https://github.com/Nyx0uf/qlImageSize'

--- a/Casks/qmind.rb
+++ b/Casks/qmind.rb
@@ -2,6 +2,7 @@ cask :v1 => 'qmind' do
   version '0.3.4'
   sha256 '498dc5b753804d25cbf15afbdb8641af1ddcf53b65ab04d3188c7a8b669f6695'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/qvacua/qmind/releases/download/v#{version}-22/Qmind-#{version}.zip"
   appcast 'http://qvacua.com/qmind/appcast.xml',
           :sha256 => '65c18e86225f5808dc956836e537be3255f610a348bd899f92016ecb1cb74aab'

--- a/Casks/qqinput.rb
+++ b/Casks/qqinput.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qqinput' do
   version '2.8.86.400'
   sha256 '5b90cf604230013d5afa974b5b4835c0d6faf55da932cebce4f72478b5665a4d'
 
+  # sogou.com is the official download host per the vendor homepage
   url "http://qqime.cdn.sogou.com/QQInput_Mac_Setup_#{version.gsub('.','_')}.dmg"
   homepage 'http://qq.pinyin.cn/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/quicklook-csv.rb
+++ b/Casks/quicklook-csv.rb
@@ -2,6 +2,7 @@ cask :v1 => 'quicklook-csv' do
   version :latest
   sha256 :no_check
 
+  # googlecode.com is the official download host per the vendor homepage
   url 'https://quicklook-csv.googlecode.com/files/QuickLookCSV.dmg'
   name 'QuickLookCSV'
   homepage 'https://github.com/p2/quicklook-csv'

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -3,10 +3,12 @@ cask :v1 => 'r' do
 
   if MacOS.release <= :snow_leopard
     sha256 'aec21b31b3a6c4e777690bd4e2f19fa71f2ae443dd645d4fa93a0399345e5aac'
+    # rstudio.com is the official download host per the vendor homepage
     url "http://cran.rstudio.com/bin/macosx/R-#{version}-snowleopard.pkg"
     pkg "R-#{version}-snowleopard.pkg"
   else
     sha256 'ea1312d3d888861f33f5225a159fe39a5e90f382996eadc388808eb59bf6003f'
+    # rstudio.com is the official download host per the vendor homepage
     url "http://cran.rstudio.com/bin/macosx/R-#{version}-mavericks.pkg"
     pkg "R-#{version}-mavericks.pkg"
   end

--- a/Casks/raven.rb
+++ b/Casks/raven.rb
@@ -2,6 +2,7 @@ cask :v1 => 'raven' do
   version '0.2.0-alpha'
   sha256 '91792dfbe2abbc13f79bcafbe903e697f99b5abccfa900084b015e2c642eb633'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/robotlolita/raven/releases/download/v#{version}/Raven-osx.zip"
   name 'Raven'
   homepage 'http://robotlolita.me/raven/'

--- a/Casks/rdm.rb
+++ b/Casks/rdm.rb
@@ -2,6 +2,7 @@ cask :v1 => 'rdm' do
   version '0.7.6.8'
   sha256 '7f5bb2ac47c7a01f99a5d3fd7ed1019d7cc9fb6230c617bf2eff9336f0eb8a16'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/uglide/RedisDesktopManager/releases/download/0.7.6/redis-desktop-manager-#{version}.dmg"
   homepage 'http://redisdesktop.com'
   license :oss

--- a/Casks/reeddit.rb
+++ b/Casks/reeddit.rb
@@ -2,6 +2,7 @@ cask :v1 => 'reeddit' do
   version '1.9'
   sha256 '7bb465aa5a8c80adfb6f73430caee9cc977afae77d2a55be97371b9516aa01a7'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/berbaquero/Reeddit-app/releases/download/v#{version}/Reeddit.app.zip"
   homepage 'http://mac.reedditapp.com'
   license :oss

--- a/Casks/reggy.rb
+++ b/Casks/reggy.rb
@@ -2,6 +2,7 @@ cask :v1 => 'reggy' do
   version '1.3'
   sha256 '5a4d72158bc524ab2f21c6cfad7b703f413707d9d078ec1923c268b110ff8dda'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/downloads/samsouder/reggy/Reggy_v#{version}.tbz"
   appcast 'http://reggyapp.com/appcast.xml',
           :sha256 => 'abfb19871bc0344469127f1cc35947b747cd3b1ee8ea2bfdd13f0d78c41c456f'

--- a/Casks/remonit.rb
+++ b/Casks/remonit.rb
@@ -2,6 +2,7 @@ cask :v1 => 'remonit' do
   version '0.2.0'
   sha256 'fb8e51c7d68d83274b2acff107e7ef4857d28c9daf4d5ac2599c14cb3d6516fe'
 
+  # rackcdn.com is the official download host per the vendor homepage
   url "http://874390f0461dc5bbf96b-8953e31051b5247f1143d89b1a42aa7d.r65.cf2.rackcdn.com/remonit-#{version}-mac.zip"
   homepage 'http://zef.io/remonit/'
   license :mit

--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'renamer' do
   version :latest
   sha256 :no_check
 
+  # creativebe.com is the official download host per the vendor homepage
   url 'http://creativebe.com/download/renamer'
   homepage 'http://renamer.com'
   license :commercial

--- a/Casks/retinizer.rb
+++ b/Casks/retinizer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'retinizer' do
   version '0.5.0'
   sha256 '34d82f6beeb934ebd73ac231c364298456374d8e52f5e3826077999507832922'
 
+  # google.com is the official download host per the vendor homepage
   url "https://sites.google.com/a/mikelpr.com/files/home/Retinizer#{version.gsub('.','')}.zip"
   homepage 'http://retinizer.mikelpr.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/rowanj-gitx.rb
+++ b/Casks/rowanj-gitx.rb
@@ -2,6 +2,7 @@ cask :v1 => 'rowanj-gitx' do
   version :latest
   sha256 :no_check
 
+  # phere.net is the official download host per the vendor homepage
   url 'http://builds.phere.net/GitX/development/GitX-dev.dmg'
   appcast 'https://s3.amazonaws.com/builds.phere.net/GitX/development/GitX-dev.xml'
   homepage 'http://rowanj.github.io/gitx/'

--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -2,6 +2,7 @@ cask :v1 => 'rstudio' do
   version '0.98.1091'
   sha256 'ea8baebe66903312bb84816669711b11f0dcd377a6f8c1c4c9f4c669ebd3dc18'
 
+  # rstudio.org is the official download host per the vendor homepage
   url "http://download1.rstudio.org/RStudio-#{version}.dmg"
   name 'RStudio'
   homepage 'http://www.rstudio.com/'

--- a/Casks/runtimebrowser.rb
+++ b/Casks/runtimebrowser.rb
@@ -2,6 +2,7 @@ cask :v1 => 'runtimebrowser' do
   version :latest
   sha256 :no_check
 
+  # seriot.ch is the official download host per the vendor homepage
   url 'http://seriot.ch/temp/runtimebrowser.zip'
   homepage 'https://github.com/nst/RuntimeBrowser'
   license :oss

--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sabnzbd' do
   version '0.7.20'
   sha256 'f7c13afe87ad91ab2f12fb6384feef79ae07bf2417395304b3d8961513d23611'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/sabnzbdplus/sabnzbdplus/#{version}/SABnzbd-#{version}-osx.dmg"
   homepage 'http://sabnzbd.org/'
   license :oss

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sage' do
   version '6.4.1'
   sha256 '3ae99dbddd5609271aa87ef38db58dd53fe2add3a58abed3b80750884100391e'
 
+  # washington.edu is the official download host per the vendor homepage
   url "http://boxen.math.washington.edu/home/sagemath/sage-mirror/osx/intel/sage-#{version}-x86_64-Darwin-OSX_10.10_x86_64-app.dmg"
   name 'Sage'
   homepage 'http://www.sagemath.org/'

--- a/Casks/sauerbraten.rb
+++ b/Casks/sauerbraten.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sauerbraten' do
   version '2013.01.26'
   sha256 'c6807484fa0d2c42ac774b97f9b21e9eace720e4403abc11b0321b2645d3589d'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sauerbraten/sauerbraten_#{version.gsub('.','_')}_collect_edition_macosx.dmg"
   homepage 'http://sauerbraten.org'
   license :oss

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -2,9 +2,11 @@ cask :v1 => 'scala-ide' do
   version '4.0.0'
 
   if Hardware::CPU.is_32_bit?
+    # typesafe.com is the official download host per the vendor homepage
     url "http://downloads.typesafe.com/scalaide-pack/#{version}.vfinal-luna-211-20141216/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
     sha256 '9739c851260211de15f8535988e7937cd4bf6e2dcb74188eb7261cff4a46deab'
   else
+    # typesafe.com is the official download host per the vendor homepage
     url "http://downloads.typesafe.com/scalaide-pack/#{version}.vfinal-luna-211-20141216/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
     sha256 '721a01bbbf682a2e32c34fb33f0240c08a2f81a9b8e181d7bca2039e98635453'
   end

--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -2,6 +2,7 @@ cask :v1 => 'scribus' do
   version '1.4.4'
   sha256 '57cdfacbfa6c60c035b746ac40ea8c46718fdfd4a9ac382b3b6c56a318fa162c'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/scribus/scribus/#{version}/scribus-#{version}.dmg"
   name 'Scribus'
   homepage 'http://www.scribus.net/canvas/Scribus'

--- a/Casks/scrup.rb
+++ b/Casks/scrup.rb
@@ -2,6 +2,7 @@ cask :v1 => 'scrup' do
   version '1.3.3'
   sha256 '5004222db9a6ddd4e6cb525d00e95f8a38e9fb623bc1397e5258b2ef2c4bd3b0'
 
+  # hunch.se is the official download host per the vendor homepage
   url "http://data.hunch.se/scrup/Scrup-#{version}-bd23160.zip"
   appcast 'https://s.rsms.me/scrup/appcast.xml',
           :sha256 => '140f4487d00bb157286f261bfddb8f7a8c29a4fc2e53a63119bdbe1c828a6d00'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -2,6 +2,7 @@ cask :v1 => 'scummvm' do
   version '1.7.0'
   sha256 'c382c231680011e7def2349baa666e142570ac833d9f4a1ca56e8f1efc5156c5'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/scummvm/scummvm/#{version}/scummvm-#{version}-macosx.dmg"
   appcast 'http://www.scummvm.org/appcasts/macosx/release.xml',
           :sha256 => 'bea2fd9739e102c781753c991b6ee6481a1c0c3f00621e96dca06a2b83e42135'

--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -2,6 +2,7 @@ cask :v1 => 'seamonkey' do
   version '2.25'
   sha256 '3217e3d1fb94376d01ca38cc926b1b23306579c96e96adfdd50f0f66fc71c5e8'
 
+  # mozilla.org is the official download host per the vendor homepage
   url "https://download.mozilla.org/?product=seamonkey-#{version}&os=osx&lang=en-US"
   homepage 'http://www.seamonkey-project.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/secondbar.rb
+++ b/Casks/secondbar.rb
@@ -2,6 +2,7 @@ cask :v1 => 'secondbar' do
   version '1.1'
   sha256 '1f2a9d837bc66c93ed2f7a1d83ef95c44888cd266ffb7982ade14f91d996d6a6'
 
+  # boastr.de is the official download host per the vendor homepage
   url 'http://boastr.de/SecondBar.zip'
   appcast 'http://blog.boastr.net/secondbar/appcast.xml',
           :sha256 => '1b991a6242ac7922bc4e76db810c6fea9ce63c1bc49e162b94e0ea2b250f2e4a'

--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sequel-pro' do
   version '1.0.2'
   sha256 'facd99344d0124cf4444acbef9006d947eadc6f96127b09e7380f014c7775f85'
 
+  # googlecode.com is the official download host per the vendor homepage
   url "https://sequel-pro.googlecode.com/files/sequel-pro-#{version}.dmg"
   appcast 'http://www.sequelpro.com/appcast/app-releases.xml',
           :sha256 => 'd6137595bccddd81edfb3a07a82b4ed818b8b1af79750397f929bf74b91d3e32'

--- a/Casks/serf.rb
+++ b/Casks/serf.rb
@@ -2,6 +2,7 @@ cask :v1 => 'serf' do
   version '0.6.3'
   sha256 'c406463486282ae9c6dc974a5d8688b8908a1fb6af46a2c1aca3785c16ac590b'
 
+  # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/serf/#{version}_darwin_amd64.zip"
   name 'Serf'
   homepage 'http://www.serfdom.io/'

--- a/Casks/shadowsocksx.rb
+++ b/Casks/shadowsocksx.rb
@@ -2,6 +2,7 @@ cask :v1 => 'shadowsocksx' do
   version '2.6.1'
   sha256 '79650f9c592b69b0cbe867962f2aeedfcd07623c12db9585b533e7c5786c6d6f'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/shadowsocksgui/dist/ShadowsocksX-#{version}.dmg"
   homepage 'https://github.com/shadowsocks/shadowsocks-iOS/wiki/Shadowsocks-for-OSX-Help'
   license :oss

--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -2,6 +2,7 @@ cask :v1 => 'shotcut' do
   version '14.11.01'
   sha256 'f364c8849ed79376006209bfb0146d1449461bb3b18a1548c55b3c8fb93f00ba'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.sub(/\.\d+$/, '')}/shotcut-osx-x86_64-#{version.gsub('.', '')}.dmg"
   homepage 'http://www.shotcut.org/'
   license :oss

--- a/Casks/sidestep.rb
+++ b/Casks/sidestep.rb
@@ -2,10 +2,11 @@ cask :v1 => 'sidestep' do
   version '1.4.1'
   sha256 'c25f7748d73b6f915aff268070ef85ca69f2902de98b044b77c49d1e1341d84e'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/chetan51/sidestep/releases/download/#{version}/Sidestep.zip"
   appcast 'http://chetansurpur.com/projects/sidestep/appcast.xml',
           :sha256 => '1d043f565c44c03f6ab5e7c90f025aba3cf480f1623a8a530f87206fab12f86a'
-  homepage 'http://chetansurpur.com/projects/sidestep'
+  homepage 'http://chetansurpur.com/projects/sidestep/'
   license :oss
 
   app 'Sidestep.app'

--- a/Casks/sidplay.rb
+++ b/Casks/sidplay.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sidplay' do
   version :latest
   sha256 :no_check
 
+  # twinbirds.com is the official download host per the vendor homepage
   url 'http://www.twinbirds.com/sidplay/SIDPLAY4.zip'
   appcast 'http://www.sidmusic.org/sidplay/mac/sidplay_appcast.xml'
   name 'SIDPLAY'

--- a/Casks/sketchupviewer.rb
+++ b/Casks/sketchupviewer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sketchupviewer' do
   version :latest
   sha256 :no_check
 
+  # trimble.com is the official download host per the vendor homepage
   # downloads can be found at http://www.sketchup.com/download/all
   url 'https://dl.trimble.com/sketchup/SketchUpViewer-en.dmg'
   homepage 'http://www.sketchup.com/intl/en/'

--- a/Casks/slate.rb
+++ b/Casks/slate.rb
@@ -2,6 +2,7 @@ cask :v1 => 'slate' do
   version :latest
   sha256 :no_check
 
+  # ninjamonkeysoftware.com is the official download host per the vendor homepage
   url 'http://slate.ninjamonkeysoftware.com/Slate.dmg'
   appcast 'https://www.ninjamonkeysoftware.com/slate/appcast.xml'
   homepage 'https://github.com/jigish/slate'

--- a/Casks/smlnj.rb
+++ b/Casks/smlnj.rb
@@ -2,6 +2,7 @@ cask :v1 => 'smlnj' do
   version '110.77'
   sha256 '77265ce1bdbca3e9c9b3053195503bf2bffafbba196596679fb64d9ceb4e25ee'
 
+  # uchicago.edu is the official download host per the vendor homepage
   url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-x86-#{version}.pkg"
   name 'Standard ML of New Jersey'
   homepage 'http://www.smlnj.org/'

--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -2,6 +2,7 @@ cask :v1 => 'snes9x' do
   version '1.53'
   sha256 '48b0cbec848e7c2a24de1b30819dc150b62e354600cbcc0a6a5e2cf8e1de48ff'
 
+  # ipherswipsite.com is the official download host per the vendor homepage
   url "http://files.ipherswipsite.com/snes9x/snes9x-#{version}-macosx-113.dmg.gz"
   homepage 'http://www.snes9x.com/'
   license :other

--- a/Casks/solidworks-edrawings.rb
+++ b/Casks/solidworks-edrawings.rb
@@ -2,6 +2,7 @@ cask :v1 => 'solidworks-edrawings' do
   version '2014 SP05'
   sha256 '986bbb63effd84a9e0ca4d9cb8fbe3a13ec25cfc15599e568ceb8ac531c6011f'
 
+  # solidworks.com is the official download host per the vendor homepage
   url 'http://dl-ak.solidworks.com/nonsecure/edrawings/e2014sp05/14.5.0.0008/mac/eDrawings%202014%20SP05.dmg'
   name 'eDrawings'
   name 'eDrawings Viewer'

--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sonic-visualiser' do
   version '2.4.1'
   sha256 '45edf5021376ed79e3a7a9a17745261f91362c05d90db17dc3179b1649c29332'
 
+  # ac.uk is the official download host per the vendor homepage
   url "https://code.soundsoftware.ac.uk/attachments/download/1186/Sonic%20Visualiser-#{version}.dmg"
   homepage 'http://www.sonicvisualiser.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/sonora.rb
+++ b/Casks/sonora.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sonora' do
   version :latest
   sha256 :no_check
 
+  # github.com is the official download host per the vendor homepage
   url 'https://github.com/downloads/sonoramac/Sonora/Sonora.zip'
   appcast 'http://getsonora.com/updates/sonora2.xml'
   name 'Sonora'

--- a/Casks/sourcedrop.rb
+++ b/Casks/sourcedrop.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sourcedrop' do
   version '1.5'
   sha256 '86437846de0cb1690ab583ee1a01ce4a01b438292b84b43e7f5709eb9fa3c144'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/hohl/sourcedrop-osx/releases/download/r#{version}/SourceDrop-r#{version}.zip"
   name 'SourceDrop'
   homepage 'http://sourcedrop.net/'

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -1,5 +1,4 @@
 cask :v1 => 'sourcetree' do
-
   if MacOS.release <= :snow_leopard
     version '1.8.1'
     sha256 '37a42f2d83940cc7e1fbd573a70c3c74a44134c956ac3305f6b153935dc01b80'
@@ -8,6 +7,7 @@ cask :v1 => 'sourcetree' do
     sha256 'fe1477ad902c2965a25560331778ec0b99eeed8e6871b88cb552910abe9e067e'
   end
 
+  # atlassian.com is the official download host per the vendor homepage
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.dmg"
   appcast 'http://www.sourcetreeapp.com/update/SparkleAppcast.xml',
           :sha256 => 'b43e0ea95de46d2c270cdbf9765e03ec3f13606cbf0bab5bcd3da0424ce2cff3'

--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sparkle' do
   version '1.8.0'
   sha256 '882f2e414d2d8a3e776f9a9888cbfcb744df88f3b061325c2aad3c965af5ac1a'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/sparkle-project/Sparkle/releases/download/#{version}/Sparkle-#{version}.tar.bz2"
   appcast 'http://sparkle-project.org/files/sparkletestcast.xml',
           :sha256 => '238db88f72b33bde99bbd1cc5c54956357a249346030af67311ba10f156cb48b'

--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sparkleshare' do
   version '1.4'
   sha256 '571a8e39591883f0af6fb9056db8c1a0835cc0babb73b07050a188165552c038'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/hbons/sparkleshare/downloads/sparkleshare-mac-#{version}.zip"
   homepage 'http://sparkleshare.org/'
   license :oss

--- a/Casks/speedcrunch.rb
+++ b/Casks/speedcrunch.rb
@@ -2,6 +2,7 @@ cask :v1 => 'speedcrunch' do
   version '0.11'
   sha256 '1ce5ef9d167614a2e63daad43a23bd8df60b8ea641df6be9aabdf826bbb5a826'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/heldercorreia/speedcrunch/downloads/SpeedCrunch-#{version}.dmg"
   homepage 'http://www.speedcrunch.org'
   license :oss

--- a/Casks/spek.rb
+++ b/Casks/spek.rb
@@ -2,6 +2,7 @@ cask :v1 => 'spek' do
   version '0.8.3'
   sha256 '648ffe37a4605d76b8d63ca677503ba63338b84c5df73961d9a5335ff144cc54'
 
+  # googlecode.com is the official download host per the vendor homepage
   url "https://spek.googlecode.com/files/spek-#{version}.dmg"
   name 'Spek'
   homepage 'http://spek.cc'

--- a/Casks/spotdox.rb
+++ b/Casks/spotdox.rb
@@ -2,6 +2,7 @@ cask :v1 => 'spotdox' do
   version :latest
   sha256 :no_check
 
+  # herokuapp.com is the official download host per the vendor homepage
   url 'https://spotdox.herokuapp.com/downloads/Spotdox.zip'
   appcast 'https://spotdox.herokuapp.com/downloads/appcast.xml'
   homepage 'http://spotdox.com/'

--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -2,6 +2,7 @@ cask :v1 => 'spotify-notifications' do
   version '0.4.8'
   sha256 '953028e9a1aad445005869598050cb8612980821a796563936f557e03b319f50'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"
   name 'Spotify Notifications'
   homepage 'http://spotify-notifications.citruspi.io/'

--- a/Casks/spyder.rb
+++ b/Casks/spyder.rb
@@ -2,6 +2,7 @@ cask :v1 => 'spyder' do
   version '2.3.2'
   sha256 '0565a5af85e26759acce04f6da1b6317e8c2ec932847bc590408a1473d0686a7'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py3.4.dmg"
   name 'Spyder'
   homepage 'https://code.google.com/p/spyderlib/'

--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sqlitebrowser' do
   version '3.4.0'
   sha256 '8347deff7680fba86fcc21abb442a05a1526896d2701ed27d8aa8c38284a41ff'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/sqlitebrowser-#{version}.dmg"
   name 'DB Browser for SQLite'
   name 'SQLite Database Browser'

--- a/Casks/srclib.rb
+++ b/Casks/srclib.rb
@@ -2,6 +2,7 @@ cask :v1 => 'srclib' do
   version :latest
   sha256 :no_check
 
+  # equinox.io is the official download host per the vendor homepage
   url 'https://api.equinox.io/1/Applications/ap_BQxVz1iWMxmjQnbVGd85V58qz6/Updates/Asset/src.zip?os=darwin&arch=amd64&channel=stable'
   homepage 'https://srclib.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -2,6 +2,7 @@ cask :v1 => 'stellarium' do
   version '0.13.1'
   sha256 '79f7835a799680c07a00dcb0687a135c8f61fd9e2f46978de069d5f1df631f44'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/stellarium/Stellarium-#{version}.dmg"
   homepage 'http://stellarium.org'
   license :oss

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sublime-text' do
   version '2.0.2'
   sha256 '906e71e19ae5321f80e7cf42eab8355146d8f2c3fd55be1f7fe5c62c57165add'
 
+  # rackcdn.com is the official download host per the vendor homepage
   url "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20#{version}.dmg"
   appcast 'http://www.sublimetext.com/updates/2/stable/appcast_osx.xml',
           :sha256 => 'e11769f18c577d4cb189c6f6485119a66db5e5d3ba4df99326080f193c1f74b3'

--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -2,6 +2,7 @@ cask :v1 => 'sweet-home3d' do
   version '4.5'
   sha256 'f1d341046fbf066d92cc625b44bb201e905017c72e9755151587a01539f5242b'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-#{version}/SweetHome3D-#{version}-macosx.dmg"
   homepage 'http://www.sweethome3d.com/'
   license :oss

--- a/Casks/synalyze-it-pro.rb
+++ b/Casks/synalyze-it-pro.rb
@@ -2,6 +2,7 @@ cask :v1 => 'synalyze-it-pro' do
   version '1.9'
   sha256 '5c772168f98df6cdf3797be94d7603145998f6899fd2f7c841a504a9136687ef'
 
+  # it.com is the official download host per the vendor homepage
   url "http://www.synalyze-it.com/Downloads/SynalyzeItProTA_#{version}.zip"
   homepage 'http://www.synalysis.net/'
   license :commercial

--- a/Casks/tag.rb
+++ b/Casks/tag.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tag' do
   version '0.4.1'
   sha256 '165631a76db33cbe5200ff64a64f5e1dad6606ae815c7609d59b7367f9344360'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/tagosx/Tag-#{version}.zip"
   name 'Tag'
   homepage 'http://sbooth.org/Tag/'

--- a/Casks/tagaini-jisho.rb
+++ b/Casks/tagaini-jisho.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tagaini-jisho' do
   version '1.0.1'
   sha256 'fda5a6da2f2854e5497329b81e6bd1eb210cd89aab50e373e120d687653edb27'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/Gnurou/tagainijisho/releases/download/#{version}/Tagaini.Jisho-#{version}.dmg"
   homepage 'http://www.tagaini.net/'
   license :gpl

--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -2,6 +2,7 @@ cask :v1 => 'teamspeak-client' do
   version '3.0.16'
   sha256 'ff0bece49ca1d7b129775e7fb492a005e0a9d2ece78b9f117cbae991a8ca8910'
 
+  # 4players.de is the official download host per the vendor homepage
   url "http://dl.4players.de/ts/releases/#{version}/TeamSpeak3-Client-macosx-#{version}.dmg"
   homepage 'http://www.teamspeak.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/teitoku.rb
+++ b/Casks/teitoku.rb
@@ -2,6 +2,7 @@ cask :v1 => 'teitoku' do
   version '0.3.2'
   sha256 '87812a8a1167ee69942f35b55e402c86f1079ab0f946c1d3a049a716bd8406e1'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/geta6/teitoku/releases/download/#{version}/teitoku-#{version}-osx.zip"
   homepage 'http://makebooth.com/i/1xkN1'
   license :mit

--- a/Casks/temperaturemonitor.rb
+++ b/Casks/temperaturemonitor.rb
@@ -2,6 +2,7 @@ cask :v1 => 'temperaturemonitor' do
   version :latest
   sha256 :no_check
 
+  # bresink.eu is the official download host per the vendor homepage
   url 'http://www.bresink.eu/Downloads/TemperatureMonitor.dmg'
   homepage 'http://www.bresink.com/osx/LegacyProducts.html'
   license :commercial

--- a/Casks/terraform.rb
+++ b/Casks/terraform.rb
@@ -2,6 +2,7 @@ cask :v1 => 'terraform' do
   version '0.3.6'
   sha256 '65b4c5bfc34bb0464b691b31ac554132c87ac0c5d7acef936c039777a27dccad'
 
+  # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/terraform/terraform_#{version}_darwin_amd64.zip"
   homepage 'http://www.terraform.io/'
   license :mpl

--- a/Casks/testflight.rb
+++ b/Casks/testflight.rb
@@ -2,6 +2,7 @@ cask :v1 => 'testflight' do
   version '1.0_beta313'
   sha256 'a8f643b66682f7ec9d710b7452dd9fdc9332edc59bc2c92d10683635c80c861f'
 
+  # cloudfront.net is the official download host per the vendor homepage
   url 'https://d193ln56du8muy.cloudfront.net/desktop_app/1381509820/TestFlight-Desktop-1.0-Beta(313).zip'
   appcast 'https://testflightapp.com/appcast.xml',
           :sha256 => 'a83cbdaafed7a635f71dfed9717e76f323a8f0c1f91deb3918e37d6d4dc88bdc'

--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -2,6 +2,7 @@ cask :v1 => 'textmate' do
   version :latest
   sha256 :no_check
 
+  # textmate.org is the official download host per the vendor homepage
   url 'https://api.textmate.org/downloads/release'
   homepage 'http://macromates.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -2,6 +2,7 @@ cask :v1 => 'the-unarchiver' do
   version '3.9.1'
   sha256 '34fa3410237e17b2cdceb801a84ed8db93c74ac0db551ffe65913c2134ebbf05'
 
+  # googlecode.com is the official download host per the vendor homepage
   url "https://theunarchiver.googlecode.com/files/TheUnarchiver#{version}.zip"
   homepage 'http://unarchiver.c3.cx/'
   license :oss

--- a/Casks/theremin.rb
+++ b/Casks/theremin.rb
@@ -2,6 +2,7 @@ cask :v1 => 'theremin' do
   version '0.7'
   sha256 '809d0f7527d072a43f33b9e1088dc2387e08bb1a3696bb60bfd8e82b8853102d'
 
+  # nn.lv is the official download host per the vendor homepage
   url 'http://f.nn.lv/ms/l5/29/Theremin.app.zip'
   appcast 'http://theremin.amd.co.at/appcastProfileInfo.php',
           :sha256 => '407e28c21827df8a17eb9ccf4d01c33f01b98f554cf33f8ffae89cdaf9e77a33'

--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -2,6 +2,7 @@ cask :v1 => 'thunder' do
   version '2.6.6.1684'
   sha256 'ae19d8fd03d10a20c10ac82071b6f65e8d371cc5fe91cd3a062e7bad370b7772'
 
+  # sandai.net is the official download host per the vendor homepage
   url "http://down.sandai.net/mac/thunder_dl#{version}_Beta.dmg"
   name '迅雷'
   name 'Thunder'

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tidal' do
   version '3.2.3.16'
   sha256 'a6511421984b4c5ad55eb6c54e0d5743dd2b33c580d5bd83cbca7b03e3e14e52'
 
+  # wimp.no is the official download host per the vendor homepage
   url "https://wimp.no/wweb/resources/wimp_files/release/TIDAL-#{version}-WW.dmg"
   homepage 'https://tidalhifi.com/us/download'
   license :closed

--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tiled' do
   version '0.10.2'
   sha256 'e96636aa597375304729a9bb20f17b1b3a1bf4ffef6a0060ba65deb0bfc2aee0'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'

--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tla-plus-toolbox' do
   version '1.4.8'
   sha256 '7f7aec6cc69af1bdbe01e35110939f83b4f880aeec88ce069b9128ab1653da3a'
 
+  # inria.fr is the official download host per the vendor homepage
   url 'https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-1.4.8-macosx.cocoa.x86_64.zip'
   name 'TLA+ Toolbox'
   homepage 'http://research.microsoft.com/en-us/um/people/lamport/tla/toolbox.html'

--- a/Casks/tomighty.rb
+++ b/Casks/tomighty.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tomighty' do
   version '1.0.1'
   sha256 '14ba9d4bc6e910e1c5bc256de4136db1e3e8d0671318b20c78f586a136a78793'
 
+  # googlecode.com is the official download host per the vendor homepage
   url "https://tomighty.googlecode.com/files/Tomighty-#{version}.dmg"
   homepage 'http://www.tomighty.org/'
   license :oss

--- a/Casks/tongbu.rb
+++ b/Casks/tongbu.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tongbu' do
   version '1.1.4'
   sha256 'b8c30ad109d1005fbcd865ceef67b8bb224595b8b40fc1e0b084d039e1d6ce50'
 
+  # leaderhero.com is the official download host per the vendor homepage
   url "http://qd.leaderhero.com/qd/zsmac/Tongbu_mac_v#{version}.dmg"
   homepage 'http://www.tongbu.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -2,6 +2,7 @@ cask :v1 => 'track-o-bot' do
   version '0.4.2'
   sha256 '3746f662cda62047c8b9e870997bfc8d4f04040b72e1573177c4da2cfc5e8cb3'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/stevschmid/track-o-bot/releases/download/#{version}/Track-o-Bot_#{version}.dmg"
   name 'Track-o-Bot'
   homepage 'https://trackobot.com/'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -2,6 +2,7 @@ cask :v1 => 'transmission' do
   version '2.84'
   sha256 '53d08a55a5ca55010d409acb10f0285a649b8879085cad83f2cbcb7faa489ad5'
 
+  # cachefly.net is the official download host per the vendor homepage
   url "https://transmission.cachefly.net/Transmission-#{version}.dmg"
   name 'Transmission'
   appcast 'http://update.transmissionbt.com/appcast.xml',

--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -2,6 +2,7 @@ cask :v1 => 'transporter-desktop' do
   version '3.0.21_17012'
   sha256 '48d36d53f6484364b3df93ccd054a30028b0f4fcb169c2d8475ca64ef108f510'
 
+  # connecteddata.com is the official download host per the vendor homepage
   url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}.dmg"
   homepage 'http://www.filetransporter.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tribler' do
   version '6.4.1'
   sha256 'aef90693c230f94ceeb5a4edf172344bd41d5d2cc918df0c2c1a2d2444495073'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
   name 'Tribler'
   homepage 'http://www.tribler.org'

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tunnelblick' do
   version '3.4.3_build_4055.4198'
   sha256 '9f9938e3160d54337212f6a9ae2b2138e21b4a5ad51b70785494afc404d96108'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_#{version}.dmg"
   appcast 'https://www.tunnelblick.net/appcast.rss',
           :sha256 => '7fa119cda4d782dc61cb75895c70b3572652df737c908270c48a09d67a874592'

--- a/Casks/tuxguitar.rb
+++ b/Casks/tuxguitar.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tuxguitar' do
   version '1.2'
   sha256 '2d79ffdfdde9205073fdaa1c34701ea8f1961f822709b5270dc57555eb926d16'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/tuxguitar/TuxGuitar/TuxGuitar-#{version}/tuxguitar-#{version}-macosx10.5-cocoa-64.dmg"
   homepage 'http://www.tuxguitar.com.ar/'
   license :oss

--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tv-browser' do
   version '3.3.3'
   sha256 '951fe8478fa2efa5f7784c23f153bcc8b0a6fcb8a7405c4990c44b3c967e73cc'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/tvbrowser/tvbrowser_#{version}_mac.dmg"
   homepage 'http://www.tvbrowser.org/'
   license :oss

--- a/Casks/tvrenamer.rb
+++ b/Casks/tvrenamer.rb
@@ -2,6 +2,7 @@ cask :v1 => 'tvrenamer' do
   version '0.6'
   sha256 'fe38d8f7fab69bc54673ef9822b01401d5d72453865842f27023ecd7de4a531a'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/tvrenamer/tvrenamer/releases/download/v#{version}/TVRenamer-#{version}-osx64.zip"
   homepage 'http://tvrenamer.org'
   license :gpl

--- a/Casks/twelf.rb
+++ b/Casks/twelf.rb
@@ -2,6 +2,7 @@ cask :v1 => 'twelf' do
   version '1.7.1'
   sha256 'be9e638d0c1dca17d70b06218084b6012fe74aecae09183db457c1c25f7cf3a0'
 
+  # plparty.org is the official download host per the vendor homepage
   url "http://twelf.plparty.org/releases/twelf-osx-#{version}.dmg"
   homepage 'http://www.twelf.org'
   license :bsd

--- a/Casks/twitterrific.rb
+++ b/Casks/twitterrific.rb
@@ -2,6 +2,7 @@ cask :v1 => 'twitterrific' do
   version '4.5.1'
   sha256 '1b43504307e8a541c97a93ecd4c56bc443f66cdd622d319db965e7e0eb760b46'
 
+  # iconfactory.com is the official download host per the vendor homepage
   url "https://iconfactory.com/assets/software/twitterrific/Twitterrific-#{version}.zip"
   appcast 'http://iconfactory.com/appcasts/Twitterrific/appcast.xml',
           :sha256 => '0d8a09937e5ea81dc2f16ff23497077fecb6bc89c3266b47d0465a13776dd7ea'

--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -2,6 +2,7 @@ cask :v1 => 'unison' do
   version '2.40.69'
   sha256 '2bcc460511f2b43fa1613cc5f9ba4dd59bb12d40b5b9fb2e9f21adaf854bcf3b'
 
+  # petitepomme.net is the official download host per the vendor homepage
   url "http://alan.petitepomme.net/unison/assets/Unison-#{version}_x64.dmg"
   homepage 'http://www.cis.upenn.edu/~bcpierce/unison/'
   license :gpl

--- a/Casks/unpkg.rb
+++ b/Casks/unpkg.rb
@@ -2,6 +2,7 @@ cask :v1 => 'unpkg' do
   version '4.5'
   sha256 'e32754b07073b383320d2bc0ce4ba9bd83a3f352043bd6f500741901f00c8c17'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/downloads/timdoug/unpkg/unpkg-#{version}.zip"
   name 'unpkg'
   homepage 'http://www.timdoug.com/unpkg/'

--- a/Casks/usb-overdrive.rb
+++ b/Casks/usb-overdrive.rb
@@ -2,6 +2,7 @@ cask :v1 => 'usb-overdrive' do
   version '3.1'
   sha256 '1a93082f1a2236bca088372c54b1933b3e491c3a986a1f13f78b59fda0c40fa2'
 
+  # senlick.com is the official download host per the vendor homepage
   url "http://www.senlick.com/macsw/USB-Overdrive-#{version.gsub('.','')}.dmg"
   homepage 'http://www.usboverdrive.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -2,6 +2,7 @@ cask :v1 => 'vagrant-manager' do
   version '2.1.2'
   sha256 '8510664b4834c98ed9b72baa30aae611f640ca2292725a8cd6ae6d99d412dd4b'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
   appcast 'http://api.lanayo.com/appcast/vagrant_manager.xml',
           :sha256 => '3dbe30121d4f32c4d600e30d58d6cfea142d9510823be7a125952aa2e05ea3af'

--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -2,6 +2,7 @@ cask :v1 => 'vagrant' do
   version '1.7.2'
   sha256 '78d02afada2f066368bd0ce1883f900f89b6dc20f860463ce125e7cb295e347c'
 
+  # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{version}.dmg"
   homepage 'http://www.vagrantup.com'
   license :mit

--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -2,6 +2,7 @@ cask :v1 => 'vienna' do
   version '3.0.2'
   sha256 'a52a8de9591483d4c440ab1390ab7f66bbafee0e27e23517b7300b0df4e461e0'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/vienna-rss/Vienna#{version}.tgz"
   appcast 'http://vienna-rss.org/changelog.xml',
           :sha256 => 'fcfbae9fe2ccae3bd3531436daa2060c16fab7d72de2a8eea1d13ccbcb66814d'

--- a/Casks/virtaal.rb
+++ b/Casks/virtaal.rb
@@ -2,6 +2,7 @@ cask :v1 => 'virtaal' do
   version '0.7.1b2'
   sha256 '41fec069ca06eb627c75b8d66460110b7970b0894e19df4f41510ac7b91bdbd0'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/translate/Virtaal/#{version.sub(%r{^(\d+\.\d+\.\d+).*},'\1')}/Virtaal-#{version.sub(%r{^(\d+\.\d+\.\d+).*},'\1')}-Mac-Beta-2.dmg"
   homepage 'http://virtaal.translatehouse.org/'
   license :oss

--- a/Casks/vox-preferences-pane.rb
+++ b/Casks/vox-preferences-pane.rb
@@ -2,6 +2,7 @@ cask :v1 => 'vox-preferences-pane' do
   version :latest
   sha256 :no_check
 
+  # devmate.com is the official download host per the vendor homepage
   url 'http://dl.devmate.com/com.coppertino.VoxPrefs/VoxPrefs.dmg'
   homepage 'http://coppertino.com/vox/addon.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -2,6 +2,7 @@ cask :v1 => 'vox' do
   version :latest
   sha256 :no_check
 
+  # devmate.com is the official download host per the vendor homepage
   url 'http://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   homepage 'http://coppertino.com/vox/osx/'
   license :closed

--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -2,6 +2,7 @@ cask :v1 => 'wesnoth' do
   version '1.12'
   sha256 '603877e2acc7b867907a2f06a71d62fb7cbd0c0e39c5b29de207b78b2121e7e2'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/wesnoth/Wesnoth_#{version}.dmg"
   homepage 'http://wesnoth.org'
   license :oss

--- a/Casks/widelands.rb
+++ b/Casks/widelands.rb
@@ -2,6 +2,7 @@ cask :v1 => 'widelands' do
   version 'Build 18'
   sha256 '1d209dcf653942788120c6f1abbe6f421fdefe6776f4feed48c58eddeb4c3722'
 
+  # launchpad.net is the official download host per the vendor homepage
   url 'https://launchpad.net/widelands/build18/build-18/+download/widelands-build18-mac.dmg'
   homepage 'https://wl.widelands.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/wineskin-winery.rb
+++ b/Casks/wineskin-winery.rb
@@ -2,6 +2,7 @@ cask :v1 => 'wineskin-winery' do
   version '1.7'
   sha256 'ef3ae1fe17a7bc622a59171985f304f506aea7ca0ad342281536dac8609eac32'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/wineskin/Wineskin%20Winery.app%20Version%20#{version}.zip"
   homepage 'http://wineskin.urgesoftware.com/'
   license :oss

--- a/Casks/wings3d.rb
+++ b/Casks/wings3d.rb
@@ -2,6 +2,7 @@ cask :v1 => 'wings3d' do
   version '1.5.3'
   sha256 'ec1bc0302fc7a12c0e5f06162673782943ac4394c2a942a6111b3f321e8be6d5'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/wings/wings-#{version}-macosx.dmg"
   homepage 'http://www.wings3d.com/'
   license :oss

--- a/Casks/x48.rb
+++ b/Casks/x48.rb
@@ -3,6 +3,7 @@ cask :v1 => 'x48' do
   version '0.6.4'
   sha256 '21184fceec8fd471d034932ac9b49f41c98cd5d730fa3fb02ccf0bcf02951f70'
 
+  # google.com is the official download host per the vendor homepage
   url "https://sites.google.com/a/sharkus.com/sharkus-com/Home/x48-#{version}%20osx.zip"
   homepage 'http://blog.sharkus.com/2012/08/osx-hp48-emulators.html'
   license :gpl

--- a/Casks/xaos.rb
+++ b/Casks/xaos.rb
@@ -2,6 +2,7 @@ cask :v1 => 'xaos' do
   version '3.6'
   sha256 '1a3864f354759c03c13150ef541b48d06cf74351360a85a8b46e73a45edc7054'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/xaos/xaos-#{version}-macosx.dmg"
   name 'XaoS'
   name 'GNU XaoS'

--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -2,6 +2,7 @@ cask :v1 => 'xld' do
   version '20141129'
   sha256 'adbf053cb2b24fb342302932b90ec745740d0421d6b5fbf48c5c35367538d9fd'
 
+  # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/xld/xld-#{version}.dmg"
   appcast 'http://xld.googlecode.com/svn/appcast/xld-appcast_e.xml',
           :sha256 => '16420b367df9b64870bd2a38ee20e688d17b065783b93371065ac7094ab93cb0'

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -2,6 +2,7 @@ cask :v1 => 'yacreader' do
   version '7.2.0'
   sha256 'e671e2c7914c070bc5ed7144db147d9ab6d6f1bc8a8272673e6dc39cb52b3101'
 
+  # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/luisangelsm/yacreader/downloads/YACReader-#{version}-MacOSX-Intel.dmg"
   homepage 'http://www.yacreader.com'
   license :oss

--- a/Casks/yorufukurou.rb
+++ b/Casks/yorufukurou.rb
@@ -2,6 +2,7 @@ cask :v1 => 'yorufukurou' do
   version :latest
   sha256 :no_check
 
+  # null.net is the official download host per the vendor homepage
   url 'http://aki-null.net/yf/YoruFukurou_SL.zip'
   appcast 'http://sites.google.com/site/yorufukurou/distribution/appcast.xml'
   homepage 'https://sites.google.com/site/yorufukurou/home-en'

--- a/Casks/younited.rb
+++ b/Casks/younited.rb
@@ -2,6 +2,7 @@ cask :v1 => 'younited' do
   version :latest
   sha256 :no_check
 
+  # secure.com is the official download host per the vendor homepage
   url 'https://download.sp.f-secure.com/younited/younited.dmg'
   homepage 'http://www.younited.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
@caskroom/maintainers These should be the last of them, which means that not counting some pending PRs, after this is merged we should not have any more casks in the main repo whose `url` and `homepage` hosts differ.

Exceptions include `github.io` homepages with `github.com` urls and `code.google.com` homepages with `googlecode.com` urls, since those really are the same host, in practice. Things like a `github.com` homepage with a `googlecode.com` url were checked, since those are different.

Pinging you all in case some are unaware of the policy<sup>1</sup> to add this comment in these cases. These are somewhat hard to detect automatically due to the weird format urls can take and the amount of TLDs there are with different parts, which means we should take extra care with new submissions (as opposed to updates). If someone can manage a script for this (I may try to eventually work on one, but definitely not now), that’d be a huge step.

---

<sup>1</sup> Introduced when we already had a bunch of them that did not comply, which is what these last PRs are meant to address.
