### PR TITLE
Add Blue Jeans desktop app

### DIFF
--- a/Casks/blue-jeans-app.rb
+++ b/Casks/blue-jeans-app.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'blue-jeans-app' do
+  version '1.5.2'
+  sha256 '757edfba7811cbc20fd001bc9b6c8e7ec06b80578b1b01d866e7fea65da0869d'
+
+  url 'https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_152.dmg'
+  name 'Blue Jeans App'
+  homepage 'http://bluejeans.com/downloads'
+  license :closed
+
+  app 'Blue Jeans Launcher.app'
+end


### PR DESCRIPTION
This pull request adds a cask for the Blue Jeans desktop application available at http://bluejeans.com/downloads.

Audit's passed:

```
Mikes-MacBook-Pro:homebrew-cask fooforge$ brew cask audit blue-jeans-app --download
==> Downloading https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_152.dmg
######################################################################## 100.0%
audit for blue-jeans-app: passed
```

One thing I'm not so sure about though is this:
The `.dmg` is only 312kb in size and installs the _"Blue Jeans Launcher.app"_ which in turn downloads the actual client upon first execution. It also installs the _"Blue Jeans.app"_ package bundle in the `/$home/Applications` directory. 

![screen shot 2015-10-13 at 7 25 05 pm](https://cloud.githubusercontent.com/assets/959793/10462786/c8a3a0aa-71e0-11e5-814f-b280773eb3ee.png)

Whether you call _"Blue Jeans Launcher.app"_ or _"Blue Jeans.app"_ doesn't matter, both results in the client launching just fine. I was just wondering if there's a better way to workaround these types of installers and if I'd better add a caveats stanza.
