### PR TITLE
Fix commit range for `audit_modified_casks`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
 script:
   - /System/Library/Frameworks/Ruby.framework/Versions/"${CASK_RUBY_TEST_VERSION}"/usr/bin/bundle exec "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/rake" test TESTOPTS="--seed=14830"
   - /System/Library/Frameworks/Ruby.framework/Versions/"${CASK_RUBY_TEST_VERSION}"/usr/bin/bundle exec "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/rake" rubocop
-  - developer/bin/audit_modified_casks "${TRAVIS_COMMIT_RANGE/.../..}"
+  - developer/bin/audit_modified_casks "${TRAVIS_BRANCH}..${TRAVIS_COMMIT}"
 
 notifications:
   irc:


### PR DESCRIPTION
The value of `TRAVIS_COMMIT_RANGE` is of the form `<target_branch_tip>...<pr_branch_tip>`. Even after replacing the `...` with `..` in #13762, this results in unrelated changes being included in the diff if the target branch (`master`) has been updated since the PR branch was created.

The commit that Travis checks out for testing (`TRAVIS_COMMIT`) is a merge of the PR branch into the target branch (`TRAVIS_BRANCH`), so the commit range `TRAVIS_BRANCH..TRAVIS_COMMIT` should only include the changes from the PR.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caskroom/homebrew-cask/13783)

<!-- Reviewable:end -->
