### PR TITLE
Update Markright to 0.1.8

### DIFF
--- a/Casks/markright.rb
+++ b/Casks/markright.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'markright' do
-  version '0.1.7'
-  sha256 '5cb5ddbc2f1684d164b9afa80f34341d4650b4cf4ac12d9cceccb8a7e3d8c9cc'
+  version '0.1.8'
+  sha256 '2a5c875a34bbe43ff1ef7cb47d377009ee5e11ac2d84381d4c5d085b7a99f4dc'
 
   url "https://github.com/dvcrn/markright/releases/download/#{version}/MarkRight_Mac.dmg"
   appcast 'https://github.com/dvcrn/markright/releases.atom'


### PR DESCRIPTION
Release tag: https://github.com/dvcrn/markright/releases/tag/0.1.8
