### PR TITLE
Upgrade Koko.app to v0.1.5 with new repo/maintainer

### DIFF
--- a/Casks/koko.rb
+++ b/Casks/koko.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'koko' do
-  version '0.1.1'
-  sha256 '0e39444b40c92eeee0488b1158c2845e7e738b276b91f6c3b0332801486a0375'
+  version '0.1.5'
+  sha256 '1a11817863d21039f02837567112d5e97a5edf6e08f214255ca05ddbf8e80766'
 
-  url "https://github.com/hachibasu/koko/releases/download/v#{version}/koko-mac.zip"
+  url "https://github.com/noraesae/koko/releases/download/v#{version}/koko-mac.zip"
   name 'Koko'
-  homepage 'https://github.com/hachibasu/koko'
+  homepage 'https://github.com/noraesae/koko'
   license :mit
 
   app 'Koko.app'


### PR DESCRIPTION
Ownership was moved from hachibasu to noraesae (based on commit [eb4a34f](https://github.com/noraesae/koko/commit/eb4a34f89d67c17285d9a87619d0e2f5e7d0cb8f))
