### PR TITLE
Add cask for GitX-dev (0.15.1964)

### DIFF
--- a/Casks/gitx-dev.rb
+++ b/Casks/gitx-dev.rb
@@ -1,0 +1,27 @@
+cask :v1 => 'gitx-dev' do
+  name 'GitX-dev'
+  name 'GitX'
+  homepage 'http://rowanj.github.io/gitx/'
+  license :gpl
+
+  if MacOS.release == :snow_leopard
+    version '0.14.81'
+    url 'https://builds.phere.net/GitX/development/GitX-dev-81.dmg'
+    sha256 '17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a'
+  elsif MacOS.release == :lion
+    version '0.15.1949'
+    url 'https://builds.phere.net/GitX/development/GitX-dev-1949.dmg'
+    sha256 '17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a'
+  else
+    version '0.15.1964'
+    url 'https://github.com/rowanj/gitx/releases/download/builds%2F0.15%2F1964/GitX-dev-1964.dmg'
+    sha256 'd88bcb7f92ca1cdf31cb3f1d2e24c03e2091ab330319aeef2e770c0dbd6f7817'
+  end
+
+  depends_on :macos => '>= :snow_leopard'
+  depends_on :arch => :intel
+  conflicts_with :cask => 'gitx'
+
+  app 'GitX.app', :target => 'GitX-dev.app'
+  binary 'GitX.app/Contents/Resources/gitx'
+end


### PR DESCRIPTION
GitX-dev is a fork (variant) of GitX, a long-defunct GUI for the git version-control system. It has been maintained and enhanced with productivity and friendliness oriented changes, with effort focused on making a first-class, maintainable tool for today's active developers.

http://rowanj.github.io/gitx/
https://github.com/rowanj/gitx

I am not the developer of GitX-dev.

Since I'm using Cask and a nifty sync script to manage GUI apps on all my Macs, be prepared to receive more contributions. :)
