### PR TITLE
List the Apache license for androidtool.

### DIFF
--- a/Casks/androidtool.rb
+++ b/Casks/androidtool.rb
@@ -6,7 +6,7 @@ cask :v1 => 'androidtool' do
   appcast 'https://github.com/mortenjust/androidtool-mac/releases.atom'
   name 'AndroidTool'
   homepage 'https://github.com/mortenjust/androidtool-mac'
-  license :unknown
+  license :apache
 
   app 'AndroidTool.app'
 end


### PR DESCRIPTION
The license file is here: https://github.com/mortenjust/androidtool-mac/blob/master/LICENSE
