### PR TITLE
Fix qgis.rb for removed Cask

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -11,5 +11,5 @@ cask :v1 => 'qgis' do
   uninstall :pkgutil => 'org.qgis.qgis-*'
 
   depends_on :cask => 'gdal-framework'
-  depends_on :cask => 'matplotlib'
+  depends_on :formula => 'matplotlib'
 end


### PR DESCRIPTION
[PR #13573](https://github.com/caskroom/homebrew-cask/pull/13573) removed Cask matplotlib, as Python formula is available.
