### PR TITLE
update Slack to 2.0.0

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -1,6 +1,6 @@
 cask 'slack' do
-  version '1.1.10'
-  sha256 '201aaf4134e842fe61efc740027140776c331ba13284bac9f1d01f887da75220'
+  version '2.0.0'
+  sha256 'd142f6ed26252c40ca56218aa95675be94788aea1516088a687ad535539dc3e0'
 
   # fastly.net is the official download host per the vendor homepage
   url "https://slack-ssb-updates.global.ssl.fastly.net/mac_public_releases/slack-#{version}.zip"


### PR DESCRIPTION
updated to 2.0.0

I may have gotten the `appcast` wrong. The url is ok, but should I update the `checkpoint`, and if so, how?
- I read https://github.com/caskroom/homebrew-cask/issues/19103
- I examined the packets (tcpdump) while "Checking for updates" in v2.0.0, and I could not find a reference to checkpoint
- I did the same with the page https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1

If I got it wrong, I'm looking for guidance here.

Anyway, Slack 2.0.0 installs well as such.

Cheers
