### PR TITLE
Update Lightroom to 6.3

### DIFF
--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -7,9 +7,6 @@ cask :v1 => 'adobe-photoshop-lightroom' do
   homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
   license :commercial
 
-  uninstall :pkgutil => "com.adobe.Lightroom#{version.to_i}",
-            :quit => "com.adobe.Lightroom#{version.to_i}",
-            :delete => "/Applications/Adobe Photoshop Lightroom #{version.to_i}.app"
   zap       :delete => [
                         '~/Library/Application Support/Adobe/Lightroom',
                         "~/Library/Preferences/com.adobe.Lightroom#{version.to_i}.plist"

--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -1,19 +1,34 @@
 cask :v1 => 'adobe-photoshop-lightroom' do
-  version '5.7.1'
-  sha256 '155a91e2c90927a05ccaa244a99fed4784fa7cf26d08c634f5f111629f6b0418'
+  version '6.3'
+  sha256 'f1282896be452a8515f92f5dd104695f54db114d5d06ba8d26175654cb26a524'
 
-  url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.to_i}.x/Lightroom_#{version.to_i}_LS11_mac_#{version.gsub('.','_')}.dmg"
+  url "http://swupdl.adobe.com/updates/oobe/aam20/mac/AdobeLightroom-#{version.to_i}.0/#{version}/setup.dmg"
   name 'Adobe Photoshop Lightroom'
   homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
   license :commercial
-
-  pkg "Adobe Photoshop Lightroom #{version.to_i}.pkg"
 
   uninstall :pkgutil => "com.adobe.Lightroom#{version.to_i}",
             :quit => "com.adobe.Lightroom#{version.to_i}",
             :delete => "/Applications/Adobe Photoshop Lightroom #{version.to_i}.app"
   zap       :delete => [
                         '~/Library/Application Support/Adobe/Lightroom',
-                        "~/Library/Preferences/com.adobe.Lightroom#{version.to_i}.plist",
+                        "~/Library/Preferences/com.adobe.Lightroom#{version.to_i}.plist"
                        ]
+
+  depends_on :cask => 'caskroom/versions/adobe-photoshop-lightroom600'
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/AdobePatchInstaller.app/Contents/MacOS/AdobePatchInstaller", '--mode=silent'
+  end
+
+  uninstall_preflight do
+    system 'brew', 'cask', 'uninstall', 'adobe-photoshop-lightroom600'
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identify the conflicting processes.'
 end


### PR DESCRIPTION
This is a complicated update from the 5.x branch to the 6.x branch. There's a requirement that 6.x be installed and then the updater must be run on top of that. And of course, in typical Adobe style, you have to run two installers that then ask for an Adobe ID _and_ a serial number. Let me know if I should move the base installer to the versions repository as `adobe-photoshop-lightroom-6` or rename it somehow. I'm open to suggestions.

TODO:
- [x] Move 6.0 installer to hombrew-versions
- [x] Make 6.3 install rely on 6.0 from hombrew-versions
- [x] Move 5.7.1 installer to homebrew-versions instead of clobbering it here
- [x] Ensure uninstalled application files match what's installed by 6.x 
- [x] Convert 6.0 to use silent, automated installer
- [ ] Convert 6.3 patch installer to use silent, automated installer
