### PR TITLE
change fish-app token to fishapp

### DIFF
--- a/Casks/fishapp.rb
+++ b/Casks/fishapp.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'fish-app' do
+cask :v1 => 'fishapp' do
   version '2.1.1'
   sha256 '92af7a82e6f46b35867ca160e42ca55a65eb86404bff47b8db489952dab488fc'
 


### PR DESCRIPTION
Dots are compressed rather than translated to hyphens.

refs #9718
