### PR TITLE
Fix Wordservice to be an App vs Service

### DIFF
--- a/Casks/wordservice.rb
+++ b/Casks/wordservice.rb
@@ -7,5 +7,5 @@ cask :v1 => 'wordservice' do
   homepage 'http://www.devontechnologies.com/products/freeware.html#c1115'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  service 'WordService/WordService.service'
+  app 'WordService.app'
 end


### PR DESCRIPTION
I tried installing the original wordservice cask and I got this error:

Error: It seems the symlink source is not there:
'/opt/homebrew-cask/Caskroom/wordservice/2.8.1/WordService/WordService.service'

After unzipping the download manually I saw that it was no longer a
"service" extension, so I made the update to the formula.
