### PR TITLE
Update 4k-youtube-to-mp3 to version 3.0

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,10 +1,10 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.10'
-  sha256 'faf7173e0b83227cfec90831b9344c552afc116cb4ae26a4e5584f16496f6e63'
+  version '3.0'
+  sha256 '29b65a99f64ba5d6a1924df989b3cc1e0b7354fface7b4cbedc02eac17f2bd33'
 
   url "http://downloads.4kdownload.com/app/4kyoutubetomp3_#{version}.dmg"
-  name '4K Youtube to MP3'
+  name '4K YouTube to MP3'
   homepage 'https://www.4kdownload.com/products/product-youtubetomp3'
   license :oss
 


### PR DESCRIPTION
After `brew cask install 4k-youtube-to-mp3` and then running it, the app immediately prompted me to upgrade to version 3.0.
