### PR TITLE
update waterfox url

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -2,8 +2,7 @@ cask 'waterfox' do
   version '40.0.2'
   sha256 '49720ec39019cc7991531677014bbd140062fb72f0d5dbd963f7f14b75da37b6'
 
-  # cloudfront.net is the official download host per the vendor homepage
-  url "https://d1th2p59px32bw.cloudfront.net/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"
+  url "https://waterfox.blob.core.windows.net/releases/osx64/installer/Waterfox+#{version}+Setup.dmg"
   name 'Waterfox'
   homepage 'https://www.waterfoxproject.org'
   license :oss


### PR DESCRIPTION
the old cloudfront url failed on me. I pulled the new url from the big download button on the Waterfox home page, tested it and installed it fine.
