### PR TITLE
Update Balsamic Mockups 3.app to v3.1.7

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'balsamiq-mockups' do
-  version '3.1.6'
-  sha256 '5f6fec35f0ab2fdaea766b5139cc9ea604782eeda6ac417b606e6d309c7b89b7'
+  version '3.1.7'
+  sha256 'e46f9d6c7abfc95b34ec6ff944efbdef9c256f5ac49fb54767c3f287fe38919a'
 
   # amazonaws is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/build_production/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"


### PR DESCRIPTION
3.1.6 fails because Balsamic deletes non-current CDN hosted files.
