### PR TITLE
Add Feed the Beast launcher

### DIFF
--- a/Casks/ftb-launcher.rb
+++ b/Casks/ftb-launcher.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'ftb-launcher' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://ftb.cursecdn.com/FTB2/launcher/FTB_Launcher.zip'
+  name 'Feed the Beast Launcher'
+  homepage 'http://www.feed-the-beast.com/'
+  license :apache
+
+  app 'Feed The Beast.app'
+end


### PR DESCRIPTION
The Feed the Beast launcher is a popular alternative minecraft launcher in
common use for its ability to easily install and run modpacks.
