### PR TITLE
SystemCommand: escape the executable if there are no args 

### DIFF
--- a/lib/hbc/system_command.rb
+++ b/lib/hbc/system_command.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'shellwords'
 
 class Hbc::SystemCommand
   def self.run(executable, options={})
@@ -6,6 +7,8 @@ class Hbc::SystemCommand
     odebug "Executing: #{command.utf8_inspect}"
     processed_stdout = ''
     processed_stderr = ''
+
+    command[0] = Shellwords.shellescape(command[0]) if command.size == 1
 
     raw_stdin, raw_stdout, raw_stderr, raw_wait_thr =
       Open3.popen3(*command.map { |arg| arg.respond_to?(:to_path) ? File.absolute_path(arg) : String(arg) })


### PR DESCRIPTION
`Open3.popen3` does not escape its first argument if it is given only one.
