### PR TITLE
Bump ClipGrab version to 3.5.5

### DIFF
--- a/Casks/clipgrab.rb
+++ b/Casks/clipgrab.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'clipgrab' do
-  version '3.5.1'
-  sha256 '6fcb973702798973acf1ae1fea60ece2b34f4926a7c8ff1f2cc71bbe2b990dff'
+  version '3.5.5'
+  sha256 '35a0a25ffaea11a4795e0564711d816f443e6c3ad6d2f8aa6de749d796220ade'
 
   url "http://download.clipgrab.de/ClipGrab-#{version}.dmg"
   name 'ClipGrab'


### PR DESCRIPTION
Current ClipGrab version (3.5.1) is no longer available for downloads.
