### PR TITLE
Update sha256 sum for pepper-flash

### DIFF
--- a/Casks/pepper-flash.rb
+++ b/Casks/pepper-flash.rb
@@ -1,6 +1,6 @@
 cask 'pepper-flash' do
   version '20.0.0.228'
-  sha256 'c94600c9b85f5e96f21580ac8aaa4be2aa8511c18379d1cb488a3d813bcbcce1'
+  sha256 'c8eb2fde34a1b886de9fe68b299ec85b0acf83012fce5d3cef0e5e6e351fcddd'
 
   url "https://admdownload.adobe.com/bin/live/AdobeFlashPlayer_#{version.to_i}ppau_a_install.dmg"
   name 'Adobe Pepper Flash Player'


### PR DESCRIPTION
```
==> Downloading https://admdownload.adobe.com/bin/live/AdobeFlashPlayer_20ppau_a_install.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask pepper-flash
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: c94600c9b85f5e96f21580ac8aaa4be2aa8511c18379d1cb488a3d813bcbcce1
Actual: c8eb2fde34a1b886de9fe68b299ec85b0acf83012fce5d3cef0e5e6e351fcddd
File: /Library/Caches/Homebrew/pepper-flash-20.0.0.228.dmg
To retry an incomplete download, remove the file above.
```

Seems the shasum of this cask is wrong.
