### PR TITLE
Fix homepage to use SSL in Minecraft Cask

### DIFF
--- a/Casks/minecraft.rb
+++ b/Casks/minecraft.rb
@@ -5,7 +5,7 @@ cask :v1 => 'minecraft' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.dmg'
   name 'Minecraft'
-  homepage 'http://minecraft.net'
+  homepage 'https://minecraft.net/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Minecraft.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
