### PR TITLE
Update reflector.rb to correct sha256 sum

### DIFF
--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'reflector' do
   version '2.2.1'
-  sha256 'c31e236a91ee3ba5c68d354e2db29ba6a97d91d4240e2ff12d7f884293df42dd'
+  sha256 '5f5f5fa619939ece736f59b7fa581c24766dd2f4acac6ae37ae34d6df7f181f1'
 
   url "http://download.airsquirrels.com/Reflector2/Mac/Reflector-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/Reflector2/Mac/Reflector2.xml'


### PR DESCRIPTION
```
$ brew cask install reflector 
==> Satisfying dependencies
complete
==> Downloading http://download.airsquirrels.com/Reflector2/Mac/Reflector-2.2.1.dmg
######################################################################## 100.0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: c31e236a91ee3ba5c68d354e2db29ba6a97d91d4240e2ff12d7f884293df42dd
Actual: 5f5f5fa619939ece736f59b7fa581c24766dd2f4acac6ae37ae34d6df7f181f1
File: /Library/Caches/Homebrew/reflector-2.2.1.dmg
To retry an incomplete download, remove the file above.
```
