### PR TITLE
Upgrade SwitchResX to v4.5.2

### DIFF
--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'switchresx' do
-  version '4.5.1'
-  sha256 '6d044b3be800f8e8c34a4b87cad7100d69a40b165f6e12297aa42516891b7aed'
+  version '4.5.2'
+  sha256 '6861861ec9ed510965a9794cb009399095c7a091268cef08031b0caca5ac71a8'
 
   url "http://www.madrau.com/data/switchresx/SwitchResX#{version.to_i}.zip"
   name 'SwitchResX'
   homepage 'http://www.madrau.com'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :freemium
 
   prefpane 'SwitchResX.prefPane'
 


### PR DESCRIPTION
- Upgraded version number and SHA for v4.5.2
- Updated license to Trial/Freemium from unknown
