### PR TITLE
Golly:  The 2.6-mac109 download is no longer available.

### DIFF
--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -1,7 +1,6 @@
 cask :v1 => 'golly' do
-  version '2.6'
-
   if MacOS.release <= :mountain_lion
+    version '2.6'
     sha256 '6fee35e8e4f63ee2c1b0913b7e8009b2548c4e4469050f9c31791900e1e97f16'
 
     url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac106.zip"
@@ -9,7 +8,8 @@ cask :v1 => 'golly' do
     app "golly-#{version}-mac106/Golly.app"
     binary "golly-#{version}-mac106/bgolly"
   else
-    sha256 '8e2e7ffd22dd046a701b6db13a1c36939eced46078c85eeccf709072183fb71c'
+    version '2.7b3'
+    sha256 '6b77df5a8dccf6963edc78071e173297f13acb08dcdea3f3d1b9a3290be19dfc'
 
     url "http://downloads.sourceforge.net/project/golly/golly/golly-#{version}/golly-#{version}-mac109.zip"
 


### PR DESCRIPTION
Closes #10155.

This pull request makes the cask use the `2.7b3` download instead.
