### PR TITLE
Update Trailer to version 1.3.2

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'trailer' do
-  version '1.3.1'
-  sha256 '7be6fb7479d51d31ff535bc5c61a2a2532149a0caf866788014d5ee12938ed1e'
+  version '1.3.2'
+  sha256 '8b41d06464ab2f5e76ee52c0d389cf457bfafd02652c27420b4dec0530c905d8'
 
   url "http://ptsochantaris.github.io/trailer/trailer#{version.gsub('.','')}.zip"
   appcast 'http://ptsochantaris.github.io/trailer/appcast.xml',
-          :sha256 => '0d255433261dc91f1d07b812c96cc48268370ce748f39fbc2bcbcc08796a6675'
+          :sha256 => 'aaf3f91888b757ec234643a9f45259fd9650a687c6146c723084e7d80979a6a4'
   name 'Trailer'
   homepage 'http://ptsochantaris.github.io/trailer/'
   license :mit


### PR DESCRIPTION
Upgraded to the latest version of Trailer (1.3.2) from 1.3.1
