### PR TITLE
Update the hashes for Amethyst 0.9.5 again

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -1,11 +1,11 @@
 cask :v1 => 'amethyst' do
   version '0.9.5'
-  sha256 '7f346ab0f200d110a0bc058e7ab590bb7dc0a5353e67b3251b5b316c49b60c4f'
+  sha256 'c4e67df3e8c2c9e885f1b5d230d87462dcfc8a50a81cffc62d1096fda589d9a8'
 
   url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   name 'Amethyst'
   appcast 'https://ianyh.com/amethyst/appcast.xml',
-          :sha256 => '51b673f6806f2343074ff53aab83e3d4c74d23befccf3882c9db72679d1d8a1a'
+          :sha256 => '7256809d4b302019f17b91ba4209ba02cbd3450758a5d17f37aaf71aa2e50306'
   homepage 'https://ianyh.com/amethyst'
   license :mit
 


### PR DESCRIPTION
The bundled app name was incorrect, so linking was not working correctly. Can
confirm that it installs correctly now.
