### PR TITLE
Upgrade Inboard to 1.0.2-271

### DIFF
--- a/Casks/inboard.rb
+++ b/Casks/inboard.rb
@@ -1,14 +1,11 @@
 cask :v1 => 'inboard' do
-  version '184'
-  sha256 '3bb602cde63f0b3401fc681cd50a3545c5a47c2326ea81cf66844039fb100522'
+  version '1.0.2-271'
+  sha256 '69fddd83a43ecce6254e524325ea5afb0108d41246e6fe618852775173821f65'
 
-  # devmate.com is the official download host per the vendor homepage
-  url "http://dl.devmate.com/com.ideabits.Inboard/#{version}/1390822305/Inboard-#{version}.dmg"
-  appcast 'http://updates.devmate.com/com.ideabits.Inboard.xml',
-          :sha256 => '3bde9bcd42058928757ce5b3edc9de1ef4f488b190b8efec40e6c7e4fd69a020'
+  url "http://inboardapp.com/trial/Inboard-#{version}.zip"
   name 'Inboard'
-  homepage 'http://inboardapp.com/beta'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'http://inboardapp.com'
+  license :commercial
 
   app 'Inboard.app'
 end


### PR DESCRIPTION
Inboard is out of beta, and the trial version is available for download.
