### PR TITLE
Updated SquidMan to v3.6

### DIFF
--- a/Casks/squidman.rb
+++ b/Casks/squidman.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'squidman' do
-  version '3.51'
-  sha256 '0bbbe1c8f26902450e62fe47e17f68f278b033355311ef295d52951feb3b6820'
+  version '3.6'
+  sha256 '26544fbad48dc29dd7ea154cd48e02fa08f673bda3ff173557b8f04f1c334e43'
 
   url "http://squidman.net/resources/downloads/SquidMan#{version}.dmg"
   homepage 'http://squidman.net/squidman/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'SquidMan.app'
 end


### PR DESCRIPTION
Updated SquidMan to v3.6, and changed the license type to :gratis.
