### PR TITLE
Use updated key to silence CocoaPods.

### DIFF
--- a/Casks/cocoapods.rb
+++ b/Casks/cocoapods.rb
@@ -15,6 +15,6 @@ cask :v1 => 'cocoapods' do
 
   postflight do
     # Because Homebrew-Cask symlinks the binstub directly, stop the app from asking the user to install the binstub.
-    system 'defaults write org.cocoapods.CocoaPods CPRequestCLIToolInstallationAgain YES'
+    system 'defaults write org.cocoapods.CocoaPods CPDoNotRequestCLIToolInstallationAgain YES'
   end
 end


### PR DESCRIPTION
This key was fixed, as it was actually the inverted case:
https://github.com/CocoaPods/CocoaPods-app/commit/251b407240f153de4d7fc26ffa4db52d79bdf542

/cc @segiddins 
