### PR TITLE
Install adobe-air before running tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,13 @@ before_install:
   - echo ls_ruby_bindir; ls "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin"
 
 # install steps
-# * brew Formulae without which some tests will be skipped
+# * brew Formulae and Casks without which some tests will be skipped
 # * bundler gem
 # * Ruby gems required for brew-cask
 install:
   - brew install cabextract
   - brew install unar
+  - cmd/brew-cask.rb install Casks/adobe-air.rb
   - echo gem_install_bundler; sudo "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/gem" install bundler --bindir="/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin"
   - echo bundle; sudo "/System/Library/Frameworks/Ruby.framework/Versions/${CASK_RUBY_TEST_VERSION}/usr/bin/bundle" --system
 


### PR DESCRIPTION
This way we can run [integration tests](https://github.com/caskroom/homebrew-cask/blob/3407a19def04a81fe8c9d9ace6a8c2e25384927f/test/cask/installer_test.rb#L60-L70) for the Adobe AIR container type.
