### PR TITLE
Update Trailer to 1.2.2

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'trailer' do
-  version '1.2.1'
-  sha256 'fbcd88fb94c2e7fa52ff17299106aed0b6cafc9b13aea38e24443d106baab119'
+  version '1.2.2'
+  sha256 '3e0093da72ab9debff400c1bba558dc1b7722ffcbc6c6f5e0420de7fe9c1b8f7'
 
   url "http://ptsochantaris.github.io/trailer/trailer#{version.gsub('.','')}.zip"
   appcast 'http://ptsochantaris.github.io/trailer/appcast.xml',
-          :sha256 => 'a85ed2eec975c1756989aea7dfa5ceed035d635d903911ba2e8ac2332a856b3b'
+          :sha256 => '0d255433261dc91f1d07b812c96cc48268370ce748f39fbc2bcbcc08796a6675'
   name 'Trailer'
   homepage 'http://ptsochantaris.github.io/trailer/'
   license :mit


### PR DESCRIPTION
This commit updates the version, the SHA, and the SHA for the
`appcast` param. I couldn't see info for what the SHA was
calculated on, so I downloaded the XML file and calculated it
on that. Please advise if there is something different to be
done.
