### PR TITLE
Add PowerPhotos 1.0

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'powerphotos' do
+  version '1.0.0'
+  sha256 '449a3b6acb91e890c931045dcaae430b6daa7910c47a6a3fb4211cd3770a3d6f'
+
+  # amazonaws.com is the official download host per the vendor homepage
+  url "https://s3.amazonaws.com/fatcatsoftware/powerphotos/PowerPhotos_#{version.gsub('.', '')}.zip"
+  name 'PowerPhotos'
+  homepage 'http://www.fatcatsoftware.com/powerphotos/'
+  license :commercial
+
+  app 'PowerPhotos.app'
+end


### PR DESCRIPTION
PowerPhotos is a new application that will eventually replace iPhoto Library Manager (which already exists in homebrew-cask).  This cask just uses the iplm cask as a starting point.
