### PR TITLE
Add Kivuto Secure Download Manager

### DIFF
--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -1,0 +1,15 @@
+cask 'sdm' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://e5.onthehub.com/Static/Installers/SDM.pkg'
+  name 'Secure Download Manager'
+  name 'SDM'
+  name 'Kivuto Secure Download Manager'
+  license :gratis
+  homepage 'https://e5.onthehub.com/WebStore/Account/SdmDownloadFaq.aspx?ws=2cbc6a33-25f4-e011-8e6c-f04da23e67f6&secure=1'
+
+  pkg 'SDM.pkg'
+
+  uninstall :pkgutil => 'e-academy.com.secureDownloadManager.SecureDownloadManager.pkg'
+end


### PR DESCRIPTION
This is a cask for the so-called Secure Download Manager that Microsoft requires people to use to download software via Dreamspark, their education program (formerly MSDNAA); though the program is actually from a company called Kivuto.

Since this is my first contribution, I’m not sure whether I got this right (even though it seems to work fine for me). In particular, I’m unsure about the uninstall stanza. Please check and test, I’d be glad to correct any problems.

Also, somewhat unrelated: Why is there no description (or even just keyword) field – was this a deliberate decision? Seems like it would be helpful to describe the program in a sentence or two (like I did above); this would also improve searchability. E.g., in this case, I’d like to mention "Dreamspark downloader" or something.
