### PR TITLE
gcloud: Add instructions for fish shell.

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -21,6 +21,13 @@ cask :v1 => 'google-cloud-sdk' do
 
       for zsh users
         source '#{staged_path}/#{token}/path.zsh.inc'
-        source '#{staged_path}/#{token}/completion.zsh.inc'"
+        source '#{staged_path}/#{token}/completion.zsh.inc'
+
+      for fish users
+        set fish_user_paths #{staged_path}/#{token}/bin
+        set -x MANPATH #{staged_path}/#{token}/help/man /usr/local/share/man /usr/share/man /opt/x11/share/man
+
+        Run fish_update_completions to generate completions for fish based on the man pages"
+
   end
 end


### PR DESCRIPTION
- Add the gcloud/bin directory to our path.
- Set up MANPATH so that fish_update_completions can generate completion
  files for it.
