### PR TITLE
Bump Ricochet to 1.1.2

### DIFF
--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -1,6 +1,6 @@
 cask 'ricochet' do
-  version '1.1.1'
-  sha256 'e621fe34692ff6f10f3db863146903547e333d3373b4a62c468b58504576290b'
+  version '1.1.2'
+  sha256 '2680912308fb2b511c379e2dc7706a850aa9fb9aa3f13ea107cc125a81be81c4'
 
   url "https://ricochet.im/releases/#{version}/Ricochet-#{version}.dmg"
   name 'Ricochet'


### PR DESCRIPTION
[Release Notes](https://github.com/ricochet-im/ricochet/releases/tag/v1.1.2)
