### PR TITLE
Uses 'all-versions' folder in wireshark source URL

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -2,7 +2,7 @@ cask :v1 => 'wireshark' do
   version '1.12.5'
   sha256 '7125c94bb9eeed3d09930613feb64b6ec794164fb5ff8c027a03c020cc6f6606'
 
-  url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
+  url "https://www.wireshark.org/download/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
   name 'Wireshark'
   homepage 'http://www.wireshark.org'
   license :gpl


### PR DESCRIPTION
`wireshark` keeps only a few recent versions in their `download/osx/` folder, but all in `download/osx/all-versions/`
