### PR TITLE
charles proxy version bump to 3.10.1

### DIFF
--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'charles' do
-  version '3.10'
-  sha256 'ee0a07d6b303a778f98dd37293aa13bce2adf0ad15648e144c1676c21cec3c31'
+  version '3.10.1'
+  sha256 '5d94f04d4936dd1dd9293f406457f13a825422dc28c5146f19581de2f8e76c9d'
 
-  url "http://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}-applejava.dmg"
+  url "http://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
   name 'Charles'
   homepage 'http://www.charlesproxy.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
Charles proxy version bump.

also shifted from apple java version to native java version, as apple has stopped sending java updates.

This should fix Issue #10522 
