### PR TITLE
Fix homepage to use SSL in Dropshare Cask

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -6,7 +6,7 @@ cask :v1 => 'dropshare' do
   name 'Dropshare'
   appcast 'https://getdropsha.re/sparkle/Dropshare.xml',
           :sha256 => 'bb9b88f179432633594ea0d417ce7b55e8a42fe24a2106e55f1fe711473ec86a'
-  homepage 'http://getdropsha.re/'
+  homepage 'https://getdropsha.re/'
   license :commercial
 
   app 'Dropshare.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
