### PR TITLE
Update praat to 5.4.10

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'praat' do
-  version '5.4.08'
+  version '5.4.10'
 
   if Hardware::CPU.is_32_bit?
-    sha256 '2a64f314b24a9ad516f8dba075d73278a31660966a10a207a4f3342f7bd3edb7'
+    sha256 'c6b52ba692ebaf67fdc9e44d5d85a0fb475e73002e72638a275ffb22dcc09a21'
     url "http://www.fon.hum.uva.nl/praat/praat#{version.gsub('.','')}_mac32.dmg"
   else
-    sha256 '3f6862f63ae9e98f60bbf25b709ba60e77d0140b0caa6fbd4ddd86d3eadb98c8'
+    sha256 'eaf81041ea413d0b693cb9138ff428f89d892ccd6b6d9d39cf96a7ab160777f1'
     url "http://www.fon.hum.uva.nl/praat/praat#{version.gsub('.','')}_mac64.dmg"
   end
 


### PR DESCRIPTION
from http://www.fon.hum.uva.nl/praat/manual/What_s_new_.html:

```
 5.4.10 (27 June 2015)

     Removed a bug introduced in version 4.5.09 (January 2007) that caused incorrect upsampling of stereo sounds when the upsampling factor was exactly 2. This bug has caused incorrect playing of stereo sounds with a sampling frequency of 22050 Hz on the Mac since January 2015.
     Removed a bug introduced in 2011 that could cause Praat to crash when you scrolled the LongSound window.
     TextGrid: Count intervals where... and Count points where.... 

5.4.09 (1 June 2015)

     Linux: the tab key can be used to play sounds on more computers.
     Windows: TextGrid files with non-BMP characters are now read correctly.
     Windows: files with names that contain non-BMP characters are now saved correctly.
     Updated manual.
```
