### PR TITLE
.travis.yml: remove 10.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
       os: osx
       osx_image: xcode7.1
       rvm: system
-    - env: OSX=10.9 HOMEBREW_RUBY=2.0.0
-      os: osx
-      osx_image: beta-xcode6.2
-      rvm: system
   fast_finish: true
 
 branches:


### PR DESCRIPTION
@jawshooah Any issue with removing this? It’s the one that most often fails, and for dumb reasons like not being able to get `bundler`.

We mention somewhere in the documentation we try to support the current OS X version and the previous one, so removing this would keep in line with that.
