### PR TITLE
Update Easyfig from app to binary

### DIFF
--- a/Casks/easyfig.rb
+++ b/Casks/easyfig.rb
@@ -8,5 +8,5 @@ cask :v1 => 'easyfig' do
   homepage 'http://mjsull.github.io/Easyfig/'
   license :gpl
 
-  app "Easyfig_mac_#{version.to_f}/Easyfig_mac_#{version.to_f}.app"
+  binary "Easyfig_#{version}_OSX/Easyfig", :target => 'easyfig'
 end


### PR DESCRIPTION
Fixes https://github.com/caskroom/homebrew-cask/pull/13628. Now it's not packed as an app bundle and should be used as a binary instead. However, it's still has a GUI.
