### PR TITLE
Profile Manager for Mozilla XUL apps (mostly Firefox)

### DIFF
--- a/Casks/profilemanager.rb
+++ b/Casks/profilemanager.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'profilemanager' do
+  version '1.0'
+  sha256 'a46295851063d8a0630cace6720813e571e86a66734a8765f9706bab939b3f48'
+
+  url 'https://ftp.mozilla.org/pub/mozilla.org/utilities/profilemanager/1.0/profilemanager.mac.dmg'
+  name 'Mozilla Profile Manager'
+  homepage 'https://developer.mozilla.org/en-US/docs/Profile_Manager'
+  license :mpl
+
+  app 'ProfileManager.app'
+end


### PR DESCRIPTION
fwiw I deliberately did not use the suggested token for this cask (as it is very generic: profilemanager). Personally, I think the added context helps in reading the output of the search command.
