### PR TITLE
version bump for freesmug-chromium

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'freesmug-chromium' do
-  version '43.0.2357.81'
-  sha256 'fc2c43f899d192d52ea84ae6940911094d6f670062b3c03e69499c689601c2fa'
+  version '43.0.2357.124'
+  sha256 'f3ded99268dad92c17f9c3d1ec2b0c82e3d8f27ec33e1881f3aafa9d3a0a5f83'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
(43.0.2357.81 to 43.0.2357.124)
