### PR TITLE
Upgraded Soundflower to 2.0b2 and new maintainer.

### DIFF
--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -1,10 +1,11 @@
 cask :v1 => 'soundflower' do
-  version '1.6.6b'
-  sha256 '61ca31d7478d057e32caaeac3c739f965ba9eb2a27570b3cc715e706d4740dfb'
+  version '2.0b2'
+  sha256 '6b5e56d53238cf0f9075886aa40580634fc9d23368239f22eccebfd97c9f8e34'
 
-  url "https://soundflower.googlecode.com/files/Soundflower-#{version}.dmg"
+  url "https://github.com/mattingalls/Soundflower/releases/download/#{version}/Soundflower-#{version}.dmg"
+
   name 'Soundflower'
-  homepage 'https://code.google.com/p/soundflower/'
+  homepage 'https://github.com/mattingalls/Soundflower'
   license :oss
 
   pkg 'Soundflower.pkg', :allow_untrusted => true

--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -8,7 +8,7 @@ cask :v1 => 'soundflower' do
   homepage 'https://github.com/mattingalls/Soundflower'
   license :oss
 
-  pkg 'Soundflower.pkg', :allow_untrusted => true
+  pkg 'Soundflower.pkg'
   postflight do
     system '/usr/bin/sudo', '-E', '--',
       '/sbin/kextload', '-b', 'com.Cycling74.driver.Soundflower'

--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -1,7 +1,6 @@
 cask :v1 => 'soundflower' do
   version '2.0b2'
   sha256 '6b5e56d53238cf0f9075886aa40580634fc9d23368239f22eccebfd97c9f8e34'
-
   url "https://github.com/mattingalls/Soundflower/releases/download/#{version}/Soundflower-#{version}.dmg"
 
   name 'Soundflower'
@@ -9,6 +8,7 @@ cask :v1 => 'soundflower' do
   license :oss
 
   pkg 'Soundflower.pkg'
+  
   postflight do
     system '/usr/bin/sudo', '-E', '--',
       '/sbin/kextload', '-b', 'com.Cycling74.driver.Soundflower'


### PR DESCRIPTION
This version is signed so does not require enabling unsigned kexts on El Capitan.

See https://github.com/RogueAmoeba/Soundflower-Original/issues/39 and https://github.com/mattingalls/Soundflower/releases and https://rogueamoeba.com/freebies/soundflower/
