### PR TITLE
Update Razer Synapse to 1.44

### DIFF
--- a/Casks/razer-synapse.rb
+++ b/Casks/razer-synapse.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'razer-synapse' do
-  version '1.41'
-  sha256 'f8fce465114da56f6d5f0771429b1f118ac547c77b9b05d3f84333f8d94b5019'
+  version '1.44'
+  sha256 '63c739c78d4f537ec64b32126fc358fba4840194296e45bd7c22638af6529984'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://razerdrivers.s3.amazonaws.com/drivers/Synapse2/mac/Razer_Synapse_Mac_Driver_v#{version}.dmg"
@@ -13,5 +13,23 @@ cask :v1 => 'razer-synapse' do
   depends_on :macos => '>= :lion'
 
   uninstall :script => '/Applications/Utilities/Uninstall Razer Synapse.app/Contents/MacOS/Uninstall Razer Synapse',
-            :pkgutil => 'com.razerzone.*'
+            :pkgutil => 'com.razerzone.*',
+            :quit =>  [
+                        'com.razerzone.RzUpdater',
+                        'com.razerzone.rzdeviceengine'
+                      ],
+            :launchctl => [
+                          'com.razer.rzupdater',
+                          'com.razerzone.rzdeviceengine'
+                          ]
+
+  zap :delete =>  [
+                    '~/Library/Preferenecs/com.razer.*',
+                    '~/Library/Preferenecs/com.razerzone.*'
+                  ]
+
+  caveats do
+    reboot
+  end
+
 end


### PR DESCRIPTION
The latest version is actually 1.44.1, but I cannot find a direct download for that version.

The uninstall script runs before the other items in the stanza but it blocks the rest of the uninstall items from running. The problem with that is the last step of the uninstall script is to restart, and I don't think the rest of the items have to time run before the machine restarts.

The uninstall script simply deletes some `launchctl` files as will as a kernel extension. Would it be acceptable to forgo using the uninstall script and perform the uninstall using Homebrew Cask keys in the uninstall stanza?
