### PR TITLE
Fix whitespace in caveats test cask

### DIFF
--- a/test/support/Casks/with-caveats.rb
+++ b/test/support/Casks/with-caveats.rb
@@ -10,7 +10,7 @@ test_cask 'with-caveats' do
   # simple string is evaluated at compile-time
   caveats <<-EOS.undent
     Here are some things you might want to know.
-    EOS
+  EOS
   # do block is evaluated at install-time
   caveats do
     "Cask token: #{token}"


### PR DESCRIPTION
as mentioned in [homebrew-versions#1876](https://github.com/caskroom/homebrew-versions/pull/1876#discussion_r58287396)
