### PR TITLE
remove `sort` for fixing the bug #9227

### DIFF
--- a/lib/hbc/artifact/symlinked.rb
+++ b/lib/hbc/artifact/symlinked.rb
@@ -83,13 +83,11 @@ class Hbc::Artifact::Symlinked < Hbc::Artifact::Base
   end
 
   def install_phase
-    # the sort is for predictability between Ruby versions
-    @cask.artifacts[self.class.artifact_dsl_key].sort.each { |artifact| link(artifact) }
+    @cask.artifacts[self.class.artifact_dsl_key].each { |artifact| link(artifact) }
   end
 
   def uninstall_phase
-    # the sort is for predictability between Ruby versions
-    @cask.artifacts[self.class.artifact_dsl_key].sort.each { |artifact| unlink(artifact) }
+    @cask.artifacts[self.class.artifact_dsl_key].each { |artifact| unlink(artifact) }
   end
 
   def preflight_checks(source, target)


### PR DESCRIPTION
I've created a cask for macvim-kaoriya (https://github.com/caskroom/homebrew-versions/pull/942). But this did not work perfectly for a bug in the `symlinked` artifact (#9227).

This patch removes `sort` methods that are added for a compatibility to old ruby versions. But it seems to work good for me in several OS X versions. (I tested some casks in 10.10, 10.9, 10.8)
