### PR TITLE
Remove hack for IntelliJ IDEs, replace with caveat

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -9,7 +9,17 @@ cask :v1 => 'appcode' do
 
   app 'AppCode.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+
+    To use existing newer Java at your own risk,
+    add JVMVersion=1.6+ to ~/Library/Preferences/IntelliJIdea14/idea.properties
+  EOS
 end

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -8,10 +8,6 @@ cask :v1 => 'intellij-idea-ce' do
 
   app 'IntelliJ IDEA 14 CE.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
-
   zap :delete => [
                   '~/Library/Application Support/IdeaIC14',
                   '~/Library/Preferences/IdeaIC14',
@@ -20,13 +16,13 @@ cask :v1 => 'intellij-idea-ce' do
                  ]
 
   caveats <<-EOS.undent
-    #{token} may require Java 7 (an older version), available from the
-    caskroom-versions repository via
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
 
-      brew cask install caskroom/versions/java7
+      brew cask install caskroom/homebrew-versions/java6
 
-    Alternatively, #{token} can be modified to use Java 8 as described in
-
-      https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
   EOS
 end

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -9,23 +9,22 @@ cask :v1 => 'intellij-idea' do
 
   app 'IntelliJ IDEA 14.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
-
   zap :delete => [
                   '~/Library/Application Support/IntelliJIdea14',
                   '~/Library/Preferences/IntelliJIdea14',
                  ]
 
   caveats <<-EOS.undent
-    #{token} may require Java 7 (an older version) available from the
-    caskroom-versions repository via
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
 
-      brew cask install caskroom/versions/java7
+      brew cask install caskroom/homebrew-versions/java6
 
-    Alternatively, #{token} can be modified to use Java 8 as described in
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
 
-      https://github.com/caskroom/homebrew-cask/issues/4500#issuecomment-43955932
+    To use existing newer Java at your own risk,
+    add JVMVersion=1.6+ to ~/Library/Preferences/IntelliJIdea14/idea.properties
   EOS
 end

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -9,13 +9,19 @@ cask :v1 => 'phpstorm' do
 
   app 'PhpStorm.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
-
   zap :delete => [
                   '~/Library/Application Support/WebIde80',
                   '~/Library/Preferences/WebIde80',
                   '~/Library/Preferences/com.jetbrains.PhpStorm.plist',
                  ]
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -11,7 +11,14 @@ cask :v1 => 'pycharm-ce' do
 
   app 'PyCharm CE.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end

--- a/Casks/pycharm-educational.rb
+++ b/Casks/pycharm-educational.rb
@@ -11,7 +11,14 @@ cask :v1 => 'pycharm-educational' do
 
   app 'PyCharm Educational.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -9,7 +9,14 @@ cask :v1 => 'pycharm' do
 
   app 'PyCharm.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -9,12 +9,19 @@ cask :v1 => 'rubymine' do
 
   app 'RubyMine.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
-
   zap :delete => [
                   "~/Library/Application Support/RubyMine#{version.gsub('.','')}",
                   "~/Library/Preferences/RubyMine#{version.gsub('.','')}",
                  ]
+
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -9,7 +9,14 @@ cask :v1 => 'webstorm' do
 
   app 'WebStorm.app'
 
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end


### PR DESCRIPTION
### Related issues:
- #9572 
- #6910 
### TL;DR reasons:
- hack was causing issues during upgrades
- vendor officially doesn't support Java >6 anyway
### Details:

@w7tek in https://github.com/caskroom/homebrew-cask/issues/9572#issuecomment-77729696

> Unfortunately, according to the conversation along the same issue, it appears the idea.properties is picked up from a different location when using the CE than when using Ultimate.

True. I've been just playing around and I can confirm that this hack

```
echo "JVMVersion=1.6+" > ~/Library/Preferences/IntelliJIdea14/idea.properties
```

only works for _IntelliJ IDEA 14_ and _AppCode_, but doesn't for any other IDE (not even IntelliJ IDEA 14 CE). Maybe they have add this functionality into IntelliJ core and AppCode has already adopted it, so other IDEs may do in the future as well?

I wonder what's the motivation of JetBrains for being stuck 4 years behind (that's when Java 7 was released)... :confused: 
