### PR TITLE
Electron: add caveat regarding symlink

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -13,7 +13,7 @@ cask :v1 => 'electron' do
   binary 'Electron.app/Contents/MacOS/Electron', :target => 'electron'
 
   caveats <<-EOS.undent
-    Starting #{token} applications with the symlink (e.g. from the terminal) will cause the app not to 
-    accept user input, use the full path instead
-  EOS  
+    Starting #{token} applications with the symlink (e.g. from the terminal)
+    will cause the app not to accept user input, use the full path instead
+  EOS
 end

--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -11,4 +11,9 @@ cask :v1 => 'electron' do
 
   app 'Electron.app'
   binary 'Electron.app/Contents/MacOS/Electron', :target => 'electron'
+
+  caveats <<-EOS.undent
+    Starting #{token} applications with the symlink (e.g. from the terminal) will cause the app not to 
+    accept user input, use the full path instead
+  EOS  
 end


### PR DESCRIPTION
Using the symlink will cause the app not to accept user input. See this issue for more details https://github.com/atom/electron/issues/1151#issuecomment-92085514
