### PR TITLE
AppCode: Remove bundled-jdk from conflicts_with

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -17,8 +17,5 @@ cask :v1 => 'appcode' do
                   '~/Library/Logs/AppCode33',
                  ]
 
-  conflicts_with :cask => [
-                           'appcode-eap',
-                           'appcode-bundled-jdk',
-                          ]
+  conflicts_with :cask => 'appcode-eap'
 end


### PR DESCRIPTION
The bundled-jdk cask has been removed from the versions repo.
