### PR TITLE
Update Aptana cask for version 3.6.1

### DIFF
--- a/Casks/aptanastudio.rb
+++ b/Casks/aptanastudio.rb
@@ -1,8 +1,7 @@
 cask :v1 => 'aptanastudio' do
-  version '3.6.0'
-  sha256 'd2207934d485cca10d6ad624a67d9f21c1bef46e0a9d58a9db334cec7fb55948'
-
-  url "http://download.aptana.com/studio3/standalone/#{version}/mac/Aptana_Studio_3_Setup_#{version}.dmg"
+  version '3.6.1'
+  sha256 '1eed9a94ce9b9bf03743f0bfdc5efd752b3470842170ba571ee25d2810c3c8f0'
+  url "https://github.com/aptana/studio3/releases/download/v#{version}/Aptana_Studio_3_Setup_#{version}.dmg"
   name 'Aptana Studio'
   homepage 'http://www.aptana.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
The download is now on github.com instead of aptana.com.
