### PR TITLE
Updated checksum for Spotify Notifications 0.5.1

### DIFF
--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'spotify-notifications' do
   version '0.5.1'
-  sha256 'd9adb821d82be7f1266d8042d2b677a4c91fe7686631c02e2d0307f9f536a722'
+  sha256 '4402ae1d466f0129051ed9b052bc228183c1ed6c6dbf23716eff5eae1d9ff310'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"


### PR DESCRIPTION
People have been [reporting issues using the latest version](https://github.com/citruspi/Spotify-Notifications/issues/40) so I've re-archived, exported, and uploaded it.

&mdash; @citruspi
