### PR TITLE
Blue Jeans - Upgrades Launcher to v1.5.8 and Browser Plugin to v2.115.99.8

### DIFF
--- a/Casks/blue-jeans-browser-plugin.rb
+++ b/Casks/blue-jeans-browser-plugin.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'blue-jeans-browser-plugin' do
-  version '2.85.47.8'
-  sha256 'b1444c3bf1ebd2d329e365e77ec4a19e5456c5ec9bfc0c2d8410952a889f56e8'
+  version '2.115.99.8'
+  sha256 '2a367b63a7d18b2249472179d10e8a51ed3b5c76241513e9397560ecc8065825'
 
   url "https://swdl.bluejeans.com/skinny/rbjnplugin_#{version}.pkg"
   name 'Blue Jeans Browser Plug-in'

--- a/Casks/blue-jeans-launcher.rb
+++ b/Casks/blue-jeans-launcher.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'blue-jeans-launcher' do
-  version '1.5.2'
-  sha256 '757edfba7811cbc20fd001bc9b6c8e7ec06b80578b1b01d866e7fea65da0869d'
+  version '1.5.8'
+  sha256 '0f9b668f6cbed26fee2b9174836c0a3ff56e8032be7ddc1b030decc41fe303d0'
 
   url "https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_#{version.delete('.')}.dmg"
   name 'Blue Jeans videoconferencing'


### PR DESCRIPTION
Here is the `brew cask audit` output:

```
brew cask audit blue-jeans-launcher --download
==> Downloading https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_158.dmg
Already downloaded: /Library/Caches/Homebrew/blue-jeans-launcher-1.5.8.dmg
audit for blue-jeans-launcher: passed
```

```
brew cask audit blue-jeans-browser-plugin --download
==> Downloading https://swdl.bluejeans.com/skinny/rbjnplugin_2.115.99.8.pkg
Already downloaded: /Library/Caches/Homebrew/blue-jeans-browser-plugin-2.115.99.8.pkg
audit for blue-jeans-browser-plugin: passed
```
