### PR TITLE
Add uninstall and zap stanzas for BlueStacks

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -8,4 +8,24 @@ cask 'bluestacks' do
   license :closed
 
   app 'BlueStacks.app'
+
+  uninstall :launchctl => [
+                           'com.BlueStacks.AppPlayer.bstservice_helper',
+                           'com.BlueStacks.AppPlayer.Service',
+                           'com.BlueStacks.AppPlayer.UninstallWatcher',
+                           'com.BlueStacks.AppPlayer.Updater'
+                          ],
+            :delete    => '/Library/PrivilegedHelperTools/com.BlueStacks.AppPlayer.bstservice_helper'
+  zap       :delete    => [
+                           '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.bluestacks.bluestacks.sfl',
+                           '~/Library/BlueStacks',
+                           '~/Library/Caches/com.bluestacks.BlueStacks',
+                           '~/Library/Caches/KSCrashReports/BlueStacks',
+                           '~/Library/Logs/BlueStacks',
+                           '~/Library/Preferences/com.BlueStacks.AppPlayer.DiagnosticTimestamp.txt',
+                           '~/Library/Preferences/com.BlueStacks.AppPlayer.plist',
+                           '~/Library/Preferences/com.BlueStacks.AppPlayer.SavedFrame.plist',
+                           '~/Library/Preferences/com.bluestacks.BlueStacks.plist'
+                          ],
+            :rmdir     => '~/Library/Caches/KSCrashReports'
 end


### PR DESCRIPTION
BlueStacks (Android emulator) embeds itself rather deeply and needs some special cleanup.
