### PR TITLE
Use /usr/bin/env bash instead of /bin/bash in a number of developer scripts

### DIFF
--- a/developer/bin/cask-switch-https
+++ b/developer/bin/cask-switch-https
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 

--- a/developer/bin/develop_brew_cask
+++ b/developer/bin/develop_brew_cask
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # develop_brew_cask
 #

--- a/developer/bin/generate_man_pages
+++ b/developer/bin/generate_man_pages
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # generate_man_pages
 #

--- a/developer/bin/irregular_cask_whitespace
+++ b/developer/bin/irregular_cask_whitespace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # irregular_cask_whitespace
 #

--- a/developer/bin/project_stats
+++ b/developer/bin/project_stats
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # project_stats
 #

--- a/developer/examples/brewcask-showargs
+++ b/developer/examples/brewcask-showargs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # brewcask-showargs
 #


### PR DESCRIPTION
I left alone anything I thought a contributor might reasonably be expected to run in the course of creating a cask, which basically means `list_*` and `generate_cask_token` (See #8023 and #8021).<sup>1</sup>

That being said, I'm a firm believer in [using bash as defined in the user's environment](https://github.com/caskroom/homebrew-cask/pull/9180) so if there are no objections...

---

1: Although since ruby 2.0 is required anyway, this might as well fail imo
