### PR TITLE
WebStorm now supports Java 8

### DIFF
--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -8,15 +8,4 @@ cask :v1 => 'webstorm' do
   license :commercial
 
   app 'WebStorm.app'
-
-  caveats <<-EOS.undent
-    #{token} requires Java 6 like any other IntelliJ-based IDE.
-    You can install it with
-
-      brew cask install caskroom/homebrew-versions/java6
-
-    The vendor (JetBrains) doesn't support newer versions of Java (yet)
-    due to several critical issues, see details at
-    https://intellij-support.jetbrains.com/entries/27854363
-  EOS
 end


### PR DESCRIPTION
WebStorm now supports Java 8 => Removing 'caveat' message
