### PR TITLE
diffmerge.rb: remove caveat

### DIFF
--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -16,9 +16,4 @@ cask :v1 => 'diffmerge' do
                          '~/Library/Preferences/SourceGear DiffMerge Preferences',
                          '~/Library/Saved Application State/com.sourcegear.DiffMerge.savedState'
                         ]
-
-  caveats <<-EOS.undent
-    Use "diffmerge --nosplash" to hide the splash screen when using
-    diffmerge with external tools such as git.
-  EOS
 end


### PR DESCRIPTION
`caveat` did not pertain to installation.
