### PR TITLE
Fix homepage to use SSL in Node.js Cask

### DIFF
--- a/Casks/node.rb
+++ b/Casks/node.rb
@@ -2,9 +2,9 @@ cask :v1 => 'node' do
   version '0.12.4'
   sha256 'ca483deb4cf71bb308e2c140c4773d7521a42e27d0f17a07f183169bb416aea0'
 
-  url "http://nodejs.org/dist/v#{version}/node-v#{version}.pkg"
+  url "https://nodejs.org/dist/v#{version}/node-v#{version}.pkg"
   name 'Node.js'
-  homepage 'http://nodejs.org'
+  homepage 'https://nodejs.org/'
   license :mit
 
   pkg  "node-v#{version}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
