### PR TITLE
Update microsoft-lync-plugin caveat

### DIFF
--- a/Casks/microsoft-lync-plugin.rb
+++ b/Casks/microsoft-lync-plugin.rb
@@ -13,4 +13,8 @@ cask :v1 => 'microsoft-lync-plugin' do
                          'Lync.Client.LwaPluginInstaller.*.LwaPlugin.pkg',
                          'Lync.Client.Plugin'
                         ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
According to [this blog post](https://blogs.office.com/2014/11/11/introducing-skype-business/), Microsoft Lync has been replaced by Skype for Business.
