### PR TITLE
generic_unar.rb: use long flags

### DIFF
--- a/lib/hbc/container/generic_unar.rb
+++ b/lib/hbc/container/generic_unar.rb
@@ -12,7 +12,7 @@ class Hbc::Container::GenericUnar < Hbc::Container::Base
       raise Hbc::CaskError.new "Expected to find unar executable. Cask #{@cask} must add: depends_on :formula => 'unar'"
     end
     Dir.mktmpdir do |unpack_dir|
-      @command.run!(unar, :args => ['-q', '-D', '-o', unpack_dir, '--', @path])
+      @command.run!(unar, :args => ['-quiet', '-no-directory', '-output-directory', unpack_dir, '--', @path])
       @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
     end
   end


### PR DESCRIPTION
@jawshooah (and other maintainers) We should try to use long flags to commands whenever possible. Short flags are fine when writing them out to run immediately, but have no place in a script, where comprehension is more important.

Do you agree?
