### PR TITLE
Remove /dist from invocation message for consul-web-ui

### DIFF
--- a/Casks/consul-web-ui.rb
+++ b/Casks/consul-web-ui.rb
@@ -12,6 +12,6 @@ cask 'consul-web-ui' do
 
   depends_on :cask => 'consul'
   caveats do
-    "Invoke consul with '-ui-dir #{staged_path}/dist'"
+    "Invoke consul with '-ui-dir #{staged_path}'"
   end
 end


### PR DESCRIPTION
The `/dist` on the end of the invocation message was incorrect.
