### PR TITLE
bbc-iplayer-downloads.rb: delete appcast (changes on each request)

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -4,8 +4,6 @@ cask 'bbc-iplayer-downloads' do
 
   # bbci.co.uk is the official download host per the vendor homepage
   url "https://a.files.bbci.co.uk/iplayer/downloads/BBC-iPlayer-Downloads-#{version}.dmg"
-  appcast 'http://ipd-hq.cloud.bbc.co.uk/downloads/update.xml',
-          :sha256 => 'beaca7e86fdda214f2ceff4d2b7902bebd3ebc998a363d3700c89fe4a2335fa2'
   name 'BBC iPlayer Downloads'
   homepage 'http://www.bbc.co.uk/iplayer/install'
   license :gratis


### PR DESCRIPTION
This `appcast` is useless to us. It changes (an `<epoch>` value) on every request, which means `:sha256` will never be correct, and we’ll always get false positives.
