### PR TITLE
Update teamspeak-client to 3.0.18.1. [Security update]

### DIFF
--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'teamspeak-client' do
-  version '3.0.17'
-  sha256 '0ceec488700527472b16d92b3a73dc2f6170865106687535bcbf589b19b7d556'
+  version '3.0.18.1'
+  sha256 '9a2dc5e348aeed85f8e9630ffdfbe9c1e770594c81892beb8b2d73f4b118e4b2'
 
   # 4players.de is the official download host per the vendor homepage
   url "http://dl.4players.de/ts/releases/#{version}/TeamSpeak3-Client-macosx-#{version}.dmg"


### PR DESCRIPTION
> [We have just released a very important security update for the TeamSpeak 3 Client addressing a RFI (Remote File Inclusion) vulnerability. Please upgrade your desktop clients to version 3.0.18.1 immediately.](http://forum.teamspeak.com/showthread.php/120755-SECURITY-UPDATE-TeamSpeak-3-Client-3-0-18-1-is-Available)
