### PR TITLE
Adding cask for Sublime Text 3

### DIFF
--- a/Casks/sublime-text-3.rb
+++ b/Casks/sublime-text-3.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'sublime-text-3' do
+  version '3083'
+  sha256 'fe6dd8d8192fdb01988f99289e5bc1d9a4e66cf67548e144002051c23369a5ff'
+
+  url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
+  name 'Sublime Text 3'
+  homepage 'https://www.sublimetext.com/3'
+  license :commercial
+
+  app 'Sublime Text.app'
+  binary 'Sublime Text.app/Contents/SharedSupport/bin/subl'
+end


### PR DESCRIPTION
There are two other casks for the Sublime text editor, but none of them are set up to use version 3. Version 3 has been in beta over over two years and is separate enough from its older versions to be given its own cask.
