### PR TITLE
Fix up QuoteFix for Mac

### DIFF
--- a/Casks/quotefix.rb
+++ b/Casks/quotefix.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'quotefix' do
-  version '2.5.2'
-  sha256 '8d914ae553b84fe5f246ab1eb030d25792ca8d626b3bbac57acee857135e85a9'
+  version '2.6.0'
+  sha256 'f7dfdafed6aded0edbb9668ce796ea5ebc890c8f769b42bd64a3de45b7f09f6b'
 
   url "https://github.com/robertklep/quotefixformac/releases/download/v#{version}/QuoteFix-v#{version}.zip"
   appcast 'https://github.com/robertklep/quotefixformac/releases.atom'
@@ -8,12 +8,16 @@ cask :v1 => 'quotefix' do
   homepage 'https://github.com/robertklep/quotefixformac'
   license :oss
 
-  artifact 'QuoteFix.mailbundle', :target => Pathname.new(File.expand_path('~')).join('Library/Mail/Bundles/QuoteFix.mailbundle')
+  stage_only true
 
   postflight do
     system 'defaults', 'write', 'com.apple.mail', 'EnableBundles', '-bool', 'true'
     system 'defaults', 'write', 'com.apple.mail', 'BundleCompatibilityVersion', '-string', '3'
+    system 'mkdir', '-p',  File.expand_path('~/Library/Mail/Bundles')
+    system 'cp', '-r',  File.join(staged_path, 'QuoteFix.mailbundle'), File.expand_path('~/Library/Mail/Bundles')
   end
+
+  uninstall :delete => File.expand_path('~/Library/Mail/Bundles/QuoteFix.mailbundle')
 
   caveats 'You may need to restart Mail.app before you can use QuoteFix'
 end


### PR DESCRIPTION
Changes:
- Bump to 2.6.0;
- Symlinking the mailbundle to `~/Library/Mail/Bundles` doesn't work, at least not on 10.10.3 (Mail.app would disable the bundle, probably due to security concerns — the destination of the link could potentially be replaced by something malicious). Therefore, `cp -r` is used instead to copy the bundle to the destination folder during post flight stage.

I'm not sure if I'm doing things in the preferred way though.
