### PR TITLE
UniFi Controller - Upgrading to v4.7.5

### DIFF
--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -1,13 +1,13 @@
 cask :v1_1 => 'unifi-controller' do
-  version '4.6.6'
-  sha256 '7ca063dfd368cd27fab2fd6fd60e317a736beafd8add9400b9b98553e8a6f858'
+  version '4.7.5'
+  sha256 '366930d34a60bc0a7748e9b19240838ff87ac16092f52d07cae27891b945f82d'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
-  name 'Unifi Controller'
-  homepage 'https://www.ubnt.com/download/?platform=unifi'
+  name 'UniFi Controller'
+  homepage 'https://www.ubnt.com/download/unifi'
   license :commercial
 
-  pkg 'Unifi.pkg'
+  pkg 'UniFi.pkg'
 
   postflight do
     set_ownership '~/Library/Application Support/UniFi'


### PR DESCRIPTION
Updating the unifi-controller cask to the latest version (4.7.5).

I also rolled a few other small fixes into this change:
- Updated the homepage URL to link directly to the UniFi Controller page (rather than the main support downloads page)
- Changed 'Unifi' to 'UniFi' where applicable
