### PR TITLE
[ADD] Appserver.io cask v1.0.2

### DIFF
--- a/Casks/appserver.rb
+++ b/Casks/appserver.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'appserver' do
+  version '1.0.2'
+  sha256 '1a578fdb626b0fab16422d003d09e89cff4f83afddc4095ae283352fe42ad3d8'
+
+  url "https://github.com/appserver-io/appserver/releases/download/#{version}/appserver-dist_#{version}-56_x86_64.pkg"
+  name 'Appserver.io'
+  homepage 'http://www.appserver.io'
+  license :oss
+
+  pkg "appserver-dist_#{version}-56_x86_64.pkg"
+
+  uninstall :pkgutil => ['com.techdivision.appserver-io.runtime','com.techdivision.appserver-io.source']
+end


### PR DESCRIPTION
This cask adds the Appserver.io (PHP Enterprise Infrastructure) to homebrew cask for easy install the provided pkg.
