### PR TITLE
Update homepages for six casks

### DIFF
--- a/Casks/fivedetails-flow.rb
+++ b/Casks/fivedetails-flow.rb
@@ -5,7 +5,7 @@ cask :v1 => 'fivedetails-flow' do
   url 'http://fivedetails.com/flow/download'
   appcast 'http://extendmac.com/flow/updates/update.php'
   name 'Flow'
-  homepage 'http://fivedetails.com'
+  homepage 'http://fivedetails.com/flow/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Flow.app'

--- a/Casks/itools.rb
+++ b/Casks/itools.rb
@@ -5,7 +5,7 @@ cask :v1 => 'itools' do
   # itools.hk is the official download host per the vendor homepage
   url "http://dl2.itools.hk/dl/iTools_#{version}.dmg"
   name 'iTools'
-  homepage 'http://pro.itools.cn/mac'
+  homepage 'http://pro.itools.cn/mac/english'
   license :gratis
 
   app 'iTools.app'

--- a/Casks/keyboardcleantool.rb
+++ b/Casks/keyboardcleantool.rb
@@ -2,8 +2,9 @@ cask :v1 => 'keyboardcleantool' do
   version :latest
   sha256 :no_check
 
+  # bettertouchtool.net is the official download host per the vendor homepage
   url 'http://bettertouchtool.net/KeyboardCleanTool.zip'
-  homepage 'http://bettertouchtool.net'
+  homepage 'http://blog.boastr.net/keyboardcleantool/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'KeyboardCleanTool.app'

--- a/Casks/lucidor.rb
+++ b/Casks/lucidor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'lucidor' do
 
   url "http://lucidor.org/lucidor/lucidor-#{version}.dmg"
   name 'Lucidor'
-  homepage 'http://lucidor.org'
+  homepage 'http://lucidor.org/lucidor/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Lucidor.app'

--- a/Casks/valentina-studio.rb
+++ b/Casks/valentina-studio.rb
@@ -3,7 +3,7 @@ cask :v1 => 'valentina-studio' do
   sha256 :no_check
 
   url 'http://www.valentina-db.com/download/release/mac_32/vstudio_5_mac.dmg'
-  homepage 'http://www.valentina-db.com/'
+  homepage 'http://www.valentina-db.com/en/valentina-studio-overview'
   license :freemium
 
   app 'Valentina Studio.app'

--- a/Casks/whiteclock.rb
+++ b/Casks/whiteclock.rb
@@ -3,7 +3,7 @@ cask :v1 => 'whiteclock' do
   sha256 '9ad4a713dca77cfbca5bf4d8d1263126ec2b95fa588ad80be4f5a79140eefb6d'
 
   url "http://www.taimila.com/downloads/WhiteClock#{version.to_i}.zip"
-  homepage 'http://www.taimila.com/?p=1221'
+  homepage 'http://www.taimila.com/blog/white-clock-for-osx/'
   license :gratis
 
   app 'WhiteClock.app'


### PR DESCRIPTION
Point itools toward the English page, the other five all now point to dedicated pages for their respective cask instead of a generic landing page.
