### PR TITLE
cask_language_reference/stanzas/url.md: refine comment rules

### DIFF
--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -25,12 +25,14 @@ Example of using `referer:`: [rrootage.rb](https://github.com/caskroom/homebrew-
 When the hostnames of `url` and `homepage` differ, the discrepancy should be documented with a comment of the form:
 
 ```
-# URL_HOSTNAME is the official download host per the vendor homepage
+# URL_SECTION was verified as official when first introduced to the cask
 ```
 
-Examples can be seen in [visit.rb](https://github.com/caskroom/homebrew-cask/blob/4f15921803cd696838eb7b2ea49357dbb0b757a5/Casks/visit.rb#L5) and [vistrails.rb](https://github.com/caskroom/homebrew-cask/blob/312ae841f1f1b2ec07f4d88b7dfdd7fbdf8d4f94/Casks/vistrails.rb#L5).
+Where `URL_SECTION` is the smallest possible portion of the URL that uniquely identifies the app or vendor. Examples can be seen in [`airfoil.rb`](https://github.com/caskroom/homebrew-cask/blob/1666993ee93e2a43f00a4dfc3c727da7c0b5ada9/Casks/airfoil.rb#L5), [`knockknock.rb`](https://github.com/caskroom/homebrew-cask/blob/6645a6090d1cb8fc026f243a47048749b31c32bf/Casks/knockknock.rb#L5), [`lightpaper.rb`](https://github.com/caskroom/homebrew-cask/blob/7a75f4e84c01bf192bd55f251b96cf2c1e086281/Casks/lightpaper.rb#L5), [`airtool.rb`](https://github.com/caskroom/homebrew-cask/blob/355211a8a3ea54046ae45022bcf71980bd2d5432/Casks/airtool.rb#L5), [`screencat.rb`](https://github.com/caskroom/homebrew-cask/blob/5fc818752c30c156c00f79b04b66406189ab2f30/Casks/screencat.rb#L5), [`0ad.rb`](https://github.com/caskroom/homebrew-cask/blob/7a75f4e84c01bf192bd55f251b96cf2c1e086281/Casks/0ad.rb#L5).
 
-These comments must be added so a user auditing the cask knows the URL is the one provided by the vendor, even though it may look unofficial or suspicious. It is our responsibility as Homebrew-Cask maintainers to verify both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning). The exception to this rule is a `homepage` of `github.io` with a `url` of `github.com`, since we know this pair of hostnames is connected.
+These comments must be added so a user auditing the cask knows the URL was verified by the Homebrew-Cask team as the one provided by the vendor, even though it may look unofficial or suspicious. It is our responsibility as Homebrew-Cask maintainers to verify both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning).
+
+The comment doesn’t mean you should trust the source blindly, but we only approve casks in which users can easily verify its authenticity with basic means, such as checking the official homepage or public repository. occasionally, slightly more elaborate techniques may be used, such as inspecting an [`appcast`](appcast.md) we established as official. Cases where such quick verifications aren’t possible (e.g. when the download URL is behind a registration wall) are [treated in a stricter manner](../../development/adding-a-cask.md#unofficial-vendorless-and-walled-builds).
 
 ## Difficulty Finding a URL
 


### PR DESCRIPTION
Note: In this context, I’m referring to audit as the process of manually checking a cask for correctness, not `brew cask audit`.

While working on #17498 and #17499, I came to the realisation I was working on the wrong solution to the right problem. The right solution involves a slight rethink of the previous comment rule.

Our current method of informing a `url` was verified (by pointing out only the host) is insufficient and flawed, as it does not account for maintainer inattention. While for cases like [`world-of-tanks`](https://github.com/caskroom/homebrew-cask/blob/master/Casks/world-of-tanks.rb) it is pretty straightforward, since the company owns both domains, the rule is particularly ineffective for popular hosts like `amazonwas.com` and `cloudfront.net`, where the host isn’t sufficiently identifiable to any application.

[`# bitbucket.org is the official download host per the vendor homepage`](https://github.com/caskroom/homebrew-cask/blob/b9d1864d88e8de3f71a23b85a8c20bcd606ec98b/Casks/yacreader.rb#L5) isn’t enough to prove maintainers kept the comment up to date with `url` changes (what if at a certain point a contribution changed the bitbucket account to a malicious one and a mistake was made in merging?). `# bitbucket.org/luisangelsm/yacreader was verified as official when first introduced to the cask` is, however, clear in this regard, as is `# rink.hockeyapp.net/api/2/apps/6ab08fb043a94f51c9109c216e295a50 was verified as official when first introduced to the cask`. In those examples, discrepancies between the comment and `url` would be catchable to a user auditing the cask, signalling a mistake in need of correction. `github.io` links would also no longer be exempt from the rule.

With that in mind, the rule template for the comment ought then to be:

```
# URL_SECTION was verified as official when first introduced to the cask
```

Where `URL_SECTION` is the smallest possible portion of the URL, including and following the top domain host, that uniquely identifies the app or vendor.

---

So what about `appcast` comments (the whole point of #17499 and half of #17498)? While working on the aforementioned issues, I also realised appcast hosts are irrelevant, since they do not pose a threat to users, only malicious `url`s do. In theory, even a third-party appcast (which is somewhat what github `releases.atom` appcasts are) can be used just as effectively with no harm.

This could only become a potential issue where [`url` is extrapolated from `appcast`](https://github.com/caskroom/homebrew-cask/blob/b9d1864d88e8de3f71a23b85a8c20bcd606ec98b/Casks/antetype.rb#L5), but as long as the maintainer actually verified the `url` as being trustworthy, which must happen anyway, the issue no longer exists. Furthermore, this can be eliminated (almost?) completely. The reason to use urls from the appcast feed is versioning (when the website download is unversioned), but now that we’re close to having in place the system to check appcasts for updates, we can switch those to the official unversioned URLs and still have `version` and `sha256`.

Things that need to be done, in order:
- [x] Remove all comments added to appcasts.
- [x] Delete `… per the appcast feed` comments and change the corresponding `url` to an official one found on the homepage, even if unversioned.
  - [x]  [caskroom/cask](https://github.com/caskroom/homebrew-cask).
  - [x]  [caskroom/versions](https://github.com/caskroom/homebrew-versions).
- [ ] Verify and improve all current `… is the official download host per the vendor homepage` comments.
  - [ ]  [caskroom/cask](https://github.com/caskroom/homebrew-cask).
  - [x]  [caskroom/versions](https://github.com/caskroom/homebrew-versions).
  - [x]  [caskroom/fonts](https://github.com/caskroom/homebrew-fonts).
- [x] Add comment to all casks with a `github.io` homepage.
  - [x]  [caskroom/cask](https://github.com/caskroom/homebrew-cask).
  - [x]  [caskroom/versions](https://github.com/caskroom/homebrew-versions).
  - [x]  [caskroom/fonts](https://github.com/caskroom/homebrew-fonts).
- [x] Add examples to documentation ([url.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md)).
