### PR TITLE
Update and improve wacom-tablet.rb

### DIFF
--- a/Casks/wacom-tablet.rb
+++ b/Casks/wacom-tablet.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'wacom-tablet' do
-  version '6.3.10w2'
-  sha256 'b94c99a3bbf063767ed51848642e8bf6f4d381e72fea7ba0bb85860cdc6fc921'
+  version '6.3.11w3'
+  sha256 'e96949fe4bd09e2edc9e47029f35e101276a21b493cc63d5e9b03a749f350062'
 
   url "http://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   homepage 'http://www.wacom.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   pkg 'Install Wacom Tablet.pkg'
 
@@ -15,10 +15,16 @@ cask :v1 => 'wacom-tablet' do
                       'com.wacom.WacomTouchDriver',
                      ],
             :kext => [
-                      'com.Wacom.iokit.TabletDriver',
+                      'com.wacom.kext.ftdi',
                       'com.wacom.kext.wacomtablet',
                       'com.silabs.driver.CP210xVCPDriver',
                       'com.silabs.driver.CP210xVCPDriver64',
                       ],
-            :pkgutil => 'com.wacom.installwacomtablet'
+            :pkgutil => 'com.wacom.TabletInstaller',
+            :delete => '/Applications/Wacom Tablet.localized'
+
+  zap :delete =>  [
+                    '~/Library//Preferences/com.wacom.wacomtablet.prefs',
+                    '~/Library//Preferences/com.wacom.wacomtouch.prefs'
+                  ]
 end


### PR DESCRIPTION
Update wacom-tablet to version 6.3.11w3

Change license to gratis

Update bundle identifier used by `:pkgutil` statement

Remove `'/Applications/Wacom Tablet.localized'` during uninstall.
Some things in this folder are not removed by the `:pkgutil` statement
so an explicit delete is necessary.

Add zap stanza to delete user preferences

Rename kext to `'com.wacom.kext.ftdi'`
