### PR TITLE
Update zap stanza in linear.app v1.2.0

### DIFF
--- a/Casks/linear.rb
+++ b/Casks/linear.rb
@@ -12,7 +12,7 @@ cask 'linear' do
   app 'linear.app'
 
   zap delete: [
-                '~/linear.json',
+                '~/.linear',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.linear.sfl',
                 '~/Library/Application Support/linear',
                 '~/Library/Caches/linear',


### PR DESCRIPTION
The config file was changed in v1.2.0 from `linear.json` to `.linear`, so I updated the zap stanza to reflect that change. I also added an additional file found at `/private/var/db/BootCaches/C5359B82-55B6-4CFA-94F8-EAC7F0CD3AAE/app.com.electron.linear.playlist` to the stanza.
