### PR TITLE
Update tether to 1.5.14

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'numi' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://dl.devmate.com/com.dmitrynikolaev.numi/beta/Numi.zip'
+  name 'Numi'
+  homepage 'http://numi.io'
+  license :unknown
+
+  app 'Numi.app'
+end

--- a/Casks/tether.rb
+++ b/Casks/tether.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'tether' do
-  version '1.3.0'
+  version '1.5.14'
   sha256 '33346da2daaa12678540a1b99a24da77ea008022b04137ecf2f4166998606c6f'
 
   url "http://hellotether.com/downloads/Tether_v#{version}.zip"


### PR DESCRIPTION
1.3.0 is no longer listed on their servers and returns a 404 from `brew
cask install tether`:

```
curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'tether' with message: Download failed:
http://hellotether.com/downloads/Tether_v1.3.0.zip
```
