### PR TITLE
`installer` and `uninstall` make their `:script` targets executable

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -10,10 +10,6 @@ cask 'anaconda' do
 
   container :type => :naked
 
-  preflight do
-    set_permissions "#{staged_path}/Anaconda3-#{version}-MacOSX-x86_64.sh", '+x'
-  end
-
   installer :script => "Anaconda3-#{version}-MacOSX-x86_64.sh",
             :args => [ '-b' ],
             :sudo => false

--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -21,8 +21,4 @@ cask 'screens-connect' do
               :must_succeed => false
               },
             :pkgutil => 'com.edovia.pkg.screens.connect.*'
-
-  uninstall_preflight do
-    set_permissions "#{staged_path}/Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool", '+x'
-  end
 end

--- a/lib/hbc/artifact/installer.rb
+++ b/lib/hbc/artifact/installer.rb
@@ -26,10 +26,12 @@ class Hbc::Artifact::Installer < Hbc::Artifact::Base
                                                                         "#{self.class.artifact_dsl_key}",
                                                                         {:must_succeed => true, :sudo => true},
                                                                         {:print_stdout => true}
-                                                                        )
+                                                                       )
         ohai "Running #{self.class.artifact_dsl_key} script #{executable}"
         raise Hbc::CaskInvalidError.new(@cask, "#{self.class.artifact_dsl_key} missing executable") if executable.nil?
-        @command.run(@cask.staged_path.join(executable), script_arguments)
+        executable_path = @cask.staged_path.join(executable)
+        @command.run('/bin/chmod', :args => ['+x', executable_path]) if File.exists?(executable_path)
+        @command.run(executable_path, script_arguments)
       end
     end
   end

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -225,15 +225,18 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
   # :early_script should not delete files, better defer that to :script.
   # If Cask writers never need :early_script it may be removed in the future.
   def uninstall_early_script(directives)
-    executable, script_arguments = self.class.read_script_arguments(directives,
+    executable, script_arguments = self.class.read_script_arguments(
+                                                                    directives,
                                                                     'uninstall',
                                                                     {:must_succeed => true, :sudo => true},
                                                                     {:print_stdout => true},
-                                                                    :early_script)
-
+                                                                    :early_script
+                                                                   )
     ohai "Running uninstall script #{executable}"
     raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :early_script without :executable") if executable.nil?
-    @command.run(@cask.staged_path.join(executable), script_arguments)
+    executable_path = @cask.staged_path.join(executable)
+    @command.run('/bin/chmod', :args => ['+x', executable_path]) if File.exists?(executable_path)
+    @command.run(executable_path, script_arguments)
     sleep 1
   end
 


### PR DESCRIPTION
Closes https://github.com/caskroom/homebrew-cask/issues/13607.

`installer` and `uninstall` had a few syntax fixes and now make their `:script` targets executable before trying to execute them.

Also fixed two casks that previously required workarounds.
