### PR TITLE
Update download link and sha for Eclipse.app casks

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -2,10 +2,10 @@ cask :v1 => 'eclipse-cpp' do
   version '4.4.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 'bc208f2d3cedeecd721dc8e19d1d1a379ba5b3a295d5622071f8f5a2c1b98905'
+    sha256 '5240642f6b27ace256a02799c27af49f3b9cc3036259247bdd9e848bbea999c7'
     url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-cpp-luna-SR1a-macosx-cocoa.tar.gz'
   else
-    sha256 'bd2fe24d261f8ae7e49cd33cf3b111aad279bdc64cc31efb2cd1fea789d5ae46'
+    sha256 '8c69c32083943c27c38c38808e652020443256c511f28832ee6a7bc31b835241'
     url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-cpp-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
   end
 

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -2,11 +2,11 @@ cask :v1 => 'eclipse-ide' do
   version '4.4.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 '49cc7ff7ac89a8598157de3262128f0240f8283ecdcc9a9ae006143913a4bee6'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-standard-luna-SR1-macosx-cocoa.tar.gz'
+    sha256 'ab9c32bc1d3ff8ebbe763b24ef8a2a1c12e3366427eaebfafaf29f349683d07c'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-standard-luna-SR1a-macosx-cocoa.tar.gz'
   else
-    sha256 '787969d8816d502675cff5b6c9ab1ef4a3b7144d3216def9f90ab623ce71edc1'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-standard-luna-SR1-macosx-cocoa-x86_64.tar.gz'
+    sha256 '528fdda23799600126b0bdd9341d3b749e315eb914a3187bc66317cf9c24d499'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-standard-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
   end
 
   homepage 'http://eclipse.org/'

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -2,11 +2,11 @@ cask :v1 => 'eclipse-java' do
   version '4.4.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 'a4e80a5e4901027f74412786898456d8ce1b6b56d9689293b472f9509d1b65cf'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-java-luna-SR1-macosx-cocoa.tar.gz'
+    sha256 '457293948e937bbe00b642f99978f69861ef8decd54bb1bb49dfc3dcea6a74d2'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-java-luna-SR1a-macosx-cocoa.tar.gz'
   else
-    sha256 'adbfcd2fa587eac82a34da76079747120031a778478b3197ad1c94e537312268'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-java-luna-SR1-macosx-cocoa-x86_64.tar.gz'
+    sha256 'f66896dc46594737d0c60e60dc7bbbb84641d33aa2545e031c2a111c579a17b7'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-java-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
   end
 
   homepage 'http://eclipse.org/'

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -2,11 +2,11 @@ cask :v1 => 'eclipse-jee' do
   version '4.4.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 'ba738cf917df43df7f118fcc2990436cbcd6f2c26290a97dcea12e143250c60f'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-jee-luna-SR1-macosx-cocoa.tar.gz'
+    sha256 '3e3d6c80fb0a4c4fa12060cd52680df0722ebc45efae27e367c1d2a8fa0b8b0b'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-jee-luna-SR1a-macosx-cocoa.tar.gz'
   else
-    sha256 'f17b229e6062cbe2bdf285188faa750d554e89524e23a9adf504fdf6cf3cb257'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-jee-luna-SR1-macosx-cocoa-x86_64.tar.gz'
+    sha256 '6f24c787d247323a69b3c2ba0312edce46a23337d61199276cd2ea8681e90612'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-jee-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
   end
 
   homepage 'http://eclipse.org/'

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -2,11 +2,11 @@ cask :v1 => 'eclipse-modeling' do
   version '4.4.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 'df00541d1291c9f4dda6917ec8f07f22b1cad645f9641be53d9988a86528099d'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-modeling-luna-SR1-macosx-cocoa.tar.gz'
+    sha256 '3224dcba37aba162a3c0e592cd8f64ad6d8296c64579c4132bb3e114890340af'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-modeling-luna-SR1a-macosx-cocoa.tar.gz'
   else
-    sha256 'ad09c657dd1795eee42f1940473ce389168f819ecff7ea022ae0b9517e37f7be'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1/eclipse-modeling-luna-SR1-macosx-cocoa-x86_64.tar.gz'
+    sha256 'd9c978019365b2de0d52fa210a9a9d23246455c5c45f62fb35f32498d42b7c44'
+    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-modeling-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
   end
 
   homepage 'http://eclipse.org/'


### PR DESCRIPTION
eclipse-cpp.rb had the correct URL however the sha was downlevel.
The remaining casks had both URL & SHA updated.
