### PR TITLE
megasync.rb: update url and license

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -2,11 +2,10 @@ cask 'megasync' do
   version :latest
   sha256 :no_check
 
-  # mega.nz is the official download host per the vendor homepage
   url 'https://mega.nz/MEGAsyncSetup.dmg'
   name 'MEGAsync'
-  homepage 'https://mega.co.nz'
-  license :gratis
+  homepage 'https://mega.nz'
+  license :oss
 
   app 'MEGAsync.app'
 


### PR DESCRIPTION
The homepage url was updated because https://mega.co.nz redirects to https://mega.nz. The license was changed because the source code can be found [here](https://mega.nz/#sourcecode) and is under a custom license.
