### PR TITLE
Remove extra space in update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When reporting bugs, remember that homebrew-cask is an independent project from 
 Before reporting a bug, make sure you have the latest versions of homebrew, homebrew-cask, and all Taps by running the following command:
 
 ```bash
-$ brew update ; brew cleanup ; brew cask cleanup
+$ brew update; brew cleanup; brew cask cleanup
 ```
 
 In addition, if you haven’t yet, run `brew uninstall --force brew-cask; brew update` once to [switch to the new system](https://github.com/caskroom/homebrew-cask#important-december-update-homebrew-cask-will-now-be-kept-up-to-date-together-with-homebrew-see-15381-for-details-if-you-havent-yet-run-brew-uninstall---force-brew-cask-brew-update-to-switch-to-the-new-system).

--- a/USAGE.md
+++ b/USAGE.md
@@ -139,7 +139,7 @@ It is generally safe to run updates from within an Application.
 When a new version homebrew-cask is released, it will appear in the output of `brew outdated` after running `brew update`. You can upgrade it via the normal Homebrew `brew upgrade` workflow:
 
 ```bash
-$ brew update ; brew cleanup ; brew cask cleanup
+$ brew update; brew cleanup; brew cask cleanup
 ```
 
 ## Additional Taps (optional)

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -183,7 +183,7 @@ in a future version.
 Homebrew-cask is implemented as a external command for Homebrew. That means
 this project is entirely built upon the Homebrew infrastructure. For
 example, upgrades to the Homebrew-cask tool are received through Homebrew:
-    `brew update ; brew cleanup ; brew cask cleanup`
+    `brew update; brew cleanup; brew cask cleanup`
 
 And updates to individual Cask definitions are received whenever you issue
 the Homebrew command:

--- a/lib/hbc/artifact/base.rb
+++ b/lib/hbc/artifact/base.rb
@@ -48,7 +48,7 @@ class Hbc::Artifact::Base
     permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :bsexec, :print_stdout, :print_stderr]
     unknown_keys = arguments.keys - permitted_keys
     unless unknown_keys.empty?
-      opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update ; brew cleanup ; brew cask cleanup" will likely fix it.}
+      opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update; brew cleanup; brew cask cleanup" will likely fix it.}
     end
     arguments.reject! {|k,v| ! permitted_keys.include?(k)}
 

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -184,7 +184,7 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
     directives_set.each do |directives|
       unknown_keys = directives.keys - [:early_script, :launchctl, :quit, :signal, :kext, :script, :pkgutil, :delete, :trash, :rmdir]
       unless unknown_keys.empty?
-        opoo %Q{Unknown arguments to #{stanza} -- #{unknown_keys.inspect}. Running "brew update ; brew cleanup ; brew cask cleanup" will likely fix it.}
+        opoo %Q{Unknown arguments to #{stanza} -- #{unknown_keys.inspect}. Running "brew update; brew cleanup; brew cask cleanup" will likely fix it.}
       end
     end
 

--- a/lib/hbc/dsl/postflight.rb
+++ b/lib/hbc/dsl/postflight.rb
@@ -7,7 +7,7 @@ class Hbc::DSL::Postflight < Hbc::DSL::Base
     permitted_keys = [:key]
     unknown_keys = options.keys - permitted_keys
     unless unknown_keys.empty?
-      opoo %Q{Unknown arguments to suppress_move_to_applications -- #{unknown_keys.inspect} (ignored). Running "brew update ; brew cleanup ; brew cask cleanup" will likely fix it.}
+      opoo %Q{Unknown arguments to suppress_move_to_applications -- #{unknown_keys.inspect} (ignored). Running "brew update; brew cleanup; brew cask cleanup" will likely fix it.}
     end
     key = options[:key] || 'moveToApplicationsFolderAlertSuppress'
     begin

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -6,7 +6,7 @@ require 'stringio'
 
 require 'hbc/utils/tty'
 
-UPDATE_CMD = "brew update ; brew cleanup ; brew cask cleanup"
+UPDATE_CMD = "brew update; brew cleanup; brew cask cleanup"
 ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
 
 # todo: temporary

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -189,7 +189,7 @@ Target location for “helper” executable links\. The default value is \fB/usr
 Output debugging information of use to Cask authors and developers\.
 .
 .SH "INTERACTION WITH HOMEBREW"
-Homebrew\-cask is implemented as a external command for Homebrew\. That means this project is entirely built upon the Homebrew infrastructure\. For example, upgrades to the Homebrew\-cask tool are received through Homebrew: \fBbrew update ; brew cleanup ; brew cask cleanup\fR
+Homebrew\-cask is implemented as a external command for Homebrew\. That means this project is entirely built upon the Homebrew infrastructure\. For example, upgrades to the Homebrew\-cask tool are received through Homebrew: \fBbrew update; brew cleanup; brew cask cleanup\fR
 .
 .P
 And updates to individual Cask definitions are received whenever you issue the Homebrew command: brew update

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -27,7 +27,7 @@ describe Hbc::DSL do
         .*
         Unexpected method 'future_feature' called on Cask unexpected-method-cask\\.
         .*
-        brew update ; brew cleanup ; brew cask cleanup
+        brew update; brew cleanup; brew cask cleanup
         .*
         https://github.com/caskroom/homebrew-cask/issues
       EOREGEX


### PR DESCRIPTION
I assume this is the more commonly used form. I've never seen anyone space out their semicolons like `foo ; bar`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caskroom/homebrew-cask/15755)

<!-- Reviewable:end -->
