### PR TITLE
Fix homepage to use SSL in Terraform Cask

### DIFF
--- a/Casks/terraform.rb
+++ b/Casks/terraform.rb
@@ -5,7 +5,7 @@ cask :v1 => 'terraform' do
   # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/terraform/terraform_#{version}_darwin_amd64.zip"
   name 'Terraform'
-  homepage 'http://www.terraform.io/'
+  homepage 'https://www.terraform.io/'
   license :mpl
 
   binary 'terraform'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
