### PR TITLE
Added CodeBlocks.app v13.12

### DIFF
--- a/Casks/codeblocks.rb
+++ b/Casks/codeblocks.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'codeblocks' do
+  version '13.12'
+  sha256 'ef0b541a8897db3132494b899034019739ccee8b8add2a36f018922a82d08b84'
+
+  url "http://sourceforge.net/projects/codeblocks/files/Binaries/#{version}/MacOS/CodeBlocks-#{version}-mac.zip"
+  name 'CodeBlocks'
+  name 'Code::Blocks'
+  homepage 'http://www.codeblocks.org'
+  license :gpl
+
+  app 'CodeBlocks.app'
+end


### PR DESCRIPTION
I'm a bit confused of whether the url is correct. I've tested it through `brew cask install codeblocks`, and it works. However, the `brew cask audit codeblocks --download` ended with the following warning and error:

```
audit for codeblocks: warning
 - SourceForge URL format incorrect.
See https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls
Error: audit failed
```

I again scrutinized the [info](CONTRIBUTING.md#sourceforge-urls) about using SourceForge and searched the existing casks for how they use SF links, and I ultimately got confused: there are casks that use the `/latest/download` url, and there are casks that use the link with version mentioning. So what is still better to use? I think when we indicate the version, it gets easier to control version changes...
