### PR TITLE
add cask file for MathType app 

### DIFF
--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'mathtype' do
+  version '6.7'
+  sha256 :no_check
+
+  url "http://www.dessci.com/en/dl/MTM#{version.gsub('.', '')}h_EN.pkg"
+  name 'MathType'
+  homepage 'www.dessci.com'
+  license :commercial
+
+  installer :manual => "MTM#{version.gsub('.', '')}h_EN.pkg"
+  # pkg "MTM#{version.gsub('.', '')}h_EN.pkg"
+  uninstall :pkgutil => "com.dessci.mathtype#{version.gsub('.', '')}Hf.MathType.pkg",
+    :trash => '/Applications/MathType 6/MathType 6 Install Log.txt',
+    :rmdir => '/Applications/MathType 6'
+end

--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -7,8 +7,7 @@ cask :v1 => 'mathtype' do
   homepage 'www.dessci.com'
   license :commercial
 
-  installer :manual => "MTM#{version.gsub('.', '')}h_EN.pkg"
-  # pkg "MTM#{version.gsub('.', '')}h_EN.pkg"
+  pkg "MTM#{version.gsub('.', '')}h_EN.pkg"
   uninstall :pkgutil => "com.dessci.mathtype#{version.gsub('.', '')}Hf.MathType.pkg",
     :trash => '/Applications/MathType 6/MathType 6 Install Log.txt',
     :rmdir => '/Applications/MathType 6'

--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'mathtype' do
   version '6.7'
-  sha256 :no_check
+  sha256 'f512b322c9b1e16c0f9c523ade1dc7f5e743768a2ac4d7fa37780abfbe05a861'
 
   url "http://www.dessci.com/en/dl/MTM#{version.gsub('.', '')}h_EN.pkg"
   name 'MathType'


### PR DESCRIPTION
add cask file: mathtype.rb

I’m wondering why the app doesn’t work well if I installed the app using `pkg`. 
This cask file try to install it using `manual`. 
Is anyone here has this situation before?
