### PR TITLE
Updated Pinta from v1.5 to v1.6

### DIFF
--- a/Casks/pinta.rb
+++ b/Casks/pinta.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pinta' do
-  version '1.5'
-  sha256 'd23093ce67c6aac77c3380aff63963ca615fcf9ef85ee1683655c599070b766e'
+  version '1.6'
+  sha256 '8d9f04397bf279166e7c23cd6686342fb6b1a7e6d70546eefa23de73c4e251bf'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/PintaProject/Pinta/releases/download/#{version}/Pinta.app.zip"


### PR DESCRIPTION
I've updated Pinta from version 1.5 to 1.6 and tested the new cask.
