### PR TITLE
updating amazon-cloud-drive-sha

### DIFF
--- a/Casks/amazon-cloud-drive.rb
+++ b/Casks/amazon-cloud-drive.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'amazon-cloud-drive' do
   version 'mac'
-  sha256 'ef849cdad1e65cbf225e5d6a2436e4472ddecaedf71f6386ac9859ceef52f20c'
+  sha256 '8bcc3aa1f558fd96922eae0356d749dd347d3a35b211e25f199466ebc185fc38'
 
   url "https://d29x207vrinatv.cloudfront.net/#{version}/AmazonCloudDriveInstaller.dmg"
   name 'Amazon Cloud Drive App'


### PR DESCRIPTION
# Description

This PR fixes te sha256 in the `amazon-cloud-drive` recipe
## Tasks
- [x] Fix SHA256 to the latest package.
