### PR TITLE
Added PocketCasts.app v1.0

### DIFF
--- a/Casks/pocketcasts.rb
+++ b/Casks/pocketcasts.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'pocketcasts' do
+  version '1.0'
+  sha256 'fe191ceb3a7157bee5a589bed248464587526ddbaeacab122960a4144d1c87da'
+
+  url 'https://github.com/mortenjust/PocketCastsOSX/releases/download/1.0/PocketCastsOSX1.0.zip'
+  name 'PocketCastsOSX'
+  homepage 'https://github.com/mortenjust/PocketCastsOSX'
+  license :oss
+
+  app 'PocketCasts.app'
+end


### PR DESCRIPTION
PocketCasts.app is an OSX wrapper to be able to use the PocketCasts web player in a separate application. This makes it able to use play/pause keys on your keyboard, which is not possible using the normal web player.
