### PR TITLE
Updated Contexts url.

### DIFF
--- a/Casks/contexts.rb
+++ b/Casks/contexts.rb
@@ -2,10 +2,10 @@ cask :v1 => 'contexts' do
   version :latest
   sha256 :no_check
 
-  url 'http://contextsformac.com/releases/Contexts.zip'
-  appcast 'http://www.contextsformac.com/releases/appcast.xml'
+  url 'http://contexts.co/releases/Contexts.zip'
+  appcast 'http://www.contexts.co/releases/appcast.xml'
   name 'Contexts'
-  homepage 'http://contextsformac.com/'
+  homepage 'http://contexts.co/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Contexts.app'


### PR DESCRIPTION
Contexts changed their url at some point. It's no longer contextsformac.com

Closes #10138
