### PR TITLE
Update Docker casks

### DIFF
--- a/Casks/docker-compose.rb
+++ b/Casks/docker-compose.rb
@@ -16,6 +16,6 @@ cask :v1_1 => 'docker-compose' do
     set_permissions "#{staged_path}/docker-compose-Darwin-x86_64", '0755'
   end
 
-  depends_on :formula => 'docker'
+  depends_on :cask => 'docker'
   depends_on :arch => :x86_64
 end

--- a/Casks/docker-machine-driver-parallels.rb
+++ b/Casks/docker-machine-driver-parallels.rb
@@ -1,0 +1,20 @@
+cask :v1 => 'docker-machine-driver-parallels' do
+  version '1.0.0'
+  sha256 '10db67d0259bf3b99b465beb8fd7d7ff9229efc6cd6139dcdedf4a1fd6b0e2c6'
+
+  url "https://github.com/Parallels/docker-machine-parallels/releases/download/v#{version}/docker-machine-driver-parallels"
+  appcast 'https://github.com/Parallels/docker-machine-parallels/releases.atom'
+  name 'Parallels driver for Docker Machine'
+  homepage 'https://github.com/Parallels/docker-machine-parallels'
+  license :unknown
+
+  container :type => :naked
+  binary 'docker-machine-driver-parallels'
+
+  postflight do
+    set_permissions "#{staged_path}/docker-machine-driver-parallels", '0755'
+  end
+
+  depends_on :cask => 'docker-machine'
+  depends_on :arch => :x86_64
+end

--- a/Casks/docker-machine.rb
+++ b/Casks/docker-machine.rb
@@ -26,6 +26,6 @@ cask :v1_1 => 'docker-machine' do
   binary 'docker-machine-driver-vmwarevcloudair'
   binary 'docker-machine-driver-vmwarevsphere'
 
-  depends_on :formula => 'docker'
+  depends_on :cask => 'docker'
   depends_on :arch => :x86_64
 end

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,0 +1,19 @@
+cask :v1 => 'docker' do
+  version '1.9.0'
+  sha256 '91a8701e41a479def5371a333657c58c36478602e1f5eb1835457a3880232a2e'
+
+  url "https://get.docker.com/builds/Darwin/x86_64/docker-#{version}"
+  appcast 'https://github.com/docker/machine/releases.atom'
+  name 'Docker Engine Client'
+  homepage 'http://docs.docker.com/engine/userguide/'
+  license :apache
+
+  container :type => :naked
+  binary "docker-#{version}", :target => 'docker'
+
+  postflight do
+    set_permissions "#{staged_path}/docker-#{version}", '0755'
+  end
+
+  depends_on :arch => :x86_64
+end


### PR DESCRIPTION
Add cask for Docker Engine Client.
Add cask for Parallels driver for Docker Machine.
Update cask for Docker Machine to depends on created Docker cask.
Update cask for Docker Compose to depends on created Docker cask.  
