### PR TITLE
Fix url, appcast and homepage to use SSL in gfxCardStatus Cask

### DIFF
--- a/Casks/gfxcardstatus.rb
+++ b/Casks/gfxcardstatus.rb
@@ -2,11 +2,11 @@ cask :v1 => 'gfxcardstatus' do
   version '2.3'
   sha256 '092b3e2fad44681ba396cf498707c8b6c228fd55310770a8323ebb9344b4d9a1'
 
-  url "http://codykrieger.com/downloads/gfxCardStatus-#{version}.zip"
-  appcast 'http://gfx.io/appcast.xml',
+  url "https://gfx.io/downloads/gfxCardStatus-#{version}.zip"
+  appcast 'https://gfx.io/appcast.xml',
           :sha256 => 'cc01a7466eb53f425920046a5b7ea0a23b35bd431b7ccca9c77bd8fa407cd718'
   name 'gfxCardStatus'
-  homepage 'http://gfx.io/'
+  homepage 'https://gfx.io/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'gfxCardStatus.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
