### PR TITLE
Fix url in VirtualBox

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -2,7 +2,7 @@ cask :v1 => 'virtualbox' do
   version '5.0.0-101573'
   sha256 '4e27a30af6e4b0f6b1ea69485237d52fc57e6b5608cc234c9480ac0538b31402'
 
-  url "http://download.virtualbox.org/virtualbox/#{version.sub(/-.*$/, '')}/VirtualBox-#{version}-OSX.dmg"
+  url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*},'')}/VirtualBox-#{version}-OSX.dmg"
   name 'VirtualBox'
   homepage 'https://www.virtualbox.org'
   license :gpl


### PR DESCRIPTION
changed url to use the Ruby %r{} expr for version substitution
made consistent with change made to virtualbox-extension-pack url

see:
https://github.com/caskroom/homebrew-cask/pull/12806
https://github.com/ftc2/homebrew-cask/commit/f7343bc20fe60d08a8238b15c38251106a6382d8
--> https://github.com/caskroom/homebrew-cask/commit/c22c57fdb44d43f5e145cd2df157ad990ef1df40
