### PR TITLE
updating Mactex

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'mactex' do
-  version '20140525'
-  sha256 '4e7fc21dbddae436f604dbeb3db2dc13c44aa9e2dd827a669a170418e84fc7e6'
+  version '20150609'
+  sha256 'e5e3c3f0c753878dd7bd55660cef87a37816179c9b323b75f36daf11a6824b62'
 
   # ctan.org is the official download host per the vendor homepage
-  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
-  name 'MacTeX'
+   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
+name 'MacTeX'
   homepage 'http://www.tug.org/mactex/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
@@ -12,8 +12,8 @@ cask :v1 => 'mactex' do
 
   uninstall :pkgutil => [
                          'org.tug.mactex.ghostscript9.10',
-                         'org.tug.mactex.gui2014',
-                         'org.tug.mactex.texlive2014'
+                         'org.tug.mactex.gui2015',
+                         'org.tug.mactex.texlive2015'
                         ],
             :delete  => [
                          '/Applications/TeX',

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mactex' do
 
   # ctan.org is the official download host per the vendor homepage
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
-name 'MacTeX'
+  name 'MacTeX'
   homepage 'http://www.tug.org/mactex/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -3,7 +3,7 @@ cask :v1 => 'mactex' do
   sha256 'e5e3c3f0c753878dd7bd55660cef87a37816179c9b323b75f36daf11a6824b62'
 
   # ctan.org is the official download host per the vendor homepage
-   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
+  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
 name 'MacTeX'
   homepage 'http://www.tug.org/mactex/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -11,7 +11,7 @@ name 'MacTeX'
   pkg "mactex-#{version}.pkg"
 
   uninstall :pkgutil => [
-                         'org.tug.mactex.ghostscript9.10',
+                         'org.tug.mactex.ghostscript9.16',
                          'org.tug.mactex.gui2015',
                          'org.tug.mactex.texlive2015'
                         ],


### PR DESCRIPTION
today is the day where texlive updates to 2015

this cask updates the version to the latest + updates the names of the packages to uninstall
