### PR TITLE
Fix homepage to use SSL in Lingon X Cask

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -5,7 +5,7 @@ cask :v1 => 'lingon-x' do
   url 'http://www.peterborgapps.com/downloads/LingonX2.zip'
   appcast 'http://www.peterborgapps.com/updates/lingonx2-appcast.xml'
   name 'Lingon X'
-  homepage 'http://www.peterborgapps.com/lingon/'
+  homepage 'https://www.peterborgapps.com/lingon/'
   license :commercial
 
   app 'Lingon X.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
