### PR TITLE
Add pdftotext cask

### DIFF
--- a/Casks/pdftotext.rb
+++ b/Casks/pdftotext.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'pdftotext' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.bluem.net/files/pdftotext.dmg'
+  name 'pdftotext'
+  homepage 'http://www.bluem.net/en/mac/packages/'
+  license :gpl
+
+  pkg 'Installer.pkg'
+  uninstall :pkgutil => 'net.bluem.pdftotext.pkg'
+end


### PR DESCRIPTION
This adds a cask for the `pdftotext` software. I'm not sure what I need to do for the `uninstall` bit.
