### PR TITLE
Fix homepage to use SSL in CommandQ Cask

### DIFF
--- a/Casks/commandq.rb
+++ b/Casks/commandq.rb
@@ -6,7 +6,7 @@ cask :v1 => 'commandq' do
   name 'CommandQ'
   appcast 'http://shine.clickontyler.com/appcast.php?id=16',
           :sha256 => 'aded9f4d5543c963c0989f53ba18c35b2053703b543b10a54c61a6b42b53dd50'
-  homepage 'http://clickontyler.com/commandq/'
+  homepage 'https://clickontyler.com/commandq/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'CommandQ.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
