### PR TITLE
Update haskell-platform to v7.10.2-a

### DIFF
--- a/Casks/haskell-platform.rb
+++ b/Casks/haskell-platform.rb
@@ -1,8 +1,10 @@
 cask :v1 => 'haskell-platform' do
-  version '7.10.2'
-  sha256 'f6a884b6304a15056d1692ba419a6d00e883c4eee998f4f4d8b4ace3d160b54b'
+  version '7.10.2-a'
+  sha256 'dd1b64ecec95178044e12a08d9038f1e2156bbd51537da07b18832531b637672'
 
-  url "https://www.haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%2064bit-signed.pkg"
+  # URL is a special case for this relase, orginal line which should work for future versions is commented below:
+  # url "https://www.haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%2064bit-signed.pkg"
+  url "https://www.haskell.org/platform/download/7.10.2/Haskell%20Platform%20#{version}%2064bit-signed.pkg"
   name 'Haskell Platform'
   homepage 'https://www.haskell.org/platform/'
   license :bsd


### PR DESCRIPTION
URL is a special case for this release, old url is commented out for quick update next version

Fixes #13075
