### PR TITLE
UniFi Controller - Upgrading to 4.8.12

### DIFF
--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'unifi-controller' do
-  version '4.7.6'
-  sha256 'e8aa26d00e93e653146f706b7ce25fc18eff532e99f123025109fddaf043e81e'
+  version '4.8.12'
+  sha256 '88b596331761ac373a3bdb7a3442e8c665dfa3f2748e80f0bcd89c4bfa8fd88d'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'


### PR DESCRIPTION
Release notes:
http://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-4-8-12-is-released/ba-p/1468911
