### PR TITLE
Bumped Bowery to version 3.6.0

### DIFF
--- a/Casks/bowery.rb
+++ b/Casks/bowery.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'bowery' do
-  version '3.5.0'
-  sha256 '10b6d86f6e137ae274f794c73b433ae7ded60f177bbcfadad9532a66da1d7681'
+  version '3.6.0'
+  sha256 'ecdb5efe10dcf39a309e5f910d0a3712fe23147200b958a88d43c8bacf8ab1e1'
 
   url "http://desktop.bowery.io/#{version}_darwin_amd64.zip"
   name 'Bowery'


### PR DESCRIPTION
Release Notes: http://bowery.io/posts/bowery-3-6-0-release/
