### PR TITLE
Upgrade Twine.app to v2.0.10

### DIFF
--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -1,8 +1,8 @@
 cask 'twine' do
-  version '2.0.8'
-  sha256 'b7c61e838343bdce86ce7a7bf3618376c23f0388ce4ce7f8209bf6fb5ac27d75'
+  version '2.0.10'
+  sha256 '3d073a624bd56817438105732e0e808b2ae9ff5bfebb455b70133cff80b0134f'
 
-  url "http://twinery.org/downloads/twine_#{version}_osx.zip"
+  url "https://bitbucket.org/klembot/twinejs/downloads/twine_#{version}_osx.zip"
   name 'Twine'
   homepage 'http://twinery.org/'
   license :gpl


### PR DESCRIPTION
Binaries are now hosted on bitbucket.org rather than twinery.org.
