### PR TITLE
Fix Visual Studio Code not being symlinked

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -8,7 +8,7 @@ cask :v1 => 'visual-studio-code' do
   license :gratis
   tags :vendor => 'Microsoft'
 
-  app 'Visual Studio Code.app'
+  app 'VSCode-darwin/Visual Studio Code.app'
 
   zap :delete => [
                   '~/Library/Application Support/Code',


### PR DESCRIPTION
I was having this error after the `0.3.0` update

```
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/visual-studio-code/latest/Visual Studio Code.app'
```
