### PR TITLE
Upgrade JDownloader to v2

### DIFF
--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -2,13 +2,26 @@ cask :v1 => 'jdownloader' do
   version :latest
   sha256 :no_check
 
-  url 'http://installer.jdownloader.org/JDownloader09Setup_mac.dmg'
-  name 'JDownloader'
+  if MacOS.release <= :snow_leopard
+    url 'http://installer.jdownloader.org/JD2Setup_10_6orlower.dmg'
+  else
+    url 'http://installer.jdownloader.org/JD2Setup.dmg'
+  end
+
+  name 'JDownloader 2'
   homepage 'http://jdownloader.org/'
   license :gpl
 
-  installer :script => 'JDownloader Installer.app/Contents/MacOS/JavaApplicationStub',
-            :args => [ '-q' ]
+  preflight do
+    system "\"#{staged_path}/JDownloader Installer.app/Contents/MacOS/JavaApplicationStub\" " \
+           "-dir \"#{staged_path}\" " \
+           '-q ' \
+           '-Dinstall4j.suppressStdout=true ' \
+           '-Dinstall4j.debug=false ' \
+           '-VcreateDesktopLinkAction\$Boolean=false ' \
+           '-VaddToDockAction\$Boolean=false ' \
+           '> /dev/null 2>&1'
+  end
 
   caveats <<-EOS.undent
     #{token} requires Java 6+, you can install the latest Java using
@@ -16,5 +29,5 @@ cask :v1 => 'jdownloader' do
       brew cask install java
   EOS
 
-  uninstall :delete => '/Applications/JDownloader.app'
+  app 'JDownloader 2.0/JDownloader2.app'
 end


### PR DESCRIPTION
With regard to https://github.com/caskroom/homebrew-versions/pull/1438 this version does not create dock/desktop icons anymore (Escaping of $ was needed) and also mutes all stdout and stderr.

One thing I noticed is, that even when the system call fails (does not return 0) the app is linked (JDownloader2.app already exists but the installer failed due to no internet connection).
Is there a way to make the `preflight` block fail if the return value is not 0?

Install4j: [Command Line Options For Generated Installers](http://resources.ej-technologies.com/install4j/help/doc/helptopics/installers/options.html)

(Based on https://github.com/winkelsdorf/homebrew-custom/commit/7798474dd1629d6492b8be2afb5738ebd806855f by @winkelsdorf, https://github.com/svenjacobs/homebrew-cask/commit/8d627e5dd8fd75201214f1fe61714093695de1d5 by @svenjacobs and https://github.com/caskroom/homebrew-versions/commit/96e9e191fc128cd27559c8ab7ae4f4029a53ce59)
