### PR TITLE
Add barXtemp.app v1.3.1

### DIFF
--- a/Casks/barxtemp.rb
+++ b/Casks/barxtemp.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'barxtemp' do
+  version '1.3.1'
+  sha256 'cf9f0da35288f95d19140cb71657aa48ca90c850d43694f851fe27e4b63a8ed2'
+
+  url "https://github.com/Gabriele91/barXtemp/releases/download/#{version}/barXtemp.app.zip"
+  appcast 'https://github.com/Gabriele91/barXtemp/releases.atom'
+  name 'barXtemp'
+  homepage 'https://gabriele91.github.io/barXtemp/'
+  license :mit
+
+  depends_on :macos => '>= :mountain_lion'
+
+  app 'barXtemp.app'
+end


### PR DESCRIPTION
Add an useful and free app to get temperature of your mac.

This is a simple OS X app to get the computer temperature. The app is accessible from the Systray and shows the CPU temperature, the integrated GPU temperature (if available), the speed of the fans and the temperature of the battery.

It is a very useful app that you can't find for free (and it is also open, because the project is under mit license and on github).
