### PR TITLE
Add CGoban.app, latest version

### DIFF
--- a/Casks/cgoban.rb
+++ b/Casks/cgoban.rb
@@ -1,0 +1,14 @@
+cask 'cgoban' do
+  version :latest
+  sha256 :no_check
+
+  # gokgs.com is the official download location of the DMG version of CGoban3
+  url "http://files.gokgs.com/javaBin/cgoban.dmg"
+  name 'CGoban'
+  homepage 'https://www.gokgs.com/download.jsp'
+  license :closed
+
+  app 'CGoban.app'
+  zap delete: '~/Library/Preferences/org.igoweb.cgoban.plist'
+
+end


### PR DESCRIPTION
This commit adds a Cask for CGoban, a Java application packged for OS X
for playing go/wéiqí/baduk on the KGS Go Server as well as editing SGF go game
records.
