### PR TITLE
Update calibre to 2.40.0

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -3,8 +3,8 @@ cask :v1 => 'calibre' do
     version '1.48.0'
     sha256 '0533283965fbc9a6618d0b27c85bdf3671fe75ff0e89eeff406fe1457ee61b14'
   else
-    version '2.39.0'
-    sha256 '85595d5917493a4e88321eb7255d8f97705f708c653c0e27669dfe6d934692ef'
+    version '2.40.0'
+    sha256 '055bb9afadeed5e98e17ad8d4dc7fec0465c1d019b6573ccaf72e7eacea1c598'
     appcast 'https://github.com/kovidgoyal/calibre/releases.atom'
   end
 


### PR DESCRIPTION
Calibre 2.40.0 [released on Oct 2<sup>nd</sup>](http://calibre-ebook.com/whats-new). 
