### PR TITLE
Fixed musicbrainz-picard url.

### DIFF
--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -2,7 +2,7 @@ cask 'musicbrainz-picard' do
   version '1.3.2'
   sha256 'e3a3139878d01cf4edd2fad20a9a6ced5d3ea669cb919e310a64947082dfdc15'
 
-  url "ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}.dmg"
+  url "http://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}.dmg"
   name 'MusicBrainz Picard'
   homepage 'https://picard.musicbrainz.org'
   license :gpl


### PR DESCRIPTION
For some odd reason using the ftp protocol was causing Musicbrainz Picard to never download (atleast, for me). This hacky little workaround fixes that issue.
