### PR TITLE
Improve error message suggestions

### DIFF
--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -384,9 +384,9 @@ def report
   puts "Proposed file name:           #{cask_file_name}"
   puts "Cask Header Line:             cask '#{cask_token}' do"
   if warnings.length > 0
-    STDERR.puts "\n"
-    STDERR.puts warnings
-    STDERR.puts "\n"
+    $stderr.puts "\n"
+    $stderr.puts warnings
+    $stderr.puts "\n"
     exit 1
   end
 end

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -116,6 +116,7 @@ class Hbc::CLI
     run_command(command, *rest)
   rescue Hbc::CaskError, Hbc::CaskSha256MismatchError => e
     onoe e
+    puts Hbc::Utils.error_message_with_suggestions if e.is_a?(Hbc::CaskHeaderParseError)
     $stderr.puts e.backtrace if Hbc.debug
     exit 1
   rescue StandardError, ScriptError, NoMemoryError => e

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -116,13 +116,13 @@ class Hbc::CLI
     run_command(command, *rest)
   rescue Hbc::CaskError, Hbc::CaskSha256MismatchError => e
     onoe e
-    puts Hbc::Utils.error_message_with_suggestions if e.is_a?(Hbc::CaskHeaderParseError)
+    $stderr.puts Hbc::Utils.error_message_with_suggestions if e.is_a?(Hbc::CaskHeaderParseError)
     $stderr.puts e.backtrace if Hbc.debug
     exit 1
   rescue StandardError, ScriptError, NoMemoryError => e
     onoe e
-    puts Hbc::Utils.error_message_with_suggestions
-    puts e.backtrace
+    $stderr.puts Hbc::Utils.error_message_with_suggestions
+    $stderr.puts e.backtrace
     exit 1
   end
 

--- a/lib/hbc/exceptions.rb
+++ b/lib/hbc/exceptions.rb
@@ -126,6 +126,9 @@ class Hbc::CaskInvalidError < Hbc::CaskError
   end
 end
 
+class Hbc::CaskHeaderParseError < Hbc::CaskInvalidError
+end
+
 class Hbc::CaskSha256MissingError < ArgumentError
 end
 

--- a/lib/hbc/source/path_base.rb
+++ b/lib/hbc/source/path_base.rb
@@ -55,7 +55,7 @@ class Hbc::Source::PathBase
           raise Hbc::CaskInvalidError.new(cask_token, "Bad header line: '#{header_token}' does not match file name")
         end
       else
-        raise Hbc::CaskInvalidError.new(cask_token, "Bad header line: parse failed")
+        raise Hbc::CaskHeaderParseError.new(cask_token, "Bad header line: parse failed")
       end
 
       # simulate "require"

--- a/lib/hbc/system_command.rb
+++ b/lib/hbc/system_command.rb
@@ -93,7 +93,7 @@ class Hbc::SystemCommand::Result
     external = File.basename(command.first)
     lines = garbage.strip.split("\n")
     opoo "Non-XML stdout from #{external}:"
-    STDERR.puts lines.map {|l| "    #{l}"}
+    $stderr.puts lines.map {|l| "    #{l}"}
   end
 
   def self._parse_plist(command, output)

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -6,7 +6,7 @@ require 'stringio'
 
 require 'hbc/utils/tty'
 
-UPDATE_CMD = "brew uninstall --force brew-cask; brew update; brew cleanup; brew cask cleanup"
+UPDATE_CMD = "brew uninstall --force brew-cask; brew untap phinze/cask; brew update; brew cleanup; brew cask cleanup"
 ISSUES_URL = "https://github.com/caskroom/homebrew-cask#reporting-bugs"
 
 # todo: temporary

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -6,7 +6,7 @@ require 'stringio'
 
 require 'hbc/utils/tty'
 
-UPDATE_CMD = "brew update; brew cleanup; brew cask cleanup"
+UPDATE_CMD = "brew uninstall --force brew-cask; brew update; brew cleanup; brew cask cleanup"
 ISSUES_URL = "https://github.com/caskroom/homebrew-cask#reporting-bugs"
 
 # todo: temporary

--- a/test/cask/dsl_test.rb
+++ b/test/cask/dsl_test.rb
@@ -48,7 +48,7 @@ describe Hbc::DSL do
     it "requires a valid header format" do
       err = lambda {
         invalid_cask = Hbc.load('invalid/invalid-header-format')
-      }.must_raise(Hbc::CaskInvalidError)
+      }.must_raise(Hbc::CaskHeaderParseError)
       err.message.must_include 'Bad header line: parse failed'
     end
 


### PR DESCRIPTION
- Print error message with suggestions if header parse failed
- Add `brew uninstall --force brew-cask` to error suggestions

Refs #16344
