### PR TITLE
Update Amethyst cask due to change to existing version

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'amethyst' do
   version '0.9.5'
-  sha256 'ceb73e48ea7774aa1e0cfbdace2599687b30ae6484ddd327713af2659c365738'
+  sha256 '7f346ab0f200d110a0bc058e7ab590bb7dc0a5353e67b3251b5b316c49b60c4f'
 
-  url "http://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
+  url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   name 'Amethyst'
-  appcast 'http://ianyh.com/amethyst/appcast.xml',
-          :sha256 => '89f4aa8866df077e3da88eb1636334093190bc1286cfee52960a29ebf3f05bc8'
-  homepage 'http://ianyh.com/amethyst'
+  appcast 'https://ianyh.com/amethyst/appcast.xml',
+          :sha256 => '51b673f6806f2343074ff53aab83e3d4c74d23befccf3882c9db72679d1d8a1a'
+  homepage 'https://ianyh.com/amethyst'
   license :mit
 
   app 'Amethyst.app'


### PR DESCRIPTION
0.9.5 had a bug that prevented in-app updates, which had to be patched in, so
the binary, and thus the checksum changed.
