### PR TITLE
Add PICAXE Compilers Latest

### DIFF
--- a/Casks/picaxe-compilers.rb
+++ b/Casks/picaxe-compilers.rb
@@ -1,0 +1,19 @@
+cask :v1 => 'picaxe-compilers' do
+  version :latest
+  sha256 :no_check
+  depends_on :arch => :intel
+
+  url 'http://www.picaxe.com/downloads/picaxe_mac_intel.zip'
+  name 'PICAXE Compilers'
+  homepage 'http://www.picaxe.com/Software/Drivers/PICAXE-Compilers/'
+  license :closed
+
+  compilers = %w(08 08m 08m2 08m2le,
+                 14m 14m2 18 18a 18m,
+                 18m2 18x 18x_1 20m,
+                 20m2 20x2 28 28a 28x,
+                 28x1 28x1_0 28x2 28x_1)
+  compilers.each do |v|
+    binary "picaxe#{v}"
+  end
+end


### PR DESCRIPTION
Created a cask that installs the PICAXE Compilers.

Used for compiling BASIC programs and downloading them onto PICAXE micro controller chips.

More info here: http://www.picaxe.com/Software/Drivers/PICAXE-Compilers/
