### PR TITLE
Updated hash for new version

### DIFF
--- a/Casks/moneydance.rb
+++ b/Casks/moneydance.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'moneydance' do
   version '2015 build 1145'
-  sha256 'e740d4214b43c16dc30c48da854576a2b4e6359ce4ea8bb40ae726539ebcd68e'
+  sha256 'a9186922d52dc27aa746689e234333c67bf53d79e9ed6e0e7c2fc790d94febaa'
 
   url 'http://infinitekind.com/stabledl/2015/Moneydance.zip'
   name 'Moneydance'


### PR DESCRIPTION
An updated version was released on March 10th - http://infinitekind.com/blog/moneydance-2015-3-so-much-smoother. The URL has stayed the same, but the hash has changed.
