### PR TITLE
Add exa v0.3.0

### DIFF
--- a/Casks/exa.rb
+++ b/Casks/exa.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'exa' do
+  version '0.3.0'
+  sha256 '228cfce7715b5b908a607e4a659e38d7c83da8c596cccf9860e6531903499dba'
+
+  # github.com is the official download host per the vendor homepage
+  url "https://github.com/ogham/exa/releases/download/v#{version}/exa-osx-x86-64.zip"
+  appcast 'https://github.com/ogham/exa/releases.atom'
+  name 'exa'
+  homepage 'http://bsago.me/exa/'
+  license :mit
+
+  binary 'exa-osx-x86-64', :target => 'exa'
+end


### PR DESCRIPTION
This is a Cask for [exa](https://github.com/ogham/exa), an `ls` replacement written in Rust. I tried to mirror existing binary-only Casks, but there are a few things I was unsure of (such as whether an `uninstall` stanza is necessary to delete the binary from `/opt/homebrew-cask/Caskroom/`).
