### PR TITLE
Update license for Dwarf Fortress to 'gratis'.

### DIFF
--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -5,7 +5,7 @@ cask :v1 => 'dwarf-fortress' do
   url "http://www.bay12games.com/dwarves/df_#{version.sub(%r{^0+\.},'').gsub('.','_')}_osx.tar.bz2"
   name 'Dwarf Fortress'
   homepage 'http://www.bay12games.com/dwarves/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   suite 'df_osx', :target => 'Dwarf Fortress'
 end


### PR DESCRIPTION
Dwarf Fortress is closed source but may be freely distributed. The
following is the copyright information provided with the software.

```
*** COPYRIGHT INFORMATION ****************************

Copyright (c) 2002-2015.  All rights are retained by Tarn Adams, save
the following:  you may redistribute the binary and accompanying files,
unmodified, provided you do so free of charge.  If you'd like to
distribute a modified version of the game or portion of the archive and
are worried about copyright infringement, please contact Tarn Adams at
toadyone@bay12games.com.

This software is still in development, and this means that there are
going to be problems, including serious problems that, however unlikely,
might damage your system or the information stored on it.  Please be
aware of this before playing.
```
