### PR TITLE
Fix homepage to use SSL in odrive Cask

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -4,7 +4,7 @@ cask :v1 => 'odrive' do
 
   url "http://cdn-mac.odrive.com/odrive.#{version}.dmg"
   name 'odrive'
-  homepage 'http://www.odrive.com'
+  homepage 'https://app.odrive.com/'
   license :gratis
 
   pkg "odrive.#{version}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
