### PR TITLE
fixes TLA+ app installation with correct app name.

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -10,7 +10,8 @@ cask 'tla-plus-toolbox' do
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/8829
-  app 'toolbox/toolbox.app', :target => 'TLA+ Toolbox.app'
+  # Fixed upstream: App name is now consistent with it's branding
+  app 'TLA+ Toolbox.app'
 
   caveats <<-EOS.undent
     #{token} requires Java. You can install the latest version with


### PR DESCRIPTION
Previously the application bundle didn't use the "branded"
name. The 1.5.2 version now uses "TLA+ Toolbox.app" as the name
for the application bundle.
