### PR TITLE
Update vectr to account for .zip structure change

### DIFF
--- a/Casks/vectr.rb
+++ b/Casks/vectr.rb
@@ -7,5 +7,5 @@ cask 'vectr' do
   homepage 'https://vectr.com'
   license :gratis
 
-  app 'Vectr.app'
+  app "vectr-mac-#{version}/Vectr.app"
 end


### PR DESCRIPTION
Vectr currently fails to install due to the zip now including the Vectr.app in a subdirectory, while this corrects the issue
