### PR TITLE
Fix android-studio zap :delete path

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -17,7 +17,7 @@ cask :v1 => 'android-studio' do
   zap :delete => [
     '~/Library/Preferences/AndroidStudio*',
     '~/Library/Preferences/com.google.android.studio.plist',
-    '~/Library/Application\ Support/AndroidStudio*',
+    '~/Library/Application Support/AndroidStudio*',
     '~/Library/Logs/AndroidStudio*',
     '~/Library/Caches/AndroidStudio*',
   ],


### PR DESCRIPTION
#10520 implemented the `zap` stanza, deriving it from the following Stack Overflow answer: http://stackoverflow.com/a/18458893

Since the commands in the SO answer did not have the paths in quotes, the space in `~/Library/Application\ Support/AndroidStudio*` was escaped with a backslash. The backslash was imported in the commit as well, even though the path was in quotes, which causes the backslash to be
interpreted literally. This pull request fixes that by removing the backslash.
