### PR TITLE
Add Messenger for Mac v0.0.4

### DIFF
--- a/Casks/messenger.rb
+++ b/Casks/messenger.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'messenger' do
+  version '0.0.4'
+  sha256 '87fefab0e0a30dfafe2fe1754cbdf014ad66fa5a6cf33ea3848b635bbe13ec61'
+
+  url 'http://fbmacmessenger.rsms.me/dist/Messenger-0.0.4.1428634580-a80cddf5538e66d6.zip'
+  name 'Messenger for Mac'
+  homepage 'http://fbmacmessenger.rsms.me/'
+  license :mit
+
+  app 'Messenger.app'
+end


### PR DESCRIPTION
From http://fbmacmessenger.rsms.me/

> Disclaimer: This is not an official Facebook product. It's a free and open-source project created by fans of Messenger.

The source code is on GitHub at https://github.com/rsms/fb-mac-messenger
