### PR TITLE
Fix homepage and appcast to use SSL in Chocolat Cask

### DIFF
--- a/Casks/chocolat.rb
+++ b/Casks/chocolat.rb
@@ -3,9 +3,9 @@ cask :v1 => 'chocolat' do
   sha256 :no_check
 
   url 'https://chocolatapp.com/download'
-  appcast 'http://chocolatapp.com/userspace/appcast/appcast_alpha.php'
+  appcast 'https://chocolatapp.com/userspace/appcast/appcast_alpha.php'
   name 'Chocolat'
-  homepage 'http://chocolatapp.com/'
+  homepage 'https://chocolatapp.com/'
   license :commercial
 
   app 'Chocolat.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
