### PR TITLE
Fix homepage to use SSL in BankID Cask

### DIFF
--- a/Casks/bankid.rb
+++ b/Casks/bankid.rb
@@ -4,7 +4,7 @@ cask :v1 => 'bankid' do
 
   url 'https://install.bankid.com/FileDownloader?fileId=Mac'
   name 'BankID'
-  homepage 'http://www.bankid.com/'
+  homepage 'https://www.bankid.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   container :type => :naked


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
