### PR TITLE
Add cask for nagbar app.

### DIFF
--- a/Casks/nagbar.rb
+++ b/Casks/nagbar.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'nagbar' do
+  version '1.2.4'
+  sha256 '7375252d44afc2735327b6c430739a60cfb72f3464bd8bd25ace696e5152083c'
+
+  url "https://sites.google.com/site/nagbarapp/NagBar-#{version}.dmg?attredirects=0&d=1"
+  name 'NagBar'
+  homepage 'https://sites.google.com/site/nagbarapp/home'
+  license :gratis
+
+  app 'NagBar.app'
+
+  zap :delete => [
+        '~/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.volendavidov.nagbar.sfl',
+        '~/Caches/com.volendavidov.NagBar',
+        '~/Preferences/com.volendavidov.NagBar.plist',
+      ]
+end


### PR DESCRIPTION
NagBar is a freeware Nagios, Icinga and Thruk monitoring client which
runs in the status bar and give updates about the monitored
services. NagBar is a Mac OS X native application created using the
Cocoa framework.

NagBar is tested on Nagios 3.x and 4.x, Icinga 1.6+ and Thruk 1.82+.

Supported Mac OS X versions are 10.7+. Tested versions are 10.8, 10.9,
10.10 and 10.11.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
