### PR TITLE
download.rb: Don't use cached download when cask uses `:latest`

### DIFF
--- a/lib/hbc/download.rb
+++ b/lib/hbc/download.rb
@@ -18,7 +18,7 @@ class Hbc::Download
     else
       downloader = Hbc::CurlDownloadStrategy.new(cask)
     end
-    downloader.clear_cache if force
+    downloader.clear_cache if force || cask.version == :latest
     begin
       downloaded_path = downloader.fetch
     rescue StandardError => e


### PR DESCRIPTION
Fixes https://github.com/caskroom/homebrew-cask/issues/13206
