### PR TITLE
Update to docker v 1.10.1

### DIFF
--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -1,6 +1,6 @@
 cask 'dockertoolbox' do
-  version '1.10.0'
-  sha256 '2ea55003578a180405eba37fc8020016a8585c3e9146a05ce0ef4af8656df181'
+  version '1.10.1'
+  sha256 'bc9f81273bf4bd699d832a434269994dea84da3d2cc67144736bbc3a71e6b7d5'
 
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',

--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -4,7 +4,7 @@ cask 'dockertoolbox' do
 
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: 'ee50da3b17a6d4097f03b74c21b6142f853f08f2a11e12f3f8e0f1ac738b3e55'
+          checkpoint: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/toolbox'
   license :apache


### PR DESCRIPTION
Update Cask to Docker version 1.10.1

Docker Update: https://github.com/docker/docker/releases

_Note_: I wasn't sure how to get the appoint checkpoint, so if someone can offer some guidance, that'd be appreciated.
