### PR TITLE
Bumped to latest version for RDM

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'remote-desktop-manager' do
   version '3.0.2.0'
-  sha256 'd5ba2c9c7242fcc55245ba39558d30de24ed27c2bff9e11a78753e2ff5e90fce'
+  sha256 '5b145d2f0b65357d0db57a1bbe7516bb7daa878e6a13398f1238f525efa327be'
 
   # devolutions.net is the official download host per the vendor homepage
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"

--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'remote-desktop-manager' do
-  version '2.0.4.0'
+  version '3.0.2.0'
   sha256 'd5ba2c9c7242fcc55245ba39558d30de24ed27c2bff9e11a78753e2ff5e90fce'
 
   # devolutions.net is the official download host per the vendor homepage

--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -6,7 +6,7 @@ cask :v1 => 'remote-desktop-manager' do
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"
   name 'Remote Desktop Manager'
   homepage 'http://mac.remotedesktopmanager.com/'
-  license :gratis
+  license :commercial
 
   app 'Remote Desktop Manager.app'
 end


### PR DESCRIPTION
Updated to v3.0.2.0 for Mac.
Tested with `brew cask audit remote-desktop-manager --download`
