### PR TITLE
brew-cask: upgrade to 0.60.1

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,15 +1,20 @@
 class BrewCask < Formula
   homepage "https://github.com/caskroom/homebrew-cask/"
-  url "https://github.com/caskroom/homebrew-cask.git", :tag => "v0.60.0"
+  url "https://github.com/caskroom/homebrew-cask.git", :tag => "v0.60.1"
 
   depends_on :ruby => "2.0"
 
   def install
+    (buildpath/"UPGRADE").write <<-EOS.undent
+      You must uninstall this formula. It is no longer needed to stay up to date,
+      as Homebrew now takes care of that automatically.
+    EOS
+    prefix.install "UPGRADE"
   end
 
   def caveats
     <<-EOS.undent
-      You can uninstall this formula as `brew tap Caskroom/cask` is now all that's
+      You must uninstall this formula as `brew tap Caskroom/cask` is now all that's
       needed to install Homebrew Cask and keep it up to date.
     EOS
   end


### PR DESCRIPTION
Over at Homebrew we've accidentally caused an edge-case problem for some Caskroom users. We recently merged https://github.com/Homebrew/homebrew/commit/915ac06d which is much stricter on empty installations, failing during install rather than just shouting about it in the audit.

We'd prefer not to revert the change there because it's quite a positive change that's much more obvious about installation problems, given installations shouldn't be empty. There's also the likelihood that if we revert, wait 3 months to add the check back, someone out there will wait 4 months before upgrade and we'll run into this again.

However, this causes some issues with Cask because when Mike rewrote the formula he left `def install` an empty hole, which was fine at the time. Anyone who hasn't updated between December 9th 2015 and January 9th 2016 will now run into a fatal error on upgrading the Cask formula, as seen in: https://github.com/Homebrew/homebrew/issues/47929

I was wondering if the Cask would be kind enough to tag one very last bug fix release, or even retag the existing tag with a similar fix to this. You may want to do this yourself rather than using this PR; this was an easy way to both explain the problem and propose a fix without sticking a `diff` blob in the middle of the text.

Obviously, if tested by Travis here this build will likely fail because there is no 0.60.1 tag. Apologies for the accidental mess here. It's one of those things we'll probably get better at if/when we can bring the two projects closer together and do more unified testing.

CC @mikemcquaid for thoughts.
