### PR TITLE
Etrecheck: update license to GPL

### DIFF
--- a/Casks/etrecheck.rb
+++ b/Casks/etrecheck.rb
@@ -5,7 +5,7 @@ cask :v1 => 'etrecheck' do
   url 'http://www.etresoft.com/download/EtreCheck.zip'
   name 'EtreCheck'
   homepage 'http://www.etresoft.com/etrecheck'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'EtreCheck.app'
 end


### PR DESCRIPTION
License is GPL according to https://github.com/etresoft/EtreCheck/blob/master/LICENSE
