### PR TITLE
Uninstall deleted 3.1 framework, not 3.2

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -33,8 +33,8 @@ cask :v1 => 'r' do
                         '/usr/bin/Rscript',
                         '/Library/Frameworks/R.Framework/Versions/Current',
                         # :pkgutil won't delete this dir if the fontconfig cache was written to at
-                        # /Library/Frameworks/R.Framework/Versions/3.1/Resources/fontconfig/cache
-                        '/Library/Frameworks/R.Framework/Versions/3.1',
+                        # /Library/Frameworks/R.Framework/Versions/3.2/Resources/fontconfig/cache
+                        '/Library/Frameworks/R.Framework/Versions/3.2',
                        ]
   zap       :delete => [
                         '~/.R',


### PR DESCRIPTION
This cask installs version 3.2.x of R Framework, but the uninstall stanza mistakenly deleted R Framework version 3.1. Probably the result of a sloppy cask update. Fixed by amending the uninstall stanza.
