### PR TITLE
Add missing azure provider binary to terraform

### DIFF
--- a/Casks/terraform.rb
+++ b/Casks/terraform.rb
@@ -11,6 +11,7 @@ cask :v1 => 'terraform' do
   binary 'terraform'
   binary 'terraform-provider-atlas'
   binary 'terraform-provider-aws'
+  binary 'terraform-provider-azure'
   binary 'terraform-provider-cloudflare'
   binary 'terraform-provider-cloudstack'
   binary 'terraform-provider-consul'


### PR DESCRIPTION
Terraform now has a `terraform-provider-azure` binary which was previously not being linked by the terraform cask formula. This pull request adds the missing link.
