### PR TITLE
Fix homepage to use SSL in AirDroid Cask

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -4,7 +4,7 @@ cask :v1 => 'airdroid' do
 
   url "http://dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"
   name 'AirDroid'
-  homepage 'http://airdroid.com'
+  homepage 'https://www.airdroid.com/'
   license :closed
 
   app 'AirDroid.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
