### PR TITLE
Updated version and hash for tether

### DIFF
--- a/Casks/tether.rb
+++ b/Casks/tether.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'tether' do
-  version '1.3.0'
-  sha256 '33346da2daaa12678540a1b99a24da77ea008022b04137ecf2f4166998606c6f'
+  version '1.5.14'
+  sha256 '3c6b8a822b25fcc600ef05bf5b6025cec58efbf3dc37790a2eebf0320a68384e'
 
   url "http://hellotether.com/downloads/Tether_v#{version}.zip"
   name 'Tether'


### PR DESCRIPTION
The older version url gave a 404 because it's no longer on Tether's servers.
