### PR TITLE
Update sequel-pro to 1.1-RC2

### DIFF
--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -1,9 +1,10 @@
 cask :v1 => 'sequel-pro' do
-  version '1.0.2'
-  sha256 'facd99344d0124cf4444acbef9006d947eadc6f96127b09e7380f014c7775f85'
+  version '1.1-RC2'
+  sha256 '35224ab0f6f410ce06b18470a5e5918f97c91fa810371ea4686609bba51a22ea'
 
   # googlecode.com is the official download host per the vendor homepage
-  url "https://sequel-pro.googlecode.com/files/sequel-pro-#{version}.dmg"
+  # url "https://sequel-pro.googlecode.com/files/sequel-pro-#{version}.dmg"
+  url 'https://github.com/sequelpro/sequelpro/releases/download/release-1.1-rc2/sequel-pro-1.1-RC2.dmg'
   appcast 'http://www.sequelpro.com/appcast/app-releases.xml',
           :sha256 => 'd6137595bccddd81edfb3a07a82b4ed818b8b1af79750397f929bf74b91d3e32'
   name 'Sequel Pro'


### PR DESCRIPTION
Sequel Pro 1.1-RC2 released for some important bugs fix in El Capitan, like sequelpro/sequelpro#2050, and I think user will like to install this version instead the stable version because of those bugs fix.
