### PR TITLE
Update TextExpander to version 5.0

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -2,11 +2,14 @@ cask :v1 => 'textexpander' do
   if MacOS.release == :snow_leopard
     version '3.4.2'
     sha256 '87859d7efcbfe479e7b78686d4d3f9be9983b2c7d68a6122acea10d4efbb1bfa'
-  elsif MacOS.release >= :lion
+  elsif MacOS.release >= :lion && MacOS.release <= :mavericks
     version '4.3.6'
     sha256 'ec90d6bd2e76bd14c0ca706d255c9673288f406b772e5ae6022e2dbe27848ee9'
+  elsif MacOS.release >= :yosemite
+    version '5.0'
+    sha256 'd0c4149fec181cd61579ac0dba0ad8e34153b09da4ee818068bd9f35d668b858'
     appcast 'http://updates.smilesoftware.com/com.smileonmymac.textexpander.xml',
-            :sha256 => 'bad991e25d6cb73352b462a1b503bd64c616bd751057f677944af5f96c1353cf'
+            :sha256 => '08fa50296cf69255e5e27cf80b0c3a37a49873d57f37432b533ae1a207aabd4c'
   end
 
   url "http://cdn.smilesoftware.com/TextExpander_#{version}.zip"


### PR DESCRIPTION
This commit updates the logic for determining which version of
TextExpander to install. Version 5.0 is only supported on Yosemite
and upwards, so I've modified the existing 4.3.6 case to be for
Lion to Mavericks only, and added a new case for Yosemite upwards.

I ran `shasum -a 256` on the file at the `appcast` URL - it is different
from that listed for 4.3.6 so I've updated, but I'm not 100% sure I'm
doing the right thing there.
