### PR TITLE
Add new nrf5x-command-line-tools: 8.2.0

### DIFF
--- a/Casks/nrf5x-command-line-tools.rb
+++ b/Casks/nrf5x-command-line-tools.rb
@@ -1,0 +1,12 @@
+cask 'nrf5x-command-line-tools' do
+  version '8.2.0'
+  sha256 '22c217ce3ef64a1e85d1ec339692fc9eed73ca8a9011cb0b21ddcd5e5bfc84ad'
+
+  url 'http://www.nordicsemi.com/eng/nordic/download_resource/53406/1/8099423'
+  name 'nRF5x Command Line Tools'
+  homepage 'http://www.nordicsemi.com/eng/nordic/Products/nRF52832/nRF5x-Command-Line-Tools-OSX/53406'
+  license :gratis
+
+  binary 'nrfjprog/nrfjprog'
+  binary 'mergehex/mergehex'
+end


### PR DESCRIPTION
nRF5x Command Line Tools were just released for OS X: https://devzone.nordicsemi.com/blogs/840/nrfjprog-pynrfjprog-intro-mac-os-x-linux-now-suppo/

I searched around a bit for how to copy .dylib files; let me know if this is the correct approach.

Thanks!
