### PR TITLE
Update port-map to not use google code

### DIFF
--- a/Casks/port-map.rb
+++ b/Casks/port-map.rb
@@ -1,14 +1,15 @@
 cask :v1 => 'port-map' do
-  version '1.3.1-r46'
-  sha256 '50e29f121139ee2f68ad978cb3921ef52f2dbfb5a0131c417516e4e5f1fa64af'
+  version :latest
+  sha256 :no_check
 
-  # googlecode.com is the official download host per the vendor homepage
-  url "https://tcmportmapper.googlecode.com/files/PortMap-#{version}.zip"
+  url 'http://www.codingmonkeys.de/portmap/download'
   appcast 'http://www.codingmonkeys.de/portmap/appcast.rss',
           :sha256 => 'c74b6bc407fe3a5daea1f3be09deabef3590fa5dc63c8ed32062f97d8bf5aa79'
   name 'Port Map'
   homepage 'http://www.codingmonkeys.de/portmap'
-  license :oss
+  license :mit
+
+  depends_on :macos => '>= :tiger'
 
   app 'Port Map.app'
 end


### PR DESCRIPTION
Unfortunately the only url I could find was a latest download. I still think this is an improvement from having a google code url.

See #10461
