### PR TITLE
Upgrade and improve LiveReload.app Cask

### DIFF
--- a/Casks/livereload.rb
+++ b/Casks/livereload.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'livereload' do
-  version '2.3.66'
-  sha256 '666b9adfa1cf4c3238e76772e78929f19a6430764e5ff2bd161072dbb5d09df8'
+  version '2.3.74'
+  sha256 '7a192cda9c15efdeea00ca53153be0c649e3d413719f8291e4f1684c0132506b'
 
   url "http://download.livereload.com/LiveReload-#{version}.zip"
   appcast 'https://s3.amazonaws.com/download.livereload.com/LiveReload-Mac-appcast.xml',
           :sha256 => 'e68aa7af8891831b795c6c57a7056ad6244fad5bd31d9487d4d4bb58afe385f0'
   name 'LiveReload'
-  homepage 'http://www.livereload.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'http://livereload.com'
+  license :oss
 
   app 'LiveReload.app'
 end


### PR DESCRIPTION
- Upgrade to version 2.3.74
- Fix homepage which had changed and was a 404 error
- Add license from https://github.com/livereload/LiveReload#license
