### PR TITLE
Adds IPMenu v1.1

### DIFF
--- a/Casks/ipmenu.rb
+++ b/Casks/ipmenu.rb
@@ -1,0 +1,10 @@
+class Ipmenu < Cask
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.macupdate.com/download/14221/ipmenu.zip'
+  homepage 'http://www.macupdate.com/app/mac/14221/ipmenu'
+  license :unknown
+
+  app 'IPMenu.app'
+end


### PR DESCRIPTION
I think I've done everything right to create the new Cask. It downloaded properly to my machine and passed the audit. Thanks for taking a look!

Description: IPMenu is a free utility that conveniently puts both your local and Internet IP address into your menu bar. To see your IP addresses, simply click on the icon. IPMenu can also e-mail you when your Internet IP address changes.
