### PR TITLE
Docs for set_permissions, set_ownership, current_user helpers for postflight and uninstall_preflight blocks

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -945,7 +945,7 @@ A fully manual method for finding bundle ids in a package file follows:
   5. Once bundle ids have been identified, the unpacked package directory can be deleted.
 
 
-## Postflight Stanza Details
+## Postflight and Uninstall_preflight Stanza Details
 
 ### Evaluation of Blocks is Always Deferred
 
@@ -954,20 +954,26 @@ and `uninstall_postflight` are not evaluated until install time or uninstall
 time.  Within a block, you may refer to the `@cask` instance variable, and
 invoke any method available on `@cask`.
 
-### Postflight Mini-DSL
+### Postflight and Uninstall_preflight Mini-DSL
 
 There is a mini-DSL available within `postflight` blocks.
 
 The following methods may be called to perform standard postflight tasks:
 
-| method                          | description |
-| ------------------------------- | ----------- |
-| `plist_set(key, value)`         | set a value in the `Info.plist` file for the app bundle.  Example: [`rubymine.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/rubymine.rb#L12)
-| `suppress_move_to_applications` | suppress a dialog asking the user to move the app to the `/Applications` folder.  Example: [`github.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/github.rb#L13).
+| method                                    | description |
+| ----------------------------------------- | ----------- |
+| `plist_set(key, value)`                   | set a value in the `Info.plist` file for the app bundle.  Example: [`rubymine.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/rubymine.rb#L12)
+| `set_ownership(paths)`                    | set user and group ownership of `paths`. Example: [`unifi-controller.rb`](https://github.com/caskroom/homebrew-cask/blob/8a452a41707af6a661049da6254571090fac5418/Casks/unifi-controller.rb#L13)
+| `set_permissions(paths, permissions_str)` | set permissions in `paths` to `permissions_str` Example: [`docker-machine.rb`](https://github.com/caskroom/homebrew-cask/blob/8a452a41707af6a661049da6254571090fac5418/Casks/docker-machine.rb#L16)
+| `suppress_move_to_applications`           | suppress a dialog asking the user to move the app to the `/Applications` folder.  Example: [`github.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/github.rb#L13).
 
 `plist_set` currently has the limitation that it only operates on the
 bundle indicated by the first `app` stanza (and the Cask must contain
 an `app` stanza).
+
+`set_ownership(paths)` defaults user ownership to the current user and
+group ownership to 'staff'. These can be changed by passing in extra options:
+`set_ownership(paths, user: 'user', group: 'group')`.
 
 `suppress_move_to_applications` optionally accepts a `:key` parameter for
 apps which use a nonstandard `defaults` key.  Example: [`alfred.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/alfred.rb).

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -25,7 +25,7 @@ Cask Domain-Specific Language (DSL) which are not needed in most cases.
  * [Depends_on Stanza Details](#depends_on-stanza-details)
  * [Conflicts_with Stanza Details](#conflicts_with-stanza-details)
  * [Uninstall Stanza Details](#uninstall-stanza-details)
- * [Postflight Stanza Details](#postflight-stanza-details)
+ * [\*flight Stanza Details](#flight-stanzas-details)
  * [Zap Stanza Details](#zap-stanza-details)
  * [Arbitrary Ruby Methods](#arbitrary-ruby-methods)
  * [Revisions to the Cask DSL](#revisions-to-the-cask-dsl)
@@ -945,7 +945,7 @@ A fully manual method for finding bundle ids in a package file follows:
   5. Once bundle ids have been identified, the unpacked package directory can be deleted.
 
 
-## Postflight and Uninstall_preflight Stanza Details
+## \*flight Stanzas Details
 
 ### Evaluation of Blocks is Always Deferred
 
@@ -954,18 +954,18 @@ and `uninstall_postflight` are not evaluated until install time or uninstall
 time.  Within a block, you may refer to the `@cask` instance variable, and
 invoke any method available on `@cask`.
 
-### Postflight and Uninstall_preflight Mini-DSL
+### \*flight Mini-DSL
 
-There is a mini-DSL available within `postflight` blocks.
+There is a mini-DSL available within these blocks.
 
-The following methods may be called to perform standard postflight tasks:
+The following methods may be called to perform standard tasks:
 
-| method                                    | description |
-| ----------------------------------------- | ----------- |
-| `plist_set(key, value)`                   | set a value in the `Info.plist` file for the app bundle.  Example: [`rubymine.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/rubymine.rb#L12)
-| `set_ownership(paths)`                    | set user and group ownership of `paths`. Example: [`unifi-controller.rb`](https://github.com/caskroom/homebrew-cask/blob/8a452a41707af6a661049da6254571090fac5418/Casks/unifi-controller.rb#L13)
-| `set_permissions(paths, permissions_str)` | set permissions in `paths` to `permissions_str` Example: [`docker-machine.rb`](https://github.com/caskroom/homebrew-cask/blob/8a452a41707af6a661049da6254571090fac5418/Casks/docker-machine.rb#L16)
-| `suppress_move_to_applications`           | suppress a dialog asking the user to move the app to the `/Applications` folder.  Example: [`github.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/github.rb#L13).
+| method                                    | availability                        | description |
+| ----------------------------------------- | ----------------------------------- | ----------- |
+| `plist_set(key, value)`                   | `postflight`, `uninstall_preflight` | set a value in the `Info.plist` file for the app bundle.  Example: [`rubymine.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/rubymine.rb#L12)
+| `set_ownership(paths)`                    | `postflight`, `uninstall_preflight` | set user and group ownership of `paths`. Example: [`unifi-controller.rb`](https://github.com/caskroom/homebrew-cask/blob/8a452a41707af6a661049da6254571090fac5418/Casks/unifi-controller.rb#L13)
+| `set_permissions(paths, permissions_str)` | `postflight`, `uninstall_preflight` | set permissions in `paths` to `permissions_str` Example: [`docker-machine.rb`](https://github.com/caskroom/homebrew-cask/blob/8a452a41707af6a661049da6254571090fac5418/Casks/docker-machine.rb#L16)
+| `suppress_move_to_applications`           | `postflight`                        | suppress a dialog asking the user to move the app to the `/Applications` folder.  Example: [`github.rb`](https://github.com/caskroom/homebrew-cask/blob/c5dbc58b7c1b6290b611677882b205d702b29190/Casks/github.rb#L13).
 
 `plist_set` currently has the limitation that it only operates on the
 bundle indicated by the first `app` stanza (and the Cask must contain

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -54,7 +54,7 @@ features which are available for the current Cask.
  * [`installer :script`](CASK_LANGUAGE_REFERENCE.md#installer-script)
  * [`license`](CASK_LANGUAGE_REFERENCE.md#license-stanza-details)
  * [`name`](CASK_LANGUAGE_REFERENCE.md#name-stanza-details)
- * [`postflight plist_set`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
+ * [`*flight plist_set`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
  * [`postflight suppress_move_to_applications`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
  * [`stage_only`](CASK_LANGUAGE_REFERENCE.md#at-least-one-artifact-stanza-is-also-required)
    * replaced undocumented `caskroom_only`
@@ -66,8 +66,8 @@ features which are available for the current Cask.
  * [`zap`](CASK_LANGUAGE_REFERENCE.md#zap-stanza-details)
 
 ### (1.1)
- * [`postflight set_ownership`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
- * [`postflight set_permissions`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
+ * [`*flight set_ownership`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
+ * [`*flight set_permissions`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
 
 
 ## Renamed Forms (1.0)
@@ -153,14 +153,14 @@ For use in *eg* interpolation:
  * [`free_license(web_page)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
 
 
-## Postflight and Uninstall_preflight Mini-DSL (1.0)
+## \*flight Mini-DSL (1.0)
 ### (1.0)
- * [`plist_set`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
- * [`suppress_move_to_applications`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
+ * [`plist_set`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
+ * [`suppress_move_to_applications`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
 
 ### (1.1)
- * [`set_ownership`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
- * [`set_permissions`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
+ * [`set_ownership`](CASK_LANGUAGE_REFERENCE.md#*flight-stanzas-details)
+ * [`set_permissions`](CASK_LANGUAGE_REFERENCE.md#*flight-stanzas-details)
 
 ## References
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -41,8 +41,8 @@ The term `:v1` identifies the DSL version (currently 1.0), and defines the
 features which are available for the current Cask.
 
 
-## New Forms (1.0)
-
+## New Forms
+###(1.0)
  * [`appcast`](CASK_LANGUAGE_REFERENCE.md#appcast-stanza-details)
  * [`artifact`](CASK_LANGUAGE_REFERENCE.md#at-least-one-artifact-stanza-is-also-required)
  * [`depends_on :cask`](CASK_LANGUAGE_REFERENCE.md#depends_on-stanza-details)
@@ -64,6 +64,10 @@ features which are available for the current Cask.
  * [`uninstall :trash`](CASK_LANGUAGE_REFERENCE.md#uninstall-key-trash)
    * *stub* - currently just a synonym for `uninstall :delete`
  * [`zap`](CASK_LANGUAGE_REFERENCE.md#zap-stanza-details)
+
+### (1.1)
+ * [`postflight set_ownership`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
+ * [`postflight set_permissions`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
 
 
 ## Renamed Forms (1.0)
@@ -138,7 +142,6 @@ For use in *eg* interpolation:
 
 ## Caveats Mini-DSL
 ### (1.0)
-
  * [`files_in_usr_local`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`logout`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
  * [`path_environment_variable(path)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
@@ -150,11 +153,14 @@ For use in *eg* interpolation:
  * [`free_license(web_page)`](CASK_LANGUAGE_REFERENCE.md#caveats-mini-dsl)
 
 
-## Postflight Mini-DSL (1.0)
-
+## Postflight and Uninstall_preflight Mini-DSL (1.0)
+### (1.0)
  * [`plist_set`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
  * [`suppress_move_to_applications`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
 
+### (1.1)
+ * [`set_ownership`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
+ * [`set_permissions`](CASK_LANGUAGE_REFERENCE.md#postflight-stanza-details)
 
 ## References
 


### PR DESCRIPTION
Refs #12977.

Note: do not forget to update examples in `doc/CASK_LANGUAGE_REFERENCE.md` after casks are updated.
