### PR TITLE
Add PDFKey Pro.app v4.3

### DIFF
--- a/Casks/pdfkey-pro.rb
+++ b/Casks/pdfkey-pro.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'pdfkey-pro' do
+  version :latest
+  sha256 :no_check
+
+  # amazonaws.com is the official download host per the vendor homepage
+  url 'http://pdfkeypro.s3.amazonaws.com/PDFKeyPro.dmg'
+  name 'PDFKey Pro'
+  homepage 'http://pdfkey.com'
+  license :freemium
+
+  app 'PDFKey Pro.app'
+end


### PR DESCRIPTION
This adds PDFKey Pro v4.3 from pdfkey.com. It points to a single download location on Amazon S3. The Cask guide wasn't clear if I should set it to its named version from the site '4.3' or leave it as :latest. I opted for the more explicit versioning.
