### PR TITLE
flash 19.0.0.226 and pepper-flash 19.

### DIFF
--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'flash' do
-  version '19.0.0.205'
-  sha256 'e2bb972aab13886622caabf87fec86f65d1c9c77744465190c6a99517be717b1'
+  version '19.0.0.226'
+  sha256 'a0a1f72b7df6c056892a614ed28e26641315428917d0b8d54a3bcebb5c7d4cba'
 
   # macromedia.com is the official download host per the vendor homepage
   url "https://fpdownload.macromedia.com/get/flashplayer/current/licensing/mac/install_flash_player_#{version.to_i}_osx_pkg.dmg"

--- a/Casks/pepper-flash.rb
+++ b/Casks/pepper-flash.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'pepper-flash' do
-  version '18'
+  version '19'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://admdownload.adobe.com/bin/live/AdobeFlashPlayer_#{version}ppau_a_install.dmg"

--- a/Casks/pepper-flash.rb
+++ b/Casks/pepper-flash.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'pepper-flash' do
-  version '19'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '19.0.0.226'
+  sha256 '735354dead04382629c39d2d6fd6e860631f13055e6746a515b20c3cd9774f91'
 
-  url "https://admdownload.adobe.com/bin/live/AdobeFlashPlayer_#{version}ppau_a_install.dmg"
+  url "https://admdownload.adobe.com/bin/live/AdobeFlashPlayer_#{version.to_i}ppau_a_install.dmg"
   name 'Pepper Flash Player'
   homepage 'https://get.adobe.com/flashplayer/otherversions'
   license :gratis


### PR DESCRIPTION
Updated flash and pepper-flash.

I notice that pepper flash has its sha256 check disabled. I'm not sure if that is good or not. But should we do the same for the flash, flash-player, and flash-player-debugger formulae since they are in the same situation?
