### PR TITLE
Add Angband.app v3.5.1

### DIFF
--- a/Casks/angband.rb
+++ b/Casks/angband.rb
@@ -2,7 +2,9 @@ cask :v1 => 'angband' do
   version '3.5.1'
   sha256 'de8af2db62de6ce19034bcb5d542e9c161a069d5b240a77d9c0497cb473ea82c'
 
-  url 'http://rephial.org/downloads/3.5/Angband-v3.5.1-osx.dmg'
+  versionnumber = /(.*)\.(.*)\.(.*)/.match(version)
+
+  url "http://rephial.org/downloads/#{versionnumber[1]}.#{versionnumber[2]}/Angband-v#{version}-osx.dmg"
   name 'Angband'
   homepage 'http://rephial.org'
   license :gpl

--- a/Casks/angband.rb
+++ b/Casks/angband.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'angband' do
+  version '3.5.1'
+  sha256 'de8af2db62de6ce19034bcb5d542e9c161a069d5b240a77d9c0497cb473ea82c'
+
+  url 'http://rephial.org/downloads/3.5/Angband-v3.5.1-osx.dmg'
+  name 'Angband'
+  homepage 'http://rephial.org'
+  license :gpl
+
+  app 'Angband.app'
+end


### PR DESCRIPTION
While an old curses based version (v3.0.9 ~ 2009) is available in
homebrew/games Angband is distributed in a OSX native app from
their official website (http://rephial.org)

Angband 3.5.1 released 2015-01-04
