### PR TITLE
Fix homepage to use SSL in Consul Cask

### DIFF
--- a/Casks/consul.rb
+++ b/Casks/consul.rb
@@ -5,7 +5,7 @@ cask :v1 => 'consul' do
   # bintray.com is the official download host per the vendor homepage
   url "https://dl.bintray.com/mitchellh/consul/#{version}_darwin_amd64.zip"
   name 'Consul'
-  homepage 'http://www.consul.io/'
+  homepage 'https://www.consul.io/'
   license :mpl
 
   binary 'consul'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
