### PR TITLE
updates version number for tla-plus-toolbox to fix broken downloads

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,5 +1,5 @@
 cask 'tla-plus-toolbox' do
-  version '1.5.1'
+  version '1.5.2'
   sha256 'd0d966c6742c6011d46e6de6760bf7300ed49649a85bccab0b097b0ec5ad42cd'
 
   # inria.fr is the official download host per the vendor homepage

--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'tla-plus-toolbox' do
   version '1.5.2'
-  sha256 'd0d966c6742c6011d46e6de6760bf7300ed49649a85bccab0b097b0ec5ad42cd'
+  sha256 '4c35713d1c5cdb8c4b3883fcd002098dcc1d2e64f9251455857fcb71a44d00e6'
 
   # inria.fr is the official download host per the vendor homepage
   url "https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"


### PR DESCRIPTION
currently downloads fail with this error message:

```
Error: Download failed on Cask 'tla-plus-toolbox' with message: Download failed: https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-1.5.1-macosx.cocoa.x86_64.zip
```

Updating the version number to 1.5.2 (current) should fix this issue.
