### PR TITLE
Update homepage and info about discontinuation in younited Cask

### DIFF
--- a/Casks/younited.rb
+++ b/Casks/younited.rb
@@ -1,12 +1,17 @@
 cask :v1 => 'younited' do
+  # todo: Cask may be deleted after October 1, 2015
   version :latest
   sha256 :no_check
 
   # secure.com is the official download host per the vendor homepage
   url 'https://download.sp.f-secure.com/younited/younited.dmg'
   name 'younited'
-  homepage 'http://www.younited.com/'
+  homepage 'https://www.younited.com/en/home'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'younited.app'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
- Use SSL on the homepage href (was already redirected)
- Add discontinued (Info from homepage)
- Add note to revalidate after the service discontinued
