### PR TITLE
Update osculator to v2.13.3-12-g5f24bc9

### DIFF
--- a/Casks/osculator.rb
+++ b/Casks/osculator.rb
@@ -1,11 +1,9 @@
 cask 'osculator' do
-  version '2.13.2-12-gbab8aab'
-  sha256 'adfa94655876daebee61ddcf2bfe3781c1591d52bcc026044d4a51c5ee979ea4'
+  version '2.13.3-12-g5f24bc9'
+  sha256 '30563bcb6f80a9498cf25d38a41c0baba3631f6bcec21a8733cbb267b1e67dfc'
 
   url "http://dl.osculator.net/releases/osculator-#{version}.dmg"
   name 'OSCulator'
-  appcast 'http://www.osculator.net/app/profileInfo.php',
-          :sha256 => '6a7b1bf7159f8bc547febab28a24f4800b3bc61ca9d4f9477282dbb172d63fdc'
   homepage 'http://www.osculator.net'
   license :commercial
 


### PR DESCRIPTION
I removed the appcast - it's still given in the app, but hasn't been updated since 2010
