### PR TITLE
Demoted "To install, drag this icon" from readme header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Homebrew Cask
-
-> "To install, drag this icon..." no more!
+"To install, drag this icon..." no more!
 
 [![Build Status](https://img.shields.io/travis/caskroom/homebrew-cask/master.svg)](https://travis-ci.org/caskroom/homebrew-cask)
 [![Code Climate](https://img.shields.io/codeclimate/github/caskroom/homebrew-cask.svg)](https://codeclimate.com/github/caskroom/homebrew-cask)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# "To install, drag this icon..." no more!
+# Homebrew Cask
+
+> "To install, drag this icon..." no more!
 
 [![Build Status](https://img.shields.io/travis/caskroom/homebrew-cask/master.svg)](https://travis-ci.org/caskroom/homebrew-cask)
 [![Code Climate](https://img.shields.io/codeclimate/github/caskroom/homebrew-cask.svg)](https://codeclimate.com/github/caskroom/homebrew-cask)


### PR DESCRIPTION
I always found the wording of the header in the readme confusing.  e.g. Did homebrew cask used be installed by icon dragging?  Do I install cask by dragging? Oh wait, its referring to what cask enables.

Care if we change the header to something more conventional and just include the concept as a pull quote?
