### PR TITLE
Add Aerial v1.1

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'aerial' do
+  version '1.1'
+  sha256 '07365e3d0c8000bc354ab0780ad0b4106f2b9061b8b9da963bae7dd921bf8465'
+
+  url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.zip"
+  appcast 'https://github.com/JohnCoates/Aerial/releases.atom'
+  name 'Aerial Screensaver'
+  homepage 'https://github.com/JohnCoates/Aerial'
+  license :mit
+
+  screen_saver 'Aerial.saver'
+end


### PR DESCRIPTION
Aerial - Apple TV Aerial Views Screen Saver
Aerial is a Mac screen saver based on the new Apple TV screen saver that displays the aerial movies Apple shot over New York, San Francisco, Hawaii, China, etc.
