### PR TITLE
Updated Spotify Notifications to v0.5.2

### DIFF
--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'spotify-notifications' do
-  version '0.5.1'
-  sha256 '4402ae1d466f0129051ed9b052bc228183c1ed6c6dbf23716eff5eae1d9ff310'
+  version '0.5.2'
+  sha256 'c464da41ae084dfc208c94656e33465c86721a54391f2ee1ecba29e269296972'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"


### PR DESCRIPTION
This updates Spotify Notifications to use the correct `version` and `sha256` values for version `0.5.2`.
