### PR TITLE
Fix homepage to use SSL in OpenVanilla Cask

### DIFF
--- a/Casks/openvanilla.rb
+++ b/Casks/openvanilla.rb
@@ -4,7 +4,7 @@ cask :v1 => 'openvanilla' do
 
   url "https://app.openvanilla.org/file/openvanilla/OpenVanilla-Installer-Mac-#{version}.zip"
   name 'OpenVanilla'
-  homepage 'http://openvanilla.org/'
+  homepage 'https://openvanilla.org/'
   license :mit
 
   input_method 'OpenVanillaInstaller.app/Contents/Resources/OpenVanilla.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
