### PR TITLE
Update links/paths in manpage, hacking.md, usage.md to reflect brew-cask structure

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -224,8 +224,8 @@ Most `brew cask` commands can accept a Cask token as an argument. As described a
 
 `brew cask` also accepts three other forms as arguments
 
-* A path to a Cask file, _eg_: `/usr/local/Cellar/brew-cask/0.25.0/Casks/google-chrome.rb`.
-* A `curl`-retrievable URI to a Cask file, _eg_: `https://raw.github.com/caskroom/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`.
+* A path to a Cask file, _eg_: `/usr/local/Library/Taps/caskroom/homebrew-cask/Casks/google-chrome.rb`.
+* A `curl`-retrievable URI to a Cask file, _eg_: `https://raw.githubusercontent.com/caskroom/homebrew-cask/f25b6babcd398abf48e33af3d887b2d00de1d661/Casks/google-chrome.rb`.
 * A file in the current working directory, _eg_: `my-modfied-google-chrome.rb`. Note that matching Tapped Cask tokens will be preferred over this form when there is a conflict. To force the use of a Cask file in the current directory, specify a pathname with slashes, _eg_: `./google-chrome.rb`.
 
 The last three forms are intended for users who wish to maintain private Casks.

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -97,7 +97,7 @@ $ /System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby /usr/l
 If you are developing a subcommand, you can force `brew cask` to dispatch a specific file by giving a fully-qualified path to the file containing the subcommand, like this:
 
 ```bash
-$ brew cask /usr/local/Cellar/brew-cask/0.37.0/rubylib/hbc/cli/info.rb google-chrome
+$ brew cask /usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/info.rb google-chrome
 ```
 
 This form can also be combined with a specific Ruby interpreter as above.

--- a/doc/src/brew-cask.1.md
+++ b/doc/src/brew-cask.1.md
@@ -208,10 +208,10 @@ Homebrew-cask also accepts three other forms in place of plain tokens:
     `caskroom/fonts/font-symbola`
 
   * A fully-qualified pathname to a Cask file, _eg_
-    `/usr/local/Cellar/brew-cask/0.25.0/Casks/google-chrome.rb`
+    `/usr/local/Library/Taps/caskroom/homebrew-cask/Casks/google-chrome.rb`
 
   * A `curl`-retrievable URI to a Cask file, _eg_
-   `https://raw.github.com/caskroom/homebrew-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google-chrome.rb`
+   `https://raw.githubusercontent.com/caskroom/homebrew-cask/f25b6babcd398abf48e33af3d887b2d00de1d661/Casks/google-chrome.rb`
 
 ## ENVIRONMENT
 

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -173,6 +173,14 @@ Target location for Input Method links\. The default value is \fB~/Library/Input
 Target location for Internet Plugin links\. The default value is \fB~/Library/Internet Plug\-Ins\fR\.
 .
 .TP
+\fB\-\-audio_unit_plugindir=<path>\fR
+Target location for Audio Unit Plugin links\. The default value is \fB~/Library/Audio/Plug\-Ins/Components\fR\.
+.
+.TP
+\fB\-\-vst_plugindir=<path>\fR
+Target location for VST Plugin links\. The default value is \fB~/Library/Audio/Plug\-Ins/VST\fR\.
+.
+.TP
 \fB\-\-screen_saverdir=<path>\fR
 Target location for Screen Saver links\. The default value is \fB~/Library/Screen Savers\fR\.
 .
@@ -209,10 +217,10 @@ Homebrew\-cask also accepts three other forms in place of plain tokens:
 A fully\-qualified token which includes the Tap name, \fIeg\fR \fBcaskroom/fonts/font\-symbola\fR
 .
 .IP "\(bu" 4
-A fully\-qualified pathname to a Cask file, \fIeg\fR \fB/usr/local/Cellar/brew\-cask/0\.25\.0/Casks/google\-chrome\.rb\fR
+A fully\-qualified pathname to a Cask file, \fIeg\fR \fB/usr/local/Library/Taps/caskroom/homebrew\-cask/Casks/google\-chrome\.rb\fR
 .
 .IP "\(bu" 4
-A \fBcurl\fR\-retrievable URI to a Cask file, \fIeg\fR \fBhttps://raw\.github\.com/caskroom/homebrew\-cask/f54bbfaae0f2fa7210484f46313a459cb8a14d2f/Casks/google\-chrome\.rb\fR
+A \fBcurl\fR\-retrievable URI to a Cask file, \fIeg\fR \fBhttps://raw\.githubusercontent\.com/caskroom/homebrew\-cask/f25b6babcd398abf48e33af3d887b2d00de1d661/Casks/google\-chrome\.rb\fR
 .
 .IP "" 0
 .


### PR DESCRIPTION
- Old github.com links were invalid
- Old `Cellar`-based structure was invalid
- Man page regenerated, including content from #15643

Refs #15381
