### PR TITLE
Add iOS Console (0.9.8) to Cask

### DIFF
--- a/Casks/ios-console.rb
+++ b/Casks/ios-console.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'ios-console' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://downloads.lemonjar.com/iosconsole_latest.zip'
+  name 'iOS Console'
+  homepage 'http://lemonjar.com/iosconsole/'
+  license :gratis
+
+  app 'iOS Console.app'
+end


### PR DESCRIPTION
I've added this as a :latest version as I can't find a versioned link.
I've also selected the :gratis license as it's free to use, but closed
source.
