### PR TITLE
Fix homepage to use SSL in Biicode Cask

### DIFF
--- a/Casks/biicode.rb
+++ b/Casks/biicode.rb
@@ -5,7 +5,7 @@ cask :v1 => 'biicode' do
   # amazonaws is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/biibinaries/release/#{version}/bii-macos-64_#{version.gsub('.', '_')}.pkg"
   name 'Biicode'
-  homepage 'http://www.biicode.com'
+  homepage 'https://www.biicode.com/'
   license :closed
 
   pkg "bii-macos-64_#{version.gsub('.', '_')}.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
