### PR TITLE
Add gcollazo-mongodb, another MongoDB.app contender

### DIFF
--- a/Casks/gcollazo-mongodb.rb
+++ b/Casks/gcollazo-mongodb.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'gcollazo-mongodb' do
+  version '1.2.0'
+  sha256 '6ad02eb126d2e78d8147b092b160e2cba99bd67cf0c95b6246ec23958e94dfc7'
+
+  # github.com is the official download host per the vendor homepage
+  url "https://github.com/gcollazo/mongodbapp/releases/download/#{version}/MongoDB.zip"
+  homepage 'http://elweb.co/mongodb-app/'
+  license :mit
+
+  app 'MongoDB.app'
+end


### PR DESCRIPTION
The mongodb.rb cask tracks a project that seems to have stalled
out.  I have found another project that also provides a varient
of the MongoDB.app that is much more up-to-date
