### PR TITLE
Fix Autopano Pro pkg file name

### DIFF
--- a/Casks/autopano-pro.rb
+++ b/Casks/autopano-pro.rb
@@ -1,5 +1,5 @@
 cask 'autopano-pro' do
-  version :latest
+  version '4.2.3'
   sha256 :no_check
 
   url 'http://download.kolor.com/app/stable/macleopard'
@@ -7,7 +7,7 @@ cask 'autopano-pro' do
   homepage 'http://www.kolor.com/panorama-software-autopano-pro.html'
   license :commercial
 
-  pkg "Autopano Pro #{version}.pkg"
+  pkg "Autopano Pro #{version.major_minor}.pkg"
 
   uninstall pkgutil: [
                        'com.kolor.pkg.AutopanoPro.*',


### PR DESCRIPTION
Pkg name has only major revision name: 4.2, minor revision is not 
Url does not contain version number as well.

First try: #19826
