### PR TITLE
Change app bundle link target to "FileBot (console).app" to avoid con…

### DIFF
--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -8,7 +8,7 @@ cask :v1 => 'filebot' do
   homepage 'http://www.filebot.net/'
   license :gpl
 
-  app 'FileBot.app'
+  app 'FileBot.app', :target => 'FileBot (console).app'
   binary 'FileBot.app/Contents/MacOS/filebot.sh', :target => 'filebot'
   caveats 'FileBot requires Java 8. Run "java -version" to verify.'
 end


### PR DESCRIPTION
…fusion with the FileBot App Store bundle

FileBot is available in the App Store as well so this packages shouldn't be called "FileBot.app" as well. The main reason for having a cask as well are the cmdline tools, so I suggest adding that in parenthesis to the Launchpad name.
