### PR TITLE
Fix homepage to use SSL in Marble Cask

### DIFF
--- a/Casks/marble.rb
+++ b/Casks/marble.rb
@@ -4,7 +4,7 @@ cask :v1 => 'marble' do
 
   url "https://files.kde.org/marble/downloads/MacOSX/Marble-#{version}.dmg"
   name 'Marble'
-  homepage 'http://www.marble.kde.org'
+  homepage 'https://marble.kde.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Marble.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
