### PR TITLE
Add name, license and zap for NetLogo.app

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -3,8 +3,14 @@ cask :v1 => 'netlogo' do
   sha256 'e2c56ba16fedba36b9868321c774fa1a5e4f4a2ec0a5268381488f376a4f4d3e'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo%20#{version}.dmg"
+  name 'NetLogo'
   homepage 'http://ccl.northwestern.edu/netlogo/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
+
+  zap :delete => [
+    '~/Library/Preferences/org.nlogo.netlogo.plist',
+    '~/Library/Saved Application State/org.nlogo.NetLogo.savedState'
+  ]
 
   app "NetLogo #{version}/NetLogo #{version}.app"
 end


### PR DESCRIPTION
NetLogo is free, open source software under the GPL (GNU General Public License), version 2, or any later version (Source: https://ccl.northwestern.edu/netlogo/docs/faq.html#license). The source code can be found here: https://github.com/NetLogo/NetLogo
