### PR TITLE
Fix homepage to use SSL in CrashPlan Cask

### DIFF
--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -4,7 +4,7 @@ cask :v1 => 'crashplan' do
 
   url "http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_#{version}_Mac.dmg"
   name 'CrashPlan'
-  homepage 'http://www.crashplan.com/'
+  homepage 'https://www.code42.com/crashplan/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install CrashPlan.pkg'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
