### PR TITLE
Update Quassel IRC to version 0.12.2

### DIFF
--- a/Casks/quassel-client.rb
+++ b/Casks/quassel-client.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'quassel-client' do
-  version '0.11.0'
-  sha256 '00e1a1b7a3fc0b5c1c382c488ab93d533a183896ca236d6170cc11e1fc28ac96'
+  version '0.12.2'
+  sha256 'fee7d5db4980a91b8a812b46f5420cf11b9185938679f7ca3191bf66327bdd2d'
 
   url "http://quassel-irc.org/pub/QuasselClient_MacOSX-x86_64_#{version}.dmg"
   name 'Quassel IRC'

--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'quassel' do
-  version '0.11.0'
-  sha256 'ba5ec89795afb3f4e8067798f9c9069d0cf31b0ccaa629dbcda28410267fefb1'
+  version '0.12.2'
+  sha256 '4dd932e5e7a0908886427fc012886a76bbf1691cdd8832a67cdbc11a10be3682'
 
   url "http://quassel-irc.org/pub/QuasselMono_MacOSX-x86_64_#{version}.dmg"
   name 'Quassel IRC'


### PR DESCRIPTION
This PR updates `quassel` and `quassel-client` to version 0.12.2.

http://quassel-irc.org/node/127
