### PR TITLE
VerizonInHomeAgent (new cask)

### DIFF
--- a/Casks/verizoninhomeagent.rb
+++ b/Casks/verizoninhomeagent.rb
@@ -1,0 +1,34 @@
+cask :v1 => 'verizoninhomeagent' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://care.verizon.net/isupport_motive/iHAPkgsMac/VerizonInHomeAgentInstaller.dmg'
+  name 'VerizonInHomeAgent'
+  homepage 'https://care.verizon.net/iha/IHAPC.aspx'
+  license :gratis
+
+  installer :manual => 'VerizonInHomeAgentInstaller.app'
+
+  uninstall :quit   => [
+                        'VDSI.VerizonUpdateCenter',
+                        'com.Verizon.IHA',
+                        'com.Verizon.VZIHAMacInstaller',
+                        'com.Verizon.Verizon-IHAUpdater'
+                       ],
+            :delete => [
+                        '/Applications/Verizon-IHAUpdater.app',
+                        '/Applications/VerizonInHomeAgent.app',
+                        '/Applications/VerizonUpdateCenter.app',
+                        '~/Desktop/VerizonInHomeAgent.app'
+                       ]
+
+  zap       :delete => [
+                        '~/Library/Caches/VDSI.VerizonUpdateCenter',
+                        '~/Library/Caches/com.Verizon.IHA',
+                        '~/Library/Caches/com.Verizon.VZIHAMacInstaller',
+                        '~/Library/Caches/com.Verizon.Verizon-IHAUpdater',
+                        '~/Library/Preferences/com.Verizon.IHA.plist',
+                        '~/Library/Saved Application State/com.Verizon.IHA.savedState',
+                        '~/Library/Saved Application State/com.Verizon.VZIHAMacInstaller.savedState'
+                       ]
+end


### PR DESCRIPTION
This cask uses a manual installer, and unfortunately does not come with an uninstall script. Quitting and removing the installed apps appears to be sufficient, though.

Getting a warning about trying to delete a relative path in the `uninstall` stanza. Why is this not permitted? Works fine in the `zap` stanza.

``` bash
$ brew cask uninstall verizoninhomeagent
==> Running uninstall process for verizoninhomeagent; your password may be necessary
==> Quitting application ID com.Verizon.Verizon-IHAUpdater
==> Quitting application ID com.Verizon.IHA
==> Quitting application ID VDSI.VerizonUpdateCenter
==> Removing files: ["/Applications/Verizon-IHAUpdater.app", "/Applications/VerizonInHomeAgent.app", "/Applications/VerizonUpdateCenter.app", "~/Desktop/VerizonInHomeAgent.app"]
Warning: Skipping delete for relative path ~/Desktop/VerizonInHomeAgent.app
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caskroom/homebrew-cask/11530)

<!-- Reviewable:end -->
