### PR TITLE
Latest screenflick via zip, not dmg

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -2,7 +2,7 @@ cask :v1 => 'screenflick' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.araelium.com/screenflick/downloads/Screenflick.dmg'
+  url 'http://www.araelium.com/screenflick/downloads/Screenflick.zip'
   name 'Screenflick'
   homepage 'http://www.araelium.com/screenflick/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
The current cask uses a DMG installer which is outdated. Araelium provide the latest version of Screenflick (2.5 at time of writing) as a zip download: http://www.araelium.com/screenflick

Unfortunately the version number is not included in either the dmg or the zip.
