### PR TITLE
Fix checksum in mattr-/Slate.app Cask

### DIFF
--- a/Casks/mattr-slate.rb
+++ b/Casks/mattr-slate.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'mattr-slate' do
   version '1.2.0'
-  sha256 '8d5405e9469ac7d1bfd8defe1e8661dedea50e6a'
+  sha256 'd409ccda9ed09f5647175f8834650e141a7375ced9665bf6af237525665d4966'
 
   # github.com is the official download host for this fork
   # see https://github.com/mattr-/slate/commit/148a51e50174c946c07c801a9f2b92222a4c0276


### PR DESCRIPTION
I've used `shasum` instead `shasum -a 256` when I did #9756
This time it should be good. Sorry for that !
