### PR TITLE
Update (url, license) and add (name, vendor, zap) stanzas for MacPaw Gemini.app

### DIFF
--- a/Casks/macpaw-gemini.rb
+++ b/Casks/macpaw-gemini.rb
@@ -3,10 +3,10 @@ cask :v1 => 'macpaw-gemini' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/download/com.macpaw.site.Gemini/macpaw%20gemini.dmg'
+  url 'http://dl.devmate.com/com.macpaw.site.Gemini/MacPawGemini.dmg'
   appcast 'http://updates.devmate.com/com.macpaw.site.Gemini.xml'
   homepage 'http://macpaw.com/gemini'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'MacPaw Gemini.app'
 end

--- a/Casks/macpaw-gemini.rb
+++ b/Casks/macpaw-gemini.rb
@@ -5,8 +5,17 @@ cask :v1 => 'macpaw-gemini' do
   # devmate.com is the official download host per the vendor homepage
   url 'http://dl.devmate.com/com.macpaw.site.Gemini/MacPawGemini.dmg'
   appcast 'http://updates.devmate.com/com.macpaw.site.Gemini.xml'
+  name 'MacPaw Gemini'
   homepage 'http://macpaw.com/gemini'
   license :commercial
+  tags :vendor => 'MacPaw'
+
+  zap :delete => [
+    '~/Library/Application Support/MacPaw Gemini',
+    '~/Library/Caches/com.macpaw.site.Gemini',
+    '~/Library/Preferences/com.macpaw.site.Gemini.plist',
+    '~/Library/Saved Application State/com.macpaw.site.Gemini.savedState'
+  ]
 
   app 'MacPaw Gemini.app'
 end


### PR DESCRIPTION
The old URL pointed to version 1.4 instead of the latest (1.5.9).

Not sure about the license but I think the `:commercial` fits here more. The software by itself allows to find the duplicates even without activation, but those, however, cannot be deleted.

Is it better to squash the commits, in this case?
