### PR TITLE
Update sagemath to version 6.5

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'sage' do
-  version '6.4.1'
-  sha256 '3ae99dbddd5609271aa87ef38db58dd53fe2add3a58abed3b80750884100391e'
+  version '6.5'
+  sha256 'f369e4e8f4d94990b318fc3d58bdf87ff0e7f10e3f26fef3b4b1fbf6e7f684d2'
 
   # washington.edu is the official download host per the vendor homepage
   url "http://boxen.math.washington.edu/home/sagemath/sage-mirror/osx/intel/sage-#{version}-x86_64-Darwin-OSX_10.10_x86_64-app.dmg"


### PR DESCRIPTION
Current url (version 6.4.1) returns a 400 error.
