### PR TITLE
Add PlistEdit Pro v1.8.2

### DIFF
--- a/Casks/plistedit-pro.rb
+++ b/Casks/plistedit-pro.rb
@@ -1,11 +1,11 @@
 cask 'plistedit-pro' do
-  version '1.8.2'
-  sha256 'd114975f724726189afbd8ac9f7113ff8c6de303ba7b892ce633b50f0951be49'
+  version :latest
+  sha256 :no_check
 
   url 'http://www.fatcatsoftware.com/plisteditpro/PlistEditPro.zip'
   name 'PlistEdit Pro'
   homepage 'http://www.fatcatsoftware.com/plisteditpro/'
-  license :freemium
+  license :commercial
 
   app 'PlistEdit Pro.app'
 
@@ -14,5 +14,4 @@ cask 'plistedit-pro' do
     '~/Library/Application Support/PlistEdit Pro'
   ]
 
-  caveats 'After the 14 day trial period, files can still be opened but can no longer be saved.'
 end

--- a/Casks/plistedit-pro.rb
+++ b/Casks/plistedit-pro.rb
@@ -1,0 +1,18 @@
+cask 'plistedit-pro' do
+  version '1.8.2'
+  sha256 'd114975f724726189afbd8ac9f7113ff8c6de303ba7b892ce633b50f0951be49'
+
+  url 'http://www.fatcatsoftware.com/plisteditpro/PlistEditPro.zip'
+  name 'PlistEdit Pro'
+  homepage 'http://www.fatcatsoftware.com/plisteditpro/'
+  license :freemium
+
+  app 'PlistEdit Pro.app'
+
+  zap :delete => [
+    '~/Library/Preferences/com.fatcatsoftware.pledpro.plist',
+    '~/Library/Application Support/PlistEdit Pro'
+  ]
+
+  caveats 'After the 14 day trial period, files can still be opened but can no longer be saved.'
+end


### PR DESCRIPTION
Created new cask for PlistEdit Pro. Commercial software with 
14 day trial. Zap command to remove preferences. Tested on 
OS X 10.11.1 El Capitan.
