### PR TITLE
kitematic 0.5.10

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -1,12 +1,17 @@
 cask :v1 => 'kitematic' do
-  version '0.5.9'
-  sha256 'dfd623e7b152c05ed3e5ba4dfaded9904a17776641ced020229d94df3b8ae5c7'
+  version '0.5.10'
+  sha256 '00380414c1d2be0d39d4120d85cccc54f64715be7ab9578e570933fe32e31025'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/kitematic/kitematic/releases/download/v#{version}/Kitematic-#{version}.zip"
   name 'Kitematic'
   homepage 'https://kitematic.com/'
-  license :affero
+  license :apache
 
   app 'Kitematic (Beta).app'
+
+  zap :delete => [
+    '~/Library/Application Support/Kitematic',
+    '~/Kitematic'
+  ]
 end


### PR DESCRIPTION
- `license` is [here](https://github.com/kitematic/kitematic/blob/master/LICENSE)
- `zap` addition comes from #9996 
