### PR TITLE
Fix download link for SurplusMeter

### DIFF
--- a/Casks/surplusmeter.rb
+++ b/Casks/surplusmeter.rb
@@ -2,8 +2,8 @@ cask :v1 => 'surplusmeter' do
   version '2.0.3'
   sha256 'a4e5fb6114983964ac4d91c3038f018a97a39f88134c776844ea27271286c375'
 
-  url "http://www.skoobysoft.com/downloads/SurplusMeterv#{version.gsub('.','')}.dmg"
-  homepage 'http://www.skoobysoft.com/utilities/utilities.html#surplusmeter'
+  url "http://iusethis.luo.ma/surplusmeter/SurplusMeterv203.dmg"
+  homepage 'http://www.macupdate.com/app/mac/20884/surplusmeter'
   license :unknown
 
   app 'SurplusMeter.app'


### PR DESCRIPTION
- Original website / domain skoobysoft.com is no longer available
- Point website to MacUpdate's page for SurplusMeter
- Download link from alternate site
- Verified, no changes to SHA256
