### PR TITLE
Fix 'pkg source file not found' installing mactex

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -7,7 +7,7 @@ cask :v1 => 'mactex' do
   homepage 'https://www.tug.org/mactex/'
   license :oss
 
-  pkg "mactex-#{version}.pkg"
+  pkg 'MacTeX.pkg'
 
   uninstall :pkgutil => [
                          'org.tug.mactex.ghostscript9.16',


### PR DESCRIPTION
The last update of mactex.rb formula broke it:

```
Error: pkg source file not found: '/opt/homebrew-cask/Caskroom/mactex/latest/mactex-latest.pkg'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/artifact/pkg.rb:43:in `run_installer'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/artifact/pkg.rb:30:in `block in install_phase'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/set.rb:232:in `each_key'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/set.rb:232:in `each'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/artifact/pkg.rb:30:in `install_phase'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/installer.rb:119:in `block in install_artifacts'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/installer.rb:117:in `each'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/installer.rb:117:in `install_artifacts'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/installer.rb:66:in `install'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/cli/install.rb:20:in `block in install_casks'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/cli/install.rb:17:in `each'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/cli/install.rb:17:in `install_casks'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/cli/install.rb:6:in `run'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/cli.rb:78:in `run_command'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/hbc/cli.rb:118:in `process'
/usr/local/Cellar/brew-cask/0.59.0/rubylib/brew-cask-cmd.rb:19:in `<main>'
```

I fixed it by updating the expected package name.
