### PR TITLE
Update homepages for 7 casks 

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -21,7 +21,7 @@ cask :v1 => 'deeper' do
     # working, or is dangerous to run, on the next OS X release.
   end
 
-  homepage 'http://www.titanium.free.fr/downloaddeeper.php'
+  homepage 'http://www.titanium.free.fr/deeper.html'
   license :gratis
 
   app 'Deeper.app'

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -21,7 +21,7 @@ cask :v1 => 'maintenance' do
     # working, or is dangerous to run, on the next OS X release.
   end
 
-  homepage 'http://www.titanium.free.fr/downloadmaintenance.php'
+  homepage 'http://www.titanium.free.fr/maintenance.html'
   license :gratis
 
   app 'Maintenance.app'

--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mediaelch' do
 
   url "http://www.kvibes.de/releases/mediaelch/#{version}/MediaElch-#{version}.dmg"
   name 'MediaElch'
-  homepage 'http://www.kvibes.de/mediaelch/'
+  homepage 'http://www.kvibes.de/en/mediaelch/'
   license :gpl
 
   app 'MediaElch.app'

--- a/Casks/mi.rb
+++ b/Casks/mi.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mi' do
 
   url "http://www.mimikaki.net/download/mi#{version}.dmg"
   name 'Mi'
-  homepage 'http://www.mimikaki.net/'
+  homepage 'http://www.mimikaki.net/en/index.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'mi.app'

--- a/Casks/murasaki.rb
+++ b/Casks/murasaki.rb
@@ -3,7 +3,7 @@ cask :v1 => 'murasaki' do
   sha256 '2dd07c47d59aff053b8be804e08b087ce8d9e127365de43a206011a63ba42966'
 
   url "http://genjiapp.com/mac/murasaki/downloads/murasaki_v#{version}.zip"
-  homepage 'http://genjiapp.com/mac/murasaki/'
+  homepage 'http://genjiapp.com/mac/murasaki/index_en.html'
   license :gratis
 
   app 'Murasaki.app'

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -20,7 +20,7 @@ cask :v1 => 'onyx' do
     # Unusual case: there is no fall-through.  The software will stop
     # working, or is dangerous to run, on the next OS X release.
   end
-  homepage 'http://www.titanium.free.fr/downloadonyx.php'
+  homepage 'http://www.titanium.free.fr/onyx.html'
   license :gratis
 
   app 'OnyX.app'

--- a/Casks/screensteps.rb
+++ b/Casks/screensteps.rb
@@ -3,7 +3,7 @@ cask :v1 => 'screensteps' do
   sha256 'e48082731531198d8c22e5218a7aa59500843e4fd4fd7f44161688aebcfc621b'
 
   url 'http://www.bluemangolearning.com/download/screensteps/2_0/release/ScreenSteps.dmg'
-  homepage 'http://www.bluemangolearning.com/'
+  homepage 'http://www.bluemangolearning.com/screensteps'
   license :commercial
 
   app 'ScreenSteps.app'


### PR DESCRIPTION
- `mi` and `murasaki` moved from Japanese to English page
- `mediaelch` moved from German to English page
- `screensteps` now points to the correct url. (Actually, it points to a redirect (`http://www.bluemangolearning.com/screensteps` to `http://www.screensteps.com/`), but the redirect has the same baseurl (`bluemangolearning.com`) as the download page, so that looked nicer, and is perhaps less likely to change?
- `onyx`, `deeper`, and `maintenance` are all on the same site, the owner just seems to have changed the urls.
