### PR TITLE
Fix android-file-transfer homepage to use SSL

### DIFF
--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -5,7 +5,7 @@ cask :v1 => 'android-file-transfer' do
   # google.com is the official download host per the vendor homepage
   url 'https://dl.google.com/dl/androidjumper/mtp/current/androidfiletransfer.dmg'
   name 'Android File Transfer'
-  homepage 'http://www.android.com/filetransfer/'
+  homepage 'https://www.android.com/filetransfer/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Android File Transfer.app'


### PR DESCRIPTION
Saves the roundtrip for the redirect from the web server and moreover SSL should be the preferred default.
