### PR TITLE
mactex: remove caveats and update uninstall

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -16,9 +16,8 @@ cask :v1 => 'mactex' do
                         ],
             :delete  => [
                          '/Applications/TeX',
+                         '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
                          '/etc/paths.d/TeX',
+                         '/etc/manpaths.d/TeX'
                         ]
-  caveats do
-    zsh_path_helper '/usr/texbin'
-  end
 end


### PR DESCRIPTION
Remove caveats for path, cause it gets added automatically.

Also delete tex from manpath.d and settings on uninstall.
