### PR TITLE
Fix homepage to use SSL in OmniGraffle Cask

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -14,7 +14,7 @@ cask :v1 => 'omnigraffle' do
   end
 
   name 'OmniGraffle'
-  homepage 'http://www.omnigroup.com/products/omnigraffle'
+  homepage 'https://www.omnigroup.com/omnigraffle/'
   license :commercial
 
   app 'OmniGraffle.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
