### PR TITLE
Use bold terminal escapes instead of white

### DIFF
--- a/lib/hbc/cli/info.rb
+++ b/lib/hbc/cli/info.rb
@@ -60,7 +60,7 @@ PURPOSE
     retval = ''
     Hbc::DSL::ClassMethods.ordinary_artifact_types.each do |type|
       if cask.artifacts[type].length > 0
-        retval = "#{Tty.blue.bold}==>#{Tty.white} Contents#{Tty.reset}\n" unless retval.length > 0
+        retval = "#{Tty.blue.bold}==>#{Tty.reset.bold} Contents#{Tty.reset}\n" unless retval.length > 0
         cask.artifacts[type].each do |artifact|
           activatable_item = type == :stage_only ? '<none>' : artifact.first
           retval.concat "  #{activatable_item} (#{type.to_s})\n"

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -78,7 +78,7 @@ class Hbc::Installer
     s = if MacOS.release >= :lion and not ENV['HOMEBREW_NO_EMOJI']
       (ENV['HOMEBREW_INSTALL_BADGE'] || "\xf0\x9f\x8d\xba") + '  '
     else
-      "#{Tty.blue.bold}==>#{Tty.white} Success!#{Tty.reset} "
+      "#{Tty.blue.bold}==>#{Tty.reset.bold} Success!#{Tty.reset} "
     end
     s << "#{@cask} staged at '#{@cask.staged_path}' (#{Hbc::Utils.cabv(@cask.staged_path)})"
   end

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -45,7 +45,7 @@ end
 # originally from Homebrew
 def ohai(title, *sput)
   title = Tty.truncate(title) if $stdout.tty? && !Hbc.verbose
-  puts "#{Tty.blue.bold}==>#{Tty.white} #{title}#{Tty.reset}"
+  puts "#{Tty.blue.bold}==>#{Tty.reset.bold} #{title}#{Tty.reset}"
   puts sput unless sput.empty?
 end
 
@@ -65,7 +65,7 @@ def odebug(title, *sput)
     if $stdout.tty? and title.to_s.length > width
       title = title.to_s[0, width - 3] + '...'
     end
-    puts "#{Tty.magenta.bold}==>#{Tty.white} #{title}#{Tty.reset}"
+    puts "#{Tty.magenta.bold}==>#{Tty.reset.bold} #{title}#{Tty.reset}"
     puts sput unless sput.empty?
   end
 end
@@ -222,13 +222,13 @@ module Hbc::Utils
 
   def self.error_message_with_suggestions
     <<-EOS.undent
-    #{ Tty.reset.white.bold }
+    #{ Tty.reset.bold }
       Most likely, this means you have an outdated version of homebrew-cask.#{
       } Please run:
 
           #{ Tty.green.normal }#{ UPDATE_CMD }
 
-      #{ Tty.white.bold }If this doesn’t fix the problem, please report this bug:
+      #{ Tty.reset.bold }If this doesn’t fix the problem, please report this bug:
 
           #{ Tty.underline }#{ ISSUES_URL }#{ Tty.reset }
 


### PR DESCRIPTION
Let the terminal decide how to display bold.  Fixes #9349. The issue arose when integrating Homebrew's `Tty` class. Homebrew's `Tty.white` actually emits escapes for bold.

Fixing `Tty.white` to do what the method name says caused loss of visibility on light backgrounds.
