### PR TITLE
Update Diskmaker X to  v5.0.3

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,11 +1,11 @@
 cask 'diskmaker-x' do
-  version :latest
-  sha256 :no_check
+  version '5.0.3'
+  sha256 '040a21bdef0c2682c518a9e9572f7547b5f1fb02b8930a8a084ae85b12e70518'
 
-  url 'http://diskmakerx.com/downloads/DiskMaker_X.dmg'
+  url "http://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   name 'DiskMaker X'
   homepage 'http://diskmakerx.com/'
   license :gratis
 
-  app 'DiskMaker X 5.app'
+  app "DiskMaker X #{version.to_i}.app"
 end


### PR DESCRIPTION
Turns Diskmaker X back into a versioned cask. The author of Diskmaker reached out to us and has re-uploaded the versioned downloads for us to use. Thanks @diskmakerx!
For more information about this commit please check the discussion related to the versioning of Diskmaker in this pull request: https://github.com/caskroom/homebrew-cask/pull/17519
