### PR TITLE
td-toolbelt.rb: uncomment zap stanza

### DIFF
--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -14,5 +14,5 @@ cask :v1 => 'td-toolbelt' do
   pkg 'td-toolbelt.pkg'
 
   uninstall :pkgutil => 'com.td.toolbelt'
-  # zap :pkgutil => 'org.ruby-lang.installer'
+  zap :pkgutil => 'org.ruby-lang.installer'
 end


### PR DESCRIPTION
I’m not sure this is correct at all, but it seems like it was [commented out before `zap` was implemented](https://github.com/caskroom/homebrew-cask/commit/5ec879da67823f047e76fe63330aec2d1d1a00b9).

@rolandwalker Do you remember what should be done with this?
