### PR TITLE
Update skalacolor to 2.10

### DIFF
--- a/Casks/colorpicker-skalacolor.rb
+++ b/Casks/colorpicker-skalacolor.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'colorpicker-skalacolor' do
-  version '2.0'
-  sha256 '9b99e02f6310284b1551a7af51f5782db847e9521d4bdd6f6a9c65c0a97ccd72'
+  version '2.10'
+  sha256 '18205f0e827116de72822064f7b10f624bb6696f90bd067e4ba90a18acba34a2'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "http://s3.amazonaws.com/bjango/files/skalacolor/skalacolor#{version}.zip"


### PR DESCRIPTION
This is version 2.1 but the download points at 2.10
