### PR TITLE
Add miniconda.rb

### DIFF
--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -1,0 +1,22 @@
+cask 'miniconda' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh'
+  name 'Continuum Analytics Miniconda'
+  homepage 'https://www.continuum.io/why-anaconda'
+  license :gratis
+
+  depends_on macos: '>= :lion'
+  container type: :naked
+
+  installer script: 'Miniconda3-latest-MacOSX-x86_64.sh',
+            args:   ['-b'],
+            sudo:   false
+
+  uninstall delete: '~/miniconda3'
+
+  caveats do
+    path_environment_variable '~/miniconda3/bin'
+  end
+end


### PR DESCRIPTION
Adds miniconda3 by Continuum Analytics. The full anaconda install is massive and often uneccesary. This is a supported and valid alternative.
