### PR TITLE
Add qlcolorcode-extra

### DIFF
--- a/Casks/qlcolorcode-extra.rb
+++ b/Casks/qlcolorcode-extra.rb
@@ -2,7 +2,7 @@ cask 'qlcolorcode-extra' do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/BrianGilbert/QLColorCode-extra/archive/master.zip"
+  url 'https://github.com/BrianGilbert/QLColorCode-extra/archive/master.zip'
   name 'QLColorCode-extra'
   homepage 'https://github.com/BrianGilbert/QLColorCode-extra/'
   license :oss

--- a/Casks/qlcolorcode-extra.rb
+++ b/Casks/qlcolorcode-extra.rb
@@ -1,6 +1,6 @@
 cask 'qlcolorcode-extra' do
   version :latest
-  sha256 "387db591a94ad8e1ff438b93aeae3433b0ac850e969b27a1d74cbcb4f7004b6a"
+  sha256 :no_check
 
   url "https://github.com/BrianGilbert/QLColorCode-extra/archive/master.zip"
   name 'QLColorCode-extra'

--- a/Casks/qlcolorcode-extra.rb
+++ b/Casks/qlcolorcode-extra.rb
@@ -1,0 +1,20 @@
+cask 'qlcolorcode-extra' do
+  version :latest
+  sha256 "387db591a94ad8e1ff438b93aeae3433b0ac850e969b27a1d74cbcb4f7004b6a"
+
+  url "https://github.com/BrianGilbert/QLColorCode-extra/archive/master.zip"
+  name 'QLColorCode-extra'
+  homepage 'https://github.com/BrianGilbert/QLColorCode-extra/'
+  license :oss
+
+  depends_on formula: 'highlight'
+
+  qlplugin 'QLColorCode-extra-master/QLColorCode.qlgenerator'
+
+  postflight do
+    # This sets the path to the highlight binary to the preferred one found in $PATH.
+    system 'defaults write org.n8gray.QLColorCode pathHL "$(which highlight)"'
+  end
+
+  zap trash: '~/Library/Preferences/org.n8gray.QLColorCode.plist'
+end

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -9,6 +9,8 @@ cask 'sizeup' do
   homepage 'https://www.irradiatedsoftware.com/sizeup/'
   license :commercial
 
+  accessibility_access true
+
   app 'SizeUp.app'
 
   zap delete: [

--- a/Casks/slate.rb
+++ b/Casks/slate.rb
@@ -10,6 +10,8 @@ cask 'slate' do
   homepage 'https://github.com/jigish/slate'
   license :gpl
 
+  accessibility_access true
+
   app 'Slate.app'
 
   zap delete: [

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -15,6 +15,8 @@ cask 'spectacle' do
   name 'Spectacle'
   homepage 'https://spectacleapp.com/'
   license :mit
+  
+  accessibility_access true
 
   app 'Spectacle.app'
 

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -15,7 +15,7 @@ cask 'spectacle' do
   name 'Spectacle'
   homepage 'https://spectacleapp.com/'
   license :mit
-  
+
   accessibility_access true
 
   app 'Spectacle.app'


### PR DESCRIPTION
qlcolorcode-extra has added support for the following filetypes: cons, hail, install, inc, make, module, less, profile, rake, sass, scss, Clojure (both .clj and .clojure extensions), coffeescript (.coffee), stylus (.stylus), handlebars (.hbs)

https://github.com/BrianGilbert/QLColorCode-extra
