### PR TITLE
strongvpn-client.rb: update the app name

### DIFF
--- a/Casks/strongvpn-client.rb
+++ b/Casks/strongvpn-client.rb
@@ -6,9 +6,9 @@ cask 'strongvpn-client' do
   url "https://mirror2.reliablehosting.com/mac/StrongVPN_Mac_#{version}.zip"
   appcast 'https://colomovers.com/mac.xml',
           checkpoint: 'd0d7858e5914ce9a1791c7c5719d4d4826bffecfead63c26e99fd44f325af46b'
-  name 'StrongVPN Client'
+  name 'StrongVPN'
   homepage 'https://strongvpn.com/vpnclient.shtml'
   license :closed
 
-  app 'StrongVPN Client.app'
+  app 'StrongVPN.app'
 end


### PR DESCRIPTION
As mentioned in #17454 , symbol link will fail in the current version. After check the downloaded .zip file, I found the name of app changed, from `StrongVPN Client.app` to `StrongVPN.app`, I think that is the reason of the bug. This PR fixed that.
