### PR TITLE
Update Xamarin Studio to v5.7.0.660-0

### DIFF
--- a/Casks/xamarin-studio.rb
+++ b/Casks/xamarin-studio.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'xamarin-studio' do
-  version '5.5.0.227-0'
-  sha256 '4c05b5174fd1d2eacef44f2f96557fc213f25381ad0ea3c139612217a20e8d46'
+  version '5.7.0.660-0'
+  sha256 'efb4b5817ff1e21d9aaac13c76607ee198d3dc71b57968faf075f01a7069133c'
 
   url "http://download.xamarin.com/studio/Mac/XamarinStudio-#{version}.dmg"
   appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          :sha256 => '713f272a1e36262f1b2c5a06f4ed1b1eb8987d240018347a51312dfedeeafcf3',
+          :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
           :format => :unknown
   homepage 'http://xamarin.com/studio'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'Xamarin Studio.app'
 end


### PR DESCRIPTION
- Updated Xamarin Studio version & sha256
- Updated appcast & its sha256
- Changed license (according to [this](http://xamarin.com/licensing))
