### PR TITLE
Upgrade DBeaver-Community to v3.5.3

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,17 +1,12 @@
 cask :v1 => 'dbeaver-community' do
-  version '3.4.5'
+  version '3.5.3'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 'fa6271e62cd7050063d263578d9d06a70834f8c0a699f3d51d2e31b922976dc6'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86.zip"
-  else
-    sha256 '5bd5476e32ee17b78127b72ab686ad4f770f0793e9378a016f999de23c725a34'
-    url "http://dbeaver.jkiss.org/files/dbeaver-#{version}-macosx.cocoa.x86_64.zip"
-  end
+  sha256 'ef24a7081119514a084f8748c2d63f50519d6a232146565bba4754de0fe8ef90'
+  url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
 
   name 'DBeaver Community Edition'
   homepage 'http://dbeaver.jkiss.org/'
   license :oss
 
-  app 'dbeaver/dbeaver.app'
+  app 'Dbeaver.app'
 end


### PR DESCRIPTION
- Support for 32-bit removed since version 3.5.0 (http://dbeaver.jkiss.org/2015/09/27/dbeaver-3-5-0/)
- New archive for DMG files added since version 3.5.3 with new file structure (http://dbeaver.jkiss.org/2015/11/09/dbeaver-3-5-3/)
