### PR TITLE
Upgrade MaciASL.app to v1.4

### DIFF
--- a/Casks/maciasl.rb
+++ b/Casks/maciasl.rb
@@ -1,19 +1,13 @@
 cask :v1 => 'maciasl' do
-  version '1.3'
+  version '1.4'
+  sha256 '24c0dbaa9a13231b8c8e364ef0e6d60656718320ce69d8bb23aa5bc27e82e87d'
 
-  if MacOS.release == :lion
-    sha256 '6ba1eafbdf8d954f3c72fc4d5d9e06e15b101522ac253772a06c8579c45675de'
-    url "http://downloads.sourceforge.net/sourceforge/maciasl/#{version}/MaciASL_Lion.zip"
-  else
-    sha256 '166b818ed26e33f15b7ee12da90126edae3a21e56abe540ef0255e7f61e9695b'
-    url "http://downloads.sourceforge.net/sourceforge/maciasl/#{version}/MaciASL_ML.zip"
-  end
-
+  url "http://downloads.sourceforge.net/sourceforge/maciasl/#{version}/MaciASL.zip"
   name 'MaciASL'
   homepage 'http://sourceforge.net/projects/maciasl/'
   license :gpl
 
   app 'MaciASL.app'
 
-  depends_on :macos => '>= :lion'
+  depends_on :macos => '>= :mountain_lion'
 end


### PR DESCRIPTION
Version v1.4 dropped support for Mac OS X Lion, use v1.3 for Lion.
