### PR TITLE
Get FileShuttle over HTTPS & update appcast URL.

### DIFF
--- a/Casks/fileshuttle.rb
+++ b/Casks/fileshuttle.rb
@@ -2,11 +2,11 @@ cask :v1 => 'fileshuttle' do
   version '2.1'
   sha256 '431b7cb2161eace5b8d39146bdd1b7cc9a85d335eb29175c1a1879208928565a'
 
-  url "http://fileshuttle.io/fileshuttle-#{version}.zip"
-  appcast 'http://updates.getfileshuttle.com/update.xml',
-          :sha256 => '9c8640556eedc9f07894e1c3d140f86ccdf27c95714aead2937ae562143079e0'
+  url "https://fileshuttle.io/fileshuttle-#{version}.zip"
+  appcast 'https://fileshuttle.io/update.xml',
+          :sha256 => 'bb04ae1f2834d488b0faf6a12320b8a75832e3de1123e9fb538c5f22e835b9d9'
   name 'FileShuttle'
-  homepage 'http://fileshuttle.io/'
+  homepage 'https://fileshuttle.io/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'FileShuttle.app'


### PR DESCRIPTION
The old domain is no longer used, updating the `appcast` URL and its `sha256`. All resources are available over HTTPS.

---

Note on license: the next version of FileShuttle (3.x) is being developed under the MIT license. Older versions do have their source publicly available ([2.x source](https://github.com/FileShuttle/fileshuttle/tree/2.x)) but were never officially released under an open license. `:gratis` might be the best fit, considering [the application’s history](https://github.com/FileShuttle/fileshuttle/issues/9#issuecomment-35065124):

> the app previously was free then went to app store and now opensourced/githubbed

Will `:gratis` be acceptable here? [CASK_LANGUAGE_REFERENCE](https://github.com/caskroom/homebrew-cask/blob/master/doc/CASK_LANGUAGE_REFERENCE.md#valid-licenses) defines `:gratis` as closed-source but overall forgets to make a distinction between [open-source and source-available](https://en.wikipedia.org/wiki/Open-source_software#Open-source_vs._source-available).

I have left it as `:unknown` until one of the Cask contributors can clear that up for me.
