### PR TITLE
Update Transporter Desktop client to 3.1.17

### DIFF
--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'transporter-desktop' do
-  version '3.1.15_18289'
-  sha256 'fecf3b1944832261900237537962a4783d709caa96c3e93ec2d828b88425ec8e'
+  version '3.1.17_18519'
+  sha256 'c62adff9e27ebdc424d7fb01b02d5d5ba06a53305c7f6d65ecde790bb487a95e'
 
   # connecteddata.com is the official download host per the vendor homepage
   url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}.dmg"


### PR DESCRIPTION
This commit updates the version to 3.1.17 and the SHA for the
downloaded file.
