### PR TITLE
Upgrade OpenRA to 20150614

### DIFF
--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'openra' do
-  version '20150424'
-  sha256 'e90b6cbb7faf941e5b794a322c345132db15e7a31e12ec0a22a9518643baf356'
+  version '20150614'
+  sha256 '30afbc56e8f8964b158fd0cc811bb9d8bdc2f22a76e1b77458f1293658ff2fc8'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
@@ -8,6 +8,8 @@ cask :v1 => 'openra' do
   name 'OpenRA'
   homepage 'http://www.openra.net/'
   license :gpl
+
+  depends_on :cask => 'mono-mdk'
 
   app 'OpenRA.app'
 end


### PR DESCRIPTION
Updated cask OpenRA to version 20150614. Added required dependency for mono-mdk.
