### PR TITLE
parallels-desktop.rb: removed caveats

### DIFF
--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -29,10 +29,4 @@ cask :v1 => 'parallels-desktop' do
                          '~/Library/Preferences/com.parallels.Parallels Desktop.plist',
                          '~/Library/Preferences/com.parallels.Parallels.plist',
                         ]
-
-  caveats <<-EOS.undent
-    The first time you run Parallels Desktop, you will need to enter your
-    password in order to complete the installation.
-
-    EOS
 end


### PR DESCRIPTION
Many applications do this. It is inevitable and the user gains nothing with the warning.
