### PR TITLE
Fix homepage to use SSL in Screenhero Cask

### DIFF
--- a/Casks/screenhero.rb
+++ b/Casks/screenhero.rb
@@ -5,7 +5,7 @@ cask :v1 => 'screenhero' do
   url 'https://secure.screenhero.com/update/screenhero/Screenhero.dmg'
   appcast 'http://dl.screenhero.com/update/screenhero/sparkle.xml'
   name 'Screenhero'
-  homepage 'http://screenhero.com'
+  homepage 'https://screenhero.com/'
   license :commercial
 
   app 'Screenhero.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
