### PR TITLE
Paraview 4.3.1

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,15 +1,15 @@
 cask :v1 => 'paraview' do
-  version '4.2.0'
+  version '4.3.1'
 
   if MacOS.release <= :mountain_lion
     sha256 '8784481c90b58b0c6158e21b7f978a7d78caa67c63d28d6d5d770ef43f0ad890'
     url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit-Lion-Python27.dmg'
   elsif MacOS.release == :snow_leopard
-    sha256 'fd4783bd2c7892ed24bc6ee59294d932e7a469cd14f7766ae05249fd1e603b'
-    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.2&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit-SnowLeopard.dmg"
+    sha256 'f968263782d1407c769c8d7b28872a43adb263d0820c9bebe0e0ea8cf2aaa3a0'
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.3&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit-SnowLeopard.dmg"
   else
-    sha256 'e2139b7f775f9c774d6a5ea00b08bcb7c57eaea7825e5f92cc6c0a58700d763f'
-    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.2&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit.dmg"
+    sha256 'cac627512f7d764ee85c601eeb9fbf269d4990f2a2345b72107d3b23a24642e6'
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.3&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit.dmg"
   end
 
   name 'ParaView'

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -14,7 +14,7 @@ cask :v1 => 'paraview' do
 
   name 'ParaView'
   homepage 'http://www.paraview.org/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :bsd
 
   app 'paraview.app'
 

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,10 +1,7 @@
 cask :v1 => 'paraview' do
   version '4.3.1'
 
-  if MacOS.release <= :mountain_lion
-    sha256 '8784481c90b58b0c6158e21b7f978a7d78caa67c63d28d6d5d770ef43f0ad890'
-    url 'http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.1&type=binary&os=osx&downloadFile=ParaView-4.1.0-Darwin-64bit-Lion-Python27.dmg'
-  elsif MacOS.release == :snow_leopard
+  if MacOS.release == :snow_leopard
     sha256 'f968263782d1407c769c8d7b28872a43adb263d0820c9bebe0e0ea8cf2aaa3a0'
     url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.3&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit-SnowLeopard.dmg"
   else
@@ -19,4 +16,5 @@ cask :v1 => 'paraview' do
   app 'paraview.app'
 
   depends_on :arch => :x86_64
+  depends_on :macos => '>= :snow_leopard'
 end

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,12 +1,14 @@
 cask :v1 => 'paraview' do
   version '4.3.1'
 
+  major_minor = version.split('.')[0..1].join('.')
+
   if MacOS.release == :snow_leopard
     sha256 'f968263782d1407c769c8d7b28872a43adb263d0820c9bebe0e0ea8cf2aaa3a0'
-    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.3&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit-SnowLeopard.dmg"
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{major_minor}&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit-SnowLeopard.dmg"
   else
     sha256 'cac627512f7d764ee85c601eeb9fbf269d4990f2a2345b72107d3b23a24642e6'
-    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v4.3&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit.dmg"
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{major_minor}&type=binary&os=osx&downloadFile=ParaView-#{version}-Darwin-64bit.dmg"
   end
 
   name 'ParaView'


### PR DESCRIPTION
Adds the following changes:
- update Paraview version to 4.3.1
- update license information to BSD (see commit for URL)
- fixes versioning logic for Paraview installation (in summary, more users can install newer versions than before)
- Compute more of the download URL from version information.
