### PR TITLE
Automate DbVisualizer.app installation

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -1,17 +1,17 @@
 cask :v1 => 'dbvisualizer' do
   version '9.2'
-  sha256 '00a9b9898b543af727683ecb8b79d9ecb45e138b44681d3bb522a207de62fd0a'
+  sha256 'caddfc43f3550487b4f4b0e6a671dde52eb402b348ce091b30aaf341c96a0630'
 
-  url "http://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.gsub('.', '_')}_java7.dmg"
+  url "http://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.gsub('.', '_')}.tgz"
   homepage 'http://www.dbvis.com/'
   license :commercial
-
-  installer :manual => 'DbVisualizer Installer.app'
 
   caveats <<-EOS.undent
     #{token} requires Java. You can install the latest version with
       brew cask install java
   EOS
+
+  app 'DbVisualizer.app'
 
   uninstall :signal => [[ 'TERM', 'com.dbvis.DbVisualizer' ]]
   zap :delete => '~/.dbvis'


### PR DESCRIPTION
A different implementation of this was originally part of #8867, but moved out as it was causing the installer GUI to show up. As recommended by a guy from DbVisualizer on the [forum](http://www.dbvis.com/forum/message.jspa?messageID=18741), I am using the .tgz version instead, which does the job of putting the .app in the right place. We can revert to a .dmg installer in unattended mode (with whatever additional actions it is doing) once they will fix the GUI issue in one of the future 9.2.x versions.
