### PR TITLE
Fix homepage to use SSL in TexturePacker Cask

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -4,7 +4,7 @@ cask :v1 => 'texturepacker' do
 
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   name 'TexturePacker'
-  homepage 'http://www.codeandweb.com/texturepacker'
+  homepage 'https://www.codeandweb.com/texturepacker'
   license :freemium
 
   app 'TexturePacker.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
