### PR TITLE
Add name, license, vendor and zap stanzas for GOG Downloader.app

### DIFF
--- a/Casks/gog-downloader.rb
+++ b/Casks/gog-downloader.rb
@@ -5,8 +5,17 @@ cask :v1 => 'gog-downloader' do
   url "http://static.gog.com/download/d3/mac-stable/GOG_Downloader_#{version}.zip"
   appcast 'https://api.gog.com/en/downloader2/status/mac-stable',
           :sha256 => '91f8021f41c170428d3ff18770356284c0239c8d8a47f2eccb2d5d1c222829c5'
+  name 'GOG Downloader'
   homepage 'http://www.gog.com/downloader'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
+  tags :vendor => 'GOG'
+
+  zap :delete => [
+    '~/Library/Application Support/GOG Downloader',
+    '~/Library/Caches/com.gog.downloader',
+    '~/Library/Preferences/com.gog.downloader.plist',
+    '~/Library/Saved Application State/com.gog.downloader.savedState'
+  ]
 
   app 'GOG Downloader.app'
 end


### PR DESCRIPTION
The app free to use but with closed source, so the license `:gratis` fits best.
