### PR TITLE
add webarchiveplayer.app 1.3.0

### DIFF
--- a/Casks/webarchiveplayer.rb
+++ b/Casks/webarchiveplayer.rb
@@ -1,0 +1,11 @@
+cask 'webarchiveplayer' do
+  version '1.3.0'
+  sha256 'c805ed32f7c49e7736bbb31b92e215cdb03843af66aa72ef7c41640ca447674c'
+
+  url "https://github.com/ikreymer/webarchiveplayer/releases/download/#{version}/webarchiveplayer.dmg"
+  name 'webarchiveplayer'
+  homepage 'https://github.com/ikreymer/webarchiveplayer'
+  license :gpl
+
+  app 'webarchiveplayer.app'
+end


### PR DESCRIPTION
WebArchivePlayer is a new desktop tool which provides a simple
point-and-click wrapper for viewing any web archive file (in WARC and
ARC format).
