### PR TITLE
Update eclipse-php to v4.5

### DIFF
--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -1,18 +1,14 @@
 cask :v1 => 'eclipse-php' do
-  version '4.4.1'
+  version '4.5'
+  sha256 'e41dd9ffb8b6297beae731bae83c1d5e4606889183b380faf37f15dc85fb3230'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '807940d356d5e860d8a282187f55c5055399af75ed35eb01a3a4bcfab44b18a4'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-php-luna-SR1a-macosx-cocoa.tar.gz'
-  else
-    sha256 '0c1e3461dde4dfa5faa0b2692431c195a25c58d1db6f5ac1b3547eddd20b6fff'
-    url 'http://download.eclipse.org/technology/epp/downloads/release/luna/SR1a/eclipse-php-luna-SR1a-macosx-cocoa-x86_64.tar.gz'
-  end
-
+  url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-php-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse for PHP Developers'
   homepage 'http://eclipse.org/'
   license :eclipse
+  depends_on :macos => '>= :leopard'
+  depends_on :arch => :x86_64
 
-  app 'eclipse/Eclipse.app'
+  app 'Eclipse.app'
 end


### PR DESCRIPTION
There is no longer a 32-bit version offered so that section was removed. The depends-on was added and the app was changed to match the other upgraded eclipse casks.
