### PR TITLE
Use HTTP for www.filebot.net

### DIFF
--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -5,7 +5,7 @@ cask :v1 => 'filebot' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/filebot/filebot/FileBot_#{version}/FileBot_#{version}-brew.tar.bz2"
   name 'FileBot'
-  homepage 'https://www.filebot.net/'
+  homepage 'http://www.filebot.net/'
   license :gpl
 
   app 'FileBot.app'


### PR DESCRIPTION
Using HTTPS causes issues with some parts of the homepage.
