### PR TITLE
Updated Dungeon Crawl Stone Soup from 0.16.0 to 0.16.1 for both the tiles and console versions.

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'dungeon-crawl-stone-soup-console' do
-  version '0.16.0'
-  sha256 '3b4750f6bedb4b7e6d0279f476b3cb55124f93871eecb1c53ebda2621ce51b43'
+  version '0.16.1'
+  sha256 '384527e0b0ce8c3df216a577461266d405bb7652d6efcaaf3730c9718590e319'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-console-macos.zip"
   name 'Dungeon Crawl Stone Soup'

--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'dungeon-crawl-stone-soup-tiles' do
-  version '0.16.0'
-  sha256 '1e75166bedce080c74dc64c2389d5487e21f271251e7aab6916774c99529e01f'
+  version '0.16.1'
+  sha256 '3fb69a2de46b051da86ad7c038ef91b8364a3c79ec8699c6120d2d041fe8bd6a'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macos.zip"
   homepage 'http://crawl.develz.org'


### PR DESCRIPTION
Updated Dungeon Crawl Stone Soup from 0.16.0 to 0.16.1 for both the tiles and console versions.
