### PR TITLE
Change hosting service name

### DIFF
--- a/Casks/nndd.rb
+++ b/Casks/nndd.rb
@@ -2,9 +2,9 @@ cask :v1 => 'nndd' do
   version '2.4.3'
   sha256 '6a73dcad2e73d877ad1503ed1162cae1a1c84f21d1abaa6aaf9b31bb2fbca531'
 
-  url 'http://dl.sourceforge.jp/nndd/62201/NNDD_v2_4_3.dmg'
+  url 'http://dl.osdn.jp/nndd/62201/NNDD_v2_4_3.dmg'
   name 'NNDD'
-  homepage 'http://sourceforge.jp/projects/nndd/'
+  homepage 'http://osdn.jp/projects/nndd/'
   license :x11
 
   preflight do


### PR DESCRIPTION
SourceForge.jp was renamed to OSDN.
