### PR TITLE
Fix url and homepage to use SSL in Logic Sniffer Cask

### DIFF
--- a/Casks/logicsniffer.rb
+++ b/Casks/logicsniffer.rb
@@ -2,9 +2,9 @@ cask :v1 => 'logicsniffer' do
   version '0.9.7.1'
   sha256 'd3901d6c2356abc5fcbbeb8dc9950148d486b98239cd26c0cca7cc1ce3c4f106'
 
-  url "http://www.lxtreme.nl/ols/ols-#{version}-full.dmg"
+  url "https://www.lxtreme.nl/ols/ols-#{version}-full.dmg"
   name 'Logic Sniffer'
-  homepage 'http://www.lxtreme.nl/ols/'
+  homepage 'https://www.lxtreme.nl/ols/'
   license :gpl
 
   app 'LogicSniffer.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
