### PR TITLE
Add citrix-receiver zap stanza

### DIFF
--- a/Casks/citrix-receiver.rb
+++ b/Casks/citrix-receiver.rb
@@ -20,4 +20,12 @@ cask :v1 => 'citrix-receiver' do
                            'com.citrix.ReceiverHelper',
                           ],
             :pkgutil   => 'com.citrix.ICAClient'
+
+  zap :delete => [
+                  '~/Library/Application Support/Citrix Receiver',
+                  '~/Library/Preferences/com.citrix.receiver.nomas.plist',
+                  '~/Library/Preferences/com.citrix.receiver.nomas.plist.lockfile',
+                  '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist',
+                  '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist.lockfile',
+                 ]
 end


### PR DESCRIPTION
Zap stanza deleted folders and files come from the Citrix Support
Knowledge Center article "How to Remove Files Remaining on System after
Uninstalling Receiver for Mac" at
http://support.citrix.com/article/CTX134237%20
