### PR TITLE
Upgrade nodeclipse to version 0.17

### DIFF
--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'nodeclipse' do
-  version '0.11-preview'
-  sha256 '01f630446313cb981ce2ee9b934977cfdbf318e09761dee244a3256f9a559003'
+  version '0.17'
+  sha256 '674991d7c22ea05975a76800e6e9fe9231064a09a2a2412e6ec0448676bfa2e8'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/project/nodeclipse/Enide-Studio-2014/#{version}/Enide-Studio-2014-011-20140228-macosx-cocoa-x86_64.zip"
+  url "http://downloads.sourceforge.net/project/nodeclipse/Enide-2015/7/Enide-2015-7-macosx-x64-20150706.zip"
   name 'Nodeclipse'
   homepage 'http://www.nodeclipse.org/'
   license :oss
@@ -11,5 +11,5 @@ cask :v1 => 'nodeclipse' do
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/8183
-  app 'eclipse/Eclipse.app', :target => 'Nodeclipse.app'
+  app 'Eclipse.app', :target => 'Nodeclipse.app'
 end


### PR DESCRIPTION
Hello,

I upgrade nodeclipse to v0.17.

Maybe it should be call Enide and v2015.7 but I wanted to keep it as it was.

Best regards,
Lionel
