### PR TITLE
Fix homepage to use SSL in SpiderOak Cask

### DIFF
--- a/Casks/spideroak.rb
+++ b/Casks/spideroak.rb
@@ -4,7 +4,7 @@ cask :v1 => 'spideroak' do
 
   url 'https://spideroak.com/getbuild?platform=mac'
   name 'SpiderOak'
-  homepage 'http://spideroak.com'
+  homepage 'https://spideroak.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'SpiderOak.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
