### PR TITLE
Update iTerm2: depends_on macos and arch

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -11,6 +11,8 @@ cask 'iterm2' do
   license :gpl
 
   auto_updates true
+  depends_on macos: '>= :lion'
+  depends_on arch: :intel
 
   app 'iTerm.app'
 


### PR DESCRIPTION
Version 2.1.4 needs `depends_on` setting :)

>  iTerm2 2.1.4 (OS 10.7+, Intel-only)

https://www.iterm2.com/downloads.html
