### PR TITLE
VirtualBox: remove vestigial symlink commands.

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -9,8 +9,6 @@ cask :v1 => 'virtualbox' do
   tags :vendor => 'Oracle'
 
   pkg 'VirtualBox.pkg'
-  binary '/Applications/VirtualBox.app/Contents/MacOS/VBoxManage'
-  binary '/Applications/VirtualBox.app/Contents/MacOS/VBoxHeadless'
 
   uninstall :script => { :executable => 'VirtualBox_Uninstall.tool', :args => %w[--unattended] },
             :pkgutil => 'org.virtualbox.pkg.*'


### PR DESCRIPTION
**Without** this patch, users may see a couple “It seems there is already a Binary at …” warnings:

```
$ brew cask install virtualbox
==> Downloading http://download.virtualbox.org/virtualbox/5.0.6/VirtualBox-5.0.6-103037-OSX.dmg
Already downloaded: /Library/Caches/Homebrew/virtualbox-5.0.6-103037.dmg
==> Running installer for virtualbox; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
Password:
==> installer: Package name is Oracle VM VirtualBox
==> installer: Installing at base path /
==> installer: The install was successful.
==> It seems there is already a Binary at '/usr/local/bin/VBoxManage'; not linking.
==> It seems there is already a Binary at '/usr/local/bin/VBoxHeadless'; not linking.
🍺  virtualbox staged at '/opt/homebrew-cask/Caskroom/virtualbox/5.0.6-103037' (4 files, 87M)
```

At some point, VirtualBox started installing these for us, as the
following shell interactions demonstrate.

```
$ pkgutil --pkg-info org.virtualbox.pkg.virtualboxcli
package-id: org.virtualbox.pkg.virtualboxcli
version: 5.0.6
volume: /
location: usr/local/bin
install-time: 1444768345
$ pkgutil --files org.virtualbox.pkg.virtualboxcli
VBoxAutostart
VBoxBalloonCtrl
VBoxDTrace
VBoxHeadless
VBoxManage
VBoxVRDP
VirtualBox
vbox-img
vboxwebsrv
```
