### PR TITLE
Fix download URL in zulu.rb

### DIFF
--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -2,7 +2,7 @@ cask 'zulu' do
   version '1.8.0_72,8.13.0.5'
   sha256 '1e6ab8b4660ad50248d5e1c9568566bb2d6206788d4ff913d6539b47520da0ac'
 
-  url "http://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.minor}.#{version.patch.underscores_to_dots}-macosx_x64.dmg",
+  url "http://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.minor}.#{version.patch}.#{version.before_comma.sub(%r{.*_}, '')}-macosx_x64.dmg",
       referer: 'http://www.azul.com/downloads/zulu/zulu-mac/'
   name 'Azul Zulu Java Standard Edition Development Kit'
   homepage 'http://www.azul.com/downloads/zulu/zulu-mac/'


### PR DESCRIPTION
Fixes https://github.com/caskroom/homebrew-cask/issues/18456.

Should be a better way, like having a version methods `before_underscore` and `after_underscore`.
