### PR TITLE
vivaldi sha256 fix

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vivaldi' do
   version '1.0.83.38'
-  sha256 '1cffe405d04a477e3c8d3901259e855c782920569bd0ff59cc1cb98a46706698'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "http://vivaldi.com/download/Vivaldi_TP_#{version}.dmg"
   name 'Vivaldi'

--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vivaldi' do
   version '1.0.83.38'
-  sha256 '54682a12066ab6b446003d3c1735e7504136a043d0dc913e510f614370de15a9'
+  sha256 '1cffe405d04a477e3c8d3901259e855c782920569bd0ff59cc1cb98a46706698'
 
   url "http://vivaldi.com/download/Vivaldi_TP_#{version}.dmg"
   name 'Vivaldi'


### PR DESCRIPTION
Just like #9292 and #9308, the checksum has changed (again)
but the version number appears the same

I've updated the sha256 to the most recent value

Perhaps we should change the sha256 to :no_check?
