### PR TITLE
Revert "owasp-zap version bump to 2.4"

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'owasp-zap' do
-  version '2.4.0'
-  sha256 'd8e296cc09908f7df9970ac6f701191bf7ccdff628d95194196a58689f8186be'
+  version '2.3.1'
+  sha256 '417d9208ea3df826f3641131f0f8c2c475cf56f7926f51be1a6c8b155c06b1c9'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/zaproxy/ZAP_#{version}_Mac_OS_X.zip"


### PR DESCRIPTION
Reverts caskroom/homebrew-cask#10611

Will submit a single patch to fix version bump with correct url
