### PR TITLE
Upgraded Spotify Notifications to 0.5.1

### DIFF
--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'spotify-notifications' do
-  version '0.4.8'
-  sha256 '953028e9a1aad445005869598050cb8612980821a796563936f557e03b319f50'
+  version '0.5.1'
+  sha256 'd9adb821d82be7f1266d8042d2b677a4c91fe7686631c02e2d0307f9f536a722'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"


### PR DESCRIPTION
After a little over a year, I've finally gotten around to releasing an update for Spotify Notifications, so I figured I'd update the cask file too.

&mdash; @citruspi

P.S. Thanks for the awesome work. I was prettty pumped when I went to install Spotify on a new machine and found Spotify Notifications available as a cask. :+1: 
