### PR TITLE
Add Cevelop C++ IDE v1.4.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,0 +1,13 @@
+cask 'cevelop' do
+  version '1.4.0'
+  sha256 '9199a6e5978e608e51de95e165f13acfdec49d265fef4bf4df5b93973f6cf2ae'
+
+  url 'https://www.cevelop.com/cevelop/downloads/cevelop-1.4.0-201603071314-macosx.cocoa.x86_64.tar.gz'
+  name 'Cevelop'
+  homepage 'https://www.cevelop.com/'
+  license :gratis
+
+  depends_on arch: :x86_64
+
+  app 'Cevelop.app'
+end


### PR DESCRIPTION
Cevelop extends Eclipse CDT with many additional features: CUTE unit
testing with Test Driven Development support, new refactorings and
quick fixes, and much more. And it's free!

It is developed by the Institute for Software at the University of Applied
Sciences in Rapperswil, Switzerland (HSR) within the context of the
REPARA project, co-funded by the European Commission within the 
Seventh Framework Programme
