### PR TITLE
RStudio Upgraded to v 0.99.473

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'rstudio' do
-  version '0.99.467'
-  sha256 '3a9c88da0eb523556627282869919e590723777cb763515be8ea442cce71a333'
+  version '0.99.473'
+  sha256 'e35fb1a76f3eeb17cdb586e146da0a3ac7b9485a27d20ad4e3f700344422036b'
 
   # rstudio.org is the official download host per the vendor homepage
   url "http://download1.rstudio.org/RStudio-#{version}.dmg"


### PR DESCRIPTION
Passes `brew cask install rstudio` and
`brew cask audit rstudio --download`
