### PR TITLE
Update dockertoolbox to 1.8.2a and fix DSL version

### DIFF
--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'dockertoolbox' do
-  version '1.8.2'
-  sha256 '282fe6d3d0d719d79e6518aad1e4c744e70905618b0873fe93352eb832b54e8d'
+  version '1.8.2a'
+  sha256 '05e74dd2c811452f1c25e7264d9a06500bd5af5861cc36a45eb7e36967d1486d'
 
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom'

--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'dockertoolbox' do
+cask :v1_1 => 'dockertoolbox' do
   version '1.8.2a'
   sha256 '05e74dd2c811452f1c25e7264d9a06500bd5af5861cc36a45eb7e36967d1486d'
 


### PR DESCRIPTION
- upgrade dockertoolbox to fix this error https://github.com/caskroom/homebrew-cask/issues/13768
- update dsl version to `:v1_1`since this uses `set_ownership`
