### PR TITLE
Fix for case-sensitive systems in Kindle Cask

### DIFF
--- a/Casks/kindle.rb
+++ b/Casks/kindle.rb
@@ -7,7 +7,7 @@ cask :v1 => 'kindle' do
   homepage 'https://www.amazon.com/gp/digital/fiona/kcp-landing-page'
   license :gratis
 
-  app 'Kindle.App'
+  app 'Kindle.app'
 
   zap :delete => [
                   '~/Library/Preferences/com.amazon.Kindle.plist',


### PR DESCRIPTION
Installing Kindle on a case-sensitive system results in the below error:

```
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/kindle/41015/Kindle.App'
```

The actual name in the DMG file is `Kindle.app`
