### PR TITLE
Fix homepage to use SSL in Mikogo Cask

### DIFF
--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -5,7 +5,7 @@ cask :v1 => 'mikogo' do
   # mikogo4.com is the official download host per the vendor homepage
   url 'http://download.mikogo4.com/mikogo.dmg'
   name 'Mikogo'
-  homepage 'http://www.mikogo.com/'
+  homepage 'https://www.mikogo.com/'
   license :gratis
 
   # Renamed for clarity: app name is inconsistent with its branding


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
