### PR TITLE
Fix homepage to use SSL in Harvest Cask

### DIFF
--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -5,7 +5,7 @@ cask :v1 => 'harvest' do
   url 'https://www.getharvest.com/harvest/mac/Harvest.zip'
   appcast 'https://www.getharvest.com/harvest/mac/appcast.xml'
   name 'Harvest'
-  homepage 'http://www.getharvest.com/mac'
+  homepage 'https://www.getharvest.com/mac'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Harvest.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
