### PR TITLE
Update Cask create scripts to emphasize versioned URLs

### DIFF
--- a/lib/hbc/cli/create.rb
+++ b/lib/hbc/cli/create.rb
@@ -29,7 +29,7 @@ class Hbc::CLI::Create < Hbc::CLI::Base
         version ''
         sha256 ''
 
-        url 'https://'
+        url "https://"      # todo: if applicable, use \#{version} rather than hardcoding version number
         name ''
         homepage ''
         license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/test/cask/cli/create_test.rb
+++ b/test/cask/cli/create_test.rb
@@ -40,7 +40,7 @@ describe Hbc::CLI::Create do
         version ''
         sha256 ''
 
-        url 'https://'
+        url "https://"      # todo: if applicable, use \#{version} rather than hardcoding version number
         name ''
         homepage ''
         license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
Fix #15564 (https://github.com/caskroom/homebrew-cask/pull/15564)
changed CONTRIBUTING.md to emphasize the use of versioned
URLs. Updated Cask create scripts to use double-quotes for urls by
default, instead of single-quotes - these are needed for versioned
URLs. Also included a comment recommending the use of versioned URLs.
