### PR TITLE
Read version stanza into Hbc::DSL::Version object

### DIFF
--- a/lib/hbc/audit.rb
+++ b/lib/hbc/audit.rb
@@ -51,7 +51,7 @@ class Hbc::Audit
 
   def check_no_string_version_latest
     odebug "Verifying version :latest does not appear as a string ('latest')"
-    if (cask.version == 'latest')
+    if cask.version.raw_version == 'latest'
       add_error "you should use version :latest instead of version 'latest'"
     end
   end
@@ -65,7 +65,7 @@ class Hbc::Audit
 
   def check_sha256_no_check_if_latest
     odebug "Verifying sha256 :no_check with version :latest"
-    if cask.version == :latest and cask.sha256 != :no_check
+    if cask.version.latest? && cask.sha256 != :no_check
       add_error "you should use sha256 :no_check when version is :latest"
     end
   end

--- a/lib/hbc/download.rb
+++ b/lib/hbc/download.rb
@@ -30,7 +30,7 @@ class Hbc::Download
   end
 
   def clear_cache
-    downloader.clear_cache if force || cask.version == :latest
+    downloader.clear_cache if force || cask.version.latest?
   end
 
   def fetch

--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -14,6 +14,7 @@ require 'hbc/dsl/postflight'
 require 'hbc/dsl/preflight'
 require 'hbc/dsl/uninstall_postflight'
 require 'hbc/dsl/uninstall_preflight'
+require 'hbc/dsl/version'
 
 module Hbc::DSL
   def self.included(base)
@@ -142,13 +143,13 @@ module Hbc::DSL
 
     def version(arg=nil)
       if arg.nil?
-        @version
+        return @version
       elsif @version
         raise Hbc::CaskInvalidError.new(self.token, "'version' stanza may only appear once")
       elsif !arg.is_a?(String) and !SYMBOLIC_VERSIONS.include?(arg)
         raise Hbc::CaskInvalidError.new(self.token, "invalid 'version' value: '#{arg.inspect}'")
       end
-      @version ||= arg
+      @version ||= Hbc::DSL::Version.new(arg)
     end
 
     SYMBOLIC_SHA256S = Set.new [
@@ -157,7 +158,7 @@ module Hbc::DSL
 
     def sha256(arg=nil)
       if arg.nil?
-        @sha256
+        return @sha256
       elsif @sha256
         raise Hbc::CaskInvalidError.new(self.token, "'sha256' stanza may only appear once")
       elsif !arg.is_a?(String) and !SYMBOLIC_SHA256S.include?(arg)

--- a/lib/hbc/dsl/base.rb
+++ b/lib/hbc/dsl/base.rb
@@ -21,6 +21,6 @@ class Hbc::DSL::Base
   end
 
   def staged_path
-    caskroom_path.join(@cask.version.to_s)
+    caskroom_path.join(@cask.version)
   end
 end

--- a/lib/hbc/dsl/version.rb
+++ b/lib/hbc/dsl/version.rb
@@ -1,0 +1,89 @@
+class Hbc::DSL::Version < ::String
+  DIVIDERS = %w[. - _ /]
+
+  PLURAL_DIVIDER_NAMES = {
+    '.' => :dots,
+    '-' => :hyphens,
+    '_' => :underscores,
+    '/' => :slashes
+  }
+
+  DIVIDER_REGEX = /(#{DIVIDERS.map { |v| Regexp.quote(v) }.join('|')})/
+
+  MAJOR_MINOR_PATCH_REGEX = /^(\d+)(?:\.(\d+)(?:\.(\d+))?)?/
+
+  def self.define_divider_deletion_method(divider)
+    plural_divider_name = PLURAL_DIVIDER_NAMES[divider]
+    method_name = "no_#{plural_divider_name}"
+    define_method(method_name) do
+      version { delete(divider) }
+    end
+  end
+
+  def self.define_divider_conversion_methods(left_divider)
+    (DIVIDERS - [left_divider]).each do |right_divider|
+      plural_left_divider_name = PLURAL_DIVIDER_NAMES[left_divider]
+      plural_right_divider_name = PLURAL_DIVIDER_NAMES[right_divider]
+      method_name =
+        "#{plural_left_divider_name}_to_#{plural_right_divider_name}"
+      define_method(method_name) do
+        version { gsub(left_divider, right_divider) }
+      end
+    end
+  end
+
+  DIVIDERS.each do |divider|
+    define_divider_deletion_method(divider)
+    define_divider_conversion_methods(divider)
+  end
+
+  attr_reader :raw_version
+
+  def initialize(raw_version)
+    @raw_version = raw_version
+    super(raw_version.to_s)
+  end
+
+  def latest?
+    to_s == 'latest'
+  end
+
+  def major
+    version { slice(MAJOR_MINOR_PATCH_REGEX, 1) }
+  end
+
+  def minor
+    version { slice(MAJOR_MINOR_PATCH_REGEX, 2) }
+  end
+
+  def patch
+    version { slice(MAJOR_MINOR_PATCH_REGEX, 3) }
+  end
+
+  def major_minor
+    version { [major, minor].reject(&:empty?).join('.') }
+  end
+
+  def major_minor_patch
+    version { [major, minor, patch].reject(&:empty?).join('.') }
+  end
+
+  def before_slash
+    version { split('/', 2)[0] }
+  end
+
+  def after_slash
+    version { split('/', 2)[1] }
+  end
+
+  def no_dividers
+    version { gsub(DIVIDER_REGEX, '') }
+  end
+
+  private
+
+  def version(&block)
+    return self if empty? || latest?
+    self.class.new(block.call)
+  end
+end

--- a/spec/cask/dsl/version_spec.rb
+++ b/spec/cask/dsl/version_spec.rb
@@ -1,0 +1,238 @@
+require 'spec_helper'
+
+describe Hbc::DSL::Version do
+  include ExpectationsHashHelper
+
+  let(:version) { described_class.new(raw_version) }
+
+  shared_examples 'version equality' do
+    let(:raw_version) { '1.2.3' }
+
+    context 'when other is nil' do
+      let(:other) { nil }
+      it { should == false }
+    end
+
+    context "when other is a String" do
+      context "when other == self.raw_version" do
+        let(:other) { '1.2.3' }
+        it { should == true }
+      end
+
+      context "when other != self.raw_version" do
+        let(:other) { '1.2.3.4' }
+        it { should == false }
+      end
+    end
+
+    context "when other is a #{described_class}" do
+      context "when other.raw_version == self.raw_version" do
+        let(:other) { described_class.new('1.2.3') }
+        it { should == true }
+      end
+
+      context "when other.raw_version != self.raw_version" do
+        let(:other) { described_class.new('1.2.3.4') }
+        it { should == false }
+      end
+    end
+  end
+
+  describe '#==' do
+    subject { version == other }
+    include_examples 'version equality'
+  end
+
+  describe '#eql?' do
+    subject { version.eql?(other) }
+    include_examples 'version equality'
+  end
+
+  shared_examples 'version expectations hash' do |method, hash|
+    subject { version.send(method) }
+    include_examples 'expectations hash', :raw_version,
+                     { :latest  => 'latest',
+                       'latest' => 'latest',
+                       ''       => '',
+                       nil      => ''
+                     }.merge(hash)
+  end
+
+
+  describe '#latest?' do
+    include_examples 'version expectations hash', :latest?, {
+      :latest  => true,
+      'latest' => true,
+      ''       => false,
+      nil      => false,
+      '1.2.3'  => false
+    }
+  end
+
+  describe 'string manipulation helpers' do
+    describe '#major' do
+      include_examples 'version expectations hash', :major, {
+        '1'         => '1',
+        '1.2'       => '1',
+        '1.2.3'     => '1',
+        '1.2.3_4-5' => '1'
+      }
+    end
+
+    describe '#minor' do
+      include_examples 'version expectations hash', :minor, {
+        '1'         => '',
+        '1.2'       => '2',
+        '1.2.3'     => '2',
+        '1.2.3_4-5' => '2'
+      }
+    end
+
+    describe '#patch' do
+      include_examples 'version expectations hash', :patch, {
+        '1'         => '',
+        '1.2'       => '',
+        '1.2.3'     => '3',
+        '1.2.3_4-5' => '3'
+      }
+    end
+
+    describe '#major_minor' do
+      include_examples 'version expectations hash', :major_minor, {
+        '1'         => '1',
+        '1.2'       => '1.2',
+        '1.2.3'     => '1.2',
+        '1.2.3_4-5' => '1.2'
+      }
+    end
+
+    describe '#major_minor_patch' do
+      include_examples 'version expectations hash', :major_minor_patch, {
+        '1'         => '1',
+        '1.2'       => '1.2',
+        '1.2.3'     => '1.2.3',
+        '1.2.3_4-5' => '1.2.3'
+      }
+    end
+
+    describe '#before_slash' do
+      include_examples 'version expectations hash', :before_slash, {
+        '1.2.3'     => '1.2.3',
+        '1.2.3/'    => '1.2.3',
+        '/abc'      => '',
+        '1.2.3/abc' => '1.2.3'
+      }
+    end
+
+    describe '#after_slash' do
+      include_examples 'version expectations hash', :after_slash, {
+        '1.2.3'     => '',
+        '1.2.3/'    => '',
+        '/abc'      => 'abc',
+        '1.2.3/abc' => 'abc'
+      }
+    end
+
+    describe '#dots_to_hyphens' do
+      include_examples 'version expectations hash', :dots_to_hyphens, {
+        '1.2.3_4-5' => '1-2-3_4-5'
+      }
+    end
+
+    describe '#dots_to_underscores' do
+      include_examples 'version expectations hash', :dots_to_underscores, {
+        '1.2.3_4-5' => '1_2_3_4-5'
+      }
+    end
+
+    describe '#dots_to_slashes' do
+      include_examples 'version expectations hash', :dots_to_slashes, {
+        '1.2.3_4-5' => '1/2/3_4-5'
+      }
+    end
+
+    describe '#hyphens_to_dots' do
+      include_examples 'version expectations hash', :hyphens_to_dots, {
+        '1.2.3_4-5' => '1.2.3_4.5'
+      }
+    end
+
+    describe '#hyphens_to_underscores' do
+      include_examples 'version expectations hash', :hyphens_to_underscores, {
+        '1.2.3_4-5' => '1.2.3_4_5'
+      }
+    end
+
+    describe '#hyphens_to_slashes' do
+      include_examples 'version expectations hash', :hyphens_to_slashes, {
+        '1.2.3_4-5' => '1.2.3_4/5'
+      }
+    end
+
+    describe '#underscores_to_dots' do
+      include_examples 'version expectations hash', :underscores_to_dots, {
+        '1.2.3_4-5' => '1.2.3.4-5'
+      }
+    end
+
+    describe '#underscores_to_hyphens' do
+      include_examples 'version expectations hash', :underscores_to_hyphens, {
+        '1.2.3_4-5' => '1.2.3-4-5'
+      }
+    end
+
+    describe '#underscores_to_slashes' do
+      include_examples 'version expectations hash', :underscores_to_slashes, {
+        '1.2.3_4-5' => '1.2.3/4-5'
+      }
+    end
+
+    describe '#slashes_to_dots' do
+      include_examples 'version expectations hash', :slashes_to_dots, {
+        '1.2.3/abc' => '1.2.3.abc'
+      }
+    end
+
+    describe '#slashes_to_hyphens' do
+      include_examples 'version expectations hash', :slashes_to_hyphens, {
+        '1.2.3/abc' => '1.2.3-abc'
+      }
+    end
+
+    describe '#slashes_to_underscores' do
+      include_examples 'version expectations hash', :slashes_to_underscores, {
+        '1.2.3/abc' => '1.2.3_abc'
+      }
+    end
+
+    describe '#no_dots' do
+      include_examples 'version expectations hash', :no_dots, {
+        '1.2.3_4-5' => '123_4-5'
+      }
+    end
+
+    describe '#no_hyphens' do
+      include_examples 'version expectations hash', :no_hyphens, {
+        '1.2.3_4-5' => '1.2.3_45'
+      }
+    end
+
+    describe '#no_underscores' do
+      include_examples 'version expectations hash', :no_underscores, {
+        '1.2.3_4-5' => '1.2.34-5'
+      }
+    end
+
+    describe '#no_slashes' do
+      include_examples 'version expectations hash', :no_slashes, {
+        '1.2.3/abc' => '1.2.3abc'
+      }
+    end
+
+    describe '#no_dividers' do
+      include_examples 'version expectations hash', :no_dividers, {
+        '1.2.3_4-5' => '12345'
+      }
+    end
+  end
+end

--- a/spec/support/Casks/version-latest-string.rb
+++ b/spec/support/Casks/version-latest-string.rb
@@ -1,0 +1,4 @@
+test_cask 'version-latest-string' do
+  version 'latest'
+  sha256 :no_check
+end

--- a/spec/support/expectations_hash_helper.rb
+++ b/spec/support/expectations_hash_helper.rb
@@ -1,0 +1,10 @@
+module ExpectationsHashHelper
+  shared_examples 'expectations hash' do |input_name, expectations|
+    expectations.each do |input_value, expected_output|
+      context "when #{input_name} is #{input_value.inspect}" do
+        let(input_name.to_sym) { input_value }
+        it { should == expected_output }
+      end
+    end
+  end
+end

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -5,7 +5,7 @@ describe Hbc::DSL do
     test_cask = Hbc.load('basic-cask')
     test_cask.url.to_s.must_equal 'http://example.com/TestCask.dmg'
     test_cask.homepage.must_equal 'http://example.com/'
-    test_cask.version.must_equal '1.2.3'
+    test_cask.version.to_s.must_equal '1.2.3'
   end
 
   describe "when a Cask includes an unknown method" do
@@ -64,7 +64,7 @@ describe Hbc::DSL do
       test_cask = Hbc.load('no-dsl-version')
       test_cask.url.to_s.must_equal 'http://example.com/TestCask.dmg'
       test_cask.homepage.must_equal 'http://example.com/'
-      test_cask.version.must_equal '1.2.3'
+      test_cask.version.to_s.must_equal '1.2.3'
     end
   end
 


### PR DESCRIPTION
I've implemented a few of the methods outlined in #12827. I'll implement more as we decide on them.

Right now we delegate a lot of methods to `to_s` to avoid having to update a ton of casks in one go. We can remove the ones we don't want over time.
