### PR TITLE
Update Trailer to 1.2.0

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'trailer' do
-  version '1.1.5'
-  sha256 'fac5b10d2613ef64a56a198e385a0d772ebd333386abca6efbc1c71481c02166'
+  version '1.2.0'
+  sha256 '44885120d8eb872c9ee53717c2e6be525e28f74889fdbbc7d0e8abe1016c3f4c'
 
   url "http://ptsochantaris.github.io/trailer/trailer#{version.gsub('.','')}.zip"
   appcast 'http://ptsochantaris.github.io/trailer/appcast.xml',
-          :sha256 => 'eca7558a05e4984335438eb7fbb1e341a6ada3fb6217db0dfdb0a672701a9e89'
+          :sha256 => '4497fd075ea4742755eeac30b1c99ccfe4ed5d5ed835bea58ae4d5b5262ed96c'
   name 'Trailer'
   homepage 'http://ptsochantaris.github.io/trailer/'
   license :mit


### PR DESCRIPTION
Upgraded to the latest version of Trailer (1.2.0) from 1.1.5
