### PR TITLE
Upgrade TaskPaper to v. 3.0.1

### DIFF
--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,11 +1,11 @@
 cask 'taskpaper' do
-  version '2.3.2'
-  sha256 'faaaef9c9b6398aa7beb6782b1704ccc74b11e251f428d6b921248235afc3a06'
+  version '3.0.1'
+  sha256 '28c4a9b66f94d618c08e406b943fdcaf5fb1a851d1d79f6b5c72d1dc091d5b95'
 
   # amazonaws.com is the official download host per the vendor homepage
   url "https://taskpaper.s3.amazonaws.com/TaskPaper-#{version}.dmg"
-  appcast 'http://www.hogbaysoftware.com/products/taskpaper/releases.rss',
-          checkpoint: '97954b28e1ea3605f77ee65af3c209b1f6dae0215ea15246578d3b9d750a02c7'
+  appcast 'https://taskpaper.s3.amazonaws.com/TaskPaper.rss',
+          checkpoint: 'b6c1c82c5dd0f12f207e4634ba6d59cfcd169e3750e8964367f272782dc13272'
   name 'TaskPaper'
   homepage 'http://www.hogbaysoftware.com/products/taskpaper'
   license :commercial


### PR DESCRIPTION
The appcast URL changed along with the release of 3.x. The previous URL
still exists, but contains information only for the releases < 3.0.
