### PR TITLE
Travis: skip tests if only casks have been modified

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,15 @@
 source 'https://rubygems.org'
 
+gem 'rake'
+
+group :debug do
+  gem 'pry'
+  gem 'pry-byebug', platforms: :mri
+end
+
 group :development do
   gem 'rubocop', github: 'bbatsov/rubocop', branch: 'master'
   gem 'rubocop-cask', '~> 0.2'
-  gem 'pry'
-  gem 'pry-byebug', platforms: :mri
 end
 
 group :release do
@@ -16,6 +21,5 @@ group :test do
   gem 'minitest', '5.4.1'
   gem 'minitest-reporters'
   gem 'mocha', '1.1.0', :require => false
-  gem 'rake'
   gem 'rspec', '~> 3.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 group :development do
   gem 'rubocop', github: 'bbatsov/rubocop', branch: 'master'
-  gem 'rubocop-cask', '~> 0.2'
+  gem 'rubocop-cask', '~> 0.3'
 end
 
 group :release do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    rubocop-cask (0.3.0)
+    rubocop-cask (0.3.1)
     ruby-progressbar (1.7.5)
     simplecov (0.11.1)
       docile (~> 1.1.0)
@@ -111,7 +111,7 @@ DEPENDENCIES
   ronn (= 0.7.3)
   rspec (~> 3.0.0)
   rubocop!
-  rubocop-cask (~> 0.2)
+  rubocop-cask (~> 0.3)
 
 BUNDLED WITH
    1.11.2

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -52,8 +52,6 @@ run ruby --version
 run which gem
 run gem --version
 
-run brew update
-
 # ensure that we are the only brew-cask available
 run brew uninstall --force brew-cask
 

--- a/ci/travis/helpers.sh
+++ b/ci/travis/helpers.sh
@@ -9,6 +9,9 @@
 set -o errexit
 set -o pipefail
 
+# enable extended globbing syntax
+shopt -s extglob
+
 CYAN='\033[0;36m'
 MAGENTA='\033[1;35m'
 NC='\033[0m' # no color
@@ -55,4 +58,17 @@ enter_build_step () {
 # allow unbound variables so Travis doesn't get mad at us
 exit_build_step () {
   set +o nounset
+}
+
+files_modified_outside_casks () {
+  git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- !(Casks)
+}
+
+# return 0 if we can't skip running the test suite
+must_run_tests () {
+  if [[ -z "${FILES_MODIFIED_OUTSIDE_CASKS+defined}" ]]; then
+    FILES_MODIFIED_OUTSIDE_CASKS="$(files_modified_outside_casks)"
+    export FILES_MODIFIED_OUTSIDE_CASKS
+  fi
+  [[ -n "${FILES_MODIFIED_OUTSIDE_CASKS}" ]]
 }

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -12,21 +12,20 @@ enter_build_step
 
 header 'Running install.sh...'
 
-# install Formulae and Casks without which some tests would be skipped
-brew_install cabextract
-brew_install unar
-run brew cask install Casks/adobe-air.rb
-
 # install bundler and project dependencies in $GEM_HOME
 run gem install --no-ri --no-rdoc bundler
-
 run which bundle
 run bundle --version
+run bundle install --path="${GEM_HOME%/*/*}" --without=debug release test
 
-run bundle install --path="${GEM_HOME%/*/*}"
+if must_run_tests; then
+  run bundle install --path="${GEM_HOME%/*/*}" --with=test
 
-# sanity check: ensure that gems are installed where they should be
-run ls "${GEM_BINDIR}"
-run ls "${GEM_HOME}/gems"
+  # install Formulae and Casks without which some tests would be skipped
+  run brew update
+  brew_install cabextract
+  brew_install unar
+  run brew cask install Casks/adobe-air.rb
+fi
 
 exit_build_step

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -16,7 +16,10 @@ header 'Running script.sh...'
 run developer/bin/audit_modified_casks "${TRAVIS_COMMIT_RANGE}"
 
 run bundle exec rake rubocop
-run bundle exec rake test:coverage
-run bundle exec rake coveralls:push || true # in case of networking errors
+
+if must_run_tests; then
+  run bundle exec rake test:coverage
+  run bundle exec rake coveralls:push || true # in case of networking errors
+fi
 
 exit_build_step


### PR DESCRIPTION
This should help out a lot with build times, since the vast majority of builds are triggered by cask update PRs.

Refs #16566.
