### PR TITLE
Add Figure53 QLab

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,0 +1,11 @@
+cask 'qlab' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://figure53.com/downloads/QLab.zip'
+  name 'QLab'
+  homepage 'https://figure53.com/qlab/'
+  license :commercial
+
+  app 'QLab.app'
+end


### PR DESCRIPTION
Adds Figure53 [QLab](https://figure53.com/qlab/)

Unfortunately, Figure53 does not provide links to specific versions, but rather simply a _latest_ version.
