### PR TITLE
Mnemosyne version update/added caveat

### DIFF
--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -4,6 +4,8 @@ cask 'mnemosyne' do
 
   # sourceforge.net is the official download host per the vendor homepage
   url "http://downloads.sourceforge.net/project/mnemosyne-proj/mnemosyne/mnemosyne-#{version}/Mnemosyne-#{version}.dmg"
+  appcast 'http://sourceforge.net/p/mnemosyne-proj/activity/feed?source=project_activity',
+          checkpoint: 'a8f3a1d3ec76cfbc00c91c8957abb728e742e61860bc694c355421e3f8f0d8bc'
   name 'Mnemosyne'
   homepage 'http://mnemosyne-proj.org/'
   license :gpl
@@ -19,11 +21,11 @@ cask 'mnemosyne' do
     Mnemosyne looks for LaTeX in the $PATH environment variable, however OS X does not set
     $PATH for applications launched via Finder.
 
-    You can set environment variables for specific apps via Launch Services, by setting the
+    You can set environment variables for specific apps via Launch Services by setting the
     LSEnvironment key in the app's Info.plist file within the app bundle. You must update the
     Launch Services registry after doing this, or the changes will not be recognised.
 
-    For example, (substituting for the location of your LaTeX installation):
+    For example (substituting for the location of your LaTeX installation):
 
       plutil -insert LSEnvironment -json "{\\"PATH\\":\\"$PATH:/Library/TeX/texbin\\"}" #{staged_path}/Mnemosyne.app/Contents/Info.plist
       /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -v -f #{staged_path}/Mnemosyne.app

--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -10,24 +10,22 @@ cask 'mnemosyne' do
 
   app 'Mnemosyne.app'
 
-  caveats do
-    puts <<-EOS.undent
-      If you want to use LaTeX inside your flashcards, you need a LaTeX installation. You can
-      get this via Homebrew Cask:
+  caveats <<-EOS.undent
+    If you want to use LaTeX inside your flashcards, you need a LaTeX installation. You can
+    get this via Homebrew Cask:
 
-        brew cask install mactex
+      brew cask install mactex
 
-      Mnemosyne looks for LaTeX in the $PATH environment variable, however OS X does not set
-      $PATH for applications launched via Finder.
+    Mnemosyne looks for LaTeX in the $PATH environment variable, however OS X does not set
+    $PATH for applications launched via Finder.
 
-      You can set environment variables for specific apps via Launch Services, by setting the
-      LSEnvironment key in the app's Info.plist file within the app bundle. You must update the
-      Launch Services registry after doing this, or the changes will not be recognised.
+    You can set environment variables for specific apps via Launch Services, by setting the
+    LSEnvironment key in the app's Info.plist file within the app bundle. You must update the
+    Launch Services registry after doing this, or the changes will not be recognised.
 
-      For example, (substituting for the location of your LaTeX installation):
+    For example, (substituting for the location of your LaTeX installation):
 
-        plutil -insert LSEnvironment -json "{\\"PATH\\":\\"$PATH:/Library/TeX/texbin\\"}" #{staged_path}/Mnemosyne.app/Contents/Info.plist
-        /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -v -f #{staged_path}/Mnemosyne.app
-      EOS
-  end
+      plutil -insert LSEnvironment -json "{\\"PATH\\":\\"$PATH:/Library/TeX/texbin\\"}" #{staged_path}/Mnemosyne.app/Contents/Info.plist
+      /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -v -f #{staged_path}/Mnemosyne.app
+    EOS
 end

--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -1,12 +1,33 @@
 cask 'mnemosyne' do
-  version '2.3'
-  sha256 '094c4f6fb50de376a5190c3712b935089579717641ce90685aa48932bf0efa07'
+  version '2.3.5'
+  sha256 '88c593fd7cdf2ceb42bf1af9977765b7a233a42185181ae873b960cf644211b7'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url "http://downloads.sourceforge.net/sourceforge/mnemosyne-proj/Mnemosyne-#{version}-Mac.dmg"
+  url "http://downloads.sourceforge.net/project/mnemosyne-proj/mnemosyne/mnemosyne-#{version}/Mnemosyne-#{version}.dmg"
   name 'Mnemosyne'
   homepage 'http://mnemosyne-proj.org/'
   license :gpl
 
   app 'Mnemosyne.app'
+
+  caveats do
+    puts <<-EOS.undent
+      If you want to use LaTeX inside your flashcards, you need a LaTeX installation. You can
+      get this via Homebrew Cask:
+
+        brew cask install mactex
+
+      Mnemosyne looks for LaTeX in the $PATH environment variable, however OS X does not set
+      $PATH for applications launched via Finder.
+
+      You can set environment variables for specific apps via Launch Services, by setting the
+      LSEnvironment key in the app's Info.plist file within the app bundle. You must update the
+      Launch Services registry after doing this, or the changes will not be recognised.
+
+      For example, (substituting for the location of your LaTeX installation):
+
+        plutil -insert LSEnvironment -json "{\\"PATH\\":\\"$PATH:/Library/TeX/texbin\\"}" #{staged_path}/Mnemosyne.app/Contents/Info.plist
+        /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -v -f #{staged_path}/Mnemosyne.app
+      EOS
+  end
 end


### PR DESCRIPTION
Updated Mnemosyne version to 2.3.5 and added note about complications with getting it to work with a LaTeX installation.

Originally I wanted to do the steps outlined in the caveat for the user automatically, but I feel like maybe that isn't appropriate. However, it seems like a common enough usage for Mnemosyne that it's worth putting in the note (especially for me as I face this problem every time I install Mnemosyne on a new machine).

Is there a way to specify options? I had originally thought of something like `brew cask install mnemosyne --with-latex` which would run the suggested commands and also have a cask dependency on MacTeX, but I couldn't find any precedent for that sort of behaviour.
