### PR TITLE
Upgrade youtrack-workflow.app to v6.0

### DIFF
--- a/Casks/youtrack-workflow.rb
+++ b/Casks/youtrack-workflow.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'youtrack-workflow' do
-  version '5.2.1'
-  sha256 'a0ecd6b54d8cb2726086aa4db2744446e75a42f02e99e975fee237200b244e91'
+  version '6.0'
+  sha256 '331bd2745696507da7ee3a6a193587fc53739face966c12736c16235211cda14'
 
-  url 'http://download-cf.jetbrains.com/charisma/youtrack-workflow-editor-8452-macos.zip'
+  url 'http://download-cf.jetbrains.com/charisma/youtrack-workflow-editor-3384fix-macos.zip'
   name 'YouTrack Workflow Editor'
-  homepage 'http://www.jetbrains.com/youtrack/download/get_youtrack.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'https://www.jetbrains.com/youtrack/download/get_youtrack.html#workflow'
+  license :gratis
 
   app 'youtrack-workflow.app'
 end


### PR DESCRIPTION
I also tried to find any mentioning of the license for YouTrack Workflow Editor but I failed. So it still remains `unknown`. Nonetheless, I have an assumption that it is freeware because nothing is mentioned against, and you can download it for free without any trials. But it will work only in the YouTrack app, which is, in turn, has a commercial license. So I don't know how this case can be defined.
