### PR TITLE
mono-mdk: downgrade El Capitan for 4.0.4.4 hotfix

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'mono-mdk' do
-  version '4.2.0'
+  version '4.0.4.4'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://download.mono-project.com/archive/#{version}/macos-10-x86/MonoFramework-MDK-#{version}.macos10.xamarin.x86.pkg"
+  url "http://download.mono-project.com/archive/4.0.4/macos-10-x86/MonoFramework-MDK-#{version}.macos10.xamarin.x86.pkg"
   name 'Mono'
   homepage 'http://mono-project.com'
   license :oss


### PR DESCRIPTION
http://www.mono-project.com/docs/about-mono/releases/4.0.4.4/

Installs binaries in /usr/local/bin rather than /usr/bin
