### PR TITLE
Fix homepage to use SSL in Pastor Cask

### DIFF
--- a/Casks/pastor.rb
+++ b/Casks/pastor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pastor' do
 
   url "https://mehlau.net/pastor/Pastor#{version.gsub('.','')}-signed.dmg"
   name 'Pastor'
-  homepage 'http://mehlau.net/pastor'
+  homepage 'https://mehlau.net/pastor/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Pastor.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
