### PR TITLE
Upgrade WavTap to 0.3.0 (retina icons)

### DIFF
--- a/Casks/wavtap.rb
+++ b/Casks/wavtap.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'wavtap' do
-  version '0.2.0'
-  sha256 'ae4bbdb82c2b04ab7fa9995ed688b59d79e91f67122ed405409f19d74e7f60e5'
+  version '0.3.0'
+  sha256 'b114703e407ce269070165421a81f74e64ac1730a85d829c148325b4ac1a18f6'
 
-  url "https://github.com/downloads/pje/WavTap/WavTap%20#{version}.pkg"
+  url "https://github.com/downloads/pje/WavTap/WavTap.#{version}.pkg"
   name 'WavTap'
   homepage 'https://github.com/pje/wavtap'
   license :mit


### PR DESCRIPTION
Hey there - first time submitting a PR to homebrew-cask.

Just a quick update to an app that's very useful to Livestreamers, which was previously almost 3 years out of date. I've updated the version number, URL, and sha256 hash.

Best,
JH
