### PR TITLE
basictex: remove caveats and update uninstall

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -10,8 +10,10 @@ cask :v1 => 'basictex' do
 
   pkg 'BasicTeX.pkg'
 
-  uninstall :pkgutil => 'org.tug.mactex.basictex2015'
-  caveats do
-    path_environment_variable '/usr/texbin'
-  end
+  uninstall :pkgutil => 'org.tug.mactex.basictex2015',
+            :delete  => [
+                         '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
+                         '/etc/paths.d/TeX',
+                         '/etc/manpaths.d/TeX'
+                        ]
 end


### PR DESCRIPTION
Since El Capitan, the path is `/Library/TeX/texbin` and it gets added automatically to `/etc/paths.d` and `/etc/manpaths.d`.
Also remove TeX from path and Settings on uninstall.
