### PR TITLE
Change folder holder app file from latest to version 1.5.2

### DIFF
--- a/Casks/firealpaca.rb
+++ b/Casks/firealpaca.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'firealpaca' do
-  version :latest
+  version '1.5.2'
   sha256 :no_check
 
   url 'http://firealpaca.com/download.php?os=mac&key=17813449013210197561d4f66c5aca8c'


### PR DESCRIPTION
I solved the problem by changing the name of the folder holding app file, and I successfully installed the app by using brew-cask. Please check it if there are anything to fix. Thank you.
