### PR TITLE
clion - drop caveat and conflicts_with

### DIFF
--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -16,16 +16,4 @@ cask :v1 => 'clion' do
                   '~/Library/Caches/clion12',
                   '~/Library/Logs/clion12',
                  ]
-
-  conflicts_with :cask => 'clion-bundled-jdk'
-  caveats <<-EOS.undent
-    #{token} requires Java 6 like any other IntelliJ-based IDE.
-    You can install it with
-
-      brew cask install caskroom/homebrew-versions/java6
-
-    The vendor (JetBrains) doesn't support newer versions of Java (yet)
-    due to several critical issues, see details at
-    https://intellij-support.jetbrains.com/entries/27854363
-  EOS
 end


### PR DESCRIPTION
JetBrains only offer the version of CLion that comes bundled with their JDK
