### PR TITLE
fix pkg source file not found error for synology-cloud-station

### DIFF
--- a/Casks/synology-cloud-station.rb
+++ b/Casks/synology-cloud-station.rb
@@ -7,7 +7,7 @@ cask :v1 => 'synology-cloud-station' do
   homepage 'https://www.synology.com/'
   license :gratis
 
-  pkg "synology-cloud-station-#{version}.pkg"
+  pkg "synology-cloud-station-#{version.sub(%r{.*-},'')}.pkg"
 
   uninstall :pkgutil => 'com.synology.CloudStation',
             :launchctl => 'com.synology.Synology Cloud Station'


### PR DESCRIPTION
When trying to install synology-cloud-station, currently you run into the following error because the package installer file name is wrongly specified:

```
~ $> brew cask install synology-cloud-station
==> Downloading https://global.download.synology.com/download/Tools/CloudStation/3.2-3482/Mac/Installer/synology-cloud-station-3482.dmg
######################################################################## 100.0%
==> Running installer for synology-cloud-station; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
Error: pkg source file not found: '/opt/homebrew-cask/Caskroom/synology-cloud-station/3.2-3482/synology-cloud-station-3.2-3482.dmg'
```

This pull request corrects the filename for the package installer.
