### PR TITLE
Add tip on string interpolation in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,11 +249,26 @@ Example:
 	app 'TexmakerMacosxLion/texmaker.app'
 	```
 
-### Indenting
+### Style guide
 
 All Casks and code in the homebrew-cask project should be indented using two
 spaces (never tabs).
 
+If relevant, you may also use string manipulations to improve the maintainability of your Cask. Here's an example from `Lynkeos.app`:
+
+```ruby
+cask :v1 => 'lynkeos' do
+  version '2.10'
+  sha256 'bd27055c51575555a1c8fe546cf057c57c0e45ea5d252510847277734dc550a4'
+
+  url "http://downloads.sourceforge.net/project/lynkeos/lynkeos/#{version}/Lynkeos-App-#{version.gsub('.', '-')}.zip"
+  name 'Lynkeos'
+  homepage 'http://lynkeos.sourceforge.net/'
+  license :gpl
+
+  app "Lynkeos-App-#{version.gsub('.', '-')}/Lynkeos.app"
+end
+```
 
 ## Testing Your New Cask
 


### PR DESCRIPTION
Hi,

I recently submitted a PR (#10739) for a new Cask that got edited by @vitorgalvao before merging. He changed the Cask to use string interpolation in the app & URL stanzas:

``` ruby
# Before
  url "http://downloads.sourceforge.net/project/upm/upm-1.13/upm-mac-1.13.tar.gz"
  app "upm-mac-1.13/UPM.app"

# After
  url "http://downloads.sourceforge.net/project/upm/upm-#{version}/upm-mac-#{version}.tar.gz"
  app "upm-mac-#{version}/UPM.app"
```

Not a big change, but IMHO completely worth it.

I feel like I could have done this myself, but it didn't come to my mind. Even though I know of string interpolation, I tried to follow the CONTRIBUTING guidelines line by line, and it isn't mentioned anywhere. This is what I'm trying to address with this PR.

This probably needs to be discussed. I'm not quite sure of who your CONTRIBUTING audience is, and what kind of language would help them the most to end up with the best Cask definition.

Let me know what you think!
