### PR TITLE
Attempted to improve cisco-spark uninstall

### DIFF
--- a/Casks/cisco-spark.rb
+++ b/Casks/cisco-spark.rb
@@ -12,6 +12,9 @@ cask :v1 => 'cisco-spark' do
 
   app 'Spark.app'
 
+  uninstall :signal => [
+                        ['TERM', 'Cisco-Systems.Spark']
+                       ]
   zap :delete => [
                    '~/Library/Preferences/Cisco-Systems.Spark.plist',
                    '~/Library/Caches/Cisco-Systems.Spark',


### PR DESCRIPTION
Despite my best attempts, I can't get this background process to quit. Hopefully someone here will be able to get this working. Upon running `brew cask uninstall cisco-spark` (with this update) I get the following error:

```
==> Quitting application ID Cisco-Systems.Spark
Password:
 ==> 45:49: execution error: Spark got an error: User canceled. (-128)
 Error: Command failed to execute!

==> Failed command:
["/usr/bin/sudo", "-E", "--", "/usr/bin/osascript", "-e", "tell application id \\\"Cisco-Systems.Spark\\\" to quit"]

==> Output of failed command:


==> Exit status of failed command:
#<Process::Status: pid 66593 exit 1>
```

I did not press any keys after typing my password that would cause it to cancel the operation. Running `./developer/bin/list_running_app_ids` contains the following line in its output:

```
Cisco-Systems.Spark Spark
```

And running `./developer/bin/list_ids_in_app /Applications/Spark.app` outputs the following result:

```
Cisco-Systems.Spark (+)
Cisco.appshare
com.cisco.MediaSession
com.cisco.tp
com.cisco.util
com.cisco.wbxaecodec
com.cisco.wbxaudioengine
com.cisco.wmeclient
com.cisco.wmeutil
com.cisco.wqos
com.cisco.wrtp
com.cisco.wseclient
com.cisco.wsertp
com.webex.wbxtrace
org.sparkle-project.Sparkle.Autoupdate
```

Finally running `ps axu | grep Spark` results in:

```
<my_username>      66448   0.0  1.1  3852020 189000   ??  S     5:15pm   0:07.35 /opt/homebrew-cask/Caskroom/cisco-spark/latest/Spark.app/Contents/MacOS/Spark
```

Going into Activity Monitory I can see it with the process name Spark. My user account owns the process. I tried running `tell application id "Cisco-Systems.Spark" to quit` in applescript but that resulted in the same user cancelled error. Let me know if there is any other useful information that I can provide. At the moment uninstalling this cask leaves a menu bar icon which stays there until the background process is quit.
