### PR TITLE
Upgrade iTunes Volume Control.app to 1.5.1

### DIFF
--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -1,13 +1,14 @@
 cask 'itunes-volume-control' do
-  version '1.4.10'
-  sha256 '2217581e374c53853dfa5dac805214233f37b016ebed313edbb8499d2ff9f70f'
+  version '1.5.1'
+  sha256 '4af853571590f30457b015c2998881d0436643579eb2a67f6e6b3aa30731c200'
 
-  url 'https://github.com/alberti42/iTunes-Volume-Control/raw/master/iTunes%20Volume%20Control.dmg'
-  appcast 'https://github.com/alberti42/iTunes-Volume-Control/releases.atom',
-          checkpoint: '16c4f984043ff2321f6be00f0d7b06a5ce87a014747aedcdd5074d9e18e2b56a'
+  # uni-bonn.de/alberti/iTunesVolumeControl was verified as official when first introduced to the cask
+  url "http://quantum-technologies.iap.uni-bonn.de/alberti/iTunesVolumeControl/iTunesVolumeControl-v#{version}.zip"
   name 'iTunes Volume Control'
   homepage 'https://github.com/alberti42/iTunes-Volume-Control'
   license :oss
+
+  auto_updates true
 
   app 'iTunes Volume Control.app'
 end


### PR DESCRIPTION
the author also keeps a link to "latest" in the readme if that's preferable
otherwise latest versions are only hosted on authors personal site
version downloads are listed in the README.md
the app has a "check for latest" feature, and I confirmed that it thinks 1.5.1 is the latest. (even though a 1.5.2 is listed in the readme, it's not present)
