### PR TITLE
Add dayone-cli

### DIFF
--- a/Casks/dayone-cli.rb
+++ b/Casks/dayone-cli.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'dayone-cli' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://dayoneapp.com/downloads/dayone-cli.pkg'
+  name 'Day One CLI'
+  homepage 'http://dayoneapp.com/tools/cli-man/'
+  license :closed
+
+  pkg 'dayone-cli.pkg'
+
+  uninstall :pkgutil => 'com.dayoneapp.dayOneCliTool.dayone.pkg'
+end

--- a/Casks/syncthing.rb
+++ b/Casks/syncthing.rb
@@ -1,0 +1,19 @@
+cask :v1 => 'syncthing' do
+  version '0.10.29'
+  appcast 'https://github.com/syncthing/syncthing/releases.atom'
+  name 'Syncthing'
+  homepage 'https://syncthing.net'
+  license :mpl
+
+  if Hardware::CPU.is_32_bit?
+    url "https://github.com/syncthing/syncthing/releases/download/v#{version}/syncthing-macosx-386-v#{version}.tar.gz"
+    sha256 'd6267d310ce7eca5930ac741cc0a2bdc0967578f1b682940eebbc2eabc007541'
+    binary "syncthing-macosx-386-v#{version}/syncthing"
+  else
+    url "https://github.com/syncthing/syncthing/releases/download/v#{version}/syncthing-macosx-amd64-v#{version}.tar.gz"
+    sha256 '8e3fd6c13b8e62d62698bcbf181473efd1f11f30eae5b340638fd3e3b672bf9e'
+    binary "syncthing-macosx-amd64-v#{version}/syncthing"
+  end
+
+  zap :delete => '~/Library/Application Support/Syncthing'
+end


### PR DESCRIPTION
The Day One CLI makes it possible for programs and scripts to interact
with a Day One Journal from the command line.

I didn't know how to add uninstall information. Other than that:

```
/usr/local/Library/Taps/caskroom/homebrew-cask/developer/bin/generate_cask_token ~/Downloads/dayone-cli.pkg
Proposed token:               dayone-clipkg
Proposed file name:           dayone-clipkg.rb
Cask Header Line:             cask :v1 => 'dayone-clipkg' do
```

I ignored this suggestion as the `pkg` suffix seemed really superflous

```
brew cask audit my-new-cask --download
audit for dayone-cli: passed
```
