### PR TITLE
Upgrade JEDict.app to v4.9.6 and change gsub to delete

### DIFF
--- a/Casks/jedict.rb
+++ b/Casks/jedict.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'jedict' do
-  version '4.9.5'
-  sha256 '6286c5f46e6c1404f007b364cc2baa3d7ce074c108be9c37de1270aca19bba78'
+  version '4.9.6'
+  sha256 '99dc7bd641a708c4d09e975e136c0dd05597620f2f47a77817b4604fc1731b9b'
 
   url "http://jedict.com/Downloads/JEDict#{version.gsub('.','')}.zip"
   name 'Jedict'

--- a/Casks/jedict.rb
+++ b/Casks/jedict.rb
@@ -2,7 +2,7 @@ cask :v1 => 'jedict' do
   version '4.9.6'
   sha256 '99dc7bd641a708c4d09e975e136c0dd05597620f2f47a77817b4604fc1731b9b'
 
-  url "http://jedict.com/Downloads/JEDict#{version.gsub('.','')}.zip"
+  url "http://jedict.com/Downloads/JEDict#{version.delete('.')}.zip"
   name 'Jedict'
   homepage 'http://www.jedict.com/'
   license :commercial


### PR DESCRIPTION
Fix for https://github.com/caskroom/homebrew-cask/pull/13127.

Version 4.9.5 has a sha256 checksum mismatch, so upgraded to 4.9.6.
