### PR TITLE
clion 1.0.1

### DIFF
--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -1,15 +1,23 @@
 cask :v1 => 'clion' do
-  version '1.0'
-  sha256 '0ff584ea63a2aff1843ba228d7185c8b6af9efac1d4a6a690a24565ee53aec35'
+  version '1.0.1'
+  sha256 'c46942a263be2d9adc007c6ef8bd2484b8b770ca6330747558c34d4c2324f7d8'
 
   url "https://download.jetbrains.com/cpp/CLion-#{version}.dmg"
   name 'CLion'
-  homepage 'http://www.jetbrains.com/clion'
+  homepage 'https://www.jetbrains.com/clion'
   license :commercial
 
   app 'CLion.app'
 
-  conflicts_with :cask => 'clion-bundled'
+  zap :delete => [
+                  '~/Library/Preferences/com.jetbrains.CLion.plist',
+                  '~/Library/Preferences/clion10',
+                  '~/Library/Application Support/clion10',
+                  '~/Library/Caches/clion10',
+                  '~/Library/Logs/clion10',
+                 ]
+
+  conflicts_with :cask => 'clion-bundled-jdk'
   caveats <<-EOS.undent
     #{token} requires Java 6 like any other IntelliJ-based IDE.
     You can install it with


### PR DESCRIPTION
Bumped version to 1.0.1 and made the following changes to bring this formula in line with caskroom/homebrew-versions#879:
- Homepage URL is https instead of http.
- Add zap stanza.
- Correct `conflicts_with` stanza to use correct name of the bundled jdk version.
