### PR TITLE
Updated carbon-copy-cloner (4.1.7.4285)

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,10 +1,8 @@
 cask 'carbon-copy-cloner' do
-  version '3.4.7'
-  sha256 '4ea19d1c9111fb67b0f7567844a413794bd2d3b6a908a8921cabd10f21101247'
+  version '4.1.7.4285'
+  sha256 'ca8a081d35606c899745bb40a64a461e14a00de7dd6e3bb48da3a3c05f265de8'
 
-  url "http://www.bombich.com/software/download_ccc_update.php?v=#{version}"
-  appcast 'https://bombich.com/software/updates/ccc.php',
-          checkpoint: 'eec027f0d0aa576e292b4fe57441f1821409c6295330787dd82533b0d483cb26'
+  url 'http://bombich.com/software/download_ccc.php?v=latest'
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
   license :commercial

--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.7.4285'
-  sha256 'ca8a081d35606c899745bb40a64a461e14a00de7dd6e3bb48da3a3c05f265de8'
+  version :latest
+  sha256 :no_check
 
   url 'http://bombich.com/software/download_ccc.php?v=latest'
   name 'Carbon Copy Cloner'


### PR DESCRIPTION
The previous appcast only had an entry for version 3. I tried to determine what the new version 4 appcast url should be, but since it's https I wasn't able to sniff it.
