### PR TITLE
Fix homepage to use SSL in Crypt Cask

### DIFF
--- a/Casks/crypt.rb
+++ b/Casks/crypt.rb
@@ -5,7 +5,7 @@ cask :v1 => 'crypt' do
   # amazonaws.com is the official download host per the vendor homepage
   url "http://voluntary.net.s3.amazonaws.com/Crypt#{version}_20100429.zip"
   name 'Crypt'
-  homepage 'http://voluntary.net/crypt/'
+  homepage 'https://voluntary.net/crypt/'
   license :mit
 
   app "Crypt#{version}.app"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
