### PR TITLE
Upgraded telephone cask version to 1.0.4

### DIFF
--- a/Casks/telephone.rb
+++ b/Casks/telephone.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'telephone' do
-  version '0.15.2'
-  sha256 '21191c1d72b425a2aa5a065678bf862c235974727aa6184c51eec540f41cb43d'
+  version '1.0.4'
+  sha256 'e2c06dffd13610fe69d90c5dd61cc80050076517f6a16e8a78ad48e2a12caf2e'
 
-  url "https://telephone.googlecode.com/files/Telephone-#{version}.dmg"
+  url "http://www.tlphn.com/resources/Telephone-#{version}.dmg"
   name 'Telephone'
-  homepage 'https://code.google.com/p/telephone/'
+  homepage 'http://www.tlphn.com/'
   license :oss
 
   app 'Telephone.app'


### PR DESCRIPTION
Also migrated urls away from google code. This is the newest version that is available from the vendors webpage. Newer versions are in the AppStore.
