### PR TITLE
Add RBTools v0.7.1

### DIFF
--- a/Casks/rbtools.rb
+++ b/Casks/rbtools.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'rbtools' do
+  version '0.7.1'
+  sha256 '6e2ffc0ea6d095f45662a51d03a9cf8e088c4dbca25e8ca261de2a1388fe53b0'
+
+  url 'https://downloads.reviewboard.org/releases/RBTools/0.7/RBTools-0.7.1.pkg'
+  name 'RBTools'
+  homepage 'https:/://www.reviewboard.org/docs/rbtools/dev/'
+  license :mit
+
+  pkg 'RBTools-0.7.1.pkg'
+  uninstall :pkgutil => 'org.reviewboard.rbtools'
+end
+


### PR DESCRIPTION
RBTools is a set of command line tools for working with Review Board (https://www.reviewboard.org).
