### PR TITLE
updated flash (20.0.0.306)

### DIFF
--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -1,14 +1,16 @@
 cask 'flash' do
   version '20.0.0.306'
-  sha256 'e189a644a15cda617181e0ff2925488ef215ac2d74feb00800688f25bf77e7be'
+  sha256 'f95046ed8511401a50dfe5aadfc595769afdbed2c4db3aeb8ff7eabdc9c01452'
 
   # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.macromedia.com/get/flashplayer/current/licensing/mac/install_flash_player_#{version.to_i}_osx_pkg.dmg"
+  url "http://fpdownload.macromedia.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
+  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
+          checkpoint: '9c7d9c10851469f828383e7731544889632f3d106ade3fc2d1771d43f9af21c7'
   name 'Adobe Flash Player'
-  homepage 'https://www.adobe.com/products/flashplayer/distribution3.html'
+  homepage 'https://get.adobe.com/flashplayer'
   license :gratis
 
-  pkg 'Install Adobe Flash Player.pkg'
+  pkg 'Install Adobe Flash Player.app/Contents/Resources/Adobe Flash Player.pkg'
 
   uninstall pkgutil: 'com.adobe.pkg.FlashPlayer',
             delete:  '/Library/Internet Plug-Ins/Flash Player.plugin'


### PR DESCRIPTION
@vitorgalvao Played around with the `autopkg` recipies and got this.
Works for me and seems to do the same thing as the old installer.

@andyli Maybe a derivative of this could help with `flash-player` for you also? At least, the appcast should be OK to reuse, assuming the two get updated at the same time.
