### PR TITLE
Update Dungeon Crawl Stone Soup (tiles and console) to 0.16.0

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -2,7 +2,7 @@ cask :v1 => 'dungeon-crawl-stone-soup-console' do
   version '0.16.0'
   sha256 '3b4750f6bedb4b7e6d0279f476b3cb55124f93871eecb1c53ebda2621ce51b43'
 
-  url "https://crawl.develz.org/release/stone_soup-#{version}-console-macosx.zip"
+  url "https://crawl.develz.org/release/stone_soup-#{version}-console-macos.zip"
   name 'Dungeon Crawl Stone Soup'
   homepage 'http://crawl.develz.org'
   license :gpl

--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'dungeon-crawl-stone-soup-console' do
-  version '0.15.0'
-  sha256 '6ce3eccae0ccf077b6d6df936c7ac51b3fcb896f32c6b001b1016199effca371'
+  version '0.16.0'
+  sha256 '3b4750f6bedb4b7e6d0279f476b3cb55124f93871eecb1c53ebda2621ce51b43'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-console-macosx.zip"
   name 'Dungeon Crawl Stone Soup'

--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'dungeon-crawl-stone-soup-tiles' do
-  version '0.15.0'
-  sha256 'b2a8abaebe84b3f25163a91a1905597e7de0dd1bf50de568b5d3d4d226b31e54'
+  version '0.16.0'
+  sha256 '1e75166bedce080c74dc64c2389d5487e21f271251e7aab6916774c99529e01f'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
   homepage 'http://crawl.develz.org'

--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -2,7 +2,7 @@ cask :v1 => 'dungeon-crawl-stone-soup-tiles' do
   version '0.16.0'
   sha256 '1e75166bedce080c74dc64c2389d5487e21f271251e7aab6916774c99529e01f'
 
-  url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
+  url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macos.zip"
   homepage 'http://crawl.develz.org'
   license :gpl
 


### PR DESCRIPTION
Update Dungeon Crawl Stone Soup from 0.15.0 to 0.16.0 (both the tiles and console variants).
