### PR TITLE
Update P4V to latest version (2015.2-1312139)

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'p4v' do
-  version '2014.3-1007540'
-  sha256 '07eac08f6bfb32e4a79bf47582116de8532fe0b18d91a014e1cd80861d6f0909'
+  version '2015.2-1312139'
+  sha256 '6f64cca4e84d344c5f420e58a72bd07c4fbf5f3eb9665b165acd8baa36c18eb9'
 
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*},'\1')}/bin.macosx107x86_64/P4V.dmg"
   name 'P4V'


### PR DESCRIPTION
This CL updates P4V to the latest version since the existing one (2014.3) always throws an error when exiting.
