### PR TITLE
Updated wiztoolsorg-restclient to not use google code anymore.

### DIFF
--- a/Casks/wiztoolsorg-restclient.rb
+++ b/Casks/wiztoolsorg-restclient.rb
@@ -2,9 +2,9 @@ cask :v1 => 'wiztoolsorg-restclient' do
   version '3.2.2'
   sha256 'd920279ef6406acb02a12485e1e8adaf1942cf196f0628c8e6b40744f6120aac'
 
-  url "https://rest-client.googlecode.com/files/restclient-ui-#{version}.dmg"
+  url "http://download.wiztools.org/rest-client/archive/restclient-ui-#{version}.dmg"
   name 'RESTClient'
-  homepage 'https://code.google.com/p/rest-client'
+  homepage 'https://github.com/wiztools/rest-client'
   license :oss
 
   app 'WizTools.org RESTClient.app'


### PR DESCRIPTION
Updated download url & homepage for wiztoolsorg-restclient as it is listed in issue #10461.

Newer versions of the REST-Client are hosted on fosshub, what should we do in such a case?
