### PR TITLE
add Cycling ‘74 Max v7.0.3

### DIFF
--- a/Casks/cycling74-max7.rb
+++ b/Casks/cycling74-max7.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'cycling74-max7' do
+  version '7.0.3-150402'
+  sha256 'c63616022a19e8aafe7c7036265599644b13f3ae640509ffe17a3c7c6953d55e'
+
+  url "http://filepivot.appspot.com/projects/maxmspjitter/files/Max#{version.sub('-','_').gsub('.','')}.dmg"
+  name 'Cycling ‘74 Max'
+  homepage 'http://cycling74.com'
+  license :commercial
+  tags :vendor => 'Cycling ‘74'
+
+  app "Max.app"
+end


### PR DESCRIPTION
There is already an cycling74-max.rb file but this points to the old 6.x Max Installer.
The new Version 7 is now a Simple App no Installer is needed anymore.
I think making a seperate Package for the new 7.x Version of Max is a good solution to separating this 2 Different types of Installation methods.
