### PR TITLE
Fix homepage to use SSL in Wuala Cask

### DIFF
--- a/Casks/wuala.rb
+++ b/Casks/wuala.rb
@@ -4,7 +4,7 @@ cask :v1 => 'wuala' do
 
   url 'https://cdn.wuala.com/files/WualaInstaller.dmg'
   name 'Wuala'
-  homepage 'http://wuala.com'
+  homepage 'https://www.wuala.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Wuala.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
