### PR TITLE
Fix calibre cask version.

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'calibre' do
-  version '2.26.0'
-  sha256 'e6dc8f60f085a50f223f03837c1d9f48fc40d8f63e65fc12947f36faf1d812ea'
+  version '2.27.0'
+  sha256 '564a3298715e7f5a2be66ac3a863121ba82b18b881f8f06746027ae101e00e58'
 
   # github.com is an official download host per the vendor homepage, and a faster mirror than the main one
   url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"


### PR DESCRIPTION
# Description

If you try to install calibre:

``` bash
brew cask install calibre
```

You'll see the following error:

``` bash
==> Downloading https://github.com/kovidgoyal/calibre/releases/download/v2.26.0/calibre-2.26.0.dmg

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'calibre' with message: Download failed: https://github.com/kovidgoyal/calibre/releases/download/v2.26.0/calibre-2.26.0.dmg
```

This PR updates the cask version to the latest **2.27.0** and fixes the issue.
# How to test?

``` bash
$ curl -I https://github.com/kovidgoyal/calibre/releases/download/v2.26.0/calibre-2.26.0.dmg
HTTP/1.1 404 Not Found
...

$ curl -I https://github.com/kovidgoyal/calibre/releases/download/v2.27.0/calibre-2.27.0.dmg
HTTP/1.1 302 Found
...
```
