### PR TITLE
Make license field for messenger more specific

### DIFF
--- a/Casks/messenger.rb
+++ b/Casks/messenger.rb
@@ -5,7 +5,7 @@ cask :v1 => 'messenger' do
   url "http://fbmacmessenger.rsms.me/dist/Messenger-#{version}.zip"
   name 'Messenger'
   homepage 'http://fbmacmessenger.rsms.me/'
-  license :oss
+  license :mit
 
   app 'Messenger.app'
 end


### PR DESCRIPTION
The readme at https://github.com/rsms/fb-mac-messenger indicates that the project is licensed under MIT license.
