### PR TITLE
Upgrade Hedgewars.app to v0.9.21 and license to GPL

### DIFF
--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -1,14 +1,14 @@
 cask :v1 => 'hedgewars' do
-  version '0.9.20'
-  sha256 '167667f32f4798733b7bfd50423493067e6a9fd19f02f45e737b324038f0d559'
+  version '0.9.21'
+  sha256 '61ca4d3a709143927559e33fa935620ca32467e0adf0728f9214cba9a6fe6966'
 
   # gna.org is the official download host per the vendor homepage
-  url "http://download.gna.org/hedgewars/Hedgewars-#{version}-3.dmg"
+  url "http://download.gna.org/hedgewars/Hedgewars-#{version}.dmg"
   appcast 'http://www.hedgewars.org/download/appcast.xml',
           :sha256 => 'bb5344972d01c4007ab4d8193fc2aaaebe68c4048213a10ba6b4cbc61210747f'
   name 'Hedgewars'
   homepage 'http://hedgewars.org'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gpl
 
   app 'Hedgewars.app'
 end


### PR DESCRIPTION
License source: https://github.com/hedgewars/hw/blob/master/README
