### PR TITLE
Update time-tracker

### DIFF
--- a/Casks/time-tracker.rb
+++ b/Casks/time-tracker.rb
@@ -6,8 +6,8 @@ cask :v1 => 'time-tracker' do
   appcast 'https://time-tracker-mac.googlecode.com/svn/appcast/timetracker-test.xml',
           :sha256 => '8737634f2e43e4eaf63d2ab603b47e46c13f3c322e2484b407f45776905777aa'
   name 'TimeTracker'
-  homepage 'https://code.google.com/p/time-tracker-mac'
-  license :oss
+  homepage 'https://github.com/rburgst/time-tracker-mac'
+  license :gpl
 
   app 'Time Tracker.app'
 end


### PR DESCRIPTION
Changed homepage and license.

For the sake of completeness here is an alternative homepage (not chosen because it is out of date): [http://rainer.4950.net/timetracker-for-mac/](http://rainer.4950.net/timetracker-for-mac/)
