### PR TITLE
automatically download beta version of Proxifier if running on currently-not-supported El Capitan

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -5,7 +5,7 @@ cask :v1 => 'proxifier' do
   url 'https://www.proxifier.com/distr/ProxifierMac.zip'
   name 'Proxifier'
   homepage 'https://www.proxifier.com/mac/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'Proxifier.app'
 end

--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -2,10 +2,22 @@ cask :v1 => 'proxifier' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.proxifier.com/distr/ProxifierMac.zip'
+  if MacOS.release == :el_capitan
+    url 'https://www.proxifier.com/distr/ProxifierMacBeta.zip'
+  else
+    url 'https://www.proxifier.com/distr/ProxifierMac.zip'
+  end
+
   name 'Proxifier'
   homepage 'https://www.proxifier.com/mac/'
   license :commercial
 
   app 'Proxifier.app'
+
+  if MacOS.release == :el_capitan
+    caveats <<-EOS.undent
+      #{token} stable version is incompatible with OS X 10.11 El Capitan.
+      Beta version has been installed instead.
+    EOS
+  end
 end


### PR DESCRIPTION
Last stable version of Proxifier was released in December 2014 (see https://www.proxifier.com/mac_download.htm).
Its kernel module is incompatible with El Capitan.
Vendor offers a beta version to El Capitan users since September 10th.

I think we should at least warn user if they try to install defunct version, if not automatically switch to Beta version.
This PR changes download URL for El Capitan users and adds a caveat.
I think that would be the most beneficial to the user.

I'll submit a revert once vendor release stable version supporting El Capitan.
