### PR TITLE
Update to 1.3.1-r2

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'openzfs' do
-  version '1.3.0'
-  sha256 'a0030181a91ecace2d31cfab26d10b2284602e2b442f71a344a9da11165cb6c7'
+  version '1.3.1-r2'
+  sha256 '7d0001f318e70f7a5ee87273a1f1cc7912908677ea9565702d05282c1ebca8b8'
 
-  url "https://openzfsonosx.org/w/images/0/0d/OpenZFS_on_OS_X_#{version}.dmg"
+  url "https://openzfsonosx.org/w/images/7/71/OpenZFS_on_OS_X_#{version}.dmg"
   name 'OpenZFS on OS X'
   homepage 'https://openzfsonosx.org'
   license :oss


### PR DESCRIPTION
Looks like 1.3.0 and before have a fairly serious bug.  This version is recommended per:

https://openzfsonosx.org/wiki/Downloads
