### PR TITLE
Update emacs.rb

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -3,6 +3,7 @@ cask :v1 => 'emacs' do
   sha256 '60b8c7d51659b6ccd86108a0f14866ab96a098797e350cb03c24040bb69d8ce2'
 
   url "http://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
+  name 'Emacs for Mac OS X'
   name 'Emacs'
   homepage 'http://emacsformacosx.com/'
   license :oss


### PR DESCRIPTION
The official name of this application is Emacs for Mac OS X according to the website. It is a customized version of GNU Emacs and certainly not what you would get when you would install GNU Emacs. Thus, this difference should be reflected by the name. 
