### PR TITLE
Fix homepage to use SSL in VyprVPN Cask

### DIFF
--- a/Casks/vyprvpn.rb
+++ b/Casks/vyprvpn.rb
@@ -4,7 +4,7 @@ cask :v1 => 'vyprvpn' do
 
   url "https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/#{version}/VyprVPN_v#{version}.dmg"
   name 'VyprVPN'
-  homepage 'http://www.goldenfrog.com/vyprvpn'
+  homepage 'https://www.goldenfrog.com/vyprvpn'
   license :commercial
 
   app 'VyprVPN.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
