### PR TITLE
Upgrade consul-template to v0.12.2

### DIFF
--- a/Casks/consul-template.rb
+++ b/Casks/consul-template.rb
@@ -1,6 +1,6 @@
 cask 'consul-template' do
-  version '0.11.1'
-  sha256 '6915e16969533ef27964199ff4194155cfa6deb43d1a863287d02c0c1b3067ff'
+  version '0.12.2'
+  sha256 'a9ab8e16cb02729153ec72a53f9f9f73efa0259521200467482fb34bd3e893b1'
 
   # hashicorp.com is the official download host per the vendor homepage
   url "https://releases.hashicorp.com/consul-template/#{version}/consul-template_#{version}_darwin_amd64.zip"
@@ -8,5 +8,5 @@ cask 'consul-template' do
   homepage 'https://github.com/hashicorp/consul-template'
   license :mpl
 
-  binary "consul-template_#{version}_darwin_amd64/consul-template"
+  binary 'consul-template'
 end


### PR DESCRIPTION
Changing the binary target because the zip does not expand into a subdirectory. This is consistent with other Hashicorp tools in the caskroom.
