### PR TITLE
Upgrade calibre to 2.21.0 (fixes currently-broken recipe)

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'calibre' do
-  version '2.20.0'
-  sha256 '235d891a90a87a72e16d4c8979497268055ef6e22c1c3d8aff3d0ce2114c41c7'
+  version '2.21.0'
+  sha256 'be3ebde825d291ef0e212939061ea2e9a095419b9ec45ab9fa766f7bad07094d'
 
   # github.com is an official download host per the vendor homepage, and a faster mirror than the main one
   url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"


### PR DESCRIPTION
This fixes the currently-broken calibre cask. However, as I noted in #10039, the current mirror should probably be changed so that the recipe isn't broken every time calibre updates (which happens every week).
