### PR TITLE
updated jabref (3.2)

### DIFF
--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -1,11 +1,22 @@
 cask 'jabref' do
-  version '2.10'
-  sha256 'c63a49e47a43bdb026dde7fb695210d9a3f8c0e71445af7d6736c5379b23baa2'
+  version '3.2'
+  sha256 'ddde9938c3d5092ffe2ba2ecd127439de4ae304d783b5e33056951f449a185b5'
 
-  url "http://downloads.sourceforge.net/project/jabref/jabref/#{version}/JabRef-#{version}-OSX.zip"
+  url "http://downloads.sourceforge.net/project/jabref/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   name 'JabRef'
-  homepage 'http://jabref.sourceforge.net/'
+  homepage 'http://www.jabref.org/'
   license :gpl
 
-  app 'JabRef.app'
+  installer script: 'JabRef Installer.app/Contents/MacOS/JavaApplicationStub',
+            args:   [
+                      '-q',
+                      '-VcreateDesktopLinkAction$Boolean=false',
+                      '-VaddToDockAction$Boolean=false',
+                      '-VshowFileAction$Boolean=false',
+                      '-Vsys.installationDir=/Applications',
+                      '-VexecutionLauncherAction$Boolean=false',
+                    ],
+            sudo:   false
+
+  uninstall delete: '/Applications/JabRef.app'
 end


### PR DESCRIPTION
Upgraded JabRef to version (3.2).
JabRef has been using install4j as installer since version (3.x), this formula updates the new url and bypass the install4j with quiet mode.
