### PR TITLE
Fix cyberduck homepage to use SSL

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -6,7 +6,7 @@ cask :v1 => 'cyberduck' do
   appcast 'https://version.cyberduck.io/changelog.rss',
           :sha256 => '8d3c4f2c2b0ec3f83a3230b38b1dfaabb25a05b5a91c4d316a6c4ef0c0fe4de8'
   name 'Cyberduck'
-  homepage 'http://cyberduck.io/'
+  homepage 'https://cyberduck.io/'
   license :gpl
 
   app 'Cyberduck.app'


### PR DESCRIPTION
Saves the roundtrip for the redirect from the web server and moreover SSL should be the preferred default.
