### PR TITLE
Add PhotoTrans.app latest version

### DIFF
--- a/Casks/phototrans.rb
+++ b/Casks/phototrans.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'phototrans' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.imobie.com/product/phototrans-mac.dmg'
+  name 'PhotoTrans'
+  homepage 'http://www.imobie.com/phototrans/'
+  license :gratis
+
+  app 'PhotoTrans.app'
+end


### PR DESCRIPTION
With PhotoTrans for Mac, you are allowed to transfer iPhone, iPad photos to / from Mac. http://www.imobie.com/phototrans
