### PR TITLE
Upgraded DevCenter to version 1.5.0

### DIFF
--- a/Casks/devcenter.rb
+++ b/Casks/devcenter.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'devcenter' do
-  version '1.4.1'
-  sha256 '204f7d9b9a52b0473fd045206006931d545ac7db1e54591325729c32f9ed4e2c'
+  version '1.5.0'
+  sha256 'f2d312e7450996f539f4f118043d091a9753c02aab1743e4b26e9b4e3bca3b83'
 
   url "https://downloads.datastax.com/devcenter/DevCenter-#{version}-macosx-x86_64.tar.gz"
   name 'DataStax DevCenter'


### PR DESCRIPTION
Upgrades the formula to install Datastax DevCenter 1.5.0 that improves existing features and adds Cassandra 3.0 features like Materialized views ([source](http://www.datastax.com/dev/blog/datastax-devcenter-1-5-is-now-materialized-with-apache-cassandra-3-0-support))
