### PR TITLE
Set gpgtools license from unknown to GPL

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gpgtools' do
   gpg "#{url}.sig",
       :key_url => 'https://gpgtools.org/GPGTools%2000D026C4.asc'
   homepage 'https://gpgtools.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   pkg 'Install.pkg'
   # todo, remove all ENV variables


### PR DESCRIPTION
According to their website (https://gpgtools.org), their code is under GPL.
