### PR TITLE
microsoft-office: Expand zap stanza, reformat uninstall and zap stanzas

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -8,10 +8,45 @@ cask :v1 => 'microsoft-office' do
 
   pkg 'Office Installer.pkg'
 
-  uninstall :pkgutil => 'com.microsoft.office.*',
+  uninstall :pkgutil   => 'com.microsoft.office.*',
             :launchctl => 'com.microsoft.office.licensing.helper'
-  zap :pkgutil => [
-                  'com.microsoft.mau.all.autoupdate.*',
-                  'com.microsoft.merp.all.errorreporting.*'
-                  ]
+  zap       :pkgutil   => [
+                           'com.microsoft.mau.all.autoupdate.*',
+                           'com.microsoft.merp.all.errorreporting.*'
+                          ],
+            :delete    => [
+                           '/Library/LaunchDaemons/com.microsoft.office.licensing.helper.plist',
+                           '/Library/PrivilegedHelperTools/com.microsoft.office.licensing.helper',
+                           '/Library/Application Support/Microsoft/MAU2.0',
+                           '/Library/Application Support/Microsoft/MERP2.0',
+                           '/Library/Preferences/com.microsoft.Excel.plist',
+                           '/Library/Preferences/com.microsoft.Outlook.plist',
+                           '/Library/Preferences/com.microsoft.PlayReady.plist',
+                           '/Library/Preferences/com.microsoft.Powerpoint.plist',
+                           '/Library/Preferences/com.microsoft.Word.plist',
+                           '/Library/Preferences/com.microsoft.office.licensing.plist',
+                           '/Library/Preferences/com.microsoft.outlook.databasedaemon.plist',
+                           '/Library/Preferences/com.microsoft.outlook.officereminders.plist',
+                           '~/Library/Application Support/Microsoft/Office',
+                           '~/Library/Preferences/com.microsoft.Excel.plist',
+                           '~/Library/Preferences/com.microsoft.Outlook.plist',
+                           '~/Library/Preferences/com.microsoft.Powerpoint.plist',
+                           '~/Library/Preferences/com.microsoft.Word.plist',
+                           '~/Library/Preferences/com.microsoft.autoupdate2.plist',
+                           '~/Library/Preferences/com.microsoft.error_reporting.plist',
+                           '~/Library/Preferences/com.microsoft.office.plist',
+                           '~/Library/Preferences/com.microsoft.office.setupassistant.plist',
+                           '~/Library/Preferences/com.microsoft.outlook.databasedaemon.plist',
+                           '~/Library/Preferences/com.microsoft.outlook.office_reminders.plist',
+                           '~/Library/Preferences/com.microsoft.outlook.officereminders.plist',
+                           '~/Documents/Microsoft User Data/Microsoft',
+                           '~/Documents/Microsoft User Data/Office 2011 Identities',
+                           '~/Documents/Microsoft User Data/Outlook Sound Sets',
+                           '~/Documents/Microsoft User Data/Saved Attachments'
+                          ],
+            :rmdir     => [
+                           '/Library/Application Support/Microsoft',
+                           '~/Library/Application Support/Microsoft',
+                           '~/Documents/Microsoft User Data'
+                          ]
 end


### PR DESCRIPTION
Much of this could be cleaned up if globs were expanded in `zap :delete` strings. There are also a bunch of plist files in `~/Library/Preferences/ByHost` of the form `com.microsoft.<app>.<machine UUID>.plist` that could be zapped if this were the case.
