### PR TITLE
Fix homepage to use SSL in Picturelife Smartloader Cask

### DIFF
--- a/Casks/picturelife.rb
+++ b/Casks/picturelife.rb
@@ -4,7 +4,7 @@ cask :v1 => 'picturelife' do
 
   url 'https://www.streamnation.com/uploader/osx/picturelife/Picturelife.dmg'
   name 'Picturelife Smartloader'
-  homepage 'http://picturelife.com'
+  homepage 'https://picturelife.com/home'
   license :gratis
 
   app 'Picturelife.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
