### PR TITLE
Add SoapUI Cask pointing to latest 5.0.0 version.

### DIFF
--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'soapui' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://sourceforge.net/projects/soapui/files/latest/download?source=files'
+  name 'SoapUI'
+  homepage 'http://www.soapui.org'
+  license :unknown
+
+  app 'SoapUI-5.0.0.app'
+end


### PR DESCRIPTION
Trying to add SoapUI app to the brew cask project. The links all live at Sourceforge. Trying to install this via terminal gives me the error:
    Error: Uh oh, could not identify primary container for '/Library/Caches/Homebrew/soapui-latest'

Any thoughts?
