### PR TITLE
ComicTagger 1.1.15-beta

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'comictagger' do
-  version '1.1.10-beta'
-  sha256 'f59514cfd15e64a8c595c4ad9707266b2c01d7744ca9f5836bee484954ce2fa6'
+  version '1.1.15-beta'
+  sha256 '6640834d966c1cc760de6aa32729bf139bf06727f8d650a4534cdf780f084960'
 
   url "https://comictagger.googlecode.com/files/ComicTagger-#{version}.dmg"
   name 'ComicTagger'


### PR DESCRIPTION
The online database at Comic Vine provides a public interface that ComicTagger uses to acquire most of the tagging info. Comic Vine has made changes that limit the amount of requests that can be made for each API key. In the 1.1.15-beta version, ComicTagger added a user-configurable API key for Comic Vine access.
