### PR TITLE
pharo: Update sha256 for 2014-12-12 file

### DIFF
--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pharo' do
   version '3.0'
-  sha256 'a13577159336d3de7e71d71c0e0f58985060d2455bc8d40d501c81e97a75b5e7'
+  sha256 'ae6461e44f768a2f04d7b1787edd2d770ad4e2e2cb5e1fe144d1f1b98ecb7114'
 
   # pharo.org is the official download host per the vendor homepage
   url "http://files.pharo.org/platform/Pharo#{version}-mac.zip"


### PR DESCRIPTION
Update sha256 for 2014-12-12 file:

http://files.pharo.org/platform/Pharo3.0-mac.zip
