### PR TITLE
Fix homepage to use SSL in Atom Cask

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -4,7 +4,7 @@ cask :v1 => 'atom' do
 
   url 'https://atom.io/download/mac'
   name 'Atom'
-  homepage 'http://atom.io'
+  homepage 'https://atom.io/'
   license :mit
 
   app 'Atom.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
