### PR TITLE
Fix homepage to use SSL in BrowserStack Cask

### DIFF
--- a/Casks/browserstacklocal.rb
+++ b/Casks/browserstacklocal.rb
@@ -5,7 +5,7 @@ cask :v1 => 'browserstacklocal' do
   url 'https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip'
   name 'BrowserStack'
   name 'BrowserStack Local'
-  homepage 'http://www.browserstack.com/'
+  homepage 'https://www.browserstack.com/'
   license :commercial
 
   binary 'BrowserStackLocal'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
