### PR TITLE
Adds operachromiumdriver as a Cask.

### DIFF
--- a/Casks/operachromiumdriver.rb
+++ b/Casks/operachromiumdriver.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'operachromiumdriver' do
+  version '0.2.2'
+  sha256 :no_check
+
+  url 'https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_mac64.zip'
+  name 'operachromiumdriver'
+  homepage 'https://github.com/operasoftware/operachromiumdriver'
+  license :apache
+
+  binary 'operadriver'
+end

--- a/Casks/operachromiumdriver.rb
+++ b/Casks/operachromiumdriver.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'operachromiumdriver' do
   version '0.2.2'
-  sha256 :no_check
+  sha256 '6584ea2b0ebb06a2c5639570fdac0a28de90bb88982ce9e74d531147106988bd'
 
   url 'https://github.com/operasoftware/operachromiumdriver/releases/download/v0.2.2/operadriver_mac64.zip'
   name 'operachromiumdriver'


### PR DESCRIPTION
operachromiumdriver is used for selenium automation of the
Opera browsers.
