### PR TITLE
Fix homepage to use SSL in Corona SDK Cask

### DIFF
--- a/Casks/coronasdk.rb
+++ b/Casks/coronasdk.rb
@@ -4,7 +4,7 @@ cask :v1 => 'coronasdk' do
 
   url 'http://developer.coronalabs.com/sites/default/files/CoronaSDK-2014.2511.dmg'
   name 'Corona SDK'
-  homepage 'http://coronalabs.com/products/corona-sdk'
+  homepage 'https://coronalabs.com/products/corona-sdk/'
   license :gratis
 
   suite 'CoronaSDK'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
