### PR TITLE
Fix Alchemy installer

### DIFF
--- a/Casks/alchemy.rb
+++ b/Casks/alchemy.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'alchemy' do
-  version '008.1'
+  version '008'
   sha256 '7527f4e2231db8167c57d2639fcba166d8fefea091cca7884bd355fb52a3449a'
 
-  url "http://al.chemy.org/files/Alchemy-#{version.sub(%r{\..*},'')}.dmg"
+  url "http://al.chemy.org/files/Alchemy-#{version}.dmg"
   name 'Alchemy'
   homepage 'http://al.chemy.org'
   license :gpl
 
-  app 'Alchemy.app'
+  app 'Alchemy/Alchemy.app'
 end


### PR DESCRIPTION
-Drop version from 008.1 to 008 (There isn’t a build for 008.1)
-Fix bad app stanza
-Remove regex from versioned URL
