### PR TITLE
epubquicklook.rb: changed to a different qlplugin that works

### DIFF
--- a/Casks/epubquicklook.rb
+++ b/Casks/epubquicklook.rb
@@ -1,13 +1,12 @@
 cask :v1 => 'epubquicklook' do
-  version :latest
-  sha256 :no_check
+  version '1.7'
+  sha256 '2508a882ad53fa2fc1b9e42e9548c8ef9fe62f1c57788a874e6c098a1704b96e'
 
-  url 'http://people.ict.usc.edu/~leuski/programming/EPUBQuickLookPlugin.dmg'
-  name 'EPUB QuickLook plugin'
-  homepage 'http://people.ict.usc.edu/~leuski/programming/epub-quickview.php'
+  url "https://github.com/jaketmp/ePub-quicklook/releases/download/v#{version}/epub.qlgenerator.zip"
+  appcast 'https://github.com/jaketmp/ePub-quicklook/releases.atom'
+  name 'EPUB QuickLook'
+  homepage 'https://github.com/jaketmp/ePub-quicklook'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  pkg 'EpubQuickLook.pkg'
-
-  uninstall :pkgutil => 'net.leuski.epubQuicklookPlugin.epub.pkg'
+  qlplugin 'epub.qlgenerator'
 end


### PR DESCRIPTION
The previous’ website was last touched in 2011, and never worked anyway.
