### PR TITLE
Remove version specific details from Diskmaker X

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,11 +1,11 @@
 cask 'diskmaker-x' do
-  version '5.0.2'
-  sha256 '9a210eb4db6d860e14d7f3e63d0cc67baeadd3a80e1ef607e3d2a44b85080472'
+  version :latest
+  sha256 :no_check
 
-  url "http://diskmakerx.com/downloads/DiskMaker_X_#{version.to_i}.dmg"
+  url 'http://diskmakerx.com/downloads/DiskMaker_X.dmg'
   name 'DiskMaker X'
   homepage 'http://diskmakerx.com/'
   license :gratis
 
-  app "DiskMaker X #{version.to_i}.app"
+  app 'DiskMaker X.app'
 end


### PR DESCRIPTION
This removes version specific details from Diskmaker X as the URL for specific versions is no longer hosted by the creator.
