### PR TITLE
Add Synth1 Audio Unit and VST

### DIFF
--- a/Casks/synth1-au.rb
+++ b/Casks/synth1-au.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'synth1-au' do
+  version '1.13beta8'
+  sha256 '78660848d78c19cdda2597bd050a2ec95fa915cc1a1ab598bde0192a1cbc9a6f'
+
+  url 'http://www.geocities.jp/daichi1969/softsynth/Synth1macau113beta8.zip'
+  name 'Synth1 (AU)'
+  name 'Synth 1 (AU)'
+  homepage 'http://www.geocities.jp/daichi1969/softsynth/'
+  license :gratis
+
+  audio_unit_plugin 'Synth1.component'
+end

--- a/Casks/synth1-vst.rb
+++ b/Casks/synth1-vst.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'synth1-vst' do
+  version '1.13beta8'
+  sha256 '6b172b9433358bce21f0af75a28505c3365d934fadee04a738336e7f5f601675'
+
+  url 'http://www.geocities.jp/daichi1969/softsynth/Synth1macvst113beta8.zip'
+  name 'Synth1 (VST)'
+  name 'Synth 1 (VST)'
+  homepage 'http://www.geocities.jp/daichi1969/softsynth/'
+  license :gratis
+
+  vst_plugin 'Synth1.vst'
+end

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -89,6 +89,8 @@ Each Cask must declare one or more *artifacts* (i.e. something to install)
 | `qlplugin`         | yes                           | relative path to a QuickLook plugin that should be linked into the `~/Library/QuickLook` folder on installation
 | `screen_saver`     | yes                           | relative path to a Screen Saver that should be linked into the `~/Library/Screen Savers` folder on installation
 | `service`          | yes                           | relative path to a service that should be linked into the `~/Library/Services` folder on installation
+| `audio_unit_plugin`| yes                           | relative path to an Audio Unit plugin that should be linked into the `~/Library/Audio/Components` folder on installation
+| `vst_plugin`       | yes                           | relative path to a VST plugin that should be linked into the `~/Library/Audio/VST` folder on installation
 | `suite`            | yes                           | relative path to a containing directory that should be linked into the `~/Applications` folder on installation (see also [Suite Stanza Details](#suite-stanza-details))
 | `artifact`         | yes                           | relative path to an arbitrary path that should be symlinked on installation. This is only for unusual cases. The `app` stanza is strongly preferred when linking `.app` bundles.
 | `installer`        | yes                           | describes an executable which must be run to complete the installation. (see [Installer Stanza Details](#installer-stanza-details))

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -89,7 +89,7 @@ names, and other aspects of this manual are still subject to change.
   * `search` or `-S` <text> | /<regexp>/:
     Perform a substring search of known Cask tokens for <text>. If the text
     is delimited by slashes, it is interpreted as a Ruby regular expression.
-	
+
   * `uninstall [--force]` or `rm` or `remove` <token> [ <token> ... ]:
     Uninstall the given Cask. With `--force`, uninstall even if the Cask
     does not appear to be present.
@@ -105,7 +105,7 @@ names, and other aspects of this manual are still subject to change.
     `uninstall` without `--force` is also imperfect. It may be unable to
     perform an `uninstall` operation if the given Cask has changed since you
     installed it. This issue is being addressed.
-	
+
   * `update`:
     For convenience. `brew cask update` is a synonym for `brew update`.
 
@@ -165,6 +165,12 @@ in a future version.
 
   * `--internet_plugindir=<path>`:
     Target location for Internet Plugin links. The default value is `~/Library/Internet Plug-Ins`.
+
+  * `--audio_unit_plugindir=<path>`:
+    Target location for Audio Unit Plugin links. The default value is `~/Library/Audio/Plug-Ins/Components`.
+
+  * `--vst_plugindir=<path>`:
+    Target location for VST Plugin links. The default value is `~/Library/Audio/Plug-Ins/VST`.
 
   * `--screen_saverdir=<path>`:
     Target location for Screen Saver links. The default value is `~/Library/Screen Savers`.

--- a/lib/hbc/artifact.rb
+++ b/lib/hbc/artifact.rb
@@ -13,6 +13,8 @@ require 'hbc/artifact/font'
 require 'hbc/artifact/input_method'
 require 'hbc/artifact/installer'
 require 'hbc/artifact/internet_plugin'
+require 'hbc/artifact/audio_unit_plugin'
+require 'hbc/artifact/vst_plugin'
 require 'hbc/artifact/nested_container'
 require 'hbc/artifact/pkg'
 require 'hbc/artifact/postflight_block'
@@ -49,6 +51,8 @@ module Hbc::Artifact
       Hbc::Artifact::Binary,
       Hbc::Artifact::InputMethod,
       Hbc::Artifact::InternetPlugin,
+      Hbc::Artifact::AudioUnitPlugin,
+      Hbc::Artifact::VstPlugin,
       Hbc::Artifact::ScreenSaver,
       Hbc::Artifact::Uninstall,
       Hbc::Artifact::PostflightBlock,

--- a/lib/hbc/artifact/audio_unit_plugin.rb
+++ b/lib/hbc/artifact/audio_unit_plugin.rb
@@ -1,0 +1,3 @@
+class Hbc::Artifact::AudioUnitPlugin < Hbc::Artifact::Symlinked
+
+end

--- a/lib/hbc/artifact/vst_plugin.rb
+++ b/lib/hbc/artifact/vst_plugin.rb
@@ -1,0 +1,3 @@
+class Hbc::Artifact::VstPlugin < Hbc::Artifact::Symlinked
+
+end

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -179,6 +179,12 @@ class Hbc::CLI
       opts.on("--internet_plugindir=MANDATORY") do |v|
         Hbc.internet_plugindir = Pathname(v).expand_path
       end
+      opts.on("--audio_unit_plugindir=MANDATORY") do |v|
+        Hbc.audio_unit_plugindir = Pathname(v).expand_path
+      end
+      opts.on("--vst_plugindir=MANDATORY") do |v|
+        Hbc.vst_plugindir = Pathname(v).expand_path
+      end
       opts.on("--screen_saverdir=MANDATORY") do |v|
        Hbc.screen_saverdir = Pathname(v).expand_path
       end

--- a/lib/hbc/cli/internal_stanza.rb
+++ b/lib/hbc/cli/internal_stanza.rb
@@ -33,6 +33,8 @@ class Hbc::CLI::InternalStanza < Hbc::CLI::InternalUseBase
                        :binary,
                        :input_method,
                        :internet_plugin,
+                       :audio_unit_plugin,
+                       :vst_plugin,
                        :screen_saver,
                        :pkg,
                        :installer,

--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -249,6 +249,8 @@ module Hbc::DSL
                                      :binary,
                                      :input_method,
                                      :internet_plugin,
+                                     :audio_unit_plugin,
+                                     :vst_plugin,
                                      :screen_saver,
                                      :pkg,
                                      :stage_only,

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -84,6 +84,22 @@ module Hbc::Locations
       @internet_plugindir = _internet_plugindir
     end
 
+    def audio_unit_plugindir
+      @audio_unit_plugindir ||= Pathname.new('~/Library/Audio/Plug-Ins/Components').expand_path
+    end
+
+    def audio_unit_plugindir=(_audio_unit_plugindir)
+      @audio_unit_plugindir = _audio_unit_plugindir
+    end
+
+    def vst_plugindir
+      @vst_plugindir ||= Pathname.new('~/Library/Audio/Plug-Ins/VST').expand_path
+    end
+
+    def vst_plugindir=(_vst_plugindir)
+      @vst_plugindir = _vst_plugindir
+    end
+
     def screen_saverdir
       @screen_saverdir ||= Pathname.new('~/Library/Screen Savers').expand_path
     end


### PR DESCRIPTION
Includes the new artifacts to represent a symlink to the ~/Library/Audio/Plug-Ins/{VST,Components} folders.
