### PR TITLE
Update sourceforge urls

### DIFF
--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'data-integration' do
-  version :latest
-  sha256 :no_check
+  version '5.4.0.1-130'
+  sha256 '240e72e2227f1e3e4c7b7173a42157a1ba0ef0e2055ffa3122d2f633ca9e14c6'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url 'http://sourceforge.net/projects/pentaho/files/latest/download'
+  url "http://downloads.sourceforge.net/sourceforge/pentaho/pdi-ce-#{version}.zip"
   name 'Pentaho Data Integration'
   homepage 'http://community.pentaho.com'
   license :oss

--- a/Casks/gawker.rb
+++ b/Casks/gawker.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'gawker' do
-  version :latest
-  sha256 :no_check
+  version '0.8.4'
+  sha256 'a834558a7850ef52f03184c628de97f50357ab42efb4725b590d1c47c39b4cd5'
 
-  url 'http://sourceforge.net/projects/gawker/files/latest/download'
+  url "http://downloads.sourceforge.net/sourceforge/gawker/Gawker_#{version}.zip"
   appcast 'http://gawker.sourceforge.net/appcast.xml'
   name 'Gawker'
   homepage 'http://gawker.sourceforge.net/Gawker.html'

--- a/Casks/iupx.rb
+++ b/Casks/iupx.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'iupx' do
-  version :latest
-  sha256 :no_check
+  version '1.2'
+  sha256 '24f2bc2dacd31ce7f3dd883b70b32fc9b8cea447a7b309333108b9888cb194d5'
 
-  url 'http://sourceforge.net/projects/iupx/files/latest/download'
+  url "http://downloads.sourceforge.net/sourceforge/iupx/iUPX_#{version.sub('.','_')}_universal.zip"
   appcast 'http://iupx.sourceforge.net/updates/appcast.xml'
   name 'iUPX'
   homepage 'http://iupx.sourceforge.net'

--- a/Casks/openmsx.rb
+++ b/Casks/openmsx.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'openmsx' do
-  version :latest
-  sha256 :no_check
+  version '0.11.0'
+  sha256 'a8624b266258558dbecc3e9f67f4b7aeab9a44a46714c4a1a9f2881aa99f17b1'
 
-  url 'http://sourceforge.net/projects/openmsx/files/latest/download'
+  url "http://downloads.sourceforge.net/sourceforge/openmsx/openmsx-#{version}-mac-x86_64-bin.dmg"
   name 'openMSX'
   homepage 'http://openmsx.sourceforge.net'
   license :gpl

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -2,7 +2,7 @@ cask :v1 => 'qtspim' do
   version '9.1.15'
   sha256 'd637a6ac90ff5ef8c372219768a97dc55f1bde2d919fce97c371b18011d0f52a'
 
-  url 'http://sourceforge.net/projects/spimsimulator/files/latest/download'
+  url "http://downloads.sourceforge.net/sourceforge/spimsimulator/QtSpim_#{version}_mac.mpkg.zip"
   name 'QtSpim'
   homepage 'http://spimsimulator.sourceforge.net/'
   license :bsd


### PR DESCRIPTION
There were actually surprisingly few sourceforge urls left to change. This should cover them all. The only one that could not be switched to a versioned url is animated-gif-quicklook, which only hosts the latest version.
