### PR TITLE
UniFi Controller - Upgrading to v4.7.6

### DIFF
--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -1,6 +1,6 @@
 cask :v1_1 => 'unifi-controller' do
-  version '4.7.5'
-  sha256 '366930d34a60bc0a7748e9b19240838ff87ac16092f52d07cae27891b945f82d'
+  version '4.7.6'
+  sha256 'e8aa26d00e93e653146f706b7ce25fc18eff532e99f123025109fddaf043e81e'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'


### PR DESCRIPTION
Upgrading the unifi-controller cask to the latest version (4.7.6).
