### PR TITLE
Update node pkgutil package name

### DIFF
--- a/Casks/node.rb
+++ b/Casks/node.rb
@@ -9,5 +9,5 @@ cask :v1 => 'node' do
 
   pkg  "node-v#{version}.pkg"
 
-  uninstall :pkgutil => 'org.nodejs'
+  uninstall :pkgutil => 'org.nodejs.node.pkg'
 end


### PR DESCRIPTION
Current cask does not really uninstall node. After changing the package name it correctly removes npm and node and everything that comes with the pkg installer.
