### PR TITLE
appcast: remove latest_version

### DIFF
--- a/lib/hbc/dsl/appcast.rb
+++ b/lib/hbc/dsl/appcast.rb
@@ -1,15 +1,11 @@
 class Hbc::DSL::Appcast
 
-  # todo  :latest_version is considered experimental
-  #       and may be removed
-
-  attr_reader :parameters, :checkpoint, :latest_version, :sha256
+  attr_reader :parameters, :checkpoint, :sha256
 
   def initialize(uri, parameters={})
     @parameters     = parameters
     @uri            = Hbc::UnderscoreSupportingURI.parse(uri)
     @checkpoint     = @parameters[:checkpoint]
-    @latest_version = @parameters[:latest_version]    # experimental
     @sha256         = @parameters[:sha256] # DEPRECATED
   end
 


### PR DESCRIPTION
I don’t even know/remember what the experiment was about, and how this could possibly be useful.
