### PR TITLE
Update STS to 3.6.4 and remove unneeded manual step before linking

### DIFF
--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -1,17 +1,17 @@
 cask :v1 => 'sts' do
-  version '3.5.1'
-  sha256 'f71274c9f946d2af6bbd12e811d7c8d371d3031415839b9aa6ed35347d2980f8'
+  version '3.6.4'
+  sha256 '9627e702f83efa19d25f6041bd86a58395ba1cc769c6e76b3f628d6c23900633'
 
   module Utils
     def self.based_on_eclipse
-      '4.3.2'   # find eclipse version at http://spring.io/tools/sts/all
+      '4.4.2'   # find eclipse version at http://spring.io/tools/sts/all
     end
   end
 
-  url "http://download.springsource.com/release/STS/#{version}/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64-installer.dmg"
+  url "http://dist.springsource.com/release/STS/#{version}.RELEASE/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64.tar.gz"
   name 'Spring Tool Suite'
   homepage 'http://spring.io/tools/sts'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :eclipse
 
-  installer :manual => "Installer - Spring Tool Suite #{version}.RELEASE.app"
+  app "sts-bundle/sts-#{version}.RELEASE/STS.app"
 end


### PR DESCRIPTION
I did not add a binary stanza for the included Pivotal tc server developer edition, because there had not been one previously, and I don't use it. I am not a ruby programmer, but I ran this through rbeautify and compared it to some other casks and this seems plausible. Thanks for your patience.
