### PR TITLE
Add oss license information for MacTex

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -6,7 +6,7 @@ cask :v1 => 'mactex' do
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   name 'MacTeX'
   homepage 'https://www.tug.org/mactex/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :oss
 
   pkg "mactex-#{version}.pkg"
 


### PR DESCRIPTION
License information is shown when running the installer from the pkg.
`oss` is the appropriate choice here, as several different licenses are
used within the package. From the license step of the installer:

> TeX Live and teTeX are covered by a variety of licenses (e.g. GNU General Public License, LGPL, BSD license, X license).  All licenses are compatible with the requirements for free and open source software, as far as we know.
