### PR TITLE
Updated to use the current CoolTermMac URL.

### DIFF
--- a/Casks/coolterm.rb
+++ b/Casks/coolterm.rb
@@ -2,7 +2,7 @@ cask :v1 => 'coolterm' do
   version :latest
   sha256 :no_check
 
-  url 'http://freeware.the-meiers.org/CoolTermMac.zip'
+  url 'http://freeware.the-meiers.org/CoolTerm_Mac.zip'
   name 'CoolTerm'
   homepage 'http://freeware.the-meiers.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
URL changed to http://freeware.the-meiers.org/CoolTerm_Mac.zip.
