### PR TITLE
Add Manuscripts.app v1.0

### DIFF
--- a/Casks/manuscripts.rb
+++ b/Casks/manuscripts.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'manuscripts' do
+  version '1.0'
+  sha256 'adc72c2a7d2c20ced73c775e3aa84e1fee0b25e488be39f12347eb7a0e393dd1'
+
+  url 'http://updates.manuscriptsapp.com/apps/manuscripts/production/download'
+  name 'Manuscripts'
+  homepage 'http://www.manuscriptsapp.com'
+  license :freemium
+
+  app 'Manuscripts.app'
+end


### PR DESCRIPTION
Add cask for [Manuscripts.app](http://www.manuscriptsapp.com) 1.0 for scientific writing. Basic version is free and supports up to 3 long documents.
