### PR TITLE
Upgrade VMware Horizon Client to 3.5.2-3151577

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'vmware-horizon-client' do
-  version '3.4.0-2769709'
-  sha256 'df0ed13716d4dbd5dae7dc77f2f29668907860b205f50132b6a1533364d3dd97'
+  version '3.5.2-3151577'
+  sha256 '52254a1203706ed8a7700b888f9d88b0754ff053698d21313d4f7683fcfff48c'
 
-  url "https://download3.vmware.com/software/view/viewclients/CART15Q2/VMware-Horizon-Client-#{version}.dmg"
+  url "https://download3.vmware.com/software/view/viewclients/CART15Q4_3/VMware-Horizon-Client-#{version}.dmg"
   name 'VMware Horizon Client'
   homepage 'https://www.vmware.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
To make sure it works properly under El Capitan.

Signed-off-by: Jonas Rosland jonas.rosland@gmail.com
