### PR TITLE
QSyncthingTray: does not depend on brew formula

### DIFF
--- a/Casks/qsyncthingtray.rb
+++ b/Casks/qsyncthingtray.rb
@@ -9,8 +9,6 @@ cask 'qsyncthingtray' do
   homepage 'https://github.com/sieren/QSyncthingTray'
   license :gpl
 
-  depends_on formula: 'syncthing'
-
   app 'QSyncthingTray.app'
 
   zap delete: '~/Library/Preferences/com.sieren.QSyncthingTray.plist'


### PR DESCRIPTION
This is "kind of" stupid to force us to use brew formula when you have a cask formula for Syncthing. If you use cask one, you cannot use this QSyncthingTray because of a conflict:

```
❯ Installing qsyncthingtray (qsyncthingtray) into /Applications ...
==> Satisfying dependencies
==> Installing Formula dependencies from Homebrew
syncthing ... ==> Error: The `brew link` step did not complete successfully
Error: Command failed to execute!

==> Failed command:
["#<Pathname:/usr/local/bin/brew>", "install", "syncthing"]

==> Output of failed command:
==> Downloading https://homebrew.bintray.com/bottles/syncthing-0.12.11.el_capitan.bottle.tar.gz
Already downloaded: /Library/Caches/Homebrew/syncthing-0.12.11.el_capitan.bottle.tar.gz
==> Pouring syncthing-0.12.11.el_capitan.bottle.tar.gz
The formula built, but is not symlinked into /usr/local
Could not symlink bin/syncthing
Target /usr/local/bin/syncthing
already exists. You may want to remove it:
  rm '/usr/local/bin/syncthing'

To force the link and overwrite all conflicting files:
  brew link --overwrite syncthing

To list all files that would be deleted:
  brew link --overwrite --dry-run syncthing

Possible conflicting files are:
/usr/local/bin/syncthing -> /opt/homebrew-cask/Caskroom/syncthing/0.12.11/syncthing-macosx-amd64-v0.12.11/syncthing
==> Caveats
To have launchd start syncthing at login:
  ln -sfv /usr/local/opt/syncthing/*.plist ~/Library/LaunchAgents
Then to load syncthing now:
  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.syncthing.plist
==> Summary
🍺  /usr/local/Cellar/syncthing/0.12.11: 6 files, 13.1M


==> Exit status of failed command:
#<Process::Status: pid 65269 exit 1>
```

I guess removing the dependency should make sense and allow users to use brew or cask one (not brew one does not provide upgrade via the web interface, which sucks).
