### PR TITLE
Fix homepage to use SSL in Hostbuddy Cask

### DIFF
--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hostbuddy' do
   url 'https://clickontyler.com/hostbuddy/download/'
   appcast 'http://shine.clickontyler.com/appcast.php?id=22'
   name 'Hostbuddy'
-  homepage 'http://clickontyler.com/hostbuddy/'
+  homepage 'https://clickontyler.com/hostbuddy/'
   license :commercial
 
   app 'Hostbuddy.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
