### PR TITLE
gdal-framework.rb: fix no_check comment

### DIFF
--- a/Casks/gdal-framework.rb
+++ b/Casks/gdal-framework.rb
@@ -1,6 +1,6 @@
 cask 'gdal-framework' do
   version '1.11.1-1'
-  sha256 :no_check # upstream package is updated in-place
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "http://www.kyngchaos.com/files/software/frameworks/GDAL_Complete-#{version.sub(%r{^(\d+\.\d+).*}, '\1')}.dmg"
   name 'GDAL Complete'


### PR DESCRIPTION
Might seem trivial, but these comments following a pattern is important (will be soon in `cask-repair`, for example).
