### PR TITLE
Update zap stanza android-file-transfer.rb

### DIFF
--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -10,5 +10,5 @@ cask 'android-file-transfer' do
 
   app 'Android File Transfer.app'
 
-  zap :delete => '~/Library/Application Support/Google/Android File Transfer',
+  zap :delete => '~/Library/Application Support/Google/Android File Transfer'
 end

--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -11,5 +11,4 @@ cask 'android-file-transfer' do
   app 'Android File Transfer.app'
 
   zap :delete => '~/Library/Application Support/Google/Android File Transfer',
-      :rmdir  => '~/Library/Application Support/Google/'
 end


### PR DESCRIPTION
The directory `'~/Library/Application Support/Google/` is used my other Google programs, and should not be removed if someone is only uninstalling Android File Transfer.
