### PR TITLE
Upgrade DBeaver-Enterprise to v3.5.3

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,17 +1,12 @@
 cask :v1 => 'dbeaver-enterprise' do
-  version '3.4.5'
+  version '3.5.3'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '6a059d046964194e516fce67df227336ce2554922267d358297f65d893595b55'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86.zip"
-  else
-    sha256 'e80d4d4476233b905304bb91bc8edb3a33514280659b55ab6aebf62ac6dc693c'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-ee-macosx.cocoa.x86_64.zip"
-  end
+  sha256 'a0ef41d9aca53ecd43f8ccd41dcb2d57391ea422429523fdab00ec69fb341fc4'
+  url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
 
   name 'DBeaver Enterprise Edition'
   homepage 'http://dbeaver.jkiss.org/'
   license :oss
 
-  app 'dbeaver/dbeaver.app'
+  app 'Dbeaver.app'
 end


### PR DESCRIPTION
- Support for 32-bit removed since version 3.5.0 (http://dbeaver.jkiss.org/2015/09/27/dbeaver-3-5-0/)
- New archive for DMG files added since version 3.5.3 with new file structure (http://dbeaver.jkiss.org/2015/11/09/dbeaver-3-5-3/)
