### PR TITLE
Fix couchbase-enterprise sha256sum & symlink path

### DIFF
--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -1,6 +1,6 @@
 cask 'couchbase-server-enterprise' do
   version '4.1.0'
-  sha256 '0b8e56ce84169fd491ef70df81317f87e140784b81aff8c8b5740a3564b264cd'
+  sha256 '237837598a1bf663debaea5c909bce36a39fbc673139cf4d4ebc55fb5c276313'
   url "http://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"
 
   name 'Couchbase Server'
@@ -9,5 +9,5 @@ cask 'couchbase-server-enterprise' do
   homepage 'http://www.couchbase.com/'
   license :apache
 
-  app 'Couchbase Server.app'
+  app 'couchbase-server-enterprise_4/Couchbase Server.app'
 end


### PR DESCRIPTION
Hash and symlink path of Couchbase server was broken, so I fixed it.
