### PR TITLE
Update pocketcasts to 1.2.1

### DIFF
--- a/Casks/pocketcasts.rb
+++ b/Casks/pocketcasts.rb
@@ -2,7 +2,7 @@ cask :v1 => 'pocketcasts' do
   version '1.2.1'
   sha256 '09837af1105cbb37ef3c74cdc0c000385686777d86c20f2601e49832d553713c'
 
-  url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCasts#{version}.zip"
+  url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCast#{version}.zip"
   appcast 'https://github.com/mortenjust/PocketCastsOSX/releases.atom'
   name 'Pocket Casts for Mac'
   homepage 'https://github.com/mortenjust/PocketCastsOSX'

--- a/Casks/pocketcasts.rb
+++ b/Casks/pocketcasts.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pocketcasts' do
-  version '1.2'
-  sha256 '385456a2d23cf5fcf88007dcfc97bbe8d9f7019e1ac7f57f1c0c676fe7f2df03'
+  version '1.2.1'
+  sha256 '09837af1105cbb37ef3c74cdc0c000385686777d86c20f2601e49832d553713c'
 
   url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCasts#{version}.zip"
   appcast 'https://github.com/mortenjust/PocketCastsOSX/releases.atom'

--- a/Casks/syncany.rb
+++ b/Casks/syncany.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'syncany' do
-  version '0.4.5-alpha'
-  sha256 '00e03cd3788a438a82c20d5c4ae0d13e69b6eec865b96084095c18aee4470a67'
+  version '0.4.6-alpha'
+  sha256 '6ff3f4eadf716616e4f91402779d77734194071ff191bba4eb2f30352c161f90'
 
   url "https://get.syncany.org/dist/releases/syncany-#{version}-x86_64.app.zip"
   name 'Syncany'


### PR DESCRIPTION
see https://github.com/mortenjust/PocketCastsOSX/releases/tag/1.2.1

(old one is broken due to a 404 error)
