### PR TITLE
Update calibre to v2.22

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'calibre' do
-  version '2.21.0'
-  sha256 'be3ebde825d291ef0e212939061ea2e9a095419b9ec45ab9fa766f7bad07094d'
+  version '2.22.0'
+  sha256 '5c692f4caaa0671c88bc51a867ae546895dde45a6988471e31e2d1471606e628'
 
   # github.com is an official download host per the vendor homepage, and a faster mirror than the main one
   url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"


### PR DESCRIPTION
A new version of calibre is out. I have updated the version and the sha256 in the file.
