### PR TITLE
Updated to libreoffice 5.1.0

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -5,8 +5,8 @@ cask 'libreoffice' do
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
   else
-    version '5.0.4'
-    sha256 '36d3a99dde9fd5bb845f93a24c091a36c97ff1adedf878ed2188704f3dfeb2ae'
+    version '5.1.0'
+    sha256 '2455e5dead1caffa3120b2604c57e3e532405bfab4069da6141029f07d6e4e58'
     # documentfoundation.org is the official download host per the vendor homepage
     url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   end


### PR DESCRIPTION
http://download.documentfoundation.org/libreoffice/stable/5.1.0/mac/x86_64/LibreOffice_5.1.0_MacOS_x86-64_sdk.dmg.mirrorlist
