### PR TITLE
Update Brave (0.7.16dev)

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,13 +1,13 @@
 cask 'brave' do
-  version '0.7.15dev'
-  sha256 '55c938c8021d151ad62ba2951e04fca45ac6d756ecd1a5fcbc936bcf790bdeac'
+  version '0.7.16dev'
+  sha256 '76c401072c769ea11d8e3673d9089a92bb743f7f8bf432927463f9c46b28d366'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '8bcbb3060182bab81e4a0af40d49b1c6a6810bae024c31ff2521b955e3bce21c'
+          checkpoint: 'ca072eb03b037e4d5308e0a400c0188ffdb4ae8da4ab44f692a0779edcaf6dbe'
   name 'Brave'
-  homepage 'http://brave.com'
+  homepage 'https://brave.com'
   license :mpl
 
   app 'Brave.app'


### PR DESCRIPTION
Following https://github.com/brave/browser-laptop/releases/tag/v0.7.16dev
