### PR TITLE
Fix chmod and lastpass uninstall

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -9,6 +9,8 @@ cask 'lastpass' do
 
   installer manual: 'LastPass Installer.app'
 
-  uninstall script: 'Uninstaller.app/Contents/Resources/uninstall.sh',
-            sudo:   true
+  uninstall script: {
+                      executable: 'Uninstaller.app/Contents/Resources/uninstall.sh',
+                      sudo:       true,
+                    }
 end

--- a/lib/hbc/artifact/installer.rb
+++ b/lib/hbc/artifact/installer.rb
@@ -30,7 +30,7 @@ class Hbc::Artifact::Installer < Hbc::Artifact::Base
         ohai "Running #{self.class.artifact_dsl_key} script #{executable}"
         raise Hbc::CaskInvalidError.new(@cask, "#{self.class.artifact_dsl_key} missing executable") if executable.nil?
         executable_path = @cask.staged_path.join(executable)
-        @command.run('/bin/chmod', :args => ['+x', executable_path]) if File.exists?(executable_path)
+        @command.run('/bin/chmod', :args => ['--', '+x', executable_path]) if File.exists?(executable_path)
         @command.run(executable_path, script_arguments)
       end
     end

--- a/lib/hbc/artifact/symlinked.rb
+++ b/lib/hbc/artifact/symlinked.rb
@@ -29,7 +29,7 @@ class Hbc::Artifact::Symlinked < Hbc::Artifact::Base
     altnames = %Q{(#{altnames})}
 
     # Some packges are shipped as u=rx (e.g. Bitcoin Core)
-    @command.run!('/bin/chmod', :args => ['u=rwx', source])
+    @command.run!('/bin/chmod', :args => ['--', 'u=rwx', source])
 
     @command.run!('/usr/bin/xattr',
                   :args => ['-w', attribute, altnames, target],

--- a/lib/hbc/artifact/uninstall_base.rb
+++ b/lib/hbc/artifact/uninstall_base.rb
@@ -332,7 +332,7 @@ class Hbc::Artifact::UninstallBase < Hbc::Artifact::Base
     ohai "Running uninstall script #{executable}"
     raise Hbc::CaskInvalidError.new(@cask, "#{stanza} :#{directive_name} without :executable.") if executable.nil?
     executable_path = @cask.staged_path.join(executable)
-    @command.run('/bin/chmod', :args => ['+x', '--', executable_path]) if File.exists?(executable_path)
+    @command.run('/bin/chmod', :args => ['--', '+x', executable_path]) if File.exists?(executable_path)
     @command.run(executable_path, script_arguments)
     sleep 1
   end

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -321,7 +321,7 @@ class Hbc::Installer
           #      slash.  This should do the right thing, but is fragile.
           @command.run!('/usr/bin/chflags', :args => ['-R', '--', '000',   path])
           @command.run!('/bin/chmod',       :args => ['-R', '--', 'u+rwx', path])
-          @command.run!('/bin/chmod',       :args => ['-R', '-N',          path])
+          @command.run!('/bin/chmod',       :args => ['-R', '-N', '--',    path])
           tried_permissions = true
           retry # rmtree
         end

--- a/lib/hbc/system_command.rb
+++ b/lib/hbc/system_command.rb
@@ -4,14 +4,16 @@ require 'shellwords'
 class Hbc::SystemCommand
   def self.run(executable, options={})
     command = _process_options(executable, options)
-    odebug "Executing: #{command.utf8_inspect}"
     processed_stdout = ''
     processed_stderr = ''
 
     command[0] = Shellwords.shellescape(command[0]) if command.size == 1
 
-    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr =
-      Open3.popen3(*command.map { |arg| arg.respond_to?(:to_path) ? File.absolute_path(arg) : String(arg) })
+    to_exec = command.map { |arg| arg.respond_to?(:to_path) ? File.absolute_path(arg) : String(arg) }
+
+    odebug "Executing: #{to_exec.utf8_inspect}"
+
+    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(*to_exec)
 
     if options[:input]
       Array(options[:input]).each { |line| raw_stdin.puts line }

--- a/test/cask/artifact/uninstall_test.rb
+++ b/test/cask/artifact/uninstall_test.rb
@@ -271,7 +271,7 @@ describe Hbc::Artifact::Uninstall do
       let(:script_pathname) { cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool') }
 
       it 'can uninstall' do
-        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod +x --] + [script_pathname])
+        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
           sudo(cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'))
@@ -285,7 +285,7 @@ describe Hbc::Artifact::Uninstall do
       let(:script_pathname) { cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool') }
 
       it 'can uninstall' do
-        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod +x --] + [script_pathname])
+        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
           sudo(cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'))

--- a/test/cask/artifact/zap_test.rb
+++ b/test/cask/artifact/zap_test.rb
@@ -273,7 +273,7 @@ describe Hbc::Artifact::Zap do
       let(:script_pathname) { cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool') }
 
       it 'can zap' do
-        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod +x --] + [script_pathname])
+        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
           sudo(cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'))
@@ -287,7 +287,7 @@ describe Hbc::Artifact::Zap do
       let(:script_pathname) { cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool') }
 
       it 'can zap' do
-        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod +x --] + [script_pathname])
+        Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
           sudo(cask.staged_path.join('MyFancyPkg','FancyUninstaller.tool'), '--please'))


### PR DESCRIPTION
I was getting errors uninstalling lastpass. I ran into three issues while diagnosing and fixing the cause:
- A problem with the formula for lastpass itself
- Confusing formatting of the commands being executed during uninstall
- Incorrect arguments being passed to `chmod`.

This pull request includes 3 independent commits addressing each of these issues. The `chmod` issue would seem to affect all formulas, and seems to be the cause of issue #17398.
