### PR TITLE
alternate_cask_taps.md: remove user maintained taps

### DIFF
--- a/doc/alternate_cask_taps.md
+++ b/doc/alternate_cask_taps.md
@@ -27,11 +27,6 @@ Possible uses of this feature include:
 
 5. Tap the repository using the command `brew tap <github-user>/<tapname>`.
 
-6. Let us know if you wish your Tap to be publicly listed here.
-
-## Alternate Cask Taps Maintained by Users
-
-* [casidiablo/custom](https://github.com/casidiablo/homebrew-custom)
-* [thehunmonkgroup/bumptop](https://github.com/thehunmonkgroup/homebrew-bumptop)
+---
 
 <sup>1</sup> While we strive to be inclusive, sometimes this does happen: [#3954](https://github.com/caskroom/homebrew-cask/pull/3954) .


### PR DESCRIPTION
Both of those were updated more than half a year ago and are for dead and discontinued apps. Not much point in maintaining this document with taps, since no one finds it anyway.
