### PR TITLE
Fix checksum for Openoffice.app

### DIFF
--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'openoffice' do
   version '4.1.2'
-  sha256 '4fe8e4b30989d0476fe3afc6d9d4374af57d38bd04f4a5e1947462bf5dde7699'
+  sha256 'cc6ca4ae4d10a295f5283ee8030da13c0110a439b164680de4fbdf5dfa926c19'
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_en-US.dmg"


### PR DESCRIPTION
This fixes the sha256 checksum for OpenOffice.

``` sh
$ brew cask install openoffice
==> Downloading http://downloads.sourceforge.net/sourceforge/openofficeorg.mirror/Apache_OpenOffice_4.1.2_MacOS_x86-64_install_en-US.dmg
######################################################################## 100,0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 4fe8e4b30989d0476fe3afc6d9d4374af57d38bd04f4a5e1947462bf5dde7699
Actual: cc6ca4ae4d10a295f5283ee8030da13c0110a439b164680de4fbdf5dfa926c19
File: /opt/boxen/cache/homebrew/openoffice-4.1.2.dmg
To retry an incomplete download, remove the file above.
```
