### PR TITLE
QSyncthingTray: depends on the cask

### DIFF
--- a/Casks/qsyncthingtray.rb
+++ b/Casks/qsyncthingtray.rb
@@ -9,7 +9,7 @@ cask 'qsyncthingtray' do
   homepage 'https://github.com/sieren/QSyncthingTray'
   license :gpl
 
-  depends_on formula: 'syncthing'
+  depends_on cask: 'syncthing'
 
   app 'QSyncthingTray.app'
 


### PR DESCRIPTION
Following https://github.com/caskroom/homebrew-cask/pull/17290

For now you have a cask recipe, [which provide a better UX](https://github.com/caskroom/homebrew-cask/pull/17290#issuecomment-172554059), so we should depend on that one [for now](https://github.com/caskroom/homebrew-cask/pull/17290#issuecomment-172693448).
