### PR TITLE
[WIP] Add Anaconda

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,15 +1,29 @@
 cask :v1 => 'anaconda' do
   version '2.3.0'
-  sha256 '6a0c94a49f41f9fda0138c8e966bd7b0a8965d6648fd21ffbd645d1453848ba5'
+  sha256 'c4bb59a57bf44dde80612041bbbcfd2e5cab8534842209ef456da7a46f919c33'
 
-  url "https://repo.continuum.io/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"
+  url "https://repo.continuum.io/archive/Anaconda-#{version}-MacOSX-x86_64.sh"
   name 'Anaconda'
   homepage 'https://store.continuum.io/cshop/anaconda/'
   license :gratis
   tags :vendor => 'Continuum Analytics'
 
-  # TODO: install stanzas
+  installer :script => 'Anaconda-#{version}-MacOSX-x86_64.sh',
+            :args => [ '-b', '-p', '#{staged_path}' ]
+
+  app 'Launcher.app'
 
   depends_on :macos => '>= :lion'
 
+  caveats do
+      <<-EOS.undent
+      To use Anaconda from the command line, you must add the 
+      $ANACONDA_ROOT/bin directory to your PATH environment variable.
+      For bash shell, add these lines to ~/.bash_profile:
+
+        export ANACONDA_ROOT=#{staged_path}
+        export PATH=$ANACONDA_ROOT/bin:"$PATH"
+
+  EOS
+  end
 end

--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -9,21 +9,15 @@ cask :v1 => 'anaconda' do
   tags :vendor => 'Continuum Analytics'
 
   installer :script => 'Anaconda-#{version}-MacOSX-x86_64.sh',
-            :args => [ '-b', '-p', '#{staged_path}' ]
+            :args => [ '-b' ]
 
   app 'Launcher.app'
 
   depends_on :macos => '>= :lion'
 
+  uninstall :delete => '~/anaconda'
+
   caveats do
-      <<-EOS.undent
-      To use Anaconda from the command line, you must add the 
-      $ANACONDA_ROOT/bin directory to your PATH environment variable.
-      For bash shell, add these lines to ~/.bash_profile:
-
-        export ANACONDA_ROOT=#{staged_path}
-        export PATH=$ANACONDA_ROOT/bin:"$PATH"
-
-  EOS
+    path_environment_variable '~/anaconda/bin'
   end
 end

--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'anaconda' do
+  version '2.3.0'
+  sha256 '6a0c94a49f41f9fda0138c8e966bd7b0a8965d6648fd21ffbd645d1453848ba5'
+
+  url "https://repo.continuum.io/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"
+  name 'Anaconda'
+  homepage 'https://store.continuum.io/cshop/anaconda/'
+  license :gratis
+  tags :vendor => 'Continuum Analytics'
+
+  # TODO: install stanzas
+
+  depends_on :macos => '>= :lion'
+
+end


### PR DESCRIPTION
Inspired by #13359, I decided to try to add [Anaconda](https://store.continuum.io/cshop/anaconda/) to `brew cask`.

The first issue is that it's actually packaged as a shell script. (ie. you run `bash Anaconda3-2.3.0-MacOSX-x86_64.sh -b` to install via command-line silently, and I'm not sure what stanza would do that)

It installs to `~/anaconda3` by default, and I'm not sure that is expected behavior for cask. (Note that we can change the default location by passing `-p {path) to it', but with the upcoming change, should we restrict things to only the Caskroom directory, anyway?

It adds itself to the path (ie. `export PATH="/Users/aditya/anaconda3/bin:$PATH"`) - would this be a caveat?

There is a GUI interface at `~/anaconda3/Launcher.app` as well that should be linked.

Help appreciated, thanks!
