### PR TITLE
Fix url, appcast and homepage to use SSL in Screenmailer Cask

### DIFF
--- a/Casks/screenmailer.rb
+++ b/Casks/screenmailer.rb
@@ -2,10 +2,10 @@ cask :v1 => 'screenmailer' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.screenmailer.com/download'
-  appcast 'http://www.screenmailer.com/releases/current/releases.xml'
+  url 'https://www.screenmailer.com/releases/current/Screenmailer.zip'
+  appcast 'https://www.screenmailer.com/releases/current/releases.xml'
   name 'Screenmailer'
-  homepage 'http://www.screenmailer.com'
+  homepage 'https://www.screenmailer.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Screenmailer.app'


### PR DESCRIPTION
The new url is from the appcast entry.
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
