### PR TITLE
fix checksum

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vivaldi' do
   version '1.0.83.38'
-  sha256 '54682a12066ab6b446003d3c1735e7504136a043d0dc913e510f614370de15a9'
+  sha256 '1cffe405d04a477e3c8d3901259e855c782920569bd0ff59cc1cb98a46706698'
 
   url "http://vivaldi.com/download/Vivaldi_TP_#{version}.dmg"
   name 'Vivaldi'


### PR DESCRIPTION
Error: sha256 mismatch
Expected: 54682a12066ab6b446003d3c1735e7504136a043d0dc913e510f614370de15a9
Actual: 1cffe405d04a477e3c8d3901259e855c782920569bd0ff59cc1cb98a46706698
File: /Library/Caches/Homebrew/vivaldi-1.0.83.38.dmg
To retry an incomplete download, remove the file above.
