### PR TITLE
Upgrade Mono-MDK package to 4.2.1.102 and switch to universal/x64

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,13 +1,13 @@
-cask 'mono-mdk' do
+cask :v1 => 'mono-mdk' do
   version '4.2.1.102'
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 'ce886f20e509544cfc4379d10a0e4c574b06f0f97ae09096a06aee0c769e1f48'
 
-  url "http://download.mono-project.com/archive/#{version.sub(%r{\.[^.]*$},'')}/macos-10-x86/MonoFramework-MDK-#{version}.macos10.xamarin.x86.pkg"
+  url "http://download.mono-project.com/archive/#{version.sub(%r{\.[^.]*$},'')}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
   homepage 'http://mono-project.com'
   license :oss
 
-  pkg "MonoFramework-MDK-#{version}.macos10.xamarin.x86.pkg"
+  pkg "MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
 
-  uninstall :pkgutil => 'com.xamarin.mono-MDK.pkg'
+  uninstall :pkgutil => 'com.xamarin.mono-*'
 end


### PR DESCRIPTION
- Upgrade to latest upstream version of mono (4.2.1.102)
- Switch to the Universal Package instead of the 32-bit/x86 version
- pkgutil removes both the MDK and MRE which are installed by this package
- shasum is specific to this version so it should be verified
