### PR TITLE
Switch mactex download link

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,9 +1,8 @@
 cask :v1 => 'mactex' do
-  version '20150613'
-  sha256 'c5f5b0fd853a17dab6e844fb5e893804af78d938fa18ee94ec3b257611a95c12'
+  version :latest
+  sha256 :no_check
 
-  # ctan.org is the official download host per the vendor homepage
-  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
+  url 'http://tug.org/cgi-bin/mactex-download/MacTeX.pkg'
   name 'MacTeX'
   homepage 'https://www.tug.org/mactex/'
   license :oss


### PR DESCRIPTION
This link automatically redirects users to the best download location, but we lose "versioning" as the URL does not have a #{version}

The package is huge, so arguably download speed is important

Based on a comment in the Gitter chat by @fanquake 
