### PR TITLE
Update PaintCode to version 2.3.1

### DIFF
--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'paintcode' do
-  version '2.2.4'
-  sha256 '645f0042a5d2111905482b0a574004c83f7e1d053f6e0d1b992ebbe57daf2776'
+  version '2.3.1'
+  sha256 '6355a0ea775de821982e0110fa094b5995ba37daf612363b75d24cf74be7a702'
 
   url "http://www.paintcodeapp.com/content/versions/#{version}/paintcode-trial.zip"
   appcast 'http://www.pixelcut.com/paintcode/appcast.xml'
@@ -8,5 +8,5 @@ cask :v1 => 'paintcode' do
   homepage 'http://www.paintcodeapp.com/'
   license :commercial
 
-  app 'PaintCode.app'
+  app 'PaintCode Trial.app'
 end


### PR DESCRIPTION
This commit updates the version and the SHA. It also changes the app
name to PaintCode Trial.app to match the content of the zip file.
