### PR TITLE
Fix homepage to use SSL in Puppet Cask

### DIFF
--- a/Casks/puppet.rb
+++ b/Casks/puppet.rb
@@ -4,7 +4,7 @@ cask :v1 => 'puppet' do
 
   url "http://downloads.puppetlabs.com/mac/puppet-#{version}.dmg"
   name 'Puppet'
-  homepage 'http://puppetlabs.com/'
+  homepage 'https://puppetlabs.com/'
   license :apache
 
   pkg "puppet-#{version}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
