### PR TITLE
Upgrade Musescore.app to v2.0

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,12 +1,13 @@
 cask :v1 => 'musescore' do
-  version '1.3'
-  sha256 'fcd106ec700f14053c9b4f3fd411d2335915c040f9071ea6da8d109e6827c3a5'
+  version '2.0'
+  sha256 'b5db0b39b6d204e997d5fb4dfcb8dabe40a0a37d08964dfc6c0df52b8a578238'
 
-  # osuosl.org is the official download host per the vendor homepage
-  url "http://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version}/MuseScore-#{version}.dmg"
+  # osuosl.org is the official download host per the vendor homepage.
+  # note the .0.dmg ending when updating this string.
+  url "http://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version}/MuseScore-#{version}.0.dmg"
   name 'MuseScore'
   homepage 'http://musescore.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
-  app 'MuseScore.app'
+  app 'MuseScore 2.app'
 end


### PR DESCRIPTION
New app name is "MuseScore 2.app".
Adjusted url, sha256, license and app parameters.

Unfortunately, the url contains the version number "2.0" as well as "2.0.0". I decided to add the last zero manually and leave a comment. I hope that is okay. I found the information about the license on the github repository of musescore. I was not able to find an official checksum, so I used `shasum -a 256` myself for now. I asked in the official forums for the checksum (they planned/announced to release them anyway). We can wait for an answer if you want.

EDIT: The checksum is correct. It's on the official download page.
