### PR TITLE
Add Abricotine - a markdown editor for desktop

### DIFF
--- a/Casks/abricotine.rb
+++ b/Casks/abricotine.rb
@@ -1,0 +1,11 @@
+cask 'abricotine' do
+  version '0.2.3'
+  sha256 '2a540ff77f1076660805ca3fde507f0095ae6a1ce83aade3e9f07613259a21f7'
+
+  url 'https://github.com/brrd/Abricotine/releases/download/0.2.2/Abricotine-osx-x64.zip'
+  name 'abricotine'
+  homepage 'http://abricotine.brrd.fr'
+  license :gpl
+
+  app 'Abricotine.app'
+end


### PR DESCRIPTION
In **Abricotine**, you can preview your document directly in the text editor rather than in a side pane.

![Another screenshot](http://i.imgur.com/ZDHgo9i.jpg)
- Write in markdown (or GFM) and export your documents in HTML,
- Preview text elements (such as headers, images, math, embedded videos, todo lists...) while you type,
- Display document table of content in the side pane,
- Display syntax highlighting for supported languages (HTML, XML, CSS, Javascript, and more to come...),
- Show helpers, anchors and hidden characters,
- Copy formated HTML in the clipboard,
- Write in a distraction-free fullscreen view,
- Manage and beautify markdown tables,
- Search and replace text,
- And more features to come...
