### PR TITLE
Fix checksum in transmission-remote-gui Cask

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,6 +1,6 @@
 cask 'transmission-remote-gui' do
   version '5.0.1'
-  sha256 'b961aeb244b2519563837745f3475d21379e3da32bae2b3cbb20ca91d1a90d75'
+  sha256 '322de6700ef13ea31ed0376a1783434b5d5660e63d267169f8ed0f8d4caf5f62'
 
   url "http://downloads.sourceforge.net/sourceforge/transgui/transgui-#{version}.dmg"
   name 'Transmission Remote GUI'


### PR DESCRIPTION
I'm getting mismatch sha256. This pull request contains the correct sha256

Installing transmission-remote-gui cask. It is not currently installed.
==> Downloading http://downloads.sourceforge.net/sourceforge/transgui/transgui-5.0.1.dmg
Error: sha256 mismatch
Expected: b961aeb244b2519563837745f3475d21379e3da32bae2b3cbb20ca91d1a90d75
Actual: 322de6700ef13ea31ed0376a1783434b5d5660e63d267169f8ed0f8d4caf5f62
File: /Library/Caches/Homebrew/transmission-remote-gui-5.0.1.dmg
To retry an incomplete download, remove the file above.
==> Verifying checksum for Cask transmission-remote-gui
==> Note: running "brew update" may fix sha256 checksum errors
Failed in installing transmission-remote-gui
