### PR TITLE
IntelliJ CE now supports Java 8

### DIFF
--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -15,15 +15,4 @@ cask :v1 => 'intellij-idea-ce' do
                   '~/Library/Caches/IdeaIC14',
                   '~/Library/Logs/IdeaIC14',
                  ]
-
-  caveats <<-EOS.undent
-    #{token} requires Java 6 like any other IntelliJ-based IDE.
-    You can install it with
-
-      brew cask install caskroom/homebrew-versions/java6
-
-    The vendor (JetBrains) doesn't support newer versions of Java (yet)
-    due to several critical issues, see details at
-    https://intellij-support.jetbrains.com/entries/27854363
-  EOS
 end


### PR DESCRIPTION
IntelliJ CE now supports Java 8 => Removing 'caveat' message
