### PR TITLE
Fix for vagrant-bar

### DIFF
--- a/Casks/vagrant-bar.rb
+++ b/Casks/vagrant-bar.rb
@@ -2,7 +2,7 @@ cask :v1 => 'vagrant-bar' do
   version '1.16'
   sha256 'f5c58690960269be9a7a2597a0aad098b4bd1676c9494f6022e9c7d1e82d81bc'
 
-  url "https://github.com/BipSync/VagrantBar/releases/download/#{version.gsub('1.','')}/Vagrant.Bar.zip"
+  url "https://github.com/BipSync/VagrantBar/releases/download/#{version}/Vagrant.Bar.zip"
   homepage 'https://github.com/BipSync/VagrantBar'
   license :oss
 


### PR DESCRIPTION
Download URL had to be changed from #{version.gsub('1.','')} to #{version}
