### PR TITLE
cask-switch-https: Fix script call when developer/bin is not in $PATH

### DIFF
--- a/developer/bin/cask-switch-https
+++ b/developer/bin/cask-switch-https
@@ -131,7 +131,7 @@ if [[ -z "$1" ]]; then
 
   for file in *.rb;
   do
-    ${program} ${options} ${file}
+    "$0" ${options} ${file}
   done
 
   exit 0


### PR DESCRIPTION
If the cask-switch-https script is not available in $PATH the recursive call fails, as the script cannot be found using its name only. `$0` contains the full path so calling `../developer/bin/cask-switch-https` works.
