### PR TITLE
Download Webstorm over https

### DIFF
--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'webstorm' do
   version '11.0.0'
-  sha256 '1a60604e7e5b131f41fd7536db0594245697134896ee4054652f0dee09a85ba9'
+  sha256 'aecc26c2cb95d610bcb60d1224b4f8e80031cd8dd1430256173ecc35f7464f40'
 
-  url "http://download-cf.jetbrains.com/webstorm/WebStorm-#{version}.dmg"
+  url "https://download.jetbrains.com/webstorm/WebStorm-#{version}-custom-jdk-bundled.dmg"
   name 'WebStorm'
   homepage 'http://www.jetbrains.com/webstorm/'
   license :commercial

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'webstorm' do
   version '11.0.0'
-  sha256 '1a60604e7e5b131f41fd7536db0594245697134896ee4054652f0dee09a85ba9'
+  sha256 'aecc26c2cb95d610bcb60d1224b4f8e80031cd8dd1430256173ecc35f7464f40'
 
   url "https://download.jetbrains.com/webstorm/WebStorm-#{version}-custom-jdk-bundled.dmg"
   name 'WebStorm'

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -2,7 +2,7 @@ cask :v1 => 'webstorm' do
   version '11.0.0'
   sha256 '1a60604e7e5b131f41fd7536db0594245697134896ee4054652f0dee09a85ba9'
 
-  url "http://download-cf.jetbrains.com/webstorm/WebStorm-#{version}.dmg"
+  url "https://download.jetbrains.com/webstorm/WebStorm-#{version}-custom-jdk-bundled.dmg"
   name 'WebStorm'
   homepage 'http://www.jetbrains.com/webstorm/'
   license :commercial


### PR DESCRIPTION
Use https rather than http to download Webstorm. Also, use the standalone version.
