### PR TITLE
Fix checksum in SwitchResX Cask

### DIFF
--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'switchresx' do
   version '4.5.2'
-  sha256 '6861861ec9ed510965a9794cb009399095c7a091268cef08031b0caca5ac71a8'
+  sha256 '8129d66e7e9c297ea6b1d866f83599d134e235b17804a510f753790ac28f8f3a'
 
   url "http://www.madrau.com/data/switchresx/SwitchResX#{version.to_i}.zip"
   name 'SwitchResX'


### PR DESCRIPTION
SwitchResX 4.5.2 was failing to install for me with a checksum mismatch. Not sure why the checksum was wrong, as it did in fact get updated in the 4.5.1 -> 4.5.2 update as seen here: https://github.com/caskroom/homebrew-cask/commit/58780b77b880bffb68ffed9e91472d68d267797e.

```
$ brew up
Updated Homebrew from d8c107d8 to 88eaeeca.

$ brew cask install switchresx
==> Downloading http://www.madrau.com/data/switchresx/SwitchResX4.zip
######################################################################## 100.0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 6861861ec9ed510965a9794cb009399095c7a091268cef08031b0caca5ac71a8
Actual: 8129d66e7e9c297ea6b1d866f83599d134e235b17804a510f753790ac28f8f3a
File: /Library/Caches/Homebrew/switchresx-4.5.2.zip
To retry an incomplete download, remove the file above.
```

I updated it for the checksum I'm seeing on my machine:

```
$ shasum -a 256 SwitchResX4.zip 
8129d66e7e9c297ea6b1d866f83599d134e235b17804a510f753790ac28f8f3a  SwitchResX4.zip
```

Ping @greg5green
