### PR TITLE
Upgrade Charles.app to v3.10.2

### DIFF
--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'charles' do
-  version '3.10.1'
-  sha256 '5d94f04d4936dd1dd9293f406457f13a825422dc28c5146f19581de2f8e76c9d'
+  version '3.10.2'
+  sha256 'd68be46d7dc9654b4b3b094a2f451226376d7bf3c5d401aecba082b27e0b8b6a'
 
   url "http://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
   name 'Charles'


### PR DESCRIPTION
 [Release notes](http://www.charlesproxy.com/documentation/version-history/):

> VERSION 3.10.2
> 
> 7 July 2015
> 
> Bug fixes and improvements.
> - SSL improvements to workaround servers that don't support TLS 1.2 (this became a problem in 3.10 under Java 8)
> - Improve initial focus in dialogs (so you don't need to click into the first text field so much)
> - Copy cURL Request improvements: includes more headers, use --blood instead of --blood-binary when appropriate, and other minor improvements that should make your cURLing better.
> - HAR: support HAR files produced by Chrome
