### PR TITLE
updated logic cask

### DIFF
--- a/Casks/logic.rb
+++ b/Casks/logic.rb
@@ -7,5 +7,5 @@ cask :v1 => 'logic' do
   homepage 'http://www.saleae.com/'
   license :commercial
 
-  app "Logic.app"
+  app 'Logic.app'
 end

--- a/Casks/logic.rb
+++ b/Casks/logic.rb
@@ -1,12 +1,11 @@
 cask :v1 => 'logic' do
-  version '1.1.15'
-  sha256 '1c37d6809bfb6daec88a7a34c6f056b93179c2471385f5e7be4d4271995995b1'
+  version '1.1.34'
+  sha256 'a30535480c38d88c023d5fe83dc53f8e97aa20f3b98fc5c6ecf08bf2ffc50eaf'
 
-  url "http://downloads.saleae.com/Logic%20#{version}%20(10.5%2B).pkg"
+  url "http://downloads.saleae.com/betas/#{version}/Logic-#{version}-Darwin.dmg"
+
   homepage 'http://www.saleae.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
-  pkg "Logic #{version} (10.5+).pkg"
-
-  uninstall :pkgutil => 'com.saleae.saleae.Logic.pkg'
+  app "Logic.app"
 end


### PR DESCRIPTION
updated `logic` cask to a newer version that support the newer Saleae devices, cf the [changelog](http://support.saleae.com/hc/en-us/articles/201589175?flash_digest=356c7198f8123de41cd1d40a8d3fd5e3ebe0b8a2). It's marked as beta, but is recommended by the Saleae team.

Signed-off-by: Guyzmo <guyzmo+github@m0g.net>
