### PR TITLE
Update biicode to 3.2

### DIFF
--- a/Casks/biicode.rb
+++ b/Casks/biicode.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'biicode' do
-  version '3.1.1'
-  sha256 '235ba2b95f23c2c1ba3b21237b7500a0234ea807e564e9c26e91132c5670b023'
+  version '3.2'
+  sha256 'b6053999d893f27474fa0e8aa2a57052c0262073566fa75589bdaff9ef961d49'
 
   # amazonaws is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/biibinaries/release/#{version}/bii-macos-64_#{version.gsub('.', '_')}.pkg"


### PR DESCRIPTION
This commit updates the version stanza to 3.2 and the SHA.

This was requested in issue https://github.com/caskroom/homebrew-cask/issues/11296
