### PR TITLE
fix dependency name conflict

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -7,7 +7,7 @@ rescue
   HBC_VERSION = HOMEBREW_CASK_VERSION
 end
 
-class Ruby20 < Requirement
+class Ruby20Dependency < Requirement
   fatal true
   default_formula "ruby"
 
@@ -35,7 +35,7 @@ class BrewCask < Formula
 
   skip_clean "bin"
 
-  depends_on Ruby20
+  depends_on Ruby20Dependency
 
   def install
     man1.install "doc/man/brew-cask.1"


### PR DESCRIPTION
Current dependency name will be conficted with the formula name of
homebrew/version/ruby20.rb, in result it will cause following error:

```
$ brew readall
Error: problem in /usr/local/Library/Formula/ruby20.rb
wrong number of arguments (3 for 0..1)
```

Fixes https://github.com/Homebrew/homebrew/issues/38638
