### PR TITLE
Update OmniGraffle version from 6.2.5 to 6.3.1

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -8,8 +8,8 @@ cask :v1 => 'omnigraffle' do
     sha256 'a2eff19909d1ba38a4f01b2beecbde2f31f4af43d30e06d2c6921ae8880f85bc'
     url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.8/OmniGraffle-#{version}.dmg"
   else
-    version '6.2.5'
-    sha256 '5ac9ea1fed94b775857e853273f7f0b610fa061b179b2109d246d6b81f5be0f6'
+    version '6.3.1'
+    sha256 '49260fd24f1380704329744d2aa2a4610478dd71f448031e179408e14052f928'
     url "http://www.omnigroup.com/ftp1/pub/software/MacOSX/10.10/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
OmniGraffle 6.2.5 is no longer available (404) for download at the
previous URL. This updates to the latest release.
