### PR TITLE
git-annex: Add 10.11/el_capitan as a supported os.

### DIFF
--- a/Casks/git-annex.rb
+++ b/Casks/git-annex.rb
@@ -34,6 +34,7 @@ cask 'git-annex' do
                       :mountain_lion
                       :mavericks
                       :yosemite
+                      :el_capitan
                     ]
 
   app 'git-annex.app'


### PR DESCRIPTION
The code already defaults to using the 10.10_Yosemite version, we just need to fix the `depends_on_macos` versioning.

Kitenet.net doesn't have a 10.11 version built.
