### PR TITLE
Update BZFlag to latest version

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -1,9 +1,8 @@
 cask 'bzflag' do
-  version '2.4.2'
-  sha256 '4ce7f007cb7c78a5243ced84d310c37637a2aa8fe9569231edd2dbc45286e293'
+  version '2.4.4'
+  sha256 'c832896a65cd3a0bdca62fce8a0fff800c15970dfde75e9f8285e49a01dafc77'
 
-  # sourceforge.net/sourceforge/bzflag was verified as official when first introduced to the cask
-  url "http://downloads.sourceforge.net/sourceforge/bzflag/BZFlag-#{version}.zip"
+  url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-MacOSX.zip"
   name 'BZFlag'
   homepage 'http://bzflag.org/'
   license :gpl


### PR DESCRIPTION
We have moved away from SourceForge and on to [GitHub](https://github.com/BZFlag-Dev/bzflag) but our binaries are [self-hosted](http://bzflag.org/downloads).
