### PR TITLE
Update P4Merge and improve script

### DIFF
--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -19,6 +19,6 @@ cask :v1 => 'p4merge' do
   caveats <<-EOS.undent
     git can be configured to use p4merge as a merge tool via
 
-      https://gist.github.com/henrik242/1510148
+      http://pempek.net/articles/2014/04/18/git-p4merge/
   EOS
 end

--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'p4merge' do
-  version '2014.2'
-  sha256 '766b6f6b8669f889f1186dd96408b5b8af6b9dc6c602784d6d6ea25130007709'
+  version '2014.3-1007540'
+  sha256 '07eac08f6bfb32e4a79bf47582116de8532fe0b18d91a014e1cd80861d6f0909'
 
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{^20},'')}/bin.macosx107x86_64/P4V.dmg"
   name 'P4Merge'

--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -5,9 +5,16 @@ cask :v1 => 'p4merge' do
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{^20},'')}/bin.macosx107x86_64/P4V.dmg"
   name 'P4Merge'
   homepage 'http://www.perforce.com/product/components/perforce-visual-merge-and-diff-tools'
-  license :oss
+  license :gratis
+  tags :vendor => 'Perforce'
 
   app 'p4merge.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.perforce.p4merge',
+                  '~/Library/Preferences/com.perforce.p4merge.plist',
+                  '~/Library/Saved Application State/com.perforce.p4merge.savedState'
+                 ]
 
   caveats <<-EOS.undent
     git can be configured to use p4merge as a merge tool via


### PR DESCRIPTION
This pull request:
1. Updates P4Merge to 2014.3-1007540 from 2014.2-985932
2. Fixes the `license` stanza
3. Adds a `:vendor` tag to match [the P4V cask](https://github.com/caskroom/homebrew-cask/blob/master/Casks/p4v.rb)
4. Adds a `zap` stanza
5. Changes the link in the caveats to point to an improved version of the command-line script
