### PR TITLE
Sequel Pro 1.1 (version bump)

### DIFF
--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -1,10 +1,8 @@
 cask :v1 => 'sequel-pro' do
-  version '1.1-RC2'
-  sha256 '35224ab0f6f410ce06b18470a5e5918f97c91fa810371ea4686609bba51a22ea'
+  version '1.1'
+  sha256 'dfefd39b64a78084db88210e2ea365effbaeb8903173f3dfd55b60421ee461fa'
 
-  # googlecode.com is the official download host per the vendor homepage
-  # url "https://sequel-pro.googlecode.com/files/sequel-pro-#{version}.dmg"
-  url 'https://github.com/sequelpro/sequelpro/releases/download/release-1.1-rc2/sequel-pro-1.1-RC2.dmg'
+  url "https://github.com/sequelpro/sequelpro/releases/download/release-#{version}/sequel-pro-#{version}.dmg"
   appcast 'http://www.sequelpro.com/appcast/app-releases.xml',
           :sha256 => 'd6137595bccddd81edfb3a07a82b4ed818b8b1af79750397f929bf74b91d3e32'
   name 'Sequel Pro'


### PR DESCRIPTION
N.B. The “Download Now” button at http://www.sequelpro.com/download
now links to GitHub, so I removed the googlecode comment.
