### PR TITLE
Logitech Control Center update to 3.9.3

### DIFF
--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -8,8 +8,8 @@ cask :v1 => 'logitech-control-center' do
     version '3.9.1.b20'
     sha256 'e2c938286c4044bc6b83a7455f659e99d5854572d308cd6a9befd39eaed57d6c'
   else
-    version '3.9.2'
-    sha256 '1882a8d39f316319c9478c704536849ccdb9476d03cc5613319832dac435b367'
+    version '3.9.3'
+    sha256 '443e9d8733325b76cf97bc73abda464e1db9fcff52bf1f9b3ba67fd2c7200c00'
     url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
   end
 


### PR DESCRIPTION
Includes support for El Capitan.
