### PR TITLE
Fix hex-fiend with chmod go=u

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -8,4 +8,8 @@ cask :v1 => 'hex-fiend' do
   license :bsd
 
   app 'Hex Fiend.app'
+
+  postflight do
+    system '/bin/chmod', '-R', 'og=u', "#{staged_path}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework"
+  end
 end


### PR DESCRIPTION
Hex Fiend does not correctly set 'group' and 'other' permissions and will crash if a non-owner runs it. The buggy files are fixed by updating their 'group' and 'other' permissions to reflect the 'user' permissions: `chmod go=u`.

---

Before this fix:

![screen shot 2015-03-05 at 3 25 38 am](https://cloud.githubusercontent.com/assets/1570168/6504013/540e4036-c2e7-11e4-885f-9f76a4991b43.png)

```
$ '/opt/homebrew-cask/Caskroom/hex-fiend/2.3.0/Hex Fiend.app/Contents/MacOS/Hex Fiend'
dyld: Library not loaded: @loader_path/../Frameworks/Sparkle.framework/Versions/A/Sparkle
  Referenced from: /opt/homebrew-cask/Caskroom/hex-fiend/2.3.0/Hex Fiend.app/Contents/MacOS/Hex Fiend
  Reason: no suitable image found.  Did find:
    /opt/homebrew-cask/Caskroom/hex-fiend/2.3.0/Hex Fiend.app/Contents/MacOS/../Frameworks/Sparkle.framework/Versions/A/Sparkle: stat() failed with errno=13
    /opt/homebrew-cask/Caskroom/hex-fiend/2.3.0/Hex Fiend.app/Contents/MacOS/../Frameworks/Sparkle.framework/Versions/A/Sparkle: stat() failed with errno=13
```

```
$ ll '/opt/homebrew-cask/Caskroom/hex-fiend/2.3.0/Hex Fiend.app/Contents/Frameworks/'
total 0
drwxr-xr-x  6 Administrator   204B Mar  5 03:16 HexFiend.framework/
drwx------  6 Administrator   204B Mar  5 03:16 Sparkle.framework/
```
