### PR TITLE
Update Deluge to 1.3_12

### DIFF
--- a/Casks/deluge.rb
+++ b/Casks/deluge.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'deluge' do
-  version '1.3.11'
-  sha256 '503b3ac13bd437bfa2c055aa1ddf26290db0c5d4fb04e130c94dc42490ce6131'
+  version '1.3.12'
+  sha256 'e8fd74918ada2ebc6994e9c0f52efbabe509147f0ede63ab6954f4811de8afdb'
 
-  url "http://download.deluge-torrent.org/mac_osx/deluge-#{version}-osx-x86.tbz2"
+  url "http://download.deluge-torrent.org/mac_osx/deluge-#{version}-osx-x64-inst.dmg"
   name 'Deluge'
   homepage 'http://deluge-torrent.org/'
   license :gpl


### PR DESCRIPTION
Update Deluge to version 1.3_12.
Installer now downloads DMG instead of tbz2 archive.
