### PR TITLE
Add Fusion360 Cask

### DIFF
--- a/Casks/fusion360.rb
+++ b/Casks/fusion360.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'fusion360' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Client%20Downloader.dmg'
+  name 'Fusion 360'
+  homepage 'http://www.autodesk.com/products/fusion-360/overview'
+  license :closed
+
+  app 'Double Click to Install.app', :target => 'Fusion360.app'
+end


### PR DESCRIPTION
RFC: this doesn't work currently, although it works fine without the :target part. I get this error:

```
==> Failed command:
["/usr/bin/xattr", "-w", "com.apple.metadata:kMDItemAlternateNames", "(\\\"Fusion360.app\\\")", "#<Pathname:/Users/drewgross/Applications/Fusion360.app>"]

==> Output of failed command:

==> Exit status of failed command:
<Process::Status: pid 66571 exit 1>
```
