### PR TITLE
alfred: bring back cli command as stub

### DIFF
--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -4,6 +4,7 @@ require 'optparse'
 require 'shellwords'
 
 require 'hbc/cli/base'
+require 'hbc/cli/alfred'
 require 'hbc/cli/audit'
 require 'hbc/cli/cat'
 require 'hbc/cli/cleanup'

--- a/lib/hbc/cli/alfred.rb
+++ b/lib/hbc/cli/alfred.rb
@@ -1,0 +1,11 @@
+class Hbc::CLI::Alfred < Hbc::CLI::Base
+  def self.run(*args)
+    ohai "Great news!"
+    ohai "As of v2.6, Alfred now has first-class support for Casks out of the box!"
+    ohai "So there's no more need for `brew cask alfred`. Go upgrade your Alfred! :)"
+  end
+
+  def self.help
+    "displays note about new built-in alfred support"
+  end
+end


### PR DESCRIPTION
Make `brew cask alfred` inform the user about the new Alfred support for
Casks. Should help with the transition.

refs #9405
