### PR TITLE
Change warning from red to yellow

### DIFF
--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -51,7 +51,7 @@ end
 
 # originally from Homebrew
 def opoo(warning)
-  $stderr.puts "#{Tty.red.underline}Warning#{Tty.reset}: #{warning}"
+  $stderr.puts "#{Tty.yellow.underline}Warning#{Tty.reset}: #{warning}"
 end
 
 # originally from Homebrew


### PR DESCRIPTION
Warnings should not look the same as errors - i.e. should not be red IMO.

Example:
![screen shot 2015-06-23 at 13 04 06](https://cloud.githubusercontent.com/assets/287584/8305615/ad4cb43a-19a8-11e5-97df-822d40297cf0.png)

This PR changes it to:

![screen shot 2015-06-23 at 13 07 45](https://cloud.githubusercontent.com/assets/287584/8305633/ebaa7aa0-19a8-11e5-8664-e8e3eaa957b1.png)

In fact these "warnings" for _"Cask is already installed"_ should even have a lower level than warning - maybe a Notice with blue colour or something like that, but this can be another PR.
