### PR TITLE
Gracefully handle interrupts (CTRL-C) at top level

### DIFF
--- a/lib/brew-cask-cmd.rb
+++ b/lib/brew-cask-cmd.rb
@@ -15,5 +15,10 @@ require 'vendor/homebrew-fork/global'
 
 require 'hbc'
 
-Hbc::CLI.process(ARGV)
+begin
+  Hbc::CLI.process(ARGV)
+rescue Interrupt => e
+  puts
+  exit 130
+end
 exit 0


### PR DESCRIPTION
Closes #12002. Supersedes #13546 

Interrupts are possible during any stage of program execution. Certain areas are protected with `Hbc::Utils.ignore_interrupts`, but for the rest we should exit gracefully without spitting out an ugly stack trace.

This behavior is intended to emulate that of [Homebrew](https://github.com/Homebrew/homebrew/blob/45c2f30693c698b659f0bbc054aea992471786f6/Library/brew.rb#L150).
