### PR TITLE
Updated HandBrake from 0.10.0 to 0.10.1

### DIFF
--- a/Casks/handbrake.rb
+++ b/Casks/handbrake.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrake' do
-  version '0.10.0'
-  sha256 'c26a1a37d03c977e0296f0198ce11bf74ee5da8aa410ea3b5eef6449e0aa3c9c'
+  version '0.10.1'
+  sha256 '7c6f231889433d932d3d483df8f4f90fab517386987376542176dd8d2d032bd2'
 
   url "http://download.handbrake.fr/releases/#{version}/HandBrake-#{version}-MacOSX.6_GUI_x86_64.dmg"
   appcast 'http://handbrake.fr/appcast.x86_64.xml',


### PR DESCRIPTION
I've updated HandBrake from version 0.10.0 to 0.10.1 and of course tested the cask.
