### PR TITLE
bitcoin-xt and bitcoin-core updated

### DIFF
--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -8,14 +8,14 @@ cask 'bitcoin-core' do
   license :mit
 
   conflicts_with cask: 'bitcoin-xt'
-  container type: :dmg
-
-  zap delete: '~/Library/Application Support/Bitcoin/'
-      delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
-
-  caveats "#{token} and Bitcoin XT will try to operate on the same Blockchain, it is not advised to run these simulatneously."
-          "Your Wallet will be deleted when use brew cask zap #{token} OR bitcoin-xt. Please move wallet.dat out of ~/Library/Application Support/Bitcoin/ or use File>Backup Wallet... beforehand. If wallet.dat got lost try to recover it with Time Machine or any other System Backup existend."
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app 'Bitcoin-Qt.app', target: 'Bitcoin Core.app'
+
+  zap delete: [
+                '~/Library/Application Support/Bitcoin/',
+                '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist',
+              ]
+
+  caveats "Your Wallet will be deleted when use brew cask zap #{token} OR bitcoin-xt. Please move wallet.dat out of ~/Library/Application Support/Bitcoin/ or use File>Backup Wallet... beforehand. If wallet.dat got lost try to recover it with Time Machine or any other System Backup existend."
 end

--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -7,6 +7,15 @@ cask 'bitcoin-core' do
   homepage 'https://bitcoin.org/'
   license :mit
 
+  conflicts_with cask: 'bitcoin-xt'
+  container type: :dmg
+
+  zap delete: '~/Library/Application Support/Bitcoin/'
+      delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
+
+  caveats "#{token} and Bitcoin XT will try to operate on the same Blockchain, it is not advised to run these simulatneously."
+          "Your Wallet will be deleted when use brew cask zap #{token} OR bitcoin-xt. Please move wallet.dat out of ~/Library/Application Support/Bitcoin/ or use File>Backup Wallet... beforehand. If wallet.dat got lost try to recover it with Time Machine or any other System Backup existend."
+
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app 'Bitcoin-Qt.app', target: 'Bitcoin Core.app'
 end

--- a/Casks/bitcoin-xt.rb
+++ b/Casks/bitcoin-xt.rb
@@ -13,7 +13,16 @@ cask 'bitcoin-xt' do
           checkpoint: '843d6ef3717eaf20b2e88f78e3eacae10dc745a0c134f34187acfdbfcfdb4d8d'
   name 'Bitcoin XT'
   homepage 'https://bitcoinxt.software/'
-  license :oss
+  license :mit
+
+  conflicts_with cask: 'bitcoin-core'
+  container type: :dmg
+
+  zap delete: '~/Library/Application Support/Bitcoin/'
+      delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
+
+  caveats "#{token} and Bitcoin Core will try to operate on the same Blockchain, it is not advised to run them simulatneously."
+          "Your Wallet will be deleted when use brew cask zap #{token} OR bitcoin-core. Please move wallet.dat out of ~/Library/Application Support/Bitcoin/ or use File>Backup Wallet... beforehand. If wallet.dat got lost try to recover it with Time Machine or any other System Backup existend."
 
   app 'Bitcoin-XT.app'
 end

--- a/Casks/bitcoin-xt.rb
+++ b/Casks/bitcoin-xt.rb
@@ -4,10 +4,8 @@ cask 'bitcoin-xt' do
 
   # github.com/bitcoinxt/bitcoinxt was verified as official when first introduced to the cask
   url "https://github.com/bitcoinxt/bitcoinxt/releases/download/v#{version}/BitcoinXT-#{version}.dmg",
-      referer: 'https://github.com/bitcoinxt/bitcoinxt/releases/',
       cookies: {
                  'i_follow_redirects' => 'yes',
-                 'logged_in'          => 'no',
                }
   appcast 'https://github.com/bitcoinxt/bitcoinxt/releases.atom',
           checkpoint: '843d6ef3717eaf20b2e88f78e3eacae10dc745a0c134f34187acfdbfcfdb4d8d'
@@ -16,13 +14,13 @@ cask 'bitcoin-xt' do
   license :mit
 
   conflicts_with cask: 'bitcoin-core'
-  container type: :dmg
-
-  zap delete: '~/Library/Application Support/Bitcoin/'
-      delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
-
-  caveats "#{token} and Bitcoin Core will try to operate on the same Blockchain, it is not advised to run them simulatneously."
-          "Your Wallet will be deleted when use brew cask zap #{token} OR bitcoin-core. Please move wallet.dat out of ~/Library/Application Support/Bitcoin/ or use File>Backup Wallet... beforehand. If wallet.dat got lost try to recover it with Time Machine or any other System Backup existend."
 
   app 'Bitcoin-XT.app'
+
+  zap delete: [
+                '~/Library/Application Support/Bitcoin/',
+                '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist',
+              ]
+
+  caveats "Your Wallet will be deleted when use brew cask zap #{token} OR bitcoin-core. Please move wallet.dat out of ~/Library/Application Support/Bitcoin/ or use File>Backup Wallet... beforehand. If wallet.dat got lost try to recover it with Time Machine or any other System Backup existend."
 end


### PR DESCRIPTION
Several small updates for bitcoin-xt/core:
-   updated license (only xt)
-   added conflicts, container, zap and caveats

Caveats is referring to conflict and warns that zap of either bitcoin-xt or bitcoin-core will delete wallet.dat (which will result in lost of all bitcoin if wallets are not backed up).
