### PR TITLE
Haroopad license is gratis.

### DIFF
--- a/Casks/haroopad.rb
+++ b/Casks/haroopad.rb
@@ -6,7 +6,7 @@ cask :v1 => 'haroopad' do
   url "https://bitbucket.org/rhiokim/haroopad-download/downloads/Haroopad-v#{version}-x64.dmg"
   name 'Haroopad'
   homepage 'http://pad.haroopress.com/'
-  license :gpl
+  license :gratis
 
   app 'Haroopad.app'
 end


### PR DESCRIPTION
The current version is not GPL or any other OSS.

The source code was last shared 2 years ago, June 2013. The version at the time was 0.3.2.
https://github.com/rhiokim/haroopad/commit/d56135cfc13d2415ee461b43cbcca33f93353bb7

> Why not open the source?
> 
> Of course, Haroopad will be the open-source at v1.0.
> https://github.com/rhiokim/haroopad#why-not-open-the-source
