### PR TITLE
Upgrade Phoenix Slides.app to 1.4.0

### DIFF
--- a/Casks/phoenix-slides.rb
+++ b/Casks/phoenix-slides.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'phoenix-slides' do
-  version '1.3.1'
-  sha256 '6e5df9e586bb33b79249d9917f99f50395f255b85bf39c5fafca64fe66aef758'
+  version '1.4.0'
+  sha256 'ab65a2c2be1b8975f27cfed925c5d820e77e7089c0ab83c15d30bc930f1bf21f'
 
-  url "http://blyt.net/phxslides/phoenix-slides-#{version.delete('.')}.zip"
+  url "http://blyt.net/phxslides/phoenix-slides-#{version.delete('.')}.dmg"
   name 'Phoenix Slides'
   homepage 'http://blyt.net/phxslides'
   license :gpl


### PR DESCRIPTION
Phoenix Slides was updated to 1.4 more than one year ago.
http://blyt.net/phxslides/
