### PR TITLE
Fix homepage to use SSL in BitTorrent Sync Cask

### DIFF
--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -7,7 +7,7 @@ cask :v1 => 'bittorrent-sync' do
   name 'BitTorrent Sync'
   # todo: response was not XML
   # appcast 'http://www.usyncapp.com/cfu.php'
-  homepage 'http://www.bittorrent.com/sync'
+  homepage 'https://www.getsync.com/'
   license :gratis
 
   app 'BitTorrent Sync.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
