### PR TITLE
Update formula to install osxfuse latest version.

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,15 +1,12 @@
 cask :v1 => 'osxfuse' do
-  version '2.8.0'
-  sha256 'ad339ffd6592c3808f63ffc5701993cc7209d29baa5cda1828ea93f6470bb273'
-
-  # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"
-  name 'OSXFUSE'
+  version '3.0.4'
+  sha256 'd6d6e9c35633d6fc631c219842233b17c0bb042a2a87919e2207ec2a62d52726'
+  url "https://github.com/osxfuse/osxfuse/releases/download/osxfuse-#{version}/osxfuse-#{version}.dmg"
+  name 'osxfuse'
   homepage 'https://osxfuse.github.io/'
   license :bsd
 
-  pkg "Install OSXFUSE #{version[0..-3]}.pkg"
-
+  pkg "Extras/FUSE for OS X #{version}.pkg"
   uninstall :pkgutil => 'com.github.osxfuse.pkg.Core|com.github.osxfuse.pkg.PrefPane',
             :kext => 'com.github.osxfuse.filesystems.osxfusefs'
 end


### PR DESCRIPTION
This version fixes a bug with NTFS-3G where loopback dirs in /Volumes are not removed after disk is unmounted.
Also, install from github rather than sourceforge.
