### PR TITLE
Update pencil license

### DIFF
--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -6,7 +6,7 @@ cask :v1 => 'pencil' do
   url "https://evoluspencil.googlecode.com/files/Pencil-#{version}-mac.tar.bz2"
   name 'Pencil'
   homepage 'http://pencil.evolus.vn'
-  license :oss
+  license :gpl
 
   app 'Pencil.app'
 end


### PR DESCRIPTION
License is GPLv2 as specified on [their google code homepage](https://code.google.com/p/evoluspencil/).
