### PR TITLE
Remove space from Kindle Previewer package filename

### DIFF
--- a/Casks/kindlepreviewer.rb
+++ b/Casks/kindlepreviewer.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'kindle-previewer' do
+cask :v1 => 'kindlepreviewer' do
   version :latest
   sha256 :no_check
 
@@ -8,6 +8,6 @@ cask :v1 => 'kindle-previewer' do
   homepage 'https://www.amazon.com/gp/feature.html/?docId=1000765261'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  pkg 'Kindle Previewer.pkg'
+  pkg 'KindlePreviewer.pkg'
   uninstall :pkgutil => 'Amazon.Kindle.Previewer.pkg'
 end


### PR DESCRIPTION
I was receiving the following error when trying to install the `kindle-previewer` application:

```
$ brew cask install kindle-previewer
==> Downloading https://kindlepreviewer.s3.amazonaws.com/KindlePreviewer.zip
Already downloaded: /Library/Caches/Homebrew/kindle-previewer-latest.zip
==> Running installer for kindle-previewer; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
Error: pkg source file not found: '/opt/homebrew-cask/Caskroom/kindle-previewer/latest/Kindle Previewer.pkg'
```

I expanded the downloaded zip file, and saw that the extracted package name didn’t contain a space, like the formula expects:

<img width="558" alt="screenshot 2015-09-16 09 20 14" src="https://cloud.githubusercontent.com/assets/296432/9899827/53bc03fa-5c54-11e5-949c-6df3ee978bb1.png">

After altering the formula to remove the space, installing succeeds locally.

```
$ brew cask edit kindle-previewer

…

$ brew cask install kindle-previewer
==> Downloading https://kindlepreviewer.s3.amazonaws.com/KindlePreviewer.zip
Already downloaded: /Library/Caches/Homebrew/kindle-previewer-latest.zip
==> Running installer for kindle-previewer; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
==> installer: Package name is Kindle Previewer 2.941
==> installer: Installing at base path /
==> installer: The install was successful.
🍺  kindle-previewer staged at '/opt/homebrew-cask/Caskroom/kindle-previewer/latest' (219M)
```

This PR contains that change :grin: 
