### PR TITLE
Fix homepage to use SSL in Paw Cask

### DIFF
--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -4,7 +4,7 @@ cask :v1 => 'paw' do
 
   url 'https://luckymarmot.com/paw/download'
   name 'Paw'
-  homepage 'http://luckymarmot.com/paw'
+  homepage 'https://luckymarmot.com/paw'
   license :commercial
 
   app 'Paw.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
