### PR TITLE
Fix homepage to use SSL in Trim Enabler Cask

### DIFF
--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -6,7 +6,7 @@ cask :v1 => 'trim-enabler' do
   url 'https://s3.amazonaws.com/cindori/TrimEnabler.dmg'
   appcast 'http://cindori.org/trimenabler/updates/update.xml'
   name 'Trim Enabler'
-  homepage 'http://www.cindori.org/software/trimenabler/'
+  homepage 'https://www.cindori.org/software/trimenabler/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Trim Enabler.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
