### PR TITLE
Use latest stable version of Proxifier on El Capitan

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -2,11 +2,7 @@ cask :v1 => 'proxifier' do
   version :latest
   sha256 :no_check
 
-  if MacOS.release <= :yosemite
-    url 'https://www.proxifier.com/distr/ProxifierMac.zip'
-  else
-    url 'https://www.proxifier.com/distr/ProxifierMacBeta.zip'
-  end
+  url 'https://www.proxifier.com/distr/ProxifierMac.zip'
 
   name 'Proxifier'
   homepage 'https://www.proxifier.com/mac/'
@@ -14,10 +10,4 @@ cask :v1 => 'proxifier' do
 
   app 'Proxifier.app'
 
-  if MacOS.release == :el_capitan
-    caveats <<-EOS.undent
-      #{token} stable version is incompatible with OS X 10.11 El Capitan.
-      Beta version has been installed instead.
-    EOS
-  end
 end


### PR DESCRIPTION
Follow-up to #14659
No need to switch to beta on El Capitan as the latest stable release now fully supports it.
