### PR TITLE
Evernote - few enhancements (version + https + license)

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -3,12 +3,12 @@ cask :v1 => 'evernote' do
   if MacOS.release <= :snow_leopard
     version '5.5.2'
     sha256 '06b6da6d74ccab08deabfdd4c9519b9bc7f7ef0f0db2a0e8b0cd72e781f2e0ed'
-    url 'http://cdn1.evernote.com/mac/release/Evernote_402634.dmg'
+    url 'https://cdn1.evernote.com/mac/release/Evernote_402634.dmg'
   else
     version '6.0.8_451398'
     sha256 'ff3e01a61eb176fccd604ebd409d818e7850fe1c1889a8f97f87640e77d11e69'
     url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
-    appcast 'http://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml'
+    appcast 'https://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml'
   end
 
   name 'Evernote'

--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -5,9 +5,9 @@ cask :v1 => 'evernote' do
     sha256 '06b6da6d74ccab08deabfdd4c9519b9bc7f7ef0f0db2a0e8b0cd72e781f2e0ed'
     url 'http://cdn1.evernote.com/mac/release/Evernote_402634.dmg'
   else
-    version :latest
-    sha256 :no_check
-    url 'https://www.evernote.com/about/download/get.php?file=EvernoteMac'
+    version '6.0.8_451398'
+    sha256 'ff3e01a61eb176fccd604ebd409d818e7850fe1c1889a8f97f87640e77d11e69'
+    url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
     appcast 'http://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml'
   end
 


### PR DESCRIPTION
I remember there has been a discussion about `latest` VS specific versions, do I understand correctly we now prefer more specific URLs over `latest` to make the "upgrades" easier for users?

<del>Regarding license see http://en.wikipedia.org/wiki/Evernote </del>
