### PR TITLE
Remove begin/rescue logic in brew-cask.rb

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,11 +1,4 @@
-begin
-  require Pathname(__FILE__).realpath.dirname.join("lib", "hbc", "version")
-rescue
-  # todo: transitional, defensive, should not be needed.
-  # remove the begin/rescue logic after 1 Feb 2015
-  require Pathname(__FILE__).realpath.dirname.join("lib", "cask", "version")
-  HBC_VERSION = HOMEBREW_CASK_VERSION
-end
+require Pathname(__FILE__).realpath.dirname.join("lib", "hbc", "version")
 
 class BrewCask < Formula
   homepage "https://github.com/caskroom/homebrew-cask/"


### PR DESCRIPTION
Per the todo:

> Transitional, defensive, should not be needed.
> Remove the begin/rescue logic after 1 Feb 2015
