### PR TITLE
Update sqlworkbenchj.rb

### DIFF
--- a/Casks/sqlworkbenchj.rb
+++ b/Casks/sqlworkbenchj.rb
@@ -1,8 +1,8 @@
 cask 'sqlworkbenchj' do
-  version '118'
-  sha256 '5983eeebec79c781e76d6b5ceb789d2c4a9fcdeb2a93ec333b0cb6cb4a291915'
+  version '119'
+  sha256 '8565105504e517ca972b4f3c99f4436b13e7a3caaf8f53a97f44a71a7c71efc6'
 
-  url "http://www.sql-workbench.net/Workbench-Build#{version}-MacJava7.tgz"
+  url "http://www.sql-workbench.net/Workbench-Build#{version}-MacJava8.tgz"
   name 'SQL Workbench/J'
   homepage 'http://www.sql-workbench.net'
   license :apache


### PR DESCRIPTION
Unfortunately, old download URLs are invalidated upon release of a new version, with old versions being moved into the `/archive` subdirectory(eg, `http://www.sql-workbench.net/Workbench-Build#{version}-MacJava7.tgz` moves to `http://www.sql-workbench.net/archive/Workbench-Build#{version}-MacJava7.tgz`). Maybe someone who knows more about Ruby and Homebrew could patch this to check both URLs for a given version # so the recipe doesn't completely break every time they update.
