### PR TITLE
Updates Godot 1.1 download link

### DIFF
--- a/Casks/godot.rb
+++ b/Casks/godot.rb
@@ -2,7 +2,7 @@ cask :v1 => 'godot' do
   version '1.1'
   sha256 'b09dc985b08fa979a8ee830806e2fae2cf0b8a1c3b0da80f6881c3451f670f3d'
 
-  url 'https://godot.blob.core.windows.net/release/2015-05-21/GodotOSX32-1.1stable.zip'
+  url "http://151.236.22.217/GodotOSX32-#{version}stable.zip"
   name 'Godot Engine'
   homepage 'http://www.godotengine.org/'
   license :mit


### PR DESCRIPTION
Sets the link to the primary download source for the app. Old link 404s.
