### PR TITLE
Update Android Studio to version 1.4.1.0

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'android-studio' do
-  version '1.4.0.10'
-  sha256 '1168faf59ffbe485bfe0e95e80bd9672a3ae5599efd2b720cf4b825bd859ffa0'
+  version '1.4.1.0'
+  sha256 'b20a6a76c07bcc770b9931705fdefac144a11ba093cf9140d328bcfe4140c387'
 
   # google.com is the official download host per the vendor homepage
-  url "https://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-ide-141.2288178-mac.zip"
+  url 'https://dl.google.com/dl/android/studio/ide-zips/1.4.1.0/android-studio-ide-141.2343393-mac.zip'
   name 'Android Studio'
   homepage 'https://developer.android.com/sdk/'
   license :apache


### PR DESCRIPTION
Hi all,

I use static url to replaced original url with `#{version}` variable in this change,  
because no only version number, but also build number are in the download url.

Maybe we can add a variable for build number to generate download url dynamically next time?

Release page: http://tools.android.com/download/studio/builds/1-4-1
