### PR TITLE
Fix homepage to use SSL in Flickr Uploadr Cask

### DIFF
--- a/Casks/flickr-uploadr.rb
+++ b/Casks/flickr-uploadr.rb
@@ -4,7 +4,7 @@ cask :v1 => 'flickr-uploadr' do
 
   url 'https://downloads.flickr.com/uploadr/FlickrUploadr.dmg'
   name 'Flickr Uploadr'
-  homepage 'http://www.flickr.com/tools/'
+  homepage 'https://www.flickr.com/tools/'
   license :gratis
 
   app 'Flickr Uploadr.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
