### PR TITLE
revert hyperdock to versioned URL and update to latest 1.6.0.1

### DIFF
--- a/Casks/hyperdock.rb
+++ b/Casks/hyperdock.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'hyperdock' do
-  version :latest
-  sha256 :no_check
+  version '1.6.0.1'
+  sha256 '30d90640052015a042ea40a4eb17889c2717cec72fd6af05dc447fd7679ce517'
 
-  url "https://bahoom.com/hyperdock/HyperDock.dmg"
+  url "https://bahoom.com/hyperdock/#{version}/HyperDock-#{version}.dmg"
   appcast 'https://bahoom.com/hyperdock/appcast.xml',
           :sha256 => '22d00db14142a74fce6466bde7dd590ee7f3c3ec277e59b31a637885f97c9542'
   name 'HyperDock'


### PR DESCRIPTION
Found the new versioned URL, so changing the cask back to that.
Updates https://github.com/caskroom/homebrew-cask/pull/14122 and also fixes the stylecop errors.
