### PR TITLE
Update Cask bettertouchtool url.

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -9,7 +9,7 @@ cask 'bettertouchtool' do
     version '1.5b'
     sha256 'f6408c0ba48588cd547bef4abdcfd723af5133af141f9f7a146d9ee7721f86e6'
 
-    url "https://boastr.net/releases/btt#{version}.zip"
+    url "https://boastr.net/releases/BetterTouchTool.zip"
     appcast 'http://appcast.boastr.net',
             :sha256 => '52653a90c3c0940803325ac01aca538f7f8b431e4bca9dfa664489a16bc83d4f'
   end


### PR DESCRIPTION
I tried installing bettertouchtool using cask, but it just returned 404.

```
==> brew cask install Caskroom/cask/bettertouchtool
==> Downloading http://boastr.net/releases/btt1.36.zip

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'bettertouchtool' with message:
  Download failed: http://boastr.net/releases/btt1.36.zip
```

I checked the [site's download](http://www.boastr.net/downloads/) and checked the url.

```
https://www.boastr.net/releases/BetterTouchTool.zip
```
