### PR TITLE
Allow :sudo in uninstall stanza (:script + :early_script)

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -748,6 +748,7 @@ of the following key/value pairs as arguments to `uninstall`.
   - `:args` - array of arguments to the uninstall script
   - `:input` - array of lines of input to be sent to `stdin` of the script
   - `:must_succeed` - set to `false` if the script is allowed to fail
+  - `:sudo` - set to `false` if the script does not need `sudo`
 * `:delete` (string or array) - single-quoted, absolute paths of files or directory trees to remove.  `:delete` should only be used as a last resort. `:pkgutil` is strongly preferred
 * `:rmdir` (string or array) - single-quoted, absolute paths of directories to remove if empty.
 * `:trash` (string or array) - currently a synonym for `:delete`.  In the future this will cause files to be moved to the Trash.

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -193,8 +193,8 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
     directives_set.select{ |h| h.key?(:early_script) }.each do |directives|
       executable, script_arguments = self.class.read_script_arguments(directives,
                                                                       'uninstall',
-                                                                      {:must_succeed => true},
-                                                                      {:sudo => true, :print_stdout => true},
+                                                                      {:must_succeed => true, :sudo => true},
+                                                                      {:print_stdout => true},
                                                                       :early_script)
 
       ohai "Running uninstall script #{executable}"
@@ -271,8 +271,8 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
     directives_set.select{ |h| h.key?(:script) }.each do |directives|
       executable, script_arguments = self.class.read_script_arguments(directives,
                                                                       'uninstall',
-                                                                      {:must_succeed => true},
-                                                                      {:sudo => true, :print_stdout => true},
+                                                                      {:must_succeed => true, :sudo => true},
+                                                                      {:print_stdout => true},
                                                                       :script)
       raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
       @command.run(@cask.staged_path.join(executable), script_arguments)


### PR DESCRIPTION
Is there any real reason why we don't support it yet?
