### PR TITLE
osxfuse 2.7.5

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,9 +1,10 @@
 cask :v1 => 'osxfuse' do
-  version '2.7.5'
-  sha256 '9be5cc9c44c2211aacea6a35aea5d47fea82599e981f051f318201a637b43f72'
+  version "2.7.5"
+  sha256 "9be5cc9c44c2211aacea6a35aea5d47fea82599e981f051f318201a637b43f72"
 
-  # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"
+  # sourceforge.net is the official download host per the vendor homepage, and
+  # avoid JS redirections...
+  url "http://aarnet.dl.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"
   homepage 'https://osxfuse.github.io/'
   license :bsd
 


### PR DESCRIPTION
Update from 2.7.4 and avoid JavaScript-based redirection!
