### PR TITLE
Update license for TexturePacker.app

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -5,7 +5,7 @@ cask :v1 => 'texturepacker' do
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   name 'TexturePacker'
   homepage 'http://www.codeandweb.com/texturepacker'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'TexturePacker.app'
 end


### PR DESCRIPTION
I guess `:commercial` licence fits here the most. It offers a 7-day trial period.
