### PR TITLE
Fix homepage to use SSL in Sococo Cask

### DIFF
--- a/Casks/sococo.rb
+++ b/Casks/sococo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sococo' do
 
   url "http://download.sococo.com/10069/Sococo_#{version.gsub('.','_')}_10069.dmg"
   name 'Sococo'
-  homepage 'http://www.sococo.com'
+  homepage 'https://www.sococo.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Sococo.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
