### PR TITLE
Updated gmail-notifier Cask

### DIFF
--- a/Casks/gmail-notifier.rb
+++ b/Casks/gmail-notifier.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'gmail-notifier' do
-  version '2.0.1'
-  sha256 '6d91b6b0e00041cde61a267c484f6f004330a96dfd608a61f7954f5b7abdd66e'
+  version '2.1.0'
+  sha256 '562cad2fd5ea034ff778b4bc37d028b34d535888eac96674e9084afdc3f20092'
 
   url "https://github.com/jashephe/Gmail-Notifier/releases/download/v#{version}/Gmail.Notifier.v#{version}.zip"
   appcast 'https://github.com/jashephe/Gmail-Notifier/releases.atom'


### PR DESCRIPTION
Updated the Gmail Notifier cask to the [latest version](https://github.com/jashephe/Gmail-Notifier/releases/tag/v2.1.0).
