### PR TITLE
Add gpgtools support for Yosemite by upgrading to 2014-12-b4

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'gpgtools' do
-  version '2013.10.22'
-  sha256 'd37ccf01e5ddd07dd84b76574e99b605ca9ead89cb0c6c126f4045e271eb3841'
+  version '2014.12-b4'
+  sha256 '711e175595fd4c1525de90b741fa0d02793df753465d27c6cefc35eb0573cd33'
 
   url "https://releases.gpgtools.org/GPG%20Suite%20-%20#{version}.dmg"
   gpg "#{url}.sig",


### PR DESCRIPTION
This is the current version being shown in project's homepage:
https://gpgtools.org
It says:

> We encourage all of our users to install this release.
> GPG Suite Beta 4 runs on OS X 10.6 and newer.

Problems are reported here:
http://support.gpgtools.org/discussions/problems/28092-mail-crashing-in-os-1010-yosemite-after-installing-gpg

Applying this locally works correctly as expected and I'm able to create emails and send them without having Mail.app crashing.
