### PR TITLE
nw: NW.js (previously node-webkit)

### DIFF
--- a/Casks/nw.rb
+++ b/Casks/nw.rb
@@ -7,5 +7,6 @@ cask :v1 => 'nw' do
   homepage 'http://nwjs.io'
   license :mit
 
-  stage_only true
+  binary "nwjs-v#{version}-osx-x64/nwjc"
+  app "nwjs-v#{version}-osx-x64/nwjs.app"
 end


### PR DESCRIPTION
`binary` and `app` stanzas, replacing `stage_only`.
- Add `nwjc` binary
- Add `nwjs.app`

Tested with successful `open -a nwjs` after trusting application once.
Successfully linked the command line tool.

``` bash
brew cask audit nw --download
```

=> `audit for nw: passed`
