### PR TITLE
Add ExifTool 10.08

### DIFF
--- a/Casks/exiftool.rb
+++ b/Casks/exiftool.rb
@@ -1,0 +1,17 @@
+cask 'exiftool' do
+  version '10.08'
+  sha256 '7dcc2d19e8c2bba0d1e565f0f7a58a6196fc3ae68f438f604ab6c672b79660d7'
+
+  url "http://www.sno.phy.queensu.ca/~phil/exiftool/ExifTool-#{version}.dmg"
+  appcast 'http://owl.phy.queensu.ca/~phil/exiftool/rss.xml',
+          :sha256 => 'f3a6a2060af3e886c5453f9152edf4e9dc6a150f288a2ceb14a29fc8b4545769'
+  name 'ExifTool by Phil Harvey'
+  homepage 'http://www.sno.phy.queensu.ca/~phil/exiftool/'
+  license :gpl
+
+  # hard-coded version in package name, gross
+  pkg 'ExifTool-10.08.pkg'
+
+  uninstall :pkgutil   => 'com.philharvey.image-exiftool'
+
+end


### PR DESCRIPTION
Created a new cask for [Phil Harvey's ExifTool](http://www.sno.phy.queensu.ca/~phil/exiftool/) command line utility for inspecting photo and video metadata via the command line. (Reads more than just EXIF metadata!) Fully tested (including uninstall) on OS X 10.11.1 El Capitan.
