### PR TITLE
Change 'keepassx' cask to install a stable release and add 'keepassx2' to install an alpha release

### DIFF
--- a/Casks/keepassx.rb
+++ b/Casks/keepassx.rb
@@ -1,13 +1,15 @@
 cask :v1 => 'keepassx' do
-  version '2.0-alpha6'
-  sha256 '55aeaba8257d728b62ba173ba56df27897552737a556dc1e4e4ed6dcd3d6dd8a'
+  version '0.4.3'
+  sha256 '15ce2e950ab78ccb6956de985c1fcbf11d27df6a58ab7bf19e106f0a1dc2fedd'
 
-  url "https://www.keepassx.org/dev/attachments/download/72/KeePassX-#{version}.dmg"
+  url "https://www.keepassx.org/releases/KeePassX-#{version}.dmg"
   name 'KeePassX'
   homepage 'http://www.keepassx.org'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'KeePassX.app'
 
   zap :delete => '~/.keepassx'
+
+  caveats "Use 'keepassx2' instead of 'keepassx' to install KeePassX 2 alpha version."
 end

--- a/Casks/keepassx2.rb
+++ b/Casks/keepassx2.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'keepassx2' do
+  version '2.0-alpha6'
+  sha256 '55aeaba8257d728b62ba173ba56df27897552737a556dc1e4e4ed6dcd3d6dd8a'
+
+  url "https://www.keepassx.org/dev/attachments/download/72/KeePassX-#{version}.dmg"
+  name 'KeePassX'
+  name 'KeePassX 2.0 Alpha 6'
+  homepage 'http://www.keepassx.org'
+  license :gpl
+
+  app 'KeePassX.app'
+
+  zap :delete => '~/.keepassx'
+end


### PR DESCRIPTION
Currently KeePassX has two major version (0.4.3 and 2.0-alpha6) and the previous
cask install a version of KeePassX alpha release.
While the format of database file of KeePassX 0.4.3 and KeePassX 2.0 Alpha is different,
some people would want to use a stable version (some 3rd party application does
not understand the database format of KeePassX 2.0 Alpha yet...)

> Q. Can I open KeePass 2.x password databases with KeePassX?Top
> 
> A. No, KeePassX does not support the KeePass 2.x (.kdbx) password database format currently.
> However, you can create an export in KeePass 1.x database format (.kdb) from KeePass 2.x,
> which KeePassX can read (and use as the native password database).

Ref:
https://www.keepassx.org/downloads
https://www.keepassx.org/news/2014/04/433
