### PR TITLE
Fix homepage to use SSL in Prepros Cask

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -4,7 +4,7 @@ cask :v1 => 'prepros' do
 
   url "http://download.alphapixels.com/Prepros-#{version}.zip"
   name 'Prepros'
-  homepage 'http://alphapixels.com/prepros/'
+  homepage 'https://prepros.io'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Prepros.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
