### PR TITLE
Casks/docear.rb: Update to version 1.2.0.0, which only provides zip

### DIFF
--- a/Casks/docear.rb
+++ b/Casks/docear.rb
@@ -1,11 +1,11 @@
 cask 'docear' do
-  version :latest
+  version '1.2.0.0_stable_build291'
   sha256 :no_check
 
-  url 'http://docear.org/download/docear.dmg'
+  url 'http://docear.org/downloads/docear_macos.zip'
   name 'Docear'
   homepage 'https://docear.org'
   license :gpl
 
-  app 'Docear.app'
+  app "docear_macos/docear-#{version}/Docear.app"
 end


### PR DESCRIPTION
Casks/docear.rb: Update to version 1.2.0.0, which only provides zip (not dmg)
