### PR TITLE
Update Reveal to version 1.6.2

### DIFF
--- a/Casks/reveal.rb
+++ b/Casks/reveal.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'reveal' do
-  version :latest
-  sha256 :no_check
+  version '1.6.2'
+  sha256 'e245d592e2397e7fd056ba47ac4b197335081302be98ee17d46249dbbcd3fa5c'
 
-  url 'http://download.revealapp.com/Reveal.app.zip'
+  url "http://download.revealapp.com/Reveal.app-#{version}.zip"
   appcast 'http://download.revealapp.com/reveal-release.xml'
   name 'Reveal'
   homepage 'http://revealapp.com/'


### PR DESCRIPTION
This commit changes the Reveal cask to use a specific version instead
of the `:latest` token.
