### PR TITLE
PyCharm CE: Switch to Bundled JDK

### DIFF
--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'pycharm-ce' do
   version '5.0'
-  sha256 'f7e2c972abdac467873df6d42705e46b7364211ea82e84974f5c81aebb82d589'
+  sha256 '770596ac464012439e2ff25b7ba3c49996f916a5af18a94a582c8427e61ca4e6'
 
-  url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-community-#{version}-jdk-bundled.dmg"
   name 'PyCharm'
   name 'PyCharm Community Edition'
   name 'PyCharm CE'
@@ -11,14 +11,4 @@ cask :v1 => 'pycharm-ce' do
 
   app 'PyCharm CE.app'
 
-  caveats <<-EOS.undent
-    #{token} requires Java 6 like any other IntelliJ-based IDE.
-    You can install it with
-
-      brew cask install caskroom/homebrew-versions/java6
-
-    The vendor (JetBrains) doesn't support newer versions of Java (yet)
-    due to several critical issues, see details at
-    https://intellij-support.jetbrains.com/entries/27854363
-  EOS
 end


### PR DESCRIPTION
The bundled JDK is now the preferred version.
