### PR TITLE
Add Epichrome v2.1.5

### DIFF
--- a/Casks/epichrome.rb
+++ b/Casks/epichrome.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'epichrome' do
+  version '2.1.5'
+  sha256 'c22bfce8afba80a7ca7ed4c0d24ac1cba173807215a9ce1d3db0b6ac396a3737'
+
+  url "https://github.com/dmarmor/epichrome/releases/download/v#{version}/epichrome-#{version}.dmg"
+  name 'Epichrome'
+  homepage 'https://github.com/dmarmor/epichrome'
+  license :oss
+
+  app 'Epichrome.app'
+end


### PR DESCRIPTION
Epichrome is an SSB creating tool backed by Chrome & a Chrome extension. This is the first version
submitted to homebrew-cask.
