### PR TITLE
Propagate --verbose flag to more tools?

### DIFF
--- a/lib/hbc/container/bzip2.rb
+++ b/lib/hbc/container/bzip2.rb
@@ -6,10 +6,20 @@ class Hbc::Container::Bzip2 < Hbc::Container::Base
   end
 
   def extract
+    ditto_debug_args = []
+    bzip_verbose_args = []
+    if Hbc.verbose
+      ditto_debug_args << '--debug'
+      bzip_verbose_args << '-vv'
+    end
+
     Dir.mktmpdir do |unpack_dir|
-      @command.run!('/usr/bin/ditto',   :args => ['--', @path, unpack_dir])
-      @command.run!('/usr/bin/bunzip2', :args => ['-q', '--', Pathname(unpack_dir).join(@path.basename)])
-      @command.run!('/usr/bin/ditto',   :args => ['--', unpack_dir, @cask.staged_path])
+      @command.run!('/usr/bin/ditto',
+        :args => ditto_debug_args + ['--', @path, unpack_dir])
+      @command.run!('/usr/bin/bunzip2',
+        :args => bzip_verbose_args + ['-q', '--', Pathname(unpack_dir).join(@path.basename)])
+      @command.run!('/usr/bin/ditto',
+        :args => ditto_debug_args + ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/hbc/container/cab.rb
+++ b/lib/hbc/container/cab.rb
@@ -13,9 +13,15 @@ class Hbc::Container::Cab < Hbc::Container::Base
     if ! Pathname.new(cabextract).exist?
       raise Hbc::CaskError.new "Expected to find cabextract executable. Cask '#{@cask}' must add: depends_on :formula => 'cabextract'"
     end
+
+    debug_args = []
+    debug_args << '--debug' if Hbc.verbose
+
     Dir.mktmpdir do |unpack_dir|
-      @command.run!(cabextract, :args => ['-d', unpack_dir, '--', @path])
-      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
+      @command.run!(cabextract,
+        :args => ['-d', unpack_dir, '--', @path])
+      @command.run!('/usr/bin/ditto',
+        :args => debug_args + ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/hbc/container/generic_unar.rb
+++ b/lib/hbc/container/generic_unar.rb
@@ -11,9 +11,16 @@ class Hbc::Container::GenericUnar < Hbc::Container::Base
     if ! Pathname.new(unar).exist?
       raise Hbc::CaskError.new "Expected to find unar executable. Cask #{@cask} must add: depends_on :formula => 'unar'"
     end
+
+    ditto_debug_args = []
+    
+    ditto_debug_args << '--debug' if Hbc.verbose
+
     Dir.mktmpdir do |unpack_dir|
-      @command.run!(unar, :args => ['-q', '-D', '-o', unpack_dir, '--', @path])
-      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
+      @command.run!(unar,
+        :args => ditto_debug_args + ['--', unpack_dir, @cask.staged_path])
+      @command.run!('/usr/bin/ditto',
+        :args => ['-q', '-D', '-o', unpack_dir, '--', @path])
     end
   end
 end

--- a/lib/hbc/container/gzip.rb
+++ b/lib/hbc/container/gzip.rb
@@ -9,10 +9,19 @@ class Hbc::Container::Gzip < Hbc::Container::Base
   end
 
   def extract
+    ditto_debug_args = []
+    gzip_verbose_args = []
+
+    ditto_debug_args << '--debug' if Hbc.verbose
+    gzip_verbose_args << '-q' if not Hbc.verbose
+
     Dir.mktmpdir do |unpack_dir|
-      @command.run!('/usr/bin/ditto',  :args => ['--', @path, unpack_dir])
-      @command.run!('/usr/bin/gunzip', :args => ['-q', '--', Pathname(unpack_dir).join(@path.basename)])
-      @command.run!('/usr/bin/ditto',  :args => ['--', unpack_dir, @cask.staged_path])
+      @command.run!('/usr/bin/ditto',
+        :args => ditto_debug_args + ['--', @path, unpack_dir])
+      @command.run!('/usr/bin/gunzip',
+        :args => gzip_verbose_args + ['--', Pathname(unpack_dir).join(@path.basename)])
+      @command.run!('/usr/bin/ditto',
+        :args => ditto_debug_args + ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/hbc/container/naked.rb
+++ b/lib/hbc/container/naked.rb
@@ -7,7 +7,11 @@ class Hbc::Container::Naked < Hbc::Container::Base
   end
 
   def extract
-    @command.run!('/usr/bin/ditto', :args => ['--', @path, @cask.staged_path.join(target_file)])
+    debug_args = []
+    debug_args << '--debug' if Hbc.verbose
+
+    @command.run!('/usr/bin/ditto',
+      :args => debug_args + ['--', @path, @cask.staged_path.join(target_file)])
   end
 
   def target_file

--- a/lib/hbc/container/tar.rb
+++ b/lib/hbc/container/tar.rb
@@ -6,9 +6,19 @@ class Hbc::Container::Tar < Hbc::Container::Base
   end
 
   def extract
+    tar_verbose_args = []
+    ditto_debug_args = []
+
+    if Hbc.verbose
+      tar_verbose_args << '-vv'
+      ditto_debug_args << '--debug'
+    end
+
     Dir.mktmpdir do |unpack_dir|
-      @command.run!('/usr/bin/tar', :args => ['xf', @path, '-C', unpack_dir])
-      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
+      @command.run!('/usr/bin/tar',
+        :args => tar_verbose_args + ['xf', @path, '-C', unpack_dir])
+      @command.run!('/usr/bin/ditto',
+        :args => ditto_debug_args + ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/hbc/container/xar.rb
+++ b/lib/hbc/container/xar.rb
@@ -6,9 +6,19 @@ class Hbc::Container::Xar < Hbc::Container::Base
   end
 
   def extract
+    xar_verbose_args = []
+    ditto_debug_args = []
+
+    if Hbc.verbose
+      xar_verbose_args << '-v'
+      ditto_debug_args << '--debug'
+    end
+
     Dir.mktmpdir do |unpack_dir|
-      @command.run!('/usr/bin/xar', :args => ['-xf', @path, '-C', unpack_dir])
-      @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
+      @command.run!('/usr/bin/xar',
+        :args => xar_verbose_args + ['-xf', @path, '-C', unpack_dir])
+      @command.run!('/usr/bin/ditto',
+        :args => ditto_debug_args + ['--', unpack_dir, @cask.staged_path])
     end
   end
 end

--- a/lib/hbc/container/zip.rb
+++ b/lib/hbc/container/zip.rb
@@ -4,6 +4,10 @@ class Hbc::Container::Zip < Hbc::Container::Base
   end
 
   def extract
-    @command.run!('/usr/bin/ditto', :args => ['-xk', '--', @path, @cask.staged_path])
+    debug_args = []
+    debug_args << '--debug' if Hbc.verbose
+
+    @command.run!('/usr/bin/ditto',
+      :args => debug_args + ['-xk', '--', @path, @cask.staged_path])
   end
 end


### PR DESCRIPTION
The tools we use for extracting the artefacts have some verbose arguments that may be useful in certain situations and I believe we should be transparently propagating these as we already do in case of `pkg`:

https://github.com/caskroom/homebrew-cask/blob/master/lib/hbc/artifact/pkg.rb#L49

I'm just not sure the option `--verbose` is good enough for some cases, so I'm thinking about `-v`, `-vv`, `-vvv` etc? There is a few tools that allow defining more granular verbose levels (e.g. bzip & tar).

The typical debugging use case of these tools is when you install a new cask and want to know what files are actually being unpacked and where.

---

This change still needs to be thoroughly tested on specific casks, I'm submitting this merely to see if there's an interest in such feature.
