### PR TITLE
Update airy sha for 2.1.89.dmg

### DIFF
--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'airy' do
   version '2.1.89'
-  sha256 'd76074e847571f724861e28ded5493746e9b24af5d99d4224d4d106b15a65908'
+  sha256 'e866ed9ac7bccbc00aebadb3ead80a378b0eedf023de9d8d8504dc6c2be7747a'
 
   url "http://www.eltima.com/download/airy-update/airy_#{version}.dmg"
   appcast 'http://mac.eltima.com/download/airy-update/airy.xml',

--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -4,7 +4,7 @@ cask :v1 => 'airy' do
 
   url "http://www.eltima.com/download/airy-update/airy_#{version}.dmg"
   appcast 'http://mac.eltima.com/download/airy-update/airy.xml',
-          :sha256 => '099e2432d465417c5eb2936ce233505afe1a9f7caad21847f8c9d09b2333187d'
+          :sha256 => 'a8e7d03bc1aa4b504ea280a08c7d10a12abff74f301495f759e6c3ca2f2a895b'
   name 'Airy'
   homepage 'http://mac.eltima.com/youtube-downloader-mac.html'
   license :commercial


### PR DESCRIPTION
Got an SHA mismatch error. Manually re-downloaded and verified new/correct SHA.
