### PR TITLE
Update GPGTools Suite to Beta 5

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'gpgtools' do
-  version '2014.12-b4'
-  sha256 '711e175595fd4c1525de90b741fa0d02793df753465d27c6cefc35eb0573cd33'
+  version '2015.02-b5-1161'
+  sha256 '06fb88a45e8c35c3bb4ce638d45c3bc42d1b8cb84c865106a0eb918fa3fd71f4'
 
-  url "https://releases.gpgtools.org/GPG%20Suite%20-%20#{version}.dmg"
+  url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   gpg "#{url}.sig",
       :key_url => 'https://gpgtools.org/GPGTools%2000D026C4.asc'
   homepage 'https://gpgtools.org/'


### PR DESCRIPTION
Update the GPGTools Suite cask to Beta 5 released the February 7th, 2015.
