### PR TITLE
Fix url, appcast and homepage to use SSL in Focus Cask

### DIFF
--- a/Casks/focus.rb
+++ b/Casks/focus.rb
@@ -2,10 +2,10 @@ cask :v1 => 'focus' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.heyfocus.com/releases/Focus-latest.zip'
-  appcast 'http://www.heyfocus.com/appcast.xml'
+  url 'https://heyfocus.com/releases/Focus-latest.zip'
+  appcast 'https://heyfocus.com/appcast.xml'
   name 'Focus'
-  homepage 'http://www.heyfocus.com/'
+  homepage 'https://heyfocus.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Focus.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
