### PR TITLE
Fix homepage to use SSL in Python Cask

### DIFF
--- a/Casks/python.rb
+++ b/Casks/python.rb
@@ -4,7 +4,7 @@ cask :v1 => 'python' do
 
   url "https://www.python.org/ftp/python/#{version}/python-#{version}-macosx10.6.pkg"
   name 'Python'
-  homepage 'http://www.python.org/'
+  homepage 'https://www.python.org/'
   license :oss
 
   pkg "python-#{version}-macosx10.6.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
