### PR TITLE
Update appcode to 3.3

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'appcode' do
-  version '3.2'
-  sha256 '0f14171093f96199bb9ef68f286ee38e9f865864b285162f933116e7153e55fd'
+  version '3.3'
+  sha256 '4d434684415479fe4a77f504910d214298959162ba532c910278b77915c24388'
 
-  url "https://download.jetbrains.com/objc/AppCode-#{version}.dmg"
+  url "https://download.jetbrains.com/objc/AppCode-#{version}-custom-jdk-bundled.dmg"
   name 'AppCode'
   homepage 'https://www.jetbrains.com/objc/'
   license :commercial
@@ -11,28 +11,14 @@ cask :v1 => 'appcode' do
 
   zap :delete => [
                   '~/Library/Preferences/com.jetbrains.AppCode.plist',
-                  '~/Library/Preferences/AppCode32',
-                  '~/Library/Application Support/AppCode32',
-                  '~/Library/Caches/AppCode32',
-                  '~/Library/Logs/AppCode32',
+                  '~/Library/Preferences/AppCode33',
+                  '~/Library/Application Support/AppCode33',
+                  '~/Library/Caches/AppCode33',
+                  '~/Library/Logs/AppCode33',
                  ]
 
   conflicts_with :cask => [
                            'appcode-eap',
                            'appcode-bundled-jdk',
                           ]
-
-  caveats <<-EOS.undent
-    #{token} requires Java 6 like any other IntelliJ-based IDE.
-    You can install it with
-
-      brew cask install caskroom/homebrew-versions/java6
-
-    The vendor (JetBrains) doesn't support newer versions of Java (yet)
-    due to several critical issues, see details at
-    https://intellij-support.jetbrains.com/entries/27854363
-
-    To use existing newer Java at your own risk,
-    add JVMVersion=1.6+ to ~/Library/Preferences/IntelliJIdea14/idea.properties
-  EOS
 end


### PR DESCRIPTION
Jetbrains now ships the bundled-jdk version by default
