### PR TITLE
Add Go2Shell.app Latest

### DIFF
--- a/Casks/go2shell.rb
+++ b/Casks/go2shell.rb
@@ -5,7 +5,7 @@ cask :v1 => 'go2shell' do
   url 'http://zipzapmac.com/DMGs/Go2Shell.dmg'
   name 'Go2Shell'
   homepage 'http://zipzapmac.com/Go2Shell'
-  license :closed
+  license :gratis
 
   app 'Go2Shell.app'
 end

--- a/Casks/go2shell.rb
+++ b/Casks/go2shell.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'go2shell' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://zipzapmac.com/DMGs/Go2Shell.dmg'
+  name 'Go2Shell'
+  homepage 'http://zipzapmac.com/Go2Shell'
+  license :closed
+
+  app 'Go2Shell.app'
+end


### PR DESCRIPTION
Go2Shell opens a terminal window to the current directory in Finder.

The app installs a Finder extension. Didn't know how to uninstall it, besides using the uninstall feature inside the app (see http://zipzapmac.com/Go2Shell).

Unfortunately:
- No versioned download available.
- No https download available.

The app is also available in the Mac App Store, but without Finder extension.
