### PR TITLE
Update licenses for 27 casks

### DIFF
--- a/Casks/camtwist.rb
+++ b/Casks/camtwist.rb
@@ -4,7 +4,7 @@ cask :v1 => 'camtwist' do
 
   url "http://camtwiststudio.com/release/CamTwist_#{version}.dmg"
   homepage 'http://camtwiststudio.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   pkg 'CamTwist.pkg'
 

--- a/Casks/cn3d.rb
+++ b/Casks/cn3d.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cn3d' do
 
   url "ftp://ftp.ncbi.nlm.nih.gov/cn3d/Cn3D-#{version}-OSX.zip"
   homepage 'http://www.ncbi.nlm.nih.gov/Structure/CN3D/cn3d.shtml'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :public_domain
 
   app 'Cn3D.app'
 end

--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -18,7 +18,7 @@ cask :v1 => 'coconutbattery' do
 
   name 'coconutBattery'
   homepage 'http://www.coconut-flavour.com/coconutbattery/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :bsd
 
   app 'coconutBattery.app'
 end

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -22,7 +22,7 @@ cask :v1 => 'deeper' do
   end
 
   homepage 'http://www.titanium.free.fr/downloaddeeper.php'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Deeper.app'
 

--- a/Casks/dragondisk.rb
+++ b/Casks/dragondisk.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dragondisk' do
 
   url "http://download.dragondisk.com/DragonDisk-#{version}.dmg"
   homepage 'http://www.dragondisk.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'dragondisk.app'
 end

--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -5,7 +5,7 @@ cask :v1 => 'dungeon-crawl-stone-soup-console' do
   url "https://crawl.develz.org/release/stone_soup-#{version}-console-macosx.zip"
   name 'Dungeon Crawl Stone Soup'
   homepage 'http://crawl.develz.org'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'Dungeon Crawl Stone Soup - Console.app'
 end

--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dungeon-crawl-stone-soup-tiles' do
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
   homepage 'http://crawl.develz.org'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'Dungeon Crawl Stone Soup - Tiles.app'
 end

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gitx' do
   url 'http://frim.frim.nl/GitXStable.app.zip'
   appcast 'http://gitx.frim.nl/Downloads/appcast.xml'
   homepage 'http://gitx.frim.nl/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'GitX.app'
   binary 'GitX.app/Contents/Resources/gitx'

--- a/Casks/grabbox.rb
+++ b/Casks/grabbox.rb
@@ -6,7 +6,7 @@ cask :v1 => 'grabbox' do
   appcast 'http://grabbox.devsoft.no/appcastBeta.xml',
           :sha256 => '8333d48af84e69f3885f7de4cd553c46a6feceadb1e354bf19a9170c277fabfe'
   homepage 'http://grabbox.devsoft.no/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'GrabBox.app'
 end

--- a/Casks/insertpic.rb
+++ b/Casks/insertpic.rb
@@ -5,7 +5,7 @@ cask :v1 => 'insertpic' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/insertPic/InsertPic_#{version}.zip"
   homepage 'http://www.getinsertpic.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'InsertPic/InsertPic.app'
 end

--- a/Casks/knox.rb
+++ b/Casks/knox.rb
@@ -6,7 +6,7 @@ cask :v1 => 'knox' do
   url "https://d13itkw33a7sus.cloudfront.net/dist/K/Knox-#{version}.zip"
   name 'Knox'
   homepage 'https://agilebits.com/knox'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Knox.app'
 end

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -5,7 +5,7 @@ cask :v1 => 'little-snitch' do
   url "http://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   name 'Little Snitch'
   homepage 'http://www.obdev.at/products/littlesnitch/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   installer :manual => 'Little Snitch Installer.app'
 

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -22,7 +22,7 @@ cask :v1 => 'maintenance' do
   end
 
   homepage 'http://www.titanium.free.fr/downloadmaintenance.php'
-  license :closed
+  license :gratis
 
   app 'Maintenance.app'
 

--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -5,7 +5,7 @@ cask :v1 => 'mediaelch' do
   url "http://www.kvibes.de/releases/mediaelch/#{version}/MediaElch-#{version}.dmg"
   name 'MediaElch'
   homepage 'http://www.kvibes.de/mediaelch/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'MediaElch.app'
 end

--- a/Casks/meerkat.rb
+++ b/Casks/meerkat.rb
@@ -7,7 +7,7 @@ cask :v1 => 'meerkat' do
           :sha256 => 'ef91167a375342e078f147e20477056552bef06ea9e306a93ffb8a17ad4e654c'
   name 'Meerkat'
   homepage 'http://codesorcery.net/meerkat'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Meerkat.app'
 end

--- a/Casks/minitube.rb
+++ b/Casks/minitube.rb
@@ -5,7 +5,7 @@ cask :v1 => 'minitube' do
   url 'http://flavio.tordini.org/files/minitube/minitube.dmg'
   appcast 'http://flavio.tordini.org/minitube-ws/appcast.xml'
   homepage 'http://flavio.tordini.org/minitube'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'Minitube.app'
 end

--- a/Casks/money.rb
+++ b/Casks/money.rb
@@ -7,7 +7,7 @@ cask :v1 => 'money' do
           :sha256 => '92fb9af194903f4f4336c54957feed8537060181eb8c5b4f5b97ccb3c32187e0'
   name 'Money'
   homepage 'http://www.jumsoft.com/money/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Money.app'
 end

--- a/Casks/murasaki.rb
+++ b/Casks/murasaki.rb
@@ -4,7 +4,7 @@ cask :v1 => 'murasaki' do
 
   url "http://genjiapp.com/mac/murasaki/downloads/murasaki_v#{version}.zip"
   homepage 'http://genjiapp.com/mac/murasaki/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Murasaki.app'
 end

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -21,7 +21,7 @@ cask :v1 => 'onyx' do
     # working, or is dangerous to run, on the next OS X release.
   end
   homepage 'http://www.titanium.free.fr/downloadonyx.php'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'OnyX.app'
 

--- a/Casks/pins.rb
+++ b/Casks/pins.rb
@@ -6,7 +6,7 @@ cask :v1 => 'pins' do
   appcast 'http://pinsapp.com/appcast.xml'
   name 'Pins'
   homepage 'http://pinsapp.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Pins.app'
 end

--- a/Casks/quickradar.rb
+++ b/Casks/quickradar.rb
@@ -7,7 +7,7 @@ cask :v1 => 'quickradar' do
           :sha256 => 'a619b28824bf188921dc93eb9d475111c0f5d68ea3ec865562d922a7c312d1f3'
   name 'QuickRadar'
   homepage 'http://www.quickradar.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :bsd
 
   app 'QuickRadar.app'
 end

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -4,7 +4,7 @@ cask :v1 => 'quicksilver' do
 
   url 'http://cdn.qsapp.com/plugins/files/com.blacktree.Quicksilver__16401.dmg'
   homepage 'http://qsapp.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :apache
 
   app 'Quicksilver.app'
 

--- a/Casks/screensteps.rb
+++ b/Casks/screensteps.rb
@@ -4,7 +4,7 @@ cask :v1 => 'screensteps' do
 
   url 'http://www.bluemangolearning.com/download/screensteps/2_0/release/ScreenSteps.dmg'
   homepage 'http://www.bluemangolearning.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'ScreenSteps.app'
 end

--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -5,7 +5,7 @@ cask :v1 => 'seamonkey' do
   # mozilla.org is the official download host per the vendor homepage
   url "https://download.mozilla.org/?product=seamonkey-#{version}&os=osx&lang=en-US"
   homepage 'http://www.seamonkey-project.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :oss
 
   app 'SeaMonkey.app'
 end

--- a/Casks/serf.rb
+++ b/Casks/serf.rb
@@ -6,7 +6,7 @@ cask :v1 => 'serf' do
   url "https://dl.bintray.com/mitchellh/serf/#{version}_darwin_amd64.zip"
   name 'Serf'
   homepage 'http://www.serfdom.io/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :mpl
 
   binary 'serf'
 end

--- a/Casks/tinygrab.rb
+++ b/Casks/tinygrab.rb
@@ -7,7 +7,7 @@ cask :v1 => 'tinygrab' do
           :sha256 => '918a398a34b634076c71660304495a85e1555529f9f3e5432fa961107a481bb3'
   name 'TinyGrab'
   homepage 'http://www.tinygrab.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'TinyGrab.app'
 end

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -4,7 +4,7 @@ cask :v1 => 'unicodechecker' do
 
   url 'http://earthlingsoft.net/UnicodeChecker/UnicodeChecker.dmg'
   homepage 'http://earthlingsoft.net/UnicodeChecker/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'UnicodeChecker.app'
 end


### PR DESCRIPTION
Three minor notes:
- `little-snitch` was committed as `:commercial`.  Their site states:

```
Little Snitch offers a free, built-in demo mode that provides the same protection and functionality
as the full version. The demo runs for three hours, and it can be restarted as often as you like.
The Network Monitor expires after 30 days.
```

I don't consider that to be enough _consistent_ functionality to qualify as `:freemium` but I recognize that someone might think so.
- `seamonkey` was stylized as `:oss` as it is tri-licensed under MPL, GPL, and LGPL.  See link in commit and http://www.seamonkey-project.org/legal/ for more info
- The `murasaki` available to us is `:gratis`, it's just the MAS version that's commercial.
