### PR TITLE
Add license and vendor for some Google products

### DIFF
--- a/Casks/google-adwords-editor.rb
+++ b/Casks/google-adwords-editor.rb
@@ -5,7 +5,7 @@ cask :v1 => 'google-adwords-editor' do
   url "https://dl.google.com/adwords_editor/#{version}/Google_AdWords_Editor.dmg"
   name 'Google AdWords Editor'
   homepage 'https://www.google.com/intl/en/adwordseditor/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
   tags :vendor => 'Google'
 
   app 'Google AdWords Editor.app'

--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -5,7 +5,8 @@ cask :v1 => 'google-drive' do
   url 'https://dl.google.com/drive/installgoogledrive.dmg'
   name 'Google Drive'
   homepage 'https://drive.google.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
+  tags :vendor => 'Google'
 
   app 'Google Drive.app'
 

--- a/Casks/google-earth-web-plugin.rb
+++ b/Casks/google-earth-web-plugin.rb
@@ -5,7 +5,8 @@ cask :v1 => 'google-earth-web-plugin' do
   url 'http://r2---sn-po4vapo3-j3ae.c.pack.google.com/edgedl/earth/plugin/current/googleearth-mac-plugin-intel.dmg'
   name 'Google Earth plug-in'
   homepage 'http://www.google.com/intl/en/earth/explore/products/plugin.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
+  tags :vendor => 'Google'
 
   internet_plugin 'Google Earth Web Plug-in.plugin'
 end

--- a/Casks/google-earth.rb
+++ b/Casks/google-earth.rb
@@ -5,7 +5,8 @@ cask :v1 => 'google-earth' do
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthMac-Intel.dmg'
   name 'Google Earth'
   homepage 'https://www.google.com/earth/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
+  tags :vendor => 'Google'
 
   app 'Google Earth.app'
 

--- a/Casks/google-hangouts.rb
+++ b/Casks/google-hangouts.rb
@@ -6,6 +6,7 @@ cask :v1 => 'google-hangouts' do
   name 'Google Hangouts'
   homepage 'https://www.google.com/tools/dlpage/hangoutplugin'
   license :gratis
+  tags :vendor => 'Google'
 
   pkg 'Google Voice and Video.pkg'
 

--- a/Casks/google-japanese-ime.rb
+++ b/Casks/google-japanese-ime.rb
@@ -6,7 +6,8 @@ cask :v1 => 'google-japanese-ime' do
   url 'https://dl.google.com/japanese-ime/latest/GoogleJapaneseInput.dmg'
   name 'Google Japanese Input Method Editor'
   homepage 'https://www.google.co.jp/ime/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
+  tags :vendor => 'Google'
 
   pkg 'GoogleJapaneseInput.pkg'
 

--- a/Casks/google-notifier.rb
+++ b/Casks/google-notifier.rb
@@ -5,7 +5,7 @@ cask :v1 => 'google-notifier' do
   url "https://dl.google.com/mac/download/GoogleNotifier_#{version}.dmg"
   name 'Google Notifier'
   homepage 'http://toolbar.google.com/gmail-helper/notifier_mac.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
   tags :vendor => 'Google'
 
   app 'Google Notifier.app'

--- a/Casks/google-plus-auto-backup.rb
+++ b/Casks/google-plus-auto-backup.rb
@@ -5,7 +5,8 @@ cask :v1 => 'google-plus-auto-backup' do
   url 'https://dl.google.com/dl/edgedl/picasa/gpautobackup_setup.dmg'
   name 'Google+ Auto Backup'
   homepage 'http://picasa.google.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
+  tags :vendor => 'Google'
 
   app 'Google+ Auto Backup.app'
 end


### PR DESCRIPTION
All the applications and plugins in this PR are free-to-use but with closed source, so the license `:gratis` matches here the most.
