### PR TITLE
Fix urls and add license in Icons8 App Cask

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -3,12 +3,12 @@ cask :v1 => 'icons8' do
   version :latest
   sha256 :no_check
 
-  url 'http://cdnd.icons8.com/download/Icons8App_for_Mac_OS.dmg'
-  name 'Icons8 App'
-  homepage 'http://icons8.com'
+  url 'http://s.icons8.com/download/Icons8App_for_Mac_OS.dmg'
   appcast 'http://icons8.com/icons8_cast',
           :sha256 => 'd12d6eaeef140a4ad9e0801fb4ffba7765f2b40de786115d40526a9523809d2e'
-  license :closed
+  name 'Icons8 App'
+  homepage 'https://icons8.com/'
+  license :freemium
 
   app 'Icons8 App.app'
 end


### PR DESCRIPTION
- Add license from homepage
- Update url with the one given by the appcast feed
- Update the homepage to use ssl
