### PR TITLE
Upgrade BlockBlock.app to v0.9.4

### DIFF
--- a/Casks/blockblock.rb
+++ b/Casks/blockblock.rb
@@ -1,6 +1,6 @@
 cask 'blockblock' do
-  version '0.9.3'
-  sha256 '719761707b8fca83014bfdd58d01d37ad0c32142d57913f8ed46c56a3011ad0c'
+  version '0.9.4'
+  sha256 'ae95c40ce4f33b4b46a62b925fb0bc0ef00c61a56c5c933c69316ff382ab397b'
 
   # bitbucket.org is the official download host per the vendor homepage
   url "https://bitbucket.org/objective-see/deploy/downloads/BlockBlock_#{version}.zip"
@@ -8,7 +8,7 @@ cask 'blockblock' do
   homepage 'https://objective-see.com/products/blockblock.html'
   license :unknown
 
-  installer :manual => 'BlockBlock.app'
+  installer :manual => 'BlockBlock_Installer.app'
 
   uninstall :quit => 'com.objectivesee.BlockBlock',
             :launchctl => [


### PR DESCRIPTION
Upgrades BlockBlock.app to version 0.9.4, and corrects the location of the installer.
