### PR TITLE
Fix homepage to use SSL in SpriteIlluminator Cask

### DIFF
--- a/Casks/spriteilluminator.rb
+++ b/Casks/spriteilluminator.rb
@@ -4,7 +4,7 @@ cask :v1 => 'spriteilluminator' do
 
   url "https://www.codeandweb.com/download/spriteilluminator/#{version}/SpriteIlluminator-#{version}-uni.dmg"
   name 'SpriteIlluminator'
-  homepage 'http://www.codeandweb.com/spriteilluminator'
+  homepage 'https://www.codeandweb.com/spriteilluminator'
   license :commercial
 
   app 'SpriteIlluminator.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
