### PR TITLE
Update Terraform to version 0.6.10

### DIFF
--- a/Casks/terraform.rb
+++ b/Casks/terraform.rb
@@ -1,6 +1,6 @@
 cask 'terraform' do
-  version '0.6.9'
-  sha256 '9cf892c073a9fce0e9f136162f82c5b2d373c32cc2c5bd5c5eb16631262fad89'
+  version '0.6.10'
+  sha256 '9009582111ba938bd7e22767f533c712fb763dffa9f390b40b17f18742bfac59'
 
   # hashicorp.com is the official download host per the vendor homepage
   url "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_darwin_amd64.zip"
@@ -29,6 +29,7 @@ cask 'terraform' do
   binary 'terraform-provider-null'
   binary 'terraform-provider-openstack'
   binary 'terraform-provider-packet'
+  binary 'terraform-provider-postgresql'
   binary 'terraform-provider-rundeck'
   binary 'terraform-provider-statuscake'
   binary 'terraform-provider-template'


### PR DESCRIPTION
Also add in the missing `terraform-provider-postgresql` plugin binary.
