### PR TITLE
Should audit check appcast shasums?

### DIFF
--- a/lib/hbc/audit.rb
+++ b/lib/hbc/audit.rb
@@ -59,6 +59,11 @@ class Hbc::Audit
         add_error "sha256 string must be of 64 hexadecimal characters"
       end
     end
+    if cask.appcast.sha256.kind_of?(String)
+      unless cask.appcast.sha256.length == 64 && cask.appcast.sha256[/^[0-9a-f]+$/i]
+        add_warning "appcast sha256 string must be of 64 hexadecimal characters"
+      end
+    end
   end
 
   def _check_sha256_invalid
@@ -66,6 +71,9 @@ class Hbc::Audit
     empty_sha256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
     if cask.sha256 == empty_sha256
       add_error "cannot use the sha256 for an empty string: #{empty_sha256}"
+    end
+    if cask.appcast.sha256 == empty_sha256
+      add_warning "cannot use the sha256 for an empty string: #{empty_sha256}"
     end
   end
 


### PR DESCRIPTION
I don't usually go mucking about in ruby, so this is meant more to open the question.

Is it worth having `cask audit` also run through any sums in the `appcast` stanza?  Officially, `audit` is to "verify installability", and the `appcast` stanza has no impact on that[1]. Still, it's cheap, and if the appcast stanza is to exist this would be valuable in the future.

---

[1]: Not that it matters, but in light of that these checks warn on failure instead of error.
