### PR TITLE
Upgrade exa to v0.4.0

### DIFF
--- a/Casks/exa.rb
+++ b/Casks/exa.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'exa' do
-  version '0.3.0'
-  sha256 '228cfce7715b5b908a607e4a659e38d7c83da8c596cccf9860e6531903499dba'
+  version '0.4.0'
+  sha256 '0b67c6112d393aed09ee73499f864db5688f1210e3ff4e88ab073a369dc3fabb'
 
   # github.com is the official download host per the vendor homepage
-  url "https://github.com/ogham/exa/releases/download/v#{version}/exa-osx-x86-64.zip"
+  url "https://github.com/ogham/exa/releases/download/v#{version}/exa-osx-x86_64.zip"
   appcast 'https://github.com/ogham/exa/releases.atom'
   name 'exa'
   homepage 'http://bsago.me/exa/'
   license :mit
 
-  binary 'exa-osx-x86-64', :target => 'exa'
+  binary 'exa-osx-x86_64', :target => 'exa'
 end


### PR DESCRIPTION
I released a new version of exa just now. iKevinY made a cask for me last time, but I'm trying to dip my toes in this time (this is my first cask)

The binary name and zip name change because I stupidly used `x86-64` instead of `x86_64` last time. It'll be correct from now on.
