### PR TITLE
Fix homepage to use SSL in LinCastor Cask

### DIFF
--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -7,7 +7,7 @@ cask :v1 => 'lincastor' do
   name 'LinCastor'
   appcast 'https://onflapp.appspot.com/lincastor',
           :sha256 => '73779a4fd108e386f7da331dc54810f33de4af3a25e66b75a8155b24382a155f'
-  homepage 'http://onflapp.wordpress.com/lincastor/'
+  homepage 'https://onflapp.wordpress.com/lincastor/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'LinCastor.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
