### PR TITLE
update calibre url format

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -2,7 +2,7 @@ cask :v1 => 'calibre' do
   version '2.20.0'
   sha256 '235d891a90a87a72e16d4c8979497268055ef6e22c1c3d8aff3d0ce2114c41c7'
 
-  url 'https://github.com/kovidgoyal/calibre/releases/download/v2.20.0/calibre-2.20.0.dmg'
+  url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"
   name 'calibre'
   homepage 'http://calibre-ebook.com/'
   license :gpl


### PR DESCRIPTION
both links works:
https://github.com/kovidgoyal/calibre/releases/download/v2.20.0/calibre-2.20.0.dmg
http://download.calibre-ebook.com/2.20.0/calibre-2.20.0.dmg
http://code.calibre-ebook.com/dist/osx

i don't want which link u guys want.
the link that always download the latest or specified version and update every time release new version.

I want to revise the pull request #9816 
