### PR TITLE
Upgrade TorBrowser.app to v4.5

### DIFF
--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser' do
-  version '4.0.8'
-  sha256 '7f7e5358da6e065a4061d5335e0d54c5e8e7b741bbf114e17fe7150ae40f2025'
+  version '4.5'
+  sha256 'af4c2f2363f192742df813f9dd5a0bcfab01c3224e8a2b35b9124082cac424b2'
 
-  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx32_en-US.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 


### PR DESCRIPTION
- Upgrade to v4.5
- Use GPG fingerprint instead of key ID
- Switch to 64bit builds

> Bug 10138: Switch to 64bit builds for MacOS
> https://blog.torproject.org/blog/tor-browser-45-released
