### PR TITLE
Updated odrive cask

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'odrive' do
-  version '2712'
-  sha256 'd7782b822b057cdb8b7ff7883296c7c546601cfdf6647ce66bddd3ace89bbcc6'
+  version '3801'
+  sha256 '3f655ccfab6a04bbcf6d5660b03ea0532184ee0840f6f5edec71d65340ebb3fe'
 
-  url "http://cdn-mac.odrive.com/odrive.#{version}.dmg"
+  url "https://d3huse1s6vwzq6.cloudfront.net/odrivesync.#{version}.dmg"
   name 'odrive'
   homepage 'https://app.odrive.com/'
   license :gratis


### PR DESCRIPTION
When I signed up for odrive, the file the site had me download looks to be a newer version than the one cask has.
