### PR TITLE
Fix homepage to use SSL in Genymotion Cask

### DIFF
--- a/Casks/genymotion.rb
+++ b/Casks/genymotion.rb
@@ -6,7 +6,7 @@ cask :v1 => 'genymotion' do
 
   url "http://files2.genymotion.com/genymotion/genymotion-#{version}/genymotion-#{version}.dmg"
   name 'Genymotion'
-  homepage 'http://www.genymotion.com/'
+  homepage 'https://www.genymotion.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Genymotion.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
