### PR TITLE
Update phpstorm to version 2016.1

### DIFF
--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -1,8 +1,8 @@
 cask 'phpstorm' do
-  version '10.0.3'
-  sha256 'bd7d28974ef5587524389659dd27516c1067c35aebeee040821c638a18439e52'
+  version '2016.1'
+  sha256 'b30a67f22cfd331eec5599b4ae5957e10fb9f75b45e48a7ffd638adf77b2810d'
 
-  url "https://download.jetbrains.com/webide/PhpStorm-#{version}-custom-jdk-bundled.dmg"
+  url "https://download.jetbrains.com/webide/PhpStorm-#{version}.dmg"
   name 'PhpStorm'
   homepage 'https://www.jetbrains.com/phpstorm/'
   license :commercial
@@ -10,11 +10,9 @@ cask 'phpstorm' do
   app 'PhpStorm.app'
 
   zap delete: [
-                "~/.WebIde#{version.major_minor.no_dots}",
-                "~/Library/Caches/WebIde#{version.major_minor.no_dots}",
-                "~/Library/Logs/WebIde#{version.major_minor.no_dots}",
-                "~/Library/Application Support/WebIde#{version.major_minor.no_dots}",
-                "~/Library/Preferences/WebIde#{version.major_minor.no_dots}",
-                '~/Library/Preferences/com.jetbrains.PhpStorm.plist',
+                "~/Library/Preferences/PhpStorm#{version}",
+                "~/Library/Caches/PhpStorm#{version}",
+                "~/Library/Logs/PhpStorm#{version}",
+                "~/Library/Application Support/PhpStorm#{version}",
               ]
 end


### PR DESCRIPTION
This updated the phpstorm cask for the current release 2016.1
- sha256sum and download URL updated
- list of directories and files has been updated
