### PR TITLE
Add suppress_move_to_applications to PhoneExpander

### DIFF
--- a/Casks/phoneexpander.rb
+++ b/Casks/phoneexpander.rb
@@ -12,4 +12,8 @@ cask 'phoneexpander' do
   auto_updates true
 
   app 'PhoneExpander.app'
+
+  postflight do
+    suppress_move_to_applications
+  end
 end


### PR DESCRIPTION
I missed adding this directive when I submitted the original cask
