### PR TITLE
Upgrade sonic-pi to latest version and fix link

### DIFF
--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'sonic-pi' do
-  version :latest
-  sha256 :no_check
+  version '2.7.0'
+  sha256 '8a02d029273a3906b4761e2d36d64d34f0c4aff4fed4253658f0dc1c0f219ff9'
 
-  url 'http://sonic-pi.net/app/sonic-pi-mac.dmg'
+  url "http://sonic-pi.net/files/releases/0#{version}/Sonic-Pi-for-Mac-v#{version}.dmg"
   name 'Sonic Pi'
   homepage 'http://sonic-pi.net/'
   license :mit


### PR DESCRIPTION
The link to sonic-pi was broken and also it was setup as "latest"
instead of using the version. This commit fixes that.
