### PR TITLE
Add Epic Games (Unreal Engine) Latest

### DIFF
--- a/Casks/epic-games.rb
+++ b/Casks/epic-games.rb
@@ -1,0 +1,20 @@
+cask :v1 => 'epic-games' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncher.dmg'
+  name 'Epic Games Launcher'
+  name 'Unreal Engine'
+  homepage 'https://www.unrealengine.com/'
+  license :other
+  tags :vendor => 'Epic Games'
+
+  app 'Epic Games Launcher.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.epicgames.UE4Editor.plist',
+                  '~/Library/Preferences/Unreal Engine/',
+                  '~/Library/Application Support/Epic/',
+                  '/Users/Shared/UnrealEngine/',
+                 ]
+end


### PR DESCRIPTION
Adds the latest download of Epic Games Launcher, more widely known as Unreal Engine. There are two bits about the config I’m not that sure about though:
1. I set the license as `other` as accessing the source requires an authentication process – create Unreal Engine account, authorize with GitHub – and use of the engine itself is defined under a custom license
2. Although the download URL is public, you don’t find this URL on the Unreal Engine website until you authenticate
