### PR TITLE
updated retroshare (0.6.0,20160206-7ded128b)

### DIFF
--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -1,16 +1,14 @@
 cask 'retroshare' do
-  version '0.6.0-RC2'
-  sha256 '94d339613f61df4a1d74fd9e7e13ca40c4773af35ffd3ab721723d58a818dfdd'
+  version '0.6.0,20160206-7ded128b'
+  sha256 '132f7bbe3f1be47a0f544a4829f3f2bff4dbe0281cddaeb01af0db7ecbd6fc77'
 
   # github.com is the official download host per the vendor homepage
-  url "https://github.com/RetroShare/RetroShare/releases/download/v#{version}/RetroShare06-RC2.dmg.zip"
+  url "https://github.com/RetroShare/RetroShare/releases/download/v#{version.before_comma}/Retroshare-#{version.before_comma}-OSX-#{version.after_comma}.dmg"
   appcast 'https://github.com/RetroShare/RetroShare/releases.atom',
-          checkpoint: '5f384599700537c1a12640de62635bae9c8b384d29c36ccb5ac9acd84a099e38'
+          checkpoint: '5096dde24860ff369e466ff1818b643a8ded3ca5923165d2ea395d9c925b1b5d'
   name 'RetroShare'
   homepage 'http://retroshare.sourceforge.net/'
   license :gpl
-
-  container nested: 'RetroShare06-RC2.dmg'
 
   app 'Retroshare.app'
 end


### PR DESCRIPTION
Closes #18368.
