### PR TITLE
Upgraded homepage urls for cantata, klystrack and tunnelblick.

### DIFF
--- a/Casks/cantata.rb
+++ b/Casks/cantata.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cantata' do
 
   url 'https://drive.google.com/uc?export=download&id=0Bzghs6gQWi60WmNlSDh6dTVzYTg'
   name 'cantata'
-  homepage 'https://code.google.com/p/cantata/'
+  homepage 'https://github.com/cdrummond/cantata'
   license :gpl
 
   app 'Cantata.app'

--- a/Casks/cantata.rb
+++ b/Casks/cantata.rb
@@ -2,6 +2,7 @@ cask :v1 => 'cantata' do
   version '1.5.2'
   sha256 '564eec8b60d7e46670b8c67686db8a69210f540626bdbaf8c837b48c0bd2ffc8'
 
+  # google.com is the official download host per the vendor homepage
   url 'https://drive.google.com/uc?export=download&id=0Bzghs6gQWi60WmNlSDh6dTVzYTg'
   name 'cantata'
   homepage 'https://github.com/cdrummond/cantata'

--- a/Casks/klystrack.rb
+++ b/Casks/klystrack.rb
@@ -5,7 +5,7 @@ cask :v1 => 'klystrack' do
   # dropboxusercontent.com is the official download host per the vendor homepage
   url 'https://dl.dropboxusercontent.com/u/1190319/Klystrack_1.6.0-1270.dmg'
   name 'Klystrack'
-  homepage 'https://code.google.com/p/klystrack/'
+  homepage 'https://kometbomb.github.io/klystrack/'
   license :mit
 
   app 'Klystrack.app'

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -7,7 +7,7 @@ cask :v1 => 'tunnelblick' do
   appcast 'https://www.tunnelblick.net/appcast.rss',
           :sha256 => '7fa119cda4d782dc61cb75895c70b3572652df737c908270c48a09d67a874592'
   name 'Tunnelblick'
-  homepage 'https://code.google.com/p/tunnelblick/'
+  homepage 'https://www.tunnelblick.net'
   license :gpl
 
   app 'Tunnelblick.app'


### PR DESCRIPTION
Google Code will close soon. Updated homepages for three casks listed in issue #10461.
- cantata redirects to github pages
- klystrack was moved to github
- tunnelblick webpage redirects at the moment to google code, but as soon as they migrate it will point to the new homepage.
