### PR TITLE
Add Rust license.

### DIFF
--- a/Casks/rust.rb
+++ b/Casks/rust.rb
@@ -4,7 +4,7 @@ cask :v1 => 'rust' do
 
   url 'http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg'
   homepage 'http://www.rust-lang.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :mit
 
   pkg 'rust-nightly-x86_64-apple-darwin.pkg'
 


### PR DESCRIPTION
Dual licensed under both MIT and Apache 2, as per [COPYRIGHT doc](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) .
