### PR TITLE
add delete list: ‘/Library/Application Support/CleverFiles’ for uninstall Disk Drill’

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -11,6 +11,8 @@ cask :v1 => 'disk-drill' do
 
   app 'Disk Drill.app'
 
+  uninstall :delete => '/Library/Application Support/CleverFiles'
+
   zap :delete => [
                   '~/Library/Application Support/DiskDrill',
                   '~/Library/Caches/com.cleverfiles.Disk_Drill',


### PR DESCRIPTION
there was un-delated files when uninstall Disk Drill app even using `zap`. 
i add the files to delete list. 
