### PR TITLE
Fix url and homepage to use SSL in Haskell Platform Cask

### DIFF
--- a/Casks/haskell-platform.rb
+++ b/Casks/haskell-platform.rb
@@ -2,9 +2,9 @@ cask :v1 => 'haskell-platform' do
   version '2014.2.0.0'
   sha256 '62f39246ad95dd2aed6ece5138f6297f945d2b450f215d074820294310e0c48a'
 
-  url "http://www.haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%2064bit.signed.pkg"
+  url "https://www.haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%2064bit.signed.pkg"
   name 'Haskell Platform'
-  homepage 'http://www.haskell.org/platform/'
+  homepage 'https://www.haskell.org/platform/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "Haskell Platform #{version} 64bit.signed.pkg"


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
