### PR TITLE
Update license stanzas for a number of apps

### DIFF
--- a/Casks/0xdbe-eap.rb
+++ b/Casks/0xdbe-eap.rb
@@ -6,7 +6,7 @@ cask :v1 => '0xdbe-eap' do
   name '0xDBE EAP'
   name '0xDBE'
   homepage 'http://www.jetbrains.com/dbe/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app '0xDBE EAP.app'
 

--- a/Casks/affinic-debugger-gui.rb
+++ b/Casks/affinic-debugger-gui.rb
@@ -6,7 +6,7 @@ cask :v1 => 'affinic-debugger-gui' do
   name 'Affinic Debugger GUI'
   name 'ADG'
   homepage 'http://www.affinic.com/?page_id=435'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :freemium
 
   app 'Affinic Debugger GUI.app'
 end

--- a/Casks/air-connect.rb
+++ b/Casks/air-connect.rb
@@ -7,7 +7,7 @@ cask :v1 => 'air-connect' do
   appcast 'http://avatron.com/updates/software/airconnect_mac/appcast.xml',
           :sha256 => 'af9bc6dc41bc632995c4e49b958a5623bc091ac0fe1fb337fbc9a571cfc1e85b'
   homepage 'http://www.avatron.com/get-air-connect/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Air Connect.app'
 end

--- a/Casks/airdisplay.rb
+++ b/Casks/airdisplay.rb
@@ -7,7 +7,7 @@ cask :v1 => 'airdisplay' do
   appcast 'https://www.avatron.com/updates/software/airdisplay/appcast.xml',
           :sha256 => '5318742e7d9f7f4da9498e3100d8b5f92abc18a574988f1d5fa5a551ad0af062'
   homepage 'http://avatron.com/apps/air-display/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   pkg 'Air Display Installer.pkg'
 

--- a/Casks/airflick.rb
+++ b/Casks/airflick.rb
@@ -5,7 +5,7 @@ cask :v1 => 'airflick' do
   url "http://ericasadun.com/ftp/AirPlay/AirFlick-#{version}.zip"
   name 'AirFlick'
   homepage 'http://ericasadun.com/ftp/AirPlay/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'AirFlick.app'
 end

--- a/Casks/airmail-amt.rb
+++ b/Casks/airmail-amt.rb
@@ -6,7 +6,7 @@ cask :v1 => 'airmail-amt' do
   url 'https://rink.hockeyapp.net/api/2/apps/af58f04487c30ac4c1e8706aa9e41c5b?format=zip'
   name 'Airmail - Account Migration Toolkit'
   homepage 'http://airmailapp.com/amt/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Airmail AMT.app'
 end

--- a/Casks/airparrot.rb
+++ b/Casks/airparrot.rb
@@ -6,7 +6,7 @@ cask :v1 => 'airparrot' do
   name 'AirParrot'
   appcast 'https://updates.airsquirrels.com/AirParrot2/Mac/AirParrot2.xml'
   homepage 'http://www.airsquirrels.com/airparrot/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'AirParrot 2.app'
 end

--- a/Casks/airstream.rb
+++ b/Casks/airstream.rb
@@ -5,7 +5,7 @@ cask :v1 => 'airstream' do
   url 'http://airstream.io/download/mac/airstream-mac.dmg'
   name 'AirStream'
   homepage 'http://airstream.io/download/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
   app 'AirStream.app'
 
   caveats <<-EOS.undent

--- a/Casks/alarm-clock.rb
+++ b/Casks/alarm-clock.rb
@@ -5,7 +5,7 @@ cask :v1 => 'alarm-clock' do
   url "http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/downloads/Alarm%20Clock%20(#{version}).dmg"
   name 'Alarm Clock'
   homepage 'http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Alarm Clock.app'
 end

--- a/Casks/alib1.rb
+++ b/Casks/alib1.rb
@@ -6,7 +6,7 @@ cask :v1 => 'alib1' do
   url 'http://presstube.com/screensavers/Presstube-ALib1-mac.zip'
   name 'ALib1'
   homepage 'http://presstube.com/blog/2011/alib1/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   screen_saver 'Presstube-ALib1.app/Contents/Resources/Presstube - ALib1.saver'
 

--- a/Casks/alinof-timer.rb
+++ b/Casks/alinof-timer.rb
@@ -5,7 +5,7 @@ cask :v1 => 'alinof-timer' do
   url 'http://www.alinofsoftware.ch/resources/AlinofTimer.pkg'
   name 'Alinof Timer'
   homepage 'http://www.alinofsoftware.ch/en/products/products-timer/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   pkg 'AlinofTimer.pkg', :allow_untrusted => true
 

--- a/Casks/all2mp3.rb
+++ b/Casks/all2mp3.rb
@@ -6,7 +6,7 @@ cask :v1 => 'all2mp3' do
   name 'All2MP3'
   appcast 'http://www.tresrrr.com/All2MP3/Appcast.xml'
   homepage 'http://www.tresrrr.com/All2MP3/ENGLISH.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'All2MP3.app'
 end

--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -6,7 +6,7 @@ cask :v1 => 'amadeus-pro' do
   url 'https://s3.amazonaws.com/AmadeusPro2/AmadeusPro.dmg'
   name 'Amadeus Pro'
   homepage 'http://www.hairersoft.com/pro.html'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Amadeus Pro.app'
 end


### PR DESCRIPTION
I had noticed quite a number of casks that still have `license :unknown`
along with the generated placeholder message. I thought I would take
some spare time to update a few of the casks where I could find
relevant information. I've stuck with the guidance on the license
stanzas section of the Cask Language Reference. Where there was doubt,
I simply didn't update.

I'm happy to continue updating these from time to time, if you're
happy to receive them.
