### PR TITLE
Add Breeze latest

### DIFF
--- a/Casks/breeze.rb
+++ b/Casks/breeze.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'breeze' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://autumnapps.com/downloads/Breeze.dmg'
+  name 'Breeze'
+  homepage 'https://autumnapps.com/breeze/'
+  license :freemium
+
+  app 'Breeze.app'
+
+  uninstall :quit => 'com.autumnapps.direct.Breeze'
+
+  zap :delete => [
+                  '~/Library/Caches/com.autumnapps.direct.Breeze',
+                  '~/Library/Preferences/com.autumnapps.direct.Breeze.plist',
+                 ]
+end


### PR DESCRIPTION
Create a cask for the Breeze application and use the latest version.

This application is free to use although it shows a pop-up that makes you wait a few seconds each time it is started. You can remove this pop-up by purchasing the application. I wasn't sure if the license should be :freemium or :gratis.
