### PR TITLE
Add Quickbooks Desktop 2016

### DIFF
--- a/Casks/quickbooks-desktop.rb
+++ b/Casks/quickbooks-desktop.rb
@@ -1,0 +1,12 @@
+cask 'quickbooks-desktop' do
+  version '2016'
+  sha256 :no_check
+
+  url "http://http-download.intuit.com/http.intuit/Downloads/2016/Latest/QuickBooksMac#{version}.dmg"
+
+  name 'QuickBooks Desktop'
+  homepage 'http://quickbooks.intuit.com/mac/'
+  license :commercial
+
+  app "QuickBooks #{version}.app"
+end


### PR DESCRIPTION
I chose to go with no hash check because I'm not sure how often they make minor version bumps. The download link should be consistent.

Otherwise it would be:

``` ruby
version '17.0.1.534 R02'
sha256 'c06518f6d9118275c4126b02b5a69234aee8f91852b5bc5b97aa117f8315b024'
```
