### PR TITLE
gcutil isn't included in google-cloud-sdk any more

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -8,7 +8,6 @@ cask :v1 => 'google-cloud-sdk' do
   tags :vendor => 'Google'
   binary 'google-cloud-sdk/bin/bq'
   binary 'google-cloud-sdk/bin/gcloud'
-  binary 'google-cloud-sdk/bin/gcutil'
   binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', :target => 'git-credential-gcloud'
   binary 'google-cloud-sdk/bin/gsutil'
   installer :script => 'google-cloud-sdk/install.sh',


### PR DESCRIPTION
Currently this Cask doesn't install because `gcutil` has been replaced by `gcloud compute`.

See more here:
https://cloud.google.com/compute/docs/gcloud-compute/transition-gcloud-gcutil
