### PR TITLE
Update Spring tool suite to latest version

### DIFF
--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'bitcoin-core' do
-  version '0.10.1'
-  sha256 '6d6c6faa23b567fe79dc5d2360f52764b48ea8adbcb183d012846856b98e0403'
+  version '0.10.2'
+  sha256 '59f569c5fa3cf313c39b0950182f5e7cde77c904015af7646f2901bba390efc4'
 
   url "https://bitcoin.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-osx.dmg"
   name 'Bitcoin'

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -1,14 +1,13 @@
 cask :v1 => 'sts' do
-  version '3.5.1'
-  sha256 'f71274c9f946d2af6bbd12e811d7c8d371d3031415839b9aa6ed35347d2980f8'
+  version '3.6.4'
+  sha256 '9627e702f83efa19d25f6041bd86a58395ba1cc769c6e76b3f628d6c23900633'
 
   module Utils
     def self.based_on_eclipse
-      '4.3.2'   # find eclipse version at http://spring.io/tools/sts/all
+      '4.4.2'   # find eclipse version at http://spring.io/tools/sts/all
     end
   end
-
-  url "http://download.springsource.com/release/STS/#{version}/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64-installer.dmg"
+  url "http://dist.springsource.com/release/STS/#{version}.RELEASE/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64.tar.gz"
   name 'Spring Tool Suite'
   homepage 'http://spring.io/tools/sts'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
This is rushed, but I noticed the cask version available wouldn't work with tomcat 8, so just to make everything work on a fresh system, I updated this cask. I noticed some weirdness in that the STS URL has only the eclipse e4.4 in one place, but 4.4.2 in another, but it looks like it's always been that way and the cask takes care of that.
