### PR TITLE
Use https in transmission download url

### DIFF
--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -2,7 +2,7 @@ cask 'transmission' do
   version '2.91'
   sha256 '8d0c36540406022a47e9b9bc64190f9e852b2b6f45fe4c0d2853ac2c604b062b'
 
-  url "http://download.transmissionbt.com/files/Transmission-#{version}.dmg"
+  url "https://download.transmissionbt.com/files/Transmission-#{version}.dmg"
   appcast 'https://update.transmissionbt.com/appcast.xml',
           checkpoint: '30717111f950e563702a12fe28cfe37b35fc5a9648e13ccb84389d5615f372e1'
   name 'Transmission'


### PR DESCRIPTION
The previous version of transmission (2.90) [may contain malware](https://forum.transmissionbt.com/viewtopic.php?f=4&t=17834) if not downloaded from https. Using https may help prevent this problem in the future.

https://news.ycombinator.com/item?id=11234589
