### PR TITLE
Update Omnipresence to v1.3

### DIFF
--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'omnipresence' do
-  version '1.1'
-  sha256 '4b6304fffdeed85054379bde7b43776957b5061f0bd089f29fe3005ed19ca49f'
+  version '1.3'
+  sha256 '2a58504aef5f7f24c74fb79ab1b59b667d83f3ba8b75b161a62de8617c089128'
 
-  url "http://downloads.omnigroup.com/software/MacOSX/10.8/OmniPresence-#{version}.dmg"
+  url "http://downloads.omnigroup.com/software/MacOSX/10.10/OmniPresence-#{version}.dmg"
   name 'OmniPresence'
   homepage 'http://www.omnigroup.com/omnipresence'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'OmniPresence.app'
 end


### PR DESCRIPTION
This commit updates the version variable to 1.3, and the SHA. It
also updates the download path with the correct OS X version.
