### PR TITLE
Add Mouse Locator 1.1

### DIFF
--- a/Casks/mouse-locator.rb
+++ b/Casks/mouse-locator.rb
@@ -1,0 +1,14 @@
+cask 'mouse-locator' do
+  version '1.1'
+  sha256 '1809760210e5afb80f9be34dc930c0c6fb84efee91747640d2d9717561149645'
+
+  url 'http://www.2point5fish.com/files/MouseLocator.dmg'
+  name 'Mouse Locator'
+  homepage 'http://www.2point5fish.com/index.html'
+  license :gratis
+
+  # Technically the Mouse Locator Installer.app has to be manually installed
+  # but all it does is copy a preference file. Automating the install/uninstall instead.
+  prefpane "Mouse Locator v#{version} Installer.app/Contents/Resources/Distribution/MouseLocator.prefPane"
+
+end


### PR DESCRIPTION
Created new cask for Mouse Locator tool. Ordinarily requires manual installation of vendor's app file, but that just installs a preference pane. Tested on OS X 10.11.1 El Capitan.

Note: because of symlinking, preference pane's activate button cannot be toggled! Need to wait for issue #13201 to be resolved to move files instead of symlinking them. Still committing though, in case it works as is on other versions on OS X.
