### PR TITLE
Add Aerial v1.1

### DIFF
--- a/Casks/aerial-screensaver.rb
+++ b/Casks/aerial-screensaver.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'aerial-screensaver' do
+  version '1.1'
+  sha256 :no_check
+
+  url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.zip"
+  name 'Aerial Screensaver'
+  homepage 'https://github.com/JohnCoates/Aerial'
+  license :mit
+
+  screen_saver 'Aerial.saver'
+end


### PR DESCRIPTION
Aerial - Apple TV Aerial Views Screen Saver
Aerial is a Mac screen saver based on the new Apple TV screen saver that displays the aerial movies Apple shot over New York, San Francisco, Hawaii, China, etc.
