### PR TITLE
Update Brave (0.8.0dev)

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.7.16dev'
-  sha256 '76c401072c769ea11d8e3673d9089a92bb743f7f8bf432927463f9c46b28d366'
+  version '0.8.0dev'
+  sha256 '20ed387ee73d545c39fa74537f63ae7d887272ba7cefef50285b194769891f5b'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'ca072eb03b037e4d5308e0a400c0188ffdb4ae8da4ab44f692a0779edcaf6dbe'
+          checkpoint: 'a07fae2c3fcae772a2f783888603dc037f3bee933426dd54855e701f7ecee108'
   name 'Brave'
   homepage 'https://brave.com'
   license :mpl


### PR DESCRIPTION
Following https://github.com/brave/browser-laptop/releases/tag/v0.8.0dev
