### PR TITLE
inkscape: enable command-line support

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -8,6 +8,8 @@ cask :v1 => 'inkscape' do
   license :gpl
 
   app 'Inkscape.app'
+  # NOTE: running inkscape on the command line requires absolute paths to files
+  binary 'Inkscape.app/Contents/Resources/bin/inkscape'
 
   zap :delete => '~/.inkscape-etc'
 


### PR DESCRIPTION
see https://inkscape.org/en/doc/inkscape-man.html

**Note:** Running `inkscape` from the command line changes the working
directory to `#{staged_path}` (i.e.,
`/opt/homebrew-cask/Caskroom/inkscape/0.91-1/Inkscape.app`), which
means that all file arguments should be given as _absolute paths_.

There is a shim script in `Inkscape.app/Contents/Resources/script`,
but it doesn't solve this issue any further than simply running
`Inkscape.app/Contents/Resources/bin/inkscape`.

See also http://wiki.inkscape.org/wiki/index.php/MacOS_X#Inkscape_command_line
