### PR TITLE
Updating URLs to current versions found on pqrs.org. 

### DIFF
--- a/Casks/seil.rb
+++ b/Casks/seil.rb
@@ -2,9 +2,9 @@ cask :v1 => 'seil' do
   version '11.1.0'
   sha256 'eb87ad8b903ba14de69ce7e64913a85d53cc59ee8af5fa916211c3a00d29bf7d'
 
-  url "https://pqrs.org/macosx/keyremap4macbook/files/Seil-#{version}.dmg"
+  url "https://pqrs.org/osx/karabiner/files/Seil-#{version}.dmg"
   name 'Seil'
-  homepage 'https://pqrs.org/macosx/keyremap4macbook/seil.html.en'
+  homepage 'https://pqrs.org/osx/karabiner/seil.html'
   license :public_domain
 
   pkg 'Seil.pkg'


### PR DESCRIPTION
This is the URL found on the project home page, it reflects rebranding from KeyRamp4MacBook to Karabiner, and is more likely to be supported/available in the future.
