### PR TITLE
Update gprojector.rb with versioned app.

### DIFF
--- a/Casks/gprojector.rb
+++ b/Casks/gprojector.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'gprojector' do
-  version :latest
-  sha256 :no_check
+  version '1.7.4'
+  sha256 '6e8d8c5659b8d9719cbf1ac95a1fee814a8411362639493ecfa383a6b929fb71'
 
-  url 'http://www.giss.nasa.gov/tools/gprojector/GProjectorOSX.dmg'
+  url 'http://www.giss.nasa.gov/tools/gprojector/G.ProjectorOSX-1.7.4.dmg'
   name 'G.Projector'
   homepage 'http://www.giss.nasa.gov/tools/gprojector/'
   license :gratis
 
-  app 'G.ProjectorOSX/G.Projector.app'
+  app 'G.Projector.app'
 
   caveats <<-EOS.undent
     #{token} requires Java 7+, you can install the latest Java using


### PR DESCRIPTION
As of July 18, G.Projector is versioned and its URL changed.
Update the Cask accordingly to fix installation.
