### PR TITLE
Fix homepage to use SSL in MoneyMoney Cask

### DIFF
--- a/Casks/moneymoney.rb
+++ b/Casks/moneymoney.rb
@@ -5,7 +5,7 @@ cask :v1 => 'moneymoney' do
   url 'http://moneymoney-app.com/download/MoneyMoney.zip'
   appcast 'http://moneymoney-app.com/update/appcast.xml'
   name 'MoneyMoney'
-  homepage 'http://moneymoney-app.com/'
+  homepage 'https://moneymoney-app.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'MoneyMoney.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
