### PR TITLE
Update gitbook.rb

### DIFF
--- a/Casks/gitbook.rb
+++ b/Casks/gitbook.rb
@@ -2,10 +2,10 @@ cask :v1 => 'gitbook' do
   version '1.1.0'
   sha256 'f8e2f7b28e7dfa18b3736f8d43d68068228774c0827fdc8c685846a129459c5f'
 
-  url "https://github.com/GitbookIO/editor/releases/download/#{version}/gitbook-mac.dmg"
-  appcast 'https://github.com/GitbookIO/editor/releases.atom'
+  url "https://github.com/GitbookIO/editor-legacy/releases/download/#{version}/gitbook-mac.dmg"
+  appcast 'https://github.com/GitbookIO/editor-legacy/releases.atom'
   name 'GitBook'
-  homepage 'https://github.com/GitbookIO/editor'
+  homepage 'https://github.com/GitbookIO/editor-legacy'
   license :apache
 
   app 'GitBook.app'


### PR DESCRIPTION
Hi, I just saw that some users are still installing the GitBook editor using homebrew (this editor is deprecated since november 2014), we changed the repository name (`editor` is now a private repository).

A new version of the editor is coming next month with support for desktop.
