### PR TITLE
Upgrade torbrowser to v4.0.5

### DIFF
--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser' do
-  version '4.0.4'
-  sha256 'c47bcb38f75f31e780b45472517b8e30632793ca969244fdc54d01dade3ac512'
+  version '4.0.5'
+  sha256 '8afa20cc70fe9bae8b0f09a96df001fee091ff89eda47bcdbc9a9370d57ea29e'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_en-US.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 


### PR DESCRIPTION
A new/different signing key is used for Torbrowser in this release:
https://www.torproject.org/docs/signing-keys.html.en
https://www.torproject.org/docs/verifying-signatures.html.en

``` bash
gpg --fingerprint 0x4E2C6E8793298290
```

``` text
pub   4096R/93298290 2014-12-15
      Key fingerprint = EF6E 286D DA85 EA2A 4BA7  DE68 4E2C 6E87 9329 8290
uid                  Tor Browser Developers (signing key) <torbrowser@torproject.org>
sub   4096R/F65C2036 2014-12-15
sub   4096R/D40814E0 2014-12-15
sub   4096R/589839A3 2014-12-15
```
