### PR TITLE
fixed the installation and tested it on Yosemite; Mavericks should work, and this version of ZFS doesn't support anything earlier

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -1,8 +1,11 @@
 cask :v1 => 'openzfs' do
-  version '1.3.1-r2'
-  sha256 '7d0001f318e70f7a5ee87273a1f1cc7912908677ea9565702d05282c1ebca8b8'
+  version       '1.3.1'
+  sha256        '7d0001f318e70f7a5ee87273a1f1cc7912908677ea9565702d05282c1ebca8b8'
 
-  url "https://openzfsonosx.org/w/images/7/71/OpenZFS_on_OS_X_#{version}.dmg"
+  revision       = "-r2"
+
+  url "https://openzfsonosx.org/w/images/7/71/OpenZFS_on_OS_X_#{version}#{revision}.dmg"
+
   name 'OpenZFS on OS X'
   homepage 'https://openzfsonosx.org'
   license :oss


### PR DESCRIPTION
tweaks to make the installation actually work; attempted to cleanup and generalize the recipe, but the '-r2' addition to the version number the openzfsonosx folks insisting on putting causes a lot of grief.  it's inconsistent with the filenames, mountpoints, and dmg file names, so handling the exception is actually quite challenging.
