### PR TITLE
Add QLGradle v0.0.1 (Quicklook plugin to preview. gradle files)

### DIFF
--- a/Casks/qlgradle.rb
+++ b/Casks/qlgradle.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'qlgradle' do
+  version '0.0.1'
+  sha256 'ea76846953ecfbd180d65167ec31cb7c316030f500a6669cd79857c03b951b63'
+
+  url "https://github.com/Urucas/QLGradle/releases/download/#{version}/QLGradle.qlgenerator.zip"
+  name 'qlgradle'
+  homepage 'https://github.com/Urucas/QLGradle'
+  license :mit 
+
+  qlplugin 'QLGradle.qlgenerator'
+end


### PR DESCRIPTION
Add a cask for QLGradle, a Quicklook plugin to preview .gradle files. 

cask:
<a href="https://github.com/vrunoa/homebrew-cask/blob/master/Casks/QLGradle.rb">https://github.com/vrunoa/homebrew-cask/blob/master/Casks/QLGradle.rb</a>

QLGradle repository:
<a href="https://github.com/Urucas/QLGradle">https://github.com/Urucas/QLGradle</a>
