### PR TITLE
Add WordPress.com App

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'wordpresscom' do
+  version '1.1'
+  sha256 '2ee6503a319180895f7e75e4ff3ba06a695524e34152bdb5f6d6f39aa6c7c50c'
+
+  url "https://public-api.wordpress.com/rest/v#{version}/desktop/osx/download?type=dmg"
+  name 'WordPress.com'
+  homepage 'https://desktop.wordpress.com/'
+  license :gpl
+
+  app 'WordPress.com.app'
+end


### PR DESCRIPTION
Added the WordPress.com app.

Note: WordPress's website for the app and the download link mark the version as 1.1 while the app itself reports 1.0.0 release.

See https://desktop.wordpress.com/
