### PR TITLE
brew cask list --versions

### DIFF
--- a/lib/hbc/cli/list.rb
+++ b/lib/hbc/cli/list.rb
@@ -3,6 +3,7 @@ class Hbc::CLI::List < Hbc::CLI::Base
     @options = Hash.new
     @options[:one] = true if arguments.delete('-1')
     @options[:long] = true if arguments.delete('-l')
+    @options[:versions] = true if arguments.delete('--versions')
 
     if arguments.any?
       retval = list_casks(*arguments)
@@ -53,6 +54,8 @@ class Hbc::CLI::List < Hbc::CLI::Base
     columns = installed_casks.map(&:to_s)
     if @options[:one]
       puts columns
+    elsif @options[:versions]
+      installed_casks.each { |cask| puts "#{cask} #{cask.version}" }
     elsif @options[:long]
       puts Hbc::SystemCommand.run!("/bin/ls", :args => ["-l", Hbc.caskroom]).stdout
     else


### PR DESCRIPTION
Hi,
I've implemented versions listing of the casks similar with brew list --versions as it was requested in #5682.

Here's a sample output:

```
android-file-transfer latest
atom latest
eclipse-jee 4.4.2
filezilla 3.10.2
firefox 36.0.1
freemind 1.0.1
gimp 2.8.14
google-chrome latest
ifunbox latest
java 1.8.0_40
java7 1.7.0_76
kodi 14.1
qtox latest
rubymine 7.0.4
rust latest
skype latest
teamviewer latest
tomahawk 0.8.2
vagrant 1.7.2
viber latest
vienna 3.0.3
vlc 2.2.0
wireshark 1.12.4
xquartz 2.7.7
```
