### PR TITLE
Add Docker Toolbox v1.8.0a

### DIFF
--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -1,0 +1,27 @@
+cask :v1 => 'dockertoolbox' do
+  version '1.8.0a'
+  sha256 '1ec3234e25970ecfaa85af85af6407deb9426917514f591e939371b4a006efc7'
+
+  url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
+  appcast 'https://github.com/docker/toolbox/releases.atom'
+  name 'Docker Toolbox'
+  homepage 'https://www.docker.com/toolbox'
+  license :apache
+
+  pkg "DockerToolbox-#{version}.pkg"
+
+  depends_on :cask => 'virtualbox'
+
+  postflight do
+    set_ownership '~/.docker'
+  end
+
+  uninstall :pkgutil => [
+    'io.boot2dockeriso.pkg.boot2dockeriso',
+    'io.docker.pkg.docker',
+    'io.docker.pkg.dockercompose',
+    'io.docker.pkg.dockermachine',
+    'io.docker.pkg.dockerquickstartterminalapp',
+    'io.docker.pkg.kitematicapp',
+  ]
+end


### PR DESCRIPTION
A first pass at a cask for the new [Docker Toolbox](https://blog.docker.com/2015/08/docker-toolbox/).

Known Issues: 
- Requires VirtualBox 5.0.0. If 4.3.x is installed, the installer will fail with an error message to that effect.
- I found that installing from this cask left some files (particularly under `~/.docker/machines`) owned by root. This prevents `docker-machine` in the initial setup script from creating the `default` boot2docker VM. Changing the ownership back (i.e. `sudo chown -R $USER: ~/.docker`) allows the "Docker Quickstart Terminal" to complete the setup successfully.
- Neither `*.app` included in the Docker Toolbox is actually called Docker Toolbox. This package installs `/Applications/Docker/Docker Quickstart Terminal.app` and `/Applications/Docker/Kitematic (Beta).app` as well as some command line tools (`docker`, `docker-machine`, `docker-compose`).

I'm not sure how best to sort out these issues, but felt it was worth documenting and sharing what I found in case anyone else wants to have a try.
