### PR TITLE
updated iordning (6.0.43)

### DIFF
--- a/Casks/iordning.rb
+++ b/Casks/iordning.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'iordning' do
-  version '6.0.11'
-  sha256 '69e174863fc72befdbbf4b0860fe51c4879d08e83a1a9335e0d9d78f045f6af8'
+  version '6.0.43'
+  sha256 '965818c8e43f51826edef0e9c4bc8a083d6b698b2fae2f63a1de2407f02c59a3'
 
   url "http://www.aderstedtsoftware.com/downloads/iOrdning#{version.to_i}.zip"
   name 'iOrdning'


### PR DESCRIPTION
Note: The English name of the Cask is Economacs, and iOrdning is a translation (the name of the app bundle is Economacs).
