### PR TITLE
Fix Autopano Pro pkg file name

### DIFF
--- a/Casks/autopano-pro.rb
+++ b/Casks/autopano-pro.rb
@@ -7,7 +7,7 @@ cask 'autopano-pro' do
   homepage 'http://www.kolor.com/panorama-software-autopano-pro.html'
   license :commercial
 
-  pkg "Autopano Pro #{version}.pkg"
+  pkg "Autopano Pro 4.2.pkg"
 
   uninstall pkgutil: [
                        'com.kolor.pkg.AutopanoPro.*',


### PR DESCRIPTION
Pkg name has only major revision name: 4.2, minor revision is not present.
Url does not contain version number as well.
As a result `version` is set to `:latest` and not `4.2` or `4.2.3`.

Without this change installation failed with pkg not found exception.
