### PR TITLE
Upgrade Subtitle Master to v2.01

### DIFF
--- a/Casks/subtitle-master.rb
+++ b/Casks/subtitle-master.rb
@@ -1,13 +1,14 @@
 cask 'subtitle-master' do
-  version '0.6'
-  sha256 'c2a4fe372f0840cdbb4fb8d6ae9d689b516d97a04ea082773308d6a65dc75f60'
+  version '2.0.1'
+  sha256 '8936495ef4aefe9bf59c28dd4d5a92574c194062067c318667e3f55428245304'
 
-  url "http://updates.subtitlemaster.com/app/Subtitle%20Master%20#{version}.zip"
-  appcast 'http://updates.subtitlemaster.com',
-          :sha256 => '07bc4aa2178fd8851caa8b4c78050c48a02358d5afc59c110d715faffc2e2479'
+  # github.com is the official download host per the vendor homepage
+  url "https://github.com/subtitle-master/subtitlemaster/releases/download/v#{version}-SNAPSHOT/Subtitle.Master-osx-v#{version}-SNAPSHOT.zip"
+  appcast 'https://github.com/subtitle-master/subtitlemaster/releases.atom',
+          :sha256 => 'e12b1034eeb5c53a908d9ddaea48e3e58d408853b4d0836bbbc50334e7a70878'
   name 'Subtitle Master'
   homepage 'http://subtitlemaster.com/'
-  license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :eclipse
 
   app 'Subtitle Master.app'
 end


### PR DESCRIPTION
The homepage redirects to their Github project, and the old download link was broken.
