### PR TITLE
Add TREZOR Bridge v1.1.0

### DIFF
--- a/Casks/trezor-bridge.rb
+++ b/Casks/trezor-bridge.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'trezor-bridge' do
+  version '1.1.0'
+  sha256 'c1d80463b6327b24c17adb431b411ccde7dcf3e94615548ccd6af2e60923fa69'
+
+  # amazonaws.com is the official download host per the vendor homepage
+  url "https://mytrezor.s3.amazonaws.com/bridge/#{version}/trezor-bridge-#{version}.pkg"
+  name 'TREZOR Bridge'
+  homepage 'https://mytrezor.com/'
+  license :gratis
+
+  pkg "trezor-bridge-#{version}.pkg"
+
+  uninstall :pkgutil   => 'com.bitcointrezor.pkg.TREZORBridge',
+            :launchctl => 'com.bitcointrezor.trezorBridge.trezord'
+
+  depends_on :formula => 'protobuf'
+  depends_on :formula => 'libmicrohttpd'
+end


### PR DESCRIPTION
Note: The package installs a LaunchAgent, but `:launchctl` appears unnecessary since the `:pkgid` seems to clean it up.

It also depends on `protobuf` and version 0.9.42 of `libmicrohttpd` (which Homebrew has not updated since 0.9.39, and I am pushing a patch for that now). Should I include `depends_on :formula` for these, considering that it actually serves no function right now?

Closes #11580.
