### PR TITLE
Fix homepage to use SSL in Packer Cask

### DIFF
--- a/Casks/packer.rb
+++ b/Casks/packer.rb
@@ -5,7 +5,7 @@ cask :v1 => 'packer' do
   # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/packer/packer_#{version}_darwin_amd64.zip"
   name 'Packer'
-  homepage 'http://www.packer.io/'
+  homepage 'https://www.packer.io/'
   license :oss
 
   binary 'packer'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
