### PR TITLE
Fix external command example: Cask => Hbc

### DIFF
--- a/developer/examples/brewcask-dumpcask.rb
+++ b/developer/examples/brewcask-dumpcask.rb
@@ -10,7 +10,7 @@
 command_name = ARGV.shift
 cask_token = ARGV.shift
 
-cask = Cask.load(cask_token)
+cask = Hbc.load(cask_token)
 
-Cask.debug = true
+Hbc.debug = true
 cask.dumpcask


### PR DESCRIPTION
The `brewcask-dumpcask.rb` example seemed to have been left out in 1ae9ce2bd0eaa0b12774b346ab0b5980291b90cb. It's still using the old namespace.
