### PR TITLE
tower.rb: Add `gittower` binary as target

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -15,7 +15,7 @@ cask :v1 => 'tower' do
                   '~/Library/Application Support/com.fournova.Tower2',
                   '~/Library/Preferences/com.fournova.Tower2.plist',
                  ]
-  
+
   caveats do
     files_in_usr_local
   end

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -9,9 +9,14 @@ cask :v1 => 'tower' do
   license :commercial
 
   app 'Tower.app'
+  binary 'Tower.app/Contents/MacOS/gittower'
 
   zap :delete => [
                   '~/Library/Application Support/com.fournova.Tower2',
                   '~/Library/Preferences/com.fournova.Tower2.plist',
                  ]
+  
+  caveats do
+    files_in_usr_local
+  end
 end


### PR DESCRIPTION
Tower includes the CLI tool `gittower`, which can be installed from the Tower preferences. This change installs the binary by symlinking it (just like the `sublime-text` formula does for example).
