### PR TITLE
Add PyCharm EE.app v1.0.1

### DIFF
--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'pycharm-edu' do
+  version '1.0.1'
+  sha256 'fedffd333b42bb43293ed08df3c463e961452c842dec8d72be37d419e30cfea6'
+
+  url "http://download-cf.jetbrains.com/python/pycharm-educational-#{version}.dmg"
+  name 'PyCharm'
+  name 'PyCharm Educational Edition'
+  name 'PyCharm EE'
+  homepage 'https://www.jetbrains.com/pycharm-educational'
+  license :apache
+
+  app 'PyCharm EE.app'
+
+  postflight do
+    plist_set(':JVMOptions:JVMVersion', '1.6+')
+  end
+end


### PR DESCRIPTION
For already three months there has been a modification of PyCharm—[PyCharm Educational Edition](http://blog.jetbrains.com/pycharm/2014/10/jetbrains-debuts-pycharm-educational-edition/) (or simply PyCharm EE)—intended for people who have no or almost no programming experience. Maybe it is not the best thing to make a cask for, however I think it is acceptable and even useful for people. And because there are casks for all the products of JetBrains, I believe for this one there can also be a cask.
