### PR TITLE
Add missing space between { and | for Minecraft Server

### DIFF
--- a/Casks/minecraft-server.rb
+++ b/Casks/minecraft-server.rb
@@ -28,7 +28,7 @@ cask :v1 => 'minecraft-server' do
 
     file_name = "#{staged_path}/EULA.txt"
     contents = File.read(file_name).gsub(/false/, 'true')
-    File.open(file_name, 'w') {|file| file.puts contents }
+    File.open(file_name, 'w') { |file| file.puts contents }
   end
 
   caveats do


### PR DESCRIPTION
Small fix missed in https://github.com/caskroom/homebrew-cask/pull/13893.
