### PR TITLE
Add Radio Silence.app

### DIFF
--- a/Casks/radio-silence.rb
+++ b/Casks/radio-silence.rb
@@ -1,0 +1,29 @@
+cask :v1 => 'radio-silence' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://radiosilenceapp.com/downloads/Radio_Silence_for_OS_X_10.9_and_later.pkg'
+  name 'Radio Silence'
+  homepage 'http://radiosilenceapp.com'
+  license :commercial
+
+  pkg 'Radio_Silence_for_OS_X_10.9_and_later.pkg'
+  # We intentionally unload the kext twice as a workaround
+  # See https://github.com/caskroom/homebrew-cask/pull/1802#issuecomment-34171151
+
+  uninstall :early_script => {
+              :executable => '/sbin/kextunload',
+              :args => ['-b', 'com.radiosilenceapp.nke.filter'],
+              :must_succeed => false,
+            },
+            :quit => 'com.radiosilenceapp.client',
+            :kext => 'com.radiosilenceapp.nke.filter',
+            :pkgutil => 'com.radiosilenceapp.radioSilence.*',
+            :launchctl => [
+                            'com.radiosilenceapp.trial',
+                            'com.radiosilenceapp.agent',
+                            'com.radiosilenceapp.nke'
+                          ]
+
+  zap :delete => '~/Library/Application Support/Radio Silence'
+end


### PR DESCRIPTION
Similar to PR #1802, an extra stanza is required so the uninstall does not fail. Both of these apps are from the same developer and using the same kext, hence the similar behavior.

Also, similar to PR #14369, the uninstall task will fail if the app is running. I'm not sure of a good way to fix that
