### PR TITLE
Fixes rubocop whitespace error introduced by #11179

### DIFF
--- a/Casks/remote-desktop-connection.rb
+++ b/Casks/remote-desktop-connection.rb
@@ -11,10 +11,10 @@ cask :v1 => 'remote-desktop-connection' do
   pkg 'RDC Installer.mpkg'
 
   uninstall :pkgutil => 'com.microsoft.rdc.all.*'
-  
+
   caveats do
     discontinued
   end
-  
+
   depends_on :macos => '<= :snow_leopard'
 end


### PR DESCRIPTION
Fixes rubocop whitespace error introduced by #11179

```
$ /System/Library/Frameworks/Ruby.framework/Versions/"${CASK_RUBY_TEST_VERSION}"/usr/bin/bundle exec "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/rake" rubocop
Running RuboCop...
Inspecting 2546 files
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................C.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Offenses:
Casks/remote-desktop-connection.rb:14:1: C: Trailing whitespace detected.
Casks/remote-desktop-connection.rb:18:1: C: Trailing whitespace detected.
2546 files inspected, 2 offenses detected
RuboCop failed!
The command "/System/Library/Frameworks/Ruby.framework/Versions/"${CASK_RUBY_TEST_VERSION}"/usr/bin/bundle exec "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/rake" rubocop" exited with 1.
Done. Your build exited with 1.
```
