### PR TITLE
Update Trailer SHA for version 1.3.9

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'trailer' do
   version '1.3.9'
-  sha256 '4f81aee67ecb732aaeaed39190ba64ab06e67a07bef95963d207117fc6313334'
+  sha256 'd539ad8e672bedf403236871f4d066871fe68c17f034a5e9fe87d0e44ea4ebbf'
 
   url "https://ptsochantaris.github.io/trailer/trailer#{version.delete('.')}.zip"
   appcast 'https://ptsochantaris.github.io/trailer/appcast.xml',


### PR DESCRIPTION
This commit updates the sha256 stanza as 1.3.9 was rebuilt.
