### PR TITLE
New Casks: beaTunes and Xpra

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'beatunes' do
+  version '4.0.24'
+  sha256 '33a0e98d42ce3ec7580912caaa165f1af2b927a28eb07bfaaf88981d617fe127'
+
+  url 'http://coxy.beatunes.com/download/beaTunes-4-0-24-osx.dmg'
+  name 'beaTunes'
+  homepage 'https://www.beatunes.com'
+  license :closed
+
+  app 'beaTunes4.app'
+end

--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'xpra' do
+  version '0.15.1'
+  sha256 'b0075aa1184d25f32019026e2dd1373f3c46de9ba8da44d18d60cee7b9a0f425'
+
+  url 'https://www.xpra.org/dists/osx/x86/Xpra.dmg'
+  name 'Xpra'
+  homepage 'https://www.xpra.org'
+  license :gpl
+
+  app 'Xpra.app'
+end


### PR DESCRIPTION
beaTunes is an advanced music application for Windows and OS X that lets you analyze, inspect, and play songs—and create compelling playlists.

Xpra is 'screen for X', and more: it allows you to run X programs, usually on a remote host and direct their display to your local machine. It also allows you to display existing desktop sessions remotely.
