### PR TITLE
Add VirtualBox Extension Pack v5.0.0-101573

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,0 +1,24 @@
+cask :v1 => 'virtualbox-extension-pack' do
+  version '5.0.0-101573'
+  sha256 'c357e36368883df821ed092d261890a95c75e50422b75848c40ad20984086a7a'
+
+  url "http://download.virtualbox.org/virtualbox/#{version.sub(/-.*$/, '')}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
+  name 'VirtualBox Extension Pack'
+  homepage 'https://www.virtualbox.org'
+  license :closed
+  tags :vendor => 'Oracle'
+
+  stage_only true
+
+  container :type => :naked
+
+  postflight do
+    system 'sudo', 'VBoxManage', 'extpack', 'install', '--replace', "#{staged_path}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
+  end
+
+  uninstall_postflight do
+    system 'sudo', 'VBoxManage', 'extpack', 'uninstall', 'Oracle VM VirtualBox Extension Pack'
+  end
+
+  depends_on :cask => 'virtualbox'
+end


### PR DESCRIPTION
installs and uninstalls using VBoxManage (part of VirtualBox)

considered putting this into the virtualbox cask, but the licenses are incompatible... doesn't seem right.

naming:
http://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html
on this page, VirtualBox is referred to as `Oracle VM VirtualBox`
the extension pack is referred to as `Oracle VM VirtualBox Extension Pack`
since the existing VirtualBox cask is named `VirtualBox`, naming this one `VirtualBox Extension Pack` would be consistent.

license:
decided on `license :closed` instead of `:gratis` because the end user and what he's doing determines whether or not it's actually free-to-use.
it's free for personal and noncommercial use only...
https://www.virtualbox.org/wiki/VirtualBox_PUEL
