### PR TITLE
Update Front.app with new download URL.

### DIFF
--- a/Casks/front.rb
+++ b/Casks/front.rb
@@ -2,7 +2,7 @@ cask :v1 => 'front' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.frontapp.com/front-latest.zip'
+  url 'https://dl.frontapp.com/osx/front.dmg'
   name 'Front'
   homepage 'https://frontapp.com/'
   license :gratis


### PR DESCRIPTION
[Front](https://frontapp.com/) changed the download link from http://dl.frontapp.com/front-latest.zip (now showing a `403` error) to https://dl.frontapp.com/osx/front.dmg.
