### PR TITLE
Updated cask for Charles proxy

### DIFF
--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -1,6 +1,6 @@
 cask 'charles' do
   version '3.11.3'
-  sha256 'db0a7d9c318ed239bc3d32a96f73ebba80e75cd31954179be42019222ae6557d'
+  sha256 '7ba8801a99ac4ab4ceda60106c381fbf206f4e94b45fe927341fa52a9e6246f5'
 
   url "https://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
   name 'Charles'

--- a/Casks/charles.rb
+++ b/Casks/charles.rb
@@ -1,5 +1,5 @@
 cask 'charles' do
-  version '3.11.2'
+  version '3.11.3'
   sha256 'db0a7d9c318ed239bc3d32a96f73ebba80e75cd31954179be42019222ae6557d'
 
   url "https://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"


### PR DESCRIPTION
Version 3.11.3 is available.
