### PR TITLE
Add PhoneBrowse.app latest version

### DIFF
--- a/Casks/phonebrowse.rb
+++ b/Casks/phonebrowse.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'phonebrowse' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.imobie.com/product/phonebrowse-mac.dmg'
+  name 'PhoneBrowse'
+  homepage 'http://www.imobie.com/phonebrowse'
+  license :gratis
+
+  app 'PhoneBrowse.app'
+end


### PR DESCRIPTION
Free to explore and browse iPhone, iPad, iPod touch file system and use your iPhone, iPad, iTouch as USB flash drive without jailbreaking. http://www.imobie.com/phonebrowse
