### PR TITLE
Add Mouse Locator 1.1 and PlistEdit Pro 1.8.2

### DIFF
--- a/Casks/mouse-locator.rb
+++ b/Casks/mouse-locator.rb
@@ -1,0 +1,14 @@
+cask 'mouse-locator' do
+  version '1.1'
+  sha256 '1809760210e5afb80f9be34dc930c0c6fb84efee91747640d2d9717561149645'
+
+  url 'http://www.2point5fish.com/files/MouseLocator.dmg'
+  name 'Mouse Locator'
+  homepage 'http://www.2point5fish.com/index.html'
+  license :gratis
+
+  # Technically the Mouse Locator Installer.app has to be manually installed
+  # but all it does is copy a preference file. Automating the install/uninstall instead.
+  prefpane "Mouse Locator v#{version} Installer.app/Contents/Resources/Distribution/MouseLocator.prefPane"
+
+end

--- a/Casks/plistedit-pro.rb
+++ b/Casks/plistedit-pro.rb
@@ -1,0 +1,18 @@
+cask 'plistedit-pro' do
+  version '1.8.2'
+  sha256 'd114975f724726189afbd8ac9f7113ff8c6de303ba7b892ce633b50f0951be49'
+
+  url 'http://www.fatcatsoftware.com/plisteditpro/PlistEditPro.zip'
+  name 'PlistEdit Pro'
+  homepage 'http://www.fatcatsoftware.com/plisteditpro/'
+  license :freemium
+
+  app 'PlistEdit Pro.app'
+
+  zap :delete => [
+    '~/Library/Preferences/com.fatcatsoftware.pledpro.plist',
+    '~/Library/Application Support/PlistEdit Pro'
+  ]
+
+  caveats 'After the 14 day trial period, files can still be opened but can no longer be saved.'
+end


### PR DESCRIPTION
Created new cask for Mouse Locator tool. Ordinarily requires manual installation of vendor's app file, but that just installs a preference pane. Tested on OS X 10.11.1 El Capitan.

Note: because of symlinking, preference pane's activate button cannot be toggled! Need to wait for issue #13201 to be resolved to move files instead of symlinking them. (Maybe it's a permissions thing?) Still committing though, in case it works as is on other versions on OS X.

Created new cask for PlistEdit Pro. Freemium software with zap command 
to remove preferences. Tested on OS X 10.11.1 El Capitan.
