### PR TITLE
add caveat for firefox

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -15,4 +15,11 @@ cask :v1 => 'firefox' do
                   '~/Library/Application Support/Firefox',
                   '~/Library/Caches/Firefox',
                  ]
+
+ caveats <<-EOS.undent
+   The Mac App Store version of 1Password won't work with a Homebrew-Cask-linked Mozilla Firefox. To bypass this limitation, you need to either:
+
+     + Move Mozilla Firefox to your /Applications directory (the app itself, not a symlink).
+     + Install 1Password from outside the Mac App Store (licenses should transfer automatically, but you should contact AgileBits about it).
+ EOS
 end


### PR DESCRIPTION
Adds in a 1Password caveat to firefox as well (currently the same as chrome). Wording is tentative, because it's not just 1Password that will have this problem, it's all externally installed addons.

Ref: https://github.com/caskroom/homebrew-cask/issues/13351

Thoughts? (I'll fix the rubocop error before merge)
