### PR TITLE
Use last known good release for chromium instead of trunk

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -3,7 +3,7 @@ cask :v1 => 'chromium' do
   sha256 :no_check
 
   # appspot.com is the official download host per the vendor homepage
-  url 'https://download-chromium.appspot.com/dl/Mac'
+  url 'https://download-chromium.appspot.com/?platform=Mac&type=continuous'
   name 'Chromium'
   homepage 'https://www.chromium.org/Home'
   license :oss


### PR DESCRIPTION
Resolves https://github.com/caskroom/homebrew-cask/issues/15357 - Chromium builds will now use LKGR instead of trunk

Thanks to @paulirish and @beaufortfrancois for the necessary changes on the `download-chromium.appspot.com` site.
