### PR TITLE
Add Audirvana Plus 2.app v2.3.3

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,0 +1,11 @@
+cask 'audirvana-plus' do
+  version '2.3.3'
+  sha256 'be36c7e6f0bebe33c0e7925c3fcae2e1b310e57d271865079d9d9cff044759af'
+
+  url 'http://audirvana.com/delivery/AudirvanaPlus_2.3.3.dmg'
+  name 'Audirvana Plus 2'
+  homepage 'http://audirvana.com'
+  license :commercial
+
+  app 'Audirvana Plus.app'
+end


### PR DESCRIPTION
Adds Audirvana Plus 2, an audio library manager, streaming and remote control App targeted towards audiophiles with support for external DACs and/or (headphone) amplifiers.
