### PR TITLE
Fixed WordPress Version

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '1.2.1'
-  sha256 '1a10ba45287e6e3a6cc2c128aed4358e7e6efb1a624f80f6b9fd0cc71528489b'
+  version :latest
+  sha256 :no_check
 
   url 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=dmg'
   appcast 'https://github.com/Automattic/wp-desktop/releases.atom',


### PR DESCRIPTION
The official download link does not properly identify the app version in the URL. As such,as soon as a new version is available, the URL will point to it, causing a validation error when attempting to validate the checksum.

I changed the version to 'latest' and removed the sha256 check to correct this issue and prevent future breakage.
