### PR TITLE
Add Telephone v1.0.4

### DIFF
--- a/Casks/telephone.rb
+++ b/Casks/telephone.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'telephone' do
+  version '1.0.4'
+  sha256 'e2c06dffd13610fe69d90c5dd61cc80050076517f6a16e8a78ad48e2a12caf2e'
+
+  url "http://www.tlphn.com/resources/Telephone-#{version}.dmg"
+  name 'Telephone'
+  homepage 'http://www.tlphn.com/'
+  license :bsd
+
+  app 'Telephone.app'
+end


### PR DESCRIPTION
 Telephone is a VoIP program which allows you to make phone calls over the internet. It can be used to call regular phones via any appropriate SIP provider. If your office or home phone works via SIP, you can use that phone number on your Mac anywhere you have decent internet connection.

license appears to be "New BSD License"
https://github.com/eofster/Telephone/blob/master/COPYRIGHT
https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22Revised_BSD_License.22.2C_.22New_BSD_License.22.2C_or_.22Modified_BSD_License.22.29
