### PR TITLE
macvim: Update to 7.4-74 for Yosemite.

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -10,8 +10,6 @@ cask :v1 => 'macvim' do
     sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
     # github.com is the official download host per the vendor homepage
     url "https://github.com/b4winckler/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Mavericks.tbz"
-    appcast 'http://b4winckler.github.io/macvim/appcast/stable.xml',
-            :sha256 => '1408f192fe672eb99d7032eff37bd93537d65499fa9b4502eb0ae1365a73d056'
   else
     version '7.4-74'
     sha256 '35ad0fbd18b144254f852b8f2822d0923e30f43a838dc8de72ebb902f7f55949'

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,16 +1,22 @@
 cask :v1 => 'macvim' do
-  version '7.4-73'
 
   if MacOS.release <= :mountain_lion
+    version '7.4-73'
     sha256 '7f573fb9693052a86845c0a9cbb0b3c3c33ee23294f9d8111187377e4d89f72c'
     # github.com is the official download host per the vendor homepage
-    url "https://github.com/eee19/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Mountain-Lion.tbz"
-  else
+    url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Mountain-Lion.tbz"
+  elsif MacOS.release == :mavericks
+    version '7.4-73'
     sha256 '557c60f3487ab68426cf982c86270f2adfd15e8a4d535f762e6d55602754d224'
     # github.com is the official download host per the vendor homepage
     url "https://github.com/b4winckler/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Mavericks.tbz"
-    appcast 'http://b4winckler.github.com/macvim/appcast/stable.xml',
+    appcast 'http://b4winckler.github.io/macvim/appcast/stable.xml',
             :sha256 => '1408f192fe672eb99d7032eff37bd93537d65499fa9b4502eb0ae1365a73d056'
+  else
+    version '7.4-74'
+    sha256 '35ad0fbd18b144254f852b8f2822d0923e30f43a838dc8de72ebb902f7f55949'
+    # github.com is the official download host per the vendor homepage
+    url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Yosemite.tbz"
   end
 
   homepage 'http://code.google.com/p/macvim/'


### PR DESCRIPTION
- Update to 7.4-74 for Yosemite
- Use the new macvim-dev Repository, see
  https://groups.google.com/forum/m/#!topic/vim_mac/-bd5RKGs8qw
