### PR TITLE
Development version (2.0rc1) of Wireshark. 

### DIFF
--- a/Casks/wireshark2.rb
+++ b/Casks/wireshark2.rb
@@ -40,5 +40,4 @@ cask :v1 => 'wireshark2' do
                          '/usr/local/bin/wireshark',
                         ]
 
-  depends_on :x11 => true
 end

--- a/Casks/wireshark2.rb
+++ b/Casks/wireshark2.rb
@@ -1,0 +1,44 @@
+cask :v1 => 'wireshark2' do
+  version '2.0.0rc1'
+  sha256 '2a8ced7cd6c1788b46aa366d91dfbad144842fdfb09443a3b72d2dfec058783b'
+
+  url 'https://2.na.dl.wireshark.org/osx/Wireshark%202.0.0rc1%20Intel%2064.dmg'
+  name 'Wireshark (development version)'
+  homepage 'https://www.wireshark.org/'
+  license :gpl
+
+  pkg "Wireshark #{version} Intel 64.pkg"
+  postflight do
+    if Process.euid == 0
+      ohai 'Note:'
+      puts <<-EOS.undent
+        You executed 'brew cask' as the superuser.
+
+        You must manually add users to group 'access_bpf' in order to use Wireshark
+      EOS
+    else
+      system '/usr/bin/sudo', '-E', '--',
+             '/usr/sbin/dseditgroup', '-o', 'edit', '-a', Etc.getpwuid(Process.euid).name, '-t', 'user', '--', 'access_bpf'
+    end
+  end
+
+  uninstall :script  => {
+                         :executable => '/usr/sbin/dseditgroup',
+                         :args => ['-o', 'delete', 'access_bpf'],
+                        },
+            :pkgutil => 'org.wireshark.*',
+            :delete  => [
+                         '/usr/local/bin/capinfos',
+                         '/usr/local/bin/dftest',
+                         '/usr/local/bin/dumpcap',
+                         '/usr/local/bin/editcap',
+                         '/usr/local/bin/mergecap',
+                         '/usr/local/bin/randpkt',
+                         '/usr/local/bin/rawshark',
+                         '/usr/local/bin/text2pcap',
+                         '/usr/local/bin/tshark',
+                         '/usr/local/bin/wireshark',
+                        ]
+
+  depends_on :x11 => true
+end


### PR DESCRIPTION
According to the developer, this is the version OSX users should "try first".
Unlike version 1, does not depend on X11.
