### PR TITLE
Update key-codes sha256

### DIFF
--- a/Casks/key-codes.rb
+++ b/Casks/key-codes.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'key-codes' do
   version '2.0.1'
-  sha256 '47d61049953e8fcf881c0c6b9c7060fed2248750f23c26b71b51092384bd5a4a'
+  sha256 '1b7b4de0d15dfd483811b913821b722afab181cad031a5d0c1172e981a0dc6bd'
 
   url 'http://manytricks.com/download/keycodes'
   appcast 'http://manytricks.com/keycodes/appcast.xml'


### PR DESCRIPTION
The maintainers of this app seemed to have updated their dmg without
bumping the version, this is the new sha256.
