### PR TITLE
Bowery version bump to 3.5.0

### DIFF
--- a/Casks/bowery.rb
+++ b/Casks/bowery.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'bowery' do
-  version '0.0.0'
-  sha256 '86fc89cab7f4cfca1e85689c228cde83612e2dc20648bbd45ae79160159ae2e3'
+  version '3.5.0'
+  sha256 '10b6d86f6e137ae274f794c73b433ae7ded60f177bbcfadad9532a66da1d7681'
 
   url "http://desktop.bowery.io/#{version}_darwin_amd64.zip"
   name 'Bowery'


### PR DESCRIPTION
0.0.0 is an alpha channel
