### PR TITLE
Use yy.mm.dd format for Armitage version stanza

### DIFF
--- a/Casks/armitage.rb
+++ b/Casks/armitage.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'armitage' do
-  version '11.20.14'
+  version '14.11.20'
   sha256 'b309fdef13c8a3a0d981ffc1ad2bfb4786a797f4e291dd4ef3bcc2806c1126f4'
 
-  url "http://www.fastandeasyhacking.com/download/armitage#{version.sub(%r{^(\d+)\.(\d+)\.(\d+)$},'\3\1\2')}.dmg"
+  url "http://www.fastandeasyhacking.com/download/armitage#{version.gsub('.', '')}.dmg"
   name 'Armitage'
   homepage 'http://www.fastandeasyhacking.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
The previous mm.dd.yy format would not play well with any future implementation of `brew cask upgrade`. In addition, the reordering in the `url` stanza is ugly and hard to read. This change solves both problems.

Relevant discussion in #11942.
