### PR TITLE
Update seashore

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'seashore' do
-  version '0.5.1'
-  sha256 '96463a3642f162a20b160d8df273e9b27a5fdbf9708bee6ebf6a6c8528047765'
+  version :latest
+  sha256 :no_check
 
   url 'http://downloads.sourceforge.net/sourceforge/seashore/Seashore.zip'
   name 'Seashore'


### PR DESCRIPTION
Removed version and checksum because the url is clearly updated in place.
