### PR TITLE
brew-cask.rb: name requirement subclass better

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -7,7 +7,7 @@ rescue
   HBC_VERSION = HOMEBREW_CASK_VERSION
 end
 
-class Ruby20Dependency < Requirement
+class Ruby20Requirement < Requirement
   fatal true
   default_formula "ruby"
 
@@ -35,7 +35,7 @@ class BrewCask < Formula
 
   skip_clean "bin"
 
-  depends_on Ruby20Dependency
+  depends_on Ruby20Requirement
 
   def install
     man1.install "doc/man/brew-cask.1"


### PR DESCRIPTION
Sorry, pedantry here that I'm about to fix globally in Homebrew/homebrew: it doesn't really make sense to use `Dependency` in the name here because this is a `Requirement` and a `Dependency` is another, similar internal Homebrew class so this change is a bit less confusing.

CC @xu-cheng
