### PR TITLE
Add license information for Rdio

### DIFF
--- a/Casks/rdio.rb
+++ b/Casks/rdio.rb
@@ -5,7 +5,7 @@ cask :v1 => 'rdio' do
   url 'https://www.rdio.com/media/static/desktop/mac/Rdio.dmg'
   appcast 'http://www.rdio.com/media/static/desktop/mac/appcast.xml'
   homepage 'http://www.rdio.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Rdio.app'
 end


### PR DESCRIPTION
Changed Rdio's license information to "gratis".

It's debatably freemium. I looked at Spotify, which has a similar model, for precedent about this.
