### PR TITLE
Fix virtualbox homepage to use SSL

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -4,7 +4,7 @@ cask :v1 => 'virtualbox' do
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(/-.*$/, '')}/VirtualBox-#{version}-OSX.dmg"
   name 'VirtualBox'
-  homepage 'http://www.virtualbox.org'
+  homepage 'https://www.virtualbox.org'
   license :gpl
   tags :vendor => 'Oracle'
 


### PR DESCRIPTION
The virtualbox homepage redirects to SSL which should be the preferred default.
