### PR TITLE
mcbopomofo.rb: change zap to uninstall

### DIFF
--- a/Casks/mcbopomofo.rb
+++ b/Casks/mcbopomofo.rb
@@ -9,5 +9,5 @@ cask 'mcbopomofo' do
 
   installer manual: 'McBopomofoInstaller.app'
 
-  zap delete: '~/Library/Input Methods/McBopomofo.app'
+  uninstall delete: '~/Library/Input Methods/McBopomofo.app'
 end


### PR DESCRIPTION
Per the website, this seems to be the way to uninstall.
