### PR TITLE
Update flux.rb to always use latest version

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'flux' do
-  version '34'
-  sha256 'caa9d9b67372aa28bc79532fbccf464e39c9a9e07280bffe273fe95847597e62'
+  version :latest
+  sha256 :no_check
 
-  url "https://justgetflux.com/mac/Flux#{version}.zip"
+  url 'https://justgetflux.com/mac/Flux.zip'
   appcast 'https://justgetflux.com/mac/macflux.xml'
   name 'f.lux'
   homepage 'https://justgetflux.com/'


### PR DESCRIPTION
Using a versioned cask for this imo is not an ideal solution. For one, it's not very relevant which exact version your using and for me, also the security of having a sha256 check weighs less than always getting latest version without any maintenance cost. Also, according to the Contribution guidelines, an unversioned link is the preferred method.
