### PR TITLE
Add discontinued to 3 casks

### DIFF
--- a/Casks/instacast.rb
+++ b/Casks/instacast.rb
@@ -10,4 +10,8 @@ cask :v1 => 'instacast' do
   license :commercial
 
   app 'Instacast.app'
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/snowflake.rb
+++ b/Casks/snowflake.rb
@@ -10,4 +10,8 @@ cask :v1 => 'snowflake' do
   license :commercial
 
   app 'Snowflake.app'
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/snowtape.rb
+++ b/Casks/snowtape.rb
@@ -10,4 +10,8 @@ cask :v1 => 'snowtape' do
   license :commercial
 
   app 'Snowtape.app'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
All of Vemedio’s products are now discontinued. The servers will continue to run for people who still use the app for as long as possible. At the moment, their website redirects to http://vemedio.com/discontinued/.

Several articles explaining the reason:
- http://www.news47ell.com/news/vemedio-ran-out-of-money-decide-to-discontinue-their-podcast-app-instacast/
- http://9to5mac.com/2015/06/14/instacast-shuts-down-vemedio-podcast-app/
