### PR TITLE
Fix url and homepage in VOX Cask

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -3,11 +3,11 @@ cask :v1 => 'vox' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
+  url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   name 'VOX'
   appcast 'http://updates.devmate.com/com.coppertino.Vox.xml',
           :sha256 => '20c1ab602462b7fc0d5b4cbd555cacf127b69a07a737579598ebcbc0f5b21319'
-  homepage 'http://coppertino.com/vox/osx/'
+  homepage 'https://coppertino.com/vox/mac'
   license :freemium
 
   app 'VOX.app'


### PR DESCRIPTION
- url supports SSL which should be used.
- homepage had changed and was a 404 error.
- homepage supports SSL which should be used.
