### PR TITLE
change manuscripts to un-versioned url

### DIFF
--- a/Casks/manuscripts.rb
+++ b/Casks/manuscripts.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'manuscripts' do
-  version '1.0'
-  sha256 'adc72c2a7d2c20ced73c775e3aa84e1fee0b25e488be39f12347eb7a0e393dd1'
+  version :latest
+  sha256 :no_check
 
   url 'http://updates.manuscriptsapp.com/apps/manuscripts/production/download'
   name 'Manuscripts'


### PR DESCRIPTION
Fixes #15113 

Download URL has no version, so this will prevent silent breakages
