### PR TITLE
Fix checksum for elm-platform package.

### DIFF
--- a/Casks/elm-platform.rb
+++ b/Casks/elm-platform.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'elm-platform' do
   version '0.16'
-  sha256 'e55a6e993264b29bf917df79ccb383ea99260082108d8c07b668718325478f1f'
+  sha256 '8d87aa2737c4c9950fdbdb1f8f1b154b28fd5c27e7b1bfb3e0bdbcc5fc6cc603'
 
   url "http://install.elm-lang.org/Elm-Platform-#{version}.pkg"
   name 'Elm'


### PR DESCRIPTION
I'm pretty sure the SHA256 for `elm-platform` is wrong. It was updated a couple days ago, so it seems reasonable that no one else has caught it yet. When I download manually I get the checksum I've changed it to, this is also the "correct" checksum reported in the `brew cask` error message.

```
$ brew cask install elm-platform
==> Downloading http://install.elm-lang.org/Elm-Platform-0.16.pkg
######################################################################## 100.0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: e55a6e993264b29bf917df79ccb383ea99260082108d8c07b668718325478f1f
Actual: 8d87aa2737c4c9950fdbdb1f8f1b154b28fd5c27e7b1bfb3e0bdbcc5fc6cc603
File: /Library/Caches/Homebrew/elm-platform-0.16.pkg
To retry an incomplete download, remove the file above.
```

I ran `brew update`, `brew upgrade brew-cask`, `brew cleanup`, and `brew cask cleanup`. These didn't solve the issue. I tested with my own fork and the 0.16 install works with this change applied.
