### PR TITLE
updated acorn (5.2.1)

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,13 +1,15 @@
 cask 'acorn' do
-  version :latest
-  sha256 :no_check
+  version '5.2.1'
+  sha256 '523665d59ebcd41d7ee5b919ab6ab981c30c1182bbd9b0ad6e2cfde531776358'
 
-  url 'http://flyingmeat.com/download/Acorn.zip'
+  url 'https://secure.flyingmeat.com/download/Acorn.zip'
   appcast 'http://www.flyingmeat.com/download/acorn5update.xml',
-          :sha256 => '62f48162e1f7d0d8d03e13dd47411714d86afb0e8a2f7b5c95bd3d9906e66da9'
+          :sha256 => '8b69771372799594671232942d939bbaa4feeeaf02ef632fe1269eb6768b5576'
   name 'Acorn'
   homepage 'http://flyingmeat.com/acorn/'
   license :commercial
+
+  auto_updates true
 
   app 'Acorn.app'
 


### PR DESCRIPTION
Yes, the url is versionless, but it has an appcast, so we can still know when it is updated.
