### PR TITLE
Add name, license, vendor and zap for Gyazo.app

### DIFF
--- a/Casks/gyazo.rb
+++ b/Casks/gyazo.rb
@@ -3,8 +3,18 @@ cask :v1 => 'gyazo' do
   sha256 '88491cc2a9d481fdb99b822ca49560427ed11578b304203c4504d83fc2562061'
 
   url "https://files.gyazo.com/setup/Gyazo_#{version}.dmg"
+  name 'Gyazo'
+  name 'Gyazo GIF'
   homepage 'https://gyazo.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :other
+  tags :vendor => 'Nota'
+
+  zap :delete => [
+    '~/Library/Caches/com.gyazo.gif',
+    '~/Library/Caches/com.gyazo.mac',
+    '~/Library/Preferences/com.gyazo.gif.plist',
+    '~/Library/Preferences/com.gyazo.mac.plist'
+  ]
 
   app 'Gyazo.app'
   app 'Gyazo GIF.app'


### PR DESCRIPTION
Technically, the Gyazo is an open-source project and licensed under the GPL. Source code is available here: https://github.com/gyazo/Gyazo

However, the Gyazo GIF, which is also a part of this package, is not available as an open-source project. The original answer of the developer on Gyazo GIF can be found here: https://github.com/gyazo/Gyazo/issues/6#issuecomment-70220549

I'm not fully sure what license would be more reasonable in this situation, so I guess the logical way in my opinion is to use the `:other` symbol.
