### PR TITLE
updated 4k-video-downloader (3.6)

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask :v1 => '4k-video-downloader' do
   version '3.6'
-  sha256 'ea2bcdb0be1358d7de11777f134547483dab71519873b16e6c1d393376143269'
+  sha256 'c298303cae1a50b381f45b8ca64f3cd1455c92558d28f1f79a2d2f5ea9fdc58e'
 
   url "http://downloads.4kdownload.com/app/4kvideodownloader_#{version}.dmg"
   name '4K Video Downloader'


### PR DESCRIPTION
It appears that the cask may be updated in place for minor version changes (e.g. the website download version is of the form 3.x, while the actual version is something along the lines of 3.x.y.z).
