### PR TITLE
Link binaries from google-cloud-sdk

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,17 +1,20 @@
 cask :v1 => 'google-cloud-sdk' do
   version :latest
   sha256 :no_check
-
   url 'https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz'
   name 'Google Cloud SDK'
   homepage 'https://cloud.google.com/sdk/'
   license :apache
   tags :vendor => 'Google'
-
+  binary 'google-cloud-sdk/bin/bq'
+  binary 'google-cloud-sdk/bin/gcloud'
+  binary 'google-cloud-sdk/bin/gcutil'
+  binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', :target => 'git-credential-gcloud'
+  binary 'google-cloud-sdk/bin/gsutil'
+  binary 'google-cloud-sdk/bin/kubectl'
   installer :script => 'google-cloud-sdk/install.sh',
             :args => %w{--usage-reporting false --bash-completion false --path-update false --rc-path false},
             :sudo => false
-
   caveats do
     "#{token} is installed at #{staged_path}/#{token}. Add your profile:
 
@@ -28,6 +31,5 @@ cask :v1 => 'google-cloud-sdk' do
         set -x MANPATH #{staged_path}/#{token}/help/man /usr/local/share/man /usr/share/man /opt/x11/share/man
 
         Run fish_update_completions to generate completions for fish based on the man pages"
-
   end
 end


### PR DESCRIPTION
This links binaries listed in google-cloud-sdk/bin to /usr/local/bin
