### PR TITLE
core: fix preflight/postflight/caveats in casks

### DIFF
--- a/lib/hbc/dsl/base.rb
+++ b/lib/hbc/dsl/base.rb
@@ -17,7 +17,7 @@ class Hbc::DSL::Base
   end
 
   def caskroom_path
-    @cask.class.caskroom.join(token)
+    @cask.caskroom_path
   end
 
   def staged_path


### PR DESCRIPTION
These were broken in the refactor to extract Hbc::Cask from Hbc.

fixes #9503 
fixes #9494
