### PR TITLE
Add set_permissions, set_ownership, current_user helpers for postflight and uninstall_preflight blocks

### DIFF
--- a/lib/hbc/dsl/postflight.rb
+++ b/lib/hbc/dsl/postflight.rb
@@ -21,4 +21,20 @@ class Hbc::DSL::Postflight < Hbc::DSL::Base
     Hbc::Utils.method_missing_message(method, @cask.to_s, 'postflight')
     return nil
   end
+
+  def set_permissions(path, permissions_str)
+    full_path = Pathname(path).expand_path
+    @command.run!('/bin/chmod', args: ['-R', '--', permissions_str, full_path],
+                                sudo: true)
+  end
+
+  def set_ownership(path, user: current_user, group: 'staff')
+    full_path = Pathname(path).expand_path
+    @command.run!('/usr/sbin/chown', args: ['-R', '--', "#{user}:#{group}", full_path],
+                                     sudo: true)
+  end
+
+  def current_user
+    Etc.getpwuid(Process.euid).name
+  end
 end

--- a/lib/hbc/dsl/postflight.rb
+++ b/lib/hbc/dsl/postflight.rb
@@ -22,15 +22,15 @@ class Hbc::DSL::Postflight < Hbc::DSL::Base
     return nil
   end
 
-  def set_permissions(path, permissions_str)
-    full_path = Pathname(path).expand_path
-    @command.run!('/bin/chmod', args: ['-R', '--', permissions_str, full_path],
+  def set_permissions(paths, permissions_str)
+    full_paths = Array(paths).map { |p| Pathname(p).expand_path }
+    @command.run!('/bin/chmod', args: ['-R', '--', permissions_str] + full_paths,
                                 sudo: true)
   end
 
-  def set_ownership(path, user: current_user, group: 'staff')
-    full_path = Pathname(path).expand_path
-    @command.run!('/usr/sbin/chown', args: ['-R', '--', "#{user}:#{group}", full_path],
+  def set_ownership(paths, user: current_user, group: 'staff')
+    full_paths = Array(paths).map { |p| Pathname(p).expand_path }
+    @command.run!('/usr/sbin/chown', args: ['-R', '--', "#{user}:#{group}"] + full_paths,
                                      sudo: true)
   end
 

--- a/lib/hbc/dsl/postflight.rb
+++ b/lib/hbc/dsl/postflight.rb
@@ -21,20 +21,4 @@ class Hbc::DSL::Postflight < Hbc::DSL::Base
     Hbc::Utils.method_missing_message(method, @cask.to_s, 'postflight')
     return nil
   end
-
-  def set_permissions(paths, permissions_str)
-    full_paths = Array(paths).map { |p| Pathname(p).expand_path }
-    @command.run!('/bin/chmod', args: ['-R', '--', permissions_str] + full_paths,
-                                sudo: true)
-  end
-
-  def set_ownership(paths, user: current_user, group: 'staff')
-    full_paths = Array(paths).map { |p| Pathname(p).expand_path }
-    @command.run!('/usr/sbin/chown', args: ['-R', '--', "#{user}:#{group}"] + full_paths,
-                                     sudo: true)
-  end
-
-  def current_user
-    Etc.getpwuid(Process.euid).name
-  end
 end

--- a/lib/hbc/staged.rb
+++ b/lib/hbc/staged.rb
@@ -25,4 +25,20 @@ module Hbc::Staged
       raise Hbc::CaskError.new("#{@cask.token}: 'bundle_identifier' failed with: #{e}")
     end
   end
+
+  def set_permissions(paths, permissions_str)
+    full_paths = Array(paths).map { |p| Pathname(p).expand_path }
+    @command.run!('/bin/chmod', args: ['-R', '--', permissions_str] + full_paths,
+                                sudo: true)
+  end
+
+  def set_ownership(paths, user: current_user, group: 'staff')
+    full_paths = Array(paths).map { |p| Pathname(p).expand_path }
+    @command.run!('/usr/sbin/chown', args: ['-R', '--', "#{user}:#{group}"] + full_paths,
+                                     sudo: true)
+  end
+
+  def current_user
+    Etc.getpwuid(Process.euid).name
+  end
 end

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -52,4 +52,27 @@ describe Hbc::DSL::Postflight do
     )
     @dsl.suppress_move_to_applications :key => 'suppressMoveToApplications'
   end
+
+  it "can set the permissions of a file" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/bin/chmod', '-R', '--', '777', Pathname('/path/to/file')]
+    )
+    @dsl.set_permissions('/path/to/file', '777')
+  end
+
+  it "can set the ownership of a file" do
+    @dsl.stubs(:current_user => 'fake_user')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'fake_user:staff', Pathname('/path/to/file')]
+    )
+    @dsl.set_ownership('/path/to/file')
+  end
+
+  it "can set the ownership of a file with a different user and group" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'other_user:other_group', Pathname('/path/to/file')]
+    )
+    @dsl.set_ownership('/path/to/file', user: 'other_user', group: 'other_group')
+  end
 end

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -60,6 +60,13 @@ describe Hbc::DSL::Postflight do
     @dsl.set_permissions('/path/to/file', '777')
   end
 
+  it "can set the permissions of multiple files" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/bin/chmod', '-R', '--', '777', Pathname('/path/to/file'), Pathname('/path/to/other-file')]
+    )
+    @dsl.set_permissions(['/path/to/file', '/path/to/other-file'], '777')
+  end
+
   it "can set the ownership of a file" do
     @dsl.stubs(:current_user => 'fake_user')
 
@@ -67,6 +74,15 @@ describe Hbc::DSL::Postflight do
       ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'fake_user:staff', Pathname('/path/to/file')]
     )
     @dsl.set_ownership('/path/to/file')
+  end
+
+  it "can set the ownership of multiple files" do
+    @dsl.stubs(:current_user => 'fake_user')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'fake_user:staff', Pathname('/path/to/file'), Pathname('/path/to/other-file')]
+    )
+    @dsl.set_ownership(['/path/to/file', '/path/to/other-file'])
   end
 
   it "can set the ownership of a file with a different user and group" do

--- a/test/cask/dsl/postflight_test.rb
+++ b/test/cask/dsl/postflight_test.rb
@@ -35,24 +35,6 @@ describe Hbc::DSL::Postflight do
     @dsl.plist_set(':JVMOptions:JVMVersion', '1.6+')
   end
 
-  it "can suppress move to applications folder alert " do
-    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
-
-    Hbc::FakeSystemCommand.expects_command(
-      ['/usr/bin/defaults', 'write', 'com.example.BasicCask', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true']
-    )
-    @dsl.suppress_move_to_applications
-  end
-
-  it "can suppress move to applications folder alert with a different key" do
-    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
-
-    Hbc::FakeSystemCommand.expects_command(
-      ['/usr/bin/defaults', 'write', 'com.example.BasicCask', 'suppressMoveToApplications', '-bool', 'true']
-    )
-    @dsl.suppress_move_to_applications :key => 'suppressMoveToApplications'
-  end
-
   it "can set the permissions of a file" do
     Hbc::FakeSystemCommand.expects_command(
       ['/usr/bin/sudo', '-E', '--', '/bin/chmod', '-R', '--', '777', Pathname('/path/to/file')]
@@ -90,5 +72,23 @@ describe Hbc::DSL::Postflight do
       ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'other_user:other_group', Pathname('/path/to/file')]
     )
     @dsl.set_ownership('/path/to/file', user: 'other_user', group: 'other_group')
+  end
+
+  it "can suppress move to applications folder alert " do
+    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/defaults', 'write', 'com.example.BasicCask', 'moveToApplicationsFolderAlertSuppress', '-bool', 'true']
+    )
+    @dsl.suppress_move_to_applications
+  end
+
+  it "can suppress move to applications folder alert with a different key" do
+    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/defaults', 'write', 'com.example.BasicCask', 'suppressMoveToApplications', '-bool', 'true']
+    )
+    @dsl.suppress_move_to_applications :key => 'suppressMoveToApplications'
   end
 end

--- a/test/cask/dsl/uninstall_preflight_test.rb
+++ b/test/cask/dsl/uninstall_preflight_test.rb
@@ -5,4 +5,72 @@ describe Hbc::DSL::UninstallPreflight do
     cask = Hbc.load('basic-cask')
     @dsl = Hbc::DSL::UninstallPreflight.new(cask, Hbc::FakeSystemCommand)
   end
+
+  it "can run system commands with list-form arguments" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['echo', 'homebrew-cask', 'rocks!']
+    )
+    @dsl.system_command("echo", :args => ["homebrew-cask", "rocks!"])
+  end
+
+  it "can get the Info.plist file for the primary app" do
+    @dsl.info_plist_file.to_s.must_include 'basic-cask/1.2.3/TestCask.app/Contents/Info.plist'
+  end
+
+  it "can execute commands on the Info.plist file" do
+    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/libexec/PlistBuddy', '-c', 'Print CFBundleIdentifier', @dsl.info_plist_file]
+    )
+    @dsl.plist_exec('Print CFBundleIdentifier')
+  end
+
+  it "can set a key in the Info.plist file" do
+    @dsl.stubs(:bundle_identifier => 'com.example.BasicCask')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/libexec/PlistBuddy', '-c', 'Set :JVMOptions:JVMVersion 1.6+', @dsl.info_plist_file]
+    )
+    @dsl.plist_set(':JVMOptions:JVMVersion', '1.6+')
+  end
+
+  it "can set the permissions of a file" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/bin/chmod', '-R', '--', '777', Pathname('/path/to/file')]
+    )
+    @dsl.set_permissions('/path/to/file', '777')
+  end
+
+  it "can set the permissions of multiple files" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/bin/chmod', '-R', '--', '777', Pathname('/path/to/file'), Pathname('/path/to/other-file')]
+    )
+    @dsl.set_permissions(['/path/to/file', '/path/to/other-file'], '777')
+  end
+
+  it "can set the ownership of a file" do
+    @dsl.stubs(:current_user => 'fake_user')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'fake_user:staff', Pathname('/path/to/file')]
+    )
+    @dsl.set_ownership('/path/to/file')
+  end
+
+  it "can set the ownership of multiple files" do
+    @dsl.stubs(:current_user => 'fake_user')
+
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'fake_user:staff', Pathname('/path/to/file'), Pathname('/path/to/other-file')]
+    )
+    @dsl.set_ownership(['/path/to/file', '/path/to/other-file'])
+  end
+
+  it "can set the ownership of a file with a different user and group" do
+    Hbc::FakeSystemCommand.expects_command(
+      ['/usr/bin/sudo', '-E', '--', '/usr/sbin/chown', '-R', '--', 'other_user:other_group', Pathname('/path/to/file')]
+    )
+    @dsl.set_ownership('/path/to/file', user: 'other_user', group: 'other_group')
+  end
 end


### PR DESCRIPTION
These should help to reduce clutter in Casks that require a postflight change to file permissions or ownership.

Refs #12604
