### PR TITLE
Add dux by @abhibeckert

### DIFF
--- a/Casks/dux.rb
+++ b/Casks/dux.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'dux' do
+  version '2014.04.15'
+  sha256 'e9cd44917e64ca445cad79b5fe8e2a2e293f96bbd4e944fd81398d36c19fa5c7'
+
+  # github.com is the official download host per the vendor homepage
+  url "https://github.com/abhibeckert/Dux/releases/download/#{version}/Dux-#{version}.zip"
+  name 'Dux'
+  homepage 'http://duxapp.com/'
+  license :public_domain
+
+  app 'Dux.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.duxapp.Dux.plist',
+                  '~/Library/Application Support/Dux/'
+                 ]
+end


### PR DESCRIPTION
License is properly the unlicense, which amounts to PD.

I struggled with the `:zap` stanza here.  `:delete` works fine, but the `:rmdir` is a no go for me.  Two folders, "Bundles" and "Themes", appear in `~/Library/Application Support/Dux/`, the former of which at least has a fair amount of stuff in it.  Even if I delete those (either manually or through `zap :delete`) so that `~/Library/Application Support/Dux/` is empty, it remains.  Help appreciated.
