### PR TITLE
Add Vectr 0.1.7

### DIFF
--- a/Casks/vectr.rb
+++ b/Casks/vectr.rb
@@ -2,10 +2,17 @@ cask :v1 => 'vectr' do
   version '0.1.7'
   sha256 '8416736f29f1b2e72d8d4595386bce554bb4ccbc49b27f92a86c6febabfbc35e'
 
+<<<<<<< Updated upstream
   url "http://download.vectr.com/desktop/vectr-mac-#{version}.zip"
   name 'Vectr'
   homepage 'https://vectr.com'
   license :gratis
+=======
+  url 'http://download.vectr.com/desktop/vectr-mac-0.1.7.zip'
+  name 'Vectr'
+  homepage 'https://vectr.com/'
+  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+>>>>>>> Stashed changes
 
   app 'Vectr.app'
 end


### PR DESCRIPTION
Adding Vectr.app version 0.1.7.

Their homepage can be found here: https://vectr.com/
