### PR TITLE
[carbon-copy-cloner] Suppress move to /Applications

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -10,4 +10,8 @@ cask 'carbon-copy-cloner' do
   license :commercial
 
   app 'Carbon Copy Cloner.app'
+
+  postflight do
+    suppress_move_to_applications
+  end
 end


### PR DESCRIPTION
It currently asks to move to /Applications on launch.
