### PR TITLE
Add RealVNC 5.2.3 (new cask)

### DIFF
--- a/Casks/real-vnc.rb
+++ b/Casks/real-vnc.rb
@@ -1,0 +1,19 @@
+cask :v1 => 'real-vnc' do
+  version '5.2.3'
+  sha256 '1e59895d261b8903e8cdc9e0419804289e62ac7834fd8efb62d678559198bd8e'
+
+  url 'https://www.realvnc.com/download/binary/1713/'
+  name 'Real VNC'
+  homepage 'https://www.realvnc.com'
+  license :freemium
+
+  container :type => :naked
+  preflight do
+    system '/bin/mv', '--', staged_path.join('1713'), staged_path.join("VNC-#{version}-MacOSX.pkg")
+  end
+
+  pkg "VNC-#{version}-MacOSX.pkg"
+
+  uninstall :early_script => '/Applications/RealVNC/Advanced.localized/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh',
+    :script => '/Applications/RealVNC/Advanced.localized/Uninstall VNC Viewer.app/Contents/Resources/uninstaller.sh'
+end


### PR DESCRIPTION
The preflight is necessary because it won't run without `.pkg` suffix.

The uninstall script from vendor seems to be a little bit buggy, it has been reported to their support though:

```
==> Running uninstall process for real-vnc; your password may be necessary
==> Running uninstall script /Applications/RealVNC/Advanced.localized/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh
Password:
==> Forgot package 'com.realvnc.vncserver.pkg' on '/'.
==> ls: /Applications/RealVNC/Advanced: No such file or directory
==> /Applications/RealVNC/Advanced.localized/Uninstall VNC Server.app/Contents/Resources/uninstallCommon.sh: line 29: ./removeFwExc.sh: No such file or direct
==> No receipt for 'com.realvnc.VNCServer.pkg' found at '/'.
==> Forgot package 'com.realvnc.vncviewer.pkg' on '/'.
==> ls: /Applications/RealVNC/Advanced: No such file or directory
==> No receipt for 'com.realvnc.VNCViewer.pkg' found at '/'.
```

Here's a full copy of the ticket: https://gist.github.com/radeksimko/8aef85a6acde5475a888

The most important parts work though - it uninstalls the pkg by its id, removes services and files.

The situation with license is very similar to Google Chrome - you won't get download link until you agree with license, but you can still go to the download URL directly (don't know if that's a feature or bug).

btw. it installs both viewer & server - see #9578 how we can prevent it
