### PR TITLE
change JOSM to fetch latest stable

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'josm' do
-  version '8677'
-  sha256 '06f60366e852c5a15c4f54e1e4f6f908d915603922fae0e74581feaaa40f4129'
+  version :latest
+  sha256 :no_check
 
-  url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
+  url "https://josm.openstreetmap.de/download/macosx/josm-macosx.zip"
   name 'JOSM'
   homepage 'http://josm.openstreetmap.de'
   license :gpl


### PR DESCRIPTION
The latest stable version of the JOSM app is available at: https://josm.openstreetmap.de/download/macosx/josm-macosx.zip

Is it better to point there instead of manually updating the cask each time?
