### PR TITLE
Updated Calibre formula to version 2.36.0

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -4,8 +4,8 @@ cask :v1 => 'calibre' do
     sha256 '0533283965fbc9a6618d0b27c85bdf3671fe75ff0e89eeff406fe1457ee61b14'
     url "http://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"
   else
-    version '2.35.0'
-    sha256 'ad68a5723b16de451a7ec5ad1c755c66115aa1f8d79fb3e200adc15aaf2f80cf'
+    version '2.36.0'
+    sha256 '2ab762f4d2829116bd0860b551f141ca5f20a7ff26ec8ab6e4b66dc59c210b61'
 
     # github.com is an official download host per the vendor homepage, and a faster mirror than the main one
     url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"


### PR DESCRIPTION
Updated using sha256 from the Mac DMG release here: https://github.com/kovidgoyal/calibre/releases/tag/v2.36.0
