### PR TITLE
Updated Mapbox Studio to 0.3.3

### DIFF
--- a/Casks/mapbox-studio.rb
+++ b/Casks/mapbox-studio.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'mapbox-studio' do
-  version '0.3.2'
-  sha256 'e89a8f55d5f1073be99bb00c29988eb6b47c1f15ed874f80296e89831ed61dfa'
+  version '0.3.3'
+  sha256 'e88ec6986fd0b3c05923cf0e647863137cf28a4246f8822949d934c873f050cb'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-v#{version}.zip"


### PR DESCRIPTION
Mapbox Studio is now at version 0.3.3. Upon installing the current version via Cask, I discovered the discrepancy, so I updated the Cask to reflect the latest release.
