### PR TITLE
Clarify that discontinued means all development has halted upstream

### DIFF
--- a/doc/CASK_LANGUAGE_REFERENCE.md
+++ b/doc/CASK_LANGUAGE_REFERENCE.md
@@ -222,7 +222,7 @@ The following methods may be called to generate standard warning messages:
 | `logout`                          | users should log out and log back in to complete installation
 | `reboot`                          | users should reboot to complete installation
 | `files_in_usr_local`              | the Cask installs files to `/usr/local`, which may confuse Homebrew
-| `discontinued`                    | software has been officially discontinued upstream
+| `discontinued`                    | all software development has been officially discontinued upstream
 | `free_license(web_page)`          | users may get an official license to use the software at `web_page`
 
 Example:


### PR DESCRIPTION
I'm actually fairly agnostic on the overall utility of this, but I do think it's somewhat more clear to a contributor.  Refer to the discussion in #16097, in particular my [comment](https://github.com/caskroom/homebrew-cask/pull/16097#issuecomment-167163990) and the two following.

Left [`lib/hbc/caveats.rb`](https://github.com/caskroom/homebrew-cask/blob/master/lib/hbc/caveats.rb#L95-L101) untouched for want of being concise.
