### PR TITLE
chrome-devtools: app renamed to Chrome DevTools App

### DIFF
--- a/Casks/chrome-devtools.rb
+++ b/Casks/chrome-devtools.rb
@@ -9,5 +9,5 @@ cask 'chrome-devtools' do
   homepage 'https://github.com/auchenberg/chrome-devtools-app'
   license :mit
 
-  app 'Chrome DevTools.app'
+  app 'Chrome DevTools App.app'
 end


### PR DESCRIPTION
Token remains the same per the token reference.
