### PR TITLE
Update mirror, previous domain host has expired

### DIFF
--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -2,8 +2,8 @@ cask :v1 => 'snes9x' do
   version '1.53'
   sha256 '48b0cbec848e7c2a24de1b30819dc150b62e354600cbcc0a6a5e2cf8e1de48ff'
 
-  # ipherswipsite.com is the official download host per the vendor homepage
-  url "http://files.ipherswipsite.com/snes9x/snes9x-#{version}-macosx-113.dmg.gz"
+  # s9x-w32.de is the only remaining mac mirror per the vendor homepage
+  url "http://www.s9x-w32.de/dl/snes9x-#{version}-macosx-113.dmg.gz"
   name 'Snes9x'
   homepage 'http://www.snes9x.com/'
   license :other


### PR DESCRIPTION
Previous domain registration for host "ipherswipsite.com" has expired.
