### PR TITLE
Fix pgweb zip archive checksum

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pgweb' do
   version '0.5.3'
-  sha256 '324ac3a019bdbd1404163e3e9e82eab8a26f8db85dd31eed4609ca0dff7cba8d'
+  sha256 'a6be3e3fc9f830647319fc31d19f6cb2cc889074f81bc27b9fa60f379ea2a6c1'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   appcast 'https://github.com/sosedoff/pgweb/releases.atom'


### PR DESCRIPTION
Current pgweb checksum is based on sha256 of the binary file, not the zip archive.
This change should fix it. 
