### PR TITLE
Update Private Eye.app download URL

### DIFF
--- a/Casks/private-eye.rb
+++ b/Casks/private-eye.rb
@@ -2,12 +2,12 @@ cask :v1 => 'private-eye' do
   version :latest
   sha256 :no_check
 
-  url 'http://radiosilenceapp.com/downloads/Private%20Eye.pkg'
+  url 'http://radiosilenceapp.com/downloads/Private_Eye_for_OS_X_10.9_and_later.pkg'
   name 'Private Eye'
   homepage 'http://radiosilenceapp.com/private-eye'
   license :oss
 
-  pkg 'Private Eye.pkg'
+  pkg 'Private_Eye_for_OS_X_10.9_and_later.pkg'
   # We intentionally unload the kext twice as a workaround
   # See https://github.com/caskroom/homebrew-cask/pull/1802#issuecomment-34171151
 
@@ -18,5 +18,6 @@ cask :v1 => 'private-eye' do
             },
             :quit => 'com.radiosilenceapp.PrivateEye',
             :kext => 'com.radiosilenceapp.nke.PrivateEye',
-            :pkgutil => 'com.radiosilenceapp.privateEye.*'
+            :pkgutil => 'com.radiosilenceapp.privateEye.*',
+            :launchctl => 'com.radiosilenceapp.nke.PrivateEye'
 end


### PR DESCRIPTION
Previous download URL was grabbing an older version. This is the new download
URL per the homepage.

Add launchctl key to uninstall stanza.

Verified workaround is still neded to unload kext.

If Private Eye is running during uninstall, the uninstall will fail becase the kext unload happens too soon after the quit. Running the uninstall a second time works or quitting the app before running unistall works. I'm not sure of a good way to solve this. Open to suggestions.
