### PR TITLE
Add ScopeBox 3.4.3

### DIFF
--- a/Casks/kollaborate-plugin-pack.rb
+++ b/Casks/kollaborate-plugin-pack.rb
@@ -1,0 +1,19 @@
+cask 'kollaborate-plugin-pack' do
+  version '1.0.6.0'
+  sha256 '74d11ff0b93650fc67e48959e377fa9ea2d7cb029eb6e79dc07b4808d8c1ab9d'
+
+  # digitalrebellion.com is the official download host per the vendor homepage
+  url "http://www.digitalrebellion.com/download/kollabplugins?version=#{version.no_dots}"
+  name 'Kollaborate Plugin Pack'
+  homepage 'https://www.kollaborate.tv/resources'
+  license :commercial
+
+  installer :manual => 'Install Kollaborate Plugin Pack.pkg'
+
+  uninstall :pkgutil => [
+                          'com.digitalrebellion.KollabPluginPack',
+                          'com.digitalrebellion.pkg.KollabPluginPack.FCPX',
+                          'com.digitalrebellion.pkg.KollabPluginPack.Premiere',
+                          'com.digitalrebellion.pkg.KollabPluginPack.SystemPlugins',
+                        ]
+end

--- a/Casks/scopebox.rb
+++ b/Casks/scopebox.rb
@@ -1,0 +1,16 @@
+cask 'scopebox' do
+  version '3.4.3'
+  sha256 'abd8be8ec861e217c61bdc17dee60984da69d18409992dd5ef85d0966938e96e'
+
+  url "http://www.divergentmedia.com/filedownload/ScopeBox%20#{version}.dmg"
+  name 'ScopeBox'
+  homepage 'http://www.divergentmedia.com/scopebox'
+  license :commercial
+
+  app 'ScopeBox.app'
+
+  zap :delete => [
+                   '~/Library/Preferences/com.divergentmedia.scopebox.plist',
+                   '~/Library/Application Support/ScopeBox',
+                 ]
+end


### PR DESCRIPTION
Monitor and capture everything from DV to 4K with top of the line
waveform and vectorscopes. Built-in ScopeLink allows use of scopes
directly in Premiere Pro, Final Cut Pro X and more.
