### PR TITLE
Add Find Empty Folders

### DIFF
--- a/Casks/find-empty-folders.rb
+++ b/Casks/find-empty-folders.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'find-empty-folders' do
+  version '1.1'
+  sha256 '6eea5c0cde96b1d2297ccbd9c98391f6c76ef2076654871faf5e27030ca1e293'
+
+  url 'http://files.tempel.org/FindEmptyFolders/FindEmptyFolders.zip'
+  name 'Find Empty Folders'
+  homepage 'http://www.tempel.org/FindEmptyFolders'
+  license :unknown
+
+  app 'Find Empty Folders.app'
+end


### PR DESCRIPTION
This simple (and currently free) program finds empty folders on
your computer. There are many solutions for this task around,
but they all lack one important capability: Folders that appear
empty but yet contain a hidden ".DS_Store" file are not found by
them. Therefore, this tool considers a folder empty even if it
contains just a .DS_Store file.
