### PR TITLE
Fix homepage to use SSL in Logic Cask

### DIFF
--- a/Casks/logic.rb
+++ b/Casks/logic.rb
@@ -4,7 +4,7 @@ cask :v1 => 'logic' do
 
   url "http://downloads.saleae.com/betas/#{version}/Logic-#{version}-Darwin.dmg"
   name 'Logic'
-  homepage 'http://www.saleae.com/'
+  homepage 'https://www.saleae.com/'
   license :commercial
 
   app 'Logic.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
