### PR TITLE
pl2303: fix pkg name, update url, review uninstall

### DIFF
--- a/Casks/pl2303.rb
+++ b/Casks/pl2303.rb
@@ -1,14 +1,18 @@
 cask :v1 => 'pl2303' do
   version '1.5.1'
-  sha256 'b6658605409e9aa63bca7a1ac94c989cc01cdf375f6881ade0ed5bb9694c22cc'
+  sha256 '101058b71da6a6bd038b05abef0e556bd3203fcd04f35d545fd711c5d34d46c2'
 
-  url "http://prolificusa.com/files/md_PL2303_MacOSX-10_6up_v#{version.gsub('.','_')}.zip"
+  url "http://prolificusa.com/files/md_PL2303_MacOSX_10.6-10.10_v#{version}.zip"
   homepage 'http://www.prolificusa.com'
   license :closed
 
-  pkg "PL2303_MacOSX_v#{version.gsub('.','_')}.pkg"
+  pkg "PL2303_MacOSX_v#{version}.pkg"
 
-  uninstall :delete => [
+  depends_on :macos => '>= 10.6'
+
+  uninstall :pkgutil => "com.prolific.prolificUsbserialCableDriverV#{version.gsub('.','')}.ProlificUsbSerial.pkg",
+            :kext => 'com.prolific.driver.PL2303',
+            :delete => [
                         '/System/Library/Extensions/ProlificUsbSerial.kext',
                         '/var/db/receipts/*PL2303*.*',
                         '/var/db/receipts/*ProlificUSbSerial*.*',


### PR DESCRIPTION
The new URL points to a release compatible with 10.6–10.10; the previous one was limited to 10.6–10.8.

Note that the included `uninstall :delete` follows instructions included in the package `readme.txt`.

Closes #9694.
