### PR TITLE
suspicious-pacakge: Don't use pkg install

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -2,12 +2,10 @@ cask :v1 => 'suspicious-package' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.mothersruin.com/software/downloads/SuspiciousPackage.pkg'
+  url 'http://www.mothersruin.com/software/downloads/SuspiciousPackage.xip'
   name 'Suspicious Package'
   homepage 'http://www.mothersruin.com/software/SuspiciousPackage/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
-  pkg 'SuspiciousPackage.pkg'
-
-  uninstall :pkgutil => 'com.mothersruin.pkg.SuspiciousPackagePlugin'
+  qlplugin 'Suspicious Package.qlgenerator'
 end


### PR DESCRIPTION
I've edited the formula so it downloads the archived qlplugin rather than a pkg (it's equivalent, as per http://www.mothersruin.com/software/SuspiciousPackage/download.html, but offers more control).
Also, added the right license (as per http://www.mothersruin.com/software/SuspiciousPackage/support.html).

However, cask doesn't seem to like `.xip` archives. Can anybody help?
