### PR TITLE
sourcetree 2.0.5.3

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -3,8 +3,8 @@ cask :v1 => 'sourcetree' do
     version '1.8.1'
     sha256 '37a42f2d83940cc7e1fbd573a70c3c74a44134c956ac3305f6b153935dc01b80'
   else
-    version '2.0.5.2'
-    sha256 '106531ed0087403020a2ba07efaaf1ce297734eb62e2a0eaea8cd5f88e18e7cb'
+    version '2.0.5.3'
+    sha256 '562e5885c10a5b1791938b7e6d1548511c5bc19fb9411c9bb2d69d6189ed9951'
   end
 
   # atlassian.com is the official download host per the vendor homepage


### PR DESCRIPTION
[SourceTree 2.0.5.3 Release Notes](https://www.sourcetreeapp.com/update/ReleaseNotes.html#version-2.0.5.3)
