### PR TITLE
Add zap stanza to obs

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -9,5 +9,11 @@ cask :v1 => 'obs' do
 
   pkg "OBS.mpkg"
 
-  uninstall :pkgutil => 'org.obsproject.pkg.obs-studio'
+  uninstall :pkgutil => 'org.obsproject.pkg.obs-studio',
+            :delete => '/Applications/SyphonInject.app'
+
+  zap :delete => [
+                  '/private/var/db/receipts/zakk.lol.SyphonInject.bom',
+                  '/private/var/db/receipts/zakk.lol.SyphonInject.plist'
+                 ]
 end


### PR DESCRIPTION
Removes its folder in Application Support, preferences, etc. leftovers from OBS and also removes http://github.com/zakk4223/SyphonInject, a dependency that gets installed alongside with OBS.
