### PR TITLE
Upgrade printrun to version 1.3 (Feb 2015 release)

### DIFF
--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'printrun' do
-  version '1.2'
-  sha256 'b270edb951cbee3e957eab3ecd3bbd4fe25e93ce478393c61f029bfff4e3b902'
+  version '1.3'
+  sha256 '707a3c985f32ec156b4dc85dae3d3434a3a052bbf239d768423d94c1b7f86998'
 
   # kapsi.fi is the official download host per the vendor homepage
-  url 'http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-10Mar2014.zip'
+  url 'http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-03Feb2015.zip'
   homepage 'https://github.com/kliment/Printrun'
   license :gpl
 
-  app 'Printrun-Mac-10Mar2014.app'
+  app 'Printrun-Mac-03Feb2015.app'
 end


### PR DESCRIPTION
This upgrades `printrun` to version 1.3 (third OS X release).
