### PR TITLE
Fix homepage to use SSL in iBoostUp Cask

### DIFF
--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -6,7 +6,7 @@ cask :v1 => 'iboostup' do
   name 'iBoostUp'
   appcast 'http://www.iboostup.com/updates',
           :sha256 => 'b2ac6238575017acfdb5c589111795207780623065cb8e65e1ee569142986592'
-  homepage 'http://www.iboostup.com'
+  homepage 'https://www.iboostup.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iBoostUp.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
