### PR TITLE
Fix homepage to use SSL in NodeBox Cask

### DIFF
--- a/Casks/nodebox.rb
+++ b/Casks/nodebox.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nodebox' do
 
   url "https://secure.nodebox.net/downloads/NodeBox-#{version}.zip"
   name 'NodeBox'
-  homepage 'http://nodebox.net/node/'
+  homepage 'https://www.nodebox.net/node/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'NodeBox.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
