### PR TITLE
Add Blue Jeans app installer

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -14,5 +14,5 @@ cask :v1 => 'blue-jeans' do
                          ['TERM', 'com.bluejeans.nw.app'],
                          ['TERM', 'com.bluejeans.nw.helper']
                        ]
-  uninstall :delete => "~/Applications/Blue Jeans.app"
+  uninstall :delete => '~/Applications/Blue Jeans.app'
 end

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -10,4 +10,9 @@ cask :v1 => 'blue-jeans' do
   depends_on :macos => '>= 10.6'
 
   installer :manual => 'Blue Jeans Launcher.app'
+  uninstall :quit => %w(
+                       com.bluejeans.nw.app
+                       com.bluejeans.nw.helper
+                     )
+  zap :delete => "~/Applications/Blue Jeans.app"
 end

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -10,9 +10,9 @@ cask :v1 => 'blue-jeans' do
   depends_on :macos => '>= 10.6'
 
   installer :manual => 'Blue Jeans Launcher.app'
-  uninstall :quit => %w(
-                       com.bluejeans.nw.app
-                       com.bluejeans.nw.helper
-                     )
-  zap :delete => "~/Applications/Blue Jeans.app"
+  uninstall :quit => [
+                       'com.bluejeans.nw.app',
+                       'com.bluejeans.nw.helper'
+                     ]
+  uninstall :delete => "~/Applications/Blue Jeans.app"
 end

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'blue-jeans' do
+  version :latest
+  sha256 :no_check
+
+  # Download page: https://bluejeans.com/downloads
+  url 'https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_152.dmg'
+  name 'Blue Jeans videoconferencing'
+  homepage 'https://bluejeans.com/'
+  license :gratis
+  depends_on :macos => '>= 10.6'
+
+  installer :manual => 'Blue Jeans Launcher.app'
+end

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -10,9 +10,9 @@ cask :v1 => 'blue-jeans' do
   depends_on :macos => '>= 10.6'
 
   installer :manual => 'Blue Jeans Launcher.app'
-  uninstall :quit => [
-                       'com.bluejeans.nw.app',
-                       'com.bluejeans.nw.helper'
-                     ]
+  uninstall :signal => [
+                         ['TERM', 'com.bluejeans.nw.app'],
+                         ['TERM', 'com.bluejeans.nw.helper']
+                       ]
   uninstall :delete => "~/Applications/Blue Jeans.app"
 end


### PR DESCRIPTION
New cask for the [Blue Jeans](http://bluejeans.com/) app installer (as opposed to the browser plugin, cask "blue-jeans-browser-plugin").

The version in the file name is 152, but it actually downloads the latest version (1.6.153 at this writing).
