### PR TITLE
Upgrade QtPass.app to v1.0.1

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'qtpass' do
-  version :latest
-  sha256 :no_check
+  version '1.0.1'
+  sha256 '9a72a87a9f5408d50aa10ac11d8a5ec13453beb95b2a27ca46a6212132f4685b'
 
-  url 'https://annejan.com/media/qtpass.dmg'
+  url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   name 'QtPass'
   homepage 'https://qtpass.org/'
   license :gpl


### PR DESCRIPTION
Changed the URL of the download location to GitHub, because this is not the official download host according to the vendor's homepage (https://qtpass.org/).
