### PR TITLE
Include license information for 0AD.

### DIFF
--- a/Casks/0ad.rb
+++ b/Casks/0ad.rb
@@ -6,7 +6,7 @@ cask :v1 => '0ad' do
   url "http://releases.wildfiregames.com/0ad-#{version}-osx64.dmg"
   name '0 A.D.'
   homepage 'http://www.play0ad.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :oss
 
   app '0ad.app'
 end


### PR DESCRIPTION
Contains a mixture of licenses, the game engine is GPL, but art assets are CC licensed, 
and contains many other components with differing licenses.
