### PR TITLE
fix arduino version

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'arduino' do
-  version '1.6.5r3'
+  version '1.6.5-r3'
   sha256 'f0127a2dc365f1ca2da53d46c432a17ebeee37255d0a978195720b811902273c'
 
   url "http://downloads.arduino.cc/arduino-#{version}-macosx.zip"


### PR DESCRIPTION
the correct url is `http://downloads.arduino.cc/arduino-1.6.5-r3-macosx.zip` version  number is missing a `-`.
