### PR TITLE
Move adobe-reader to https:// download URL

### DIFF
--- a/Casks/adobe-reader.rb
+++ b/Casks/adobe-reader.rb
@@ -2,7 +2,7 @@ cask :v1 => 'adobe-reader' do
   version '2015.009.20069'
   sha256 '5b04f44a94882568aebb51ab31ebbf4bc53a3791a23af7c52af5db02cddd444a'
 
-  url "http://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.gsub('.', '')[2..-1]}/AcroRdrDC_#{version.gsub('.', '')[2..-1]}_MUI.dmg"
+  url "https://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.gsub('.', '')[2..-1]}/AcroRdrDC_#{version.gsub('.', '')[2..-1]}_MUI.dmg"
   name 'Adobe Acrobat Reader DC'
   homepage 'https://www.adobe.com/products/reader.html'
   license :gratis


### PR DESCRIPTION
Changed formula download worked correctly.

Feel free to say if there's a compelling reason for the http:// URL.
