### PR TITLE
Add MakeiPhoneRingtone.app latest version.

### DIFF
--- a/Casks/makeiphoneringtone.rb
+++ b/Casks/makeiphoneringtone.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'makeiphoneringtone' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://rogueamoeba.com/freebies/download/MakeiPhoneRingtone.zip'
+  name 'MakeiPhoneRingtone'
+  homepage 'http://rogueamoeba.com/freebies/'
+  license :gratis
+
+  app 'MakeiPhoneRingtone.app'
+end


### PR DESCRIPTION
MakeiPhoneRingtone is a quick drag and drop utility to turn AAC files into ringtones for your iPhone.
