### PR TITLE
Fixed puppet cask

### DIFF
--- a/Casks/puppet.rb
+++ b/Casks/puppet.rb
@@ -9,4 +9,5 @@ cask :v1 => 'puppet' do
   pkg "puppet-#{version}.pkg"
 
   uninstall :pkgutil => 'com.puppetlabs.puppet'
+  depends_on :cask => 'facter'
 end


### PR DESCRIPTION
Puppet was crashing when it couldn't find facter.  This fixes the dep chain.
