### PR TITLE
Fix Duet recipe: Do not delete apple provided file when uninstalling

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -10,6 +10,5 @@ cask :v1 => 'duet' do
 
   app 'duet.app'
 
-  uninstall :kext => 'com.karios.driver.DuetDisplay',
-            :delete => '/usr/libexec/coreduetd'
+  uninstall :kext => 'com.karios.driver.DuetDisplay'
 end


### PR DESCRIPTION
Duet recipe deletes "/usr/libexec/coreduet" when `brew cask uninstall duet`.

But this file is OS X default file that Apple provides.

Deleting this file cause Spotlight and Safari freeze.

Please review and merge.
