### PR TITLE
attempt to clean up launchctl plists on uninstall (rebased)

### DIFF
--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'pathname'
 
 class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
 
@@ -210,9 +211,22 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
         [false, true].each do |with_sudo|
           plist_status = @command.run('/bin/launchctl', :args => ['list', service], :sudo => with_sudo, :print_stderr => false).stdout
           if %r{^\{}.match(plist_status)
-            @command.run('/bin/launchctl',  :args => ['unload', '-w', '--', service], :sudo => with_sudo)
+            result = @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
+            if result.success?
+              paths = ["/Library/LaunchAgents/#{service}.plist",
+                       "/Library/LaunchDaemons/#{service}.plist"]
+              paths.each { |elt| elt.prepend('~') } unless with_sudo
+              paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
+              paths.each do |path|
+                @command.run!('/bin/rm', :args => ['-f', '--', path], :sudo => with_sudo)
+              end
+            end
             sleep 1
-            @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
+          end
+          # undocumented and untested: pass a path to uninstall :launchctl
+          if Pathname(service).exist?
+            @command.run!('/bin/launchctl', :args => ['unload', '-w', '--', service], :sudo => with_sudo)
+            @command.run!('/bin/rm',        :args => ['-f', '--', service], :sudo => with_sudo)
             sleep 1
           end
         end

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -118,7 +118,6 @@ describe Hbc::Artifact::Uninstall do
       )
 
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'remove', 'my.fancy.package.service'])
-      Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'unload', '-w', '--', 'my.fancy.package.service'])
 
       Hbc::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/kextstat', '-l', '-b', 'my.fancy.package.kernelextension'], 'loaded')
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', 'my.fancy.package.kernelextension'])

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -120,7 +120,6 @@ describe Hbc::Artifact::Zap do
       )
 
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'remove', 'my.fancy.package.service'])
-      Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/launchctl', 'unload', '-w', '--', 'my.fancy.package.service'])
 
       Hbc::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/sbin/kextstat', '-l', '-b', 'my.fancy.package.kernelextension'], 'loaded')
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/sbin/kextunload', '-b', 'my.fancy.package.kernelextension'])


### PR DESCRIPTION
separate `launchctl unload` and comment that this command was intended for unloading jobs by pathname rather than bundle ID. Leave that undocumented for now as it is untested.

This is just a rebase of @rolandwalker's #8523 onto the current master to resolve merge conflicts, as requested by @vitorgalvao in #11940.
