### PR TITLE
Fix urls in Deezer.app Cask

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -2,9 +2,9 @@ cask :v1 => 'deezer' do
   version '1.1_4191'
   sha256 'f9d491fb8d4b055a60b3d4a13a4e8b19e4b9b8d70dc8740df734afeee5482a34'
 
-  url "https://cdns-content.deezer.com/builds/mac/Deezer_#{version.sub(%r{^[^_]*_(\d+)},'\1')}.dmg"
+  url "http://e-cdn-content.deezer.com/builds/mac/Deezer_#{version.sub(%r{^[^_]*_(\d+)},'\1')}.dmg"
   name 'Deezer'
-  homepage 'https://www.deezer.com/formac'
+  homepage 'http://www.deezer.com/formac'
   license :gratis
 
   app 'Deezer.app'


### PR DESCRIPTION
The old url pointed to an outdated https Deezer domain for which the
SSL certificate has expired. This resulted in the following error
when trying to run brew cask install deezer:

`curl: (60) SSL certificate problem: Invalid certificate chain
More details here: http://curl.haxx.se/docs/sslcerts.html`

This commit updates the url to reflect the url used when downloading
via a browser. The homepage url has also been updated as it
doesn't use https.
