### PR TITLE
Upgrade inform to v7.6L38.

### DIFF
--- a/Casks/inform.rb
+++ b/Casks/inform.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'inform' do
-  version '7.6L02'
-  sha256 '182134881d44b1c096af979d9cff195d33ec51d7c1f81f59a7c25d5a917d8987'
+  version '7.6L38'
+  sha256 '79a478600bbcb10347711794349c19c12ce8109a701e3aa737f638f6d4e9127b'
 
-  url "http://inform7.com/download/content/6L02/I#{version.gsub('.','-')}-OSX.dmg"
+
+  url "http://inform7.com/download/content/#{version.split('.')[1]}/I#{version.gsub('.','-')}-OSX.dmg"
   name 'Inform'
   homepage 'http://inform7.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
Upgrade inform to latest version (Non-Mac App Store).
Use string ops to improve ease of upgrade in future (using string.split on version)
