### PR TITLE
Fix homepage to use SSL in Air Connect Cask

### DIFF
--- a/Casks/air-connect.rb
+++ b/Casks/air-connect.rb
@@ -6,7 +6,7 @@ cask :v1 => 'air-connect' do
   name 'Air Connect'
   appcast 'http://avatron.com/updates/software/airconnect_mac/appcast.xml',
           :sha256 => 'af9bc6dc41bc632995c4e49b958a5623bc091ac0fe1fb337fbc9a571cfc1e85b'
-  homepage 'http://www.avatron.com/get-air-connect/'
+  homepage 'https://avatron.com/get-air-connect/'
   license :gratis
 
   app 'Air Connect.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
