### PR TITLE
Upgraded Texpad.app to v1.7.8

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,13 +1,26 @@
 cask :v1 => 'texpad' do
-  version '1.6.14'
-  sha256 '18fcbe93e77e5b5bc848172546962fcde397a26fd543efcc1054004369192f7e'
 
-  url "https://cloud.texpadapp.com/bundles/Texpad_#{version.gsub('.','_')}.zip"
+  if MacOS.release >= :mavericks
+    version '1.7.8'
+    sha256 'e67a47d88245a966bd69716c248df5656cd4e96834f5dd323d4ffe6725260fe8'
+    url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.gsub('.','_')}.zip"
+  elsif MacOS.release <= :mountain_lion && MacOS.release >= :snow_leopard
+    version '1.6.14'
+    sha256 '18fcbe93e77e5b5bc848172546962fcde397a26fd543efcc1054004369192f7e'
+    url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.gsub('.','_')}.zip"
+  else
+    # If the app is used on MacOS lower than Snow Leopard,
+    # unexpected behaviour or failures can occur.
+  end
+
+  depends_on :macos => '>= :snow_leopard'
+
   appcast 'https://www.texpadapp.com/static-collected/upgrades/texpadappcast.xml',
           :sha256 => 'a8522a4533df93fbf9d50489aa5f1c91bb01916faebd81ee20f56ea96dad8d97'
+
   name 'Texpad'
   homepage 'https://www.texpadapp.com/osx'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Texpad.app'
 end


### PR DESCRIPTION
- Fixed #10546 
- Separated versions up to MacOS releases
- Added license 
