### PR TITLE
Add SmartCutter

### DIFF
--- a/Casks/smartcutter.rb
+++ b/Casks/smartcutter.rb
@@ -12,9 +12,10 @@ cask 'smartcutter' do
 
   # This might remove preferences for all FameRing products on the system
   # but right now SmartCutter is the only OS X application by the company.
-  zap :delete => [
+  zap :delete => 
+  [
     '~/Library/Application Support/FameRing/',
-    '~/Library/Preferences/fltk.org/'
+    '~/Library/Preferences/fltk.org/',
   ]
 
   caveats 'The unregistered version can be used indefinitely and applies a watermark at beginning of exported files.'

--- a/Casks/smartcutter.rb
+++ b/Casks/smartcutter.rb
@@ -1,0 +1,21 @@
+cask 'smartcutter' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.fame-ring.com/SmartCutter.dmg'
+  name 'Smart Cutter'
+  name 'Smart Cutter for DV and DVB'
+  homepage 'http://www.fame-ring.com/smart_cutter.html'
+  license :commercial
+
+  app 'SmartCutter.app'
+
+  # This might remove preferences for all FameRing products on the system
+  # but right now SmartCutter is the only OS X application by the company.
+  zap :delete => [
+    '~/Library/Application Support/FameRing/',
+    '~/Library/Preferences/fltk.org/'
+  ]
+
+  caveats 'The unregistered version can be used indefinitely and applies a watermark at beginning of exported files.'
+end


### PR DESCRIPTION
Created new cask for SmartCutter lossless video trimmer tool for OS X.
Commercial software. The unregistered version can be used indefinitely 
and applies a watermark at beginning of exported files.
