### PR TITLE
Add Basecamp 3.app v1.0.2

### DIFF
--- a/Casks/basecamp.rb
+++ b/Casks/basecamp.rb
@@ -1,0 +1,14 @@
+cask 'basecamp' do
+  version :latest
+  sha256 :no_check
+
+  # bc3-desktop.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://bc3-desktop.s3.amazonaws.com/mac/basecamp3.dmg'
+  name 'Basecamp 3'
+  homepage 'https://basecamp.com/help/3/guides/apps/mac'
+  license :gratis
+
+  auto_updates true
+
+  app 'Basecamp 3.app'
+end


### PR DESCRIPTION
Just released in the last 24 hours. No known versioned download URL.
