### PR TITLE
Add SimpleMovieX

### DIFF
--- a/Casks/simplemoviex.rb
+++ b/Casks/simplemoviex.rb
@@ -1,0 +1,13 @@
+cask 'simplemoviex' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://simplemoviex.com/SimpleMovieX/SimpleMovieX.zip'
+  name 'SimpleMovieX'
+  homepage 'http://simplemoviex.com/SimpleMovieX/'
+  license :freemium
+
+  app 'SimpleMovieX.app'
+
+  zap :delete => '~/Library/Preferences/com.BJ.SimpleMovieX.plist'
+end


### PR DESCRIPTION
Added cask for SimpleMovieX, a QuickTime Player Pro replacement from the folks at AeroQuartet. Easily batch cuts, edit chapter metadata, work with AVI files and other professional-level tasks—all losslessly. Not meant as a replacement for an actual NLE like Final Cut Pro, but intended to serve ["a well-defined role in Apple product matrix"](http://simplemoviex.com/SimpleMovieX/compare.html).

Based on the older, now-legacy QuickTime Player 32-bit framework, i.e. QuickTime Player 7, but still runs on current generation machines. Tested on OS X 10.11.1 El Capitan.

Demo offers the same features as the full working version, except for slower saving and limiting the number of chapter markers. There is no time limitation.
