### PR TITLE
update license info for hiera

### DIFF
--- a/Casks/hiera.rb
+++ b/Casks/hiera.rb
@@ -5,7 +5,7 @@ cask 'hiera' do
   url "https://downloads.puppetlabs.com/mac/hiera-#{version}.dmg"
   name 'Puppet Labs Hiera'
   homepage 'https://projects.puppetlabs.com/projects/hiera'
-  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :apache
 
   pkg "hiera-#{version}.pkg"
 


### PR DESCRIPTION
It's `:apache` like the rest of Puppetlabs' stuff.
