### PR TITLE
update qgis installer .pkg file name

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -10,7 +10,7 @@ cask 'qgis' do
   depends_on cask: 'gdal-framework'
   depends_on formula: 'matplotlib'
 
-  pkg 'Install QGIS.pkg'
+  pkg '4 Install QGIS.pkg'
 
   uninstall pkgutil: 'org.qgis.qgis-*'
 


### PR DESCRIPTION
With the recent QGIS version update from 2.12.1-1 to 2.14.0-1, the installer .pkg filename changed from "Install QGIS.pkg" to "4 Install QGIS.pkg".  Edited the qgis.rb to reflect the new installer name.  Tested and it installed correctly.
