### PR TITLE
Make symlink targets writeable, so we can write altnames

### DIFF
--- a/lib/hbc/artifact/symlinked.rb
+++ b/lib/hbc/artifact/symlinked.rb
@@ -27,6 +27,10 @@ class Hbc::Artifact::Symlinked < Hbc::Artifact::Base
     altnames.concat(', ') if altnames.length > 0
     altnames.concat(%Q{"#{target.basename}"})
     altnames = %Q{(#{altnames})}
+
+    # Some packges are shipped as u=rx (e.g. Bitcoin Core)
+    @command.run!('/bin/chmod', :args => ['u=rwx', source])
+
     @command.run!('/usr/bin/xattr',
                   :args => ['-w', attribute, altnames, target],
                   :print_stderr => false)


### PR DESCRIPTION
Fixes #9667.

I was also thinking if I should first read the existing set of permissions, change it, run `xattr` and then change it back as it was, so that _nobody knows we were here_ :smile_cat:

but since we're already changing the content of that app my writing the alt name, I don't think it's necessary.
