### PR TITLE
Fix homepage to use SSL in Dolphin Cask

### DIFF
--- a/Casks/dolphin.rb
+++ b/Casks/dolphin.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dolphin' do
 
   url "http://dl.dolphin-emu.org/builds/dolphin-master-#{version}.dmg"
   name 'Dolphin'
-  homepage 'http://www.dolphin-emu.org/'
+  homepage 'https://dolphin-emu.org/'
   license :gpl
 
   app 'Dolphin.app'


### PR DESCRIPTION
The HTTP URL is already getting redirected to HTTPS. Using the HTTPS URL directly
makes it more secure and saves a HTTP round-trip.
