### PR TITLE
chameleon-ssd-optimizer 'version :latest'

### DIFF
--- a/Casks/chameleon-ssd-optimizer.rb
+++ b/Casks/chameleon-ssd-optimizer.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'chameleon-ssd-optimizer' do
-  version '0.9.9g'
-  sha256 'd02749075f205919d2803468906c773f27d362eaf9d54f5cca06166cb7050573'
+  version :latest
+  sha256 :no_check
 
-  url "http://chameleon.alessandroboschini.com/download/ChameleonSSDOptimizer#{version.delete('.')}.zip"
+  url "http://chameleon.alessandroboschini.com/cdownload.php"
   appcast 'http://chameleon.alessandroboschini.com/sparkle/profileInfo.php'
   name 'Chameleon SSD optimizer'
   homepage 'http://chameleon.alessandroboschini.com/'


### PR DESCRIPTION
Upstream now uses permanent link for latest stable version.
