### PR TITLE
Revert OSXFUSE back to v2.8.0

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,14 +1,14 @@
 cask :v1 => 'osxfuse' do
-  version '3.0.4'
-  sha256 'd6d6e9c35633d6fc631c219842233b17c0bb042a2a87919e2207ec2a62d52726'
+  version '2.8.0'
+  sha256 'ad339ffd6592c3808f63ffc5701993cc7209d29baa5cda1828ea93f6470bb273'
 
-  url "https://github.com/osxfuse/osxfuse/releases/download/osxfuse-#{version}/osxfuse-#{version}.dmg"
-  appcast 'https://github.com/osxfuse/osxfuse/releases.atom'
-  name 'osxfuse'
+  # sourceforge.net is the official download host per the vendor homepage
+  url "http://downloads.sourceforge.net/project/osxfuse/osxfuse-#{version}/osxfuse-#{version}.dmg"
+  name 'OSXFUSE'
   homepage 'https://osxfuse.github.io/'
   license :bsd
 
-  pkg "Extras/FUSE for OS X #{version}.pkg"
+  pkg "Install OSXFUSE #{version[0..-3]}.pkg"
 
   uninstall :pkgutil => 'com.github.osxfuse.pkg.Core|com.github.osxfuse.pkg.PrefPane',
             :kext => 'com.github.osxfuse.filesystems.osxfusefs'


### PR DESCRIPTION
As requested in https://github.com/caskroom/homebrew-cask/issues/13441. Currently the v3.0.4 is too unstable to use in production.
