### PR TITLE
Add GOG.com Galaxy Client v1.0.0.836

### DIFF
--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'gog-galaxy' do
+  version '1.0.0.836'
+  sha256 '878319173e0f157981fd3d5009e451653024bdb8e3b4f0ff5565c491ba815f4d'
+
+  url "http://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
+  name 'GOG Galaxy Client'
+  homepage 'http://www.gog.com/galaxy'
+  license :gratis
+  tags :vendor => 'GOG'
+
+  pkg "galaxy_client_#{version}.pkg"
+
+  uninstall :pkgutil => "com.gog.galaxy.galaxy_client_#{version}.pkg",
+            :delete => '/Applications/GalaxyClient.app'
+end


### PR DESCRIPTION
- As no public api for the Galaxy Client is available, the :latest key cannot be used.
- The :delete key had to be used because the .pkg file doesn't leave a receipt after installing the .app, so using the :pkgutil key leaves the .app behind when uninstalling.
- The app just made public beta, so no "stable" version is available.

This is my first contribution, so if I missed anything, let me know!
