### PR TITLE
Add Audacity 2.1.1

### DIFF
--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'audacity' do
+  version '2.1.1'
+  sha256 '266fa1b2f3aff3894730a8b0e9fcf5c24c93e726f15180855d2516c5c44de10e'
+
+  url "http://app.oldfoss.com:81/download/Audacity/audacity-macosx-ub-#{version}.dmg"
+  name 'Audacity'
+  homepage 'http://audacityteam.org'
+  license :gpl
+
+  app 'Audacity/Audacity.app'
+end


### PR DESCRIPTION
Using the alternative download link from OldFoss as listed at http://audacityteam.org/download/mac seems to work.

I am aware of #12972 and the issue with FossHub, but it seems that OldFoss allows direct downloads.
