### PR TITLE
Fix qgis.rb for removed Cask: 'matplotlib'

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -11,5 +11,5 @@ cask :v1 => 'qgis' do
   uninstall :pkgutil => 'org.qgis.qgis-*'
 
   depends_on :cask => 'gdal-framework'
-  depends_on :cask => 'matplotlib'
+  depends_on 'matplotlib'
 end


### PR DESCRIPTION
Removed cask is available as Python formula
