### PR TITLE
update prey cask

### DIFF
--- a/Casks/prey.rb
+++ b/Casks/prey.rb
@@ -1,14 +1,17 @@
 cask :v1 => 'prey' do
-  version '0.6.4'
-  sha256 '361996d067539da7881aa3618b737ba4a0846df13ca8c9b8b07151d42f81fb86'
+  version '1.3.6'
+  sha256 'd6c1c5dac39b0404a194290e4b0e3b975debfd32e174327aa14a345b5a8e8262'
 
-  url "https://preyproject.com/releases/current/prey-#{version}-mac-batch.mpkg.zip"
+  # amazonaws.com is the official download host per the vendor homepage
+  url "https://s3.amazonaws.com/prey-releases/node-client/#{version}/prey-mac-#{version}-x64.pkg"
   homepage 'https://preyproject.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
-  pkg "prey-#{version}-mac-batch.mpkg"
+  pkg "prey-mac-#{version}-x64.pkg"
 
-  uninstall :pkgutil => 'com.forkhq.prey'
+  uninstall :pkgutil => 'com.prey.agent',
+            :launchctl => 'com.prey.agent'
+
   caveats <<-EOS.undent
     To complete installation, Prey requires an API key. It may be set
     as an environment variable as follows:


### PR DESCRIPTION
Prey is now using a new version `1.3.6` based on node.

May be the current cask for `0.6.4` should be added to [caskroom/homebrew-versions](http://github.com/caskroom/homebrew-versions) as a legacy version.
