### PR TITLE
switch mactex (20150613) back to versioned download

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,8 +1,10 @@
 cask 'mactex' do
-  version :latest
-  sha256 :no_check
+  version '20150613'
+  sha256 'c5f5b0fd853a17dab6e844fb5e893804af78d938fa18ee94ec3b257611a95c12'
 
   url 'http://tug.org/cgi-bin/mactex-download/MacTeX.pkg'
+  appcast 'http://www.tug.org/mactex/downloading.html#checksum',
+      checkpoint: 'ef3bd331dbea7053d322e153a6a2c2db98ab93f70e0689e9eef5cf57220606ce'
   name 'MacTeX'
   homepage 'https://www.tug.org/mactex/'
   license :oss


### PR DESCRIPTION
Found a suitable HTML page for an appcast (Not that the package changes very often, releases are once a year)
