### PR TITLE
Updated TinyUmbrella to version 8.2.0.48

### DIFF
--- a/Casks/tinyumbrella.rb
+++ b/Casks/tinyumbrella.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'tinyumbrella' do
-  version '8.2.0.48'
-  sha256 '1de31924e50cbb2038ecdc795e4c01a518e468d45537622fdda63920e3ca2364'
+  version :latest
+  sha256 :no_check
 
-  url "http://blog.firmwareumbrella.com/download/343/"
+  url 'http://blog.firmwareumbrella.com/download/343/'
   homepage 'http://blog.firmwareumbrella.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/tinyumbrella.rb
+++ b/Casks/tinyumbrella.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'tinyumbrella' do
-  version '7.12'
-  sha256 'f9cf39967e68ff9730a8fc6365ded9168fd370595e778d7fd38e4cbccd61ad27'
+  version '8.2.0.48'
+  sha256 '1de31924e50cbb2038ecdc795e4c01a518e468d45537622fdda63920e3ca2364'
 
-  url "http://cache.firmwareumbrella.com/downloads/TinyUmbrella-#{version}.00.app.zip"
+  url "http://blog.firmwareumbrella.com/download/343/"
   homepage 'http://blog.firmwareumbrella.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 


### PR DESCRIPTION
Fixes #10221.

I used the app-only download. At the moment download links are not handled in a clever way, so for now the url does not contain the version tag. I also did not add a license, because notcom does not provide one.
