### PR TITLE
Update todotxt to v1.4.0.

### DIFF
--- a/Casks/todotxt.rb
+++ b/Casks/todotxt.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'todotxt' do
-  version '1.2.8'
-  sha256 '9d74c1ff59775271010a242fc4065e02dc24d1be47cfa349c5ed991c4cf5045e'
+  version '1.4.0'
+  sha256 '8caa4f7447fc93c067eece1764a292f0c635fe992f6eaf0417bab2a783b8ec8c'
 
   url "https://github.com/mjdescy/TodoTxtMac/releases/download/#{version}/TodoTxtMac.app.zip"
   name 'TodoTxtMac'


### PR DESCRIPTION
TodoTxtMac was updated to version 1.4.0.
