### PR TITLE
Fix Autopano Pro pkg file name

### DIFF
--- a/Casks/autopano-pro.rb
+++ b/Casks/autopano-pro.rb
@@ -1,13 +1,13 @@
 cask 'autopano-pro' do
-  version :latest
-  sha256 :no_check
+  version '4.2.3'
+  sha256 '07fb35d00fa7f8926e00ede0031ef1c56a6e0e89d1f3d7485b4fa00da765fb99'
 
   url 'http://download.kolor.com/app/stable/macleopard'
   name 'Autopano Pro'
   homepage 'http://www.kolor.com/panorama-software-autopano-pro.html'
   license :commercial
 
-  pkg "Autopano Pro #{version}.pkg"
+  pkg "Autopano Pro #{version.major_minor}.pkg"
 
   uninstall pkgutil: [
                        'com.kolor.pkg.AutopanoPro.*',


### PR DESCRIPTION
Pkg name has only major revision name: 4.2, minor revision is not present.
Url does not contain version number as well.
#19831 #19826
