### PR TITLE
google-nik-collection: URL fixed + correct license added

### DIFF
--- a/Casks/google-nik-collection.rb
+++ b/Casks/google-nik-collection.rb
@@ -2,10 +2,10 @@ cask :v1 => 'google-nik-collection' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.google.com/dl/edgedl/photos/nikcollection-latest.dmg'
+  url 'http://dl.google.com/dl/edgedl/photos/nikcollection-demo.dmg'
   name 'Nik Collection'
   homepage 'https://www.google.com/nikcollection/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
   tags :vendor => 'Google'
 
   installer :manual => 'Nik Collection.app'


### PR DESCRIPTION
Google has apparently changed URL and licensing, so they now only provide limited demo version.
