### PR TITLE
Change CotEditor's license to Apache 2

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -20,7 +20,7 @@ cask 'coteditor' do
           checkpoint: '1628004e59ec855cd21ba3a1164ade66c105eed940f839adefd23326ff17b719'
   name 'CotEditor'
   homepage 'https://coteditor.com/'
-  license :gpl
+  license :apache
 
   app 'CotEditor.app'
 end


### PR DESCRIPTION
The license was changed to the Apache license version 2 since 2015.
- cf. https://github.com/coteditor/CotEditor/blob/develop/LICENSE
- cf. https://github.com/coteditor/CotEditor/issues/405
