### PR TITLE
Switch firefox to official download via FTP (served by CDN)

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -2,7 +2,7 @@ cask :v1 => 'firefox' do
   version '36.0' 
   sha256 '97ccc2f03a8af73903b0cae61e17a7b9f336fe320592380f1c811dbc3b0e9e5a'
 
-  url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
+  url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
   name 'Firefox'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/en-US/firefox/'


### PR DESCRIPTION
In #9916, the Firefox download URL was changed to an FTP mirror of sorts, which allowed for us to use versioned releases instead of `:latest` (and thus provide checksums and what not). However, this is not the origin mirror. In fact, the home page on the mirror (which is also shown on all Mozilla FTP mirrors) says:

> releases.mozilla.org sends you to the CDN (origin is still ftp.mo), which will result in faster downloads, so use releases.mozilla.org when possible.

This pull request changes the download URL to use `releases.mozilla.org` instead, which is the "origin" mirror and is also branded under the same domain as the `homepage` (`mozilla.org`). The actual directory structure after the domain name is still the same (the directory structure is consistent between mirrors), and the files are identical, so the checksum also did not have to be changed.
