### PR TITLE
Upgraded RStudio to 0.99.482

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'rstudio' do
-  version '0.99.473'
-  sha256 'e35fb1a76f3eeb17cdb586e146da0a3ac7b9485a27d20ad4e3f700344422036b'
+  version '0.99.482'
+  sha256 '1d8ebc577c55bd3ad1472786cd8b86520f8e852113a6e816cefecaa8c93c475e'
 
   # rstudio.org is the official download host per the vendor homepage
   url "http://download1.rstudio.org/RStudio-#{version}.dmg"


### PR DESCRIPTION
Passes `brew cask install rstudio` and `brew cask audit rstudio --download`
