### PR TITLE
Set world readable permissions on Blender so that it can be used system wide.

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -9,4 +9,8 @@ cask :v1 => 'blender' do
 
   app "blender-#{version}-OSX_10.6-x86_64/Blender.app"
   app "blender-#{version}-OSX_10.6-x86_64/BlenderPlayer.app"
+
+  postflight do
+    set_permissions "#{staged_path}/blender-#{version}-OSX_10.6-x86_64/", '0755'
+  end
 end


### PR DESCRIPTION
The directory in the Blender ZIP has its permissions set to 0700. This means that `brew cask install --appdir='/Applications' blender` will not have the desired effect of properly installing Blender for every user on the system.
