### PR TITLE
Fix Chainsaw formula

### DIFF
--- a/Casks/chainsaw.rb
+++ b/Casks/chainsaw.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'chainsaw' do
-  version '2.1.0'
-  sha256 '3449c1d0fca70f78b656a151dabaf5c8149e1dbec2854b7a662b7f242ce299d2'
+  version :latest
+  sha256 :no_check
 
-  url "http://people.apache.org/~sdeboy/apache-chainsaw-#{version}-SNAPSHOT.dmg"
+  url "https://logging.apache.org/chainsaw/webstart/chainsaw.dmg"
   name 'Chainsaw'
   homepage 'http://logging.apache.org/chainsaw/'
   license :apache
@@ -11,5 +11,5 @@ cask :v1 => 'chainsaw' do
 
   zap :delete => '~/.chainsaw'
   
-  depends_on => :ppc
+  depends_on :arch => :ppc
 end


### PR DESCRIPTION
The old url points to a corrupted file. I confirmed this by manually
downloaded the DMG. When trying to open the application you'll get the
error dialog:

```
"Chainsaw.app" is damaged and can't be opened."
```

The new url is from the official download link.

This also fixes the syntax for the PPC dependancy.
