### PR TITLE
Add Upthere Home latest

### DIFF
--- a/Casks/upthere-home.rb
+++ b/Casks/upthere-home.rb
@@ -1,0 +1,26 @@
+cask 'upthere-home' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://upthere.com/apps/mac/UpthereHome.zip'
+  name 'Upthere Home'
+  homepage 'https://upthere.com/'
+  license :closed
+
+  app 'Upthere Home.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Upthere',
+                  '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.upthere.home.osx.sfl',
+                  '~/Library/Caches/com.crashlytics.data/com.upthere.home.osx',
+                  '~/Library/Caches/com.upthere.home.osx',
+                  '~/Library/Caches/io.fabric.sdk.mac.data/com.upthere.home.osx',
+                  '~/Library/Preferences/com.upthere.home.osx.UPUserDefaults.plist',
+                  '~/Library/Preferences/com.upthere.home.osx.plist',
+                  '~/Library/Preferences/com.upthere.home.osx.features.plist'
+                 ],
+      :rmdir  => [
+                  '~/Library/Caches/com.crashlytics.data',
+                  '~/Library/Caches/io.fabric.sdk.mac.data'
+                 ]
+end


### PR DESCRIPTION
Upthere Home is the OS X client of the cloud service [Upthere](https://upthere.com/). The project is currently in public beta.

I'm not sure what I should put in the license field, so I just wrote `:closed`. The client will of course be free to use, but service pricing is not clear yet (everything's free during public beta, at least for now).
