### PR TITLE
Add discontinued caveat to kobito

### DIFF
--- a/Casks/kobito.rb
+++ b/Casks/kobito.rb
@@ -10,4 +10,8 @@ cask 'kobito' do
   license :gratis
 
   app 'Kobito.app'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Last version available for direct download; I always feel weird using 'discontinued' for these.
https://twitter.com/kobitoapp/status/679183539028426752
