### PR TITLE
Update LaunchBar formula to version 6.3.

### DIFF
--- a/Casks/launchbar.rb
+++ b/Casks/launchbar.rb
@@ -5,8 +5,8 @@ cask :v1 => 'launchbar' do
     sha256 '22a1ec0c10de940e5efbcccd18b8b048d95fb7c63213a01c7976a76d6be69a4d'
     url "http://www.obdev.at/downloads/launchbar/legacy/LaunchBar-#{version}.dmg"
   else
-    version '6.2'
-    sha256 'c40a30db70b4a14e97faf2a7a74ca26e2e0143223ad25f7ec8ae7df38f436463'
+    version '6.3'
+    sha256 '0ee5bacc02dc5213fc80934fed66124a718fd72d654ce3a4365cc694d76c1578'
     url "http://www.obdev.at/downloads/launchbar/LaunchBar-#{version}.dmg"
   end
 


### PR DESCRIPTION
The LaunchBar formula is currently failing on post-mountain-lion versions of OS X because LaunchBar 6.3 has been released and the link to 6.2 is no broken. Fixes this updating the URL and SHA.
