### PR TITLE
Update netlogo.rb

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -12,5 +12,5 @@ cask :v1 => 'netlogo' do
     '~/Library/Saved Application State/org.nlogo.NetLogo.savedState'
   ]
 
-  app "NetLogo #{version.sub(%r{\.\d+$},'')}/NetLogo ##{version.sub(%r{\.\d+$},'')}.app"
+  app "NetLogo #{version.sub(%r{\.\d+$},'')}/NetLogo #{version.sub(%r{\.\d+$},'')}.app"
 end

--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -12,5 +12,5 @@ cask :v1 => 'netlogo' do
     '~/Library/Saved Application State/org.nlogo.NetLogo.savedState'
   ]
 
-  app "NetLogo #{version}/NetLogo #{version}.app"
+  app "NetLogo #{version.sub(%r{\.\d+$},'')}/NetLogo ##{version.sub(%r{\.\d+$},'')}.app"
 end


### PR DESCRIPTION
When trying to install:
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/netlogo/5.2.0/NetLogo 5.2.0/NetLogo 5.2.0.app'

=> 5.2 in the name of the app and not 5.2.0
