### PR TITLE
Fix homepage to use SSL in ownCloud Cask

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -4,7 +4,7 @@ cask :v1 => 'owncloud' do
 
   url "https://download.owncloud.com/desktop/stable/ownCloud-#{version}.pkg"
   name 'ownCloud'
-  homepage 'http://owncloud.com'
+  homepage 'https://owncloud.com/'
   license :gpl
 
   pkg "ownCloud-#{version}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
