### PR TITLE
New SHA256 for MRO

### DIFF
--- a/Casks/mro.rb
+++ b/Casks/mro.rb
@@ -1,6 +1,6 @@
 cask 'mro' do
   version '3.2.3'
-  sha256 'c15ba6cd1f9fb910ef964e571c890c4a5db4f3d4c7850db5008802226c834ef0'
+  sha256 '86637ae5a19067a61c2a190e90ebd8b5fe1d895069975ca67cfee0fbadda50ef'
 
   url "https://mran.revolutionanalytics.com/install/mro/#{version}/MRO-#{version}-OSX.pkg"
   name 'Microsoft R Open'


### PR DESCRIPTION
Microsoft may have updated the package? I verified sha1 of package matches the one given here:

https://mran.revolutionanalytics.com/download/
