### PR TITLE
fontforge: don't symlink executable

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -9,7 +9,4 @@ cask :v1 => 'fontforge' do
   license :bsd
 
   app 'FontForge.app'
-  binary 'FontForge.app/Contents/MacOS/FontForge'
-
-  conflicts_with :formula => 'fontforge'
 end


### PR DESCRIPTION
Removes the conflict with Homebrew/homebrew and stops symlinking the executable.

The executable knows it is being symlinked and throws objections around, so short-term it's easier for people to prepend their PATH if they want to use the GUI FontForge executable.

Closes #11860
