### PR TITLE
README.md: Add in command to tap cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It’s implemented as a `homebrew` [external command](https://github.com/Homebre
 ## Let’s try it!
 
 ```bash
+$ brew tap caskroom/cask
 $ brew cask install google-chrome
 => Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
 => Success! google-chrome installed to /opt/homebrew-cask/Caskroom/google-chrome/stable-channel


### PR DESCRIPTION
As we no longer get automatically installed by homebrew, let's add in the tap command to the readme again
