### PR TITLE
Fix homepage to use SSL in ImageOptim Cask

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -3,9 +3,9 @@ cask :v1 => 'imageoptim' do
   sha256 :no_check
 
   url 'https://imageoptim.com/ImageOptim.tbz2'
-  appcast 'http://imageoptim.com/appcast.xml'
+  appcast 'https://imageoptim.com/appcast.xml'
   name 'ImageOptim'
-  homepage 'http://imageoptim.com/'
+  homepage 'https://imageoptim.com/'
   license :gpl
 
   app 'ImageOptim.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
