### PR TITLE
Update licenses for 5 casks

### DIFF
--- a/Casks/gephi.rb
+++ b/Casks/gephi.rb
@@ -6,7 +6,7 @@ cask :v1 => 'gephi' do
   url "https://launchpadlibrarian.net/127456772/gephi-#{version}.dmg"
   name 'Gephi'
   homepage 'https://gephi.github.io/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :oss
 
   app 'Gephi.app'
 end

--- a/Casks/onlabs.rb
+++ b/Casks/onlabs.rb
@@ -6,7 +6,7 @@ cask :v1_1 => 'onlabs' do
   appcast 'https://github.com/lalyos/onlabs/releases.atom'
   name 'onlabs'
   homepage 'https://github.com/lalyos/onlabs'
-  license :unknown # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :mit
 
   container :type => :naked
 

--- a/Casks/screenmailer.rb
+++ b/Casks/screenmailer.rb
@@ -6,7 +6,7 @@ cask :v1 => 'screenmailer' do
   appcast 'https://www.screenmailer.com/releases/current/releases.xml'
   name 'Screenmailer'
   homepage 'https://www.screenmailer.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Screenmailer.app'
 end

--- a/Casks/spark.rb
+++ b/Casks/spark.rb
@@ -5,7 +5,7 @@ cask :v1 => 'spark' do
   url 'http://www.shadowlab.org/softwares/Spark/Spark.dmg'
   name 'Spark'
   homepage 'http://www.shadowlab.org/softwares/spark.php'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :mit
 
   app 'Spark.app'
 

--- a/Casks/spotifree.rb
+++ b/Casks/spotifree.rb
@@ -7,7 +7,7 @@ cask :v1 => 'spotifree' do
   appcast 'http://spotifree.gordinskiy.com/appcast.xml'
   name 'Spotifree'
   homepage 'http://spotifree.gordinskiy.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :oss
 
   app 'Spotifree.app'
 end


### PR DESCRIPTION
Of note:
- spotifree has a good portion of the MIT license, but not all of it.  There's a confusing issue (https://github.com/ArtemGordinsky/Spotifree/issues/19) but regardless, the intent is clearly for it to be `:oss`
- gephi is dual-licensed https://github.com/gephi/gephi/blob/master/COPYING.txt
