### PR TITLE
Update Screencloud to v1.2.0

### DIFF
--- a/Casks/screencloud.rb
+++ b/Casks/screencloud.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'screencloud' do
-  version '1.1.6'
-  sha256 '0858d973388be02514a7756233d06fabd8d9d44fb2d17a2859129337c03dc0d1'
+  version '1.2.0'
+  sha256 'e1a1a569a77fa1f92d27df2c55e60c7c0fe73a03904ae2eb67bb01c68188ffd5'
 
   url "https://screencloud.net/files/mac/ScreenCloud-#{version}.dmg"
   name 'ScreenCloud'


### PR DESCRIPTION
There is new version of Screencloud app. 
This pull request update the cask to latest version 1.2.0. 
