### PR TITLE
Fix diskmaker-x version naming scheme

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -7,5 +7,5 @@ cask :v1 => 'diskmaker-x' do
   homepage 'http://diskmakerx.com/'
   license :gratis
 
-  app "DiskMaker X #{version}.app"
+  app "DiskMaker X #{version.to_i}.app"
 end


### PR DESCRIPTION
Looks like they only using the major version number in the actual app name. No promises that this revision will work forever though.
