### PR TITLE
Update sencha caveat

### DIFF
--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -24,7 +24,7 @@ cask :v1 => 'sencha' do
     <<-EOS.undent
       Installing this Cask means you have AGREED to the Sencha Cmd License
 
-        http://www.sencha.com/legal/sencha-cmd-license
+        http://www.sencha.com/legal/sencha-tools-software-license-agreement/
 
       Sencha Cmd appends 2 lines to your ~/.bashrc or ~/.profile file:
 


### PR DESCRIPTION
The old license link is broken and according to [this page](http://www.sencha.com/legal/), Sencha Cmd is now under the Tools Software License Agreement.
