### PR TITLE
visual-studio-code 0.7.0

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,14 +1,15 @@
 cask :v1 => 'visual-studio-code' do
-  version :latest
-  sha256 :no_check
+  version '0.7.0'
+  sha256 '386b8aa79c05a587f25a367fb753ef9c6082389aa384b4f8571a4a7507bbb4ac'
 
-  url 'https://go.microsoft.com/fwlink/?LinkID=534106'
+  # vo.msecnd.net is the official download host per the vendor homepage
+  url "https://az764295.vo.msecnd.net/public/#{version}/VSCode-darwin.zip"
   name 'Visual Studio Code'
   homepage 'https://code.visualstudio.com/'
   license :gratis
   tags :vendor => 'Microsoft'
 
-  app 'VSCode-darwin-signed/Visual Studio Code.app'
+  app 'Visual Studio Code.app'
 
   zap :delete => [
                   '~/Library/Application Support/Code',


### PR DESCRIPTION
- Updated link to new url based on javascript (old link broke)
- Updated folder path inside archive (changed from last release)
- Converted to versioned package with sha check
