### PR TITLE
Update tex-live-utility to 1.19, new hosting

### DIFF
--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'tex-live-utility' do
-  version '1.17'
-  sha256 '9a913cbf0e158258c513fc0905f65632b36d372d1b4b9afe6b6f08dd005ff232'
+  version '1.19'
+  sha256 'ef6beecc42d6b194f18795b46951bf274a5c838d8192f56e4437225af56e2820'
 
-  url "https://mactlmgr.googlecode.com/files/TeX%20Live%20Utility.app-#{version}.tar.gz"
-  appcast 'http://mactlmgr.googlecode.com/svn/trunk/appcast/tlu_appcast.xml',
-          :sha256 => '46284194061f7d6cc766ac15ed11267a4dbaa27a6f6643b3afe930fe7d89d746'
-  homepage 'https://code.google.com/p/mactlmgr/'
+  url 'https://github.com/amaxwell/tlutility/releases/download/1.19/TeX.Live.Utility.app-1.19.tar.gz'
+  appcast 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml',
+          :sha256 => '9ca9e537751be33f6757984dd7d1d28a84d680bddb53c37fc7942adcd72b0eca'
+  homepage 'https://github.com/amaxwell/tlutility'
   license :oss
 
   app 'TeX Live Utility.app'


### PR DESCRIPTION
The author switched to github for newer versions.
