### PR TITLE
Upgrade Pagico to v7.4.1868

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '7.1.1797'
-  sha256 '1693cbc6995c5665646465eea9e9c23590b65e21722bc3f16c1392fb8b95eabb'
+  version '7.4.1868'
+  sha256 '77244bef8628daac7ed5ee12e78e2e8084946c5b901b15757670c76364c0e9ba'
 
   url "https://www.pagico.com/downloads/Pagico_Desktop_r#{version.split('.')[2]}.dmg"
   name 'Pagico'


### PR DESCRIPTION
Note: previous sha256 for r1797 was wrong

brew cask install pagico
==> Satisfying dependencies
complete
==> Downloading https://www.pagico.com/downloads/Pagico_Desktop_r1797.dmg
Already downloaded: /Library/Caches/Homebrew/pagico-7.1.1797.dmg
==> Verifying checksum for Cask pagico
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 1693cbc6995c5665646465eea9e9c23590b65e21722bc3f16c1392fb8b95eabb
Actual: f30ed11f85d6fbcd0fe42bbe6ca20b89183d486cf4d0fcecdd696a2297b42c98
File: /Library/Caches/Homebrew/pagico-7.1.1797.dmg
To retry an incomplete download, remove the file above.
