### PR TITLE
Add Sonarr Menu Helper App 2.2

### DIFF
--- a/Casks/sonarr-menu-helper.rb
+++ b/Casks/sonarr-menu-helper.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'sonarr-menu-helper' do
+  version '2.2'
+  sha256 :no_check
+
+  url 'https://github.com/jefbarn/Sonarr/releases/download/2.2/Sonarr.zip'
+  name 'Sonarr Menu Helper'
+  homepage 'https://github.com/jefbarn/Sonarr'
+  license :unknown
+
+  app 'Sonarr.app'
+
+  depends_on :cask => 'mono-mdk'
+end


### PR DESCRIPTION
This helper app conflicts with the standalone app. Is there any way to warn about a possible conflict, like with normal package formulas?

I tried this, but obviously it didn't work.

```
conflicts_with :cask => 'sonarr', :because => "This helper app will replace the standalone Sonarr.app."
```
