### PR TITLE
A new release to replace "old" v3.1.0

### DIFF
--- a/Casks/futuniuniu.rb
+++ b/Casks/futuniuniu.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'futuniuniu' do
-  version '3.0.2_0306'
-  sha256 '74eb05cb30e47cc55a7931400fa376003663fee5652d61ebd1c9a6516b57e0fc'
+  version '3.1.0'
+  sha256 'afb319d434646de5f3b55cf53233a704c5a17a1235c72966ebbf05d404dba0d9'
 
-  url "https://www.futu5.com/client/nn/mac/FUTUNNForMac_#{version}.dmg"
+  url 'https://www.futu5.com/client/nn/mac/FUTUNNForMac_3.1.0_0409.dmg'
   homepage 'http://www.futu5.com'
   license :commercial
 

--- a/Casks/futuniuniu.rb
+++ b/Casks/futuniuniu.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'futuniuniu' do
-  version '2.16.360'
-  sha256 '29d76b841bf9f93510f4caebd632a4dab07e9faf794285fe4e0a35766db2e9dc'
+  version '3.0.2_0306'
+  sha256 '74eb05cb30e47cc55a7931400fa376003663fee5652d61ebd1c9a6516b57e0fc'
 
-  url 'https://www.futu5.com/client/nn/mac/FTNNForMac_2.16.360_1210.dmg'
+  url "https://www.futu5.com/client/nn/mac/FUTUNNForMac_#{version}.dmg"
   homepage 'http://www.futu5.com'
   license :commercial
 

--- a/Casks/futuniuniu.rb
+++ b/Casks/futuniuniu.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'futuniuniu' do
-  version '3.1.0'
-  sha256 'afb319d434646de5f3b55cf53233a704c5a17a1235c72966ebbf05d404dba0d9'
+  version '3.1.0_0416'
+  sha256 'ab1f4c21cc5bb879754f8cef2adab0d250cdd2b99fa8daa52ffb6762091b0ea6'
 
-  url 'https://www.futu5.com/client/nn/mac/FUTUNNForMac_3.1.0_0409.dmg'
+  url "https://www.futu5.com/client/nn/mac/FUTUNNForMac_#{version}.dmg"
   homepage 'http://www.futu5.com'
   license :commercial
 


### PR DESCRIPTION
The old verion of v3.1.0(released at 9 March), seems has some problems, so they just released a "new" v3.1.0 (release toay, 16 March) instead.
