### PR TITLE
Add Kollaborate Plugin Pack 1.0.6.0

### DIFF
--- a/Casks/kollaborate-plugin-pack.rb
+++ b/Casks/kollaborate-plugin-pack.rb
@@ -1,0 +1,19 @@
+cask 'kollaborate-plugin-pack' do
+  version '1.0.6.0'
+  sha256 '74d11ff0b93650fc67e48959e377fa9ea2d7cb029eb6e79dc07b4808d8c1ab9d'
+
+  # digitalrebellion.com is the official download host per the vendor homepage
+  url "http://www.digitalrebellion.com/download/kollabplugins?version=#{version.no_dots}"
+  name 'Kollaborate Plugin Pack'
+  homepage 'https://www.kollaborate.tv/resources'
+  license :gratis
+
+  installer :manual => 'Install Kollaborate Plugin Pack.pkg'
+
+  uninstall :pkgutil => [
+                          'com.digitalrebellion.KollabPluginPack',
+                          'com.digitalrebellion.pkg.KollabPluginPack.FCPX',
+                          'com.digitalrebellion.pkg.KollabPluginPack.Premiere',
+                          'com.digitalrebellion.pkg.KollabPluginPack.SystemPlugins',
+                        ]
+end


### PR DESCRIPTION
Upload directly to the cloud from Final Cut Pro X and Adobe Premiere
Pro to Digital Rebellion's Kollaborate video editing servers. Also
can integrate with OS X's Today window to see project activity at a
glance.

Note: manual execution of the package installer specified in order for
users to select which plugin(s) they need.
