### PR TITLE
Update license for GitUp.app, add depends_on and binary

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -6,7 +6,10 @@ cask :v1 => 'gitup' do
   url 'https://s3-us-west-2.amazonaws.com/gitup-builds/stable/GitUp.zip'
   name 'GitUp'
   homepage 'http://gitup.co'
-  license :commercial
+  license :gpl
+
+  depends_on :macos => '>= :mountain_lion'
 
   app 'GitUp.app'
+  binary 'GitUp.app/Contents/SharedSupport/gitup'
 end


### PR DESCRIPTION
It has become entirely open source now: https://github.com/git-up/GitUp
