### PR TITLE
Correct artifact stanza in google-earth-web-plugin

### DIFF
--- a/Casks/google-earth-web-plugin.rb
+++ b/Casks/google-earth-web-plugin.rb
@@ -8,5 +8,6 @@ cask :v1 => 'google-earth-web-plugin' do
   license :gratis
   tags :vendor => 'Google'
 
-  internet_plugin 'Google Earth Web Plug-in.plugin'
+  pkg 'Install Google Earth.pkg'
+  uninstall :pkgutil => 'com.Google.GoogleEarthPlugin.plugin'
 end


### PR DESCRIPTION
It seem that the nuance of creating a plugin file in `/Library/Internet\ Plug-ins` is handled by the maintainers with logic they rolled into a pkg.

Despite the name of the .pkg file, it seems to have just installed the plugin and not the full Google Earth app, so it seems that this cask is still valid. Without this change, installation fails.
