### PR TITLE
Adding Fiddler proxy

### DIFF
--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -9,8 +9,8 @@ cask :v1 => 'fiddler' do
   homepage 'http://www.telerik.com/fiddler'
   license :commercial
   tags :vendor => 'Telerik'
-  
+
   depends_on :cask => 'mono-mdk'
-  
+
   app 'Fiddler.app'
 end

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'fiddler' do
+  version '4.4.5.0'
+  sha256 '35ca5899d19269b24e7d648fbf6b5f20275075691392a122c93a2365bff70acd'
+
+  # sourceforge.net is the official download host per the vendor homepage
+  url "http://ericlawrence.com/dl/InstallFiddler.dmg"
+  name 'Telerik Fiddler Proxy'
+  name 'Fiddler Proxy'
+  name 'Fiddler'
+  homepage 'http://www.telerik.com/fiddler'
+  license :apache
+  tags :vendor => 'Telerik'
+
+  app 'Fiddler.app'
+end

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -1,8 +1,7 @@
 cask :v1 => 'fiddler' do
-  version '4.4.5.0'
-  sha256 '35ca5899d19269b24e7d648fbf6b5f20275075691392a122c93a2365bff70acd'
+  version :latest
+  sha256 :no_check
 
-  # sourceforge.net is the official download host per the vendor homepage
   url 'http://ericlawrence.com/dl/InstallFiddler.dmg'
   name 'Telerik Fiddler Proxy'
   name 'Fiddler Proxy'
@@ -10,6 +9,6 @@ cask :v1 => 'fiddler' do
   homepage 'http://www.telerik.com/fiddler'
   license :apache
   tags :vendor => 'Telerik'
-
+  depends_on :formula => 'Mono'
   app 'Fiddler.app'
 end

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -7,8 +7,10 @@ cask :v1 => 'fiddler' do
   name 'Fiddler Proxy'
   name 'Fiddler'
   homepage 'http://www.telerik.com/fiddler'
-  license :apache
+  license :commercial
   tags :vendor => 'Telerik'
-  depends_on :formula => 'Mono'
+  
+  depends_on :formula => 'mono'
+  
   app 'Fiddler.app'
 end

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -3,7 +3,7 @@ cask :v1 => 'fiddler' do
   sha256 '35ca5899d19269b24e7d648fbf6b5f20275075691392a122c93a2365bff70acd'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://ericlawrence.com/dl/InstallFiddler.dmg"
+  url 'http://ericlawrence.com/dl/InstallFiddler.dmg'
   name 'Telerik Fiddler Proxy'
   name 'Fiddler Proxy'
   name 'Fiddler'

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -10,7 +10,7 @@ cask :v1 => 'fiddler' do
   license :commercial
   tags :vendor => 'Telerik'
   
-  depends_on :formula => 'mono'
+  depends_on :cask => 'mono-mdk'
   
   app 'Fiddler.app'
 end


### PR DESCRIPTION
There is no version specific url hence generic one used.

Also this requires mono however i am not sure how we can link dependency, please guide.

details about required is http://fiddler.wikidot.com/mono suggests we need mono 3.1.2
