### PR TITLE
Updated NoMachine cask

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'nomachine' do
-  version '4.6.16_1'
-  sha256 'd837380a5cf91e8c4331558784a96df66652d66b60f9362791d2047d610fa3a5'
+  version '5.0.43_3'
+  sha256 '3312b00653cacc3d75c4b7ae61d61f515dd7d1f7c4639abdcfc047e6185ec614'
 
   url "http://download.nomachine.com/download/#{version.split('.')[0..1].join('.')}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'


### PR DESCRIPTION
Updated the NoMachine cask to the most recent version on found on the website
which is 5.0.43_3

```
fzakaria $ brew cask audit nomachine 
audit for nomachine: passed
fzakaria $ brew cask audit nomachine --download
==> Downloading http://download.nomachine.com/download/5.0/MacOSX/nomachine_5.0.43_3.dmg
######################################################################## 100.0%
audit for nomachine: passed
```
