### PR TITLE
Update Marked 2 to version 2.5.3910

### DIFF
--- a/Casks/marked.rb
+++ b/Casks/marked.rb
@@ -1,8 +1,9 @@
 cask :v1 => 'marked' do
-  version :latest
-  sha256 :no_check
+  version '2.5.3910'
+  sha256 'd3c9193fff0c349e0efaf5f14fd9c44d18545044e469d27340ef2c44864f02de'
 
-  url 'http://marked2app.com/download/Marked.zip'
+  # abyss.designheresy.com is the download host from the appcast feed
+  url "http://abyss.designheresy.com/marked/Marked#{version}.zip"
   appcast 'http://abyss.designheresy.com/marked/marked.xml'
   name 'Marked'
   homepage 'http://marked2app.com'


### PR DESCRIPTION
This commit updates the version, sha256 and url stanzas. The version
is obtained from the appcast feed that was previously included in
this cask. Sorry if this is not an approved way to obtain a versioned
download URL.
