### PR TITLE
updating xdk-iot version to 1878

### DIFF
--- a/Casks/intel-xdk-iot.rb
+++ b/Casks/intel-xdk-iot.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'intel-xdk-iot' do
-  version '52'
-  sha256 'f8b378b36848245503127fc079a4dccf483aa949eb0b05ea0b7c50f0153b3db1'
+  version '1878'
+  sha256 '009bfc7b24a2eede47ff408a41ae2b57a9c4944d8b2fd5a00e377c06dcf656ef'
 
-  url "https://download.xdk.intel.com/iot-packages/iot_web_mac_master-iot_00#{version}.dmg"
+  url "https://download.xdk.intel.com/iot-packages/iot_web_mac_master-iot_#{version}.dmg"
   name 'Intel XDK IoT Edition'
   homepage 'https://software.intel.com/en-us/html5/xdk-iot'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
updating version https://software.intel.com/en-us/html5/xdk-iot#download
