### PR TITLE
Patch sourcetree URLs to use SSL

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -9,10 +9,10 @@ cask :v1 => 'sourcetree' do
 
   # atlassian.com is the official download host per the vendor homepage
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.dmg"
-  appcast 'http://www.sourcetreeapp.com/update/SparkleAppcast.xml',
+  appcast 'https://www.sourcetreeapp.com/update/SparkleAppcast.xml',
           :sha256 => 'b43e0ea95de46d2c270cdbf9765e03ec3f13606cbf0bab5bcd3da0424ce2cff3'
   name 'SourceTree'
-  homepage 'http://www.sourcetreeapp.com/'
+  homepage 'https://www.sourcetreeapp.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
   tags :vendor => 'Atlassian'
 


### PR DESCRIPTION
The URLs for `homepage` and `appcast` support SSL which should be prefered.
