### PR TITLE
fix sha256 sum for tuxera-ntfs

### DIFF
--- a/Casks/bilibili.rb
+++ b/Casks/bilibili.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'bilibili' do
-  version '2.13'
-  sha256 '91b640374cd0f70c6b5da9bb542665d2b07d3f9149e2d8f22fb64958376cf024'
+  version '2.14'
+  sha256 '13cdf426bb3fe555cde886c7f840213c477c7a2b850428df50325367c7b71eee'
 
   url "https://github.com/typcn/bilibili-mac-client/releases/download/#{version}/Bilibili.dmg.zip"
   name 'Bilibili'
   appcast 'http://app.eqoe.cn/updates/bilimac.xml',
-          :sha256 => '48a288cedaf3f038ee0cb2117d6cf1f8d491bc41e59ed9b2766c26acef434176'
+          :sha256 => '57f3d58234c12ea9fbb733d8cba182e9511f5ab85c4fa72b76904492ee8e7154'
   homepage 'https://github.com/typcn/bilibili-mac-client/'
   license :gpl
 

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -30,8 +30,8 @@ cask :v1 => 'cocktail' do
     url "http://www.maintain.se/downloads/sparkle/yosemite/Cocktail_#{version}.zip"
     appcast 'http://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml'
   else
-    version '9.0'
-    sha256 '4c5760519bd9ac544050a70df3c63b2367be8e37b52a68a88ab03cc2c4dcdad4'
+    version '9.0.1'
+    sha256 'e3cefa7f47f3c9f6b5fb82b2185b92a897cef682e7930c82651fdd310901686e'
 
     url "http://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
     appcast 'http://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml'

--- a/Casks/inloop-qlplayground.rb
+++ b/Casks/inloop-qlplayground.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'inloop-qlplayground' do
+  version '1.0'
+  sha256 '44c25a7da0dc3748b01deb0c01634044ccbc625b4266b4fea0630cbedb773929'
+
+  url "https://github.com/inloop/qlplayground/releases/download/v#{version}/inloop-qlplayground.v#{version}.zip"
+  name 'inloop-qlplayground'
+  homepage 'https://github.com/inloop/qlplayground'
+  license :mit
+
+  qlplugin 'inloop-qlplayground.qlgenerator'
+end

--- a/Casks/malwarebytes-anti-malware.rb
+++ b/Casks/malwarebytes-anti-malware.rb
@@ -1,14 +1,25 @@
 cask :v1 => 'malwarebytes-anti-malware' do
   version '1.0.2.8'
-  sha256 '90f2109cf4f1150c9888ec0ed1110407880b1fc39e17f8daeba862878bd9a796'
+  sha256 '065d31d146031074b4e249a8994fffedf589fffbc114ad3c6bb98c2195878de4'
 
-  url "https://mbam-mac-dl.malwarebytes.org/MBAM-Mac-#{version}.dmg"
+  # mbamupdates.com is the official download host per the vendor homepage
+  url "https://data-cdn.mbamupdates.com/v1/mbam-mac/data/mbam-mac-#{version}.zip"
   name 'Malwarebytes Anti-Malware for Mac'
-  appcast 'http://data-cdn.mbamupdates.com/v1/mbam-mac/updates.xml',
+  name 'AdwareMedic'
+  appcast 'https://data-cdn.mbamupdates.com/v1/mbam-mac/updates.xml',
           :sha256 => '065d31d146031074b4e249a8994fffedf589fffbc114ad3c6bb98c2195878de4',
           :format => :sparkle
   homepage 'https://www.malwarebytes.org/antimalware/mac/'
   license :gratis
 
   app 'Malwarebytes Anti-Malware.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.malwarebytes.antimalware.plist',
+                  '~/Library/Caches/com.malwarebytes.antimalware',
+                  '~/Library/Application Support/com.malwarebytes.antimalware',
+                  '~/Library/Saved Application State/com.malwarebytes.antimalware.savedState'
+                 ]
+
+  depends_on :macos => '>= :lion'
 end

--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -10,4 +10,28 @@ cask :v1 => 'openemu' do
   license :oss
 
   app 'OpenEmu.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/org.openemu.OpenEmu.plist',
+                  '~/Library/Caches/org.openemu.OpenEmu',
+                  '~/Library/Application Support/OpenEmu',
+                  '~/Library/Saved Application State/org.openemu.OpenEmu.savedState',
+                  '~/Library/Application Support/org.openemu.OEXPCCAgent.Agents',
+                  '~/Library/Preferences/org.openemu.CrabEmu.plist',
+                  '~/Library/Preferences/org.openemu.desmume.plist',
+                  '~/Library/Preferences/org.openemu.FCEU.plist',
+                  '~/Library/Preferences/org.openemu.Gambatte.plist',
+                  '~/Library/Preferences/org.openemu.GenesisPlus.plist',
+                  '~/Library/Preferences/org.openemu.Higan.plist',
+                  '~/Library/Preferences/org.openemu.Mednafen.plist',
+                  '~/Library/Preferences/org.openemu.NeoPop.plist',
+                  '~/Library/Preferences/org.openemu.Nestopia.plist',
+                  '~/Library/Preferences/org.openemu.Picodrive.plist',
+                  '~/Library/Preferences/org.openemu.SNES9x.plist',
+                  '~/Library/Preferences/org.openemu.Stella.plist',
+                  '~/Library/Preferences/org.openemu.TwoMbit.plist',
+                  '~/Library/Preferences/org.openemu.VisualBoyAdvance.plist'
+                 ]
+
+  depends_on :macos => '>= :lion'
 end

--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'reflector' do
   version '2.2.1'
-  sha256 'c31e236a91ee3ba5c68d354e2db29ba6a97d91d4240e2ff12d7f884293df42dd'
+  sha256 '5f5f5fa619939ece736f59b7fa581c24766dd2f4acac6ae37ae34d6df7f181f1'
 
   url "http://download.airsquirrels.com/Reflector2/Mac/Reflector-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/Reflector2/Mac/Reflector2.xml'

--- a/Casks/tuxera-ntfs.rb
+++ b/Casks/tuxera-ntfs.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'tuxera-ntfs' do
-  version '2015'
-  sha256 '4bed675786cbec9b8e80a0af2f12b7fda381b16978bf103458bc1011c8a24934'
+  version :latest
+  sha256 :no_check
 
   url 'https://www.tuxera.com/mac/tuxerantfs_2015.dmg'
   name 'Tuxera NTFS'

--- a/Casks/wineskin-winery.rb
+++ b/Casks/wineskin-winery.rb
@@ -9,4 +9,14 @@ cask :v1 => 'wineskin-winery' do
   license :gpl
 
   app 'Wineskin Winery.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Wineskin',
+                  '~/Library/Preferences/com.urgesoftware.wineskin.wineskin.plist',
+                  '~/Library/Caches/com.urgesoftware.wineskin.wineskinwinery',
+                  '~/Library/Saved Application State/com.urgesoftware.wineskin.wineskin.savedState'
+                 ],
+      :rmdir => '~/Applications/Wineskin'
+
+  depends_on :macos => '>= :snow_leopard'
 end


### PR DESCRIPTION
```
$ brew cask install tuxera-ntfs
==> Downloading https://www.tuxera.com/mac/tuxerantfs_2015.dmg
######################################################################## 100.0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 4bed675786cbec9b8e80a0af2f12b7fda381b16978bf103458bc1011c8a24934
Actual: de47cbbbcd9be8241a31a7924a6840a70215300154d352f28c31d8fbb2edbf2e
File: /Library/Caches/Homebrew/tuxera-ntfs-2015.dmg
To retry an incomplete download, remove the file above.
```
