### PR TITLE
Fix url and homepage to use SSL in Kontroll Cask

### DIFF
--- a/Casks/kontroll.rb
+++ b/Casks/kontroll.rb
@@ -2,9 +2,9 @@ cask :v1 => 'kontroll' do
   version :latest
   sha256 :no_check
 
-  url 'http://kontroll.io/download/Kontroll.zip'
+  url 'https://kontroll.io/download/Kontroll.zip'
   name 'Kontroll'
-  homepage 'http://kontroll.io/'
+  homepage 'https://kontroll.io/'
   license :gratis
 
   app 'Kontroll.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
