### PR TITLE
Fix homepage to use SSL in Mozilla Thunderbird Cask

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -4,7 +4,7 @@ cask :v1 => 'thunderbird' do
 
   url "https://download.mozilla.org/?product=thunderbird-#{version}&os=osx&lang=en-US"
   name 'Mozilla Thunderbird'
-  homepage 'http://www.mozilla.org/en-US/thunderbird/'
+  homepage 'https://www.mozilla.org/en-US/thunderbird/'
   license :mpl
   tags :vendor => 'Mozilla'
 


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
