### PR TITLE
ghc.rb: removed caveats

### DIFF
--- a/Casks/ghc.rb
+++ b/Casks/ghc.rb
@@ -7,5 +7,4 @@ cask :v1 => 'ghc' do
   license :oss
 
   app 'ghc-7.8.3.app'
-  caveats 'To add GHC to your PATH, launch the app and follow the included instructions.'
 end


### PR DESCRIPTION
“Open the app and follow instructions” doesn’t seem to add much.
