### PR TITLE
Geneious 9 only needs legacy Java on older systems

### DIFF
--- a/Casks/geneious.rb
+++ b/Casks/geneious.rb
@@ -1,15 +1,22 @@
 cask 'geneious' do
   version '9.1.2'
-  sha256 '304afaac8251594d03379737e8263f45297da822b63b306d056057a950255ff2'
+  if MacOS.release <= '10.6'
+    sha256 '304afaac8251594d03379737e8263f45297da822b63b306d056057a950255ff2'
 
-  url "http://assets.geneious.com/installers/geneious/release/Geneious_mac64_#{version.dots_to_underscores}.dmg"
+    url "http://assets.geneious.com/installers/geneious/release/Geneious_mac64_#{version.dots_to_underscores}.dmg"
+
+    caveats do
+      depends_on_java('6')
+    end
+  else
+    sha256 '1e7da712b396e34c0f87d36745d7f23c4ae4d4557926e42e11d6def623be18b3'
+
+    url "http://assets.geneious.com/installers/geneious/release/Geneious_mac64_#{version.dots_to_underscores}_with_jre.dmg"
+  end
+
   name 'Geneious'
   homepage 'http://www.geneious.com/'
   license :commercial
 
   app 'Geneious.app'
-
-  caveats do
-    depends_on_java('6')
-  end
 end


### PR DESCRIPTION
Per the release notes, starting in 9.0:
  Geneious no longer requires legacy Java 6 from Apple, Oracle Java 8 is
  now bundled. A distribution that uses legacy Java 6 is also available
  for older machines, however, this will be discontinued for R10.

http://assets.geneious.com/documentation/geneious/release_notes.html#v9.0
