### PR TITLE
sabnzbd.rb: added support for mac os v10.6-10.7

### DIFF
--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -8,7 +8,15 @@ cask :v1 => 'sabnzbd' do
   homepage 'https://sabnzbd.org/'
   license :gpl
 
-  app 'SABnzbd.app'
+  depends_on :macos => '>= :snow_leopard'
+
+  if MacOS.release <= :snow_leopard
+    app 'Snow Leopard/SABnzbd.app'
+  elsif MacOS.release <= :lion
+    app 'Lion/SABnzbd.app'
+  else
+    app 'SABnzbd.app'
+  end
 
   zap :delete => [
                   '~/Library/Application Support/SABnzbd/sabnzbd.ini',


### PR DESCRIPTION
the sabnzbd .dmg contains separate .app releases for mac os x v10.6, v10.7, and v10.8+
i added some conditionals to select the right .app and also made the cask depend on v10.6
