### PR TITLE
Upgrade Parallels Desktop.app to v10.1.3-28868

### DIFF
--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'parallels-desktop' do
-  version '10.1.2-28859'
-  sha256 'f2c14d5318bf96e4c6d8cb43574124e3633bfe3c0d54198fd506ade6da34c394'
+  version '10.1.3-28868'
+  sha256 '138e6b501ba54641fbe7e4314c96f05af5c59ddb7212582a30cf07d24bd02c63'
 
-  url "http://download.parallels.com/desktop/v10/updates/#{version.sub(/-.*$/, '')}/ParallelsDesktop-#{version}.dmg"
+  url "http://download.parallels.com/desktop/v#{version[/^\w+/]}/#{version.sub(/-.*$/, '')}/ParallelsDesktop-#{version}.dmg"
   homepage 'http://www.parallels.com/products/desktop/'
   license :commercial
 


### PR DESCRIPTION
Besides upgrading the app to the newer version, I also dared extract the `/v10/` part of the URL by simple slicing the version string. If it is acceptable here (since the cask is a ruby file) so great.
