### PR TITLE
Fix url, homepage to use SSL in GlimmerBlocker Cask

### DIFF
--- a/Casks/glimmerblocker.rb
+++ b/Casks/glimmerblocker.rb
@@ -2,9 +2,9 @@ cask :v1 => 'glimmerblocker' do
   version '1.5.3'
   sha256 '872f3edc5f6dc3b92ba17eaf00236308e561bf353ffb1579cc5d7afc27bbf0a5'
 
-  url "http://glimmerblocker.org/downloads/GlimmerBlocker-#{version}.dmg"
+  url "https://glimmerblocker.org/downloads/GlimmerBlocker-#{version}.dmg"
   name 'GlimmerBlocker'
-  homepage 'http://glimmerblocker.org'
+  homepage 'https://glimmerblocker.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'GlimmerBlocker.pkg'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
