### PR TITLE
Fix pl2303 v1.6.1_20160309

### DIFF
--- a/Casks/pl2303.rb
+++ b/Casks/pl2303.rb
@@ -7,12 +7,12 @@ cask 'pl2303' do
   homepage 'http://www.prolific.com.tw'
   license :closed
 
-  pkg "PL2303_MacOSX_v#{version}.pkg"
+  pkg "PL2303_MacOSX_#{version}.pkg"
 
   uninstall pkgutil: "com.prolific.prolificUsbserialCableDriverV#{version.gsub('.', '_')}.ProlificUsbSerial.pkg",
             kext:    'com.prolific.driver.PL2303',
             delete:  [
-                       '/System/Library/Extensions/ProlificUsbSerial.kext',
+                       '/Library/Extensions/ProlificUsbSerial.kext',
                        '/var/db/receipts/*PL2303*.*',
                        '/var/db/receipts/*ProlificUSbSerial*.*',
                      ]


### PR DESCRIPTION
Missed some changes in the pkg structure of the source package.
- Package Name is now without „v“ as prefix of the version
- Kext Location was changed
