### PR TITLE
Add Livestream Producer

### DIFF
--- a/Casks/livestream-producer.rb
+++ b/Casks/livestream-producer.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'livestream-producer' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://cdn.livestream.com/producer/LivestreamProducer.pkg'
+  name 'Livestream Producer'
+  homepage 'https://new.livestream.com/producer/software'
+  license :gratis
+
+  pkg 'LivestreamProducer.pkg'
+
+  uninstall :pkgutil => [
+                         'com.livestream.livestreamProducer.LivestreamProducer.pkg',
+                         'com.livestream.livestreamProducer.ProcasterAudioRedirector.pkg',
+                         'com.livestream.livestreamProducer.postflight.pkg',
+                         'com.livestream.livestreamProducer.preflight.pkg'
+                        ]
+end


### PR DESCRIPTION
Been a while since I've done this, so I don't remember how to structure the pkg uninstaller. I've got these IDs for the pkg:

```
com.livestream.livestreamProducer.LivestreamProducer.pkg
com.livestream.livestreamProducer.ProcasterAudioRedirector.pkg
com.livestream.livestreamProducer.postflight.pkg
com.livestream.livestreamProducer.preflight.pkg
```

Just let me know how I should add this and I'll update.
