### PR TITLE
Update DNSCrypt to 1.0.5

### DIFF
--- a/Casks/dnscrypt.rb
+++ b/Casks/dnscrypt.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'dnscrypt' do
-  version '1.0.4'
-  sha256 '14e08b4e4bba7e7a0761e318eca559a980e95dc46fafd7251011785f0cf10993'
+  version '1.0.5'
+  sha256 '9d0cec793f33ba107bd724830398d6b156f5a7b3c8f33a5d3ae529c588041a36'
 
   url "https://github.com/alterstep/dnscrypt-osxclient/releases/download/#{version}/dnscrypt-osxclient-#{version}.dmg"
   name 'DNSCrypt'


### PR DESCRIPTION
Upstream Release Notes
- Updated DNSCrypt proxy to version 1.4.3 (from 1.4.1)
- Updated libsodium to 1.0.1-minimal (from 0.7.0-minimal)
