### PR TITLE
Add MenuMeters v1.9 (yujitach El Capitan port)

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'yujitach-menumeters' do
+  version '1.9'
+  sha256 'ecfda83c213c5562b9be1b9fd430c78303d5b246d92e3e31822dcbe01acf3107'
+
+  url "http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
+  name 'MenuMeters'
+  name 'MenuMeters El Capitan Port'
+  homepage 'http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
+  license :gpl
+
+  prefpane 'MenuMeters.prefPane'
+
+  zap :delete => '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'
+end


### PR DESCRIPTION
This is a fork of Alex Harper’s MenuMeters, by Yuji Tachikawa. 
It adds OS X El Capitan support to the utility.
The fork is in development at https://github.com/yujitach/MenuMeters.
