### PR TITLE
Separate verification from download

### DIFF
--- a/lib/hbc.rb
+++ b/lib/hbc.rb
@@ -34,6 +34,7 @@ require 'hbc/underscore_supporting_uri'
 require 'hbc/url'
 require 'hbc/url_checker'
 require 'hbc/utils'
+require 'hbc/verify'
 require 'hbc/version'
 
 require 'vendor/plist'

--- a/lib/hbc/download.rb
+++ b/lib/hbc/download.rb
@@ -1,7 +1,10 @@
 require 'digest'
+require 'hbc/verify'
 
 class Hbc::Download
   attr_reader :cask
+
+  include Hbc::Verify
 
   def initialize(cask)
     @cask = cask
@@ -27,31 +30,7 @@ class Hbc::Download
                    HOMEBREW_CACHE_CASKS.join(downloaded_path.basename)
     rescue StandardError => e
     end
-    _compare_sha256(downloaded_path, cask)
+    Hbc::Verify.checksum(downloaded_path, cask)
     downloaded_path
-  end
-
-  private
-  def _calc_sha256(path)
-    require 'digest/sha2'
-    Digest::SHA2.file(path).hexdigest
-  end
-
-  def _compare_sha256(path, cask)
-    begin
-      expected = cask.sha256
-    rescue RuntimeError => e
-    end
-    return if expected == :no_check
-    computed = _calc_sha256(path)
-    if expected.nil? or expected.empty?
-      raise Hbc::CaskSha256MissingError.new("sha256 required: sha256 '#{computed}'")
-    end
-    if expected == computed
-      odebug "SHA256 checksums match"
-    else
-      ohai 'Note: running "brew update" may fix sha256 checksum errors'
-      raise Hbc::CaskSha256MismatchError.new(path, expected, computed)
-    end
   end
 end

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 
 require 'hbc/cask_dependencies'
 require 'hbc/staged'
+require 'hbc/verify'
 
 class Hbc::Installer
 
@@ -11,6 +12,7 @@ class Hbc::Installer
   # should be explicit checks on whether staged state is valid in
   # every method.
   include Hbc::Staged
+  include Hbc::Verify
 
   PERSISTENT_METADATA_SUBDIRS = [ 'gpg' ]
 
@@ -59,6 +61,7 @@ class Hbc::Installer
     begin
       satisfy_dependencies(skip_cask_deps)
       download
+      verify
       extract_primary_container
       install_artifacts
       save_caskfile force
@@ -86,6 +89,10 @@ class Hbc::Installer
     @downloaded_path = download.perform
     odebug "Downloaded to -> #{@downloaded_path}"
     @downloaded_path
+  end
+
+  def verify
+    Hbc::Verify.all(@downloaded_path, @cask)
   end
 
   def extract_primary_container

--- a/lib/hbc/verify.rb
+++ b/lib/hbc/verify.rb
@@ -1,6 +1,10 @@
 require 'digest'
 
 module Hbc::Verify
+  def self.all(path, cask)
+    checksum(path, cask)
+  end
+
   def self.checksum(path, cask)
     begin
       expected = cask.sha256

--- a/lib/hbc/verify.rb
+++ b/lib/hbc/verify.rb
@@ -1,0 +1,21 @@
+require 'digest'
+
+module Hbc::Verify
+  def self.checksum(path, cask)
+    begin
+      expected = cask.sha256
+    rescue RuntimeError => e
+    end
+    return if expected == :no_check
+    computed = Digest::SHA2.file(path).hexdigest
+    if expected.nil? or expected.empty?
+      raise Hbc::CaskSha256MissingError.new("sha256 required: sha256 '#{computed}'")
+    end
+    if expected == computed
+      odebug "SHA256 checksums match"
+    else
+      ohai 'Note: running "brew update" may fix sha256 checksum errors'
+      raise Hbc::CaskSha256MismatchError.new(path, expected, computed)
+    end
+  end
+end


### PR DESCRIPTION
Simple refactor, aiding future updates in general and #8749 in particular. We gain a better arrangement for expansion by isolating download strategies and pathstitching from a general provider of verification methods.

Refer to #5971, #7062.

Kindly summoning @phinze for review.
