### PR TITLE
long update command now uses ';' instead of '&&'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When reporting bugs, remember that homebrew-cask is an independent project from 
 Before reporting a bug, make sure you have the latest versions of homebrew, homebrew-cask, and all Taps by running the following command:
 
 ```bash
-$ brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
+$ brew update ; brew cleanup ; brew cask cleanup
 ```
 
 If the issue persists, please run the problematic command with the `--verbose` flag and post its and `brew cask doctor`’s outputs in distinct [fenced code blocks](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks).

--- a/USAGE.md
+++ b/USAGE.md
@@ -139,7 +139,7 @@ It is generally safe to run updates from within an Application.
 When a new version homebrew-cask is released, it will appear in the output of `brew outdated` after running `brew update`. You can upgrade it via the normal Homebrew `brew upgrade` workflow:
 
 ```bash
-$ brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
+$ brew update ; brew cleanup ; brew cask cleanup
 ```
 
 ## Additional Taps (optional)

--- a/doc/man/brew-cask.1
+++ b/doc/man/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "November 2015" "Homebrew-cask" "brew-cask"
+.TH "BREW\-CASK" "1" "December 2015" "Homebrew-cask" "brew-cask"
 .
 .SH "SYNOPSIS"
 \fBbrew cask\fR command [options] [\fItoken\fR \.\.\.]
@@ -189,7 +189,7 @@ Target location for “helper” executable links\. The default value is \fB/usr
 Output debugging information of use to Cask authors and developers\.
 .
 .SH "INTERACTION WITH HOMEBREW"
-Homebrew\-cask is implemented as a external command for Homebrew\. That means this project is entirely built upon the Homebrew infrastructure\. For example, upgrades to the Homebrew\-cask tool are received through Homebrew: \fBbrew update && brew upgrade brew\-cask && brew cleanup && brew cask cleanup\fR
+Homebrew\-cask is implemented as a external command for Homebrew\. That means this project is entirely built upon the Homebrew infrastructure\. For example, upgrades to the Homebrew\-cask tool are received through Homebrew: \fBbrew update ; brew cleanup ; brew cask cleanup\fR
 .
 .P
 And updates to individual Cask definitions are received whenever you issue the Homebrew command: brew update

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -89,7 +89,7 @@ names, and other aspects of this manual are still subject to change.
   * `search` or `-S` <text> | /<regexp>/:
     Perform a substring search of known Cask tokens for <text>. If the text
     is delimited by slashes, it is interpreted as a Ruby regular expression.
-	
+
   * `uninstall [--force]` or `rm` or `remove` <token> [ <token> ... ]:
     Uninstall the given Cask. With `--force`, uninstall even if the Cask
     does not appear to be present.
@@ -105,7 +105,7 @@ names, and other aspects of this manual are still subject to change.
     `uninstall` without `--force` is also imperfect. It may be unable to
     perform an `uninstall` operation if the given Cask has changed since you
     installed it. This issue is being addressed.
-	
+
   * `update`:
     For convenience. `brew cask update` is a synonym for `brew update`.
 
@@ -183,7 +183,7 @@ in a future version.
 Homebrew-cask is implemented as a external command for Homebrew. That means
 this project is entirely built upon the Homebrew infrastructure. For
 example, upgrades to the Homebrew-cask tool are received through Homebrew:
-    `brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup`
+    `brew update ; brew cleanup ; brew cask cleanup`
 
 And updates to individual Cask definitions are received whenever you issue
 the Homebrew command:

--- a/lib/hbc/artifact/base.rb
+++ b/lib/hbc/artifact/base.rb
@@ -48,7 +48,7 @@ class Hbc::Artifact::Base
     permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :bsexec, :print_stdout, :print_stderr]
     unknown_keys = arguments.keys - permitted_keys
     unless unknown_keys.empty?
-      opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}
+      opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update ; brew cleanup ; brew cask cleanup" will likely fix it.}
     end
     arguments.reject! {|k,v| ! permitted_keys.include?(k)}
 

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -184,7 +184,7 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
     directives_set.each do |directives|
       unknown_keys = directives.keys - [:early_script, :launchctl, :quit, :signal, :kext, :script, :pkgutil, :delete, :trash, :rmdir]
       unless unknown_keys.empty?
-        opoo %Q{Unknown arguments to #{stanza} -- #{unknown_keys.inspect}. Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}
+        opoo %Q{Unknown arguments to #{stanza} -- #{unknown_keys.inspect}. Running "brew update ; brew cleanup ; brew cask cleanup" will likely fix it.}
       end
     end
 

--- a/lib/hbc/dsl/postflight.rb
+++ b/lib/hbc/dsl/postflight.rb
@@ -7,7 +7,7 @@ class Hbc::DSL::Postflight < Hbc::DSL::Base
     permitted_keys = [:key]
     unknown_keys = options.keys - permitted_keys
     unless unknown_keys.empty?
-      opoo %Q{Unknown arguments to suppress_move_to_applications -- #{unknown_keys.inspect} (ignored). Running "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup" will likely fix it.}
+      opoo %Q{Unknown arguments to suppress_move_to_applications -- #{unknown_keys.inspect} (ignored). Running "brew update ; brew cleanup ; brew cask cleanup" will likely fix it.}
     end
     key = options[:key] || 'moveToApplicationsFolderAlertSuppress'
     begin

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -6,7 +6,7 @@ require 'stringio'
 
 require 'hbc/utils/tty'
 
-UPDATE_CMD = "brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup"
+UPDATE_CMD = "brew update ; brew cleanup ; brew cask cleanup"
 ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
 
 # todo: temporary

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -27,7 +27,7 @@ describe Hbc::DSL do
         .*
         Unexpected method 'future_feature' called on Cask unexpected-method-cask\\.
         .*
-        brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
+        brew update ; brew cleanup ; brew cask cleanup
         .*
         https://github.com/caskroom/homebrew-cask/issues
       EOREGEX


### PR DESCRIPTION
As per https://github.com/caskroom/homebrew-cask/issues/15532.
On hold until https://github.com/caskroom/homebrew-cask/pull/15381.

Decided to go ahead and remove the `upgrade` part as well, since [that will stop being needed](https://github.com/caskroom/homebrew-cask/pull/15381).
