### PR TITLE
Upgrade PyCharm CE.app from 4.5.4 to 5.0

### DIFF
--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'pycharm-ce' do
-  version '4.5.4'
-  sha256 'b42161a213316ee6cc3c0fc95f2c8316ddbdda7e3b2d771aa9ae6b520d43d156'
+  version '5.0'
+  sha256 'f7e2c972abdac467873df6d42705e46b7364211ea82e84974f5c81aebb82d589'
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"
   name 'PyCharm'


### PR DESCRIPTION
This commit upgrades PyCharm CE.app to latest version 5.0.

JetBrains offers also a version with a bundled JDK, should this cask
be switched to that version and the caveeat removed?
