### PR TITLE
Fix homepage to use SSL in Electrum-LTC Cask

### DIFF
--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -6,7 +6,7 @@ cask :v1 => 'electrum-ltc' do
   gpg "#{url}.asc",
       :key_id => '9914864dfc33499c6ca2beea22453004695506fd'
   name 'Electrum-LTC'
-  homepage 'http://electrum-ltc.org'
+  homepage 'https://electrum-ltc.org/'
   license :gpl
 
   app 'Electrum-LTC.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
