### PR TITLE
Update Jitsi

### DIFF
--- a/Casks/jitsi.rb
+++ b/Casks/jitsi.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'jitsi' do
-  version '2.4'
-  sha256 'ceb6b2ab04206a51faf1dbffb704a7a60ae2b7c47834b50f87da5557f543ad13'
+  version '2.6'
+  sha256 '574bae43116792ce1f2ab5e61486388eee07cdfab618f8a251f66ed7ed01d27d'
 
-  url "https://download.jitsi.org/jitsi/macosx/jitsi-#{version}-latest.dmg"
+  url "https://download.jitsi.org/jitsi/macosx/jitsi-#{version}.5390.dmg"
   appcast 'https://download.jitsi.org/jitsi/macosx/sparkle/updates.xml',
           :sha256 => 'db2939816e8a38c7197160ab455626af9aadc2c5603f2212e372cffb85b31949'
   homepage 'https://jitsi.org/'


### PR DESCRIPTION
Jitsi 2.6 is the new stable build line: https://jitsi.org/Main/Download
jitsi-2.6-latest link does not exist: https://download.jitsi.org/jitsi/macosx/
