### PR TITLE
Add Drop to GIF.app version 1.25

### DIFF
--- a/Casks/drop-to-gif.rb
+++ b/Casks/drop-to-gif.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'drop-to-gif' do
+  version '1.25'
+  sha256 '2d137b0dccde1087d619af41edb48bf4f1b7f7badcc7cafa8ae3f2770d843824'
+
+  # github.com is the official download host per the vendor homepage
+  url "https://github.com/mortenjust/droptogif/releases/download/#{version}/Drop.to.GIF.zip"
+  appcast 'https://github.com/mortenjust/droptogif/releases.atom'
+  name 'Drop to GIF'
+  homepage 'http://mortenjust.github.io/droptogif'
+  license :oss
+
+  app 'Drop to GIF.app'
+end


### PR DESCRIPTION
Zero-click movie to GIF conversion. Select a folder to watch and every movie saved or moved into that folder will be converted to an animated GIF. https://github.com/mortenjust/droptogif
