### PR TITLE
Add Swift-Clean at latest version

### DIFF
--- a/Casks/swift-clean.rb
+++ b/Casks/swift-clean.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'swift-clean' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://swiftcleanapp.com/sparky/Swift-Clean.zip'
+  name 'Swift-Clean'
+  homepage 'http://swiftcleanapp.com/'
+  license :commercial
+
+  app 'Swift-Clean.app'
+end


### PR DESCRIPTION
This commit adds the app Swift-Clean for the first time. I have not
found a versioned download link yet, so have used the `:latest`
token for now.
