### PR TITLE
Updated LibreOffice to v4.4.0 (64 bit only)

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'libreoffice' do
-  version '4.3.5'
-
   if Hardware::CPU.is_32_bit? or MacOS.release < :mountain_lion
+    version '4.3.5'
     sha256 '0121e87396a880884a6fac02e7799fe5bc4cbfe0e346a60aa21176acbd44602f'
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else
-    sha256 '46d33f40207fcdc8737e44ee951432727ed19788721746ea44e59cc14da15553'
+    version '4.4.0'
+    sha256 '297bc7952db491feee8d1823ff424e8d6e4ccdcddc9b66a37c99d32c6b19016c'
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end


### PR DESCRIPTION
Today the latest stable version of LibreOffice, version 4.4.0 was released.
Since this version has no more support for 32 bit CPU or OS X version older than 10.8 (Mountain Lion), we have to install different versions based on OS and CPU architecture.

(For further information read the [_notes_ on the LibreOffice website](http://www.libreoffice.org/get-help/system-requirements/#Apple)
