### PR TITLE
Fix url and appcast to use SSL in MoneyMoney Cask

### DIFF
--- a/Casks/moneymoney.rb
+++ b/Casks/moneymoney.rb
@@ -2,8 +2,8 @@ cask :v1 => 'moneymoney' do
   version :latest
   sha256 :no_check
 
-  url 'http://moneymoney-app.com/download/MoneyMoney.zip'
-  appcast 'http://moneymoney-app.com/update/appcast.xml'
+  url 'https://moneymoney-app.com/download/MoneyMoney.zip'
+  appcast 'https://moneymoney-app.com/update/appcast.xml'
   name 'MoneyMoney'
   homepage 'https://moneymoney-app.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
