### PR TITLE
Update BitTorrent Sync app

### DIFF
--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -3,11 +3,11 @@ cask :v1 => 'bittorrent-sync' do
   sha256 :no_check
 
   # getsyncapp.com is the official download host per the vendor homepage
-  url 'http://download.getsyncapp.com/endpoint/btsync/os/osx/track/stable'
+  url 'https://download-cdn.getsyncapp.com/stable/osx/BitTorrent-Sync.dmg'
   name 'BitTorrent Sync'
   # todo: response was not XML
   # appcast 'http://www.usyncapp.com/cfu.php'
-  homepage 'http://www.bittorrent.com/sync'
+  homepage 'https://www.getsync.com/'
   license :gratis
 
   app 'BitTorrent Sync.app'


### PR DESCRIPTION
Update URL for new major version 2.0 (previous URL downloads v1.4).
