### PR TITLE
Update Xerox Print Driver to v3.56.0_1528

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -1,7 +1,7 @@
 cask :v1 => 'xerox-print-driver' do
   name 'Xerox Print Driver'
   homepage 'http://www.support.xerox.com/support/colorqube-8900/downloads'
-  license :closed
+  license :gratis
   tags :vendor => 'Xerox'
 
   if MacOS.release <= :leopard
@@ -12,10 +12,14 @@ cask :v1 => 'xerox-print-driver' do
     version '2.112.0'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx/pt_BR/XeroxPrintDriver.#{version}.dmg"
     sha256 '3517cb64f283f12c60030710073812131361ddae358950bc35afe72b163a9bf7'
-  else
+  elsif MacOS.release <= :lion
     version '3.52.0_1481'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx107/pt_BR/XeroxPrintDriver.#{version}.dmg"
     sha256 'ed958701b6adca202f0b7936cfea0fac64c2161e228f35e00f341e29df36c18f'
+  else
+    version '3.56.0_1528'
+    url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1010/ar/XeroxPrintDriver.#{version}.dmg"
+    sha256 'c5ad100646c8e06b0912f0c8899fde4b1f2c3aaa038a95cf374a312a47adba7c'
   end
 
   pkg "Xerox Print Driver #{version.sub(/_.*/,'')}.pkg"


### PR DESCRIPTION
Leaving Lion at v3.52.0_1481 per vendor download page
