### PR TITLE
Updated sqlitestudio (add zap)

### DIFF
--- a/Casks/sqlitestudio.rb
+++ b/Casks/sqlitestudio.rb
@@ -3,9 +3,14 @@ cask 'sqlitestudio' do
   sha256 '9f93d31dfcb6746fb613aed31920b14e34932ae0055c811e74b1aa01ef060a7c'
 
   url "http://sqlitestudio.pl/files/sqlitestudio3/complete/macosx/sqlitestudio-#{version}.dmg"
+  appcast 'http://sqlitestudio.pl/rss.rvt',
+          :checkpoint => '63b2d8a5a549703a785c4df869d95cf44e35d8ed6af404721ecc62c23d09b932'
   name 'SQLiteStudio'
   homepage 'http://sqlitestudio.pl'
   license :gpl
 
   app 'SQLiteStudio.app'
+
+  zap :delete => '~/Library/Saved Application State/com.yourcompany.SQLiteStudio.savedState',
+      :trash  => '~/.config/sqlitestudio'
 end


### PR DESCRIPTION
Is the `:rmdir => '~/.config'` needed or would `:delete/:trash` remove the empty parent dir automatically?

Would http://sqlitestudio.pl/rss.rvt be suitable as an appcast? It does not only contain app updates.
