### PR TITLE
Do not require a DSL version in cask header

### DIFF
--- a/lib/hbc/source/path_base.rb
+++ b/lib/hbc/source/path_base.rb
@@ -46,18 +46,11 @@ class Hbc::Source::PathBase
 
       # munge text
       cask_contents.sub!(%r{\A(\s*\#[^\n]*\n)+}, '');
-      if %r{\A\s*cask\s+:v([\d_]+)(test)?\s+=>\s+([\'\"])(\S+?)\3(?:\s*,\s*|\s+)do\s*\n}.match(cask_contents)
-        dsl_version_string = $1
-        is_test = ! $2.nil?
+      if %r{\A\s*(test_)?cask\s+(?::v[\d_]+(test)?\s+=>\s+)?([\'\"])(\S+?)\3(?:\s*,\s*|\s+)do\s*\n}.match(cask_contents)
+        is_test = $1 || $2
         header_token = $4
-        dsl_version = Gem::Version.new(dsl_version_string.gsub('_','.'))
         superclass_name = is_test ? 'Hbc::TestCask' : 'Hbc::Cask'
         cask_contents.sub!(%r{\A[^\n]+\n}, "class #{cask_class_name} < #{superclass_name}\n")
-        # todo the minimum DSL version should be defined globally elsewhere
-        minimum_dsl_version = Gem::Version.new('1.0')
-        unless dsl_version >= minimum_dsl_version
-          raise Hbc::CaskInvalidError.new(cask_token, "Bad header line: 'v#{dsl_version_string}' is less than required minimum version '#{minimum_dsl_version}'")
-        end
         if header_token != cask_token
           raise Hbc::CaskInvalidError.new(cask_token, "Bad header line: '#{header_token}' does not match file name")
         end

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -60,12 +60,11 @@ describe Hbc::DSL do
       err.message.must_include 'does not match file name'
     end
 
-    it "requires a valid minimum DSL version in the header" do
-      err = lambda {
-        invalid_cask = Hbc.load('invalid/invalid-header-version')
-      }.must_raise(Hbc::CaskInvalidError)
-      err.message.must_include 'Bad header line:'
-      err.message.must_include 'is less than required minimum version'
+    it "does not require a DSL version in the header" do
+      test_cask = Hbc.load('no-dsl-version')
+      test_cask.url.to_s.must_equal 'http://example.com/TestCask.dmg'
+      test_cask.homepage.must_equal 'http://example.com/'
+      test_cask.version.must_equal '1.2.3'
     end
   end
 

--- a/test/support/Casks/no-dsl-version.rb
+++ b/test/support/Casks/no-dsl-version.rb
@@ -1,0 +1,9 @@
+test_cask 'no-dsl-version' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url 'http://example.com/TestCask.dmg'
+  homepage 'http://example.com/'
+
+  app 'TestCask.app'
+end


### PR DESCRIPTION
Following up on #15782. Casks can now be created with no DSL version in the header. For example:

``` rb
cask 'no-dsl-version' do
  version :latest
  ...
end
```

Casks with DSL versions in the header are still valid, but the DSL version will be ignored.
