### PR TITLE
Fix homepage to use SSL in Backblaze Downloader Cask

### DIFF
--- a/Casks/backblaze-downloader.rb
+++ b/Casks/backblaze-downloader.rb
@@ -4,7 +4,7 @@ cask :v1 => 'backblaze-downloader' do
 
   url 'https://secure.backblaze.com/mac_restore_downloader'
   name 'Backblaze Downloader'
-  homepage 'http://www.backblaze.com/'
+  homepage 'https://www.backblaze.com/'
   license :commercial
 
   app 'Backblaze Downloader.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
