### PR TITLE
Allow tokens passed to `brew cask style` to end with `.rb`

### DIFF
--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -121,6 +121,7 @@ module Hbc::Locations
     end
 
     def path(query)
+      query = query.sub(/\.rb$/i, '')
       if query.include?('/')
         token_with_tap = query
       else


### PR DESCRIPTION
Allow tokens passed to `brew cask style` to end with `.rb`

Fixes #19072.
