### PR TITLE
Add Bitpost 0.9.8.3

### DIFF
--- a/Casks/bitpost.rb
+++ b/Casks/bitpost.rb
@@ -1,0 +1,11 @@
+cask 'bitpost' do
+  version '0.9.8.3'
+  sha256 '8e58ddf022eae721bfca6ecb456edf40baa23ea31076ee9c1ad75e947b0cea2b'
+
+  url "http://voluntary.net.s3.amazonaws.com/Bitpost.#{version}.zip"
+  name 'Bitpost'
+  homepage 'https://voluntary.net/bitpost/'
+  license :mit
+
+  app 'Bitpost.app'
+end


### PR DESCRIPTION
Added [Bitpost](https://voluntary.net/bitpost/), a user-friendly OS X [Bitmessage](http://bitmessage.org/) client.
