### PR TITLE
Use new transmission-remote-gui Sourceforge URL

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -2,7 +2,7 @@ cask 'transmission-remote-gui' do
   version '5.0.1'
   sha256 'b961aeb244b2519563837745f3475d21379e3da32bae2b3cbb20ca91d1a90d75'
 
-  url "http://downloads.sourceforge.net/sourceforge/transgui/transgui-#{version}.dmg"
+  url "http://downloads.sourceforge.net/project/transgui/#{version}/transgui-#{version}.dmg"
   name 'Transmission Remote GUI'
   homepage 'http://sourceforge.net/projects/transgui/'
   license :oss


### PR DESCRIPTION
After many redirects, the old one returns HTML.
