### PR TITLE
Add PhoneTrans.app latest version

### DIFF
--- a/Casks/phonetrans.rb
+++ b/Casks/phonetrans.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'phonetrans' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.imobie.com/product/phonetrans-mac.dmg'
+  name 'PhoneTrans'
+  homepage 'http://www.imobie.com/phonetrans'
+  license :gratis
+
+  app 'PhoneTrans.app'
+end


### PR DESCRIPTION
One of the best free iTunes alternatives, also a versatile iPhone iPad and iPod touch Music transfer freeware for iPhone, iPad and iPod touch. http://www.imobie.com/phonetrans
