### PR TITLE
Fix homepage to use SSL in Mendeley Cask

### DIFF
--- a/Casks/mendeley-desktop.rb
+++ b/Casks/mendeley-desktop.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mendeley-desktop' do
 
   url "http://desktop-download.mendeley.com/download/Mendeley-Desktop-#{version}-OSX-Universal.dmg"
   name 'Mendeley'
-  homepage 'http://www.mendeley.com/'
+  homepage 'https://www.mendeley.com/'
   license :gratis
 
   app 'Mendeley Desktop.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
