### PR TITLE
Spring Tool Suite: Automate (un)installation + add license

### DIFF
--- a/Casks/spring-tool-suite.rb
+++ b/Casks/spring-tool-suite.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'sts' do
+cask :v1 => 'spring-tool-suite' do
   version '3.5.1'
   sha256 'f71274c9f946d2af6bbd12e811d7c8d371d3031415839b9aa6ed35347d2980f8'
 

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -10,7 +10,7 @@ cask :v1 => 'sts' do
 
   url "http://download.springsource.com/release/STS/#{version}/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64-installer.dmg"
   homepage 'http://spring.io/tools/sts'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :eclipse
 
   installer :script => "Installer - Spring Tool Suite #{version}.RELEASE.app/Contents/MacOS/JavaApplicationStub",
             :args => [ '-q' ]

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -12,5 +12,14 @@ cask :v1 => 'sts' do
   homepage 'http://spring.io/tools/sts'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  installer :manual => "Installer - Spring Tool Suite #{version}.RELEASE.app"
+  installer :script => "Installer - Spring Tool Suite #{version}.RELEASE.app/Contents/MacOS/JavaApplicationStub",
+            :args => [ '-q' ]
+
+  caveats <<-EOS.undent
+    #{token} requires Java 6+, you can install the latest Java using
+
+      brew cask install java
+  EOS
+
+  uninstall :delete => '~/springsource'
 end


### PR DESCRIPTION
Shouldn't we rename the cask to `spring-tool-suite` based on the filename?

License source: https://spring.io/tools

> The Spring Tool Suite as well as the Groovy & Grails Tool Suite are built on top of the Eclipse platform, which is provided by the Eclipse Foundation under the Eclipse Public License.
