### PR TITLE
Android Studio 1.1+ works with Java 7 and 8

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -9,12 +9,4 @@ cask :v1 => 'android-studio' do
   license :apache
 
   app 'Android Studio.app'
-
-  caveats <<-EOS.undent
-    If you have Java 7 or above installed, you may want to use it as Android Studio JDK, for example:
-
-    export STUDIO_JDK=/Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk
-
-    Please take a look at this post: http://tools.android.com/recent/androidstudio1rc3_releasecandidate3released
-  EOS
 end


### PR DESCRIPTION
As of version 1.1, Android Studio already bundles this on Info.plist:

```
<key>JVMVersion</key>
<string>1.6*,1.7+</string>
```

From what I'm seeing on my machine, with jdk1.8.0_20, we don't need to show the caveats for users nor need to set a environment variable. What the Android Studio is doing is the same we did some time ago, updating the Info.plist to 1.6+.

After this version, I think we can close #7996 too.
