### PR TITLE
Resolve dbvisualizer installer issue found in Issue 10199

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -17,7 +17,7 @@ cask :v1 => 'dbvisualizer' do
   zap :delete => '~/.dbvis'
 
   caveats <<-EOS.undent
-    #{token} requires Java. You can install the latest version with
-      brew cask install java
+    #{token} requires Java 7. You can install the latest version with
+      brew cask install caskroom/versions/java7
   EOS
 end


### PR DESCRIPTION
The dmg is specifically java7 but `brew cask install java` currently installs java 8. This should hopefully clear up some confusion. I didn't know if I should add more to the caveats section about having both java 7 and 8 installed and manually running `export JAVA_HOME=<java7 location>` to ensure java 7 is in use for this operation.
