### PR TITLE
Fix homepage to use SSL in PhysicsEditor Cask

### DIFF
--- a/Casks/physicseditor.rb
+++ b/Casks/physicseditor.rb
@@ -4,7 +4,7 @@ cask :v1 => 'physicseditor' do
 
   url "https://www.codeandweb.com/download/physicseditor/#{version}/PhysicsEditor-#{version}-uni.dmg"
   name 'PhysicsEditor'
-  homepage 'http://www.codeandweb.com/physicseditor'
+  homepage 'https://www.codeandweb.com/physicseditor'
   license :freemium
 
   app 'PhysicsEditor.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
