### PR TITLE
Add CLion RC v141.352.13

### DIFF
--- a/Casks/clion-rc.rb
+++ b/Casks/clion-rc.rb
@@ -1,0 +1,23 @@
+cask :v1 => 'clion-rc' do
+  version '141.352.13'
+  sha256 'e91cb72119470197a4f442e230c361ddcd92d6e66b28c8b3ab5e3a234e07262e'
+
+  url "http://download-cf.jetbrains.com/cpp/CLion-#{version}.dmg"
+  name 'CLion RC'
+  name 'CLion'
+  homepage 'http://www.jetbrains.com/clion/'
+  license :commercial
+
+  app 'CLion.app'
+
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
+end


### PR DESCRIPTION
Note, that it is a **release candidate** build, not an **EAP** version, so I created a new cask for it.

Also, I'm interested in the necessity to make a cask for almost the same `DMG` file but with bundled custom JDK, which is needed because of the `OS X 10.10+` problem with `Java 6+`. This `CLion-141.352.13-custom-jdk-bundled.dmg` comprises the application itself **with** a `JDK 8 bundle`. So it is the same app but with some additions for the users of the latest OS X.
