### PR TITLE
Rust compiler updated to latest stable version 1.5.0

### DIFF
--- a/Casks/rust.rb
+++ b/Casks/rust.rb
@@ -1,6 +1,6 @@
 cask 'rust' do
-  version '1.3.0'
-  sha256 '26dfc4ec42b89aaac4d5db1bbb688e22fe6a276dc40e8c7c6da795b61b6d3ffa'
+  version '1.5.0'
+  sha256 '5b0870d858f7527d96fc4f81d4371ae70d332c948cbbf0a7ad284a764974b81f'
 
   url "https://static.rust-lang.org/dist/rust-#{version}-x86_64-apple-darwin.pkg"
   name 'Rust'


### PR DESCRIPTION
Current Cask version (1.3.0) is out of date
