### PR TITLE
RSpec: run specs in random order, same as MiniTest

### DIFF
--- a/spec/cask/artifact/binary_spec.rb
+++ b/spec/cask/artifact/binary_spec.rb
@@ -11,6 +11,9 @@ describe Hbc::Artifact::Binary do
   let(:expected_path) {
     Hbc.binarydir.join('binary')
   }
+  before(:each) {
+    Hbc.binarydir.mkpath
+  }
   after(:each) {
     if expected_path.exist?
       FileUtils.rm expected_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,5 +42,6 @@ Hbc.default_tap = project_root.join('spec', 'support')
 Hbc.caskroom = Hbc.homebrew_prefix.join('TestCaskroom')
 
 RSpec.configure do |config|
+  config.order = :random
   config.include ShutupHelper
 end


### PR DESCRIPTION
For consistency and peace of mind—this enforces sane spec design, which ensures that specs can be run out-of-order without messing anything up.
