### PR TITLE
Update Bowery.pkg to version 0.0.0

### DIFF
--- a/Casks/bowery.rb
+++ b/Casks/bowery.rb
@@ -1,10 +1,11 @@
 cask :v1 => 'bowery' do
-  version '3.3.1'
-  sha256 '7ebe18bd25df7156027e5be857528a20c86ca8251a94d437086c77c6fb8b1f73'
+  version '0.0.0'
+  sha256 '86fc89cab7f4cfca1e85689c228cde83612e2dc20648bbd45ae79160159ae2e3'
 
   url "http://desktop.bowery.io/#{version}_darwin_amd64.zip"
+  name 'Bowery'
   homepage 'http://bowery.io/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :freemium
 
   pkg 'bowery.pkg'
 


### PR DESCRIPTION
The version number is set to `0.0.0` because of a complete rewrite of the app.
