### PR TITLE
Update remote-desktop-connection

### DIFF
--- a/Casks/remote-desktop-connection.rb
+++ b/Casks/remote-desktop-connection.rb
@@ -8,6 +8,8 @@ cask :v1 => 'remote-desktop-connection' do
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
   tags :vendor => 'Microsoft'
 
+  depends_on :macos => '>= :leopard'
+
   pkg 'RDC Installer.mpkg'
 
   uninstall :pkgutil => 'com.microsoft.rdc.all.*'
@@ -15,6 +17,4 @@ cask :v1 => 'remote-desktop-connection' do
   caveats do
     discontinued
   end
-
-  depends_on :macos => '<= :snow_leopard'
 end


### PR DESCRIPTION
According to the homepage, this should program should work on 10.5.8 and later.

Fixes #12488 
