### PR TITLE
Adding Amazon Workspaces

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'amazon-workspaces' do
+  version :latest
+  sha256 :no_check
+
+  # cloudfront.net is the official download host per the vendor homepage
+  url 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg'
+  name 'Amazon Workspaces'
+  homepage 'https://aws.amazon.com/workspaces/'
+  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  pkg 'WorkSpaces.pkg'
+
+  uninstall :pkgutil => 'com.amazon.workspaces'
+end


### PR DESCRIPTION
Proposed token:               workspaces
Proposed file name:           workspaces.rb
Cask Header Line:             cask :v1 => 'workspaces' do

I overrode the proposed token/filename with amazon-workspaces to make it match with its sister product (Zocalo: https://github.com/caskroom/homebrew-cask/blob/master/Casks/amazon-zocalo.rb).
