### PR TITLE
Fix homepage to use SSL in OBS Cask

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -6,7 +6,7 @@ cask :v1 => 'obs' do
   url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-#{version}-installer.dmg"
   appcast 'https://github.com/jp9000/obs-studio/releases.atom'
   name 'OBS'
-  homepage 'http://obsproject.com/'
+  homepage 'https://obsproject.com/'
   license :gpl
 
   pkg 'OBS.mpkg'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
