### PR TITLE
Add eSigner - eParakstītājs Latest.

### DIFF
--- a/Casks/eparakstitajs.rb
+++ b/Casks/eparakstitajs.rb
@@ -1,7 +1,7 @@
 cask :v1 => 'eparakstitajs' do
   version :latest
   sha256 :no_check
-  
+
   url 'https://www.eparaksts.lv/files/ep3/eparakstitajs3-distribution.pkg'
   name 'eParakstītājs 3.0'
   homepage 'https://www.eparaksts.lv'

--- a/Casks/eparakstitajs.rb
+++ b/Casks/eparakstitajs.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'eparakstitajs' do
+  version :latest
+  sha256 :no_check
+  
+  url 'https://www.eparaksts.lv/files/ep3/eparakstitajs3-distribution.pkg'
+  name 'eParakstītājs 3.0'
+  homepage 'https://www.eparaksts.lv'
+  license :closed
+
+  pkg 'eparakstitajs3-distribution.pkg'
+end


### PR DESCRIPTION
This Cask installs middleware and signer which can be used to sign and verify documents with Latvian government issued eID card.
