### PR TITLE
add cask for internet plugins for using of Korean bank

### DIFF
--- a/Casks/aos-firewall.rb
+++ b/Casks/aos-firewall.rb
@@ -1,0 +1,16 @@
+cask :v1 => 'aos-firewall' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://ahnlabdownload.nefficient.co.kr/aos/sup/aosfirewall.dmg'
+  name 'AOS Firewall'
+  homepage 'http://www.ahnlab.com'
+  license :gratis
+
+  pkg 'AOSFirewall.pkg'
+  uninstall :pkgutil =>
+    [
+      'com.ahnlab.aosFirewall.*',
+      'com.ahnlab.firewall.*'
+    ]
+end

--- a/Casks/cross-web.rb
+++ b/Casks/cross-web.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'cross-web' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://open.citibank.co.kr/3rdParty/initech/plugin/down/npCrossWeb_Mac.pkg'
+  name 'Cross WEB'
+  homepage 'https://open.citibank.co.kr'
+  license :gratis
+
+  pkg 'npCrossWeb_Mac.pkg'
+  uninstall :pkgutil => 'kr.co.iniline.pkg.CrossWebPackage'
+end

--- a/Casks/ip-inside-agent-for-citibank.rb
+++ b/Casks/ip-inside-agent-for-citibank.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'ip-inside-agent-for-citibank' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://open.citibank.co.kr/3rdParty/interezen/OSX-MAC/IPinsideAgent.dmg'
+  name 'IP inside Agent for CitiBank'
+  homepage 'https://open.citibank.co.kr'
+  license :gratis
+
+  pkg 'IPinsideAgent.pkg'
+  uninstall :pkgutil =>
+    [
+      'INTEREZEN Internet Plug-in Launch',
+      'INTEREZEN Internet Plug-in Uninstaller',
+      'INTEREZEN Internet Plug-in'
+    ],
+    :rmdir => '/Applications/IPinside'
+end

--- a/Casks/ip-inside-agent-for-hana-bank.rb
+++ b/Casks/ip-inside-agent-for-hana-bank.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'ip-inside-agent-for-hana-bank' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://open.hanabank.com/interezen/agent/IPinsideAgent.dmg'
+  name 'IP inside Agent for Hana Bank'
+  homepage 'https://open.hanabank.com'
+  license :gratis
+
+  pkg 'IPinsideAgent.pkg'
+  uninstall :pkgutil => 'I3GManager.Plugin.ipinsideAgent.*',
+    :rmdir => '/Applications/IPinside'
+end

--- a/Casks/veraport.rb
+++ b/Casks/veraport.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'veraport' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://open.citibank.co.kr/3rdParty/wizvera/veraport/down/veraport.pkg'
+  name 'VeraPort'
+  homepage 'https://open.citibank.co.kr'
+  license :gratis
+
+  pkg 'veraport.pkg'
+  uninstall :pkgutil => 'com.wizvera.veraport.veraport.*',
+    :rmdir => '/Applications/Veraport'
+end

--- a/Casks/xecureweb-unified.rb
+++ b/Casks/xecureweb-unified.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'xecureweb-unified' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://open.hanabank.com/softforum/xwuni/install/xw_unified_install_mac_universal.pkg'
+  name 'XecureWeb Unified'
+  homepage 'https://open.hanabank.com'
+  license :gratis
+
+  pkg 'xw_unified_install_mac_universal.pkg'
+  uninstall :pkgutil => 'com.softforum.xecurewebunifiedclient'
+end


### PR DESCRIPTION
#13008
#13004
#13011

add cask files: aos-firewall.rb, cross-web.rb, ip-inside-agent-for-citibank.rb, ip-inside-agent-for-hana-bank.rb, veraport.rb, xecureweb-unified.rb

there was some problems that i don’t understand when i tried to rebase it, so i changed branches. 
