### PR TITLE
Fix homepage to use SSL in XAMPP Cask

### DIFF
--- a/Casks/xampp.rb
+++ b/Casks/xampp.rb
@@ -5,7 +5,7 @@ cask :v1 => 'xampp' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/xampp/XAMPP%20Mac%20OS%20X/#{version.sub(%r{-\d+$},'')}/xampp-osx-#{version}-installer.dmg"
   name 'XAMPP'
-  homepage 'http://www.apachefriends.org/'
+  homepage 'https://www.apachefriends.org/'
   license :gpl
 
   installer :script => 'XAMPP.app/Contents/MacOS/osx-intel',


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
