### PR TITLE
Add QuickSync v3.3

### DIFF
--- a/Casks/quicksync.rb
+++ b/Casks/quicksync.rb
@@ -2,7 +2,7 @@ cask :v1 => 'quicksync' do
   version '3.3'
   sha256 'e3e64020e952dee692811119f966e1cf62bfc48c5ef110a39e5d92a20e9d0a3a'
 
-  url 'http://www.gigaset.com/fileadmin/gigaset/images/CORE/QuickSync/Mac_V3.3/QuickSync.dmg'
+  url "http://www.gigaset.com/fileadmin/gigaset/images/CORE/QuickSync/Mac_V#{version}/QuickSync.dmg"
   name 'QuickSync'
   homepage 'http://www.gigaset.com/en_US/kundenservice/downloads/quicksync/quicksync-fuer-mac.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/quicksync.rb
+++ b/Casks/quicksync.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'quicksync' do
+  version '3.3'
+  sha256 'e3e64020e952dee692811119f966e1cf62bfc48c5ef110a39e5d92a20e9d0a3a'
+
+  url 'http://www.gigaset.com/fileadmin/gigaset/images/CORE/QuickSync/Mac_V3.3/QuickSync.dmg'
+  name 'QuickSync'
+  homepage 'http://www.gigaset.com/en_US/kundenservice/downloads/quicksync/quicksync-fuer-mac.html'
+  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  app 'QuickSync.app'
+end


### PR DESCRIPTION
Gigaset QuickSync allows you to easy synchronize your Mac OS contacts
with your address data on Gigaset handsets via  Bluetooth®, USB cable or
ethernet (LAN) (depending on the device one or more connection types are
available).
