### PR TITLE
Fix docker-machine.rb

### DIFF
--- a/Casks/docker-machine.rb
+++ b/Casks/docker-machine.rb
@@ -9,11 +9,42 @@ cask :v1_1 => 'docker-machine' do
   homepage 'https://docs.docker.com/machine'
   license :apache
 
-  container :type => :naked
-  binary 'docker-machine_darwin-amd64', :target => 'docker-machine'
+  container :type => :zip
+
+  binary 'docker-machine'
+  binary 'docker-machine-driver-amazonec2'
+  binary 'docker-machine-driver-azure'
+  binary 'docker-machine-driver-digitalocean'
+  binary 'docker-machine-driver-exoscale'
+  binary 'docker-machine-driver-generic'
+  binary 'docker-machine-driver-google'
+  binary 'docker-machine-driver-hyperv'
+  binary 'docker-machine-driver-none'
+  binary 'docker-machine-driver-openstack'
+  binary 'docker-machine-driver-rackspace'
+  binary 'docker-machine-driver-softlayer'
+  binary 'docker-machine-driver-virtualbox'
+  binary 'docker-machine-driver-vmwarefusion'
+  binary 'docker-machine-driver-vmwarevcloudair'
+  binary 'docker-machine-driver-vmwarevsphere'
 
   postflight do
-    set_permissions "#{staged_path}/docker-machine_darwin-amd64", '0755'
+    set_permissions "#{staged_path}/docker-machine", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-amazonec2", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-azure", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-digitalocean", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-exoscale", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-generic", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-google", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-hyperv", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-none", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-openstack", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-rackspace", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-softlayer", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-virtualbox", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-vmwarefusion", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-vmwarevcloudair", '0755'
+    set_permissions "#{staged_path}/docker-machine-driver-vmwarevsphere", '0755'
   end
 
   depends_on :formula => 'docker'


### PR DESCRIPTION
Upgrade type of container to zip-archive and replace one binary to list of binaries.

In current version of Docker Machine 0.5.0 they split functionality to a main command and a bunch of drivers (separate binaries). Also they put it all in the zip-archive.
