### PR TITLE
Add soundcast.app latest

### DIFF
--- a/Casks/soundcast.rb
+++ b/Casks/soundcast.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'soundcast' do
+  version :latest
+  sha256 :no_check
+
+  # dropboxusercontent.com is the official download host per the vendor homepage
+  url 'https://dl.dropboxusercontent.com/u/6618408/soundcast.zip'
+  name 'Soundcast'
+  homepage 'https://github.com/andresgottlieb/soundcast'
+  license :mit
+
+  depends_on :cask => 'soundflower'
+
+  app 'soundcast.app'
+end


### PR DESCRIPTION
Soundcast allows you to output your OSX audio to a chromecast
