### PR TITLE
Add cool-retro-term 1.0.0

### DIFF
--- a/Casks/cool-retro-term.rb
+++ b/Casks/cool-retro-term.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'cool-retro-term' do
+  version '1.0.0'
+  sha256 'ccb1c78b54e1c2dcde1a660730da2b0f6d2e4213e3748e5ad81a5653926c920e'
+
+  url 'https://github.com/Swordfish90/cool-retro-term/releases/download/v1.0.0/cool-retro-term100.dmg'
+  name 'cool-retro-term'
+  homepage 'https://github.com/Swordfish90/cool-retro-term'
+  license :gpl
+
+  app 'cool-retro-term.app'
+end


### PR DESCRIPTION
This commit adds the cask for version 1.0.0 of [cool-retro-term](https://github.com/Swordfish90/cool-retro-term).
