### PR TITLE
Updated PsychoPy to v1.83.03 via official github

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,9 +1,8 @@
 cask 'psychopy' do
-  version '1.82.00'
-  sha256 '42f980455815d6dd883d125265ed97cecdf4b366608620dadbf12965f40254ad'
+  version '1.83.03'
+  sha256 'bfb5d1d07e7df089d3056e6f4fd9ff6847628d4ed7a24f508f7c79190d1bc753'
 
-  # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/sourceforge/psychpy/StandalonePsychoPy-#{version}-OSX.dmg"
+  url "https://github.com/psychopy/psychopy/releases/download/1.83.03/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
   name 'PsychoPy'
   homepage 'http://www.psychopy.org/'
   license :oss

--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -2,7 +2,7 @@ cask 'psychopy' do
   version '1.83.03'
   sha256 'bfb5d1d07e7df089d3056e6f4fd9ff6847628d4ed7a24f508f7c79190d1bc753'
 
-  url "https://github.com/psychopy/psychopy/releases/download/1.83.03/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
+  url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
   name 'PsychoPy'
   homepage 'http://www.psychopy.org/'
   license :oss


### PR DESCRIPTION
2 things happened here:
1. psychopy **moved its official release source** from sourceforge.net to github.com 
   - as seen on the "downloads" link on the vendor's main page:
     http://www.psychopy.org/
   - and as noted on the sourceforge description:
     http://sourceforge.net/projects/psychpy/?source=directory
2. **updated to latest release** of psychopy 1.83.03 released 15 Dec 2015 via github.

Note: The last (obsolete) release on sourceforge is v1.82.00
