### PR TITLE
Add ttscoff/MMD-QuickLook

### DIFF
--- a/Casks/ttscoff-mmd-quicklook.rb
+++ b/Casks/ttscoff-mmd-quicklook.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'ttscoff-mmd-quicklook' do
+  version '1.1'
+  sha256 '0bab1550b048b7bf2c29cbf81c8ae63277420204f1a35004047316e26cbac424'
+
+  url "https://github.com/ttscoff/MMD-QuickLook/releases/download/#{version}/MultiMarkdown.QuickLook.qlgenerator.zip"
+  appcast 'https://github.com/ttscoff/mmd-quicklook/releases.atom'
+  name 'MMD-QuickLook'
+  homepage 'https://github.com/ttscoff/mmd-quicklook'
+  license :oss
+
+  qlplugin 'MultiMarkdown QuickLook.qlgenerator'
+end


### PR DESCRIPTION
This is a quick fork of Fletcher Penney's MMD Quicklook project. It adds
some styling to the default Quick Look preview (based on GitHub CSS) and
allows for customization via a .mdqlstyle.css file in your home folder.

---

I added `license :oss` as it is dual licenced under GPL and MIT brought in by mother project https://github.com/fletcher/peg-multimarkdown/blob/master/LICENSE
