### PR TITLE
Fix the-unarchiver homepage to link the product page and not the home…

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -5,7 +5,7 @@ cask :v1 => 'the-unarchiver' do
   # googlecode.com is the official download host per the vendor homepage
   url "https://theunarchiver.googlecode.com/files/TheUnarchiver#{version}_legacy.zip"
   name 'The Unarchiver'
-  homepage 'http://unarchiver.c3.cx/'
+  homepage 'http://unarchiver.c3.cx/unarchiver'
   license :oss
 
   app 'The Unarchiver.app'


### PR DESCRIPTION
Homepage of the `the-unarchiver` cask is now on a subpage.
