### PR TITLE
reaper 5.12

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,19 +1,19 @@
 cask 'reaper' do
-  version '5.111'
+  version '5.12'
 
   if Hardware::CPU.is_32_bit?
-    sha256 'b6c980388d15502d08e37fbe7dabe70ed7119d32ba38a85b650a590ebad919a8'
+    sha256 '7f771717227112fe43bee71f2df30baf2890ea31fb998c1bb7a5ab6f48c9af6f'
     url "http://www.reaper.fm/files/#{version.to_i}.x/reaper#{version.delete('.')}_i386.dmg"
     app 'REAPER.app'
     app 'ReaMote.app'
   else
-    sha256 '6c9112712d58215db7ed86eba11e3d2d092b20b5fcdc493e2ce1554a76ad06e0'
+    sha256 '85c66a111de23ca4a65c2ed080ae08f17d72f43ec30b25d9f6144076edd14d9a'
     url "http://www.reaper.fm/files/#{version.to_i}.x/reaper#{version.delete('.')}_x86_64.dmg"
     app 'REAPER64.app'
     app 'ReaMote64.app'
   end
 
-  name 'Reaper'
+  name 'REAPER'
   homepage 'http://www.reaper.fm/'
   license :commercial
 


### PR DESCRIPTION
Update REAPER to v5.12, and fixes the name which should be in uppercase (it's short for "Rapid Environment for Audio Production, Engineering, and Recording").
