### PR TITLE
Fix homepage to use SSL in ShareTool Cask

### DIFF
--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sharetool' do
 
   url "http://files.bainsware.com/sharetool_#{version.gsub('.','')}.dmg"
   name 'ShareTool'
-  homepage 'http://bainsware.com/'
+  homepage 'https://www.bainsware.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   container :nested => "ShareTool #{version.to_i}.dmg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
