### PR TITLE
Add PodTrans.app latest version

### DIFF
--- a/Casks/podtrans.rb
+++ b/Casks/podtrans.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'podtrans' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.imobie.com/product/podtrans-mac.dmg'
+  name 'PodTrans'
+  homepage 'http://www.imobie.com/podtrans'
+  license :gratis
+
+  app 'PodTrans.app'
+end


### PR DESCRIPTION
Free and easy-to-use iPod Music Transfer that supports all models of iPod nano, iPod shuffle, iPod classic, iPod touch and iPod mini. http://www.imobie.com/podtrans
