### PR TITLE
Update bittorrent-sync.rb

### DIFF
--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -3,7 +3,7 @@ cask :v1 => 'bittorrent-sync' do
   sha256 :no_check
 
   # getsyncapp.com is the official download host per the vendor homepage
-  url 'http://download.getsyncapp.com/endpoint/btsync/os/osx/track/stable'
+  url 'https://download-cdn.getsyncapp.com/stable/osx/BitTorrent-Sync.dmg'
   name 'BitTorrent Sync'
   # todo: response was not XML
   # appcast 'http://www.usyncapp.com/cfu.php'


### PR DESCRIPTION
The old URL hasn't been updated for the newest v2 URL (still points to v1.4). Updated the URL to what the website now uses.
