### PR TITLE
Updated gitbook cask to point to new download

### DIFF
--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'charles' do
-  version '3.10.2'
-  sha256 'd68be46d7dc9654b4b3b094a2f451226376d7bf3c5d401aecba082b27e0b8b6a'
+  version '3.11'
+  sha256 'b31efe7c80464a92984d7a76e8a41df0d766c4047695b083f7278a9668585592'
 
   url "http://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
+
   name 'Charles'
   homepage 'http://www.charlesproxy.com/'
   license :commercial

--- a/Casks/gitbook.rb
+++ b/Casks/gitbook.rb
@@ -1,16 +1,11 @@
 cask :v1_1 => 'gitbook' do
-  version '1.1.0'
-  sha256 'f8e2f7b28e7dfa18b3736f8d43d68068228774c0827fdc8c685846a129459c5f'
+  version :latest
+  sha256 :no_check
 
-  url "https://github.com/GitbookIO/editor-legacy/releases/download/#{version}/gitbook-mac.dmg"
-  appcast 'https://github.com/GitbookIO/editor-legacy/releases.atom'
+  url "http://downloads.editor.gitbook.com/download/osx"
   name 'GitBook'
-  homepage 'https://github.com/GitbookIO/editor-legacy'
-  license :apache
+  homepage 'https://www.gitbook.com/editor'
+  license :unknown
 
-  app 'GitBook.app'
-
-  caveats do
-    discontinued
-  end
+  app 'GitBook Editor.app'
 end


### PR DESCRIPTION
Previous cask pointed at discontinued github repo vs. new download
