### PR TITLE
blender: add shim script for CLI use

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -9,4 +9,17 @@ cask 'blender' do
 
   app "blender-#{version}-OSX_10.6-x86_64/blender.app"
   app "blender-#{version}-OSX_10.6-x86_64/blenderplayer.app"
+  # shim script
+  shimscript = "#{staged_path}/blenderwrapper"
+  binary shimscript, target: 'blender'
+
+  preflight do
+    pythonversion = '3.4'
+    File.open(shimscript, 'w') do |f|
+      f.puts '#!/bin/bash'
+      f.puts "export PYTHONHOME=#{staged_path}/blender-#{version}-OSX_10.6-x86_64/blender.app/Contents/Resources/#{version}/python/lib/python#{pythonversion}"
+      f.puts "#{staged_path}/blender-#{version}-OSX_10.6-x86_64/blender.app/Contents/MacOS/blender $@"
+      FileUtils.chmod '+x', f
+    end
+  end
 end


### PR DESCRIPTION
- allows blender installed with cask to be used in external toolchains
- simply adding `binary 'blender-#{version}-OSX_10.6-x86_64/blender.app/Contents/MacOS/blender'` is insufficient, since blender needs a custom `PYTHONPATH` pointing to its bundled python library
- wrapper shim script is generated during `preflight`, then linked with `binary`
