### PR TITLE
Fix dsl and url in synth1-au and synth1-vst casks

### DIFF
--- a/Casks/synth1-au.rb
+++ b/Casks/synth1-au.rb
@@ -1,8 +1,8 @@
-cask :v1 => 'synth1-au' do
+cask 'synth1-au' do
   version '1.13beta8'
   sha256 '78660848d78c19cdda2597bd050a2ec95fa915cc1a1ab598bde0192a1cbc9a6f'
 
-  url 'http://www.geocities.jp/daichi1969/softsynth/Synth1macau113beta8.zip'
+  url "http://www.geocities.jp/daichi1969/softsynth/Synth1macau#{version.delete('.')}.zip"
   name 'Synth1 (AU)'
   name 'Synth 1 (AU)'
   homepage 'http://www.geocities.jp/daichi1969/softsynth/'

--- a/Casks/synth1-vst.rb
+++ b/Casks/synth1-vst.rb
@@ -1,8 +1,8 @@
-cask :v1 => 'synth1-vst' do
+cask 'synth1-vst' do
   version '1.13beta8'
   sha256 '6b172b9433358bce21f0af75a28505c3365d934fadee04a738336e7f5f601675'
 
-  url 'http://www.geocities.jp/daichi1969/softsynth/Synth1macvst113beta8.zip'
+  url "http://www.geocities.jp/daichi1969/softsynth/Synth1macvst#{version.delete('.')}.zip"
   name 'Synth1 (VST)'
   name 'Synth 1 (VST)'
   homepage 'http://www.geocities.jp/daichi1969/softsynth/'


### PR DESCRIPTION
- Use and interpolate version
- Remove dsl version erroneously introduced in abe5fa7
