### PR TITLE
Fix download link for SurplusMeter

### DIFF
--- a/Casks/surplusmeter.rb
+++ b/Casks/surplusmeter.rb
@@ -2,10 +2,10 @@ cask :v1 => 'surplusmeter' do
   version '2.0.3'
   sha256 'a4e5fb6114983964ac4d91c3038f018a97a39f88134c776844ea27271286c375'
 
-  url "http://www.skoobysoft.com/downloads/SurplusMeterv#{version.gsub('.','')}.dmg"
   name 'SurplusMeter'
-  homepage 'http://www.skoobysoft.com/utilities/utilities.html#surplusmeter'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  url "http://iusethis.luo.ma/surplusmeter/SurplusMeterv203.dmg"
+  homepage 'http://www.macupdate.com/app/mac/20884/surplusmeter'
+  license :gpl
 
   app 'SurplusMeter.app'
 end


### PR DESCRIPTION
- Original website / domain skoobysoft.com is no longer available
- Point website to MacUpdate's page for SurplusMeter
- Download link from alternate site
- Verified, no changes to SHA256
- Update license to GPL
