### PR TITLE
Upgrade yacreader to 8.0.0.

### DIFF
--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'yacreader' do
-  version '7.2.0'
-  sha256 'e671e2c7914c070bc5ed7144db147d9ab6d6f1bc8a8272673e6dc39cb52b3101'
+  version '8.0.0'
+  sha256 '6e6e2f857a3f1ad4fa19c57550677e5e46c63ffaea955e353a832e51461d3e80'
 
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/luisangelsm/yacreader/downloads/YACReader-#{version}-MacOSX-Intel.dmg"


### PR DESCRIPTION
Upgraded version of yacreader to 8.0.0, had some trouble getting
consistent download from bitbucket, but seemed like a temporary problem.
