### PR TITLE
Remove Java dependency

### DIFF
--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -14,7 +14,4 @@ cask 'charles' do
                 '~/Library/Preferences/com.xk72.charles.config',
               ]
 
-  caveats do
-    depends_on_java
-  end
 end


### PR DESCRIPTION
From the [downloads page](http://www.charlesproxy.com/latest-release/download.do):

> Mac OS X users
> 
> The main download of Charles now includes Java 8, so you no longer need to use the alternative download for better SSL support. The alternative download is now strictly for oldies.
