### PR TITLE
Fix homepage to use SSL in LaunchBar Cask

### DIFF
--- a/Casks/launchbar.rb
+++ b/Casks/launchbar.rb
@@ -11,7 +11,7 @@ cask :v1 => 'launchbar' do
   end
 
   name 'LaunchBar'
-  homepage 'http://www.obdev.at/products/launchbar/'
+  homepage 'https://www.obdev.at/products/launchbar/'
   license :commercial
 
   app 'LaunchBar.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
