### PR TITLE
Add Helium floating browser window

### DIFF
--- a/Casks/helium-browser.rb
+++ b/Casks/helium-browser.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'helium-browser' do
+  version '1.6'
+  sha256 '5a019169d9002198212fcac12ff325501a1c0939ef056e374c01dba934899115'
+
+  url 'https://github.com/JadenGeller/Helium/releases/download/v1.6/Helium.app.zip'
+  name 'Helium'
+  homepage 'http://heliumfloats.com'
+  license :mit
+
+  app 'Helium.app'
+end


### PR DESCRIPTION
I chose to name this cask `helium-browser` to not clash with the existing `helium` cask and because a vendor prefix wouldn't make it easier to distinguish in my opinion. Feel free to suggest another name and/or decline my pull request.
