### PR TITLE
10.10.3 fix: pull bsexec from mount commands

### DIFF
--- a/lib/hbc/container/dmg.rb
+++ b/lib/hbc/container/dmg.rb
@@ -32,8 +32,6 @@ class Hbc::Container::Dmg < Hbc::Container::Base
 
   def mount!
     plist = @command.run('/usr/bin/hdiutil',
-      # :startup may not be the minimum necessary privileges
-      :bsexec => :startup,
       # realpath is a failsafe against unusual filenames
       :args => %w[mount -plist -nobrowse -readonly -noidme -mountrandom /tmp] + [Pathname.new(@path).realpath],
       :input => %w[y]
@@ -60,15 +58,11 @@ class Hbc::Container::Dmg < Hbc::Container::Base
       mountpath = Pathname.new(mount).realpath
       next unless mountpath.exist?
       @command.run('/usr/sbin/diskutil',
-                   # :startup may not be the minimum necessary privileges
-                   :bsexec => :startup,
                    :args => ['eject', mountpath],
                    :print_stderr => false)
       next unless mountpath.exist?
       sleep 1
       @command.run('/usr/sbin/diskutil',
-                   # :startup may not be the minimum necessary privileges
-                   :bsexec => :startup,
                    :args => ['eject', mountpath],
                    :print_stderr => false)
       next unless mountpath.exist?


### PR DESCRIPTION
It seems like in 10.10.3 apple, in its infinite wisdom, decided that the
bsexec option for launchctl would suddenly require root privileges.

Since we were proactively using bsexec for all DMG mounts, this was
breaking dmg-based Casks for all early adopters of 10.10.3.

We can regroup to try and address #7132 another way, but for now, just
pulling all the bsexec stuff out.
