### PR TITLE
Add final three apps in the Laurence Anthony 'ant' suite

### DIFF
--- a/Casks/antfileconverter.rb
+++ b/Casks/antfileconverter.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'antfileconverter' do
+  version '1.2.0'
+  sha256 '97080a3932ca46f604506da21fa7c0b4e6b1e1aaa1a02f926eb6bc9cc21b841c'
+
+  url "http://www.laurenceanthony.net/software/antfileconverter/releases/AntFileConverter#{version.delete('.')}/AntFileConverter.zip"
+  name 'AntFileConverter'
+  homepage 'http://www.laurenceanthony.net/software/antfileconverter/'
+  license :gratis
+
+  app 'AntFileConverter.app'
+end

--- a/Casks/antpconc.rb
+++ b/Casks/antpconc.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'antpconc' do
+  version '1.1.0'
+  sha256 '3b8f25e876f4c3c6d5e9765b0891a377aae277e1a76adb8183b1ec948a23771c'
+
+  url "http://www.laurenceanthony.net/software/antpconc/releases/AntPConc#{version.delete('.')}/AntPConc.zip"
+  name 'AntPConc'
+  homepage 'http://www.laurenceanthony.net/software/antpconc'
+  license :gratis
+
+  app 'AntPConc.app'
+end

--- a/Casks/protant.rb
+++ b/Casks/protant.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'protant' do
+  version '1.0.0'
+  sha256 '98906ca80b98ce8fc7ec11eea6bba29f629a072752bb1c2f9ba07a1355effee1'
+
+  url "http://www.laurenceanthony.net/software/protant/releases/ProtAnt#{version.delete('.')}/ProtAnt.zip"
+  name 'ProtAnt'
+  homepage 'http://www.laurenceanthony.net/software/protant'
+  license :gratis
+
+  app 'ProtAnt.app'
+end


### PR DESCRIPTION
This adds three new casks, antfileconverter, protant, and antpconc, which should complete the suite of mac apps from http://www.laurenceanthony.net/software/ — antconc, antwordprofiler, segmentant, and tagant were already there.
