### PR TITLE
Fix homepage to use SSL in Jing Cask

### DIFF
--- a/Casks/jing.rb
+++ b/Casks/jing.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jing' do
   url 'http://download.techsmith.com/jing/mac/jing.dmg'
   appcast 'http://www.techsmith.com/redirect.asp?product=jing&ver=2.0.0&lang=enu&target=SparkleAppcast'
   name 'Jing'
-  homepage 'http://www.techsmith.com/jing.html'
+  homepage 'https://www.techsmith.com/jing.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Jing.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
