### PR TITLE
Add AnyList

### DIFF
--- a/Casks/anylist.rb
+++ b/Casks/anylist.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'anylist' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://files.anylistapp.com/mac/AnyList.zip'
+  name 'AnyList'
+  homepage 'https://www.anylistapp.com/'
+  license :gratis
+
+  app 'AnyList.app'
+end


### PR DESCRIPTION
I'm basing the gratis license on [these docs](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#license-stanza-details) which say the license would be gratis for "a free app to access a paid service".

Using the AnyList Mac app requires an [AnyList Complete](https://www.anylistapp.com/anylist-complete) subscription.
