### PR TITLE
Travis: run audit and style check before tests

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -12,10 +12,6 @@ enter_build_step
 
 header 'Running script.sh...'
 
-run bundle exec rake test:coverage
-run bundle exec rake coveralls:push || true # in case of networking errors
-run bundle exec rake rubocop
-
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
   TRAVIS_BRANCH_COMMIT="$(git rev-parse --verify -q "${TRAVIS_BRANCH}")"
   TRAVIS_COMMIT_RANGE="${TRAVIS_BRANCH_COMMIT}..${TRAVIS_COMMIT}"
@@ -26,5 +22,9 @@ fi
 
 # audit any modified casks (download if version, sha256, or url changed)
 run developer/bin/audit_modified_casks "${TRAVIS_COMMIT_RANGE}"
+
+run bundle exec rake rubocop
+run bundle exec rake test:coverage
+run bundle exec rake coveralls:push || true # in case of networking errors
 
 exit_build_step


### PR DESCRIPTION
Audit and RuboCop are more likely to fail, and finish more quickly than
the test suite.

As [suggested](https://github.com/caskroom/homebrew-cask/pull/16402#issuecomment-169405362) by @Amorymeltzer.
