### PR TITLE
Fix homepage to use SSL in Tresorit Cask

### DIFF
--- a/Casks/tresorit.rb
+++ b/Casks/tresorit.rb
@@ -5,7 +5,7 @@ cask :v1 => 'tresorit' do
   # windows.net is the official download host per the vendor homepage
   url 'https://installerstorage.blob.core.windows.net/public/install/Tresorit.dmg'
   name 'Tresorit'
-  homepage 'http://tresorit.com'
+  homepage 'https://tresorit.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tresorit.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
