### PR TITLE
Updated BetterTouchTool Cask with new release location

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,10 +6,10 @@ cask 'bettertouchtool' do
     # bettertouchtool.com is the official download host per the vendor homepage
     url "http://bettertouchtool.net/btt#{version}.zip"
   else
-    version '1.49'
+    version '1.5'
     sha256 'a0ea79136322c634545c0b9da6001944fad5ec734b891fbc63c5485ba0cfd516'
 
-    url "http://boastr.net/releases/btt#{version}.zip"
+    url "https://bettertouchtool.com/releases/BetterTouchTool.zip"
     appcast 'http://appcast.boastr.net',
             :sha256 => '1cb51646c9d3a28ec6f6904f04d83a3d73aface7ca055793439a2746d8f2a112'
   end


### PR DESCRIPTION
BetterTouchTool's releases are now at a new address. This only applies for versions 1.5 and greater, which have the same compatibility as the 1.49 release that 1.5 replaces
