### PR TITLE
Update ejector.rb

### DIFF
--- a/Casks/ejector.rb
+++ b/Casks/ejector.rb
@@ -1,6 +1,6 @@
 cask 'ejector' do
   version '0.8.1'
-  sha256 :c6fefa1788a1a67793456e9620e18b9613c19634b649ebf6578e9c082ff4946e
+  sha256 'c6fefa1788a1a67793456e9620e18b9613c19634b649ebf6578e9c082ff4946e'
 
   url "http://www.jeb.com.fr/soft/Ejector-v#{version}.dmg"
   name 'Ejector'

--- a/Casks/ejector.rb
+++ b/Casks/ejector.rb
@@ -1,6 +1,6 @@
 cask 'ejector' do
   version '0.8.1'
-  sha256 :no_check
+  sha256 :c6fefa1788a1a67793456e9620e18b9613c19634b649ebf6578e9c082ff4946e
 
   url "http://www.jeb.com.fr/soft/Ejector-v#{version}.dmg"
   name 'Ejector'

--- a/Casks/ejector.rb
+++ b/Casks/ejector.rb
@@ -1,6 +1,6 @@
 cask 'ejector' do
-  version '0.9.0'
-  sha256 '78e588ba2f9b02c753af7e4f432c0dc980d3745c3b8d3978b6b11e113e109f19'
+  version '0.8.1'
+  sha256 :no_check
 
   url "http://www.jeb.com.fr/soft/Ejector-v#{version}.dmg"
   name 'Ejector'


### PR DESCRIPTION
The current version number is 0.8.1.  The version number indicated (0.9.0) results in a non-functional link.
