### PR TITLE
Update Sage to 6.10/6.9

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,22 +1,35 @@
 cask 'sage' do
-  if MacOS.release <= :lion
-    version '6.6'
-    sha256 'bdd740d8c92df5467269787aaf00e8cd0b2430cead259a4f15ef04e92b274282'
+  if MacOS.release <= :mavericks
+    version '6.9'
+    sha256 '21f460c90db2a9ee83d196937587de5daab8c6712b0f24366b6a1c15a8dd592b'
     # mit.edu is an official download host per the vendor download page
-    url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-x86_64-Darwin-OSX_10.7_x86_64-app.dmg"
-  else
+    url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-x86_64-Darwin-OSX-10.7-app.dmg"
+  elsif MacOS.release <= :yosemite
     version '6.9'
     sha256 '03112bf747cf807f308d518f34c1982ca3c9599e65bf64a6782efc78136198a4'
     # mit.edu is an official download host per the vendor download page
     url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-x86_64-Darwin-OSX_10.10_x86_64-app.dmg"
+  else
+    version '6.10'
+    sha256 '00092f6450267a46f94bfd69f148e71e05d5e4edbac234101afa63f40db45d1b'
+    # mit.edu is an official download host per the vendor download page
+    url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-OSX_10.11.2-x86_64.app.dmg"
   end
 
   name 'Sage'
   homepage 'http://www.sagemath.org/'
   license :gpl
 
-  app "Sage-#{version}.app"
-  binary "Sage-#{version}.app/Contents/Resources/sage/sage"
+  depends_on :macos => '>= :lion'
+  depends_on :arch => :x86_64
+
+  if MacOS.release <= :yosemite
+    app "Sage-#{version}.app"
+    binary "Sage-#{version}.app/Contents/Resources/sage/sage"
+  else
+    app "SageMath-#{version}.app"
+    binary "SageMath-#{version}.app/Contents/Resources/sage/sage"
+  end
 
   zap :delete => [
                    '~/.sage',


### PR DESCRIPTION
SageMath has a number of different packages for different versions of OS X. I altered the original cask file to reflect this release structure.

Testing is needed for the releases for OS X versions 10.7 >= 10.9, and for 10.10.

Confirmed working on OS X 10.11.2, assumed working on OS X <= 10.10.

It would be great to be able to warn users on OS X 10.6 and below that their version of OS X is not supported by SageMath. Does anyone know how to do this? I tried checking the documentation but couldn't really find a way to do this.
