### PR TITLE
Add Wiring 1.0

### DIFF
--- a/Casks/wiring.rb
+++ b/Casks/wiring.rb
@@ -1,0 +1,12 @@
+cask 'wiring' do
+  version '1.0-101'
+  sha256 'ff593ccfc8a1ef988b86f7610141c9bd0e5d3763b64e04f28257a374042830a8'
+
+  url 'http://wiring.org.co/download/wiring-0101-macosx.zip'
+  name 'Wiring'
+  homepage 'http://wiring.org.co/'
+  license :gpl 
+
+  app 'Wiring.app'
+end
+


### PR DESCRIPTION
After reading https://arduinohistory.github.io/ I noticed this needed to be added to cask.
