### PR TITLE
Update BaseX to 8.1.1

### DIFF
--- a/Casks/basex.rb
+++ b/Casks/basex.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'basex' do
-  version '7.8.1'
-  sha256 '495b4c32cb916c02543a5f19b702c01516b1b8f452be537259dd6d1ad040ca87'
+  version '8.1.1'
+  sha256 '89e02ebbbb9df544157dd6d896d6c65de47731b45ca67a490e269499614def15'
 
-  url "http://files.basex.org/releases/#{version}/BaseX781.app.zip"
+  url "http://files.basex.org/releases/8.1.1/BaseX811.app.tar.bz2"
   name 'BaseX'
   homepage 'http://basex.org/home/'
   license :bsd

--- a/Casks/basex.rb
+++ b/Casks/basex.rb
@@ -2,7 +2,7 @@ cask :v1 => 'basex' do
   version '8.1.1'
   sha256 '89e02ebbbb9df544157dd6d896d6c65de47731b45ca67a490e269499614def15'
 
-  url "http://files.basex.org/releases/8.1.1/BaseX811.app.tar.bz2"
+  url 'http://files.basex.org/releases/8.1.1/BaseX811.app.tar.bz2'
   name 'BaseX'
   homepage 'http://basex.org/home/'
   license :bsd


### PR DESCRIPTION
I remove `#{version}` to URL because version its also in file name but in different format.
