### PR TITLE
Fix fantastical homepage to use SSL

### DIFF
--- a/Casks/fantastical.rb
+++ b/Casks/fantastical.rb
@@ -6,7 +6,7 @@ cask :v1 => 'fantastical' do
   appcast 'https://flexibits.com/fantastical/appcast2.php',
           :sha256 => '25b925b46633c66b6d10dda0f213614da63da9c80a231dc39c8ffb86e8b883e4'
   name 'Fantastical'
-  homepage 'http://flexibits.com/fantastical'
+  homepage 'https://flexibits.com/fantastical'
   license :freemium
 
   app 'Fantastical 2.app'


### PR DESCRIPTION
The fantastical homepage has SSL which should be the preferred default.
