### PR TITLE
Add license, vendor and zap for AppFresh.app

### DIFF
--- a/Casks/appfresh.rb
+++ b/Casks/appfresh.rb
@@ -6,7 +6,16 @@ cask :v1 => 'appfresh' do
   name 'AppFresh'
   appcast 'http://backend.metaquark.de/appcast/appfresh.xml'
   homepage 'http://metaquark.de/appfresh/mac'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
+  tags :vendor => 'metaquark'
 
-  app 'appfresh.app'
+  zap :delete => [
+    '~/Library/Application Support/AppFresh',
+    '~/Library/Application Support/Growl/Tickets/AppFresh.growlTicket',
+    '~/Library/Caches/de.metaquark.appfresh',
+    '~/Preferences/de.metaquark.appfresh.plist',
+    '~/Library/Saved Application State/de.metaquark.appfresh.savedState'
+  ]
+
+  app 'AppFresh.app'
 end


### PR DESCRIPTION
The app offers 14-day trial period, so the license is `:commercial`. Also made a minor modification in the `app` stanza.
