### PR TITLE
Add dayone-cli

### DIFF
--- a/Casks/dayone-cli.rb
+++ b/Casks/dayone-cli.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'dayone-cli' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://dayoneapp.com/downloads/dayone-cli.pkg'
+  name 'Day One CLI'
+  homepage 'http://dayoneapp.com/tools/cli-man/'
+  license :closed
+
+  pkg 'dayone-cli.pkg'
+
+  uninstall :pkgutil => 'com.dayoneapp.dayOneCliTool.dayone.pkg'
+end


### PR DESCRIPTION
The Day One CLI makes it possible for programs and scripts to interact
with a Day One Journal from the command line.
