### PR TITLE
Update cocoaspell license to gratis from unknown

### DIFF
--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -6,7 +6,7 @@ cask :v1 => 'cocoaspell' do
   url "http://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg"
   name 'cocoAspell'
   homepage 'http://cocoaspell.leuski.net/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   pkg 'cocoAspell.pkg'
 


### PR DESCRIPTION
License (in .pkg installer) is close to BSD, but not quite - no modifications allowed
Software still allowed for free
