### PR TITLE
New patch version of pycharm

### DIFF
--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'pycharm-ce' do
-  version '4.5.1'
+  version '4.5.2'
   sha256 '472ade2737d1d86b6d83f1d6e3ae85e011a2194d2a94f1397ae09eeb229f79af'
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pycharm-ce' do
   version '4.5.2'
-  sha256 '472ade2737d1d86b6d83f1d6e3ae85e011a2194d2a94f1397ae09eeb229f79af'
+  sha256 'e1541e68a3c59464f7f8266f144ebc4dc99499da914d001f768e0e0b1dc2d6fd'
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"
   name 'PyCharm'


### PR DESCRIPTION
Pycharm's version has updated to 4.5.2. It seemed pretty straightforward to update it so `brew cask` will install it.
