### PR TITLE
Fix homepage to use SSL in NoteDup Cask

### DIFF
--- a/Casks/notedup.rb
+++ b/Casks/notedup.rb
@@ -4,7 +4,7 @@ cask :v1 => 'notedup' do
 
   url 'https://app.yinxiang.com/shard/s10/sh/a2d0903c-f751-48fd-a5c0-68d7bcd0c450/ce188822309c0124ba328248e1bed420/res/03724cac-da8f-4981-ac1d-946bb46fa19c/NoteDup_Mac_2014031401.zip'
   name 'NoteDup'
-  homepage 'http://appcenter.yinxiang.com/app/notedup/mac/'
+  homepage 'https://appcenter.yinxiang.com/app/notedup/mac/'
   license :closed
 
   app 'NoteDup.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
