### PR TITLE
readme: clarify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It’s implemented as a `homebrew` [external command](https://github.com/Homebre
 
 ## Let’s try it!
 
+To start using Homebrew-Cask, you just need [Homebrew](http://brew.sh/) installed.
+
 ```bash
 $ brew cask install google-chrome
 => Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg


### PR DESCRIPTION
In light of https://github.com/caskroom/homebrew-cask/pull/15973.

If we merge this, we can then do the same on the homepage.
