### PR TITLE
Update proXPN Cask version, all urls and add license

### DIFF
--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'proxpn' do
-  version :latest
-  sha256 :no_check
+  version '4.0.3'
+  sha256 'ef4f436a6ce68f533f25ad9bf9c2b2616875f65d05abf9b0b884983f44ed7647'
 
-  url 'https://proxpn.com/mac.dmg'
-  appcast 'http://www.proxpn.org/updater/appcast.rss'
+  url "https://www.proxpn.biz/updater/proXPN-MacOSX-10.5-#{version}.dmg"
+  appcast 'https://www.proxpn.biz/updater/appcast.rss'
   name 'proXPN'
-  homepage 'http://proxpn.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  homepage 'https://www.proxpn.biz/'
+  license :freemium
 
   app 'ProXPN.app'
 end


### PR DESCRIPTION
The download of the `latest` url only contains version 4.0.2.
Based on `appcast` version 4.0.3 should be already out.
It is possible to use the domain with com, org and biz.
Now it should be consistent and ssl is preferred.
