### PR TITLE
Improve MaciASL.app version check for Mac OS X Lion

### DIFF
--- a/Casks/maciasl.rb
+++ b/Casks/maciasl.rb
@@ -1,13 +1,21 @@
 cask :v1 => 'maciasl' do
-  version '1.4'
-  sha256 '24c0dbaa9a13231b8c8e364ef0e6d60656718320ce69d8bb23aa5bc27e82e87d'
+  if MacOS.release == :lion
+    version '1.3'
+    sha256 '6ba1eafbdf8d954f3c72fc4d5d9e06e15b101522ac253772a06c8579c45675de'
 
-  url "http://downloads.sourceforge.net/sourceforge/maciasl/#{version}/MaciASL.zip"
+    url "http://downloads.sourceforge.net/sourceforge/maciasl/#{version}/MaciASL_Lion.zip"
+  else
+    version '1.4'
+    sha256 '24c0dbaa9a13231b8c8e364ef0e6d60656718320ce69d8bb23aa5bc27e82e87d'
+
+    url "http://downloads.sourceforge.net/sourceforge/maciasl/#{version}/MaciASL.zip"
+  end
+
   name 'MaciASL'
   homepage 'http://sourceforge.net/projects/maciasl/'
   license :gpl
 
   app 'MaciASL.app'
 
-  depends_on :macos => '>= :mountain_lion'
+  depends_on :macos => '>= :lion'
 end


### PR DESCRIPTION
Add v1.3 version for Mac OS X Lion, use v1.4 for OS X Mountain Lion and later.
