### PR TITLE
Update Litecoin to v-0.10.2.2

### DIFF
--- a/Casks/litecoin.rb
+++ b/Casks/litecoin.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'litecoin' do
-  version '0.8.7.5'
-  sha256 'b1067004335b9ab1495137cdd31e4051ca496b09f52412051c0ced586b9875e3'
+  version '0.10.2.2'
+  sha256 'f37c813319504dcb50883eaf9c77795df1be1fe748b5e452ca19c89c2b7543da'
 
-  url "https://download.litecoin.org/litecoin-#{version}/osx/Litecoin-Qt-#{version}.dmg"
+  url "https://download.litecoin.org/litecoin-#{version}/osx/litecoin-#{version}-osx.dmg"
   gpg "#{url}.asc",
       :key_id => 'dc380da43082f16378c97414c37e4723969276f5'
   name 'Litecoin'


### PR DESCRIPTION
I updated path to dmg but I'm not sure where :key_id comes from -- I kept it the same.

Caskroom/cask/litecoin
