### PR TITLE
Add Tiny.app

### DIFF
--- a/Casks/tiny.rb
+++ b/Casks/tiny.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'tiny' do
+  version '1.0.5'
+  sha256 'a525930919b2cf1ecb60531e5f8787d8657464f861a922e280fdf10a71d0a581'
+
+  # The official download comes from the same domain as the homepage.
+  # The website is hosted on github pages, so the github link is used
+  # to allow for a trusted https connection.
+  url 'https://raw.githubusercontent.com/nicnocquee/delightfuldev-website/gh-pages/tiny/Tiny.zip'
+  appcast 'https://raw.githubusercontent.com/nicnocquee/delightfuldev-website/gh-pages/tiny/update.xml',
+          :sha256 => '3c630fc76fda5c9e1704b1d1a84c43a0a6c96905acb70a4e1c6b71fef9806165'
+  name 'Tiny'
+  homepage 'http://www.delightfuldev.com/tiny/'
+  license :gratis
+
+  app 'Tiny.app'
+
+  depends_on :macos => '>= 10.10'
+end


### PR DESCRIPTION
Notes:
- The official website is hosted on GitHub pages. HTTPS connections do
  not validate on the CNAME domain, so raw.githubusercontent.com links
  are used for secure connections.
- The zip download currently has no version info included. This will
  lead to downloads breaking when a new version is released.
- No formal license document is provided on the homepage, but the
  download modal has this to say about payment:
  
  > No, really, Tiny is FREE. Instead of asking you to pay for my coffee
  > while making this app, I ask you to donate to Wikipedia instead. Or
  > help fund healthcare for patients around the world via Watsi. Or
  > simply make someone's day. As The Doctor said, Be Magnificent!
