### PR TITLE
Bump Canon IR printer driver UFRII to 10.08.01

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,13 +1,13 @@
 cask :v1 => 'canon-imagerunner-printer-driver-ufrii' do
-  version '10.06.00'
-  sha256 'a7ddf16161055f697ded4dc39d9b027976b4d5d78b4ee837dd26d79402781fa1'
+  version '10.08.01'
+  sha256 '4255b1236bbf6b30b6b78db277fd2425d051ee58fd13a954068f5790ab7e2a28'
 
-  url "http://downloads.canon.com/isg_public/UFRII_v#{version}_Mac.zip"
+  url "http://downloads.canon.com/bisg2015/drivers/mac/UFRII_v#{version}_MAC.zip"
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/cusa/sna/office/color_imagerunner_advance/imagerunner_advance_c5030/imagerunner_advance_c5030#DriversAndSoftware'
   license :gratis
 
-  container :nested => "UFRII_v#{version}_Mac.dmg"
+  container :nested => "UFRII_v#{version}_MAC.dmg"
   pkg 'UFRII_LT_LIPS_LX_Installer.pkg'
 
   uninstall :pkgutil => 'jp.co.canon.CUPSPrinter.*'


### PR DESCRIPTION
As released on 10/06/15 (see homepage).
