### PR TITLE
Fix homepage to use SSL in OmniPlan Cask

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -4,7 +4,7 @@ cask :v1 => 'omniplan' do
 
   url 'https://www.omnigroup.com/download/latest/omniplan'
   name 'OmniPlan'
-  homepage 'http://www.omnigroup.com/products/omniplan/'
+  homepage 'https://www.omnigroup.com/omniplan/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'OmniPlan.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
