### PR TITLE
Add support for uninstalling login items

### DIFF
--- a/developer/bin/list_login_items_for_app
+++ b/developer/bin/list_login_items_for_app
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+#
+# list_login_items_for_app
+#
+
+###
+### dependencies
+###
+
+require 'open3'
+
+###
+### methods
+###
+
+def usage
+  <<-EOS
+Usage: list_login_items_for_app <path.app>
+
+Given an Application (app) bundle directory on disk, find all
+login items associated with that app, which you can use in a
+Cask uninstall stanza, eg
+
+    uninstall :login_item => 'login item name'
+
+Note that you will likely need to have opened the app at least
+once for any login items to be present.
+
+See CONTRIBUTING.md for more information.
+
+EOS
+end
+
+def process_args
+  if ARGV.first =~ /^-+h(?:elp)?$/
+    puts usage
+    exit 0
+  elsif ARGV.length == 1
+    $app_path = ARGV.first
+  else
+    puts usage
+    exit 1
+  end
+end
+
+def list_login_items_for_app(app_path)
+  out, err, status = Open3.capture3(
+    '/usr/bin/osascript', '-e',
+    "tell application \"System Events\" to get the name of every login item " \
+    "whose path contains \"#{File.basename(app_path)}\""
+  )
+  if status.exitstatus > 0
+    $stderr.puts err
+    exit status.exitstatus
+  end
+  puts out.gsub(', ', "\n")
+end
+
+###
+### main
+###
+
+process_args
+list_login_items_for_app $app_path

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -642,6 +642,7 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
 * `:launchctl` (string or array) - ids of `launchctl` jobs to remove
 * `:quit` (string or array) - bundle ids of running applications to quit
 * `:signal` (array of arrays) - signal numbers and bundle ids of running applications to send a Unix signal to (used when `:quit` does not work)
+* `:login_item` (string or array) - names of login items to remove
 * `:kext` (string or array) - bundle ids of kexts to unload from the system
 * `:pkgutil` (string, regexp or array of strings and regexps) - strings or regexps matching bundle ids of packages to uninstall using `pkgutil`
 * `:script` (string or hash) - relative path to an uninstall script to be run via sudo; use hash if args are needed
@@ -741,6 +742,16 @@ An example, with commonly-used signals in ascending order of severity:
 Note that when multiple running processes match the given Bundle ID, all matching processes will be signaled.
 
 Unlike `:quit` directives, Unix signals originate from the current user, not from the superuser. This is construed as a safety feature, since the superuser is capable of bringing down the system via signals. However, this inconsistency may also be considered a bug, and should be addressed in some fashion in a future version.
+
+### Uninstall key :login_item
+
+Login items associated with an Application bundle on disk can be listed using the command:
+
+```bash
+$ ./developer/bin/list_login_items_for_app </path/to/application.app>
+```
+
+Note that you will likely need to have opened the app at least once for any login items to be present.
 
 ### Uninstall Key :kext
 

--- a/doc/cask_language_deltas.md
+++ b/doc/cask_language_deltas.md
@@ -62,6 +62,10 @@ The term `:v1` identifies the DSL version (currently 1.0), and defines the featu
 * [`*flight set_ownership`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
 * [`*flight set_permissions`](CASK_LANGUAGE_REFERENCE.md#flight-stanzas-details)
 
+### (1.2)
+
+* [`uninstall :login_item`](CASK_LANGUAGE_REFERENCE.md#uninstall-key-login_item)
+
 ## Renamed Forms (1.0)
 
 | old form                                | new form

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -140,6 +140,19 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
                                '~/Library/Workflows',
                               ].map{|x| %r{\A~}.match(x) ? Pathname.new(x).expand_path : Pathname.new(x)}
 
+  ORDERED_DIRECTIVES = [
+                        :early_script,
+                        :launchctl,
+                        :quit,
+                        :signal,
+                        :kext,
+                        :script,
+                        :pkgutil,
+                        :delete,
+                        :trash,
+                        :rmdir
+                       ]
+
   # todo: these methods were consolidated here from separate
   #       sources and should be refactored for consistency
 
@@ -174,169 +187,181 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
   end
 
   def uninstall_phase
-    dispatch_uninstall_directives(self.class.artifact_dsl_key)
+    dispatch_uninstall_directives
   end
 
-  def dispatch_uninstall_directives(stanza, expand_tilde=true)
+  def dispatch_uninstall_directives(expand_tilde=true)
     directives_set = @cask.artifacts[stanza]
     ohai "Running #{stanza} process for #{@cask}; your password may be necessary"
 
     directives_set.each do |directives|
-      unknown_keys = directives.keys - [:early_script, :launchctl, :quit, :signal, :kext, :script, :pkgutil, :delete, :trash, :rmdir]
-      unless unknown_keys.empty?
-        opoo %Q{Unknown arguments to #{stanza} -- #{unknown_keys.inspect}. Running "brew update; brew cleanup; brew cask cleanup" will likely fix it.}
+      warn_for_unknown_directives(directives)
+    end
+
+    ORDERED_DIRECTIVES.each do |directive_sym|
+      directives_set.select { |h| h.key?(directive_sym) }.each do |directives|
+        args = [directives]
+        args << expand_tilde if [:delete, :trash, :rmdir].include?(directive_sym)
+        send("uninstall_#{directive_sym}", *args)
       end
     end
+  end
 
-    # Preserve prior functionality of script which runs first. Should rarely be needed.
-    # :early_script should not delete files, better defer that to :script.
-    # If Cask writers never need :early_script it may be removed in the future.
-    directives_set.select{ |h| h.key?(:early_script) }.each do |directives|
-      executable, script_arguments = self.class.read_script_arguments(directives,
-                                                                      'uninstall',
-                                                                      {:must_succeed => true, :sudo => true},
-                                                                      {:print_stdout => true},
-                                                                      :early_script)
+  private
 
-      ohai "Running uninstall script #{executable}"
-      raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :early_script without :executable") if executable.nil?
-      @command.run(@cask.staged_path.join(executable), script_arguments)
-      sleep 1
+  def stanza
+    self.class.artifact_dsl_key
+  end
+
+  def warn_for_unknown_directives(directives)
+    unknown_keys = directives.keys - ORDERED_DIRECTIVES
+    unless unknown_keys.empty?
+      opoo %Q{Unknown arguments to #{stanza} -- #{unknown_keys.inspect}. Running "brew update; brew cleanup; brew cask cleanup" will likely fix it.}
     end
+  end
 
-    # :launchctl must come before :quit/:signal for cases where app would instantly re-launch
-    directives_set.select{ |h| h.key?(:launchctl) }.each do |directives|
-      Array(directives[:launchctl]).each do |service|
-        ohai "Removing launchctl service #{service}"
-        [false, true].each do |with_sudo|
-          plist_status = @command.run('/bin/launchctl', :args => ['list', service], :sudo => with_sudo, :print_stderr => false).stdout
-          if %r{^\{}.match(plist_status)
-            result = @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
-            sleep 1
-          end
-          paths = ["/Library/LaunchAgents/#{service}.plist",
-                   "/Library/LaunchDaemons/#{service}.plist"]
-          paths.each { |elt| elt.prepend(ENV['HOME']) } unless with_sudo
-          paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
-          paths.each do |path|
-            @command.run!('/bin/rm', :args => ['-f', '--', path], :sudo => with_sudo)
-          end
-          # undocumented and untested: pass a path to uninstall :launchctl
-          if Pathname(service).exist?
-            @command.run!('/bin/launchctl', :args => ['unload', '-w', '--', service], :sudo => with_sudo)
-            @command.run!('/bin/rm',        :args => ['-f', '--', service], :sudo => with_sudo)
-            sleep 1
-          end
+  # Preserve prior functionality of script which runs first. Should rarely be needed.
+  # :early_script should not delete files, better defer that to :script.
+  # If Cask writers never need :early_script it may be removed in the future.
+  def uninstall_early_script(directives)
+    executable, script_arguments = self.class.read_script_arguments(directives,
+                                                                    'uninstall',
+                                                                    {:must_succeed => true, :sudo => true},
+                                                                    {:print_stdout => true},
+                                                                    :early_script)
+
+    ohai "Running uninstall script #{executable}"
+    raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :early_script without :executable") if executable.nil?
+    @command.run(@cask.staged_path.join(executable), script_arguments)
+    sleep 1
+  end
+
+  # :launchctl must come before :quit/:signal for cases where app would instantly re-launch
+  def uninstall_launchctl(directives)
+    Array(directives[:launchctl]).each do |service|
+      ohai "Removing launchctl service #{service}"
+      [false, true].each do |with_sudo|
+        plist_status = @command.run('/bin/launchctl', :args => ['list', service], :sudo => with_sudo, :print_stderr => false).stdout
+        if %r{^\{}.match(plist_status)
+          result = @command.run!('/bin/launchctl', :args => ['remove', service], :sudo => with_sudo)
+          sleep 1
         end
-      end
-    end
-
-    # :quit/:signal must come before :kext so the kext will not be in use by a running process
-    directives_set.select{ |h| h.key?(:quit) }.each do |directives|
-      Array(directives[:quit]).each do |id|
-        ohai "Quitting application ID #{id}"
-        num_running = @command.run!('/usr/bin/osascript', :args => ['-e', %Q{tell application "System Events" to count processes whose bundle identifier is "#{id}"}], :sudo => true).stdout.to_i
-        if num_running > 0
-          @command.run!('/usr/bin/osascript', :args => ['-e', %Q{tell application id "#{id}" to quit}], :sudo => true)
-          sleep 3
+        paths = ["/Library/LaunchAgents/#{service}.plist",
+                 "/Library/LaunchDaemons/#{service}.plist"]
+        paths.each { |elt| elt.prepend(ENV['HOME']) } unless with_sudo
+        paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
+        paths.each do |path|
+          @command.run!('/bin/rm', :args => ['-f', '--', path], :sudo => with_sudo)
         end
-      end
-    end
-
-    # :signal should come after :quit so it can be used as a backup when :quit fails
-    directives_set.select{ |h| h.key?(:signal) }.each do |directives|
-      Array(directives[:signal]).flatten.each_slice(2) do |pair|
-        raise Hbc::CaskInvalidError.new(@cask, "Each #{stanza} :signal must have 2 elements.") unless pair.length == 2
-        signal, id = pair
-        ohai "Signalling '#{signal}' to application ID '#{id}'"
-        pid_string = @command.run!('/usr/bin/osascript', :args => ['-e', %Q{tell application "System Events" to get the unix id of every process whose bundle identifier is "#{id}"}], :sudo => true).stdout
-        if pid_string.match(%r{\A\d+(?:\s*,\s*\d+)*\Z})    # sanity check
-          pids = pid_string.split(%r{\s*,\s*}).map(&:strip).map(&:to_i)
-          if pids.length > 0
-            # Note that unlike :quit, signals are sent from the
-            # current user (not upgraded to the superuser).  This is a
-            # todo item for the future, but there should be some
-            # additional thought/safety checks about that, as a
-            # misapplied "kill" by root could bring down the system.
-            # The fact that we learned the pid from AppleScript is
-            # already some degree of protection, though indirect.
-            Process.kill(signal, *pids)
-            sleep 3
-          end
-        end
-      end
-    end
-
-    # :kext should be unloaded before attempting to delete the relevant file
-    directives_set.select{ |h| h.key?(:kext) }.each do |directives|
-      Array(directives[:kext]).each do |kext|
-        ohai "Unloading kernel extension #{kext}"
-        is_loaded = @command.run!('/usr/sbin/kextstat', :args => ['-l', '-b', kext], :sudo => true).stdout
-        if is_loaded.length > 1
-          @command.run!('/sbin/kextunload', :args => ['-b', kext], :sudo => true)
+        # undocumented and untested: pass a path to uninstall :launchctl
+        if Pathname(service).exist?
+          @command.run!('/bin/launchctl', :args => ['unload', '-w', '--', service], :sudo => with_sudo)
+          @command.run!('/bin/rm',        :args => ['-f', '--', service], :sudo => with_sudo)
           sleep 1
         end
       end
     end
+  end
 
-    # :script must come before :pkgutil, :delete, or :trash so that the script file is not already deleted
-    directives_set.select{ |h| h.key?(:script) }.each do |directives|
-      executable, script_arguments = self.class.read_script_arguments(directives,
-                                                                      'uninstall',
-                                                                      {:must_succeed => true, :sudo => true},
-                                                                      {:print_stdout => true},
-                                                                      :script)
-      raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
-      @command.run(@cask.staged_path.join(executable), script_arguments)
-      sleep 1
-    end
-
-    directives_set.select{ |h| h.key?(:pkgutil) }.each do |directives|
-      ohai "Removing files from pkgutil Bill-of-Materials"
-      Array(directives[:pkgutil]).each do |regexp|
-        pkgs = Hbc::Pkg.all_matching(regexp, @command)
-        pkgs.each(&:uninstall)
+  # :quit/:signal must come before :kext so the kext will not be in use by a running process
+  def uninstall_quit(directives)
+    Array(directives[:quit]).each do |id|
+      ohai "Quitting application ID #{id}"
+      num_running = @command.run!('/usr/bin/osascript', :args => ['-e', %Q{tell application "System Events" to count processes whose bundle identifier is "#{id}"}], :sudo => true).stdout.to_i
+      if num_running > 0
+        @command.run!('/usr/bin/osascript', :args => ['-e', %Q{tell application id "#{id}" to quit}], :sudo => true)
+        sleep 3
       end
     end
+  end
 
-    directives_set.select{ |h| h.key?(:delete) }.each do |directives|
-      Array(directives[:delete]).flatten.each_slice(PATH_ARG_SLICE_SIZE) do |path_slice|
-        ohai "Removing files: #{path_slice.utf8_inspect}"
-        path_slice = self.class.expand_path_strings(path_slice) if expand_tilde
-        path_slice = self.class.remove_relative_path_strings(:delete, path_slice)
-        path_slice = self.class.remove_undeletable_path_strings(:delete, path_slice)
-        @command.run!('/bin/rm', :args => path_slice.unshift('-rf', '--'), :sudo => true)
+  # :signal should come after :quit so it can be used as a backup when :quit fails
+  def uninstall_signal(directives)
+    Array(directives[:signal]).flatten.each_slice(2) do |pair|
+      raise Hbc::CaskInvalidError.new(@cask, "Each #{stanza} :signal must have 2 elements.") unless pair.length == 2
+      signal, id = pair
+      ohai "Signalling '#{signal}' to application ID '#{id}'"
+      pid_string = @command.run!('/usr/bin/osascript', :args => ['-e', %Q{tell application "System Events" to get the unix id of every process whose bundle identifier is "#{id}"}], :sudo => true).stdout
+      if pid_string.match(%r{\A\d+(?:\s*,\s*\d+)*\Z})    # sanity check
+        pids = pid_string.split(%r{\s*,\s*}).map(&:strip).map(&:to_i)
+        if pids.length > 0
+          # Note that unlike :quit, signals are sent from the
+          # current user (not upgraded to the superuser).  This is a
+          # todo item for the future, but there should be some
+          # additional thought/safety checks about that, as a
+          # misapplied "kill" by root could bring down the system.
+          # The fact that we learned the pid from AppleScript is
+          # already some degree of protection, though indirect.
+          Process.kill(signal, *pids)
+          sleep 3
+        end
       end
     end
+  end
 
-    # :trash functionality is stubbed as a synonym for :delete
-    # todo: make :trash work differently, moving files to the Trash
-    directives_set.select{ |h| h.key?(:trash) }.each do |directives|
-      Array(directives[:trash]).flatten.each_slice(PATH_ARG_SLICE_SIZE) do |path_slice|
-        ohai "Removing files: #{path_slice.utf8_inspect}"
-        path_slice = self.class.expand_path_strings(path_slice) if expand_tilde
-        path_slice = self.class.remove_relative_path_strings(:trash, path_slice)
-        path_slice = self.class.remove_undeletable_path_strings(:trash, path_slice)
-        @command.run!('/bin/rm', :args => path_slice.unshift('-rf', '--'), :sudo => true)
+  # :kext should be unloaded before attempting to delete the relevant file
+  def uninstall_kext(directives)
+    Array(directives[:kext]).each do |kext|
+      ohai "Unloading kernel extension #{kext}"
+      is_loaded = @command.run!('/usr/sbin/kextstat', :args => ['-l', '-b', kext], :sudo => true).stdout
+      if is_loaded.length > 1
+        @command.run!('/sbin/kextunload', :args => ['-b', kext], :sudo => true)
+        sleep 1
       end
     end
+  end
 
-    directives_set.select{ |h| h.key?(:rmdir) }.each do |directives|
-      Array(directives[:rmdir]).flatten.each do |directory|
-        directory = self.class.expand_path_strings([directory]).first if expand_tilde
-        directory = self.class.remove_relative_path_strings(:rmdir, [ directory ]).first
-        directory = self.class.remove_undeletable_path_strings(:rmdir, [ directory ]).first
-        next unless directory.to_s.length > 0
-        ohai "Removing directory if empty: #{directory.to_s.utf8_inspect}"
-        directory = Pathname.new(directory)
-        next unless directory.exist?
-        @command.run!('/bin/rm', :args => [ '-f', '--', directory.join('.DS_Store') ],
+  # :script must come before :pkgutil, :delete, or :trash so that the script file is not already deleted
+  def uninstall_script(directives)
+    executable, script_arguments = self.class.read_script_arguments(directives,
+                                                                    'uninstall',
+                                                                    {:must_succeed => true, :sudo => true},
+                                                                    {:print_stdout => true},
+                                                                    :script)
+    raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :script without :executable.") if executable.nil?
+    @command.run(@cask.staged_path.join(executable), script_arguments)
+    sleep 1
+  end
+
+  def uninstall_pkgutil(directives)
+    ohai "Removing files from pkgutil Bill-of-Materials"
+    Array(directives[:pkgutil]).each do |regexp|
+      pkgs = Hbc::Pkg.all_matching(regexp, @command)
+      pkgs.each(&:uninstall)
+    end
+  end
+
+  def uninstall_delete(directives, expand_tilde=true)
+    Array(directives[:delete]).flatten.each_slice(PATH_ARG_SLICE_SIZE) do |path_slice|
+      ohai "Removing files: #{path_slice.utf8_inspect}"
+      path_slice = self.class.expand_path_strings(path_slice) if expand_tilde
+      path_slice = self.class.remove_relative_path_strings(:delete, path_slice)
+      path_slice = self.class.remove_undeletable_path_strings(:delete, path_slice)
+      @command.run!('/bin/rm', :args => path_slice.unshift('-rf', '--'), :sudo => true)
+    end
+  end
+
+  # :trash functionality is stubbed as a synonym for :delete
+  # todo: make :trash work differently, moving files to the Trash
+  def uninstall_trash(directives, expand_tilde=true)
+    uninstall_delete(directives, expand_tilde)
+  end
+
+  def uninstall_rmdir(directives, expand_tilde=true)
+    Array(directives[:rmdir]).flatten.each do |directory|
+      directory = self.class.expand_path_strings([directory]).first if expand_tilde
+      directory = self.class.remove_relative_path_strings(:rmdir, [ directory ]).first
+      directory = self.class.remove_undeletable_path_strings(:rmdir, [ directory ]).first
+      next unless directory.to_s.length > 0
+      ohai "Removing directory if empty: #{directory.to_s.utf8_inspect}"
+      directory = Pathname.new(directory)
+      next unless directory.exist?
+      @command.run!('/bin/rm', :args => [ '-f', '--', directory.join('.DS_Store') ],
+                               :sudo => true,
+                               :print_stderr => false)
+      @command.run('/bin/rmdir', :args => [ '--', directory ],
                                  :sudo => true,
                                  :print_stderr => false)
-        @command.run('/bin/rmdir', :args => [ '--', directory ],
-                                   :sudo => true,
-                                   :print_stderr => false)
-      end
     end
   end
 end

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -145,6 +145,7 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
                         :launchctl,
                         :quit,
                         :signal,
+                        :login_item,
                         :kext,
                         :script,
                         :pkgutil,
@@ -296,6 +297,16 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
           sleep 3
         end
       end
+    end
+  end
+
+  def uninstall_login_item(directives)
+    Array(directives[:login_item]).each do |name|
+      ohai "Removing login item #{name}"
+      @command.run!('/usr/bin/osascript',
+                    :args => ['-e', %Q{tell application "System Events" to delete every login item whose name is "#{name}"}],
+                    :sudo => false)
+      sleep 1
     end
   end
 

--- a/lib/hbc/artifact/zap.rb
+++ b/lib/hbc/artifact/zap.rb
@@ -9,6 +9,6 @@ class Hbc::Artifact::Zap < Hbc::Artifact::UninstallBase
 
   def zap_phase
     expand_tilde = true
-    dispatch_uninstall_directives(self.class.artifact_dsl_key, expand_tilde)
+    dispatch_uninstall_directives(expand_tilde)
   end
 end

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -34,6 +34,8 @@ describe Hbc::Artifact::Uninstall do
       Hbc::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Hbc::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
+      Hbc::FakeSystemCommand.expects_command(['/usr/bin/osascript', '-e', 'tell application "System Events" to delete every login item whose name is "Fancy"'])
+
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'])
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--', Pathname.new('/permissible/absolute/path'), Pathname.new('~/permissible/path/with/tilde').expand_path])
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-f', '--', Pathname.new(TestHelper.local_binary_path('empty_directory')).join('.DS_Store')])

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -37,6 +37,8 @@ describe Hbc::Artifact::Zap do
       Hbc::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application "System Events" to count processes whose bundle identifier is "my.fancy.package.app"'], '1')
       Hbc::FakeSystemCommand.stubs_command(['/usr/bin/sudo', '-E', '--', '/usr/bin/osascript', '-e', 'tell application id "my.fancy.package.app" to quit'])
 
+      Hbc::FakeSystemCommand.expects_command(['/usr/bin/osascript', '-e', 'tell application "System Events" to delete every login item whose name is "Fancy"'])
+
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', @cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'])
       Hbc::FakeSystemCommand.expects_command(['/usr/bin/sudo', '-E', '--', '/bin/rm', '-rf', '--',
                                                Pathname.new('~/Library/Preferences/my.fancy.app.plist').expand_path])

--- a/test/support/Casks/with-installable.rb
+++ b/test/support/Casks/with-installable.rb
@@ -6,13 +6,14 @@ cask :v1test => 'with-installable' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
-  uninstall :script => { :executable => 'MyFancyPkg/FancyUninstaller.tool', :args => %w[--please] },
-            :quit   => 'my.fancy.package.app',
-            :delete => [
-                        '/permissible/absolute/path',
-                        '~/permissible/path/with/tilde',
-                        'impermissible/relative/path',
-                        '/another/impermissible/../relative/path',
-                       ],
-           :rmdir  =>  TestHelper.local_binary_path('empty_directory')
+  uninstall :script     => { :executable => 'MyFancyPkg/FancyUninstaller.tool', :args => %w[--please] },
+            :quit       => 'my.fancy.package.app',
+            :login_item => 'Fancy',
+            :delete     => [
+                            '/permissible/absolute/path',
+                            '~/permissible/path/with/tilde',
+                            'impermissible/relative/path',
+                            '/another/impermissible/../relative/path',
+                           ],
+           :rmdir       => TestHelper.local_binary_path('empty_directory')
 end

--- a/test/support/Casks/with-zap.rb
+++ b/test/support/Casks/with-zap.rb
@@ -12,5 +12,6 @@ cask :v1test => 'with-zap' do
                   :args => %w[--please]
                   },
       :quit => 'my.fancy.package.app',
+      :login_item => 'Fancy',
       :delete => '~/Library/Preferences/my.fancy.app.plist'
 end


### PR DESCRIPTION
Closes #14854.

I've also included some refactorings for `Hbc::Artifact::UninstallBase` which will make it easier to maintain existing directives and add new ones in the future.

This will require changes to the language reference and language delta docs, but I wanted to get some input first.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caskroom/homebrew-cask/15740)

<!-- Reviewable:end -->
