### PR TITLE
panic-unison.rb: delete appcast

### DIFF
--- a/Casks/panic-unison.rb
+++ b/Casks/panic-unison.rb
@@ -3,7 +3,6 @@ cask 'panic-unison' do
   sha256 'b9d08af6ea52fbcf8fe0eebaec9b7b68c7a280d4455de030d99ca9731cca66d9'
 
   url "http://download.panic.com/Unison/Unison%20#{version}.zip"
-  appcast 'http://www.panic.com/updates/update.php'
   name 'Unison'
   homepage 'https://panic.com/unison/'
   license :gratis


### PR DESCRIPTION
Appcast does not work. Irrelevant either way, since the app was discontinued.
