### PR TITLE
Update cleanmymac versions and strings

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -10,11 +10,12 @@ cask 'cleanmymac' do
     app 'CleanMyMac.app'
     # TODO: add uninstall and zap stanzas for legacy app
   elsif MacOS.release <= :lion
-    version '2.3.5-1427986644'
-    sha256 '16e192edcf58f25c6763349ef0e5194268bec4d000912b64b34f5897b4784097'
+    version '2.4-1443544143'
+    sha256 '0d08f4d9b36493359f6ca3ff2f96a9b769a8eed4ea017ecbb2d5644f75aafad0'
     # devmate.com is the official download host per the appcast feed
     url "https://dl.devmate.com/com.macpaw.CleanMyMac2/#{version.sub(%r{-.*$}, '')}/#{version.sub(%r{.*?-}, '')}/CleanMyMac#{version.to_i}-#{version.sub(%r{-.*$}, '')}.zip"
-    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.to_i}.xml"
+    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.to_i}.xml",
+            :sha256 => '612be3e443f49b6b1d5539611693714b2897b9b774896ac15c048daec76a34cb'
     app "CleanMyMac #{version.to_i}.app"
 
     uninstall :launchctl => "com.macpaw.CleanMyMac#{version.to_i}.Agent"
@@ -32,11 +33,13 @@ cask 'cleanmymac' do
                      "~/Library/Preferences/com.macpaw.CleanMyMac#{version.to_i}.plist",
                    ]
   else
-    version '3.2.1-1448556223'
-    sha256 'a5e7587d7edcece90c0d5b0b6aed8d008b6a1a93cb6911f0cf2e9e0c0453e6c4'
+    version '3.3.0-1451475053'
+    sha256 '14038d3554f771e32840dbd0936235d62b95713638b4b1ca94daf32847da389f'
 
     # devmate.com is the official download host per the appcast feed
     url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.to_i}/#{version.sub(%r{-.*$}, '')}/#{version.sub(%r{.*?-}, '')}/CleanMyMac3-#{version.sub(%r{-.*$}, '')}.zip"
+    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.to_i}.xml",
+            :sha256 => 'e62a4026c55f52a3c31a0070e8fb9d49c63244697dff9332a3ab37f74d02c5aa'
     app "CleanMyMac #{version.to_i}.app"
 
     postflight do

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -1,66 +1,67 @@
 cask 'cleanmymac' do
   if MacOS.release <= :snow_leopard
-    version '1.11-1417522595'
+    version '1.11,1417522595'
     sha256 'ac5d4bf36882dd34bdb0a68eb384a6b3aba355be896d03dfa40a120c6bef4a0d'
 
     # devmate.com is the official download host per the appcast feed
-    url "https://dl.devmate.com/com.macpaw.CleanMyMac/#{version.sub(%r{-.*$}, '')}/#{version.sub(%r{.*?-}, '')}/CleanMyMacClassic-#{version.sub(%r{-.*$}, '')}.zip"
+    url "https://dl.devmate.com/com.macpaw.CleanMyMac/#{version.major_minor}/#{version.after_comma}/CleanMyMacClassic-#{version.major_minor}.zip"
     appcast 'http://updates.devmate.com/com.macpaw.CleanMyMac.xml',
             :sha256 => '13bbf950696a9410fec848e80652f2826209b347fdb329b117371e25445951f5'
     app 'CleanMyMac.app'
     # TODO: add uninstall and zap stanzas for legacy app
   elsif MacOS.release <= :lion
-    version '2.4-1443544143'
+    version '2.4,1443544143'
     sha256 '0d08f4d9b36493359f6ca3ff2f96a9b769a8eed4ea017ecbb2d5644f75aafad0'
-    # devmate.com is the official download host per the appcast feed
-    url "https://dl.devmate.com/com.macpaw.CleanMyMac2/#{version.sub(%r{-.*$}, '')}/#{version.sub(%r{.*?-}, '')}/CleanMyMac#{version.to_i}-#{version.sub(%r{-.*$}, '')}.zip"
-    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.to_i}.xml",
-            :sha256 => '612be3e443f49b6b1d5539611693714b2897b9b774896ac15c048daec76a34cb'
-    app "CleanMyMac #{version.to_i}.app"
 
-    uninstall :launchctl => "com.macpaw.CleanMyMac#{version.to_i}.Agent"
+    # devmate.com is the official download host per the appcast feed
+    url "https://dl.devmate.com/com.macpaw.CleanMyMac2/#{version.major_minor_patch}/#{version.after_comma}/CleanMyMac#{version.to_i}-#{version.major_minor_patch}.zip"
+    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.major}.xml",
+            :sha256 => '612be3e443f49b6b1d5539611693714b2897b9b774896ac15c048daec76a34cb'
+    app "CleanMyMac #{version.major}.app"
+
+    uninstall :launchctl => "com.macpaw.CleanMyMac#{version.major}.Agent"
 
     zap :delete => [
-                     "/Library/LaunchDaemons/com.macpaw.CleanMyMac#{version.to_i}.Agent.plist",
-                     "/Library/PrivilegedHelperTools/com.macpaw.CleanMyMac#{version.to_i}.Agent",
-                     "/Users/Shared/CleanMyMac #{version.to_i}",
-                     "/private/var/run/com.macpaw.CleanMyMac#{version.to_i}.Agent.socket",
-                     "~/Library/Application Support/CleanMyMac #{version.to_i}",
-                     "~/Library/Caches/CleanMyMac #{version.to_i}",
-                     "~/Library/Logs/CleanMyMac #{version.to_i}.log",
-                     "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.to_i}-Helper.plist",
-                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.to_i}.KnowledgeBase.plist",
-                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.to_i}.plist",
+                     "/Library/LaunchDaemons/com.macpaw.CleanMyMac#{version.major}.Agent.plist",
+                     "/Library/PrivilegedHelperTools/com.macpaw.CleanMyMac#{version.major}.Agent",
+                     "/Users/Shared/CleanMyMac #{version.major}",
+                     "/private/var/run/com.macpaw.CleanMyMac#{version.major}.Agent.socket",
+                     "~/Library/Application Support/CleanMyMac #{version.major}",
+                     "~/Library/Caches/CleanMyMac #{version.major}",
+                     "~/Library/Logs/CleanMyMac #{version.major}.log",
+                     "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.major}-Helper.plist",
+                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.KnowledgeBase.plist",
+                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.plist",
                    ]
   else
-    version '3.3.0-1451475053'
+    version '3.3.0,1451475053'
     sha256 '14038d3554f771e32840dbd0936235d62b95713638b4b1ca94daf32847da389f'
 
     # devmate.com is the official download host per the appcast feed
-    url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.to_i}/#{version.sub(%r{-.*$}, '')}/#{version.sub(%r{.*?-}, '')}/CleanMyMac3-#{version.sub(%r{-.*$}, '')}.zip"
-    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.to_i}.xml",
+    url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.major}/#{version.major_minor_patch}/#{version.after_comma}/CleanMyMac3-#{version.major_minor_patch}.zip"
+    appcast "http://updates.devmate.com/com.macpaw.CleanMyMac#{version.major}.xml",
             :sha256 => 'e62a4026c55f52a3c31a0070e8fb9d49c63244697dff9332a3ab37f74d02c5aa'
-    app "CleanMyMac #{version.to_i}.app"
+    app "CleanMyMac #{version.major}.app"
 
     postflight do
       suppress_move_to_applications
     end
 
-    uninstall :launchctl => "com.macpaw.CleanMyMac#{version.to_i}.Agent"
+    uninstall :launchctl => "com.macpaw.CleanMyMac#{version.major}.Agent"
 
     zap :delete => [
-                     "/Library/LaunchDaemons/com.macpaw.CleanMyMac#{version.to_i}.Agent.plist",
-                     "/Library/PrivilegedHelperTools/com.macpaw.CleanMyMac#{version.to_i}.Agent",
-                     "/Users/Shared/CleanMyMac #{version.to_i}",
-                     "/private/var/run/com.macpaw.CleanMyMac#{version.to_i}.Agent.socket",
-                     "~/Library/Application Support/CleanMyMac #{version.to_i}",
-                     "~/Library/Application Support/CleanMyMac #{version.to_i} Menu",
-                     "~/Library/Caches/CleanMyMac #{version.to_i}",
-                     "~/Library/Logs/CleanMyMac #{version.to_i}.log",
-                     "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.to_i}-Helper.plist",
-                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.to_i}.KnowledgeBase.plist",
-                     "~/Library/Preferences/com.macpaw.cleanmymac#{version.to_i}.menu.plist",
-                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.to_i}.plist",
+                     "/Library/LaunchDaemons/com.macpaw.CleanMyMac#{version.major}.Agent.plist",
+                     "/Library/PrivilegedHelperTools/com.macpaw.CleanMyMac#{version.major}.Agent",
+                     "/Users/Shared/CleanMyMac #{version.major}",
+                     "/private/var/run/com.macpaw.CleanMyMac#{version.major}.Agent.socket",
+                     "~/Library/Application Support/CleanMyMac #{version.major}",
+                     "~/Library/Application Support/CleanMyMac #{version.major} Menu",
+                     "~/Library/Caches/CleanMyMac #{version.major}",
+                     "~/Library/Logs/CleanMyMac #{version.major}.log",
+                     "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.major}-Helper.plist",
+                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.KnowledgeBase.plist",
+                     "~/Library/Preferences/com.macpaw.cleanmymac#{version.major}.menu.plist",
+                     "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.plist",
                    ]
   end
 


### PR DESCRIPTION
These commits[1]
1. Update versions, add a sha, and add an appcast+sha
2. Use the new string methods

Assuming I got the latter correct, this should be straightforward.

---

This [cask](https://github.com/caskroom/homebrew-cask/blob/77b529d0011fcc687852b04a5c4bb1c1edf10433/Casks/cleanmymac.rb), though, gave me a headache as I have been trying to square away some recent decisions, namely what belongs in caskroom/homebrew-versions[3] and the use of discontinued[3].  Basically, I'm not sure what those decisions mean for our use of `MacOS.release` in the main repo.
- CleanMyMac Classic (version 1) is old, legacy, no longer under development, and should be moved to caskroom/homebrew-versions and caveat-ed
- CleanMyMac2 was last updated alongside version 3 in late December, to be El Capitan-able, which means it's an "alternate" version and should go to caskroom/homebrew-versions
  - Is version 3 more similar to a "pro-version" and should be moved while version 2 stays in the same repo?  No, but both should be available to a user on 10.8-10.11 since they are different products.
- Either way, version 1 and 2 don't have their own homepages (even though 2 appears to be actively developed), and would need to exist under the same cask as version 3?
  - But version 2 and version 3 are different products.
- Does the lack of a homepage or the lack of updates signify `discontinued`, or is a note from the developer required?

Broadly speaking, if something has a different `#{version.major}` for a below-Yosemite `MacOS.release`, does it belong in the main repo?  Is it not, by definition, a "legacy" version?  Do we keep it here to avoid multiple casks, or is it dishonest to offer users a version of software that is discontinued without saying so?  I can't figure it out.

Pinging @vitorgalvao for obvious reasons.

---

1: Kept them separate since they are different tasks, but also to make it easy in case the string methods didn't work (difficult to check old operating systems); happy to squash once travis is happy if preferred.
2: See caskroom/homebrew-versions#1450 and caskroom/homebrew-versions#1504
3: See #16097 and #16225
