### PR TITLE
Renamed Mapbox Studio to Mapbox Studio Classic

### DIFF
--- a/Casks/mapbox-studio-classic.rb
+++ b/Casks/mapbox-studio-classic.rb
@@ -1,12 +1,13 @@
-cask :v1 => 'mapbox-studio' do
+cask :v1 => 'mapbox-studio-classic' do
   version '0.3.3'
   sha256 'e88ec6986fd0b3c05923cf0e647863137cf28a4246f8822949d934c873f050cb'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-v#{version}.zip"
   name 'Mapbox Studio'
-  homepage 'https://www.mapbox.com/mapbox-studio/'
+  homepage 'https://www.mapbox.com/mapbox-studio-classic/'
   license :bsd
 
+  # App name is still Mapbox Studio.app, per vendor, despite "classic" designation
   app "mapbox-studio-darwin-x64-v#{version}/Mapbox Studio.app"
 end

--- a/Casks/mapbox-studio.rb
+++ b/Casks/mapbox-studio.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'mapbox-studio' do
-  version '0.3.2'
-  sha256 'e89a8f55d5f1073be99bb00c29988eb6b47c1f15ed874f80296e89831ed61dfa'
+  version '0.3.3'
+  sha256 'e88ec6986fd0b3c05923cf0e647863137cf28a4246f8822949d934c873f050cb'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://mapbox.s3.amazonaws.com/mapbox-studio/mapbox-studio-darwin-x64-v#{version}.zip"


### PR DESCRIPTION
The developers of Mapbox now refer to the desktop app as Mapbox Studio Classic and the web-based version as Mapbox Studio. To avoid confusion and to adhere to the Vendor's naming, I have updated this cask to reflect the new changes.

Worth nothing, despite the changes to the name, the Vendor continues to name the app bundle "Mapbox Studio.app", so this remains unchanged in the cask until/unless the Vendor changes it in the future.
