### PR TITLE
Upgrade iojs to v2.4.0

### DIFF
--- a/Casks/iojs.rb
+++ b/Casks/iojs.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'iojs' do
-  version '2.2.1'
-  sha256 '471c531417c21462b971bdc0bc6391721c3c24f1606b6a2fcba04c365e47f0d0'
+  version '2.4.0'
+  sha256 '7d842eb47b4208f8eb1e9fd7d34e8c1d8b5cde70ba731c2d7565c76f2629b98f'
 
   url "https://iojs.org/dist/v#{version}/iojs-v#{version}.pkg"
   name 'io.js'


### PR DESCRIPTION
As of now, `brew` considers [iojs v3.1.0](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/iojs.rb) as stable. 

Yet for react-native development, if you have a higher version, you might have problems. 
2.5, and 3.0 have been tried and didn’t work. Downgrading to 2.4 solved problems.
