### PR TITLE
Google Earth switched to pkg from app

### DIFF
--- a/Casks/google-earth.rb
+++ b/Casks/google-earth.rb
@@ -8,7 +8,12 @@ cask :v1 => 'google-earth' do
   license :gratis
   tags :vendor => 'Google'
 
-  app 'Google Earth.app'
+  pkg 'Install Google Earth.pkg'
+
+  uninstall :pkgutil => [
+              'com.Google.GoogleEarthPlus',
+              'com.Google.GoogleEarthPlugin.plugin',
+            ]
 
   zap :delete => [
                   '~/Library/Application Support/Google Earth',


### PR DESCRIPTION
This patch fixes Google Earth, but it'll install to `/Applications/Google Earth.app`. I don't know if there's a way to get it to install under `/opt/homebrew-cask/Caskroom/...` and have a symlink at `~/Applications/Google Earth.app`.
