### PR TITLE
Change weka-3-6-12-oracle-jvm.dmg sourceforge url

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -3,7 +3,7 @@ cask :v1 => 'weka' do
   sha256 'a0a8683342c6b367a29f4f2ca226db115e9a603b2ffc91c34525bb0f664d7b8c'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/sourceforge/weka/weka-#{version.gsub('.','-')}-oracle-jvm.dmg"
+  url "http://sourceforge.net/projects/weka/files/weka-3-6-osx/3.6.12/weka-#{version.gsub('.','-')}-oracle-jvm.dmg/download"
   name 'Weka'
   homepage 'http://www.cs.waikato.ac.nz/ml/weka/'
   license :gpl


### PR DESCRIPTION
Mainly because previous url used to return a wrong sha256 sum.

``` bash
$ brew-cask install weka
...
Error: sha256 mismatch
Expected: a0a8683342c6b367a29f4f2ca226db115e9a603b2ffc91c34525bb0f664d7b8c
Actual: 070630884bcbb1f01865c5d58587d06a64b2063a850ea8e44e1c323ee267c956
...
```
