### PR TITLE
GitHub appcasts

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -4,6 +4,7 @@ cask :v1 => 'aether' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/nehbit/aether-public/releases/download/v#{version}-OSX/Aether.#{version}.dmg"
+  appcast 'https://github.com/nehbit/aether-public/releases.atom'
   name 'Aether'
   homepage 'http://getaether.net/'
   license :affero

--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -4,6 +4,7 @@ cask :v1 => 'angry-ip-scanner' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/angryziber/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"
+  appcast 'https://github.com/angryziber/ipscan/releases.atom'
   name 'Angry IP Scanner'
   homepage 'http://angryip.org'
   license :gpl

--- a/Casks/anybar.rb
+++ b/Casks/anybar.rb
@@ -3,6 +3,7 @@ cask :v1 => 'anybar' do
   sha256 'aaf23b72b682fe4db6ea19908a2e0ffceb54c33aa1c551c5de833c56bca74ef6'
 
   url "https://github.com/tonsky/AnyBar/releases/download/#{version}/AnyBar-#{version}.zip"
+  appcast 'https://github.com/tonsky/AnyBar/releases.atom'
   name 'AnyBar'
   homepage 'https://github.com/tonsky/AnyBar'
   license :eclipse

--- a/Casks/apns-pusher.rb
+++ b/Casks/apns-pusher.rb
@@ -3,6 +3,7 @@ cask :v1 => 'apns-pusher' do
   sha256 '6aa54050bea8603b45e6737bf2cc6997180b1a58f1d02095f5141176a1335205'
 
   url "https://github.com/blommegard/APNS-Pusher/releases/download/v#{version}/APNS.Pusher.app.zip"
+  appcast 'https://github.com/blommegard/APNS-Pusher/releases.atom'
   name 'APNS Pusher'
   homepage 'https://github.com/blommegard/APNS-Pusher'
   license :mit

--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -9,6 +9,7 @@ cask :v1 => 'aquamacs' do
     sha256 '0bdbbe20afd1d2f2bc23fd583de9475a8826493fcf9fe0e4d2717353cf5f04b2'
     # github.com is the official download host per the vendor homepage
     url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}/Aquamacs-Emacs-#{version}.dmg"
+    appcast 'https://github.com/davidswelt/aquamacs-emacs/releases.atom'
   end
 
   name 'Aquamacs'

--- a/Casks/atom-shell.rb
+++ b/Casks/atom-shell.rb
@@ -3,6 +3,7 @@ cask :v1 => 'atom-shell' do
   sha256 '57071e7ac13fa9f8c6a533fab42f82dc1e51ce357aef64c26c7300ed73c7851b'
 
   url "https://github.com/atom/atom-shell/releases/download/v#{version}/atom-shell-v#{version}-darwin-x64.zip"
+  appcast 'https://github.com/atom/atom-shell/releases.atom'
   name 'Atom Shell'
   homepage 'https://github.com/atom/atom-shell'
   license :mit

--- a/Casks/atraci.rb
+++ b/Casks/atraci.rb
@@ -3,6 +3,7 @@ cask :v1 => 'atraci' do
   sha256 '69ea5a32574473b4a7ad39a1743b9eb05262530f8b6d0b25b32d21f03115df12'
 
   url "https://github.com/Atraci/Atraci/releases/download/#{version}/Atraci-mac.zip"
+  appcast 'https://github.com/Atraci/Atraci/releases.atom'
   name 'Atraci'
   homepage 'http://atraci.github.io/Atraci-website/'
   license :mit

--- a/Casks/audioscrobbler.rb
+++ b/Casks/audioscrobbler.rb
@@ -3,6 +3,7 @@ cask :v1 => 'audioscrobbler' do
   sha256 'd14bd947f32a5e6c17645d9378b69b0aded91b95dd87a9a8971e013a8fff5063'
 
   url "https://github.com/mxcl/Audioscrobbler.app/releases/download/#{version}/Audioscrobbler-#{version}.zip"
+  appcast 'https://github.com/mxcl/Audioscrobbler.app/releases.atom'
   name 'Audioscrobbler'
   homepage 'https://github.com/mxcl/Audioscrobbler.app'
   license :gpl

--- a/Casks/autodmg.rb
+++ b/Casks/autodmg.rb
@@ -3,6 +3,7 @@ cask :v1 => 'autodmg' do
   sha256 'a18cc5a840e56faaba133ab0cb3ea24e50b71a81cc87cd436ef71e739e62fea0'
 
   url "https://github.com/MagerValp/AutoDMG/releases/download/v#{version}/AutoDMG-#{version}.dmg"
+  appcast 'https://github.com/MagerValp/AutoDMG/releases.atom'
   name 'AutoDMG'
   homepage 'https://github.com/MagerValp/AutoDMG'
   license :apache

--- a/Casks/barmaid.rb
+++ b/Casks/barmaid.rb
@@ -3,6 +3,7 @@ cask :v1 => 'barmaid' do
   sha256 'c0dc73a2ce71a5e6266c792c03aa496ed3b345471e48fd52218db7415394ba27'
 
   url "https://github.com/zenonas/barmaid/releases/download/v#{version}/Barmaid-v#{version.gsub('-', '')}.dmg"
+  appcast 'https://github.com/zenonas/barmaid/releases.atom'
   name 'Barmaid'
   homepage 'https://github.com/zenonas/barmaid'
   license :mit

--- a/Casks/beacon-scanner.rb
+++ b/Casks/beacon-scanner.rb
@@ -3,6 +3,7 @@ cask :v1 => 'beacon-scanner' do
   sha256 '1c7662420ab616004e0f76320b76bf9ee5c3c75292c553bc891ac4986208bbb4'
 
   url "https://github.com/mlwelles/BeaconScanner/releases/download/#{version}/BeaconScanner.zip"
+  appcast 'https://github.com/mlwelles/BeaconScanner/releases.atom'
   name 'BeaconScanner'
   homepage 'https://github.com/mlwelles/BeaconScanner/'
   license :mit

--- a/Casks/beardedspice.rb
+++ b/Casks/beardedspice.rb
@@ -4,6 +4,7 @@ cask :v1 => 'beardedspice' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/beardedspice/beardedspice/raw/releases/BeardedSpice-#{version}.tar.gz"
+  appcast 'https://github.com/beardedspice/beardedspice/raw.atom'
   name 'BeardedSpice'
   homepage 'http://www.beardedspice.com'
   license :oss

--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -4,6 +4,7 @@ cask :v1 => 'blink1control' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
+  appcast 'https://github.com/todbot/blink1/releases.atom'
   name 'Blink1Control'
   homepage 'http://blink1.thingm.com/'
   license :cc

--- a/Casks/bob.rb
+++ b/Casks/bob.rb
@@ -3,6 +3,7 @@ cask :v1 => 'bob' do
   sha256 'e73e5a5a2a4750cfa62f405846d87abc6fc32dba6df4b1bf74f910cee2cf8e87'
 
   url "https://github.com/casperstorm/Bob/releases/download/#{version}/Bob.zip"
+  appcast 'https://github.com/casperstorm/Bob/releases.atom'
   name 'Bob'
   homepage 'https://github.com/casperstorm/Bob'
   license :mit

--- a/Casks/boot2docker.rb
+++ b/Casks/boot2docker.rb
@@ -3,6 +3,7 @@ cask :v1 => 'boot2docker' do
   sha256 'd9399912d3cee93f862fc7b39a4be73807a4759162e27a85bf9de53d9f938059'
 
   url "https://github.com/boot2docker/osx-installer/releases/download/v#{version}/Boot2Docker-#{version}.pkg"
+  appcast 'https://github.com/boot2docker/osx-installer/releases.atom'
   name 'Boot2Docker'
   homepage 'https://github.com/boot2docker/osx-installer'
   license :apache

--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -3,6 +3,7 @@ cask :v1 => 'brackets' do
   sha256 '405ed2a85ea95cb1a2d240c7cbf4a1bb6ff916f85fd6667c936b69f933bb1cbe'
 
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
+  appcast 'https://github.com/adobe/brackets/releases.atom'
   name 'Brackets'
   homepage 'http://brackets.io'
   license :mit

--- a/Casks/breach.rb
+++ b/Casks/breach.rb
@@ -4,6 +4,7 @@ cask :v1 => 'breach' do
 
   # githubusercontent.com is the official download host per the vendor homepage
   url "https://raw.githubusercontent.com/breach/releases/master/v#{version}/breach-v#{version}-darwin-ia32.tar.gz"
+  appcast 'https://raw.githubusercontent.com/breach/releases/master.atom'
   name 'Breach'
   homepage 'http://breach.cc'
   license :mit

--- a/Casks/butter.rb
+++ b/Casks/butter.rb
@@ -3,6 +3,7 @@ cask :v1 => 'butter' do
   sha256 '32c9c20453bb4702e10f4d51e93b316eb0f9d4cc57224c526cc5050346913099'
 
   url "https://github.com/harukasan/butter/releases/download/v#{version}/Butter_#{version}.dmg"
+  appcast 'https://github.com/harukasan/butter/releases.atom'
   name 'Butter'
   homepage 'https://github.com/harukasan/butter'
   license :mit

--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -4,6 +4,7 @@ cask :v1 => 'calibre' do
 
   # github.com is an official download host per the vendor homepage, and a faster mirror than the main one
   url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"
+  appcast 'https://github.com/kovidgoyal/calibre/releases.atom'
   name 'calibre'
   homepage 'http://calibre-ebook.com/'
   license :gpl

--- a/Casks/catch.rb
+++ b/Casks/catch.rb
@@ -4,8 +4,7 @@ cask :v1 => 'catch' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/mipstian/catch/releases/download/#{version}/Catch-#{version}.zip"
-  appcast 'https://raw.github.com/mipstian/catch/master/update/appcast.xml',
-          :sha256 => 'd559363812ead3090bf597711821d4e47dd281e7695f4e377767fffd56637a2d'
+  appcast 'https://github.com/mipstian/catch/releases.atom'
   homepage 'http://www.giorgiocalderolla.com/index.html#catch'
   license :oss
 

--- a/Casks/cd-to.rb
+++ b/Casks/cd-to.rb
@@ -3,6 +3,7 @@ cask :v1 => 'cd-to' do
   sha256 'a92def521d332a373f655a41338d0ec18dfaa6e24eb9ec2ca6df281398db3d46'
 
   url "https://github.com/jbtule/cdto/releases/download/#{version.gsub('.', '_')}/cdto_#{version.gsub('.', '_').gsub(/_\d$/, '')}.zip"
+  appcast 'https://github.com/jbtule/cdto/releases.atom'
   homepage 'https://github.com/jbtule/cdto'
   license :mit
 

--- a/Casks/clementine.rb
+++ b/Casks/clementine.rb
@@ -4,8 +4,7 @@ cask :v1 => 'clementine' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/clementine-player/Clementine/releases/download/#{version}/clementine-#{version}.dmg"
-  appcast 'https://clementine-data.appspot.com/sparkle',
-          :sha256 => 'aa4ef8bb841b9eea028181b5a884073fe51893f4a15d7061eb84f117ff161383'
+  appcast 'https://github.com/clementine-player/Clementine/releases.atom'
   name 'Clementine'
   homepage 'http://www.clementine-player.org/'
   license :gpl

--- a/Casks/cloudytabs.rb
+++ b/Casks/cloudytabs.rb
@@ -3,8 +3,7 @@ cask :v1 => 'cloudytabs' do
   sha256 '7ba67b0f7415fe2d2cb545866eb0e9c7c2bea8980445921a9da5d2bf55711d76'
 
   url "https://github.com/josh-/CloudyTabs/releases/download/v#{version}/CloudyTabs.zip"
-  appcast 'http://joshparnham.com/projects/cloudytabs/appcast.xml',
-          :sha256 => '70140cb26a2a25589d739d6dac6f2e04118a938814909fe08c720b0174adf2b4'
+  appcast 'https://github.com/josh-/CloudyTabs/releases.atom'
   homepage 'https://github.com/josh-/CloudyTabs/'
   license :mit
 

--- a/Casks/cocoarestclient.rb
+++ b/Casks/cocoarestclient.rb
@@ -3,8 +3,7 @@ cask :v1 => 'cocoarestclient' do
   sha256 '78400a16afc4017a68b5506e7a6270d72ade48b3e77a802eaaaaae80a0f6319f'
 
   url "https://github.com/mmattozzi/cocoa-rest-client/releases/download/#{version}/CocoaRestClient-#{version}.dmg"
-  appcast 'http://restlesscode.org/cocoa-rest-client/appcast.xml',
-          :sha256 => '32d1b71d2ade6fc17554d1e7bcbc900c9ace68c34046ea7c2d785142e0d60520'
+  appcast 'https://github.com/mmattozzi/cocoa-rest-client/releases.atom'
   homepage 'http://mmattozzi.github.io/cocoa-rest-client/'
   license :bsd
 

--- a/Casks/consul-template.rb
+++ b/Casks/consul-template.rb
@@ -3,6 +3,7 @@ cask :v1 => 'consul-template' do
   sha256 '32aeb5e50bf00fc46c3ae195a7d43ae539ce13115893b18bb9f2d63e373bed7e'
 
   url "https://github.com/hashicorp/consul-template/releases/download/v#{version}/consul-template_#{version}_darwin_amd64.tar.gz"
+  appcast 'https://github.com/hashicorp/consul-template/releases.atom'
   name 'Consul Template'
   homepage 'https://github.com/hashicorp/consul-template'
   license :mpl

--- a/Casks/coreos-osx-gui.rb
+++ b/Casks/coreos-osx-gui.rb
@@ -3,6 +3,7 @@ cask :v1 => 'coreos-osx-gui' do
   sha256 'acef0c3090f4c249c95d8cfb281da65787133b2e64ec4ae8d1925bdb2cc2a3cb'
 
   url "https://github.com/rimusz/coreos-osx-gui/releases/download/v0.8.4/CoreOS_GUI_v#{version}.dmg"
+  appcast 'https://github.com/rimusz/coreos-osx-gui/releases.atom'
   homepage 'https://github.com/rimusz/coreos-osx-gui'
   license :oss
 

--- a/Casks/corsixth.rb
+++ b/Casks/corsixth.rb
@@ -3,6 +3,7 @@ cask :v1 => 'corsixth' do
   sha256 '2d9fbe47ac31955643ee1de0e53fd30ddac9e64d5a1c205c46ecd3bfda1929b4'
 
   url "https://github.com/CorsixTH/CorsixTH/releases/download/v#{version}/CorsixTH-#{version}-OSX.dmg"
+  appcast 'https://github.com/CorsixTH/CorsixTH/releases.atom'
   name 'CorsixTH'
   homepage 'https://github.com/CorsixTH/CorsixTH'
   license :mit

--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -4,8 +4,7 @@ cask :v1 => 'coteditor' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
-  appcast 'http://coteditor.com/appcast.xml',
-          :sha256 => '6707d7d9110e85cd98346efd2ad3507477707136ef5d8df0c309fb042be568f9'
+  appcast 'https://github.com/coteditor/CotEditor/releases.atom'
   name 'CotEditor'
   homepage 'http://coteditor.com/'
   license :gpl

--- a/Casks/cryptol.rb
+++ b/Casks/cryptol.rb
@@ -4,6 +4,7 @@ cask :v1 => 'cryptol' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/GaloisInc/cryptol/releases/download/v#{version}/cryptol-#{version}-MacOSX-64.tar.gz"
+  appcast 'https://github.com/GaloisInc/cryptol/releases.atom'
   gpg "#{url}.sig",
       :key_url => 'http://cryptol.net/files/Galois.asc'
   homepage 'http://cryptol.net/'

--- a/Casks/ctivo.rb
+++ b/Casks/ctivo.rb
@@ -3,8 +3,7 @@ cask :v1 => 'ctivo' do
   sha256 '55ad469432634a77be432741ee6dfc5480c3baf652a6d2b3cde70f919c1d13d7'
 
   url "https://github.com/dscottbuch/cTiVo/releases/download/v#{version}.468/cTiVo_#{version}_468.zip"
-  appcast 'https://github.com/dscottbuch/cTiVo/blob/master/update/sparklecast.xml',
-          :sha256 => 'd5462bd4d454bcd9e3d55d8ee85fc32913d332d0dba41c14be3a33ac1d6f4c54'
+  appcast 'https://github.com/dscottbuch/cTiVo/releases.atom'
   homepage 'https://github.com/dscottbuch/cTiVo'
   license :oss
 

--- a/Casks/d235j-xbox360-controller-driver.rb
+++ b/Casks/d235j-xbox360-controller-driver.rb
@@ -3,6 +3,7 @@ cask :v1 => 'd235j-xbox360-controller-driver' do
   sha256 'a7efe48fae89aa592e904d1dc3ba9a73b2d644362eac88feb5e73a774e3fcf88'
 
   url "https://github.com/d235j/360Controller/releases/download/v#{version}-unofficial/360ControllerInstall_#{version}_unofficial.dmg"
+  appcast 'https://github.com/d235j/360Controller/releases.atom'
   homepage 'https://github.com/d235j/360Controller'
   license :gpl
 

--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -4,6 +4,7 @@ cask :v1 => 'darktable' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
+  appcast 'https://github.com/darktable-org/darktable/releases.atom'
   name 'darktable'
   homepage 'http://www.darktable.org/'
   license :gpl

--- a/Casks/dataurlmaker.rb
+++ b/Casks/dataurlmaker.rb
@@ -3,6 +3,7 @@ cask :v1 => 'dataurlmaker' do
   sha256 'dc297a57ea7180273a17fe8503f7ed7423afb66e210f67d32c4e566fa8e797e1'
 
   url "https://github.com/sveinbjornt/Data-URL-Toolkit/raw/master/Releases/DataURLMaker-#{version}.zip"
+  appcast 'https://github.com/sveinbjornt/Data-URL-Toolkit/raw.atom'
   homepage 'https://github.com/sveinbjornt/Data-URL-Toolkit'
   license :gpl
 

--- a/Casks/dnscrypt.rb
+++ b/Casks/dnscrypt.rb
@@ -3,6 +3,7 @@ cask :v1 => 'dnscrypt' do
   sha256 '9d0cec793f33ba107bd724830398d6b156f5a7b3c8f33a5d3ae529c588041a36'
 
   url "https://github.com/alterstep/dnscrypt-osxclient/releases/download/#{version}/dnscrypt-osxclient-#{version}.dmg"
+  appcast 'https://github.com/alterstep/dnscrypt-osxclient/releases.atom'
   name 'DNSCrypt'
   homepage 'https://github.com/alterstep/dnscrypt-osxclient'
   license :oss

--- a/Casks/docker-machine.rb
+++ b/Casks/docker-machine.rb
@@ -4,6 +4,7 @@ cask :v1 => 'docker-machine' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/docker/machine/releases/download/#{version}/docker-machine_darwin-amd64"
+  appcast 'https://github.com/docker/machine/releases.atom'
   name 'Docker Machine'
   homepage 'https://docs.docker.com/machine'
   license :apache

--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -4,6 +4,7 @@ cask :v1 => 'dogecoin' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/dogecoin/dogecoin/releases/download/v#{version}/dogecoin-#{version}-mac.zip"
+  appcast 'https://github.com/dogecoin/dogecoin/releases.atom'
   homepage 'http://dogecoin.com/'
   license :mit
 

--- a/Casks/dropletmanager.rb
+++ b/Casks/dropletmanager.rb
@@ -3,6 +3,7 @@ cask :v1 => 'dropletmanager' do
   sha256 'ed8011cef55f3bcdde4e7e7e331775808e4701fc41acc3191d3e4d80f8ab8335'
 
   url "https://github.com/deivuh/DODropletManager-OSX/releases/download/v#{version}/DropletManager.v#{version}.zip"
+  appcast 'https://github.com/deivuh/DODropletManager-OSX/releases.atom'
   homepage 'https://github.com/deivuh/DODropletManager-OSX'
   license :gpl
 

--- a/Casks/dux.rb
+++ b/Casks/dux.rb
@@ -4,6 +4,7 @@ cask :v1 => 'dux' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/abhibeckert/Dux/releases/download/#{version}/Dux-#{version}.zip"
+  appcast 'https://github.com/abhibeckert/Dux/releases.atom'
   name 'Dux'
   homepage 'http://duxapp.com/'
   license :public_domain

--- a/Casks/dwihn0r-keepassx.rb
+++ b/Casks/dwihn0r-keepassx.rb
@@ -3,6 +3,7 @@ cask :v1 => 'dwihn0r-keepassx' do
   sha256 '53ae446d458ef0ab6dae268ba17b0eb9779959f3f821552de89122bd434769e2'
 
   url "https://github.com/dwihn0r/keepassx/releases/download/v#{version}/KeePassX-#{version}-OSX.zip"
+  appcast 'https://github.com/dwihn0r/keepassx/releases.atom'
   homepage 'https://github.com/dwihn0r/keepassx/'
   license :gpl
 

--- a/Casks/easysimbl.rb
+++ b/Casks/easysimbl.rb
@@ -3,6 +3,7 @@ cask :v1 => 'easysimbl' do
   sha256 'd8afe8bfd7ea32f6d8ad1d4438ddc9ce2ad47e66942e6b6e900807daa59ddd50'
 
   url "https://github.com/norio-nomura/EasySIMBL/releases/download/EasySIMBL-#{version}/EasySIMBL-#{version}.zip"
+  appcast 'https://github.com/norio-nomura/EasySIMBL/releases.atom'
   name 'EasySIMBL'
   homepage 'https://github.com/norio-nomura/EasySIMBL'
   license :gpl

--- a/Casks/feedbinnotifier.rb
+++ b/Casks/feedbinnotifier.rb
@@ -3,6 +3,7 @@ cask :v1 => 'feedbinnotifier' do
   sha256 '20f94b5cecc2b730da1cfaae3633ce41f7b6ef6b28f56b7684538394544515f8'
 
   url "https://github.com/kmikael/FeedbinNotifier/releases/download/v#{version}/FeedbinNotifier.zip"
+  appcast 'https://github.com/kmikael/FeedbinNotifier/releases.atom'
   name 'Feedbin Notifier'
   homepage 'http://kmikael.github.io/FeedbinNotifier'
   license :mit

--- a/Casks/fenix.rb
+++ b/Casks/fenix.rb
@@ -4,6 +4,7 @@ cask :v1 => 'fenix' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/coreybutler/fenix/releases/download/v#{version}/fenix-osx-#{version}.zip"
+  appcast 'https://github.com/coreybutler/fenix/releases.atom'
   homepage 'http://fenixwebserver.com/'
   license :gpl
 

--- a/Casks/fontprep.rb
+++ b/Casks/fontprep.rb
@@ -3,6 +3,7 @@ cask :v1 => 'fontprep' do
   sha256 '769d64b78d1a8db42dcb02beff6f929670448f77259388c9d01692374be2ec46'
 
   url "https://github.com/briangonzalez/fontprep/releases/download/v3.1.1/FontPrep_#{version}.zip"
+  appcast 'https://github.com/briangonzalez/fontprep/releases.atom'
   name 'FontPrep'
   homepage 'https://github.com/briangonzalez/fontprep'
   license :gpl

--- a/Casks/gcollazo-mongodb.rb
+++ b/Casks/gcollazo-mongodb.rb
@@ -4,6 +4,7 @@ cask :v1 => 'gcollazo-mongodb' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/gcollazo/mongodbapp/releases/download/#{version}/MongoDB.zip"
+  appcast 'https://github.com/gcollazo/mongodbapp/releases.atom'
   homepage 'http://elweb.co/mongodb-app/'
   license :mit
 

--- a/Casks/ghc.rb
+++ b/Casks/ghc.rb
@@ -3,6 +3,7 @@ cask :v1 => 'ghc' do
   sha256 '084f0eaf2807e67185ce44dd1a7a91c539df833b36fce307f3156c95b94afb9e'
 
   url "https://github.com/ghcformacosx/ghc-dot-app/releases/download/v#{version}/ghc-#{version}.zip"
+  appcast 'https://github.com/ghcformacosx/ghc-dot-app/releases.atom'
   homepage 'http://ghcformacosx.github.io/'
   license :oss
 

--- a/Casks/gingr.rb
+++ b/Casks/gingr.rb
@@ -4,6 +4,7 @@ cask :v1 => 'gingr' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/marbl/gingr/releases/download/v#{version}/gingr-OSX64-v#{version}.zip"
+  appcast 'https://github.com/marbl/gingr/releases.atom'
   homepage 'http://harvest.readthedocs.org/en/latest/content/gingr.html'
   license :bsd
 

--- a/Casks/gitbook.rb
+++ b/Casks/gitbook.rb
@@ -3,6 +3,7 @@ cask :v1 => 'gitbook' do
   sha256 'f8e2f7b28e7dfa18b3736f8d43d68068228774c0827fdc8c685846a129459c5f'
 
   url "https://github.com/GitbookIO/editor/releases/download/#{version}/gitbook-mac.dmg"
+  appcast 'https://github.com/GitbookIO/editor/releases.atom'
   name 'GitBook'
   homepage 'https://github.com/GitbookIO/editor'
   license :apache

--- a/Casks/gitifier.rb
+++ b/Casks/gitifier.rb
@@ -3,8 +3,7 @@ cask :v1 => 'gitifier' do
   sha256 '59068f250654d0d1588c544f34148bd81a8855b78f868fca8ae49dd3d24d1ee4'
 
   url "https://github.com/jsuder/Gitifier/releases/download/#{version}/Gitifier-#{version}.zip"
-  appcast 'http://sparkle.psionides.eu/feed/gitifier',
-          :sha256 => '5bf8682d28e0a59966f8107efbca6be05b60a32252da7288952b35c3fb4e269b'
+  appcast 'https://github.com/jsuder/Gitifier/releases.atom'
   name 'Gitifier'
   homepage 'http://psionides.github.io/Gitifier/'
   license :eclipse

--- a/Casks/glyphish-color-changer.rb
+++ b/Casks/glyphish-color-changer.rb
@@ -3,6 +3,7 @@ cask :v1 => 'glyphish-color-changer' do
   sha256 '2fe6d7b5b056a67ca69c4f5cf477bc0c9ecf47a8d7aa95eefcb97c0fde0e75d8'
 
   url "https://github.com/glyphish/color-changer/releases/download/v#{version}/#{version}.zip"
+  appcast 'https://github.com/glyphish/color-changer/releases.atom'
   name 'Glyphish Color Changer'
   homepage 'https://github.com/glyphish/color-changer'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/glyphish-gallery.rb
+++ b/Casks/glyphish-gallery.rb
@@ -3,6 +3,7 @@ cask :v1 => 'glyphish-gallery' do
   sha256 'c5f224d44ecf4a853a51105d1fce8b4e3eab099ddc16791ce412a7a679b104a7'
 
   url "https://github.com/glyphish/gallery/releases/download/v#{version}/v#{version}.zip"
+  appcast 'https://github.com/glyphish/gallery/releases.atom'
   homepage 'https://github.com/glyphish/gallery'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/gmail-notifier.rb
+++ b/Casks/gmail-notifier.rb
@@ -3,6 +3,7 @@ cask :v1 => 'gmail-notifier' do
   sha256 '6d91b6b0e00041cde61a267c484f6f004330a96dfd608a61f7954f5b7abdd66e'
 
   url "https://github.com/jashephe/Gmail-Notifier/releases/download/v#{version}/Gmail.Notifier.v#{version}.zip"
+  appcast 'https://github.com/jashephe/Gmail-Notifier/releases.atom'
   homepage 'https://github.com/jashephe/Gmail-Notifier'
   license :bsd
 

--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -3,6 +3,7 @@ cask :v1 => 'goldencheetah' do
   sha256 '53daceee5b54baa742278e370b2bada1ba02d32c9fa77afa757dd5cb51f4fb52'
 
   url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/v#{version}/GoldenCheetah-64bit-#{version}.0-QT5.dmg"
+  appcast 'https://github.com/GoldenCheetah/GoldenCheetah/releases.atom'
   name 'GoldenCheetah'
   homepage 'http://www.goldencheetah.org/'
   license :gpl

--- a/Casks/google-refine.rb
+++ b/Casks/google-refine.rb
@@ -4,6 +4,7 @@ cask :v1 => 'google-refine' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenRefine/OpenRefine/releases/download/2.5/google-refine-#{version}.dmg"
+  appcast 'https://github.com/OpenRefine/OpenRefine/releases.atom'
   homepage 'http://openrefine.org/'
   license :bsd
 

--- a/Casks/graphsketcher.rb
+++ b/Casks/graphsketcher.rb
@@ -3,6 +3,7 @@ cask :v1 => 'graphsketcher' do
   sha256 '34fe6fc319b2fcfe0bf51e02bc05d020b2867ff1ee20587becb60d7e67309be6'
 
   url "https://github.com/graphsketcher/GraphSketcher/releases/download/#{version}/GraphSketcher.zip"
+  appcast 'https://github.com/graphsketcher/GraphSketcher/releases.atom'
   homepage 'https://github.com/graphsketcher/GraphSketcher'
   license :mit
 

--- a/Casks/gravit.rb
+++ b/Casks/gravit.rb
@@ -4,6 +4,7 @@ cask :v1 => 'gravit' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/quasado/gravit-hub/releases/download/#{version}/Gravit-Mac-OSX.dmg"
+  appcast 'https://github.com/quasado/gravit-hub/releases.atom'
   homepage 'http://gravit.io/'
   license :cc
 

--- a/Casks/gulp.rb
+++ b/Casks/gulp.rb
@@ -3,6 +3,7 @@ cask :v1 => 'gulp' do
   sha256 '59fed5d8c801c9302debf463f2d274404548e23433c965144e69a0b4a2e23851'
 
   url "https://github.com/sindresorhus/gulp-app/releases/download/#{version}/gulp.app.zip"
+  appcast 'https://github.com/sindresorhus/gulp-app/releases.atom'
   homepage 'https://github.com/sindresorhus/gulp-app'
   license :mit
 

--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -4,6 +4,7 @@ cask :v1 => 'hammerspoon' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip"
+  appcast 'https://github.com/Hammerspoon/hammerspoon/releases.atom'
   name 'Hammerspoon'
   homepage 'http://www.hammerspoon.org/'
   license :mit

--- a/Casks/happygrep.rb
+++ b/Casks/happygrep.rb
@@ -3,6 +3,7 @@ cask :v1 => 'happygrep' do
   sha256 '05c5f33142c9ea4559b20ca421c76fa0b081ae3edc0d6e3b8f7c3dd8ba21a518'
 
   url "https://github.com/happypeter/happygrep/releases/download/v#{version}/happygrep.zip"
+  appcast 'https://github.com/happypeter/happygrep/releases.atom'
   homepage 'https://github.com/happypeter/happygrep'
   license :mit
 

--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -4,6 +4,7 @@ cask :v1 => 'hex-fiend' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex.Fiend.app.zip"
+  appcast 'https://github.com/ridiculousfish/HexFiend/releases.atom'
   homepage 'http://ridiculousfish.com/hexfiend/'
   license :bsd
 

--- a/Casks/hive.rb
+++ b/Casks/hive.rb
@@ -4,8 +4,7 @@ cask :v1 => 'hive' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/hivewallet/hive-osx/releases/download/#{version}/Hive-#{version}.zip"
-  appcast 'https://hivewallet.com/hive-osx-appcast.xml',
-          :sha256 => '53a58f4b4bc888cde3e036ee3b09b44f0ba19b321492c82a93acc01891d310e1'
+  appcast 'https://github.com/hivewallet/hive-osx/releases.atom'
   homepage 'http://www.hivewallet.com'
   license :gpl
 

--- a/Casks/honer.rb
+++ b/Casks/honer.rb
@@ -3,6 +3,7 @@ cask :v1 => 'honer' do
   sha256 'bae10bea6875dbc5c948fb2e86b168c15ee3738d485bd7ab2a9758e64812c531'
 
   url "https://github.com/puffnfresh/Honer.app/releases/download/v#{version}/Honer-6e3863f2.zip"
+  appcast 'https://github.com/puffnfresh/Honer.app/releases.atom'
   homepage 'https://github.com/puffnfresh/Honer.app'
   license :mit
 

--- a/Casks/hub.rb
+++ b/Casks/hub.rb
@@ -3,6 +3,7 @@ cask :v1 => 'hub' do
   sha256 'dd34cbdc644f2c486af6af34eb193b56e6ea96e37756a0411e8f0dc065cdcf2b'
 
   url "https://github.com/github/hub/releases/download/v#{version}/hub-mac-amd64-#{version}.tar.gz"
+  appcast 'https://github.com/github/hub/releases.atom'
   name 'hub'
   homepage 'https://github.com/github/hub'
   license :mit

--- a/Casks/icons.rb
+++ b/Casks/icons.rb
@@ -3,6 +3,7 @@ cask :v1 => 'icons' do
   sha256 '1c9fc20d8b10677c11f70d43e511227209d83f260bfbef6fddf00a7469e8f8c1'
 
   url "https://github.com/exherb/icons/releases/download/#{version}/icons-v#{version}-macos-x64.zip"
+  appcast 'https://github.com/exherb/icons/releases.atom'
   name 'Icons'
   homepage 'https://github.com/exherb/icons'
   license :mit

--- a/Casks/imagemin.rb
+++ b/Casks/imagemin.rb
@@ -3,6 +3,7 @@ cask :v1 => 'imagemin' do
   sha256 '8a4304d37eaa8a71fbeb550aece6a80c98dbcdf7a9fb6eb09faae1ad93df40d6'
 
   url "https://github.com/kevva/imagemin-app/releases/download/#{version}/imagemin-app-v#{version}-darwin.zip"
+  appcast 'https://github.com/kevva/imagemin-app/releases.atom'
   name 'imagemin'
   homepage 'https://github.com/kevva/imagemin-app'
   license :mit

--- a/Casks/jewelrybox.rb
+++ b/Casks/jewelrybox.rb
@@ -3,6 +3,7 @@ cask :v1 => 'jewelrybox' do
   sha256 '96c0bae3cc0ce312ce3df290a4d1eddff2da781dfaafe4707b298dc17eb53993'
 
   url "https://github.com/remear/jewelrybox/releases/download/#{version}/JewelryBox_v#{version}.tar.bz2"
+  appcast 'https://github.com/remear/jewelrybox/releases.atom'
   homepage 'https://github.com/remear/jewelrybox'
   license :oss
 

--- a/Casks/keepingyouawake.rb
+++ b/Casks/keepingyouawake.rb
@@ -3,9 +3,7 @@ cask :v1 => 'keepingyouawake' do
   sha256 'e1f40532043949b785d0cb1d6f6a5a3a4ed4073a3db4ca6ed9b3d0275d7d1c2f'
 
   url "https://github.com/newmarcel/KeepingYouAwake/releases/download/#{version}/KeepingYouAwake-#{version}.zip"
-  appcast 'https://newmarcel.github.io/KeepingYouAwake/appcast.xml',
-    :sha256 => '738fcec2775620870b759319b9c49fabb71cfff9eaf330048c9725816c52254d',
-    :format => :sparkle
+  appcast 'https://github.com/newmarcel/KeepingYouAwake/releases.atom'
   name 'KeepingYouAwake'
   homepage 'https://github.com/newmarcel/KeepingYouAwake'
   license :mit

--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -4,6 +4,7 @@ cask :v1 => 'keycastr' do
 
   # github.com/lqez is the official download host per the vendor homepage
   url "https://github.com/lqez/keycastr/releases/download/#{version}/KeyCastr.zip"
+  appcast 'https://github.com/lqez/keycastr/releases.atom'
   homepage 'https://github.com/keycastr/keycastr'
   license :bsd
 

--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -4,6 +4,7 @@ cask :v1 => 'kitematic' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/kitematic/kitematic/releases/download/v#{version}/Kitematic-#{version}.zip"
+  appcast 'https://github.com/kitematic/kitematic/releases.atom'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
   license :apache

--- a/Casks/launchrocket.rb
+++ b/Casks/launchrocket.rb
@@ -3,6 +3,7 @@ cask :v1 => 'launchrocket' do
   sha256 '51dc78902fecfb7ec26ab5c6516b84d1c62692349864ef48aca2fde81bd2ef4a'
 
   url "https://github.com/jimbojsb/launchrocket/releases/download/v#{version}/LaunchRocket.prefPane.zip"
+  appcast 'https://github.com/jimbojsb/launchrocket/releases.atom'
   homepage 'https://github.com/jimbojsb/launchrocket'
   license :mit
 

--- a/Casks/lights-out-pane.rb
+++ b/Casks/lights-out-pane.rb
@@ -3,6 +3,7 @@ cask :v1 => 'lights-out-pane' do
   sha256 'eb33e8a0242cbc69ebb7b6ee9c67fb69941e203fe560f37a83677f3c9cceeebf'
 
   url "https://github.com/samturner/lights-out/releases/download/v#{version}/lights-out.prefPane.zip"
+  appcast 'https://github.com/samturner/lights-out/releases.atom'
   homepage 'http://samturner.github.io/lights-out/'
   license :gpl
 

--- a/Casks/lmms.rb
+++ b/Casks/lmms.rb
@@ -4,6 +4,7 @@ cask :v1 => 'lmms' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}.dmg"
+  appcast 'https://github.com/LMMS/lmms/releases.atom'
   homepage 'https://lmms.io'
   license :gpl
 

--- a/Casks/lunchy.rb
+++ b/Casks/lunchy.rb
@@ -3,6 +3,7 @@ cask :v1 => 'lunchy' do
   sha256 '13afd65921d3251dbd5f6c44bdf6f6a037d10228a69876c658470a23fc573f7f'
 
   url "https://github.com/sosedoff/lunchy-go/releases/download/v#{version}/#{version}_darwin_amd64.zip"
+  appcast 'https://github.com/sosedoff/lunchy-go/releases.atom'
   homepage 'https://github.com/sosedoff/lunchy-go'
   license :mit
 

--- a/Casks/mac-linux-usb-loader.rb
+++ b/Casks/mac-linux-usb-loader.rb
@@ -3,7 +3,7 @@ cask :v1 => 'mac-linux-usb-loader' do
   sha256 'd122b24db9f6cf35ea1ea7d260123ca4c123f2191a4b20a8c3639d9aacd6d0e8'
 
   url "https://github.com/SevenBits/Mac-Linux-USB-Loader/releases/download/v#{version}/Mac.Linux.USB.Loader.zip"
-  appcast 'https://sevenbits.github.io/appcasts/mlul.xml'
+  appcast 'https://github.com/SevenBits/Mac-Linux-USB-Loader/releases.atom'
   name 'Mac Linux USB Loader'
   homepage 'https://sevenbits.github.io/Mac-Linux-USB-Loader/'
   license :bsd

--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -3,8 +3,7 @@ cask :v1 => 'macpass' do
   sha256 '6d69ce183d5be1031df344b3cf4941a3d9495dc6dedb2d67611bbd89b754427d'
 
   url "https://github.com/mstarke/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
-  appcast 'http://www.nomadsland.de/macpass_appcast.xml',
-          :sha256 => 'd5f71e87922f4f6ec0b736d242c6b8ea8f25767eb4218cd56c90c8fa2b7b4908'
+  appcast 'https://github.com/mstarke/MacPass/releases.atom'
   name 'MacPass'
   homepage 'http://mstarke.github.io/MacPass/'
   license :gpl

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -15,6 +15,7 @@ cask :v1 => 'macvim' do
     sha256 '35ad0fbd18b144254f852b8f2822d0923e30f43a838dc8de72ebb902f7f55949'
     # github.com is the official download host per the vendor homepage
     url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.sub(%r{^.*-},'')}/MacVim-snapshot-#{version.sub(%r{^.*-},'')}-Yosemite.tbz"
+    appcast 'https://github.com/macvim-dev/macvim/releases.atom'
   end
 
   homepage 'http://code.google.com/p/macvim/'

--- a/Casks/maddthesane-perian.rb
+++ b/Casks/maddthesane-perian.rb
@@ -3,6 +3,7 @@ cask :v1 => 'maddthesane-perian' do
   sha256 'cc13f5b587f0cb53c5f95329d75686cd32eb599b125fe30e4ae31c3ab58d3a9e'
 
   url "https://github.com/MaddTheSane/perian/releases/download/#{version}/Perian.prefPane.zip"
+  appcast 'https://github.com/MaddTheSane/perian/releases.atom'
   homepage 'https://github.com/MaddTheSane/perian'
   license :gpl
 

--- a/Casks/management-tools.rb
+++ b/Casks/management-tools.rb
@@ -3,6 +3,7 @@ cask :v1 => 'management-tools' do
   sha256 '439ccc0a690d2c995bfb7d1b91d30732cabbd8e00163b3c84b43a2b19c547d8f'
 
   url "https://github.com/univ-of-utah-marriott-library-apple/management_tools/releases/download/v#{version}/Management_Tools_#{version}.dmg"
+  appcast 'https://github.com/univ-of-utah-marriott-library-apple/management_tools/releases.atom'
   name 'Management Tools'
   homepage 'https://github.com/univ-of-utah-marriott-library-apple/management_tools'
   license :mit

--- a/Casks/mattr-slate.rb
+++ b/Casks/mattr-slate.rb
@@ -5,6 +5,7 @@ cask :v1 => 'mattr-slate' do
   # github.com is the official download host for this fork
   # see https://github.com/mattr-/slate/commit/148a51e50174c946c07c801a9f2b92222a4c0276
   url "https://github.com/mattr-/slate/releases/download/v#{version}/Slate.zip"
+  appcast 'https://github.com/mattr-/slate/releases.atom'
   name 'Slate'
   homepage 'https://github.com/mattr-/slate'
   license :gpl

--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -3,6 +3,7 @@ cask :v1 => 'mcedit' do
   sha256 '2932e5c96c2d3d9ec77b3b71a2e4596f5f96edd820e316921dfedcfe72bafc5c'
 
   url "https://github.com/Khroki/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
+  appcast 'https://github.com/Khroki/MCEdit-Unified/releases.atom'
   name 'MCEdit-Unified'
   homepage 'http://khroki.github.io/MCEdit-Unified/'
   license :mit

--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -3,6 +3,7 @@ cask :v1 => 'metaz' do
   sha256 '7dcc71a917bed0d5686884c4ec198275a1f656ce09db71fa49cc73e46933820c'
 
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"
+  appcast 'https://github.com/griff/metaz/releases.atom'
   name 'MetaZ'
   homepage 'http://griff.github.io/metaz/'
   license :mit

--- a/Casks/mirador.rb
+++ b/Casks/mirador.rb
@@ -4,6 +4,7 @@ cask :v1 => 'mirador' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/mirador/mirador/releases/download/#{version}/mirador-macosx-#{version}.zip"
+  appcast 'https://github.com/mirador/mirador/releases.atom'
   homepage 'http://fathom.info/mirador/'
   license :gpl
 

--- a/Casks/mjolnir.rb
+++ b/Casks/mjolnir.rb
@@ -3,6 +3,7 @@ cask :v1 => 'mjolnir' do
   sha256 '7f7a9579427f258a34663abed46845c81c35f676f63b2ae1acef2a7729745572'
 
   url "https://github.com/sdegutis/mjolnir/releases/download/#{version}/Mjolnir-#{version}.tgz"
+  appcast 'https://github.com/sdegutis/mjolnir/releases.atom'
   homepage 'http://mjolnir.io'
   license :mit
 

--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -4,6 +4,7 @@ cask :v1 => 'mongodb' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/orelord/mongodbx-app/releases/download/v#{version}/MongoDBX-#{version}-2.4.9.zip"
+  appcast 'https://github.com/orelord/mongodbx-app/releases.atom'
   homepage 'http://mongodbx-app.orelord.com/'
   license :oss
 

--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -12,11 +12,10 @@ cask :v1 => 'monolingual' do
   else
     version '1.6.3'
     sha256 '7b6d0dd47952e3c864901f05be3a1cc7f47c86c8addc104b60d0d832722235d0'
-    appcast 'https://ingmarstein.github.io/Monolingual/appcast.xml',
-            :sha256 => 'a536d84e8430d0ba64638e5696f67e96259cfdb81aacd8c2df0a078ff3ea4672'
   end
 
   url "https://github.com/IngmarStein/Monolingual/releases/download/v#{version}/Monolingual-#{version}.dmg"
+  appcast 'https://github.com/IngmarStein/Monolingual/releases.atom'
   homepage 'https://ingmarstein.github.io/Monolingual/'
   license :gpl
 

--- a/Casks/moscow-ml.rb
+++ b/Casks/moscow-ml.rb
@@ -4,6 +4,7 @@ cask :v1 => 'moscow-ml' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/kfl/mosml/releases/download/ver-#{version}/mosml-#{version}.pkg"
+  appcast 'https://github.com/kfl/mosml/releases.atom'
   name 'Moscow ML'
   homepage 'http://mosml.org/'
   license :gpl

--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -4,8 +4,7 @@ cask :v1 => 'mplayer-osx-extended' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/sttz/MPlayer-OSX-Extended/releases/download/#{version}/MPlayer-OSX-Extended_#{version}.zip"
-  appcast 'http://mplayerosx.ch/updates.xml',
-          :sha256 => '2c74b034df3d97edc5748201d35cb5dec7c3715212d6cf4bd7f8bdd1a087e3cc'
+  appcast 'https://github.com/sttz/MPlayer-OSX-Extended/releases.atom'
   homepage 'http://www.mplayerosx.ch/'
   license :gpl
 

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -4,6 +4,7 @@ cask :v1 => 'mpv' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/mpv-player/mpv/releases/download/v#{version}/mpv_#{version}_mac.tar.bz2"
+  appcast 'https://github.com/mpv-player/mpv/releases.atom'
   name 'mpv'
   homepage 'http://mpv.io/'
   license :gpl

--- a/Casks/multidoge.rb
+++ b/Casks/multidoge.rb
@@ -4,6 +4,7 @@ cask :v1 => 'multidoge' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/langerhans/multidoge/releases/download/v#{version}/multidoge-#{version}.dmg"
+  appcast 'https://github.com/langerhans/multidoge/releases.atom'
   name 'MultiDoge'
   homepage 'http://multidoge.org/'
   license :mit

--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -3,6 +3,7 @@ cask :v1 => 'munki' do
   sha256 'd2287454a1b3aa66ef49e41a34dfa55cfffd45d3e00de5d2288b3fd7ced2e42c'
 
   url "https://github.com/munki/munki/releases/download/v#{version}/munkitools-#{version}.pkg"
+  appcast 'https://github.com/munki/munki/releases.atom'
   name 'Munki'
   homepage 'http://munki.github.io/munki/'
   license :apache

--- a/Casks/nimbus.rb
+++ b/Casks/nimbus.rb
@@ -3,8 +3,7 @@ cask :v1 => 'nimbus' do
   sha256 '4915e57131db72e08c45e375e4a52a4441f70ef9cfb5a70e433d66949708e82b'
 
   url "https://github.com/jnordberg/irccloudapp/releases/download/#{version}/Nimbus-#{version}.zip"
-  appcast 'https://github.com/jnordberg/irccloudapp/raw/master/appcast.xml',
-          :sha256 => 'aa3b9af94d19e8df33fc083ea87ffa8fe227742965d42368822b3e4d6ded9d03'
+  appcast 'https://github.com/jnordberg/irccloudapp/releases.atom'
   homepage 'https://github.com/jnordberg/irccloudapp'
   license :mit
 

--- a/Casks/nosleep.rb
+++ b/Casks/nosleep.rb
@@ -4,6 +4,7 @@ cask :v1 => 'nosleep' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/integralpro/nosleep/releases/download/v#{version}/NoSleep-#{version}.dmg"
+  appcast 'https://github.com/integralpro/nosleep/releases.atom'
   name 'NoSleep'
   homepage 'https://code.google.com/p/macosx-nosleep-extension/'
   license :gpl

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -4,6 +4,7 @@ cask :v1 => 'obs' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-#{version}-installer.dmg"
+  appcast 'https://github.com/jp9000/obs-studio/releases.atom'
   homepage 'http://obsproject.com/'
   license :gpl
 

--- a/Casks/onlabs.rb
+++ b/Casks/onlabs.rb
@@ -3,6 +3,7 @@ cask :v1 => 'onlabs' do
   sha256 '4fa575158f80d60f40826fab0b77217cc343ca0fc4af5e7840c606a4f4bd97c5'
 
   url "https://github.com/lalyos/onlabs/releases/download/v#{version}/onlabs_darwin_amd64"
+  appcast 'https://github.com/lalyos/onlabs/releases.atom'
   name 'onlabs'
   homepage 'https://github.com/lalyos/onlabs'
   license :unknown # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -4,8 +4,7 @@ cask :v1 => 'openemu' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}.zip"
-  appcast 'https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast.xml',
-          :sha256 => '0bc7baf23728b6c53a7d3c502fff9ccb0df150446a1164dc9e8ebcefc1c5a619'
+  appcast 'https://github.com/OpenEmu/OpenEmu/releases.atom'
   homepage 'http://openemu.org/'
   license :oss
 

--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -4,6 +4,7 @@ cask :v1 => 'openra' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
+  appcast 'https://github.com/OpenRA/OpenRA/releases.atom'
   homepage 'http://www.openra.net/'
   license :gpl
 

--- a/Casks/p5.rb
+++ b/Casks/p5.rb
@@ -5,6 +5,7 @@ cask :v1 => 'p5' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/processing/p5.js-editor/releases/download/v#{version}/p5.zip"
+  appcast 'https://github.com/processing/p5.js-editor/releases.atom'
   homepage 'http://p5js.org/download/#editor'
   license :mit
 

--- a/Casks/pandoc.rb
+++ b/Casks/pandoc.rb
@@ -4,6 +4,7 @@ cask :v1 => 'pandoc' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/jgm/pandoc/releases/download/#{version}/pandoc-#{version}-osx.pkg"
+  appcast 'https://github.com/jgm/pandoc/releases.atom'
   name 'Pandoc'
   homepage 'http://johnmacfarlane.net/pandoc'
   license :gpl

--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -4,6 +4,7 @@ cask :v1 => 'pdfsam-basic' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/torakiki/pdfsam-v2/releases/download/v#{version}/pdfsam-#{version}.dmg"
+  appcast 'https://github.com/torakiki/pdfsam-v2/releases.atom'
   homepage 'http://www.pdfsam.org/'
   license :gpl
 

--- a/Casks/pdfshaver.rb
+++ b/Casks/pdfshaver.rb
@@ -3,6 +3,7 @@ cask :v1 => 'pdfshaver' do
   sha256 'ebfacb5e30b0939c4549f36fe88be10c0d4bae1ffaa4616e70daf849d19df9d0'
 
   url "https://github.com/tparry/PDFShaver.app/releases/download/v#{version}/PDFShaver.zip"
+  appcast 'https://github.com/tparry/PDFShaver.app/releases.atom'
   homepage 'https://github.com/tparry/PDFShaver.app'
   license :public_domain
 

--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -3,6 +3,7 @@ cask :v1 => 'pgweb' do
   sha256 'ffc7f22d9591660902f8725bb392ec861f80fb9747021d93262a640d672fea02'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
+  appcast 'https://github.com/sosedoff/pgweb/releases.atom'
   name 'pgweb'
   homepage 'https://github.com/sosedoff/pgweb'
   license :mit

--- a/Casks/pinta.rb
+++ b/Casks/pinta.rb
@@ -4,6 +4,7 @@ cask :v1 => 'pinta' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/PintaProject/Pinta/releases/download/#{version}/Pinta.app.zip"
+  appcast 'https://github.com/PintaProject/Pinta/releases.atom'
   name 'Pinta'
   homepage 'http://pinta-project.com/'
   license :mit

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -4,6 +4,7 @@ cask :v1 => 'plover' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/openstenoproject/plover/releases/download/v#{version}/Plover.dmg"
+  appcast 'https://github.com/openstenoproject/plover/releases.atom'
   name 'Plover'
   homepage 'http://stenoknight.com/wiki/Main_Page'
   license :gpl

--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -4,6 +4,7 @@ cask :v1 => 'postgres' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/PostgresApp/PostgresApp/releases/download/#{version}/Postgres-#{version}.zip"
+  appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom'
   name 'Postgres'
   homepage 'http://postgresapp.com/'
   license :oss

--- a/Casks/powerkey.rb
+++ b/Casks/powerkey.rb
@@ -3,6 +3,7 @@ cask :v1 => 'powerkey' do
   sha256 '47bfb13458883218cab6106bd948b8516c3a42a733180b49c410f26d4d465ca1'
 
   url "https://github.com/pkamb/PowerKey/releases/download/v#{version}/PowerKey#{version}.zip"
+  appcast 'https://github.com/pkamb/PowerKey/releases.atom'
   homepage 'http://pkamb.github.io/PowerKey/'
   license :mit
 

--- a/Casks/prismatik.rb
+++ b/Casks/prismatik.rb
@@ -4,6 +4,7 @@ cask :v1 => 'prismatik' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/woodenshark/Lightpack/releases/download/#{version}/Prismatik.#{version}.dmg"
+  appcast 'https://github.com/woodenshark/Lightpack/releases.atom'
   name 'Prismatik'
   homepage 'http://lightpack.tv/'
   license :gpl

--- a/Casks/privacy-services-manager.rb
+++ b/Casks/privacy-services-manager.rb
@@ -3,6 +3,7 @@ cask :v1 => 'privacy-services-manager' do
   sha256 'fde9160728499ee1a24171b09f160b1e55892b59d8af7293ee3c5205766eb886'
 
   url "https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager/releases/download/#{version}/Privacy_Services_Management_#{version}.dmg"
+  appcast 'https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager/releases.atom'
   name 'Privacy Services Manager'
   name 'Privacy Services Management'
   homepage 'https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager'

--- a/Casks/provisioning.rb
+++ b/Casks/provisioning.rb
@@ -3,6 +3,7 @@ cask :v1 => 'provisioning' do
   sha256 '554590ab653776babbc453892653d052f1ec09c6473fc91f4a071f1a7a953144'
 
   url "https://github.com/chockenberry/Provisioning/releases/download/#{version}/Provisioning-#{version}.zip"
+  appcast 'https://github.com/chockenberry/Provisioning/releases.atom'
   homepage 'https://github.com/chockenberry/Provisioning'
   license :oss
 

--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -3,6 +3,7 @@ cask :v1 => 'provisionql' do
   sha256 '463d66986316ceadbca6acbd58e1381d26f6a80d464532342678ac46ec2492c0'
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
+  appcast 'https://github.com/ealeksandrov/ProvisionQL/releases.atom'
   homepage 'https://github.com/ealeksandrov/ProvisionQL'
   license :mit
 

--- a/Casks/purescript.rb
+++ b/Casks/purescript.rb
@@ -4,6 +4,7 @@ cask :v1 => 'purescript' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/purescript/purescript/releases/download/v#{version}/macos.tar.gz"
+  appcast 'https://github.com/purescript/purescript/releases.atom'
   name 'PureScript'
   homepage 'http://purescript.org'
   license :mit

--- a/Casks/pusher.rb
+++ b/Casks/pusher.rb
@@ -3,6 +3,7 @@ cask :v1 => 'pusher' do
   sha256 '735ad86c7139058e0ae1d2fb7ad0bc516b4b9284e6e0046a1255c360d58dba3c'
 
   url "https://github.com/noodlewerk/NWPusher/releases/download/#{version}/pusher.app.zip"
+  appcast 'https://github.com/noodlewerk/NWPusher/releases.atom'
   name 'Pusher'
   name 'NWPusher'
   homepage 'https://github.com/noodlewerk/NWPusher'

--- a/Casks/putio-adder.rb
+++ b/Casks/putio-adder.rb
@@ -3,6 +3,7 @@ cask :v1 => 'putio-adder' do
   sha256 'f0ed3f2a8c4bd5ab3d83dcef72403785c72f990692190de58f1f7d3edf85c0a3'
 
   url "https://github.com/nicoSWD/put.io-adder/releases/download/v#{version}/put.io-adder-v#{version}.app.zip"
+  appcast 'https://github.com/nicoSWD/put.io-adder/releases.atom'
   name 'Put.IO Adder'
   homepage 'https://github.com/nicoSWD/put.io-adder'
   license :mit

--- a/Casks/qldds.rb
+++ b/Casks/qldds.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qldds' do
   sha256 '8abd0978eb90b1ef55b5ac079960b028cbc926673535a0802bccd590fb253bc6'
 
   url "https://github.com/Marginal/QLdds/releases/download/rel-#{version.gsub('.','')}/QLdds_#{version.gsub('.','')}.pkg"
+  appcast 'https://github.com/Marginal/QLdds/releases.atom'
   name 'QuickLook DDS'
   homepage 'https://github.com/Marginal/QLdds'
   license :gpl

--- a/Casks/qlgradle.rb
+++ b/Casks/qlgradle.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qlgradle' do
   sha256 'ea76846953ecfbd180d65167ec31cb7c316030f500a6669cd79857c03b951b63'
 
   url "https://github.com/Urucas/QLGradle/releases/download/#{version}/QLGradle.qlgenerator.zip"
+  appcast 'https://github.com/Urucas/QLGradle/releases.atom'
   name 'qlgradle'
   homepage 'https://github.com/Urucas/QLGradle'
   license :mit

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qlmarkdown' do
   sha256 '045712562665673924397bbbef1ee1157b44e23c9744feda6feda27e107802d3'
 
   url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"
+  appcast 'https://github.com/toland/qlmarkdown/releases.atom'
   name 'QLMarkdown'
   homepage 'https://github.com/toland/qlmarkdown'
   license :bsd

--- a/Casks/qlnetcdf.rb
+++ b/Casks/qlnetcdf.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qlnetcdf' do
   sha256 'a02db25dab9795d75fb13a155c465678f940a3586d7a0521cc7005590bf9898a'
 
   url "https://github.com/tobeycarman/QLNetcdf/releases/download/v#{version}/QLNetcdf.qlgenerator.zip"
+  appcast 'https://github.com/tobeycarman/QLNetcdf/releases.atom'
   homepage 'https://github.com/tobeycarman/QLNetcdf/'
   license :mit
 

--- a/Casks/qlprettypatch.rb
+++ b/Casks/qlprettypatch.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qlprettypatch' do
   sha256 'ae2cb623cc741bf053fdfad0b5f1435c3bbad6d4b3f37d43b407296c46462182'
 
   url "https://github.com/atnan/QLPrettyPatch/releases/download/v#{version}/QLPrettyPatch.qlgenerator.zip"
+  appcast 'https://github.com/atnan/QLPrettyPatch/releases.atom'
   homepage 'https://github.com/atnan/QLPrettyPatch'
   license :bsd
 

--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -3,6 +3,7 @@ cask :v1 => 'qlvideo' do
   sha256 'df4db7b2f43a365ee528a7cb5cc921a59b46950060708d2c97551be606aa58d5'
 
   url "https://github.com/Marginal/QLVideo/releases/download/rel-#{version.gsub('.', '')}/QLVideo_#{version.gsub('.', '')}.pkg"
+  appcast 'https://github.com/Marginal/QLVideo/releases.atom'
   name 'QuickLook Video'
   homepage 'https://github.com/Marginal/QLVideo'
   license :gpl

--- a/Casks/qmind.rb
+++ b/Casks/qmind.rb
@@ -4,8 +4,7 @@ cask :v1 => 'qmind' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/qvacua/qmind/releases/download/v#{version}-22/Qmind-#{version}.zip"
-  appcast 'http://qvacua.com/qmind/appcast.xml',
-          :sha256 => '65c18e86225f5808dc956836e537be3255f610a348bd899f92016ecb1cb74aab'
+  appcast 'https://github.com/qvacua/qmind/releases.atom'
   homepage 'http://qvacua.com'
   license :gpl
 

--- a/Casks/quickgeojson.rb
+++ b/Casks/quickgeojson.rb
@@ -3,6 +3,7 @@ cask :v1 => 'quickgeojson' do
   sha256 '7f4cd78619e2ea12f4afcba017f08d72468dc1c9268f2b2ed6f1690bd4e3fa86'
 
   url "https://github.com/irees/quickgeojson/releases/download/#{version}/quickgeojson.qlgenerator.zip"
+  appcast 'https://github.com/irees/quickgeojson/releases.atom'
   name 'quickgeojson'
   homepage 'https://github.com/irees/quickgeojson'
   license :bsd

--- a/Casks/quicknfo.rb
+++ b/Casks/quicknfo.rb
@@ -3,6 +3,7 @@ cask :v1 => 'quicknfo' do
   sha256 'ee5c03f78ff60e69e776bec39896ac48496915de35fcb3e2bd0d9c20ad92b5bb'
 
   url "https://github.com/The-Master777/QuickNFO/releases/download/v#{version}/QuickNFO.qlgenerator.zip"
+  appcast 'https://github.com/The-Master777/QuickNFO/releases.atom'
   homepage 'https://github.com/planbnet/QuickNFO'
   license :oss
 

--- a/Casks/quotefix.rb
+++ b/Casks/quotefix.rb
@@ -3,6 +3,7 @@ cask :v1 => 'quotefix' do
   sha256 '8d914ae553b84fe5f246ab1eb030d25792ca8d626b3bbac57acee857135e85a9'
 
   url "https://github.com/robertklep/quotefixformac/releases/download/v#{version}/QuoteFix-v#{version}.zip"
+  appcast 'https://github.com/robertklep/quotefixformac/releases.atom'
   homepage 'https://github.com/robertklep/quotefixformac'
   license :oss
 

--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -3,6 +3,7 @@ cask :v1 => 'radiant-player' do
   sha256 'eed8d2c0d5457938b65ad41fd01ff9ea3745518e7951e62f68974b2884016dbf'
 
   url "https://github.com/kbhomes/radiant-player-mac/releases/download/v#{version}/Radiant.Player.zip"
+  appcast 'https://github.com/kbhomes/radiant-player-mac/releases.atom'
   name 'Radiant Player'
   homepage 'http://kbhomes.github.io/radiant-player-mac/'
   license :mit

--- a/Casks/raven.rb
+++ b/Casks/raven.rb
@@ -4,6 +4,7 @@ cask :v1 => 'raven' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/robotlolita/raven/releases/download/v#{version}/Raven-osx.zip"
+  appcast 'https://github.com/robotlolita/raven/releases.atom'
   name 'Raven'
   homepage 'http://robotlolita.me/raven/'
   license :mit

--- a/Casks/rdm.rb
+++ b/Casks/rdm.rb
@@ -4,6 +4,7 @@ cask :v1 => 'rdm' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/uglide/RedisDesktopManager/releases/download/0.7.6/redis-desktop-manager-#{version}.dmg"
+  appcast 'https://github.com/uglide/RedisDesktopManager/releases.atom'
   homepage 'http://redisdesktop.com'
   license :gpl
 

--- a/Casks/reeddit.rb
+++ b/Casks/reeddit.rb
@@ -4,6 +4,7 @@ cask :v1 => 'reeddit' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/berbaquero/Reeddit-app/releases/download/v#{version}/Reeddit.app.zip"
+  appcast 'https://github.com/berbaquero/Reeddit-app/releases.atom'
   name 'Reeddit'
   homepage 'http://mac.reedditapp.com'
   license :mit

--- a/Casks/rythem.rb
+++ b/Casks/rythem.rb
@@ -3,6 +3,7 @@ cask :v1 => 'rythem' do
   sha256 'd4c5c578fb0f4d155cc07af22184f88a9b190a7453d0dc45962fd179f72da34d'
 
   url "https://github.com/AlloyTeam/Rythem/releases/download/filter/Rythem-#{version}.dmg"
+  appcast 'https://github.com/AlloyTeam/Rythem/releases.atom'
   name 'Rythem'
   homepage 'https://github.com/AlloyTeam/Rythem'
   license :mit

--- a/Casks/safari-tab-switching.rb
+++ b/Casks/safari-tab-switching.rb
@@ -3,6 +3,7 @@ cask :v1 => 'safari-tab-switching' do
   sha256 'cda2d24dd7f273d5e26bf3ee32c1e711ebf28c0c44c619fa9f4e7f8efea488ca'
 
   url "https://github.com/rs/SafariTabSwitching/releases/download/#{version}/Safari.Tab.Switching-#{version}.zip"
+  appcast 'https://github.com/rs/SafariTabSwitching/releases.atom'
   name 'Safari Tab Switching'
   homepage 'https://github.com/rs/SafariTabSwitching'
   license :oss

--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -4,6 +4,7 @@ cask :v1 => 'shotcut' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.sub(/\.\d+$/, '')}/shotcut-osx-x86_64-#{version.gsub('.', '')}.dmg"
+  appcast 'https://github.com/mltframework/shotcut/releases.atom'
   homepage 'http://www.shotcut.org/'
   license :gpl
 

--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -3,6 +3,7 @@ cask :v1 => 'shuttle' do
   sha256 '116a216b8f0a9485ed82d944b5ae99bfad1c96a7d2aa3c296808ab824264d7a4'
 
   url "https://github.com/fitztrev/shuttle/releases/download/#{version}/Shuttle.zip"
+  appcast 'https://github.com/fitztrev/shuttle/releases.atom'
   homepage 'http://fitztrev.github.io/shuttle/'
   license :mit
 

--- a/Casks/sidestep.rb
+++ b/Casks/sidestep.rb
@@ -4,8 +4,7 @@ cask :v1 => 'sidestep' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/chetan51/sidestep/releases/download/#{version}/Sidestep.zip"
-  appcast 'http://chetansurpur.com/projects/sidestep/appcast.xml',
-          :sha256 => '1d043f565c44c03f6ab5e7c90f025aba3cf480f1623a8a530f87206fab12f86a'
+  appcast 'https://github.com/chetan51/sidestep/releases.atom'
   homepage 'http://chetansurpur.com/projects/sidestep/'
   license :mit
 

--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -4,6 +4,7 @@ cask :v1 => 'sigil' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/user-none/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"
+  appcast 'https://github.com/user-none/Sigil/releases.atom'
   name 'Sigil'
   homepage 'http://sigil-ebook.com/'
   license :gpl

--- a/Casks/sourcedrop.rb
+++ b/Casks/sourcedrop.rb
@@ -4,6 +4,7 @@ cask :v1 => 'sourcedrop' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/hohl/sourcedrop-osx/releases/download/r#{version}/SourceDrop-r#{version}.zip"
+  appcast 'https://github.com/hohl/sourcedrop-osx/releases.atom'
   name 'SourceDrop'
   homepage 'http://sourcedrop.net/'
   license :bsd

--- a/Casks/spark-dev.rb
+++ b/Casks/spark-dev.rb
@@ -3,6 +3,7 @@ cask :v1 => 'spark-dev' do
   sha256 'f2fa70e23590c6b57f1415dabee56f60671637526fd0348fdd019d1304b341ff'
 
   url "https://github.com/spark/spark-dev/releases/download/v#{version}/spark-dev-mac.zip"
+  appcast 'https://github.com/spark/spark-dev/releases.atom'
   homepage 'https://github.com/spark/spark-dev'
   license :apache
 

--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -4,8 +4,7 @@ cask :v1 => 'sparkle' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/sparkle-project/Sparkle/releases/download/#{version}/Sparkle-#{version}.tar.bz2"
-  appcast 'http://sparkle-project.org/files/sparkletestcast.xml',
-          :sha256 => '238db88f72b33bde99bbd1cc5c54956357a249346030af67311ba10f156cb48b'
+  appcast 'https://github.com/sparkle-project/Sparkle/releases.atom'
   name 'Sparkle'
   homepage 'http://sparkle-project.org/'
   license :mit

--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -4,6 +4,7 @@ cask :v1 => 'spotify-notifications' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"
+  appcast 'https://github.com/citruspi/Spotify-Notifications/releases.atom'
   name 'Spotify Notifications'
   homepage 'http://spotify-notifications.citruspi.io/'
   license :public_domain

--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -4,6 +4,7 @@ cask :v1 => 'sqlitebrowser' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/sqlitebrowser-#{version}.dmg"
+  appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom'
   name 'DB Browser for SQLite'
   name 'SQLite Database Browser'
   homepage 'http://sqlitebrowser.org'

--- a/Casks/sshfs.rb
+++ b/Casks/sshfs.rb
@@ -3,6 +3,7 @@ cask :v1 => 'sshfs' do
   sha256 'f8f4f71814273ea42dbe6cd92199f7cff418571ffd1b10c0608878d3472d2162'
 
   url "https://github.com/osxfuse/sshfs/releases/download/osxfuse-sshfs-#{version}/sshfs-#{version}.pkg"
+  appcast 'https://github.com/osxfuse/sshfs/releases.atom'
   homepage 'http://osxfuse.github.io/'
   license :gpl
 

--- a/Casks/streamtools.rb
+++ b/Casks/streamtools.rb
@@ -8,6 +8,7 @@ cask :v1 => 'streamtools' do
   else
     sha256 '5ca21f4c4c2091c96c508bb277cb5c022f18a8cd3c53abb1ceb11ca0f6454309'
     url "https://github.com/nytlabs/streamtools/releases/download/#{version}/st_darwin_amd64-#{version}.tar.gz"
+    appcast 'https://github.com/nytlabs/streamtools/releases.atom'
     binary "st_darwin_amd64-#{version}/st"
   end
 

--- a/Casks/subl.rb
+++ b/Casks/subl.rb
@@ -3,6 +3,7 @@ cask :v1 => 'subl' do
   sha256 '2f66cd6f873b51fa7bf31a6fe0bff1af4ac2cf0d9fff21a4b0f647c1cdcd6eef'
 
   url "https://github.com/dhoulb/subl/releases/download/v#{version}/Subl.app.zip"
+  appcast 'https://github.com/dhoulb/subl/releases.atom'
   name 'subl:// URL handler'
   homepage 'https://github.com/dhoulb/subl'
   license :oss

--- a/Casks/tabula.rb
+++ b/Casks/tabula.rb
@@ -3,6 +3,7 @@ cask :v1 => 'tabula' do
   sha256 'b6a2663cbf440d27cc94ac9ac05ac1875136e81f63980a25e1acaf6a3250e131'
 
   url "https://github.com/jazzido/tabula/releases/download/v0.9.5/tabula-mac-#{version}.zip"
+  appcast 'https://github.com/jazzido/tabula/releases.atom'
   name 'Tabula'
   homepage 'http://tabula.nerdpower.org'
   license :mit

--- a/Casks/tagaini-jisho.rb
+++ b/Casks/tagaini-jisho.rb
@@ -4,6 +4,7 @@ cask :v1 => 'tagaini-jisho' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/Gnurou/tagainijisho/releases/download/#{version}/Tagaini.Jisho-#{version}.dmg"
+  appcast 'https://github.com/Gnurou/tagainijisho/releases.atom'
   homepage 'http://www.tagaini.net/'
   license :gpl
 

--- a/Casks/tagger.rb
+++ b/Casks/tagger.rb
@@ -3,8 +3,7 @@ cask :v1 => 'tagger' do
   sha256 'a4745dcf88f1691d2c681a87e6cfb6326200b6a2d9dfb53c2c62c67905a09e16'
 
   url "https://github.com/Bilalh/Tagger/releases/download/1.8.0/Tagger_#{version}.zip"
-  appcast 'http://bilalh.github.com/sparkle/tagger/appcast.xml',
-          :sha256 => 'df4ef5a84c4900943529c0a45e7bf47a0823985fd558462899b5029fb32ce25e'
+  appcast 'https://github.com/Bilalh/Tagger/releases.atom'
   homepage 'http://bilalh.github.io/projects/tagger/'
   license :cc
 

--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -7,6 +7,7 @@ cask :v1 => 'tagspaces' do
   else
     sha256 '42f115adb5ea7eb687c5b5b07d8843e895a8ed492a46800120e46f1c1f450aa2'
     url "https://github.com/uggrock/tagspaces/releases/download/#{version}/tagspaces-#{version}-osx64.zip"
+    appcast 'https://github.com/uggrock/tagspaces/releases.atom'
   end
 
   homepage 'http://www.tagspaces.org'

--- a/Casks/teitoku.rb
+++ b/Casks/teitoku.rb
@@ -4,6 +4,7 @@ cask :v1 => 'teitoku' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/geta6/teitoku/releases/download/#{version}/teitoku-#{version}-osx.zip"
+  appcast 'https://github.com/geta6/teitoku/releases.atom'
   homepage 'http://makebooth.com/i/1xkN1'
   license :mit
 

--- a/Casks/tiddlywiki.rb
+++ b/Casks/tiddlywiki.rb
@@ -7,6 +7,7 @@ cask :v1 => 'tiddlywiki' do
   else
     sha256 'e7ec36897c60c40f56ac0e1c66395e1c517ca403d9d1c0188738be6a7a0b8400'
     url "https://github.com/Jermolene/TiddlyDesktop/releases/download/v#{version}/tiddlydesktop-mac64-#{version}.zip"
+    appcast 'https://github.com/Jermolene/TiddlyDesktop/releases.atom'
   end
 
   homepage 'https://github.com/Jermolene/TiddlyDesktop'

--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -4,6 +4,7 @@ cask :v1 => 'tiled' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
+  appcast 'https://github.com/bjorn/tiled/releases.atom'
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
   license :gpl

--- a/Casks/todotxt.rb
+++ b/Casks/todotxt.rb
@@ -3,6 +3,7 @@ cask :v1 => 'todotxt' do
   sha256 'a1ca515ba0f521e7a4eab8da5db684323fe655621d7dc68f77b837a94c47528a'
 
   url "https://github.com/mjdescy/TodoTxtMac/releases/download/#{version}/TodoTxtMac.app.zip"
+  appcast 'https://github.com/mjdescy/TodoTxtMac/releases.atom'
   name 'TodoTxtMac'
   homepage 'https://mjdescy.github.io/TodoTxtMac/'
   license :mit

--- a/Casks/tokaido.rb
+++ b/Casks/tokaido.rb
@@ -3,6 +3,7 @@ cask :v1 => 'tokaido' do
   sha256 '72752b8e4e9f0e554661d8fb58879a82cac6dc5d19762367c89ca191f497d258'
 
   url "https://github.com/tokaido/tokaidoapp/releases/download/v#{version}/Tokaido.zip"
+  appcast 'https://github.com/tokaido/tokaidoapp/releases.atom'
   name 'Tokaido'
   homepage 'https://github.com/tokaido/tokaidoapp'
   license :mit

--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -4,6 +4,7 @@ cask :v1 => 'track-o-bot' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/stevschmid/track-o-bot/releases/download/#{version}/Track-o-Bot_#{version}.dmg"
+  appcast 'https://github.com/stevschmid/track-o-bot/releases.atom'
   name 'Track-o-Bot'
   homepage 'https://trackobot.com/'
   license :gpl

--- a/Casks/traktable.rb
+++ b/Casks/traktable.rb
@@ -3,6 +3,7 @@ cask :v1 => 'traktable' do
   sha256 '77d3800f02f2b5a2aef8a56e7986b731831738673e35c633d743df87bc556225'
 
   url "https://github.com/yo-han/Traktable/releases/download/#{version}/Traktable.zip"
+  appcast 'https://github.com/yo-han/Traktable/releases.atom'
   name 'Traktable'
   homepage 'http://yo-han.github.io/Traktable/'
   license :oss

--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -4,6 +4,7 @@ cask :v1 => 'tribler' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
+  appcast 'https://github.com/Tribler/tribler/releases.atom'
   name 'Tribler'
   homepage 'http://www.tribler.org'
   license :gpl

--- a/Casks/tvrenamer.rb
+++ b/Casks/tvrenamer.rb
@@ -4,6 +4,7 @@ cask :v1 => 'tvrenamer' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/tvrenamer/tvrenamer/releases/download/v#{version}/TVRenamer-#{version}-osx64.zip"
+  appcast 'https://github.com/tvrenamer/tvrenamer/releases.atom'
   homepage 'http://tvrenamer.org'
   license :gpl
 

--- a/Casks/uncrustifyx.rb
+++ b/Casks/uncrustifyx.rb
@@ -3,8 +3,7 @@ cask :v1 => 'uncrustifyx' do
   sha256 '017c0781ce05db59c1a3fe52a140166df55aa2d87286a7cf5ba5e3eb6b06c7df'
 
   url "https://github.com/ryanmaxwell/UncrustifyX/releases/download/#{version}/UncrustifyX-#{version}.zip"
-  appcast 'https://raw.github.com/ryanmaxwell/uncrustifyx/appcast/uncrustifyx-appcast.xml',
-          :sha256 => 'b81877f4c038cccd6849ed1fa5f76e3a705d681165865a4238b43d034f028bba'
+  appcast 'https://github.com/ryanmaxwell/UncrustifyX/releases.atom'
   homepage 'https://github.com/ryanmaxwell/UncrustifyX'
   license :mit
 

--- a/Casks/vagrant-bar.rb
+++ b/Casks/vagrant-bar.rb
@@ -3,6 +3,7 @@ cask :v1 => 'vagrant-bar' do
   sha256 'f5c58690960269be9a7a2597a0aad098b4bd1676c9494f6022e9c7d1e82d81bc'
 
   url "https://github.com/BipSync/VagrantBar/releases/download/#{version}/Vagrant.Bar.zip"
+  appcast 'https://github.com/BipSync/VagrantBar/releases.atom'
   homepage 'https://github.com/BipSync/VagrantBar'
   license :oss
 

--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -4,8 +4,7 @@ cask :v1 => 'vagrant-manager' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
-  appcast 'http://api.lanayo.com/appcast/vagrant_manager.xml',
-          :sha256 => '706d0efbb0f4cad1fb74c7ae2ce7b0c2cfed40c7d82881b418e2df014f9fd730'
+  appcast 'https://github.com/lanayotech/vagrant-manager/releases.atom'
   name 'Vagrant Manager'
   homepage 'http://vagrantmanager.com/'
   license :mit

--- a/Casks/vessel.rb
+++ b/Casks/vessel.rb
@@ -3,6 +3,7 @@ cask :v1 => 'vessel' do
   sha256 '25cd21e0e36fe0a4617081b78c9b9184655c82d3289a1235a0d8d9db0547027e'
 
   url "https://github.com/awvessel/vessel/releases/download/#{version}/Vessel.app.zip"
+  appcast 'https://github.com/awvessel/vessel/releases.atom'
   name 'Vessel'
   homepage 'http://awvessel.github.io'
   license :bsd

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -4,6 +4,7 @@ cask :v1 => 'vimr' do
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-#{version.sub(%r{-.*},'')}.tar.bz2"
+  appcast 'https://github.com/qvacua/vimr/releases.atom'
   name 'VimR'
   homepage 'http://vimr.org/'
   license :gpl

--- a/Casks/webpquicklook.rb
+++ b/Casks/webpquicklook.rb
@@ -3,6 +3,7 @@ cask :v1 => 'webpquicklook' do
   sha256 'b7495e90589f2f9ee13c331d840ff638399817bd906da61aa32bb21a9c26f32b'
 
   url "https://github.com/dchest/webp-quicklook/releases/download/v#{version}/WebP-#{version}.qlgenerator.zip"
+  appcast 'https://github.com/dchest/webp-quicklook/releases.atom'
   name 'WebP QuickLook Plugin'
   homepage 'https://github.com/dchest/webp-quicklook'
   license :mit

--- a/Casks/youll-never-take-me-alive.rb
+++ b/Casks/youll-never-take-me-alive.rb
@@ -3,6 +3,7 @@ cask :v1 => 'youll-never-take-me-alive' do
   sha256 'e055e96ed1816b30b420533af8f9de90da088b339d51aa99a5c20c636e8ba9c8'
 
   url "https://github.com/iSECPartners/yontma-mac/releases/download/#{version}/yontma-#{version}.dmg"
+  appcast 'https://github.com/iSECPartners/yontma-mac/releases.atom'
   name 'You\'ll Never Take Me Alive!'
   name 'YoNTMA'
   homepage 'https://github.com/iSECPartners/yontma-mac'

--- a/Casks/yubiswitch.rb
+++ b/Casks/yubiswitch.rb
@@ -3,6 +3,7 @@ cask :v1 => 'yubiswitch' do
   sha256 '590a89bea366f126044507226163499ae639a6ceb729fa03f93d24250f67066e'
 
   url "https://github.com/pallotron/yubiswitch/releases/download/v#{version}/yubiswitch_#{version}.dmg"
+  appcast 'https://github.com/pallotron/yubiswitch/releases.atom'
   homepage 'https://github.com/pallotron/yubiswitch'
   license :gpl
 


### PR DESCRIPTION
When we have a `https://github.com/username/projectname/releases/…` `url`, we can easily get an `appcast` by removing everything after `releases` and appending `.atom`.

This allows us to add a bunch more `appcast`s and warrants a new `github` `:format`, particularly since some of these, since they’re automatically generated by github, should link to more than one file, and in `:format => github` we should need to specify a few more arguments to narrow options down to the one we want.

Existing `appcast`s were also replaced with the github ones, since that should make maintaining them way easier for us, with a better guarantee they’re kept up-to-date and that we can actually trust the url (some `appcast`s are hosted on unexpected domains, which adds the overhead of maintainers having to verify them).
