### PR TITLE
Add Arturia software

### DIFF
--- a/Casks/arturia-analog-lab.rb
+++ b/Casks/arturia-analog-lab.rb
@@ -1,0 +1,11 @@
+cask 'arturia-analog-lab' do
+  version '1.2.4.126'
+  sha256 'e66182ba1887d0c1369299c9c7ba6a06d709083b8aa6c8163108973d99b7e220'
+
+  url "https://downloads.arturia.com/products/analoglab/soft/Analog_Lab_#{version.dots_to_underscores}.pkg"
+  name 'Arturia Analog Lab'
+  homepage 'http://www.arturia.com/products/analog-classics/analoglab/overview'
+  license :commercial
+
+  pkg "Analog_Lab_#{version.dots_to_underscores}.pkg"
+end

--- a/Casks/arturia-midi-control-center.rb
+++ b/Casks/arturia-midi-control-center.rb
@@ -1,0 +1,11 @@
+cask 'arturia-midi-control-center' do
+  version '1.2.2.429'
+  sha256 'fba9e3e4835ece3c4a030c98a03c10051a0d8e3f103405843ee113e7f620892e'
+
+  url "https://downloads.arturia.com/extra/mcc/MIDI_Control_Center_#{version.dots_to_underscores}.pkg"
+  name 'Arturia Midi Control Center'
+  homepage 'http://www.arturia.com/support/downloads&manuals'
+  license :commercial
+
+  pkg "MIDI_Control_Center_#{version.dots_to_underscores}.pkg"
+end

--- a/Casks/arturia-mini-v.rb
+++ b/Casks/arturia-mini-v.rb
@@ -1,0 +1,11 @@
+cask 'arturia-mini-v' do
+  version '2.7.0.76'
+  sha256 '872df33f4dd685525660cdb8b7ac65da7c4c40b9b15a2e7df5b772cd67b853fd'
+
+  url "https://downloads.arturia.com/products/mini-v/soft/Mini_V2_#{version.dots_to_underscores}.pkg"
+  name 'Arturia Mini V'
+  homepage 'http://www.arturia.com/products/analog-classics/mini-v/overview'
+  license :commercial
+
+  pkg "Mini_V2_#{version.dots_to_underscores}.pkg"
+end

--- a/Casks/arturia-software-center.rb
+++ b/Casks/arturia-software-center.rb
@@ -1,0 +1,11 @@
+cask 'arturia-software-center' do
+  version '1.1.3.145'
+  sha256 '92e8195ff52cc2870a736b400d192917a16aca92560f94ce0a6f592e5fcc4934'
+
+  url "http://downloads.arturia.com/infrastructure/asc/soft/Arturia_Software_Center_#{version.dots_to_underscores}.pkg"
+  name 'Arturia Software Center'
+  homepage 'http://www.arturia.com/support/downloads&manuals'
+  license :commercial
+
+  pkg "Arturia_Software_Center_#{version.dots_to_underscores}.pkg"
+end


### PR DESCRIPTION
This includes casks for:
- Analog Lab
- Midi Control Center
- Mini V
- Software Center

I wasn't entirely sure whether this required one commit per product, or if you're happy with a single commit here. There are many more Arturia products available here, but as I don't have licenses for any of these, I can't check that they work etc.

Also note. Analog Lab and Mini V both have demo versions available with the following limitations

> Saving/Loading and import/export are disabled. The demo is limited to 20 minutes.

I wasn't sure whether this qualified the product as one where `license :freemium` applies or if what I put (`license: commercial`) was better here.
