### PR TITLE
Updated for latest 0.7.6 release

### DIFF
--- a/Casks/shortcat.rb
+++ b/Casks/shortcat.rb
@@ -1,10 +1,8 @@
 cask :v1 => 'shortcat' do
-  version '0.7.5'
-  sha256 '344bfee21417481189600c09a282b9ed4a76b674b4789d3232a29d8f640446fc'
+  version '0.7.6'
+  sha256 'b78f20a94e0270ea1b0376677c07559db0e91c4ac53227b588adee46f971be1b'
 
   url "https://files.shortcatapp.com/v#{version}/Shortcat.zip"
-  appcast 'https://shortcatapp.com/updates/appcast.xml',
-          :sha256 => '38804c1de1cceb99418fb8393b57a99d78815c4d87dd850fe6b9acb0a4dc01de'
   name 'Shortcat'
   homepage 'http://shortcatapp.com/'
   license :commercial


### PR DESCRIPTION
0.7.6 was released to fix the beta expiry.  Updated for this version.
Removed appcast.  Feed points to an html page now.
