### PR TITLE
checksums of QQ was changed

### DIFF
--- a/Casks/qq.rb
+++ b/Casks/qq.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'qq' do
   version '4.0.4'
-  sha256 'c0db5ee1d19532e8be16a5e6b3e57e09296ce8677f9b2728c7740a38217ff307'
+  sha256 '8d55ab564ead24e451b21f20f04b7bfdafda5d3273276ae5710b9a240f2e6e8f'
 
   url "http://dldir1.qq.com/qqfile/QQforMac/QQ_V#{version}.dmg"
   name 'QQ'


### PR DESCRIPTION
The sha256 checksum of http://dldir1.qq.com/qqfile/QQforMac/QQ_V4.0.4.dmg was changed to `8d55ab564ead24e451b21f20f04b7bfdafda5d3273276ae5710b9a240f2e6e8f`.

btw:
HTTP Header `Last-Modified` is `Thu, 24 Sep 2015 13:10:32 GMT`.
