### PR TITLE
Update the-unarchiver cask to use "legacy" version. Closes #10785.

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'the-unarchiver' do
   version '3.9.1'
-  sha256 '34fa3410237e17b2cdceb801a84ed8db93c74ac0db551ffe65913c2134ebbf05'
+  sha256 '4911c332df7f4bb23877652700e845fe097b793ae37450948319398009e923a3'
 
   # googlecode.com is the official download host per the vendor homepage
-  url "https://theunarchiver.googlecode.com/files/TheUnarchiver#{version}.zip"
+  url "https://theunarchiver.googlecode.com/files/TheUnarchiver#{version}_legacy.zip"
   homepage 'http://unarchiver.c3.cx/'
   license :oss
 


### PR DESCRIPTION
- The app's "Mac Apple Store" version Preference window is broken in OS X 10.10
- The "legacy" version isn't sandboxed and fixes this issue
- See related issue https://code.google.com/p/theunarchiver/issues/detail?id=758
