### PR TITLE
updated hopper-disassembler code

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -9,5 +9,5 @@ cask :v1 => 'hopper-disassembler' do
   homepage 'http://www.hopperapp.com/'
   license :commercial
 
-  app 'Hopper Disassembler v3.app'
+  app 'Hopper Disassembler.app'
 end


### PR DESCRIPTION
the zip file doesn't have v3 prefix now and it unzips to just Hopper Disassembler.app hence removed v3
