### PR TITLE
update Slic3r to v1.2.9 from 1.1.7 and update license

### DIFF
--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -1,11 +1,12 @@
 cask :v1 => 'slic3r' do
-  version '1.1.7'
-  sha256 '41ae1c3c5ee7ddeb2431698b63f6e4112c68b830de9f024730388a1eb062f80b'
+  version '1.2.9'
+  sha256 '2e8579791192332bb2ee6dce860d78edd4bb010ff06d0d7692dedee641a1bc1c'
 
   url "http://dl.slic3r.org/mac/slic3r-osx-uni-#{version.gsub('.', '-')}-stable.dmg"
   name 'Slic3r'
   homepage 'http://slic3r.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :affero
 
   app 'Slic3r.app'
+  binary 'Slic3r.app/Contents/MacOS/slic3r'
 end


### PR DESCRIPTION
- download-link was broken
- license is stated on [homepage](http://slic3r.org) footer as AGPLv3
- added binary link for CLI usage

It will break on every update of slic3r again as they move old versions into a subdirectory: http://dl.slic3r.org/mac/.
