### PR TITLE
Fix URL in gnucash Cask

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -3,7 +3,7 @@ cask :v1 => 'gnucash' do
   sha256 'd0ed3339ac2f483219aab0b2c3317116b8ddb3a36e86722295899f2eeabbe74e'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/sourceforge/gnucash/Gnucash-Intel-#{version}.dmg"
+  url "http://downloads.sourceforge.net/project/gnucash/gnucash%20(stable)/#{version[/[^-]+/]}/Gnucash-Intel-#{version}.dmg"
   name 'GnuCash'
   homepage 'http://www.gnucash.org'
   license :gpl


### PR DESCRIPTION
The prior URL resulted in downloading the HTML rather than the dmg.
