### PR TITLE
Updating qlmarkdown to Version 1.3.5

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -16,5 +16,5 @@ cask :v1 => 'qlmarkdown' do
     system '/usr/bin/ditto', '-xk', '--', "#{staged_path}/QLMarkdown.qlgenerator.zip", "#{staged_path}/QLMarkdown.qlgenerator"
   end
 
-  qlplugin 'QLMarkdown.qlgenerator'
+  qlplugin 'QLMarkdown.qlgenerator/QLMarkdown.qlgenerator'
 end

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'qlmarkdown' do
-  version '1.3.4'
+  version '1.3.5'
   sha256 'a290edf5b6124cbd4e526217e0979a9011c8ef3b964a33458f5063d51a9b15f2'
 
   url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"


### PR DESCRIPTION
Never done this sort of thing before, but the `brew cask install qlmarkdown` is working for me, so hopefully this fixes https://github.com/toland/qlmarkdown/issues/60
