### PR TITLE
speeds-at-ver: initial cask

### DIFF
--- a/Casks/speeds-at-ver.rb
+++ b/Casks/speeds-at-ver.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'speeds-at-ver' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://raw.github.com/orta/GamesScreenSaver/master/web/SpeedS@ver.saver.zip'
+  name 'SpeedS@ver'
+  homepage 'https://github.com/orta/SpeedS-ver'
+  license :mit
+
+  screen_saver 'SpeedS@ver.saver'
+end


### PR DESCRIPTION
Speedrun screensaver, following the correct naming guidelines as pointed out in #15063
