### PR TITLE
Upgrade wkhtmltopdf to 0.12.2.1

### DIFF
--- a/Casks/wkhtmltopdf.rb
+++ b/Casks/wkhtmltopdf.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'wkhtmltopdf' do
-  version '0.12.2'
+  version '0.12.2.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 '63a3aaf56602e1630e136c5b43903e4d4757412f56184381d27be2fe9395967b'
+    sha256 '582d7da3226809a5ca8bfc6c60903a368fe4c7c54fc31df13bbd0bd2ed093968f1'
     # sourceforge.net is the official download host per the vendor homepage
     url "http://downloads.sourceforge.net/project/wkhtmltopdf/#{version}/wkhtmltox-#{version}_osx-carbon-i386.pkg"
     pkg "wkhtmltox-#{version}_osx-carbon-i386.pkg"
   else
-    sha256 'f53fc73dde8eee05a3a3c05e9666123e5e71fef77b8b658f78801a9a8223b6a9'
+    sha256 'c2fd9b39182453ba9672f528e7a503928e51bc6a45c3117da06a5193af338d35'
     # sourceforge.net is the official download host per the vendor homepage
     url "http://downloads.sourceforge.net/project/wkhtmltopdf/#{version}/wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
     pkg "wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"


### PR DESCRIPTION
Version 0.12.2.1 was released 2015-01-19 and old version 0.12.2 is unavailable as of 2015-01-21.
- http://wkhtmltopdf.org/downloads.html
- http://sourceforge.net/projects/wkhtmltopdf/files/0.12.2.1/
