### PR TITLE
Update torbrowser to 4.0.6

### DIFF
--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'torbrowser' do
-  version '4.0.5'
+  version '4.0.6'
   sha256 '8afa20cc70fe9bae8b0f09a96df001fee091ff89eda47bcdbc9a9370d57ea29e'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_en-US.dmg"


### PR DESCRIPTION
TorBrowser 4.0.5 no longer available for download.
