### PR TITLE
Fix App Stanza target in Sassquatch Cask

### DIFF
--- a/Casks/sassquatch.rb
+++ b/Casks/sassquatch.rb
@@ -7,5 +7,5 @@ cask 'sassquatch' do
   homepage 'http://sassquatch.thoughtbot.com'
   license :commercial
 
-  app 'Sassquatch.app'
+  app 'Sassquatch/Sassquatch.app', :target => 'Sassquatch.app'
 end


### PR DESCRIPTION
This fixes the following error, which I was seeing when trying to install Sassquatch:

``` bash
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/sassquatch/1.5.0/Sassquatch.app'
```
