### PR TITLE
Add discontinued caveat for Latexian.app

### DIFF
--- a/Casks/latexian.rb
+++ b/Casks/latexian.rb
@@ -9,4 +9,8 @@ cask 'latexian' do
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Latexian/Latexian.app'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Taco Software is closed as it says on their [homepage](http://tacosw.com/). The download URL is still available, though.
