### PR TITLE
Cask changes for Sublime Text

### DIFF
--- a/Casks/sublime-text-2.rb
+++ b/Casks/sublime-text-2.rb
@@ -1,12 +1,12 @@
-cask :v1 => 'sublime-text' do
+cask :v1 => 'sublime-text-2' do
   version '2.0.2'
   sha256 '906e71e19ae5321f80e7cf42eab8355146d8f2c3fd55be1f7fe5c62c57165add'
-
+  
   # rackcdn.com is the official download host per the vendor homepage
   url "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/2/stable/appcast_osx.xml',
           :sha256 => 'e11769f18c577d4cb189c6f6485119a66db5e5d3ba4df99326080f193c1f74b3'
-  name 'Sublime Text'
+  name 'Sublime Text 2'
   homepage 'https://www.sublimetext.com/2'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 

--- a/Casks/sublime-text-3.rb
+++ b/Casks/sublime-text-3.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'sublime-text-3' do
+  version 'Build 3083'
+  sha256 'fe6dd8d8192fdb01988f99289e5bc1d9a4e66cf67548e144002051c23369a5ff'
+
+  url "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20#{URI.escape(version)}.dmg"
+  appcast 'https://www.sublimetext.com/updates/3/stable/appcast_osx.xml',
+          :sha256 => '3e72a8db0cbef96c6d9884f145787f0e1ef07a89846889d61a6a3257464a29fa'
+
+  name 'Sublime Text 3'
+  homepage 'http://www.sublimetext.com/3'
+  license :freemium
+  tags :vendor => 'Sublime Text'
+
+  app 'Sublime Text.app'
+  binary 'Sublime Text.app/Contents/SharedSupport/bin/subl'
+
+end


### PR DESCRIPTION
- Added cask for Sublime Text 3.
- Renamed Sublime Text 2 cask to include version number in order to prevent confusion.
