### PR TITLE
Clarify Pgloader licence

### DIFF
--- a/Casks/pgloader.rb
+++ b/Casks/pgloader.rb
@@ -5,7 +5,7 @@ cask :v1 => 'pgloader' do
   url "http://pgloader.io/files/pgloader-#{version}.pkg"
   name 'Pgloader'
   homepage 'http://pgloader.io'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :oss
 
   pkg "pgloader-#{version}.pkg"
 


### PR DESCRIPTION
As specified on https://github.com/dimitri/pgloader#licence Pgloader is available under the PostgreSQL License, a liberal Open Source license, similar to the BSD or MIT licenses.
