### PR TITLE
changed paw to versioned url

### DIFF
--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -3,7 +3,7 @@ cask :v1 => 'paw' do
   sha256 '80af2f3bfd973c920d636453f9a9fb8b1d7c3fbd461e72132c2bf12373d06254'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url 'https://luckymarmot-distribution.s3.amazonaws.com/paw/Paw-#{version}.zip'
+  url "https://luckymarmot-distribution.s3.amazonaws.com/paw/Paw-#{version}.zip"
   name 'Paw'
   homepage 'https://luckymarmot.com/paw'
   license :commercial

--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'paw' do
-  version :latest
-  sha256 :no_check
+  version '2.2.2'
+  sha256 '80af2f3bfd973c920d636453f9a9fb8b1d7c3fbd461e72132c2bf12373d06254'
 
-  url 'https://luckymarmot.com/paw/download'
+  # amazonaws.com is the official download host per the vendor homepage
+  url 'https://luckymarmot-distribution.s3.amazonaws.com/paw/Paw-#{version}.zip'
   name 'Paw'
   homepage 'https://luckymarmot.com/paw'
   license :commercial


### PR DESCRIPTION
The generic download URL on the homepage redirects to a versioned AWS url.

```
wget https://luckymarmot.com/paw/download
...
HTTP request sent, awaiting response... 302 FOUND
Location: https://luckymarmot-distribution.s3.amazonaws.com/paw/Paw-2.2.2.zip
```
