### PR TITLE
Fix homepage to use SSL in f.lux Cask

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -5,7 +5,7 @@ cask :v1 => 'flux' do
   url 'https://justgetflux.com/mac/Flux.zip'
   appcast 'https://justgetflux.com/mac/macflux.xml'
   name 'f.lux'
-  homepage 'http://justgetflux.com'
+  homepage 'https://justgetflux.com/'
   license :gratis
 
   app 'Flux.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
