### PR TITLE
added scripts for outdated appcasts

### DIFF
--- a/developer/bin/find_outdated_appcasts
+++ b/developer/bin/find_outdated_appcasts
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+readonly caskroom_online='https://github.com/caskroom'
+readonly caskroom_repos_dir='/tmp/caskroom_repos'
+readonly caskroom_repos=(homebrew-cask homebrew-versions homebrew-fonts homebrew-eid homebrew-unofficial)
+readonly curl_flags=(--silent --location --header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36')
+inaccessible_appcasts=()
+
+if [[ ! $(which 'ghi') ]] || ! security find-internet-password -s github.com -l 'ghi token' &> /dev/null; then
+  echo -e "$(tput setaf 1)
+    This script requires 'ghi' installed and configured.
+    If you have [Homebrew](http://brew.sh), you can install it with 'brew install ghi'.
+    To configure it, run 'ghi config --auth <username>'. Your Github password will be required, but is never stored.
+  $(tput sgr0)" | sed -E 's/ {4}//' >&2
+  exit 1
+fi
+
+function message {
+  echo "${1}"
+}
+
+function go_to_repos_dir {
+  [[ ! -d "${caskroom_repos_dir}" ]] && mkdir -p "${caskroom_repos_dir}"
+  cd "${caskroom_repos_dir}" || exit 1
+}
+
+function go_to_repo_and_update {
+  local repo_name repo_dir casks_dir
+
+  repo_name="${1}"
+  repo_dir="${caskroom_repos_dir}/${repo_name}"
+  casks_dir="${repo_dir}/Casks"
+
+  if [[ ! -d "${repo_dir}" ]]; then
+    go_to_repos_dir
+
+    message "Cloning ${repo_name}…"
+    git clone "https://github.com/caskroom/${repo_name}.git" --quiet
+
+    cd "${casks_dir}" || exit 1
+  else
+    cd "${casks_dir}" || exit 1
+
+    message "Updating ${repo_name}…"
+    git pull --rebase origin master --quiet
+  fi
+}
+
+function open_issue {
+  local repo_name cask_name cask_url version appcast_url issue_number
+
+  repo_name="${1}"
+  cask_name="${2}"
+  cask_url="${caskroom_online}/${repo_name}/blob/master/Casks/${cask_name}.rb"
+  version="${3}"
+  appcast_url="${4}"
+
+  message="$(echo "Outdated cask: ${cask_name}
+
+    Outdated cask: [\`${cask_name}\`](${cask_url}).
+
+    Info:
+    + version: \`${version}\`.
+    + appcast url: ${appcast_url}.
+  " | sed -E 's/^ {4}//')"
+
+  issue_number=$(ghi open --label 'outdated appcast' --message "${message}" | head -1 | perl -pe 's/^#(\d+): .*/\1/')
+  message "Opened issue: https://github.com/caskroom/${repo_name}/issues/${issue_number}."
+}
+
+function is_appcast_available {
+  local appcast_url
+
+  appcast_url="${1}"
+
+  http_status="$(curl "${curl_flags[@]}" --head --write-out '%{http_code}' "${appcast_url}" -o '/dev/null')"
+
+  [[ "${http_status}" == 200 ]]
+}
+
+function report_outdated_appcasts {
+  local repo_name cask_name appcast_url current_checkpoint new_checkpoint version
+
+  repo_name="${1}"
+
+  for cask_file in ./*; do
+    appcast_url="$(brew cask _stanza appcast "${cask_file}")"
+    [[ -z "${appcast_url}" ]] && continue # skip early if there is no appcast
+
+    cask_name="$(basename "${cask_file%.*}")"
+
+    message "Verifying appcast checkpoint for ${cask_name}…"
+
+    if is_appcast_available "${appcast_url}"; then
+      current_checkpoint="$(brew cask _stanza --yaml appcast "${cask_file}" | grep '^- :checkpoint' | awk '{print $3}')"
+      new_checkpoint="$(curl "${curl_flags[@]}" --compressed "${appcast_url}" | sed 's|<pubDate>[^<]*</pubDate>||g' | shasum --algorithm 256 | awk '{ print $1 }')"
+    else
+      message "There was an error checking the appcast for ${cask_name}."
+      inaccessible_appcasts+=("${repo_name}/${cask_name}")
+      continue
+    fi
+
+    if [[ "${current_checkpoint}" != "${new_checkpoint}" ]]; then
+      version="$(brew cask _stanza version "${cask_file}")"
+
+      message "${cask_name} is outdated. Opening issue in ${repo_name}…"
+      open_issue "${repo_name}" "${cask_name}" "${version}" "${appcast_url}"
+    fi
+  done
+}
+
+for repo in "${caskroom_repos[@]}"; do
+  go_to_repo_and_update "${repo}"
+  report_outdated_appcasts "${repo}"
+done
+
+if [[ ${#inaccessible_appcasts[@]} -gt 0 ]];then
+  echo # empty line
+  message 'Some casks have appcasts that errored out, and may need to be rechecked:'
+  printf '%s\n' "${inaccessible_appcasts[@]}"
+fi

--- a/developer/bin/fix_outdated_appcasts
+++ b/developer/bin/fix_outdated_appcasts
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+IFS=$'\n'
+
+readonly caskroom_repos_dir='/tmp/caskroom_repos'
+readonly caskroom_repos=(homebrew-cask homebrew-versions homebrew-fonts homebrew-eid homebrew-unofficial)
+
+if [[ ! $(which 'ghi') ]] || ! security find-internet-password -s github.com -l 'ghi token' &> /dev/null; then
+  echo -e "$(tput setaf 1)
+    This script requires 'ghi' installed and configured.
+    If you have [Homebrew](http://brew.sh), you can install it with 'brew install ghi'.
+    To configure it, run 'ghi config --auth <username>'. Your Github password will be required, but is never stored.
+  $(tput sgr0)" | sed -E 's/ {4}//' >&2
+  exit 1
+fi
+
+if [[ ! $(which 'cask-repair') ]]; then
+  echo -e "$(tput setaf 1)
+    This script requires 'cask-repair'.
+    If you have [Homebrew](http://brew.sh), you can install it with 'brew install vitorgalvao/tiny-scripts/cask-repair'.
+  $(tput sgr0)" | sed -E 's/ {4}//' >&2
+  exit 1
+fi
+
+function message {
+  echo "${1}"
+}
+
+function go_to_repos_dir {
+  [[ ! -d "${caskroom_repos_dir}" ]] && mkdir -p "${caskroom_repos_dir}"
+  cd "${caskroom_repos_dir}" || exit 1
+}
+
+function go_to_repo_and_update {
+  local repo_name repo_dir casks_dir
+
+  repo_name="${1}"
+  repo_dir="${caskroom_repos_dir}/${repo_name}"
+  casks_dir="${repo_dir}/Casks"
+
+  if [[ ! -d "${repo_dir}" ]]; then
+    go_to_repos_dir
+
+    message "Cloning ${repo_name}…"
+    git clone "https://github.com/caskroom/${repo_name}.git" --quiet
+
+    cd "${casks_dir}" || exit 1
+  else
+    cd "${casks_dir}" || exit 1
+
+    message "Updating ${repo_name}…"
+    git pull --rebase origin master --quiet
+  fi
+}
+
+function fix_outdated_appcasts {
+  local issue_number cask_name pr_number
+
+  for line in $(ghi list --state open --no-pulls --label 'outdated appcast' --reverse | tail -n +2); do
+    [[ "${line}" == 'None.' ]] && break # exit early if there are no relevant issues in repo
+
+    issue_number="$(awk '{print $1}' <<< "${line}")"
+    cask_name="$(awk '{print $4}' <<< "${line}")"
+
+    cask-repair --pull origin --push origin --open-appcast --closes-issue "${issue_number}" --blind-submit "${cask_name}"
+
+    if [[ "$?" -eq 0 ]]; then
+      pr_number="$(ghi list --pulls --creator | sed -n 2p | awk '{print $1}')"
+      ghi edit --label 'outdated appcast' "${pr_number}" &>/dev/null
+      ghi comment --close --message "Closing in favour of #${pr_number}." "${issue_number}" &>/dev/null
+    fi
+  done
+}
+
+for repo in "${caskroom_repos[@]}"; do
+  go_to_repo_and_update "${repo}"
+  fix_outdated_appcasts
+done

--- a/developer/bin/merge_outdated_appcasts
+++ b/developer/bin/merge_outdated_appcasts
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+IFS=$'\n'
+
+readonly caskroom_online='https://github.com/caskroom'
+readonly caskroom_repos_dir='/tmp/caskroom_repos'
+readonly caskroom_repos=(homebrew-cask homebrew-versions homebrew-fonts homebrew-eid homebrew-unofficial)
+
+if [[ ! $(which 'ghi') ]] || ! security find-internet-password -s github.com -l 'ghi token' &> /dev/null; then
+  echo -e "$(tput setaf 1)
+    This script requires 'ghi' installed and configured.
+    If you have [Homebrew](http://brew.sh), you can install it with 'brew install ghi'.
+    To configure it, run 'ghi config --auth <username>'. Your Github password will be required, but is never stored.
+  $(tput sgr0)" | sed -E 's/ {4}//' >&2
+  exit 1
+fi
+
+if [[ ! $(which 'fastmerge') ]]; then
+  echo -e "$(tput setaf 1)
+    This script requires 'fastmerge'.
+    If you have [Homebrew](http://brew.sh), you can install it with 'brew install vitorgalvao/tiny-scripts/fastmerge'.
+  $(tput sgr0)" | sed -E 's/ {4}//' >&2
+  exit 1
+fi
+
+function message {
+  echo "${1}"
+}
+
+function go_to_repos_dir {
+  [[ ! -d "${caskroom_repos_dir}" ]] && mkdir -p "${caskroom_repos_dir}"
+  cd "${caskroom_repos_dir}" || exit 1
+}
+
+function go_to_repo_and_update {
+  local repo_name repo_dir casks_dir
+
+  repo_name="${1}"
+  repo_dir="${caskroom_repos_dir}/${repo_name}"
+  casks_dir="${repo_dir}/Casks"
+
+  if [[ ! -d "${repo_dir}" ]]; then
+    go_to_repos_dir
+
+    message "Cloning ${repo_name}…"
+    git clone "https://github.com/caskroom/${repo_name}.git" --quiet
+
+    cd "${casks_dir}" || exit 1
+  else
+    cd "${casks_dir}" || exit 1
+
+    message "Updating ${repo_name}…"
+    git pull --rebase origin master --quiet
+  fi
+}
+
+function delete_current_branch {
+  local current_branch
+
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  git checkout master --quiet
+  git branch -D "${current_branch}" --quiet
+}
+
+function delete_cask_repair_branches {
+  [[ $(ghi list --state open --pulls --label 'outdated appcast' | tail -1) == 'None.' ]] && cask-repair --push origin --delete-branches
+}
+
+function merge_outdated_appcasts {
+  local repo_name pr_number cask_name pr_url last_commit
+
+  repo_name="${1}"
+
+  for line in $(ghi list --state open --pulls --label 'outdated appcast' --reverse | tail -n +2); do
+    [[ "${line}" == 'None.' ]] && break # exit early if there are no relevant issues in repo
+
+    pr_number="$(awk '{print $1}' <<< "${line}")"
+    cask_name="$(awk '{print $3}' <<< "${line}")"
+    pr_url="${caskroom_online}/${repo_name}/pull/${pr_number}"
+
+    hub checkout "${pr_url}" &>/dev/null
+    last_commit="$(git log -n 1 --pretty=format:'%H')"
+    delete_current_branch
+
+    if [[ "$(hub ci-status "${last_commit}")" == 'success' ]]; then
+      message "Merging pull request for ${cask_name}…"
+      fastmerge --maintainer --remote origin "${pr_url}"
+    else
+      continue
+    fi
+  done
+}
+
+for repo in "${caskroom_repos[@]}"; do
+  go_to_repo_and_update "${repo}"
+  merge_outdated_appcasts "${repo}"
+  delete_cask_repair_branches
+  git gc
+done


### PR DESCRIPTION
To run these, simply do it. It doesn’t matter where, they take care of everything. How they work:

`find_outdated_appcasts`:
- Loop through every cask.
  - If it has an `appcast`, verify it.
    - If outdated, open an issue with details and `outdated appcast` label.

Snippet of output:

```
→ ~/Desktop/find_outdated_appcasts
Cloning homebrew-cask…
Verifying appcast checkpoint for 33-rpm…
Verifying appcast checkpoint for a-better-finder-attributes…
Verifying appcast checkpoint for a-better-finder-rename…
Verifying appcast checkpoint for accessmenubarapps…
Verifying appcast checkpoint for acorn…
Verifying appcast checkpoint for activity-audit…
Verifying appcast checkpoint for actotracker…
Verifying appcast checkpoint for adapter…
Verifying appcast checkpoint for adguard…
Verifying appcast checkpoint for adium…
adium is outdated. Opening issue in homebrew-cask…
Opened issue: https://github.com/caskroom/homebrew-cask/issues/17851.
Verifying appcast checkpoint for adventure…
Verifying appcast checkpoint for aerial…
Verifying appcast checkpoint for aether…
Verifying appcast checkpoint for air-connect…
Verifying appcast checkpoint for air-video-server-hd…

… Many lines later …

Some casks have appcasts that errored out, and may need to be rechecked:
homebrew-cask/butler
homebrew-cask/moom
homebrew-cask/name-mangler
homebrew-cask/witch
homebrew-cask/wordpresscom
```

`fix_outdated_appcasts`:
- Grab all issues (no PRs) with label `outdated appcast` and loop through them.
  - Open their `appcast` in the browser (or whatever default app).
  - Initiate `cask-repair` (it will [`blind-submit`](https://github.com/vitorgalvao/tiny-scripts/blob/c37288b9c1f8153a395eb516790a39a661e09488/cask-repair#L40)).
    - If successful (i.e. if it submits the PR), close the issue that originated it.

`merge_outdated_appcasts`:
- Grab all PRs (no issues) with label `outdated appcast` and loop through them.
  - Check if CI passed.
    - If it did, `fastmerge` it.
- Again, grab all PRs (no issues) with label `outdated appcast`.
  - If there are none, [`cask-repair --delete-branches`](https://github.com/vitorgalvao/tiny-scripts/blob/c37288b9c1f8153a395eb516790a39a661e09488/cask-repair#L41).

Snippet of output:

```
Updating homebrew-cask…
Merging pull request for kube-cluster…
Applying #17915 as patch…
Merged and closed issue.
Merging pull request for macspice…
Applying #17916 as patch…
Merged and closed issue.
Merging pull request for peakhour…
Applying #17917 as patch…
Merged and closed issue.
Merging pull request for pngcommentator…
Applying #17918 as patch…
Merged and closed issue.
To https://github.com/caskroom/homebrew-cask.git
 - [deleted]         update-fauxpas
 - [deleted]         update-kube-cluster
 - [deleted]         update-macspice
 - [deleted]         update-peakhour
 - [deleted]         update-pngcommentator
```

You might notice `find_outdated_appcasts` outputs full URLs (as does `fix_outdated_appcasts`, through `cask-repair`), while `merge_outdated_appcasts` (through `fastmerge`) does not. However, that will indeed happen if there’s an error. So opening issues and errors (i.e. when you might want to directly go to the issue) produces the full link, while closing them successfully does not. Showing a bunch of links in a row (i.e. a lot of merging successes) is confusing and makes it harder for the eyes to parse, but when spaced out (occasional opening of issues and PR submissions) calls attention to them. Quick tip to iTerm2 users, <kbd>⌘</kbd>+click on a URL will open it.

As for the duplication between the scripts, this is one of those cases where they all do similar things but require minute differences in various areas, and jumbling them all together, at least in this initial step, would cause more confusion than what is worth.

There may also be some doubts regarding interacting directly with upstream instead of using forks, and again this is one of those cases of “first lets see if we can get it to work at all”. Doing it this way, at least initially, is easier for various reasons, including not having to worry if the maintainer has all the repos tapped/cloned and not having to worry about the naming they gave to their branches.

The final consideration is when and how to run these. I’ve been doing it so successfully for a while, but from the moment any maintainer can do it, we risk stepping on toes. I’ve been thinking of systems where the script would assign the issue to who ran it, and only run if issues were assigned to you, hence mitigating possible clashes, but all solutions require a lot of web requests, slow down operations considerably, and are convoluted. Easiest way I can think is: whoever ran the `find` script commits to running the other two that same day. That way, one person at a time is responsible.

Now, who to run them and when? Initially I thought about having a bot run both the `find` and `merge` scripts regularly (once or twice a week), but there are some considerations. Although I do have a server I could employ for this, it’s shared, and I’m not sure we should trust it with such responsibility<sup>1</sup>. Also, having the bot open issues when there’s no one to run the `fix` script soon after leaves us with a mess of issues.

So if we decide a human is to run all three scripts, we need a way to let others know when we do so, to avoid stumbling on each other.

Until we come up with a system to do so (suggestions very welcome), I don’t mind being the one to do it. I’m guessing some of you might be curious to try them at least once before, though, so if you are, reply to this issue (so others know not to run the script as well) and go for it.

---

<sup>1</sup> Yes, it is git and we can reverse things, but I’m more worried about malicious commits we fail to catch. Unfortunately, there’s no way in Github to have a maintainer that can only handle issues (we would need the bot to be a maintainer to label issues). We could forego the labeling mechanic entirely and have the bot with no permissions just open issues with a certain name we can grab, but that is prone to errors.
