### PR TITLE
Fix homepage to use SSL in Inkscape Cask

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -5,7 +5,7 @@ cask :v1 => 'inkscape' do
   # fastly.net is the official download host per the vendor homepage
   url "https://inkscape.global.ssl.fastly.net/media/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
   name 'Inkscape'
-  homepage 'http://inkscape.org'
+  homepage 'https://inkscape.org/'
   license :gpl
 
   app 'Inkscape.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
