### PR TITLE
make issues url point to reporting-bugs instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,7 +275,7 @@ bundle exec rubocop Casks/my-new-cask.rb
 
 Keep in mind all of these checks will be made when you submit your PR, so by doing them in advance you’re saving everyone a lot of time and trouble.
 
-If your application and homebrew-cask do not work well together, feel free to [file an issue](https://github.com/caskroom/homebrew-cask/issues) after checking out open issues.
+If your application and homebrew-cask do not work well together, feel free to [file an issue](https://github.com/caskroom/homebrew-cask#reporting-bugs) after checking out open issues.
 
 ## Finding a Home For Your Cask
 

--- a/developer/bin/update_issue_template_urls
+++ b/developer/bin/update_issue_template_urls
@@ -18,7 +18,7 @@ shopt -s nocasematch  # case-insensitive regular expressions
 script_subdir='developer/bin'
 template_subdir='doc/issue_templates'
 generate_url_script='generate_issue_template_urls'
-files_to_update=('README.md')
+files_to_update=('README.md' 'doc/FAQ.md')
 
 ###
 ### functions

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -12,7 +12,7 @@ The idea is for each Cask to encapsulate and automate the story of how a given a
 
 __Yes, yes, yes!__ Please fork/pull request to update Casks, add features and clean up documentation! Anything you can do to help out is very welcome.
 
-It's also [__pretty darn easy__ to create Casks](../CONTRIBUTING.md), so please build more of them for the software you use. And if homebrew-cask doesn't support the packaging format of your software, please [open an issue](https://github.com/caskroom/homebrew-cask/issues) and we can get it working together.
+It's also [__pretty darn easy__ to create Casks](../CONTRIBUTING.md), so please build more of them for the software you use. And if homebrew-cask doesn't support the packaging format of your software, please [open an issue][feature_request_template] and we can get it working together.
 
 The whole idea is to build a _community-maintained_ list of easily installable packages, so the community part is important! Every little bit counts.
 
@@ -29,3 +29,5 @@ Some applications such as Thunderbird or Firefox provides many localized version
 This is a problem with the bookkeeping in the current implementation of Cask, which gets confused if a cask is updated after installation. For now, use the `brew cask uninstall --force` to uninstall these packages.
 
 This issue is currently being addressed [here](https://github.com/caskroom/homebrew-cask/issues/4688) and [here](https://github.com/caskroom/homebrew-cask/issues/4678).
+
+[feature_request_template]: https://github.com/caskroom/homebrew-cask/issues/new?title=Feature%20request%3A&body=%23%23%23%20Description%20of%20feature%2Fenhancement%0A%0A%0A%0A%23%23%23%20Justification%0A%0A%0A%0A%23%23%23%20Example%20use%20case%0A%0A%0A%0A

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -7,7 +7,7 @@ require 'stringio'
 require 'hbc/utils/tty'
 
 UPDATE_CMD = "brew update; brew cleanup; brew cask cleanup"
-ISSUES_URL = "https://github.com/caskroom/homebrew-cask/issues"
+ISSUES_URL = "https://github.com/caskroom/homebrew-cask#reporting-bugs"
 
 # todo: temporary
 Tty = Hbc::Utils::Tty

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -29,7 +29,7 @@ describe Hbc::DSL do
         .*
         brew update; brew cleanup; brew cask cleanup
         .*
-        https://github.com/caskroom/homebrew-cask/issues
+        https://github.com/caskroom/homebrew-cask#reporting-bugs
       EOREGEX
 
       TestHelper.must_output(self, attempt_unknown_method, expected)


### PR DESCRIPTION
If we use this link directly even in CLI messages, perhaps more people will use the templates, and save us all a bunch of time.
