### PR TITLE
Update Endless Sky to 0.8.7

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'endlesssky' do
-  version '0.8.4'
-  sha256 'e98d1ff580fd69dfdc62a3e892bceabf76f52c1c830fdf1ef2f1c17ace04700d'
+  version '0.8.7'
+  sha256 'cd8e56145a7b8639c9302798e5dfb8d2684bfc734a6d6aa38ef498b457816840'
 
-  url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
+  url "https://github.com/endless-sky/endless-sky/releases/download/#{version}/endless-sky-macosx-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'


### PR DESCRIPTION
Bump version number, SHA, and it seems this release uses a slightly different URL to get the download.
