### PR TITLE
Fix homepage and update url and appcast to use SSL in LoadMyTracks Cask

### DIFF
--- a/Casks/loadmytracks.rb
+++ b/Casks/loadmytracks.rb
@@ -2,10 +2,11 @@ cask :v1 => 'loadmytracks' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.cluetrust.com/Downloads/LoadMyTracks.dmg'
-  appcast 'http://www.cluetrust.com/AppCasts/LoadMyTracks.xml'
+  # cluetrust.com is the official download host per the product homepage
+  url 'https://www.cluetrust.com/Downloads/LoadMyTracks.dmg'
+  appcast 'https://www.cluetrust.com/AppCasts/LoadMyTracks.xml'
   name 'LoadMyTracks'
-  homepage 'http://www.cluetrust.com/loadmytracks.html'
+  homepage 'http://www.loadmytracks.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'LoadMyTracks.app'


### PR DESCRIPTION
Product has now his own homepage on a new domain.
The url and appcast stanza URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip."
