### PR TITLE
Updated basictex to point to the new .pkg filename

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -3,7 +3,7 @@ cask :v1 => 'basictex' do
   sha256 :no_check
 
   # ctan.org is the official download host per the vendor homepage
-  url 'http://mirror.ctan.org/systems/mac/mactex/mactex-basic.pkg'
+  url 'http://mirror.ctan.org/systems/mac/mactex/basictex.pkg'
   name 'BasicTeX'
   homepage 'http://www.tug.org/mactex/morepackages.html'
   license :oss

--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -3,14 +3,14 @@ cask :v1 => 'basictex' do
   sha256 :no_check
 
   # ctan.org is the official download host per the vendor homepage
-  url 'http://mirror.ctan.org/systems/mac/mactex/basictex.pkg'
+  url 'http://mirror.ctan.org/systems/mac/mactex/BasicTeX.pkg'
   name 'BasicTeX'
   homepage 'http://www.tug.org/mactex/morepackages.html'
   license :oss
 
-  pkg 'mactex-basic.pkg'
+  pkg 'BasicTeX.pkg'
 
-  uninstall :pkgutil => 'org.tug.mactex.basictex2014'
+  uninstall :pkgutil => 'org.tug.mactex.basictex2015'
   caveats do
     path_environment_variable '/usr/texbin'
   end


### PR DESCRIPTION
At some point, BasicTeX changed the package filename and the URL had yet to be updated. See here:
http://mirror.ctan.org/systems/mac/mactex/
