### PR TITLE
Fix homepage to use SSL in Splice Cask

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -5,7 +5,7 @@ cask :v1 => 'splice' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://spliceosx.s3.amazonaws.com/Splice.dmg'
   name 'Splice'
-  homepage 'http://splice.com'
+  homepage 'https://splice.com/'
   license :gratis
 
   installer :script => 'Splice Installer.app/Contents/MacOS/Splice Installer',


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
