### PR TITLE
Update cDock.app to 7.3

### DIFF
--- a/Casks/cdock.rb
+++ b/Casks/cdock.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'cdock' do
-  version '4.2'
-  sha256 '586f1a8972e12b4d71439ef915eca1396d915e28efbcee66ce84bee921aeb0ad'
+  version '7.3'
+  sha256 '88aeadaa446241970bd96685ef9ddb53220b493f321ac0e579d0e7653ef6d984'
 
   url "http://downloads.sourceforge.net/project/cdock/cDock/cDock_v#{version}.zip"
   name 'cDock'


### PR DESCRIPTION
https://github.com/caskroom/homebrew-cask/issues/10570

`:target => '/Applications/cDock.app'` is used to fix the alert on application start.
