### PR TITLE
Fix homepage to use SSL in GitHub Cask

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -4,7 +4,7 @@ cask :v1 => 'github' do
 
   url 'https://central.github.com/mac/latest'
   name 'GitHub'
-  homepage 'http://mac.github.com'
+  homepage 'https://mac.github.com/'
   license :oss
 
   app 'GitHub.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
