### PR TITLE
Add application GitUp to Cask

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'gitup' do
+  version :latest
+  sha256 :no_check
+
+  # amazonaws.com is the official download host per the vendor homepage
+  url 'https://s3-us-west-2.amazonaws.com/gitup-builds/stable/GitUp.zip'
+  name 'GitUp'
+  homepage 'http://gitup.co'
+  license :gratis
+
+  app 'GitUp.app'
+end


### PR DESCRIPTION
This commit adds the application GitUp for the first time. I have been
unable to find a versioned download link. It's pre-release software so
I've added to cask instead of versions. There is no full release yet,
so I figured it was okay here for now.
