### PR TITLE
Update svnx license

### DIFF
--- a/Casks/svnx.rb
+++ b/Casks/svnx.rb
@@ -7,7 +7,7 @@ cask :v1 => 'svnx' do
   appcast 'https://svnx.googlecode.com/svn/wiki/svnX.rss.xml',
           :sha256 => '35166bbbcb22ee3704eddabcf6946eb60f415859c198c8b5480b346334c91056'
   homepage 'https://code.google.com/p/svnx/'
-  license :oss
+  license :gratis
 
   app 'svnX.app'
 end


### PR DESCRIPTION
According to [this page](https://code.google.com/p/svnx/issues/detail?id=200) the svnx source is being updated privately now which means that it should no longer be considered open source.
