### PR TITLE
Add EditReady 1.3.8

### DIFF
--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -1,0 +1,17 @@
+cask 'editready' do
+  version '1.3.8'
+  sha256 '74eda021699b29c7922ed1ddfa61556e2433df271fce1c7bc619a69b99a0d5db'
+
+  url "http://www.divergentmedia.com/filedownload/editready%20#{version}.dmg"
+  name 'EditReady'
+  homepage 'http://www.divergentmedia.com/editready'
+  license :commercial
+
+  app 'EditReady.app'
+
+  zap :delete =>
+                 [
+                   '~/Library/Application Support/EditReady',
+                   '~/Library/Preferences/com.divergentmedia.EditReady.plist',
+                 ]
+end


### PR DESCRIPTION
Add EditReady 1.3.8

Added cask for EditReady, a video editing app for transcoding
inter-frame delivery/prosumer codec footage (AVCHD, H.264, etc.) into
intra-frame editing formats (e.g. ProRes).

Note: version specific URL deduced. The original is simply
http://www.divergentmedia.com/filedownload/editready
