### PR TITLE
Fix homepage to use SSL in Skitch Cask

### DIFF
--- a/Casks/skitch.rb
+++ b/Casks/skitch.rb
@@ -4,7 +4,7 @@ cask :v1 => 'skitch' do
 
   url "http://cdn1.evernote.com/skitch/mac/release/Skitch-#{version}.zip"
   name 'Skitch'
-  homepage 'http://evernote.com/skitch/'
+  homepage 'https://evernote.com/skitch/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Skitch.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
