### PR TITLE
Fix homepage to use SSL in Prott Cask

### DIFF
--- a/Casks/prott.rb
+++ b/Casks/prott.rb
@@ -4,7 +4,7 @@ cask :v1 => 'prott' do
 
   url 'https://prottapp.com/app/gadgets/prott.dmg'
   name 'Prott'
-  homepage 'http://prottapp.com/'
+  homepage 'https://prottapp.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Prott.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
