### PR TITLE
Remove launchjob files during uninstall, even if they are not loaded

### DIFF
--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -212,16 +212,14 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
           plist_status = @command.run('/bin/launchctl', :args => ['list', service], :sudo => with_sudo, :print_stderr => false).stdout
           if %r{^\{}.match(plist_status)
             result = @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
-            if result.success?
-              paths = ["/Library/LaunchAgents/#{service}.plist",
-                       "/Library/LaunchDaemons/#{service}.plist"]
-              paths.each { |elt| elt.prepend(ENV['HOME']) } unless with_sudo
-              paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
-              paths.each do |path|
-                @command.run!('/bin/rm', :args => ['-f', '--', path], :sudo => with_sudo)
-              end
-            end
             sleep 1
+          end
+          paths = ["/Library/LaunchAgents/#{service}.plist",
+                   "/Library/LaunchDaemons/#{service}.plist"]
+          paths.each { |elt| elt.prepend(ENV['HOME']) } unless with_sudo
+          paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
+          paths.each do |path|
+            @command.run!('/bin/rm', :args => ['-f', '--', path], :sudo => with_sudo)
           end
           # undocumented and untested: pass a path to uninstall :launchctl
           if Pathname(service).exist?

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -215,7 +215,7 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
             if result.success?
               paths = ["/Library/LaunchAgents/#{service}.plist",
                        "/Library/LaunchDaemons/#{service}.plist"]
-              paths.each { |elt| elt.prepend('~') } unless with_sudo
+              paths.each { |elt| elt.prepend(ENV['HOME']) } unless with_sudo
               paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
               paths.each do |path|
                 @command.run!('/bin/rm', :args => ['-f', '--', path], :sudo => with_sudo)


### PR DESCRIPTION
This fixes the original implementation in #8523 to correctly remove user launchjob files, and to do so even when the jobs have not been loaded.

Fixes #14728

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caskroom/homebrew-cask/14730)

<!-- Reviewable:end -->
