### PR TITLE
Extract travis build logic into scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,21 @@ sudo: false
 
 env:
   global:
-    - HOMEBREW_RUBY=2.0.0
     - LANG=en_US.UTF-8
     - LANGUAGE=en_US.UTF-8
     - LC_ALL=en_US.UTF-8
-    - CASK_TAP_DIR=/usr/local/Library/Taps/caskroom/homebrew-cask
 
 matrix:
   include:
-    - env: OSX=10.11
+    - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
       os: osx
       osx_image: xcode7.2
       rvm: system
-    - env: OSX=10.10
+    - env: OSX=10.10 HOMEBREW_RUBY=2.0.0
       os: osx
       osx_image: xcode7.1
       rvm: system
-    - env: OSX=10.9
+    - env: OSX=10.9 HOMEBREW_RUBY=2.0.0
       os: osx
       osx_image: beta-xcode6.2
       rvm: system
@@ -30,61 +28,17 @@ cache:
     - /usr/local
     - $HOME/.gem
 
-# before_install steps
-# * set TRAVIS_COMMIT (https://github.com/travis-ci/travis-ci/issues/2666)
-# * set PATH according to env matrix
-# * update Homebrew
-# * uninstall pre-installed brew-cask
-# * rsync repo to tap directory and run from there
-# * informational feedback
 before_install:
-  - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"
-  - env | grep TRAVIS_
-  - sw_vers
-  - export HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/$HOMEBREW_RUBY/usr/bin/ruby"
-  - printenv HOMEBREW_RUBY_PATH
-  - export PATH="$HOME/.gem/ruby/$HOMEBREW_RUBY/bin:$PATH"
-  - printenv PATH
-  - which ruby
-  - ruby --version
-  - which gem
-  - gem --version
-  - brew update
-  - brew uninstall --force brew-cask
-  - mkdir -p "$CASK_TAP_DIR"
-  - rsync -az --delete "$TRAVIS_BUILD_DIR/" "$CASK_TAP_DIR/"
-  - export TRAVIS_BUILD_DIR="$CASK_TAP_DIR"
-  - cd "$CASK_TAP_DIR"
+  - . ci/travis/before_install.sh
 
-# install steps
-# * brew Formulae and Casks without which some tests will be skipped
-# * install bundler gem
-# * bundle gems required for testing brew-cask
 install:
-  - brew install cabextract
-  - brew install unar
-  - brew cask install Casks/adobe-air.rb
-  - gem install --no-ri --no-rdoc --user-install bundler
-  - bundle install
+  - . ci/travis/install.sh
 
-# before_script steps
-# * informational feedback
 before_script:
-  - which rake
-  - rake --version
-  - which bundle
-  - bundle --version
+  - . ci/travis/before_script.sh
 
-# script steps
-# * run test suite
-# * lint with rubocop
-# * audit any modified casks (download if version, sha256, or url changed)
-# @@@ todo: setting the --seed here is an ugly temporary hack, to remain only
-#     until test-suite glitches are fixed.
 script:
-  - bundle exec rake test TESTOPTS="--seed=14830"
-  - bundle exec rake rubocop
-  - developer/bin/audit_modified_casks "$TRAVIS_BRANCH..$TRAVIS_COMMIT"
+  - . ci/travis/script.sh
 
 notifications:
   irc:

--- a/ci/travis/README.md
+++ b/ci/travis/README.md
@@ -1,0 +1,5 @@
+## Travis-CI Scripts
+
+The bash scripts in this directory are run only in Travis-CI, and are placed here to help simplify the [`.travis.yml`](../../.travis.yml) configuration file.
+
+These scripts are not meant to be run locally by users or developers of Homebrew-Cask.

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# before_install.sh
+#
+# This file is meant to be sourced during the `before_install` phase of the
+# Travis build. Do not attempt to source or run it locally.
+#
+# shellcheck disable=SC1090
+. "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
+
+enter_build_step
+
+header 'Running before_install.sh...'
+
+# unset rvm hook functions
+unset -f cd gem
+
+# see https://github.com/travis-ci/travis-ci/issues/2666
+TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"
+export TRAVIS_COMMIT
+
+# print all travis-defined environment variables
+run env | grep TRAVIS
+
+# print detailed OSX version info
+run sw_vers
+
+# capture system ruby and gem locations
+export SYSTEM_RUBY_HOME="/System/Library/Frameworks/Ruby.framework/Versions/${HOMEBREW_RUBY%.*}"
+export SYSTEM_RUBY_BINDIR="${SYSTEM_RUBY_HOME}/usr/bin"
+export SYSTEM_GEM_HOME="${SYSTEM_RUBY_HOME}/usr/lib/ruby/gems/${HOMEBREW_RUBY}"
+export SYSTEM_GEM_BINDIR="${SYSTEM_GEM_HOME}/bin"
+
+# capture user gem locations
+export GEM_HOME="$HOME/.gem/ruby/${HOMEBREW_RUBY}"
+export GEM_BINDIR="${GEM_HOME}/bin"
+
+# ensure that the gems we install are used before system gems
+export GEM_PATH="${GEM_HOME}:${SYSTEM_GEM_HOME}"
+export PATH="${GEM_BINDIR}:${SYSTEM_GEM_BINDIR}:${SYSTEM_RUBY_BINDIR}:$PATH"
+
+# ensure that brew uses the ruby we want it to
+export HOMEBREW_RUBY_PATH="${SYSTEM_RUBY_BINDIR}/ruby"
+
+run which ruby
+run ruby --version
+
+run which gem
+run gem --version
+
+run brew update
+
+# ensure that we are the only brew-cask available
+run brew uninstall --force brew-cask
+
+# mirror the repo as a tap, then run the build from there
+export CASK_TAP_DIR='/usr/local/Library/Taps/caskroom/homebrew-cask'
+run mkdir -p "${CASK_TAP_DIR}"
+run rsync -az --delete "${TRAVIS_BUILD_DIR}/" "${CASK_TAP_DIR}/"
+export TRAVIS_BUILD_DIR="${CASK_TAP_DIR}"
+run cd "${CASK_TAP_DIR}" || exit 1
+
+exit_build_step

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# before_script.sh
+#
+# This file is meant to be sourced during the `before_script` phase of the
+# Travis build. Do not attempt to source or run it locally.
+#
+# shellcheck disable=SC1090
+. "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
+
+enter_build_step
+
+header 'Running before_script.sh...'
+
+run which bundle
+run bundle --version
+
+run which rake
+run rake --version
+
+exit_build_step

--- a/ci/travis/helpers.sh
+++ b/ci/travis/helpers.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# helpers.sh
+#
+# Helper functions for Travis build scripts.
+#
+
+# force strict error checking
+set -o errexit
+set -o pipefail
+
+CYAN='\033[0;36m'
+MAGENTA='\033[1;35m'
+NC='\033[0m' # no color
+
+# log command before running and add a blank line
+run () {
+  echo -e "${MAGENTA}>>>${NC} $*"
+  command "$@"
+  local retval=$?
+  echo
+  return $retval
+}
+
+# print args as a cyan header
+header () {
+  echo
+  echo -e "${CYAN}$*${NC}"
+  echo
+}
+
+# disallow unbound variables during build step
+enter_build_step () {
+  set -o nounset
+}
+
+# allow unbound variables so Travis doesn't get mad at us
+exit_build_step () {
+  set +o nounset
+}

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# install.sh
+#
+# This file is meant to be sourced during the `install` phase of the Travis
+# build. Do not attempt to source or run it locally.
+#
+# shellcheck disable=SC1090
+. "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
+
+enter_build_step
+
+header 'Running install.sh...'
+
+# install Formulae and Casks without which some tests would be skipped
+run brew install cabextract
+run brew install unar
+run brew cask install Casks/adobe-air.rb
+
+# install bundler and project dependencies in $GEM_HOME
+run gem install --no-ri --no-rdoc bundler
+
+run which bundle
+run bundle --version
+
+run bundle install --path="${GEM_HOME%/*/*}"
+
+# sanity check: ensure that gems are installed where they should be
+run ls "${GEM_BINDIR}"
+run ls "${GEM_HOME}/gems"
+
+exit_build_step

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# script.sh
+#
+# This file is meant to be sourced during the `script` phase of the Travis
+# build. Do not attempt to source or run it locally.
+#
+# shellcheck disable=SC1090
+. "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
+
+enter_build_step
+
+header 'Running script.sh...'
+
+# @@@ todo: setting the --seed here is an ugly temporary hack, to remain only
+#     until test-suite glitches are fixed.
+run bundle exec rake test TESTOPTS='--seed=14830'
+
+run bundle exec rake rubocop
+
+# audit any modified casks (download if version, sha256, or url changed)
+run developer/bin/audit_modified_casks "${TRAVIS_BRANCH}..${TRAVIS_COMMIT}"
+
+exit_build_step

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -18,7 +18,9 @@ run bundle exec rake test TESTOPTS='--seed=14830'
 
 run bundle exec rake rubocop
 
-# audit any modified casks (download if version, sha256, or url changed)
-run developer/bin/audit_modified_casks "${TRAVIS_BRANCH}..${TRAVIS_COMMIT}"
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+  # audit any modified casks (download if version, sha256, or url changed)
+  run developer/bin/audit_modified_casks "${TRAVIS_BRANCH}..${TRAVIS_COMMIT}"
+fi
 
 exit_build_step

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -26,6 +26,7 @@ describe "Repo layout" do
   TOPLEVEL_DIRS = %w{
                      .git
                      Casks
+                     ci
                      cmd
                      developer
                      doc


### PR DESCRIPTION
I like this setup much better. Build scripts should be just that, scripts. We were doing way too much inside `.travis.yml`, and I think splitting out each build phase into its own script gives us a much better separation of concerns, and a more maintainable build flow overall.
