### PR TITLE
Added Skyfonts 4.9.0.0

### DIFF
--- a/Casks/monotype-skyfonts.rb
+++ b/Casks/monotype-skyfonts.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'monotype-skyfonts' do
-  version '4.9.0.0'
-  sha256 '0e6982d6fb27b3570fe529a9c055bc486ff995dbd72d21c6c0999208839f7456'
+  version '4.7.1.0'
+  sha256 '9a473e2b2d89d62b4fc2d9d3400a064636c210c62dfd935dd26e693a4c5c5bad'
 
   # skyfonts.com is the official download host per the vendor homepage
   url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"

--- a/Casks/skyfonts.rb
+++ b/Casks/skyfonts.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'skyfonts' do
+  version '4.9.0.0'
+  sha256 '0e6982d6fb27b3570fe529a9c055bc486ff995dbd72d21c6c0999208839f7456'
+
+  # skyfonts.com is the official download host per the vendor homepage
+  url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
+  name 'SkyFonts'
+  homepage 'https://www.fonts.com/web-fonts/google'
+  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  app 'SkyFonts.app'
+end


### PR DESCRIPTION
Reverted my latest change and introduced this one as the previous one broke: They changed the name of the app inside the DMG and that needs either the change of the app name inside the `monotype-skyfonts.rb` which will break previous installations or a new Cask which has the right naming.

Please decide which approach is the preferred one.
