### PR TITLE
quotefixformac.rb: turn caveats into actions

### DIFF
--- a/Casks/quotefix.rb
+++ b/Casks/quotefix.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'quotefixformac' do
+cask :v1 => 'quotefix' do
   version '2.5.2'
   sha256 '8d914ae553b84fe5f246ab1eb030d25792ca8d626b3bbac57acee857135e85a9'
 

--- a/Casks/quotefixformac.rb
+++ b/Casks/quotefixformac.rb
@@ -6,18 +6,12 @@ cask :v1 => 'quotefixformac' do
   homepage 'https://github.com/robertklep/quotefixformac'
   license :oss
 
-  stage_only true
-
-  caveats do
-    <<-EOS.undent
-      To enable mail plugins and link QuoteFix:
-
-        defaults write com.apple.mail EnableBundles -bool true
-        defaults write com.apple.mail BundleCompatibilityVersion -string 3
-
-        mkdir -p ~/Library/Mail/Bundles
-        cp -R #{staged_path}/QuoteFix.mailbundle ~/Library/Mail/Bundles/
-        killall Mail; open -a Mail
-    EOS
+  artifact 'QuoteFix.mailbundle', :target => Pathname.new(File.expand_path('~')).join('/Library/Mail/Bundles/QuoteFix.mailbundle')
+  
+  postflight do
+    system 'defaults', 'write', 'com.apple.mail', 'EnableBundles', '-bool', 'true'
+    system 'defaults', 'write', 'com.apple.mail', 'BundleCompatibilityVersion', '-string', '3'
   end
+
+  caveats 'You may need to restart Mail.app before you can use QuoteFix'
 end


### PR DESCRIPTION
Does `artifact` symlink or hardlink? The former may be necessary, but if `artifact` doesn't suffice, we may just add the harlink action to the `postflight`.
