### PR TITLE
Fix homepage to use SSL in MacVim Cask

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -19,7 +19,7 @@ cask :v1 => 'macvim' do
   end
 
   name 'MacVim'
-  homepage 'http://code.google.com/p/macvim/'
+  homepage 'https://github.com/macvim-dev/macvim'
   license :oss
 
   app "MacVim-snapshot-#{version.sub(%r{^.*-},'')}/MacVim.app"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
