### PR TITLE
Fix homepage to use SSL in OmniPresence Cask

### DIFF
--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -4,7 +4,7 @@ cask :v1 => 'omnipresence' do
 
   url "http://downloads.omnigroup.com/software/MacOSX/10.10/OmniPresence-#{version}.dmg"
   name 'OmniPresence'
-  homepage 'http://www.omnigroup.com/omnipresence'
+  homepage 'https://www.omnigroup.com/omnipresence'
   license :commercial
 
   app 'OmniPresence.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
