### PR TITLE
Update omnifocus-clip-o-tron to v1.0.1

### DIFF
--- a/Casks/omnifocus-clip-o-tron.rb
+++ b/Casks/omnifocus-clip-o-tron.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'omnifocus-clip-o-tron' do
-  version '1.0'
-  sha256 '904e808ca65d1f2db4c1356255200ec73364ff7f23528fd4ff857edead39a312'
+  version '1.0.1'
+  sha256 '5de811bbca02f67e5669bd3d32f7d0c78eca220769af154d1358805ab7e004a6'
 
   url "http://www.omnigroup.com/ftp/pub/software/MacOSX/10.9/OmniFocus-Clip-o-Tron-Installer-#{version}.dmg"
   name 'OmniFocus Clip-O-Tron'
   homepage 'http://support.omnigroup.com/omnifocus-clip-o-tron'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   installer :manual => 'OmniFocus Clip-o-Tron.app'
 end


### PR DESCRIPTION
The 1.0 version has been removed and the cask fails to install with the following 

```
$ brew cask install omnifocus-clip-o-tron
==> Downloading http://www.omnigroup.com/ftp/pub/software/MacOSX/10.9/OmniFocus-Clip-o-Tron-Installer-1.0.dmg
######################################################################## 100.0%
curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'omnifocus-clip-o-tron' with message: Download failed: http://www.omnigroup.com/ftp/pub/software/MacOSX/10.9/OmniFocus-Clip-o-Tron-Installer-1.0.dmg
```
