### PR TITLE
Fix homepage to use SSL in Processing Cask

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -4,7 +4,7 @@ cask :v1 => 'processing' do
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   name 'Processing'
-  homepage 'http://processing.org/'
+  homepage 'https://processing.org/'
   license :gpl
 
   app 'Processing.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
