### PR TITLE
Upgrade Omnigraffle to v6.2.5

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -8,8 +8,8 @@ cask :v1 => 'omnigraffle' do
     sha256 'a2eff19909d1ba38a4f01b2beecbde2f31f4af43d30e06d2c6921ae8880f85bc'
     url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.8/OmniGraffle-#{version}.dmg"
   else
-    version '6.2.4'
-    sha256 'f3b02a8ce77452209772d724c50a9ec5b4827eb86cd557435ae60938d3c6f5dd'
+    version '6.2.5'
+    sha256 '5ac9ea1fed94b775857e853273f7f0b610fa061b179b2109d246d6b81f5be0f6'
     url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.10/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
This update only affects the OS X 10.10 version of Omnigraffle. The
previous v6.2.4 release has been removed from their site.
