### PR TITLE
Update Transporter Desktop to version 3.1.28

### DIFF
--- a/Casks/transporter-desktop.rb
+++ b/Casks/transporter-desktop.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'transporter-desktop' do
-  version '3.1.21_18654'
-  sha256 '43ac53ed8c35bde7296b183f8aa3f0f12b91a986c80e8c7e0f6acdcbc5d32dee'
+  version '3.1.28_18973'
+  sha256 '48dfd52e287073e277711160dc3f4eab16d521994717aecb36539fdb6ff8befe'
 
   # connecteddata.com is the official download host per the vendor homepage
   url "https://secure.connecteddata.com/mac/2.5/software/Transporter_Desktop_#{version}.dmg"


### PR DESCRIPTION
This commit updates the version and sha256 stanzas
