### PR TITLE
Renamed BaseCamp to Garmin BaseCamp following token standards

### DIFF
--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -1,9 +1,9 @@
-cask :v1 => 'basecamp' do
+cask :v1 => 'garmin-basecamp' do
   version '4.4.7'
   sha256 '9145350f7fd4206049aca7baeaf069118bd619f8135bf049b8a86d18e97f1986'
 
   url "http://download.garmin.com/software/BaseCampforMac_#{version.gsub('.', '')}.dmg"
-  name 'BaseCamp'
+  name 'Garmin BaseCamp'
   homepage 'http://www.garmin.com/en-US/shop/downloads/basecamp'
   license :gratis
 


### PR DESCRIPTION
Renamed BaseCamp to Garmin BaseCamp, following the [token standards](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_token_reference.md). This also makes it easier to find when searching for garmin.
