### PR TITLE
Upgrade Linphone to v3.8.5

### DIFF
--- a/Casks/linphone.rb
+++ b/Casks/linphone.rb
@@ -1,14 +1,25 @@
 cask :v1 => 'linphone' do
-  version '3.8.1'
-  sha256 '925943867ee62c49450bf423479a8eb8cb42107e1319b4054233c4e4ac4a252c'
+  version '3.8.5'
+  sha256 '250d6b0b8ca3fd5029185b479199ae47b5d8c57062007a2bbb864ca63034a5de'
 
   # gnu.org is the official download host per the vendor homepage
-  url "http://download-mirror.savannah.gnu.org/releases/linphone/#{version.sub(%r{\d+$},'')}x/macos/linphone-#{version}.dmg"
+  url "http://download-mirror.savannah.gnu.org/releases/linphone/#{version.sub(%r{\d+$},'')}x/macos/linphone-#{version}.pkg"
   gpg "#{url}.sig",
       :key_id => '3ecd52dee2f56985'
   name 'Linphone'
   homepage 'https://www.linphone.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
+
+  container :type => :xar
+
+  preflight do
+    system '/usr/bin/tar', '-xf', "#{staged_path}/linphone.pkg/Payload", '-C', staged_path
+  end
+
+  postflight do
+    system 'rm', '-rf', "#{staged_path}/linphone.pkg"
+    system 'rm', '-f', "#{staged_path}/Distribution"
+  end
 
   app 'Linphone.app'
 end


### PR DESCRIPTION
Linphone went from .dmg to .pkg with a gzip'd cpio payload inside of it.

the gpg stanza might need to be fixed in the future when it's a
more developed feature.

packed within `linphone.pkg/Scripts` is a postinstall shell script that copies a
downloaded .dylib into `/Applications/Linphone.app` which is unfortunately
inconsistent with brew-cask's default linking to `~/Applications/Linphone.app`...
fortunately, when installing 3.8.5 normally without brew-cask, i did NOT find
that .dylib within the installed .app, so this postinstall script seems to not
be executed. to re-iterate, the cask yields a .app that is identical to what you
get by running the .pkg installer manually.
if not running the postinstall script is that is a bug in Linphone's .pkg, then the
script should be ran by this cask in future versions if Linphone fixes it.
to do this, it would need to be unpacked:
  `system '/usr/bin/tar', '-xf', "#{staged_path}/linphone.pkg/Scripts", '-C', staged_path`
and then, after somehow modifying the path therein as necessary, it should be
executed and removed:
  `system "#{staged_path}/postinstall"`
  `system 'rm', '-f', "#{staged_path}/postinstall"`
