### PR TITLE
Fix homepage to use SSL in Tactor Cask

### DIFF
--- a/Casks/tactor.rb
+++ b/Casks/tactor.rb
@@ -7,7 +7,7 @@ cask :v1 => 'tactor' do
   name 'Tactor'
   appcast 'https://onflapp.appspot.com/tactor',
           :sha256 => 'de6620c8fd971681e356f2c24280ae9d38d09b78cafd2f25593fe50a235fd997'
-  homepage 'http://onflapp.wordpress.com/tactor/'
+  homepage 'https://onflapp.wordpress.com/tactor/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tactor.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
