### PR TITLE
Fix homepage to use SSL in Zotero Cask

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -4,7 +4,7 @@ cask :v1 => 'zotero' do
 
   url "https://download.zotero.org/standalone/#{version}/Zotero-#{version}.dmg"
   name 'Zotero'
-  homepage 'http://www.zotero.org/'
+  homepage 'https://www.zotero.org/'
   license :affero
 
   app 'Zotero.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
