### PR TITLE
kitematic last releases are Beta

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -8,5 +8,5 @@ cask :v1 => 'kitematic' do
   homepage 'https://kitematic.com/'
   license :affero
 
-  app 'Kitematic.app'
+  app 'Kitematic (Beta).app'
 end


### PR DESCRIPTION
Last releases are Beta.

Last no-Beta version are 0.4.5, merged from Vitor Galvao previously: https://github.com/caskroom/homebrew-cask/commit/c9b420be2e30f39bd98f07f8daccff4c8781615b
