### PR TITLE
Fix homepage to use SSL in Max Cask

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cycling74-max' do
 
   url "http://filepivot.appspot.com/projects/maxmspjitter/files/Max#{version.sub('-','_').gsub('.','')}.dmg"
   name 'Max'
-  homepage 'http://cycling74.com'
+  homepage 'https://cycling74.com/'
   license :commercial
   tags :vendor => 'Cycling ‘74'
 


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
