### PR TITLE
Update homepage of breach

### DIFF
--- a/Casks/breach.rb
+++ b/Casks/breach.rb
@@ -4,10 +4,8 @@ cask 'breach' do
 
   # githubusercontent.com is the official download host per the vendor homepage
   url "https://raw.githubusercontent.com/breach/releases/master/v#{version}/breach-v#{version}-darwin-ia32.tar.gz"
-  appcast 'https://raw.githubusercontent.com/breach/releases/master.atom',
-          :sha256 => '986915f2caa2c8f9538f0b77832adc8abf3357681d4de5ee93a202ebf19bd8b8'
   name 'Breach'
-  homepage 'http://breach.cc'
+  homepage 'http://breach.github.io/breach_core/'
   license :mit
 
   app "breach-v#{version}-darwin-ia32/Breach.app"


### PR DESCRIPTION
Original homepage has a dummy site, Github project points to github.io.
The appcast does not work.
