### PR TITLE
upgrade sketch to version 3.5.2

### DIFF
--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -1,6 +1,6 @@
 cask 'sketch' do
-  version '3.5.1'
-  sha256 'f5ee1e689c941bf480fcc7a462347ca45d9ec94dde8395e79a879e12882f643e'
+  version '3.5.2'
+  sha256 'fac9182c50a96cbc144bddb3984c82195980d6a4dc92fa3c2e40a59574f40a81'
 
   url 'http://www.sketchapp.com/static/download/sketch.zip'
   appcast "http://www.sketchapp.com/appcast#{version.major}.xml",

--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -4,7 +4,7 @@ cask 'sketch' do
 
   url 'http://www.sketchapp.com/static/download/sketch.zip'
   appcast "http://www.sketchapp.com/appcast#{version.major}.xml",
-          checkpoint: 'e4686b564a5645a0405f999055cb4f43efd328e5c9703e968b5596e9508a38bd'
+          checkpoint: 'c9f08a2d76447a3f3fac479f053fb2612441c214454f151b85c460b9f726390d'
   name 'Sketch'
   homepage 'http://www.sketchapp.com/'
   license :commercial


### PR DESCRIPTION
Upgrades sketch from 3.5.1 to 3.5.2, see http://www.sketchapp.com/whats-new/:

**Bug Fix**
- Fixes a vulnerability in the updater by now delivering all updates over https
