### PR TITLE
Apply RuboCop to test casks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - '**/Gemfile'
     - '**/Rakefile'
     - '**/brew-cask.rb'
+    - '**/invalid-header-format.rb'
     - '**/spec/*.rb'
     - '**/spec/support/*.rb'
     - '**/test/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,18 +5,25 @@ AllCops:
     - '**/Gemfile'
     - '**/Rakefile'
     - '**/brew-cask.rb'
+    - '**/spec/*.rb'
+    - '**/spec/support/*.rb'
+    - '**/test/*.rb'
+    - '**/test/support/*.rb'
     - 'developer/**/*'
     - 'lib/**/*'
-    - 'spec/**/*'
-    - 'test/**/*'
+    - 'spec/cask/**/*'
+    - 'test/cask/**/*'
+    - 'test/Casks/**/*'
+    - 'test/plist/**/*'
+    - 'test/support/shared_examples/**/*'
 
 Metrics/LineLength:
   Exclude:
-    - 'Casks/**/*'
+    - '**/Casks/**/*'
 
 Performance/StringReplacement:
   Exclude:
-    - 'Casks/**/*'
+    - '**/Casks/**/*'
 
 Style/AlignHash:
   EnforcedHashRocketStyle: table
@@ -27,15 +34,15 @@ Style/BarePercentLiterals:
 
 Style/Documentation:
   Exclude:
-    - 'Casks/**/*'
+    - '**/Casks/**/*'
 
 Style/EmptyElse:
   Exclude:
-    - 'Casks/**/*'
+    - '**/Casks/**/*'
 
 Style/FileName:
   Exclude:
-    - 'Casks/**/*'
+    - '**/Casks/**/*'
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets

--- a/spec/support/Casks/missing-homepage.rb
+++ b/spec/support/Casks/missing-homepage.rb
@@ -1,4 +1,5 @@
 test_cask 'missing-homepage' do
-  url 'http://localhost/something.dmg'
   version '1.2.3'
+
+  url 'http://localhost/something.dmg'
 end

--- a/spec/support/Casks/missing-license.rb
+++ b/spec/support/Casks/missing-license.rb
@@ -1,4 +1,5 @@
 test_cask 'missing-license' do
   version '1.2.3'
+
   url 'http://localhost/something.dmg'
 end

--- a/spec/support/Casks/missing-name.rb
+++ b/spec/support/Casks/missing-name.rb
@@ -1,4 +1,5 @@
 test_cask 'missing-name' do
   version '1.2.3'
+
   url 'http://localhost/something.dmg'
 end

--- a/spec/support/Casks/missing-sha256.rb
+++ b/spec/support/Casks/missing-sha256.rb
@@ -1,4 +1,5 @@
 test_cask 'missing-sha256' do
   version '1.2.3'
+
   url 'http://localhost/something.dmg'
 end

--- a/spec/support/Casks/missing-url.rb
+++ b/spec/support/Casks/missing-url.rb
@@ -1,4 +1,5 @@
 test_cask 'missing-url' do
   version '1.2.3'
+
   homepage 'http://example.com'
 end

--- a/spec/support/Casks/osdn-correct-url-format.rb
+++ b/spec/support/Casks/osdn-correct-url-format.rb
@@ -1,5 +1,6 @@
 test_cask 'osdn-correct-url-format' do
   version '1.2.3'
-  homepage 'http://osdn.jp/projects/something/'
+
   url 'http://user.dl.osdn.jp/something/id/Something-1.2.3.dmg'
+  homepage 'http://osdn.jp/projects/something/'
 end

--- a/spec/support/Casks/osdn-incorrect-url-format.rb
+++ b/spec/support/Casks/osdn-incorrect-url-format.rb
@@ -1,5 +1,6 @@
 test_cask 'osdn-incorrect-url-format' do
   version '1.2.3'
-  homepage 'http://osdn.jp/projects/something/'
+
   url 'http://osdn.jp/projects/something/files/Something-1.2.3.dmg/download'
+  homepage 'http://osdn.jp/projects/something/'
 end

--- a/spec/support/Casks/sourceforge-correct-url-format.rb
+++ b/spec/support/Casks/sourceforge-correct-url-format.rb
@@ -1,5 +1,6 @@
 test_cask 'sourceforge-correct-url-format' do
   version '1.2.3'
-  homepage 'http://sourceforge.net/projects/something/'
+
   url 'http://downloads.sourceforge.net/project/something/Something-1.2.3.dmg'
+  homepage 'http://sourceforge.net/projects/something/'
 end

--- a/spec/support/Casks/sourceforge-incorrect-url-format.rb
+++ b/spec/support/Casks/sourceforge-incorrect-url-format.rb
@@ -1,5 +1,6 @@
 test_cask 'sourceforge-incorrect-url-format' do
   version '1.2.3'
-  homepage 'http://sourceforge.net/projects/something/'
+
   url 'http://sourceforge.net/projects/something/files/Something-1.2.3.dmg/download'
+  homepage 'http://sourceforge.net/projects/something/'
 end

--- a/spec/support/Casks/sourceforge-version-latest-correct-url-format.rb
+++ b/spec/support/Casks/sourceforge-version-latest-correct-url-format.rb
@@ -1,5 +1,6 @@
 test_cask 'sourceforge-version-latest-correct-url-format' do
   version :latest
-  homepage 'http://sourceforge.net/projects/something/'
+
   url 'http://sourceforge.net/projects/something/files/latest/download'
+  homepage 'http://sourceforge.net/projects/something/'
 end

--- a/test/support/Casks/auto-updates.rb
+++ b/test/support/Casks/auto-updates.rb
@@ -5,7 +5,7 @@ test_cask 'auto-updates' do
   url TestHelper.local_binary_url('transmission-2.61.dmg')
   homepage 'http://example.com/auto-updates'
 
-  app 'Transmission.app'
-
   auto_updates true
+
+  app 'Transmission.app'
 end

--- a/test/support/Casks/cab-container.rb
+++ b/test/support/Casks/cab-container.rb
@@ -6,5 +6,6 @@ test_cask 'cab-container' do
   homepage 'http://example.com/cab-container'
 
   depends_on :formula => 'cabextract'
+
   app 'cabcontainer/Application.app'
 end

--- a/test/support/Casks/invalid/invalid-appcast-multiple.rb
+++ b/test/support/Casks/invalid/invalid-appcast-multiple.rb
@@ -3,11 +3,11 @@ test_cask 'invalid-appcast-multiple' do
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
   url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/invalid-appcast-multiple'
   appcast 'http://example.com/appcast1.xml',
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
   appcast 'http://example.com/appcast2.xml',
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  homepage 'http://example.com/invalid-appcast-multiple'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-appcast-url.rb
+++ b/test/support/Casks/invalid/invalid-appcast-url.rb
@@ -3,9 +3,9 @@ test_cask 'invalid-appcast-url' do
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
   url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/invalid-appcast-url'
   appcast 1,
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  homepage 'http://example.com/invalid-appcast-url'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
+++ b/test/support/Casks/invalid/invalid-gpg-conflicting-keys.rb
@@ -5,7 +5,7 @@ test_cask 'invalid-gpg-conflicting-keys' do
   url TestHelper.local_binary_url('caffeine.zip')
   homepage 'http://example.com/invalid-gpg-conflicting-keys'
   gpg 'http://example.com/gpg-signature.asc',
-      :key_id => '01234567',
+      :key_id  => '01234567',
       :key_url => 'http://example.com/gpg-key-url'
 
   app 'Caffeine.app'

--- a/test/support/Casks/invalid/invalid-stage-only-conflict.rb
+++ b/test/support/Casks/invalid/invalid-stage-only-conflict.rb
@@ -5,6 +5,6 @@ test_cask 'invalid-stage-only-conflict' do
   url TestHelper.local_binary_url('transmission-2.61.dmg')
   homepage 'http://example.com/invalid-stage-only-conflict'
 
-  stage_only true
   app 'Transmission.app'
+  stage_only true
 end

--- a/test/support/Casks/nested-app.rb
+++ b/test/support/Casks/nested-app.rb
@@ -6,5 +6,6 @@ test_cask 'nested-app' do
   homepage 'http://example.com/nested-app'
 
   container :nested => 'NestedApp.dmg'
+
   app 'MyNestedApp.app'
 end

--- a/test/support/Casks/rar-container.rb
+++ b/test/support/Casks/rar-container.rb
@@ -6,5 +6,6 @@ test_cask 'rar-container' do
   homepage 'http://example.com/rar-container'
 
   depends_on :formula => 'unar'
+
   app 'rarcontainer/Application.app'
 end

--- a/test/support/Casks/sevenzip-container.rb
+++ b/test/support/Casks/sevenzip-container.rb
@@ -6,5 +6,6 @@ test_cask 'sevenzip-container' do
   homepage 'http://example.com/sevenzip-container'
 
   depends_on :formula => 'unar'
+
   app 'sevenzipcontainer/Application.app'
 end

--- a/test/support/Casks/stuffit-container.rb
+++ b/test/support/Casks/stuffit-container.rb
@@ -6,5 +6,6 @@ test_cask 'stuffit-container' do
   homepage 'http://www.tobias-jung.de/seekingprofont/'
 
   depends_on :formula => 'unar'
+
   artifact 'sheldonmac/v1.0'
 end

--- a/test/support/Casks/with-accessibility-access.rb
+++ b/test/support/Casks/with-accessibility-access.rb
@@ -5,7 +5,7 @@ test_cask 'with-accessibility-access' do
   url 'http://example.com/TestCask.dmg'
   homepage 'http://example.com/'
 
-  app 'TestCask.app'
-
   accessibility_access true
+
+  app 'TestCask.app'
 end

--- a/test/support/Casks/with-appcast.rb
+++ b/test/support/Casks/with-appcast.rb
@@ -3,9 +3,9 @@ test_cask 'with-appcast' do
   sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
   url TestHelper.local_binary_url('caffeine.zip')
-  homepage 'http://example.com/with-appcast'
   appcast 'http://example.com/appcast.xml',
           :sha256 => '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  homepage 'http://example.com/with-appcast'
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -6,6 +6,7 @@ test_cask 'with-caveats' do
   homepage 'http://example.com/local-caffeine'
 
   app 'Caffeine.app'
+
   # simple string is evaluated at compile-time
   caveats <<-EOS.undent
     Here are some things you might want to know.

--- a/test/support/Casks/with-conditional-caveats.rb
+++ b/test/support/Casks/with-conditional-caveats.rb
@@ -9,6 +9,6 @@ test_cask 'with-conditional-caveats' do
 
   # a do block may print and use a DSL
   caveats do
-    puts 'This caveat is conditional' if false
+    puts 'This caveat is conditional' if false # rubocop:disable Lint/LiteralInCondition
   end
 end

--- a/test/support/Casks/with-conditional-caveats.rb
+++ b/test/support/Casks/with-conditional-caveats.rb
@@ -6,6 +6,7 @@ test_cask 'with-conditional-caveats' do
   homepage 'http://example.com/local-caffeine'
 
   app 'Caffeine.app'
+
   # a do block may print and use a DSL
   caveats do
     puts 'This caveat is conditional' if false

--- a/test/support/Casks/with-conflicts-with.rb
+++ b/test/support/Casks/with-conflicts-with.rb
@@ -6,5 +6,6 @@ test_cask 'with-conflicts-with' do
   homepage 'http://example.com/with-conflicts-with'
 
   conflicts_with :formula => 'unar'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on-cask.rb
+++ b/test/support/Casks/with-depends-on-cask.rb
@@ -6,5 +6,6 @@ test_cask 'with-depends-on-cask' do
   homepage 'http://example.com/with-depends-on-cask'
 
   depends_on :cask => 'local-transmission'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on-formula.rb
+++ b/test/support/Casks/with-depends-on-formula.rb
@@ -6,5 +6,6 @@ test_cask 'with-depends-on-formula' do
   homepage 'http://example.com/with-depends-on-formula'
 
   depends_on :formula => 'unar'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-depends-on-macos-array.rb
+++ b/test/support/Casks/with-depends-on-macos-array.rb
@@ -6,7 +6,7 @@ test_cask 'with-depends-on-macos-array' do
   homepage 'http://example.com/with-depends-on-macos-array'
 
   # since all OS releases are included, this should always pass
-  depends_on :macos => [ '10.0', '10.1', '10.2', '10.3', '10.3', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10', MacOS.release.to_s ]
+  depends_on :macos => ['10.0', '10.1', '10.2', '10.3', '10.3', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10', MacOS.release.to_s]
 
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-gpg-key-url.rb
+++ b/test/support/Casks/with-gpg-key-url.rb
@@ -6,5 +6,6 @@ test_cask 'with-gpg-key-url' do
   homepage 'http://example.com/with-gpg-key-url'
   gpg 'http://example.com/gpg-signature.asc',
       :key_url => 'http://example.com/gpg-key-url'
+
   app 'Caffeine.app'
 end

--- a/test/support/Casks/with-installable.rb
+++ b/test/support/Casks/with-installable.rb
@@ -6,14 +6,15 @@ test_cask 'with-installable' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
+
   uninstall :script     => { :executable => 'MyFancyPkg/FancyUninstaller.tool', :args => %w[--please] },
             :quit       => 'my.fancy.package.app',
             :login_item => 'Fancy',
             :delete     => [
-                            '/permissible/absolute/path',
-                            '~/permissible/path/with/tilde',
-                            'impermissible/relative/path',
-                            '/another/impermissible/../relative/path',
+                             '/permissible/absolute/path',
+                             '~/permissible/path/with/tilde',
+                             'impermissible/relative/path',
+                             '/another/impermissible/../relative/path',
                            ],
-           :rmdir       => TestHelper.local_binary_path('empty_directory')
+            :rmdir      => TestHelper.local_binary_path('empty_directory')
 end

--- a/test/support/Casks/with-installer-script.rb
+++ b/test/support/Casks/with-installer-script.rb
@@ -9,7 +9,7 @@ test_cask 'with-installer-script' do
             :args   => ['--flag']
   # acceptable alternate form
   installer :script => {
-                        :executable => '/usr/bin/false',
-                        :args       => ['--flag'],
+                         :executable => '/usr/bin/false',
+                         :args       => ['--flag'],
                        }
 end

--- a/test/support/Casks/with-pkgutil-zap.rb
+++ b/test/support/Casks/with-pkgutil-zap.rb
@@ -6,7 +6,8 @@ test_cask 'with-pkgutil-zap' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'Fancy.pkg'
-  zap :pkgutil => 'my.fancy.package.*',
-      :kext => 'my.fancy.package.kernelextension',
+
+  zap :pkgutil   => 'my.fancy.package.*',
+      :kext      => 'my.fancy.package.kernelextension',
       :launchctl => 'my.fancy.package.service'
 end

--- a/test/support/Casks/with-uninstall-delete.rb
+++ b/test/support/Casks/with-uninstall-delete.rb
@@ -8,9 +8,9 @@ test_cask 'with-uninstall-delete' do
   pkg 'Fancy.pkg'
 
   uninstall :delete => [
-                        '/permissible/absolute/path',
-                        '~/permissible/path/with/tilde',
-                        'impermissible/relative/path',
-                        '/another/impermissible/../relative/path',
+                         '/permissible/absolute/path',
+                         '~/permissible/path/with/tilde',
+                         'impermissible/relative/path',
+                         '/another/impermissible/../relative/path',
                        ]
 end

--- a/test/support/Casks/with-uninstall-kext.rb
+++ b/test/support/Casks/with-uninstall-kext.rb
@@ -6,5 +6,6 @@ test_cask 'with-uninstall-kext' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'Fancy.pkg'
+
   uninstall :kext => 'my.fancy.package.kernelextension'
 end

--- a/test/support/Casks/with-uninstall-pkgutil.rb
+++ b/test/support/Casks/with-uninstall-pkgutil.rb
@@ -6,5 +6,6 @@ test_cask 'with-uninstall-pkgutil' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'Fancy.pkg'
+
   uninstall :pkgutil => 'my.fancy.package.*'
 end

--- a/test/support/Casks/with-uninstall-rmdir.rb
+++ b/test/support/Casks/with-uninstall-rmdir.rb
@@ -6,5 +6,6 @@ test_cask 'with-uninstall-rmdir' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
+
   uninstall :rmdir => TestHelper.local_binary_path('empty_directory')
 end

--- a/test/support/Casks/with-uninstall-signal.rb
+++ b/test/support/Casks/with-uninstall-signal.rb
@@ -8,7 +8,7 @@ test_cask 'with-uninstall-signal' do
   pkg 'MyFancyPkg/Fancy.pkg'
 
   uninstall :signal => [
-                        ['TERM', 'my.fancy.package.app'],
-                        ['KILL', 'my.fancy.package.app']
+                         ['TERM', 'my.fancy.package.app'],
+                         ['KILL', 'my.fancy.package.app'],
                        ]
 end

--- a/test/support/Casks/with-uninstall-trash.rb
+++ b/test/support/Casks/with-uninstall-trash.rb
@@ -8,9 +8,9 @@ test_cask 'with-uninstall-trash' do
   pkg 'Fancy.pkg'
 
   uninstall :trash => [
-                       '/permissible/absolute/path',
-                       '~/permissible/path/with/tilde',
-                       'impermissible/relative/path',
-                       '/another/impermissible/../relative/path',
+                        '/permissible/absolute/path',
+                        '~/permissible/path/with/tilde',
+                        'impermissible/relative/path',
+                        '/another/impermissible/../relative/path',
                       ]
 end

--- a/test/support/Casks/with-zap-delete.rb
+++ b/test/support/Casks/with-zap-delete.rb
@@ -8,9 +8,9 @@ test_cask 'with-zap-delete' do
   pkg 'Fancy.pkg'
 
   zap :delete => [
-                        '/permissible/absolute/path',
-                        '~/permissible/path/with/tilde',
-                        'impermissible/relative/path',
-                        '/another/impermissible/../relative/path',
-                       ]
+                   '/permissible/absolute/path',
+                   '~/permissible/path/with/tilde',
+                   'impermissible/relative/path',
+                   '/another/impermissible/../relative/path',
+                 ]
 end

--- a/test/support/Casks/with-zap-kext.rb
+++ b/test/support/Casks/with-zap-kext.rb
@@ -6,5 +6,6 @@ test_cask 'with-zap-kext' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'Fancy.pkg'
+
   zap :kext => 'my.fancy.package.kernelextension'
 end

--- a/test/support/Casks/with-zap-pkgutil.rb
+++ b/test/support/Casks/with-zap-pkgutil.rb
@@ -6,5 +6,6 @@ test_cask 'with-zap-pkgutil' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'Fancy.pkg'
+
   zap :pkgutil => 'my.fancy.package.*'
 end

--- a/test/support/Casks/with-zap-rmdir.rb
+++ b/test/support/Casks/with-zap-rmdir.rb
@@ -6,5 +6,6 @@ test_cask 'with-zap-rmdir' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
+
   zap :rmdir => TestHelper.local_binary_path('empty_directory')
 end

--- a/test/support/Casks/with-zap-signal.rb
+++ b/test/support/Casks/with-zap-signal.rb
@@ -8,7 +8,7 @@ test_cask 'with-zap-signal' do
   pkg 'MyFancyPkg/Fancy.pkg'
 
   zap :signal => [
-                        ['TERM', 'my.fancy.package.app'],
-                        ['KILL', 'my.fancy.package.app']
-                       ]
+                   ['TERM', 'my.fancy.package.app'],
+                   ['KILL', 'my.fancy.package.app'],
+                 ]
 end

--- a/test/support/Casks/with-zap-trash.rb
+++ b/test/support/Casks/with-zap-trash.rb
@@ -8,9 +8,9 @@ test_cask 'with-zap-trash' do
   pkg 'Fancy.pkg'
 
   zap :trash => [
-                       '/permissible/absolute/path',
-                       '~/permissible/path/with/tilde',
-                       'impermissible/relative/path',
-                       '/another/impermissible/../relative/path',
-                      ]
+                  '/permissible/absolute/path',
+                  '~/permissible/path/with/tilde',
+                  'impermissible/relative/path',
+                  '/another/impermissible/../relative/path',
+                ]
 end

--- a/test/support/Casks/with-zap.rb
+++ b/test/support/Casks/with-zap.rb
@@ -6,12 +6,14 @@ test_cask 'with-zap' do
   homepage 'http://example.com/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
+
   uninstall :quit => 'my.fancy.package.app.from.uninstall'
-  zap :script => {
-                  :executable => 'MyFancyPkg/FancyUninstaller.tool',
-                  :args => %w[--please]
-                  },
-      :quit => 'my.fancy.package.app',
+
+  zap :script     => {
+                       :executable => 'MyFancyPkg/FancyUninstaller.tool',
+                       :args       => %w[--please],
+                     },
+      :quit       => 'my.fancy.package.app',
       :login_item => 'Fancy',
-      :delete => '~/Library/Preferences/my.fancy.app.plist'
+      :delete     => '~/Library/Preferences/my.fancy.app.plist'
 end


### PR DESCRIPTION
Also be more explicit about what we are excluding in `.rubocop.yml`. This allows us to consistently lint test casks, and also will make future updates to the list of files we lint a bit easier.
