### PR TITLE
Updated Komodo IDE and Edit to version 9

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'komodo-edit' do
-  version '8.5.4-14424'
-  sha256 '424558813e2926386e9d1de2bf93eb772a9b61b2f90688efc13e073d0d1b452e'
+  version '9.0.0-15707'
+  sha256 '1937614d15bfe81e1488e9e67a26fb12e86870c1edafc77d1cb72df151febf85'
 
   # activestate.com is the official download host per the vendor homepage
   url "http://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"
   homepage 'http://komodoide.com/komodo-edit'
   license :mpl
 
-  app 'Komodo Edit 8.app'
+  app 'Komodo Edit 9.app'
 end

--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'komodo-ide' do
-  version '8.5.4-86985'
-  sha256 'dde427a79aa17f5404b15bb286c075857fe5407f98395cc97f3e0e9c8b27851c'
+  version '9.0.0-87165'
+  sha256 '2af28265d322eac0bb4fb0096d657e4e9585933e6d53cc3b3cd3f6b04914097a'
 
   # activestate.com is the official download host per the vendor homepage
   url "http://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
   homepage 'http://komodoide.com/'
   license :commercial
 
-  app 'Komodo IDE 8.app'
+  app 'Komodo IDE 9.app'
 end


### PR DESCRIPTION
This updated Komodo Edit from 8.5.4-14424 to 9.0.0-15707, and Komodo IDE from 8.5.4-86985 to 9.0.0-87165.
