### PR TITLE
Downgrade Bartender to version 1.2.39

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'bartender' do
-  version '1.2.40'
-  sha256 '530abbc8139a04a71af41e459a34fc9a352d18a0cbd7f39d6446c4d5ca7cb0ab'
+  version '1.2.39'
+  sha256 '8c9b8cdbefcc458598a41a1a8d77d9456e45b977836546c4fe41b6d086b00f33'
 
   url "http://macbartender.com/updates/#{version.gsub('.', '-')}/Bartender.zip",
       :referer => 'http://www.macbartender.com'


### PR DESCRIPTION
This commit changes the version and sha256 stanzas.

I updated this cask to 1.2.40 after following a prompt in the app. I
did not realise I was accepting testing versions of the app, and
version 1.2.40 was not a normal stable release. Sorry to anyone who
has been negatively affected by running the testing version in this
period.
