### PR TITLE
error in url : zip to DMG

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -3,7 +3,7 @@ cask :v1 => 'owasp-zap' do
   sha256 'd8e296cc09908f7df9970ac6f701191bf7ccdff628d95194196a58689f8186be'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/sourceforge/zaproxy/ZAP_#{version}_Mac_OS_X.zip"
+  url "http://downloads.sourceforge.net/project/zaproxy/#{version}/ZAP_#{version}_Mac_OS_X.dmg" 
   name 'OWASP Zed Attack Proxy'
   name 'OWASP ZAP'
   name 'ZAP'


### PR DESCRIPTION
Consider it a mistake from my end. format changed from zip to dmg.
and download url seems to include version too..

Not on my desktop hence can't edit local first before sending out the request. Would keep in mind to test local before i push cask update.

-Anant
