### PR TITLE
version bump freesmug-chromium

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'freesmug-chromium' do
-  version '43.0.2357.124'
-  sha256 'f3ded99268dad92c17f9c3d1ec2b0c82e3d8f27ec33e1881f3aafa9d3a0a5f83'
+  version '43.0.2357.130'
+  sha256 '530570afc135d3121f4df9f2edf4ffce3f3b817415694454ed7a9402b5dad387'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
(version 43.0.2357.124 to version 43.0.2357.130)
