### PR TITLE
added casks for microchip's mplab xc compilers support.

### DIFF
--- a/Casks/mplab-xc16.rb
+++ b/Casks/mplab-xc16.rb
@@ -1,0 +1,43 @@
+cask :v1 => 'mplab-xc16' do
+  version '1.24'
+  sha256 'f717ff76388d8b46b0add82048a42fa34f56879814775fe798300a33266c47b3'
+
+  url "http://ww1.microchip.com/downloads/en/DeviceDoc/xc16-v#{version}-full-install-osx-installer.dmg"
+  name 'MPLab XC16 Compiler'
+  homepage 'http://www.microchip.com/pagehandler/en-us/devtools/mplabxc/home.html'
+  license :freemium
+
+  installer :script => "xc16-v#{version}-osx-installer.app/Contents/MacOS/installbuilder.sh",
+            :args => ['--mode', 'unattended',
+                      '--unattendedmodeui', 'none',
+                      '--netclient', '0',
+                      '--netservername', '""',
+                      '--installerfunction', 'installcompiler',
+                      '--ModifyAll', '0',
+                      '--prefix', "/opt/homebrew-cask/Caskroom/mplab-xc16/#{version}"]
+
+  postflight do
+    system '/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "/opt/homebrew-cask/Caskroom/mplab-xc16/#{version}"
+    system '/bin/rm', '-rf', '--', "/opt/homebrew-cask/Caskroom/mplab-xc16/xc16-v#{version}-osx-installer.app"
+  end
+
+  binary 'bin/sim30'
+  binary 'bin/xc16-ar'
+  binary 'bin/xc16-as'
+  binary 'bin/xc16-bin2hex'
+  binary 'bin/xc16-cc1'
+  binary 'bin/xc16-gcc'
+  binary 'bin/xc16-ld'
+  binary 'bin/xc16-nm'
+  binary 'bin/xc16-objdump'
+  binary 'bin/xc16-pa'
+  binary 'bin/xc16-ranlib'
+  binary 'bin/xc16-readelf'
+  binary 'bin/xc16-strings'
+  binary 'bin/xc16-strip'
+
+  uninstall :script => {
+                :executable => "Uninstall-xc16-v#{version}.app/Contents/MacOS/installbuilder.sh",
+                :args => ['--mode', 'unattended']
+  }
+end

--- a/Casks/mplab-xc32.rb
+++ b/Casks/mplab-xc32.rb
@@ -1,0 +1,53 @@
+cask :v1 => 'mplab-xc32' do
+  version '1.34'
+  sha256 '47d97c5e535f66b02c2046d1665f7be91bbfe458f80a63a9eda12db0fc136098'
+
+  url "http://ww1.microchip.com/downloads/en/DeviceDoc/xc32-v#{version}-full-install-osx-installer.dmg"
+  name 'MPLab XC32 Compiler'
+  homepage 'http://www.microchip.com/pagehandler/en-us/devtools/mplabxc/home.html'
+  license :freemium
+
+  installer :script => "xc32-v#{version}-osx-installer.app/Contents/MacOS/installbuilder.sh",
+            :args => ['--mode', 'unattended',
+                      '--unattendedmodeui', 'none',
+                      '--netclient', '0',
+                      '--netservername', '""',
+                      '--installerfunction', 'installcompiler',
+                      '--ModifyAll', '0',
+                      '--prefix', "/opt/homebrew-cask/Caskroom/mplab-xc32/#{version}"]
+
+  postflight do
+    system '/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "/opt/homebrew-cask/Caskroom/mplab-xc32/#{version}"
+    system '/bin/rm', '-rf', '--', "/opt/homebrew-cask/Caskroom/mplab-xc32/xc32-v#{version}-osx-installer.app"
+  end
+
+  binary 'bin/xc32-addr2line'
+  binary 'bin/xc32-ar'
+  binary 'bin/xc32-as'
+  binary 'bin/xc32-bin2hex'
+  binary 'bin/xc32-c++'
+  binary 'bin/xc32-c++filt'
+  binary 'bin/xc32-cc1'
+  binary 'bin/xc32-cc1plus'
+  binary 'bin/xc32-collect2'
+  binary 'bin/xc32-conv'
+  binary 'bin/xc32-cpp'
+  binary 'bin/xc32-elfedit'
+  binary 'bin/xc32-g++'
+  binary 'bin/xc32-gcc'
+  binary 'bin/xc32-ld'
+  binary 'bin/xc32-nm'
+  binary 'bin/xc32-objcopy'
+  binary 'bin/xc32-objdump'
+  binary 'bin/xc32-ranlib'
+  binary 'bin/xc32-readelf'
+  binary 'bin/xc32-size'
+  binary 'bin/xc32-strings'
+  binary 'bin/xc32-strip'
+  binary 'bin/xclm', :target => 'xc32lm'
+
+  uninstall :script => {
+                :executable => "Uninstall-xc32-v#{version}.app/Contents/MacOS/installbuilder.sh",
+                :args => ['--mode', 'unattended']
+  }
+end

--- a/Casks/mplab-xc8.rb
+++ b/Casks/mplab-xc8.rb
@@ -1,0 +1,50 @@
+cask :v1 => 'mplab-xc8' do
+  version '1.33'
+  sha256 '3f3b65b0808241ea2fdb984aad28c88de9a813eeaa5c0a7bb19c3e63a31ca03d'
+
+  url "http://ww1.microchip.com/downloads/en/DeviceDoc/xc8-v#{version}-full-install-osx-installer.dmg"
+  name 'MPLab XC32 Compiler'
+  homepage 'http://www.microchip.com/pagehandler/en-us/devtools/mplabxc/home.html'
+  license :freemium
+
+  installer :script => "xc8-v#{version}-osx.app/Contents/MacOS/installbuilder.sh",
+            :args => ['--mode', 'unattended',
+                      '--unattendedmodeui', 'none',
+                      '--netclient', '0',
+                      '--netservername', '""',
+                      '--installerfunction', 'installcompiler',
+                      '--ModifyAll', '0',
+                      '--prefix', "/opt/homebrew-cask/Caskroom/mplab-xc8/#{version}"]
+
+  postflight do
+    system '/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "/opt/homebrew-cask/Caskroom/mplab-xc8/#{version}"
+    system '/bin/rm', '-rf', '--', "/opt/homebrew-cask/Caskroom/mplab-xc8/xc8-v#{version}-osx-installer.app"
+  end
+
+  binary 'bin/aspic'
+  binary 'bin/aspic18'
+  binary 'bin/cgpic'
+  binary 'bin/cgpic18'
+  binary 'bin/clist'
+  binary 'bin/cpp'
+  binary 'bin/cromwell'
+  binary 'bin/dump'
+  binary 'bin/hexmate'
+  binary 'bin/hlink'
+  binary 'bin/libr'
+  binary 'bin/mcc18'
+  binary 'bin/mplib'
+  binary 'bin/mplink'
+  binary 'bin/objtohex'
+  binary 'bin/p1'
+  binary 'bin/picc'
+  binary 'bin/picc18'
+  binary 'bin/xc8'
+  binary 'bin/xstrip'
+  binary 'bin/xclm', :target => 'xc8lm'
+
+  uninstall :script => {
+                :executable => "Uninstall-xc8-v#{version}.app/Contents/MacOS/installbuilder.sh",
+                :args => ['--mode', 'unattended']
+  }
+end


### PR DESCRIPTION
- binary casks that deploy the compilers in /usr/local/bin/,
- install and uninstall script support,
- support for the xc32, xc16 and xc8 compilers for the PIC32, 16 and 8 series
