### PR TITLE
Add Kindle Comic Converter v4.6.2

### DIFF
--- a/Casks/kindlecomicconverter.rb
+++ b/Casks/kindlecomicconverter.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'kindlecomicconverter' do
+  version '4.6.2'
+  sha256 '13d1bb6d19780bc106b82b64b65922b28c412dbbab1c0007320bac9cef3c0ce9'
+
+  url 'http://kcc.iosphe.re/OSX/KindleComicConverter_osx_4.6.2.zip'
+  name 'Kindle Comic Converter'
+  homepage 'http://kcc.iosphe.re'
+  license :isc
+
+  app 'KindleComicConverter.app'
+end


### PR DESCRIPTION
A comic and manga optimizer and converter for ereader devices.
Name says Kindle but it is compatible with all devices.
