### PR TITLE
Added cask for bordertool2

### DIFF
--- a/Casks/bordertool2.rb
+++ b/Casks/bordertool2.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'bordertool2' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://xvi.rpc1.org/BorderTool%202.zip'
+  name 'BorderTool 2'
+  homepage 'http://xvi.rpc1.org/'
+  license :gratis
+
+  app 'BorderTool 2.app'
+end


### PR DESCRIPTION
I've added a cask for the BorderTool 2 save editor for Borderlands 2 authored by xvi, available here
It is important to note that this is not a sequel or a different version of the BorderTool cask I've submitted in a separate request. This is an entirely different application.

Name changed per @vitorgalvao instruction [here](https://github.com/caskroom/homebrew-cask/pull/12350)
