### PR TITLE
updated origin (latest)

### DIFF
--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -3,7 +3,7 @@ cask 'origin' do
   sha256 :no_check
 
   # akamaihd.net is the official download host per the vendor homepage
-  url 'https://eaassets-a.akamaihd.net/Origin-Client-Download/origin/mac/Origin.dmg'
+  url 'https://eaassets-a.akamaihd.net/Origin-Client-Download/origin/mac/live/Origin.dmg'
   name 'Origin'
   homepage 'https://origin.com'
   license :gratis


### PR DESCRIPTION
Updated the download url to mirror the url provided on the origin downloads page. The current url was causing an older version of the origin client to be downloaded.
