### PR TITLE
Update Launchbar version to 6.2

### DIFF
--- a/Casks/launchbar.rb
+++ b/Casks/launchbar.rb
@@ -5,8 +5,8 @@ cask :v1 => 'launchbar' do
     sha256 '22a1ec0c10de940e5efbcccd18b8b048d95fb7c63213a01c7976a76d6be69a4d'
     url "http://www.obdev.at/downloads/launchbar/legacy/LaunchBar-#{version}.dmg"
   else
-    version '6.1.6'
-    sha256 '7ae2d6fdb9d12817cd1ed49cfd35606cb7f3a3162c369108555ee8adc2940335'
+    version '6.2'
+    sha256 'c40a30db70b4a14e97faf2a7a74ca26e2e0143223ad25f7ec8ae7df38f436463'
     url "http://www.obdev.at/downloads/launchbar/LaunchBar-#{version}.dmg"
   end
 


### PR DESCRIPTION
This commit updates the Launchbar version to 6.2 and also updates
the SHA to the correct version.
