### PR TITLE
Upgrade steelseries-engine to 3.5.3

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'steelseries-engine' do
-  version '3.4.3'
-  sha256 'b7723aca601080fb734651a7f898ab31dd51ca29f03edb7362f79c90a14909c6'
+  version '3.5.3'
+  sha256 'ae25d45e7af3a1a2f3519ee1c74b9c1361e9bbcd3f2d78c915a69ae923d530e5'
 
   url "http://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"
   name 'SteelSeries Engine 3'


### PR DESCRIPTION
Steelseries recently added support for OSX 10.11 with 3.5.X. 3.4.x is non-functional on OSX 10.11.
