### PR TITLE
Upgrade Texpad.app to v1.7.26

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,7 +1,7 @@
 cask 'texpad' do
   if MacOS.release >= :mavericks
-    version '1.7.21'
-    sha256 'cae312b89d25752917bf66572fd1c6b6722097b651abe9a1a1b399dc36493512'
+    version '1.7.26'
+    sha256 'b6769040aa090bf8dcbc5c9ec7a82f37e1b76a599f5e1254264da93161116efd'
   elsif MacOS.release <= :mountain_lion && MacOS.release >= :snow_leopard
     version '1.7.21'
     sha256 'cae312b89d25752917bf66572fd1c6b6722097b651abe9a1a1b399dc36493512'
@@ -12,7 +12,7 @@ cask 'texpad' do
 
   url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.gsub('.', '_')}.zip"
   appcast 'https://www.texpadapp.com/static-collected/upgrades/texpadappcast.xml',
-          checkpoint: '4842788b8dd25bb010c19f6ad6230e0288c371185fd4f581003213c0b64b3d5a'
+          checkpoint: '429d16b265fba65235563f930d3ab43cfc74ee30d1dcc69fe33cd2eb8fdb4c0f'
   name 'Texpad'
   homepage 'https://www.texpadapp.com/osx'
   license :commercial


### PR DESCRIPTION
For users running >= mavericks, the most current version of Texpad.app is 1.7.26. For users running < mavericks, 1.7.21 is the highest version they can run.
