### PR TITLE
Fix incorrect screencat sha256

### DIFF
--- a/Casks/screencat.rb
+++ b/Casks/screencat.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'screencat' do
   version '2.0.0'
-  sha256 'a963fa07c3831a7643a1a5aad4bbe8790eef88e4de35d681a3f7adc18e6c2814'
+  sha256 'd0587d3c7c926825019d296ad677c4469fa6cdf47ab434f556d74c372e5a18e6'
 
   url "https://github.com/maxogden/screencat/releases/download/#{version}/ScreenCat.zip"
   name 'ScreenCat'


### PR DESCRIPTION
For some reason the sha256 for screencat is wrong. This PR provides the correct sha256.
