### PR TITLE
Add WhatsMac.app version 1.0

### DIFF
--- a/Casks/whatsmac.rb
+++ b/Casks/whatsmac.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'whatsmac' do
+  version '1.0.0'
+  sha256 '5a0cd10ddaa3a4efa13fca4f703e1290c22849ccc72e84304a705c218c175186'
+
+  url "https://github.com/stonesam92/WhatsMac/releases/download/v#{version}/WhatsMac.#{version.to_f}.zip"
+  appcast 'https://github.com/stonesam92/WhatsMac/releases.atom'
+  name 'WhatsMac'
+  homepage 'https://github.com/stonesam92/WhatsMac'
+  license :oss
+
+  app 'WhatsMac.app'
+end


### PR DESCRIPTION
A Mac app wrapper around WhatsApp's web client, WhatsApp Web. https://github.com/stonesam92/WhatsMac

Currently added version[0.. -3] to remove the last `.0` from the version number. 
@vitorgalvao maybe there is a better way to handle this?
