### PR TITLE
ios7-screensaver: updated homepage and description

### DIFF
--- a/Casks/ios7-screensaver.rb
+++ b/Casks/ios7-screensaver.rb
@@ -3,8 +3,8 @@ cask :v1 => 'ios7-screensaver' do
   sha256 '5b71814a11a701fc074994eba0af7f35533aa35acc6eaa78c2e70ce923e9f19d'
 
   url 'https://www.weebly.com/uploads/2/5/7/9/25796706/ios_7_lockscreen_by_bodysoulspirit.dmg'
-  name 'iOS screensaver for OS X'
-  homepage 'http://bodysoulspirit.weebly.com/ios-7-screensaver-for-mac-os-x-by-bodysoulspirit.html'
+  name 'iOS 7 Lock Screensaver for OSX'
+  homepage 'http://bodysoulspirit.weebly.com/ios-screensaver-for-osx.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   screen_saver 'Install iOS 7 screensaver.app/Contents/Resources/iOS 7 lockscreen by bodysoulspirit.qtz'


### PR DESCRIPTION
The homepage has moved to http://bodysoulspirit.weebly.com/ios-screensaver-for-osx.html.
