### PR TITLE
Updated Deezer.app to v1.1_4191

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'deezer' do
-  version '1.0_4174'
-  sha256 'c506f6215b097a2eec5605030d053f70bf7a747a5138a5c7f997b247eeccc151'
+  version '1.1_4191'
+  sha256 'f9d491fb8d4b055a60b3d4a13a4e8b19e4b9b8d70dc8740df734afeee5482a34'
 
-  url "https://cdns-content.deezer.com/builds/mac/Deezer#{version.sub(%r{^[^_]*(_\d+)},'\1')}.dmg"
+  url "https://cdns-content.deezer.com/builds/mac/Deezer_#{version.sub(%r{^[^_]*_(\d+)},'\1')}.dmg"
   name 'Deezer'
   homepage 'https://www.deezer.com/formac'
   license :gratis


### PR DESCRIPTION
Updated Deezer version to v1.1 (Build 4191)

Also cleaned up the method for extracting the build number from the "version" parameter.
