### PR TITLE
maintaining.md: add labels section

### DIFF
--- a/doc/maintaining.md
+++ b/doc/maintaining.md
@@ -48,6 +48,31 @@ possible, *etc*.
 __TODO__: Maybe one of our more active Cask reviewers can fill in the things
 they look for in incoming Casks.
 
+## Labels
+
+Every open issue and pull request must have a label added to it, unless the maintainer immediately acts on it (closing/merging) after looking at it. Labels should be consistent accross repositories: not every repository needs every label, but their meaning and color must be the same throughout. Currently, our labels are:
+
+Label | Description | Issues | Pull Requests
+----- | ----------- | :----: | :-----------:
+**bug** | Something isn’t working as expected. A modification/addition/removal . Must always be accompanied by **cask** or **core** | &#x2713; | &#x2713;
+**cask** | Relates directly to a cask. Must always be accompanied by **bug** or **enhancement**. | &#x2713; | &#x2713;
+**cask request** | Either a request for a new cask or a call for correction in an existing one. | &#x2713; |
+**chief bug** | When multiple people open new issues for the same bug, the main issue where its progression is being tracked should have this label. Every other one should be marked **duplicate** and closed. | &#x2713; |
+**core** | Relates directly to the code of the core, homebrew-cask itself. Must always be accompanied by **bug** or **enhancement**. | &#x2713; | &#x2713;
+**discussion** | A matter that benefits from discussion before a decision is to be made. Any opinion should be given by users and maintainers alike, even if that opinion is “I have no strong feelings on the matter”. | &#x2713; |
+**documentation** | Relates to the documentation. | &#x2713; | &#x2713;
+**duplicate** | An issue or pull request that is essentially the same as another. Should be immediately closed. | &#x2713; | &#x2713;
+**enhancement** | Something we want implemented. Must always be accompanied by **cask** or **core**. | &#x2713; | &#x2713;
+**future** | Something that can currently only be referenced and will only be possible to act upon in the future, after certain conditions are met. Currently references [changes to the installation behaviour](https://github.com/caskroom/homebrew-cask/issues/13201). To be used sparingly. | &#x2713; | &#x2713;
+**meta** | Relates to homebrew-cask itself as a project and its policies/decisions. | &#x2713; |
+**on hold** | A pull request that depends on another being merged before it itself can be as well. |  | &#x2713;
+**roadmap** | Roadmap for feature implementation. | &#x2713; |
+**ready to implement** | Usually accompanied by the closing of a **discussion** issue. It succinctly describes in points the implementation of something yet to be written, be it a feature or a documentation section. Anyone looking at such an issue can safely ignore every post following the top one, as it should always be kept up-to-date with the discussion. | &#x2713; |
+**travis bug** | Bug related to [Travis CI](https://travis-ci.org/). | &#x2713; | &#x2713;
+**upstream** | Something we have no hand in, and can only be fixed with intervention from developers outside homebrew-cask. Always refers to a cask, and never to the core. | &#x2713; | &#x2713;
+**awaiting maintainer feedback** | A maintainer requires input from other maintainers to proceed. Other maintainers should occasionaly check this label and give their feedback on the subject, if able. | &#x2713; | &#x2713;
+**awaiting user reply** | A maintainer requires further action or information from the original poster to proceed. Particularly useful to weed out those cases where issues and pull requests would otherwise be left open indefinitely because the original poster never replies. | &#x2713; | &#x2713;
+
 ## Reviewing Core PRs
 
 Occasionally we'll get submissions from users that fix bugs or add features to


### PR DESCRIPTION
@caskroom/maintainers This is documentation on our labels, and how to use them. In the past I’ve seen us using these somewhat inconsistently from each other, so this aims to bring us all to the same page.

I’ll call attention to one particular part: **cask**, **core**, **enhancement**, and **bug** should never be used alone. the first two should always be used in conjunction with one of the last two.

As another small note (and also pointed out in this documentation), **cask request** (relatively recent) should also be used when a user points out a cask is outdated. The idea of **cask request** being “I can’t update/add it right now, but anyone else, even if not a maintainer, should be able to quickly see them so they can contribute/fix it”.
