### PR TITLE
libreoffice 4.4.1

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -5,8 +5,8 @@ cask :v1 => 'libreoffice' do
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else
-    version '4.4.0'
-    sha256 '297bc7952db491feee8d1823ff424e8d6e4ccdcddc9b66a37c99d32c6b19016c'
+    version '4.4.1'
+    sha256 '0bb9e740ea0bcb40402c64ee0b8c37c35fdf56997e2bf7d926b8a58640af07ab'
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end
@@ -14,7 +14,7 @@ cask :v1 => 'libreoffice' do
       :key_id => 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
   homepage 'https://www.libreoffice.org/'
-  license :oss
+  license :mpl
 
   app 'LibreOffice.app'
 end


### PR DESCRIPTION
Bump, and license update. The license document inside the DMG says it is MPLv2:

> This product is made available subject to the terms of the Mozilla Public License, v. 2.0. A copy of the MPL Version 2 license can be found below.
