### PR TITLE
Update TeX Live Utility to v1.21

### DIFF
--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'tex-live-utility' do
-  version '1.19'
-  sha256 'ef6beecc42d6b194f18795b46951bf274a5c838d8192f56e4437225af56e2820'
+  version '1.21'
+  sha256 '51fb396fa1bcb73af575c653415d16f422d842a6f8029f75c85ce1a6e0f92cf0'
 
-  url 'https://github.com/amaxwell/tlutility/releases/download/1.19/TeX.Live.Utility.app-1.19.tar.gz'
+  url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
   appcast 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml',
           :sha256 => '9ca9e537751be33f6757984dd7d1d28a84d680bddb53c37fc7942adcd72b0eca'
   name 'TeX Live Utility'


### PR DESCRIPTION
And use string interpolation to dynamically add version info to download URL. Not sure if sha256 for appcast should also be updated...
