### PR TITLE
Add a cask for Kancolle

### DIFF
--- a/Casks/kanmemo.rb
+++ b/Casks/kanmemo.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'kanmemo' do
+  version '0.15'
+  sha256 'af64ae0846ab0b4366693bc602a81ba7e626bafee820862594c4bcbf92acfcef'
+
+  url "http://relog.xii.jp/download/kancolle/KanmusuMemory-#{version}-mac.dmg"
+  appcast 'https://github.com/ioriayane/KanmusuMemory/releases.atom'
+  name 'KanmusuMemory'
+  homepage 'http://relog.xii.jp/mt5r/2013/08/post-349.html'
+  license :apache
+
+  app 'KanmusuMemory.app'
+end


### PR DESCRIPTION
# WHAT

Added a cask for the Kancolle(艦隊これくしょん-艦これ-)
Kancolle is a online pc game. and kanmemo is a browser for the Kancolle.
# REF
- https://github.com/ioriayane/KanmusuMemory
- http://www.dmm.com/netgame/feature/kancolle.html (Japanese official site)
