### PR TITLE
Upgrade NeteaseMusic.app to v1.4.1_440

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask 'neteasemusic' do
-  version '1.4.0_418'
-  sha256 'da5e545bbe213a7f073602519da29c3d4d68bb25de99804c4dd61dd6d02dc763'
+  version '1.4.1_440'
+  sha256 '2d3335eb23a3a721fd0815b305f873685a178845660953ffd6e900f461efe5e3'
 
   # 126.net is the official download host per the vendor homepage
   url "http://s1.music.126.net/download/osx/NeteaseMusic_#{version}_web.dmg"


### PR DESCRIPTION
upgrade neteasemusic to new version: 1.4.1
- update new binary url. 
- update binary checksum.
