### PR TITLE
Fix homepage to use SSL in FBReader Cask

### DIFF
--- a/Casks/fbreader.rb
+++ b/Casks/fbreader.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fbreader' do
 
   url "http://fbreader.org/files/macos/FBReader%20#{version.gsub(/-/, '%20')}.dmg"
   name 'FBReader'
-  homepage 'http://fbreader.org/content/macos'
+  homepage 'https://fbreader.org/content/macos'
   license :gpl
 
   app 'FBReader.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
