### PR TITLE
Update casks to use set_permissions helper

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -12,6 +12,6 @@ cask :v1 => 'adobe-arh' do
   binary 'arh'
 
   postflight do
-    system '/bin/chmod', '--', '755', "#{staged_path}/arh"
+    set_permissions "#{staged_path}/arh", '755'
   end
 end

--- a/Casks/docker-compose.rb
+++ b/Casks/docker-compose.rb
@@ -13,7 +13,7 @@ cask :v1 => 'docker-compose' do
   binary 'docker-compose-Darwin-x86_64', :target => 'docker-compose'
 
   postflight do
-    system '/bin/chmod', '--', '0755', "#{staged_path}/docker-compose-Darwin-x86_64"
+    set_permissions "#{staged_path}/docker-compose-Darwin-x86_64", '0755'
   end
 
   depends_on :formula => 'docker'

--- a/Casks/docker-machine.rb
+++ b/Casks/docker-machine.rb
@@ -13,7 +13,7 @@ cask :v1 => 'docker-machine' do
   binary 'docker-machine_darwin-amd64', :target => 'docker-machine'
 
   postflight do
-    system '/bin/chmod', '--', '0755', "#{staged_path}/docker-machine_darwin-amd64"
+    set_permissions "#{staged_path}/docker-machine_darwin-amd64", '0755'
   end
 
   depends_on :formula => 'docker'

--- a/Casks/dogestry.rb
+++ b/Casks/dogestry.rb
@@ -12,6 +12,6 @@ cask :v1 => 'dogestry' do
   binary "dogestry-darwin-#{version}", :target => 'dogestry'
 
   postflight do
-    system '/bin/chmod', '--', '0755', "#{staged_path}/dogestry-darwin-#{version}"
+    set_permissions "#{staged_path}/dogestry-darwin-#{version}", '0755'
   end
 end

--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -12,6 +12,6 @@ cask :v1 => 'hex-fiend' do
   app 'Hex Fiend.app'
 
   postflight do
-    system '/bin/chmod', '-R', 'og=u', "#{staged_path}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework"
+    set_permissions "#{staged_path}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework", 'og=u'
   end
 end

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -10,6 +10,6 @@ cask :v1 => 'jxplorer' do
 
   app "jxplorer-#{version}.app"
   postflight do
-    system '/bin/chmod', '--', 'a+x', "#{staged_path}/jxplorer-#{version}.app/Contents/MacOS/jxplorer"
+    set_permissions "#{staged_path}/jxplorer-#{version}.app/Contents/MacOS/jxplorer", 'a+x'
   end
 end

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -9,6 +9,7 @@ cask :v1 => 'jxplorer' do
   license :apache
 
   app "jxplorer-#{version}.app"
+
   postflight do
     set_permissions "#{staged_path}/jxplorer-#{version}.app/Contents/MacOS/jxplorer", 'a+x'
   end

--- a/Casks/onlabs.rb
+++ b/Casks/onlabs.rb
@@ -13,6 +13,6 @@ cask :v1 => 'onlabs' do
   binary 'onlabs_darwin_amd64', :target => 'onlabs'
 
   postflight do
-    system '/bin/chmod', '755', "#{staged_path}/onlabs_darwin_amd64"
+    set_permissions "#{staged_path}/onlabs_darwin_amd64", '755'
   end
 end

--- a/Casks/openarena.rb
+++ b/Casks/openarena.rb
@@ -10,6 +10,6 @@ cask :v1 => 'openarena' do
   app "openarena-#{version}/OpenArena.app"
 
   postflight do
-    system '/bin/chmod', '--', '755', "#{staged_path}/openarena-#{version}/OpenArena.app/Contents/MacOS/openarena.ub"
+    set_permissions "#{staged_path}/openarena-#{version}/OpenArena.app/Contents/MacOS/openarena.ub", '755'
   end
 end

--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -13,6 +13,6 @@ cask :v1 => 'parse' do
   binary 'parse-latest', :target => 'parse'
 
   postflight do
-    system '/bin/chmod', '--', '0755', "#{staged_path}/parse-latest"
+    set_permissions "#{staged_path}/parse-latest", '0755'
   end
 end

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -11,6 +11,6 @@ cask :v1 => 'pd-extended' do
   app 'Pd-extended.app'
 
   postflight do
-    system '/bin/chmod', '-R', '--', 'u+w', "#{staged_path}/Pd-extended.app"
+    set_permissions "#{staged_path}/Pd-extended.app", 'u+w'
   end
 end

--- a/Casks/pd.rb
+++ b/Casks/pd.rb
@@ -10,6 +10,6 @@ cask :v1 => 'pd' do
   app 'Pd-0.46-6-64bit.app'
 
   postflight do
-    system '/bin/chmod', '-R', '--', 'u+w', "#{staged_path}/Pd-0.46-5-64bit.app"
+    set_permissions "#{staged_path}/Pd-0.46-5-64bit.app", 'u+w'
   end
 end

--- a/Casks/quick-search-box.rb
+++ b/Casks/quick-search-box.rb
@@ -11,7 +11,7 @@ cask :v1_1 => 'quick-search-box' do
   app 'Quick Search Box.app'
 
   postflight do
-    system '/bin/chmod', '-R', '--', 'u+w', staged_path
+    set_permissions staged_path, 'u+w'
   end
 
   zap :delete => '~/Library/Application Support/Google/Quick Search Box',

--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -23,6 +23,6 @@ cask :v1 => 'screens-connect' do
             :pkgutil => 'com.edovia.pkg.screens.connect.*'
 
   uninstall_preflight do
-    system '/bin/chmod', '+x', "#{staged_path}/Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool"
+    set_permissions "#{staged_path}/Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool", '+x'
   end
 end

--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -9,8 +9,9 @@ cask :v1 => 'stack' do
   license :bsd
 
   binary "stack-#{version}", :target => 'stack'
+
   postflight do
-    system '/bin/chmod', '+x', "#{staged_path}/stack-#{version}"
+    set_permissions "#{staged_path}/stack-#{version}", '+x'
   end
 
   depends_on :arch => :x86_64

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -9,6 +9,7 @@ cask :v1 => 'voicemac' do
   license :isc
 
   app 'VoiceMac/VoiceMac.app'
+
   postflight do
     set_permissions "#{staged_path}/VoiceMac/VoiceMac.app/Contents/Info.plist", 'a+r'
   end

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -10,6 +10,6 @@ cask :v1 => 'voicemac' do
 
   app 'VoiceMac/VoiceMac.app'
   postflight do
-    system '/bin/chmod', '--', 'a+r', "#{staged_path}/VoiceMac/VoiceMac.app/Contents/Info.plist"
+    set_permissions "#{staged_path}/VoiceMac/VoiceMac.app/Contents/Info.plist", 'a+r'
   end
 end


### PR DESCRIPTION
Update 15 casks to use `set_permissions` helper for `postflight` and `uninstall_preflight` blocks.
