### PR TITLE
Add Trifacta Wrangler.app

### DIFF
--- a/Casks/trifacta-wrangler.rb
+++ b/Casks/trifacta-wrangler.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'trifacta-wrangler' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://wrangler-distribution-cdn.trifacta.com/Trifacta+Wrangler.dmg'
+  name 'Trifacta Wrangler'
+  name 'Data Wrangler'
+  homepage 'https://www.trifacta.com/'
+  license :freemium
+
+  app 'Trifacta Wrangler.app'
+end


### PR DESCRIPTION
The cask also includes the alternate name of Data Wrangler
which was the Stanford predecessor to this product.
