### PR TITLE
Fix homepage to use SSL in Flow Cask

### DIFF
--- a/Casks/flow.rb
+++ b/Casks/flow.rb
@@ -4,7 +4,7 @@ cask :v1 => 'flow' do
 
   url 'http://www.getflow.com/mac/download'
   name 'Flow'
-  homepage 'http://www.getflow.com/'
+  homepage 'https://www.getflow.com/'
   license :commercial
 
   app 'Flow.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
