### PR TITLE
Switch to HTTPS for 360 Casks

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -10,7 +10,7 @@ cask 'ableton-live-suite' do
   end
 
   name 'Ableton Live Suite'
-  homepage 'http://ableton.com/en/live'
+  homepage 'https://ableton.com/en/live'
   license :commercial
 
   app "Ableton Live #{version[0]} Suite.app"

--- a/Casks/acquia-dev-desktop.rb
+++ b/Casks/acquia-dev-desktop.rb
@@ -2,7 +2,7 @@ cask 'acquia-dev-desktop' do
   version '2-2015-07-27'
   sha256 '0d0f750912157d25220d6d09cb3175e6bfcaf8cd3b412fcf7621ec516951de42'
 
-  url "http://www.acquia.com/sites/default/files/downloads/dev-desktop/AcquiaDevDesktop-#{version}.dmg"
+  url "https://www.acquia.com/sites/default/files/downloads/dev-desktop/AcquiaDevDesktop-#{version}.dmg"
   name 'Acquia Dev Desktop'
   homepage 'https://www.acquia.com/products-services/dev-desktop'
   license :gratis

--- a/Casks/activity-audit.rb
+++ b/Casks/activity-audit.rb
@@ -2,9 +2,9 @@ cask 'activity-audit' do
   version '1.1.5'
   sha256 '5e37e7912e679c0392c25125f577a639a73e8aaef7f7364c4364b29e12726ebb'
 
-  url "http://www.dssw.co.uk/activityaudit/dsswactivityaudit-#{version.delete('.')}.dmg"
+  url "https://www.dssw.co.uk/activityaudit/dsswactivityaudit-#{version.delete('.')}.dmg"
   name 'Activity Audit'
-  appcast 'http://version.dssw.co.uk/activityaudit/standard',
+  appcast 'https://version.dssw.co.uk/activityaudit/standard',
           :sha256 => 'ac63a66d06ecf116f7ad04b5b680b12f0534e07685e6eb9dfe4e13f9b03ce508'
   homepage 'https://www.dssw.co.uk/activityaudit'
   license :commercial

--- a/Casks/actual-odbc-pack.rb
+++ b/Casks/actual-odbc-pack.rb
@@ -3,7 +3,7 @@ cask 'actual-odbc-pack' do
   sha256 :no_check
 
   # cachefly.net is the official download host per the vendor homepage
-  url 'http://actualtechnologies.cachefly.net/Actual_ODBC_Pack.dmg'
+  url 'https://actualtechnologies.cachefly.net/Actual_ODBC_Pack.dmg'
   name 'Actual ODBC Driver Pack'
   name 'Actual ODBC Drivers'
   homepage 'https://www.actualtech.com/products.php'

--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -2,7 +2,7 @@ cask 'adobe-air' do
   version '20.0'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://airdownload.adobe.com/air/mac/download/#{version}/AdobeAIR.dmg"
+  url "https://airdownload.adobe.com/air/mac/download/#{version}/AdobeAIR.dmg"
   name 'Adobe AIR'
   homepage 'https://get.adobe.com/air/'
   license :gratis

--- a/Casks/adobe-arh.rb
+++ b/Casks/adobe-arh.rb
@@ -2,7 +2,7 @@ cask 'adobe-arh' do
   version :latest
   sha256 :no_check
 
-  url 'http://airdownload.adobe.com/air/distribution/latest/mac/arh'
+  url 'https://airdownload.adobe.com/air/distribution/latest/mac/arh'
   name 'AIR Redistribution Helper'
   name 'ARH'
   homepage 'http://help.adobe.com/en_US/air/redist/WS485a42d56cd19641-70d979a8124ef20a34b-8000.html'

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -2,7 +2,7 @@ cask 'airmedia' do
   version '1.0.4.5'
   sha256 '28023efa567969d87e5cc701fc8a80341d12d9f0a7e77dc1d946e343ab2bdf09'
 
-  url "http://www.crestron.com/downloads/software/airmedia_guest_os_x_#{version}.dmg"
+  url "https://www.crestron.com/downloads/software/airmedia_guest_os_x_#{version}.dmg"
   name 'Crestron AirMedia'
   homepage 'http://www.crestron.com/airmedia'
   license :gratis

--- a/Casks/airparrot.rb
+++ b/Casks/airparrot.rb
@@ -2,7 +2,7 @@ cask 'airparrot' do
   version '2.3.0'
   sha256 'e407d950566f9960bfaaa1046212eddf8dafb87e19710b38a500542f717bd483'
 
-  url "http://download.airsquirrels.com/AirParrot2/Mac/AirParrot-#{version}.dmg"
+  url "https://download.airsquirrels.com/AirParrot2/Mac/AirParrot-#{version}.dmg"
   name 'AirParrot'
   appcast 'https://updates.airsquirrels.com/AirParrot2/Mac/AirParrot2.xml',
           :sha256 => '3bc86152636f525c719ca4b8e46c5b43430e4f86cb393b94a4c7540e85490493'

--- a/Casks/airserver.rb
+++ b/Casks/airserver.rb
@@ -3,10 +3,10 @@ cask 'airserver' do
   sha256 'b4d08ac1db459ea01ae1812a11421ad1f380ed417eb6b857b5142c86b3e09d29'
 
   url "http://dl.airserver.com/mac/AirServer-#{version}.dmg"
-  appcast 'http://www.airserver.com/downloads/mac/appcast.xml',
+  appcast 'https://www.airserver.com/downloads/mac/appcast.xml',
           :sha256 => '9a8cf6d84b044351c28a4c5e3e1f38eef70a81e6e74ff5aff38298ba55c45631'
   name 'AirServer'
-  homepage 'http://www.airserver.com'
+  homepage 'https://www.airserver.com'
   license :commercial
 
   app 'AirServer.app'

--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -4,7 +4,7 @@ cask 'alfred' do
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.zip"
   name 'Alfred'
-  homepage 'http://www.alfredapp.com/'
+  homepage 'https://www.alfredapp.com/'
   license :freemium
 
   app 'Alfred 2.app'

--- a/Casks/aliwangwang.rb
+++ b/Casks/aliwangwang.rb
@@ -5,9 +5,9 @@ cask 'aliwangwang' do
   # alicdn.com is the official download host per the vendor homepage
   url "https://dbison.alicdn.com/updates/macww-nosandbox-#{version}.dmg"
   name 'Ali Wangwang'
-  appcast 'http://update.labs.etao.com/macww/updates.xml',
+  appcast 'https://update.labs.etao.com/macww/updates.xml',
           :sha256 => 'be61920aa7408e95378893f2829a8292d19bf06df1d95e854425df31ff49cc0f'
-  homepage 'http://wangwang.taobao.com'
+  homepage 'https://wangwang.taobao.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'AliWangwang.app'

--- a/Casks/anvil.rb
+++ b/Casks/anvil.rb
@@ -3,7 +3,7 @@ cask 'anvil' do
   sha256 '13def7101b594964501f3bf32d76ffd16e4b7f97c6bf9bc81c1b891d75624cbe'
 
   # amazonaws.com is the official download host as per the vendor homepage
-  url "http://s3.amazonaws.com/sparkler_versions/versions/uploads/000/000/120/original/Anvil_#{version}.zip"
+  url "https://s3.amazonaws.com/sparkler_versions/versions/uploads/000/000/120/original/Anvil_#{version}.zip"
   name 'Anvil'
   appcast 'https://sparkler.herokuapp.com/apps/3/updates.xml',
           :sha256 => 'dcceaecafb1a41694b3d63a033481cab9babd85f451121fd60947621a91a3beb'

--- a/Casks/appcleaner.rb
+++ b/Casks/appcleaner.rb
@@ -2,11 +2,11 @@ cask 'appcleaner' do
   version '3.2.1'
   sha256 '96ba58688df66dd605b9e109d3c75726eab143193a25c2c2c9e3ddcb5135ad09'
 
-  url "http://www.freemacsoft.net/downloads/AppCleaner_#{version}.zip"
+  url "https://www.freemacsoft.net/downloads/AppCleaner_#{version}.zip"
   name 'AppCleaner'
-  appcast 'http://www.freemacsoft.net/appcleaner/Updates.xml',
+  appcast 'https://www.freemacsoft.net/appcleaner/Updates.xml',
           :sha256 => 'bd9df047d51943acc4bc6cf55d88edb5b6785a53337ee2a0f74dd521aedde87d'
-  homepage 'http://www.freemacsoft.net/appcleaner/'
+  homepage 'https://www.freemacsoft.net/appcleaner/'
   license :gratis
 
   app 'AppCleaner.app'

--- a/Casks/audiomate.rb
+++ b/Casks/audiomate.rb
@@ -4,10 +4,10 @@ cask 'audiomate' do
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/downloads.9labs.io/audiomate/#{version.sub(%r{_.*},'')}/#{version.sub(%r{.*_},'')}/AudioMate-v#{version.sub(%r{_.*},'')}.dmg"
-  appcast 'http://backend.9labs.io/appcast/audiomate',
+  appcast 'https://backend.9labs.io/appcast/audiomate',
           :sha256 => '9e431475ead844f83a2d9dbd7d5e975404a0a6fa9a5c80a769d08bf740654516'
   name 'AudioMate'
-  homepage 'http://audiomateapp.com/'
+  homepage 'https://audiomateapp.com/'
   license :mit
 
   app 'AudioMate.app'

--- a/Casks/baiducloud.rb
+++ b/Casks/baiducloud.rb
@@ -6,7 +6,7 @@ cask 'baiducloud' do
   name '百度云同步盘'
   name 'Baidu Yun Tong Bu Pan'
   name 'Baigu Cloud'
-  homepage 'http://pan.baidu.com'
+  homepage 'https://pan.baidu.com'
   license :gratis
 
   app '百度云同步盘.app'

--- a/Casks/baiduhi.rb
+++ b/Casks/baiduhi.rb
@@ -2,10 +2,10 @@ cask 'baiduhi' do
   version '1.6.0.0'
   sha256 '15de7fee8818b6ae9565a15e97fc0c3938041a129bc9cec1a359ddc8dc82590f'
 
-  url "http://bs.baidu.com/app-res/mac/machi_#{version}.dmg"
+  url "https://bs.baidu.com/app-res/mac/machi_#{version}.dmg"
   name '百度 Hi'
   name 'Baidu Hi'
-  homepage 'http://im.baidu.com/'
+  homepage 'https://im.baidu.com/'
   license :gratis
 
   app '百度Hi.app'

--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -2,12 +2,12 @@ cask 'bartender' do
   version '2.0.7'
   sha256 'e96ee3ab2fe6bca413a16899cd1388e69a58ac00ab87e597138163d0632a1689'
 
-  url "http://macbartender.com/B2/updates/#{version.gsub('.', '-')}/Bartender%20#{version.to_i}.zip",
+  url "https://macbartender.com/B2/updates/#{version.gsub('.', '-')}/Bartender%20#{version.to_i}.zip",
       :referer => 'http://www.macbartender.com'
-  appcast 'http://www.macbartender.com/B2/updates/updates.php',
+  appcast 'https://www.macbartender.com/B2/updates/updates.php',
           :sha256 => 'c5d7d68b33e5c378262b384031ceb19400ed4b7878c1f04029e516c42a90f9a7'
   name 'Bartender'
-  homepage 'http://www.macbartender.com/'
+  homepage 'https://www.macbartender.com/'
   license :commercial
 
   app "Bartender #{version.to_i}.app"

--- a/Casks/battery-guardian.rb
+++ b/Casks/battery-guardian.rb
@@ -3,7 +3,7 @@ cask 'battery-guardian' do
   sha256 :no_check
 
   url 'https://www.dssw.co.uk/batteryguardian/dsswbatteryguardian.dmg'
-  appcast 'http://version.dssw.co.uk/batteryguardian/standard',
+  appcast 'https://version.dssw.co.uk/batteryguardian/standard',
           :sha256 => '6e86f2691ab9d2c1486b54e60b9528fb4f85c689e86a150300233d8485ce3306'
   name 'Battery Guardian'
   homepage 'https://www.dssw.co.uk/batteryguardian'

--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -4,7 +4,7 @@ cask 'battery-report' do
 
   url 'https://www.dssw.co.uk/batteryreport/dsswbatteryreport.dmg'
   name 'Battery Report'
-  appcast 'http://version.dssw.co.uk/batteryreport/standard',
+  appcast 'https://version.dssw.co.uk/batteryreport/standard',
           :sha256 => 'a8dc71fa600b5ab05dded9de519da81aa3853ee0d8d0b2753177d4041443b420'
   homepage 'https://www.dssw.co.uk/batteryreport'
   license :commercial

--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -3,7 +3,7 @@ cask 'bbc-iplayer-downloads' do
   sha256 'a895f1473d9f0d8e9f185bb2a98c0cd56ccf0c4c9b05b8fe3ae705bcf88fcf40'
 
   # bbci.co.uk is the official download host per the vendor homepage
-  url "http://a.files.bbci.co.uk/iplayer/downloads/BBC-iPlayer-Downloads-#{version}.dmg"
+  url "https://a.files.bbci.co.uk/iplayer/downloads/BBC-iPlayer-Downloads-#{version}.dmg"
   name 'BBC iPlayer Downloads'
   appcast 'http://ipd-hq.cloud.bbc.co.uk/downloads/update.xml',
           :sha256 => '58f93571ce9fbcbf08fc7f6b14e587cbdacd985c844cf3767876af0a8bce1de2'

--- a/Casks/beaker.rb
+++ b/Casks/beaker.rb
@@ -3,7 +3,7 @@ cask 'beaker' do
   sha256 '76cbdb1ccafdf5ad10179fa2493e91ab6de16916b366a6c9592a5792ab50bdde'
 
   # cloudfront.net is the official download host per the vendor homepage
-  url "http://d299yghl10frh5.cloudfront.net/beaker-notebook-#{version}-mac.dmg"
+  url "https://d299yghl10frh5.cloudfront.net/beaker-notebook-#{version}-mac.dmg"
   name 'Beaker'
   homepage 'http://beakernotebook.com/'
   license :apache

--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -3,7 +3,7 @@ cask 'bee' do
   sha256 '18b43b184c3d600be528e08d381c42a67cae1bf9d3e090d21a13f1e1be9b70a8'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://bee-app.s3.amazonaws.com/public/Bee-#{version}.zip"
+  url "https://bee-app.s3.amazonaws.com/public/Bee-#{version}.zip"
   appcast 'http://neat.io/appcasts/bee-appcast.xml',
           :sha256 => '6914fc3ec81e1cb0eb39ccca2a4e0d8b9a3b213e926b8d3ef5a5a11100347833'
   name 'Bee'

--- a/Casks/bestres.rb
+++ b/Casks/bestres.rb
@@ -3,7 +3,7 @@ cask 'bestres' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.icyberon.BestRes/BestRes.zip'
+  url 'https://dl.devmate.com/com.icyberon.BestRes/BestRes.zip'
   name 'BestRes'
   homepage 'http://icyberon.com/bestres/'
   license :gratis

--- a/Casks/better-window-manager.rb
+++ b/Casks/better-window-manager.rb
@@ -2,7 +2,7 @@ cask 'better-window-manager' do
   version '1.13.14'
   sha256 '2d3e802c4317c0d9995cd42378d1a317fb9049086c7aafe9fece66970b81b6b1'
 
-  url "http://gngrwzrd.com/BetterWindowManager-#{version}.zip"
+  url "https://gngrwzrd.com/BetterWindowManager-#{version}.zip"
   name 'Better Window Manager'
   appcast 'https://www.gngrwzrd.com/betterwindowmanager-appcast.xml',
           :sha256 => 'db3d611bb08871b390bd7d609db9e2d62ef23c22fd9906dfa1368138196aceec'

--- a/Casks/bittorrent.rb
+++ b/Casks/bittorrent.rb
@@ -2,9 +2,9 @@ cask 'bittorrent' do
   version :latest
   sha256 :no_check
 
-  url 'http://download-new.utorrent.com/os/osx/track/stable/endpoint/btmac'
+  url 'https://download-new.utorrent.com/os/osx/track/stable/endpoint/btmac'
   name 'BitTorrent'
-  homepage 'http://www.bittorrent.com'
+  homepage 'https://www.bittorrent.com'
   license :gratis
 
   installer :manual => 'Bittorrent.app'

--- a/Casks/boinc.rb
+++ b/Casks/boinc.rb
@@ -2,7 +2,7 @@ cask 'boinc' do
   version '7.6.12'
   sha256 '194c91040807d995a5f54574c207d12b8970008319e146abb8fcfa13f75e39c6'
 
-  url "http://boinc.berkeley.edu/dl/boinc_#{version}_macOSX_x86_64.zip"
+  url "https://boinc.berkeley.edu/dl/boinc_#{version}_macOSX_x86_64.zip"
   name 'BOINC'
   name 'Berkeley Open Infrastructure for Network Computing'
   homepage 'https://boinc.berkeley.edu/'

--- a/Casks/bootchamp.rb
+++ b/Casks/bootchamp.rb
@@ -2,11 +2,11 @@ cask 'bootchamp' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.kainjow.com/downloads/BootChamp.zip'
+  url 'https://www.kainjow.com/downloads/BootChamp.zip'
   name 'BootChamp'
-  appcast 'http://kainjow.com/updates/bootchamp.xml',
+  appcast 'https://kainjow.com/updates/bootchamp.xml',
           :sha256 => 'b117cae73e7f24153c05549dab19cbd82013a410b5db89dbc6f9e36d5fd67f4f'
-  homepage 'http://www.kainjow.com/'
+  homepage 'https://www.kainjow.com/'
   license :oss
 
   app 'BootChamp.app'

--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -4,7 +4,7 @@ cask 'borgbackup' do
 
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   name 'BorgBackup'
-  homepage 'http://borgbackup.readthedocs.org/en/stable/'
+  homepage 'https://borgbackup.readthedocs.org/en/stable/'
   license :bsd
   gpg "#{url}.asc",
       :key_id => '243ACFA951F78E01'

--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -2,7 +2,7 @@ cask 'bose-soundtouch' do
   version '9.0.41.11243'
   sha256 '3eb78048bc8aa46b9d2613ff28d760fa7e47133384aca74f44aab4bc10c95f8a'
 
-  url "http://worldwide.bose.com/downloads/assets/updates/soundtouch_app-m/SoundTouch-#{version}-osx-10.9-installer.app.dmg"
+  url "https://worldwide.bose.com/downloads/assets/updates/soundtouch_app-m/SoundTouch-#{version}-osx-10.9-installer.app.dmg"
   name 'Bose Soundtouch Controller App'
   homepage 'https://www.soundtouch.com'
   license :closed

--- a/Casks/budget.rb
+++ b/Casks/budget.rb
@@ -2,9 +2,9 @@ cask 'budget' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.snowmintcs.com/downloads/budget.dmg'
+  url 'https://www.snowmintcs.com/downloads/budget.dmg'
   name 'Budget'
-  homepage 'http://www.snowmintcs.com/products/budgetmac/'
+  homepage 'https://www.snowmintcs.com/products/budgetmac/'
   license :commercial
 
   app 'Budget.app'

--- a/Casks/bwana.rb
+++ b/Casks/bwana.rb
@@ -4,7 +4,7 @@ cask 'bwana' do
 
   url 'https://www.bruji.com/bwana/bwana.dmg'
   name 'Bwana'
-  homepage 'http://www.bruji.com/bwana/'
+  homepage 'https://www.bruji.com/bwana/'
   license :mit
 
   app 'Bwana.app'

--- a/Casks/c3.rb
+++ b/Casks/c3.rb
@@ -6,7 +6,7 @@ cask 'c3' do
   # cloudfront.net is the official download host per the vendor homepage
   url "https://d2xj26462na9l3.cloudfront.net/c3/C3-#{version}.dmg"
   name 'C3'
-  homepage 'http://www.downloadc3.com/'
+  homepage 'https://www.downloadc3.com/'
   license :gratis
 
   app 'c3.app'

--- a/Casks/camranger.rb
+++ b/Casks/camranger.rb
@@ -4,7 +4,7 @@ cask 'camranger' do
 
   url "http://www.camranger.com/downloadFiles/CamRanger_#{version.gsub('.', '_')}.dmg"
   name 'CamRanger'
-  homepage 'http://camranger.com/mac-downloads'
+  homepage 'https://camranger.com/mac-downloads'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'CamRanger.app'

--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -2,7 +2,7 @@ cask 'canon-imagerunner-printer-driver-ufrii' do
   version '10.08.01'
   sha256 '4255b1236bbf6b30b6b78db277fd2425d051ee58fd13a954068f5790ab7e2a28'
 
-  url "http://downloads.canon.com/bisg2015/drivers/mac/UFRII_v#{version}_MAC.zip"
+  url "https://downloads.canon.com/bisg2015/drivers/mac/UFRII_v#{version}_MAC.zip"
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/cusa/sna/office/color_imagerunner_advance/imagerunner_advance_c5030/imagerunner_advance_c5030#DriversAndSoftware'
   license :gratis

--- a/Casks/carlson-minot.rb
+++ b/Casks/carlson-minot.rb
@@ -4,7 +4,7 @@ cask 'carlson-minot' do
 
   url "https://www.carlson-minot.com/downloads/arm-#{version}-arm-none-linux-gnueabi.osx.intelx86.bin.pkg"
   name 'Carlson-Minot Toolchain'
-  homepage 'http://www.carlson-minot.com'
+  homepage 'https://www.carlson-minot.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg "arm-#{version}-arm-none-linux-gnueabi.osx.intelx86.bin.pkg"

--- a/Casks/cathode.rb
+++ b/Casks/cathode.rb
@@ -3,7 +3,7 @@ cask 'cathode' do
   sha256 'dd176890c8e8d6d37334440b13402d04b5344d009804f8624985cef3c081ac8b'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://s3.amazonaws.com/cjcaufield/products/cathode/cathode_#{version.gsub('.','')}.zip"
+  url "https://s3.amazonaws.com/cjcaufield/products/cathode/cathode_#{version.gsub('.','')}.zip"
   appcast 'http://store.secretgeometry.com/appcast.php?id=7',
           :sha256 => '4c319653dc0883e0534eae3b2e51ecf92e6ff7f91d9329e1c2e8c39139cb1eee'
   name 'Cathode'

--- a/Casks/ccleaner.rb
+++ b/Casks/ccleaner.rb
@@ -2,7 +2,7 @@ cask 'ccleaner' do
   version '1.11.336'
   sha256 '811a758772125bf6be99c655098f15422f4f7834575fb687c744547cf9ebed74'
 
-  url "http://download.piriform.com/mac/CCMacSetup#{version.sub(%r{^(\d+)\.(\d+).*},'\1\2')}.dmg"
+  url "https://download.piriform.com/mac/CCMacSetup#{version.sub(%r{^(\d+)\.(\d+).*},'\1\2')}.dmg"
   name 'Piriform CCleaner'
   homepage 'https://www.piriform.com/ccleaner'
   license :freemium

--- a/Casks/cdock.rb
+++ b/Casks/cdock.rb
@@ -7,7 +7,7 @@ cask 'cdock' do
           :sha256 => '962f344212a4dfdfb421854d1151dbab96336c87fda9f9105748b4d1a5770392'
   name 'cDock2'
   name 'cDock'
-  homepage 'http://w0lfschild.github.io/cdock'
+  homepage 'https://w0lfschild.github.io/cdock'
   license :bsd
 
   app 'cDock.app'

--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -2,9 +2,9 @@ cask 'charles' do
   version '3.11.2'
   sha256 'db0a7d9c318ed239bc3d32a96f73ebba80e75cd31954179be42019222ae6557d'
 
-  url "http://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
+  url "https://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
   name 'Charles'
-  homepage 'http://www.charlesproxy.com/'
+  homepage 'https://www.charlesproxy.com/'
   license :commercial
 
   app 'Charles.app'

--- a/Casks/chat.rb
+++ b/Casks/chat.rb
@@ -3,7 +3,7 @@ cask 'chat' do
   sha256 '430028e75c0a01ae2f8cad9b3b2bb64ae30893c5fc4ce524b5c5dd3a9413c123'
 
   # devmate.com is the official download host per the appcast feed
-  url "http://dl.devmate.com/com.perma.chat/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/Chat-#{version.sub(%r{-.*$},'')}.zip"
+  url "https://dl.devmate.com/com.perma.chat/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/Chat-#{version.sub(%r{-.*$},'')}.zip"
   appcast 'http://updateinfo.devmate.com/com.perma.chat/updates.xml',
           :sha256 => '8009a30326218077e451fc3e3096eb37c7eaa1c667d32f5beccdece99c6c8a4b'
   name 'Chat'

--- a/Casks/cheatsheet.rb
+++ b/Casks/cheatsheet.rb
@@ -2,11 +2,11 @@ cask 'cheatsheet' do
   version '1.2.2'
   sha256 '41cfec767f761e2400d5ad700c936339c8c2e80a9dfbaf44b66375e63192763c'
 
-  url "http://mediaatelier.com/CheatSheet/CheatSheet_#{version}.zip"
-  appcast 'http://mediaatelier.com/CheatSheet/feed.php',
+  url "https://mediaatelier.com/CheatSheet/CheatSheet_#{version}.zip"
+  appcast 'https://mediaatelier.com/CheatSheet/feed.php',
           :sha256 => 'f6349cacc2bc850b37ad4d8a0a9b4e59f1491793ac0bb6b85081a550ca40455f'
   name 'CheatSheet'
-  homepage 'http://www.cheatsheetapp.com/CheatSheet/'
+  homepage 'https://www.cheatsheetapp.com/CheatSheet/'
   license :gratis
 
   app 'CheatSheet.app'

--- a/Casks/chemdoodle.rb
+++ b/Casks/chemdoodle.rb
@@ -2,9 +2,9 @@ cask 'chemdoodle' do
   version '6.0.1'
   sha256 '004c4d828230f4640678ba31ef07bf878e00ef3f225144fa088a81c4279c1776'
 
-  url "http://www.chemdoodle.com/downloads/ChemDoodle-osx-#{version}.dmg"
+  url "https://www.chemdoodle.com/downloads/ChemDoodle-osx-#{version}.dmg"
   name 'ChemDoodle'
-  homepage 'http://www.chemdoodle.com'
+  homepage 'https://www.chemdoodle.com'
   license :commercial
 
   suite 'ChemDoodle'

--- a/Casks/chronoagent.rb
+++ b/Casks/chronoagent.rb
@@ -4,7 +4,7 @@ cask 'chronoagent' do
 
   url 'http://downloads.econtechnologies.com/CA_Mac_Download.dmg'
   name 'ChronoAgent'
-  homepage 'http://www.econtechnologies.com'
+  homepage 'https://www.econtechnologies.com'
   license :commercial
 
   pkg 'Install.pkg'

--- a/Casks/chronosync.rb
+++ b/Casks/chronosync.rb
@@ -4,7 +4,7 @@ cask 'chronosync' do
 
   url 'http://downloads.econtechnologies.com/CS4_Download.dmg'
   name 'ChronoSync'
-  homepage 'http://www.econtechnologies.com'
+  homepage 'https://www.econtechnologies.com'
   license :commercial
 
   pkg 'Install.pkg'

--- a/Casks/cisco-spark.rb
+++ b/Casks/cisco-spark.rb
@@ -4,7 +4,7 @@ cask 'cisco-spark' do
 
   url 'https://download.ciscospark.com/mac/Spark.dmg'
   name 'Cisco Systems Spark'
-  homepage 'http://www.webex.com/projectsquared/'
+  homepage 'https://www.webex.com/projectsquared/'
   license :gratis
 
   depends_on :macos => '>= :mavericks'

--- a/Casks/cleanapp.rb
+++ b/Casks/cleanapp.rb
@@ -10,7 +10,7 @@ cask 'cleanapp' do
     sha256 '7d306172c00ccc7f11281cb855d845a67e52457bc9b673a4a1690c8c2f1b343b'
   end
 
-  url "http://download.syniumsoftware.com/CleanApp/CleanApp%20#{version}.dmg"
+  url "https://download.syniumsoftware.com/CleanApp/CleanApp%20#{version}.dmg"
   name 'Synium Software CleanApp'
   homepage 'http://www.syniumsoftware.com/cleanapp'
   license :commercial

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -4,7 +4,7 @@ cask 'cleanmymac' do
     sha256 'ac5d4bf36882dd34bdb0a68eb384a6b3aba355be896d03dfa40a120c6bef4a0d'
 
     # devmate.com is the official download host per the appcast feed
-    url "http://dl.devmate.com/com.macpaw.CleanMyMac/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/CleanMyMacClassic-#{version.sub(%r{-.*$},'')}.zip"
+    url "https://dl.devmate.com/com.macpaw.CleanMyMac/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/CleanMyMacClassic-#{version.sub(%r{-.*$},'')}.zip"
     appcast 'http://updates.devmate.com/com.macpaw.CleanMyMac.xml',
             :sha256 => '13bbf950696a9410fec848e80652f2826209b347fdb329b117371e25445951f5'
     app 'CleanMyMac.app'
@@ -13,7 +13,7 @@ cask 'cleanmymac' do
     version '2.3.5-1427986644'
     sha256 '16e192edcf58f25c6763349ef0e5194268bec4d000912b64b34f5897b4784097'
     # devmate.com is the official download host per the appcast feed
-    url "http://dl.devmate.com/com.macpaw.CleanMyMac2/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/CleanMyMac#{version.to_i}-#{version.sub(%r{-.*$},'')}.zip"
+    url "https://dl.devmate.com/com.macpaw.CleanMyMac2/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/CleanMyMac#{version.to_i}-#{version.sub(%r{-.*$},'')}.zip"
     appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.to_i}.xml"
     app "CleanMyMac #{version.to_i}.app"
 
@@ -36,7 +36,7 @@ cask 'cleanmymac' do
     sha256 'a5e7587d7edcece90c0d5b0b6aed8d008b6a1a93cb6911f0cf2e9e0c0453e6c4'
 
     # devmate.com is the official download host per the appcast feed
-    url "http://dl.devmate.com/com.macpaw.CleanMyMac#{version.to_i}/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/CleanMyMac3-#{version.sub(%r{-.*$},'')}.zip"
+    url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.to_i}/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{.*?-},'')}/CleanMyMac3-#{version.sub(%r{-.*$},'')}.zip"
     app "CleanMyMac #{version.to_i}.app"
 
     postflight do

--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -2,9 +2,9 @@ cask 'cmake' do
   version '3.4.1'
   sha256 '3c6d84b32d3e787a7161244db310f36441c015f6f39345887d65cacbcfb9107d'
 
-  url "http://www.cmake.org/files/v#{version.sub(%r{\.\d+$},'')}/cmake-#{version}-Darwin-x86_64.dmg"
+  url "https://www.cmake.org/files/v#{version.sub(%r{\.\d+$},'')}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'
-  homepage 'http://cmake.org'
+  homepage 'https://cmake.org'
   license :bsd
 
   app 'CMake.app'

--- a/Casks/colorpicker-skalacolor.rb
+++ b/Casks/colorpicker-skalacolor.rb
@@ -3,9 +3,9 @@ cask 'colorpicker-skalacolor' do
   sha256 '18205f0e827116de72822064f7b10f624bb6696f90bd067e4ba90a18acba34a2'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://s3.amazonaws.com/bjango/files/skalacolor/skalacolor#{version}.zip"
+  url "https://s3.amazonaws.com/bjango/files/skalacolor/skalacolor#{version}.zip"
   name 'Skala Color'
-  homepage 'http://bjango.com/mac/skalacolor/'
+  homepage 'https://bjango.com/mac/skalacolor/'
   license :gratis
 
   colorpicker 'Skala Color Installer.app/Contents/Resources/SkalaColor.colorPicker'

--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -4,7 +4,7 @@ cask 'colour-contrast-analyser' do
 
   url "http://files.paciellogroup.com/resources/CCA_#{version}.dmg"
   name 'Colour Contrast Analyser'
-  homepage 'http://www.paciellogroup.com/resources/contrastanalyser/'
+  homepage 'https://www.paciellogroup.com/resources/contrastanalyser/'
   license :gpl
 
   app 'Colour Contrast Analyser.app'

--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -19,7 +19,7 @@ cask 'coteditor' do
   appcast 'https://github.com/coteditor/CotEditor/releases.atom',
           :sha256 => 'dac6ecbea56d959f6f6b7239abf6f415709898c7b502ad37aebb8747c8f489af'
   name 'CotEditor'
-  homepage 'http://coteditor.com/'
+  homepage 'https://coteditor.com/'
   license :gpl
 
   app 'CotEditor.app'

--- a/Casks/crashcrier.rb
+++ b/Casks/crashcrier.rb
@@ -2,9 +2,9 @@ cask 'crashcrier' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.kainjow.com/downloads/CrashCrier.zip'
+  url 'https://www.kainjow.com/downloads/CrashCrier.zip'
   name 'CrashCrier'
-  homepage 'http://www.kainjow.com/'
+  homepage 'https://www.kainjow.com/'
   license :mit
 
   app 'CrashCrier.app'

--- a/Casks/crashlytics.rb
+++ b/Casks/crashlytics.rb
@@ -7,7 +7,7 @@ cask 'crashlytics' do
   appcast 'https://ssl-download-crashlytics-com.s3.amazonaws.com/mac/version.xml',
           :sha256 => '39e2fdc58426b1771c42d26218de331494fdbabb91ad4df77cbb14357cf1a423'
   name 'Crashlytics'
-  homepage 'http://crashlytics.com'
+  homepage 'https://crashlytics.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Crashlytics.app'

--- a/Casks/cumulus.rb
+++ b/Casks/cumulus.rb
@@ -6,7 +6,7 @@ cask 'cumulus' do
   appcast 'https://github.com/gillesdemey/Cumulus/releases.atom',
           :sha256 => '97c90bfc6b090a781a3096907cf90ab0fa2b5c8b5eb1146a6207272840671e27'
   name 'Cumulus'
-  homepage 'http://gillesdemey.github.io/Cumulus/'
+  homepage 'https://gillesdemey.github.io/Cumulus/'
   license :oss
 
   app 'Cumulus.app'

--- a/Casks/cura.rb
+++ b/Casks/cura.rb
@@ -2,7 +2,7 @@ cask 'cura' do
   version '15.04.2'
   sha256 '48157d41c03d1a8d19edb4c2a7e2356f57d0a6d6a64a50c087962d64b1841a6b'
 
-  url "http://software.ultimaker.com/current/Cura-#{version}-MacOS.dmg"
+  url "https://software.ultimaker.com/current/Cura-#{version}-MacOS.dmg"
   name 'Cura'
   homepage 'https://ultimaker.com/en/products/software'
   license :oss

--- a/Casks/curb.rb
+++ b/Casks/curb.rb
@@ -2,11 +2,11 @@ cask 'curb' do
   version '1.1.1'
   sha256 '832750d2a75272763c5c2f681b11670584626c9d93bf993d6b3af96234558f68'
 
-  url "http://mrrsoftware.com/Downloads/Curb/Curb-#{version.gsub('.','_')}.zip"
-  appcast 'http://www.mrrsoftware.com/Downloads/Curb/CurbSoftwareUpdates.xml',
+  url "https://mrrsoftware.com/Downloads/Curb/Curb-#{version.gsub('.','_')}.zip"
+  appcast 'https://www.mrrsoftware.com/Downloads/Curb/CurbSoftwareUpdates.xml',
           :sha256 => '2025c4fc40a80f7ca7fb4076deb357a133990ef0e9576ceb5a5dca5f03a7c500'
   name 'Curb'
-  homepage 'http://mrrsoftware.com/curb'
+  homepage 'https://mrrsoftware.com/curb'
   license :gratis
 
   app 'Curb.app'

--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -3,17 +3,17 @@ cask 'daisydisk' do
   if MacOS.release == :snow_leopard
     version '2.1.2'
     sha256 'd0a606dee19e524d6fa7b79fd48b3b9865123ca4126fb8805f8e96c317b57b31'
-    url "http://www.daisydiskapp.com/downloads/DaisyDisk_#{version}.dmg"
+    url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version}.dmg"
   else
     version :latest
     sha256 :no_check
-    url 'http://www.daisydiskapp.com/downloads/DaisyDisk.zip'
+    url 'https://www.daisydiskapp.com/downloads/DaisyDisk.zip'
   end
 
-  appcast 'http://www.daisydiskapp.com/downloads/appcastFeed.php',
+  appcast 'https://www.daisydiskapp.com/downloads/appcastFeed.php',
           :sha256 => '622ac0e225a09a7a40476f014aa9ea53adc483546d73e942729d86b2c9cc0907'
   name 'DaisyDisk'
-  homepage 'http://www.daisydiskapp.com'
+  homepage 'https://www.daisydiskapp.com'
   license :freemium
 
   app 'DaisyDisk.app'

--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -7,7 +7,7 @@ cask 'darktable' do
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
           :sha256 => 'db63bd878b86eeabbf524a936fb843661b9778d2a3f17b022a7a83de7cc3b076'
   name 'darktable'
-  homepage 'http://www.darktable.org/'
+  homepage 'https://www.darktable.org/'
   license :gpl
 
   app 'darktable.app'

--- a/Casks/debookee.rb
+++ b/Casks/debookee.rb
@@ -2,11 +2,11 @@ cask 'debookee' do
   version '4.2.2'
   sha256 '483c2cfa4162fbc23411c33101c99c774d7f5594075270979fded40ce884b8c2'
 
-  url 'http://www.iwaxx.com/debookee/debookee.zip'
-  appcast 'http://www.iwaxx.com/debookee/appcast.php',
+  url 'https://www.iwaxx.com/debookee/debookee.zip'
+  appcast 'https://www.iwaxx.com/debookee/appcast.php',
           :sha256 => '42d6b8de182952c1b32fbc12614a3690d125688c97f47618b26cc7aa192b761b'
   name 'Debookee'
-  homepage 'http://www.iwaxx.com/debookee/'
+  homepage 'https://www.iwaxx.com/debookee/'
   license :commercial
 
   app "Debookee #{version}/Debookee.app"

--- a/Casks/deep-dreamer.rb
+++ b/Casks/deep-dreamer.rb
@@ -2,7 +2,7 @@ cask 'deep-dreamer' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.devmate.com/com.realmacsoftware.deepdreamer/DeepDreamer.zip'
+  url 'https://dl.devmate.com/com.realmacsoftware.deepdreamer/DeepDreamer.zip'
   name 'Deep Dreamer'
   homepage 'http://realmacsoftware.com/deepdreamer'
   license :commercial

--- a/Casks/delayedlauncher.rb
+++ b/Casks/delayedlauncher.rb
@@ -2,7 +2,7 @@ cask 'delayedlauncher' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.taoeffect.com/delayedlauncher/DelayedLauncher.zip'
+  url 'https://www.taoeffect.com/delayedlauncher/DelayedLauncher.zip'
   appcast 'https://www.taoeffect.com/delayedlauncher/appcast.xml',
           :sha256 => '7890874b09454101e7af04a798fea7a6daea3c18f820b628ce51c12c9d4b2f00'
   name 'DelayedLauncher'

--- a/Casks/devcenter.rb
+++ b/Casks/devcenter.rb
@@ -4,7 +4,7 @@ cask 'devcenter' do
 
   url "https://downloads.datastax.com/devcenter/DevCenter-#{version}-macosx-x86_64.tar.gz"
   name 'DataStax DevCenter'
-  homepage 'http://www.datastax.com/what-we-offer/products-services/devcenter'
+  homepage 'https://www.datastax.com/what-we-offer/products-services/devcenter'
   license :gratis
 
   app 'devcenter/DevCenter.app'

--- a/Casks/dfontsplitter.rb
+++ b/Casks/dfontsplitter.rb
@@ -2,11 +2,11 @@ cask 'dfontsplitter' do
   version '0.4.1'
   sha256 'd9345ffe0e9be0c096e65114be21fc3aac676a9a3a53e84f1d6cebff0b7796b3'
 
-  url "http://peter.upfold.org.uk/files/dfontsplitter/dfontsplitter-#{version}-mac.zip"
-  appcast 'http://apps.upfold.org.uk/appupdate/dfontsplitter.xml',
+  url "https://peter.upfold.org.uk/files/dfontsplitter/dfontsplitter-#{version}-mac.zip"
+  appcast 'https://apps.upfold.org.uk/appupdate/dfontsplitter.xml',
           :sha256 => 'b7a3ed81f5e160a4888afdb5810d97f5b2ed828ecec4569dc1d1a6bd825bcc59'
   name 'DfontSplitter'
-  homepage 'http://peter.upfold.org.uk/projects/dfontsplitter'
+  homepage 'https://peter.upfold.org.uk/projects/dfontsplitter'
   license :gpl
 
   app 'DfontSplitter.app'

--- a/Casks/dispcalgui.rb
+++ b/Casks/dispcalgui.rb
@@ -4,7 +4,7 @@ cask 'dispcalgui' do
 
   url 'http://dispcalgui.hoech.net/download/dispcalGUI.dmg'
   name 'dispcalGUI'
-  homepage 'http://dispcalgui.hoech.net'
+  homepage 'https://dispcalgui.hoech.net'
   license :gpl
 
   app 'dispcalGUI.app'

--- a/Casks/displaperture.rb
+++ b/Casks/displaperture.rb
@@ -4,7 +4,7 @@ cask 'displaperture' do
 
   url 'http://manytricks.com/download/displaperture'
   name 'Displaperture'
-  homepage 'http://manytricks.com/displaperture'
+  homepage 'https://manytricks.com/displaperture'
   license :gratis
 
   app 'Displaperture.app'

--- a/Casks/dmd.rb
+++ b/Casks/dmd.rb
@@ -4,7 +4,7 @@ cask 'dmd' do
 
   url "http://downloads.dlang.org/releases/2.x/#{version}/dmd.#{version}.dmg"
   name 'DMD'
-  homepage 'http://dlang.org/'
+  homepage 'https://dlang.org/'
   license :oss
 
   pkg 'DMD2.pkg'

--- a/Casks/docear.rb
+++ b/Casks/docear.rb
@@ -4,7 +4,7 @@ cask 'docear' do
 
   url 'http://docear.org/download/docear.dmg'
   name 'Docear'
-  homepage 'http://docear.org'
+  homepage 'https://docear.org'
   license :gpl
 
   app 'Docear.app'

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -6,7 +6,7 @@ cask 'docker' do
   appcast 'https://github.com/docker/machine/releases.atom',
           :sha256 => '2840ae55fa5e849ab523eae9f9d6c2a2cd055d42503caa055cdb43120baee94c'
   name 'Docker Engine Client'
-  homepage 'http://docs.docker.com/engine/userguide/'
+  homepage 'https://docs.docker.com/engine/userguide/'
   license :apache
 
   container :type => :naked

--- a/Casks/dockmod.rb
+++ b/Casks/dockmod.rb
@@ -13,7 +13,7 @@ cask 'dockmod' do
 
   url "http://spyresoft.com/dockmod/download.php?version=#{version}"
   name 'DockMod'
-  homepage 'http://spyresoft.com/dockmod/'
+  homepage 'https://spyresoft.com/dockmod/'
   license :freemium
 
   app 'DockMod.app'

--- a/Casks/doxygen.rb
+++ b/Casks/doxygen.rb
@@ -4,7 +4,7 @@ cask 'doxygen' do
 
   url "ftp://ftp.stack.nl/pub/users/dimitri/Doxygen-#{version}.dmg"
   name 'Doxygen'
-  homepage 'http://www.stack.nl/~dimitri/doxygen/'
+  homepage 'https://www.stack.nl/~dimitri/doxygen/'
   license :gpl
 
   app 'Doxygen.app'

--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -3,7 +3,7 @@ cask 'duet' do
   sha256 'd3123f40c9d6d9989e8f9f9dd2ca3f3ccad79304ce739fcaa32d2334de4de4d2'
 
   # devmate.com is the official download host per the vendor homepage
-  url "http://dl.devmate.com/com.kairos.duet/#{version.sub(%r{_.*},'')}/#{version.sub(%r{.*_},'')}/duet-#{version.sub(%r{_.*},'')}.zip"
+  url "https://dl.devmate.com/com.kairos.duet/#{version.sub(%r{_.*},'')}/#{version.sub(%r{.*_},'')}/duet-#{version.sub(%r{_.*},'')}.zip"
   name 'Duet'
   appcast 'http://updates.duetdisplay.com/checkMacUpdates',
           :sha256 => 'df779f7d35f7327a12bec484865311b869e6d09ccc6b43e11599d1dd47d1bc9d'

--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -4,7 +4,7 @@ cask 'dungeon-crawl-stone-soup-console' do
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-console-macos.zip"
   name 'Dungeon Crawl Stone Soup'
-  homepage 'http://crawl.develz.org'
+  homepage 'https://crawl.develz.org'
   license :gpl
 
   app 'Dungeon Crawl Stone Soup - Console.app'

--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -4,7 +4,7 @@ cask 'dungeon-crawl-stone-soup-tiles' do
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macos.zip"
   name 'Dungeon Crawl Stone Soup'
-  homepage 'http://crawl.develz.org'
+  homepage 'https://crawl.develz.org'
   license :gpl
 
   app 'Dungeon Crawl Stone Soup - Tiles.app'

--- a/Casks/dupeguru-me.rb
+++ b/Casks/dupeguru-me.rb
@@ -2,11 +2,11 @@ cask 'dupeguru-me' do
   version '6.8.1'
   sha256 '65720a2cdd17242c30ce848133a6c53e018ea0088f1990fee8d45114c921a118'
 
-  url "http://download.hardcoded.net/dupeguru_me_osx_#{version.gsub('.', '_')}.dmg"
+  url "https://download.hardcoded.net/dupeguru_me_osx_#{version.gsub('.', '_')}.dmg"
   name 'dupeGuru Music Edition'
-  appcast 'http://www.hardcoded.net/updates/dupeguru_me.appcast',
+  appcast 'https://www.hardcoded.net/updates/dupeguru_me.appcast',
           :sha256 => '06048bd2a5358e315d2e53c7110d593d2e6d1565fb742e53f2c7ac3cb07a8cc3'
-  homepage 'http://www.hardcoded.net/dupeguru_me/'
+  homepage 'https://www.hardcoded.net/dupeguru_me/'
   license :bsd
 
   app 'dupeGuru ME.app'

--- a/Casks/dupeguru-pe.rb
+++ b/Casks/dupeguru-pe.rb
@@ -2,11 +2,11 @@ cask 'dupeguru-pe' do
   version '2.10.1'
   sha256 '5a0abebfe3932fe0df10bd301f37d884f987537f1d137fecd2263db82f0457a9'
 
-  url "http://download.hardcoded.net/dupeguru_pe_osx_#{version.gsub('.', '_')}.dmg"
+  url "https://download.hardcoded.net/dupeguru_pe_osx_#{version.gsub('.', '_')}.dmg"
   name 'dupeGuru Picture Edition'
-  appcast 'http://www.hardcoded.net/updates/dupeguru_pe.appcast',
+  appcast 'https://www.hardcoded.net/updates/dupeguru_pe.appcast',
           :sha256 => '0701e9b52a39df2198dae34a4bfef88ca84d75d4ce191dd88943437af921737a'
-  homepage 'http://www.hardcoded.net/dupeguru_pe/'
+  homepage 'https://www.hardcoded.net/dupeguru_pe/'
   license :bsd
 
   app 'dupeGuru PE.app'

--- a/Casks/dupeguru.rb
+++ b/Casks/dupeguru.rb
@@ -2,11 +2,11 @@ cask 'dupeguru' do
   version '3.9.1'
   sha256 '844a929ebb60f3a43a466d3ce3e5ac25b1a79c1a81ae63e19bd9356391589d56'
 
-  url "http://download.hardcoded.net/dupeguru_osx_#{version.gsub('.', '_')}.dmg"
+  url "https://download.hardcoded.net/dupeguru_osx_#{version.gsub('.', '_')}.dmg"
   name 'dupeGuru'
-  appcast 'http://www.hardcoded.net/updates/dupeguru.appcast',
+  appcast 'https://www.hardcoded.net/updates/dupeguru.appcast',
           :sha256 => '3abf01d99fb21c356cb439132cab9c734f6d514b4a19e7fcc1b4c408fcd08dbb'
-  homepage 'http://www.hardcoded.net/dupeguru/'
+  homepage 'https://www.hardcoded.net/dupeguru/'
   license :bsd
 
   app 'dupeGuru.app'

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -4,7 +4,7 @@ cask 'dymo-label' do
 
   url "http://download.dymo.com/dymo/Software/Mac/DLS#{version.to_i}Setup.#{version}.dmg"
   name 'Dymo Label'
-  homepage 'http://www.dymo.com/en-US/online-support'
+  homepage 'https://www.dymo.com/en-US/online-support'
   license :gratis
 
   pkg "DYMO Label v.#{version.to_i}.pkg"

--- a/Casks/dymo-stamps.rb
+++ b/Casks/dymo-stamps.rb
@@ -4,7 +4,7 @@ cask 'dymo-stamps' do
 
   url 'http://download.endicia.com/dymostamps/dymostamps.dmg'
   name 'Dymo Stamps'
-  homepage 'http://www.dymo.com/en-US/online-support'
+  homepage 'https://www.dymo.com/en-US/online-support'
   license :gratis
 
   app 'DYMO Stamps.app'

--- a/Casks/dyn-updater.rb
+++ b/Casks/dyn-updater.rb
@@ -11,7 +11,7 @@ cask 'dyn-updater' do
 
   name 'Dyn Updater'
   name 'Dyn Updater App'
-  homepage 'http://dyn.com/apps/updater/'
+  homepage 'https://dyn.com/apps/updater/'
   license :gratis
 
   app 'Dyn Updater.app'

--- a/Casks/dynamiclyrics.rb
+++ b/Casks/dynamiclyrics.rb
@@ -4,7 +4,7 @@ cask 'dynamiclyrics' do
 
   url "http://dl.martianz.cn/dynamiclyrics/DynamicLyricsBuild#{version.sub(%r{^.*\.},'')}.zip"
   name 'DynamicLyrics'
-  homepage 'http://martianz.cn/dynamiclyrics/'
+  homepage 'https://martianz.cn/dynamiclyrics/'
   license :oss
 
   app 'DynamicLyrics.app'

--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -5,7 +5,7 @@ cask 'eagle' do
   # cadsoft.de is the official download host per the vendor homepage
   url "http://web.cadsoft.de/ftp/eagle/program/#{version.sub(%r{\.\d+$},'')}/eagle-mac64-#{version}.zip"
   name 'CadSoft EAGLE'
-  homepage 'http://www.cadsoftusa.com/'
+  homepage 'https://www.cadsoftusa.com/'
   license :freemium
 
   pkg "eagle-mac64-#{version}.pkg"

--- a/Casks/easyfig.rb
+++ b/Casks/easyfig.rb
@@ -6,7 +6,7 @@ cask 'easyfig' do
   appcast 'https://github.com/mjsull/Easyfig/releases.atom',
           :sha256 => 'd05167d251fddaee8dd7a88aa792f8375495e6643bde0d03be2754b5300971d8'
   name 'EasyFig'
-  homepage 'http://mjsull.github.io/Easyfig/'
+  homepage 'https://mjsull.github.io/Easyfig/'
   license :gpl
 
   binary "Easyfig_#{version}_OSX/Easyfig", :target => 'easyfig'

--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -4,7 +4,7 @@ cask 'eclipse-installer' do
 
   url 'http://eclipse.org/downloads/download.php?file=/oomph/products/eclipse-inst-mac64.tar.gz&r=1'
   name 'Eclipse Installer'
-  homepage 'http://eclipse.org/'
+  homepage 'https://eclipse.org/'
   license :eclipse
 
   app 'Eclipse Installer.app'

--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -5,7 +5,7 @@ cask 'emby-server' do
   # github.com is the official download host per the vendor homepage
   url 'https://github.com/MediaBrowser/Emby.Releases/raw/master/Server/Emby.Server.Mac.pkg'
   name 'Emby Server'
-  homepage 'http://emby.media/'
+  homepage 'https://emby.media/'
   license :gpl
 
   pkg 'Emby.Server.Mac.pkg'

--- a/Casks/etrecheck.rb
+++ b/Casks/etrecheck.rb
@@ -2,9 +2,9 @@ cask 'etrecheck' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.etresoft.com/download/EtreCheck.zip'
+  url 'https://www.etresoft.com/download/EtreCheck.zip'
   name 'EtreCheck'
-  homepage 'http://www.etresoft.com/etrecheck'
+  homepage 'https://www.etresoft.com/etrecheck'
   license :gpl
 
   app 'EtreCheck.app'

--- a/Casks/evasi0n.rb
+++ b/Casks/evasi0n.rb
@@ -5,7 +5,7 @@ cask 'evasi0n' do
   # box.com is the official download host per the vendor homepage
   url 'https://evad3rs.box.com/shared/static/gu7bfneoh85aajgic0xp.dmg'
   name 'evasi0n7'
-  homepage 'http://evasi0n.com'
+  homepage 'https://evasi0n.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'evasi0n 7.app'

--- a/Casks/evom.rb
+++ b/Casks/evom.rb
@@ -2,7 +2,7 @@ cask 'evom' do
   version :latest
   sha256 :no_check
 
-  url 'http://files.thelittleappfactory.com/evom/Evom.zip'
+  url 'https://files.thelittleappfactory.com/evom/Evom.zip'
   appcast 'https://files.thelittleappfactory.com/evom/appcast.xml',
           :sha256 => 'ed7a09825022f8643d2ca67c0deccb727a45b95306b83bf5b3ea8df989195991'
   name 'Evom'

--- a/Casks/fakethunder.rb
+++ b/Casks/fakethunder.rb
@@ -7,7 +7,7 @@ cask 'fakethunder' do
   appcast 'http://martianlaboratory.com/fakethunder/update.xml',
           :sha256 => '71c38833d0f6e1fb929d6914e2cbaa3978a5155cde21353eae7a73d046b10731'
   name 'fakeThunder'
-  homepage 'http://martianz.cn/fakethunder/'
+  homepage 'https://martianz.cn/fakethunder/'
   license :gpl
 
   app 'fakeThunder.app'

--- a/Casks/farbox.rb
+++ b/Casks/farbox.rb
@@ -2,7 +2,7 @@ cask 'farbox' do
   version '0.5.3.6'
   sha256 '8884a7cc281467565dff6b698bc168288a04510d51c4f6e8717f0db784dafb2b'
 
-  url "http://www.farbox.com/download/farbox_editor?fb_file_hash=editor/farbox_#{version}.dmg"
+  url "https://www.farbox.com/download/farbox_editor?fb_file_hash=editor/farbox_#{version}.dmg"
   name 'farbox'
   homepage 'https://www.farbox.com/'
   license :gratis

--- a/Casks/fbreader.rb
+++ b/Casks/fbreader.rb
@@ -2,7 +2,7 @@ cask 'fbreader' do
   version '0.99.5-alpha'
   sha256 'c05e23d66942b49533e0eabc9d39e2062c9a11086369c31b417a1937ac5886f9'
 
-  url "http://fbreader.org/files/macos/FBReader%20#{version.gsub(/-/, '%20')}.dmg"
+  url "https://fbreader.org/files/macos/FBReader%20#{version.gsub(/-/, '%20')}.dmg"
   name 'FBReader'
   homepage 'https://fbreader.org/content/macos'
   license :gpl

--- a/Casks/feisty-dog-tag.rb
+++ b/Casks/feisty-dog-tag.rb
@@ -7,7 +7,7 @@ cask 'feisty-dog-tag' do
   name 'Tag'
   appcast 'https://www.feisty-dog.com/panel/updates/Tag',
           :sha256 => '9e3d6f54c3bca3928a340c96fece9866131d77b8723dc86cc898fab3264d5807'
-  homepage 'http://www.feisty-dog.com/tag/'
+  homepage 'https://www.feisty-dog.com/tag/'
   license :commercial
 
   app 'Tag.app'

--- a/Casks/fender-amp-drivers.rb
+++ b/Casks/fender-amp-drivers.rb
@@ -3,7 +3,7 @@ cask 'fender-amp-drivers' do
   sha256 'e68de1a1c1068d34dda354e2678ddac4a796b2ccdface95b034a438455442919'
 
   # fmicassets.com is the official download host per the vendor homepage
-  url "http://www.fmicassets.com/fender/support/software/fender_software/fender_fuse/mac/FenderFUSE_FULL_#{version}.dmg"
+  url "https://www.fmicassets.com/fender/support/software/fender_software/fender_fuse/mac/FenderFUSE_FULL_#{version}.dmg"
   name 'Fender FUSE'
   homepage 'https://fuse.fender.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -5,7 +5,7 @@ cask 'filebot' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/filebot/filebot/FileBot_#{version}/FileBot_#{version}-brew.tar.bz2"
   name 'FileBot'
-  homepage 'http://www.filebot.net/'
+  homepage 'https://www.filebot.net/'
   license :gpl
 
   app 'FileBot.app'

--- a/Casks/flip4mac.rb
+++ b/Casks/flip4mac.rb
@@ -2,9 +2,9 @@ cask 'flip4mac' do
   version '3.3.7'
   sha256 'daaa82dfceb46e879078aacdced1a724e821586d8f6a8573d5f9d650f0fa41be'
 
-  url "http://www.telestream.net/download-files/flip4mac/#{version.sub(%r{^(\d+)\.(\d+).*$},'\1-\2')}/Flip4Mac-#{version}.dmg"
+  url "https://www.telestream.net/download-files/flip4mac/#{version.sub(%r{^(\d+)\.(\d+).*$},'\1-\2')}/Flip4Mac-#{version}.dmg"
   name 'Flip4Mac'
-  homepage 'http://www.telestream.net/flip4mac/'
+  homepage 'https://www.telestream.net/flip4mac/'
   license :commercial
 
   depends_on :macos => '>= :snow_leopard'

--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -4,7 +4,7 @@ cask 'folding-at-home' do
 
   url "https://fah.stanford.edu/file-releases/public/release/fah-installer/osx-10.6.4-64bit/v#{version.sub(/\.\d+$/, '')}/fah-installer_#{version}_x86_64.mpkg.zip"
   name 'Folding@home'
-  homepage 'http://folding.stanford.edu'
+  homepage 'https://folding.stanford.edu'
   license :closed
 
   pkg "fah-installer_#{version}_x86_64.pkg"

--- a/Casks/foldingtext.rb
+++ b/Casks/foldingtext.rb
@@ -3,7 +3,7 @@ cask 'foldingtext' do
   sha256 '007e882d1d09273accf84d95ed15e89db056da9bebf81258098d3efb38ce6df2'
 
   # amazonaws.com is the official download host per the appcast feed
-  url "http://foldingtext.s3.amazonaws.com/FoldingText-#{version}.dmg"
+  url "https://foldingtext.s3.amazonaws.com/FoldingText-#{version}.dmg"
   name 'FoldingText'
   appcast 'https://foldingtext.s3.amazonaws.com/FoldingText.rss',
           :sha256 => 'edb29d497e4b36ad241ff05f35fcafb4c3712c8b1062b22a1dbd3ed8cb0354df'

--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -4,7 +4,7 @@ cask 'fotomagico' do
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version}.app.zip"
   name 'FotoMagico'
-  homepage 'http://www.boinx.com/fotomagico/'
+  homepage 'https://www.boinx.com/fotomagico/'
   license :commercial
 
   app 'FotoMagico.app'

--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -5,7 +5,7 @@ cask 'freac' do
   # sourceforge.net is the official download host per the vendor homepage
   url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
   name 'fre:ac'
-  homepage 'http://www.freac.org'
+  homepage 'https://www.freac.org'
   license :gpl
 
   app 'freac.app'

--- a/Casks/galileo-arduino.rb
+++ b/Casks/galileo-arduino.rb
@@ -2,7 +2,7 @@ cask 'galileo-arduino' do
   version '1.5.3'
   sha256 '8fafc626fb7d0918d7f4ddb98d59823c0fcc9b3aeb8e1d252ae9688b4095c153'
 
-  url "http://downloadmirror.intel.com/23171/eng/Intel_Galileo_Arduino_SW_#{version}_on_MacOSX%20_v1.0.0.zip"
+  url "https://downloadmirror.intel.com/23171/eng/Intel_Galileo_Arduino_SW_#{version}_on_MacOSX%20_v1.0.0.zip"
   name 'Intel Galileo Arduino SW'
   homepage 'https://communities.intel.com/docs/DOC-22226'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -4,7 +4,7 @@ cask 'ganttproject' do
 
   url "https://dl.ganttproject.biz/ganttproject-#{version.sub(%r{-.*},'')}/ganttproject-#{version}.dmg"
   name 'GanttProject'
-  homepage 'http://www.ganttproject.biz'
+  homepage 'https://www.ganttproject.biz'
   license :oss
 
   app 'GanttProject.app'

--- a/Casks/garagebuy.rb
+++ b/Casks/garagebuy.rb
@@ -3,7 +3,7 @@ cask 'garagebuy' do
   sha256 'b54c2b2e11f9a449fa3211c6db98c6f26f2418b88c89cb0272c9014c6f5c23ea'
 
   # iwascoding.de is the official download host per the vendor homepage
-  url "http://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"
+  url "https://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"
   name 'GarageBuy'
   homepage 'https://www.iwascoding.com/GarageBuy'
   license :gratis

--- a/Casks/ghostlab.rb
+++ b/Casks/ghostlab.rb
@@ -2,11 +2,11 @@ cask 'ghostlab' do
   version '2.0.10'
   sha256 '1174edf1e0496b2dff3b1a9c17fd31690259afb48227baa478e55e96c522821a'
 
-  url "http://awesome.vanamco.com/Ghostlab2/update/packages/mac/Ghostlab2-#{version}.zip"
-  appcast 'http://awesome.vanamco.com/Ghostlab2/update/ghostlab2-cast.xml',
+  url "https://awesome.vanamco.com/Ghostlab2/update/packages/mac/Ghostlab2-#{version}.zip"
+  appcast 'https://awesome.vanamco.com/Ghostlab2/update/ghostlab2-cast.xml',
           :sha256 => '432ca432eca3602fd2daece9ed1a357dd185db0a17521e7545e981d75c54b8ef'
   name 'Ghostlab'
-  homepage 'http://vanamco.com/ghostlab/'
+  homepage 'https://vanamco.com/ghostlab/'
   license :commercial
 
   app 'Ghostlab2.app'

--- a/Casks/glo-bible.rb
+++ b/Casks/glo-bible.rb
@@ -6,7 +6,7 @@ cask 'glo-bible' do
   url 'http://immersion.vo.llnwd.net/o42/pub/glo/mac/en-us/Glo.dmg'
   name 'Glo'
   name 'Glo Bible'
-  homepage 'http://globible.com/gloformac/'
+  homepage 'https://globible.com/gloformac/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Glo Bible.app'

--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -5,7 +5,7 @@ cask 'glyphs' do
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   name 'Glyphs'
   homepage 'https://www.glyphsapp.com'
-  appcast "http://updates.glyphsapp.com/appcast#{version.to_i}.xml",
+  appcast "https://updates.glyphsapp.com/appcast#{version.to_i}.xml",
           :sha256 => '0a9a4017b75917044ab9b33428ee6b6b9123cab29ab9c8229eeecc005e9c75e1'
   license :commercial
 

--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -4,7 +4,7 @@ cask 'gns3' do
 
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   name 'GNS3'
-  homepage 'http://www.gns3.com/'
+  homepage 'https://www.gns3.com/'
   license :gpl
 
   app 'GNS3.app'

--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -4,7 +4,7 @@ cask 'go-agent' do
 
   url "http://download.go.cd/gocd/go-agent-#{version}-osx.zip"
   name 'Go Agent'
-  homepage 'http://www.go.cd/'
+  homepage 'https://www.go.cd/'
   license :apache
 
   app 'Go Agent.app'

--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -4,7 +4,7 @@ cask 'go-server' do
 
   url "http://download.go.cd/gocd/go-server-#{version}-osx.zip"
   name 'Go Server'
-  homepage 'http://www.go.cd/'
+  homepage 'https://www.go.cd/'
   license :apache
 
   app 'Go Server.app'

--- a/Casks/gog-downloader.rb
+++ b/Casks/gog-downloader.rb
@@ -2,7 +2,7 @@ cask 'gog-downloader' do
   version '1.2_512'
   sha256 '353604a2123feacf438c6586b3ec20967dca637b0a97d36203adbc3e1dfdefce'
 
-  url "http://static.gog.com/download/d3/mac-stable/GOG_Downloader_#{version}.zip"
+  url "https://static.gog.com/download/d3/mac-stable/GOG_Downloader_#{version}.zip"
   appcast 'https://api.gog.com/en/downloader2/status/mac-stable',
           :sha256 => '91f8021f41c170428d3ff18770356284c0239c8d8a47f2eccb2d5d1c222829c5'
   name 'GOG Downloader'

--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -4,7 +4,7 @@ cask 'goodsync' do
 
   url 'https://www.goodsync.com/download/goodsync-mac.dmg'
   name 'GoodSync'
-  homepage 'http://www.goodsync.com'
+  homepage 'https://www.goodsync.com'
   license :commercial
 
   app 'GoodSync.app'

--- a/Casks/google-notifier.rb
+++ b/Casks/google-notifier.rb
@@ -4,7 +4,7 @@ cask 'google-notifier' do
 
   url "https://dl.google.com/mac/download/GoogleNotifier_#{version}.dmg"
   name 'Google Notifier'
-  homepage 'http://toolbar.google.com/gmail-helper/notifier_mac.html'
+  homepage 'https://toolbar.google.com/gmail-helper/notifier_mac.html'
   license :gratis
 
   app 'Google Notifier.app'

--- a/Casks/gopro-studio.rb
+++ b/Casks/gopro-studio.rb
@@ -2,7 +2,7 @@ cask 'gopro-studio' do
   version '2.5.7.321'
   sha256 '63d875d8b6a2a715ada3224a5b81cb79d82199195f6f22e908c4c1455a3829c9'
 
-  url "http://software.gopro.com/Mac/GoProStudio-#{version}.dmg"
+  url "https://software.gopro.com/Mac/GoProStudio-#{version}.dmg"
   name 'GoPro Studio'
   homepage 'https://shop.gopro.com/APAC/softwareandapp/gopro-studio/GoPro-Studio.html#/start=1'
   license :commercial

--- a/Casks/grammarly.rb
+++ b/Casks/grammarly.rb
@@ -2,7 +2,7 @@ cask 'grammarly' do
   version :latest
   sha256 :no_check
 
-  url 'http://download-editor.grammarly.com/osx/Grammarly.dmg'
+  url 'https://download-editor.grammarly.com/osx/Grammarly.dmg'
   name 'Grammarly'
   homepage 'https://grammarly.com/'
   license :closed

--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -2,11 +2,11 @@ cask 'grandtotal' do
   version '4.1.3'
   sha256 '17a3fea3abab3013ee1181cd1d7bebe499d6d5f3e362e116cc3345c0ea3e319a'
 
-  url "http://mediaatelier.com/GrandTotal4/GrandTotal_#{version}.zip"
-  appcast 'http://mediaatelier.com/GrandTotal4/feed.php',
+  url "https://mediaatelier.com/GrandTotal4/GrandTotal_#{version}.zip"
+  appcast 'https://mediaatelier.com/GrandTotal4/feed.php',
           :sha256 => 'ab9702415ea6acfc11715b8b359a7b97f2b91311d29ae46e6f9a6ab8a3898a90'
   name 'GrandTotal'
-  homepage 'http://www.mediaatelier.com/GrandTotal4/'
+  homepage 'https://www.mediaatelier.com/GrandTotal4/'
   license :commercial
 
   depends_on :macos => '>= :mountain_lion'

--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -7,7 +7,7 @@ cask 'hazel' do
   name 'Hazel'
   appcast 'http://update.noodlesoft.com/Products/Hazel/generate-appcast.php',
           :sha256 => 'c0668f7c61d403b4690d48eb410eb49e8247ef3f91fafe97e4228b07d8a7678a'
-  homepage 'http://www.noodlesoft.com/hazel.php'
+  homepage 'https://www.noodlesoft.com/hazel.php'
   license :freemium
 
   prefpane 'Hazel.prefPane'

--- a/Casks/houdahgeo.rb
+++ b/Casks/houdahgeo.rb
@@ -2,11 +2,11 @@ cask 'houdahgeo' do
   version '4.4'
   sha256 '065c215e8c61081d4ff6c925ea20a56ba87d08633d2796aa423066ba9cf1f041'
 
-  url "http://houdah.com/houdahGeo/download_assets/HoudahGeo#{version}.zip"
-  appcast "http://www.houdah.com/houdahGeo/updates#{version.to_i}/profileInfo.php",
+  url "https://houdah.com/houdahGeo/download_assets/HoudahGeo#{version}.zip"
+  appcast "https://www.houdah.com/houdahGeo/updates#{version.to_i}/profileInfo.php",
           :sha256 => '35e84cc740c5f5ee1fcfd1936946a63ea58b97c1b2bad97b4e84d5b3446c5aeb'
   name 'HoudahGeo'
-  homepage 'http://houdah.com/houdahGeo/'
+  homepage 'https://houdah.com/houdahGeo/'
   license :commercial
 
   depends_on :macos => '>= :mountain_lion'

--- a/Casks/houdahspot.rb
+++ b/Casks/houdahspot.rb
@@ -2,11 +2,11 @@ cask 'houdahspot' do
   version '4.1'
   sha256 'ecd30e68eb8a19e70887701b24b978c82b2498df46873bd2a08882b5484b8630'
 
-  url "http://www.houdah.com/houdahSpot/download_assets/HoudahSpot#{version}.zip"
-  appcast "http://www.houdah.com/houdahSpot/updates/cast#{version.to_i}.xml",
+  url "https://www.houdah.com/houdahSpot/download_assets/HoudahSpot#{version}.zip"
+  appcast "https://www.houdah.com/houdahSpot/updates/cast#{version.to_i}.xml",
           :sha256 => 'c726d86606a58e564c077246d0e6f7238a0ebf286c047aadcd9affa1162bda71'
   name 'HoudahSpot'
-  homepage 'http://www.houdah.com/houdahSpot/'
+  homepage 'https://www.houdah.com/houdahSpot/'
   license :commercial
 
   app 'HoudahSpot.app'

--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -6,7 +6,7 @@ cask 'hype' do
   name 'Tumult Hype'
   appcast 'https://tumult.com/hype/appcast_hype2.xml',
           :sha256 => '07aef09835937ee8af2d7938f30d9871faa6f935b36bc93850e021e32ebf6717'
-  homepage 'http://tumult.com/hype/'
+  homepage 'https://tumult.com/hype/'
   license :commercial
 
   # Renamed for consistency: app name is different in the Finder and in a shell.

--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -3,7 +3,7 @@ cask 'hyper' do
   sha256 :no_check
 
   # amazonaws.com is the official download host per the vendor homepage
-  url 'http://hyper-install.s3.amazonaws.com/hyper-mac.pkg'
+  url 'https://hyper-install.s3.amazonaws.com/hyper-mac.pkg'
   name 'Hyper'
   homepage 'https://hyper.sh/'
   license :apache

--- a/Casks/hypo.rb
+++ b/Casks/hypo.rb
@@ -3,11 +3,11 @@ cask 'hypo' do
   sha256 '7f815338d91baf6cac953b9f85350f32285d063a90e4ba3197266f23fc54cd4c'
 
   # github.io is the official download host per the vendor homepage
-  url "http://hypo.github.io/HypoAppPublic/hypo-#{version}.app.tbz"
-  appcast 'http://hypo.github.io/HypoAppPublic/appcast.xml',
+  url "https://hypo.github.io/HypoAppPublic/hypo-#{version}.app.tbz"
+  appcast 'https://hypo.github.io/HypoAppPublic/appcast.xml',
           :sha256 => '917c51dfaf3bc58c265e8f465813d82ace4f4d0765b0dfaa322fb26a2e545018'
   name 'hypo'
-  homepage 'http://hypo.cc/mac.html'
+  homepage 'https://hypo.cc/mac.html'
   license :gratis
 
   app 'Hypo.app'

--- a/Casks/ibettercharge.rb
+++ b/Casks/ibettercharge.rb
@@ -3,7 +3,7 @@ cask 'ibettercharge' do
   sha256 'd4c3b410b77836ecc97bf6133e7109934c2d0a6b64349083d2c03b0280e21985'
 
   # dl.devmate.com is the official download host per the appcast feed
-  url "http://dl.devmate.com/com.softorino.iBetterCharge/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{^.*?-},'')}/iBetterCharge-#{version.sub(%r{-.*$},'')}.zip"
+  url "https://dl.devmate.com/com.softorino.iBetterCharge/#{version.sub(%r{-.*$},'')}/#{version.sub(%r{^.*?-},'')}/iBetterCharge-#{version.sub(%r{-.*$},'')}.zip"
   appcast 'http://hook.softorino.com/ibc/appcast.xml',
           :sha256 => 'ccfa0731f1d7861bf01427351e5758c3752e1816a5e55b02dad23c4323fcabfe'
   name 'iBetterCharge'

--- a/Casks/icecat.rb
+++ b/Casks/icecat.rb
@@ -4,7 +4,7 @@ cask 'icecat' do
 
   url "https://ftp.gnu.org/gnu/gnuzilla/#{version}/icecat-#{version}.en-US.mac.dmg"
   name 'IceCat'
-  homepage 'http://www.gnu.org/software/gnuzilla/'
+  homepage 'https://www.gnu.org/software/gnuzilla/'
   license :gpl
 
   app 'IceCat.app'

--- a/Casks/ideskcal.rb
+++ b/Casks/ideskcal.rb
@@ -2,7 +2,7 @@ cask 'ideskcal' do
   version '2.6.5'
   sha256 'b42acab35ad8d3e1ffa7bb95adde768515d5a924b18b4768d70c0442e6477285'
 
-  url "http://hashbangind.com/files/iDeskCal-#{version}.zip"
+  url "https://hashbangind.com/files/iDeskCal-#{version}.zip"
   appcast 'https://hashbangind.com/appcasts/iDeskCal-profileInfo.php',
           :sha256 => 'fe555566a6286329c5068140fb3ce75d14d48e97fdcf6e15d974eff5cd1ebf86'
   name 'iDeskCal'

--- a/Casks/imagealpha.rb
+++ b/Casks/imagealpha.rb
@@ -6,13 +6,13 @@ cask 'imagealpha' do
   else
     version '1.4.0'
     sha256 '7dc856013d5e5b8ecaa63dba2da8bd0db17de22ee60790e3b664898327727ed8'
-    appcast 'http://pngmini.com/appcast.xml',
+    appcast 'https://pngmini.com/appcast.xml',
             :sha256 => '6586efef537dc200f439a265d1daee36ef4af08c43c81e4a56fcd4fae088ddbb'
   end
 
-  url "http://pngmini.com/ImageAlpha#{version}.tar.bz2"
+  url "https://pngmini.com/ImageAlpha#{version}.tar.bz2"
   name 'ImageAlpha'
-  homepage 'http://pngmini.com/'
+  homepage 'https://pngmini.com/'
   license :gpl
 
   app 'ImageAlpha.app'

--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -5,7 +5,7 @@ cask 'imazing' do
   # devmate.com is the official download host per the vendor homepage
   url "https://dl.devmate.com/com.DigiDNA.iMazingMac/#{version.sub(%r{-.*},'')}/#{version.sub(%r{.*-},'')}/iMazingforMac-#{version.sub(%r{-.*},'')}.dmg"
   name 'iMazing'
-  appcast 'http://updates.devmate.com/com.DigiDNA.iMazingMac.xml',
+  appcast 'https://updates.devmate.com/com.DigiDNA.iMazingMac.xml',
           :sha256 => '57e3299100e16ac2f4f828d652c5e5a104d09119fb299ad39007dec5275e07e8'
   homepage 'https://imazing.com/'
   license :commercial

--- a/Casks/imitone.rb
+++ b/Casks/imitone.rb
@@ -2,9 +2,9 @@ cask 'imitone' do
   version '0.8.0'
   sha256 '965f52c4cb43d0331033b8be3b9578ef46a54e4a3b8eb93feb322bbfc2714eaa'
 
-  url "http://imitone.com/beta/imitone-#{version}.dmg"
+  url "https://imitone.com/beta/imitone-#{version}.dmg"
   name 'imitone'
-  homepage 'http://imitone.com/'
+  homepage 'https://imitone.com/'
   license :commercial
 
   app 'imitone.app'

--- a/Casks/inc.rb
+++ b/Casks/inc.rb
@@ -5,7 +5,7 @@ cask 'inc' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'http://inc-static.kippt.com.s3.amazonaws.com/apps/inc-osx.zip'
   name 'Inc'
-  homepage 'http://sendtoinc.com/apps/'
+  homepage 'https://sendtoinc.com/apps/'
   license :gratis
 
   app 'Inc.app'

--- a/Casks/infinit.rb
+++ b/Casks/infinit.rb
@@ -4,7 +4,7 @@ cask 'infinit' do
 
   url 'https://download.infinit.io/macosx/app/Infinit.dmg'
   name 'Infinit'
-  homepage 'http://www.infinit.io/'
+  homepage 'https://www.infinit.io/'
   license :gratis
 
   app 'Infinit.app'

--- a/Casks/instabridge.rb
+++ b/Casks/instabridge.rb
@@ -6,7 +6,7 @@ cask 'instabridge' do
   name 'Instabridge'
   appcast 'http://cdn.instabridge.com/mac/updates.xml',
           :sha256 => '9974b9ea1d1701dd12aa42235de7bf2b4b2f1966c92e435ec92eae53e241c058'
-  homepage 'http://instabridge.com/'
+  homepage 'https://instabridge.com/'
   license :gratis
 
   app 'Instabridge.app'

--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -5,7 +5,7 @@ cask 'instead' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/instead/instead/#{version}/Instead-#{version}.dmg"
   name 'INSTEAD'
-  homepage 'http://instead.syscall.ru/'
+  homepage 'https://instead.syscall.ru/'
   license :mit
 
   app 'Instead.app'

--- a/Casks/intensify-pro.rb
+++ b/Casks/intensify-pro.rb
@@ -6,7 +6,7 @@ cask 'intensify-pro' do
   name 'Intensify Pro'
   appcast 'http://cdn.macphun.com/updates/IntensifyPro/appcast.xml',
           :sha256 => '1478fc12d15d86c890f76810c70d58ce7b1f2086c6ddf8f302a06e97404f133d'
-  homepage 'http://macphun.com/intensify'
+  homepage 'https://macphun.com/intensify'
   license :commercial
 
   app 'Intensify Pro.app'

--- a/Casks/iordning.rb
+++ b/Casks/iordning.rb
@@ -2,10 +2,10 @@ cask 'iordning' do
   version '6.0.43'
   sha256 '965818c8e43f51826edef0e9c4bc8a083d6b698b2fae2f63a1de2407f02c59a3'
 
-  url "http://www.aderstedtsoftware.com/downloads/iOrdning#{version.to_i}.zip"
+  url "https://www.aderstedtsoftware.com/downloads/iOrdning#{version.to_i}.zip"
   name 'iOrdning'
   name 'Economacs'
-  homepage 'http://aderstedtsoftware.com/'
+  homepage 'https://aderstedtsoftware.com/'
   license :commercial
 
   app 'iOrdning.app'

--- a/Casks/ipartition.rb
+++ b/Casks/ipartition.rb
@@ -2,9 +2,9 @@ cask 'ipartition' do
   version '3.4.5'
   sha256 '0b66c44dfb4b8525056b68bfd8f4d56fe4b78fd0e5e4705659bfd242e2722319'
 
-  url "http://coriolis-systems.com/downloads/iPartition-#{version}.zip"
+  url "https://coriolis-systems.com/downloads/iPartition-#{version}.zip"
   name 'iPartition'
-  homepage 'http://coriolis-systems.com/iPartition.php'
+  homepage 'https://coriolis-systems.com/iPartition.php'
   license :commercial
 
   app 'iPartition.app'

--- a/Casks/irip.rb
+++ b/Casks/irip.rb
@@ -2,7 +2,7 @@ cask 'irip' do
   sha256 :no_check
   version :latest
 
-  url 'http://files.thelittleappfactory.com/iRip2/iRip.zip'
+  url 'https://files.thelittleappfactory.com/iRip2/iRip.zip'
   appcast 'https://files.thelittleappfactory.com/iRip2/appcast.xml',
           :sha256 => 'a4b4db7521ac5d24eff02cfc8405eb7f2e323677483a28433970c774ea733641'
   name 'iRip'

--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -5,7 +5,7 @@ cask 'istat-menus' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus#{version}.zip"
   name 'iStats Menus'
-  homepage 'http://bjango.com/mac/istatmenus/'
+  homepage 'https://bjango.com/mac/istatmenus/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iStat Menus.app'

--- a/Casks/istat-server.rb
+++ b/Casks/istat-server.rb
@@ -2,9 +2,9 @@ cask 'istat-server' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.bjango.com/istatserver/'
+  url 'https://download.bjango.com/istatserver/'
   name 'iStat Server'
-  homepage 'http://bjango.com/mac/istatserver/'
+  homepage 'https://bjango.com/mac/istatserver/'
   license :gratis
 
   pkg 'iStat Server.pkg'

--- a/Casks/itouch-server.rb
+++ b/Casks/itouch-server.rb
@@ -4,7 +4,7 @@ cask 'itouch-server' do
 
   url "http://logitech.com/pub/techsupport/mouse/mac/touchmousev#{version}.dmg"
   name 'Logitech Touch Mouse Server'
-  homepage 'http://support.logitech.com/en_us/product/6367'
+  homepage 'https://support.logitech.com/en_us/product/6367'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iTouch-Server.app'

--- a/Casks/ivolume.rb
+++ b/Casks/ivolume.rb
@@ -2,9 +2,9 @@ cask 'ivolume' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.mani.de/download/ivolume/iVolume3Mac.dmg'
+  url 'https://www.mani.de/download/ivolume/iVolume3Mac.dmg'
   name 'iVolume'
-  homepage 'http://www.mani.de/en/ivolume/'
+  homepage 'https://www.mani.de/en/ivolume/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'iVolume.app'

--- a/Casks/ivpn.rb
+++ b/Casks/ivpn.rb
@@ -2,11 +2,11 @@ cask 'ivpn' do
   version '7.4.1'
   sha256 'b1e1803fe7b2f1232a3bfc4c5fddd682cc92d147ab57cab48f6391358716df2c'
 
-  url "http://macserve.org.uk/downloads/ivpn/iVPN_#{version}.zip"
+  url "https://macserve.org.uk/downloads/ivpn/iVPN_#{version}.zip"
   appcast 'http://macserve.org.uk:8090/profileInfo.php',
           :sha256 => 'fcaa1830a2c5a2731b724ac9dfdd25dc5bd9a7bfd10f56b4b48fd79d6e8d87f3'
   name 'iVPN'
-  homepage 'http://macserve.org.uk/projects/ivpn/'
+  homepage 'https://macserve.org.uk/projects/ivpn/'
   license :commercial
 
   app 'iVPN.app'

--- a/Casks/jaksta.rb
+++ b/Casks/jaksta.rb
@@ -6,7 +6,7 @@ cask 'jaksta' do
   name 'Jaksta'
   appcast 'http://downloads.jaksta.com/release/mac/sparkle/JakstaforMac.xml',
           :sha256 => '17d58d78dc008d18226c67348f377fc60b1dc84f42cc3fae438094c6e81c3072'
-  homepage 'http://www.jaksta.com/Products#JakstaMediaRecorderMac'
+  homepage 'https://www.jaksta.com/Products#JakstaMediaRecorderMac'
   license :commercial
 
   app 'Jaksta.app'

--- a/Casks/jbidwatcher.rb
+++ b/Casks/jbidwatcher.rb
@@ -6,7 +6,7 @@ cask 'jbidwatcher' do
   name 'JBidwatcher'
   appcast 'https://www.jbidwatcher.com/sparkle/updates.xml',
           :sha256 => 'aa8cc693e2f0047a2214f990d5f418f026acf473dcb1f0f76204f7fee730077b'
-  homepage 'http://www.jbidwatcher.com'
+  homepage 'https://www.jbidwatcher.com'
   license :cc
 
   app 'JBidwatcher.app'

--- a/Casks/jira-client.rb
+++ b/Casks/jira-client.rb
@@ -2,7 +2,7 @@ cask 'jira-client' do
   version '3.7.0'
   sha256 'c4a4b45b260d59992c9e548618f6dfac1221a084d4564c81b5d2f0943d7b9739'
 
-  url "http://d1.almworks.com/.files/jiraclient-#{version.gsub('.','_')}.dmg"
+  url "https://d1.almworks.com/.files/jiraclient-#{version.gsub('.','_')}.dmg"
   name 'JIRA Client'
   homepage 'http://almworks.com/jiraclient'
   license :closed

--- a/Casks/jive-chime.rb
+++ b/Casks/jive-chime.rb
@@ -5,7 +5,7 @@ cask 'jive-chime' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3-us-west-2.amazonaws.com/chime-desktop/prod/osx/Jive%20Chime.dmg'
   name 'Jive Chime'
-  homepage 'http://jivechime.com/'
+  homepage 'https://jivechime.com/'
   license :gratis
 
   app 'Jive Chime.app'

--- a/Casks/jollysfastvnc.rb
+++ b/Casks/jollysfastvnc.rb
@@ -2,11 +2,11 @@ cask 'jollysfastvnc' do
   version '1.52_1413501'
   sha256 '0b0f4eb3d8a4aed33d36acfbac9fb34763d7b8faca00f8efc88ea2a9d9a0352e'
 
-  url "http://www.jinx.de/JollysFastVNC_files/JollysFastVNC.#{version.sub(%r{_.*},'')}.(#{version.sub(%r{.*_},'')}).10.7.dmg"
-  appcast 'http://www.jinx.de/JollysFastVNC.update.0E.i386.xml',
+  url "https://www.jinx.de/JollysFastVNC_files/JollysFastVNC.#{version.sub(%r{_.*},'')}.(#{version.sub(%r{.*_},'')}).10.7.dmg"
+  appcast 'https://www.jinx.de/JollysFastVNC.update.0E.i386.xml',
           :sha256 => 'a7e1113e717a81fdab3cb6054b730e1b32c38f5de976bbe2a1c6fffc22a6956f'
   name 'JollysFastVNC'
-  homepage 'http://www.jinx.de/JollysFastVNC.html'
+  homepage 'https://www.jinx.de/JollysFastVNC.html'
   license :commercial
 
   depends_on :macos => '>= :lion'

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -4,7 +4,7 @@ cask 'josm' do
 
   url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
   name 'JOSM'
-  homepage 'http://josm.openstreetmap.de'
+  homepage 'https://josm.openstreetmap.de'
   license :gpl
 
   app 'JOSM.app'

--- a/Casks/jump-desktop.rb
+++ b/Casks/jump-desktop.rb
@@ -2,11 +2,11 @@ cask 'jump-desktop' do
   version :latest
   sha256 :no_check
 
-  url 'http://jumpdesktop.com/downloads/jdmac'
+  url 'https://jumpdesktop.com/downloads/jdmac'
   name 'Jump Desktop'
-  appcast 'http://service.jumpdesktop.com/update/jdmac-web/appcast.xml',
+  appcast 'https://service.jumpdesktop.com/update/jdmac-web/appcast.xml',
           :sha256 => '146cdb8cdc75e641405a08aa9d409ac2aec195520aacd5c632fdac68ba3ba563'
-  homepage 'http://jumpdesktop.com/#jdmac'
+  homepage 'https://jumpdesktop.com/#jdmac'
   license :commercial
 
   app 'Jump Desktop.app'

--- a/Casks/justinmind.rb
+++ b/Casks/justinmind.rb
@@ -3,7 +3,7 @@ cask 'justinmind' do
   sha256 :no_check
 
   # cloudfront.net is the official download host per the vendor homepage
-  url 'http://d2ld3he4yll0xl.cloudfront.net/Justinmind_Prototyper_MacOS.dmg'
+  url 'https://d2ld3he4yll0xl.cloudfront.net/Justinmind_Prototyper_MacOS.dmg'
   name 'Justinmind Prototyper'
   homepage 'http://www.justinmind.com/'
   license :commercial

--- a/Casks/kawasemi.rb
+++ b/Casks/kawasemi.rb
@@ -2,10 +2,10 @@ cask 'kawasemi' do
   version :latest
   sha256 :no_check
 
-  url 'http://store.monokakido.jp/download/Kawasemi2/Kawasemi2.dmg'
+  url 'https://store.monokakido.jp/download/Kawasemi2/Kawasemi2.dmg'
   name 'かわせみ'
   name 'Kawasemi'
-  homepage 'http://www.monokakido.jp/mac/kawasemi2.html'
+  homepage 'https://www.monokakido.jp/mac/kawasemi2.html'
   license :commercial
 
   pkg 'Kawasemi2 Installer.app/Contents/Resources/Kawasemi2.pkg'

--- a/Casks/keepassx.rb
+++ b/Casks/keepassx.rb
@@ -4,7 +4,7 @@ cask 'keepassx' do
 
   url "https://www.keepassx.org/releases/#{version}/KeePassX-#{version}.dmg"
   name 'KeePassX'
-  homepage 'http://www.keepassx.org'
+  homepage 'https://www.keepassx.org'
   license :bsd
 
   app 'KeePassX.app'

--- a/Casks/kensington-trackball-works.rb
+++ b/Casks/kensington-trackball-works.rb
@@ -3,7 +3,7 @@ cask 'kensington-trackball-works' do
   sha256 '285511269aea2e0517198b354923676655c72142062dcba7bdc41bc29d1f08d1'
 
   # windows.net is the official download host per the vendor homepage
-  url 'http://accoblobstorageus.blob.core.windows.net/software/a7d905eb-8a38-49e5-b25a-11d59a7e765f.dmg'
+  url 'https://accoblobstorageus.blob.core.windows.net/software/a7d905eb-8a38-49e5-b25a-11d59a7e765f.dmg'
   name 'Kensington TrackballWorks'
   homepage 'http://www.kensington.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/key-codes.rb
+++ b/Casks/key-codes.rb
@@ -3,10 +3,10 @@ cask 'key-codes' do
   sha256 '1b7b4de0d15dfd483811b913821b722afab181cad031a5d0c1172e981a0dc6bd'
 
   url 'http://manytricks.com/download/keycodes'
-  appcast 'http://manytricks.com/keycodes/appcast.xml',
+  appcast 'https://manytricks.com/keycodes/appcast.xml',
           :sha256 => '8d887901c2bfd31cfe644b0c2cce15b153decffc96199fd6f41080de5ae13f16'
   name 'Key Codes'
-  homepage 'http://manytricks.com/keycodes/'
+  homepage 'https://manytricks.com/keycodes/'
   license :gratis
 
   app 'Key Codes.app'

--- a/Casks/keyboard-maestro.rb
+++ b/Casks/keyboard-maestro.rb
@@ -3,9 +3,9 @@ cask 'keyboard-maestro' do
   sha256 'd80b9cc8790c9b1595bfe132f47f12f54210fc3430c462d8cd668784c4f1c6c0'
 
   # stairways.com is the official download host per the vendor homepage
-  url "http://files.stairways.com/keyboardmaestro-#{version.delete('.')}.zip"
+  url "https://files.stairways.com/keyboardmaestro-#{version.delete('.')}.zip"
   name 'Keyboard Maestro'
-  homepage 'http://www.keyboardmaestro.com/'
+  homepage 'https://www.keyboardmaestro.com/'
   license :commercial
 
   depends_on :macos => '>= :yosemite'

--- a/Casks/keymo.rb
+++ b/Casks/keymo.rb
@@ -2,7 +2,7 @@ cask 'keymo' do
   version '1.2.1'
   sha256 '6ae33f5287e8be279c87f0bb5d22e77f806b9e2438f826935de5d6df34641d67'
 
-  url "http://manytricks.com/download/_do_not_hotlink_/keymo#{version.delete('.')}.dmg"
+  url "https://manytricks.com/download/_do_not_hotlink_/keymo#{version.delete('.')}.dmg"
   appcast 'http://manytricks.com/keymo/appcast.xml',
           :sha256 => '0fada217a8b17fe20397e043c45a94fa984b8928877efb59ffa88997c5b2939a'
   name 'Keymo'

--- a/Casks/kindle-comic-converter.rb
+++ b/Casks/kindle-comic-converter.rb
@@ -4,7 +4,7 @@ cask 'kindle-comic-converter' do
 
   url "https://kcc.iosphe.re/OSX/KindleComicConverter_osx_#{version}.dmg"
   name 'Kindle Comic Converter'
-  homepage 'http://kcc.iosphe.re'
+  homepage 'https://kcc.iosphe.re'
   license :isc
 
   app 'Kindle Comic Converter.app'

--- a/Casks/kinsky.rb
+++ b/Casks/kinsky.rb
@@ -2,9 +2,9 @@ cask 'kinsky' do
   version '4.3.17'
   sha256 '624d2ee1c2ab62e347b7effe0ec8b1bd32d6e70d9cae6fb62d8fb8e2995c7173'
 
-  url "http://oss.linn.co.uk/Releases/Kinsky/Davaar/Kinsky_#{version}_osx.pkg"
+  url "https://oss.linn.co.uk/Releases/Kinsky/Davaar/Kinsky_#{version}_osx.pkg"
   name 'Kinsky'
-  homepage 'http://oss.linn.co.uk/trac/wiki/DownloadKinsky'
+  homepage 'https://oss.linn.co.uk/trac/wiki/DownloadKinsky'
   license :bsd
 
   pkg "Kinsky_#{version}_osx.pkg"

--- a/Casks/kkbox.rb
+++ b/Casks/kkbox.rb
@@ -2,7 +2,7 @@ cask 'kkbox' do
   version '5.2.80-80ddc30'
   sha256 '6c8094410d428ce9dfcf41039b8d8008cf8571cd622dbcaa3e4b9ddb103f92ac'
 
-  url "http://download.kkbox.com/files/KKBOX-#{version}.dmg"
+  url "https://download.kkbox.com/files/KKBOX-#{version}.dmg"
   name 'KKBOX'
   homepage 'https://www.kkbox.com/'
   license :commercial

--- a/Casks/kobo.rb
+++ b/Casks/kobo.rb
@@ -3,7 +3,7 @@ cask 'kobo' do
   sha256 :no_check
 
   # akamaihd.net is the official download host per the vendor homepage
-  url 'http://kbdownload1-a.akamaihd.net/desktop/kobodesktop/kobosetup.dmg'
+  url 'https://kbdownload1-a.akamaihd.net/desktop/kobodesktop/kobosetup.dmg'
   name 'Kobo'
   homepage 'https://www.kobo.com/'
   license :gratis

--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -3,7 +3,7 @@ cask 'komodo-ide' do
   sha256 'f3e97a5b57b91e524a41f0dac11df991d19ed5ff81f33e26602b7be8bb2935a3'
 
   # activestate.com is the official download host per the vendor homepage
-  url "http://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
+  url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*},'')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
   name 'Komodo IDE'
   homepage 'https://komodoide.com/'
   license :commercial

--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -3,7 +3,7 @@ cask 'krita' do
   sha256 '9a4ef8e39f170ba3e81663f7049f1f136920048834628ff5cdd1cd0a4ec6b0b7'
 
   # kde.org is the official download host per the vendor homepage
-  url "http://files.kde.org/krita/osx/krita-#{version}.dmg"
+  url "https://files.kde.org/krita/osx/krita-#{version}.dmg"
   name 'Krita'
   homepage 'https://krita.org/'
   license :gpl

--- a/Casks/laconicism.rb
+++ b/Casks/laconicism.rb
@@ -2,9 +2,9 @@ cask 'laconicism' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.earslap.com/assets/laconicism/Laconicism.dmg'
+  url 'https://www.earslap.com/assets/laconicism/Laconicism.dmg'
   name 'Laconicism'
-  homepage 'http://www.earslap.com/weblog/music-release-laconicism.html'
+  homepage 'https://www.earslap.com/weblog/music-release-laconicism.html'
   license :cc
 
   app 'Laconicism.app'

--- a/Casks/leech.rb
+++ b/Casks/leech.rb
@@ -4,9 +4,9 @@ cask 'leech' do
 
   url 'http://manytricks.com/download/leech'
   name 'Leech'
-  appcast 'http://manytricks.com/leech/appcast.xml',
+  appcast 'https://manytricks.com/leech/appcast.xml',
           :sha256 => 'ef4c85840f37dc92c0999f88e5e64acc5eb76b3e3933582710cdb703583473a1'
-  homepage 'http://manytricks.com/leech/'
+  homepage 'https://manytricks.com/leech/'
   license :commercial
 
   app 'Leech.app'

--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -4,7 +4,7 @@ cask 'letterfix' do
 
   url "http://dl.sourceforge.jp/letter-fix/62451/LetterFix-#{version}a.dmg"
   name 'LetterFix'
-  homepage 'http://sourceforge.jp/projects/letter-fix/'
+  homepage 'https://sourceforge.jp/projects/letter-fix/'
   license :mit
 
   pkg "LetterFix-#{version}.pkg"

--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -2,11 +2,11 @@ cask 'liteicon' do
   version '3.6.2'
   sha256 'b9b12c02e69c38f983568a2231d0bd85690839736b1e5595a7d3358c2c7cf304'
 
-  url "http://www.freemacsoft.net/downloads/LiteIcon_#{version}.zip"
-  appcast 'http://www.freemacsoft.net/liteicon/updates.xml',
+  url "https://www.freemacsoft.net/downloads/LiteIcon_#{version}.zip"
+  appcast 'https://www.freemacsoft.net/liteicon/updates.xml',
           :sha256 => 'cbaf744ac1473a475f81af1191005ba3307caa501e3a4541039ad836ce774631'
   name 'LiteIcon'
-  homepage 'http://www.freemacsoft.net/liteicon/'
+  homepage 'https://www.freemacsoft.net/liteicon/'
   license :gratis
 
   app 'LiteIcon.app'

--- a/Casks/live-interior-3d-pro.rb
+++ b/Casks/live-interior-3d-pro.rb
@@ -2,7 +2,7 @@ cask 'live-interior-3d-pro' do
   version :latest
   sha256 :no_check
 
-  url 'http://s3.amazonaws.com/belightsoft/LiveInterior3DPro.dmg'
+  url 'https://s3.amazonaws.com/belightsoft/LiveInterior3DPro.dmg'
   name 'Live Interior 3D Pro'
   homepage 'https://www.belightsoft.com/products/liveinterior/proversion.php'
   license :commercial

--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -4,7 +4,7 @@ cask 'livechat' do
 
   url 'http://www.livechatinc.com/download/Mac/LiveChat.dmg'
   name 'LiveChat'
-  homepage 'http://livechatinc.com'
+  homepage 'https://livechatinc.com'
   license :commercial
 
   app 'LiveChat.app'

--- a/Casks/livestation.rb
+++ b/Casks/livestation.rb
@@ -4,7 +4,7 @@ cask 'livestation' do
 
   url "http://updates.livestation.com/releases/Livestation-#{version}.dmg"
   name 'Livestation'
-  homepage 'http://www.livestation.com'
+  homepage 'https://www.livestation.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Livestation.app'

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -14,7 +14,7 @@ cask 'logitech-control-center' do
   end
 
   name 'Logitech Control Center'
-  homepage 'http://support.logitech.com/en_us/product/3129'
+  homepage 'https://support.logitech.com/en_us/product/3129'
   license :closed
 
   pkg 'LCC Installer.app/Contents/Resources/Logitech Control Center.mpkg'

--- a/Casks/logitech-myharmony.rb
+++ b/Casks/logitech-myharmony.rb
@@ -2,7 +2,7 @@ cask 'logitech-myharmony' do
   version '1.0'
   sha256 '537a11f2174dc748c27aff02bf01569b5bb2c93539b339c6fd61a7da07bb059f'
 
-  url "http://app.myharmony.com/prod/mac/#{version}/MyHarmony-App.dmg"
+  url "https://app.myharmony.com/prod/mac/#{version}/MyHarmony-App.dmg"
   name 'MyHarmony'
   homepage 'https://setup.myharmony.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -4,7 +4,7 @@ cask 'logitech-options' do
 
   url "http://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"
   name 'Logitech Options'
-  homepage 'http://support.logitech.com/en_us/software/options-mac'
+  homepage 'https://support.logitech.com/en_us/software/options-mac'
   license :closed
 
   pkg 'LogiMgr Installer.app/Contents/Resources/LogiMgr.mpkg'

--- a/Casks/logmein-hamachi.rb
+++ b/Casks/logmein-hamachi.rb
@@ -5,7 +5,7 @@ cask 'logmein-hamachi' do
   # logmein.com is the official download host per the vendor homepage
   url 'https://secure.logmein.com/LogMeInHamachi.zip'
   name 'LogMeIn Hamachi'
-  homepage 'http://vpn.net'
+  homepage 'https://vpn.net'
   license :freemium
 
   installer :script => 'LogMeInHamachiInstaller.app/Contents/MacOS/Lili',

--- a/Casks/love.rb
+++ b/Casks/love.rb
@@ -5,7 +5,7 @@ cask 'love' do
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/rude/love/downloads/love-#{version}-macosx-x64.zip"
   name 'LÖVE'
-  homepage 'http://love2d.org'
+  homepage 'https://love2d.org'
   license :oss
 
   app 'love.app'

--- a/Casks/lynxlet.rb
+++ b/Casks/lynxlet.rb
@@ -2,9 +2,9 @@ cask 'lynxlet' do
   version '0.8.1'
   sha256 '78224e5bfcfcea7d63a22e3baaeac0df215673b94af32c572714b061cf05789f'
 
-  url "http://habilis.net/lynxlet/Lynxlet_#{version}.dmg"
+  url "https://habilis.net/lynxlet/Lynxlet_#{version}.dmg"
   name 'Lynxlet'
-  homepage 'http://habilis.net/lynxlet/'
+  homepage 'https://habilis.net/lynxlet/'
   license :closed
 
   app 'Lynxlet.app'

--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -6,7 +6,7 @@ cask 'lyx' do
   gpg "#{url}.sig",
       :key_id => 'de7a44fac7fb382d'
   name 'LyX'
-  homepage 'http://www.lyx.org'
+  homepage 'https://www.lyx.org'
   license :gpl
 
   app 'LyX.app'

--- a/Casks/macintosh-explorer.rb
+++ b/Casks/macintosh-explorer.rb
@@ -4,7 +4,7 @@ cask 'macintosh-explorer' do
 
   url 'http://www.ragesw.com/downloads/ragesw/mac_explorer_alt.dmg'
   name 'Macintosh Explorer'
-  homepage 'http://www.ragesw.com/products/explorer.html'
+  homepage 'https://www.ragesw.com/products/explorer.html'
   license :gratis
 
   app 'Macintosh Explorer.app'

--- a/Casks/macpaw-gemini.rb
+++ b/Casks/macpaw-gemini.rb
@@ -4,7 +4,7 @@ cask 'macpaw-gemini' do
 
   # devmate.com is the official download host per the vendor homepage
   url 'https://dl.devmate.com/com.macpaw.site.Gemini/MacPawGemini.dmg'
-  appcast 'http://updates.devmate.com/com.macpaw.site.Gemini.xml',
+  appcast 'https://updates.devmate.com/com.macpaw.site.Gemini.xml',
           :sha256 => '2d207012f1af4396c5cd8a4aa7a889418862436dd0cdc63b4e54880fe306c8db'
   name 'MacPaw Gemini'
   homepage 'https://macpaw.com/gemini'

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -22,7 +22,7 @@ cask 'macports' do
   gpg "#{url}.asc",
       :key_id => '01ff673fb4aae6cd'
   name 'MacPorts'
-  homepage 'http://www.macports.org'
+  homepage 'https://www.macports.org'
   license :bsd
 
   uninstall :pkgutil => 'org.macports.MacPorts'

--- a/Casks/mailfollowup.rb
+++ b/Casks/mailfollowup.rb
@@ -24,7 +24,7 @@ cask 'mailfollowup' do
 
   url "https://www.cs.unc.edu/~welch/MailFollowup/media/MailFollowUp_#{version}.dmg.zip"
   name 'MailFollowUp'
-  homepage 'http://www.cs.unc.edu/~welch/MailFollowup/'
+  homepage 'https://www.cs.unc.edu/~welch/MailFollowup/'
   license :gratis
 
   container :nested => "MailFollowUp_#{version}.dmg"

--- a/Casks/makerbot-desktop.rb
+++ b/Casks/makerbot-desktop.rb
@@ -3,7 +3,7 @@ cask 'makerbot-desktop' do
   sha256 '1012556c76df6220640606bb1041a6cf6cc28975ffba6b75b653228512b9da91'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://s3.amazonaws.com/downloads-makerbot-com/makerware/MakerBot%20Bundle%20BETA%20#{version}.dmg"
+  url "https://s3.amazonaws.com/downloads-makerbot-com/makerware/MakerBot%20Bundle%20BETA%20#{version}.dmg"
   name 'MakerBot Desktop'
   homepage 'http://www.makerbot.com/desktop'
   license :gratis

--- a/Casks/manuscripts.rb
+++ b/Casks/manuscripts.rb
@@ -2,7 +2,7 @@ cask 'manuscripts' do
   version :latest
   sha256 :no_check
 
-  url 'http://updates.manuscriptsapp.com/apps/manuscripts/production/download'
+  url 'https://updates.manuscriptsapp.com/apps/manuscripts/production/download'
   name 'Manuscripts'
   homepage 'http://www.manuscriptsapp.com'
   license :freemium

--- a/Casks/marsedit.rb
+++ b/Casks/marsedit.rb
@@ -3,10 +3,10 @@ cask 'marsedit' do
   sha256 'b7e9d15d2b7e07442742900b11362a9d7b28d34557e530dd23282d8e8f62b6c3'
 
   url "http://www.red-sweater.com/marsedit/MarsEdit#{version}.zip"
-  appcast 'http://www.red-sweater.com/marsedit/appcast3.php',
+  appcast 'https://www.red-sweater.com/marsedit/appcast3.php',
           :sha256 => '3250869e30276202cdc41279ba3a7936114a87ed9d157c836362b0f3add9aa62'
   name 'MarsEdit'
-  homepage 'http://www.red-sweater.com/marsedit/'
+  homepage 'https://www.red-sweater.com/marsedit/'
   license :commercial
 
   app 'MarsEdit.app'

--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -2,7 +2,7 @@ cask 'mathtype' do
   version '6.7'
   sha256 'f512b322c9b1e16c0f9c523ade1dc7f5e743768a2ac4d7fa37780abfbe05a861'
 
-  url "http://www.dessci.com/en/dl/MTM#{version.delete('.')}h_EN.pkg"
+  url "https://www.dessci.com/en/dl/MTM#{version.delete('.')}h_EN.pkg"
   name 'MathType'
   homepage 'www.dessci.com'
   license :commercial

--- a/Casks/mauve.rb
+++ b/Casks/mauve.rb
@@ -2,7 +2,7 @@ cask 'mauve' do
   version '2.3.1'
   sha256 '586fe214eb6c430f2a98fd865856111b79502ff526ab2f6268dab1d99b337907'
 
-  url "http://asap.genetics.wisc.edu/software/mauve/downloads/Mauve-#{version}.dmg"
+  url "https://asap.genetics.wisc.edu/software/mauve/downloads/Mauve-#{version}.dmg"
   name 'Mauve'
   homepage 'http://asap.genetics.wisc.edu/software/mauve/'
   license :gpl

--- a/Casks/maxthon.rb
+++ b/Casks/maxthon.rb
@@ -4,7 +4,7 @@ cask 'maxthon' do
 
   url "https://dl.maxthon.com/mac/Maxthon-#{version}.dmg"
   name 'Maxthon'
-  homepage 'http://www.maxthon.com/'
+  homepage 'https://www.maxthon.com/'
   license :gratis
 
   app 'Maxthon.app'

--- a/Casks/memoryanalyzer.rb
+++ b/Casks/memoryanalyzer.rb
@@ -4,7 +4,7 @@ cask 'memoryanalyzer' do
 
   url "http://www.eclipse.org/downloads/download.php?file=/mat/#{version.to_f}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.x86_64.zip&r=1"
   name 'Eclipse Memory Analyzer'
-  homepage 'http://www.eclipse.org/mat/'
+  homepage 'https://www.eclipse.org/mat/'
   license :eclipse
 
   app 'mat/MemoryAnalyzer.app'

--- a/Casks/menuola.rb
+++ b/Casks/menuola.rb
@@ -2,7 +2,7 @@ cask 'menuola' do
   version '2.0'
   sha256 'd97170adab805f1a52fef6c59287724783d80b5b23821dd97c0a85b4a72261dd'
 
-  url "http://geocom.co.nz/downloads/Menuolav#{version.to_i}.dmg.zip"
+  url "https://geocom.co.nz/downloads/Menuolav#{version.to_i}.dmg.zip"
   appcast 'https://www.geocom.co.nz/menuola.xml',
           :sha256 => 'e18b081046702171648c929872c692adc2d1b816f5e9aff93b0612a11a3ea362'
   name 'Menuola'

--- a/Casks/microsoft-intellipoint.rb
+++ b/Casks/microsoft-intellipoint.rb
@@ -2,7 +2,7 @@ cask 'microsoft-intellipoint' do
   version '8.2'
   sha256 '1a4612d3237084d0502d947793c097575febc95442130e2384c8fbf4b52cac9e'
 
-  url 'http://download.microsoft.com/download/B/1/0/B109F931-70E2-425F-8681-EAAB75845AB8/Microsoft-Mouse_d305.dmg'
+  url 'https://download.microsoft.com/download/B/1/0/B109F931-70E2-425F-8681-EAAB75845AB8/Microsoft-Mouse_d305.dmg'
   name 'Microsoft IntelliPoint'
   homepage 'https://www.microsoft.com/hardware/en-us/mice'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/microsoft-intellitype.rb
+++ b/Casks/microsoft-intellitype.rb
@@ -2,7 +2,7 @@ cask 'microsoft-intellitype' do
   version '8.2'
   sha256 '8aaaef8fc2722f1e896facb23c69ef759f7ecd92d94031c51ca0a890d198cd58'
 
-  url 'http://download.microsoft.com/download/B/1/0/B109F931-70E2-425F-8681-EAAB75845AB8/Microsoft-Desktop_d305.dmg'
+  url 'https://download.microsoft.com/download/B/1/0/B109F931-70E2-425F-8681-EAAB75845AB8/Microsoft-Desktop_d305.dmg'
   name 'Microsoft IntelliType'
   homepage 'https://www.microsoft.com/hardware/en-us/keyboards'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/microsoft-lync.rb
+++ b/Casks/microsoft-lync.rb
@@ -2,7 +2,7 @@ cask 'microsoft-lync' do
   version '14.2.1_150923'
   sha256 'da1264855e3a7b372639862ed1b35a8e03c49ee5f26a440ac74daced5a743449'
 
-  url "http://download.microsoft.com/download/5/0/0/500C7E1F-3235-47D4-BC11-95A71A1BA3ED/lync_#{version}.dmg"
+  url "https://download.microsoft.com/download/5/0/0/500C7E1F-3235-47D4-BC11-95A71A1BA3ED/lync_#{version}.dmg"
   name 'Microsoft Lync 2011'
   homepage 'https://www.microsoft.com/en-us/download/details.aspx?id=36517'
   license :gratis

--- a/Casks/midi-monitor.rb
+++ b/Casks/midi-monitor.rb
@@ -2,11 +2,11 @@ cask 'midi-monitor' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.snoize.com/MIDIMonitor/MIDIMonitor.zip'
-  appcast 'http://www.snoize.com/MIDIMonitor/MIDIMonitor.xml',
+  url 'https://www.snoize.com/MIDIMonitor/MIDIMonitor.zip'
+  appcast 'https://www.snoize.com/MIDIMonitor/MIDIMonitor.xml',
           :sha256 => '17373cdb264f04bddc35e44fec61685246aa5dd3fb774c74ecd8a003ec804a7f'
   name 'MIDI Monitor'
-  homepage 'http://www.snoize.com/MIDIMonitor/'
+  homepage 'https://www.snoize.com/MIDIMonitor/'
   license :bsd
 
   app 'MIDI Monitor.app'

--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -3,7 +3,7 @@ cask 'mikogo' do
   sha256 :no_check
 
   # mikogo4.com is the official download host per the vendor homepage
-  url 'http://download.mikogo4.com/mikogo.dmg'
+  url 'https://download.mikogo4.com/mikogo.dmg'
   name 'Mikogo'
   homepage 'https://www.mikogo.com/'
   license :gratis

--- a/Casks/mixxx.rb
+++ b/Casks/mixxx.rb
@@ -2,9 +2,9 @@ cask 'mixxx' do
   version '1.11.0'
   sha256 '21fa06153a1a019c001f96024caa940ea6307a29f4cebd334fb2b7f071013314'
 
-  url "http://downloads.mixxx.org/mixxx-#{version}/mixxx-#{version}-macintel.dmg"
+  url "https://downloads.mixxx.org/mixxx-#{version}/mixxx-#{version}-macintel.dmg"
   name 'Mixxx'
-  homepage 'http://www.mixxx.org'
+  homepage 'https://www.mixxx.org'
   license :gpl
 
   app 'Mixxx.app'

--- a/Casks/moneyguru.rb
+++ b/Casks/moneyguru.rb
@@ -2,11 +2,11 @@ cask 'moneyguru' do
   version '2.9.3'
   sha256 '5f47715fa02c5fcd6595a733b35b99bd86b3008dff2a566deb692a7abe0b21a6'
 
-  url "http://download.hardcoded.net/moneyguru_osx_#{version.gsub('.', '_')}.dmg"
+  url "https://download.hardcoded.net/moneyguru_osx_#{version.gsub('.', '_')}.dmg"
   name 'moneyGuru'
-  appcast 'http://www.hardcoded.net/updates/moneyguru.appcast',
+  appcast 'https://www.hardcoded.net/updates/moneyguru.appcast',
           :sha256 => '32714462ad203d85285fd449dd472c609c8445384b579ff0dbac794e27bc8749'
-  homepage 'http://www.hardcoded.net/moneyguru/'
+  homepage 'https://www.hardcoded.net/moneyguru/'
   license :bsd
 
   app 'moneyGuru.app'

--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -7,7 +7,7 @@ cask 'mongodb' do
   appcast 'https://github.com/gcollazo/mongodbapp/releases.atom',
           :sha256 => '5c46c5a7620876b92d6dfb17be2c92fe00c6b97601c9a827ad7c9b1aa47853e6'
   name 'MongoDB'
-  homepage 'http://elweb.co/mongodb-app/'
+  homepage 'https://elweb.co/mongodb-app/'
   license :mit
 
   app 'MongoDB.app'

--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -2,11 +2,11 @@ cask 'moom' do
   version '3.2.2'
   sha256 '8f9a5ce372ce6b8c992a123c4a531bcfac2483ca90fd9818475ac4eabe33ade2'
 
-  url "http://manytricks.com/download/_do_not_hotlink_/moom#{version.gsub('.','')}.dmg"
-  appcast 'http://manytricks.com/moom/appcast.xml',
+  url "https://manytricks.com/download/_do_not_hotlink_/moom#{version.gsub('.','')}.dmg"
+  appcast 'https://manytricks.com/moom/appcast.xml',
           :sha256 => '9d25269c3dfe53866ec4dc2622566f628110472b3c980b0582d24f691a02205c'
   name 'Moom'
-  homepage 'http://manytricks.com/moom/'
+  homepage 'https://manytricks.com/moom/'
   license :commercial
 
   app 'Moom.app'

--- a/Casks/mozyhome.rb
+++ b/Casks/mozyhome.rb
@@ -4,7 +4,7 @@ cask 'mozyhome' do
 
   url "https://secure.mozy.com/downloads/mozy-#{version.gsub('.','_')}.dmg"
   name 'MozyHome'
-  homepage 'http://mozy.com/'
+  homepage 'https://mozy.com/'
   license :commercial
 
   pkg 'MozyHome Installer.pkg'

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -7,7 +7,7 @@ cask 'mpv' do
   appcast 'https://github.com/mpv-player/mpv/releases.atom',
           :sha256 => '36931e63138ed1389a1f3f9d64fe074a8eb70e273eff849f025e2bddf648e3f7'
   name 'mpv'
-  homepage 'http://mpv.io/'
+  homepage 'https://mpv.io/'
   license :gpl
 
   app 'mpv.app'

--- a/Casks/multiply.rb
+++ b/Casks/multiply.rb
@@ -2,7 +2,7 @@ cask 'multiply' do
   version '1.1.1'
   sha256 'f4056d2e88886ee30ad8a6e05efcfcf37559a26190753610067248087ec4abff'
 
-  url "http://acondigital.com/software/Multiply_OSX_#{version.gsub('.', '_')}.pkg.zip"
+  url "https://acondigital.com/software/Multiply_OSX_#{version.gsub('.', '_')}.pkg.zip"
   name 'Multiply'
   homepage 'https://acondigital.com/products/multiply/'
   license :gratis

--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -4,7 +4,7 @@ cask 'musicbrainz-picard' do
 
   url "ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}.dmg"
   name 'MusicBrainz Picard'
-  homepage 'http://picard.musicbrainz.org'
+  homepage 'https://picard.musicbrainz.org'
   license :gpl
 
   app 'MusicBrainz Picard.app'

--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -3,10 +3,10 @@ cask 'name-mangler' do
   sha256 :no_check
 
   url 'http://manytricks.com/download/namemangler'
-  appcast 'http://manytricks.com/namemangler/appcast.xml',
+  appcast 'https://manytricks.com/namemangler/appcast.xml',
           :sha256 => '07b3d34b96bfbc008a7d1df5314abf97b404cf5d92a379ec13269585c7a7d30c'
   name 'Name Mangler'
-  homepage 'http://manytricks.com/namemangler/'
+  homepage 'https://manytricks.com/namemangler/'
   license :freemium
 
   app 'Name Mangler.app'

--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -2,11 +2,11 @@ cask 'namechanger' do
   version '3.0.2'
   sha256 '1aaa59d31eb2cf49f8a20fd0e34fff2174b16fb74b6242ead4ad5be13505c9fd'
 
-  url "http://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.gsub('.','_')}.zip"
-  appcast 'http://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
+  url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.gsub('.','_')}.zip"
+  appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
           :sha256 => '96883950ff45e3ff57b2a1257d1c4dd4df0ab38a895a186023968ed4ea164dd3'
   name 'NameChanger'
-  homepage 'http://www.mrrsoftware.com/MRRSoftware/NameChanger.html'
+  homepage 'https://www.mrrsoftware.com/MRRSoftware/NameChanger.html'
   license :gratis
 
   app 'NameChanger.app'

--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -5,7 +5,7 @@ cask 'nanobox' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/tools.nanobox.io/cli/darwin/amd64/nanobox'
   name 'nanobox'
-  homepage 'http://www.nanobox.io/'
+  homepage 'https://www.nanobox.io/'
   license :mpl
 
   depends_on :cask => 'virtualbox'

--- a/Casks/narrative-uploader.rb
+++ b/Casks/narrative-uploader.rb
@@ -2,8 +2,8 @@ cask 'narrative-uploader' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.getnarrative.com/appcast/installers/NarrativeUploader.dmg'
-  appcast 'http://dl.getnarrative.com/appcast/osx.xml',
+  url 'https://dl.getnarrative.com/appcast/installers/NarrativeUploader.dmg'
+  appcast 'https://dl.getnarrative.com/appcast/osx.xml',
           :sha256 => '82825330318ddb9cec11226ad6c040fa63defbd4a2356b0f18b976f2117e22d0'
   name 'Narrative Uploader'
   homepage 'http://getnarrative.com'

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -2,7 +2,7 @@ cask 'natron' do
   version '1.2.1'
   sha256 '39478124e8814dea23e8c2d47afb8862992ef5510b8776b441b04b8d1b7553cd'
 
-  url "http://downloads.natron.fr/Mac/releases/Natron_MacOSX_x86-64bits_v#{version}.dmg"
+  url "https://downloads.natron.fr/Mac/releases/Natron_MacOSX_x86-64bits_v#{version}.dmg"
   name 'Natron'
   homepage 'https://natron.inria.fr/'
   license :mpl

--- a/Casks/neat.rb
+++ b/Casks/neat.rb
@@ -4,7 +4,7 @@ cask 'neat' do
 
   url "http://cdn.neatco.com/Neat-#{version}-Release.dmg"
   name 'Neat for Mac'
-  homepage 'http://www.neat.com'
+  homepage 'https://www.neat.com'
   license :gratis
 
   pkg 'Install Neat.pkg'

--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -4,7 +4,7 @@ cask 'netlogo' do
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version.to_f}.dmg"
   name 'NetLogo'
-  homepage 'http://ccl.northwestern.edu/netlogo/'
+  homepage 'https://ccl.northwestern.edu/netlogo/'
   license :gpl
 
   zap :delete => [

--- a/Casks/night-owl.rb
+++ b/Casks/night-owl.rb
@@ -3,7 +3,7 @@ cask 'night-owl' do
   sha256 :no_check
 
   # null.net is the official download host per the vendor homepage
-  url 'http://aki-null.net/yf/NightOwl.zip'
+  url 'https://aki-null.net/yf/NightOwl.zip'
   name 'YoruFukurou'
   name 'NightOwl'
   appcast 'https://sites.google.com/site/yorufukurou/distribution/appcast.xml',

--- a/Casks/node-profiler.rb
+++ b/Casks/node-profiler.rb
@@ -2,7 +2,7 @@ cask 'node-profiler' do
   version '0.12.6'
   sha256 '25047304ab6b894b6aa4f910b606b6e6c31e680e7194016d6a0cee39af9631be'
 
-  url "http://profiler.oss-cn-hangzhou.aliyuncs.com/node-profiler-v#{version}.pkg"
+  url "https://profiler.oss-cn-hangzhou.aliyuncs.com/node-profiler-v#{version}.pkg"
   name 'node-profiler'
   homepage 'http://alinode.aliyun.com/'
   license :mit

--- a/Casks/noiz2sa.rb
+++ b/Casks/noiz2sa.rb
@@ -4,7 +4,7 @@ cask 'noiz2sa' do
 
   url 'https://workram.com/downloads.php?f=Noiz2sa', :referer => 'https://workram.com/games/noiz2sa'
   name 'Noiz2sa'
-  homepage 'http://workram.com/games/noiz2sa/'
+  homepage 'https://workram.com/games/noiz2sa/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Noiz2sa.app'

--- a/Casks/notebook.rb
+++ b/Casks/notebook.rb
@@ -2,7 +2,7 @@ cask 'notebook' do
   version '4.0.7v759'
   sha256 'e7d8f89090c51959eda0b1fd1dd1c5446bcd90a0a428937bb4ff19831187ddf4'
 
-  url "http://www.circusponies.com/availabledownloads/NoteBook/CircusPoniesNoteBook#{version}.dmg"
+  url "https://www.circusponies.com/availabledownloads/NoteBook/CircusPoniesNoteBook#{version}.dmg"
   name 'Notebook'
   name 'Circus Ponies Notebook'
   homepage 'http://www.circusponies.com/'

--- a/Casks/nti-shadow.rb
+++ b/Casks/nti-shadow.rb
@@ -2,7 +2,7 @@ cask 'nti-shadow' do
   version '5.0.0.52'
   sha256 'fb432cf051ecdf0a84000ab10c945a80e940188c33f8938465102d786f388ee2'
 
-  url "http://ftp4.nticorp.com/update/NTI_Shadow_#{version}_Free_Update_Mac.dmg"
+  url "https://ftp4.nticorp.com/update/NTI_Shadow_#{version}_Free_Update_Mac.dmg"
   name 'NTI Shadow 5 for Mac'
   homepage 'http://www.nticorp.com/en/us/product/shadow_5_mac.asp'
   license :commercial

--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -3,9 +3,9 @@ cask 'numi' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.dmitrynikolaev.numi/Numi.zip'
+  url 'https://dl.devmate.com/com.dmitrynikolaev.numi/Numi.zip'
   name 'Numi'
-  homepage 'http://numi.io/'
+  homepage 'https://numi.io/'
   license :gratis
 
   app 'Numi.app'

--- a/Casks/on-the-job.rb
+++ b/Casks/on-the-job.rb
@@ -4,9 +4,9 @@ cask 'on-the-job' do
 
   url 'http://stuntsoftware.com/downloads/OnTheJob.zip'
   name 'On The Job'
-  appcast 'http://stuntsoftware.com/PHP/sparkle/onthejob.php',
+  appcast 'https://stuntsoftware.com/PHP/sparkle/onthejob.php',
           :sha256 => 'dc68765c1d326ba50aeda9af4ed46c208c6c0b9a85379eb71be0ba3a92887bd0'
-  homepage 'http://stuntsoftware.com/onthejob/'
+  homepage 'https://stuntsoftware.com/onthejob/'
   license :commercial
 
   app 'On The Job.app'

--- a/Casks/open-sankore.rb
+++ b/Casks/open-sankore.rb
@@ -3,7 +3,7 @@ cask 'open-sankore' do
   sha256 '773e563a312b64542b0ca905b290606b46c85372e24e2ab5c807de7933f38828'
 
   # cndp.fr is the official download host per the vendor homepage
-  url "http://www.cndp.fr/open-sankore/OpenSankore/Releases/v#{version}/Open-Sankore_MacOSX_#{version}.dmg"
+  url "https://www.cndp.fr/open-sankore/OpenSankore/Releases/v#{version}/Open-Sankore_MacOSX_#{version}.dmg"
   name 'Open-Sankore'
   homepage 'http://open-sankore.org/'
   license :gpl

--- a/Casks/openlp.rb
+++ b/Casks/openlp.rb
@@ -4,7 +4,7 @@ cask 'openlp' do
 
   url "https://get.openlp.org/#{version}/OpenLP-#{version}.dmg"
   name 'OpenLP'
-  homepage 'http://openlp.org'
+  homepage 'https://openlp.org'
   license :gpl
 
   app 'OpenLP.app'

--- a/Casks/opera-mobile-emulator.rb
+++ b/Casks/opera-mobile-emulator.rb
@@ -2,7 +2,7 @@ cask 'opera-mobile-emulator' do
   version '12.1'
   sha256 'de7e456dae31d140eefa25dae55e96b9dd773167d72c4e0ff407002922a05f1f'
 
-  url "http://get.geo.opera.com/pub/opera/sdlbream/1210/Opera_Mobile_Emulator_#{version}_Mac.dmg"
+  url "https://get.geo.opera.com/pub/opera/sdlbream/1210/Opera_Mobile_Emulator_#{version}_Mac.dmg"
   name 'Opera Mobile Emulator'
   name 'Opera Mobile Classic Emulator'
   homepage 'http://www.opera.com/developer/mobile-emulator'

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -2,7 +2,7 @@ cask 'opera' do
   version '34.0.2036.25'
   sha256 '8e1caec4cf7492d763ea77d07e40d29afc22d4b2b3c139a95b01f89fbb2ff79f'
 
-  url "http://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
+  url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'
   homepage 'http://www.opera.com/'
   license :gratis

--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -5,7 +5,7 @@ cask 'origin' do
   # akamaihd.net is the official download host per the vendor homepage
   url 'https://eaassets-a.akamaihd.net/Origin-Client-Download/origin/mac/Origin.dmg'
   name 'Origin'
-  homepage 'http://origin.com'
+  homepage 'https://origin.com'
   license :gratis
 
   app 'Origin.app'

--- a/Casks/outwit-hub.rb
+++ b/Casks/outwit-hub.rb
@@ -4,7 +4,7 @@ cask 'outwit-hub' do
 
   url 'https://www.outwit.com/downloads/release/outwit-hub.en-US.mac64.dmg'
   name 'OutWit Hub'
-  homepage 'http://www.outwit.com'
+  homepage 'https://www.outwit.com'
   license :freemium
 
   app 'Outwit Hub.app'

--- a/Casks/overdrive-media-console.rb
+++ b/Casks/overdrive-media-console.rb
@@ -2,7 +2,7 @@ cask 'overdrive-media-console' do
   version '1.2'
   sha256 '6e04ac61337647aa86c67d04d62552a0c0a31a3104bf4856aa726e8317272be9'
 
-  url 'http://app.overdrive.com/downloads/ODMediaConsoleSetup.dmg'
+  url 'https://app.overdrive.com/downloads/ODMediaConsoleSetup.dmg'
   name 'OverDrive Media Console'
   homepage 'https://www.overdrive.com/'
   license :commercial

--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -4,7 +4,7 @@ cask 'p4merge' do
 
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*},'\1')}/bin.macosx107x86_64/P4V.dmg"
   name 'Perforce P4Merge'
-  homepage 'http://www.perforce.com/product/components/perforce-visual-merge-and-diff-tools'
+  homepage 'https://www.perforce.com/product/components/perforce-visual-merge-and-diff-tools'
   license :gratis
 
   app 'p4merge.app'

--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -5,7 +5,7 @@ cask 'p4v' do
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*},'\1')}/bin.macosx107x86_64/P4V.dmg"
   name 'Perforce Visual Client'
   name 'P4V'
-  homepage 'http://www.perforce.com/product/components/perforce-visual-client'
+  homepage 'https://www.perforce.com/product/components/perforce-visual-client'
   license :gratis
 
   app 'p4v.app'

--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -3,8 +3,8 @@ cask 'paintcode' do
   sha256 :no_check
 
   # pixelcut.com is the official download host per the appcast feed
-  url 'http://www.pixelcut.com/paintcode/paintcode.zip'
-  appcast 'http://www.pixelcut.com/paintcode/appcast.xml',
+  url 'https://www.pixelcut.com/paintcode/paintcode.zip'
+  appcast 'https://www.pixelcut.com/paintcode/appcast.xml',
           :sha256 => 'eeecc5760ba2d0c726cb7e1b23264314f99defc16832e0e7b6881af1cd97540f'
   name 'PaintCode'
   homepage 'http://www.paintcodeapp.com/'

--- a/Casks/pandora.rb
+++ b/Casks/pandora.rb
@@ -4,7 +4,7 @@ cask 'pandora' do
 
   url "https://www.pandora.com/static/desktop_app/pandora_#{version.gsub('.','_')}.air"
   name 'Pandora'
-  homepage 'http://www.pandora.com/'
+  homepage 'https://www.pandora.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   depends_on :cask => 'adobe-air'

--- a/Casks/panic-unison.rb
+++ b/Casks/panic-unison.rb
@@ -2,7 +2,7 @@ cask 'panic-unison' do
   version '2.2'
   sha256 'b9d08af6ea52fbcf8fe0eebaec9b7b68c7a280d4455de030d99ca9731cca66d9'
 
-  url "http://download.panic.com/Unison/Unison%20#{version}.zip"
+  url "https://download.panic.com/Unison/Unison%20#{version}.zip"
   name 'Unison'
   homepage 'https://panic.com/unison/'
   license :gratis

--- a/Casks/paragon-vmdk-mounter.rb
+++ b/Casks/paragon-vmdk-mounter.rb
@@ -4,7 +4,7 @@ cask 'paragon-vmdk-mounter' do
 
   url 'http://dl.paragon-software.com/free/VMDK_MOUNTER_2014.dmg'
   name 'Paragon VMDK Mounter'
-  homepage 'http://www.paragon-software.com/home/vd-mounter-mac-free/'
+  homepage 'https://www.paragon-software.com/home/vd-mounter-mac-free/'
   license :freemium
 
   pkg 'Paragon VMDK Mounter.pkg'

--- a/Casks/pdfmasher.rb
+++ b/Casks/pdfmasher.rb
@@ -2,11 +2,11 @@ cask 'pdfmasher' do
   version '0.7.4'
   sha256 '09940d6730d90bcf873e4d54262625ad566371258d14b0a6ac07a3b6dbcb9c30'
 
-  url "http://download.hardcoded.net/pdfmasher_osx_#{version.gsub('.', '_')}.dmg"
+  url "https://download.hardcoded.net/pdfmasher_osx_#{version.gsub('.', '_')}.dmg"
   name 'PdfMasher'
-  appcast 'http://www.hardcoded.net/updates/pdfmasher.appcast',
+  appcast 'https://www.hardcoded.net/updates/pdfmasher.appcast',
           :sha256 => '2007b9ce4044a444b80a80ec40016ae267a910f37880f0bed4dc881f2c3b18af'
-  homepage 'http://www.hardcoded.net/pdfmasher/'
+  homepage 'https://www.hardcoded.net/pdfmasher/'
   license :gpl
 
   app 'PdfMasher.app'

--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -2,11 +2,11 @@ cask 'pdfpen' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.smilesoftware.com/com.smileonmymac.PDFpen/PDFpen.zip'
+  url 'https://dl.smilesoftware.com/com.smileonmymac.PDFpen/PDFpen.zip'
   name 'PDFpen'
-  appcast 'http://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
+  appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
           :sha256 => '20c1ab602462b7fc0d5b4cbd555cacf127b69a07a737579598ebcbc0f5b21319'
-  homepage 'http://smilesoftware.com/PDFpen/'
+  homepage 'https://smilesoftware.com/PDFpen/'
   license :commercial
 
   app 'PDFpen.app'

--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -2,11 +2,11 @@ cask 'pdfpenpro' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/PDFpenPro.zip'
+  url 'https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/PDFpenPro.zip'
   name 'PDFpenPro'
-  appcast 'http://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
+  appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
           :sha256 => '20c1ab602462b7fc0d5b4cbd555cacf127b69a07a737579598ebcbc0f5b21319'
-  homepage 'http://www.smilesoftware.com/PDFpenPro/'
+  homepage 'https://www.smilesoftware.com/PDFpenPro/'
   license :commercial
 
   app 'PDFpenPro.app'

--- a/Casks/perian.rb
+++ b/Casks/perian.rb
@@ -5,7 +5,7 @@ cask 'perian' do
   # cachefly.net is the official download host per the vendor homepage
   url "https://perian.cachefly.net/Perian_#{version}.dmg"
   name 'Perian'
-  homepage 'http://www.perian.org/'
+  homepage 'https://www.perian.org/'
   license :gpl
 
   prefpane 'Perian.prefPane'

--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -5,7 +5,7 @@ cask 'pharo' do
   # pharo.org is the official download host per the vendor homepage
   url "http://files.pharo.org/platform/Pharo#{version}-mac.zip"
   name 'Pharo'
-  homepage 'http://pharo.org'
+  homepage 'https://pharo.org'
   license :oss
 
   app "Pharo#{version}.app"

--- a/Casks/pineapple.rb
+++ b/Casks/pineapple.rb
@@ -5,7 +5,7 @@ cask 'pineapple' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/com.nathansuniversity/Pineapple/Releases/Pineapple-#{version}-Python3.5.dmg"
   name 'Pineapple'
-  homepage 'http://nwhitehead.github.io/pineapple/'
+  homepage 'https://nwhitehead.github.io/pineapple/'
   license :gpl
 
   app 'Pineapple.app'

--- a/Casks/plug.rb
+++ b/Casks/plug.rb
@@ -2,11 +2,11 @@ cask 'plug' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.plugformac.com/updates/plug2/Plug-latest.dmg'
-  appcast 'http://www.plugformac.com/updates/plug2/sparklecast.xml',
+  url 'https://www.plugformac.com/updates/plug2/Plug-latest.dmg'
+  appcast 'https://www.plugformac.com/updates/plug2/sparklecast.xml',
           :sha256 => '8fadae02277ffed6b487550fd8e45690289cc228e2f3c9b1667ceb34fa559610'
   name 'Plug'
-  homepage 'http://www.plugformac.com/'
+  homepage 'https://www.plugformac.com/'
   license :gratis
 
   app 'Plug.app'

--- a/Casks/poedit.rb
+++ b/Casks/poedit.rb
@@ -4,7 +4,7 @@ cask 'poedit' do
     version '1.5.7'
     sha256 '2017538011239f07924b709e4c13aa3fd7f83a96f76208b8b746fcee29251caf'
 
-    url "http://poedit.net/dl/poedit-#{version}.dmg"
+    url "https://poedit.net/dl/poedit-#{version}.dmg"
   else
     version '1.8.6'
     sha256 'ca51faff5a818e4bb1fab96055d1f1b5e45ca1c5e84110400397b6f57dc49dcf'

--- a/Casks/polar-websync.rb
+++ b/Casks/polar-websync.rb
@@ -4,7 +4,7 @@ cask 'polar-websync' do
 
   url "https://www.polarpersonaltrainer.com/downloads/websync_#{version}.dmg"
   name 'Polar WebSync Software'
-  homepage 'http://www.polar.com/us-en/support/downloads/Polar_WebSync_Software'
+  homepage 'https://www.polar.com/us-en/support/downloads/Polar_WebSync_Software'
   license :closed
 
   # cannot be installed automatically, because it presents a choice

--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -2,7 +2,7 @@ cask 'pomodone' do
   version :latest
   sha256 :no_check
 
-  url 'http://app.pomodoneapp.com/PomoDone.dmg'
+  url 'https://app.pomodoneapp.com/PomoDone.dmg'
   name 'PomoDone'
   homepage 'http://pomodoneapp.com/'
   license :gratis

--- a/Casks/popkey.rb
+++ b/Casks/popkey.rb
@@ -5,7 +5,7 @@ cask 'popkey' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://popkey-downloads.s3.amazonaws.com/releases/darwin/PopKeySetup.dmg'
   name 'PopKey'
-  homepage 'http://popkey.co/send-gifs?ref=header_app_nav_section'
+  homepage 'https://popkey.co/send-gifs?ref=header_app_nav_section'
   license :gratis
 
   app 'PopKey.app'

--- a/Casks/porthole.rb
+++ b/Casks/porthole.rb
@@ -3,7 +3,7 @@ cask 'porthole' do
   sha256 :no_check
 
   url 'http://getporthole.com/downloads/trial'
-  appcast 'http://update.getporthole.com/appcast.rss',
+  appcast 'https://update.getporthole.com/appcast.rss',
           :sha256 => '3ef0f2a1f0df7613bdeab8603c49420bd3f15a81b83804cb01352ee3ce9cf806'
   name 'Porthole'
   homepage 'http://getporthole.com/'

--- a/Casks/power-manager-pro.rb
+++ b/Casks/power-manager-pro.rb
@@ -3,7 +3,7 @@ cask 'power-manager-pro' do
   sha256 :no_check
 
   url 'https://www.dssw.co.uk/powermanager/dsswpowermanagerpro.dmg'
-  appcast 'http://version.dssw.co.uk/powermanager/professional',
+  appcast 'https://version.dssw.co.uk/powermanager/professional',
           :sha256 => 'efb8f5e10013d3c8d3cca67f3434b80a8548c77c04960f9ec17dc2e51e70f7ca'
   name 'Power Manager Pro'
   homepage 'https://www.dssw.co.uk/powermanager'

--- a/Casks/power-manager.rb
+++ b/Casks/power-manager.rb
@@ -3,7 +3,7 @@ cask 'power-manager' do
   sha256 :no_check
 
   url 'https://www.dssw.co.uk/powermanager/dsswpowermanager.dmg'
-  appcast 'http://version.dssw.co.uk/powermanager/application',
+  appcast 'https://version.dssw.co.uk/powermanager/application',
           :sha256 => '8a476c045add431b90ad47eb0bd6317bac80696e74b6c1a5e6f4dee6e172f651'
   name 'Power Manager'
   homepage 'https://www.dssw.co.uk/powermanager'

--- a/Casks/powermate.rb
+++ b/Casks/powermate.rb
@@ -4,7 +4,7 @@ cask 'powermate' do
 
   url "http://support.griffintechnology.com/sites/default/files/PowerMate_v#{version}.zip"
   name 'Griffin Powermate'
-  homepage 'http://support.griffintechnology.com/support/powermate/'
+  homepage 'https://support.griffintechnology.com/support/powermate/'
   license :gratis
 
   app 'PowerMate.app'

--- a/Casks/pphelper.rb
+++ b/Casks/pphelper.rb
@@ -2,7 +2,7 @@ cask 'pphelper' do
   version :latest
   sha256 :no_check
 
-  url 'http://ghost.25pp.com/soft/pp_mac.dmg'
+  url 'https://ghost.25pp.com/soft/pp_mac.dmg'
   name 'pp助手'
   name 'pphelper'
   appcast 'https://liveupdate.25pp.com/macpc/Appcast.xml',

--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -7,7 +7,7 @@ cask 'pritunl' do
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
           :sha256 => 'bc21320479679d2db525581edfaf33e0f8abab534e658aa190eb973a0050ca98'
   name 'Pritunl OpenVPN Client'
-  homepage 'http://client.pritunl.com'
+  homepage 'https://client.pritunl.com'
   license :gpl
 
   pkg 'Pritunl.pkg'

--- a/Casks/pubu.rb
+++ b/Casks/pubu.rb
@@ -4,7 +4,7 @@ cask 'pubu' do
 
   url "http://facecdn.u.qiniudn.com/downloads/%E7%80%91%E5%B8%83_OSX_V#{version}_Beta.zip"
   name '瀑布'
-  homepage 'http://pubu.im'
+  homepage 'https://pubu.im'
   license :gratis
 
   app '瀑布.app'

--- a/Casks/punto-switcher.rb
+++ b/Casks/punto-switcher.rb
@@ -3,9 +3,9 @@ cask 'punto-switcher' do
   sha256 :no_check
 
   # yandex.net is the official download host per the vendor homepage
-  url 'http://cache-default02d.cdn.yandex.net/download.cdn.yandex.net/punto/mac/PuntoSwitcher.zip'
+  url 'https://cache-default02d.cdn.yandex.net/download.cdn.yandex.net/punto/mac/PuntoSwitcher.zip'
   name 'Punto Switcher'
-  homepage 'http://punto.yandex.ru'
+  homepage 'https://punto.yandex.ru'
   license :gratis
 
   pkg 'PuntoSwitcher Installer.pkg'

--- a/Casks/qfinder.rb
+++ b/Casks/qfinder.rb
@@ -4,7 +4,7 @@ cask 'qfinder' do
 
   url 'https://download.qnap.com/webstart/QNAPQfinder_Mac.dmg'
   name 'Qnap Qfinder'
-  homepage 'http://www.qnap.com/i/in/utility/#block_1'
+  homepage 'https://www.qnap.com/i/in/utility/#block_1'
   license :gratis
 
   pkg 'Qfinder.pkg'

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -4,7 +4,7 @@ cask 'qiyimedia' do
 
   url 'http://static.qiyi.com/ext/common/QIYImedia_Mac_5.dmg'
   name '爱奇艺视频'
-  homepage 'http://www.iqiyi.com'
+  homepage 'https://www.iqiyi.com'
   license :gratis
 
   app '爱奇艺.app'

--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -3,7 +3,7 @@ cask 'qlimagesize' do
   sha256 :no_check
 
   # whine.fr is the official download host per the vendor homepage
-  url 'http://repo.whine.fr/qlImageSize.pkg'
+  url 'https://repo.whine.fr/qlImageSize.pkg'
   name 'qlImageSize'
   homepage 'https://github.com/Nyx0uf/qlImageSize'
   license :bsd

--- a/Casks/qqmusic.rb
+++ b/Casks/qqmusic.rb
@@ -4,7 +4,7 @@ cask 'qqmusic' do
 
   url "http://dldir1.qq.com/music/clntupate/mac/QQMusic#{version}.dmg"
   name 'QQ音乐'
-  homepage 'http://y.qq.com'
+  homepage 'https://y.qq.com'
   license :commercial
 
   app 'QQMusic.app'

--- a/Casks/qrq.rb
+++ b/Casks/qrq.rb
@@ -2,9 +2,9 @@ cask 'qrq' do
   version '0.3.1'
   sha256 '76712d07f2d61b5d382c4c0c02a0c067e752c745db6b931717b3eb1e42e5076a'
 
-  url "http://fkurz.net/ham/qrq/qrq-#{version}.dmg"
+  url "https://fkurz.net/ham/qrq/qrq-#{version}.dmg"
   name 'qrq'
-  homepage 'http://fkurz.net/ham/qrq.html'
+  homepage 'https://fkurz.net/ham/qrq.html'
   license :gpl
 
   app 'qrq.app'

--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -4,7 +4,7 @@ cask 'qt-creator' do
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.to_f}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'
-  homepage 'http://www.qt.io/developers/'
+  homepage 'https://www.qt.io/developers/'
   license :gpl
 
   app 'Qt Creator.app'

--- a/Casks/quickbooks-desktop.rb
+++ b/Casks/quickbooks-desktop.rb
@@ -2,9 +2,9 @@ cask 'quickbooks-desktop' do
   version '2016'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://http-download.intuit.com/http.intuit/Downloads/#{version}/Latest/QuickBooksMac#{version}.dmg"
+  url "https://http-download.intuit.com/http.intuit/Downloads/#{version}/Latest/QuickBooksMac#{version}.dmg"
   name 'QuickBooks Desktop'
-  homepage 'http://quickbooks.intuit.com/mac/'
+  homepage 'https://quickbooks.intuit.com/mac/'
   license :commercial
 
   app "QuickBooks #{version}.app"

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -12,7 +12,7 @@ cask 'quicksilver' do
 
   url "https://qs0.qsapp.com/plugins/download.php?qsversion=#{version.sub(%r{^.*?-},'')}.dmg"
   name 'Quicksilver'
-  homepage 'http://qsapp.com/'
+  homepage 'https://qsapp.com/'
   license :apache
 
   app 'Quicksilver.app'

--- a/Casks/quiterss.rb
+++ b/Casks/quiterss.rb
@@ -2,9 +2,9 @@ cask 'quiterss' do
   version '0.17.7'
   sha256 '7967cd729044152b1e876eba9492fbfc307104b259dbb2bb664d486836cda3dd'
 
-  url "http://quiterss.org/files/#{version}/QuiteRSS-#{version}.dmg"
+  url "https://quiterss.org/files/#{version}/QuiteRSS-#{version}.dmg"
   name 'QuiteRSS'
-  homepage 'http://quiterss.org/'
+  homepage 'https://quiterss.org/'
   license :gpl
 
   app 'Quiterss.app'

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -4,18 +4,18 @@ cask 'r' do
     version '3.2.1'
     sha256 '88b9a20af00a916f3902ccac83098643b95a2801eb4775d38130b26871323a3f'
     # rstudio.com is the official download host per the vendor homepage
-    url "http://cran.rstudio.com/bin/macosx/R-#{version}-snowleopard.pkg"
+    url "https://cran.rstudio.com/bin/macosx/R-#{version}-snowleopard.pkg"
     pkg "R-#{version}-snowleopard.pkg"
   else
     version '3.2.3'
     sha256 '27068a2b50f19758c41908d6a959c927eb15a7d8736951d4cc61b4eb5d78c590'
     # rstudio.com is the official download host per the vendor homepage
-    url "http://cran.rstudio.com/bin/macosx/R-#{version}.pkg"
+    url "https://cran.rstudio.com/bin/macosx/R-#{version}.pkg"
     pkg "R-#{version}.pkg"
   end
 
   name 'R'
-  homepage 'http://www.r-project.org/'
+  homepage 'https://www.r-project.org/'
   license :gpl
 
   depends_on :macos => '>= :snow_leopard'

--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -6,7 +6,7 @@ cask 'radiant-player' do
   appcast 'https://github.com/radiant-player/radiant-player-mac/releases.atom',
           :sha256 => 'fd476d1c9ce75b9b33de45259ccd6f45095ef5e0702219333edccd6aac6a06ab'
   name 'Radiant Player'
-  homepage 'http://radiant-player.github.io/radiant-player-mac/'
+  homepage 'https://radiant-player.github.io/radiant-player-mac/'
   license :mit
 
   app 'Radiant Player.app'

--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -3,8 +3,8 @@ cask 'rapidweaver' do
   sha256 :no_check # required as upstream package is updated in-place
 
   # devmate.com is the official download host per the appcast feed
-  url "http://dl.devmate.com/com.realmacsoftware.rapidweaver#{version.to_i}/RapidWeaver#{version.to_i}.zip"
-  appcast "http://updates.devmate.com/com.realmacsoftware.rapidweaver#{version.to_i}.xml",
+  url "https://dl.devmate.com/com.realmacsoftware.rapidweaver#{version.to_i}/RapidWeaver#{version.to_i}.zip"
+  appcast "https://updates.devmate.com/com.realmacsoftware.rapidweaver#{version.to_i}.xml",
             :sha256 => '4dfae736ef9b65d391e69bb5db65ec275968f9a7d6c2cda6d57be2e6abc9fe5b'
   name 'RapidWeaver'
   homepage 'http://realmacsoftware.com/rapidweaver'

--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -2,11 +2,11 @@ cask 'raw-photo-processor' do
   version '4.7.2'
   sha256 'ef300adaaf3399f43741a51f06c062a34c4e809eecdbbffce2cd15af414fbd7f'
 
-  url 'http://www.raw-photo-processor.com/RPP/RPP_64.zip'
+  url 'https://www.raw-photo-processor.com/RPP/RPP_64.zip'
   appcast 'http://www.raw-photo-processor.com/rpp_updates.xml',
           :sha256 => '83e550582ec77d965383ba778ce68e0e0c3f71501a546fab8619119ec2825287'
   name 'Raw Photo Processor'
-  homepage 'http://www.raw-photo-processor.com/RPP/Overview.html'
+  homepage 'https://www.raw-photo-processor.com/RPP/Overview.html'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   # note: this value changes with each version

--- a/Casks/razer-synapse.rb
+++ b/Casks/razer-synapse.rb
@@ -5,7 +5,7 @@ cask 'razer-synapse' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://razerdrivers.s3.amazonaws.com/drivers/Synapse2/mac/Razer_Synapse_Mac_Driver_v#{version}.dmg"
   name 'Razer Synapse'
-  homepage 'http://www.razerzone.com/synapse/'
+  homepage 'https://www.razerzone.com/synapse/'
   license :gratis
 
   pkg 'Razer Synapse.pkg'

--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -10,7 +10,7 @@ cask 'razorsql' do
   end
 
   name 'RazorSQL'
-  homepage 'http://razorsql.com/download_mac.html'
+  homepage 'https://razorsql.com/download_mac.html'
   license :commercial
 
   app 'RazorSQL.app'

--- a/Casks/readcube.rb
+++ b/Casks/readcube.rb
@@ -2,7 +2,7 @@ cask 'readcube' do
   version '2.0.12'
   sha256 'fe833ae0b0317f85781344d422027fdb2b8e6dd6e30860fff8e427d60c1c5a3c'
 
-  url "http://download.readcube.com/desktop/#{version}/ReadCubeSetup.zip"
+  url "https://download.readcube.com/desktop/#{version}/ReadCubeSetup.zip"
   name 'ReadCube'
   homepage 'https://www.readcube.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -3,7 +3,7 @@ cask 'redcine-x-pro' do
   sha256 '9393f84d839214ef4b692434ced8f4f9ecd12f8f49d8230d84c1bef9fe44d4db'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://s3.amazonaws.com/red_3/downloads/software/rcx/REDCINE-X_PRO_Build_#{version.to_i}_OSX.zip"
+  url "https://s3.amazonaws.com/red_3/downloads/software/rcx/REDCINE-X_PRO_Build_#{version.to_i}_OSX.zip"
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'
   license :commercial

--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -2,7 +2,7 @@ cask 'reflector' do
   version '2.3.1'
   sha256 'e780b023343029eb7ccda2667b4da7d2c8f7f894419796a180c41e1056a53942'
 
-  url "http://download.airsquirrels.com/Reflector2/Mac/Reflector-#{version}.dmg"
+  url "https://download.airsquirrels.com/Reflector2/Mac/Reflector-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/Reflector2/Mac/Reflector2.xml',
           :sha256 => '06e14635a5e8f3bab90d1c052f3bb3696fa652c1cf77f5745a67dc3b65fe9e83'
   name 'Reflector 2'

--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -2,9 +2,9 @@ cask 'rekordbox' do
   version '3.2.2'
   sha256 'f12cafb0764177bafbb267342c3bd367572c42cc9e340081a0e84ef2bf7ed433'
 
-  url "http://rekordbox.com/_app/files/Install_rekordbox_#{version.gsub('.','_')}.pkg.zip"
+  url "https://rekordbox.com/_app/files/Install_rekordbox_#{version.gsub('.','_')}.pkg.zip"
   name 'rekordbox'
-  homepage 'http://rekordbox.com/en/'
+  homepage 'https://rekordbox.com/en/'
   license :closed
 
   pkg "Install_rekordbox_#{version.gsub('.','_')}.pkg"

--- a/Casks/remoteviewer.rb
+++ b/Casks/remoteviewer.rb
@@ -3,9 +3,9 @@ cask 'remoteviewer' do
   sha256 '96ec9eb33422ac8a717238a7f99fded7c50503198d7302028a09f4e536b02849'
 
   # freedesktop.org is the official download host per the vendor homepage
-  url "http://people.freedesktop.org/~teuf/spice-gtk-osx/dmg/#{version.sub(%r{-.*},'')}/RemoteViewer-#{version}.dmg"
+  url "https://people.freedesktop.org/~teuf/spice-gtk-osx/dmg/#{version.sub(%r{-.*},'')}/RemoteViewer-#{version}.dmg"
   name 'Remote Viewer'
-  homepage 'http://www.ovirt.org/SPICE_Remote-Viewer_on_OS_X'
+  homepage 'https://www.ovirt.org/SPICE_Remote-Viewer_on_OS_X'
   license :gratis
 
   app 'RemoteViewer.app'

--- a/Casks/resolutionator.rb
+++ b/Casks/resolutionator.rb
@@ -4,9 +4,9 @@ cask 'resolutionator' do
 
   url 'http://manytricks.com/download/resolutionator'
   name 'Resolutionator'
-  appcast 'http://manytricks.com/resolutionator/appcast.xml',
+  appcast 'https://manytricks.com/resolutionator/appcast.xml',
           :sha256 => 'daf1d476cf2235d77b3f0303b5f2672cafff7b713914a50a28d68c6747fece2f'
-  homepage 'http://manytricks.com/resolutionator/'
+  homepage 'https://manytricks.com/resolutionator/'
   license :gratis
 
   depends_on :macos => '>= :mountain_lion'

--- a/Casks/retas-studio.rb
+++ b/Casks/retas-studio.rb
@@ -3,7 +3,7 @@ cask 'retas-studio' do
   sha256 '387d299ac77dad4a4116605e492e7c69614c463cde2ce5df439caaa55c9befb5'
 
   # clip-studio.com is the official download host per the vendor homepage
-  url "http://www.clip-studio.com/clip_site/rental/rental_download/rsrental/dl?f=lib/retasstudio/data/#{version.delete('.')}/RS_#{version.delete('.')}_app.dmg"
+  url "https://www.clip-studio.com/clip_site/rental/rental_download/rsrental/dl?f=lib/retasstudio/data/#{version.delete('.')}/RS_#{version.delete('.')}_app.dmg"
   name 'RETAS STUDIO'
   homepage 'http://www.retasstudio.net/'
   license :commercial

--- a/Casks/rethinkdb.rb
+++ b/Casks/rethinkdb.rb
@@ -2,9 +2,9 @@ cask 'rethinkdb' do
   version '2.0.1'
   sha256 'd5bdab6e7d347aa00b7733dc87e08a876406dee675eaae830f9d37c283350466'
 
-  url "http://download.rethinkdb.com/osx/rethinkdb-#{version}.dmg"
+  url "https://download.rethinkdb.com/osx/rethinkdb-#{version}.dmg"
   name 'RethinkDB'
-  homepage 'http://www.rethinkdb.com'
+  homepage 'https://www.rethinkdb.com'
   license :affero
 
   pkg "rethinkdb-#{version}.pkg"

--- a/Casks/retini.rb
+++ b/Casks/retini.rb
@@ -4,7 +4,7 @@ cask 'retini' do
 
   url 'https://github.com/terwanerik/Retini/raw/master/Retini.zip'
   name 'Retini'
-  homepage 'http://terwanerik.github.io/Retini/'
+  homepage 'https://terwanerik.github.io/Retini/'
   license :mit
 
   app 'Retini.app'

--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -2,9 +2,9 @@ cask 'retroarch' do
   version '1.2.2'
   sha256 'fb5bb649edb2be67ca106166be27e3c4be8fe0d84169a4af1ae6e00ad3b3e784'
 
-  url "http://buildbot.libretro.com/stable/#{version}/osx-x86_64/RetroArch-OSX10.7-x86_64-v#{version}.zip"
+  url "https://buildbot.libretro.com/stable/#{version}/osx-x86_64/RetroArch-OSX10.7-x86_64-v#{version}.zip"
   name 'RetroArch'
-  homepage 'http://www.libretro.com/'
+  homepage 'https://www.libretro.com/'
   license :gpl
 
   app 'RetroArch.app'

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -3,7 +3,7 @@ cask 'ridibooks' do
   sha256 '27e06ef0625f8958a909c7801bfd0108d975164fec9b241d1a12ab083edea2e0'
 
   # ridicorp.com is the official download host per the vendor homepage
-  url "http://cdn.ridicorp.com/app/mac/ridibooks-#{version}.dmg"
+  url "https://cdn.ridicorp.com/app/mac/ridibooks-#{version}.dmg"
   name 'Ridibooks'
   homepage 'https://ridibooks.com/support/app/download'
   license :gratis

--- a/Casks/ringtones.rb
+++ b/Casks/ringtones.rb
@@ -2,7 +2,7 @@ cask 'ringtones' do
   version :latest
   sha256 :no_check
 
-  url 'http://files.thelittleappfactory.com/ringtones/Ringtones.zip'
+  url 'https://files.thelittleappfactory.com/ringtones/Ringtones.zip'
   appcast 'https://files.thelittleappfactory.com/ringtones/appcast.xml',
           :sha256 => 'd367eeb825e7a4dc409fa8b7daee6644ef13a31b058f2395e4347490bbad01b3'
   name 'Ringtones'

--- a/Casks/ripit.rb
+++ b/Casks/ripit.rb
@@ -2,7 +2,7 @@ cask 'ripit' do
   version :latest
   sha256 :no_check
 
-  url 'http://files.thelittleappfactory.com/ripit/RipIt.zip'
+  url 'https://files.thelittleappfactory.com/ripit/RipIt.zip'
   appcast 'https://files.thelittleappfactory.com/ripit/appcast.xml',
           :sha256 => 'b2f4306183f5a193000dbfc55e70949e3c7394488264e4dac6c42ee463970b30'
   name 'RipIt'

--- a/Casks/robomongo.rb
+++ b/Casks/robomongo.rb
@@ -2,9 +2,9 @@ cask 'robomongo' do
   version '0.8.5'
   sha256 'fdf9fb0bb94accf92217de6424a1760cf4ed4ab1dbda929b7892b5ddde4074e0'
 
-  url "http://app.robomongo.org/files/mac/Robomongo-#{version}-x86_64.dmg"
+  url "https://app.robomongo.org/files/mac/Robomongo-#{version}-x86_64.dmg"
   name 'Robomongo'
-  homepage 'http://robomongo.org'
+  homepage 'https://robomongo.org'
   license :gpl
 
   app 'Robomongo.app'

--- a/Casks/rodeo.rb
+++ b/Casks/rodeo.rb
@@ -3,7 +3,7 @@ cask 'rodeo' do
   sha256 '7c91c88715e05cebf6ce2f64551c26d560c1675d786c7f1b5ff6bee03b5fcc79'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://rodeo-releases.s3.amazonaws.com/#{version}/Rodeo-v#{version}-darwin_64.dmg"
+  url "https://rodeo-releases.s3.amazonaws.com/#{version}/Rodeo-v#{version}-darwin_64.dmg"
   name 'Rodeo'
   homepage 'http://rodeo.yhat.com/'
   license :closed

--- a/Casks/rrootage.rb
+++ b/Casks/rrootage.rb
@@ -4,7 +4,7 @@ cask 'rrootage' do
 
   url 'https://workram.com/downloads.php?f=rRootage', :referer => 'https://workram.com/games/rrootage'
   name 'rRootage'
-  homepage 'http://workram.com/games/rrootage/'
+  homepage 'https://workram.com/games/rrootage/'
   license :bsd
 
   app 'rRootage.app'

--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -5,7 +5,7 @@ cask 'rstudio' do
   # rstudio.org is the official download host per the vendor homepage
   url "https://download1.rstudio.org/RStudio-#{version}.dmg"
   name 'RStudio'
-  homepage 'http://www.rstudio.com/'
+  homepage 'https://www.rstudio.com/'
   license :affero
 
   app 'RStudio.app'

--- a/Casks/rust.rb
+++ b/Casks/rust.rb
@@ -4,7 +4,7 @@ cask 'rust' do
 
   url "https://static.rust-lang.org/dist/rust-#{version}-x86_64-apple-darwin.pkg"
   name 'Rust'
-  homepage 'http://www.rust-lang.org/'
+  homepage 'https://www.rust-lang.org/'
   license :oss
 
   pkg "rust-#{version}-x86_64-apple-darwin.pkg"

--- a/Casks/sachsen.rb
+++ b/Casks/sachsen.rb
@@ -3,7 +3,7 @@ cask 'sachsen' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/eu.lauterbach.Sachsen/Sachsen.zip'
+  url 'https://dl.devmate.com/eu.lauterbach.Sachsen/Sachsen.zip'
   name 'Sachsen'
   homepage 'http://www.ccll1.net/sachsen/'
   license :commercial

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -3,11 +3,11 @@ cask 'scala-ide' do
 
   if Hardware::CPU.is_32_bit?
     # typesafe.com is the official download host per the vendor homepage
-    url "http://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20150928/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
+    url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20150928/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
     sha256 '3f43fef5ccb7f01b6e539c9270e26799361c006b3bfdba2140a9af8e8eafe197'
   else
     # typesafe.com is the official download host per the vendor homepage
-    url "http://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20151201/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+    url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20151201/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
     sha256 '3a7ad459cf2257da2cb8694b47c6fdb30ff3c3bcc020e03636fc49635a476ef6'
   end
 

--- a/Casks/schnapps.rb
+++ b/Casks/schnapps.rb
@@ -2,7 +2,7 @@ cask 'schnapps' do
   version :latest
   sha256 :no_check
 
-  url 'http://d15xn61otjv90c.cloudfront.net/download/Schnapps_latest.zip'
+  url 'https://d15xn61otjv90c.cloudfront.net/download/Schnapps_latest.zip'
   name 'Schnapps'
   appcast 'http://schnappsformac.com/download/appcast.xml',
           :sha256 => '1fa261b1b268b99f43353523c760d602ae10e41ae1a7daeadeb98e9d9fae4f4b'

--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -2,11 +2,11 @@ cask 'screenflow' do
   version '5.0.3'
   sha256 '5f729b09b04c29e20af3048aaccd8e60ad0527c4e6e5f0cdb07e82d73da3af88'
 
-  url "http://www.telestream.net/download-files/screenflow/5-0/ScreenFlow-#{version}.dmg"
-  appcast 'http://www.telestream.net/updater/screenflow/appcast.xml',
+  url "https://www.telestream.net/download-files/screenflow/5-0/ScreenFlow-#{version}.dmg"
+  appcast 'https://www.telestream.net/updater/screenflow/appcast.xml',
           :sha256 => '349eb93b3e0822e316cfa1d29f151ac14de555a6cdbfa962c8d6b774be44f037'
   name 'ScreenFlow'
-  homepage 'http://www.telestream.net/screenflow/'
+  homepage 'https://www.telestream.net/screenflow/'
   license :commercial
 
   app 'ScreenFlow.app'

--- a/Casks/scriptql.rb
+++ b/Casks/scriptql.rb
@@ -2,9 +2,9 @@ cask 'scriptql' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.kainjow.com/downloads/ScriptQL_qlgenerator.zip'
+  url 'https://www.kainjow.com/downloads/ScriptQL_qlgenerator.zip'
   name 'ScriptQL'
-  homepage 'http://www.kainjow.com/'
+  homepage 'https://www.kainjow.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   qlplugin 'ScriptQL.qlgenerator'

--- a/Casks/scroll-reverser.rb
+++ b/Casks/scroll-reverser.rb
@@ -6,7 +6,7 @@ cask 'scroll-reverser' do
   else
     version '1.7.2'
     sha256 'f0ad4d18daae486b14ea5b6809c5222af6c5fc74536574151dce2271d3a67c06'
-    appcast 'http://softwareupdate.pilotmoon.com/update/scrollreverser/appcast.xml',
+    appcast 'https://softwareupdate.pilotmoon.com/update/scrollreverser/appcast.xml',
             :sha256 => 'ed8e2d6748eb8b79897ca1b84a1597e86afb7845b469a278c83c07e08e6eb886'
   end
 

--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -2,11 +2,11 @@ cask 'semulov' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.kainjow.com/downloads/Semulov.zip'
+  url 'https://www.kainjow.com/downloads/Semulov.zip'
   name 'Semulov'
-  appcast 'http://kainjow.com/updates/semulov.xml',
+  appcast 'https://kainjow.com/updates/semulov.xml',
           :sha256 => 'd458ce08acdc5848d165c397192bb502f12a878b10680e355b31e47b54f57442'
-  homepage 'http://www.kainjow.com'
+  homepage 'https://www.kainjow.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Semulov.app'

--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -2,9 +2,9 @@ cask 'sencha' do
   version '6.0.2.14'
   sha256 '7d131f333585ed74a31c4c4efa9ecc5176cf5d5410eeddb631c974a847216cec'
 
-  url "http://cdn.sencha.com/cmd/#{version}/jre/SenchaCmd-#{version}-osx.app.zip"
+  url "https://cdn.sencha.com/cmd/#{version}/jre/SenchaCmd-#{version}-osx.app.zip"
   name 'Sencha Cmd'
-  homepage 'http://www.sencha.com/products/sencha-cmd/'
+  homepage 'https://www.sencha.com/products/sencha-cmd/'
   license :freemium
 
   installer :script => "SenchaCmd-#{version}-osx.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/sente.rb
+++ b/Casks/sente.rb
@@ -14,7 +14,7 @@ cask 'sente' do
   appcast 'https://www.thirdstreetsoftware.com/rss/Sente65.xml?v=6.6.0',
           :sha256 => '2083ee7a01313014c7d600e13018709521fd3f53d767bd31cd8d2caec2120c7f'
   name 'Sente'
-  homepage 'http://www.thirdstreetsoftware.com'
+  homepage 'https://www.thirdstreetsoftware.com'
   license :freemium
 
   app 'Sente 6.app'

--- a/Casks/sequin.rb
+++ b/Casks/sequin.rb
@@ -4,7 +4,7 @@ cask 'sequin' do
 
   url 'ftp://ftp.ncbi.nih.gov/sequin/sequin.mac.dmg'
   name 'Sequin'
-  homepage 'http://www.ncbi.nlm.nih.gov/Sequin/'
+  homepage 'https://www.ncbi.nlm.nih.gov/Sequin/'
   license :unknown
 
   app 'Sequin Folder/Sequin.app'

--- a/Casks/shiori.rb
+++ b/Casks/shiori.rb
@@ -2,11 +2,11 @@ cask 'shiori' do
   version '1.0.2'
   sha256 'c832edc2762fdaadc80bfe042ee6f7bd128955e3d7b27bdc5baf5806a0c8a719'
 
-  url "http://aki-null.net/shiori/release/Shiori_#{version}.zip"
-  appcast 'http://aki-null.net/shiori/appcast.xml',
+  url "https://aki-null.net/shiori/release/Shiori_#{version}.zip"
+  appcast 'https://aki-null.net/shiori/appcast.xml',
           :sha256 => '244668dde7c677ddaaccc55c997874e13d3c8de5213c5e0810eeacd6fdcc713e'
   name 'Shiori'
-  homepage 'http://aki-null.net/shiori/'
+  homepage 'https://aki-null.net/shiori/'
   license :gratis
 
   app 'Shiori.app'

--- a/Casks/short-menu.rb
+++ b/Casks/short-menu.rb
@@ -3,7 +3,7 @@ cask 'short-menu' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.floschliep.Short-Menu/ShortMenu.zip'
+  url 'https://dl.devmate.com/com.floschliep.Short-Menu/ShortMenu.zip'
   name 'Short Menu'
   homepage 'http://appiculous.com/short-menu-mac/'
   license :commercial

--- a/Casks/shruplay.rb
+++ b/Casks/shruplay.rb
@@ -4,7 +4,7 @@ cask 'shruplay' do
 
   url 'http://cdn.getshru.com/wp-content/uploads/2015/10/SHRUPlayMac_2015_05_16.zip'
   name 'PDX Pet Design SHRUPlay'
-  homepage 'http://getshru.com/'
+  homepage 'https://getshru.com/'
   license :gratis
 
   app 'ShruPlay.app'

--- a/Casks/silverlight.rb
+++ b/Casks/silverlight.rb
@@ -2,7 +2,7 @@ cask 'silverlight' do
   version '5.1.41105.0'
   sha256 :no_check    # required as upstream package is updated in-place
 
-  url 'http://download.microsoft.com/download/8/5/8/858377D7-5FDE-410D-B2FA-411B8078D227/41105/41105.00/Silverlight.dmg'
+  url 'https://download.microsoft.com/download/8/5/8/858377D7-5FDE-410D-B2FA-411B8078D227/41105/41105.00/Silverlight.dmg'
   name 'Silverlight'
   homepage 'https://www.microsoft.com/silverlight/'
   license :gratis

--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -2,11 +2,11 @@ cask 'simpholders' do
   version '2.1'
   sha256 '68472926b108bc46b84fd2b6c1083b9fd1810f5fb70fc0924818d60f5bb8e668'
 
-  url "http://simpholders.com/site/assets/files/1115/simpholders_#{version.gsub('.','_')}.dmg"
+  url "https://simpholders.com/site/assets/files/1115/simpholders_#{version.gsub('.','_')}.dmg"
   appcast 'http://kfi-apps.com/appcasts/simpholders/',
           :sha256 => 'baa9148ebfb168d1c86480da0863b89a9eeb7b70e8d8e1e5806c7f7e1a0fdec2'
   name 'SimPholders'
-  homepage 'http://simpholders.com/'
+  homepage 'https://simpholders.com/'
   license :commercial
 
   app 'SimPholders.app'

--- a/Casks/simple-sync.rb
+++ b/Casks/simple-sync.rb
@@ -4,7 +4,7 @@ cask 'simple-sync' do
 
   # roomieremote.com is the official download host per the vendor homepage
   url "https://www.roomieremote.com/b/SimpleSync-#{version.delete('.')}.zip"
-  appcast 'http://www.roomieremote.com/b/Simple-SyncAppcast.xml',
+  appcast 'https://www.roomieremote.com/b/Simple-SyncAppcast.xml',
           :sha256 => '3968102cbd303c83db82ef0a73170e0891d5ff681996f94b69c8c80120659d51'
   name 'Simple Sync'
   homepage 'https://simplecontrol.com/simple-sync'

--- a/Casks/skynet-edge.rb
+++ b/Casks/skynet-edge.rb
@@ -2,9 +2,9 @@ cask 'skynet-edge' do
   version :latest
   sha256 :no_check
 
-  url 'http://joinskynet.com/ignition/v2/skynet/macosx/Skynet%20Edge.app.zip'
+  url 'https://joinskynet.com/ignition/v2/skynet/macosx/Skynet%20Edge.app.zip'
   name 'Skynet'
-  homepage 'http://joinskynet.com/'
+  homepage 'https://joinskynet.com/'
   license :freemium
 
   app 'Skynet Edge.app'

--- a/Casks/sleep-monitor.rb
+++ b/Casks/sleep-monitor.rb
@@ -3,7 +3,7 @@ cask 'sleep-monitor' do
   sha256 :no_check
 
   url 'https://www.dssw.co.uk/sleepmonitor/dsswsleepmonitor.dmg'
-  appcast 'http://version.dssw.co.uk/sleepmonitor/standard',
+  appcast 'https://version.dssw.co.uk/sleepmonitor/standard',
           :sha256 => '9eb95c6a71ff0f70ece946a49ff9e6c5e48bdd08436e88a1d447263cb36e8ac2'
   name 'Sleep Monitor'
   homepage 'https://www.dssw.co.uk/sleepmonitor'

--- a/Casks/slimboat.rb
+++ b/Casks/slimboat.rb
@@ -2,9 +2,9 @@ cask 'slimboat' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.slimboat.com/release/slimboat.dmg'
+  url 'https://www.slimboat.com/release/slimboat.dmg'
   name 'SlimBoat'
-  homepage 'http://www.slimboat.com'
+  homepage 'https://www.slimboat.com'
   license :gratis
 
   app 'SlimBoat.app'

--- a/Casks/slingshot.rb
+++ b/Casks/slingshot.rb
@@ -2,7 +2,7 @@ cask 'slingshot' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.airsquirrels.com/Slingshot/Mac/Slingshot.dmg'
+  url 'https://download.airsquirrels.com/Slingshot/Mac/Slingshot.dmg'
   appcast 'https://updates.airsquirrels.com/Slingshot/Mac/Slingshot.xml',
           :sha256 => '412888289e91de20b475819622788cf78414d6815c702f5beeb479b405a515ac'
   name 'Slingshot'

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -2,9 +2,9 @@ cask 'smartsynchronize' do
   version '3.4.3'
   sha256 'd0542f16dd665044bc2de8f1cc9316419a2590fd883a7886ee44d7ecae10930e'
 
-  url "http://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.gsub('.','_')}.dmg"
+  url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.gsub('.','_')}.dmg"
   name 'SmartSynchronize'
-  homepage 'http://www.syntevo.com/smartsynchronize/'
+  homepage 'https://www.syntevo.com/smartsynchronize/'
   license :commercial
 
   app 'SmartSynchronize.app'

--- a/Casks/snippets.rb
+++ b/Casks/snippets.rb
@@ -3,7 +3,7 @@ cask 'snippets' do
   sha256 '32167664dacd3301dd89e618093c3ce7a7dcd0204061d34f7759bad3c9a7cc78'
 
   url 'http://snippets.me/download/mac/Snippets-468.zip'
-  appcast 'http://snippets.me/mac/appcast.xml',
+  appcast 'https://snippets.me/mac/appcast.xml',
           :sha256 => '4158b1f63ea202992e9ffdcf231e7c21323cc1a0ed52305e69effc0858b902d3'
   name 'Snippets'
   homepage 'http://snippets.me/'

--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -5,7 +5,7 @@ cask 'soapui' do
   # smartbear.com is the official download host per the vendor homepage
   url "http://cdn01.downloads.smartbear.com/soapui/#{version}/SoapUI-#{version}.dmg"
   name 'SmartBear SoapUI'
-  homepage 'http://www.soapui.org'
+  homepage 'https://www.soapui.org'
   license :oss
 
   # Installer runs install4j from the distribution in quiet mode.

--- a/Casks/softraid.rb
+++ b/Casks/softraid.rb
@@ -2,9 +2,9 @@ cask 'softraid' do
   version '5.1'
   sha256 '3ce535878cb92e7401f044a683c7e6e2e6ec6576695adac85f15c10c2d9b1548'
 
-  url "http://www.softraid.com/updates/SoftRAID%20#{version}.dmg"
+  url "https://www.softraid.com/updates/SoftRAID%20#{version}.dmg"
   name 'SoftRAID'
-  homepage 'http://www.softraid.com/'
+  homepage 'https://www.softraid.com/'
   license :commercial
 
   app "SoftRAID #{version}/SoftRAID #{version}.app"

--- a/Casks/sony-ericsson-bridge.rb
+++ b/Casks/sony-ericsson-bridge.rb
@@ -2,11 +2,11 @@ cask 'sony-ericsson-bridge' do
   version :latest
   sha256 :no_check
 
-  url 'http://www-support-downloads.sonymobile.com/Software%20Downloads/Bridge%20for%20Mac/SonyBridgeForMac_web.dmg'
+  url 'https://www-support-downloads.sonymobile.com/Software%20Downloads/Bridge%20for%20Mac/SonyBridgeForMac_web.dmg'
   name 'Sony Ericsson Bridge for Mac'
-  appcast 'http://dl-desktop-macapps.sonyericsson.com/production/Bridge/Databases_Prod/appcast.xml',
+  appcast 'https://dl-desktop-macapps.sonyericsson.com/production/Bridge/Databases_Prod/appcast.xml',
           :sha256 => '0e516c239fff99ac24ec531546195ba185675bd890a0a09599e6f3fb5cd30fba'
-  homepage 'http://support.sonymobile.com/au/tools/bridge-for-mac/'
+  homepage 'https://support.sonymobile.com/au/tools/bridge-for-mac/'
   license :gratis
 
   app 'Sony Ericsson Bridge for Mac.app'

--- a/Casks/sparkbox.rb
+++ b/Casks/sparkbox.rb
@@ -3,7 +3,7 @@ cask 'sparkbox' do
   sha256 '1b5eb4fb54de0e3151405ab3f8d643b13188a68ea4a1a2a2a2f552cf7f138b30'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://s3.amazonaws.com/IcyBlaze-iDocument2/Download/sparkbox_#{version}.zip"
+  url "https://s3.amazonaws.com/IcyBlaze-iDocument2/Download/sparkbox_#{version}.zip"
   appcast 'http://matrix.icyblaze.com/index.php/checkupdate/p/8',
           :sha256 => '689d0cb42cfc174417072972c37919522a9a0f63e170424f7486c7b77d148650'
   name 'Sparkbox'

--- a/Casks/speak.rb
+++ b/Casks/speak.rb
@@ -5,7 +5,7 @@ cask 'speak' do
   # amazonaws.com is the official download host per the vendor homepage
   url 'https://s3.amazonaws.com/speak-production-releases/darwin/install-speak.dmg'
   name 'Speak'
-  homepage 'http://speak.io/'
+  homepage 'https://speak.io/'
   license :gratis
 
   app 'Speak.app'

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -7,14 +7,14 @@ cask 'spectacle' do
     version '1.0.1'
     sha256 '8b41469acb8ae5bc845f1441c2cf630f72f0fc14ad324e78336b0cb4268216d7'
 
-    appcast 'http://spectacleapp.com/updates/appcast.xml',
+    appcast 'https://spectacleapp.com/updates/appcast.xml',
             :sha256 => 'd79bb2db04e7e53a7bb9184f9c048e4dde76a06e1be1232a9761f60db3836084'
   end
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://s3.amazonaws.com/spectacle/downloads/Spectacle+#{version}.zip"
   name 'Spectacle'
-  homepage 'http://spectacleapp.com/'
+  homepage 'https://spectacleapp.com/'
   license :mit
 
   app 'Spectacle.app'

--- a/Casks/starrealms.rb
+++ b/Casks/starrealms.rb
@@ -2,9 +2,9 @@ cask 'starrealms' do
   version '2.33'
   sha256 'd87c71d3592f0002c4d5fa8b2264b1a5924d72ae4d0fc5d7d68d428d3f83ecc1'
 
-  url "http://downloads.starrealms.com/StarRealms-v#{version.delete('.')}.dmg"
+  url "https://downloads.starrealms.com/StarRealms-v#{version.delete('.')}.dmg"
   name 'Star Realms'
-  homepage 'http://www.starrealms.com/digital-game/'
+  homepage 'https://www.starrealms.com/digital-game/'
   license :freemium
 
   app 'StarRealms.app'

--- a/Casks/steelseries-exactmouse-tool.rb
+++ b/Casks/steelseries-exactmouse-tool.rb
@@ -4,7 +4,7 @@ cask 'steelseries-exactmouse-tool' do
 
   url 'http://downloads.steelseriescdn.com/drivers/tools/steelseries-exactmouse-tool.dmg'
   name 'SteelSeries ExactMouse Tool'
-  homepage 'http://steelseries.com/support/downloads'
+  homepage 'https://steelseries.com/support/downloads'
   license :gratis
 
   app 'SteelSeries ExactMouse Tool.app'

--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -4,10 +4,10 @@ cask 'subler' do
 
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
-  appcast 'http://subler.org/appcast/appcast.xml',
+  appcast 'https://subler.org/appcast/appcast.xml',
           :sha256 => '84e09cb84fd262c23b9ed61298ea98f1b6a611e4d355f8f95ed6a6890510b840'
   name 'Subler'
-  homepage 'http://subler.org/'
+  homepage 'https://subler.org/'
   license :gpl
 
   app 'Subler.app'

--- a/Casks/sunlogin-remote.rb
+++ b/Casks/sunlogin-remote.rb
@@ -5,7 +5,7 @@ cask 'sunlogin-remote' do
   url "http://download.oray.com/sunlogin/SunloginRemote_v#{version}.dmg"
   name 'Sunlogin Remote'
   name '向日葵控制端'
-  homepage 'http://sunlogin.oray.com'
+  homepage 'https://sunlogin.oray.com'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Sunlogin Remote.app'

--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -2,7 +2,7 @@ cask 'superduper' do
   version :latest
   sha256 :no_check
 
-  url 'http://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'
+  url 'https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'
   name 'SuperDuper!'
   homepage 'http://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html'
   license :freemium

--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -2,7 +2,7 @@ cask 'swinsian' do
   version '1.11.5'
   sha256 '65dca978e36ebd96b8b62517edc290a74ae4782b85406d0078207f1c56216db8'
 
-  url "http://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
+  url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml',
           :sha256 => '2a35cec534d9207c938050968042f1c02b581d6666e92de50c6396dfe67c371b'
   name 'Swinsian'

--- a/Casks/synthesia.rb
+++ b/Casks/synthesia.rb
@@ -5,7 +5,7 @@ cask 'synthesia' do
   # amazonaws.com is the official download host per the vendor homepage
   url "https://synthesia.s3.amazonaws.com/files/Synthesia-#{version}.dmg"
   name 'Synthesia'
-  homepage 'http://www.synthesiagame.com'
+  homepage 'https://www.synthesiagame.com'
   license :freemium
 
   app 'Synthesia.app'

--- a/Casks/sysex-librarian.rb
+++ b/Casks/sysex-librarian.rb
@@ -2,8 +2,8 @@ cask 'sysex-librarian' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.snoize.com/SysExLibrarian/SysExLibrarian.zip'
-  appcast 'http://www.snoize.com/SysExLibrarian/SysExLibrarian.xml',
+  url 'https://www.snoize.com/SysExLibrarian/SysExLibrarian.zip'
+  appcast 'https://www.snoize.com/SysExLibrarian/SysExLibrarian.xml',
           :sha256 => 'b2bf48b31196149f1d2e4cec64ff1903aadb39d419128d44fff9aa46ee626f8b'
   name 'SysEx Librarian'
   homepage 'http://www.snoize.com/SysExLibrarian'

--- a/Casks/tagalicious.rb
+++ b/Casks/tagalicious.rb
@@ -2,7 +2,7 @@ cask 'tagalicious' do
   version :latest
   sha256 :no_check
 
-  url 'http://files.thelittleappfactory.com/tagalicious/Tagalicious.zip'
+  url 'https://files.thelittleappfactory.com/tagalicious/Tagalicious.zip'
   appcast 'https://files.thelittleappfactory.com/tagalicious/appcast.xml',
           :sha256 => '2d746cee53d08fbee50fef97a583ebf2af9a46e79a42dbd5d15dbc449290d586'
   name 'Tagalicious'

--- a/Casks/tangerine.rb
+++ b/Casks/tangerine.rb
@@ -4,7 +4,7 @@ cask 'tangerine' do
 
   url 'http://distrib.karelia.com/downloads/Tangerine!-4008.zip'
   name 'Tangerine!'
-  appcast 'http://launch.karelia.com/appcast.php?version=0&product=13&appname=Tangerine!',
+  appcast 'https://launch.karelia.com/appcast.php?version=0&product=13&appname=Tangerine!',
           :sha256 => 'c8e3f2ce6c968bd670dd33e2be1412a3a7f7614256737c05e7f3c3e5414e2bc9'
   homepage 'https://www.karelia.com/products/tangerine/'
   license :commercial

--- a/Casks/tcl.rb
+++ b/Casks/tcl.rb
@@ -3,9 +3,9 @@ cask 'tcl' do
   sha256 '2aae9686f40a7216e185877e7bf8421af35f597c20545d565511367587659bb9'
 
   # activestate.com is the official download host per the vendor homepage
-  url "http://downloads.activestate.com/ActiveTcl/releases/#{version.sub(%r{\.\d+$},'')}/ActiveTcl#{version}-macosx10.5-i386-x86_64-threaded.dmg"
+  url "https://downloads.activestate.com/ActiveTcl/releases/#{version.sub(%r{\.\d+$},'')}/ActiveTcl#{version}-macosx10.5-i386-x86_64-threaded.dmg"
   name 'ActiveTcl'
-  homepage 'http://tcl.tk/'
+  homepage 'https://tcl.tk/'
   license :oss
 
   depends_on :macos => '>= :leopard'

--- a/Casks/td-agent.rb
+++ b/Casks/td-agent.rb
@@ -2,7 +2,7 @@ cask 'td-agent' do
   version '2.1.4'
   sha256 '14ffe35c81622590b0fa65f7ce61b6db39a1035fe7c4b4a10eae77e2901845c7'
 
-  url "http://packages.treasuredata.com/2/macosx/td-agent-#{version}-0.dmg"
+  url "https://packages.treasuredata.com/2/macosx/td-agent-#{version}-0.dmg"
   name 'td-agent'
   homepage 'https://www.fluentd.org/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/td-toolbelt.rb
+++ b/Casks/td-toolbelt.rb
@@ -4,7 +4,7 @@ cask 'td-toolbelt' do
 
   url 'http://toolbelt.treasuredata.com/mac'
   name 'Treasure Data Toolbelt'
-  homepage 'http://toolbelt.treasuredata.com/'
+  homepage 'https://toolbelt.treasuredata.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   container :type => :naked

--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -5,7 +5,7 @@ cask 'teamspeak-client' do
   # 4players.de is the official download host per the vendor homepage
   url "http://dl.4players.de/ts/releases/#{version}/TeamSpeak3-Client-macosx-#{version}.dmg"
   name 'TeamSpeak Client'
-  homepage 'http://www.teamspeak.com/'
+  homepage 'https://www.teamspeak.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TeamSpeak 3 Client.app'

--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -2,33 +2,33 @@ cask 'textexpander' do
   if Hardware::CPU.type == :ppc && MacOS.release <= :leopard
     version '2.5'
     sha256 'dfcb5a66fd590dc6dabd4fe8586a0d83cf7d264e23d9e309c0d77ae8cd89ad86'
-    url "http://cdn.smilesoftware.com/TextExpander%20#{version}.zip"
+    url "https://cdn.smilesoftware.com/TextExpander%20#{version}.zip"
   elsif MacOS.release <= :panther
     version '1.3.1'
     sha256 '1c2a94f5ee79a685f9258aeda7b27e54664a496060b0091283fbd0d80f8aa1c9'
-    url "http://cdn.smilesoftware.com/TextExpander%20#{version}.dmg"
+    url "https://cdn.smilesoftware.com/TextExpander%20#{version}.dmg"
   elsif MacOS.release <= :leopard
     version '2.8.1'
     sha256 'ab6d15adef2b5c35766c99440ebc968c38869b299e6829645c74bd74294557a4'
-    url "http://cdn.smilesoftware.com/TextExpander%20#{version}.dmg"
+    url "https://cdn.smilesoftware.com/TextExpander%20#{version}.dmg"
   elsif MacOS.release <= :snow_leopard
     version '3.4.2'
     sha256 '87859d7efcbfe479e7b78686d4d3f9be9983b2c7d68a6122acea10d4efbb1bfa'
-    url "http://cdn.smilesoftware.com/TextExpander_#{version}.zip"
+    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
   elsif MacOS.release <= :mavericks
     version '4.3.6'
     sha256 'ec90d6bd2e76bd14c0ca706d255c9673288f406b772e5ae6022e2dbe27848ee9'
-    url "http://cdn.smilesoftware.com/TextExpander_#{version}.zip"
+    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
   else
     version '513.0-1446607872'
     sha256 '28873bc18f4d62eda453e31609966d971f8165691ec4b5f3a8a37382cec5145c'
     url "https://dl.smilesoftware.com/com.smileonmymac.textexpander/#{version.sub(%r{-.*},'')}/#{version.sub(%r{.*-},'')}/TextExpander-#{version.sub(%r{-.*},'')}.zip"
-    appcast 'http://updates.smilesoftware.com/com.smileonmymac.textexpander.xml',
+    appcast 'https://updates.smilesoftware.com/com.smileonmymac.textexpander.xml',
             :sha256 => '65f23f21d5b01119e939eef7bcedb5453b80e27e4076cbb4991e68bfce0db636'
   end
 
   name 'TextExpander'
-  homepage 'http://www.smilesoftware.com/TextExpander/'
+  homepage 'https://www.smilesoftware.com/TextExpander/'
   license :commercial
 
   app 'TextExpander.app'

--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -5,7 +5,7 @@ cask 'textmate' do
   # textmate.org is the official download host per the vendor homepage
   url "https://api.textmate.org/downloads/TextMate_#{version}.tbz"
   name 'TextMate'
-  homepage 'http://macromates.com/'
+  homepage 'https://macromates.com/'
   license :gpl
 
   app 'TextMate.app'

--- a/Casks/tg-pro.rb
+++ b/Casks/tg-pro.rb
@@ -2,11 +2,11 @@ cask 'tg-pro' do
   version '2.8.8'
   sha256 'dcb4221d4b72960c306e248a0be947107ab3622b0c38570684b2f12c8ef87a44'
 
-  url "http://www.tunabellysoftware.com/resources/TGPro_#{version.gsub('.','_')}.zip"
+  url "https://www.tunabellysoftware.com/resources/TGPro_#{version.gsub('.','_')}.zip"
   name 'TG Pro'
-  appcast 'http://tunabellysoftware.com/resources/sparkle/tgpro/profileInfo.php',
+  appcast 'https://tunabellysoftware.com/resources/sparkle/tgpro/profileInfo.php',
           :sha256 => 'ae55143d14a7a75093439c723db19e8672952efff4e38de0e0682a5037c455de'
-  homepage 'http://www.tunabellysoftware.com/tgpro/'
+  homepage 'https://www.tunabellysoftware.com/tgpro/'
   license :commercial
 
   app 'TG Pro.app'

--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -2,9 +2,9 @@ cask 'the-archive-browser' do
   version '1.10.1'
   sha256 '6bdb2ff4af904bd5228b0c399ce6d285807a3674e54bbc3a887a26ab1282d0cc'
 
-  url "http://wakaba.c3.cx/releases/TheArchiveBrowser/TheArchiveBrowser#{version}.zip"
+  url "https://wakaba.c3.cx/releases/TheArchiveBrowser/TheArchiveBrowser#{version}.zip"
   name 'The Archive Browser'
-  homepage 'http://archivebrowser.c3.cx'
+  homepage 'https://archivebrowser.c3.cx'
   license :commercial
 
   app 'The Archive Browser.app'

--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -3,10 +3,10 @@ cask 'the-hit-list' do
   sha256 '0a6bd16d26c19a27f2146cdba27fc5c8119da8c382643d285203b41fadaebe98'
 
   url 'http://distrib.karelia.com/downloads/TheHitList-302.zip'
-  appcast 'http://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List',
+  appcast 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List',
           :sha256 => 'd34151b1e3f683b4d20c74ea1aa19539c607eeb529a3d137e42a8f63525447c4'
   name 'The Hit List'
-  homepage 'http://www.karelia.com/products/the-hit-list/mac.html'
+  homepage 'https://www.karelia.com/products/the-hit-list/mac.html'
   license :commercial
 
   app 'The Hit List.app'

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -4,7 +4,7 @@ cask 'the-unarchiver' do
 
   url "http://unarchiver.c3.cx/downloads/TheUnarchiver#{version}.dmg"
   name 'The Unarchiver'
-  homepage 'http://unarchiver.c3.cx/unarchiver'
+  homepage 'https://unarchiver.c3.cx/unarchiver'
   license :oss
 
   app 'The Unarchiver.app'

--- a/Casks/time-sink.rb
+++ b/Casks/time-sink.rb
@@ -4,9 +4,9 @@ cask 'time-sink' do
 
   url 'http://manytricks.com/download/timesink'
   name 'Time Sink'
-  appcast 'http://manytricks.com/timesink/appcast.xml',
+  appcast 'https://manytricks.com/timesink/appcast.xml',
           :sha256 => '9d3f4080a3b044f321311ca0649f5d8a3f409d7232a52d9a85638103808ee67e'
-  homepage 'http://manytricks.com/timesink/'
+  homepage 'https://manytricks.com/timesink/'
   license :commercial
 
   app 'Time Sink.app'

--- a/Casks/timings.rb
+++ b/Casks/timings.rb
@@ -2,8 +2,8 @@ cask 'timings' do
   version '2.4.4'
   sha256 '35627d1c6a46f600555fbefcfac8e2422932a651ec36717a2934146ac3acd719'
 
-  url "http://mediaatelier.com/Timings2/Timings_#{version}.zip"
-  appcast 'http://mediaatelier.com/Timings2/feed.php',
+  url "https://mediaatelier.com/Timings2/Timings_#{version}.zip"
+  appcast 'https://mediaatelier.com/Timings2/feed.php',
           :sha256 => '1d13902682950cfe77c621cde054c08502903b0effca0e09703b562da5d9e683'
   name 'Timings'
   homepage 'http://mediaatelier.com/Timings'

--- a/Casks/tinyumbrella.rb
+++ b/Casks/tinyumbrella.rb
@@ -4,7 +4,7 @@ cask 'tinyumbrella' do
 
   url 'https://blog.firmwareumbrella.com/download/343/'
   name 'TinyUmbrella'
-  homepage 'http://blog.firmwareumbrella.com/'
+  homepage 'https://blog.firmwareumbrella.com/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TinyUmbrella.app'

--- a/Casks/tk-suite-client.rb
+++ b/Casks/tk-suite-client.rb
@@ -4,7 +4,7 @@ cask 'tk-suite-client' do
 
   url "ftp://ftp.agfeo.de/pub/software/TK-Suite-Client_intel32_agfeo_#{version}.dmg"
   name 'TK-Suite Client'
-  homepage 'http://agfeo.de/agfeo_web/hp3.nsf/lu/2064'
+  homepage 'https://agfeo.de/agfeo_web/hp3.nsf/lu/2064'
   license :closed
 
   app 'TK-Suite-Client.app'

--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -5,7 +5,7 @@ cask 'tla-plus-toolbox' do
   # inria.fr is the official download host per the vendor homepage
   url "https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"
   name 'TLA+ Toolbox'
-  homepage 'http://research.microsoft.com/en-us/um/people/lamport/tla/toolbox.html'
+  homepage 'https://research.microsoft.com/en-us/um/people/lamport/tla/toolbox.html'
   license :mit
 
   # Renamed for clarity: app name is inconsistent with its branding.

--- a/Casks/torustrooper.rb
+++ b/Casks/torustrooper.rb
@@ -4,7 +4,7 @@ cask 'torustrooper' do
 
   url 'https://workram.com/downloads.php?f=TorusTrooper', :referer => 'https://workram.com/games'
   name 'Torus Trooper'
-  homepage 'http://workram.com/games/'
+  homepage 'https://workram.com/games/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TorusTrooper.app'

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -7,7 +7,7 @@ cask 'tower' do
   appcast "https://updates.fournova.com/updates/tower#{version.to_i}-mac/stable",
           :sha256 => '40c701368d0ceea7fcbdaa0f09a86004869ae823423b2fcc87797590fab06669'
   name 'Tower'
-  homepage 'http://www.git-tower.com/'
+  homepage 'https://www.git-tower.com/'
   license :commercial
 
   app 'Tower.app'

--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -4,7 +4,7 @@ cask 'transmit' do
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   name 'Transmit'
-  homepage 'http://panic.com/transmit'
+  homepage 'https://panic.com/transmit'
   license :commercial
 
   app 'Transmit.app'

--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -7,7 +7,7 @@ cask 'tribler' do
   appcast 'https://github.com/Tribler/tribler/releases.atom',
           :sha256 => '6dc37806e7e565d4cbaa8cf7a6961cd411d6906454ce511cd79b0145462f6949'
   name 'Tribler'
-  homepage 'http://www.tribler.org'
+  homepage 'https://www.tribler.org'
   license :gpl
 
   app 'Tribler.app'

--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -4,7 +4,7 @@ cask 'typora' do
 
   url 'http://typora.io/download/typora_latest.zip'
   name 'Typora'
-  appcast 'http://typora.io/download/dev_update.xml',
+  appcast 'https://typora.io/download/dev_update.xml',
           :sha256 => 'af9b77a097850693934f4c560c2bf673a4259d477a399f1c3baeaeb259cfbaf7'
   homepage 'http://typora.io'
   license :gratis

--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -3,9 +3,9 @@ cask 'unetbootin' do
   sha256 'b9356ad2ef3cfa6881690ddc1136c45e6d3f25063fdeaeeb477633500b0c7684'
 
   # launchpad.net is the official download host per the vendor homepage
-  url "http://launchpad.net/unetbootin/trunk/#{version}/+download/unetbootin-mac-#{version}.zip"
+  url "https://launchpad.net/unetbootin/trunk/#{version}/+download/unetbootin-mac-#{version}.zip"
   name 'UNetbootin'
-  homepage 'http://unetbootin.github.io/'
+  homepage 'https://unetbootin.github.io/'
   license :gpl
 
   app 'unetbootin.app'

--- a/Casks/validator-sac.rb
+++ b/Casks/validator-sac.rb
@@ -2,11 +2,11 @@ cask 'validator-sac' do
   version '0.10.8'
   sha256 '1555a9d20fdd35398407cded18f2208ad28b9d4647dcf8eef320354e63556f15'
 
-  url "http://habilis.net/download/Validator-SAC_#{version}.zip"
+  url "https://habilis.net/download/Validator-SAC_#{version}.zip"
   name 'Validator S.A.C.'
-  appcast 'http://habilis.net/download/validator-sac.xml',
+  appcast 'https://habilis.net/download/validator-sac.xml',
           :sha256 => '0b01f16e91ba9915b50b443f807deb6aa252966de6ac7e8b73ae78ccbb78a0c6'
-  homepage 'http://habilis.net/validator-sac/'
+  homepage 'https://habilis.net/validator-sac/'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Validator-SAC.app'

--- a/Casks/vectr.rb
+++ b/Casks/vectr.rb
@@ -2,7 +2,7 @@ cask 'vectr' do
   version '0.1.8'
   sha256 'c160ed7897c42664b3792757deeb16775719ab1bf9ff0c3d4be47299e8a5a238'
 
-  url "http://download.vectr.com/desktop/vectr-mac-#{version}.zip"
+  url "https://download.vectr.com/desktop/vectr-mac-#{version}.zip"
   name 'Vectr'
   homepage 'https://vectr.com'
   license :gratis

--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -3,7 +3,7 @@ cask 'visit' do
   sha256 '9dc908c9d298f65ba4be58b5772338c92bc771043054e8eb2979c77a8a56f865'
 
   # nersc.gov is the official download host per the vendor homepage
-  url "http://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
+  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
   license :bsd

--- a/Casks/visualvm.rb
+++ b/Casks/visualvm.rb
@@ -4,7 +4,7 @@ cask 'visualvm' do
 
   url "https://java.net/downloads/visualvm/release138/VisualVM_#{version.delete('.')}.dmg"
   name 'VisualVM'
-  homepage 'http://visualvm.java.net'
+  homepage 'https://visualvm.java.net'
   license :gpl
 
   app 'VisualVM.app'

--- a/Casks/vox-preferences-pane.rb
+++ b/Casks/vox-preferences-pane.rb
@@ -3,11 +3,11 @@ cask 'vox-preferences-pane' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.coppertino.VoxPrefs/VoxPrefs.dmg'
+  url 'https://dl.devmate.com/com.coppertino.VoxPrefs/VoxPrefs.dmg'
   appcast 'http://updateinfo.devmate.com/com.coppertino.VoxPrefs/updates.xml',
           :sha256 => '25284589df6ed7b6b3819c23c70e77ac8f8122fec303f7ecb1e11cb173f7bb12'
   name 'VOX Preferences'
-  homepage 'http://coppertino.com/addon'
+  homepage 'https://coppertino.com/addon'
   license :gratis
 
   prefpane 'Vox Preferences.prefPane'

--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -5,7 +5,7 @@ cask 'vox' do
   # devmate.com is the official download host per the vendor homepage
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   name 'VOX'
-  appcast 'http://updates.devmate.com/com.coppertino.Vox.xml',
+  appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
           :sha256 => '66ec1b8207f876ef8b77dc062301f8c149c4899647cbe9549ee9f4547a919bad'
   homepage 'https://coppertino.com/vox/mac'
   license :freemium

--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -9,7 +9,7 @@ cask 'vuescan' do
   end
 
   name 'VueScan'
-  homepage 'http://www.hamrick.com'
+  homepage 'https://www.hamrick.com'
   license :commercial
 
   app 'VueScan.app'

--- a/Casks/vuze.rb
+++ b/Casks/vuze.rb
@@ -2,7 +2,7 @@ cask 'vuze' do
   version :latest
   sha256 :no_check
 
-  url 'http://cf1.vuze.com/files/J7/VuzeBittorrentClientInstaller.dmg'
+  url 'https://cf1.vuze.com/files/J7/VuzeBittorrentClientInstaller.dmg'
   name 'Vuze'
   homepage 'https://www.vuze.com/'
   license :gpl

--- a/Casks/wacom-bamboo-tablet.rb
+++ b/Casks/wacom-bamboo-tablet.rb
@@ -4,7 +4,7 @@ cask 'wacom-bamboo-tablet' do
 
   url "http://cdn.wacom.com/u/productsupport/drivers/mac/consumer/pentablet_#{version}.dmg"
   name 'Wacom Bamboo Tablet'
-  homepage 'http://us.wacom.com/en/support/drivers'
+  homepage 'https://us.wacom.com/en/support/drivers'
   license :unknown    # todo: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Install Wacom Tablet.pkg'

--- a/Casks/wacom-graphire2-tablet.rb
+++ b/Casks/wacom-graphire2-tablet.rb
@@ -2,7 +2,7 @@ cask 'wacom-graphire2-tablet' do
   version '6.1.7-4'
   sha256 '593cdd4c51bee7714aecbef77d6e3809dd80a8393893ee1937f9c15c567bb4b4'
 
-  url "http://www.wacom.asia/sites/default/files/drivers/WacomTablet_#{version}.dmg"
+  url "https://www.wacom.asia/sites/default/files/drivers/WacomTablet_#{version}.dmg"
   name 'Graphire2 Wacom Tablet'
   homepage 'https://www.wacom.asia/taxonomy/term/21'
   license :gratis

--- a/Casks/wacom-graphire4-tablet.rb
+++ b/Casks/wacom-graphire4-tablet.rb
@@ -4,7 +4,7 @@ cask 'wacom-graphire4-tablet' do
 
   url "http://cdn.wacom.com/U/Drivers/Mac/Consumer/#{version.sub(%r{-.*},'').delete('.')}/PenTablet_#{version}.dmg"
   name 'Graphire4 (CTE) Legacy Driver'
-  homepage 'http://us.wacom.com/en/support/legacy-drivers/'
+  homepage 'https://us.wacom.com/en/support/legacy-drivers/'
   license :gratis
 
   pkg 'Install Bamboo.pkg'

--- a/Casks/waltr.rb
+++ b/Casks/waltr.rb
@@ -3,7 +3,7 @@ cask 'waltr' do
   sha256 :no_check
 
   # devmate.com is the official download host per the vendor homepage
-  url 'http://dl.devmate.com/com.softorino.Waltr/WALTR.zip'
+  url 'https://dl.devmate.com/com.softorino.Waltr/WALTR.zip'
   name 'WALTR'
   homepage 'http://softorino.com/waltr'
   license :commercial

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -4,7 +4,7 @@ cask 'webstorm' do
 
   url "https://download.jetbrains.com/webstorm/WebStorm-#{version}-custom-jdk-bundled.dmg"
   name 'WebStorm'
-  homepage 'http://www.jetbrains.com/webstorm/'
+  homepage 'https://www.jetbrains.com/webstorm/'
   license :commercial
 
   app 'WebStorm.app'

--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -5,7 +5,7 @@ cask 'wesnoth' do
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/sourceforge/wesnoth/Wesnoth_#{version}.dmg"
   name 'The Battle for Wesnoth'
-  homepage 'http://wesnoth.org'
+  homepage 'https://wesnoth.org'
   license :gpl
 
   app 'Wesnoth.app'

--- a/Casks/wingide.rb
+++ b/Casks/wingide.rb
@@ -2,7 +2,7 @@ cask 'wingide' do
   version '5.1.8-1'
   sha256 'e3f12e467fd0a17160406010cc6d6fd2b7c84e725848cce4694307706a8eb6c8'
 
-  url "http://wingware.com/pub/wingide/#{version.sub(%r{-\d+},'')}/wingide-#{version}.dmg"
+  url "https://wingware.com/pub/wingide/#{version.sub(%r{-\d+},'')}/wingide-#{version}.dmg"
   name 'WingIDE'
   homepage 'http://www.wingware.com/'
   license :commercial

--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -8,12 +8,12 @@ cask 'witch' do
     sha256 :no_check
 
     url 'http://manytricks.com/download/witch'
-    appcast 'http://manytricks.com/witch/appcast.xml',
+    appcast 'https://manytricks.com/witch/appcast.xml',
             :sha256 => '36fc6fa7454af97645ec12d1ee76fed2ff3a4bf6339e931b257fe75bd46f5027'
   end
 
   name 'Witch'
-  homepage 'http://manytricks.com/witch/'
+  homepage 'https://manytricks.com/witch/'
   license :commercial
 
   prefpane 'Witch.prefPane'

--- a/Casks/wowhead-client.rb
+++ b/Casks/wowhead-client.rb
@@ -6,7 +6,7 @@ cask 'wowhead-client' do
   name 'Wowhead Client'
   appcast 'https://client.wowhead.com/files/wowhead-client-appcast.xml',
           :sha256 => '70f04bcdeedb2c902e80b6b22b9cd328d0f77af88e981f5865b019afd94130bc'
-  homepage 'http://wowhead.com'
+  homepage 'https://wowhead.com'
   license :gratis
 
   app 'Wowhead Client.app'

--- a/Casks/x-lite.rb
+++ b/Casks/x-lite.rb
@@ -3,7 +3,7 @@ cask 'x-lite' do
   sha256 'a92c4d2f15f4969a5204ca470f55c0e174a2c759d716ff14ec5b952a0d90bbcf'
 
   # amazonaws.com is the official download host per the vendor homepage
-  url "http://counterpath.s3.amazonaws.com/downloads/X-Lite_#{version}.dmg"
+  url "https://counterpath.s3.amazonaws.com/downloads/X-Lite_#{version}.dmg"
   name 'X-Lite'
   homepage 'http://www.counterpath.com/x-lite/'
   license :commercial

--- a/Casks/xee.rb
+++ b/Casks/xee.rb
@@ -4,7 +4,7 @@ cask 'xee' do
 
   url "http://xee.c3.cx/downloads/Xee#{version}.dmg"
   name 'Xee³'
-  homepage 'http://xee.c3.cx/'
+  homepage 'https://xee.c3.cx/'
   license :commercial
 
   app 'Xee³.app'

--- a/Casks/xmind.rb
+++ b/Casks/xmind.rb
@@ -4,7 +4,7 @@ cask 'xmind' do
 
   url "http://www.xmind.net/xmind/downloads/xmind7-macosx-#{version}.dmg"
   name 'XMind'
-  homepage 'http://www.xmind.net'
+  homepage 'https://www.xmind.net'
   license :freemium
 
   zap :delete => [

--- a/Casks/xscreensaver.rb
+++ b/Casks/xscreensaver.rb
@@ -2,9 +2,9 @@ cask 'xscreensaver' do
   version '5.33'
   sha256 'ba83ae56a7c011c9bd39824b94679e1082375e7d0bc2ebe0afe813147fe38c11'
 
-  url "http://www.jwz.org/xscreensaver/xscreensaver-#{version}.dmg"
+  url "https://www.jwz.org/xscreensaver/xscreensaver-#{version}.dmg"
   name 'XScreenSaver'
-  homepage 'http://www.jwz.org/xscreensaver/'
+  homepage 'https://www.jwz.org/xscreensaver/'
   license :bsd
 
   screen_saver 'Screen Savers/Abstractile.saver'

--- a/Casks/xslimmer.rb
+++ b/Casks/xslimmer.rb
@@ -6,7 +6,7 @@ cask 'xslimmer' do
   appcast 'http://www.xslimmer.com/releases.xml',
           :sha256 => '7f27ccf84109291c59781abe74950f67d53cdb89365497c2925a5d1106f3a15a'
   name 'Xslimmer'
-  homepage 'http://latenitesoft.com/xslimmer/'
+  homepage 'https://latenitesoft.com/xslimmer/'
   license :commercial
 
   app 'Xslimmer.app'

--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -2,7 +2,7 @@ cask 'yourkit-java-profiler' do
   version '2015-build-15084'
   sha256 'd92862a6ffcb70a8cbfcd851e78c9ab5d2c1e57ec3feb24dcc374e1be5a3cb63'
 
-  url "http://www.yourkit.com/download/yjp-#{version}-mac.zip"
+  url "https://www.yourkit.com/download/yjp-#{version}-mac.zip"
   name 'YourKit Java Profiler'
   homepage 'https://www.yourkit.com/overview/'
   license :commercial

--- a/Casks/zipeg.rb
+++ b/Casks/zipeg.rb
@@ -4,7 +4,7 @@ cask 'zipeg' do
 
   url 'https://www.zipeg.net/downloads/zipeg_mac.dmg'
   name 'Zipeg'
-  homepage 'http://www.zipeg.net/'
+  homepage 'https://www.zipeg.net/'
   license :gratis
 
   app 'Zipeg.app'

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -5,7 +5,7 @@ cask 'zoomus' do
   url 'https://zoom.us/client/latest/zoomusInstaller.pkg'
   name 'Zoom'
   name 'Zoom.us'
-  homepage 'http://www.zoom.us'
+  homepage 'https://www.zoom.us'
   license :gratis
 
   pkg 'zoomusInstaller.pkg'

--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -39,7 +39,7 @@ cask 'alfred' do
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.zip"
   name 'Alfred'
-  homepage 'http://www.alfredapp.com/'
+  homepage 'https://www.alfredapp.com/'
   license :freemium
 
   app 'Alfred 2.app'

--- a/test/cask/cli/home_test.rb
+++ b/test/cask/cli/home_test.rb
@@ -23,14 +23,14 @@ describe Hbc::CLI::Home do
   it 'opens the homepage for the specified Cask' do
     Hbc::CLI::Home.run('alfred')
     Hbc::CLI::Home.system_commands.must_equal [
-      ['/usr/bin/open', '--', 'http://www.alfredapp.com/']
+      ['/usr/bin/open', '--', 'https://www.alfredapp.com/']
     ]
   end
 
   it 'works for multiple Casks' do
     Hbc::CLI::Home.run('alfred', 'adium')
     Hbc::CLI::Home.system_commands.must_equal [
-      ['/usr/bin/open', '--', 'http://www.alfredapp.com/'],
+      ['/usr/bin/open', '--', 'https://www.alfredapp.com/'],
       ['/usr/bin/open', '--', 'https://www.adium.im/']
     ]
   end


### PR DESCRIPTION
Every changed URL was:
- reachable using a valid HTTPS connection and
- 'curl head' returned a status code of 200.

I did not verify the whole download, as I'm currently on limited bandwidth. Some casks redirect from HTTPS to HTTP (e.q. sourceforge links) those are left with HTTP.

Should I add more verification?

The script used can be found at [cask-switch-https](https://github.com/tsparber/script-collection/blob/master/cask-switch-https). Does this script also fit somewhere into homebrew-cask? I would happily create a pull request.

Log testing all Casks with a http url/appcast/homepage: https://gist.github.com/tsparber/da281e1912fc0a1ced20

As usually there should be one PR per changed cask: Should I create 360 separate PRs?
