### PR TITLE
README.md: no longer needed to specifcally install homebrew-cask, to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ It’s implemented as a `homebrew` [external command](https://github.com/Homebre
 ## Let’s try it!
 
 ```bash
-$ brew install caskroom/cask/brew-cask
 $ brew cask install google-chrome
 => Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
 => Success! google-chrome installed to /opt/homebrew-cask/Caskroom/google-chrome/stable-channel


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew/pull/45773.
