### PR TITLE
Fix homepage to use SSL in Jawbone Updater Cask

### DIFF
--- a/Casks/jawbone-updater.rb
+++ b/Casks/jawbone-updater.rb
@@ -4,7 +4,7 @@ cask :v1 => 'jawbone-updater' do
 
   url "http://content.jawbone.com/store/dashboard/Jawbone_Updater-#{version}.pkg"
   name 'Jawbone Updater'
-  homepage 'http://jawbone.com/'
+  homepage 'https://jawbone.com/'
   license :gpl
 
   pkg "Jawbone_Updater-#{version}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
