### PR TITLE
Install Additional Emacs Utility Binaries

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -8,4 +8,9 @@ cask 'emacs' do
   license :oss
 
   app 'Emacs.app'
+  binary 'Emacs.app/Contents/MacOS/bin/emacsclient', target: 'emacsclient'
+  binary 'Emacs.app/Contents/MacOS/bin/ctags', target: 'ctags'
+  binary 'Emacs.app/Contents/MacOS/bin/grep-changelog', target: 'grep-changelog'
+  binary 'Emacs.app/Contents/MacOS/bin/ebrowse', target: 'ebrowse'
+  binary 'Emacs.app/Contents/MacOS/bin/etags', target: 'etags'
 end

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -8,9 +8,9 @@ cask 'emacs' do
   license :oss
 
   app 'Emacs.app'
-  binary 'Emacs.app/Contents/MacOS/bin/emacsclient', target: 'emacsclient'
-  binary 'Emacs.app/Contents/MacOS/bin/ctags', target: 'ctags'
-  binary 'Emacs.app/Contents/MacOS/bin/grep-changelog', target: 'grep-changelog'
-  binary 'Emacs.app/Contents/MacOS/bin/ebrowse', target: 'ebrowse'
-  binary 'Emacs.app/Contents/MacOS/bin/etags', target: 'etags'
+  binary 'Emacs.app/Contents/MacOS/bin/emacsclient'
+  binary 'Emacs.app/Contents/MacOS/bin/ctags'
+  binary 'Emacs.app/Contents/MacOS/bin/grep-changelog'
+  binary 'Emacs.app/Contents/MacOS/bin/ebrowse'
+  binary 'Emacs.app/Contents/MacOS/bin/etags'
 end


### PR DESCRIPTION
When installing Emacs, it's nice to also be able to use `emacsclient` etc too. Now cask knows about them, these utilities get installed in the right place.

There may be other things we should be symlinking that get installed, but I don't know what they are. 
