### PR TITLE
Updating 32-bit version for libreoffice cask to 4.3.7 because 4.3.6 i…

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,7 +1,7 @@
 cask :v1 => 'libreoffice' do
   if Hardware::CPU.is_32_bit? || MacOS.release < :mountain_lion
-    version '4.3.6'
-    sha256 '02b78ed4e58090af93782fa6986493c115e92eae9bbc878c26cbd12633735445'
+    version '4.3.7'
+    sha256 '2964a952ab633426df402de2f128cf788354ac622b7c30b25209d185d17617ec'
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else


### PR DESCRIPTION
…s no longer hosted
