### PR TITLE
update darktable to 1.6.6

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'darktable' do
-  version '1.6.4'
-  sha256 'e5bbf00fefcf116aec0e66d1d0cf2e2396cb0b19107402d2ef70d1fa0ab375f6'
+  version '1.6.6'
+  sha256 'bce9a792ee362c47769839ec3e49973c07663dbdf6533ef5a987c93301358607'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"


### PR DESCRIPTION
http://www.darktable.org/2015/04/released-darktable-1-6-6/
