### PR TITLE
Fix homepage to use SSL in iBrowse Cask

### DIFF
--- a/Casks/ibrowse.rb
+++ b/Casks/ibrowse.rb
@@ -7,7 +7,7 @@ cask :v1 => 'ibrowse' do
   name 'iBrowse'
   appcast 'https://www.macroplant.com/ibrowse/ib-appcast.xml',
           :sha256 => '2dd21aed73c84b3b7c85ca29292f1c347fbadd5f9fd78866bd5db55d2c70e88f'
-  homepage 'http://www.ibrowseapp.com/'
+  homepage 'https://www.ibrowseapp.com/'
   license :gratis
 
   app 'iBrowse.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
