### PR TITLE
osxfuse Version bump and fixed url

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'osxfuse' do
-  version '2.7.4'
-  sha256 'e5f43f673062725d76b6c10d379d576f6148f32fab42f6d18455b11f41e92969'
+  version '2.7.5'
+  sha256 '9be5cc9c44c2211aacea6a35aea5d47fea82599e981f051f318201a637b43f72'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"


### PR DESCRIPTION
For some reason I was getting sha miss matches.  I think the URL that it was pulling from wasn't following all redirects, and this URL seemed to provide a direct download.

This may or may not be the way you want to handle this situation.
