### PR TITLE
Clarify most :oss licenses

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -6,7 +6,7 @@ cask :v1 => 'aether' do
   url "https://github.com/nehbit/aether-public/releases/download/v#{version}-OSX/Aether.#{version}.dmg"
   name 'Aether'
   homepage 'http://getaether.net/'
-  license :oss
+  license :affero
 
   app 'Aether.app'
 end

--- a/Casks/all-the-gifs.rb
+++ b/Casks/all-the-gifs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'all-the-gifs' do
   url 'https://raw.github.com/orta/GIFs/master/web/GIFs.app.zip'
   name 'All The GIFs'
   homepage 'https://github.com/orta/GIFs'
-  license :oss
+  license :bsd
 
   app 'All The GIFs.app'
 end

--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -7,7 +7,7 @@ cask :v1 => 'amethyst' do
   appcast 'http://ianyh.github.io/Amethyst/appcast.xml',
           :sha256 => '483c803029845953a1d93aa93f7ba2856d0cf1ca5a246d7d98b61508f7b09ff8'
   homepage 'http://ianyh.com/amethyst'
-  license :oss
+  license :mit
 
   app 'Amethyst.app'
 end

--- a/Casks/apns-pusher.rb
+++ b/Casks/apns-pusher.rb
@@ -5,7 +5,7 @@ cask :v1 => 'apns-pusher' do
   url "https://github.com/blommegard/APNS-Pusher/releases/download/v#{version}/APNS.Pusher.app.zip"
   name 'APNS Pusher'
   homepage 'https://github.com/blommegard/APNS-Pusher'
-  license :oss
+  license :mit
 
   app 'APNS Pusher.app'
 end

--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -6,7 +6,7 @@ cask :v1 => 'appium' do
   url "https://bitbucket.org/appium/appium.app/downloads/appium-#{version}.dmg"
   name 'Appium'
   homepage 'http://appium.io'
-  license :oss
+  license :apache
 
   app 'Appium.app'
 end

--- a/Casks/aquaterm.rb
+++ b/Casks/aquaterm.rb
@@ -5,7 +5,7 @@ cask :v1 => 'aquaterm' do
   url "http://downloads.sourceforge.net/project/aquaterm/AquaTerm/v#{version}/AquaTerm-#{version}.dmg"
   name 'AquaTerm'
   homepage 'http://aquaterm.sourceforge.net/'
-  license :oss
+  license :bsd
 
   pkg 'AquaTermInstaller.pkg'
 

--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -5,7 +5,7 @@ cask :v1 => 'aria-maestosa' do
   url "http://downloads.sourceforge.net/sourceforge/ariamaestosa/AriaMaestosa-osx-#{version}.zip"
   name 'Aria Maestosa'
   homepage 'http://ariamaestosa.sourceforge.net'
-  license :oss
+  license :gpl
 
   app "AriaMaestosa-#{version}/Aria Maestosa.app"
 end

--- a/Casks/arrsync.rb
+++ b/Casks/arrsync.rb
@@ -5,7 +5,7 @@ cask :v1 => 'arrsync' do
   url "http://downloads.sourceforge.net/sourceforge/arrsync/arrsync-#{version}.dmg"
   name 'arRsync'
   homepage 'http://arrsync.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'arRsync.app'
 end

--- a/Casks/audioscrobbler.rb
+++ b/Casks/audioscrobbler.rb
@@ -5,7 +5,7 @@ cask :v1 => 'audioscrobbler' do
   url "https://github.com/mxcl/Audioscrobbler.app/releases/download/#{version}/Audioscrobbler-#{version}.zip"
   name 'Audioscrobbler'
   homepage 'https://github.com/mxcl/Audioscrobbler.app'
-  license :oss
+  license :gpl
 
   app 'Audioscrobbler.app'
 end

--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -6,7 +6,7 @@ cask :v1 => 'avidemux' do
   url "http://downloads.sourceforge.net/avidemux/Avidemux_#{version}_ml_64bits.dmg"
   name 'Avidemux'
   homepage 'http://www.avidemux.org/'
-  license :oss
+  license :gpl
 
   app 'Avidemux2.6.app'
 end

--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -6,7 +6,7 @@ cask :v1 => 'bibdesk' do
   appcast 'http://bibdesk.sourceforge.net/bibdesk.xml',
           :sha256 => '1e2b0f0c5e7de9f352ffa2f5b894ec5c4c3c0bb22c4a2018fa5b054df1ebfaa5'
   homepage 'http://bibdesk.sourceforge.net/'
-  license :oss
+  license :bsd
 
   app 'BibDesk.app'
 

--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -7,7 +7,7 @@ cask :v1 => 'bit-slicer' do
   appcast 'http://zorg.tejat.net/bitslicer/update.php',
           :sha256 => '11d0afe33a4cbf65a8df4c4d323b150853a62b0cbfe77d36dc70b5113aeca631'
   homepage 'https://github.com/zorgiepoo/bit-slicer/'
-  license :oss
+  license :bsd
 
   app 'Bit Slicer.app'
 end

--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -5,7 +5,7 @@ cask :v1 => 'blink1control' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
   homepage 'http://blink1.thingm.com/'
-  license :oss
+  license :cc
 
   app 'Blink1Control.app'
 end

--- a/Casks/bob.rb
+++ b/Casks/bob.rb
@@ -4,7 +4,7 @@ cask :v1 => 'bob' do
 
   url "https://github.com/casperstorm/Bob/releases/download/#{version}/Bob.zip"
   homepage 'https://github.com/casperstorm/Bob'
-  license :oss
+  license :mit
 
   app 'Bob.app'
 end

--- a/Casks/boot2docker.rb
+++ b/Casks/boot2docker.rb
@@ -4,7 +4,7 @@ cask :v1 => 'boot2docker' do
 
   url "https://github.com/boot2docker/osx-installer/releases/download/v#{version}/Boot2Docker-#{version}.pkg"
   homepage 'https://github.com/boot2docker/osx-installer'
-  license :oss
+  license :apache
 
   pkg "Boot2Docker-#{version}.pkg"
 

--- a/Casks/boxofsnoo-fairmount.rb
+++ b/Casks/boxofsnoo-fairmount.rb
@@ -7,7 +7,7 @@ cask :v1 => 'boxofsnoo-fairmount' do
           :sha256 => '3587cb776ce0e4e8237f215800b7dffba0f25865cb84550e87ea8bbac838c423'
   name 'Fairmount'
   homepage 'https://github.com/BoxOfSnoo/Fairmount'
-  license :oss
+  license :gpl
 
   app 'Fairmount.app'
 end

--- a/Casks/brain-workshop.rb
+++ b/Casks/brain-workshop.rb
@@ -4,7 +4,7 @@ cask :v1 => 'brain-workshop' do
 
   url "http://downloads.sourceforge.net/project/brainworkshop/brainworkshop/Brain%20Workshop%204.8/brainworkshop-#{version}-MacOSX.zip"
   homepage 'http://brainworkshop.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Brain Workshop.app'
 end

--- a/Casks/bricksmith.rb
+++ b/Casks/bricksmith.rb
@@ -5,7 +5,7 @@ cask :v1 => 'bricksmith' do
   url "http://downloads.sourceforge.net/sourceforge/bricksmith/bricksmith/Bricksmith%20#{version}/BricksmithComplete#{version}.zip"
   name 'Bricksmith'
   homepage 'http://bricksmith.sourceforge.net/'
-  license :oss
+  license :bsd
 
   app 'Bricksmith/Bricksmith.app'
 end

--- a/Casks/brushviewql.rb
+++ b/Casks/brushviewql.rb
@@ -4,7 +4,7 @@ cask :v1 => 'brushviewql' do
 
   url 'http://brushviewer.sourceforge.net/brushviewql.zip'
   homepage 'http://brushviewer.sourceforge.net/'
-  license :oss
+  license :gpl
 
   qlplugin 'BrushViewQL/BrushViewQL.qlgenerator'
 end

--- a/Casks/ccmenu.rb
+++ b/Casks/ccmenu.rb
@@ -7,7 +7,7 @@ cask :v1 => 'ccmenu' do
           :sha256 => 'a72951f416906d309cb7ec8d233bf5546540641efa99332e0f1bdde119b51cac'
   name 'CCMenu'
   homepage 'http://ccmenu.sourceforge.net/'
-  license :oss
+  license :bsd
 
   app 'CCMenu.app'
 end

--- a/Casks/celestia.rb
+++ b/Casks/celestia.rb
@@ -5,7 +5,7 @@ cask :v1 => 'celestia' do
   url "http://downloads.sourceforge.net/sourceforge/celestia/celestia-osx-#{version}.dmg"
   name 'Celestia'
   homepage 'http://sourceforge.net/projects/celestia'
-  license :oss
+  license :gpl
 
   app 'Celestia.app'
 end

--- a/Casks/chicken.rb
+++ b/Casks/chicken.rb
@@ -7,7 +7,7 @@ cask :v1 => 'chicken' do
           :sha256 => 'a649ec458aa8ea0bd34ed395a85d35d7ca333f2442d1c209c8f159226ba92088'
   name 'Chicken'
   homepage 'http://sourceforge.net/projects/chicken/'
-  license :oss
+  license :gpl
 
   app 'Chicken.app'
 

--- a/Casks/clementine.rb
+++ b/Casks/clementine.rb
@@ -8,7 +8,7 @@ cask :v1 => 'clementine' do
           :sha256 => 'aa4ef8bb841b9eea028181b5a884073fe51893f4a15d7061eb84f117ff161383'
   name 'Clementine'
   homepage 'http://www.clementine-player.org/'
-  license :oss
+  license :gpl
 
   app 'clementine.app'
 

--- a/Casks/cloudfoundry-cli.rb
+++ b/Casks/cloudfoundry-cli.rb
@@ -6,7 +6,7 @@ cask :v1 => 'cloudfoundry-cli' do
   url "http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v#{version}/installer-osx-amd64.pkg"
   name 'Cloud Foundry CLI'
   homepage 'https://github.com/cloudfoundry/cli'
-  license :oss
+  license :apache
 
   pkg 'installer-osx-amd64.pkg'
 

--- a/Casks/cloudytabs.rb
+++ b/Casks/cloudytabs.rb
@@ -6,7 +6,7 @@ cask :v1 => 'cloudytabs' do
   appcast 'http://joshparnham.com/projects/cloudytabs/appcast.xml',
           :sha256 => '70140cb26a2a25589d739d6dac6f2e04118a938814909fe08c720b0174adf2b4'
   homepage 'https://github.com/josh-/CloudyTabs/'
-  license :oss
+  license :mit
 
   app 'CloudyTabs.app'
 end

--- a/Casks/coccinellida.rb
+++ b/Casks/coccinellida.rb
@@ -6,7 +6,7 @@ cask :v1 => 'coccinellida' do
   appcast 'http://coccinellida.sourceforge.net/sparkle.xml',
           :sha256 => '8d868a49b014c2ccee0289d54a0a22883c6eadc20e2246f58c49939ad00b55a1'
   homepage 'http://coccinellida.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Coccinellida.app'
 end

--- a/Casks/cocoadialog.rb
+++ b/Casks/cocoadialog.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cocoadialog' do
   url "https://github.com/downloads/mstratman/cocoadialog/CocoaDialog-#{version}.dmg"
   name 'cocoaDialog'
   homepage 'http://mstratman.github.io/cocoadialog/'
-  license :oss
+  license :gpl
 
   app 'CocoaDialog.app'
 end

--- a/Casks/cocoarestclient.rb
+++ b/Casks/cocoarestclient.rb
@@ -6,7 +6,7 @@ cask :v1 => 'cocoarestclient' do
   appcast 'http://restlesscode.org/cocoa-rest-client/appcast.xml',
           :sha256 => '32d1b71d2ade6fc17554d1e7bcbc900c9ace68c34046ea7c2d785142e0d60520'
   homepage 'http://mmattozzi.github.io/cocoa-rest-client/'
-  license :oss
+  license :bsd
 
   app 'CocoaRestClient.app'
 end

--- a/Casks/cord.rb
+++ b/Casks/cord.rb
@@ -7,7 +7,7 @@ cask :v1 => 'cord' do
           :sha256 => '891e1675b678f03d7f050ecb426c28362dab3c92da1592fce8a36afcb7606b69'
   name 'CoRD'
   homepage 'http://cord.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'CoRD.app'
 

--- a/Casks/corsixth.rb
+++ b/Casks/corsixth.rb
@@ -5,7 +5,7 @@ cask :v1 => 'corsixth' do
   url "https://github.com/CorsixTH/CorsixTH/releases/download/v#{version}/CorsixTH-#{version}-OSX.dmg"
   name 'CorsixTH'
   homepage 'https://github.com/CorsixTH/CorsixTH'
-  license :oss
+  license :mit
 
   app 'CorsixTH.app'
 end

--- a/Casks/cuda-z.rb
+++ b/Casks/cuda-z.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cuda-z' do
 
   url "http://downloads.sourceforge.net/sourceforge/cuda-z/CUDA-Z-#{version}.dmg"
   homepage 'http://cuda-z.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'Cuda-Z.app'
 end

--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -6,7 +6,7 @@ cask :v1 => 'darktable' do
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
   name 'darktable'
   homepage 'http://www.darktable.org/'
-  license :oss
+  license :gpl
 
   app 'darktable.app'
 end

--- a/Casks/desmume.rb
+++ b/Casks/desmume.rb
@@ -6,7 +6,7 @@ cask :v1 => 'desmume' do
   url "http://downloads.sourceforge.net/sourceforge/desmume/desmume-#{version}-mac.dmg"
   name 'DeSmuME'
   homepage 'http://www.desmume.org'
-  license :oss
+  license :gpl
 
   app 'DeSmuME.app'
 end

--- a/Casks/dewdrop.rb
+++ b/Casks/dewdrop.rb
@@ -6,7 +6,7 @@ cask :v1 => 'dewdrop' do
   appcast 'http://dewdrop.dangelov.com/mac-appcast/updates.xml',
           :sha256 => 'cc5d4548c5de855094a44f026c78cf7a3dfccd9b29a79c29eeb7caaa4bd7acb3'
   homepage 'http://dewdrop.dangelov.com/'
-  license :oss
+  license :gpl
 
   app 'Dewdrop.app'
 

--- a/Casks/dia.rb
+++ b/Casks/dia.rb
@@ -6,7 +6,7 @@ cask :v1 => 'dia' do
   url "http://downloads.sourceforge.net/dia-installer/dia/#{version.sub(%r{-.*},'')}/Dia-#{version}.dmg"
   name 'Dia'
   homepage 'http://dia-installer.de/'
-  license :oss
+  license :gpl
 
   app 'Dia.app'
 end

--- a/Casks/diashapes.rb
+++ b/Casks/diashapes.rb
@@ -6,7 +6,7 @@ cask :v1 => 'diashapes' do
   url "http://downloads.sourceforge.net/project/dia-installer/diashapes/#{version}/diashapes-#{version}.dmg"
   name 'Dia'
   homepage 'http://dia-installer.de/'
-  license :oss
+  license :gpl
 
   app 'Diashapes.app'
 end

--- a/Casks/djv.rb
+++ b/Casks/djv.rb
@@ -6,7 +6,7 @@ cask :v1 => 'djv' do
   name 'DJV'
   name 'DJV Imaging'
   homepage 'http://djv.sourceforge.net'
-  license :oss
+  license :bsd
 
   app "djv-#{version}-OSX-64.app"
 end

--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -5,7 +5,7 @@ cask :v1 => 'djview' do
   url "http://downloads.sourceforge.net/sourceforge/djvu/djvulibre-3.5.22%2Bdjview-#{version}-intel-3.zip"
   name 'DjView'
   homepage 'http://djvu.sourceforge.net/'
-  license :oss
+  license :gpl
 
   container :nested => "djvulibre-3.5.22+djview-#{version}-intel.dmg"
   app 'DjView.app'

--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -5,7 +5,7 @@ cask :v1 => 'dosbox' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/dosbox/dosbox/#{version}/DOSBox-#{version}-1_Universal.dmg"
   homepage 'http://www.dosbox.com'
-  license :oss
+  license :gpl
 
   app 'DOSBox.app'
 end

--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -5,7 +5,7 @@ cask :v1 => 'double-commander' do
   url "http://downloads.sourceforge.net/sourceforge/doublecmd/doublecmd-#{version}-5390.qt.x86_64.dmg"
   name 'Double Commander'
   homepage 'http://doublecmd.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Double Commander.app'
 end

--- a/Casks/doublecommand.rb
+++ b/Casks/doublecommand.rb
@@ -4,7 +4,7 @@ cask :v1 => 'doublecommand' do
 
   url "http://doublecommand.sourceforge.net/files/DoubleCommand-#{version}.dmg"
   homepage 'http://doublecommand.sourceforge.net'
-  license :oss
+  license :gpl
 
   pkg "DoubleCommand-#{version}.pkg"
 

--- a/Casks/dropletmanager.rb
+++ b/Casks/dropletmanager.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dropletmanager' do
 
   url "https://github.com/deivuh/DODropletManager-OSX/releases/download/v#{version}/DropletManager.v#{version}.zip"
   homepage 'https://github.com/deivuh/DODropletManager-OSX'
-  license :oss
+  license :gpl
 
   app 'DropletManager.app'
 end

--- a/Casks/dvdstyler.rb
+++ b/Casks/dvdstyler.rb
@@ -6,7 +6,7 @@ cask :v1 => 'dvdstyler' do
   url "http://downloads.sourceforge.net/sourceforge/dvdstyler/DVDStyler-#{version}-MacOSX.dmg"
   name 'DVDStyler'
   homepage 'http://dvdstyler.org'
-  license :oss
+  license :gpl
 
   app 'DVDStyler.app'
 end

--- a/Casks/dwihn0r-keepassx.rb
+++ b/Casks/dwihn0r-keepassx.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dwihn0r-keepassx' do
 
   url "https://github.com/dwihn0r/keepassx/releases/download/v#{version}/KeePassX-#{version}-OSX.zip"
   homepage 'https://github.com/dwihn0r/keepassx/'
-  license :oss
+  license :gpl
 
   app 'KeePassX.app'
 end

--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -5,7 +5,7 @@ cask :v1 => 'exist-db' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/exist/eXist-db-#{version}.dmg"
   homepage 'http://exist-db.org/'
-  license :oss
+  license :gpl
 
   app 'eXist-db.app'
 end

--- a/Casks/feedbinnotifier.rb
+++ b/Casks/feedbinnotifier.rb
@@ -5,7 +5,7 @@ cask :v1 => 'feedbinnotifier' do
   url "https://github.com/kmikael/FeedbinNotifier/releases/download/v#{version}/FeedbinNotifier.zip"
   name 'Feedbin Notifier'
   homepage 'http://kmikael.github.io/FeedbinNotifier'
-  license :oss
+  license :mit
 
   app 'FeedbinNotifier.app'
 end

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -5,7 +5,7 @@ cask :v1 => 'filebot' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/filebot/filebot/FileBot_#{version}/FileBot_#{version}.app.tar.gz"
   homepage 'http://www.filebot.net/'
-  license :oss
+  license :gpl
 
   app 'FileBot.app'
   binary 'FileBot.app/Contents/MacOS/filebot.sh', :target => 'filebot'

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -12,7 +12,7 @@ cask :v1 => 'filezilla' do
   url "http://downloads.sourceforge.net/project/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
-  license :oss
+  license :gpl
 
   app 'FileZilla.app'
   # todo verify that this does not contain user-generate content

--- a/Casks/fpc.rb
+++ b/Casks/fpc.rb
@@ -5,7 +5,7 @@ cask :v1 => 'fpc' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/freepascal/fpc-#{version}.intel-macosx.dmg"
   homepage 'http://www.freepascal.org/'
-  license :oss
+  license :gpl
 
   pkg "fpc-#{version}rc1.intel-macosx.pkg"
 

--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -4,7 +4,7 @@ cask :v1 => 'freecad' do
 
   url "http://downloads.sourceforge.net/sourceforge/free-cad/FreeCAD-#{version}_osx_x64.zip"
   homepage 'http://sourceforge.net/projects/free-cad/'
-  license :oss
+  license :gpl
 
   app "FreeCAD-#{version}_osx_x64/FreeCAD.app"
 end

--- a/Casks/freecol.rb
+++ b/Casks/freecol.rb
@@ -6,7 +6,7 @@ cask :v1 => 'freecol' do
   url "http://downloads.sourceforge.net/sourceforge/freecol/freecol-#{version}-mac.tar.bz2"
   name 'FreeCol'
   homepage 'http://freecol.org'
-  license :oss
+  license :gpl
 
   app 'FreeCol.app'
 end

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -4,7 +4,7 @@ cask :v1 => 'freefilesync' do
 
   url "http://downloads.sourceforge.net/project/freefilesync/FreeFileSync/#{version}/FreeFileSync_#{version}_Mac_OS_X_64-bit.zip"
   homepage 'http://freefilesync.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'FreeFileSync.app'
   app 'RealtimeSync.app'

--- a/Casks/freemind.rb
+++ b/Casks/freemind.rb
@@ -4,7 +4,7 @@ cask :v1 => 'freemind' do
 
   url "http://downloads.sourceforge.net/project/freemind/freemind/#{version}/FreeMind_#{version}.dmg"
   homepage 'freemind.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'FreeMind.app'
 end

--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -6,7 +6,7 @@ cask :v1 => 'freesmug-chromium' do
   url "http://downloads.sourceforge.net/sourceforge/osxportableapps/ChromiumOSX_#{version}.dmg"
   appcast 'http://osxportableapps.sourceforge.net/chromium/chrcast.xml'
   homepage 'http://www.freesmug.org/chromium'
-  license :oss
+  license :gpl
 
   app 'Chromium.app'
 end

--- a/Casks/fugu.rb
+++ b/Casks/fugu.rb
@@ -5,7 +5,7 @@ cask :v1 => 'fugu' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/fugussh/Unstable/fugu-#{version}/Fugu-#{version}.zip"
   homepage 'http://rsug.itd.umich.edu/software/fugu/'
-  license :oss
+  license :bsd
 
   app 'Fugu.app'
 end

--- a/Casks/fwbuilder.rb
+++ b/Casks/fwbuilder.rb
@@ -5,7 +5,7 @@ cask :v1 => 'fwbuilder' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/fwbuilder/fwbuilder-#{version}.dmg"
   homepage 'http://www.fwbuilder.org'
-  license :oss
+  license :gpl
 
   app "fwbuilder-#{version}.app"
 end

--- a/Casks/gawker.rb
+++ b/Casks/gawker.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gawker' do
   appcast 'http://gawker.sourceforge.net/appcast.xml'
   name 'Gawker'
   homepage 'http://gawker.sourceforge.net/Gawker.html'
-  license :oss
+  license :gpl
 
   app 'Gawker.app'
 end

--- a/Casks/gingr.rb
+++ b/Casks/gingr.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gingr' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/marbl/gingr/releases/download/v#{version}/gingr-OSX64-v#{version}.zip"
   homepage 'http://harvest.readthedocs.org/en/latest/content/gingr.html'
-  license :oss
+  license :bsd
 
   app 'gingr.app'
 end

--- a/Casks/gitifier.rb
+++ b/Casks/gitifier.rb
@@ -7,7 +7,7 @@ cask :v1 => 'gitifier' do
           :sha256 => '5bf8682d28e0a59966f8107efbca6be05b60a32252da7288952b35c3fb4e269b'
   name 'Gitifier'
   homepage 'http://psionides.github.io/Gitifier/'
-  license :oss
+  license :eclipse
 
   app 'Gitifier.app'
 end

--- a/Casks/gmail-notifier.rb
+++ b/Casks/gmail-notifier.rb
@@ -4,7 +4,7 @@ cask :v1 => 'gmail-notifier' do
 
   url "https://github.com/jashephe/Gmail-Notifier/releases/download/v#{version}/Gmail.Notifier.v#{version}.zip"
   homepage 'https://github.com/jashephe/Gmail-Notifier'
-  license :oss
+  license :bsd
 
   app 'Gmail Notifier.app'
 end

--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gnucash' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-#{version}.dmg"
   homepage 'http://www.gnucash.org'
-  license :oss
+  license :gpl
 
   app 'Gnucash.app'
   app 'FinanceQuote Update.app'

--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -18,7 +18,7 @@ cask :v1 => 'golly' do
   end
 
   homepage 'http://golly.sourceforge.net/'
-  license :oss
+  license :gpl
 
   caveats do
     files_in_usr_local

--- a/Casks/google-refine.rb
+++ b/Casks/google-refine.rb
@@ -5,7 +5,7 @@ cask :v1 => 'google-refine' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenRefine/OpenRefine/releases/download/2.5/google-refine-#{version}.dmg"
   homepage 'http://openrefine.org/'
-  license :oss
+  license :bsd
 
   app 'Google Refine.app'
 

--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gramps' do
   url "http://downloads.sourceforge.net/project/gramps/Stable/#{version.sub(%r{-\d},'')}/Gramps-Intel-#{version}.dmg"
   name 'Gramps'
   homepage 'https://gramps-project.org/'
-  license :oss
+  license :gpl
 
   app 'Gramps.app'
 end

--- a/Casks/grandperspective.rb
+++ b/Casks/grandperspective.rb
@@ -4,7 +4,7 @@ cask :v1 => 'grandperspective' do
 
   url "http://downloads.sourceforge.net/project/grandperspectiv/grandperspective/#{version}/GrandPerspective-#{version.gsub('.','_')}.dmg"
   homepage 'http://grandperspectiv.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'GrandPerspective.app'
 

--- a/Casks/graphsketcher.rb
+++ b/Casks/graphsketcher.rb
@@ -4,7 +4,7 @@ cask :v1 => 'graphsketcher' do
 
   url "https://github.com/graphsketcher/GraphSketcher/releases/download/#{version}/GraphSketcher.zip"
   homepage 'https://github.com/graphsketcher/GraphSketcher'
-  license :oss
+  license :mit
 
   app 'GraphSketcher/GraphSketcher.app'
 end

--- a/Casks/gravit.rb
+++ b/Casks/gravit.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gravit' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/quasado/gravit-hub/releases/download/#{version}/Gravit-Mac-OSX.dmg"
   homepage 'http://gravit.io/'
-  license :oss
+  license :cc
 
   app 'Gravit.app'
 end

--- a/Casks/gulp.rb
+++ b/Casks/gulp.rb
@@ -4,7 +4,7 @@ cask :v1 => 'gulp' do
 
   url "https://github.com/sindresorhus/gulp-app/releases/download/#{version}/gulp.app.zip"
   homepage 'https://github.com/sindresorhus/gulp-app'
-  license :oss
+  license :mit
 
   app 'gulp.app'
 end

--- a/Casks/gurps-character-sheet.rb
+++ b/Casks/gurps-character-sheet.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gurps-character-sheet' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/gcs-java/gcs-#{version}-mac.zip"
   homepage 'http://gurpscharactersheet.com'
-  license :oss
+  license :mpl
 
   app "gcs-#{version}-mac/GURPS Character Sheet.app"
 end

--- a/Casks/happygrep.rb
+++ b/Casks/happygrep.rb
@@ -4,7 +4,7 @@ cask :v1 => 'happygrep' do
 
   url "https://github.com/happypeter/happygrep/releases/download/v#{version}/happygrep.zip"
   homepage 'https://github.com/happypeter/happygrep'
-  license :oss
+  license :mit
 
   binary 'happygrep'
 end

--- a/Casks/haroopad.rb
+++ b/Casks/haroopad.rb
@@ -6,7 +6,7 @@ cask :v1 => 'haroopad' do
   url "https://bitbucket.org/rhiokim/haroopad-download/downloads/Haroopad-v#{version}-x64.dmg"
   name 'Haroopad'
   homepage 'http://pad.haroopress.com/'
-  license :oss
+  license :gpl
 
   app 'haroopad.app'
 end

--- a/Casks/hexchat.rb
+++ b/Casks/hexchat.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hexchat' do
   # hexchat.net is the official download host per the vendor homepage
   url "http://dl.hexchat.net/hexchat/osx/HexChat-#{version}.app.zip"
   homepage 'http://hexchat.github.io'
-  license :oss
+  license :gpl
 
   app 'HexChat.app'
 end

--- a/Casks/hive.rb
+++ b/Casks/hive.rb
@@ -7,7 +7,7 @@ cask :v1 => 'hive' do
   appcast 'https://hivewallet.com/hive-osx-appcast.xml',
           :sha256 => '53a58f4b4bc888cde3e036ee3b09b44f0ba19b321492c82a93acc01891d310e1'
   homepage 'http://www.hivewallet.com'
-  license :oss
+  license :gpl
 
   app 'Hive.app'
 

--- a/Casks/honer.rb
+++ b/Casks/honer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'honer' do
 
   url "https://github.com/puffnfresh/Honer.app/releases/download/v#{version}/Honer-6e3863f2.zip"
   homepage 'https://github.com/puffnfresh/Honer.app'
-  license :oss
+  license :mit
 
   app 'Honer.app'
 end

--- a/Casks/hosts.rb
+++ b/Casks/hosts.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hosts' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/downloads/specialunderwear/Hosts.prefpane/Hosts-#{version}.pkg"
   homepage 'http://permanentmarkers.nl/software.html'
-  license :oss
+  license :gpl
 
   pkg "Hosts-#{version}.pkg"
 

--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hugin' do
   url "http://downloads.sourceforge.net/sourceforge/hugin/Hugin-#{version}.dmg"
   name 'Hugin'
   homepage 'http://hugin.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Hugin.app'
 end

--- a/Casks/hyro.rb
+++ b/Casks/hyro.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hyro' do
   url "https://jawerty.github.io/Hyro/apps/Hyro-#{version}.dmg"
   name 'Hyro'
   homepage 'http://jawerty.github.io/Hyro/'
-  license :oss
+  license :mit
 
   app 'Hyro.app'
 end

--- a/Casks/icons.rb
+++ b/Casks/icons.rb
@@ -5,7 +5,7 @@ cask :v1 => 'icons' do
   url "https://github.com/exherb/icons/releases/download/#{version}/icons-v#{version}-macos-x64.zip"
   name 'Icons'
   homepage 'https://github.com/exherb/icons'
-  license :oss
+  license :mit
 
   app 'Icons.app'
 end

--- a/Casks/imgur.rb
+++ b/Casks/imgur.rb
@@ -4,7 +4,7 @@ cask :v1 => 'imgur' do
 
   url 'https://github.com/zbuc/imgurBar/raw/master/imgur.dmg'
   homepage 'https://github.com/zbuc/imgurBar'
-  license :oss
+  license :bsd
 
   app 'imgur.app'
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -5,7 +5,7 @@ cask :v1 => 'inkscape' do
   # fastly.net is the official download host per the vendor homepage
   url "https://inkscape.global.ssl.fastly.net/media/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
   homepage 'http://inkscape.org'
-  license :oss
+  license :gpl
 
   app 'Inkscape.app'
 

--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -5,7 +5,7 @@ cask :v1 => 'instead' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/instead/instead/#{version}/Instead-#{version}.dmg"
   homepage 'http://instead.syscall.ru/'
-  license :oss
+  license :mit
 
   app 'Instead.app'
 end

--- a/Casks/iupx.rb
+++ b/Casks/iupx.rb
@@ -6,7 +6,7 @@ cask :v1 => 'iupx' do
   appcast 'http://iupx.sourceforge.net/updates/appcast.xml'
   name 'iUPX'
   homepage 'http://iupx.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'iUPX.app'
 end

--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jabref' do
   url "http://downloads.sourceforge.net/project/jabref/jabref/#{version}/JabRef-#{version}-OSX.zip"
   name 'JabRef'
   homepage 'http://jabref.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'JabRef.app'
 end

--- a/Casks/jedit.rb
+++ b/Casks/jedit.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jedit' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/jedit/jedit#{version}install.dmg"
   homepage 'http://www.jedit.org'
-  license :oss
+  license :gpl
 
   app 'jEdit.app'
 end

--- a/Casks/jenkins-menu.rb
+++ b/Casks/jenkins-menu.rb
@@ -7,7 +7,7 @@ cask :v1 => 'jenkins-menu' do
   appcast 'http://qvacua.com/jenkinsmenu/appcast.xml',
           :sha256 => '420aaafc9de36c174ba1b43d1dfd4719603808f1754da8b7bb2a4ef1e934429d'
   homepage 'http://qvacua.com'
-  license :oss
+  license :gpl
 
   app 'Jenkins Menu.app'
 end

--- a/Casks/jsonlook.rb
+++ b/Casks/jsonlook.rb
@@ -6,7 +6,7 @@ cask :v1 => 'jsonlook' do
   url 'https://dl.dropbox.com/u/3878216/github/jsonlook.qlgenerator.zip'
   name 'jsonlook'
   homepage 'https://github.com/rjregenold/jsonlook'
-  license :oss
+  license :mit
 
   qlplugin 'jsonlook.qlgenerator'
 end

--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jubler' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/jubler/Jubler-#{version}.dmg"
   homepage 'http://www.jubler.org/'
-  license :oss
+  license :gpl
 
   app 'Jubler.app'
 end

--- a/Casks/jumpcut.rb
+++ b/Casks/jumpcut.rb
@@ -7,7 +7,7 @@ cask :v1 => 'jumpcut' do
           :sha256 => '908a13b8cf3ef67128d6bd1a09ef6f7e70a60e7c39f67e36d1a178fcb30bb38c'
   name 'Jumpcut'
   homepage 'http://jumpcut.sourceforge.net/'
-  license :oss
+  license :mit
 
   app 'Jumpcut.app'
 end

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jxplorer' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/jxplorer/jxplorer/version%20#{version}/jxplorer-#{version}-osx.zip"
   homepage 'http://jxplorer.org'
-  license :oss
+  license :apache
 
   app "jxplorer-#{version}.app"
   postflight do

--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -6,7 +6,7 @@ cask :v1 => 'kdiff3' do
   url "http://downloads.sourceforge.net/project/kdiff3/kdiff3/#{version}/kdiff3-#{version}-MacOSX-64Bit.dmg"
   name 'KDiff3'
   homepage 'http://kdiff3.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'kdiff3.app'
   binary 'kdiff3.app/Contents/MacOS/kdiff3'

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -5,7 +5,7 @@ cask :v1 => 'keycastr' do
   # github.com/lqez is the official download host per the vendor homepage
   url "https://github.com/lqez/keycastr/releases/download/#{version}/KeyCastr.zip"
   homepage 'https://github.com/keycastr/keycastr'
-  license :oss
+  license :bsd
 
   app 'KeyCastr.app'
 

--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -5,7 +5,7 @@ cask :v1 => 'keystore-explorer' do
   url "http://downloads.sourceforge.net/project/keystore-explorer/KSE%20#{version}/kse-#{version.gsub('.','')}.dmg"
   name 'KeyStore Explorer'
   homepage 'http://keystore-explorer.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app "KeyStore Explorer #{version}.app"
 end

--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -5,7 +5,7 @@ cask :v1 => 'kid3' do
 
   url "http://downloads.sourceforge.net/sourceforge/kid3/kid3-#{version}-Darwin.dmg"
   homepage 'http://kid3.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Kid3.app'
 end

--- a/Casks/laullon-gitx.rb
+++ b/Casks/laullon-gitx.rb
@@ -8,7 +8,7 @@ cask :v1 => 'laullon-gitx' do
   appcast 'http://gitx.laullon.com/appcast.xml',
           :sha256 => '7ce5197de931145d75c57c2171fba559481e79e23bedd58ec107b476731f693b'
   homepage 'http://gitx.laullon.com/'
-  license :oss
+  license :gpl
 
   app 'GitX.app'
   binary 'GitX.app/Contents/Resources/gitx'

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -5,7 +5,7 @@ cask :v1 => 'lazarus' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/lazarus/lazarus-#{version}-i386-macosx.dmg"
   homepage 'http://lazarus.freepascal.org/'
-  license :oss
+  license :gpl
 
   pkg 'lazarus.pkg'
 

--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -4,7 +4,7 @@ cask :v1 => 'letterfix' do
 
   url "http://dl.sourceforge.jp/letter-fix/62451/LetterFix-2.3.2a.dmg"
   homepage 'http://sourceforge.jp/projects/letter-fix/'
-  license :oss
+  license :mit
 
   pkg "LetterFix-#{version}.pkg"
 

--- a/Casks/limechat.rb
+++ b/Casks/limechat.rb
@@ -13,7 +13,7 @@ cask :v1 => 'limechat' do
   appcast 'http://limechat.net/mac/appcast.xml',
           :sha256 => '32dd2f6795c4f19940a8bb8a093b5b297167c28a4b6712cb94d6de14f1002e4f'
   homepage 'http://limechat.net/mac/'
-  license :oss
+  license :gpl
 
   app 'LimeChat.app'
 

--- a/Casks/linkliar.rb
+++ b/Casks/linkliar.rb
@@ -4,7 +4,7 @@ cask :v1 => 'linkliar' do
 
   url 'https://github.com/halo/LinkLiar/blob/master/latest_build/LinkLiar.zip?raw=true'
   homepage 'https://github.com/halo/LinkLiar'
-  license :oss
+  license :mit
 
   prefpane 'LinkLiar.prefPane'
 end

--- a/Casks/lisanet-gimp.rb
+++ b/Casks/lisanet-gimp.rb
@@ -6,7 +6,7 @@ cask :v1 => 'lisanet-gimp' do
   url "http://downloads.sourceforge.net/gimponosx/Gimp-#{version}-Mavericks-Yosemite.dmg"
   name 'GIMP'
   homepage 'http://gimp.lisanet.de'
-  license :oss
+  license :gpl
 
   app 'Gimp.app'
 end

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -5,7 +5,7 @@ cask :v1 => 'liteide' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/liteide/X#{version}/liteidex#{version}.macosx.zip"
   homepage 'https://github.com/visualfc/liteide'
-  license :oss
+  license :gpl
 
   app 'LiteIDE.app'
 end

--- a/Casks/logisim.rb
+++ b/Casks/logisim.rb
@@ -6,7 +6,7 @@ cask :v1 => 'logisim' do
   url "http://downloads.sourceforge.net/project/circuit/#{version.sub(%r{\d+$},'x')}/#{version}/logisim-macosx-#{version}.tar.gz"
   name 'Logisim'
   homepage 'http://www.cburch.com/logisim/'
-  license :oss
+  license :gpl
 
   app 'Logisim.app'
 end

--- a/Casks/luminance-hdr.rb
+++ b/Casks/luminance-hdr.rb
@@ -4,7 +4,7 @@ cask :v1 => 'luminance-hdr' do
 
   url "http://downloads.sourceforge.net/sourceforge/qtpfsgui/Luminance%20HDR%20#{version}-MacOSX-10.8.dmg"
   homepage 'http://qtpfsgui.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app "Luminance HDR #{version}.app"
 end

--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -7,7 +7,7 @@ cask :v1 => 'macpass' do
           :sha256 => 'd5f71e87922f4f6ec0b736d242c6b8ea8f25767eb4218cd56c90c8fa2b7b4908'
   name 'MacPass'
   homepage 'http://mstarke.github.io/MacPass/'
-  license :oss
+  license :gpl
 
   app 'MacPass.app'
 end

--- a/Casks/mame.rb
+++ b/Casks/mame.rb
@@ -5,7 +5,7 @@ cask :v1 => 'mame' do
   url "http://downloads.sourceforge.net/mameosx/MAMEOSX-#{version}.dmg"
   name 'MAME'
   homepage 'http://mameosx.sourceforge.net/'
-  license :oss
+  license :gratis
 
   app 'MAME OS X.app'
 end

--- a/Casks/media-converter.rb
+++ b/Casks/media-converter.rb
@@ -5,7 +5,7 @@ cask :v1 => 'media-converter' do
   url "http://downloads.sourceforge.net/project/media-converter/media-converter/#{version}/media-converter-#{version}.zip"
   name 'Media Converter'
   homepage 'http://media-converter.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Media Converter.localized/Media Converter.app'
 end

--- a/Casks/menubarfilter.rb
+++ b/Casks/menubarfilter.rb
@@ -5,7 +5,7 @@ cask :v1 => 'menubarfilter' do
   url 'https://github.com/downloads/wez/MenuBarFilter/MenuBarFilter.zip'
   name 'Menubarfilter'
   homepage 'http://wez.github.com/MenuBarFilter/'
-  license :oss
+  license :apache
 
   app 'MenuBarFilter.app'
 end

--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -4,7 +4,7 @@ cask :v1 => 'meshlab' do
 
   url "http://downloads.sourceforge.net/project/meshlab/meshlab/MeshLab%20v#{version}/MeshLabMac_v132.dmg"
   homepage 'http://meshlab.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'meshlab.app'
 end

--- a/Casks/miditrail.rb
+++ b/Casks/miditrail.rb
@@ -4,7 +4,7 @@ cask :v1 => 'miditrail' do
 
   url "http://dl.sourceforge.jp/miditrail/60194/MIDITrail-Ver.#{version}-MacOSX.zip"
   homepage 'http://en.sourceforge.jp/projects/miditrail/'
-  license :oss
+  license :bsd
 
   app 'MIDITrail/MIDITrail.app'
 end

--- a/Casks/milkmaid.rb
+++ b/Casks/milkmaid.rb
@@ -5,7 +5,7 @@ cask :v1 => 'milkmaid' do
   url "https://github.com/downloads/jgallen23/MilkMaid/MilkMaid-#{version}.tar.gz"
   name 'MilkMaid'
   homepage 'https://github.com/jgallen23/MilkMaid'
-  license :oss
+  license :mit
 
   app 'MilkMaid.app'
 

--- a/Casks/mjolnir.rb
+++ b/Casks/mjolnir.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mjolnir' do
 
   url "https://github.com/sdegutis/mjolnir/releases/download/#{version}/Mjolnir-#{version}.tgz"
   homepage 'http://mjolnir.io'
-  license :oss
+  license :mit
 
   app 'Mjolnir.app'
 end

--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -5,7 +5,7 @@ cask :v1 => 'mnemosyne' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/mnemosyne-proj/Mnemosyne-#{version}-Mac.dmg"
   homepage 'http://mnemosyne-proj.org/'
-  license :oss
+  license :gpl
 
   app 'Mnemosyne.app'
 end

--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -18,7 +18,7 @@ cask :v1 => 'monolingual' do
 
   url "https://github.com/IngmarStein/Monolingual/releases/download/v#{version}/Monolingual-#{version}.dmg"
   homepage 'https://ingmarstein.github.io/Monolingual/'
-  license :oss
+  license :gpl
 
   app 'Monolingual.app'
 end

--- a/Casks/moreamp.rb
+++ b/Casks/moreamp.rb
@@ -5,7 +5,7 @@ cask :v1 => 'moreamp' do
   url "http://downloads.sourceforge.net/project/moreamp/moreamp/MoreAmp-#{version}/MoreAmp-#{version}-binOSX104intel.dmg"
   name 'MoreAmp'
   homepage 'http://sourceforge.net/projects/moreamp/'
-  license :oss
+  license :gpl
 
   app 'MoreAmp.app'
 end

--- a/Casks/movist.rb
+++ b/Casks/movist.rb
@@ -4,7 +4,7 @@ cask :v1 => 'movist' do
 
   url 'https://github.com/downloads/samiamwork/Movist/Movist.app.zip'
   homepage 'https://github.com/samiamwork/Movist'
-  license :oss
+  license :gpl
 
   app 'Movist.app'
 end

--- a/Casks/multidoge.rb
+++ b/Casks/multidoge.rb
@@ -6,7 +6,7 @@ cask :v1 => 'multidoge' do
   url "https://github.com/langerhans/multidoge/releases/download/v#{version}/multidoge-#{version}.dmg"
   name 'MultiDoge'
   homepage 'http://multidoge.org/'
-  license :oss
+  license :mit
 
   app 'MultiDoge.app'
 end

--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -6,7 +6,7 @@ cask :v1 => 'mumble' do
   gpg "#{url}.sig",
       :key_url => 'http://mumble.info/gpg/mumble-auto-build-2014.asc'
   homepage 'http://mumble.sourceforge.net'
-  license :oss
+  license :bsd
 
   app 'Mumble.app'
 end

--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -5,7 +5,7 @@ cask :v1 => 'munki' do
   url "https://github.com/munki/munki/releases/download/v#{version}/munkitools-#{version}.pkg"
   name 'Munki'
   homepage 'http://munki.github.io/munki/'
-  license :oss
+  license :apache
 
   pkg "munkitools-#{version}.pkg"
 

--- a/Casks/nally.rb
+++ b/Casks/nally.rb
@@ -5,7 +5,7 @@ cask :v1 => 'nally' do
   # github.com is the official download host per the vendor homepage
   url "https://yllan.github.com/nally/download/Nally-#{version}.app.zip"
   homepage 'http://yllan.org/app/Nally/'
-  license :oss
+  license :gpl
 
   app 'Nally.app'
 end

--- a/Casks/nide.rb
+++ b/Casks/nide.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nide' do
 
   url "https://github.com/downloads/Coreh/nide/nide-v#{version}.dmg"
   homepage 'http://coreh.github.io/nide/'
-  license :oss
+  license :mit
 
   app 'Nide.app'
 end

--- a/Casks/noisy.rb
+++ b/Casks/noisy.rb
@@ -5,7 +5,7 @@ cask :v1 => 'noisy' do
   url 'https://github.com/downloads/jonshea/Noisy/Noisy.zip'
   name 'Noisy'
   homepage 'https://github.com/jonshea/Noisy'
-  license :oss
+  license :bsd
 
   app 'Noisy.app'
 end

--- a/Casks/nomacs.rb
+++ b/Casks/nomacs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'nomacs' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/nomacs/nomacs-#{version}-x86_64.dmg"
   homepage 'http://www.nomacs.org/'
-  license :oss
+  license :gpl
 
   app 'nomacs.app'
 end

--- a/Casks/nosleep.rb
+++ b/Casks/nosleep.rb
@@ -6,7 +6,7 @@ cask :v1 => 'nosleep' do
   url "https://github.com/integralpro/nosleep/releases/download/v#{version}/NoSleep-#{version}.dmg"
   name 'NoSleep'
   homepage 'https://code.google.com/p/macosx-nosleep-extension/'
-  license :oss
+  license :gpl
 
   pkg 'NoSleep.pkg'
 

--- a/Casks/ntfs-free.rb
+++ b/Casks/ntfs-free.rb
@@ -5,7 +5,7 @@ cask :v1 => 'ntfs-free' do
   url "http://downloads.sourceforge.net/sourceforge/ntfsfree/NTFS-free-#{version}.pkg"
   name 'NTFS-FREE'
   homepage 'http://sourceforge.net/projects/ntfsfree/'
-  license :oss
+  license :apache
 
   pkg "NTFS-free-#{version}.pkg"
 

--- a/Casks/objektiv.rb
+++ b/Casks/objektiv.rb
@@ -7,7 +7,7 @@ cask :v1 => 'objektiv' do
   appcast 'http://nthloop.com/objektiv/appcast.xml'
   name 'Objektiv'
   homepage 'http://nthloop.github.io/Objektiv/'
-  license :oss
+  license :mit
 
   app 'Objektiv.app'
 end

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'obs' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-#{version}-installer.dmg"
   homepage 'http://obsproject.com/'
-  license :oss
+  license :gpl
 
   pkg "OBS Studio.mpkg"
 

--- a/Casks/octave.rb
+++ b/Casks/octave.rb
@@ -5,7 +5,7 @@ cask :v1 => 'octave' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/octave/Octave%20MacOSX%20Binary/2013-12-30%20binary%20installer%20of%20Octave%203.8.0%20for%20OSX%2010.9.1%20%28beta%29/GNU_Octave_#{version}.dmg"
   homepage 'https://gnu.org/software/octave/'
-  license :oss
+  license :gpl
 
   pkg "Octave-#{version}.mpkg"
 

--- a/Casks/openmsx.rb
+++ b/Casks/openmsx.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openmsx' do
 
   url 'http://sourceforge.net/projects/openmsx/files/latest/download'
   homepage 'http://openmsx.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'openMSX.app'
 end

--- a/Casks/opennx.rb
+++ b/Casks/opennx.rb
@@ -6,7 +6,7 @@ cask :v1 => 'opennx' do
   url "http://downloads.sourceforge.net/sourceforge/opennx/OpenNX-#{version}.dmg"
   name 'OpenNX'
   homepage 'http://opennx.net/'
-  license :oss
+  license :gpl
 
   pkg 'OpenNX.pkg'
 

--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -6,7 +6,7 @@ cask :v1 => 'openoffice' do
   url "http://downloads.sourceforge.net/sourceforge/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_en-US.dmg"
   name 'OpenOffice'
   homepage 'http://www.openoffice.org/'
-  license :oss
+  license :apache
   tags :vendor => 'Apache'
 
   app 'OpenOffice.app'

--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -5,7 +5,7 @@ cask :v1 => 'openra' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
   homepage 'http://www.openra.net/'
-  license :oss
+  license :gpl
 
   app 'OpenRA.app'
 end

--- a/Casks/opensong.rb
+++ b/Casks/opensong.rb
@@ -5,7 +5,7 @@ cask :v1 => 'opensong' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/opensong/OpenSongOSX-V#{version}.dmg"
   homepage 'http://www.opensong.org/'
-  license :oss
+  license :gpl
 
   app "OpenSong V#{version}/OpenSongOSX-Cocoa.app"
   app "Opensong V#{version}/OpenSongOSX.app"

--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -5,7 +5,7 @@ cask :v1 => 'osxfuse' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"
   homepage 'https://osxfuse.github.io/'
-  license :oss
+  license :bsd
 
   pkg "Install OSXFUSE #{version[0..-3]}.pkg"
 

--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -8,7 +8,7 @@ cask :v1 => 'owasp-zap' do
   name 'OWASP ZAP'
   name 'ZAP'
   homepage 'https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project'
-  license :oss
+  license :apache
   tags :vendor => 'OWASP'
 
   app 'OWASP ZAP.app'

--- a/Casks/packet-peeper.rb
+++ b/Casks/packet-peeper.rb
@@ -5,7 +5,7 @@ cask :v1 => 'packet-peeper' do
   # bitbucket is the official download host per the vendor homepage
   url "https://bitbucket.org/choll/packetpeeper/downloads/PacketPeeper_#{version}.dmg"
   homepage 'http://packetpeeper.org/'
-  license :oss
+  license :gpl
 
   app 'Packet Peeper.app'
 end

--- a/Casks/paintbrush.rb
+++ b/Casks/paintbrush.rb
@@ -7,7 +7,7 @@ cask :v1 => 'paintbrush' do
   appcast 'http://paintbrush.sourceforge.net/updates2x.xml',
           :sha256 => 'ac96943a5d298201b711c719416073357f60545ef5ee7bf0853bbcf191bdc3d9'
   homepage 'http://paintbrush.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Paintbrush.app'
 

--- a/Casks/panini.rb
+++ b/Casks/panini.rb
@@ -4,7 +4,7 @@ cask :v1 => 'panini' do
 
   url "http://downloads.sourceforge.net/sourceforge/pvqt/Panini-#{version}B-mac.dmg"
   homepage 'http://sourceforge.net/projects/pvqt/'
-  license :oss
+  license :gpl
 
   app 'Panini.app'
 end

--- a/Casks/password-gorilla.rb
+++ b/Casks/password-gorilla.rb
@@ -6,7 +6,7 @@ cask :v1 => 'password-gorilla' do
   url "http://gorilla.dp100.com/downloads/gorilla.mac.#{version.gsub('.','')}.zip"
   name 'Password Gorilla'
   homepage 'https://github.com/zdia/gorilla'
-  license :oss
+  license :gpl
 
   app 'Password Gorilla.app'
   caveats <<-EOS.undent

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -6,7 +6,7 @@ cask :v1 => 'pd-extended' do
   url "http://downloads.sourceforge.net/project/pure-data/pd-extended/#{version}/Pd-#{version}-extended-macosx105-i386.dmg"
   name 'Pd-extended'
   homepage 'http://puredata.info/downloads/pd-extended'
-  license :oss
+  license :gpl
 
   app 'Pd-extended.app'
 

--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -5,7 +5,7 @@ cask :v1 => 'pdfsam-basic' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/torakiki/pdfsam-v2/releases/download/v#{version}/pdfsam-#{version}.dmg"
   homepage 'http://www.pdfsam.org/'
-  license :oss
+  license :gpl
 
   app "PDFsam Basic #{version}.app"
 end

--- a/Casks/pdfshaver.rb
+++ b/Casks/pdfshaver.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pdfshaver' do
 
   url "https://github.com/tparry/PDFShaver.app/releases/download/v#{version}/PDFShaver.zip"
   homepage 'https://github.com/tparry/PDFShaver.app'
-  license :oss
+  license :public_domain
 
   app 'PDFShaver.app'
 end

--- a/Casks/peepopen.rb
+++ b/Casks/peepopen.rb
@@ -5,7 +5,7 @@ cask :v1 => 'peepopen' do
   url 'https://topfunky.github.io/PeepOpen/dl/PeepOpen.dmg'
   appcast 'https://peepcode.com/system/apps/PeepOpen/appcast.xml'
   homepage 'http://topfunky.github.io/PeepOpen/'
-  license :oss
+  license :mit
 
   app 'PeepOpen.app'
 end

--- a/Casks/phantomjs.rb
+++ b/Casks/phantomjs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'phantomjs' do
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{version}-macosx.zip"
   homepage 'http://phantomjs.org/'
-  license :oss
+  license :bsd
 
   binary "phantomjs-#{version}-macosx/bin/phantomjs"
 end

--- a/Casks/phoenix.rb
+++ b/Casks/phoenix.rb
@@ -4,7 +4,7 @@ cask :v1 => 'phoenix' do
 
   url 'https://raw.github.com/sdegutis/phoenix/master/Builds/Phoenix-LATEST.app.tar.gz'
   homepage 'https://github.com/sdegutis/Phoenix'
-  license :oss
+  license :mit
 
   app 'Phoenix.app'
 

--- a/Casks/pinta.rb
+++ b/Casks/pinta.rb
@@ -6,7 +6,7 @@ cask :v1 => 'pinta' do
   url "https://github.com/PintaProject/Pinta/releases/download/#{version}/Pinta.app.zip"
   name 'Pinta'
   homepage 'http://pinta-project.com/'
-  license :oss
+  license :mit
 
   app 'Pinta.app'
 

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -6,7 +6,7 @@ cask :v1 => 'plover' do
   url "https://github.com/openstenoproject/plover/releases/download/v#{version}/Plover.dmg"
   name 'Plover'
   homepage 'http://stenoknight.com/wiki/Main_Page'
-  license :oss
+  license :gpl
 
   app 'plover.app'
 

--- a/Casks/pngyu.rb
+++ b/Casks/pngyu.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pngyu' do
 
   url "http://nukesaq88.github.io/Pngyu/download/Pngyu_mac_#{version.gsub('.','')}.zip"
   homepage 'http://nukesaq88.github.io/Pngyu/'
-  license :oss
+  license :bsd
 
   app 'Pngyu.app'
 end

--- a/Casks/powerkey.rb
+++ b/Casks/powerkey.rb
@@ -4,7 +4,7 @@ cask :v1 => 'powerkey' do
 
   url "https://github.com/pkamb/PowerKey/releases/download/v#{version}/PowerKey#{version}.zip"
   homepage 'http://pkamb.github.io/PowerKey/'
-  license :oss
+  license :mit
 
   app 'PowerKey.app'
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -5,7 +5,7 @@ cask :v1 => 'printrun' do
   # kapsi.fi is the official download host per the vendor homepage
   url 'http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-10Mar2014.zip'
   homepage 'https://github.com/kliment/Printrun'
-  license :oss
+  license :gpl
 
   app 'Printrun-Mac-10Mar2014.app'
 end

--- a/Casks/ps3-media-server.rb
+++ b/Casks/ps3-media-server.rb
@@ -6,7 +6,7 @@ cask :v1 => 'ps3-media-server' do
   url "http://downloads.sourceforge.net/project/ps3mediaserver/pms-#{version}-setup-macosx.tar.gz"
   name 'PS3 Media Server'
   homepage 'http://www.ps3mediaserver.org/'
-  license :oss
+  license :gpl
 
   installer :manual => 'PS3 Media Server Setup.app'
 end

--- a/Casks/psi.rb
+++ b/Casks/psi.rb
@@ -6,7 +6,7 @@ cask :v1 => 'psi' do
   url "http://downloads.sourceforge.net/sourceforge/psi/Psi-#{version}.dmg"
   name 'Psi'
   homepage 'http://psi-im.org/'
-  license :oss
+  license :gpl
 
   app 'Psi.app'
 end

--- a/Casks/pusher.rb
+++ b/Casks/pusher.rb
@@ -6,7 +6,7 @@ cask :v1 => 'pusher' do
   name 'Pusher'
   name 'NWPusher'
   homepage 'https://github.com/noodlewerk/NWPusher'
-  license :oss
+  license :bsd
 
   app 'Pusher.app'
 end

--- a/Casks/putio-adder.rb
+++ b/Casks/putio-adder.rb
@@ -5,7 +5,7 @@ cask :v1 => 'putio-adder' do
   url "https://github.com/nicoSWD/put.io-adder/releases/download/v#{version}/put.io-adder-v#{version}.zip"
   name 'Put.IO Adder'
   homepage 'https://github.com/nicoSWD/put.io-adder'
-  license :oss
+  license :mit
 
   app 'put.io adder.app'
 end

--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -5,7 +5,7 @@ cask :v1 => 'qbittorrent' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/qbittorrent/qbittorrent-#{version}.dmg"
   homepage 'http://www.qbittorrent.org'
-  license :oss
+  license :gpl
 
   app 'qBittorrent.app'
 end

--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -7,7 +7,7 @@ cask :v1 => 'qdesktop' do
   appcast 'http://qvacua.com/qdesktop/appcast.xml',
           :sha256 => '9714a19fae1e50cfdc06a1f300dae791d400b4c64a0f679b29d633ea8a59b46b'
   homepage 'http://qvacua.com'
-  license :oss
+  license :gpl
 
   app 'Qdesktop.app'
 end

--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -6,7 +6,7 @@ cask :v1 => 'qlimagesize' do
   url 'http://repo.whine.fr/qlImageSize.pkg'
   name 'qlImageSize'
   homepage 'https://github.com/Nyx0uf/qlImageSize'
-  license :oss
+  license :bsd
 
   pkg 'qlImageSize.pkg'
 

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -5,7 +5,7 @@ cask :v1 => 'qlmarkdown' do
   url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"
   name 'QLMarkdown'
   homepage 'https://github.com/toland/qlmarkdown'
-  license :oss
+  license :bsd
 
   # Fix broken zip file with no toplevel bundle directory.  This was
   # not needed for version 1.3.2.  We could add an option to the main

--- a/Casks/qlstephen.rb
+++ b/Casks/qlstephen.rb
@@ -4,7 +4,7 @@ cask :v1 => 'qlstephen' do
 
   url 'https://github.com/downloads/whomwah/qlstephen/QLStephen.qlgenerator.zip'
   homepage 'http://whomwah.github.io/qlstephen/'
-  license :oss
+  license :mit
 
   qlplugin 'QLStephen.qlgenerator'
 end

--- a/Casks/qrfcview.rb
+++ b/Casks/qrfcview.rb
@@ -4,7 +4,7 @@ cask :v1 => 'qrfcview' do
 
   url "https://github.com/downloads/saghul/qrfcview-osx/qRFCView-#{version}-1.dmg"
   homepage 'https://saghul.github.io/qrfcview-osx'
-  license :oss
+  license :gpl
 
   app 'qRFCView.app'
 end

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -4,7 +4,7 @@ cask :v1 => 'qtspim' do
 
   url 'http://sourceforge.net/projects/spimsimulator/files/latest/download'
   homepage 'http://spimsimulator.sourceforge.net/'
-  license :oss
+  license :bsd
 
   app 'QtSpim.app'
 end

--- a/Casks/rdm.rb
+++ b/Casks/rdm.rb
@@ -5,7 +5,7 @@ cask :v1 => 'rdm' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/uglide/RedisDesktopManager/releases/download/0.7.6/redis-desktop-manager-#{version}.dmg"
   homepage 'http://redisdesktop.com'
-  license :oss
+  license :gpl
 
   app 'rdm.app'
 end

--- a/Casks/reeddit.rb
+++ b/Casks/reeddit.rb
@@ -6,7 +6,7 @@ cask :v1 => 'reeddit' do
   url "https://github.com/berbaquero/Reeddit-app/releases/download/v#{version}/Reeddit.app.zip"
   name 'Reeddit'
   homepage 'http://mac.reedditapp.com'
-  license :oss
+  license :mit
 
   app 'Reeddit.app'
 end

--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -4,7 +4,7 @@ cask :v1 => 'retroshare' do
 
   url "http://downloads.sourceforge.net/project/retroshare/RetroShare/#{version}/Retroshare-V#{version}-svn6877_OSX10.6u.dmg"
   homepage 'http://retroshare.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Retroshare.app'
 end

--- a/Casks/rythem.rb
+++ b/Casks/rythem.rb
@@ -5,7 +5,7 @@ cask :v1 => 'rythem' do
   url "https://github.com/AlloyTeam/Rythem/releases/download/filter/Rythem-#{version}.dmg"
   name 'Rythem'
   homepage 'https://github.com/AlloyTeam/Rythem'
-  license :oss
+  license :mit
 
   app 'Rythem.app'
 end

--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -5,7 +5,7 @@ cask :v1 => 'sabnzbd' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/sabnzbdplus/sabnzbdplus/#{version}/SABnzbd-#{version}-osx.dmg"
   homepage 'http://sabnzbd.org/'
-  license :oss
+  license :gpl
 
   app 'SABnzbd.app'
 

--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -6,7 +6,7 @@ cask :v1 => 'scribus' do
   url "http://downloads.sourceforge.net/project/scribus/scribus/#{version}/scribus-#{version}.dmg"
   name 'Scribus'
   homepage 'http://www.scribus.net/canvas/Scribus'
-  license :oss
+  license :gpl
 
   app 'Scribus.app'
 end

--- a/Casks/scrup.rb
+++ b/Casks/scrup.rb
@@ -8,7 +8,7 @@ cask :v1 => 'scrup' do
           :sha256 => '140f4487d00bb157286f261bfddb8f7a8c29a4fc2e53a63119bdbe1c828a6d00'
   name 'Scrup'
   homepage 'https://github.com/rsms/scrup'
-  license :oss
+  license :mit
 
   app 'Scrup.app'
 end

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -7,7 +7,7 @@ cask :v1 => 'scummvm' do
   appcast 'http://www.scummvm.org/appcasts/macosx/release.xml',
           :sha256 => 'bea2fd9739e102c781753c991b6ee6481a1c0c3f00621e96dca06a2b83e42135'
   homepage 'http://scummvm.org/'
-  license :oss
+  license :gpl
 
   app 'ScummVM.app'
 end

--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -5,7 +5,7 @@ cask :v1 => 'seafile-client' do
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/haiwen/seafile/downloads/seafile-client-#{version}.dmg"
   homepage 'http://seafile.com/'
-  license :oss
+  license :gpl
 
   app 'Seafile Client.app'
 end

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -4,7 +4,7 @@ cask :v1 => 'seashore' do
 
   url 'http://downloads.sourceforge.net/sourceforge/seashore/Seashore.zip'
   homepage 'http://seashore.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'Seashore.app'
 end

--- a/Casks/shiftit.rb
+++ b/Casks/shiftit.rb
@@ -6,7 +6,7 @@ cask :v1 => 'shiftit' do
   appcast 'https://raw.github.com/fikovnik/ShiftIt/develop/release/appcast.xml',
           :sha256 => '16b9da1fa91aa964ad0fda907147d55e50da844d39a5fe5abcd0224abb954be3'
   homepage 'https://github.com/fikovnik/ShiftIt'
-  license :oss
+  license :gpl
 
   app 'ShiftIt.app'
 end

--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -5,7 +5,7 @@ cask :v1 => 'shotcut' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.sub(/\.\d+$/, '')}/shotcut-osx-x86_64-#{version.gsub('.', '')}.dmg"
   homepage 'http://www.shotcut.org/'
-  license :oss
+  license :gpl
 
   app 'Shotcut.app'
 end

--- a/Casks/sidestep.rb
+++ b/Casks/sidestep.rb
@@ -7,7 +7,7 @@ cask :v1 => 'sidestep' do
   appcast 'http://chetansurpur.com/projects/sidestep/appcast.xml',
           :sha256 => '1d043f565c44c03f6ab5e7c90f025aba3cf480f1623a8a530f87206fab12f86a'
   homepage 'http://chetansurpur.com/projects/sidestep/'
-  license :oss
+  license :mit
 
   app 'Sidestep.app'
 end

--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -5,7 +5,7 @@ cask :v1 => 'sigil' do
   url "https://github.com/user-none/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"
   name 'Sigil'
   homepage 'http://code.google.com/p/sigil/'
-  license :oss
+  license :gpl
 
   app 'Sigil.app'
 end

--- a/Casks/simpletag.rb
+++ b/Casks/simpletag.rb
@@ -5,7 +5,7 @@ cask :v1 => 'simpletag' do
   url "http://downloads.sourceforge.net/sourceforge/simpletag/simpletag-gui-#{version}-osx.zip"
   name 'SimpleTAG'
   homepage 'http://sourceforge.net/projects/simpletag/'
-  license :oss
+  license :gpl
 
   app "simpletag-gui-jface-#{version}/SimpleTAG-GUI.app"
 end

--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -7,7 +7,7 @@ cask :v1 => 'skim' do
           :sha256 => '92ff99e126c3daf99d680dd23f16ab84e26430e96478bbaeb71180756dd12ce1'
   name 'Skim'
   homepage 'http://skim-app.sourceforge.net/'
-  license :oss
+  license :bsd
 
   app 'Skim.app'
   binary 'Skim.app/Contents/SharedSupport/displayline'

--- a/Casks/slate.rb
+++ b/Casks/slate.rb
@@ -7,7 +7,7 @@ cask :v1 => 'slate' do
   appcast 'https://www.ninjamonkeysoftware.com/slate/appcast.xml'
   name 'Slate'
   homepage 'https://github.com/jigish/slate'
-  license :oss
+  license :gpl
 
   app 'Slate.app'
 

--- a/Casks/sonora.rb
+++ b/Casks/sonora.rb
@@ -7,7 +7,7 @@ cask :v1 => 'sonora' do
   appcast 'http://getsonora.com/updates/sonora2.xml'
   name 'Sonora'
   homepage 'http://getsonora.com/'
-  license :oss
+  license :gratis
 
   app 'Sonora.app'
 end

--- a/Casks/sourcedrop.rb
+++ b/Casks/sourcedrop.rb
@@ -6,7 +6,7 @@ cask :v1 => 'sourcedrop' do
   url "https://github.com/hohl/sourcedrop-osx/releases/download/r#{version}/SourceDrop-r#{version}.zip"
   name 'SourceDrop'
   homepage 'http://sourcedrop.net/'
-  license :oss
+  license :bsd
 
   app "SourceDrop.app"
 end

--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -5,7 +5,7 @@ cask :v1 => 'sparkleshare' do
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/hbons/sparkleshare/downloads/sparkleshare-mac-#{version}.zip"
   homepage 'http://sparkleshare.org/'
-  license :oss
+  license :gpl
 
   app 'SparkleShare.app'
 end

--- a/Casks/speedcrunch.rb
+++ b/Casks/speedcrunch.rb
@@ -5,7 +5,7 @@ cask :v1 => 'speedcrunch' do
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/heldercorreia/speedcrunch/downloads/SpeedCrunch-#{version}.dmg"
   homepage 'http://www.speedcrunch.org'
-  license :oss
+  license :gpl
 
   app 'SpeedCrunch.app'
 end

--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -6,7 +6,7 @@ cask :v1 => 'spotify-notifications' do
   url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"
   name 'Spotify Notifications'
   homepage 'http://spotify-notifications.citruspi.io/'
-  license :oss
+  license :public_domain
 
   app 'Spotify Notifications.app'
 end

--- a/Casks/spyder.rb
+++ b/Casks/spyder.rb
@@ -6,7 +6,7 @@ cask :v1 => 'spyder' do
   url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py3.4.dmg"
   name 'Spyder'
   homepage 'https://code.google.com/p/spyderlib/'
-  license :oss
+  license :mit
 
   app 'Spyder.app'
 end

--- a/Casks/sqlexplorer.rb
+++ b/Casks/sqlexplorer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sqlexplorer' do
 
   url "http://downloads.sourceforge.net/project/eclipsesql/SQL%20Explorer%20RCP%20%28exc%20JRE%29/#{version}/sqlexplorer_rcp-#{version}.macosx.cocoa.x86.tgz"
   homepage 'http://eclipsesql.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'SQLExplorer/sqlexplorer.app'
 end

--- a/Casks/squirrel.rb
+++ b/Casks/squirrel.rb
@@ -4,7 +4,7 @@ cask :v1 => 'squirrel' do
 
   url "https://dl.bintray.com/lotem/rime/Squirrel-#{version}.zip"
   homepage 'https://github.com/lotem/squirrel'
-  license :oss
+  license :gpl
 
   pkg 'Squirrel.pkg'
 

--- a/Casks/sshfs.rb
+++ b/Casks/sshfs.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sshfs' do
 
   url "https://github.com/osxfuse/sshfs/releases/download/osxfuse-sshfs-#{version}/sshfs-#{version}.pkg"
   homepage 'http://osxfuse.github.io/'
-  license :oss
+  license :gpl
 
   pkg "sshfs-#{version}.pkg"
 

--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -4,7 +4,7 @@ cask :v1 => 'stella' do
 
   url "http://downloads.sourceforge.net/project/stella/stella/#{version}/Stella-#{version}_intel-macosx.dmg"
   homepage 'http://stella.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'Stella.app'
 end

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -5,7 +5,7 @@ cask :v1 => 'stellarium' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/stellarium/Stellarium-#{version}.dmg"
   homepage 'http://stellarium.org'
-  license :oss
+  license :gpl
 
   app 'Stellarium.app'
 end

--- a/Casks/streamtools.rb
+++ b/Casks/streamtools.rb
@@ -13,5 +13,5 @@ cask :v1 => 'streamtools' do
 
   name 'streamtools'
   homepage 'http://nytlabs.github.io/streamtools/'
-  license :oss
+  license :apache
 end

--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -6,7 +6,7 @@ cask :v1 => 'subler' do
   appcast 'http://subler.googlecode.com/svn/doc/appcast.xml',
           :sha256 => 'b8d659a84089c8ebd4969c7e5393b0472d844c79d43bad33cbfbbe153f2dfb51'
   homepage 'https://bitbucket.org/galad87/subler'
-  license :oss
+  license :gpl
 
   app 'Subler.app'
 end

--- a/Casks/supertuxkart.rb
+++ b/Casks/supertuxkart.rb
@@ -4,7 +4,7 @@ cask :v1 => 'supertuxkart' do
 
   url "http://downloads.sourceforge.net/sourceforge/supertuxkart/supertuxkart-#{version}-osx.dmg"
   homepage 'http://supertuxkart.sourceforge.net'
-  license :oss
+  license :gpl
 
   app 'Supertuxkart.app'
 end

--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -5,7 +5,7 @@ cask :v1 => 'sweet-home3d' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-#{version}/SweetHome3D-#{version}-macosx.dmg"
   homepage 'http://www.sweethome3d.com/'
-  license :oss
+  license :gpl
 
   app 'Sweet Home 3D.app'
 end

--- a/Casks/tag.rb
+++ b/Casks/tag.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tag' do
   url "http://downloads.sourceforge.net/sourceforge/tagosx/Tag-#{version}.zip"
   name 'Tag'
   homepage 'http://sbooth.org/Tag/'
-  license :oss
+  license :gpl
 
   app "Tag-#{version}/Tag.app"
 end

--- a/Casks/tagger.rb
+++ b/Casks/tagger.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tagger' do
   appcast 'http://bilalh.github.com/sparkle/tagger/appcast.xml',
           :sha256 => 'df4ef5a84c4900943529c0a45e7bf47a0823985fd558462899b5029fb32ce25e'
   homepage 'http://bilalh.github.io/projects/tagger/'
-  license :oss
+  license :cc
 
   app 'Tagger.app'
 end

--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -4,7 +4,7 @@ cask :v1 => 'texstudio' do
 
   url "http://downloads.sourceforge.net/sourceforge/texstudio/texstudio_#{version}_osx_qt5.zip"
   homepage 'http://texstudio.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'texstudio.app'
 end

--- a/Casks/thyme.rb
+++ b/Casks/thyme.rb
@@ -5,7 +5,7 @@ cask :v1 => 'thyme' do
   url "https://joaomoreno.github.io/thyme/dist/Thyme-#{version}.dmg"
   name 'Thyme'
   homepage 'http://joaomoreno.github.io/thyme/'
-  license :oss
+  license :mit
 
   app 'Thyme.app'
 end

--- a/Casks/tiddlywiki.rb
+++ b/Casks/tiddlywiki.rb
@@ -10,7 +10,7 @@ cask :v1 => 'tiddlywiki' do
   end
 
   homepage 'https://github.com/Jermolene/TiddlyDesktop'
-  license :oss
+  license :bsd
 
   app 'TiddlyWiki.app'
 end

--- a/Casks/tikz-editor.rb
+++ b/Casks/tikz-editor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tikz-editor' do
 
   url "https://github.com/downloads/fredokun/TikZ-Editor/TikZ%20Editor-#{version}.dmg"
   homepage 'https://github.com/fredokun/TikZ-Editor'
-  license :oss
+  license :gpl
 
   app 'TikZ Editor.app'
 end

--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tiled' do
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
-  license :oss
+  license :gpl
 
   app 'Tiled.app'
 end

--- a/Casks/tokaido.rb
+++ b/Casks/tokaido.rb
@@ -5,7 +5,7 @@ cask :v1 => 'tokaido' do
   url "https://github.com/tokaido/tokaidoapp/releases/download/v#{version}/Tokaido.zip"
   name 'Tokaido'
   homepage 'https://github.com/tokaido/tokaidoapp'
-  license :oss
+  license :mit
 
   app 'Tokaido.app'
 end

--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tortoisehg' do
 
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.zip"
   homepage 'http://tortoisehg.bitbucket.org/'
-  license :oss
+  license :gpl
 
   app 'TortoiseHg.app'
 end

--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tribler' do
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
   name 'Tribler'
   homepage 'http://www.tribler.org'
-  license :oss
+  license :gpl
 
   app 'Tribler.app'
 end

--- a/Casks/trim-ios-screenshots.rb
+++ b/Casks/trim-ios-screenshots.rb
@@ -5,7 +5,7 @@ cask :v1 => 'trim-ios-screenshots' do
   url "https://github.com/downloads/osteslag/trim-ios-screenshots/Trim_iOS_Screenshots-#{version}.zip"
   name 'Trim iOS Screenshots'
   homepage 'https://github.com/osteslag/trim-ios-screenshots'
-  license :oss
+  license :bsd
 
   app 'Trim iOS Screenshots.app'
 end

--- a/Casks/tuxguitar.rb
+++ b/Casks/tuxguitar.rb
@@ -5,7 +5,7 @@ cask :v1 => 'tuxguitar' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/tuxguitar/TuxGuitar/TuxGuitar-#{version}/tuxguitar-#{version}-macosx10.5-cocoa-64.dmg"
   homepage 'http://www.tuxguitar.com.ar/'
-  license :oss
+  license :gpl
 
   app 'Tuxguitar.app'
 end

--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -5,7 +5,7 @@ cask :v1 => 'tv-browser' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/tvbrowser/tvbrowser_#{version}_mac.dmg"
   homepage 'http://www.tvbrowser.org/'
-  license :oss
+  license :gpl
 
   app 'TV-Browser.app'
 end

--- a/Casks/ultrastardeluxe.rb
+++ b/Casks/ultrastardeluxe.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ultrastardeluxe' do
 
   url "http://downloads.sourceforge.net/sourceforge/ultrastardx/UltraStarDeluxe-#{version}.dmg"
   homepage 'http://ultrastardx.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'UltraStarDeluxe.app'
 end

--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -4,7 +4,7 @@ cask :v1 => 'unetbootin' do
 
   url "http://downloads.sourceforge.net/sourceforge/unetbootin/unetbootin-mac-#{version}.zip"
   homepage 'http://unetbootin.sourceforge.net/'
-  license :oss
+  license :gpl
 
   app 'unetbootin.app'
 end

--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -5,7 +5,7 @@ cask :v1 => 'universal-media-server' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/unimediaserver/Official%20Releases/OS%20X/UMS-#{version}-Java8.dmg"
   homepage 'http://universalmediaserver.com'
-  license :oss
+  license :gpl
 
   app 'Universal Media Server.app'
 end

--- a/Casks/universalmailer.rb
+++ b/Casks/universalmailer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'universalmailer' do
 
   url "http://universalmailer.github.io/UniversalMailer/zips/UniversalMailer-v#{version.gsub('.','_')}.zip"
   homepage 'http://universalmailer.github.io/UniversalMailer/'
-  license :oss
+  license :mit
 
   pkg 'UniversalMailer.pkg'
 

--- a/Casks/unpkg.rb
+++ b/Casks/unpkg.rb
@@ -6,7 +6,7 @@ cask :v1 => 'unpkg' do
   url "https://github.com/downloads/timdoug/unpkg/unpkg-#{version}.zip"
   name 'unpkg'
   homepage 'http://www.timdoug.com/unpkg/'
-  license :oss
+  license :gpl
 
   app "unpkg #{version}/unpkg.app"
 end

--- a/Casks/utc-menu-clock.rb
+++ b/Casks/utc-menu-clock.rb
@@ -4,7 +4,7 @@ cask :v1 => 'utc-menu-clock' do
 
   url "https://github.com/downloads/netik/UTCMenuClock/UTCMenuClock_#{version}_installer.pkg"
   homepage 'https://github.com/netik/UTCMenuClock'
-  license :oss
+  license :apache
 
   pkg "UTCMenuClock_#{version}_installer.pkg"
 

--- a/Casks/vassal.rb
+++ b/Casks/vassal.rb
@@ -6,7 +6,7 @@ cask :v1 => 'vassal' do
   url "http://downloads.sourceforge.net/project/vassalengine/VASSAL-current/VASSAL-#{version}/VASSAL-#{version}-macosx.dmg"
   name 'VASSAL'
   homepage 'http://www.vassalengine.org'
-  license :oss
+  license :gpl
 
   app 'VASSAL.app'
 end

--- a/Casks/vessel.rb
+++ b/Casks/vessel.rb
@@ -4,7 +4,7 @@ cask :v1 => 'vessel' do
 
   url "https://github.com/awvessel/vessel/releases/download/#{version}/Vessel.app.zip"
   homepage 'http://awvessel.github.io'
-  license :oss
+  license :bsd
 
   app 'Vessel.app'
 end

--- a/Casks/virtaal.rb
+++ b/Casks/virtaal.rb
@@ -5,7 +5,7 @@ cask :v1 => 'virtaal' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/translate/Virtaal/#{version.sub(%r{^(\d+\.\d+\.\d+).*},'\1')}/Virtaal-#{version.sub(%r{^(\d+\.\d+\.\d+).*},'\1')}-Mac-Beta-2.dmg"
   homepage 'http://virtaal.translatehouse.org/'
-  license :oss
+  license :gpl
 
   app 'Virtaal.app'
 end

--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -6,7 +6,7 @@ cask :v1 => 'vistrails' do
   url "http://downloads.sourceforge.net/project/vistrails/vistrails/v#{version.sub(%r{-.*},'')}/vistrails-mac-10.6-intel-#{version}.dmg"
   name 'VisTrails'
   homepage 'http://www.vistrails.org/'
-  license :oss
+  license :bsd
 
   suite 'VisTrails'
 end

--- a/Casks/wavtap.rb
+++ b/Casks/wavtap.rb
@@ -4,7 +4,7 @@ cask :v1 => 'wavtap' do
 
   url "https://github.com/downloads/pje/WavTap/WavTap%20#{version}.pkg"
   homepage 'https://github.com/pje/wavtap'
-  license :oss
+  license :mit
 
   pkg "WavTap #{version}.pkg"
 

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -5,7 +5,7 @@ cask :v1 => 'weka' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/weka/weka-#{version.gsub('.','-')}-oracle-jvm.dmg"
   homepage 'http://www.cs.waikato.ac.nz/ml/weka/'
-  license :oss
+  license :gpl
 
   app "weka-#{version.gsub('.','-')}-oracle-jvm.app"
 end

--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -5,7 +5,7 @@ cask :v1 => 'wesnoth' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/wesnoth/Wesnoth_#{version}.dmg"
   homepage 'http://wesnoth.org'
-  license :oss
+  license :gpl
 
   app 'Wesnoth.app'
 end

--- a/Casks/wineskin-winery.rb
+++ b/Casks/wineskin-winery.rb
@@ -5,7 +5,7 @@ cask :v1 => 'wineskin-winery' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/wineskin/Wineskin%20Winery.app%20Version%20#{version}.zip"
   homepage 'http://wineskin.urgesoftware.com/'
-  license :oss
+  license :gpl
 
   app 'Wineskin Winery.app'
 end

--- a/Casks/woodhouse.rb
+++ b/Casks/woodhouse.rb
@@ -6,7 +6,7 @@ cask :v1 => 'woodhouse' do
   appcast 'http://phinze.github.com/woodhouse/appcast.xml',
           :sha256 => '60e19f2463f90a57417229593f456df23d1ba55781d305db7ac5d47d0ecbcf79'
   homepage 'https://github.com/phinze/woodhouse/'
-  license :oss
+  license :mit
 
   app 'Woodhouse.app'
 end

--- a/Casks/xampp.rb
+++ b/Casks/xampp.rb
@@ -6,7 +6,7 @@ cask :v1 => 'xampp' do
   url "http://downloads.sourceforge.net/project/xampp/XAMPP%20Mac%20OS%20X/#{version.sub(%r{-\d+$},'')}/xampp-osx-#{version}-installer.dmg"
   name 'XAMPP'
   homepage 'http://www.apachefriends.org/'
-  license :oss
+  license :gpl
 
   installer :manual => 'XAMPP.app'
 

--- a/Casks/xaos.rb
+++ b/Casks/xaos.rb
@@ -7,7 +7,7 @@ cask :v1 => 'xaos' do
   name 'XaoS'
   name 'GNU XaoS'
   homepage 'http://matek.hu/xaos'
-  license :oss
+  license :gpl
 
   app 'XaoS.app'
 end

--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -4,7 +4,7 @@ cask :v1 => 'xca' do
 
   url "http://downloads.sourceforge.net/sourceforge/xca/xca-#{version}_x86.dmg"
   homepage 'http://xca.sourceforge.net/'
-  license :oss
+  license :bsd
 
   app 'xca.app'
 end

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -6,7 +6,7 @@ cask :v1 => 'yacreader' do
   url "https://bitbucket.org/luisangelsm/yacreader/downloads/YACReader-#{version}-MacOSX-Intel.dmg"
   name 'YACReader'
   homepage 'http://www.yacreader.com'
-  license :oss
+  license :gpl
 
   app 'YACReader.app'
   app 'YACReaderLibrary.app'

--- a/Casks/zeroinstall.rb
+++ b/Casks/zeroinstall.rb
@@ -6,7 +6,7 @@ cask :v1 => 'zeroinstall' do
   url "http://downloads.sourceforge.net/project/zero-install/0install/#{version}/ZeroInstall.pkg"
   name 'Zero Install'
   homepage 'http://0install.net'
-  license :oss
+  license :gpl
 
   pkg 'ZeroInstall.pkg'
 


### PR DESCRIPTION
Referencing @rolandwalker's [comment in #7999](https://github.com/caskroom/homebrew-cask/pull/7999#issuecomment-66556343), this is an attempt to specify more exact licenses for a number of casks automatically marked `:oss` based on either a github, sourceforge, or bitbucket link.  **This isn't all of them**, merely the low-hanging _most_ of them; the others were largely unclear.

I tried to include a link to the license for almost all of them; sourceforge projects are mostly links to a project (home)page that states what license is being used.

Some notes:
- `all-the-gifs` - Released under a modified BSD license, mainly limiting wholesale copying: https://github.com/orta/GIFs/blob/master/LICENSE
- `bob` - MIT but I couldn't find the actual text of the license as required by the MIT license  https://github.com/casperstorm/Bob/blob/development/README.md
- `happygrep` - Ditto.  https://github.com/happypeter/happygrep/blob/master/README.md
- `imgur` - Ditto, but with BSD.  https://github.com/zbuc/imgurBar/blob/master/README.md
- `graphsketcher` - Marked as MIT when in actuality it is the OmniSource License (https://github.com/graphsketcher/GraphSketcher/blob/master/OmniSourceLicense.html) but as they themselves admit at https://www.omnigroup.com/developer it is basically just the MIT license repackaged
- `mame` - Comitted as `:gratis` since MAMEOSX source is open (MIT, http://mameosx.sourceforge.net/license.php) but the underlying MAME code is not open as the developers specifically state.  It appears (https://github.com/mamedev/mame/blob/master/docs/license.txt) to largely differ in terms of not allowing any commercial products/activity.
- `sonora` - `:gratis` as the _code_ is licensed under the 3-clause BSD, but the assets (e.g. designs) are not libre, and the application is not available for distribution.  See more information at https://github.com/sonoramac/Sonora/blob/master/README.md
- `pdfshaver` and `spotify-notifications` are `:public_domain`
