### PR TITLE
Remove depends_on_java caveat from jetbrain products

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -18,8 +18,4 @@ cask 'appcode' do
                 '~/Library/Caches/AppCode33',
                 '~/Library/Logs/AppCode33',
               ]
-
-  caveats do
-    depends_on_java
-  end
 end

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -14,8 +14,4 @@ cask 'intellij-idea' do
                 '~/Library/Preferences/IntelliJIdea15',
                 '~/Library/Preferences/com.jetbrains.intellij.plist',
               ]
-
-  caveats do
-    depends_on_java
-  end
 end

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -14,8 +14,4 @@ cask 'phpstorm' do
                 '~/Library/Preferences/WebIde100',
                 '~/Library/Preferences/com.jetbrains.PhpStorm.plist',
               ]
-
-  caveats do
-    depends_on_java
-  end
 end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -8,8 +8,4 @@ cask 'pycharm' do
   license :commercial
 
   app 'PyCharm.app'
-
-  caveats do
-    depends_on_java
-  end
 end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -13,8 +13,4 @@ cask 'rubymine' do
                 "~/Library/Application Support/RubyMine#{version.delete('.')}",
                 "~/Library/Preferences/RubyMine#{version.delete('.')}",
               ]
-
-  caveats do
-    depends_on_java
-  end
 end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -17,8 +17,4 @@ cask 'webstorm' do
                 '~/Library/Caches/WebStorm11',
                 '~/Library/Logs/WebStorm11',
               ]
-
-  caveats do
-    depends_on_java
-  end
 end


### PR DESCRIPTION
Hey. 

Hopefully it does not offend anybody, that this fixes multiple casks.

All current versions of jetbrains products bring a bundled version of java with them [1], therefore it is not necessary to install a JDK if you want to use them.

If you have any questions, I am happy to answer them :+1: 

[1]: [Jet Brains Support Article](https://intellij-support.jetbrains.com/hc/en-us/articles/206544879-Selecting-the-JDK-version-the-IDE-will-run-under) (have a look at the Mac OSX Section)
