### PR TITLE
sigil.rb: updated sha256 due to updated binary

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'sigil' do
-  version '0.8.6'
-  sha256 'b69d642d7f1126b7f7d1c542773267c1dbaa764e2ec473258ff93d3a8f385c71'
+  version '0.8.7'
+  sha256 'a34ad28a758c64202cb380dcb3831d8f3a6afc100926be7be93d12f39f9493d7'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/user-none/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"


### PR DESCRIPTION
Version 0.8.7 is out.
