### PR TITLE
Add vimr binary link to VimR.app

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -10,4 +10,5 @@ cask :v1 => 'vimr' do
   license :gpl
 
   app 'VimR.app'
+  binary 'VimR.app/Contents/Resources/vimr'
 end


### PR DESCRIPTION
Users now are able to use `vimr` in the terminal.
