### PR TITLE
Remove invalid argument separator passed to chmod

### DIFF
--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -321,7 +321,7 @@ class Hbc::Installer
           #      slash.  This should do the right thing, but is fragile.
           @command.run!('/usr/bin/chflags', :args => ['-R', '--', '000',   path])
           @command.run!('/bin/chmod',       :args => ['-R', '--', 'u+rwx', path])
-          @command.run!('/bin/chmod',       :args => ['-R', '-N', '--',    path])
+          @command.run!('/bin/chmod',       :args => ['-R', '-N',          path])
           tried_permissions = true
           retry # rmtree
         end


### PR DESCRIPTION
Apple chmod stops parsing options after reading `-N` (which removes ACL) and expects a file name immediately following. The command `chmod -N -- file` attempts to clear the ACL on the file `--`, rather
than `file`.

A recent commit changed all chmod invocations to use the argument separator for consistency. However, there is no way to use the argument separator in a chmod invocation involving `-N`. See line 163 of [the chmod source](http://www.opensource.apple.com/source/file_cmds/file_cmds-251/chmod/chmod.c).
