### PR TITLE
Update Cloak download URL to our new official URL.

### DIFF
--- a/Casks/cloak.rb
+++ b/Casks/cloak.rb
@@ -2,8 +2,7 @@ cask :v1 => 'cloak' do
   version '2.0.11'
   sha256 '8dbebffcfe6db8b20a15ce11231fea248a42281cde73d08b661b1e9861ec7eed'
 
-  # amazonaws.com is the official download host per the vendor homepage
-  url "https://s3.amazonaws.com/static.getcloak.com/osx/updates/Release/Cloak-#{version}.dmg"
+  url "https://static.getcloak.com/downloads/osx/updates/Release/Cloak-#{version}.dmg"
   name 'Cloak'
   homepage 'https://www.getcloak.com'
   license :gratis


### PR DESCRIPTION
Update Cloak's URL to our new official endpoint.

PS: I'm one of the founders of GetCloak.com. The parent company is Bourgeois Bits LLC (bbits here on github.)
