### PR TITLE
Added install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ It’s implemented as a `homebrew` [external command](https://github.com/Homebre
 [![Coverage Status](https://img.shields.io/coveralls/caskroom/homebrew-cask.svg)](https://coveralls.io/r/caskroom/homebrew-cask)
 [![Join the chat at https://gitter.im/caskroom/homebrew-cask](https://img.shields.io/badge/gitter-join%20chat-blue.svg)](https://gitter.im/caskroom/homebrew-cask)
 
+## Get Cask
+
+```bash
+$ brew tap caskroom/cask
+```
+
 ## Let’s try it!
 
 ```bash


### PR DESCRIPTION
Please excuse me if this was omitted for a reason.  It seemed strange to me that the latest install instructions were not present in the README, so I added them.
