### PR TITLE
Update Trailer.app to version 1.2.1

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'trailer' do
-  version '1.2.0'
-  sha256 '44885120d8eb872c9ee53717c2e6be525e28f74889fdbbc7d0e8abe1016c3f4c'
+  version '1.2.1'
+  sha256 'fbcd88fb94c2e7fa52ff17299106aed0b6cafc9b13aea38e24443d106baab119'
 
   url "http://ptsochantaris.github.io/trailer/trailer#{version.gsub('.','')}.zip"
   appcast 'http://ptsochantaris.github.io/trailer/appcast.xml',
-          :sha256 => '4497fd075ea4742755eeac30b1c99ccfe4ed5d5ed835bea58ae4d5b5262ed96c'
+          :sha256 => 'a85ed2eec975c1756989aea7dfa5ceed035d635d903911ba2e8ac2332a856b3b'
   name 'Trailer'
   homepage 'http://ptsochantaris.github.io/trailer/'
   license :mit


### PR DESCRIPTION
Upgraded to the latest version of Trailer (1.2.1) from 1.2.0
