### PR TITLE
CONDUCT.md: revert to 0.3b

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,12 +1,8 @@
 # Contributor Code of Conduct
-## Version 0.4
+## Version 0.3b
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of Homebrew Cask, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-If any participant in this project has issues or takes exception with a contribution, they are obligated to provide constructive feedback and never resort to personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+We provide constructive feedback and never resort to personal attacks, trolling, harrassment, insults, or other unprofessional conduct. We are considerate of the effort of others. We are tactful when we provide criticism, and graceful when we face it.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
-
-We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.
+We extend courtesy and respect to everyone who volunteers their labor for this project. We welcome and encourage contributors regardless of their background or attributes including, but not limited to: age, culture, ethnicity, national origin, gender identity or expression, ability or disability, physical or mental difference, experience, politics, race, religion, sex, sexual orientation, socio-economic status, and subculture.


### PR DESCRIPTION
Reverts to the last good changes made by @ndr-qef. @caskroom/maintainers, you can see some of his concerns at https://github.com/CoralineAda/contributor_covenant/issues/17, and why I believe this reversal should happen at https://github.com/caskroom/homebrew-cask/issues/14053 and https://github.com/caskroom/homebrew-cask/pull/4055#issuecomment-49564508.

If there are no objections, I’ll merge this on the 5<sup>th</sup> of October (one week from today).
