### PR TITLE
A cask for Tor Messenger (beta)

### DIFF
--- a/Casks/tormessenger.rb
+++ b/Casks/tormessenger.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'tormessenger' do
+  version '0.1.0b3'
+  sha256 'cbe94d9707badfddf00c0ccd03bb7690a338a21aa070c7ce647e9343f1745f7f'
+
+  url "https://dist.torproject.org/tormessenger/#{version}/TorMessenger-#{version}-osx64_en-US.dmg"
+  name 'Tor Messenger'
+  homepage '' # there is no homepage yet
+  license :oss 
+
+  app 'Tor Messenger.app'
+end


### PR DESCRIPTION
Added a cask for new messenger by Tor Project
https://blog.torproject.org/blog/tor-messenger-beta-chat-over-tor-easily
