### PR TITLE
IceCat 38.5.2 has been released.

### DIFF
--- a/Casks/icecat.rb
+++ b/Casks/icecat.rb
@@ -1,8 +1,8 @@
 cask 'icecat' do
-  version '31.8.0'
-  sha256 'd5ec5308bba40f8498f89cd70c5bfb2ce51370543a326c0e9697cbeb5c41c0c9'
+  version '38.5.2'
+  sha256 '87792c64b4b1e815db3c95406dcae3920932c76dd51ed678112e4fcdc3cd6e2b'
 
-  url "https://ftp.gnu.org/gnu/gnuzilla/#{version}/icecat-#{version}.en-US.mac.dmg"
+  url "https://ftp.gnu.org/gnu/gnuzilla/#{version}/icecat-#{version}.en-US.mac64.dmg"
   name 'IceCat'
   homepage 'https://www.gnu.org/software/gnuzilla/'
   license :gpl


### PR DESCRIPTION
IceCat 38.5.2 has been released, brew cask version was 31.8.0.
