### PR TITLE
Add Startupizer

### DIFF
--- a/Casks/startupizer.rb
+++ b/Casks/startupizer.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'startupizer' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://gentlebytes.com/content/appcasts/startupizer/latest.php'
+  name 'Startupizer'
+  name 'Startupizer2'
+  homepage 'http://gentlebytes.com/startupizer/'
+  license :commercial
+
+  app 'Startupizer2.app'
+
+  zap :delete => [
+                  '~/Library/Caches/com.gentlebytes.Startupizer2',
+                  '~/Library/Preferences/com.gentlebytes.Startupizer2.plist',
+                 ]
+end


### PR DESCRIPTION
"Startupizer 2 is advanced yet simple to use login items handler. It greatly enhances built in OS X login items functionality by offering conditional startup and dependencies management."
