### PR TITLE
Fix url in Screenhero.app Cask

### DIFF
--- a/Casks/screenhero.rb
+++ b/Casks/screenhero.rb
@@ -2,7 +2,7 @@ cask :v1 => 'screenhero' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.screenhero.com/update/screenhero/Screenhero.dmg'
+  url 'https://secure.screenhero.com/update/screenhero/Screenhero.dmg'
   appcast 'http://dl.screenhero.com/update/screenhero/sparkle.xml'
   name 'Screenhero'
   homepage 'http://screenhero.com'


### PR DESCRIPTION
I've updated the URL to match the latest https://screenhero.com/ . The previous URL installed a version that wouldn't allow me to login.
