### PR TITLE
Fix homepage to use SSL in MAMP Cask

### DIFF
--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mamp' do
 
   url "http://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"
   name 'MAMP'
-  homepage 'http://www.mamp.info/'
+  homepage 'https://www.mamp.info/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "MAMP_MAMP_PRO_#{version}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
