### PR TITLE
Update GnuCash to 2.6.6-5

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'gnucash' do
-  version '2.6.6-4'
-  sha256 '2dceb6ed0281018f467d69cdc19b98078ec90794b17b4c457b29d93e02ca0152'
+  version '2.6.6-5'
+  sha256 'fa4f240d2ad9266038c360f5a2cfc1c492425cca3fcfa82e19820e5cb7b590f5'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-#{version}.dmg"


### PR DESCRIPTION
As it seems the resently uploaded gnucash version was incorrectly
packaged, here comes a new update for a correct 2.6.6.
