### PR TITLE
Fix missing subfolder in QLMarkdown Cask

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -16,5 +16,5 @@ cask :v1 => 'qlmarkdown' do
     system '/usr/bin/ditto', '-xk', '--', "#{staged_path}/QLMarkdown.qlgenerator.zip", "#{staged_path}/QLMarkdown.qlgenerator"
   end
 
-  qlplugin 'QLMarkdown.qlgenerator'
+  qlplugin 'QLMarkdown.qlgenerator/QLMarkdown.qlgenerator'
 end


### PR DESCRIPTION
When extracting the ZIP file, the actual QuickLook generator is located inside a directory of the same name, `QLMarkdown.qlgenerator`. This fix ensures that the generator is properly linked into `~/Library/QuickLook`.
