### PR TITLE
Add ScanSnap Manager for Fujitsu ScanSnap s1500

### DIFF
--- a/Casks/scansnap-manager-s1500.rb
+++ b/Casks/scansnap-manager-s1500.rb
@@ -1,0 +1,16 @@
+cask 'scansnap-manager-s1500' do
+  version :latest
+  sha256 :no_check
+
+  # pfultd.com is the official download host per the vendor homepage
+  url 'http://origin.pfultd.com/downloads/IMAGE/driver/ss/mgr/m-s1500/MacS1500ManagerV32L80WW.dmg'
+  name 'ScanSnap Manager for Fujitsu ScanSnap s1500'
+  homepage 'https://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/s1500.html'
+  license :gratis
+
+  depends_on :macos => '>= :lion'
+
+  pkg 'ScanSnap Manager.pkg'
+
+  uninstall :pkgutil => 'jp.co.pfu.ScanSnap.*'
+end


### PR DESCRIPTION
$ brew cask install scansnap-manager-s1500
==> Satisfying dependencies
complete
==> Downloading http://origin.pfultd.com/downloads/IMAGE/driver/ss/mgr/m-s1500/MacS1500ManagerV32L80WW.dmg
###### ################################################################## 100.0%

==> No checksum defined for Cask scansnap-manager-s1500, skipping verification
==> Running installer for scansnap-manager-s1500; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
Password:
==> installer: Package name is ScanSnap Manager
==> installer: Installing at base path /
==> installer: The install was successful.
🍺  scansnap-manager-s1500 staged at '/opt/homebrew-cask/Caskroom/scansnap-manager-s1500/latest' (178 files, 466M)
