### PR TITLE
Update CleanArchiver to use #{version} substitution, update license field

### DIFF
--- a/Casks/cleanarchiver.rb
+++ b/Casks/cleanarchiver.rb
@@ -2,10 +2,10 @@ cask :v1 => 'cleanarchiver' do
   version '3.0a6'
   sha256 '9b24c7ac24e976b6d364a81e746dcd1526fcbda57e787cd3c0fce00eba1b5847'
 
-  url 'https://www.sopht.jp/pub/Mac/CleanArchiver-3.0a6.dmg'
+  url "https://www.sopht.jp/pub/Mac/CleanArchiver-#{version}.dmg"
   name 'CleanArchiver'
   homepage 'https://www.sopht.jp/cleanarchiver/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :bsd
 
   app 'CleanArchiver.app'
 end


### PR DESCRIPTION
After examining the source code, I determined that CleanArchiver is released under a BSD 3-Clause license. Also updated the `url` field to use `#{version}` to make future upkeep easier.
