### PR TITLE
Fix homepage to use SSL in ezeep Cask

### DIFF
--- a/Casks/ezeep.rb
+++ b/Casks/ezeep.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ezeep' do
 
   url 'https://packages.ezeep.com/osx/ezeep-latest.dmg'
   name 'ezeep'
-  homepage 'http://www.ezeep.com/'
+  homepage 'https://www.ezeep.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ezeep.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
