### PR TITLE
Fix homepage to use SSL in Dump Truck Cask

### DIFF
--- a/Casks/dump-truck.rb
+++ b/Casks/dump-truck.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dump-truck' do
 
   url 'https://www.goldenfrog.com/downloads/dumptruck/dumptruck.dmg'
   name 'Dump Truck'
-  homepage 'http://www.goldenfrog.com/dumptruck'
+  homepage 'https://www.goldenfrog.com/dumptruck'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Dump Truck.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
