### PR TITLE
Fix homepage to use SSL in MuseScore Cask

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -5,7 +5,7 @@ cask :v1 => 'musescore' do
   # osuosl.org is the official download host per the vendor homepage.
   url "http://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version}/MuseScore-#{version}.dmg"
   name 'MuseScore'
-  homepage 'http://musescore.org/'
+  homepage 'https://musescore.org/'
   license :gpl
 
   app 'MuseScore 2.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
