### PR TITLE
Update Transporter Desktop to 3.1.21

### DIFF
--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'transporter-desktop' do
-  version '3.1.17_18519'
-  sha256 'c62adff9e27ebdc424d7fb01b02d5d5ba06a53305c7f6d65ecde790bb487a95e'
+  version '3.1.21_18654'
+  sha256 '43ac53ed8c35bde7296b183f8aa3f0f12b91a986c80e8c7e0f6acdcbc5d32dee'
 
   # connecteddata.com is the official download host per the vendor homepage
   url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}.dmg"


### PR DESCRIPTION
This commit updates the version number and SHA for the 3.1.21 version.
