### PR TITLE
Updates to comments of diverging hostnames

### DIFF
--- a/doc/cask_language_reference/stanzas/appcast.md
+++ b/doc/cask_language_reference/stanzas/appcast.md
@@ -17,3 +17,17 @@ There are a few different ways the `appcast` can be determined:
  * The popular update framework [Sparkle](http://sparkle-project.org) generally uses the `SUFeedURL` property in `Contents/Info.plist` inside `.app` bundles. You can use the script [`find_sparkle_appcast`](https://github.com/caskroom/homebrew-cask/blob/master/developer/bin/find_sparkle_appcast) to add this automatically. (Example Cask: [`glyphs`](https://github.com/caskroom/homebrew-cask/blob/161f85b605e160ff96e7dd11732d85609e13dc51/Casks/glyphs.rb#L6#L7))
 
 * An appcast can be any URL hosted by the app’s developer that changes every time a new release is out (e.g. a changelog HTML page). (Example Cask: [`shortcat`](https://github.com/caskroom/homebrew-cask/blob/161f85b605e160ff96e7dd11732d85609e13dc51/Casks/shortcat.rb#L6#L7))
+
+## When Appcast and Homepage Hostnames Differ, Add a Comment
+
+When the hostnames of `appcast` and `homepage` differ, the discrepancy should be documented with a comment of the form:
+
+```
+# URL_HOSTNAME verified as official when first introduced to the cask
+```
+
+Examples can be seen in [insert examples].
+
+These comments must be added so a user auditing the cask knows the appcast’s URL was verified by the Homebrew-Cask team as the one provided by the vendor, even though it may look unofficial or suspicious. It is our responsibility as Homebrew-Cask maintainers to verify both the `appcast` and `homepage` information when first added (or subsequently modified, apart from versioning). The exception to this rule is a `homepage` of `github.io` with a `appcast` of `github.com`, since we know this pair of hostnames is connected.
+
+The comment doesn’t mean you should trust the source blindly, but we only approve casks in which users can easily verify its authenticity, either by visiting the `homepage` or inspecting the app’s `Info.plist`.

--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -25,12 +25,14 @@ Example of using `:referer`: [rrootage.rb](https://github.com/caskroom/homebrew-
 When the hostnames of `url` and `homepage` differ, the discrepancy should be documented with a comment of the form:
 
 ```
-# URL_HOSTNAME is the official download host per the vendor homepage
+# URL_HOSTNAME verified as official when first introduced to the cask
 ```
 
-Examples can be seen in [visit.rb](https://github.com/caskroom/homebrew-cask/blob/cafcd7cf7922022ea607c5811c63d45863c7ed36/Casks/visit.rb#L5) and [vistrails.rb](https://github.com/caskroom/homebrew-cask/blob/cafcd7cf7922022ea607c5811c63d45863c7ed36/Casks/vistrails.rb#L5).
+Examples can be seen in [insert examples].
 
-These comments must be added so a user auditing the cask knows the URL is the one provided by the vendor, even though it may look unofficial or suspicious. It is our responsibility as Homebrew-Cask maintainers to verify both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning). The exception to this rule is a `homepage` of `github.io` with a `url` of `github.com`, since we know this pair of hostnames is connected.
+These comments must be added so a user auditing the cask knows the URL was verified by the Homebrew-Cask team as the one provided by the vendor, even though it may look unofficial or suspicious. It is our responsibility as Homebrew-Cask maintainers to verify both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning). The exception to this rule is a `homepage` of `github.io` with a `url` of `github.com`, since we know this pair of hostnames is connected.
+
+The comment doesn’t mean you should trust the source blindly, but we only approve casks in which users can easily verify its authenticity, either by visiting the `homepage` or inspecting the `appcast`. Cases where such quick verification isn’t possible (e.g. when the download URL is behind a registration wall) are [treated in a stricter way](../../development/adding-a-cask.md#unofficial-vendorless-and-walled-builds).
 
 ## Difficulty Finding a URL
 


### PR DESCRIPTION
@caskroom/maintainers Need some feedback.
- Slightly changed the rule for `url`.
- Added a rule to add this comment to `appcast` (see also #17498).

Reasons for the rule change to `url`:
- Only one comment is needed (instead of two: `# URL_HOSTNAME is the official download host per the [vendor homepage/appcast feed]`).
- Serves to explain related but slightly different reasons (rare but they do occur, and we usually bend the definition a bit).
- Makes it clear it was _verified_ (i.e. someone did indeed check it) and it was done so _only when first introduced_ (so users don’t think it’s verified regularly).
- The same comment can be used for both `appcast` and `url`.

In case there are concerns with the word “introduced”, I’ll point out the final result in a cask will be something like: `# amazonaws.com verified as official when first introduced to the cask` so it should be clear we’re referring to when the hostname itself was introduced (in case it changes, at which point we’ll need to verify it once more, as usual), not the cask.

If agreed upon, will make the following changes:
- [ ] Update all casks across all official repos.
  - [ ]  [caskroom/cask](https://github.com/caskroom/homebrew-cask).
  - [ ]  [caskroom/versions](https://github.com/caskroom/homebrew-versions).
  - [ ]  [caskroom/fonts](https://github.com/caskroom/homebrew-fonts).
- [ ] Add examples to documentation:
  - [ ] [url.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md).
  - [ ]  [appcast.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md).
