### PR TITLE
Update Bit Slicer (quick 1.7.5 bug-fix)

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'bit-slicer' do
   version '1.7.5'
-  sha256 '286487687fbd9a46f3d7bfa943a912a3e05183af06ebfaef8f6820253d5f93e7'
+  sha256 '1180666794b41ddba4895c6f90ba9e428f49c115f0eb260d76061c6c6aa9f1a9'
 
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/zorgiepoo/bit-slicer/downloads/Bit%20Slicer%20#{version}.zip"
   name 'Bit Slicer'
   appcast 'http://zorg.tejat.net/bitslicer/update.php',
-          :sha256 => '2dca07d414e8888b06c0354fe4b381e91ff0945b381081db8f32bc0563d3b51e'
+          :sha256 => 'ad8cdd11fb138f98a29bf24a31d3f82f086e6abf813787f91679ce5ec015239c'
   homepage 'https://github.com/zorgiepoo/bit-slicer/'
   license :bsd
 


### PR DESCRIPTION
I had to fix a potential crash on startup. I decided to keep the human readable version string the same.
