### PR TITLE
Use documentation format for test reporters

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--format documentation

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,7 @@ HOMEBREW_CACHE.join('Casks').mkpath
 # must be called after testing_env so at_exit hooks are in proper order
 require 'minitest/autorun'
 require 'minitest/reporters'
-Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new(color: true)
 
 # Force mocha to patch MiniTest since we have both loaded thanks to homebrew's testing_env
 require 'mocha/api'


### PR DESCRIPTION
I don't know about you guys, but I find this format much more useful than the `.............` output by the default reporter.
