### PR TITLE
Update owasp-zap.rb

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'owasp-zap' do
-  version '2.4.0'
-  sha256 'd8e296cc09908f7df9970ac6f701191bf7ccdff628d95194196a58689f8186be'
+  version '2.4.1'
+  sha256 '98c9cab401dd95c021ee32cf4030aa63a64f08a82c6fe0d2493663e3c6e1c5a3'
 
-  # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/sourceforge/zaproxy/ZAP_#{version}_Mac_OS_X.dmg"
+  # GitHub is the official download host per the vendor homepage
+  url "https://github.com/zaproxy/zaproxy/releases/download/#{version}/ZAP_#{version}_MAC_OS_X.dmg"
   name 'OWASP Zed Attack Proxy'
   name 'OWASP ZAP'
   name 'ZAP'


### PR DESCRIPTION
Updated for 2.4.1 and the ZAP downloads have moved to GitHub
