### PR TITLE
Fix homepage to use SSL in Wizard101 Cask

### DIFF
--- a/Casks/wizard101.rb
+++ b/Casks/wizard101.rb
@@ -6,7 +6,7 @@ cask :v1 => 'wizard101' do
   name 'Wizard101'
   appcast 'http://versionec.us.wizard101.com//Wizard101.xml',
           :sha256 => '537ab70a2fe32fd73c7d56950ea5edee58e1e0b1daf0014a2c921d3550d18740'
-  homepage 'http://wizard101.com'
+  homepage 'https://www.wizard101.com/'
   license :unknown
 
   app 'Wizard101.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
