### PR TITLE
Update GoCD Server and Agent to version 16.2.1-3027

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,8 +1,8 @@
 cask 'go-agent' do
-  version '15.1.0-1863'
-  sha256 '9777b5069326ef0a178b9c6df114c06d4bf881fb532881b15ba3966bbfbf56d7'
+  version '16.2.1-3027'
+  sha1 '22cf595a6bfdd980524c540dc205fe06e2ff1f47'
 
-  url "http://download.go.cd/gocd/go-agent-#{version}-osx.zip"
+  url "http://download.go.cd/binaries/osx/go-agent-#{version}-osx.zip"
   name 'Go Agent'
   homepage 'https://www.go.cd/'
   license :apache

--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,8 +1,8 @@
 cask 'go-server' do
-  version '15.1.0-1863'
-  sha256 '25e8aed4e85b8e20af955baa9fded7d48fe5dde9ef71e4542593775b3273eb32'
+  version '16.2.1-3027'
+  sha1 '04d485692e075d035bb2ff1b2f1d64b1d1675aee'
 
-  url "http://download.go.cd/gocd/go-server-#{version}-osx.zip"
+  url "http://download.go.cd/binaries/osx/go-server-#{version}-osx.zip"
   name 'Go Server'
   homepage 'https://www.go.cd/'
   license :apache


### PR DESCRIPTION
Hi guys

I tried using the cask-repair, but it seems that GoCD has updated the download path.
Can you check if my PR is ok?

Thanks
