### PR TITLE
Add ScanSnap Manager for Fujitsu ScanSnap iX500.

### DIFF
--- a/Casks/scansnap-manager-ix500.rb
+++ b/Casks/scansnap-manager-ix500.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'scansnap-manager-ix500' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://origin.pfultd.com/downloads/IMAGE/driver/ss/mgr/m-ix500/ScanSnap.dmg'
+  name 'ScanSnap Manager for Fujitsu ScanSnap iX500'
+  homepage 'http://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/ix500.html'
+  license :gratis
+
+  pkg 'ScanSnap Manager.pkg'
+
+  uninstall :pkgutil => 'jp.co.pfu.ScanSnap.*'
+  
+  depends_on :macos => '>= :lion'
+end


### PR DESCRIPTION
I just cribbed off of the other ScanSnap Manager packages.

I know this works.

However, the installer does pop open an interactive prompt to set up the scanner. I don't know if that makes it inappropriate for Homebrew Cask.

Feedback welcome.
