### PR TITLE
Fix sha256 on Arduino 1.6.7

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -1,6 +1,6 @@
 cask 'arduino' do
   version '1.6.7'
-  sha256 '20d6ecdd068930d3e74ef5de6ec3115e57b9ad7183fbee51b0d42e52cd5df5aa'
+  sha256 '9ad1a3096904c132e7a0817c9d7afc17a891ded3fb73a50ac1d5845d6a7d68a3'
 
   url "https://downloads.arduino.cc/arduino-#{version}-macosx.zip"
   name 'Arduino'


### PR DESCRIPTION
This PR is fix of sha256 for arudino 1.6.7.

In executing the `brew cask install arduino`, get error of sha256 mismatch.

```
 brew cask install arduino                         
==> Downloading https://downloads.arduino.cc/arduino-1.6.7-macosx.zip
######################################################################## 100.0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 20d6ecdd068930d3e74ef5de6ec3115e57b9ad7183fbee51b0d42e52cd5df5aa
Actual: 9ad1a3096904c132e7a0817c9d7afc17a891ded3fb73a50ac1d5845d6a7d68a3
File: /Library/Caches/Homebrew/arduino-1.6.7.zip
To retry an incomplete download, remove the file above.
```

It will change the actual checksum.
