### PR TITLE
Updating parallels-sdk version to match desktop

### DIFF
--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'parallels-virtualization-sdk' do
-  version '10.2.1-29006'
-  sha256 '5cfa2afa2e21344876c9d27e6731ed5bdf0a234178114cdefbf9c110ea3fb4ac'
+  version '11.0.0-31193'
+  sha256 '5966961fa96e2124f7f4e8454620880f3fa618f46cb9cb46fcc7d6ec55e10718'
 
   url "http://download.parallels.com/desktop/v#{version[/^\w+/]}/#{version.sub(/-.*$/, '')}/ParallelsVirtualizationSDK-#{version}-mac.dmg"
   name 'Parallels Virtualization SDK'


### PR DESCRIPTION
Update the Parallels Virtualization SDK in step with the release for Parallels Desktop 
