### PR TITLE
Changed dukto cask to not use google code anymore.

### DIFF
--- a/Casks/dukto.rb
+++ b/Casks/dukto.rb
@@ -2,9 +2,9 @@ cask :v1 => 'dukto' do
   version 'R6'
   sha256 '86f06ca92a28b5835cb3eaadfb09897f581a5da3fb8ee8246897b1bf4ee7348a'
 
-  url "https://dukto.googlecode.com/files/Dukto#{version}-OSX.dmg"
+  url "https://downloads.sourceforge.net/sourceforge/dukto/Dukto#{version}-OSX.dmg"
   name 'Dukto'
-  homepage 'https://code.google.com/p/dukto/'
+  homepage 'http://www.msec.it/dukto/'
   license :oss
 
   app 'Dukto.app'


### PR DESCRIPTION
Updated download url & homepage for dukto as it is listed in issue #10461.
