### PR TITLE
Add AppTrans.app latest version

### DIFF
--- a/Casks/apptrans.rb
+++ b/Casks/apptrans.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'apptrans' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.imobie.com/product/apptrans-mac.dmg'
+  name 'AppTrans'
+  homepage 'http://www.imobie.com/apptrans/'
+  license :gratis
+
+  app 'AppTrans.app'
+end


### PR DESCRIPTION
AppTrans for Mac is a simple and intuitive utility that can help you transfer iOS Apps freely. http://www.imobie.com/apptrans/
