### PR TITLE
Fix URL in Psequel.app Cask

### DIFF
--- a/Casks/psequel.rb
+++ b/Casks/psequel.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'psequel' do
-  version :latest
-  sha256 :no_check
+  version '1.1.2'
+  sha256 '19c2721002ed35e899bfdc9fd1a52f1d8cbc42e869b407eaf536ce82a32763f5'
 
-  url 'http://www.psequel.com/download'
+  url "http://www.psequel.com/download?version=#{version}"
   name 'PSequel'
   homepage 'http://www.psequel.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :closed
 
   app 'PSequel.app'
 end


### PR DESCRIPTION
URL was unversioned and failed to download.
Also reverted version to 1.1.2 as today's 1.2.0 release is crashing for users, as reported on twitter (@psequel).
