### PR TITLE
Fix download URL in wkhtmltopdf Cask

### DIFF
--- a/Casks/wkhtmltopdf.rb
+++ b/Casks/wkhtmltopdf.rb
@@ -3,13 +3,13 @@ cask :v1 => 'wkhtmltopdf' do
 
   if Hardware::CPU.is_32_bit?
     sha256 '582d7da3226809a5ca8bfc6c60903a368fe4c7c54fc31df13bbd0bd2ed093968f1'
-    # sourceforge.net is the official download host per the vendor homepage
-    url "http://downloads.sourceforge.net/project/wkhtmltopdf/#{version}/wkhtmltox-#{version}_osx-carbon-i386.pkg"
+    # gna.org is the official download host per the vendor homepage
+    url "http://download.gna.org/wkhtmltopdf/#{version.split('.').take(2).join('.')}/#{version}/wkhtmltox-#{version}_osx-carbon-i386.pkg"
     pkg "wkhtmltox-#{version}_osx-carbon-i386.pkg"
   else
     sha256 'c2fd9b39182453ba9672f528e7a503928e51bc6a45c3117da06a5193af338d35'
-    # sourceforge.net is the official download host per the vendor homepage
-    url "http://downloads.sourceforge.net/project/wkhtmltopdf/#{version}/wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
+    # gna.org is the official download host per the vendor homepage
+    url "http://download.gna.org/wkhtmltopdf/#{version.split('.').take(2).join('.')}/#{version}/wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
     pkg "wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
   end
 


### PR DESCRIPTION
The wkhtmltopdf project changed their download location to gna.org
instead of using Sourceforge.
