### PR TITLE
Upgrade adobe-dng-converter to v9.1.1

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'adobe-dng-converter' do
-  version '9.1'
-  sha256 '5c6b29cc1a1c98def767fdd99d5e82ba118d7902aa31cab4c207ea058cc65187'
+  version '9.1.1'
+  sha256 'c48ad14fe396f2bba0bdd028c4a0be76458c7076fa5d36822943ce84fbe20e1d'
 
   url "http://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.gsub('.', '_')}.dmg"
   name 'Adobe Camera Raw and DNG Converter'


### PR DESCRIPTION
Heya! Small update to `adobe-dng-converter` to freshen it up--here's the installation transcript:

```
> brew cask install https://raw.githubusercontent.com/fnichol/homebrew-cask/adobe-dng-converter-9.1.1/Casks/adobe-dng-converter.rb
==> Downloading https://raw.githubusercontent.com/fnichol/homebrew-cask/adobe-dng-converter-9.1.1/Casks/adobe-dng-converter.rb
######################################################################## 100.0%
==> Downloading http://download.adobe.com/pub/adobe/dng/mac/DNGConverter_9_1_1.dmg
######################################################################## 100.0%
==> Running installer for adobe-dng-converter; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
==> installer: Package name is Adobe DNG Converter 9.1.1
==> installer: Upgrading at base path /
==> installer: The upgrade was successful.
🍺  adobe-dng-converter staged at '/opt/homebrew-cask/Caskroom/adobe-dng-converter/9.1.1' (223M)
```

Thanks!!
