### PR TITLE
Ftdi vcp driver load kext fix

### DIFF
--- a/Casks/ftdi-vcp-driver.rb
+++ b/Casks/ftdi-vcp-driver.rb
@@ -15,6 +15,30 @@ cask :v1 => 'ftdi-vcp-driver' do
   license :gratis
 
   uninstall :pkgutil => 'com.FTDI.ftdiusbserialdriverinstaller.*',
-            :kext    => 'com.FTDI.driver.FTDIUSBSerialDriver'
+            :kext    => 'com.FTDI.driver.FTDIUSBSerialDriver',
+            :delete  => '/Library/Extensions/FTDIUSBSerialDriver.kext'
+
+  caveats do
+    reboot
+
+    <<-EOC.undent
+      If you don't want to reboot, you can load the driver using the following
+      command:
+
+        sudo /sbin/kextload -b com.FTDI.driver.FTDIUSBSerialDriver
+
+      Once you've rebooted or loaded the driver, you can connect your FTDI
+      based cable to a USB port and it will show up in /dev, usually like this:
+
+        /dev/tty.usbserial-XXXXXXXX
+
+      where XXXXXXXX is a random ID, based on the serial number of your FTDI
+      based cable.
+
+      NOTE: If your FTDI based cable was already connected before you installed
+      the driver, you'll need to unplug the cable from the USB port and
+      reconnect it for it to show up in /dev.
+    EOC
+  end
 
 end


### PR DESCRIPTION
The `ftdi-vcp-driver` cask did not load the kext that it installs on installation. This means that the driver will not work until the next reboot. The user was not informed as a caveat that they need to reboot to use the driver after installation.

I figured it would be better to load the kext for the user after installation so that the user can begin using the driver right away.

On uninstall, the kext was being unloaded correctly and `pkgutil` was clearing up it's side of things, but the kext was still left in `/Library/Extensions` so I fixed that too, by deleting it at uninstall.

Added caveats section to warn users that they need to disconnect/reconnect their FTDI cable for it to show up in `/dev` if they had it connected prior to installation.
