### PR TITLE
Fix homepage and appcast to use SSL in TileMill Cask

### DIFF
--- a/Casks/tilemill.rb
+++ b/Casks/tilemill.rb
@@ -4,10 +4,10 @@ cask :v1 => 'tilemill' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://tilemill.s3.amazonaws.com/latest/TileMill-#{version}.zip"
-  appcast 'http://mapbox.com/tilemill/platforms/osx/appcast2.xml',
+  appcast 'https://www.mapbox.com/tilemill/platforms/osx/appcast2.xml/',
           :sha256 => '839122af3c2d526d97557078a0f84dc6c3c146bd35bcba915949c671be79ac02'
   name 'TileMill'
-  homepage 'http://www.mapbox.com/tilemill/'
+  homepage 'https://www.mapbox.com/tilemill/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TileMill.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
