### PR TITLE
Add support for Xcode plug-ins artifact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,7 @@ Additional stanzas you might need for special use-cases:
 | `suite`                | relative path to a containing directory that should be linked into the `~/Applications` folder on installation
 | `container :nested =>` | relative path to an inner container that must be extracted before moving on with the installation; this allows us to support dmg inside tar, zip inside dmg, etc.
 | `caveats`              | a string or Ruby block providing the user with Cask-specific information at install time (see also [Caveats Stanza Details](doc/CASK_LANGUAGE_REFERENCE.md#caveats-stanza-details))
+| `xcplugin`             | relative path to a Xcode plugin that should be linked into the `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins` folder on installation
 
 Even more special-use stanzas are listed at [Optional Stanzas](doc/CASK_LANGUAGE_REFERENCE.md#optional-stanzas) and [Legacy Stanzas](doc/CASK_LANGUAGE_REFERENCE.md#legacy-stanzas).
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -196,6 +196,8 @@ Default is `/usr/local/bin`
 Default is `~/Library/Input Methods`
 * `--screen_saverdir=/my/path` changes the path for Screen Saver symlinks.
 Default is `~/Library/Screen Savers`
+* `--xcplugindir=/my/path` changes the path for Xcode Plugin symlinks.
+Default is `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins`
 
 To make these settings persistent, you might want to add the following line to your `.bash_profile` or `.zshenv`:
 

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -93,6 +93,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 | `artifact`         | yes                           | relative path to an arbitrary path that should be symlinked on installation. This is only for unusual cases. The `app` stanza is strongly preferred when linking `.app` bundles.
 | `installer`        | yes                           | describes an executable which must be run to complete the installation. (see [Installer Stanza Details](#installer-stanza-details))
 | `stage_only`       | no                            | `true`. Assert that the Cask contains no activatable artifacts.
+| `xcplugin`         | yes                           | relative path to a Xcode plugin that should be linked into the `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins` folder on installation
 
 ## Optional Stanzas
 
@@ -425,7 +426,7 @@ artifact 'openman.1', :target => '/usr/local/share/man/man1/openman.1'
 
 ### :target Works on Most Artifact Types
 
-The `:target` key works similarly for most Cask artifacts, such as `app`, `binary`, `colorpicker`, `font`, `input_method`, `prefpane`, `qlplugin`, `service`, `suite`, and `artifact`.
+The `:target` key works similarly for most Cask artifacts, such as `app`, `binary`, `colorpicker`, `font`, `input_method`, `prefpane`, `qlplugin`, `service`, `suite`, `xcplugin`, and `artifact`.
 
 ### :target Should Only Be Used in Select Cases
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -119,6 +119,7 @@ The term `:v1` identifies the DSL version (currently 1.0), and defines the featu
 * [`uninstall`](CASK_LANGUAGE_REFERENCE.md#uninstall-stanza-details)
 * [`url`](CASK_LANGUAGE_REFERENCE.md#url-stanza-details)
 * [`version`](CASK_LANGUAGE_REFERENCE.md#required-stanzas)
+* [`xcplugin`](CASK_LANGUAGE_REFERENCE.md#at-least-one-artifact-stanza-is-also-required)
 * [`zap`](CASK_LANGUAGE_REFERENCE.md#zap-stanza-details)
 
 ## Other Supported Non-stanza Methods (1.0)

--- a/doc/man/brew-cask.1
+++ b/doc/man/brew-cask.1
@@ -177,6 +177,10 @@ Target location for Internet Plugin links\. The default value is \fB~/Library/In
 Target location for Screen Saver links\. The default value is \fB~/Library/Screen Savers\fR\.
 .
 .TP
+\fB\-\-xcplugindir=<path>\fR
+Target location for Xcode Plugin links\. The default value is \fB~/Library/Application Support/Developer/Shared/Xcode/Plug-ins\fR\.
+.
+.TP
 \fB\-\-no\-binaries\fR
 Do not link “helper” executables to \fB/usr/local/bin\fR\.
 .

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -169,6 +169,9 @@ in a future version.
   * `--screen_saverdir=<path>`:
     Target location for Screen Saver links. The default value is `~/Library/Screen Savers`.
 
+  * `--xcplugindir=<path>`:
+    Target location for Xcode Plugin links. The default value is `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins`.
+
   * `--no-binaries`:
     Do not link “helper” executables to `/usr/local/bin`.
 

--- a/lib/hbc/artifact.rb
+++ b/lib/hbc/artifact.rb
@@ -24,6 +24,7 @@ require 'hbc/artifact/service'
 require 'hbc/artifact/stage_only'
 require 'hbc/artifact/suite'
 require 'hbc/artifact/uninstall'
+require 'hbc/artifact/xcplugin'
 require 'hbc/artifact/zap'
 
 module Hbc::Artifact
@@ -52,6 +53,7 @@ module Hbc::Artifact
       Hbc::Artifact::ScreenSaver,
       Hbc::Artifact::Uninstall,
       Hbc::Artifact::PostflightBlock,
+      Hbc::Artifact::Xcplugin,
       Hbc::Artifact::Zap,
     ]
   end

--- a/lib/hbc/artifact/xcplugin.rb
+++ b/lib/hbc/artifact/xcplugin.rb
@@ -1,0 +1,5 @@
+class Hbc::Artifact::Xcplugin < Hbc::Artifact::Symlinked
+  def self.artifact_english_name
+    'Xcode Plugin'
+  end
+end

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -182,6 +182,9 @@ class Hbc::CLI
       opts.on("--screen_saverdir=MANDATORY") do |v|
        Hbc.screen_saverdir = Pathname(v).expand_path
       end
+      opts.on("--xcplugindir=MANDATORY") do |v|
+        Hbc.xcplugindir = Pathname(v).expand_path
+      end
 
       opts.on("--no-binaries") do |v|
         Hbc.no_binaries = true

--- a/lib/hbc/cli/internal_stanza.rb
+++ b/lib/hbc/cli/internal_stanza.rb
@@ -34,6 +34,7 @@ class Hbc::CLI::InternalStanza < Hbc::CLI::InternalUseBase
                        :input_method,
                        :internet_plugin,
                        :screen_saver,
+                       :xcplugin,
                        :pkg,
                        :installer,
                        :stage_only,

--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -250,6 +250,7 @@ module Hbc::DSL
                                      :input_method,
                                      :internet_plugin,
                                      :screen_saver,
+                                     :xcplugin,
                                      :pkg,
                                      :stage_only,
                                     ]

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -92,6 +92,14 @@ module Hbc::Locations
       @screen_saverdir = _screen_saverdir
     end
 
+    def xcplugindir
+      @xcplugindir ||= Pathname.new('~/Library/Application Support/Developer/Shared/Xcode/Plug-ins').expand_path
+    end
+
+    def xcplugindir=(_xcplugindir)
+      @xcplugindir = _xcplugindir
+    end
+
     def default_tap
       @default_tap ||= 'caskroom/homebrew-cask'
     end


### PR DESCRIPTION
Add `xcplugin` stanza.
I want to use Homebrew-Cask for managing Xcode plugins. (as alternate of [Alcatraz](http://alcatraz.io).)
