### PR TITLE
Add zap stanza to gitx.rb

### DIFF
--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -16,4 +16,11 @@ cask 'gitx' do
 
   app 'GitX.app'
   binary 'GitX.app/Contents/Resources/gitx'
+
+  zap :delete => [
+                   '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/nl.frim.gitx.sfl',
+                   '~/Library/Caches/nl.frim.GitX',
+                   '~/Library/Preferences/nl.frim.GitX.plist',
+                   '~/Library/Saved Application State/nl.frim.GitX.savedState',
+                 ]
 end


### PR DESCRIPTION
Some trivial things to delete, would be basically free were #16339 ever implemented and put to full use. But without `bundle_id`, `zap :delete` is still the way to kick it out of my system.
