### PR TITLE
Update parse to installer.sh form

### DIFF
--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -2,15 +2,17 @@ cask :v1 => 'parse' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.parse.com/downloads/cloud_code/parse'
+  url 'https://parse.com/downloads/cloud_code/cli/parse-osx/latest'
   name 'Parse'
   homepage 'https://parse.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  container :type => :naked
-  binary 'parse'
+  depends_on :formula => 'unar'
+
+  container :type => :generic_unar # The downloaded file don't have a .gz suffix, so specifying :gzip here won't work.
+  binary 'parse-latest', :target => 'parse'
 
   postflight do
-    system '/bin/chmod', '--', '0755', "#{staged_path}/parse"
+    system '/bin/chmod', '--', '0755', "#{staged_path}/parse-latest"
   end
 end


### PR DESCRIPTION
## Why

Upgrade parse cask to current form specified in [Quick Start](https://parse.com/apps/quickstart#cloud_code/unix).
## Screenshots
### Current Quick Start page of Parse.com

![screen shot 2015-06-14 at 2 53 11 pm](https://cloud.githubusercontent.com/assets/922234/8147634/122ea758-12a8-11e5-9c9c-1633f8216d6b.png)
### Test result on local machine

![screen shot 2015-06-14 at 3 12 30 pm](https://cloud.githubusercontent.com/assets/922234/8147633/11ec9e58-12a8-11e5-9709-7c8860b8c3c1.png)
