### PR TITLE
Add Flycut v1.5

### DIFF
--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'flycut' do
+  version '1.5'
+  sha256 '0a0d3d91194ba8f4e53a9ad004452cb7b0bc5541322f849a203a75720f875908'
+
+  url 'https://github.com/downloads/TermiT/Flycut/flycut1.5.pkg'
+  name 'Flycut'
+  homepage 'https://github.com/TermiT/Flycut'
+  license :mit
+
+  pkg 'flycut1.5.pkg', :allow_untrusted => true
+
+  uninstall :pkgutil => 'com.generalarcade.flycut'
+end


### PR DESCRIPTION
Flycut is a clipboard manager that was forked from a project called
Jumpcut.
