### PR TITLE
Upgrade Scribus.app to 1.4.5

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'scribus' do
-  version '1.4.5-r2'
-  sha256 'e07be2772e8e1b897d21e636d05d4065af17757d33b85022fac3c0f99fdc6b63'
+  version '1.4.5'
+  sha256 '2cae3e4afa552e2db4209e3e3efae816202bb3055857b57bdcd60e1b2eca410c'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/scribus/scribus/#{version}/scribus-#{version}.dmg"


### PR DESCRIPTION
Upgraded Scribus.app to stable version 1.4.5

Changed version from 1.4.5-r2 to 1.4.5
Updated sha256 to be valid for new Scribus download dmg file.
