### PR TITLE
Fix empty appcast shasums

### DIFF
--- a/Casks/beotsmusic.rb
+++ b/Casks/beotsmusic.rb
@@ -5,8 +5,8 @@ cask 'beotsmusic' do
   # github.com is the official download host per the vendor homepage
   url "https://github.com/kiding/beotsmusic/releases/download/#{version}/BeotsMusic.dmg"
   name 'BeotsMusic'
-  appcast 'https://raw.github.com/kiding/beotsmusic/master/appcast.xml',
-          :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  appcast 'https://github.com/kiding/beotsmusic/releases.atom',
+          :sha256 => '58053ecb7f438e794ec2a78ea671f29736a54098d0847a91cf5c67f4e5b7eccf'
   homepage 'http://beotsmusic.kiding.net/'
   license :mit
 

--- a/Casks/biba.rb
+++ b/Casks/biba.rb
@@ -4,8 +4,8 @@ cask 'biba' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3-us-west-1.amazonaws.com/downloads.biba.com/builds/Biba-OSX-#{version}.dmg"
-  appcast 'https://biba.com/osx_downloads/appcast',
-          :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  appcast 'https://s3-us-west-1.amazonaws.com/downloads.biba.com/appcast/mac',
+          :sha256 => 'cfefc565fa942aa6d1da310db7a72a37e7ba4dcef26353fef020e35da2c39f77'
   name 'Biba'
   homepage 'https://www.biba.com'
   license :closed

--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -5,7 +5,7 @@ cask 'robofont' do
   url 'http://robofont.com/downloads/RoboFont_1410152315.dmg'
   name 'RoboFont'
   appcast 'http://doc.robofont.com/appcast',
-          :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+          :sha256 => 'c235649bb973653a99e043bab89681dcd0407976ae1cdc56237e963492bd8562'
   homepage 'http://robofont.com'
   license :other # See http://doc.robofont.com/license-agreement/
 

--- a/Casks/shiftit.rb
+++ b/Casks/shiftit.rb
@@ -4,8 +4,8 @@ cask 'shiftit' do
 
   url "https://github.com/fikovnik/ShiftIt/releases/download/version-#{version}/ShiftIt-#{version}.zip"
   name 'ShiftIt'
-  appcast 'https://raw.github.com/fikovnik/ShiftIt/develop/release/appcast.xml',
-          :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  appcast 'https://github.com/fikovnik/ShiftIt/releases.atom',
+          :sha256 => '27768f3e0be91ae446110e3e478d895b543745f2c01f914cfb2b932f1070fba8'
   homepage 'https://github.com/fikovnik/ShiftIt'
   license :gpl
 

--- a/Casks/ubersicht.rb
+++ b/Casks/ubersicht.rb
@@ -5,7 +5,7 @@ cask 'ubersicht' do
   url "http://tracesof.net/uebersicht/releases/Uebersicht-#{version}.app.zip"
   name 'Übersicht'
   appcast 'http://tracesof.net/uebersicht/updates.xml.rss',
-          :sha256 => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+          :sha256 => 'e6901656bbb25e9f6f026798f6a118256a15b43599ef0c30089a53699473685e'
   homepage 'http://tracesof.net/uebersicht'
   license :gpl
 


### PR DESCRIPTION
With #15959 this should remove all casks with currently invalid (empty hash) `appcast` shas.  Refs proposed audits in #15831.
- A few had their appcast urls changed (two raw.github -> releases.atom; 1 redirect)
- `robofont` wasn't happy with curl?  wget worked
