### PR TITLE
Adding Zoho Docs cask

### DIFF
--- a/Casks/zoho-docs.rb
+++ b/Casks/zoho-docs.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'zoho-docs' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://docs.zoho.com/downloaddocument.do?docId=cm31cb748186d0ce240ed9f5733ff288d0d8a'
+  name 'Zoho Docs'
+  homepage 'https://www.zoho.com/docs/download-page.html'
+  license :closed
+
+  app 'Zoho Docs.app'
+end


### PR DESCRIPTION
Zoho Docs provides a sync utility (much like Dropbox or Google
Drive). This appears to be unversioned from a download perspective
so is tagged as latest.

Working on Yosemite.
