### PR TITLE
fix :launchctl id, add :login_item key

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -16,7 +16,7 @@ cask 'airtool' do
                          'com.adriangranados.airtool.airtool-bpf.*',
                          'com.adriangranados.airtool.Airtool.pkg'
                         ],
-            :launchctl => 'com.adriangranados.airtool.airtool-bpf',
+            :launchctl => 'com.adriangranados.airtool.airtool-bpf.pkg',
             :login_item => 'Airtool'
 
   zap :delete => [

--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -13,11 +13,11 @@ cask 'airtool' do
   pkg "airtool_#{version}.pkg"
 
   uninstall :pkgutil => [
-                         'com.adriangranados.airtool.airtool-bpf.pkg',
-                         'com.adriangranados.airtool.airtool-bpf.plist.pkg',
+                         'com.adriangranados.airtool.airtool-bpf.*',
                          'com.adriangranados.airtool.Airtool.pkg'
                         ],
-            :launchctl => 'com.adriangranados.airtool.airtool-bpf'
+            :launchctl => 'com.adriangranados.airtool.airtool-bpf',
+            :login_item => 'Airtool'
 
   zap :delete => [
                   '/Library/Application Support/Airtool',


### PR DESCRIPTION
fix for #16209
for some reason 

```
:launchctl => 'com.adriangranados.airtool.airtool-bpf',
```

is not working despite list_installed_launchjob_id  returning above id.
the code that works is

```
:launchctl => 'com.adriangranados.airtool.airtool-bpf.pkg',
```

also added :login_item key
