### PR TITLE
Update Tangerine! to 1.4.3

### DIFF
--- a/Casks/tangerine.rb
+++ b/Casks/tangerine.rb
@@ -1,8 +1,8 @@
 cask 'tangerine' do
-  version '1.4.8'
-  sha256 'dea00674331b1aa663cf00f64b0ce208638a136575987e1a7f50bd135117f2d9'
+  version '1.4.3'
+  sha256 '67f03f203eef2efdce782d1ee249ac14bf276dcd3219287f218dc2d3ceaa73df'
 
-  url 'http://distrib.karelia.com/downloads/Tangerine!-4008.zip'
+  url 'http://distrib.karelia.com/downloads/Tangerine!-4010.zip'
   appcast 'https://launch.karelia.com/appcast.php?version=0&product=13&appname=Tangerine!',
           checkpoint: '074d108b7f07806dd2a3d9d86b5dbf7c4d0a362c6937f8a29c453829c9a212bb'
   name 'Tangerine!'


### PR DESCRIPTION
I don't know why 1.4.8 was listed as the prior version.  The version that was being downloaded (build 4008) was actually 1.4.2.  The current version (build number 4010) is version 1.4.3.
