### PR TITLE
Upgrade Ableton Live 9 Trial.app to v9.2.1

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'ableton-live' do
-  version '9.2'
+  version '9.2.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 '76af66fabf29349a86d86ba07c42756ed0edf36c0b2f4df02f715509997187e5'
+    sha256 'ce37b5ec6c2f717c8db83e39a75398e462bd131d39df5a559b265fa27eba38f6'
     url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_32.dmg"
   else
-    sha256 '6ef19ad81674dbfb842e6964961d865ebe29c6399581d47efb1d77cf7db2cf86'
+    sha256 '30599a21a857be855e687e3d5a162cefb84ff98491bc2757d0580e811114295e'
     url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   end
 
@@ -13,7 +13,7 @@ cask :v1 => 'ableton-live' do
   homepage 'https://ableton.com/en/live'
   license :commercial
 
-  app "Ableton Live #{version[0]} Suite.app"
+  app "Ableton Live #{version.to_i} Trial.app"
 
   zap :delete => '~/Library/*/*[Aa]bleton*',
       :rmdir => '~/Music/Ableton/Factory Packs'


### PR DESCRIPTION
Also fixes https://github.com/caskroom/homebrew-cask/issues/13260.
