### PR TITLE
Fix ginbox.rb name and required MacOS version

### DIFF
--- a/Casks/ginbox.rb
+++ b/Casks/ginbox.rb
@@ -9,7 +9,7 @@ cask :v1 => 'ginbox' do
   homepage 'https://github.com/chenasraf/gInbox'
   license :apache
 
-  depends_on :macos => '>= :lion'
+  depends_on :macos => '>= :mavericks'
 
   app 'Inbox by Google.app'
 end


### PR DESCRIPTION
This commit fixes two issues with the ginbox cask:
1. Cask filename (gInbox.rb) was not all lowercase and didn't match the actual name in the formula (ginbox). I changed the filename to all lowercase per the [Homebrew Formula Cookbook (A Quick Word on Naming)](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md#a-quick-word-on-naming).
2. I have bumped up the minimum required MacOS version to Mavericks, as this is what the developer has stated is the required version, starting with [gInbox 0.2.3](https://github.com/chenasraf/gInbox/releases/tag/0.2.3).
