### PR TITLE
Update comictagger website

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -2,7 +2,8 @@ cask :v1 => 'comictagger' do
   version '1.1.15-beta'
   sha256 '6640834d966c1cc760de6aa32729bf139bf06727f8d650a4534cdf780f084960'
 
-  url "https://comictagger.googlecode.com/files/ComicTagger-#{version}.dmg"
+  # googledrive.com is the official download host per the vendor homepage
+  url "https://googledrive.com/host/0Bw4IursaqWhhOHF6Wk9ab3FkejQ/#{version}/ComicTagger-#{version}.dmg"
   name 'ComicTagger'
   homepage 'http://code.google.com/p/comictagger/'
   license :oss


### PR DESCRIPTION
The URL changed to googledrive.com as of the latest release in #9735
https://code.google.com/p/comictagger/wiki/Downloads?tm=2
