### PR TITLE
Fix homepage to use SSL in Mosh Cask

### DIFF
--- a/Casks/mosh.rb
+++ b/Casks/mosh.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mosh' do
 
   url "https://mosh.mit.edu/mosh-#{version}-3.pkg"
   name 'Mosh'
-  homepage 'http://mosh.mit.edu/'
+  homepage 'https://mosh.mit.edu/'
   license :gpl
 
   pkg "mosh-#{version}-3.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
