### PR TITLE
Update OmniFocus cask formatting

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -13,6 +13,12 @@ cask :v1 => 'omnifocus' do
     url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
   end
 
+  name 'OmniFocus'
+  homepage 'https://www.omnigroup.com/omnifocus/'
+  license :commercial
+
+  app 'OmniFocus.app'
+
   if MacOS.release <= :mountain_lion
     zap :delete => [
                     '~/Library/Application Support/OmniFocus/Plug-Ins',
@@ -27,10 +33,4 @@ cask :v1 => 'omnifocus' do
                     '~/Library/Caches/Metadata/com.omnigroup.OmniFocus2'
                    ]
   end
-
-  name 'OmniFocus'
-  homepage 'https://www.omnigroup.com/omnifocus/'
-  license :commercial
-
-  app 'OmniFocus.app'
 end


### PR DESCRIPTION
While submitting a homebrew versions cask for the OmniFocus beta,
I was made aware of the poor ordering of some of the stanzas. As
I had based that cask off this one, I thought it prudent to tidy
the stanzas in this cask where possible.

Note that I have left the url stanza in the wrong order so as not
to duplicate the conditional logic more than is necessary.

_Edit:_
While doing this PR I noticed that there was a "latest" download
link available for OmniFocus, so I updated to use it. Are latest
links preferred, or explicit versions?

_Further Edit:_
Changed back to favour explicit version number
