### PR TITLE
Upgrade PowerMate.app to v1.2.4

### DIFF
--- a/Casks/powermate.rb
+++ b/Casks/powermate.rb
@@ -1,8 +1,8 @@
 cask 'powermate' do
-  version '1.2.4_0'
+  version '1.2.4'
   sha256 '6fd755961bb5a486cb3ab9d47217f7877d4bb021134f32a3c32ceede3fd3cf3d'
 
-  url "http://support.griffintechnology.com/sites/default/files/PowerMate_v#{version}.zip"
+  url 'https://support.griffintechnology.com/wp-content/uploads/sites/3/2015/08/PowerMate_v1.2.4.zip'
   name 'Griffin Powermate'
   homepage 'https://support.griffintechnology.com/support/powermate/'
   license :gratis


### PR DESCRIPTION
This seems to be the latest version, [as per the support page](https://support.griffintechnology.com/product/powermate/).

I hardcoded the version number in the URL because it's unlikely to have a matching base path for any subsequent version.
