### PR TITLE
epic-games-launcher 2.11

### DIFF
--- a/Casks/epic-games-launcher.rb
+++ b/Casks/epic-games-launcher.rb
@@ -1,6 +1,6 @@
 cask 'epic-games-launcher' do
-  version '2.3.0-2604750'
-  sha256 'e9e2d4d2753a9d3fee021df6ff421b1340d947e05c542a69ea08146160c82d94'
+  version '2.11.0-2904489'
+  sha256 '807348dc48bbbca7e46504035e9e0ceb7f36f2b3eba91e0a521acc0b87ea0c19'
 
   url "https://download.epicgames.com/Builds/UnrealEngineLauncher/Installers/EpicGamesLauncher-#{version}.dmg"
   name 'Epic Games Launcher'


### PR DESCRIPTION
There is actually link to always-latest version: `https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncher.dmg`. May be it's better to use it and disable sha256 check?
