### PR TITLE
Add new GitBook Editor

### DIFF
--- a/cask/gitbook-editor.rb
+++ b/cask/gitbook-editor.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'gitbook-editor' do
+  version '4.1.4'
+  sha256 'fa9db4e241c5e9e82d87265cb0fe5e874221e06802e6f6b5811799fb764ca15f'
+
+  url "http://downloads.editor.gitbook.com/download/osx?user=chaucerling"
+  name 'GitBook Editor'
+  homepage 'https://www.gitbook.com/editor'
+  license :unknown
+
+  app 'GitBook Editor.app'
+end


### PR DESCRIPTION
[The old gitbook editor](https://github.com/GitbookIO/editor-legacy) is discontinued, but still opensource on github #11977
This new one is provided on official downlaod page now.
