### PR TITLE
Fix url and homepage to use SSL in Spacious Cask

### DIFF
--- a/Casks/spacious.rb
+++ b/Casks/spacious.rb
@@ -2,9 +2,9 @@ cask :v1 => 'spacious' do
   version :latest
   sha256 :no_check
 
-  url 'http://static.iospirit.com/static/objectfiles/file/159/Spacious.zip'
+  url 'https://www.iospirit.com/static/objectfiles/file/159/Spacious.zip'
   name 'Spacious'
-  homepage 'http://www.iospirit.com/products/spacious'
+  homepage 'https://www.iospirit.com/products/spacious'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Spacious.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
