### PR TITLE
Fix installer in MathType.app cask

### DIFF
--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -7,7 +7,7 @@ cask :v1 => 'mathtype' do
   homepage 'www.dessci.com'
   license :commercial
 
-  pkg "MTM#{version.delete('.')}h_EN.pkg"
+  installer :manual => "MTM#{version.delete('.')}h_EN.pkg"
 
   uninstall :pkgutil => "com.dessci.mathtype#{version.delete('.')}Hf.MathType.pkg",
             :delete => "/Applications/MathType #{version.to_i}"


### PR DESCRIPTION
Uses `installer :manual` instead of `pkg` to install `MathType.app`. Otherwise, the installation fails because the manual installer is needed to generate the encrypted license file.

If the manual installer is required, then why use Cask at all? Answer: the benefits of easily downloading the installation package and easily uninstalling the application (which works correctly). Also, the cask is useful if you have a script to install all of your system's applications.

Fixes: #14419  
