### PR TITLE
generic_unar.rb: use -force-overwrite

### DIFF
--- a/lib/hbc/container/generic_unar.rb
+++ b/lib/hbc/container/generic_unar.rb
@@ -12,7 +12,7 @@ class Hbc::Container::GenericUnar < Hbc::Container::Base
       raise Hbc::CaskError.new "Expected to find unar executable. Cask #{@cask} must add: depends_on :formula => 'unar'"
     end
     Dir.mktmpdir do |unpack_dir|
-      @command.run!(unar, :args => ['-quiet', '-no-directory', '-output-directory', unpack_dir, '--', @path])
+      @command.run!(unar, :args => ['-force-overwrite', '-quiet', '-no-directory', '-output-directory', unpack_dir, '--', @path])
       @command.run!('/usr/bin/ditto', :args => ['--', unpack_dir, @cask.staged_path])
     end
   end


### PR DESCRIPTION
Fixes https://github.com/caskroom/homebrew-cask/issues/15025.

However, I’m not yet entirely sure why this is needed, and we should address that.

Under [`generic_unar`](https://github.com/caskroom/homebrew-cask/blob/master/lib/hbc/container/generic_unar.rb) we’re [creating a temporary directory](https://github.com/caskroom/homebrew-cask/blob/master/lib/hbc/container/generic_unar.rb#L14) where [we unpack to](https://github.com/caskroom/homebrew-cask/blob/master/lib/hbc/container/generic_unar.rb#L15). That is causing an error:

``` ruby
==>   ./  (dir)... Skipping existing file.
==> Extraction to directory "/var/folders/s_/k7wmmgf93wqdvpkq39ng29z80000gn/T/d20151126-2381-18l87c7" failed (1 file failed.)
Error: Command failed to execute!

==> Failed command:
["#<Pathname:/usr/local/bin/unar>", "-q", "-D", "-o", "/var/folders/s_/k7wmmgf93wqdvpkq39ng29z80000gn/T/d20151126-2381-18l87c7", "--", "#<Pathname:/Library/Caches/Homebrew/suspicious-package-latest.xip>"]
```

It was the `==>   ./  (dir)... Skipping existing file.` line that gave me the insight to try and force the unpacking. It seems to work for `suspicious-package` and not break the other `unar`-dependent casks.

The problem seems to lie somewhere with the creation of the temporary directory. At first look from my quick tests, it seems like it’s not even being created, but I’m messing it up somewhere there, since if it wasn’t being created, then this fix wouldn’t work and the other `unar`-dependent cask would also be broken.
