### PR TITLE
Update octave to 3.8.2-1

### DIFF
--- a/Casks/octave.rb
+++ b/Casks/octave.rb
@@ -1,18 +1,20 @@
 cask :v1 => 'octave' do
-  version '3.8.0-6'
-  sha256 'b51c20b109e15928350624011885e658b45009da0acb8872a1347688f8f62963'
+  version '3.8.2-1'
+  sha256 'a7a1e11038665a56df9282531873c1bffaa65872069ac914377b8c910f3b1fd8'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/project/octave/Octave%20MacOSX%20Binary/2013-12-30%20binary%20installer%20of%20Octave%203.8.0%20for%20OSX%2010.9.1%20%28beta%29/GNU_Octave_#{version}.dmg"
+  url "https://downloads.sourceforge.net/sourceforge/octave/GNU_Octave_#{version}.dmg"
   homepage 'https://gnu.org/software/octave/'
   license :gpl
 
   pkg "Octave-#{version}.mpkg"
 
-  uninstall :pkgutil => [
+  uninstall :quit    => 'org.octave.Octave',
+            :pkgutil => [
                          'org.macports.octave-next',
                          'org.octave.cli-app',
-                         'org.octave.gui-app',
+                         'org.octave.gui-app'
                         ],
-            :delete => '/usr/local/octave/3.8.0'
+            :delete  => "/usr/local/octave/#{version.sub(/-.*/,'')}"
+  zap       :rmdir   => '/usr/local/octave'
 end


### PR DESCRIPTION
The Octave installer also installs a bunch of macports packages.
Not sure whether it's safe to delete these, but I included them for
review.
