### PR TITLE
New exception if uninstall fails but cask is installed

### DIFF
--- a/lib/hbc/cask.rb
+++ b/lib/hbc/cask.rb
@@ -75,6 +75,10 @@ class Hbc::Cask
     staged_path.exist?
   end
 
+  def installed_at_all?
+    caskroom_path.exist?
+  end
+
   def to_s
     @token
   end

--- a/lib/hbc/cli/uninstall.rb
+++ b/lib/hbc/cli/uninstall.rb
@@ -6,7 +6,13 @@ class Hbc::CLI::Uninstall < Hbc::CLI::Base
     cask_tokens.each do |cask_token|
       odebug "Uninstalling Cask #{cask_token}"
       cask = Hbc.load(cask_token)
-      raise Hbc::CaskNotInstalledError.new(cask) unless cask.installed? or force
+      if !cask.installed? and !force
+        if cask.installed_at_all?
+          raise Hbc::CaskUninstallVersionError.new(cask)
+        else 
+          raise Hbc::CaskNotInstalledError.new(cask)
+        end
+      end
       Hbc::Installer.new(cask).uninstall(force)
     end
   end

--- a/lib/hbc/exceptions.rb
+++ b/lib/hbc/exceptions.rb
@@ -11,6 +11,17 @@ class Hbc::CaskNotInstalledError < Hbc::CaskError
   end
 end
 
+class Hbc::CaskUninstallVersionError < Hbc::CaskError
+  attr_reader :token
+  def initialize(token)
+    @token = token
+  end
+
+  def to_s
+    "#{token} has an updated version, use uninstall --force to remove"
+  end
+end
+
 class Hbc::CaskUnavailableError < Hbc::CaskError
   attr_reader :token
   def initialize(token)


### PR DESCRIPTION
I ran into the well-known problem with uninstalling casks when the version has been incremented a bit ago (see for example #2988); my understanding is that this error would be simple to fix but right now it exists due to the project looking forward to `brew cask upgrade`. I think an exception like this is helpful: it informs the users that the problem is known and tells them how to proceed. All that's needed is to check `/opt/homebrew-cask/Caskroom/[cask]` rather than checking for a specific version. I'm really not very familiar with Ruby. If there's interest in merging this in I can try to look at tests as necessary but I'd appreciate help.
