### PR TITLE
Fix incorrect sha256 for Komodo Edit

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'komodo-edit' do
   version '9.0.1-15745'
-  sha256 'a5b6960c4d6d791cfa72e9dfc9e94aa53f326a808bd012c6e16ec23b15356545'
+  sha256 '39dc064cead52b3de0cab8f499867d26e1e8feeeca91488c00cd72ceb9d31089'
 
   # activestate.com is the official download host per the vendor homepage
   url "http://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"


### PR DESCRIPTION
Correct hash is `39dc064cead52b3de0cab8f499867d26e1e8feeeca91488c00cd72ceb9d31089`, not `a5b6960c4d6d791cfa72e9dfc9e94aa53f326a808bd012c6e16ec23b15356545` -- thanks @teacher4711.
