### PR TITLE
updated tg-pro (2.9.5)

### DIFF
--- a/Casks/tg-pro.rb
+++ b/Casks/tg-pro.rb
@@ -1,10 +1,10 @@
 cask 'tg-pro' do
-  version '2.9.6'
-  sha256 '25efbea93252b1663b61c277ccb384901a3307240fc20fca78bfd755eecc19a8'
+  version '2.9.5'
+  sha256 '6f8cb96bf91ee3a69a5f91c47232427826e5516355d45656c4be9118d5c5b78a'
 
   url "https://www.tunabellysoftware.com/resources/TGPro_#{version.dots_to_underscores}.zip"
   appcast 'https://www.tunabellysoftware.com/resources/sparkle/tgpro/profileInfo.php',
-          checkpoint: '02c1b37a912451494ffa8bd5e1fa1672122eae3b2618d1a85180736209a46481'
+          checkpoint: 'b36f84edfaf65508dba094649cac418bf527ee486552f2d0f5a883df1a23227e'
   name 'TG Pro'
   homepage 'https://www.tunabellysoftware.com/tgpro/'
   license :commercial


### PR DESCRIPTION
Closes #17879.

Version is not a typo, and is what is shown on the homepage. For some reason it went down.
