### PR TITLE
Added cask for bordertool 2

### DIFF
--- a/Casks/bordertool-2.rb
+++ b/Casks/bordertool-2.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'bordertool-2' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://xvi.rpc1.org/BorderTool%202.zip'
+  name 'BorderTool 2'
+  homepage 'http://xvi.rpc1.org/'
+  license :gratis
+
+  app 'BorderTool 2.app'
+end


### PR DESCRIPTION
I've added a cask for the BorderTool 2 save editor for Borderlands 2 authored by xvi, available [here](http://xvi.rpc1.org/)
It is important to note that this is not a sequel or a different version of the BorderTool cask I've submitted in a separate request.  This is an entirely different application.
