### PR TITLE
Upgrade  TLA+ Toolbox to 1.5.1

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'tla-plus-toolbox' do
-  version '1.4.8'
-  sha256 '7f7aec6cc69af1bdbe01e35110939f83b4f880aeec88ce069b9128ab1653da3a'
+  version '1.5.1'
+  sha256 'd0d966c6742c6011d46e6de6760bf7300ed49649a85bccab0b097b0ec5ad42cd'
 
   # inria.fr is the official download host per the vendor homepage
-  url 'https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-1.4.8-macosx.cocoa.x86_64.zip'
+  url 'https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-1.5.1-macosx.cocoa.x86_64.zip'
   name 'TLA+ Toolbox'
   homepage 'http://research.microsoft.com/en-us/um/people/lamport/tla/toolbox.html'
   license :mit


### PR DESCRIPTION
This updates TLA+ Toolbox to version 1.5.1.
