### PR TITLE
brew-cask: depend on Ruby 2.0.

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -7,12 +7,35 @@ rescue
   HBC_VERSION = HOMEBREW_CASK_VERSION
 end
 
+class Ruby20 < Requirement
+  fatal true
+  default_formula "ruby"
+
+  satisfy :build_env => false do
+    next unless which "ruby"
+    version = /\d\.\d/.match `ruby --version 2>&1`
+    next unless version
+    Version.new(version.to_s) >= Version.new("2.0")
+  end
+
+  env do
+    ENV.prepend_path "PATH", which("ruby").dirname
+  end
+
+  def message; <<-EOS.undent
+    brew-cask needs Ruby >=2.0
+    EOS
+  end
+end
+
 class BrewCask < Formula
   homepage "https://github.com/caskroom/homebrew-cask/"
   url "https://github.com/caskroom/homebrew-cask.git", :tag => "v#{HBC_VERSION}"
   head "https://github.com/caskroom/homebrew-cask.git", :branch => "master"
 
   skip_clean "bin"
+
+  depends_on Ruby20
 
   def install
     man1.install "doc/man/brew-cask.1"


### PR DESCRIPTION
Nicer to do this at Homebrew time so it can e.g. install the Ruby rather than throwing an error at runtime.
