### PR TITLE
add cask for Bitdefender Adware Removal Tool 

### DIFF
--- a/Casks/adware-removal-tool.rb
+++ b/Casks/adware-removal-tool.rb
@@ -1,0 +1,16 @@
+cask :v1 => 'adware-removal-tool' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://download.bitdefender.com/mac/tools/Adware%20Removal%20Tool.zip'
+  name 'Bitdefender Adware Removal Tool for Mac'
+  homepage 'http://www.bitdefender.com'
+  license :gratis
+
+  app 'Adware Removal Tool.app'
+
+  zap :trash => [
+    '~/Library/Preferences/com.bitdefender.com.bitdefender.Adware-Removal-Tool.plist',
+    '~/Library/Saved Application State/com.com.bitdefender.Adware-Removal-Tool.savedState'
+  ]
+end


### PR DESCRIPTION
i added adware-removal-tool.rb 
this is new version. 
i asked to pull to add bitdefender-adware-removal-tool.rb before. 
i changed the name to adware-removal-tool.rb to follow ‘token reference’. 
and removed “uninstall :pkgutil” line that was no need. 
