### PR TITLE
Use bash as defined in the user's environment (/usr/bin/env bash)

### DIFF
--- a/bin/brew-cask
+++ b/bin/brew-cask
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # brew-cask
 #


### PR DESCRIPTION
Use `/usr/bin/env bash` instead of `/bin/bash` for the `brew-cask` shim, as changed in #8089.

This is really more of a suggestion, and while I generally think `/usr/bin/env bash` is preferable – people may have a `bash` executable preferable to (or somewhere different than) the one whichever `MacOS.release` their machine shipped with – I recognize that there are also advantages to just using `/bin/bash` – some hacker could have maliciously placed a non-bash executable named `bash` in your `$PATH` – and so I firmly leave this up to the maintainers.

Pinging @rolandwalker since you made the move to bash in the first place.
