### PR TITLE
Fix url and homepage to use SSL in Unified Remote Cask

### DIFF
--- a/Casks/unified-remote.rb
+++ b/Casks/unified-remote.rb
@@ -2,9 +2,9 @@ cask :v1 => 'unified-remote' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.unifiedremote.com/download/macosx-setup'
+  url 'https://www.unifiedremote.com/download/mac'
   name 'Unified Remote'
-  homepage 'http://www.unifiedremote.com'
+  homepage 'https://www.unifiedremote.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Unified Remote.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
