### PR TITLE
verify.rb: Warning on sha :no_check

### DIFF
--- a/lib/hbc/verify.rb
+++ b/lib/hbc/verify.rb
@@ -10,7 +10,10 @@ module Hbc::Verify
       expected = cask.sha256
     rescue RuntimeError => e
     end
-    return if expected == :no_check
+    if expected == :no_check
+      ohai `Checksum not available`
+      return
+    end
     computed = Digest::SHA2.file(path).hexdigest
     if expected.nil? or expected.empty?
       raise Hbc::CaskSha256MissingError.new("sha256 required: sha256 '#{computed}'")


### PR DESCRIPTION
Fixes https://github.com/caskroom/homebrew-cask/issues/7062

Wasn't sure if I should toss up an "error" instead, as we're not _doing_ anything about a shasum of `:no_check` (yet).

Currently not working but I find discussing on a PR (with code) more productive than with an issue, anyway.
