### PR TITLE
Update HipChat license info

### DIFF
--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hipchat' do
   url 'https://www.hipchat.com/downloads/latest/mac'
   appcast 'https://www.hipchat.com/release_notes/appcast/mac'
   homepage 'https://www.hipchat.com/'
-  license :commercial
+  license :freemium
 
   app 'HipChat.app'
 


### PR DESCRIPTION
HipChat used to be 100% paid (with a free trial) and is now freemium.
