### PR TITLE
Update OmniOutliner to user version instead of latest

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'omnioutliner' do
-  version :latest
-  sha256 :no_check
+  version '4.2.2'
+  sha256 '22b30eb4964caaa7be8e6a279ded2eae78f6f2e8db40b812f0b17e27597c9e85'
 
-  url 'https://www.omnigroup.com/download/latest/omnioutliner'
+  url "http://downloads2.omnigroup.com/software/MacOSX/10.10/OmniOutliner-#{version}.dmg"
   name 'OmniOutliner'
   homepage 'http://www.omnigroup.com/omnioutliner/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'OmniOutliner.app'
 end


### PR DESCRIPTION
This commit updates the version to be 4.2.2 instead of the :latest
identifier, specifies a SHA and updates the license to commercial
