### PR TITLE
Revert "Delete Subversion support"

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -291,6 +291,16 @@ Web browsers may obscure the direct `url` download location for a variety of rea
 $ ./developer/bin/list_url_attributes_on_file <file>
 ```
 
+### Subversion URLs
+
+In rare cases, a distribution may not be available over ordinary HTTP/S. Subversion URLs are also supported, and can be specified by appending the following key/value pairs to `url`:
+
+| key                | value       |
+| ------------------ | ----------- |
+| `:using`           | the symbol `:svn` is the only legal value
+| `:revision`        | a string identifying the subversion revision to download
+| `:trust_cert`      | set to `true` to automatically trust the certificate presented by the server (avoiding an interactive prompt)
+
 ## Appcast Stanza Details
 
 The value of the `appcast` stanza is a string, holding the URL for an appcast which provides information on future updates.

--- a/lib/hbc/download.rb
+++ b/lib/hbc/download.rb
@@ -23,6 +23,7 @@ class Hbc::Download
 
   def downloader
     @downloader ||= case cask.url.using
+    when :svn then Hbc::SubversionDownloadStrategy.new(cask)
     when :post then Hbc::CurlPostDownloadStrategy.new(cask)
     else Hbc::CurlDownloadStrategy.new(cask)
     end

--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -104,3 +104,81 @@ class Hbc::CurlPostDownloadStrategy < Hbc::CurlDownloadStrategy
     end
   end
 end
+
+class Hbc::SubversionDownloadStrategy < Hbc::HbSubversionDownloadStrategy
+
+  # super does not provide checks for already-existing downloads
+  def fetch
+    if tarball_path.exist?
+      puts "Already downloaded: #{tarball_path}"
+    else
+      super
+      compress
+    end
+    tarball_path
+  end
+
+  # This primary reason for redefining this method is the trust_cert
+  # option, controllable from the Cask definition. We also force
+  # consistent timestamps.  The rest of this method is similar to
+  # Homebrew's, but translated to local idiom.
+  def fetch_repo target, url, revision=uri_object.revision, ignore_externals=false
+    # Use "svn up" when the repository already exists locally.
+    # This saves on bandwidth and will have a similar effect to verifying the
+    # cache as it will make any changes to get the right revision.
+    svncommand = target.directory? ? 'up' : 'checkout'
+    args = [svncommand]
+
+    # SVN shipped with XCode 3.1.4 can't force a checkout.
+    args << '--force' unless MacOS.release == :leopard
+
+    # make timestamps consistent for checksumming
+    args.concat(%w[--config-option config:miscellany:use-commit-times=yes])
+
+    if uri_object.trust_cert
+      args << '--trust-server-cert'
+      args << '--non-interactive'
+    end
+
+    args << url unless target.directory?
+    args << target
+    args << '-r' << revision if revision
+    args << '--ignore-externals' if ignore_externals
+    @command.run!('/usr/bin/svn',
+                  :args => args,
+                  :print_stderr => false)
+  end
+
+  def tarball_path
+    @tarball_path ||= cached_location.dirname.join(cached_location.basename.to_s + "-#{@cask.version}.tar")
+  end
+
+  private
+
+  # TODO/UPDATE: the tar approach explained below is fragile
+  # against challenges such as case-sensitive filesystems,
+  # and must be re-implemented.
+  #
+  # Seems nutty: we "download" the contents into a tape archive.
+  # Why?
+  # * A single file is tractable to the rest of the Cask toolchain,
+  # * An alternative would be to create a Directory container type.
+  #   However, some type of file-serialization trick would still be
+  #   needed in order to enable calculating a single checksum over
+  #   a directory.  So, in that alternative implementation, the
+  #   special cases would propagate outside this class, including
+  #   the use of tar or equivalent.
+  # * SubversionDownloadStrategy.cached_location is not versioned
+  # * tarball_path provides a needed return value for our overridden
+  #   fetch method.
+  # * We can also take this private opportunity to strip files from
+  #   the download which are protocol-specific.
+
+  def compress
+    Dir.chdir(cached_location) do
+      @command.run!('/usr/bin/tar', :args => ['-s/^\.//', '--exclude', '.svn', '-cf', Pathname.new(tarball_path), '--', '.'],
+                                    :print_stderr => false)
+    end
+    clear_cache
+  end
+end

--- a/spec/cask/download_strategy_spec.rb
+++ b/spec/cask/download_strategy_spec.rb
@@ -143,4 +143,144 @@ describe 'download strategies' do
       end
     end
   end
+
+  describe Hbc::SubversionDownloadStrategy do
+    let(:url_options) {{
+      :using => :svn
+    }}
+    let(:fake_system_command) { class_double(Hbc::SystemCommand) }
+    let(:downloader) { Hbc::SubversionDownloadStrategy.new(cask, fake_system_command) }
+    before do
+      allow(fake_system_command).to receive(:run!)
+    end
+
+    it 'returns a tarball path on fetch' do
+      allow(downloader).to receive(:compress)
+      allow(downloader).to receive(:fetch_repo)
+
+      retval = shutup { downloader.fetch }
+
+      expect(retval).to equal(downloader.tarball_path)
+    end
+
+    it 'calls fetch_repo with default arguments for a simple Cask' do
+      allow(downloader).to receive(:compress)
+      allow(downloader).to receive(:fetch_repo)
+
+      shutup { downloader.fetch }
+
+      expect(downloader).to have_received(:fetch_repo).with(
+        downloader.cached_location,
+        cask.url.to_s
+      )
+    end
+
+    it 'calls svn with default arguments for a simple Cask' do
+      allow(downloader).to receive(:compress)
+
+      shutup { downloader.fetch }
+
+      expect(fake_system_command).to have_received(:run!).with(
+        '/usr/bin/svn',
+        hash_including(:args => [
+          'checkout',
+          '--force',
+          '--config-option',
+          'config:miscellany:use-commit-times=yes',
+          cask.url.to_s,
+          downloader.cached_location]))
+
+    end
+
+    context 'with trust_cert set on the URL' do
+      let(:url_options) {{
+        :using => :svn,
+        :trust_cert => true
+      }}
+
+      it 'adds svn arguments for :trust_cert' do
+        allow(downloader).to receive(:compress)
+
+        shutup { downloader.fetch }
+
+        expect(fake_system_command).to have_received(:run!).with(
+          '/usr/bin/svn',
+          hash_including(:args => [
+          'checkout',
+          '--force',
+          '--config-option',
+          'config:miscellany:use-commit-times=yes',
+          '--trust-server-cert',
+          '--non-interactive',
+          cask.url.to_s,
+          downloader.cached_location,
+        ]))
+      end
+    end
+
+    context 'with :revision set on url' do
+      let(:url_options) {{
+        :using => :svn,
+        :revision => '10'
+      }}
+
+      it 'adds svn arguments for :revision' do
+        allow(downloader).to receive(:compress)
+
+        shutup { downloader.fetch }
+
+        expect(fake_system_command).to have_received(:run!).with(
+          '/usr/bin/svn',
+          hash_including(:args => [
+          'checkout',
+          '--force',
+          '--config-option',
+          'config:miscellany:use-commit-times=yes',
+          cask.url.to_s,
+          downloader.cached_location,
+          '-r',
+          '10',
+        ]))
+
+      end
+    end
+
+    it 'runs tar to serialize svn downloads' do
+      # sneaky stub to remake the directory, since homebrew code removes it
+      # before tar is called
+      allow(downloader).to receive(:fetch_repo) {
+        downloader.cached_location.mkdir
+      }
+
+      shutup { downloader.fetch }
+
+      expect(fake_system_command).to have_received(:run!).with(
+        '/usr/bin/tar',
+        hash_including(:args => [
+        '-s/^\\.//',
+        '--exclude',
+        '.svn',
+        '-cf',
+        downloader.tarball_path,
+        '--',
+        '.',
+      ]))
+    end
+  end
+
+  # does not work yet, because (for unknown reasons), the tar command
+  # returns an error code when running under the test suite
+  # it 'creates a tarball matching the expected checksum' do
+  #   cask = Hbc.load('svn-download-check-cask')
+  #   downloader = Hbc::SubversionDownloadStrategy.new(cask)
+  #   # special mocking required for tar to have something to work with
+  #   def downloader.fetch_repo(target, url, revision=nil, ignore_externals=false)
+  #     target.mkpath
+  #     FileUtils.touch(target.join('empty_file.txt'))
+  #     File.utime(1000,1000,target.join('empty_file.txt'))
+  #   end
+  #   expect(shutup { downloader.fetch }).to equal(downloader.tarball_path)
+  #   d = Hbc::Download.new(cask)
+  #   d.send(:_check_sums, downloader.tarball_path, cask.sums)
+  # end
 end


### PR DESCRIPTION
Reverts caskroom/homebrew-cask#16118.

Looks like [there was a case for this](https://github.com/caskroom/homebrew-fonts/issues/428) after all.

This necessity makes me dislike subversion support even more, though. The reason we’re doing it this way is `svn`, unlike `git`, allows us to checkout a single directory from the repo, making for a smaller download.

Download size in itself isn’t that big a deal, I’d say, since worst case scenario the download of a full fonts repo should be ≈250MBs (Google Fonts) and there are bigger apps. With caching, and since users likely don’t install fonts all the time, that wouldn’t be a huge deal, except that since we need to separate apps by directory before linking (moving, in the future) we’d leave users with a bunch of copies of those uncompressed repos, and that is not good.

However, using subversion in this manner is in itself bad for casks, I’d argue, since it requires [an important additional value](https://github.com/caskroom/homebrew-fonts/blob/ab1e0df2005278a6b132b1b8a5d4dc55cd0ff233/Casks/font-sauce-code-powerline.rb#L8) to `url`s. This [subversion revision](https://github.com/caskroom/homebrew-cask/pull/16118/files#diff-eb6c53cc0d6eb7ed0964481ed17f8624L300) value is (seems like) an obtuse parameter to get in the context of a github repo, and I’m not even sure there’s an easy way for contributors to know when to updated it and to what value. It also makes the cask somewhat more difficult to understand in the sense that [its `url` value](https://github.com/caskroom/homebrew-fonts/blob/ab1e0df2005278a6b132b1b8a5d4dc55cd0ff233/Casks/font-sauce-code-powerline.rb#L6) will seem to lead nowhere.

In light of all this, I’d rather have yet a different solution. I briefly considered a sibling project, like [our sister](https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#unofficial-vendorless-and-walled-builds) [alehouse](https://github.com/alehouse) to host these multiple-fonts-per-repo fonts. I was envisioning a script that regularly would download those repos, package fonts as individual zip files, and push them to a github repo. Corresponding cask font files would then be set to `:latest` (fonts is one case where you absolutely always want the latest) and download from there. Those wouldn’t really be official links, though, and there may be other things I’m also not predicting there.

Any ideas?
