### PR TITLE
Fix homepage to use SSL in Munki Cask

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -5,7 +5,7 @@ cask :v1 => 'munki' do
   url "https://github.com/munki/munki/releases/download/v#{version}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom'
   name 'Munki'
-  homepage 'http://munki.github.io/munki/'
+  homepage 'https://www.munki.org/munki/'
   license :apache
 
   pkg "munkitools-#{version}.pkg"

--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -2,6 +2,7 @@ cask :v1 => 'munki' do
   version '2.1.1.2352'
   sha256 'd2287454a1b3aa66ef49e41a34dfa55cfffd45d3e00de5d2288b3fd7ced2e42c'
 
+  # github.com is the official download host per the vendor homepage
   url "https://github.com/munki/munki/releases/download/v#{version}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom'
   name 'Munki'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
