### PR TITLE
Add TonePrint.app v3.1

### DIFF
--- a/Casks/toneprint.rb
+++ b/Casks/toneprint.rb
@@ -1,0 +1,11 @@
+cask 'toneprint' do
+  version '3.1'
+  sha256 :no_check
+
+  url 'http://cdn-downloads.tcelectronic.com/media/5607727/toneprint-3100-r1373.dmg'
+  name 'TonePrint Editor'
+  homepage 'http://www.tcelectronic.com/toneprint-editor/support/'
+  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  app 'TonePrint.app'
+end


### PR DESCRIPTION
TonePrint Editor by TC Electronics is an editor effect settings for
their line of TonePrint guitar pedals. Surely there is enough of an
overlap between developers and guitar players that this command has been
tried before, but no one has created a cask. More fun for me!
