### PR TITLE
Update Transporter Desktop version to 3.1.15

### DIFF
--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'transporter-desktop' do
-  version '3.0.21_17012'
-  sha256 '48d36d53f6484364b3df93ccd054a30028b0f4fcb169c2d8475ca64ef108f510'
+  version '3.1.15_18289'
+  sha256 'fecf3b1944832261900237537962a4783d709caa96c3e93ec2d828b88425ec8e'
 
   # connecteddata.com is the official download host per the vendor homepage
   url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}.dmg"
   homepage 'http://www.filetransporter.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Transporter Desktop.app'
 end


### PR DESCRIPTION
This commit updates the version number, the SHA, and the license
type to :commercial.
