### PR TITLE
Add Boxcryptor.app

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,0 +1,11 @@
+cask :v2 => 'boxcryptor' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://www.boxcryptor.com/l/download-macosx'
+  name 'Boxcryptor'
+  homepage 'https://www.boxcryptor.com/en'
+  license :commercial
+
+  app 'Boxcryptor.app'
+end


### PR DESCRIPTION
This is different than Boxcryptor Classic (v1).  This is v2, but is
effectively a different piece of software.  Both are current.  Classic
should remain available and not be moved to versions or boneyard.
