### PR TITLE
spideroakone v6

### DIFF
--- a/Casks/spideroak.rb
+++ b/Casks/spideroak.rb
@@ -3,9 +3,9 @@ cask :v1 => 'spideroak' do
   sha256 :no_check
 
   url 'https://spideroak.com/getbuild?platform=mac'
-  name 'SpiderOak'
+  name 'SpiderOakONE'
   homepage 'https://spideroak.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
-  app 'SpiderOak.app'
+  pkg 'SpiderOakONE.pkg'
 end


### PR DESCRIPTION
New name for SpiderOak consumer edition, SpiderOakONE, along with new
version upgrade.  New version is no longer an “app” but a package
installer.  There is no uninstall script and it does not appear to
create any additional directories outside of “Application
Support/SpiderOakONE”.
