### PR TITLE
Update casks to use set_ownership helper

### DIFF
--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -8,9 +8,9 @@ cask :v1 => 'mamp' do
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "MAMP_MAMP_PRO_#{version}.pkg"
+
   postflight do
-    system '/usr/bin/sudo', '-E', '--',
-           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", '/Applications/MAMP', '/Applications/MAMP PRO'
+    set_ownership ['/Applications/MAMP', '/Applications/MAMP PRO']
   end
 
   uninstall :pkgutil => 'de.appsolute.installer.(mamp|mampacticon|mampendinstall|mamppro).pkg',

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -10,8 +10,7 @@ cask :v1 => 'private-internet-access' do
   installer :script => 'Private Internet Access Installer.app/Contents/MacOS/runner.sh'
 
   postflight do
-    system '/usr/bin/sudo', '-E', '--',
-           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", Pathname.new(File.expand_path('~')).join('.pia_manager')
+    set_ownership '~/.pia_manager'
   end
 
   uninstall :delete => '/Applications/Private Internet Access.app'

--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -16,8 +16,7 @@ cask :v1 => 'sencha' do
                        }
 
   postflight do
-    system  '/usr/bin/sudo', '-E', '--',
-            '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", '/opt/Sencha'
+    set_ownership '/opt/Sencha'
   end
 
   caveats do

--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -10,8 +10,7 @@ cask :v1 => 'unifi-controller' do
   pkg 'Unifi.pkg'
 
   postflight do
-    system '/usr/bin/sudo', '-E', '--',
-           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", Pathname.new(File.expand_path('~')).join('Library/Application Support/UniFi')
+    set_ownership '~/Library/Application Support/UniFi'
   end
 
   uninstall :pkgutil => 'com.ubnt.UniFi'

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -16,8 +16,7 @@ cask :v1 => 'vmware-fusion' do
   app 'VMware Fusion.app'
 
   uninstall_preflight do
-    system '/usr/bin/sudo', '-E', '--',
-           '/usr/sbin/chown', '-R', '--', "#{Etc.getpwuid(Process.euid).name}:staff", "#{staged_path}/VMware Fusion.app"
+    set_ownership "#{staged_path}/VMware Fusion.app"
   end
 
   zap :delete => [


### PR DESCRIPTION
Update `mamp`, `private-internet-access`, `sencha`, `unifi-controller`, and `vmware-fusion` casks to use the `set_ownership` helper for `postflight` and `uninstall_preflight` blocks.
