### PR TITLE
Fix irregular newlines

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -18,5 +18,4 @@ cask 'ableton-live-standard' do
   zap :delete => '~/Library/*/*[Aa]bleton*',
       :rmdir => '~/Music/Ableton/Factory Packs'
       #:trash => '~/Music/Ableton/User Library'
-
 end

--- a/Casks/anylogic.rb
+++ b/Casks/anylogic.rb
@@ -11,6 +11,7 @@ cask 'anylogic' do
   depends_on :macos => '>= :lion'
 
   pkg 'Install AnyLogic.pkg'
+
   uninstall :pkgutil => 'com.anylogic.AnyLogic'
 
   caveats <<-EOS.undent
@@ -20,5 +21,4 @@ cask 'anylogic' do
     For activation instructions, check up on
       http://www.anylogic.com/upload/activation-guides/AnyLogic_#{version.slice(/\w+/)}_PLE_License.pdf
   EOS
-
 end

--- a/Casks/application-loader.rb
+++ b/Casks/application-loader.rb
@@ -8,5 +8,6 @@ cask 'application-loader' do
   license :gratis
 
   pkg 'ApplicationLoader.pkg'
+
   uninstall :pkgutil => 'com.apple.pkg.ApplicationLoader'
 end

--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -8,5 +8,6 @@ cask 'chessx' do
   license :gpl
 
   pkg 'chessx-installer.mpkg'
+
   uninstall :pkgutil => 'net.sourceforge.chessx'
 end

--- a/Casks/ftdi-vcp-driver.rb
+++ b/Casks/ftdi-vcp-driver.rb
@@ -40,5 +40,4 @@ cask 'ftdi-vcp-driver' do
       reconnect it for it to show up in /dev.
     EOC
   end
-
 end

--- a/Casks/gobbler.rb
+++ b/Casks/gobbler.rb
@@ -8,6 +8,7 @@ cask 'gobbler' do
   license :gratis
 
   installer :manual => 'Gobbler.app'
+
   uninstall :script  => {
                           :executable => '/Library/Gobbler/Uninstaller/uninstall_gobbler.sh',
                           :args => ['-f'],

--- a/Casks/google-earth-web-plugin.rb
+++ b/Casks/google-earth-web-plugin.rb
@@ -9,5 +9,6 @@ cask 'google-earth-web-plugin' do
   tags :vendor => 'Google'
 
   pkg 'Install Google Earth.pkg'
+
   uninstall :pkgutil => 'com.Google.GoogleEarthPlugin.plugin'
 end

--- a/Casks/kindlepreviewer.rb
+++ b/Casks/kindlepreviewer.rb
@@ -9,5 +9,6 @@ cask 'kindlepreviewer' do
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'KindlePreviewer.pkg'
+
   uninstall :pkgutil => 'Amazon.Kindle.Previewer.pkg'
 end

--- a/Casks/mipony.rb
+++ b/Casks/mipony.rb
@@ -8,5 +8,6 @@ cask 'mipony' do
   license :unknown
 
   pkg 'Mipony-Installer.pkg', :allow_untrusted => true
+
   uninstall :pkgutil => 'net.installer.mipony.*'
 end

--- a/Casks/neat.rb
+++ b/Casks/neat.rb
@@ -8,6 +8,7 @@ cask 'neat' do
   license :gratis
 
   pkg 'Install Neat.pkg'
+
   uninstall :pkgutil => 'com.neat.pkg.NeatBall',
             :quit    => 'com.neatreceipts.nrm'
 end

--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -9,5 +9,4 @@ cask 'proxifier' do
   license :commercial
 
   app 'Proxifier.app'
-
 end

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -8,5 +8,6 @@ cask 'qtspim' do
   license :bsd
 
   pkg 'QtSpim.mpkg'
+
   uninstall :pkgutil => 'org.larusstone.pkg.QtSpim'
 end

--- a/Casks/razer-synapse.rb
+++ b/Casks/razer-synapse.rb
@@ -31,5 +31,4 @@ cask 'razer-synapse' do
   caveats do
     reboot
   end
-
 end

--- a/Casks/terminology.rb
+++ b/Casks/terminology.rb
@@ -8,5 +8,6 @@ cask 'terminology' do
   license :gratis
 
   installer :script => 'Terminology-for-OS-X/Install.command', :sudo => false
+
   uninstall :delete => Pathname.new(File.expand_path('~')).join('Library/Dictionaries/Terminology.dictionary')
 end

--- a/Casks/wd-my-cloud.rb
+++ b/Casks/wd-my-cloud.rb
@@ -11,5 +11,4 @@ cask 'wd-my-cloud' do
 
   uninstall  :pkgutil => 'com.wdc.wdMyCloud.*',
              :rmdir => '/Applications/WD My Cloud'
-
 end


### PR DESCRIPTION
Fix some irregular newlines after running `irregular_cask_whitespace`.

There are still some files with irregular whitespace reported, but I think these should be correct and the script updated (for example allow # before uninstall)
