### PR TITLE
Add SteelSeries ExactMouse Latest

### DIFF
--- a/Casks/steelseries-exactmouse.rb
+++ b/Casks/steelseries-exactmouse.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'steelseries-exactmouse' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://downloads.steelseriescdn.com/drivers/tools/steelseries-exactmouse-tool.dmg'
+  name 'SteelSeries ExactMouse'
+  name 'ExactMouse'
+  homepage 'http://steelseries.com/support/downloads'
+  license :gratis
+
+  app 'SteelSeries ExactMouse Tool.app'
+end


### PR DESCRIPTION
Adds the app from SteelSeries to turn off mouse acceleration in OS X. There’s no versioned download so this just grabs the one URL they return, assuming it’s always going to be the latest version (they haven’t updated the tool since 2010, but ¯_(ツ)_/¯).
