### PR TITLE
spyder version bump with caution

### DIFF
--- a/Casks/spyder.rb
+++ b/Casks/spyder.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'spyder' do
-  version '2.3.2'
-  sha256 '0565a5af85e26759acce04f6da1b6317e8c2ec932847bc590408a1473d0686a7'
+  version '2.3.4'
+  sha256 'dbc71eb3c3952171fa37251ed441be80c525c47143626b4315f3775b8b4b1fed'
 
   # bitbucket.org is the official download host per the vendor homepage
-  url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py3.4.dmg"
+  url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py2.7.dmg"
   name 'Spyder'
-  homepage 'https://code.google.com/p/spyderlib/'
+  homepage 'https://github.com/spyder-ide/spyder'
   license :mit
 
   app 'Spyder.app'


### PR DESCRIPTION
i have version bumped this however it is to be noted that previous release was for python 3.4 however the released marked above is for python 2.7

till 2.3.3 they had both 2.7 and 3.4 release however 2.3.4 has only 2.7 release.

also homepage updated as suggested by Issue #10461
