### PR TITLE
Update Tower to use specific version, not :latest

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'tower' do
-  version :latest
-  sha256 :no_check
+  version '2.2.1-277'
+  sha256 'e8fd917eb00674b1a0db1a95165e12a782d2286ea631b7b19337b0ca54aff22a'
 
-  url 'https://www.git-tower.com/download'
+  # amazonaws.com is the official download host per the vendor homepage
+  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/277-0be85680/Tower-2-#{version}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/stable'
   name 'Tower'
   homepage 'http://www.git-tower.com/'


### PR DESCRIPTION
This commit changes Tower to stop using the `:latest` identifier and
use a specific version instead. It also includes a SHA.
