### PR TITLE
Update grandtotal to v4.1.3

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,12 +1,12 @@
 cask :v1 => 'grandtotal' do
-  version '4.0.3'
-  sha256 'd20b1132398af4f6969ed7c15e22f8a1f01158e0a758d0798e675531c6af9b1b'
+  version '4.1.3'
+  sha256 '17a3fea3abab3013ee1181cd1d7bebe499d6d5f3e362e116cc3345c0ea3e319a'
 
-  url "http://mediaatelier.com/GrandTotal3/GrandTotal_#{version}.zip"
-  appcast 'http://mediaatelier.com/GrandTotal3/feed.php',
-          :sha256 => '11fa077fba9cf8c6f9786dd29879edcf664480b1a1a1dbb3137a8a0c94b8a1b0'
+  url "http://mediaatelier.com/GrandTotal4/GrandTotal_#{version}.zip"
+  appcast 'http://mediaatelier.com/GrandTotal4/feed.php',
+          :sha256 => 'ab9702415ea6acfc11715b8b359a7b97f2b91311d29ae46e6f9a6ab8a3898a90'
   name 'GrandTotal'
-  homepage 'http://www.mediaatelier.com/GrandTotal3/'
+  homepage 'http://www.mediaatelier.com/GrandTotal4/'
   license :commercial
 
   depends_on :macos => '>= :mountain_lion'


### PR DESCRIPTION
Previous v3 links just redirected to 4 (e.g. homepage)
