### PR TITLE
Rename jenkins binary to prevent confusion with jenkins-cli.jar

### DIFF
--- a/Casks/jenkins.rb
+++ b/Casks/jenkins.rb
@@ -8,7 +8,7 @@ cask :v1 => 'jenkins' do
   license :cc
 
   pkg "jenkins-#{version}.pkg"
-  binary '/Library/Application Support/Jenkins/jenkins-runner.sh', :target => 'jenkins'
+  binary '/Library/Application Support/Jenkins/jenkins-runner.sh', :target => 'jenkins-runner'
 
   uninstall :script    => '/Library/Application Support/Jenkins/Uninstall.command',
             :pkgutil   => 'org.jenkins-ci.*pkg',


### PR DESCRIPTION
Jenkins comes with a [CLI tool](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI) already, `jenkins-cli.jar`.

Until we've done something about [wrapper scripts](https://github.com/caskroom/homebrew-cask/pull/8279#issuecomment-70591386), we can't utilize that tool. But we can disambiguate it from the runner script.
