### PR TITLE
Update Eclipse packages to the 4.5 aka Mars release

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-cpp' do
-  version '4.4.1'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '5240642f6b27ace256a02799c27af49f3b9cc3036259247bdd9e848bbea999c7'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-cpp-luna-SR1a-macosx-cocoa.tar.gz'
-  else
-    sha256 '8c69c32083943c27c38c38808e652020443256c511f28832ee6a7bc31b835241'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-cpp-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
-  end
+  sha256 '6732013ac98123004f8053d1d06452d2b5bffb13077f4db22a9358479c7a2d31'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-cpp-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse IDE for C/C++ Developers'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-ide' do
-  version '4.4.1'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 'ab9c32bc1d3ff8ebbe763b24ef8a2a1c12e3366427eaebfafaf29f349683d07c'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-standard-luna-SR1a-macosx-cocoa.tar.gz'
-  else
-    sha256 '528fdda23799600126b0bdd9341d3b749e315eb914a3187bc66317cf9c24d499'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-standard-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
-  end
+  sha256 'd50777bfa13728d46f6fbfb82309aa53d42661e694e1bf379e83db578efaba16'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-committers-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse IDE for Eclipse Committers'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-java' do
-  version '4.4.2'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '9a5424bb9c0e4ec336fcfae85aec3dbab5163e403dcde3abb6054b1cbe2d4b7a'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR2/eclipse-java-luna-SR2-macosx-cocoa.tar.gz'
-  else
-    sha256 '00e7890cf46d6b8ada002f39f7d2ed576c52eb87039b4e2ce92eeffce9866fea'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR2/eclipse-java-luna-SR2-macosx-cocoa-x86_64.tar.gz'
-  end
+  sha256 '6145fcd4e15f03dac50898fe489e56b8cbe5ef152f191907e3b9ee52a3c1c09e'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-java-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse IDE for Java Developers'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-jee' do
-  version '4.4.2'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '319a0c224c356aca62d3aae2b157cb958031e4afb4dfd41f6ab853915cd62dba'
-    url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/luna/SR2/eclipse-java-luna-SR2-macosx-cocoa.tar.gz&r=1'
-  else
-    sha256 '27e4307b45b76f664c52c43995cc2dca605cc751aa4605baf08b625eacf3d6ab'
-    url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/luna/SR2/eclipse-jee-luna-SR2-macosx-cocoa-x86_64.tar.gz&r=1'
-  end
+  sha256 '84fb3aedf7eb7202b02ca3d1d5b4f6eeaac5d36bd298759334df4f4e74e0ae51'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse IDE for Java EE Developers'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-modeling' do
-  version '4.4.1'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '3224dcba37aba162a3c0e592cd8f64ad6d8296c64579c4132bb3e114890340af'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-modeling-luna-SR1a-macosx-cocoa.tar.gz'
-  else
-    sha256 'd9c978019365b2de0d52fa210a9a9d23246455c5c45f62fb35f32498d42b7c44'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-modeling-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
-  end
+  sha256 '5e8b32911af23b7361b686f226308929a165f71dfcf7aa3c0e91ddd311491302'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-modeling-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse Modeling Tools'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-platform' do
-  version '4.4.2-201502041700'
+  version '4.5-201506032000'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '8ea83c03a714300008e2d2859a6be9238cdfe7a74cdb0bf7b4ef9e3e3bafcf5f'
-    url "http://download.eclipse.org/eclipse/downloads/drops#{version.to_i}/R-#{version}/eclipse-SDK-#{version.sub(%r{-.*},'')}-macosx-cocoa.tar.gz"
-  else
-    sha256 'e49cc9b6379a4eed7613f997b0b4c415f34bb858069a134f8ad46b1585761395'
-    url "http://download.eclipse.org/eclipse/downloads/drops#{version.to_i}/R-#{version}/eclipse-SDK-#{version.sub(%r{-.*},'')}-macosx-cocoa-x86_64.tar.gz"
-  end
+  sha256 '953b7ecacb3c84667c616e1b640240de8cf5c045f475d0aebc6179316ed083d6'
+  url "http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.to_i}/R-#{version}/eclipse-SDK-#{version.sub(%r{-.*},'')}-macosx-cocoa-x86_64.tar.gz&r=1"
 
   name 'Eclipse'
   name 'Eclipse SDK'
   homepage 'http://eclipse.org'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-ptp' do
-  version '4.4.2'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 'fb911562252d666053c75b56420f53bb35e80cdb820ab323e866cca279650fcd'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR2/eclipse-parallel-luna-SR2-macosx-cocoa.tar.gz'
-  else
-    sha256 '03bfcd97156101c9763a2ccb189dc66a597c97c101ff345793cd07f7fc2dee3a'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR2/eclipse-parallel-luna-SR2-macosx-cocoa-x86_64.tar.gz'
-  end
+  sha256 'a3a65de4af4b2db327732cfec8c0ea4d2aa4ada66089ce004b42eac4e5727e8b'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-parallel-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse Parallel Tools Platform'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,18 +1,15 @@
 cask :v1 => 'eclipse-rcp' do
-  version '4.4.1'
+  version '4.5'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 'd1801a1742ff9a96252f30a6234ee306023d228d0a22ab09a79f8ab6f0509132'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-rcp-luna-SR1a-macosx-cocoa.tar.gz'
-  else
-    sha256 'a105f7457c2820c8852c6e066e500e916074ba2d71eb87c4f296b3e77c1de44a'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-rcp-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
-  end
+  sha256 '6142fa040b9166b08991a1224ee30822450fec4eedc1fe4b5dcca7333dfe3af7'
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-rcp-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
 
   name 'Eclipse'
   name 'Eclipse for RCP and RAP Developers'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end


### PR DESCRIPTION
There is no Eclipse for PHP Developers 4.5 package yet
Support for 32bit packages is dropped in Mars release
