### PR TITLE
Fix linkliar

### DIFF
--- a/Casks/linkliar.rb
+++ b/Casks/linkliar.rb
@@ -1,11 +1,14 @@
 cask 'linkliar' do
-  version :latest
-  sha256 :no_check
+  version '1.1.2'
+  sha256 '33b41b807daf1e87add1a361aa810f4e6e6840545f70664f0607afb6ccc11767'
 
-  url 'https://github.com/halo/LinkLiar/blob/master/latest_build/LinkLiar.zip?raw=true'
+  url "https://github.com/halo/LinkLiar/releases/download/#{version}/LinkLiar.app.zip"
+  appcast 'https://github.com/halo/LinkLiar/releases.atom',
+          checkpoint: 'c0b394576f668e81bcd5ece23aa070b9b2d7451c1f694b9dfee3ca9ddfdafe93'
+          
   name 'LinkLiar'
   homepage 'https://github.com/halo/LinkLiar'
   license :mit
 
-  prefpane 'LinkLiar.prefPane'
+  app 'LinkLiar.app'
 end


### PR DESCRIPTION
The existing URL 404'd because it used an schema Github no longer supports.

As a bonus I added a sha256 and appcast support for fun.
