### PR TITLE
Further Travis optimizations

### DIFF
--- a/ci/travis/helpers.sh
+++ b/ci/travis/helpers.sh
@@ -60,17 +60,9 @@ exit_build_step () {
   set +o nounset
 }
 
-modified_files () {
-  if [[ -z "${MODIFIED_FILES+defined}" ]]; then
-    MODIFIED_FILES="$(git diff --name-only "${TRAVIS_COMMIT_RANGE}" --)"
-    export MODIFIED_FILES
-  fi
-  echo "${MODIFIED_FILES}"
-}
-
 modified_cask_files () {
   if [[ -z "${MODIFIED_CASK_FILES+defined}" ]]; then
-    MODIFIED_CASK_FILES="$(modified_files | grep '^Casks/.*\.rb')"
+    MODIFIED_CASK_FILES="$(git diff --name-only --diff-filter=AM "${TRAVIS_COMMIT_RANGE}" -- Casks)"
     export MODIFIED_CASK_FILES
   fi
   echo "${MODIFIED_CASK_FILES}"
@@ -78,7 +70,7 @@ modified_cask_files () {
 
 modified_files_outside_casks () {
   if [[ -z "${MODIFIED_FILES_OUTSIDE_CASKS+defined}" ]]; then
-    MODIFIED_FILES_OUTSIDE_CASKS="$(modified_files | grep -v ^Casks)"
+    MODIFIED_FILES_OUTSIDE_CASKS="$(git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- !(Casks))"
     export MODIFIED_FILES_OUTSIDE_CASKS
   fi
   echo "${MODIFIED_FILES_OUTSIDE_CASKS}"

--- a/ci/travis/helpers.sh
+++ b/ci/travis/helpers.sh
@@ -60,15 +60,34 @@ exit_build_step () {
   set +o nounset
 }
 
-files_modified_outside_casks () {
-  git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- !(Casks)
+modified_files () {
+  if [[ -z "${MODIFIED_FILES+defined}" ]]; then
+    MODIFIED_FILES="$(git diff --name-only "${TRAVIS_COMMIT_RANGE}" --)"
+    export MODIFIED_FILES
+  fi
+  echo "${MODIFIED_FILES}"
 }
 
-# return 0 if we can't skip running the test suite
-must_run_tests () {
-  if [[ -z "${FILES_MODIFIED_OUTSIDE_CASKS+defined}" ]]; then
-    FILES_MODIFIED_OUTSIDE_CASKS="$(files_modified_outside_casks)"
-    export FILES_MODIFIED_OUTSIDE_CASKS
+modified_cask_files () {
+  if [[ -z "${MODIFIED_CASK_FILES+defined}" ]]; then
+    MODIFIED_CASK_FILES="$(modified_files | grep '^Casks/.*\.rb')"
+    export MODIFIED_CASK_FILES
   fi
-  [[ -n "${FILES_MODIFIED_OUTSIDE_CASKS}" ]]
+  echo "${MODIFIED_CASK_FILES}"
+}
+
+modified_files_outside_casks () {
+  if [[ -z "${MODIFIED_FILES_OUTSIDE_CASKS+defined}" ]]; then
+    MODIFIED_FILES_OUTSIDE_CASKS="$(modified_files | grep -v ^Casks)"
+    export MODIFIED_FILES_OUTSIDE_CASKS
+  fi
+  echo "${MODIFIED_FILES_OUTSIDE_CASKS}"
+}
+
+any_casks_modified () {
+  [[ -n "$(modified_cask_files)" ]]
+}
+
+must_run_tests () {
+  [[ -n "$(modified_files_outside_casks)" ]]
 }

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -12,10 +12,11 @@ enter_build_step
 
 header 'Running script.sh...'
 
-# audit any modified casks (download if version, sha256, or url changed)
-run developer/bin/audit_modified_casks "${TRAVIS_COMMIT_RANGE}"
-
-run bundle exec rubocop
+if any_casks_modified; then
+  modified_casks=($(modified_cask_files))
+  run developer/bin/audit_modified_casks "${TRAVIS_COMMIT_RANGE}"
+  run bundle exec rubocop --force-exclusion "${modified_casks[@]}"
+fi
 
 if must_run_tests; then
   run bundle exec rake test:coverage


### PR DESCRIPTION
Only run `rubocop` against modified casks.
