### PR TITLE
Update google-chrome 1Password compatibility info

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -28,7 +28,7 @@ cask :v1 => 'google-chrome' do
   caveats <<-EOS.undent
     The Mac App Store version of 1Password won't work with a Homebrew-Cask-linked Google Chrome. To bypass this limitation, you need to either:
 
-      + Move Google Chrome to your /Applications directory (the app itself, not a symlink).
+      + Move Google Chrome to your /Applications directory (the app itself, not a symlink; note that moving to ~/Applications is not sufficient).
       + Install 1Password from outside the Mac App Store (licenses should transfer automatically, but you should contact AgileBits about it).
   EOS
 end


### PR DESCRIPTION
Added a bit more information regarding moving Chrome to Applications folder (that it must be /Applications and not ~/Applications)
