### PR TITLE
Add user-generated content to zap in 4 casks

### DIFF
--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -18,10 +18,7 @@ cask 'cocoaspell' do
   zap :delete => [
                  '~/.aspell.conf',
                  '~/.aspell.en.prepl',
-                 # Debatable. The Pws holds user-created content, though typically
-                 # created through the application, and the user is not likely aware
-                 # of this particular file.
-                 # '~/.aspell.en.pws',
+                 '~/.aspell.en.pws',
                 ]
 
   caveats <<-EOS.undent

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -17,8 +17,8 @@ cask 'filezilla' do
   app 'FileZilla.app'
 
   zap :delete => [
+                  '~/.config/filezilla',
                   '~/Library/Saved Application State/de.filezilla.savedState',
                   '~/Library/Preferences/de.filezilla.plist',
-                 ],
-      :rmdir => '~/.config/filezilla'
+                 ]
 end

--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -16,8 +16,7 @@ cask 'soulver' do
   end
 
   zap :delete => [
-                  # todo verify that this does not contain user-generated content
-                  # '~/Library/Application Support/Soulver',
+                  '~/Library/Application Support/Soulver',
                   '~/Library/Preferences/com.acqualia.soulver.plist',
                   '~/Library/Autosave Information/Unsaved Soulver Document.soulver',
                   # todo glob/expand support

--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -12,4 +12,6 @@ cask 'vagrant' do
 
   uninstall :script => { :executable => 'uninstall.tool', :input => %w[Yes] },
             :pkgutil => 'com.vagrant.vagrant'
+
+  zap :delete => '~/.vagrant.d'
 end


### PR DESCRIPTION
`soulver`, `filezilla`, and `cocoaspell`  ETA: `vagrant`

As decided in #10156, `zap` should remove _everything_, including user-generated content.  We have not yet done the necessary work on `zap` to include articulating what is being removed (#12790) and to `:trash` rather than `:delete`, hence this makes me (somewhat) uneasy, especially as this is behavior is undocumented.  That being said, these aren't the first: there's been at least one invitation (#10008) and at least two others already in place (#13083 and the reversal of #8455 by #14481), so the cat is out of the bag.
