### PR TITLE
Update Mumble to v1.2.10

### DIFF
--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'mumble' do
-  version '1.2.9'
-  sha256 'd0c630a4fb65be50407080e2f97a47cd3aeeb67ddc52e9e02dd454421404e449'
+  version '1.2.10'
+  sha256 'f88f56e049b3375544f57777da20ca8461d4b631e4ef0de26fbfc5b789601504'
 
-  url "http://downloads.sourceforge.net/sourceforge/mumble/Mumble-#{version}.dmg"
+  url "https://github.com/mumble-voip/mumble/releases/download/#{version}/Mumble-#{version}.dmg"
   gpg "#{url}.sig",
-      :key_url => 'http://mumble.info/gpg/mumble-auto-build-2014.asc'
+      :key_url => 'http://mumble.info/gpg/mumble-auto-build-2015.asc'
   name 'Mumble'
-  homepage 'http://mumble.sourceforge.net'
+  homepage 'http://www.mumble.info'
   license :bsd
 
   app 'Mumble.app'


### PR DESCRIPTION
Note:
- Mumble now publishes the app through GitHub,
- all their social media profiles link to www.mumble.info as the official homepage,
- the `:key_url` has been updated to actually work.
