### PR TITLE
Upgrade iTerm2 to v2.1.1

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'iterm2' do
   # note: "2" is not a version number, but indicates a different vendor
-  version '2.0'
-  sha256 '6a59e1b96d9037b6ff1b8aaaf7aed5cff572d74d6e58390db16028433769c058'
+  version '2.1.1'
+  sha256 'b8f1bbd11cdb3e26fd9fab6971c28ebeb422361b2cc5fd6e4a843836d5dedeb0'
 
-  url "https://www.iterm2.com/downloads/stable/iTerm2_v#{version.sub('.','_')}.zip"
+  url "https://iterm2.com/downloads/stable/iTerm2-#{version.gsub('.','_')}.zip"
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
   appcast 'https://iterm2.com/appcasts/final.xml',
-          :sha256 => 'd8e8c6f4990676b33c81d7b577b96ef5eed9f8f872c104d02f25e0290b0a8ee5'
+          :sha256 => 'c9d0c5800f6851fc55c07d95109f4cb8ef8dfc12a2c1713c1a4dcc5505fba100'
   license :gpl
 
   app 'iTerm.app'


### PR DESCRIPTION
Upgrades iTerm2 to the latest release.
