### PR TITLE
Add name, license, vendor and zap for CCleaner.app

### DIFF
--- a/Casks/ccleaner.rb
+++ b/Casks/ccleaner.rb
@@ -3,8 +3,17 @@ cask :v1 => 'ccleaner' do
   sha256 '464a75b9d038dec0334f70846d5ea68679ff907e57b9ec373331c5da18cb4865'
 
   url "http://download.piriform.com/mac/CCMacSetup#{version.sub(%r{^(\d+)\.(\d+).*},'\1\2')}.dmg"
+  name 'CCleaner'
   homepage 'http://www.piriform.com/ccleaner'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :freemium
+  tags :vendor => 'Piriform'
+
+  zap :delete => [
+    '~/Library/Application Support/CCleaner',
+    '~/Library/Caches/com.piriform.ccleaner',
+    '~/Library/Preferences/com.piriform.ccleaner.plist',
+    '~/Library/Saved Application State/com.piriform.ccleaner.savedState'
+  ]
 
   app 'CCleaner.app'
 end


### PR DESCRIPTION
The app is free, but payment gives extra features, so the license `:freemium` describes the app perfectly.
