### PR TITLE
Update the version of antirsi

### DIFF
--- a/Casks/antirsi.rb
+++ b/Casks/antirsi.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'antirsi' do
-  version '1.4njr4'
-  sha256 'b8c36cac71fe0b097b9435ab869b2a11e97e0f99b3227929cb333d14d5e88552'
+  version '2.1'
+  sha256 'f2fc074959d65a11ed7302e1759f08342e0bb6472ce763af9aeec6703592e16f'
 
-  url "http://sabi.net/nriley/software/AntiRSI-#{version}.zip"
+  url "http://antirsi.onnlucky.com/AntiRSI-#{version}.zip"
   name 'AntiRSI'
-  homepage 'http://sabi.net/nriley/software/#antirsi'
+  homepage 'http://antirsi.onnlucky.com/'
   license :gpl
 
   app 'AntiRSI.app'


### PR DESCRIPTION
This is the current (and presumably last?) version that can be downloaded without the Mac App Store.
