### PR TITLE
Updated lots of links to use SSL

### DIFF
--- a/Casks/0xdbe-eap.rb
+++ b/Casks/0xdbe-eap.rb
@@ -2,10 +2,10 @@ cask :v1 => '0xdbe-eap' do
   version '142.2675.6'
   sha256 '5494d5bd9acac414c1003d71751ab51258ba27fdfbf88947e09a4c3d1b39e539'
 
-  url "http://download.jetbrains.com/dbe/0xdbe-#{version}.dmg"
+  url "https://download.jetbrains.com/dbe/0xdbe-#{version}.dmg"
   name '0xDBE EAP'
   name '0xDBE'
-  homepage 'http://www.jetbrains.com/dbe/'
+  homepage 'https://www.jetbrains.com/dbe/'
   license :commercial
 
   app '0xDBE EAP.app'

--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -4,7 +4,7 @@ cask :v1 => '4k-video-downloader' do
 
   url "http://downloads.4kdownload.com/app/4kvideodownloader_#{version}.dmg"
   name '4K Video Downloader'
-  homepage 'http://www.4kdownload.com/products/product-videodownloader'
+  homepage 'https://www.4kdownload.com/products/product-videodownloader'
   license :freemium
 
   app '4K Video Downloader.app'

--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -5,7 +5,7 @@ cask :v1 => '4k-youtube-to-mp3' do
 
   url "http://downloads.4kdownload.com/app/4kyoutubetomp3_#{version}.dmg"
   name '4K Youtube to MP3'
-  homepage 'http://www.4kdownload.com/products/product-youtubetomp3'
+  homepage 'https://www.4kdownload.com/products/product-youtubetomp3'
   license :oss
 
   app '4K YouTube to MP3.app'

--- a/Casks/abgx360.rb
+++ b/Casks/abgx360.rb
@@ -3,7 +3,7 @@ cask :v1 => 'abgx360' do
   sha256 'b2b066d1500e6c6a64d103b2c1a9e1760be0a4e16df314b4868024c19df8c741'
 
   # dropbox.com is the official download host per the vendor homepage
-  url "http://dl.dropbox.com/u/59058148/abgx360-#{version}.pkg"
+  url "https://dl.dropbox.com/u/59058148/abgx360-#{version}.pkg"
   name 'abgx360'
   homepage 'http://abgx360.xecuter.com/'
   license :oss

--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ableton-live' do
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   name 'Ableton Live'
-  homepage 'http://ableton.com/en/live'
+  homepage 'https://ableton.com/en/live'
   license :commercial
 
   app "Ableton Live #{version[0]} Suite.app"

--- a/Casks/actotracker.rb
+++ b/Casks/actotracker.rb
@@ -5,7 +5,7 @@ cask :v1 => 'actotracker' do
   # dropboxusercontent.com is the official download host per the vendor homepage
   url 'https://dl.dropboxusercontent.com/u/7614970/ActoTracker.zip'
   name 'ActoTracker'
-  appcast 'http://onflapp.appspot.com/actotracker',
+  appcast 'https://onflapp.appspot.com/actotracker',
           :sha256 => '0d79b9232c6a18446e56fd91c7b65962b5486164c3a269dc5e1867b1a5354778'
   homepage 'https://onflapp.wordpress.com/actotracker/'
   license :gratis

--- a/Casks/actual-odbc-pack.rb
+++ b/Casks/actual-odbc-pack.rb
@@ -6,7 +6,7 @@ cask :v1 => 'actual-odbc-pack' do
   url 'http://actualtechnologies.cachefly.net/Actual_ODBC_Pack.dmg'
   name 'Actual ODBC Driver Pack'
   name 'Actual ODBC Drivers'
-  homepage 'http://www.actualtech.com/products.php'
+  homepage 'https://www.actualtech.com/products.php'
   license :commercial
 
   pkg 'Actual ODBC Pack.pkg'

--- a/Casks/adafruit-arduino.rb
+++ b/Casks/adafruit-arduino.rb
@@ -3,9 +3,9 @@ cask :v1 => 'adafruit-arduino' do
   sha256 'de1c64233c8a2c6b039f9eddd4c417e594afee51558cd9f2f335a831580e2d42'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://adafruit-download.s3.amazonaws.com/Adafruit%20Arduino%20#{version}%20-%20Mac%2011-8-13.zip"
+  url "https://adafruit-download.s3.amazonaws.com/Adafruit%20Arduino%20#{version}%20-%20Mac%2011-8-13.zip"
   name 'Adafruit Arduino'
-  homepage 'http://adafruit.com'
+  homepage 'https://adafruit.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app "Adafruit Arduino #{version}.app"

--- a/Casks/adapter.rb
+++ b/Casks/adapter.rb
@@ -6,7 +6,7 @@ cask :v1 => 'adapter' do
   name 'Adapter'
   appcast 'https://www.macroplant.com/adapter/adapterAppcast.xml',
           :sha256 => '036eb7f0efa1ea980a1233e39f4342dcc2751e048acdfb967532864930ca84de'
-  homepage 'http://www.macroplant.com/adapter/'
+  homepage 'https://www.macroplant.com/adapter/'
   license :gratis
 
   app 'Adapter.app'

--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -4,7 +4,7 @@ cask :v1 => 'adobe-dng-converter' do
 
   url "http://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.gsub('.', '_')}.dmg"
   name 'Adobe Camera Raw and DNG Converter'
-  homepage 'http://www.adobe.com/support/downloads/product.jsp?product=106&platform=Macintosh'
+  homepage 'https://www.adobe.com/support/downloads/product.jsp?product=106&platform=Macintosh'
   license :gratis
 
   pkg "DNGConverter_#{version.gsub('.', '_')}.pkg"

--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -4,7 +4,7 @@ cask :v1 => 'adobe-photoshop-lightroom' do
 
   url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.to_i}.x/Lightroom_#{version.to_i}_LS11_mac_#{version.gsub('.','_')}.dmg"
   name 'Adobe Photoshop Lightroom'
-  homepage 'http://www.adobe.com/products/photoshop-lightroom.html'
+  homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
   license :commercial
 
   pkg "Adobe Photoshop Lightroom #{version.to_i}.pkg"

--- a/Casks/adobe-reader.rb
+++ b/Casks/adobe-reader.rb
@@ -4,7 +4,7 @@ cask :v1 => 'adobe-reader' do
 
   url "http://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.gsub('.', '')[2..-1]}/AcroRdrDC_#{version.gsub('.', '')[2..-1]}_MUI.dmg"
   name 'Adobe Acrobat Reader DC'
-  homepage 'http://www.adobe.com/products/reader.html'
+  homepage 'https://www.adobe.com/products/reader.html'
   license :gratis
   tags :vendor => 'Adobe'
 

--- a/Casks/air-connect.rb
+++ b/Casks/air-connect.rb
@@ -4,7 +4,7 @@ cask :v1 => 'air-connect' do
 
   url 'http://downloads.avatron.com/AirConnectInstaller.zip'
   name 'Air Connect'
-  appcast 'http://avatron.com/updates/software/airconnect_mac/appcast.xml',
+  appcast 'https://avatron.com/updates/software/airconnect_mac/appcast.xml',
           :sha256 => 'af9bc6dc41bc632995c4e49b958a5623bc091ac0fe1fb337fbc9a571cfc1e85b'
   homepage 'https://avatron.com/get-air-connect/'
   license :gratis

--- a/Casks/airdisplay.rb
+++ b/Casks/airdisplay.rb
@@ -6,7 +6,7 @@ cask :v1 => 'airdisplay' do
   name 'Air Display'
   appcast 'https://www.avatron.com/updates/software/airdisplay/appcast.xml',
           :sha256 => '5318742e7d9f7f4da9498e3100d8b5f92abc18a574988f1d5fa5a551ad0af062'
-  homepage 'http://avatron.com/apps/air-display/'
+  homepage 'https://avatron.com/apps/air-display/'
   license :commercial
 
   pkg 'Air Display Installer.pkg'

--- a/Casks/alarm-clock.rb
+++ b/Casks/alarm-clock.rb
@@ -2,9 +2,9 @@ cask :v1 => 'alarm-clock' do
   version '2.4.5'
   sha256 '285d277572be83c632c696d565a8413c2d5149a460392177e9e1b601ffce8778'
 
-  url "http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/downloads/Alarm%20Clock%20(#{version}).dmg"
+  url "https://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/downloads/Alarm%20Clock%20(#{version}).dmg"
   name 'Alarm Clock'
-  homepage 'http://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/'
+  homepage 'https://wayback.archive.org/web/20130123192255/http://www.robbiehanson.com/alarmclock/'
   license :gratis
 
   app 'Alarm Clock.app'

--- a/Casks/alice.rb
+++ b/Casks/alice.rb
@@ -2,9 +2,9 @@ cask :v1 => 'alice' do
   version '1.4'
   sha256 '0d6259bdff7fd0309b532188445d0dd4f7ea4d50f5570e9b46d282fbade74ce1'
 
-  url "http://www.ps.uni-saarland.de/alice/download/Alice-#{version}-4-i386.dmg"
+  url "https://www.ps.uni-saarland.de/alice/download/Alice-#{version}-4-i386.dmg"
   name 'Alice'
-  homepage 'http://www.ps.uni-saarland.de/alice/'
+  homepage 'https://www.ps.uni-saarland.de/alice/'
   license :mit
 
   app 'Alice.app'

--- a/Casks/amazon-workdocs.rb
+++ b/Casks/amazon-workdocs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'amazon-workdocs' do
   # cloudfront.net is the official download host per the vendor homepage
   url 'https://d28gdqadgmua23.cloudfront.net/mac/Amazon%20WorkDocs.pkg'
   name 'Amazon WorkDocs'
-  homepage 'http://aws.amazon.com/workdocs/'
+  homepage 'https://aws.amazon.com/workdocs/'
   license :gratis
 
   pkg 'Amazon WorkDocs.pkg'

--- a/Casks/anvil.rb
+++ b/Casks/anvil.rb
@@ -5,7 +5,7 @@ cask :v1 => 'anvil' do
   # herokuapp.com is the official download host as per the vendor homepage
   url 'https://sparkler.herokuapp.com/apps/3/download'
   name 'Anvil'
-  appcast 'http://sparkler.herokuapp.com/apps/3/updates.xml'
+  appcast 'https://sparkler.herokuapp.com/apps/3/updates.xml'
   homepage 'http://anvilformac.com/'
   license :mit
 

--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -3,9 +3,9 @@ cask :v1 => 'apache-couchdb' do
   sha256 'c94dcc4e2ff163dfd3df52a3170f5f18be05beda3bf64c3e12a78dfe622dbf8f'
 
   # mirrorservice.org is the official download host per the vendor homepage
-  url "http://www.mirrorservice.org/sites/ftp.apache.org/couchdb/binary/mac/#{version}/Apache-CouchDB-#{version}.zip"
+  url "https://www.mirrorservice.org/sites/ftp.apache.org/couchdb/binary/mac/#{version}/Apache-CouchDB-#{version}.zip"
   name 'Apache CouchDB'
-  homepage 'http://couchdb.apache.org/'
+  homepage 'https://couchdb.apache.org/'
   license :apache
 
   app 'Apache CouchDB.app'

--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -5,7 +5,7 @@ cask :v1 => 'apache-directory-studio' do
   # apache.org is the official download host per the vendor homepage
   url "http://www.us.apache.org/dist/directory/studio/#{version}/ApacheDirectoryStudio-#{version}-macosx.cocoa.x86_64.tar.gz"
   name 'Apache Directory Studio'
-  homepage 'http://directory.apache.org/studio/'
+  homepage 'https://directory.apache.org/studio/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ApacheDirectoryStudio.app'

--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'app-tamer' do
   name 'AppTamer'
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT',
           :sha256 => 'bd1cff488e1a43a407cb8f9b572e827d56c922d3ef6a91a3459b055cec903f30'
-  homepage 'http://www.stclairsoft.com/AppTamer/'
+  homepage 'https://www.stclairsoft.com/AppTamer/'
   license :commercial
 
   app 'App Tamer.app'

--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -2,9 +2,9 @@ cask :v1 => 'appcode' do
   version '3.1.7'
   sha256 '07e044187062c183af49c67259fe8ea207a846476c21d105c2643779ac4b405c'
 
-  url "http://download.jetbrains.com/objc/AppCode-#{version}.dmg"
+  url "https://download.jetbrains.com/objc/AppCode-#{version}.dmg"
   name 'AppCode'
-  homepage 'http://www.jetbrains.com/objc/'
+  homepage 'https://www.jetbrains.com/objc/'
   license :commercial
 
   app 'AppCode.app'

--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -4,7 +4,7 @@ cask :v1 => 'arduino' do
 
   url "http://arduino.cc/download.php?f=/arduino-#{version}-macosx.zip"
   name 'Arduino'
-  homepage 'http://arduino.cc/'
+  homepage 'https://arduino.cc/'
   license :oss
 
   app 'Arduino.app'

--- a/Casks/art-directors-toolkit.rb
+++ b/Casks/art-directors-toolkit.rb
@@ -4,7 +4,7 @@ cask :v1 => 'art-directors-toolkit' do
 
   url "http://www.code-line.com/download/ArtDirectorsToolkit#{version.to_i}i.zip"
   name 'Art Directors Toolkit'
-  homepage 'http://code-line.com/artdirectorstoolkit'
+  homepage 'https://code-line.com/artdirectorstoolkit'
   license :commercial
 
   app "Art Directors Toolkit #{version.to_i}i.app"

--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -2,10 +2,10 @@ cask :v1 => 'atext' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.trankynam.com/atext/downloads/aText.dmg'
+  url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   name 'aText'
-  appcast 'http://www.trankynam.com/atext/aText-Appcast.xml'
-  homepage 'http://www.trankynam.com/atext/'
+  appcast 'https://www.trankynam.com/atext/aText-Appcast.xml'
+  homepage 'https://www.trankynam.com/atext/'
   license :commercial
 
   app 'aText.app'

--- a/Casks/atraci.rb
+++ b/Casks/atraci.rb
@@ -5,7 +5,7 @@ cask :v1 => 'atraci' do
   url "https://github.com/Atraci/Atraci/releases/download/#{version}/Atraci-mac.zip"
   appcast 'https://github.com/Atraci/Atraci/releases.atom'
   name 'Atraci'
-  homepage 'http://atraci.github.io/Atraci-website/'
+  homepage 'https://atraci.github.io/Atraci-website/'
   license :mit
 
   app 'Atraci.app'

--- a/Casks/au-lab.rb
+++ b/Casks/au-lab.rb
@@ -4,7 +4,7 @@ cask :v1 => 'au-lab' do
 
   url 'http://images.apple.com/itunes/mastered-for-itunes/docs/au_lab.zip'
   name 'AU Lab'
-  homepage 'http://www.apple.com/itunes/mastered-for-itunes/'
+  homepage 'https://www.apple.com/itunes/mastered-for-itunes/'
   license :gratis
 
   container :nested => 'AU Lab Image.dmg'

--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -4,9 +4,9 @@ cask :v1 => 'audio-hijack' do
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   name 'Audio Hijack'
-  appcast 'http://www.rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.audiohijack3',
+  appcast 'https://www.rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.audiohijack3',
           :sha256 => '50ff37091962a7b91773d2ef82c012d9a136775a4f40482f2bc8b42e27186f5b'
-  homepage 'http://www.rogueamoeba.com/audiohijack/'
+  homepage 'https://www.rogueamoeba.com/audiohijack/'
   license :commercial
 
   app 'Audio Hijack.app'

--- a/Casks/aurora.rb
+++ b/Casks/aurora.rb
@@ -4,9 +4,9 @@ cask :v1 => 'aurora' do
 
   url "https://www.oneperiodic.com/files/Aurora%20v#{version}.zip"
   name 'Aurora'
-  appcast 'http://www.oneperiodic.com/aurora5.xml',
+  appcast 'https://www.oneperiodic.com/aurora5.xml',
           :sha256 => 'dae31492d459b5b8c1061a5866868b7f8f3f82afebf55a09ba8d559fdae185dd'
-  homepage 'http://www.oneperiodic.com/products/aurora/'
+  homepage 'https://www.oneperiodic.com/products/aurora/'
   license :commercial
 
   app 'Aurora.app'

--- a/Casks/avast.rb
+++ b/Casks/avast.rb
@@ -5,7 +5,7 @@ cask :v1 => 'avast' do
   url 'http://download.ff.avast.com/mac/avast_free_mac_security.dmg'
   name 'Avast'
   name 'Avast Mac Security'
-  homepage 'http://www.avast.com/'
+  homepage 'https://www.avast.com/'
   license :commercial
 
   pkg 'Avast Mac Security.pkg'

--- a/Casks/avidcodecsle.rb
+++ b/Casks/avidcodecsle.rb
@@ -4,7 +4,7 @@ cask :v1 => 'avidcodecsle' do
 
   url "http://resources.avid.com/supportfiles/attach/AvidCodecsLE_#{version.gsub('.','_')}/Mac/AvidCodecsLE.pkg.zip"
   name 'Avid DNxHR codec'
-  homepage 'http://www.avid.com/US/industries/workflow/DNxHD-Codec'
+  homepage 'https://www.avid.com/US/industries/workflow/DNxHD-Codec'
   license :commercial
 
   pkg 'AvidCodecsLE.pkg'

--- a/Casks/axure-rp-pro.rb
+++ b/Casks/axure-rp-pro.rb
@@ -5,7 +5,7 @@ cask :v1 => 'axure-rp-pro' do
   # cachefly.net is the official download host per the vendor homepage
   url 'https://axure.cachefly.net/AxureRP-Pro-Setup.dmg'
   name 'Axure RP'
-  homepage 'http://www.axure.com/'
+  homepage 'https://www.axure.com/'
   license :commercial
 
   app 'Axure RP Pro 7.0.app'

--- a/Casks/azure-cli.rb
+++ b/Casks/azure-cli.rb
@@ -4,7 +4,7 @@ cask :v1 => 'azure-cli' do
 
   url 'http://go.microsoft.com/fwlink/?linkid=252249&clcid=0x409'
   name 'Microsoft Azure SDK'
-  homepage 'http://azure.microsoft.com/en-us/documentation/articles/command-line-tools/'
+  homepage 'https://azure.microsoft.com/en-us/documentation/articles/command-line-tools/'
   license :gratis
   tags :vendor => 'Microsoft'
 

--- a/Casks/bandage.rb
+++ b/Casks/bandage.rb
@@ -5,7 +5,7 @@ cask :v1 => 'bandage' do
   url "https://github.com/rrwick/Bandage/releases/download/v#{version}/Bandage_Mac_v#{version}.zip"
   appcast 'https://github.com/rrwick/Bandage/releases.atom'
   name 'Bandage'
-  homepage 'http://rrwick.github.io/Bandage/'
+  homepage 'https://rrwick.github.io/Bandage/'
   license :gpl
 
   app 'Bandage.app'

--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -5,7 +5,7 @@ cask :v1 => 'basictex' do
   # ctan.org is the official download host per the vendor homepage
   url 'http://mirror.ctan.org/systems/mac/mactex/BasicTeX.pkg'
   name 'BasicTeX'
-  homepage 'http://www.tug.org/mactex/morepackages.html'
+  homepage 'https://www.tug.org/mactex/morepackages.html'
   license :oss
 
   pkg 'BasicTeX.pkg'

--- a/Casks/basis-sync.rb
+++ b/Casks/basis-sync.rb
@@ -3,9 +3,9 @@ cask :v1 => 'basis-sync' do
   sha256 '9d2434cbd8bf49a42df236bc9b4a4b999a28a2ce2e990237ac908199638328b5'
 
   # amazonaws is the official download host per the vendor homepage
-  url "http://mybasis-duck.s3.amazonaws.com/client/BasisSync-#{version}.dmg"
+  url "https://mybasis-duck.s3.amazonaws.com/client/BasisSync-#{version}.dmg"
   name 'Basis Sync'
-  homepage 'http://www.mybasis.com/'
+  homepage 'https://www.mybasis.com/'
   license :closed
 
   app 'Basis Sync.app'

--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -19,7 +19,7 @@ cask :v1 => 'bassjump' do
     pkg 'BassJumpInstaller.pkg'
   end
 
-  homepage 'http://www.twelvesouth.com/product/bassjump-2-for-macbook'
+  homepage 'https://www.twelvesouth.com/product/bassjump-2-for-macbook'
   license :gratis
 
   uninstall :pkgutil => [

--- a/Casks/beatport-pro.rb
+++ b/Casks/beatport-pro.rb
@@ -2,7 +2,7 @@ cask :v1 => 'beatport-pro' do
   version '2.1.6_155'
   sha256 '21581878a33921082167ba4eaddf031edf5c0b30b36928412c844d8c7572cf63'
 
-  url "http://pro.beatport.com/mac/#{version}/beatportpro_#{version}.dmg"
+  url "https://pro.beatport.com/mac/#{version}/beatportpro_#{version}.dmg"
   name 'Beatport'
   name 'Beatport Pro'
   appcast 'https://pro.beatport.com/mac/appcast.xml',

--- a/Casks/better-window-manager.rb
+++ b/Casks/better-window-manager.rb
@@ -2,11 +2,11 @@ cask :v1 => 'better-window-manager' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.gngrwzrd.com/BetterWindowManager.zip'
+  url 'https://www.gngrwzrd.com/BetterWindowManager.zip'
   name 'Better Window Manager'
-  appcast 'http://www.gngrwzrd.com/betterwindowmanager-appcast.xml',
+  appcast 'https://www.gngrwzrd.com/betterwindowmanager-appcast.xml',
           :sha256 => '321b6bbe7df6f95f49b0c855748d4da1cee655e0ce252988686825068b02f6d9'
-  homepage 'http://www.gngrwzrd.com/better-window-manager/'
+  homepage 'https://www.gngrwzrd.com/better-window-manager/'
   license :commercial
 
   app 'Better Window Manager.app'

--- a/Casks/bimedesktop.rb
+++ b/Casks/bimedesktop.rb
@@ -5,7 +5,7 @@ cask :v1 => 'bimedesktop' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/bimeio/bimedesktop/BimeDesktop-mac.zip'
   name 'BIME Desktop'
-  homepage 'http://www.bimeanalytics.com/'
+  homepage 'https://www.bimeanalytics.com/'
   license :gratis
 
   app 'BimeDesktop.app'

--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -2,9 +2,9 @@ cask :v1 => 'birdfont' do
   version '1.9'
   sha256 'a32b41608250bcba58572be36591a8a9c0907d8d724f31c6e6d18fc8137e5903'
 
-  url "http://birdfont.org/download/birdfont-#{version}-free.dmg"
+  url "https://birdfont.org/download/birdfont-#{version}-free.dmg"
   name 'BirdFont'
-  homepage 'http://birdfont.org/'
+  homepage 'https://birdfont.org/'
   license :freemium
 
   app 'BirdFont.app'

--- a/Casks/black-light.rb
+++ b/Casks/black-light.rb
@@ -4,7 +4,7 @@ cask :v1 => 'black-light' do
 
   url "https://littoral.michelf.ca/apps/black-light/black-light-#{version}.zip"
   name 'Black Light'
-  homepage 'http://michelf.ca/projects/black-light'
+  homepage 'https://michelf.ca/projects/black-light'
   license :commercial
 
   app 'Black Light.app'

--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -2,9 +2,9 @@ cask :v1 => 'blender' do
   version '2.74'
   sha256 '5648c679ac40fe34560426aa6e533b94e832882c79abc06c442dc21e78e1cbc9'
 
-  url "http://download.blender.org/release/Blender#{version.to_f}/blender-#{version}-OSX_10.6-x86_64.zip"
+  url "https://download.blender.org/release/Blender#{version.to_f}/blender-#{version}-OSX_10.6-x86_64.zip"
   name 'Blender'
-  homepage 'http://www.blender.org/'
+  homepage 'https://www.blender.org/'
   license :gpl
 
   app 'Blender/blender.app'

--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -6,7 +6,7 @@ cask :v1 => 'blink1control' do
   url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
   appcast 'https://github.com/todbot/blink1/releases.atom'
   name 'Blink1Control'
-  homepage 'http://blink1.thingm.com/'
+  homepage 'https://blink1.thingm.com/'
   license :cc
 
   app 'Blink1Control.app'

--- a/Casks/boinxtv.rb
+++ b/Casks/boinxtv.rb
@@ -4,7 +4,7 @@ cask :v1 => 'boinxtv' do
 
   url "https://cdn.boinx.com/software/boinxtv/Boinx_BoinxTV_#{version}.app.zip"
   name 'BoinxTV'
-  homepage 'http://boinx.com/boinxtv/'
+  homepage 'https://boinx.com/boinxtv/'
   license :commercial
 
   app 'BoinxTV.app'

--- a/Casks/camerabag.rb
+++ b/Casks/camerabag.rb
@@ -5,7 +5,7 @@ cask :v1 => 'camerabag' do
   # amazonaws.com is the official download host per the vendor homepage
   url "http://downloads.nevercenter.com.s3.amazonaws.com/CameraBag_Mac_#{version.gsub('.','_')}.dmg"
   name 'CameraBag'
-  homepage 'http://nevercenter.com/camerabag/desktop/'
+  homepage 'https://nevercenter.com/camerabag/desktop/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'CameraBag 2.app'

--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -3,9 +3,9 @@ cask :v1 => 'camtasia' do
   sha256 :no_check
 
   url 'http://download.techsmith.com/camtasiamac/enu/Camtasia.dmg'
-  appcast 'http://techsmithredirect.appspot.com/cmac?target=sparkleappcast&product=camtasiamac&lang=enu&ver=2.7.1&os=mac&code=none'
+  appcast 'https://techsmithredirect.appspot.com/cmac?target=sparkleappcast&product=camtasiamac&lang=enu&ver=2.7.1&os=mac&code=none'
   name 'Camtasia'
-  homepage 'http://www.techsmith.com/camtasia.html'
+  homepage 'https://www.techsmith.com/camtasia.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Camtasia 2.app'

--- a/Casks/candybar.rb
+++ b/Casks/candybar.rb
@@ -4,12 +4,12 @@ cask :v1_1 => 'candybar' do
 
   url "https://panic.com/candybar/d/CandyBar%20#{version}.zip"
   name 'CandyBar'
-  homepage 'http://www.panic.com/blog/candybar-mountain-lion-and-beyond'
+  homepage 'https://www.panic.com/blog/candybar-mountain-lion-and-beyond'
   license :gratis
 
   app 'CandyBar.app'
   caveats do
     discontinued
-    free_license 'http://panic.com/bin/setup.php/cb3/PPQA-YAMA-E3KP-VHXG-B6AL-L'
+    free_license 'https://panic.com/bin/setup.php/cb3/PPQA-YAMA-E3KP-VHXG-B6AL-L'
   end
 end

--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -2,11 +2,11 @@ cask :v1 => 'carbon-copy-cloner' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.bombich.com/software/download_ccc.php?v=latest&l=alternate'
-  appcast 'http://www.bombich.com/software/updates/ccc.php',
+  url 'https://www.bombich.com/software/download_ccc.php?v=latest&l=alternate'
+  appcast 'https://www.bombich.com/software/updates/ccc.php',
           :sha256 => 'ec02ebdd3e4bee0527d46e8256372249780fb1a4fb93ddb782e9da87787bbdff'
   name 'Carbon Copy Cloner'
-  homepage 'http://bombich.com/'
+  homepage 'https://bombich.com/'
   license :commercial
 
   app 'Carbon Copy Cloner.app'

--- a/Casks/cartographica.rb
+++ b/Casks/cartographica.rb
@@ -3,7 +3,7 @@ cask :v1 => 'cartographica' do
   sha256 :no_check
 
   # cluetrust.com is the official download host per the vendor homepage
-  url 'http://www.cluetrust.com/Downloads/Cartographica.dmg'
+  url 'https://www.cluetrust.com/Downloads/Cartographica.dmg'
   name 'Cartographica'
   appcast 'https://www.cluetrust.com/AppCasts/Cartographica.xml',
           :sha256 => '9bb9075d8da457886cb86043d4807cbdd210e9f6c883f99ade7898911f90dd35'

--- a/Casks/ccleaner.rb
+++ b/Casks/ccleaner.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ccleaner' do
 
   url "http://download.piriform.com/mac/CCMacSetup#{version.sub(%r{^(\d+)\.(\d+).*},'\1\2')}.dmg"
   name 'CCleaner'
-  homepage 'http://www.piriform.com/ccleaner'
+  homepage 'https://www.piriform.com/ccleaner'
   license :freemium
   tags :vendor => 'Piriform'
 

--- a/Casks/chainsaw.rb
+++ b/Casks/chainsaw.rb
@@ -4,7 +4,7 @@ cask :v1 => 'chainsaw' do
 
   url 'https://logging.apache.org/chainsaw/webstart/chainsaw.dmg'
   name 'Chainsaw'
-  homepage 'http://logging.apache.org/chainsaw/'
+  homepage 'https://logging.apache.org/chainsaw/'
   license :apache
 
   app 'Chainsaw.app'

--- a/Casks/charlessoft-timetracker.rb
+++ b/Casks/charlessoft-timetracker.rb
@@ -2,9 +2,9 @@ cask :v1 => 'charlessoft-timetracker' do
   version :latest
   sha256 :no_check
 
-  url 'http://charlessoft.com/TimeTracker.zip'
+  url 'https://charlessoft.com/TimeTracker.zip'
   name 'TimeTracker'
-  homepage 'http://charlessoft.com/'
+  homepage 'https://charlessoft.com/'
   license :unknown
 
   app 'TimeTracker.app'

--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -5,7 +5,7 @@ cask :v1 => 'chatology' do
   url 'https://flexibits.com/chatology/download'
   appcast 'https://flexibits.com/chatology/appcast.php'
   name 'Chatology'
-  homepage 'http://flexibits.com/chatology'
+  homepage 'https://flexibits.com/chatology'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Chatology.app'

--- a/Casks/chromatic.rb
+++ b/Casks/chromatic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'chromatic' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/Chromatic.zip'
-  appcast 'http://mrgeckosmedia.com/applications/appcast/Chromatic'
+  url 'https://download.mrgeckosmedia.com/Chromatic.zip'
+  appcast 'https://mrgeckosmedia.com/applications/appcast/Chromatic'
   name 'Chromatic'
   homepage 'https://mrgeckosmedia.com/applications/info/Chromatic'
   license :isc

--- a/Casks/chromecast.rb
+++ b/Casks/chromecast.rb
@@ -5,7 +5,7 @@ cask :v1 => 'chromecast' do
   # google.com is the official download host per the vendor homepage
   url "https://dl.google.com/chromecast/setup/mac/chromecast-setup.#{version}.dmg"
   name 'Chromecast'
-  homepage 'http://chromecast.com/'
+  homepage 'https://chromecast.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Chromecast.app'

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -5,7 +5,7 @@ cask :v1 => 'chromium' do
   # appspot.com is the official download host per the vendor homepage
   url 'https://download-chromium.appspot.com/dl/Mac'
   name 'Chromium'
-  homepage 'http://www.chromium.org/Home'
+  homepage 'https://www.chromium.org/Home'
   license :oss
 
   app 'chrome-mac/Chromium.app'

--- a/Casks/cinch.rb
+++ b/Casks/cinch.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cinch' do
   url 'https://www.irradiatedsoftware.com/download/Cinch.zip'
   appcast 'https://www.irradiatedsoftware.com/updates/profiles/cinch.php'
   name 'Cinch'
-  homepage 'http://www.irradiatedsoftware.com/cinch/'
+  homepage 'https://www.irradiatedsoftware.com/cinch/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Cinch.app'

--- a/Casks/citrix-receiver.rb
+++ b/Casks/citrix-receiver.rb
@@ -5,7 +5,7 @@ cask :v1 => 'citrix-receiver' do
   # edgesuite.net is the official download host per the vendor homepage
   url 'http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixReceiverWeb.dmg'
   name 'Citrix Receiver'
-  homepage 'http://www.citrix.com/receiver'
+  homepage 'https://www.citrix.com/receiver'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install Citrix Receiver.pkg'

--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -2,11 +2,11 @@ cask :v1 => 'clamxav' do
   version '2.7.5'
   sha256 '33c6c76cb3e6f8ec9c23b521135b320ea5300910d9e929eaa0556e2bed15cbfe'
 
-  url "http://www.clamxav.com/downloads/ClamXav_#{version}.dmg"
-  appcast 'http://www.clamxav.com/sparkle/profileInfo.php',
+  url "https://www.clamxav.com/downloads/ClamXav_#{version}.dmg"
+  appcast 'https://www.clamxav.com/sparkle/profileInfo.php',
           :sha256 => '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b'
   name 'ClamXav'
-  homepage 'http://www.clamxav.com/'
+  homepage 'https://www.clamxav.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ClamXav.app'

--- a/Casks/cleanarchiver.rb
+++ b/Casks/cleanarchiver.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cleanarchiver' do
 
   url "https://www.sopht.jp/pub/Mac/CleanArchiver-#{version}.dmg"
   name 'CleanArchiver'
-  appcast 'http://www.sopht.jp/cleanarchiver/appcast.xml',
+  appcast 'https://www.sopht.jp/cleanarchiver/appcast.xml',
           :sha256 => '8027040d84f421c4861374d4e51fc63da34a999ed9d4f90fb6682202dd7eeecc'
   homepage 'https://www.sopht.jp/cleanarchiver/'
   license :bsd

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -53,6 +53,6 @@ cask :v1 => 'cleanmymac' do
   end
 
   name 'CleanMyMac'
-  homepage 'http://macpaw.com/cleanmymac'
+  homepage 'https://macpaw.com/cleanmymac'
   license :commercial
 end

--- a/Casks/clipmenu.rb
+++ b/Casks/clipmenu.rb
@@ -4,7 +4,7 @@ cask :v1 => 'clipmenu' do
 
   # dropbox.com is the official download host per the vendor homepage
   url "https://dl.dropbox.com/u/1140644/clipmenu/ClipMenu_#{version}.dmg"
-  appcast 'http://feeds.feedburner.com/clipmenu-appcast',
+  appcast 'https://feeds.feedburner.com/clipmenu-appcast',
           :sha256 => 'e9f9df0e48aad4e00b8df26fd622f42a0218f5be662b6d2ee496664c5f45b4a3'
   name 'ClipMenu'
   homepage 'http://www.clipmenu.com/'

--- a/Casks/cloud.rb
+++ b/Casks/cloud.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cloud' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.dmg"
   name 'CloudApp'
-  homepage 'http://getcloudapp.com/'
+  homepage 'https://getcloudapp.com/'
   license :gratis
 
   app 'CloudApp.app'

--- a/Casks/cn3d.rb
+++ b/Casks/cn3d.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cn3d' do
 
   url "ftp://ftp.ncbi.nlm.nih.gov/cn3d/Cn3D-#{version}-OSX.zip"
   name 'Cn3D'
-  homepage 'http://www.ncbi.nlm.nih.gov/Structure/CN3D/cn3d.shtml'
+  homepage 'https://www.ncbi.nlm.nih.gov/Structure/CN3D/cn3d.shtml'
   license :public_domain
 
   app 'Cn3D.app'

--- a/Casks/cocoadialog.rb
+++ b/Casks/cocoadialog.rb
@@ -4,7 +4,7 @@ cask :v1 => 'cocoadialog' do
 
   url "https://github.com/downloads/mstratman/cocoadialog/CocoaDialog-#{version}.dmg"
   name 'cocoaDialog'
-  homepage 'http://mstratman.github.io/cocoadialog/'
+  homepage 'https://mstratman.github.io/cocoadialog/'
   license :gpl
 
   app 'CocoaDialog.app'

--- a/Casks/cocoarestclient.rb
+++ b/Casks/cocoarestclient.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cocoarestclient' do
   url "https://github.com/mmattozzi/cocoa-rest-client/releases/download/#{version}/CocoaRestClient-#{version}.dmg"
   appcast 'https://github.com/mmattozzi/cocoa-rest-client/releases.atom'
   name 'CocoaRestClient'
-  homepage 'http://mmattozzi.github.io/cocoa-rest-client/'
+  homepage 'https://mmattozzi.github.io/cocoa-rest-client/'
   license :bsd
 
   app 'CocoaRestClient.app'

--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -3,21 +3,21 @@ cask :v1 => 'coconutbattery' do
   if MacOS.release <= :tiger
     version '2.6.6'
     sha256 '8d235b237e42754ceda26af2babc160fd23f890d0fe6d7780b86a8e9c6effe42'
-    url "http://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
+    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
   elsif MacOS.release <= :snow_leopard
     version '2.8'
     sha256 'fcfc81214ff26afff9f5c6c7cdc455b23ac898b6918f864b641a9e31526692d4'
-    url "http://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
+    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
   else
     version '3.2'
     sha256 'aaef17e76819cae5042d3363d51753a0511779bfa7f58302958f85e0efc5adca'
-    url "http://www.coconut-flavour.com/downloads/coconutBattery_#{version.gsub('.','_')}.zip"
+    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.gsub('.','_')}.zip"
     appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml',
             :sha256 => 'a95480443b9b1161ce66fea8649507ba5449f82e8eb83d89db090df7c03fbb1f'
   end
 
   name 'coconutBattery'
-  homepage 'http://www.coconut-flavour.com/coconutbattery/'
+  homepage 'https://www.coconut-flavour.com/coconutbattery/'
   license :bsd
 
   app 'coconutBattery.app'

--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -2,11 +2,11 @@ cask :v1 => 'codekit' do
   version '2.3.10-19033'
   sha256 '6ace696b81de91d7f5d2b24cb27a6609a72aeadc2d36fb6cda56af2b768b34c8'
 
-  url "http://incident57.com/codekit/files/codekit-#{version.sub(%r{.*-},'')}.zip"
+  url "https://incident57.com/codekit/files/codekit-#{version.sub(%r{.*-},'')}.zip"
   appcast 'https://incident57.com/codekit/appcast/ck2appcast.xml',
           :sha256 => 'fba4e9552ebabca2b700f6bdcdbb83132856d6c467f536250fc34beed9a8f104'
   name 'CodeKit'
-  homepage 'http://incident57.com/codekit/'
+  homepage 'https://incident57.com/codekit/'
   license :commercial
 
   app 'CodeKit.app'

--- a/Casks/colorpicker-developer.rb
+++ b/Casks/colorpicker-developer.rb
@@ -2,9 +2,9 @@ cask :v1 => 'colorpicker-developer' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.panic.com/picker/developercolorpicker.zip'
+  url 'https://download.panic.com/picker/developercolorpicker.zip'
   name 'Developer Color Picker'
-  homepage 'http://download.panic.com/picker/'
+  homepage 'https://download.panic.com/picker/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   colorpicker 'Developer Color Picker/DeveloperColorPicker.colorPicker'

--- a/Casks/colorport.rb
+++ b/Casks/colorport.rb
@@ -4,7 +4,7 @@ cask :v1 => 'colorport' do
 
   url 'http://www.xrite.com/downloader.aspx?FileID=1168&Type=M&returnurl=%2fcolorport-utility-software%2fsupport%2fd1168'
   name 'ColorPort Utility Software'
-  homepage 'http://www.xrite.com/colorport-utility-software/support/d1168'
+  homepage 'https://www.xrite.com/colorport-utility-software/support/d1168'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "ColorPort#{version.sub(%r{^(\d+)\.(\d+).*},'\1\2')}Distribution.mpkg"

--- a/Casks/colors.rb
+++ b/Casks/colors.rb
@@ -3,7 +3,7 @@ cask :v1_1 => 'colors' do
   sha256 '073f3055613b4f57e4f6a1acc8540ad8eca316e61a5202fa72f055928d83d600'
 
   # googlecode.com is the official download host per the vendor homepage
-  url "http://tmitter.googlecode.com/files/Colors-#{version}.zip"
+  url "https://tmitter.googlecode.com/files/Colors-#{version}.zip"
   name 'Colors'
   homepage 'https://github.com/13bold/Colors/'
   license :mit

--- a/Casks/colorschemer-studio.rb
+++ b/Casks/colorschemer-studio.rb
@@ -3,9 +3,9 @@ cask :v1 => 'colorschemer-studio' do
   sha256 :no_check
 
   url 'https://www.colorschemer.com/colorschemerstudio.dmg'
-  appcast 'http://www.colorschemer.com/appcast/studio2_mac.xml'
+  appcast 'https://www.colorschemer.com/appcast/studio2_mac.xml'
   name 'ColorSchemer Studio'
-  homepage 'http://www.colorschemer.com'
+  homepage 'https://www.colorschemer.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ColorSchemer Studio 2.app'

--- a/Casks/combine-pdfs.rb
+++ b/Casks/combine-pdfs.rb
@@ -2,11 +2,11 @@ cask :v1 => 'combine-pdfs' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.monkeybreadsoftware.de/Freeware/CombinePDFs.dmg'
+  url 'https://www.monkeybreadsoftware.de/Freeware/CombinePDFs.dmg'
   name 'Combine PDFs'
-  appcast 'http://www.monkeybreadsoftware.de/Freeware/CombinePDFs/appcast.xml',
+  appcast 'https://www.monkeybreadsoftware.de/Freeware/CombinePDFs/appcast.xml',
           :sha256 => '0cae6e0d6f3dd42f2ed7e51e77047eb6590f8eec3263f9ae8226d65acb453dc6'
-  homepage 'http://www.monkeybreadsoftware.de/Freeware/CombinePDFs.shtml'
+  homepage 'https://www.monkeybreadsoftware.de/Freeware/CombinePDFs.shtml'
   license :commercial
 
   app 'Combine PDFs.app'

--- a/Casks/comicbooklover.rb
+++ b/Casks/comicbooklover.rb
@@ -3,9 +3,9 @@ cask :v1 => 'comicbooklover' do
   sha256 :no_check
 
   url 'https://www.bitcartel.com/downloads/comicbooklover.zip'
-  appcast 'http://www.bitcartel.com/appcast/comicbooklover-1.7-dsa.xml'
+  appcast 'https://www.bitcartel.com/appcast/comicbooklover-1.7-dsa.xml'
   name 'ComicBookLover'
-  homepage 'http://www.bitcartel.com/comicbooklover/'
+  homepage 'https://www.bitcartel.com/comicbooklover/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ComicBookLover.app'

--- a/Casks/comicbookloversync.rb
+++ b/Casks/comicbookloversync.rb
@@ -4,7 +4,7 @@ cask :v1 => 'comicbookloversync' do
 
   url 'https://www.bitcartel.com/downloads/comicbookloversync.zip'
   name 'ComicBookLover Sync'
-  homepage 'http://www.bitcartel.com/comicbooklover'
+  homepage 'https://www.bitcartel.com/comicbooklover/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ComicBookLoverSync.app'

--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -5,7 +5,7 @@ cask :v1 => 'comictagger' do
   # googledrive.com is the official download host per the vendor homepage
   url "https://googledrive.com/host/0Bw4IursaqWhhOHF6Wk9ab3FkejQ/#{version}/ComicTagger-#{version}.dmg"
   name 'ComicTagger'
-  homepage 'http://code.google.com/p/comictagger/'
+  homepage 'https://code.google.com/p/comictagger/'
   license :apache
 
   app 'ComicTagger.app'

--- a/Casks/commandq.rb
+++ b/Casks/commandq.rb
@@ -4,7 +4,7 @@ cask :v1 => 'commandq' do
 
   url 'https://clickontyler.com/commandq/download/'
   name 'CommandQ'
-  appcast 'http://shine.clickontyler.com/appcast.php?id=16',
+  appcast 'https://shine.clickontyler.com/appcast.php?id=16',
           :sha256 => 'aded9f4d5543c963c0989f53ba18c35b2053703b543b10a54c61a6b42b53dd50'
   homepage 'https://clickontyler.com/commandq/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/cookie.rb
+++ b/Casks/cookie.rb
@@ -2,9 +2,9 @@ cask :v1 => 'cookie' do
   version :latest
   sha256 :no_check
 
-  url 'http://sweetpproductions.com/products/cookie/Cookie.dmg'
+  url 'https://sweetpproductions.com/products/cookie/Cookie.dmg'
   name 'Cookie'
-  homepage 'http://sweetpproductions.com/'
+  homepage 'https://sweetpproductions.com/'
   license :commercial
 
   app 'Cookie.app'

--- a/Casks/cornerstone.rb
+++ b/Casks/cornerstone.rb
@@ -6,7 +6,7 @@ cask :v1 => 'cornerstone' do
   appcast 'https://www.zennaware.com/cornerstone/appcast/feed2.php',
           :sha256 => '9c86ba0e2bdbcede056976040a507ebd3c34f4229ae2fd1fa402ab937adc95e6'
   name 'Cornerstone'
-  homepage 'http://www.zennaware.com/cornerstone/'
+  homepage 'https://www.zennaware.com/cornerstone/'
   license :commercial
 
   app 'Cornerstone.app'

--- a/Casks/coronasdk.rb
+++ b/Casks/coronasdk.rb
@@ -2,7 +2,7 @@ cask :v1 => 'coronasdk' do
   version '2014.2511'
   sha256 '19f2d1a7bd3ffb45f830cebd1d2fcfd292967cb3f5211e29e3c73b66a8f220e6'
 
-  url 'http://developer.coronalabs.com/sites/default/files/CoronaSDK-2014.2511.dmg'
+  url 'https://developer.coronalabs.com/sites/default/files/CoronaSDK-2014.2511.dmg'
   name 'Corona SDK'
   homepage 'https://coronalabs.com/products/corona-sdk/'
   license :gratis

--- a/Casks/couleurs.rb
+++ b/Casks/couleurs.rb
@@ -2,11 +2,11 @@ cask :v1 => 'couleurs' do
   version '1.1'
   sha256 'c05e5121e2d2cfdb6b4cac234b8e8bce4b0990209249d134b51e1d8ef63919ff'
 
-  url "http://couleursapp.com/couleurs-#{version}.zip"
+  url "https://couleursapp.com/couleurs-#{version}.zip"
   name 'Couleurs'
   appcast 'https://couleursapp.com/updates/releases.xml',
           :sha256 => 'a90f989c95a673f780d6fd891aab8574cb2a1393640da89caa792a9521de4114'
-  homepage 'http://couleursapp.com/'
+  homepage 'https://couleursapp.com/'
   license :gratis
 
   app 'Couleurs.app'

--- a/Casks/createuserpkg.rb
+++ b/Casks/createuserpkg.rb
@@ -2,9 +2,9 @@ cask :v1 => 'createuserpkg' do
   version '1.2.4'
   sha256 '4bac91af9d8fb2e34c036964c6f9bf49a8f19f8e994b30e2900a0ddbebef246f'
 
-  url "http://magervalp.github.io/CreateUserPkg/Distributions/CreateUserPkg-#{version}.dmg"
+  url "https://magervalp.github.io/CreateUserPkg/Distributions/CreateUserPkg-#{version}.dmg"
   name 'CreateUserPkg'
-  homepage 'http://magervalp.github.io/CreateUserPkg/'
+  homepage 'https://magervalp.github.io/CreateUserPkg/'
   license :apache
 
   app 'CreateUserPkg.app'

--- a/Casks/crosspack-avr.rb
+++ b/Casks/crosspack-avr.rb
@@ -2,9 +2,9 @@ cask :v1 => 'crosspack-avr' do
   version '2013-12-16'
   sha256 '959f9bf00429a0e46e649a14d7891cb4086c9cf2d032d9f66899d6efbb628f6e'
 
-  url "http://www.obdev.at/downloads/crosspack/CrossPack-AVR-#{version.gsub('-','')}.dmg"
+  url "https://www.obdev.at/downloads/crosspack/CrossPack-AVR-#{version.gsub('-','')}.dmg"
   name 'CrossPack'
-  homepage 'http://www.obdev.at/products/crosspack/'
+  homepage 'https://www.obdev.at/products/crosspack/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'CrossPack-AVR.pkg'

--- a/Casks/cvc4.rb
+++ b/Casks/cvc4.rb
@@ -5,7 +5,7 @@ cask :v1 => 'cvc4' do
     sha256 '436ebe16872a08bb41270cb1302c4258a7ccd187bf8e68ad8301300e49fb7718'
 
     # Mountain Lion package might work on older releases, per homepage
-    url "http://cvc4.cs.nyu.edu/builds/macos/cvc4-#{version}.MacOs85.MountainLion.mpkg"
+    url "https://cvc4.cs.nyu.edu/builds/macos/cvc4-#{version}.MacOs85.MountainLion.mpkg"
 
     pkg "cvc4-#{version}.MacOs85.MountainLion.mpkg"
   else
@@ -13,13 +13,13 @@ cask :v1 => 'cvc4' do
     sha256 'e3a0da4cf3187a58c9cc36e24623ac0ddbfd7ac18b389b7c8cca1a4d3fcbc03f'
 
     # Mavericks package appears to work on Yosemite
-    url "http://cvc4.cs.nyu.edu/builds/macos/cvc4-#{version}.MacOs9.Mavericks.mpkg"
+    url "https://cvc4.cs.nyu.edu/builds/macos/cvc4-#{version}.MacOs9.Mavericks.mpkg"
 
     pkg "cvc4-#{version}.MacOs9.Mavericks.mpkg"
   end
 
   name 'CVC4'
-  homepage 'http://cvc4.cs.nyu.edu/'
+  homepage 'https://cvc4.cs.nyu.edu/'
   license :oss
 
   uninstall :pkgutil => 'org.macports.cvc4'

--- a/Casks/cyberghost.rb
+++ b/Casks/cyberghost.rb
@@ -2,11 +2,11 @@ cask :v1 => 'cyberghost' do
   version '5.0.14.11'
   sha256 'c1f10d6734482b319d66ef546cf31c35f9386b1befd80de6495e48f47c9d610e'
 
-  url "http://download.cyberghostvpn.com/mac/cg5mac_#{version}.dmg"
+  url "https://download.cyberghostvpn.com/mac/cg5mac_#{version}.dmg"
   name 'CyberGhost'
-  appcast 'http://download.cyberghostvpn.com/mac/updates/cyberghost_mac_update.inf',
+  appcast 'https://download.cyberghostvpn.com/mac/updates/cyberghost_mac_update.inf',
           :sha256 => '47b058275557f590e834a9ca94f67f697d05565b020a437251377df35564c9fc'
-  homepage 'http://www.cyberghostvpn.com/'
+  homepage 'https://www.cyberghostvpn.com/'
   license :gratis
 
   app 'CyberGhost 5.app'

--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -2,7 +2,7 @@ cask :v1 => 'cycling74-max' do
   version '7.0.3-150402'
   sha256 'c63616022a19e8aafe7c7036265599644b13f3ae640509ffe17a3c7c6953d55e'
 
-  url "http://filepivot.appspot.com/projects/maxmspjitter/files/Max#{version.sub('-','_').gsub('.','')}.dmg"
+  url "https://filepivot.appspot.com/projects/maxmspjitter/files/Max#{version.sub('-','_').gsub('.','')}.dmg"
   name 'Max'
   homepage 'https://cycling74.com/'
   license :commercial

--- a/Casks/daemon-tools-lite.rb
+++ b/Casks/daemon-tools-lite.rb
@@ -7,7 +7,7 @@ cask :v1 => 'daemon-tools-lite' do
   appcast 'http://resources.web-search-home.com/xml/DAEMONToolsLite-appcast.xml',
           :sha256 => 'b4b3096744ad084a0a016a248cafee02670f4773fe29131ae50ddacaaf601b3d'
   name 'DAEMON Tools Lite'
-  homepage 'http://www.daemon-tools.cc/products/dtMacLite'
+  homepage 'https://www.daemon-tools.cc/products/dtMacLite'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'DAEMON Tools Lite.app'

--- a/Casks/data-rescue.rb
+++ b/Casks/data-rescue.rb
@@ -6,7 +6,7 @@ cask :v1 => 'data-rescue' do
   name 'Data Rescue 4'
   appcast 'https://www.prosofteng.com/resources/dr4/dr4_appcast.xml',
           :sha256 => 'eeb2acd7dde94cb21a2c2d9bbc817bc2c790d5276c606741988fc3d54672d87c'
-  homepage 'http://www.prosofteng.com/products/data_rescue.php'
+  homepage 'https://www.prosofteng.com/products/data_rescue.php'
   license :commercial
 
   app 'Data Rescue 4.app'

--- a/Casks/data-science-studio.rb
+++ b/Casks/data-science-studio.rb
@@ -2,7 +2,7 @@ cask :v1 => 'data-science-studio' do
   version '2.0.0'
   sha256 '97a2e10d14a26d337ba71170ddc5e4ad6e2b3eafe36adcd02048c7da2d402774'
 
-  url "http://downloads.dataiku.com/public/studio/Data%20Science%20Studio%20#{version}.dmg"
+  url "https://downloads.dataiku.com/public/studio/Data%20Science%20Studio%20#{version}.dmg"
   name 'Data Science Studio'
   homepage 'https://www.dataiku.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -2,9 +2,9 @@ cask :v1 => 'dbvisualizer' do
   version '9.2.7'
   sha256 '8e7519ab68dac5d31ba9354a2d68b9bee88776bd61eb249e5468ea6e14a7548e'
 
-  url "http://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.gsub('.', '_')}_java7.dmg"
+  url "https://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.gsub('.', '_')}_java7.dmg"
   name 'DbVisualizer'
-  homepage 'http://www.dbvis.com/'
+  homepage 'https://www.dbvis.com/'
   license :commercial
 
   preflight do

--- a/Casks/deathtodsstore.rb
+++ b/Casks/deathtodsstore.rb
@@ -2,9 +2,9 @@ cask :v1 => 'deathtodsstore' do
   version '1.0.4'
   sha256 'ea5f92d902b99be9f385df47e9cbb15bf9d4dcda3bb9534be3aed71e26b18ffb'
 
-  url 'http://www.aorensoftware.com/Downloads/Files/DeathToDSStore.zip'
+  url 'https://www.aorensoftware.com/Downloads/Files/DeathToDSStore.zip'
   name 'DeathToDSStore'
-  homepage 'http://www.aorensoftware.com/blog/2011/12/24/death-to-ds_store/'
+  homepage 'https://www.aorensoftware.com/blog/2011/12/24/death-to-ds_store/'
   license :mit
 
   app 'DeathToDSStore.app'

--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -2,9 +2,9 @@ cask :v1 => 'default-folder-x' do
   version '4.6.14'
   sha256 '621fe0042ed44da7eab369471ae345e19432cf3a5c70cf0290e567ce805f6b99'
 
-  url "http://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
+  url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   name 'Default Folder X'
-  homepage 'http://www.stclairsoft.com/DefaultFolderX'
+  homepage 'https://www.stclairsoft.com/DefaultFolderX'
   license :commercial
 
   installer :manual => 'Default Folder X Installer.app'

--- a/Casks/delicious-library.rb
+++ b/Casks/delicious-library.rb
@@ -2,11 +2,11 @@ cask :v1 => 'delicious-library' do
   version :latest
   sha256 :no_check
 
-  url 'http://delicious-monster.com/downloads/DeliciousLibrary3.zip'
+  url 'https://delicious-monster.com/downloads/DeliciousLibrary3.zip'
   name 'Delicious Library'
-  appcast 'http://www.delicious-monster.com/downloads/DeliciousLibrary3.xml',
+  appcast 'https://www.delicious-monster.com/downloads/DeliciousLibrary3.xml',
           :sha256 => '5f9eaea34e47cd1255f02a48ddca41433cd27aec146387a3221d1267b286c6e6'
-  homepage 'http://delicious-monster.com/'
+  homepage 'https://delicious-monster.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Delicious Library 3.app'

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -5,7 +5,7 @@ cask :v1 => 'deltawalker' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/deltawalker/DeltaWalker-#{version}_64.dmg"
   name 'DeltaWalker'
-  homepage 'http://www.deltopia.com/compare-merge-sync/macosx/'
+  homepage 'https://www.deltopia.com/compare-merge-sync/macosx/'
   license :commercial
 
   app 'DeltaWalker.app'

--- a/Casks/dictunifier.rb
+++ b/Casks/dictunifier.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dictunifier' do
 
   url "https://mac-dictionary-kit.googlecode.com/files/DictUnifier-#{version}.zip"
   name 'DictUnifier'
-  homepage 'http://code.google.com/p/mac-dictionary-kit/'
+  homepage 'https://code.google.com/p/mac-dictionary-kit/'
   license :oss
 
   app 'DictUnifier.app'

--- a/Casks/difffork.rb
+++ b/Casks/difffork.rb
@@ -3,7 +3,7 @@ cask :v1 => 'difffork' do
   sha256 'e366234c71a797a7f2fe794195bc8096157f2a77f883b24e8f6cf78438fc433a'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url 'http://dotfork.s3.amazonaws.com/DiffFork.app.zip'
+  url 'https://dotfork.s3.amazonaws.com/DiffFork.app.zip'
   name 'DiffFork'
   appcast 'http://www.dotfork.com/difffork/appcast.xml',
           :sha256 => 'e415fa377e3ea812e61e0d8a4695a42eafa96e9610f8f56d257a340f099d547e'

--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -4,7 +4,7 @@ cask :v1 => 'diffmerge' do
 
   url "http://download-us.sourcegear.com/DiffMerge/4.2.0/DiffMerge.#{version}.intel.stable.dmg"
   name 'DiffMerge'
-  homepage 'http://www.sourcegear.com/diffmerge'
+  homepage 'https://www.sourcegear.com/diffmerge'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'DiffMerge.app'

--- a/Casks/divvy.rb
+++ b/Casks/divvy.rb
@@ -3,9 +3,9 @@ cask :v1 => 'divvy' do
   sha256 :no_check
 
   url 'https://mizage.com/downloads/Divvy.zip'
-  appcast 'http://mizage.com/updates/profiles/divvy.php'
+  appcast 'https://mizage.com/updates/profiles/divvy.php'
   name 'Divvy'
-  homepage 'http://mizage.com/divvy/'
+  homepage 'https://mizage.com/divvy/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Divvy.app'

--- a/Casks/djay-pro.rb
+++ b/Casks/djay-pro.rb
@@ -4,7 +4,7 @@ cask :v1 => 'djay-pro' do
 
   url 'https://www.algoriddim.com/files/djay.zip'
   name 'djay Pro'
-  appcast 'http://www.algoriddim.com/djay-mac/releasenotes/appcast',
+  appcast 'https://www.algoriddim.com/djay-mac/releasenotes/appcast',
           :sha256 => '4f31a04bd5952dac697eeb74d1a5872578e2c3e108e1d70a2612926e824b6a45',
           :format => :sparkle
   homepage 'http://algoriddim.com/djay-mac'

--- a/Casks/dolphin.rb
+++ b/Casks/dolphin.rb
@@ -2,7 +2,7 @@ cask :v1 => 'dolphin' do
   version '4.0-6734'
   sha256 'f1a038c16ff37735775c0f2a89f5b0127f67e20f1ec0e47cae26547ef4258b46'
 
-  url "http://dl.dolphin-emu.org/builds/dolphin-master-#{version}.dmg"
+  url "https://dl.dolphin-emu.org/builds/dolphin-master-#{version}.dmg"
   name 'Dolphin'
   homepage 'https://dolphin-emu.org/'
   license :gpl

--- a/Casks/dragondrop.rb
+++ b/Casks/dragondrop.rb
@@ -2,11 +2,11 @@ cask :v1 => 'dragondrop' do
   version :latest
   sha256 :no_check
 
-  url 'http://shinyplasticbag.com/dragondrop/dragondrop.dmg'
+  url 'https://shinyplasticbag.com/dragondrop/dragondrop.dmg'
   name 'DragonDrop'
   appcast 'https://shinyplasticbag.com/dragondrop/updates.xml',
           :sha256 => '5d68912968cd59c8e98393dd5d4781f951d90837efbba42c1ba6fe17135860f0'
-  homepage 'http://shinyplasticbag.com/dragondrop/'
+  homepage 'https://shinyplasticbag.com/dragondrop/'
   license :commercial
 
   app 'DragonDrop.app'

--- a/Casks/dsp-radio.rb
+++ b/Casks/dsp-radio.rb
@@ -4,7 +4,7 @@ cask :v1 => 'dsp-radio' do
 
   url 'http://dl2sdr.homepage.t-online.de/files/DSP_Radio_141.zip'
   name 'DSP Radio'
-  homepage 'http://dl2sdr.homepage.t-online.de/'
+  homepage 'https://dl2sdr.homepage.t-online.de/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app "DSP Radio #{version}.app"

--- a/Casks/dterm.rb
+++ b/Casks/dterm.rb
@@ -3,9 +3,9 @@ cask :v1 => 'dterm' do
   sha256 :no_check
 
   url 'http://files.decimus.net/DTerm/DTerm.zip'
-  appcast 'http://decimus.net/appcasts/DTerm.xml'
+  appcast 'https://decimus.net/appcasts/DTerm.xml'
   name 'DTerm'
-  homepage 'http://decimus.net/DTerm'
+  homepage 'https://decimus.net/DTerm'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'DTerm.app'

--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -3,7 +3,7 @@ cask :v1 => 'duplicati' do
   sha256 'd97065d012fb929fa4e37b5efab2d246b6aef667f892a95301a1271f704963f2'
 
   # googlecode.com is the official download host per the vendor homepage
-  url "http://duplicati.googlecode.com/files/Duplicati%20#{version}.dmg"
+  url "https://duplicati.googlecode.com/files/Duplicati%20#{version}.dmg"
   name 'Duplicati'
   homepage 'http://www.duplicati.com/'
   license :oss

--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -2,9 +2,9 @@ cask :v1 => 'eaglefiler' do
   version '1.6.5'
   sha256 '1b1c714be59f3e8ea3ed1fd2322672c08d217f8360b61172feeb4ea952f382b7'
 
-  url "http://c-command.com/downloads/EagleFiler-#{version}.dmg"
+  url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   name 'EagleFiler'
-  homepage 'http://c-command.com/eaglefiler/'
+  homepage 'https://c-command.com/eaglefiler/'
   license :commercial
 
   app 'EagleFiler.app'

--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-cpp' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-cpp-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse IDE for C/C++ Developers'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-ide' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-committers-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse IDE for Eclipse Committers'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-java' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-java-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse IDE for Java Developers'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-jee' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse IDE for Java EE Developers'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-modeling' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-modeling-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse Modeling Tools'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-php' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-php-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse for PHP Developers'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-platform' do
   url "http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.to_i}/R-#{version}/eclipse-SDK-#{version.sub(%r{-.*},'')}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse'
   name 'Eclipse SDK'
-  homepage 'http://eclipse.org'
+  homepage 'https://eclipse.org'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-ptp' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-parallel-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse Parallel Tools Platform'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -5,7 +5,7 @@ cask :v1 => 'eclipse-rcp' do
   url 'http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/R/eclipse-rcp-mars-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse'
   name 'Eclipse for RCP and RAP Developers'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
   depends_on :macos => '>= :leopard'
   depends_on :arch => :x86_64

--- a/Casks/epub-to-pdf.rb
+++ b/Casks/epub-to-pdf.rb
@@ -2,7 +2,7 @@ cask :v1 => 'epub-to-pdf' do
   version '3.1'
   sha256 'dcfc59d57f756802e844614b7dae43bca67284ec85fe6b909f244e41f20987b3'
 
-  url "http://epub-2-pdf.googlecode.com/files/e2p-#{version.to_i}.dmg"
+  url "https://epub-2-pdf.googlecode.com/files/e2p-#{version.to_i}.dmg"
   name 'epub-2-pdf'
   appcast 'https://code.google.com/feeds/p/epub-2-pdf/downloads/basic',
           :sha256 => '229b6653b24597a90cf5c48f1fca8de73892d6342c7800e84c9d828e976dfe24',

--- a/Casks/escritorio-movistar.rb
+++ b/Casks/escritorio-movistar.rb
@@ -2,9 +2,9 @@ cask :v1 => 'escritorio-movistar' do
   version '8.9'
   sha256 '0709299be3faf37e99497ffdf6668c6f0f90cb335fa86e797f8a04548a65689b'
 
-  url "http://www.movistar.es/estaticos/descargaaplicaciones/Escritorio%20Movistar_v#{version}.pkg"
+  url "https://www.movistar.es/estaticos/descargaaplicaciones/Escritorio%20Movistar_v#{version}.pkg"
   name 'Escritorio Movistar'
-  homepage 'http://www.movistar.es/particulares/servicios/descargaaplicaciones'
+  homepage 'https://www.movistar.es/particulares/servicios/descargaaplicaciones'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "Escritorio Movistar_v#{version}.pkg"

--- a/Casks/exhaust.rb
+++ b/Casks/exhaust.rb
@@ -2,9 +2,9 @@ cask :v1 => 'exhaust' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/Exhaust.zip'
+  url 'https://download.mrgeckosmedia.com/Exhaust.zip'
   name 'Exhaust'
-  appcast 'http://mrgeckosmedia.com/applications/appcast/Exhaust'
+  appcast 'https://mrgeckosmedia.com/applications/appcast/Exhaust'
   homepage 'https://mrgeckosmedia.com/applications/info/Exhaust'
   license :oss
 

--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -5,7 +5,7 @@ cask :v1 => 'expandrive' do
   url 'http://updates.expandrive.com/apps/expandrive/download_latest'
   name 'ExpanDrive'
   appcast 'http://updates.expandrive.com/appcast/expandrive.xml?version=3'
-  homepage 'http://www.expandrive.com/expandrive'
+  homepage 'https://www.expandrive.com/expandrive'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ExpanDrive.app'

--- a/Casks/eye-fi.rb
+++ b/Casks/eye-fi.rb
@@ -2,7 +2,7 @@ cask :v1 => 'eye-fi' do
   version '3.4.35'
   sha256 '7de117d0ee443683ad5ca7b3ab4ef5fc9e96c1a3d226cf87358c46b1270fca4e'
 
-  url "http://download.eyefi.com/x2/#{version}/Eye-Fi.dmg"
+  url "https://download.eyefi.com/x2/#{version}/Eye-Fi.dmg"
   name 'Eye-Fi Center'
   homepage 'http://support.eye.fi/downloads'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/eye-one-profiler.rb
+++ b/Casks/eye-one-profiler.rb
@@ -4,7 +4,7 @@ cask :v1 => 'eye-one-profiler' do
 
   url 'http://www.xrite.com/downloader.aspx?FileID=1455&Type=M&returnurl=%2fi1profiler-i1publish%2fsupport%2fd1455'
   name 'i1Profiler'
-  homepage 'http://www.xrite.com/i1profiler-i1publish/support/d1455'
+  homepage 'https://www.xrite.com/i1profiler-i1publish/support/d1455'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'i1Profiler.pkg'

--- a/Casks/fdt.rb
+++ b/Casks/fdt.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fdt' do
 
   url 'http://fdt.powerflasher.com/update/fdt/installer/FDT_osx64.dmg'
   name 'FDT'
-  homepage 'http://fdt.powerflasher.com/'
+  homepage 'https://fdt.powerflasher.com/'
   license :commercial
 
   app 'FDT.app'

--- a/Casks/feedbinnotifier.rb
+++ b/Casks/feedbinnotifier.rb
@@ -5,7 +5,7 @@ cask :v1 => 'feedbinnotifier' do
   url "https://github.com/kmikael/FeedbinNotifier/releases/download/v#{version}/FeedbinNotifier.zip"
   appcast 'https://github.com/kmikael/FeedbinNotifier/releases.atom'
   name 'Feedbin Notifier'
-  homepage 'http://kmikael.github.io/FeedbinNotifier'
+  homepage 'https://kmikael.github.io/FeedbinNotifier'
   license :mit
 
   app 'FeedbinNotifier.app'

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -5,7 +5,7 @@ cask :v1 => 'filebot' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/filebot/filebot/FileBot_#{version}/FileBot_#{version}-brew.tar.bz2"
   name 'FileBot'
-  homepage 'http://www.filebot.net/'
+  homepage 'https://www.filebot.net/'
   license :gpl
 
   app 'FileBot.app'

--- a/Casks/finderminder.rb
+++ b/Casks/finderminder.rb
@@ -2,7 +2,7 @@ cask :v1 => 'finderminder' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.irradiatedsoftware.com/download/FinderMinder.zip'
+  url 'https://www.irradiatedsoftware.com/download/FinderMinder.zip'
   name 'FinderMinder'
   homepage 'http://irradiatedsoftware.com/labs'
   license :gratis

--- a/Casks/firestr.rb
+++ b/Casks/firestr.rb
@@ -2,11 +2,11 @@ cask :v1 => 'firestr' do
   version '0.10'
   sha256 '13174b218589f86cc6c13624fc5ef535addbc39516f9b6f44dbc22e168cc48de'
 
-  url "http://mempko.com/firestr/build/#{version}/firestr_#{version}.dmg"
+  url "https://mempko.com/firestr/build/#{version}/firestr_#{version}.dmg"
   name 'Firestr'
   name 'Firestar'
   name 'Fire★'
-  homepage 'http://mempko.com/firestr/firestr.html'
+  homepage 'https://mempko.com/firestr/firestr.html'
   license :gpl
 
   app 'Firestr.app'

--- a/Casks/fission.rb
+++ b/Casks/fission.rb
@@ -2,11 +2,11 @@ cask :v1 => 'fission' do
   version :latest
   sha256 :no_check
 
-  url 'http://neutral.rogueamoeba.com/mirror/files/Fission.zip'
+  url 'https://neutral.rogueamoeba.com/mirror/files/Fission.zip'
   name 'Fission'
-  appcast 'http://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Fission',
+  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Fission',
           :sha256 => '56a9412e5dffad3e7c87fd2d32c70d7f1a28fa1cc851a6ad8c462bdab3614088'
-  homepage 'http://rogueamoeba.com/fission/'
+  homepage 'https://rogueamoeba.com/fission/'
   license :commercial
 
   app 'Fission.app'

--- a/Casks/fitbit-connect.rb
+++ b/Casks/fitbit-connect.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fitbit-connect' do
 
   url "http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20141029_#{version}.dmg"
   name 'Fitbit Connect'
-  homepage 'http://www.fitbit.com/'
+  homepage 'https://www.fitbit.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install Fitbit Connect.pkg'

--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -3,7 +3,7 @@ cask :v1 => 'flash' do
   sha256 '6a1aa09aae039d52601a2408480e0be8e841e9e74d9ccf0deaf0000d095ac2d8'
 
   # macromedia.com is the official download host per the vendor homepage
-  url "http://fpdownload.macromedia.com/get/flashplayer/current/licensing/mac/install_flash_player_#{version.to_i}_osx_pkg.dmg"
+  url "https://fpdownload.macromedia.com/get/flashplayer/current/licensing/mac/install_flash_player_#{version.to_i}_osx_pkg.dmg"
   name 'Adobe Flash Player'
   homepage 'https://www.adobe.com/products/flashplayer/distribution3.html'
   license :gratis

--- a/Casks/flixster-desktop.rb
+++ b/Casks/flixster-desktop.rb
@@ -3,11 +3,11 @@ cask :v1 => 'flixster-desktop' do
   sha256 :no_check
 
   # cloudfront.net is the official download host per the vendor homepage
-  url 'http://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
+  url 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
   name 'Flixster Desktop for Mac'
-  appcast 'http://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
+  appcast 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
           :sha256 => '56ab4151b24f968dfc4234186b9f566ebc99c9c75729bcc2508f722fad0700fa'
-  homepage 'http://www.flixster.com/about/ultraviolet/'
+  homepage 'https://www.flixster.com/about/ultraviolet/'
   license :gratis
 
   postflight do

--- a/Casks/foldingtext.rb
+++ b/Casks/foldingtext.rb
@@ -5,7 +5,7 @@ cask :v1 => 'foldingtext' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/foldingtext/FoldingText.dmg'
   name 'FoldingText'
-  appcast 'http://foldingtext.s3.amazonaws.com/FoldingText.rss',
+  appcast 'https://foldingtext.s3.amazonaws.com/FoldingText.rss',
           :sha256 => '5915bc0f4b102f040737726cb09086eef336203b78c9ea202356bc56efbec767'
   homepage 'http://www.foldingtext.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/fontexplorer-x-pro.rb
+++ b/Casks/fontexplorer-x-pro.rb
@@ -4,7 +4,7 @@ cask :v1 => 'fontexplorer-x-pro' do
 
   url "http://fast.fontexplorerx.com/FontExplorerXPro#{version.gsub('.','')}.dmg"
   name 'FontExplorer X Pro'
-  homepage 'http://www.fontexplorerx.com/'
+  homepage 'https://www.fontexplorerx.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'FontExplorer X Pro.app'

--- a/Casks/fotowall.rb
+++ b/Casks/fotowall.rb
@@ -3,7 +3,7 @@ cask :v1 => 'fotowall' do
   sha256 'f49ad020eb6d36b9ad5492edd24ce608aef4466b727b5d0811ed4218b35d0c8c'
 
   # googlecode.com is the official download host per the vendor homepage
-  url "http://fotowall.googlecode.com/files/Fotowall-#{version}-OSX.dmg"
+  url "https://fotowall.googlecode.com/files/Fotowall-#{version}-OSX.dmg"
   name 'Fotowall'
   homepage 'http://www.enricoros.com/opensource/fotowall/'
   license :oss

--- a/Casks/freedv.rb
+++ b/Casks/freedv.rb
@@ -2,9 +2,9 @@ cask :v1 => 'freedv' do
   version '0.96.6'
   sha256 'e8c42dbb7fc5b8dd88020aa000149185adc5f9583094617966008e5b39d54970'
 
-  url "http://files.freedv.org/OSX/FreeDV-#{version}.dmg"
+  url "https://files.freedv.org/OSX/FreeDV-#{version}.dmg"
   name 'FreeDV'
-  homepage 'http://freedv.org/'
+  homepage 'https://freedv.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'FreeDV.app'

--- a/Casks/freezer.rb
+++ b/Casks/freezer.rb
@@ -2,7 +2,7 @@ cask :v1 => 'freezer' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/Freezer.zip'
+  url 'https://download.mrgeckosmedia.com/Freezer.zip'
   appcast 'https://mrgeckosmedia.com/applications/appcast/Freezer'
   name 'Freezer'
   homepage 'https://mrgeckosmedia.com/applications/info/Freezer'

--- a/Casks/gambit-c.rb
+++ b/Casks/gambit-c.rb
@@ -4,12 +4,12 @@ cask :v1 => 'gambit-c' do
   if Hardware::CPU.is_32_bit?
     sha256 '002ea1d272a4328a0448eab69e6256e104d888bc3c98133d072092457f842bbf'
     # umontreal.ca is the official download host per the vendor homepage
-    url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel32.dmg"
+    url "https://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel32.dmg"
     pkg "gambc-v#{version.gsub('.', '_')}-macosx-intel32.pkg"
   else
     sha256 'bfdad5d4c5025b3ab21926554d870cb37a68607534b78912f81c62db29054a02'
     # umontreal.ca is the official download host per the vendor homepage
-    url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel64.dmg"
+    url "https://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/prebuilt/gambc-v#{version.gsub('.', '_')}-macosx-intel64.dmg"
     pkg "gambc-v#{version.gsub('.', '_')}-macosx-intel64.pkg"
   end
 

--- a/Casks/gamesalad.rb
+++ b/Casks/gamesalad.rb
@@ -7,7 +7,7 @@ cask :v1 => 'gamesalad' do
   name 'GameSalad'
   appcast 'https://gamesalad.com/download/studioUpdates',
           :sha256 => 'b6b47498451094af58cbc95720a7e44707257b840f2f796896b18320fc1b84e8'
-  homepage 'http://gamesalad.com/'
+  homepage 'https://gamesalad.com/'
   license :commercial
 
   app 'GameSalad.app'

--- a/Casks/garagebuy.rb
+++ b/Casks/garagebuy.rb
@@ -5,7 +5,7 @@ cask :v1 => 'garagebuy' do
   # iwascoding.de is the official download host per the vendor homepage
   url "http://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"
   name 'GarageBuy'
-  homepage 'http://www.iwascoding.com/GarageBuy'
+  homepage 'https://www.iwascoding.com/GarageBuy'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'GarageBuy.app'

--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -2,11 +2,11 @@ cask :v1 => 'garagesale' do
   version '6.9.2'
   sha256 '034918633b8cac8dd2cbc0613c8ff5be29e6f5dbba909b46d29d61ee0ba1d943'
 
-  url "http://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
+  url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   appcast 'http://www.iwascoding.com/GarageSale/AppCast.php',
           :sha256 => '3bc0ac9ead57616b1261263671045ca70cedc5061047da72e536c266cc6a2f4d'
   name 'GarageSale'
-  homepage 'http://www.iwascoding.com/GarageSale/'
+  homepage 'https://www.iwascoding.com/GarageSale/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'GarageSale.app'

--- a/Casks/garmin-ant-agent.rb
+++ b/Casks/garmin-ant-agent.rb
@@ -4,7 +4,7 @@ cask :v1 => 'garmin-ant-agent' do
 
   url "http://download.garmin.com/software/ANTAgentforMac_#{version.gsub('.','')}.dmg"
   name 'Garmin ANT Agent'
-  homepage 'http://www8.garmin.com/support/download_details.jsp?id=4417'
+  homepage 'https://www8.garmin.com/support/download_details.jsp?id=4417'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install Garmin ANT Agent.pkg'

--- a/Casks/garmin-basecamp.rb
+++ b/Casks/garmin-basecamp.rb
@@ -4,7 +4,7 @@ cask :v1 => 'garmin-basecamp' do
 
   url "http://download.garmin.com/software/BaseCampforMac_#{version.gsub('.', '')}.dmg"
   name 'Garmin BaseCamp'
-  homepage 'http://www.garmin.com/en-US/shop/downloads/basecamp'
+  homepage 'https://www.garmin.com/en-US/shop/downloads/basecamp'
   license :gratis
 
   pkg 'Install BaseCamp.pkg'

--- a/Casks/garmin-communicator.rb
+++ b/Casks/garmin-communicator.rb
@@ -4,7 +4,7 @@ cask :v1 => 'garmin-communicator' do
 
   url "http://download.garmin.com/software/CommunicatorPluginforMac_#{version.gsub('.','')}.dmg"
   name 'Garmin Communicator Plugin'
-  homepage 'http://www8.garmin.com/support/download_details.jsp?id=3739'
+  homepage 'https://www8.garmin.com/support/download_details.jsp?id=3739'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install Communicator Plugin.pkg'

--- a/Casks/garmin-express.rb
+++ b/Casks/garmin-express.rb
@@ -4,7 +4,7 @@ cask :v1 => 'garmin-express' do
 
   url 'http://download.garmin.com/omt/express/GarminExpress.dmg'
   name 'Garmin Express'
-  homepage 'http://www.garmin.com/express'
+  homepage 'https://www.garmin.com/express'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install Garmin Express.pkg'

--- a/Casks/gephi.rb
+++ b/Casks/gephi.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gephi' do
   # launchpadlibrarian.net is the official download host per the vendor homepage
   url "https://launchpadlibrarian.net/127456772/gephi-#{version}.dmg"
   name 'Gephi'
-  homepage 'http://gephi.org/'
+  homepage 'https://gephi.github.io/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Gephi.app'

--- a/Casks/geppetto.rb
+++ b/Casks/geppetto.rb
@@ -12,7 +12,7 @@ cask :v1 => 'geppetto' do
   end
 
   name 'Geppetto'
-  homepage 'http://puppetlabs.github.io/geppetto/'
+  homepage 'https://puppetlabs.github.io/geppetto/'
   license :oss
 
   app 'geppetto/Geppetto.app'

--- a/Casks/ghc.rb
+++ b/Casks/ghc.rb
@@ -5,7 +5,7 @@ cask :v1 => 'ghc' do
   url "https://github.com/ghcformacosx/ghc-dot-app/releases/download/v#{version}/ghc-#{version}.zip"
   appcast 'https://github.com/ghcformacosx/ghc-dot-app/releases.atom'
   name 'GHC'
-  homepage 'http://ghcformacosx.github.io/'
+  homepage 'https://ghcformacosx.github.io/'
   license :oss
 
   app "ghc-#{version.sub(/-.+/,'')}.app"

--- a/Casks/giffun.rb
+++ b/Casks/giffun.rb
@@ -3,9 +3,9 @@ cask :v1 => 'giffun' do
   sha256 '057e89ee3e5e39c82f40ea490f9f601a487bf688f55cd7e5e7e3b3f9ce812a4a'
 
   # dropbox.com is the official download host per the vendor homepage
-  url "http://dl.dropbox.com/u/2000860/GIFfun-#{version}.dmg"
+  url "https://dl.dropbox.com/u/2000860/GIFfun-#{version}.dmg"
   name 'GIFfun'
-  homepage 'http://www.stone.com/GIFfun/'
+  homepage 'https://www.stone.com/GIFfun/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'GIFfun.app'

--- a/Casks/gingr.rb
+++ b/Casks/gingr.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gingr' do
   url "https://github.com/marbl/gingr/releases/download/v#{version}/gingr-OSX64-v#{version}.zip"
   appcast 'https://github.com/marbl/gingr/releases.atom'
   name 'Gingr'
-  homepage 'http://harvest.readthedocs.org/en/latest/content/gingr.html'
+  homepage 'https://harvest.readthedocs.org/en/latest/content/gingr.html'
   license :bsd
 
   app 'Gingr.app'

--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -26,7 +26,7 @@ cask :v1 => 'git-annex' do
   gpg "#{url}.sig",
       :key_url => 'https://downloads.kitenet.net/git-annex/gpg-pubkey.asc'
   name 'git-annex'
-  homepage 'http://git-annex.branchable.com/'
+  homepage 'https://git-annex.branchable.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'git-annex.app'

--- a/Casks/gitifier.rb
+++ b/Casks/gitifier.rb
@@ -5,7 +5,7 @@ cask :v1 => 'gitifier' do
   url "https://github.com/jsuder/Gitifier/releases/download/#{version}/Gitifier-#{version}.zip"
   appcast 'https://github.com/jsuder/Gitifier/releases.atom'
   name 'Gitifier'
-  homepage 'http://psionides.github.io/Gitifier/'
+  homepage 'https://psionides.github.io/Gitifier/'
   license :eclipse
 
   app 'Gitifier.app'

--- a/Casks/gitter.rb
+++ b/Casks/gitter.rb
@@ -2,8 +2,8 @@ cask :v1 => 'gitter' do
   version '1.162'
   sha256 'faeeba7c607a0faff20c613ffbaf3f98bde88de0e1c73a638dc20e6e915ba81c'
 
-  url "http://update.gitter.im/osx/Gitter-#{version}.dmg"
-  appcast 'http://update.gitter.im/osx/appcast.xml',
+  url "https://update.gitter.im/osx/Gitter-#{version}.dmg"
+  appcast 'https://update.gitter.im/osx/appcast.xml',
           :sha256 => 'dfee81f1a8d4bafa8e412145a58b6db603ec3f37604f7818ba7a3af7ef88004c'
   name 'Gitter'
   homepage 'https://gitter.im/'

--- a/Casks/gog-downloader.rb
+++ b/Casks/gog-downloader.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gog-downloader' do
   appcast 'https://api.gog.com/en/downloader2/status/mac-stable',
           :sha256 => '91f8021f41c170428d3ff18770356284c0239c8d8a47f2eccb2d5d1c222829c5'
   name 'GOG Downloader'
-  homepage 'http://www.gog.com/downloader'
+  homepage 'https://www.gog.com/downloader'
   license :gratis
   tags :vendor => 'GOG'
 

--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -4,7 +4,7 @@ cask :v1 => 'gog-galaxy' do
 
   url "http://cdn.gog.com/open/galaxy/client/installers/galaxy_client_#{version}.pkg"
   name 'GOG Galaxy Client'
-  homepage 'http://www.gog.com/galaxy'
+  homepage 'https://www.gog.com/galaxy'
   license :gratis
   tags :vendor => 'GOG'
 

--- a/Casks/google-earth-web-plugin.rb
+++ b/Casks/google-earth-web-plugin.rb
@@ -4,7 +4,7 @@ cask :v1 => 'google-earth-web-plugin' do
 
   url 'http://r2---sn-po4vapo3-j3ae.c.pack.google.com/edgedl/earth/plugin/current/googleearth-mac-plugin-intel.dmg'
   name 'Google Earth plug-in'
-  homepage 'http://www.google.com/intl/en/earth/explore/products/plugin.html'
+  homepage 'https://www.google.com/intl/en/earth/explore/products/plugin.html'
   license :gratis
   tags :vendor => 'Google'
 

--- a/Casks/google-nik-collection.rb
+++ b/Casks/google-nik-collection.rb
@@ -2,7 +2,7 @@ cask :v1 => 'google-nik-collection' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.google.com/dl/edgedl/photos/nikcollection-demo.dmg'
+  url 'https://dl.google.com/dl/edgedl/photos/nikcollection-demo.dmg'
   name 'Nik Collection'
   homepage 'https://www.google.com/nikcollection/'
   license :commercial

--- a/Casks/google-plus-auto-backup.rb
+++ b/Casks/google-plus-auto-backup.rb
@@ -4,7 +4,7 @@ cask :v1 => 'google-plus-auto-backup' do
 
   url 'https://dl.google.com/dl/edgedl/picasa/gpautobackup_setup.dmg'
   name 'Google+ Auto Backup'
-  homepage 'http://picasa.google.com/'
+  homepage 'https://picasa.google.com/'
   license :gratis
   tags :vendor => 'Google'
 

--- a/Casks/gopro-studio.rb
+++ b/Casks/gopro-studio.rb
@@ -4,7 +4,7 @@ cask :v1 => 'gopro-studio' do
 
   url "http://software.gopro.com/Mac/GoProStudio-#{version}.dmg"
   name 'GoPro Studio'
-  homepage 'http://shop.gopro.com/APAC/softwareandapp/gopro-studio/GoPro-Studio.html#/start=1'
+  homepage 'https://shop.gopro.com/APAC/softwareandapp/gopro-studio/GoPro-Studio.html#/start=1'
   license :commercial
 
   pkg 'GoPro Studio.pkg'

--- a/Casks/groovesquid.rb
+++ b/Casks/groovesquid.rb
@@ -6,7 +6,7 @@ cask :v1 => 'groovesquid' do
   url "https://github.com/groovesquid/groovesquid/releases/download/v#{version}/Groovesquid.dmg"
   appcast 'https://github.com/groovesquid/groovesquid/releases.atom'
   name 'Groovesquid'
-  homepage 'http://groovesquid.com/'
+  homepage 'https://groovesquid.com/'
   license :gpl
 
   app 'Groovesquid.app'

--- a/Casks/handbrakebatch.rb
+++ b/Casks/handbrakebatch.rb
@@ -2,10 +2,10 @@ cask :v1_1 => 'handbrakebatch' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.osomac.com/appcasts/handbrakebatch/HandBrakeBatch.zip'
+  url 'https://www.osomac.com/appcasts/handbrakebatch/HandBrakeBatch.zip'
   appcast 'https://www.osomac.com/appcasts/handbrakebatch/HandBrakeBatch.xml'
   name 'HandBrakeBatch'
-  homepage 'http://www.osomac.com/apps/osx/handbrake-batch/'
+  homepage 'https://www.osomac.com/apps/osx/handbrake-batch/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'HandBrakeBatch.app'

--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -6,7 +6,7 @@ cask :v1 => 'hands-off' do
   appcast 'http://www.metakine.com/sparkle/handsoff2/checkupdate.php',
           :sha256 => '1b948ddb214ba0bc85016341a77b389eabc70b77f3c43c24081776880396f03c'
   name 'Hands Off!'
-  homepage 'http://www.oneperiodic.com/products/handsoff/'
+  homepage 'https://www.oneperiodic.com/products/handsoff/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Hands Off!.app'

--- a/Casks/hermes.rb
+++ b/Casks/hermes.rb
@@ -7,7 +7,7 @@ cask :v1 => 'hermes' do
   appcast 'https://hermesapp.org/versions.xml',
           :sha256 => 'abfa2b7257a081bcff21eb97c9425c09444baac4d979309c0d93b623a4b567f5'
   name 'Hermes'
-  homepage 'http://hermesapp.org/'
+  homepage 'https://hermesapp.org/'
   license :mit
 
   app 'Hermes.app'

--- a/Casks/hex.rb
+++ b/Casks/hex.rb
@@ -5,7 +5,7 @@ cask :v1 => 'hex' do
   # gameforge.com is the official download host per the vendor homepage
   url 'http://dl.hex.gameforge.com/HexInstaller.dmg'
   name 'HEX'
-  homepage 'http://hextcg.com/'
+  homepage 'https://hextcg.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Hex.app'

--- a/Casks/historyhound.rb
+++ b/Casks/historyhound.rb
@@ -6,7 +6,7 @@ cask :v1 => 'historyhound' do
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?HH',
           :sha256 => '22beb79fed4fa0f4a46c8970654ecc649eb4609fc2664b3458cde51b86470930'
   name 'HistoryHound'
-  homepage 'http://www.stclairsoft.com/HistoryHound/'
+  homepage 'https://www.stclairsoft.com/HistoryHound/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'HistoryHound.app'

--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -3,7 +3,7 @@ cask :v1 => 'hostbuddy' do
   sha256 :no_check
 
   url 'https://clickontyler.com/hostbuddy/download/'
-  appcast 'http://shine.clickontyler.com/appcast.php?id=22'
+  appcast 'https://shine.clickontyler.com/appcast.php?id=22'
   name 'Hostbuddy'
   homepage 'https://clickontyler.com/hostbuddy/'
   license :commercial

--- a/Casks/hot-shots.rb
+++ b/Casks/hot-shots.rb
@@ -2,9 +2,9 @@ cask :v1 => 'hot-shots' do
   version '2.2'
   sha256 '51f055625e3e5d7856e2aaf9a7f7559fd66b3acca51304bb8f29fac716530f88'
 
-  url "http://gngrwzrd.com/HotShots#{version.to_i}.zip"
+  url "https://gngrwzrd.com/HotShots#{version.to_i}.zip"
   name 'Hot Shots'
-  homepage 'http://gngrwzrd.com/hotshots/'
+  homepage 'https://gngrwzrd.com/hotshots/'
   license :commercial
 
   app "Hot Shots #{version.to_i}.app"

--- a/Casks/hotswitch.rb
+++ b/Casks/hotswitch.rb
@@ -2,11 +2,11 @@ cask :v1 => 'hotswitch' do
   version :latest
   sha256 :no_check
 
-  url 'http://oniatsu.github.io/HotSwitch/release/zip/HotSwitch.zip'
+  url 'https://oniatsu.github.io/HotSwitch/release/zip/HotSwitch.zip'
   name 'HotSwitch'
-  appcast 'http://oniatsu.github.io/HotSwitch/release/appcast.xml',
+  appcast 'https://oniatsu.github.io/HotSwitch/release/appcast.xml',
           :sha256 => 'c0a545a269cf17dcded22fe34da603cca9d793a8d5f8dbf60d4e760e2a6cb4cf'
-  homepage 'http://oniatsu.github.io/HotSwitch/'
+  homepage 'https://oniatsu.github.io/HotSwitch/'
   license :mit
 
   app 'HotSwitch.app'

--- a/Casks/hp-eprint.rb
+++ b/Casks/hp-eprint.rb
@@ -2,7 +2,7 @@ cask :v1 => 'hp-eprint' do
   version '2.5.0'
   sha256 'cba1598dc5d03fbf28fa649dafca5cd251f273066cc3a050966834a73ba66c3e'
 
-  url "http://ftp.hp.com/pub/softlib/software13/COL43009/ds-104730-8/HP-ePrint_v#{version}.dmg"
+  url "https://ftp.hp.com/pub/softlib/software13/COL43009/ds-104730-8/HP-ePrint_v#{version}.dmg"
   name 'HP ePrint'
   homepage 'http://h20331.www2.hp.com/hpsub/us/en/eprint/overview.html'
   license :gratis

--- a/Casks/httpscoop.rb
+++ b/Casks/httpscoop.rb
@@ -2,11 +2,11 @@ cask :v1 => 'httpscoop' do
   version '1.4.3'
   sha256 'cf3d9767a86e996ecbb3c7abe7e1b43eef985d6125bb3c6680f9246e4db9214e'
 
-  url "http://www.tuffcode.com/releases/HTTPScoop_#{version}.dmg"
-  appcast 'http://www.tuffcode.com/releases/httpscoop-appcast.xml',
+  url "https://www.tuffcode.com/releases/HTTPScoop_#{version}.dmg"
+  appcast 'https://www.tuffcode.com/releases/httpscoop-appcast.xml',
           :sha256 => 'f3d7449544aa64c7709cdb8c5ccd93f2a056550add5fc7493fc402b2c515c5cb'
   name 'HTTP Scoop'
-  homepage 'http://www.tuffcode.com'
+  homepage 'https://www.tuffcode.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'HTTPScoop.app'

--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -2,9 +2,9 @@ cask :v1 => 'hype' do
   version :latest
   sha256 :no_check
 
-  url 'http://tumult.com/hype/download/Hype.zip'
+  url 'https://tumult.com/hype/download/Hype.zip'
   name 'Hype'
-  appcast 'http://tumult.com/hype/appcast_hype2.xml',
+  appcast 'https://tumult.com/hype/appcast_hype2.xml',
           :sha256 => 'b8435a77bb13d39ddaecb92a1510786ceb135225e207aaaac91e7ef230d9edea'
   homepage 'http://tumult.com/hype/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/hyro.rb
+++ b/Casks/hyro.rb
@@ -4,7 +4,7 @@ cask :v1 => 'hyro' do
 
   url "https://jawerty.github.io/Hyro/apps/Hyro-#{version}.dmg"
   name 'Hyro'
-  homepage 'http://jawerty.github.io/Hyro/'
+  homepage 'https://jawerty.github.io/Hyro/'
   license :mit
 
   app 'Hyro.app'

--- a/Casks/ibank.rb
+++ b/Casks/ibank.rb
@@ -18,6 +18,6 @@ cask :v1 => 'ibank' do
   end
 
   name 'iBank'
-  homepage 'http://www.iggsoftware.com/ibank'
+  homepage 'https://www.iggsoftware.com/ibank'
   license :commercial
 end

--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -2,9 +2,9 @@ cask :v1 => 'iboostup' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.iboostup.com/iboostup.dmg'
+  url 'https://www.iboostup.com/iboostup.dmg'
   name 'iBoostUp'
-  appcast 'http://www.iboostup.com/updates',
+  appcast 'https://www.iboostup.com/updates',
           :sha256 => 'b2ac6238575017acfdb5c589111795207780623065cb8e65e1ee569142986592'
   homepage 'https://www.iboostup.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -3,8 +3,8 @@ cask :v1 => 'icons8' do
   version :latest
   sha256 :no_check
 
-  url 'http://s.icons8.com/download/Icons8App_for_Mac_OS.dmg'
-  appcast 'http://icons8.com/icons8_cast',
+  url 'https://s.icons8.com/download/Icons8App_for_Mac_OS.dmg'
+  appcast 'https://icons8.com/icons8_cast',
           :sha256 => 'd12d6eaeef140a4ad9e0801fb4ffba7765f2b40de786115d40526a9523809d2e'
   name 'Icons8 App'
   homepage 'https://icons8.com/'

--- a/Casks/iloc.rb
+++ b/Casks/iloc.rb
@@ -2,9 +2,9 @@ cask :v1 => 'iloc' do
   version '0.3'
   sha256 '3c9909b73ba4a17aef20cdc7efea2333d94f23fca2c87bc6c402bc4f17ce9ef3'
 
-  url "http://derailer.org/iloc/iloc-#{version}.tgz"
+  url "https://derailer.org/iloc/iloc-#{version}.tgz"
   name 'iloc'
-  homepage 'http://derailer.org/iloc'
+  homepage 'https://derailer.org/iloc'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   binary "iloc-#{version}/iloc"

--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -7,7 +7,7 @@ cask :v1 => 'imazing' do
   name 'iMazing'
   appcast 'http://updates.devmate.com/com.DigiDNA.iMazingMac.xml',
           :sha256 => '20c1ab602462b7fc0d5b4cbd555cacf127b69a07a737579598ebcbc0f5b21319'
-  homepage 'http://imazing.com/'
+  homepage 'https://imazing.com/'
   license :commercial
 
   app 'iMazing.app'

--- a/Casks/insomniax.rb
+++ b/Casks/insomniax.rb
@@ -6,7 +6,7 @@ cask :v1 => 'insomniax' do
   name 'InsomniaX'
   appcast 'http://insomniax.semaja2.net/profile/profileInfo.php',
           :sha256 => '834f8bedbd0037f7e65a47c62939f2073f6b1efc5014ddd3f3d6e37650c246cb'
-  homepage 'http://semaja2.net/projects/insomniaxinfo/'
+  homepage 'https://semaja2.net/projects/insomniaxinfo/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'InsomniaX.app'

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -2,7 +2,7 @@ cask :v1 => 'intellij-idea-ce' do
   version '14.1.4'
   sha256 '67c3cf1e6b72ffddb1b8573ddcb407ab3b476a75dbd8e866adbf264bb2daeeb6'
 
-  url "http://download.jetbrains.com/idea/ideaIC-#{version}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIC-#{version}.dmg"
   name 'IntelliJ IDEA Community Edition'
   homepage 'https://www.jetbrains.com/idea/'
   license :apache

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -2,7 +2,7 @@ cask :v1 => 'intellij-idea' do
   version '14.1.4'
   sha256 '211b8a146870bbf1ac20a0498a49863dbbc1f06989a4780c602ba115a9c0a943'
 
-  url "http://download.jetbrains.com/idea/ideaIU-#{version}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIU-#{version}.dmg"
   name 'IntelliJ IDEA'
   homepage 'https://www.jetbrains.com/idea/'
   license :commercial

--- a/Casks/intermission.rb
+++ b/Casks/intermission.rb
@@ -4,7 +4,7 @@ cask :v1 => 'intermission' do
 
   url 'http://dm.rogueamoeba.com/mirror/files/Intermission.zip'
   name 'Intermission'
-  homepage 'http://rogueamoeba.com/intermission/'
+  homepage 'https://rogueamoeba.com/intermission/'
   license :commercial
 
   app 'Intermission.app'

--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -2,7 +2,7 @@ cask :v1 => 'invisionsync' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.invisionapp.com/app/InVisionSync.zip'
+  url 'https://www.invisionapp.com/app/InVisionSync.zip'
   name 'InVision Sync'
   appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml',
           :sha256 => 'd061f71101d85d806b19c532847e468b4a93222805dcd464ea25028961638a80'

--- a/Casks/ip-in-menu-bar.rb
+++ b/Casks/ip-in-menu-bar.rb
@@ -2,10 +2,10 @@ cask :v1 => 'ip-in-menu-bar' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.monkeybreadsoftware.de/Software/IPinmenubar.dmg'
+  url 'https://www.monkeybreadsoftware.de/Software/IPinmenubar.dmg'
   name 'IP in menubar'
   name 'IP in menu bar'
-  homepage 'http://www.monkeybreadsoftware.de/Software/IPinmenubar.shtml'
+  homepage 'https://www.monkeybreadsoftware.de/Software/IPinmenubar.shtml'
   license :unknown # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'IP in menu bar.app'

--- a/Casks/ipass-open-mobile.rb
+++ b/Casks/ipass-open-mobile.rb
@@ -2,7 +2,7 @@ cask :v1 => 'ipass-open-mobile' do
   version '2.3.1.183'
   sha256 '5f46d35dd729ed543b6b69b7384d61e0108adc657073460e78c37eda74175c7e'
 
-  url "http://www.ipass.com/misc/sw_downloads/Open-Mobile-Mac-V#{version}.dmg"
+  url "https://www.ipass.com/misc/sw_downloads/Open-Mobile-Mac-V#{version}.dmg"
   name 'iPass Open Mobile'
   homepage 'https://ipass.com/'
   license :commercial

--- a/Casks/isabelle.rb
+++ b/Casks/isabelle.rb
@@ -2,9 +2,9 @@ cask :v1 => 'isabelle' do
   version '2015'
   sha256 '350ed097785edb35bb653510a9021e90983b06cd94899093e7c3e6c0300815ee'
 
-  url "http://www.cl.cam.ac.uk/research/hvg/Isabelle/dist/Isabelle#{version}.dmg"
+  url "https://www.cl.cam.ac.uk/research/hvg/Isabelle/dist/Isabelle#{version}.dmg"
   name 'Isabelle'
-  homepage 'http://www.cl.cam.ac.uk/research/hvg/Isabelle/'
+  homepage 'https://www.cl.cam.ac.uk/research/hvg/Isabelle/'
   license :bsd
 
   app "Isabelle#{version}.app"

--- a/Casks/istopmotion.rb
+++ b/Casks/istopmotion.rb
@@ -4,7 +4,7 @@ cask :v1 => 'istopmotion' do
 
   url "https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_#{version}.app.zip"
   name 'iStopMotion'
-  homepage 'http://www.boinx.com/istopmotion/mac/'
+  homepage 'https://www.boinx.com/istopmotion/mac/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iStopMotion 3.app'

--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -3,7 +3,7 @@ cask :v1 => 'istumbler' do
   if MacOS.release <= :mountain_lion
     version '99'
     sha256 'ac30e44fe86132c93a5b33699de00e86628e2f51a42015d2225b91521a198b63'
-    url "http://istumbler.net/archive/release#{version}/downloads/iStumbler-#{version}.zip"
+    url "https://istumbler.net/archive/release#{version}/downloads/iStumbler-#{version}.zip"
   elsif MacOS.release == :mavericks
     version '100'
     sha256 '71f6a6b0e255a853664ed4900835a42f2d23dcb05de35acfb3ac2ec1c5fb2edc'
@@ -17,7 +17,7 @@ cask :v1 => 'istumbler' do
   name 'iStumbler'
   appcast 'https://istumbler.net/feeds/appcast.rss',
           :sha256 => '6f5814a0cd44fb1825657a2cca3e91dd1038bd1a4796c79f40de5ec82105ab2d'
-  homepage 'http://istumbler.net/'
+  homepage 'https://istumbler.net/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iStumbler.app'

--- a/Casks/jabber-video.rb
+++ b/Casks/jabber-video.rb
@@ -13,7 +13,7 @@ cask :v1 => 'jabber-video' do
   postflight do
     # Remove ForcedConfig.plist from App bundle. This plist prevents us from editing the internal, external servers and Sip domain
     # See Cisco Jabber Video for Telepresence 4.8 Administrator Guide for more details
-    # http://www.cisco.com/c/en/us/td/docs/telepresence/endpoint/Jabber_Video/4_8/CJAB_BK_J4DBC2E7_00_jabber-video-admin-guide-4-8/CJAB_BK_J4DBC2E7_00_jabber-video-admin-guide-4-8_chapter_011.html#CJAB_TP_P465596C_00
+    # https://www.cisco.com/c/en/us/td/docs/telepresence/endpoint/Jabber_Video/4_8/CJAB_BK_J4DBC2E7_00_jabber-video-admin-guide-4-8/CJAB_BK_J4DBC2E7_00_jabber-video-admin-guide-4-8_chapter_011.html#CJAB_TP_P465596C_00
     system '/bin/rm', '--', "#{staged_path}/Jabber Video.app/Contents/Resources/ForcedConfig.plist"
   end
 

--- a/Casks/jadengeller-helium.rb
+++ b/Casks/jadengeller-helium.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jadengeller-helium' do
   url "https://github.com/JadenGeller/Helium/releases/download/v#{version}/Helium.app.zip"
   appcast 'https://github.com/JadenGeller/Helium/releases.atom'
   name 'Helium'
-  homepage 'http://jadengeller.github.io/Helium/'
+  homepage 'https://jadengeller.github.io/Helium/'
   license :mit
 
   app 'Helium.app'

--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -2,11 +2,11 @@ cask :v1 => 'jameica' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64.zip'
+  url 'https://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64.zip'
   gpg "#{url}.asc",
       :key_id => '5a8ed9cfc0db6c70'
   name 'Jameica'
-  homepage 'http://www.willuhn.de/products/jameica/'
+  homepage 'https://www.willuhn.de/products/jameica/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Jameica.app'

--- a/Casks/janusvr.rb
+++ b/Casks/janusvr.rb
@@ -3,7 +3,7 @@ cask :v1 => 'janusvr' do
   sha256 :no_check
 
   # toronto.edu is the official download host per the vendor homepage
-  url 'http://www.dgp.toronto.edu/~mccrae/projects/firebox/downloads/janusvr.dmg'
+  url 'https://www.dgp.toronto.edu/~mccrae/projects/firebox/downloads/janusvr.dmg'
   name 'Janus VR'
   homepage 'http://janusvr.com/'
   license :gratis

--- a/Casks/jaspersoft-studio.rb
+++ b/Casks/jaspersoft-studio.rb
@@ -5,7 +5,7 @@ cask :v1 => 'jaspersoft-studio' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/jasperstudio/JaspersoftStudio-#{version}/TIBCOJaspersoftStudio-#{version}.final-mac-x86_64.dmg"
   name 'Jaspersoft Studio'
-  homepage 'http://community.jaspersoft.com/project/jaspersoft-studio'
+  homepage 'https://community.jaspersoft.com/project/jaspersoft-studio'
   license :oss
 
   app "Jaspersoft Studio #{version}.final/Jaspersoft Studio.app"

--- a/Casks/jawbone-updater.rb
+++ b/Casks/jawbone-updater.rb
@@ -2,7 +2,7 @@ cask :v1 => 'jawbone-updater' do
   version '2.2.4'
   sha256 '2e9184cde74779f75c6827e0fcf021230da3f6aad48fd1f3d293e5e355264f7d'
 
-  url "http://content.jawbone.com/store/dashboard/Jawbone_Updater-#{version}.pkg"
+  url "https://content.jawbone.com/store/dashboard/Jawbone_Updater-#{version}.pkg"
   name 'Jawbone Updater'
   homepage 'https://jawbone.com/'
   license :gpl

--- a/Casks/jenkins.rb
+++ b/Casks/jenkins.rb
@@ -4,7 +4,7 @@ cask :v1 => 'jenkins' do
 
   url "http://mirrors.jenkins-ci.org/osx/jenkins-#{version}.pkg"
   name 'Jenkins'
-  homepage 'http://jenkins-ci.org/'
+  homepage 'https://jenkins-ci.org/'
   license :mit
 
   pkg "jenkins-#{version}.pkg"

--- a/Casks/jettison.rb
+++ b/Casks/jettison.rb
@@ -2,11 +2,11 @@ cask :v1 => 'jettison' do
   version '1.4.3'
   sha256 '5836546099a85e212bd1cfbc79b35e5cf4d99e7056edff4a2b4fbdfdf3bdbd6a'
 
-  url "http://www.stclairsoft.com/download/Jettison-#{version}.dmg"
+  url "https://www.stclairsoft.com/download/Jettison-#{version}.dmg"
   name 'Jettison'
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?JT',
           :sha256 => '0373bcc3c6c29abf5878f4db77bcf310241676ee0e4957940e041d158aad8442'
-  homepage 'http://www.stclairsoft.com/Jettison/'
+  homepage 'https://www.stclairsoft.com/Jettison/'
   license :freemium
 
   app 'Jettison.app'

--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -2,9 +2,9 @@ cask :v1 => 'jitouch' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.jitouch.com/jitouch_yosemite.zip'
+  url 'https://www.jitouch.com/jitouch_yosemite.zip'
   name 'jitouch'
-  homepage 'http://www.jitouch.com'
+  homepage 'https://www.jitouch.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   prefpane 'jitouch/Jitouch.prefPane'

--- a/Casks/juliastudio.rb
+++ b/Casks/juliastudio.rb
@@ -12,7 +12,7 @@ cask :v1 => 'juliastudio' do
   end
 
   name 'Julia Studio'
-  homepage 'http://forio.com/labs/julia-studio/'
+  homepage 'https://forio.com/labs/julia-studio/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'JuliaStudio.app'

--- a/Casks/kindle-previewer.rb
+++ b/Casks/kindle-previewer.rb
@@ -5,7 +5,7 @@ cask :v1 => 'kindle-previewer' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://kindlepreviewer.s3.amazonaws.com/KindlePreviewer.zip'
   name 'Kindle Previewer'
-  homepage 'http://www.amazon.com/gp/feature.html/?docId=1000765261'
+  homepage 'https://www.amazon.com/gp/feature.html/?docId=1000765261'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Kindle Previewer.app'

--- a/Casks/kindlegen.rb
+++ b/Casks/kindlegen.rb
@@ -5,7 +5,7 @@ cask :v1 => 'kindlegen' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v#{version.gsub('.', '_')}.zip"
   name 'KindleGen'
-  homepage 'http://www.amazon.com/gp/feature.html?docId=1000765211'
+  homepage 'https://www.amazon.com/gp/feature.html?docId=1000765211'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   binary 'kindlegen'

--- a/Casks/kkbox.rb
+++ b/Casks/kkbox.rb
@@ -4,7 +4,7 @@ cask :v1 => 'kkbox' do
 
   url "http://download.kkbox.com/files/KKBOX-#{version}.dmg"
   name 'KKBOX'
-  homepage 'http://www.kkbox.com/'
+  homepage 'https://www.kkbox.com/'
   license :commercial
 
   app 'KKBOX.app'

--- a/Casks/kobo.rb
+++ b/Casks/kobo.rb
@@ -5,7 +5,7 @@ cask :v1 => 'kobo' do
   # akamaihd.net is the official download host per the vendor homepage
   url 'http://kbdownload1-a.akamaihd.net/desktop/kobodesktop/kobosetup.dmg'
   name 'Kobo'
-  homepage 'http://www.kobo.com/'
+  homepage 'https://www.kobo.com/'
   license :gratis
 
   app 'Kobo.app'

--- a/Casks/kodi.rb
+++ b/Casks/kodi.rb
@@ -6,7 +6,7 @@ cask :v1 => 'kodi' do
   url "http://mirrors.xbmc.org/releases/osx/x86_64/kodi-#{version}-Helix-x86_64.dmg"
   name 'Kodi'
   name 'XBMC' # former
-  homepage 'http://kodi.tv/'
+  homepage 'https://kodi.tv/'
   license :gpl
 
   app 'Kodi.app'

--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -3,7 +3,7 @@ cask :v1 => 'komodo-edit' do
   sha256 '39dc064cead52b3de0cab8f499867d26e1e8feeeca91488c00cd72ceb9d31089'
 
   # activestate.com is the official download host per the vendor homepage
-  url "http://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"
+  url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"
   name 'Komodo Edit'
   homepage 'http://komodoide.com/komodo-edit'
   license :mpl

--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -5,7 +5,7 @@ cask :v1 => 'komodo-ide' do
   # activestate.com is the official download host per the vendor homepage
   url "http://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
   name 'Komodo IDE'
-  homepage 'http://komodoide.com/'
+  homepage 'https://komodoide.com/'
   license :commercial
 
   app 'Komodo IDE 9.app'

--- a/Casks/launchbar.rb
+++ b/Casks/launchbar.rb
@@ -3,11 +3,11 @@ cask :v1 => 'launchbar' do
   if MacOS.release <= :mountain_lion
     version '5.6.4'
     sha256 '22a1ec0c10de940e5efbcccd18b8b048d95fb7c63213a01c7976a76d6be69a4d'
-    url "http://www.obdev.at/downloads/launchbar/legacy/LaunchBar-#{version}.dmg"
+    url "https://www.obdev.at/downloads/launchbar/legacy/LaunchBar-#{version}.dmg"
   else
     version '6.4'
     sha256 '320c177839bad91f3dda90bd2fb4476bb31c5a6d723437505d776456dd8688cc'
-    url "http://www.obdev.at/downloads/launchbar/LaunchBar-#{version}.dmg"
+    url "https://www.obdev.at/downloads/launchbar/LaunchBar-#{version}.dmg"
   end
 
   name 'LaunchBar'

--- a/Casks/lifeslice.rb
+++ b/Casks/lifeslice.rb
@@ -7,7 +7,7 @@ cask :v1 => 'lifeslice' do
   name 'LifeSlice'
   appcast 'http://wanderingstan.com/apps/lifeslice/sparkle-lifeslice-appcast-xml.php',
           :sha256 => '90bd0939501fdc8a5b52bb24532919424ee1201a1b6281761b9e91d3b9068c61'
-  homepage 'http://wanderingstan.github.io/Lifeslice/'
+  homepage 'https://wanderingstan.github.io/Lifeslice/'
   license :oss
 
   app 'LifeSlice.app'

--- a/Casks/lights-out-pane.rb
+++ b/Casks/lights-out-pane.rb
@@ -5,7 +5,7 @@ cask :v1 => 'lights-out-pane' do
   url "https://github.com/samturner/lights-out/releases/download/v#{version}/lights-out.prefPane.zip"
   appcast 'https://github.com/samturner/lights-out/releases.atom'
   name 'Lights Out'
-  homepage 'http://samturner.github.io/lights-out/'
+  homepage 'https://samturner.github.io/lights-out/'
   license :gpl
 
   prefpane 'lights-out.prefPane'

--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -6,7 +6,7 @@ cask :v1 => 'linein' do
   name 'LineIn'
   appcast 'https://rogueamoeba.com/freebies/version-linein.rss',
           :sha256 => '212705064a7c63980fa1eb4ec1f1334212bf8e23a639b507c31b0d09b65d7db8'
-  homepage 'http://www.rogueamoeba.com/freebies/'
+  homepage 'https://www.rogueamoeba.com/freebies/'
   license :gratis
 
   app 'LineIn.app'

--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -2,8 +2,8 @@ cask :v1 => 'lingon-x' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.peterborgapps.com/downloads/LingonX2.zip'
-  appcast 'http://www.peterborgapps.com/updates/lingonx2-appcast.xml'
+  url 'https://www.peterborgapps.com/downloads/LingonX2.zip'
+  appcast 'https://www.peterborgapps.com/updates/lingonx2-appcast.xml'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
   license :commercial

--- a/Casks/linphone.rb
+++ b/Casks/linphone.rb
@@ -7,7 +7,7 @@ cask :v1 => 'linphone' do
   gpg "#{url}.sig",
       :key_id => '3ecd52dee2f56985'
   name 'Linphone'
-  homepage 'http://www.linphone.org/'
+  homepage 'https://www.linphone.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Linphone.app'

--- a/Casks/lovewallpaper.rb
+++ b/Casks/lovewallpaper.rb
@@ -5,7 +5,7 @@ cask :v1 => 'lovewallpaper' do
   # qdcdn.com is the official download host per the vendor homepage
   url 'http://s.qdcdn.com/lovebizhi/LoveWallpaper4Mac.dmg'
   name '爱壁纸HD'
-  homepage 'http://www.lovebizhi.com/'
+  homepage 'https://www.lovebizhi.com/'
   license :gratis
 
   app 'LoveWallpaper4Mac.app'

--- a/Casks/lpk25-editor.rb
+++ b/Casks/lpk25-editor.rb
@@ -5,7 +5,7 @@ cask :v1 => 'lpk25-editor' do
   # rackcdn.com is the official download host per the vendor homepage
   url 'http://6be54c364949b623a3c0-4409a68c214f3a9eeca8d0265e9266c0.r0.cf2.rackcdn.com/453/downloads/lpk25_editor_mac_00.zip'
   name 'LPK25 Editor'
-  homepage 'http://www.akaipro.com/index.php/product/lpk25'
+  homepage 'https://www.akaipro.com/index.php/product/lpk25'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'LPK25_Editor/LPK25 Editor.app'

--- a/Casks/macdrops.rb
+++ b/Casks/macdrops.rb
@@ -2,9 +2,9 @@ cask :v1 => 'macdrops' do
   version '1.1'
   sha256 'c91f10418d8dd88f395603f9b824fc1ef319ec91affe2326cff5bce7f2bd63bb'
 
-  url "http://interfacelift.com/apps/macdrops/v1/Macdrops_v#{version}.dmg"
+  url "https://interfacelift.com/apps/macdrops/v1/Macdrops_v#{version}.dmg"
   name 'Macdrops'
-  homepage 'http://interfacelift.com/apps/macdrops/v1'
+  homepage 'https://interfacelift.com/apps/macdrops/v1'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app "Macdrops v#{version}.app"

--- a/Casks/macid.rb
+++ b/Casks/macid.rb
@@ -2,9 +2,9 @@ cask :v1 => 'macid' do
   version '1.2.2'
   sha256 '6dd7ad1992355be510df33ee6c0209690c6d3522a93afa9d6750b999b36c67be'
 
-  url "http://macid.co/app/#{version}/MacID-for-OS-X.zip"
+  url "https://macid.co/app/#{version}/MacID-for-OS-X.zip"
   name 'MacID'
-  homepage 'http://macid.co/'
+  homepage 'https://macid.co/'
   license :gratis
 
   app 'MacID.app'

--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -5,7 +5,7 @@ cask :v1 => 'macpass' do
   url "https://github.com/mstarke/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
   appcast 'https://github.com/mstarke/MacPass/releases.atom'
   name 'MacPass'
-  homepage 'http://mstarke.github.io/MacPass/'
+  homepage 'https://mstarke.github.io/MacPass/'
   license :gpl
 
   app 'MacPass.app'

--- a/Casks/macpaw-gemini.rb
+++ b/Casks/macpaw-gemini.rb
@@ -3,10 +3,10 @@ cask :v1 => 'macpaw-gemini' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.macpaw.site.Gemini/MacPawGemini.dmg'
+  url 'https://dl.devmate.com/com.macpaw.site.Gemini/MacPawGemini.dmg'
   appcast 'http://updates.devmate.com/com.macpaw.site.Gemini.xml'
   name 'MacPaw Gemini'
-  homepage 'http://macpaw.com/gemini'
+  homepage 'https://macpaw.com/gemini'
   license :commercial
   tags :vendor => 'MacPaw'
 

--- a/Casks/macscale.rb
+++ b/Casks/macscale.rb
@@ -3,7 +3,7 @@ cask :v1 => 'macscale' do
   sha256 :no_check
 
   # brinscall.com is the official download host per the vendor homepage
-  url 'http://www.brinscall.com/MacScale.zip'
+  url 'https://www.brinscall.com/MacScale.zip'
   name 'MacScale'
   appcast 'https://www.brinscall.com/updates/macscale.xml',
           :sha256 => 'd5796f727a8ed5e9ed5d59dce484c66a38219edad80b9fb5f6343a3857ed7c1b'

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -5,7 +5,7 @@ cask :v1 => 'mactex' do
   # ctan.org is the official download host per the vendor homepage
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   name 'MacTeX'
-  homepage 'http://www.tug.org/mactex/'
+  homepage 'https://www.tug.org/mactex/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "mactex-#{version}.pkg"

--- a/Casks/magic-launch.rb
+++ b/Casks/magic-launch.rb
@@ -4,7 +4,7 @@ cask :v1 => 'magic-launch' do
 
   url "https://www.oneperiodic.com/files/Magic%20Launch%20v#{version}.zip"
   name 'Magic Launch'
-  homepage 'http://www.oneperiodic.com/products/magiclaunch/'
+  homepage 'https://www.oneperiodic.com/products/magiclaunch/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   prefpane 'Magic Launch.prefPane'

--- a/Casks/mailbox.rb
+++ b/Casks/mailbox.rb
@@ -7,7 +7,7 @@ cask :v1 => 'mailbox' do
   appcast 'https://mb-dtop.s3.amazonaws.com/external-beta/external-beta-appcast.xml',
           :sha256 => '7f1958d4be2af3ea5283bc586f97d73df07cb559ae954f4914815529d99e62dc'
   name 'Mailbox'
-  homepage 'http://www.mailboxapp.com/'
+  homepage 'https://www.mailboxapp.com/'
   license :gratis
 
   app 'Mailbox (Beta).app'

--- a/Casks/makeiphoneringtone.rb
+++ b/Casks/makeiphoneringtone.rb
@@ -2,11 +2,11 @@ cask :v1 => 'makeiphoneringtone' do
   version :latest
   sha256 :no_check
 
-  url 'http://rogueamoeba.com/freebies/download/MakeiPhoneRingtone.zip'
+  url 'https://rogueamoeba.com/freebies/download/MakeiPhoneRingtone.zip'
   name 'MakeiPhoneRingtone'
   appcast 'https://rogueamoeba.com/freebies/version-mir.rss',
           :sha256 => '537cf0c3d30d57c1fa5912271b9b00f335d87caffd13ebd2fe762caaa7ea9f13'
-  homepage 'http://rogueamoeba.com/freebies/'
+  homepage 'https://rogueamoeba.com/freebies/'
   license :gratis
 
   app 'MakeiPhoneRingtone.app'

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -2,7 +2,7 @@ cask :v1 => 'mamp' do
   version '3.3'
   sha256 'fb50cfbf54c82f92808ae46bef50944a1c40fc607b43ad1767c78edc18d0b1d1'
 
-  url "http://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"
+  url "https://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"
   name 'MAMP'
   homepage 'https://www.mamp.info/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -5,7 +5,7 @@ cask :v1 => 'mcedit' do
   url "https://github.com/Khroki/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
   appcast 'https://github.com/Khroki/MCEdit-Unified/releases.atom'
   name 'MCEdit-Unified'
-  homepage 'http://khroki.github.io/MCEdit-Unified/'
+  homepage 'https://khroki.github.io/MCEdit-Unified/'
   license :mit
 
   app 'mcedit.app'

--- a/Casks/mdrp.rb
+++ b/Casks/mdrp.rb
@@ -4,9 +4,9 @@ cask :v1 => 'mdrp' do
 
   url 'http://www.macdvdripperpro.com/download/'
   name 'Mac DVDRipper Pro'
-  appcast 'http://www.macdvdripperpro.com/mdrp_sparkle5.xml',
+  appcast 'https://www.macdvdripperpro.com/mdrp_sparkle5.xml',
           :sha256 => '8e4f7c395dda29438cf1f4a931a626d484886109a01ea9ee733fa6d7c24f4634'
-  homepage 'http://www.macdvdripperpro.com/'
+  homepage 'https://www.macdvdripperpro.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'MDRP.app'

--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mediainfo' do
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   name 'MediaInfo'
-  homepage 'http://mediaarea.net/en/MediaInfo'
+  homepage 'https://mediaarea.net/en/MediaInfo'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'MediaInfo.app'

--- a/Casks/menubarfilter.rb
+++ b/Casks/menubarfilter.rb
@@ -4,7 +4,7 @@ cask :v1 => 'menubarfilter' do
 
   url 'https://github.com/downloads/wez/MenuBarFilter/MenuBarFilter.zip'
   name 'Menubarfilter'
-  homepage 'http://wez.github.com/MenuBarFilter/'
+  homepage 'https://wez.github.com/MenuBarFilter/'
   license :apache
 
   app 'MenuBarFilter.app'

--- a/Casks/menuola.rb
+++ b/Casks/menuola.rb
@@ -3,10 +3,10 @@ cask :v1 => 'menuola' do
   sha256 'd97170adab805f1a52fef6c59287724783d80b5b23821dd97c0a85b4a72261dd'
 
   url "http://geocom.co.nz/downloads/Menuolav#{version.to_i}.dmg.zip"
-  appcast 'http://www.geocom.co.nz/menuola.xml',
+  appcast 'https://www.geocom.co.nz/menuola.xml',
           :sha256 => 'e18b081046702171648c929872c692adc2d1b816f5e9aff93b0612a11a3ea362'
   name 'Menuola'
-  homepage 'http://www.geocom.co.nz'
+  homepage 'https://www.geocom.co.nz'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   container :nested => 'Menuola.dmg'

--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -5,7 +5,7 @@ cask :v1 => 'metaz' do
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"
   appcast 'https://github.com/griff/metaz/releases.atom'
   name 'MetaZ'
-  homepage 'http://griff.github.io/metaz/'
+  homepage 'https://griff.github.io/metaz/'
   license :mit
 
   app 'MetaZ.app'

--- a/Casks/microsoft-intellipoint.rb
+++ b/Casks/microsoft-intellipoint.rb
@@ -4,7 +4,7 @@ cask :v1 => 'microsoft-intellipoint' do
 
   url 'http://download.microsoft.com/download/B/1/0/B109F931-70E2-425F-8681-EAAB75845AB8/Microsoft-Mouse_d305.dmg'
   name 'Microsoft IntelliPoint'
-  homepage 'http://www.microsoft.com/hardware/en-us/mice'
+  homepage 'https://www.microsoft.com/hardware/en-us/mice'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Microsoft Mouse Installer.app/Contents/Resources/Microsoft Mouse.pkg'

--- a/Casks/microsoft-intellitype.rb
+++ b/Casks/microsoft-intellitype.rb
@@ -4,7 +4,7 @@ cask :v1 => 'microsoft-intellitype' do
 
   url 'http://download.microsoft.com/download/B/1/0/B109F931-70E2-425F-8681-EAAB75845AB8/Microsoft-Desktop_d305.dmg'
   name 'Microsoft IntelliType'
-  homepage 'http://www.microsoft.com/hardware/en-us/keyboards'
+  homepage 'https://www.microsoft.com/hardware/en-us/keyboards'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Microsoft Desktop Installer.app/Contents/Resources/Microsoft Desktop.mpkg/Contents/Packages/Microsoft Keyboard.pkg'

--- a/Casks/microsoft-lync.rb
+++ b/Casks/microsoft-lync.rb
@@ -4,7 +4,7 @@ cask :v1 => 'microsoft-lync' do
 
   url "http://download.microsoft.com/download/5/0/0/500C7E1F-3235-47D4-BC11-95A71A1BA3ED/lync_#{version}.dmg"
   name 'Microsoft Lync 2011'
-  homepage 'http://www.microsoft.com/mac/enterprise/lync'
+  homepage 'https://www.microsoft.com/mac/enterprise/lync'
   license :gratis
 
   pkg 'Lync Installer.pkg'

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -4,7 +4,7 @@ cask :v1 => 'microsoft-office' do
 
   url 'http://officecdn.microsoft.com/pr/MacOffice2011/en-US/MicrosoftOffice2011.dmg'
   name 'Microsoft Office'
-  homepage 'http://www.microsoft.com/mac'
+  homepage 'https://www.microsoft.com/mac'
   license :commercial
 
   pkg 'Office Installer.pkg'

--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -4,7 +4,7 @@ cask :v1 => 'mindjet-mindmanager' do
 
   url 'http://www.mindjet.com/mm-mac-dmg'
   name 'Mindjet Mindmanager'
-  homepage 'http://www.mindjet.com/mindmanager/'
+  homepage 'https://www.mindjet.com/mindmanager/'
   license :commercial
 
   app 'Mindjet MindManager.app'

--- a/Casks/mitmproxy.rb
+++ b/Casks/mitmproxy.rb
@@ -2,9 +2,9 @@ cask :v1 => 'mitmproxy' do
   version '0.12.1'
   sha256 'c8bd02613bef8f02755a266208a6621b222fabb260dcb439fde62522efc1277e'
 
-  url "http://mitmproxy.org/download/osx-mitmproxy-#{version}.tar.gz"
+  url "https://mitmproxy.org/download/osx-mitmproxy-#{version}.tar.gz"
   name 'mitmproxy'
-  homepage 'http://mitmproxy.org/'
+  homepage 'https://mitmproxy.org/'
   license :mit
 
   binary "osx-mitmproxy-#{version}/mitmproxy"

--- a/Casks/money.rb
+++ b/Casks/money.rb
@@ -6,7 +6,7 @@ cask :v1 => 'money' do
   appcast 'http://www.jumsoft.com/downloads/updates/money4.rss',
           :sha256 => '92fb9af194903f4f4336c54957feed8537060181eb8c5b4f5b97ccb3c32187e0'
   name 'Money'
-  homepage 'http://www.jumsoft.com/money/'
+  homepage 'https://www.jumsoft.com/money/'
   license :commercial
 
   app 'Money.app'

--- a/Casks/mongochef.rb
+++ b/Casks/mongochef.rb
@@ -2,9 +2,9 @@ cask :v1 => 'mongochef' do
   version '2.0.7'
   sha256 'bc699e2c9fd2062acc4fdad5b519b9a1c95e53991c5c594b95b88b33bf17c00c'
 
-  url "http://cdn.3t.io/mongochef/mac/#{version}/MongoChef.dmg"
+  url "https://cdn.3t.io/mongochef/mac/#{version}/MongoChef.dmg"
   name 'MongoChef'
-  homepage 'http://3t.io/mongochef/'
+  homepage 'https://3t.io/mongochef/'
   # License is free for personal use (gratis) and paid for business use (commercial)
   license :other
 

--- a/Casks/monotype-skyfonts.rb
+++ b/Casks/monotype-skyfonts.rb
@@ -5,7 +5,7 @@ cask :v1 => 'monotype-skyfonts' do
   # skyfonts.com is the official download host per the vendor homepage
   url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
   name 'Monotype SkyFonts'
-  homepage 'http://www.fonts.com/web-fonts/google'
+  homepage 'https://www.fonts.com/web-fonts/google'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Monotype Skyfonts.app'

--- a/Casks/mypaint.rb
+++ b/Casks/mypaint.rb
@@ -3,7 +3,7 @@ cask :v1 => 'mypaint' do
   sha256 'a7e1066b4f7ff6d0f5faa3154e5cf97637607d2143ea9121ac36037c03e41848'
 
   # dropbox.com is the official download host per the vendor homepage.
-  url "http://dl.dropbox.com/u/942685/MyPaint-#{version}.pkg"
+  url "https://dl.dropbox.com/u/942685/MyPaint-#{version}.pkg"
   name 'MyPaint'
   homepage 'http://mypaint.intilinux.com'
   license :oss

--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -6,7 +6,7 @@ cask :v1 => 'mysqlworkbench' do
   name 'MySQL Workbench'
   gpg "#{url}.asc",
       :key_id => '8c718d3b5072e1f5'
-  homepage 'http://www.mysql.com/products/workbench'
+  homepage 'https://www.mysql.com/products/workbench'
   license :gpl
 
   app 'MySQLWorkbench.app'

--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -16,7 +16,7 @@ cask :v1 => 'ncar-ncl' do
 
   name 'NCAR Command Language'
   name 'ncl'
-  homepage 'http://www.ncl.ucar.edu/'
+  homepage 'https://www.ncl.ucar.edu/'
   license :oss
 
   depends_on :cask => 'xquartz'
@@ -44,7 +44,7 @@ cask :v1 => 'ncar-ncl' do
     export DYLD_FALLBACK_LIBRARY_PATH=$(dirname $(gfortran --print-file-name libgfortran.3.dylib)):$DYLD_FALLBACK_LIBRARY_PATH
 
     For other information, please see:
-    http://www.ncl.ucar.edu/Download/macosx.shtml
+    https://www.ncl.ucar.edu/Download/macosx.shtml
     EOS
   end
 end

--- a/Casks/netgeargenie.rb
+++ b/Casks/netgeargenie.rb
@@ -4,7 +4,7 @@ cask :v1 => 'netgeargenie' do
 
   url 'http://updates1.netgear.com/netgeargenie/mac/update/NETGEARGenieInstaller.dmg'
   name 'NETGEARGenie'
-  homepage 'http://www.netgear.com/home/discover/apps/genie.aspx'
+  homepage 'https://www.netgear.com/home/discover/apps/genie.aspx'
   license :gratis
 
   pkg "NETGEAR_Genie_Installer_#{version}.pkg"

--- a/Casks/nicecast.rb
+++ b/Casks/nicecast.rb
@@ -4,9 +4,9 @@ cask :v1 => 'nicecast' do
 
   url 'https://rogueamoeba.com/nicecast/download/Nicecast.zip'
   name 'Nicecast'
-  appcast 'http://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Nicecast',
+  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Nicecast',
           :sha256 => '8f6d50cbc369b27a014c2393eaf9f9c7fb35e5467adba4233f5aead1b8dfaeca'
-  homepage 'http://rogueamoeba.com/nicecast'
+  homepage 'https://rogueamoeba.com/nicecast'
   license :commercial
 
   app 'Nicecast.app'

--- a/Casks/nide.rb
+++ b/Casks/nide.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nide' do
 
   url "https://github.com/downloads/Coreh/nide/nide-v#{version}.dmg"
   name 'Nide'
-  homepage 'http://coreh.github.io/nide/'
+  homepage 'https://coreh.github.io/nide/'
   license :mit
 
   app 'Nide.app'

--- a/Casks/night-owl.rb
+++ b/Casks/night-owl.rb
@@ -6,7 +6,7 @@ cask :v1 => 'night-owl' do
   url 'http://aki-null.net/yf/NightOwl.zip'
   name 'YoruFukurou'
   name 'NightOwl'
-  appcast 'http://sites.google.com/site/yorufukurou/distribution/appcast.xml'
+  appcast 'https://sites.google.com/site/yorufukurou/distribution/appcast.xml'
   homepage 'https://sites.google.com/site/yorufukurou/home-en'
   license :gratis
 

--- a/Casks/nmap.rb
+++ b/Casks/nmap.rb
@@ -2,9 +2,9 @@ cask :v1 => 'nmap' do
   version '6.47'
   sha256 'eb277f24d4d77d323400c23c5e0b4296143524dc2e4ddbe844cc3c4c7fc878d2'
 
-  url "http://nmap.org/dist/nmap-#{version}.dmg"
+  url "https://nmap.org/dist/nmap-#{version}.dmg"
   name 'Nmap'
-  homepage 'http://nmap.org/'
+  homepage 'https://nmap.org/'
   license :gpl
 
   pkg "nmap-#{version}.mpkg"

--- a/Casks/no-ip-duc.rb
+++ b/Casks/no-ip-duc.rb
@@ -4,7 +4,7 @@ cask :v1 => 'no-ip-duc' do
 
   url "https://www.noip.com/client/mac/noip#{version}.dmg"
   name 'No-IP DUC'
-  homepage 'http://www.noip.com/download?page=mac'
+  homepage 'https://www.noip.com/download?page=mac'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'No-IP DUC.app'

--- a/Casks/nocturne.rb
+++ b/Casks/nocturne.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nocturne' do
 
   url "https://blacktree-nocturne.googlecode.com/files/Nocturne.#{version}.zip"
   name 'Nocturne'
-  homepage 'http://code.google.com/p/blacktree-nocturne/'
+  homepage 'https://code.google.com/p/blacktree-nocturne/'
   license :oss
 
   app 'Nocturne.app'

--- a/Casks/nomacs.rb
+++ b/Casks/nomacs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'nomacs' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/nomacs/nomacs-#{version}-x86_64.dmg"
   name 'nomacs'
-  homepage 'http://www.nomacs.org/'
+  homepage 'https://www.nomacs.org/'
   license :gpl
 
   app 'nomacs.app'

--- a/Casks/nottingham.rb
+++ b/Casks/nottingham.rb
@@ -4,7 +4,7 @@ cask :v1 => 'nottingham' do
 
   url "http://dl.clickontyler.com/nottingham/nottingham20_#{version}.zip"
   name 'Nottingham'
-  appcast 'http://shine.clickontyler.com/appcast.php?id=11',
+  appcast 'https://shine.clickontyler.com/appcast.php?id=11',
           :sha256 => '77be52d9c62393c316d5f6a5ac10f72579e31189dd08447b2f42e1f81736979d'
   homepage 'https://clickontyler.com/nottingham/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/noun-project.rb
+++ b/Casks/noun-project.rb
@@ -5,7 +5,7 @@ cask :v1 => 'noun-project' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/nounproject/mac/Noun-Project-#{version}.dmg"
   name 'Noun Project'
-  appcast 'http://thenounproject.com/for-mac/feed/',
+  appcast 'https://thenounproject.com/for-mac/feed/',
           :sha256 => 'f70a95f1158dd41211d4866577c33ad1959ad8ce76c2ed093ed767596620c5c4'
   homepage 'https://thenounproject.com'
   license :commercial

--- a/Casks/objektiv.rb
+++ b/Casks/objektiv.rb
@@ -6,7 +6,7 @@ cask :v1 => 'objektiv' do
   url 'http://nthloop.com/objektiv/objektiv-latest.zip'
   appcast 'http://nthloop.com/objektiv/appcast.xml'
   name 'Objektiv'
-  homepage 'http://nthloop.github.io/Objektiv/'
+  homepage 'https://nthloop.github.io/Objektiv/'
   license :mit
 
   app 'Objektiv.app'

--- a/Casks/omnidisksweeper.rb
+++ b/Casks/omnidisksweeper.rb
@@ -4,7 +4,7 @@ cask :v1 => 'omnidisksweeper' do
 
   url 'https://www.omnigroup.com/download/latest/OmniDiskSweeper'
   name 'OmniDiskSweeper'
-  homepage 'http://www.omnigroup.com/products/omnidisksweeper/'
+  homepage 'https://www.omnigroup.com/products/omnidisksweeper/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'OmniDiskSweeper.app'

--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -2,7 +2,7 @@ cask :v1 => 'omnipresence' do
   version '1.4'
   sha256 '9a8752fa8e4ee4d82bd435f624635f1157f7c1538b96622af361ef43d95f2e02'
 
-  url "http://downloads.omnigroup.com/software/MacOSX/10.10/OmniPresence-#{version}.dmg"
+  url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniPresence-#{version}.dmg"
   name 'OmniPresence'
   homepage 'https://www.omnigroup.com/omnipresence'
   license :commercial

--- a/Casks/omniweb.rb
+++ b/Casks/omniweb.rb
@@ -2,9 +2,9 @@ cask :v1 => 'omniweb' do
   version '5.11.2'
   sha256 'f1179f1dcf96ed7b2732a18049c79c4043131b267deabb06b5a10c19f1ce750f'
 
-  url "http://downloads.omnigroup.com/software/MacOSX/10.4/OmniWeb-#{version}.dmg"
+  url "https://downloads.omnigroup.com/software/MacOSX/10.4/OmniWeb-#{version}.dmg"
   name 'OmniWeb'
-  homepage 'http://www.omnigroup.com/products/omniweb/'
+  homepage 'https://www.omnigroup.com/products/omniweb/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'OmniWeb.app'

--- a/Casks/opendns-updater.rb
+++ b/Casks/opendns-updater.rb
@@ -2,7 +2,7 @@ cask :v1 => 'opendns-updater' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.opendns.com/download/mac/'
+  url 'https://www.opendns.com/download/mac/'
   name 'OpenDNS Updater'
   appcast 'https://opendnsupdate.appspot.com/macupdatecheck/ipupdater/AppCast.xml',
           :sha256 => 'd5938a67e84d710e93b5e74a1b515f6881a3f0ff251bfbb5ea61ecdf1596a4a6'

--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -5,7 +5,7 @@ cask :v1 => 'openoffice' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_en-US.dmg"
   name 'OpenOffice'
-  homepage 'http://www.openoffice.org/'
+  homepage 'https://www.openoffice.org/'
   license :apache
   tags :vendor => 'Apache'
 

--- a/Casks/orbitum.rb
+++ b/Casks/orbitum.rb
@@ -2,7 +2,7 @@ cask :v1 => 'orbitum' do
   version :latest
   sha256 :no_check
 
-  url 'http://orbitum.com/orbitum.dmg'
+  url 'https://orbitum.com/orbitum.dmg'
   name 'Orbitum'
   homepage 'http://orbitum.com/'
   license :gratis

--- a/Casks/origami.rb
+++ b/Casks/origami.rb
@@ -6,7 +6,7 @@ cask :v1 => 'origami' do
   appcast 'https://facebook.github.io/origami/update/updates.xml.rss',
           :sha256 => 'cd9fc6d5cdad06e1df1e6808bd7fdaa3999b52a765f29cc6b3dcbf6c11220540'
   name 'Origami'
-  homepage 'http://facebook.github.io/origami'
+  homepage 'https://facebook.github.io/origami'
   license :gratis
 
   pkg "Origami #{version}.pkg"

--- a/Casks/ormr.rb
+++ b/Casks/ormr.rb
@@ -2,7 +2,7 @@ cask :v1 => 'ormr' do
   version :latest
   sha256 :no_check
 
-  url 'http://getormr.com/dn/Ormr.pkg'
+  url 'https://getormr.com/dn/Ormr.pkg'
   name 'Ormr'
   homepage 'http://getormr.com/home/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -3,9 +3,9 @@ cask :v1 => 'pacifist' do
   sha256 :no_check
 
   url 'https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg'
-  appcast 'http://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi'
+  appcast 'https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi'
   name 'Pacifist'
-  homepage 'http://www.charlessoft.com/'
+  homepage 'https://www.charlessoft.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Pacifist.app'

--- a/Casks/pangu.rb
+++ b/Casks/pangu.rb
@@ -5,7 +5,7 @@ cask :v1 => 'pangu' do
   # 25pp.com is the official download host per the vendor homepage
   url "http://dl.pangu.25pp.com/jb/Pangu8_v#{version}.dmg"
   name 'Pangu8'
-  homepage 'http://en.pangu.io/'
+  homepage 'https://en.pangu.io/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'pangu8.app'

--- a/Casks/panic-unison.rb
+++ b/Casks/panic-unison.rb
@@ -5,7 +5,7 @@ cask :v1_1 => 'panic-unison' do
   url "http://download.panic.com/Unison/Unison%20#{version}.zip"
   appcast 'http://www.panic.com/updates/update.php'
   name 'Unison'
-  homepage 'http://panic.com/unison/'
+  homepage 'https://panic.com/unison/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
   tags :vendor => 'Panic'
 

--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -6,7 +6,7 @@ cask :v1 => 'paparazzi' do
   appcast 'https://derailer.org/paparazzi/appcast/',
           :sha256 => '05c4173db7a34788c01999a5c20d5d9dcede3d4cf981cc2268fc24c195b38efe'
   name 'Paparazzi!'
-  homepage 'http://derailer.org/paparazzi/'
+  homepage 'https://derailer.org/paparazzi/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Paparazzi!.app'

--- a/Casks/paragon-extfs.rb
+++ b/Casks/paragon-extfs.rb
@@ -4,7 +4,7 @@ cask :v1 => 'paragon-extfs' do
 
   url 'http://dl.paragon-software.com/demo/extmac_trial_u.dmg'
   name 'Paragon ExtFS'
-  homepage 'http://www.paragon-software.com/home/extfs-mac/'
+  homepage 'https://www.paragon-software.com/home/extfs-mac/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'FSInstaller.app/Contents/Resources/Paragon ExtFS for Mac OS X.pkg'

--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -4,7 +4,7 @@ cask :v1 => 'paragon-ntfs' do
 
   url 'http://dl.paragon-software.com/demo/ntfsmac_trial_u.dmg'
   name 'Paragon NTFS for Mac'
-  homepage 'http://www.paragon-software.com/home/ntfs-mac/'
+  homepage 'https://www.paragon-software.com/home/ntfs-mac/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'FSInstaller.app/Contents/Resources/Paragon NTFS for Mac OS X.pkg'

--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -4,7 +4,7 @@ cask :v1 => 'parallels-desktop' do
 
   url "http://download.parallels.com/desktop/v#{version[/^\w+/]}/#{version.sub(/-.*$/, '')}/ParallelsDesktop-#{version}.dmg"
   name 'Parallels Desktop'
-  homepage 'http://www.parallels.com/products/desktop/'
+  homepage 'https://www.parallels.com/products/desktop/'
   license :commercial
 
   app 'Parallels Desktop.app'

--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -4,7 +4,7 @@ cask :v1 => 'parallels-virtualization-sdk' do
 
   url "http://download.parallels.com/desktop/v#{version[/^\w+/]}/#{version.sub(/-.*$/, '')}/ParallelsVirtualizationSDK-#{version}-mac.dmg"
   name 'Parallels Virtualization SDK'
-  homepage 'http://www.parallels.com/products/desktop/download/'
+  homepage 'https://www.parallels.com/products/desktop/download/'
   license :gratis
 
   pkg 'Parallels Virtualization SDK.pkg'

--- a/Casks/pashua.rb
+++ b/Casks/pashua.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pashua' do
 
   url 'https://www.bluem.net/files/Pashua.dmg'
   name 'Pashua'
-  homepage 'http://www.bluem.net/en/mac/pashua/'
+  homepage 'https://www.bluem.net/en/mac/pashua/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Pashua.app'

--- a/Casks/pastebotsync-pane.rb
+++ b/Casks/pastebotsync-pane.rb
@@ -3,7 +3,7 @@ cask :v1 => 'pastebotsync-pane' do
   sha256 :no_check
 
   # tapbots.net is the official download host per the vendor homepage
-  url 'http://tapbots.net/pastebot/PastebotSync.dmg'
+  url 'https://tapbots.net/pastebot/PastebotSync.dmg'
   name 'Pastebot Sync'
   homepage 'http://tapbots.com/software/pastebot/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/paye-tools.rb
+++ b/Casks/paye-tools.rb
@@ -4,7 +4,7 @@ cask :v1 => 'paye-tools' do
 
   url "https://www.gov.uk/government/uploads/uploaded/hmrc/payetools-rti-#{version}-osx.zip"
   name 'Basic PAYE Tools'
-  homepage 'http://www.hmrc.gov.uk/payerti/payroll/bpt/paye-tools.htm'
+  homepage 'https://www.hmrc.gov.uk/payerti/payroll/bpt/paye-tools.htm'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   installer :script => "payetools-rti-#{version}-osx.app/Contents/MacOS/osx-intel",

--- a/Casks/pdfkey-pro.rb
+++ b/Casks/pdfkey-pro.rb
@@ -3,7 +3,7 @@ cask :v1 => 'pdfkey-pro' do
   sha256 :no_check
 
   # amazonaws.com is the official download host per the vendor homepage
-  url 'http://pdfkeypro.s3.amazonaws.com/PDFKeyPro.dmg'
+  url 'https://pdfkeypro.s3.amazonaws.com/PDFKeyPro.dmg'
   name 'PDFKey Pro'
   homepage 'http://pdfkey.com'
   license :freemium

--- a/Casks/pdftotext.rb
+++ b/Casks/pdftotext.rb
@@ -2,9 +2,9 @@ cask :v1_1 => 'pdftotext' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.bluem.net/files/pdftotext.dmg'
+  url 'https://www.bluem.net/files/pdftotext.dmg'
   name 'pdftotext'
-  homepage 'http://www.bluem.net/en/mac/packages/'
+  homepage 'https://www.bluem.net/en/mac/packages/'
   license :gpl
 
   pkg 'Installer.pkg'

--- a/Casks/peepopen.rb
+++ b/Casks/peepopen.rb
@@ -4,7 +4,7 @@ cask :v1 => 'peepopen' do
 
   url 'https://topfunky.github.io/PeepOpen/dl/PeepOpen.dmg'
   name 'PeepOpen'
-  homepage 'http://topfunky.github.io/PeepOpen/'
+  homepage 'https://topfunky.github.io/PeepOpen/'
   license :mit
 
   app 'PeepOpen.app'

--- a/Casks/pepper-flash.rb
+++ b/Casks/pepper-flash.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pepper-flash' do
 
   url "https://admdownload.adobe.com/bin/live/AdobeFlashPlayer_#{version.to_i}ppau_a_install.dmg"
   name 'Pepper Flash Player'
-  homepage 'http://get.adobe.com/flashplayer/otherversions'
+  homepage 'https://get.adobe.com/flashplayer/otherversions'
   license :gratis
   tags :vendor => 'Adobe'
 

--- a/Casks/pg-commander.rb
+++ b/Casks/pg-commander.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pg-commander' do
 
   url "https://eggerapps.at/pgcommander/download/pgcommander-#{version}.zip"
   name 'PG Commander'
-  homepage 'http://eggerapps.at/pgcommander/'
+  homepage 'https://eggerapps.at/pgcommander/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PG Commander.app'

--- a/Casks/pgadmin3.rb
+++ b/Casks/pgadmin3.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pgadmin3' do
   sha256 '0712106cca16240db9962214384874c108fe8397d0c418a79dfb3639f8f140da'
 
   # postgresql.org is the official download host per the vendor homepage
-  url "http://ftp.postgresql.org/pub/pgadmin3/release/v#{version}/osx/pgadmin3-#{version}.dmg"
+  url "https://ftp.postgresql.org/pub/pgadmin3/release/v#{version}/osx/pgadmin3-#{version}.dmg"
   gpg "#{url}.sig",
       :key_id => 'e0c4ceeb826b1fda4fb468e024adfaaf698f1519'
   name 'pgAdmin'

--- a/Casks/photozoom-pro.rb
+++ b/Casks/photozoom-pro.rb
@@ -4,7 +4,7 @@ cask :v1 => 'photozoom-pro' do
 
   url 'https://www.benvista.com/photozoompro/download/mac'
   name 'PhotoZoom Pro'
-  homepage 'http://www.benvista.com/photozoompro'
+  homepage 'https://www.benvista.com/photozoompro'
   license :freemium
 
   app 'PhotoZoom Pro 6.app'

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -2,9 +2,9 @@ cask :v1 => 'phpstorm' do
   version '8.0.3'
   sha256 '6c9b36ebfed67f5ec2e6a96f2f61826653b312686ecd8a298e0e2ca3e3a09559'
 
-  url "http://download.jetbrains.com/webide/PhpStorm-#{version}.dmg"
+  url "https://download.jetbrains.com/webide/PhpStorm-#{version}.dmg"
   name 'PhpStorm'
-  homepage 'http://www.jetbrains.com/phpstorm/'
+  homepage 'https://www.jetbrains.com/phpstorm/'
   license :commercial
 
   app 'PhpStorm.app'

--- a/Casks/picasa.rb
+++ b/Casks/picasa.rb
@@ -4,7 +4,7 @@ cask :v1 => 'picasa' do
 
   url "https://dl.google.com/photos/picasamac#{version.gsub('.', '')}.dmg"
   name 'Picasa'
-  homepage 'http://picasa.google.com/'
+  homepage 'https://picasa.google.com/'
   license :gratis
 
   app 'Picasa.app'

--- a/Casks/piezo.rb
+++ b/Casks/piezo.rb
@@ -2,11 +2,11 @@ cask :v1 => 'piezo' do
   version :latest
   sha256 :no_check
 
-  url 'http://neutral.rogueamoeba.com/mirror/files/Piezo.zip'
+  url 'https://neutral.rogueamoeba.com/mirror/files/Piezo.zip'
   name 'Piezo'
-  appcast 'http://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Piezo',
+  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Piezo',
           :sha256 => 'c8dc37b74425eb9f11e86989ea9e11ae6878afd3d542516224c7e7b36281ccf3'
-  homepage 'http://rogueamoeba.com/piezo/'
+  homepage 'https://rogueamoeba.com/piezo/'
   license :commercial
 
   app 'Piezo.app'

--- a/Casks/pixelpeeper.rb
+++ b/Casks/pixelpeeper.rb
@@ -3,9 +3,9 @@ cask :v1 => 'pixelpeeper' do
   sha256 :no_check
 
   url 'https://www.irradiatedsoftware.com/download/PixelPeeper.zip'
-  appcast 'http://www.irradiatedsoftware.com/updates/profiles/pixelpeeper.php'
+  appcast 'https://www.irradiatedsoftware.com/updates/profiles/pixelpeeper.php'
   name 'PixelPeeper'
-  homepage 'http://www.irradiatedsoftware.com/labs'
+  homepage 'https://www.irradiatedsoftware.com/labs'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PixelPeeper.app'

--- a/Casks/pixelstick.rb
+++ b/Casks/pixelstick.rb
@@ -5,7 +5,7 @@ cask :v1 => 'pixelstick' do
   url 'https://plumamazing.com/bin/pixelstick/pixelstick.zip'
   appcast 'https://plumamazing.com/appcastSSL.php?pid=100'
   name 'PixelStick'
-  homepage 'http://plumamazing.com/mac/pixelstick'
+  homepage 'https://plumamazing.com/mac/pixelstick'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'PixelStick.app'

--- a/Casks/pixlr.rb
+++ b/Casks/pixlr.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pixlr' do
 
   url "https://cdn2.pixlr.com/mac/Autodesk_Pixlr_ver#{version}_Mac_Installer.dmg"
   name 'Pixlr'
-  appcast 'http://updatefeed.pixlr.com/pixlr-for-mac-appfeed.xml',
+  appcast 'https://updatefeed.pixlr.com/pixlr-for-mac-appfeed.xml',
           :sha256 => '3748c8735f5f9441a1f12a170296628822372604c41feb41193156792f9e9512'
   homepage 'https://pixlr.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/plain-clip.rb
+++ b/Casks/plain-clip.rb
@@ -4,7 +4,7 @@ cask :v1 => 'plain-clip' do
 
   url 'https://www.bluem.net/files/Plain-Clip.dmg'
   name 'Plain Clip'
-  homepage 'http://www.bluem.net/en/mac/plain-clip'
+  homepage 'https://www.bluem.net/en/mac/plain-clip'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Plain Clip.app'

--- a/Casks/playonmac.rb
+++ b/Casks/playonmac.rb
@@ -4,7 +4,7 @@ cask :v1 => 'playonmac' do
 
   url "http://repository.playonmac.com/PlayOnMac/PlayOnMac_#{version}.dmg"
   name 'PlayOnMac'
-  homepage 'http://www.playonmac.com/en'
+  homepage 'https://www.playonmac.com/en'
   license :gpl
 
   app 'PlayOnMac.app'

--- a/Casks/pngyu.rb
+++ b/Casks/pngyu.rb
@@ -2,9 +2,9 @@ cask :v1 => 'pngyu' do
   version '1.0.1'
   sha256 'f853a3566236200391a40d12df9519b39f4d30053ab6ed6f60670b7eacca6217'
 
-  url "http://nukesaq88.github.io/Pngyu/download/Pngyu_mac_#{version.gsub('.','')}.zip"
+  url "https://nukesaq88.github.io/Pngyu/download/Pngyu_mac_#{version.gsub('.','')}.zip"
   name 'Pngyu'
-  homepage 'http://nukesaq88.github.io/Pngyu/'
+  homepage 'https://nukesaq88.github.io/Pngyu/'
   license :bsd
 
   app 'Pngyu.app'

--- a/Casks/pokemon-showdown.rb
+++ b/Casks/pokemon-showdown.rb
@@ -2,7 +2,7 @@ cask :v1 => 'pokemon-showdown' do
   version :latest
   sha256 :no_check
 
-  url 'http://pokemonshowdown.com/files/pokemonshowdown-mac.zip'
+  url 'https://pokemonshowdown.com/files/pokemonshowdown-mac.zip'
   name 'Pokémon Showdown'
   homepage 'http://pokemonshowdown.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -2,9 +2,9 @@ cask :v1 => 'pokerstars' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.pokerstars.com/PokerStars.app.zip'
+  url 'https://www.pokerstars.com/PokerStars.app.zip'
   name 'PokerStars'
-  homepage 'http://www.pokerstars.com/'
+  homepage 'https://www.pokerstars.com/'
   license :freemium
 
   app 'PokerStars.app'

--- a/Casks/pollev-presenter.rb
+++ b/Casks/pollev-presenter.rb
@@ -7,7 +7,7 @@ cask :v1 => 'pollev-presenter' do
   name 'PollEv Presenter'
   appcast 'https://polleverywhere-app.s3.amazonaws.com/mac-beta/appcast.xml',
           :sha256 => 'dbfce32dced0e0370f6757d34aa89e176cab2495dcaaafc4a4fba85090e35bf6'
-  homepage 'http://www.polleverywhere.com/'
+  homepage 'https://www.polleverywhere.com/'
   license :gratis
   tags :vendor => 'Poll Everywhere'
 

--- a/Casks/pongsaver.rb
+++ b/Casks/pongsaver.rb
@@ -2,9 +2,9 @@ cask :v1 => 'pongsaver' do
   version :latest
   sha256 :no_check
 
-  url 'http://rogueamoeba.com/freebies/download/PongSaver.zip'
+  url 'https://rogueamoeba.com/freebies/download/PongSaver.zip'
   name 'PongSaver'
-  homepage 'http://rogueamoeba.com/freebies/'
+  homepage 'https://rogueamoeba.com/freebies/'
   license :gratis
 
   screen_saver 'PongSaver.saver'

--- a/Casks/powerkey.rb
+++ b/Casks/powerkey.rb
@@ -5,7 +5,7 @@ cask :v1 => 'powerkey' do
   url "https://github.com/pkamb/PowerKey/releases/download/v#{version}/PowerKey#{version}.zip"
   appcast 'https://github.com/pkamb/PowerKey/releases.atom'
   name 'PowerKey'
-  homepage 'http://pkamb.github.io/PowerKey/'
+  homepage 'https://pkamb.github.io/PowerKey/'
   license :mit
 
   app 'PowerKey.app'

--- a/Casks/pphelper.rb
+++ b/Casks/pphelper.rb
@@ -5,7 +5,7 @@ cask :v1 => 'pphelper' do
   url 'http://ghost.25pp.com/soft/pp_mac.dmg'
   name 'pp助手'
   name 'pphelper'
-  appcast 'http://liveupdate.25pp.com/macpc/Appcast.xml',
+  appcast 'https://liveupdate.25pp.com/macpc/Appcast.xml',
           :sha256 => 'fcffad714bc89ca0670d8bc0f8cc3371bbf4f078459bc219e6ee7db92ab2e180'
   homepage 'http://pro.25pp.com/pp_mac_ios'
   license :gratis

--- a/Casks/preference-manager.rb
+++ b/Casks/preference-manager.rb
@@ -3,9 +3,9 @@ cask :v1 => 'preference-manager' do
   sha256 :no_check
 
   url 'http://download.digitalrebellion.com/Pref_Man.dmg'
-  appcast 'http://www.digitalrebellion.com/rss/appcasts/pref_man_appcast.xml'
+  appcast 'https://www.digitalrebellion.com/rss/appcasts/pref_man_appcast.xml'
   name 'Preference Manager'
-  homepage 'http://www.digitalrebellion.com/prefman'
+  homepage 'https://www.digitalrebellion.com/prefman'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Preference Manager.app'

--- a/Casks/presenter.rb
+++ b/Casks/presenter.rb
@@ -4,7 +4,7 @@ cask :v1 => 'presenter' do
 
   url "http://files.ipevo.com/download/driver/ipevo_presenter/Presenter_mac_#{version}.zip"
   name 'IPEVO Presenter'
-  homepage 'http://support.ipevo.com/support/qa/IPEVO-Presenter'
+  homepage 'https://support.ipevo.com/support/qa/IPEVO-Presenter'
   license :commercial
   tags :vendor => 'IPEVO'
 

--- a/Casks/propane.rb
+++ b/Casks/propane.rb
@@ -3,9 +3,9 @@ cask :v1 => 'propane' do
   sha256 :no_check
 
   url 'https://propaneapp.com/appcast/Propane.zip'
-  appcast 'http://propaneapp.com/appcast/release.xml'
+  appcast 'https://propaneapp.com/appcast/release.xml'
   name 'Propane'
-  homepage 'http://propaneapp.com/'
+  homepage 'https://propaneapp.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Propane.app'

--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -6,7 +6,7 @@ cask :v1 => 'propresenter' do
   appcast 'https://www.renewedvision.com/update/ProPresenter6.php',
           :sha256 => '2cb31297b4531c578b3a84b07638c7e0f9e07af1f4591b97bba44e438a8a3dd7'
   name 'ProPresenter'
-  homepage 'http://www.renewedvision.com/propresenter.php'
+  homepage 'https://www.renewedvision.com/propresenter.php'
   license :commercial
 
   app 'ProPresenter 6.app'

--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -2,9 +2,9 @@ cask :v1 => 'proxifier' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.proxifier.com/distr/ProxifierMac.zip'
+  url 'https://www.proxifier.com/distr/ProxifierMac.zip'
   name 'Proxifier'
-  homepage 'http://www.proxifier.com/mac/'
+  homepage 'https://www.proxifier.com/mac/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Proxifier.app'

--- a/Casks/puppet.rb
+++ b/Casks/puppet.rb
@@ -2,7 +2,7 @@ cask :v1 => 'puppet' do
   version '3.7.4'
   sha256 '8eb17151199cc8c726fd64a56aba20b25627f699ce841ce9d04dbe59edbe3223'
 
-  url "http://downloads.puppetlabs.com/mac/puppet-#{version}.dmg"
+  url "https://downloads.puppetlabs.com/mac/puppet-#{version}.dmg"
   name 'Puppet'
   homepage 'https://puppetlabs.com/'
   license :apache

--- a/Casks/puush.rb
+++ b/Casks/puush.rb
@@ -5,7 +5,7 @@ cask :v1 => 'puush' do
   url 'https://puush.me/dl/puush.zip'
   appcast 'https://puush.me/dl/puush.xml?hax=jax'
   name 'puush'
-  homepage 'http://puush.me/'
+  homepage 'https://puush.me/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'puush.app'

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -6,7 +6,7 @@ cask :v1 => 'pycharm-ce' do
   name 'PyCharm'
   name 'PyCharm Community Edition'
   name 'PyCharm CE'
-  homepage 'http://www.jetbrains.com/pycharm'
+  homepage 'https://www.jetbrains.com/pycharm'
   license :apache
 
   app 'PyCharm CE.app'

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -4,7 +4,7 @@ cask :v1 => 'pycharm' do
 
   url "https://download.jetbrains.com/python/pycharm-professional-#{version}.dmg"
   name 'PyCharm'
-  homepage 'http://www.jetbrains.com/pycharm/'
+  homepage 'https://www.jetbrains.com/pycharm/'
   license :commercial
 
   app 'PyCharm.app'

--- a/Casks/qfinder.rb
+++ b/Casks/qfinder.rb
@@ -3,7 +3,7 @@ cask :v1 => 'qfinder' do
   sha256 :no_check
 
   name 'Qfinder'
-  url 'http://download.qnap.com/webstart/QNAPQfinder_Mac.dmg'
+  url 'https://download.qnap.com/webstart/QNAPQfinder_Mac.dmg'
   homepage 'http://www.qnap.com/i/in/utility/#block_1'
   license :gratis
   tags :vendor => 'Qnap'

--- a/Casks/qget.rb
+++ b/Casks/qget.rb
@@ -3,8 +3,8 @@ cask :v1 => 'qget' do
   sha256 :no_check
 
   name 'Qget'
-  url 'http://download.qnap.com/webstart/QNAPQGet_Mac.dmg'
-  homepage 'http://www.qnap.com/i/in/utility/#block_5'
+  url 'https://download.qnap.com/webstart/QNAPQGet_Mac.dmg'
+  homepage 'https://www.qnap.com/i/in/utility/#block_5'
   license :gratis
   tags :vendor => 'Qnap'
 

--- a/Casks/qlstephen.rb
+++ b/Casks/qlstephen.rb
@@ -4,7 +4,7 @@ cask :v1 => 'qlstephen' do
 
   url 'https://github.com/downloads/whomwah/qlstephen/QLStephen.qlgenerator.zip'
   name 'QLStephen'
-  homepage 'http://whomwah.github.io/qlstephen/'
+  homepage 'https://whomwah.github.io/qlstephen/'
   license :mit
 
   qlplugin 'QLStephen.qlgenerator'

--- a/Casks/qsync.rb
+++ b/Casks/qsync.rb
@@ -3,8 +3,8 @@ cask :v1 => 'qsync' do
   sha256 :no_check
 
   name 'Qsync'
-  url 'http://download.qnap.com/webstart/QNAPQsync_Mac.dmg'
-  homepage 'http://www.qnap.com/i/in/utility/#block_3'
+  url 'https://download.qnap.com/webstart/QNAPQsync_Mac.dmg'
+  homepage 'https://www.qnap.com/i/in/utility/#block_3'
   license :gratis
   tags :vendor => 'Qnap'
 

--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -4,7 +4,7 @@ cask :v1 => 'qtpass' do
 
   url 'https://annejan.com/media/qtpass.dmg'
   name 'QtPass'
-  homepage 'http://qtpass.org/'
+  homepage 'https://qtpass.org/'
   license :gpl
 
   app 'QtPass.app'

--- a/Casks/quicklock.rb
+++ b/Casks/quicklock.rb
@@ -3,7 +3,7 @@ cask :v1 => 'quicklock' do
   sha256 :no_check
 
   # cl.ly is the official download host per the vendor homepage
-  url 'http://cl.ly/2C1b3Y0u3E2Y/download/QuickLock.app.zip'
+  url 'https://cl.ly/2C1b3Y0u3E2Y/download/QuickLock.app.zip'
   name 'QuickLock'
   appcast 'http://quicklockapp.com/appcast.xml',
           :sha256 => '2f6ef1ba9c7c94fc16948e8cc706388579bf898a738b383d54f4ff6f7dec41c6'

--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -5,7 +5,7 @@ cask :v1 => 'radiant-player' do
   url "https://github.com/kbhomes/radiant-player-mac/releases/download/v#{version}/Radiant.Player.zip"
   appcast 'https://github.com/kbhomes/radiant-player-mac/releases.atom'
   name 'Radiant Player'
-  homepage 'http://kbhomes.github.io/radiant-player-mac/'
+  homepage 'https://kbhomes.github.io/radiant-player-mac/'
   license :mit
 
   app 'Radiant Player.app'

--- a/Casks/raptor.rb
+++ b/Casks/raptor.rb
@@ -2,9 +2,9 @@ cask :v1 => 'raptor' do
   version '98u3f5'
   sha256 'e19dc03ab5e0f7bb17179ce4bcf364211cee3928d7182d3db1dd0c4cf7ee87e0'
 
-  url "http://raptor-chess-interface.googlecode.com/files/Raptor_v#{version}_OS_X_Cocoa_x86_64.dmg"
+  url "https://raptor-chess-interface.googlecode.com/files/Raptor_v#{version}_OS_X_Cocoa_x86_64.dmg"
   name 'Raptor Chess Interface'
-  homepage 'http://code.google.com/p/raptor-chess-interface/'
+  homepage 'https://code.google.com/p/raptor-chess-interface/'
   license :bsd
 
   app "Raptor_v#{version}/Raptor.app"

--- a/Casks/rdio.rb
+++ b/Casks/rdio.rb
@@ -3,9 +3,9 @@ cask :v1 => 'rdio' do
   sha256 :no_check
 
   url 'https://www.rdio.com/media/static/desktop/mac/Rdio.dmg'
-  appcast 'http://www.rdio.com/media/static/desktop/mac/appcast.xml'
+  appcast 'https://www.rdio.com/media/static/desktop/mac/appcast.xml'
   name 'Rdio'
-  homepage 'http://www.rdio.com'
+  homepage 'https://www.rdio.com'
   license :gratis
 
   app 'Rdio.app'

--- a/Casks/recovery-disk-assistant.rb
+++ b/Casks/recovery-disk-assistant.rb
@@ -4,7 +4,7 @@ cask :v1 => 'recovery-disk-assistant' do
 
   url 'https://support.apple.com/downloads/DL1433/en_US/RecoveryDiskAssistant.dmg'
   name 'Recovery Disk Assistant'
-  homepage 'http://support.apple.com/kb/HT4848'
+  homepage 'https://support.apple.com/kb/HT4848'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Recovery Disk Assistant.app'

--- a/Casks/remote-desktop-connection.rb
+++ b/Casks/remote-desktop-connection.rb
@@ -4,7 +4,7 @@ cask :v1 => 'remote-desktop-connection' do
 
   url "http://download.microsoft.com/download/C/F/0/CF0AE39A-3307-4D39-9D50-58E699C91B2F/RDC_#{version}_ALL.dmg"
   name 'Remote Desktop Connection'
-  homepage 'http://www.microsoft.com/en-us/download/details.aspx?id=18140'
+  homepage 'https://www.microsoft.com/en-us/download/details.aspx?id=18140'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
   tags :vendor => 'Microsoft'
 

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ridibooks' do
 
   url 'http://ridibooks.com/getapp?os=mac'
   name 'Ridibooks'
-  homepage 'http://ridibooks.com/support/app/download'
+  homepage 'https://ridibooks.com/support/app/download'
   license :gratis
 
   app 'Ridibooks.app'

--- a/Casks/riffworkst4.rb
+++ b/Casks/riffworkst4.rb
@@ -5,7 +5,7 @@ cask :v1 => 'riffworkst4' do
 
   url 'https://www.sonomawireworks.com/accountManagerUI/files/RiffWorksT4.dmg'
   name 'RiffWorks T4'
-  homepage 'http://www.sonomawireworks.com/T4/'
+  homepage 'https://www.sonomawireworks.com/T4/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "RiffWorksT4V#{version.gsub('.','_')}.pkg"

--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ringcentral' do
 
   url 'http://downloads.ringcentral.com/sp/RingCentralForMac'
   name 'RingCentral for Mac'
-  homepage 'http://www.ringcentral.com/office/features/desktop-apps/overview.html'
+  homepage 'https://www.ringcentral.com/office/features/desktop-apps/overview.html'
   license :closed
 
   app 'RingCentral for Mac.app'

--- a/Casks/roboto.rb
+++ b/Casks/roboto.rb
@@ -7,7 +7,7 @@ cask :v1 => 'roboto' do
   name 'Roboto'
   appcast 'https://roboto.build/mac/app-cast.xml',
           :sha256 => 'e8ace5183bbceaa8972a5e493f256f73f5a2d595a588231e43de8d21b6a105c2'
-  homepage 'http://roboto.build/'
+  homepage 'https://roboto.build/'
   license :gratis
 
   app 'Roboto.app'

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -4,7 +4,7 @@ cask :v1 => 'rubymine' do
 
   url "http://download-cf.jetbrains.com/ruby/RubyMine-#{version}.dmg"
   name 'RubyMine'
-  homepage 'http://www.jetbrains.com/ruby/'
+  homepage 'https://www.jetbrains.com/ruby/'
   license :commercial
 
   app 'RubyMine.app'

--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -5,7 +5,7 @@ cask :v1 => 'sabnzbd' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/sabnzbdplus/sabnzbdplus/#{version}/SABnzbd-#{version}-osx.dmg"
   name 'SABnzbd'
-  homepage 'http://sabnzbd.org/'
+  homepage 'https://sabnzbd.org/'
   license :gpl
 
   app 'SABnzbd.app'

--- a/Casks/safe-in-cloud.rb
+++ b/Casks/safe-in-cloud.rb
@@ -2,10 +2,10 @@ cask :v1 => 'safe-in-cloud' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.safe-in-cloud.com/images/downloads/Safe%20In%20Cloud.dmg'
+  url 'https://www.safe-in-cloud.com/images/downloads/Safe%20In%20Cloud.dmg'
   name 'SafeInCloud'
   name 'SafeInCloud Password Manager'
-  homepage 'http://www.safe-in-cloud.com'
+  homepage 'https://www.safe-in-cloud.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Safe In Cloud.app'

--- a/Casks/sandvox.rb
+++ b/Casks/sandvox.rb
@@ -6,7 +6,7 @@ cask :v1 => 'sandvox' do
   name 'Sandvox'
   appcast 'http://launch.karelia.com/appcast.php',
           :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-  homepage 'http://www.karelia.com/products/sandvox/'
+  homepage 'https://www.karelia.com/products/sandvox/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Sandvox.app'

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -3,11 +3,11 @@ cask :v1 => 'scala-ide' do
 
   if Hardware::CPU.is_32_bit?
     # typesafe.com is the official download host per the vendor homepage
-    url "http://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20150119/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
+    url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20150119/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
     sha256 '2398c727bde5fe694516829735ad22731eee4793ec0d91864c5d507493ce4b4d'
   else
     # typesafe.com is the official download host per the vendor homepage
-    url "http://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20150119/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+    url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20150119/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
     sha256 '79151623c1b5fd53b10a9361d872939937737dfa9708c60687098beef4f42159'
   end
 

--- a/Casks/scapple.rb
+++ b/Casks/scapple.rb
@@ -4,7 +4,7 @@ cask :v1 => 'scapple' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://scrivener.s3.amazonaws.com/Scapple.dmg'
-  appcast 'http://www.literatureandlatte.com/downloads/scapple/scapple.xml'
+  appcast 'https://www.literatureandlatte.com/downloads/scapple/scapple.xml'
   name 'Scapple'
   homepage 'https://www.literatureandlatte.com/scapple.php'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -2,7 +2,7 @@ cask :v1 => 'scilab' do
   version '5.5.2'
   sha256 '6e855c4aae6f75d37ced77bea64ac5cf33f65f3925107c65547b2a5fede3bd91'
 
-  url "http://www.scilab.org/download/#{version}/scilab-#{version}-x86_64_yosemite.dmg"
+  url "https://www.scilab.org/download/#{version}/scilab-#{version}-x86_64_yosemite.dmg"
   name 'Scilab'
   homepage 'https://www.scilab.org'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/scout.rb
+++ b/Casks/scout.rb
@@ -4,7 +4,7 @@ cask :v1 => 'scout' do
 
   url "https://github.com/downloads/mhs/scout-app/ScoutAppInstaller-#{version}.dmg"
   name 'Scout'
-  homepage 'http://mhs.github.io/scout-app/'
+  homepage 'https://mhs.github.io/scout-app/'
   license :oss
 
   installer :manual => 'Install Scout.app'

--- a/Casks/screencat.rb
+++ b/Casks/screencat.rb
@@ -4,7 +4,7 @@ cask :v1 => 'screencat' do
 
   url "https://github.com/maxogden/screencat/releases/download/#{version}/ScreenCat.zip"
   name 'ScreenCat'
-  homepage 'http://maxogden.github.io/screencat/'
+  homepage 'https://maxogden.github.io/screencat/'
   license :oss
 
   app 'ScreenCat.app'

--- a/Casks/screenstagram.rb
+++ b/Casks/screenstagram.rb
@@ -5,7 +5,7 @@ cask :v1 => 'screenstagram' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://screenstagram.s3.amazonaws.com/screenstagram_#{version}.dmg"
   name 'Screenstagram'
-  homepage 'http://screenstagram.s3.amazonaws.com/download.html'
+  homepage 'https://screenstagram.s3.amazonaws.com/download.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   screen_saver 'Screenstagram 2.saver'

--- a/Casks/scribbleton.rb
+++ b/Casks/scribbleton.rb
@@ -2,9 +2,9 @@ cask :v1 => 'scribbleton' do
   version :latest
   sha256 :no_check
 
-  url 'http://scribbleton.com/initiate_download/mac'
+  url 'https://scribbleton.com/initiate_download/mac'
   name 'Scribbleton'
-  homepage 'http://scribbleton.com/'
+  homepage 'https://scribbleton.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Scribbleton.app'

--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -4,9 +4,9 @@ cask :v1 => 'scrivener' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
-  appcast 'http://www.literatureandlatte.com/downloads/scrivener-2.xml'
+  appcast 'https://www.literatureandlatte.com/downloads/scrivener-2.xml'
   name 'Scrivener'
-  homepage 'http://literatureandlatte.com/scrivener.php'
+  homepage 'https://literatureandlatte.com/scrivener.php'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Scrivener.app'

--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'second-life-viewer' do
 
   url "http://download.cloud.secondlife.com/Viewer_3/Second_Life_#{version.gsub('.','_')}_i386.dmg"
   name 'Second Life Viewer'
-  homepage 'http://secondlife.com/'
+  homepage 'https://secondlife.com/'
   license :gpl
   tags :vendor => 'Linden Lab'
 

--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -3,10 +3,10 @@ cask :v1 => 'selfcontrol' do
   sha256 'cd1fb7bd5524d81e784ad67f8639cfb836261f07d7e6db75458a398b17f9a1f9'
 
   url "http://downloads.selfcontrolapp.com/SelfControl-#{version}.zip"
-  appcast 'http://selfcontrolapp.com/SelfControlAppcast.xml',
+  appcast 'https://selfcontrolapp.com/SelfControlAppcast.xml',
           :sha256 => '05d48c097c072ffd92d4d938b6984c8a09f446a556dc30acf25e3896cc3e0826'
   name 'SelfControl'
-  homepage 'http://selfcontrolapp.com/'
+  homepage 'https://selfcontrolapp.com/'
   license :gpl
 
   app 'SelfControl.app'

--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -2,7 +2,7 @@ cask :v1 => 'sencha' do
   version '5.1.3.61'
   sha256 '6083490b578191d2b8307b375e115c93c2223683e49636893edadfa1d76a412c'
 
-  url "http://cdn.sencha.com/cmd/#{version}/SenchaCmd-#{version}-osx.app.zip"
+  url "https://cdn.sencha.com/cmd/#{version}/SenchaCmd-#{version}-osx.app.zip"
   name 'Sencha Cmd'
   homepage 'http://www.sencha.com/products/sencha-cmd/'
   license :freemium

--- a/Casks/send-to-kindle.rb
+++ b/Casks/send-to-kindle.rb
@@ -5,7 +5,7 @@ cask :v1 => 'send-to-kindle' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/sendtokindle/SendToKindleForMac-installer-v#{version}.pkg"
   name 'Send to Kindle'
-  homepage 'http://www.amazon.com/gp/sendtokindle/mac'
+  homepage 'https://www.amazon.com/gp/sendtokindle/mac'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "SendToKindleForMac-installer-v#{version}.pkg"

--- a/Casks/sente.rb
+++ b/Casks/sente.rb
@@ -3,7 +3,7 @@ cask :v1 => 'sente' do
   sha256 'b8c6c2ad8b95810fd7107a606a1ce08013bc217b3d2a13a51599ccb3cd29c631'
 
   url "https://www.thirdstreetsoftware.com/downloads/Sente-#{version}.11672.zip"
-  appcast 'http://www.thirdstreetsoftware.com/rss/Sente65.xml?v=6.6.0',
+  appcast 'https://www.thirdstreetsoftware.com/rss/Sente65.xml?v=6.6.0',
           :sha256 => '2083ee7a01313014c7d600e13018709521fd3f53d767bd31cd8d2caec2120c7f'
   name 'Sente'
   homepage 'http://www.thirdstreetsoftware.com'

--- a/Casks/shadowsweeper.rb
+++ b/Casks/shadowsweeper.rb
@@ -4,7 +4,7 @@ cask :v1 => 'shadowsweeper' do
 
   url 'https://www.irradiatedsoftware.com/download/ShadowSweeper.zip'
   name 'ShadowSweeper'
-  homepage 'http://www.irradiatedsoftware.com/labs/'
+  homepage 'https://www.irradiatedsoftware.com/labs/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ShadowSweeper.app'

--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -2,7 +2,7 @@ cask :v1 => 'sharetool' do
   version '2.4.2'
   sha256 '2990ecc1dd5f359fa25bd6c787f0efdd6b509919d00ef78c0d76fa83eef5c18e'
 
-  url "http://files.bainsware.com/sharetool_#{version.gsub('.','')}.dmg"
+  url "https://files.bainsware.com/sharetool_#{version.gsub('.','')}.dmg"
   name 'ShareTool'
   homepage 'https://www.bainsware.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/shelf-leveler.rb
+++ b/Casks/shelf-leveler.rb
@@ -2,7 +2,7 @@ cask :v1 => 'shelf-leveler' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/ShelfLeveler.zip'
+  url 'https://download.mrgeckosmedia.com/ShelfLeveler.zip'
   name 'Shelf Leveler'
   homepage 'https://mrgeckosmedia.com/applications/info/Shelf-Leveler'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/shortcat.rb
+++ b/Casks/shortcat.rb
@@ -6,7 +6,7 @@ cask :v1 => 'shortcat' do
   appcast 'https://shortcatapp.com/updates/appcast.xml',
           :sha256 => '38804c1de1cceb99418fb8393b57a99d78815c4d87dd850fe6b9acb0a4dc01de'
   name 'Shortcat'
-  homepage 'http://shortcatapp.com/'
+  homepage 'https://shortcatapp.com/'
   license :commercial
   tags :vendor => 'Sproutcube'
 

--- a/Casks/shrinkit.rb
+++ b/Casks/shrinkit.rb
@@ -4,7 +4,7 @@ cask :v1 => 'shrinkit' do
 
   url "https://download.panic.com/shrinkit/ShrinkIt%20#{version}.zip"
   name 'ShrinkIt'
-  homepage 'http://www.panic.com/blog/shrinkit-1-2/'
+  homepage 'https://www.panic.com/blog/shrinkit-1-2/'
   license :gratis
 
   app 'ShrinkIt.app'

--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -5,7 +5,7 @@ cask :v1 => 'shuttle' do
   url "https://github.com/fitztrev/shuttle/releases/download/#{version}/Shuttle.zip"
   appcast 'https://github.com/fitztrev/shuttle/releases.atom'
   name 'Shuttle'
-  homepage 'http://fitztrev.github.io/shuttle/'
+  homepage 'https://fitztrev.github.io/shuttle/'
   license :mit
 
   app 'Shuttle.app'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -5,7 +5,7 @@ cask :v1 => 'silicon-labs-vcp-driver' do
   url 'https://www.silabs.com/Support%20Documents/Software/Mac_OSX_VCP_Driver.zip'
   name 'Silicon Labs VCP Driver'
   name 'CP210x USB to UART Bridge VCP Driver'
-  homepage 'http://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx'
+  homepage 'https://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx'
   license :gratis
 
   container :nested => 'SiLabsUSBDriverDisk.dmg'

--- a/Casks/silo.rb
+++ b/Casks/silo.rb
@@ -4,7 +4,7 @@ cask :v1 => 'silo' do
 
   url "https://nevercenter.com/download/Install_Silo_#{version.gsub('.','_')}_mac.zip"
   name 'Silo'
-  homepage 'http://nevercenter.com/silo/'
+  homepage 'https://nevercenter.com/silo/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
   container :nested => "Install_Silo_#{version.gsub('.','_')}_mac.dmg"
 

--- a/Casks/silverback.rb
+++ b/Casks/silverback.rb
@@ -4,7 +4,7 @@ cask :v1 => 'silverback' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://silverback.s3.amazonaws.com/silverback2.zip'
-  appcast 'http://silverback.s3.amazonaws.com/release/appcast.xml'
+  appcast 'https://silverback.s3.amazonaws.com/release/appcast.xml'
   name 'Silverback'
   homepage 'http://silverbackapp.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/silverlight.rb
+++ b/Casks/silverlight.rb
@@ -4,7 +4,7 @@ cask :v1 => 'silverlight' do
 
   url 'http://silverlight.dlservice.microsoft.com/download/B/D/C/BDCE18B1-73C1-47BA-9B11-46A4C14CF7B0/40416.00/Silverlight.dmg'
   name 'Silverlight'
-  homepage 'http://www.microsoft.com/silverlight/'
+  homepage 'https://www.microsoft.com/silverlight/'
   license :gratis
 
   pkg 'Silverlight.pkg'

--- a/Casks/simple-css.rb
+++ b/Casks/simple-css.rb
@@ -2,9 +2,9 @@ cask :v1 => 'simple-css' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.hostm.com/downloads/simplecss/mac/SimpleCSS.zip'
+  url 'https://www.hostm.com/downloads/simplecss/mac/SimpleCSS.zip'
   name 'Simple CSS'
-  homepage 'http://www.hostm.com/css'
+  homepage 'https://www.hostm.com/css'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Simple CSS.app'

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -3,9 +3,9 @@ cask :v1 => 'sizeup' do
   sha256 :no_check
 
   url 'https://www.irradiatedsoftware.com/download/SizeUp.zip'
-  appcast 'http://www.irradiatedsoftware.com/updates/profiles/sizeup.php'
+  appcast 'https://www.irradiatedsoftware.com/updates/profiles/sizeup.php'
   name 'SizeUp'
-  homepage 'http://www.irradiatedsoftware.com/sizeup/'
+  homepage 'https://www.irradiatedsoftware.com/sizeup/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'SizeUp.app'

--- a/Casks/sketch-tool.rb
+++ b/Casks/sketch-tool.rb
@@ -4,7 +4,7 @@ cask :v1 => 'sketch-tool' do
 
   url 'http://sketchtool.bohemiancoding.com/sketchtool-latest.zip'
   name 'SketchTool'
-  homepage 'http://bohemiancoding.com/sketch/tool/'
+  homepage 'https://bohemiancoding.com/sketch/tool/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   binary 'sketchtool/bin/sketchtool'

--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -3,9 +3,9 @@ cask :v1 => 'sketch' do
   sha256 :no_check
 
   url 'http://bohemiancoding.com/static/download/sketch.zip'
-  appcast 'http://www.bohemiancoding.com/sketch/appcast.xml'
+  appcast 'https://www.bohemiancoding.com/sketch/appcast.xml'
   name 'Sketch'
-  homepage 'http://www.bohemiancoding.com/sketch/'
+  homepage 'https://www.bohemiancoding.com/sketch/'
   license :commercial
 
   app 'Sketch.app'

--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -2,11 +2,11 @@ cask :v1 => 'sketchup' do
   version :latest
   sha256 :no_check
 
-  # downloads can be found at http://www.sketchup.com/download/all
+  # downloads can be found at https://www.sketchup.com/download/all
   # trimble.com is the official download host per the vendor homepage
   url 'https://dl.trimble.com/sketchup/SketchUpMake-en.dmg'
   name 'SketchUp'
-  homepage 'http://www.sketchup.com/intl/en/'
+  homepage 'https://www.sketchup.com/intl/en/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   suite 'SketchUp 2015'

--- a/Casks/sketchupviewer.rb
+++ b/Casks/sketchupviewer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'sketchupviewer' do
   # downloads can be found at http://www.sketchup.com/download/all
   url 'https://dl.trimble.com/sketchup/SketchUpViewer-en.dmg'
   name 'SketchUpViewer'
-  homepage 'http://www.sketchup.com/products/sketchup-viewer'
+  homepage 'https://www.sketchup.com/products/sketchup-viewer'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'SketchUpViewer.app'

--- a/Casks/skitch.rb
+++ b/Casks/skitch.rb
@@ -2,7 +2,7 @@ cask :v1 => 'skitch' do
   version '2.7.8'
   sha256 'f6e78f45434b3aac53f70aeb1e7ab9514148d1632894c73a2f06a91a04a4a2ec'
 
-  url "http://cdn1.evernote.com/skitch/mac/release/Skitch-#{version}.zip"
+  url "https://cdn1.evernote.com/skitch/mac/release/Skitch-#{version}.zip"
   name 'Skitch'
   homepage 'https://evernote.com/skitch/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -3,7 +3,7 @@ cask :v1 => 'slicy' do
   sha256 :no_check
 
   url 'https://macrabbit.com/slicy/get/'
-  appcast 'http://update.macrabbit.com/slicy/1.1.3.xml'
+  appcast 'https://update.macrabbit.com/slicy/1.1.3.xml'
   name 'Slicy'
   homepage 'http://macrabbit.com/slicy/'
   license :commercial

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -2,9 +2,9 @@ cask :v1 => 'smartgit' do
   version '6.5.7'
   sha256 'c56e43e25785384906111a724acdf353b1cfecbc9bc7f8d0f5b5020e95662a67'
 
-  url "http://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.gsub('.', '_')}.dmg"
+  url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.gsub('.', '_')}.dmg"
   name 'SmartGit'
-  homepage 'http://www.syntevo.com/smartgit/'
+  homepage 'https://www.syntevo.com/smartgit/'
   license :commercial
 
   app 'SmartGit.app'

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -3,9 +3,9 @@ cask :v1 => 'snagit' do
   sha256 :no_check
 
   url 'http://download.techsmith.com/snagitmac/enu/Snagit.dmg'
-  appcast 'http://techsmithredirect.appspot.com/'
+  appcast 'https://techsmithredirect.appspot.com/'
   name 'Snagit'
-  homepage 'http://www.techsmith.com/snagit.html'
+  homepage 'https://www.techsmith.com/snagit.html'
   license :commercial
 
   app 'Snagit.app'

--- a/Casks/sonora.rb
+++ b/Casks/sonora.rb
@@ -4,9 +4,9 @@ cask :v1 => 'sonora' do
 
   # github.com is the official download host per the vendor homepage
   url 'https://github.com/downloads/sonoramac/Sonora/Sonora.zip'
-  appcast 'http://getsonora.com/updates/sonora2.xml'
+  appcast 'https://getsonora.com/updates/sonora2.xml'
   name 'Sonora'
-  homepage 'http://getsonora.com/'
+  homepage 'https://getsonora.com/'
   license :gratis
 
   app 'Sonora.app'

--- a/Casks/sophos-anti-virus-home-edition.rb
+++ b/Casks/sophos-anti-virus-home-edition.rb
@@ -2,9 +2,9 @@ cask :v1 => 'sophos-anti-virus-home-edition' do
   version :latest
   sha256 :no_check
 
-  url 'http://downloads.sophos.com/home-edition/savosx_he_r.zip'
+  url 'https://downloads.sophos.com/home-edition/savosx_he_r.zip'
   name 'Sophos Anti-Virus Home Edition'
-  homepage 'http://www.sophos.com/en-us/products/free-tools/sophos-antivirus-for-mac-home-edition.aspx/'
+  homepage 'https://www.sophos.com/en-us/products/free-tools/sophos-antivirus-for-mac-home-edition.aspx/'
   license :gratis
   tags :vendor => 'Sophos'
 

--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -5,7 +5,7 @@ cask :v1 => 'soundcleod' do
   url 'https://github.com/salomvary/soundcleod/raw/master/dist/SoundCleod.dmg'
   appcast 'https://raw.github.com/salomvary/soundcleod/master/appcast.xml'
   name 'SoundCleod'
-  homepage 'http://salomvary.github.io/soundcleod/'
+  homepage 'https://salomvary.github.io/soundcleod/'
   license :mit
 
   app 'SoundCleod.app'

--- a/Casks/soundnote.rb
+++ b/Casks/soundnote.rb
@@ -2,8 +2,8 @@ cask :v1 => 'soundnote' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/SoundNote.zip'
-  appcast 'http://mrgeckosmedia.com/applications/appcast/SoundNote'
+  url 'https://download.mrgeckosmedia.com/SoundNote.zip'
+  appcast 'https://mrgeckosmedia.com/applications/appcast/SoundNote'
   name 'SoundNote'
   homepage 'https://mrgeckosmedia.com/applications/info/SoundNote'
   license :isc

--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -4,21 +4,21 @@ cask :v1 => 'spamsieve' do
     version '2.9.6'
     sha256 'f060af29ab260450f0c0a906ada3e60408c9b6cd871e1df272dde2521bafeed3'
 
-    url "http://c-command.com/downloads/SpamSieve-#{version}-tiger.dmg"
+    url "https://c-command.com/downloads/SpamSieve-#{version}-tiger.dmg"
   elsif MacOS.release == :leopard
     version '2.9.14'
     sha256 '9acd154e5c379b21ca752ff70bd59766cc2f91532a10ea12dce87f71101d2f11'
 
-    url "http://c-command.com/downloads/SpamSieve-#{version}-leopard.dmg"
+    url "https://c-command.com/downloads/SpamSieve-#{version}-leopard.dmg"
   else
     version '2.9.20'
     sha256 'd9515b853148f14c384052217c9b528c0ca878f044ad58ed0feae49f69494770'
 
-    url "http://c-command.com/downloads/SpamSieve-#{version}.dmg"
+    url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
   end
 
   name 'SpamSieve'
-  homepage 'http://c-command.com/spamsieve/'
+  homepage 'https://c-command.com/spamsieve/'
   license :commercial
 
   app 'SpamSieve.app'

--- a/Casks/speedlimit.rb
+++ b/Casks/speedlimit.rb
@@ -4,7 +4,7 @@ cask :v1 => 'speedlimit' do
 
   url 'https://mschrag.github.io/speedlimit/SpeedLimit.prefPane.zip'
   name 'speedlimit'
-  homepage 'http://mschrag.github.io/'
+  homepage 'https://mschrag.github.io/'
   license :oss
 
   prefpane 'SpeedLimit.prefPane'

--- a/Casks/splayerx.rb
+++ b/Casks/splayerx.rb
@@ -2,7 +2,7 @@ cask :v1 => 'splayerx' do
   version '1.1.8'
   sha256 '75a3decacd5a8efe5b6f5638999281159cb7ddf598d158a89f3d6e157c276433'
 
-  url "http://bitbucket.org/Tomasen/splayerx/downloads/SPlayerX_#{version}.zip"
+  url "https://bitbucket.org/Tomasen/splayerx/downloads/SPlayerX_#{version}.zip"
   name 'SPlayerX'
   homepage 'https://bitbucket.org/Tomasen/splayerx/wiki/Home'
   license :oss

--- a/Casks/spotdox.rb
+++ b/Casks/spotdox.rb
@@ -6,7 +6,7 @@ cask :v1 => 'spotdox' do
   url 'https://spotdox.herokuapp.com/downloads/Spotdox.zip'
   appcast 'https://spotdox.herokuapp.com/downloads/appcast.xml'
   name 'Spotdox'
-  homepage 'http://spotdox.com/'
+  homepage 'https://spotdox.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Spotdox.app'

--- a/Casks/srware-iron.rb
+++ b/Casks/srware-iron.rb
@@ -2,10 +2,10 @@ cask :v1 => 'srware-iron' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.srware.net/downloads/iron-mac64.zip'
+  url 'https://www.srware.net/downloads/iron-mac64.zip'
   name 'SRWare Iron'
   name 'Iron'
-  homepage 'http://www.srware.net/en/software_srware_iron.php'
+  homepage 'https://www.srware.net/en/software_srware_iron.php'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
   tags :vendor => 'SRWare'
 

--- a/Casks/sshfs.rb
+++ b/Casks/sshfs.rb
@@ -5,7 +5,7 @@ cask :v1 => 'sshfs' do
   url "https://github.com/osxfuse/sshfs/releases/download/osxfuse-sshfs-#{version}/sshfs-#{version}.pkg"
   appcast 'https://github.com/osxfuse/sshfs/releases.atom'
   name 'SSHFS'
-  homepage 'http://osxfuse.github.io/'
+  homepage 'https://osxfuse.github.io/'
   license :gpl
 
   pkg "sshfs-#{version}.pkg"

--- a/Casks/stackato.rb
+++ b/Casks/stackato.rb
@@ -2,9 +2,9 @@ cask :v1 => 'stackato' do
   version '3.2.2'
   sha256 '12bbc6ce6bd4b142c13a02cbfa97c10a4a1759e416d9906064224d757765ef05'
 
-  url "http://downloads.activestate.com/stackato/client/v#{version}/stackato-#{version}-macosx10.5-i386-x86_64.zip"
+  url "https://downloads.activestate.com/stackato/client/v#{version}/stackato-#{version}-macosx10.5-i386-x86_64.zip"
   name 'Stackato'
-  homepage 'http://docs.stackato.com/user/client/'
+  homepage 'https://docs.stackato.com/user/client/'
   license :apache
 
   binary "stackato-#{version}-macosx10.5-i386-x86_64/stackato"

--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -2,7 +2,7 @@ cask :v1 => 'stattransfer' do
   version '12'
   sha256 '2559dffffd73f996604860e6fbdf2fd3ef4903bf8a37acc6016b6ea52affebd2'
 
-  url 'http://www.stattransfer.com/downloads/stdemo.dmg'
+  url 'https://www.stattransfer.com/downloads/stdemo.dmg'
   name 'Stat/Transfer'
   homepage 'https://stattransfer.com/'
   license :commercial

--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -3,10 +3,10 @@ cask :v1 => 'stay' do
   sha256 'b7b3062fdec9b8b7a5be57d0a03dfec3aefe20fa8fd19e64da8ebbd0078f24b0'
 
   url "https://cordlessdog.com/stay/versions/Stay%20#{version}.zip"
-  appcast 'http://cordlessdog.com/stay/appcast.xml',
+  appcast 'https://cordlessdog.com/stay/appcast.xml',
           :sha256 => '43ace797403b9b44186e2f37c76912e3e18a45334ad4462577aa037e886ebd6c'
   name 'Stay'
-  homepage 'http://cordlessdog.com/stay/'
+  homepage 'https://cordlessdog.com/stay/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Stay.app'

--- a/Casks/streakerbar.rb
+++ b/Casks/streakerbar.rb
@@ -2,7 +2,7 @@ cask :v1 => 'streakerbar' do
   version '1.1'
   sha256 '61735052d8e7613dc4d898c4236ed8b277ad742456c2067e4a750c7a937529f5'
 
-  url "http://github.com/chaserx/streakerbar/releases/download/v#{version}/streakerbar.zip"
+  url "https://github.com/chaserx/streakerbar/releases/download/v#{version}/streakerbar.zip"
   appcast 'https://github.com/chaserx/streakerbar/releases.atom'
   name 'streakerbar'
   homepage 'https://github.com/chaserx/streakerbar'

--- a/Casks/streamtools.rb
+++ b/Casks/streamtools.rb
@@ -13,6 +13,6 @@ cask :v1 => 'streamtools' do
   end
 
   name 'streamtools'
-  homepage 'http://nytlabs.github.io/streamtools/'
+  homepage 'https://nytlabs.github.io/streamtools/'
   license :apache
 end

--- a/Casks/strongvpn-client.rb
+++ b/Casks/strongvpn-client.rb
@@ -7,7 +7,7 @@ cask :v1 => 'strongvpn-client' do
   appcast 'https://colomovers.com/mac.xml',
           :sha256 => '4d1440058cd3a699e61c75312b34dc9871f7614eac1dc0e5386eb2fd4eeae7b7'
   name 'StrongVPN Client'
-  homepage 'http://strongvpn.com/vpnclient.shtml'
+  homepage 'https://strongvpn.com/vpnclient.shtml'
   license :closed
 
   app 'StrongVPN Client.app'

--- a/Casks/structurer.rb
+++ b/Casks/structurer.rb
@@ -2,9 +2,9 @@ cask :v1 => 'structurer' do
   version :latest
   sha256 :no_check
 
-  url 'http://cdn.tutsplus.com/net/uploads/legacy/892_structurer/Structurer.zip'
+  url 'https://cdn.tutsplus.com/net/uploads/legacy/892_structurer/Structurer.zip'
   name 'Structurer'
-  homepage 'http://code.tutsplus.com/articles/free-mac-utility-app-structurer--net-17153'
+  homepage 'https://code.tutsplus.com/articles/free-mac-utility-app-structurer--net-17153'
   license :gratis
 
   app 'Structurer.app'

--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -10,7 +10,7 @@ cask :v1 => 'sts' do
 
   url "http://dist.springsource.com/release/STS/#{version}.RELEASE/dist/e#{Utils.based_on_eclipse.gsub(/\.\d$/, '')}/spring-tool-suite-#{version}.RELEASE-e#{Utils.based_on_eclipse}-macosx-cocoa-x86_64.tar.gz"
   name 'Spring Tool Suite'
-  homepage 'http://spring.io/tools/sts'
+  homepage 'https://spring.io/tools/sts'
   license :eclipse
 
   app "sts-bundle/sts-#{version}.RELEASE/STS.app"

--- a/Casks/subclassed-mnemosyne.rb
+++ b/Casks/subclassed-mnemosyne.rb
@@ -2,9 +2,9 @@ cask :v1 => 'subclassed-mnemosyne' do
   version '1.1'
   sha256 'c641f423f449104615f614bedc7a54938ae67b63a97842351a3258b0a283f6b3'
 
-  url 'http://www.subclassed.com/download/Mnemosyne.zip'
+  url 'https://www.subclassed.com/download/Mnemosyne.zip'
   name 'Mnemosyne'
-  homepage 'http://www.subclassed.com/apps/mnemosyne/details'
+  homepage 'https://www.subclassed.com/apps/mnemosyne/details'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Mnemosyne.app'

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -4,10 +4,10 @@ cask :v1 => 'sublime-text' do
 
   # rackcdn.com is the official download host per the vendor homepage
   url "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20#{version}.dmg"
-  appcast 'http://www.sublimetext.com/updates/2/stable/appcast_osx.xml',
+  appcast 'https://www.sublimetext.com/updates/2/stable/appcast_osx.xml',
           :sha256 => 'e11769f18c577d4cb189c6f6485119a66db5e5d3ba4df99326080f193c1f74b3'
   name 'Sublime Text'
-  homepage 'http://www.sublimetext.com/2'
+  homepage 'https://www.sublimetext.com/2'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Sublime Text 2.app'

--- a/Casks/sumbolon.rb
+++ b/Casks/sumbolon.rb
@@ -2,11 +2,11 @@ cask :v1 => 'sumbolon' do
   version '1.0.5'
   sha256 '9127c381dc19916f91a834dca76b237d43a5fe0ca92a79a1c7ed0a8dd791692d'
 
-  url "http://www.rwe-uk.com/uploads/updates/Sumbolon%20#{version}.zip"
+  url "https://www.rwe-uk.com/uploads/updates/Sumbolon%20#{version}.zip"
   name 'Sumbolon'
-  appcast 'http://www.rwe-uk.com/sparkle/sumbolon',
+  appcast 'https://www.rwe-uk.com/sparkle/sumbolon',
           :sha256 => '3570d9e02c0145a825373c078dd60e80ea32dbc2b2019285a6023802320ba431'
-  homepage 'http://www.rwe-uk.com/app/sumbolon'
+  homepage 'https://www.rwe-uk.com/app/sumbolon'
   license :commercial
 
   app 'Sumbolon.app'

--- a/Casks/sunvox.rb
+++ b/Casks/sunvox.rb
@@ -2,7 +2,7 @@ cask :v1 => 'sunvox' do
   version '1.8.1'
   sha256 'd1631d8744593763a6ce1c2459f95798ec494abe7068c5c692d45028db06f7e2'
 
-  url "http://www.warmplace.ru/soft/sunvox/sunvox-#{version}.zip"
+  url "https://www.warmplace.ru/soft/sunvox/sunvox-#{version}.zip"
   name 'SunVox'
   homepage 'http://www.warmplace.ru/soft/sunvox/'
   license :gratis

--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -2,9 +2,9 @@ cask :v1 => 'supersync' do
   version '6.1'
   sha256 'c97191ea844a581bbafc8382cac6449be577c1c8b5639c64033fb200fc3a79dc'
 
-  url "http://supersync.com/downloads/SuperSync-#{version}.dmg"
+  url "https://supersync.com/downloads/SuperSync-#{version}.dmg"
   name 'SuperSync'
-  homepage 'http://supersync.com/'
+  homepage 'https://supersync.com/'
   license :commercial
 
   app 'SuperSync.app'

--- a/Casks/svnx.rb
+++ b/Casks/svnx.rb
@@ -4,7 +4,7 @@ cask :v1 => 'svnx' do
 
   url "https://svnx.googlecode.com/files/svnX%20#{version}.dmg"
   name 'SvnX'
-  appcast 'http://svnx.googlecode.com/svn/wiki/svnX.rss.xml',
+  appcast 'https://svnx.googlecode.com/svn/wiki/svnX.rss.xml',
           :sha256 => '35166bbbcb22ee3704eddabcf6946eb60f415859c198c8b5480b346334c91056'
   homepage 'https://code.google.com/p/svnx/'
   license :oss

--- a/Casks/swift-publisher.rb
+++ b/Casks/swift-publisher.rb
@@ -3,11 +3,11 @@ cask :v1 => 'swift-publisher' do
   sha256 :no_check
 
   # amazonaws.com is the official download host per the vendor homepage
-  url 'http://s3.amazonaws.com/belightsoft/SwiftPublisher.dmg'
+  url 'https://s3.amazonaws.com/belightsoft/SwiftPublisher.dmg'
   name 'Swift Publisher'
-  appcast 'http://www.belightsoft.com/download/updates/appcast_SwiftPublisher3.xml',
+  appcast 'https://www.belightsoft.com/download/updates/appcast_SwiftPublisher3.xml',
           :sha256 => '73bf29fcb6fa689fa32e5a1666ffb8db22401a6033a91e2866fc95d1be7ffd96'
-  homepage 'http://www.belightsoft.com/products/swiftpublisher/overview.php'
+  homepage 'https://www.belightsoft.com/products/swiftpublisher/overview.php'
   license :closed
 
   app 'Swift Publisher 3.app'

--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -3,9 +3,9 @@ cask :v1 => 'swinsian' do
   sha256 :no_check
 
   url 'https://swinsian.com/sparkle/Swinsian.zip'
-  appcast 'http://www.swinsian.com/sparkle/sparklecast.xml'
+  appcast 'https://www.swinsian.com/sparkle/sparklecast.xml'
   name 'Swinsian'
-  homepage 'http://swinsian.com'
+  homepage 'https://swinsian.com'
   license :commercial
 
   app 'Swinsian.app'

--- a/Casks/switchup.rb
+++ b/Casks/switchup.rb
@@ -2,11 +2,11 @@ cask :v1 => 'switchup' do
   version '1.7'
   sha256 'e35b6cbd212b501e615fa2c678c65d9539cbb72f9d913ccd9748d9a645527ebe'
 
-  url "http://www.irradiatedsoftware.com/downloads/SwitchUp_#{version}.zip"
-  appcast 'http://www.irradiatedsoftware.com/updates/profiles/switchup.php',
+  url "https://www.irradiatedsoftware.com/downloads/SwitchUp_#{version}.zip"
+  appcast 'https://www.irradiatedsoftware.com/updates/profiles/switchup.php',
           :sha256 => 'a9feeb5f7dcb832042ad2d8083844e6f26c0537628820870b27e1d8a8d5abb82'
   name 'SwitchUp'
-  homepage 'http://www.irradiatedsoftware.com/switchup/'
+  homepage 'https://www.irradiatedsoftware.com/switchup/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'SwitchUp.app'

--- a/Casks/synalyze-it-pro.rb
+++ b/Casks/synalyze-it-pro.rb
@@ -7,7 +7,7 @@ cask :v1 => 'synalyze-it-pro' do
   name 'Synalyze It! Pro'
   appcast 'http://www.synalyze-it.com/SynalyzeItPro/appcast.xml',
           :sha256 => 'af1d32eca0a3085a258172fb4048c52211b0aefb6784593159d8f2a755224e61'
-  homepage 'http://www.synalysis.net/'
+  homepage 'https://www.synalysis.net/'
   license :commercial
 
   app 'Synalyze It! Pro.app'

--- a/Casks/synology-assistant.rb
+++ b/Casks/synology-assistant.rb
@@ -4,7 +4,7 @@ cask :v1 => 'synology-assistant' do
 
   url "https://global.download.synology.com/download/Tools/SynologyAssistant/#{version.sub(%r{.*-},'')}/Mac/Synology-Assistant-#{version}.dmg"
   name 'Synology Assistant'
-  homepage 'http://www.synology.com/'
+  homepage 'https://www.synology.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Synology Assistant.app'

--- a/Casks/synology-cloud-station.rb
+++ b/Casks/synology-cloud-station.rb
@@ -4,7 +4,7 @@ cask :v1 => 'synology-cloud-station' do
 
   url "https://global.download.synology.com/download/Tools/CloudStation/#{version}/Mac/synology-cloud-station-#{version}.dmg"
   name 'Synology Cloud Station'
-  homepage 'http://www.synology.com/'
+  homepage 'https://www.synology.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "synology-cloud-station-#{version}.pkg"

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -4,7 +4,7 @@ cask :v1 => 'synology-photo-station-uploader' do
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version}-Mac-Installer.dmg"
   name 'Synology Photo Station Uploader'
-  homepage 'http://www.synology.com/'
+  homepage 'https://www.synology.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "PhotoStationUploader-#{version}-Mac-Installer.pkg"

--- a/Casks/syphon-virtual-screen.rb
+++ b/Casks/syphon-virtual-screen.rb
@@ -4,7 +4,7 @@ cask :v1 => 'syphon-virtual-screen' do
 
   url 'https://github.com/andreacremaschi/Syphon-virtual-screen/releases/download/1.3/Syphon.Virtual.Screen.mpkg.zip'
   name 'Syphon Virtual Screen'
-  homepage 'http://andreacremaschi.github.io/Syphon-virtual-screen/'
+  homepage 'https://andreacremaschi.github.io/Syphon-virtual-screen/'
   license :unknown
 
   pkg 'Syphon Virtual Screen.mpkg'

--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tableau-public' do
 
   url 'https://downloads.tableausoftware.com/public/TableauPublic.dmg'
   name 'Tableau Public'
-  homepage 'http://www.tableausoftware.com/public'
+  homepage 'https://www.tableausoftware.com/public'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tableau Public.app'

--- a/Casks/tableau.rb
+++ b/Casks/tableau.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tableau' do
 
   url 'https://downloads.tableausoftware.com/tssoftware/TableauDesktop.dmg'
   name 'Tableau'
-  homepage 'http://www.tableausoftware.com/'
+  homepage 'https://www.tableausoftware.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tableau.app'

--- a/Casks/tagger.rb
+++ b/Casks/tagger.rb
@@ -5,7 +5,7 @@ cask :v1 => 'tagger' do
   url "https://github.com/Bilalh/Tagger/releases/download/1.8.0/Tagger_#{version}.zip"
   appcast 'https://github.com/Bilalh/Tagger/releases.atom'
   name 'Tagger'
-  homepage 'http://bilalh.github.io/projects/tagger/'
+  homepage 'https://bilalh.github.io/projects/tagger/'
   license :cc
 
   app 'Tagger.app'

--- a/Casks/tangerine.rb
+++ b/Casks/tangerine.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tangerine' do
   name 'Tangerine!'
   appcast 'http://launch.karelia.com/appcast.php?version=0&product=13&appname=Tangerine!',
           :sha256 => 'c8e3f2ce6c968bd670dd33e2be1412a3a7f7614256737c05e7f3c3e5414e2bc9'
-  homepage 'http://www.karelia.com/products/tangerine/'
+  homepage 'https://www.karelia.com/products/tangerine/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tangerine!.app'

--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -3,7 +3,7 @@ cask :v1 => 'taskpaper' do
   sha256 'faaaef9c9b6398aa7beb6782b1704ccc74b11e251f428d6b921248235afc3a06'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://taskpaper.s3.amazonaws.com/TaskPaper-#{version}.dmg"
+  url "https://taskpaper.s3.amazonaws.com/TaskPaper-#{version}.dmg"
   appcast 'http://www.hogbaysoftware.com/products/taskpaper/releases.rss'
   name 'TaskPaper'
   homepage 'http://www.hogbaysoftware.com/products/taskpaper'

--- a/Casks/td-agent.rb
+++ b/Casks/td-agent.rb
@@ -4,7 +4,7 @@ cask :v1 => 'td-agent' do
 
   url "http://packages.treasuredata.com/2/macosx/td-agent-#{version}-0.dmg"
   name 'td-agent'
-  homepage 'http://www.fluentd.org/'
+  homepage 'https://www.fluentd.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "tdagent-#{version}-0.pkg"

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -4,7 +4,7 @@ cask :v1 => 'teamviewer' do
 
   url 'https://download.teamviewer.com/download/TeamViewer.dmg'
   name 'TeamViewer'
-  homepage 'http://www.teamviewer.com/'
+  homepage 'https://www.teamviewer.com/'
   license :freemium
 
   pkg 'Install TeamViewer.pkg'

--- a/Casks/teensy.rb
+++ b/Casks/teensy.rb
@@ -4,7 +4,7 @@ cask :v1 => 'teensy' do
 
   url 'https://www.pjrc.com/teensy/teensy.dmg'
   name 'Teensy'
-  homepage 'http://pjrc.com/teensy/loader_mac.html'
+  homepage 'https://pjrc.com/teensy/loader_mac.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'teensy.app'

--- a/Casks/terminology.rb
+++ b/Casks/terminology.rb
@@ -4,7 +4,7 @@ cask :v1 => 'terminology' do
 
   url 'http://media.agiletortoise.com/Terminology-for-OS-X/Terminology-for-OS-X.zip'
   name 'terminology'
-  homepage 'http://agiletortoise.com/terminology/mac/'
+  homepage 'https://agiletortoise.com/terminology/mac/'
   license :gratis
 
   installer :script => 'Terminology-for-OS-X/Install.command', :sudo => false

--- a/Casks/textsoap.rb
+++ b/Casks/textsoap.rb
@@ -3,7 +3,7 @@ cask :v1 => 'textsoap' do
   sha256 :no_check
 
   # amazonaws.com is the official download host per the vendor homepage
-  url 'http://unmarked.s3.amazonaws.com/textsoap7.zip'
+  url 'https://unmarked.s3.amazonaws.com/textsoap7.zip'
   name 'TextSoap'
   appcast 'https://unmarked.s3.amazonaws.com/appcast/textsoap7.xml',
           :sha256 => '37211786d3aca6f891665256f383906a337bea31958b4b7a2ff0fbbaae98709e'

--- a/Casks/the-cheat.rb
+++ b/Casks/the-cheat.rb
@@ -2,7 +2,7 @@ cask :v1 => 'the-cheat' do
   version '1.2.5'
   sha256 '24ed774cc21adc2355077123d04c2657295a41183fd5555c41a2342063c3dedc'
 
-  url "http://chazmcgarvey.github.com/thecheat/thecheat-#{version}.dmg"
+  url "https://chazmcgarvey.github.com/thecheat/thecheat-#{version}.dmg"
   name 'The Cheat'
   homepage 'https://github.com/chazmcgarvey/thecheat'
   license :gratis

--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -4,7 +4,7 @@ cask :v1 => 'thebrain' do
 
   url "http://assets.thebrain.com/downloads/TheBrain_macos_J7_#{version.gsub('.', '_')}-a.dmg"
   name 'TheBrain'
-  homepage 'http://www.thebrain.com/'
+  homepage 'https://www.thebrain.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TheBrain.app'

--- a/Casks/things.rb
+++ b/Casks/things.rb
@@ -3,9 +3,9 @@ cask :v1 => 'things' do
   sha256 :no_check
 
   url 'https://culturedcode.com/things/download/'
-  appcast 'http://downloads.culturedcode.com/things/download/Things_Updates.php'
+  appcast 'https://downloads.culturedcode.com/things/download/Things_Updates.php'
   name 'Things'
-  homepage 'http://culturedcode.com/things/'
+  homepage 'https://culturedcode.com/things/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Things.app'

--- a/Casks/thinkorswim.rb
+++ b/Casks/thinkorswim.rb
@@ -4,7 +4,7 @@ cask :v1 => 'thinkorswim' do
 
   url 'https://mediaserver.thinkorswim.com/installer/InstFiles/thinkorswim_installer.dmg'
   name 'thinkDesktop'
-  homepage 'http://mediaserver.thinkorswim.com/installer/install.html#macosx'
+  homepage 'https://mediaserver.thinkorswim.com/installer/install.html#macosx'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   installer :script => 'thinkorswim Installer.app/Contents/MacOS/JavaApplicationStub',

--- a/Casks/thyme.rb
+++ b/Casks/thyme.rb
@@ -5,7 +5,7 @@ cask :v1 => 'thyme' do
   url "https://github.com/joaomoreno/thyme/releases/download/#{version}/Thyme.#{version}.dmg"
   appcast 'https://github.com/joaomoreno/thyme/releases.atom'
   name 'Thyme'
-  homepage 'http://joaomoreno.github.io/thyme/'
+  homepage 'https://joaomoreno.github.io/thyme/'
   license :mit
 
   app 'Thyme.app'

--- a/Casks/ti-connect-ce.rb
+++ b/Casks/ti-connect-ce.rb
@@ -4,7 +4,7 @@ cask :v1 => 'ti-connect-ce' do
 
   url "http://edudownload.ti.com/downloads/files/cdn/ti-connect-ce/TIConnectCE-#{version}.dmg"
   name 'TI Connect™ CE'
-  homepage 'http://education.ti.com/en/us/products/computer_software/connectivity-software/ti-connect-ce-software'
+  homepage 'https://education.ti.com/en/us/products/computer_software/connectivity-software/ti-connect-ce-software'
   license :gratis
 
   app 'TI Connect CE.app'

--- a/Casks/tickets.rb
+++ b/Casks/tickets.rb
@@ -3,10 +3,10 @@ cask :v1 => 'tickets' do
   sha256 '8f2d7879581fb2604158367fb6e7eda8bc9ebf15e97781b69b64355f2832af6e'
 
   url 'https://www.irradiatedsoftware.com/download/Tickets.zip'
-  appcast 'http://www.irradiatedsoftware.com/updates/profiles/tickets.php',
+  appcast 'https://www.irradiatedsoftware.com/updates/profiles/tickets.php',
           :sha256 => '24a551412959452baf56b0cba06fdd502057f76812d596136b7fda1c14895386'
   name 'Tickets'
-  homepage 'http://www.irradiatedsoftware.com/tickets/'
+  homepage 'https://www.irradiatedsoftware.com/tickets/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tickets.app'

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -5,7 +5,7 @@ cask :v1 => 'tidal' do
   # wimp.no is the official download host per the vendor homepage
   url "https://wimp.no/wweb/resources/wimp_files/release/TIDAL-#{version}-WW.dmg"
   name 'TIDAL'
-  appcast 'http://client.wimpmusic.com/wimpsetup/desktop/update/tidal.update.osx.WW.xml?version=3.2.3.16',
+  appcast 'https://client.wimpmusic.com/wimpsetup/desktop/update/tidal.update.osx.WW.xml?version=3.2.3.16',
           :sha256 => '8f3fff452fee6817ed1fafb09782d9548aaf987cdc6304170686d65963d94e4f'
   homepage 'https://tidalhifi.com/us/download'
   license :closed

--- a/Casks/time-tracker.rb
+++ b/Casks/time-tracker.rb
@@ -3,7 +3,7 @@ cask :v1 => 'time-tracker' do
   sha256 'a6c982ee82f8babcf0f42d49950e5b3a1d613946736a7ee4a272b05916271aeb'
 
   url "https://time-tracker-mac.googlecode.com/files/Time%20Tracker-#{version}.zip"
-  appcast 'http://time-tracker-mac.googlecode.com/svn/appcast/timetracker-test.xml',
+  appcast 'https://time-tracker-mac.googlecode.com/svn/appcast/timetracker-test.xml',
           :sha256 => '8737634f2e43e4eaf63d2ab603b47e46c13f3c322e2484b407f45776905777aa'
   name 'TimeTracker'
   homepage 'https://code.google.com/p/time-tracker-mac'

--- a/Casks/timeedition.rb
+++ b/Casks/timeedition.rb
@@ -5,7 +5,7 @@ cask :v1 => 'timeedition' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/timeedition/timeEdition#{version}-macosx.dmg.zip"
   name 'timeEdition'
-  homepage 'http://www.timeedition.com/old/en/'
+  homepage 'https://www.timeedition.com/old/en/'
   license :gpl
 
   container :nested => "timeEdition#{version}-macosx.dmg"

--- a/Casks/tinyumbrella.rb
+++ b/Casks/tinyumbrella.rb
@@ -2,7 +2,7 @@ cask :v1 => 'tinyumbrella' do
   version :latest
   sha256 :no_check
 
-  url 'http://blog.firmwareumbrella.com/download/343/'
+  url 'https://blog.firmwareumbrella.com/download/343/'
   name 'TinyUmbrella'
   homepage 'http://blog.firmwareumbrella.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/todoist.rb
+++ b/Casks/todoist.rb
@@ -4,7 +4,7 @@ cask :v1 => 'todoist' do
 
   # cloudfront.net is the official download host per the appcast feed
   url 'https://d2dq6e731uoz0t.cloudfront.net/f34bc666b8a2458496a5c00a115f7cbd/as/Todoist.zip'
-  appcast 'http://todoist.com/static/native_apps/mac_app.xml'
+  appcast 'https://todoist.com/static/native_apps/mac_app.xml'
   name 'Todoist'
   homepage 'https://todoist.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/tomahawk.rb
+++ b/Casks/tomahawk.rb
@@ -6,7 +6,7 @@ cask :v1 => 'tomahawk' do
   appcast 'http://download.tomahawk-player.org/sparkle/update.php',
           :sha256 => 'ef1c646c36717abdd5ffb12bd3a8f758fe12d575d975f6dca5353144679aca4f'
   name 'Tomahawk'
-  homepage 'http://www.tomahawk-player.org/'
+  homepage 'https://www.tomahawk-player.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tomahawk.app'

--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -2,11 +2,11 @@ cask :v1 => 'trailer' do
   version '1.3.5'
   sha256 '906b13316d243c7791c1258f5b895a1528148808c9c3cc1e9dc7a36c50495ebe'
 
-  url "http://ptsochantaris.github.io/trailer/trailer#{version.gsub('.','')}.zip"
-  appcast 'http://ptsochantaris.github.io/trailer/appcast.xml',
+  url "https://ptsochantaris.github.io/trailer/trailer#{version.gsub('.','')}.zip"
+  appcast 'https://ptsochantaris.github.io/trailer/appcast.xml',
           :sha256 => 'aaf3f91888b757ec234643a9f45259fd9650a687c6146c723084e7d80979a6a4'
   name 'Trailer'
-  homepage 'http://ptsochantaris.github.io/trailer/'
+  homepage 'https://ptsochantaris.github.io/trailer/'
   license :mit
 
   app 'Trailer.app'

--- a/Casks/traktable.rb
+++ b/Casks/traktable.rb
@@ -5,7 +5,7 @@ cask :v1 => 'traktable' do
   url "https://github.com/yo-han/Traktable/releases/download/#{version}/Traktable.zip"
   appcast 'https://github.com/yo-han/Traktable/releases.atom'
   name 'Traktable'
-  homepage 'http://yo-han.github.io/Traktable/'
+  homepage 'https://yo-han.github.io/Traktable/'
   license :oss
 
   app 'Traktable.app'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -5,7 +5,7 @@ cask :v1 => 'transmission' do
   # cachefly.net is the official download host per the vendor homepage
   url "https://transmission.cachefly.net/Transmission-#{version}.dmg"
   name 'Transmission'
-  appcast 'http://update.transmissionbt.com/appcast.xml',
+  appcast 'https://update.transmissionbt.com/appcast.xml',
           :sha256 => 'f7177b7ad0bc07a74b484e0033dbf356e112cd1225c8050657b1e21aeaf7bdd3'
   homepage 'http://www.transmissionbt.com/'
   license :gpl

--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -4,7 +4,7 @@ cask :v1 => 'trim-enabler' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/cindori/TrimEnabler.dmg'
-  appcast 'http://cindori.org/trimenabler/updates/update.xml'
+  appcast 'https://cindori.org/trimenabler/updates/update.xml'
   name 'Trim Enabler'
   homepage 'https://www.cindori.org/software/trimenabler/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/tripmode.rb
+++ b/Casks/tripmode.rb
@@ -2,7 +2,7 @@ cask :v1 => 'tripmode' do
   version :latest
   sha256 :no_check
 
-  url 'http://tripmode.ch/TripMode.pkg'
+  url 'https://tripmode.ch/TripMode.pkg'
   name 'TripMode'
   appcast 'http://updates.tripmode.ch/app/appcast.xml'
   homepage 'https://www.tripmode.ch/'

--- a/Casks/triumph.rb
+++ b/Casks/triumph.rb
@@ -2,9 +2,9 @@ cask :v1 => 'triumph' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.audiofile-engineering.com/triumph/download/Triumph.dmg'
+  url 'https://www.audiofile-engineering.com/triumph/download/Triumph.dmg'
   name 'Triumph'
-  homepage 'http://www.audiofile-engineering.com/triumph/'
+  homepage 'https://www.audiofile-engineering.com/triumph/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Triumph.app'

--- a/Casks/tuck.rb
+++ b/Casks/tuck.rb
@@ -2,10 +2,10 @@ cask :v1 => 'tuck' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.irradiatedsoftware.com/downloads/Tuck.zip'
-  appcast 'http://www.irradiatedsoftware.com/updates/profiles/tuck.php'
+  url 'https://www.irradiatedsoftware.com/downloads/Tuck.zip'
+  appcast 'https://www.irradiatedsoftware.com/updates/profiles/tuck.php'
   name 'Tuck'
-  homepage 'http://www.irradiatedsoftware.com/labs/'
+  homepage 'https://www.irradiatedsoftware.com/labs/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Tuck.app'

--- a/Casks/tuneup.rb
+++ b/Casks/tuneup.rb
@@ -2,9 +2,9 @@ cask :v1 => 'tuneup' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.tuneupmedia.com/redirect/mac-download'
+  url 'https://www.tuneupmedia.com/redirect/mac-download'
   name 'TuneUp'
-  homepage 'http://www.tuneupmedia.com/'
+  homepage 'https://www.tuneupmedia.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   # todo: installer :manual should have a matching uninstall

--- a/Casks/tuxera-ntfs.rb
+++ b/Casks/tuxera-ntfs.rb
@@ -4,7 +4,7 @@ cask :v1 => 'tuxera-ntfs' do
 
   url 'https://www.tuxera.com/mac/tuxerantfs_2014.dmg'
   name 'Tuxera NTFS'
-  homepage 'http://www.tuxera.com/products/tuxera-ntfs-for-mac/'
+  homepage 'https://www.tuxera.com/products/tuxera-ntfs-for-mac/'
   license :closed
 
   pkg '.packages/Flat/Install Tuxera NTFS.mpkg'

--- a/Casks/twitterrific.rb
+++ b/Casks/twitterrific.rb
@@ -4,7 +4,7 @@ cask :v1 => 'twitterrific' do
 
   # iconfactory.com is the official download host per the vendor homepage
   url "https://iconfactory.com/assets/software/twitterrific/Twitterrific-#{version}.zip"
-  appcast 'http://iconfactory.com/appcasts/Twitterrific/appcast.xml',
+  appcast 'https://iconfactory.com/appcasts/Twitterrific/appcast.xml',
           :sha256 => '0d8a09937e5ea81dc2f16ff23497077fecb6bc89c3266b47d0465a13776dd7ea'
   name 'Twitterrific'
   homepage 'http://twitterrific.com/mac'

--- a/Casks/typed.rb
+++ b/Casks/typed.rb
@@ -6,7 +6,7 @@ cask :v1 => 'typed' do
   name 'Typed'
   appcast 'http://updateinfo.devmate.com/com.realmacsoftware.typed/updates.xml',
           :sha256 => 'd1b7029476838fa90d608eeb2f58d0874ef00e3ce3250d78f4a0660bdccfd6d8'
-  homepage 'http://realmacsoftware.com/typed/'
+  homepage 'https://realmacsoftware.com/typed/'
   license :commercial
 
   app 'Typed.app'

--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -3,10 +3,10 @@ cask :v1 => 'ukelele' do
   sha256 'e6200f418dee4ad10fa126536218086273ef8e896b95ede8ba73ddb42ed02ec3'
 
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_#{version}&filename=Ukelele_#{version}.dmg"
-  appcast 'http://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=ukelele_su_feed&filename=ukelele_su_feed.xml',
+  appcast 'https://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=ukelele_su_feed&filename=ukelele_su_feed.xml',
           :sha256 => '5409cb8f49f6de2b0a4c2d638a637d2c460c79532914c57ae87adc4551ed8d16'
   name 'Ukelele'
-  homepage 'http://scripts.sil.org/ukelele'
+  homepage 'https://scripts.sil.org/ukelele'
   license :gratis
 
   app 'Ukelele.app'

--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -2,7 +2,7 @@ cask :v1 => 'unifi-controller' do
   version '3.2.10'
   sha256 'e5aae4e05bac3d6903f91ac5fb74e7a3940795b549c71880e5dae4d163cddea2'
 
-  url "http://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
+  url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'Unifi Controller'
   homepage 'https://community.ubnt.com/t5/UniFi-Updates-Blog/bg-p/Blog_UniFi'
   license :commercial

--- a/Casks/uninstallpkg.rb
+++ b/Casks/uninstallpkg.rb
@@ -2,11 +2,11 @@ cask :v1 => 'uninstallpkg' do
   version '1.0.7'
   sha256 '6f5b88434635afe3eee07dcd0b183f00233ccd089ba0c45e3c4a3c8ddaa1fa4a'
 
-  url "http://www.corecode.at/downloads/uninstallpkg_#{version}.zip"
+  url "https://www.corecode.at/downloads/uninstallpkg_#{version}.zip"
   appcast 'https://www.corecode.at/uninstallpkg/uninstallpkg.xml',
           :sha256 => '5f5de8cb9ee55d7c96582f7359a41c9530170f589f45bdad5ee3f04dd22c829d'
   name 'UninstallPKG'
-  homepage 'http://www.corecode.at/uninstallpkg/'
+  homepage 'https://www.corecode.at/uninstallpkg/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'UninstallPKG.app'

--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -5,7 +5,7 @@ cask :v1 => 'unison' do
   # petitepomme.net is the official download host per the vendor homepage
   url "http://alan.petitepomme.net/unison/assets/Unison-OS-X-#{version}.zip"
   name 'Unison'
-  homepage 'http://www.cis.upenn.edu/~bcpierce/unison/'
+  homepage 'https://www.cis.upenn.edu/~bcpierce/unison/'
   license :gpl
 
   app 'Unison.app'

--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -4,7 +4,7 @@ cask :v1 => 'unity' do
 
   url "http://netstorage.unity3d.com/unity/unity-#{version}.dmg"
   name 'Unity'
-  homepage 'http://unity3d.com/unity/'
+  homepage 'https://unity3d.com/unity/'
   license :commercial
 
   pkg 'Unity.pkg'

--- a/Casks/universalmailer.rb
+++ b/Casks/universalmailer.rb
@@ -2,9 +2,9 @@ cask :v1 => 'universalmailer' do
   version '2.1.5'
   sha256 '93055459aacd9c31b609ee00ef175a6c17e0c33657c9fef1db486f73b51dc437'
 
-  url "http://universalmailer.github.io/UniversalMailer/zips/UniversalMailer-v#{version.gsub('.','_')}.zip"
+  url "https://universalmailer.github.io/UniversalMailer/zips/UniversalMailer-v#{version.gsub('.','_')}.zip"
   name 'Universal Mailer'
-  homepage 'http://universalmailer.github.io/UniversalMailer/'
+  homepage 'https://universalmailer.github.io/UniversalMailer/'
   license :mit
 
   pkg 'UniversalMailer.pkg'

--- a/Casks/unpkg.rb
+++ b/Casks/unpkg.rb
@@ -5,7 +5,7 @@ cask :v1 => 'unpkg' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/downloads/timdoug/unpkg/unpkg-#{version}.zip"
   name 'unpkg'
-  homepage 'http://www.timdoug.com/unpkg/'
+  homepage 'https://www.timdoug.com/unpkg/'
   license :gpl
 
   app "unpkg #{version}/unpkg.app"

--- a/Casks/videobox.rb
+++ b/Casks/videobox.rb
@@ -2,11 +2,11 @@ cask :v1 => 'videobox' do
   version '4.1.2'
   sha256 'bd9e6ae942b729b02c40ad076814be7c5e2f966325c9c5e982070d03443408c5'
 
-  url "http://download.tastyapps.com/videobox_#{version}.dmg"
+  url "https://download.tastyapps.com/videobox_#{version}.dmg"
   name 'Videobox'
   appcast 'https://casts.tastyapps.com/cast.html',
           :sha256 => 'a5946b653f3d86f641836b458e4781d2e97449f0f160674812b18a4700ae30a2'
-  homepage 'http://www.tastyapps.com/videobox/'
+  homepage 'https://www.tastyapps.com/videobox/'
   license :closed
 
   app 'Videobox.app'

--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -5,7 +5,7 @@ cask :v1 => 'viscosity' do
   url 'https://www.sparklabs.com/downloads/Viscosity.dmg'
   appcast 'http://www.viscosityvpn.com/update/viscosity.xml'
   name 'Viscosity'
-  homepage 'http://www.sparklabs.com/viscosity/'
+  homepage 'https://www.sparklabs.com/viscosity/'
   license :commercial
 
   app 'Viscosity.app'

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -2,7 +2,7 @@ cask :v1 => 'visual-studio-code' do
   version :latest
   sha256 :no_check
 
-  url 'http://go.microsoft.com/fwlink/?LinkID=534106'
+  url 'https://go.microsoft.com/fwlink/?LinkID=534106'
   name 'Visual Studio Code'
   homepage 'https://code.visualstudio.com/'
   license :gratis

--- a/Casks/visualack.rb
+++ b/Casks/visualack.rb
@@ -7,7 +7,7 @@ cask :v1 => 'visualack' do
   appcast 'https://kjkpub.s3.amazonaws.com/vack/appcast.xml',
           :sha256 => '6efd94f78b76082e0dd4a67fc12357f0ab8b0468690fdf6251c5e5a9e5a4d591'
   name 'VisualAck'
-  homepage 'http://blog.kowalczyk.info/software/vack/'
+  homepage 'https://blog.kowalczyk.info/software/vack/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'VisualAck.app'

--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -13,7 +13,7 @@ cask :v1 => 'vitalsource-bookshelf' do
   name 'VitalSource Bookshelf'
   appcast 'https://services.vitalbook.com/version/check',
           :sha256 => 'a310b400eadb9aabc7bcf12e5e56ee2dd80d595288a380d8d2a572b242016bb8'
-  homepage 'http://www.vitalsource.com/bookshelf-features'
+  homepage 'https://www.vitalsource.com/bookshelf-features'
   license :freemium
 
   app 'VitalSource Bookshelf.app'

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -4,7 +4,7 @@ cask :v1 => 'vmware-fusion' do
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   name 'VMware Fusion'
-  homepage 'http://www.vmware.com/products/fusion/'
+  homepage 'https://www.vmware.com/products/fusion/'
   license :commercial
   tags :vendor => 'VMware'
 

--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -4,7 +4,7 @@ cask :v1 => 'vmware-horizon-client' do
 
   url "https://download3.vmware.com/software/view/viewclients/CART14Q4/VMware-Horizon-Client-#{version}.dmg"
   name 'VMware Horizon Client'
-  homepage 'http://www.vmware.com/'
+  homepage 'https://www.vmware.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'VMware Horizon Client.app'

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -2,7 +2,7 @@ cask :v1 => 'voicemac' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/VoiceMac.zip'
+  url 'https://download.mrgeckosmedia.com/VoiceMac.zip'
   appcast 'https://mrgeckosmedia.com/applications/appcast/VoiceMac'
   name 'VoiceMac'
   homepage 'https://mrgeckosmedia.com/applications/info/VoiceMac'

--- a/Casks/vuze.rb
+++ b/Casks/vuze.rb
@@ -4,7 +4,7 @@ cask :v1 => 'vuze' do
 
   url 'http://cf1.vuze.com/files/J7/VuzeBittorrentClientInstaller.dmg'
   name 'Vuze'
-  homepage 'http://www.vuze.com/'
+  homepage 'https://www.vuze.com/'
   license :gpl
 
   installer :script => 'Vuze Installer.app/Contents/MacOS/JavaApplicationStub',

--- a/Casks/wakeonlan.rb
+++ b/Casks/wakeonlan.rb
@@ -2,9 +2,9 @@ cask :v1 => 'wakeonlan' do
   version '1.0'
   sha256 '00d86efd23e9d5de5451e26d6957f3af1a1a3bc66d11c50b8563454113fd5ab1'
 
-  url "http://www.readpixel.com/downloads/files/WakeOnLan#{version}.zip"
+  url "https://www.readpixel.com/downloads/files/WakeOnLan#{version}.zip"
   name 'WakeOnLan'
-  homepage 'http://www.readpixel.com/wakeonlan/'
+  homepage 'https://www.readpixel.com/wakeonlan/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'WakeOnLan/WakeOnLan.app'

--- a/Casks/webex-nbr-player.rb
+++ b/Casks/webex-nbr-player.rb
@@ -4,7 +4,7 @@ cask :v1 => 'webex-nbr-player' do
 
   url 'https://welcome.webex.com/client/WBXclient-T29L10NSP12-10075/mac/intel/webexnbrplayer_intel.dmg'
   name 'Webex Network Recording player'
-  homepage 'http://www.webex.com/play-webex-recording.html'
+  homepage 'https://www.webex.com/play-webex-recording.html'
   license :gratis
 
   pkg 'Network Recording Player.pkg'

--- a/Casks/weibox.rb
+++ b/Casks/weibox.rb
@@ -6,7 +6,7 @@ cask :v1 => 'weibox' do
   appcast 'https://weiboformac.sinaapp.com/appcast/wm2.xml',
           :sha256 => '2aefd31728fb15674f7afd1bc2fd4b47f42b6720227f2ee81b8a6d80344815c3'
   name 'WeiboX'
-  homepage 'http://weiboformac.sinaapp.com'
+  homepage 'https://weiboformac.sinaapp.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'WeiboX.app'

--- a/Casks/welly.rb
+++ b/Casks/welly.rb
@@ -3,7 +3,7 @@ cask :v1 => 'welly' do
   sha256 'cb24a26432d8927b1159a1865602c3f30b5190f628167c954e4d6cc723cfcb0f'
 
   url "https://welly.googlecode.com/files/Welly.v#{version}.fix.zip"
-  appcast 'http://welly.googlecode.com/svn/wiki/WellyUpdate.xml',
+  appcast 'https://welly.googlecode.com/svn/wiki/WellyUpdate.xml',
           :sha256 => '0f7d24defff0753fd85883c94111714eded290bae284a2244aba5bfa63224a8c'
   name 'Welly'
   homepage 'https://code.google.com/p/welly/'

--- a/Casks/wiretap-studio.rb
+++ b/Casks/wiretap-studio.rb
@@ -4,7 +4,7 @@ cask :v1 => 'wiretap-studio' do
 
   url 'http://www.ambrosiasw.com/dl/wiretap'
   name 'WireTap Studio'
-  appcast 'http://www.AmbrosiaSW.com/updates/profile.php/wiretap_studio/release',
+  appcast 'https://www.AmbrosiaSW.com/updates/profile.php/wiretap_studio/release',
           :sha256 => 'b1903154579259dce440840029c34294417fe68a4ede2eddc6ee6ef27acca8c2'
   homepage 'http://www.ambrosiasw.com/utilities/wiretap/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/woodhouse.rb
+++ b/Casks/woodhouse.rb
@@ -4,7 +4,7 @@ cask :v1 => 'woodhouse' do
 
   url "https://github.com/downloads/phinze/woodhouse/Woodhouse-#{version}.dmg"
   name 'Woodhouse'
-  appcast 'http://phinze.github.com/woodhouse/appcast.xml',
+  appcast 'https://phinze.github.com/woodhouse/appcast.xml',
           :sha256 => '60e19f2463f90a57417229593f456df23d1ba55781d305db7ac5d47d0ecbcf79'
   homepage 'https://github.com/phinze/woodhouse/'
   license :mit

--- a/Casks/worksnaps-client.rb
+++ b/Casks/worksnaps-client.rb
@@ -4,7 +4,7 @@ cask :v1 => 'worksnaps-client' do
 
   url "https://www.worksnaps.net/download/WSClient-mac-#{version}.dmg"
   name 'Worksnaps Client'
-  homepage 'http://www.worksnaps.net/'
+  homepage 'https://www.worksnaps.net/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Worksnaps Client.app'

--- a/Casks/wowhead-client.rb
+++ b/Casks/wowhead-client.rb
@@ -4,7 +4,7 @@ cask :v1 => 'wowhead-client' do
 
   url 'https://static.wowhead.com/download/Wowhead_Client.dmg'
   name 'Wowhead Client'
-  appcast 'http://client.wowhead.com/files/wowhead-client-appcast.xml',
+  appcast 'https://client.wowhead.com/files/wowhead-client-appcast.xml',
           :sha256 => '70f04bcdeedb2c902e80b6b22b9cd328d0f77af88e981f5865b019afd94130bc'
   homepage 'http://wowhead.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/xamarin-android.rb
+++ b/Casks/xamarin-android.rb
@@ -2,12 +2,12 @@ cask :v1 => 'xamarin-android' do
   version '4.20.0-28'
   sha256 '3f38009ee76b54c7aca174ee0046c0e2aa5729c844739e863b7319f460dd428d'
 
-  url "http://download.xamarin.com/MonoforAndroid/Mac/mono-android-#{version}.pkg"
+  url "https://download.xamarin.com/MonoforAndroid/Mac/mono-android-#{version}.pkg"
   name 'Xamarin.Android'
-  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+  appcast 'https://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
           :format => :unknown
-  homepage 'http://xamarin.com/android'
+  homepage 'https://xamarin.com/android'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "mono-android-#{version}.pkg"

--- a/Casks/xamarin-ios.rb
+++ b/Casks/xamarin-ios.rb
@@ -2,12 +2,12 @@ cask :v1 => 'xamarin-ios' do
   version '8.6.0.51'
   sha256 'af65207d86529fff3ede3e6bc1d394fe7bc1abca67cc502e05c3d725710125c6'
 
-  url "http://download.xamarin.com/MonoTouch/Mac/monotouch-#{version}.pkg"
+  url "https://download.xamarin.com/MonoTouch/Mac/monotouch-#{version}.pkg"
   name 'Xamarin.iOS'
-  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+  appcast 'https://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
           :format => :unknown
-  homepage 'http://xamarin.com/ios'
+  homepage 'https://xamarin.com/ios'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "monotouch-#{version}.pkg"

--- a/Casks/xamarin-jdk.rb
+++ b/Casks/xamarin-jdk.rb
@@ -2,9 +2,9 @@ cask :v1 => 'xamarin-jdk' do
   version '1.7.0_71'
   sha256 '70a18547b529a111c4e5cf133532082e142908819b0d61e273c21dee86fcc87a'
 
-  url 'http://download.xamarin.com/Installer/MonoForAndroid/jdk-7u71-macosx-x64.dmg'
+  url 'https://download.xamarin.com/Installer/MonoForAndroid/jdk-7u71-macosx-x64.dmg'
   name 'Xamarin Java JDK'
-  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+  appcast 'https://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
           :format => :unknown
   homepage 'https://xamarin.com/platform'

--- a/Casks/xamarin-mdk.rb
+++ b/Casks/xamarin-mdk.rb
@@ -2,9 +2,9 @@ cask :v1 => 'xamarin-mdk' do
   version '3.12.0'
   sha256 '9591affdb4a342cbba3da0a1d7013592f1c801e2deb7eb70ec9cc1545dda468a'
 
-  url 'http://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-3.12.0.68.macos10.xamarin.x86.pkg'
+  url 'https://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-3.12.0.68.macos10.xamarin.x86.pkg'
   name 'Xamarin Mono MDK'
-  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+  appcast 'https://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
           :format => :unknown
   homepage 'https://xamarin.com/platform'

--- a/Casks/xamarin-studio.rb
+++ b/Casks/xamarin-studio.rb
@@ -2,12 +2,12 @@ cask :v1 => 'xamarin-studio' do
   version '5.7.0.661-0'
   sha256 '6a126005fafaa19cd8a9c6153c2a7c4b502cf8293e8c977bfbac38f03e0f2e2e'
 
-  url "http://download.xamarin.com/studio/Mac/XamarinStudio-#{version}.dmg"
+  url "https://download.xamarin.com/studio/Mac/XamarinStudio-#{version}.dmg"
   name 'Xamarin Studio'
-  appcast 'http://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+  appcast 'https://xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           :sha256 => '79c309d6dbe6f08f1d022c9376a4678cc94f57be084007df90c5a12839b35cdd',
           :format => :unknown
-  homepage 'http://xamarin.com/studio'
+  homepage 'https://xamarin.com/studio'
   license :gpl
 
   app 'Xamarin Studio.app'

--- a/Casks/xamarin.rb
+++ b/Casks/xamarin.rb
@@ -2,9 +2,9 @@ cask :v1 => 'xamarin' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.xamarin.com/Installer/Mac/XamarinInstaller.dmg'
+  url 'https://download.xamarin.com/Installer/Mac/XamarinInstaller.dmg'
   name 'Xamarin Platform'
-  homepage 'http://xamarin.com/platform'
+  homepage 'https://xamarin.com/platform'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   installer :manual => 'Install Xamarin.app'

--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -4,7 +4,7 @@ cask :v1 => 'xld' do
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/xld/xld-#{version}.dmg"
-  appcast 'http://xld.googlecode.com/svn/appcast/xld-appcast_e.xml',
+  appcast 'https://xld.googlecode.com/svn/appcast/xld-appcast_e.xml',
           :sha256 => '16420b367df9b64870bd2a38ee20e688d17b065783b93371065ac7094ab93cb0'
   name 'X Lossless Decoder'
   name 'XLD'

--- a/Casks/xmarks-safari.rb
+++ b/Casks/xmarks-safari.rb
@@ -4,7 +4,7 @@ cask :v1 => 'xmarks-safari' do
 
   url "https://static.xmarks.com/clients/safari/xmarks_for_safari_#{version}.dmg"
   name 'Xmarks'
-  homepage 'http://www.xmarks.com/'
+  homepage 'https://www.xmarks.com/'
   license :gratis
 
   pkg 'Xmarks for Safari Installer.pkg'

--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -3,10 +3,10 @@ cask :v1 => 'xquartz' do
   sha256 'c9b3a373b7fd989331117acb9696fffd6b9ee1a08ba838b02ed751b184005211'
 
   url "https://xquartz.macosforge.org/downloads/SL/XQuartz-#{version}.dmg"
-  appcast 'http://xquartz-dl.macosforge.org/sparkle/release.xml',
+  appcast 'https://xquartz-dl.macosforge.org/sparkle/release.xml',
           :sha256 => '9792f0d6abd547e523f6ca33c4dd3847134bc3d46d77ac91b93fe932d6123568'
   name 'XQuartz'
-  homepage 'http://xquartz.macosforge.org/'
+  homepage 'https://xquartz.macosforge.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'XQuartz.pkg'

--- a/Casks/xscope.rb
+++ b/Casks/xscope.rb
@@ -2,8 +2,8 @@ cask :v1 => 'xscope' do
   version '4.1.3'
   sha256 'e967c296b6fd84270d926007b056826b3bc8826744f83ea2bea139609d082ad5'
 
-  url "http://iconfactory.com/assets/software/xscope/xScope-#{version}.zip"
-  appcast 'http://iconfactory.com/appcasts/xScope/appcast.xml',
+  url "https://iconfactory.com/assets/software/xscope/xScope-#{version}.zip"
+  appcast 'https://iconfactory.com/appcasts/xScope/appcast.xml',
           :sha256 => '419794f0698b7ddb0a433e712d68064ce5907253ff849f22de95354d3e7eaa2a'
   name 'xScope'
   homepage 'http://iconfactory.com/software/xscope'

--- a/Casks/xtorrent.rb
+++ b/Casks/xtorrent.rb
@@ -5,7 +5,7 @@ cask :v1 => 'xtorrent' do
   # dreamhosters.com is the official download host per the vendor homepage
   url "http://acquisition.dreamhosters.com/xtorrent/Xtorrent#{version}.dmg"
   name 'Xtorrent'
-  appcast 'http://xtorrent.s3.amazonaws.com/appcast.xml',
+  appcast 'https://xtorrent.s3.amazonaws.com/appcast.xml',
           :sha256 => '21d8752a39782479a9f6f2485b0aba0af3f1f12d17ebc938c7526e5ca1a8b355'
   homepage 'http://www.xtorrent.com'
   license :freemium

--- a/Casks/xtrafinder.rb
+++ b/Casks/xtrafinder.rb
@@ -2,9 +2,9 @@ cask :v1 => 'xtrafinder' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.trankynam.com/xtrafinder/downloads/XtraFinder.dmg'
+  url 'https://www.trankynam.com/xtrafinder/downloads/XtraFinder.dmg'
   name 'XtraFinder'
-  homepage 'http://www.trankynam.com/xtrafinder/'
+  homepage 'https://www.trankynam.com/xtrafinder/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'XtraFinder.pkg'

--- a/Casks/yandex.rb
+++ b/Casks/yandex.rb
@@ -4,7 +4,7 @@ cask :v1 => 'yandex' do
 
   url 'https://download.cdn.yandex.net/browser/yandex/ru/Yandex.dmg'
   name 'Yandex.Browser'
-  homepage 'http://browser.yandex.com/'
+  homepage 'https://browser.yandex.com/'
   license :gratis
 
   app 'Yandex.app'

--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -2,11 +2,11 @@ cask :v1 => 'yate' do
   version :latest
   sha256 :no_check
 
-  url 'http://2manyrobots.com/Builds/Yate/Yate.dmg'
+  url 'https://2manyrobots.com/Builds/Yate/Yate.dmg'
   name 'Yate'
-  appcast 'http://2manyrobots.com/Updates/Yate/appcast.xml',
+  appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml',
           :sha256 => 'dcffb9d2f0b19ef6427906fa1f742d546166f214fcc6d0ae0b423e19a146d8c0'
-  homepage 'http://2manyrobots.com/yate/'
+  homepage 'https://2manyrobots.com/yate/'
   license :commercial
 
   app 'Yate.app'

--- a/Casks/yed.rb
+++ b/Casks/yed.rb
@@ -4,7 +4,7 @@ cask :v1 => 'yed' do
 
   url "https://www.yworks.com/products/yed/demo/yEd-#{version}_with-JRE8.dmg"
   name 'yEd'
-  homepage 'http://www.yworks.com/en/products/yfiles/yed/'
+  homepage 'https://www.yworks.com/en/products/yfiles/yed/'
   license :gratis
   tags :vendor => 'yWorks'
 

--- a/Casks/ynab.rb
+++ b/Casks/ynab.rb
@@ -5,7 +5,7 @@ cask :v1 => 'ynab' do
   url "https://www.youneedabudget.com/CDNOrigin/download/ynab4/liveCaptive/Mac/YNAB4_LiveCaptive_#{version}.dmg"
   name 'YNAB'
   name 'You Need A Budget'
-  homepage 'http://www.youneedabudget.com/'
+  homepage 'https://www.youneedabudget.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'YNAB 4.app'

--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -4,7 +4,7 @@ cask :v1 => 'yourkit-java-profiler' do
 
   url "http://www.yourkit.com/download/yjp-#{version}-mac.zip"
   name 'YourKit Java Profiler'
-  homepage 'http://www.yourkit.com/overview/'
+  homepage 'https://www.yourkit.com/overview/'
   license :commercial
   tags :vendor => 'YourKit'
 

--- a/Casks/youview.rb
+++ b/Casks/youview.rb
@@ -2,8 +2,8 @@ cask :v1 => 'youview' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mrgeckosmedia.com/YouView.zip'
-  appcast 'http://mrgeckosmedia.com/applications/appcast/YouView'
+  url 'https://download.mrgeckosmedia.com/YouView.zip'
+  appcast 'https://mrgeckosmedia.com/applications/appcast/YouView'
   name 'YouView'
   homepage 'https://mrgeckosmedia.com/applications/info/YouView'
   license :oss

--- a/Casks/yubikey-personalization-gui.rb
+++ b/Casks/yubikey-personalization-gui.rb
@@ -4,7 +4,7 @@ cask :v1 => 'yubikey-personalization-gui' do
 
   url "https://developers.yubico.com/yubikey-personalization-gui/Releases/yubikey-personalization-gui-#{version}.pkg"
   name 'YubiKey Personalization GUI'
-  homepage 'http://www.yubico.com/products/services-software/personalization-tools/use/'
+  homepage 'https://www.yubico.com/products/services-software/personalization-tools/use/'
   license :bsd
 
   pkg "yubikey-personalization-gui-#{version}.pkg"

--- a/Casks/zendserver.rb
+++ b/Casks/zendserver.rb
@@ -4,7 +4,7 @@ cask :v1 => 'zendserver' do
 
   url "http://downloads.zend.com/zendserver/#{version}/ZendServer-#{version}-php-5.5.7.dmg"
   name 'Zend Server'
-  homepage 'http://www.zend.com/en/products/server/'
+  homepage 'https://www.zend.com/en/products/server/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Zend Server.pkg'

--- a/Casks/zendstudio.rb
+++ b/Casks/zendstudio.rb
@@ -4,7 +4,7 @@ cask :v1 => 'zendstudio' do
 
   url "http://downloads.zend.com/studio-eclipse/#{version}/ZendStudio-#{version}-macosx.cocoa.x86_64.dmg"
   name 'Zend Studio'
-  homepage 'http://www.zend.com/en/products/studio/'
+  homepage 'https://www.zend.com/en/products/studio/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'ZendStudio.app'

--- a/Casks/zipeg.rb
+++ b/Casks/zipeg.rb
@@ -2,7 +2,7 @@ cask :v1 => 'zipeg' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.zipeg.net/downloads/zipeg_mac.dmg'
+  url 'https://www.zipeg.net/downloads/zipeg_mac.dmg'
   name 'Zipeg'
   homepage 'http://www.zipeg.net/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/zoommy.rb
+++ b/Casks/zoommy.rb
@@ -4,7 +4,7 @@ cask :v1 => 'zoommy' do
 
   url 'http://zoommyapp.com/zoommy.zip'
   name 'Zoommy'
-  homepage 'http://zoommyapp.com/'
+  homepage 'https://zoommyapp.com/'
   license :gratis
 
   app 'Zoommy.app'


### PR DESCRIPTION
I have manually tested all of the links that I have changed to make sure they had valid ssl certificates, they weren't being redirected to http, and that they were actually going to the correct pages. I did not test some of the links to amazonaws, github, and googlecode as it is quite safe to assume they all have proper ssl support. This should cover almost all of the links that can be updated to https.
