### PR TITLE
Update istat-menus sha256 for v5.11

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'istat-menus' do
   version '5.11'
-  sha256 '720782256c427808669cef16bdb01cd7953c22d6f8a78d10a796f7e0fbcacf3e'
+  sha256 '5931ff8a024ea54f9268e66c650ae4a33b399ae25ca36586b7814d960ed77d19'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus#{version}.zip"


### PR DESCRIPTION
Updating to correct sha256 checksum for istat-menus v5.11
