### PR TITLE
Add Mouseposé

### DIFF
--- a/Casks/mousepose.rb
+++ b/Casks/mousepose.rb
@@ -1,0 +1,22 @@
+cask :v1 => 'mousepose' do
+  version '3.2.7'
+  sha256 '05a3c5175206e971b386a75cd28e51873fdff6c47e24c5673a8116af127d336c'
+
+  url "https://cdn.boinx.com/software/mousepose/Boinx_Mousepose_#{version}-10878.app.zip"
+  name 'Mouseposé'
+  name 'Mousepose'
+  homepage 'https://www.boinx.com/mousepose/'
+  license :gratis
+
+  # Renamed for consistency: app name is different in the Finder and in a shell.
+  # Original discussion: https://github.com/caskroom/homebrew-cask/pull/15708
+  app 'Mousepose.app', :target => "Mousepose\314\201.app"
+
+  zap :delete => [
+                  '~/Library/Application Support/com.boinx.Mousepose',
+                  '~/Library/Caches/com.boinx.Mousepose/',
+                  '~/Library/Cookies/com.boinx.Mousepose.binarycookies',
+                  '~/Library/Preferences/com.boinx.Mousepose.plist',
+                  '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.boinx.mousepose.sfl',
+                 ]
+end


### PR DESCRIPTION
"When turned on, it dims the screen and puts a spotlight on the area around the mouse pointer, easily guiding the audience‘s attention to an area of interest."

---

Some notes:
- The download link (`url`) is not obvious on [the vendor's webpage](https://www.boinx.com/mousepose/overview/) - only Mac App Store link - but is [not hidden](https://forum.boinx.com/discussion/4516/can-t-update-due-to-error) for those who have purchased the license elsewhere.
- Ideally the app should be installed as "Mouseposé.app" (as is the case with "normal" installation process), but this cask installs it as "Mousepose.app". Specifying the `app` stanza as `'Mouseposé.app'` yields the following error:
  
  ```
  Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/mousepose/3.2.7/Mouseposé.app'
  ```
  
  I couldn't find a way to resolve this.
