### PR TITLE
Upgrade GeoTag to v3.5

### DIFF
--- a/Casks/geotag.rb
+++ b/Casks/geotag.rb
@@ -3,8 +3,8 @@ cask :v1 => 'geotag' do
     version '2.2'
     sha256 'c5553af3b37903b7e4f402d8c9fbeced63492295c6bdd25987dd70ab367c32e9'
   else
-    version '3.4.4'
-    sha256 '987380bf59e4465bf2ab65b04711114abda493e9b78cb26d25e4e4c903004225'
+    version '3.5'
+    sha256 'b8c46486502a90856087de7e637d73c6ce21db62cde2c1483d33e2e3e2da16d3'
   end
 
   url "http://www.snafu.org/GeoTag/GeoTag-#{version}.dmg"


### PR DESCRIPTION
This commit upgrades GeoTag.app from v3.4.4 to v3.5
