### PR TITLE
Update visual-studio-code to 0.10.2

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'visual-studio-code' do
-  version '0.10.1'
-  sha256 'b71089670b3c2a259bf26ad6a6ad7b0abc9bb805353e8087f5c86361a5f8defc'
+  version '0.10.2'
+  sha256 '3371bff1e11daa49ad77ad1eed683d1baaf073477c1baff20626250d5ee6153e'
 
   # vo.msecnd.net is the official download host per the vendor homepage
-  url "https://az764295.vo.msecnd.net/public/#{version}-release/VSCode-darwin.zip"
+  url "https://az764295.vo.msecnd.net/public/#{version}/VSCode-darwin.zip"
   name 'Visual Studio Code'
   homepage 'https://code.visualstudio.com/'
   license :mit


### PR DESCRIPTION
For some reason the `-release` suffix seems to have been removed again.
