### PR TITLE
Fix broken app name for All The GIFs

### DIFF
--- a/Casks/gifs.rb
+++ b/Casks/gifs.rb
@@ -1,11 +1,11 @@
-cask :v1 => 'all-the-gifs' do
+cask :v1 => 'gifs' do
   version :latest
   sha256 :no_check
 
   url 'https://raw.github.com/orta/GIFs/master/web/GIFs.app.zip'
-  name 'All The GIFs'
+  name 'GIFs'
   homepage 'https://github.com/orta/GIFs'
   license :bsd
 
-  app 'All The GIFs.app'
+  app 'GIFs.app'
 end


### PR DESCRIPTION
The app name inside the zip file appears to have been changed from
All The GIFs.app to simply GIFs.app
