### PR TITLE
Cannot install minecraft through homebrew-cask

### DIFF
--- a/Casks/minecraft.rb
+++ b/Casks/minecraft.rb
@@ -3,7 +3,7 @@ cask 'minecraft' do
   sha256 :no_check
 
   # mojang.com was verified as official when first introduced to the cask
-  url 'https://launcher.mojang.com/download/Minecraft.dmgg'
+  url 'https://launcher.mojang.com/download/Minecraft.dmg'
   name 'Minecraft'
   homepage 'https://minecraft.net/'
   license :commercial


### PR DESCRIPTION
Though I've just tried to install the minecraft, I couldn't install it.
The file path to minecraft.dmg would be wrong, isn't it?
Please fixing this bug..
