### PR TITLE
Fix Splice installation instructions

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -10,12 +10,9 @@ cask 'splice' do
   homepage 'https://splice.com/'
   license :gratis
 
-  installer script: 'Splice Installer.app/Contents/MacOS/Splice Installer',
-            args:   ['-q'],
-            sudo:   false
+  app 'Splice.app'
 
-  uninstall quit:   'com.splice.Splice',
-            delete: '/Applications/Splice.app'
+  uninstall quit:   'com.splice.Splice'
 
   zap delete: [
                 '~/Library/Application Support/*Splice*',


### PR DESCRIPTION
Splice is distributed as both a version specific zip file and an installer. We
use the former, but the instructions were written for the latter.
