### PR TITLE
Upgrade Back-in-Time to v4

### DIFF
--- a/Casks/back-in-time.rb
+++ b/Casks/back-in-time.rb
@@ -2,10 +2,10 @@ cask :v1 => 'back-in-time' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.tri-edre.fr/pub/files/backintime3.dmg'
+  url 'http://www.tri-edre.com/pub/files/backintime4.dmg'
   name 'Back-In-Time'
-  homepage 'http://www.tri-edre.fr/english/backintime.html'
+  homepage 'http://www.tri-edre.com/english/backintime.html'
   license :commercial
 
-  app 'Back-In-Time 3.app'
+  app 'Back-In-Time 4.app'
 end


### PR DESCRIPTION
Current version is 4.0.2; download URL is unversioned except for major releases.
