### PR TITLE
fix broken rubocop on ff caveat

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -17,8 +17,7 @@ cask :v1 => 'firefox' do
                  ]
 
   caveats <<-EOS.undent
-  The Mac App Store version of 1Password won't work with a Homebrew-Cask-linked Mozilla Firefox. To bypass this limitation, you need to either:
-  
+  The Mac App Store version of 1Password won't work with a Homebrew-cask-linked Mozilla Firefox. To bypass this limitation, you need to either:
     + Move Mozilla Firefox to your /Applications directory (the app itself, not a symlink).
     + Install 1Password from outside the Mac App Store (licenses should transfer automatically, but you should contact AgileBits about it).
   EOS


### PR DESCRIPTION
Pushed wrong version of https://github.com/caskroom/homebrew-cask/pull/14707

Fixing rubocop errors on FF cask
