### PR TITLE
Adding bitscope binaries for OSX 10'.6 or later.

### DIFF
--- a/Casks/bitscope-chart.rb
+++ b/Casks/bitscope-chart.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'bitscope-chart' do
+  version '1.1'
+  sha256 'e7c2900281cf289e6ae458a04c8435024aa526ef2df8d0b17874e71f9c92c3a8'
+
+  url 'http://bitscope.com/download/files/bitscope-chart_1.1.DC01G.app.tgz'
+  name 'Bitscope'
+  homepage 'http://www.bitscope.com/'
+  license :unknown
+
+  app 'bitscope-chart.app'
+
+end

--- a/Casks/bitscope-dso.rb
+++ b/Casks/bitscope-dso.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'bitscope-dso' do
+  version '2.8'
+  sha256 'd32d924368bc8e093d4be9f1d2c90d7741d8347ac18f10db1d31c964cef44b16'
+
+  url 'http://bitscope.com/download/files/bitscope-dso_2.8.FE22G.app.tgz'
+  name 'Bitscope'
+  homepage 'http://www.bitscope.com/'
+  license :unknown
+
+  app 'bitscope-dso.app'
+
+end

--- a/Casks/bitscope-logic.rb
+++ b/Casks/bitscope-logic.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'bitscope-logic' do
+  version '1.2'
+  sha256 'e0093f292209f6ad306873911c3551bdafa201e09ed634c9080e3b58e9bf6196'
+
+  url 'http://bitscope.com/download/files/bitscope-logic_1.2.DJ20B.app.tgz'
+  name 'Bitscope'
+  homepage 'http://www.bitscope.com/'
+  license :unknown
+
+  app 'bitscope-logic.app'
+
+end

--- a/Casks/bitscope-meter.rb
+++ b/Casks/bitscope-meter.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'bitscope-meter' do
+  version '2.0'
+  sha256 'de1877050993fde72e1efbe135035b9dc2589cc60fb80e0c876057c89cd56f82'
+
+  url 'http://bitscope.com/download/files/bitscope-meter_2.0.DD14E.app.tgz'
+  name 'Bitscope'
+  homepage 'http://www.bitscope.com/'
+  license :unknown
+
+  app 'bitscope-meter.app'
+
+end


### PR DESCRIPTION
The casks included are bitscope-dso, bitscope-logic, bitscope-meter and bitscope-chart.
All binaries for 64 bit
bitscope-library is not (yet) included!
