### PR TITLE
Change Thunderbird license from :oss to :mpl

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -4,7 +4,7 @@ cask :v1 => 'thunderbird' do
 
   url "https://download.mozilla.org/?product=thunderbird-#{version}&os=osx&lang=en-US"
   homepage 'http://www.mozilla.org/en-US/thunderbird/'
-  license :oss
+  license :mpl
 
   app 'Thunderbird.app'
 end


### PR DESCRIPTION
As Wikipedia says, Thunderbird is licensed under MPL, which is more precise than just `:oss`.
http://en.wikipedia.org/wiki/Mozilla_Thunderbird
