### PR TITLE
Fix homepage to use SSL in Balsamiq Mockups Cask

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -5,7 +5,7 @@ cask :v1 => 'balsamiq-mockups' do
   # amazonaws is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/build_production/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"
   name 'Balsamiq Mockups'
-  homepage 'http://balsamiq.com/'
+  homepage 'https://balsamiq.com/'
   license :commercial
 
   app "Balsamiq Mockups #{version.to_i}.app"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
