### PR TITLE
azure-cli: Update to 0.9.10 and improve cask script

### DIFF
--- a/Casks/azure-cli.rb
+++ b/Casks/azure-cli.rb
@@ -1,16 +1,17 @@
 cask :v1 => 'azure-cli' do
-  version '0.9.9'
-  sha256 '82cc0eec6f33e8c7dee457155112c7ba82559bae16494cf4f92fd2730851562f'
+  version '0.9.10'
+  sha256 '4e219aad00040520e780fba42d9b715761dc0d3ee590a8c8bc7a83119cb3b79b'
 
-  # vo.msecnd.net is the official download host per the vendor homepage
-  url "http://az412849.vo.msecnd.net/downloads04/azure-cli.#{version}.dmg"
+  # azuresdkscu.blob.core.windows.net is the official download host per the vendor homepage
+  url "https://azuresdkscu.blob.core.windows.net/downloads04/azure-cli.#{version}.dmg"
   name 'Microsoft Azure CLI'
   homepage 'https://azure.microsoft.com/en-us/documentation/articles/xplat-cli/'
-  license :gratis
+  license :apache
   tags :vendor => 'Microsoft'
 
   pkg 'Install Command Line Interface.pkg'
 
-  uninstall :script => '/usr/local/bin/azure-uninstall',
-            :pkgutil => 'com.microsoft.azure.*'
+  uninstall :script => '/usr/local/bin/azure-uninstall'
+
+  zap :delete => '~/.azure'
 end


### PR DESCRIPTION
This pull request:
1. Updates the azure-cli package to 0.9.10
2. Changes the download URL to use Microsoft's new Azure Storage endpoint and also HTTPS  
   The old one still works, but it can't hurt to update to the new one.
3. Removes the `:pkgutil` directive from the `uninstall` stanza  
   The `azure-uninstall` script [already handles removal of `pkgutil` receipts](https://github.com/Azure/azure-xplat-cli/blob/dev/tools/osx-setup/scripts/azure-uninstall#L20-L21).
4. Adds a `zap` stanza to remove the user's preferences
5. Fixes the license
