### PR TITLE
teleport.rb: use app instead of prefpane

### DIFF
--- a/Casks/teleport.rb
+++ b/Casks/teleport.rb
@@ -7,5 +7,5 @@ cask :v1 => 'teleport' do
   homepage 'http://www.abyssoft.com/software/teleport/'
   license :gratis
 
-  prefpane 'teleport/teleport.prefPane'
+  app 'teleport.app'
 end


### PR DESCRIPTION
teleport has been converted to an app in version 1.2+ so it no longer
needs to use prefpane
