### PR TITLE
Xamarin-specific JDK and MDK

### DIFF
--- a/Casks/xamarin-jdk.rb
+++ b/Casks/xamarin-jdk.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'xamarin-jdk' do
+  version '1.7.0_71'
+  sha256 '70a18547b529a111c4e5cf133532082e142908819b0d61e273c21dee86fcc87a'
+
+  url 'http://download.xamarin.com/Installer/MonoForAndroid/jdk-7u71-macosx-x64.dmg'
+  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+          :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
+          :format => :unknown
+  homepage 'https://xamarin.com/platform'
+  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  pkg 'JDK 7 Update 71.pkg'
+
+  uninstall :pkgutil => 'com.oracle.jdk7u71'
+end

--- a/Casks/xamarin-mdk.rb
+++ b/Casks/xamarin-mdk.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'xamarin-mdk' do
+  version '3.12.0'
+  sha256 '9591affdb4a342cbba3da0a1d7013592f1c801e2deb7eb70ec9cc1545dda468a'
+
+  url 'http://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-3.12.0.68.macos10.xamarin.x86.pkg'
+  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+          :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
+          :format => :unknown
+  homepage 'https://xamarin.com/platform'
+  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  pkg 'MonoFramework-MDK-3.12.0.68.macos10.xamarin.x86.pkg'
+
+  uninstall :pkgutil => 'com.xamarin.mono-MDK.pkg'
+end


### PR DESCRIPTION
As discussed in #9174, the Xamarin GUI installer fetches unique copies of the Oracle JDK and the Mono MDK which are both hosted on Xamarin's download server, as shown in the [Xamarin appcast](http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml).

The new `xamarin-jdk` and `xamarin-mdk` Casks allow `homebrew-cask` users to replicate the Xamarin GUI installer as closely as possible.
