### PR TITLE
Update DCSS Tiles to 0.17.1-1

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,8 +1,8 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.16.2'
-  sha256 '610b6c876c4704a343e066f5a9a1704c491fe25820707c7af66ebf3e6728ab61'
+  version '0.17.1-1'
+  sha256 'ef6eb0e5a9fb3ab9a08f50a264eb10c0ab29ff7a114eeea5a841d4448ff1475c'
 
-  url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macos.zip"
+  url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org'
   license :gpl


### PR DESCRIPTION
Version bump, URL changed slightly.

Tested manually on my machine. Download works, execution succeeds.
