### PR TITLE
Add uninstall parameter to Parallels Virtualization SDK

### DIFF
--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -7,6 +7,7 @@ cask :v1 => 'parallels-virtualization-sdk' do
   homepage 'http://www.parallels.com/products/desktop/download/'
   license :gratis
 
-  app 'Parallels Virtualization SDK.app'
+  pkg 'Parallels Virtualization SDK.pkg'
+  uninstall :pkgutil => 'com.parallels.pkg.sdk'
 
 end


### PR DESCRIPTION
The most-possibly-ever-final fix here :( Sorry. Now, everything gets unpacked and done the way it is supposed to. Tested for a gillion times. And added an uninstall parameter.
