### PR TITLE
Update to `:v1_1` casks with new helpers

### DIFF
--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'adobe-arh' do
+cask :v1_1 => 'adobe-arh' do
   version :latest
   sha256 :no_check
 

--- a/Casks/docker-compose.rb
+++ b/Casks/docker-compose.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'docker-compose' do
+cask :v1_1 => 'docker-compose' do
   version '1.3.3'
   sha256 '6872c2c760940fb15470f07085fa23ff536db4cccaed4541c15b6856fb0675d0'
 

--- a/Casks/docker-machine.rb
+++ b/Casks/docker-machine.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'docker-machine' do
+cask :v1_1 => 'docker-machine' do
   version 'v0.3.0'
   sha256 '1b94543ee506bfc75cad43662b346e3560aacf9d47fc78b9d27c2158df486026'
 

--- a/Casks/dogestry.rb
+++ b/Casks/dogestry.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'dogestry' do
+cask :v1_1 => 'dogestry' do
   version '2.0.1'
   sha256 '71a33b0c0b9c432df998d235693a765cdcefb0c7cefe9a45653a9f673da9349e'
 

--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'hex-fiend' do
+cask :v1_1 => 'hex-fiend' do
   version '2.3.0'
   sha256 '0e0a683971c872ee734af2a3440f1f2abb8d442609077bd5c3e212ab3b5439f7'
 

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'jxplorer' do
+cask :v1_1 => 'jxplorer' do
   version '3.3.1'
   sha256 'b51995a93203590e6690d8ad54f73cd7af1c9f2bef6219adca79c58eda71d860'
 

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'mamp' do
+cask :v1_1 => 'mamp' do
   version '3.4'
   sha256 '4351c048f770b99bc69da6d5240e7b1cff2dbaef485dec7e04327187f3d8df55'
 

--- a/Casks/onlabs.rb
+++ b/Casks/onlabs.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'onlabs' do
+cask :v1_1 => 'onlabs' do
   version '0.1.9'
   sha256 '4fa575158f80d60f40826fab0b77217cc343ca0fc4af5e7840c606a4f4bd97c5'
 

--- a/Casks/openarena.rb
+++ b/Casks/openarena.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'openarena' do
+cask :v1_1 => 'openarena' do
   version '0.8.8'
   sha256 '5a8faf7f5b51f351b0a1618c06b6b98a5f1a6758f1d39818de2c87df2a0bac4a'
 

--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'parse' do
+cask :v1_1 => 'parse' do
   version :latest
   sha256 :no_check
 

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'pd-extended' do
+cask :v1_1 => 'pd-extended' do
   version '0.43.4'
   sha256 'abe7bd637b1495ad9d5a500f0a18550c1600e34ee17e60aa1a48e4dbdee59bb9'
 

--- a/Casks/pd.rb
+++ b/Casks/pd.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'pd' do
+cask :v1_1 => 'pd' do
   version '0.46-6'
   sha256 'fad5a77f01f25fb6b8c73e67d5d7ab3cc3ca87b5eb46d2fbe0be0e30d3f64823'
 

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'private-internet-access' do
+cask :v1_1 => 'private-internet-access' do
   version :latest
   sha256 :no_check
 

--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'screens-connect' do
+cask :v1_1 => 'screens-connect' do
   version '3.2.3'
   sha256 'bdffd7b7e750d5bcb23d2895588b5d14c8d0cdd5211391d537ee781b43321afc'
 

--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'sencha' do
+cask :v1_1 => 'sencha' do
   version '5.1.3.61'
   sha256 '6083490b578191d2b8307b375e115c93c2223683e49636893edadfa1d76a412c'
 

--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'stack' do
+cask :v1_1 => 'stack' do
   version '0.1.2.0'
   sha256 '6e1039d9c5144fb03dbfb1f569a830724593191305998e9be87579d985feb36c'
 

--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'unifi-controller' do
+cask :v1_1 => 'unifi-controller' do
   version '4.6.6'
   sha256 '7ca063dfd368cd27fab2fd6fd60e317a736beafd8add9400b9b98553e8a6f858'
 

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'vmware-fusion' do
+cask :v1_1 => 'vmware-fusion' do
   version '7.1.2-2779224'
   sha256 '93e809ece4f915fcb462affabfce2d7c85eb08314b548e2cde44cb2a67ad7d76'
 

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'voicemac' do
+cask :v1_1 => 'voicemac' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
Forgot about this when merging #12983 and #12984.
