### PR TITLE
Update openzfs to 1.4.2

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -1,13 +1,20 @@
 cask :v1 => 'openzfs' do
-  version '1.3.1-r2'
-  sha256 '7d0001f318e70f7a5ee87273a1f1cc7912908677ea9565702d05282c1ebca8b8'
+  version '1.4.2'
+  sha256 '189fc9bfe231cf51b65dac2665cecb65f632979fd13bcafa3f4e3b486880237f'
 
-  url "https://openzfsonosx.org/w/images/7/71/OpenZFS_on_OS_X_#{version}.dmg"
+  url "https://openzfsonosx.org/w/images/0/0f/OpenZFS_on_OS_X_#{version}.dmg"
   name 'OpenZFS on OS X'
   homepage 'https://openzfsonosx.org'
   license :oss
 
-  pkg "OpenZFS on OS X #{version.sub(%r{-.*},'')} Mavericks or higher.pkg"
+  # OpenZFS on OSX has no version below Mountain Lion.
+  if MacOS.release == :mountain_lion
+    pkg "OpenZFS on OS X #{version.sub(%r{-.*},'')} Mountain Lion.pkg"
+  elsif MacOS.release == :mavericks
+    pkg "OpenZFS on OS X #{version.sub(%r{-.*},'')} Mavericks.pkg"
+  elsif MacOS.release >= :yosemite
+    pkg "OpenZFS on OS X #{version.sub(%r{-.*},'')} Yosemite or higher.pkg"
+  end
 
   uninstall :pkgutil => 'net.lundman.openzfs.*'
 end


### PR DESCRIPTION
Just released: https://twitter.com/openzfsonosx/status/647038780482781184

Changelog:

correct kernel thread priorities (Jorgen Lundman)
VFS nolocks rework from 10a286 (Jorgen Lundman)
vnop_pageout_v2 replacement (Jorgen Lundman)
Permanent Storage work, incomplete (Jorgen Lundman)
mmapped file data written twice fix (Jorgen Lundman)
InvariantDisks fixes (ilovezfs) (cbreak)
SA corruption fixes (ZFSOnLinux)
SA recover status alerts when detected (Jorgen Lundman)
Modify-After-Free bugs and deadlock fixes (Jorgen Lundman)
Complete Re-port of IllumOS taskq (Jorgen Lundman)
Revert back to using taskq_dispatch_ent() (Jorgen Lundman)
Remove async unlinkeddrain (Jorgen Lundman)
Remove internal unused flag XATTR (Brendon Humphrey)
Additional ioctls from HFS (Brendon Humphrey)
Merge with upstream ZOL 20150520
New pool feature "filesystem_limits"
New pool feature "large_blocks"
