### PR TITLE
Add Helium (new cask)

### DIFF
--- a/Casks/helium.rb
+++ b/Casks/helium.rb
@@ -1,0 +1,16 @@
+cask :v1 => 'helium' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://download.clockworkmod.com/carbon/carbon-mac.zip'
+  name 'Helium'
+  name 'Carbon'
+  homepage 'https://www.clockworkmod.com/carbon'
+  license :gratis
+
+  app 'Helium.app'
+
+  uninstall :quit => 'com.koushikdutta.Helium'
+
+  zap :delete => '~/Library/Saved Application State/com.koushikdutta.Helium.savedState'
+end


### PR DESCRIPTION
This is the desktop companion to ClockworkMod's [Helium backup app](https://play.google.com/store/apps/details?id=com.koushikdutta.backup) for Android, formerly known as Carbon.
