### PR TITLE
Add 'ReadyTalk Desktop.app' as readytalk-desktop cask

### DIFF
--- a/Casks/readytalk-desktop.rb
+++ b/Casks/readytalk-desktop.rb
@@ -1,0 +1,11 @@
+cask 'readytalk-desktop' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://core.callinfo.com/packages/runtime/rtd-readytalk/darwin-x86_64/setup.dmg'
+  name 'ReadyTalk Desktop'
+  homepage 'https://www.readytalk.com/products-services/integrations/productivity/readytalk-desktop'
+  license :gratis
+
+  app 'ReadyTalk Desktop.app'
+end

--- a/Casks/readytalk-desktop.rb
+++ b/Casks/readytalk-desktop.rb
@@ -2,6 +2,7 @@ cask 'readytalk-desktop' do
   version :latest
   sha256 :no_check
 
+  # callinfo.com was verified as official when first introduced to the cask
   url 'https://core.callinfo.com/packages/runtime/rtd-readytalk/darwin-x86_64/setup.dmg'
   name 'ReadyTalk Desktop'
   homepage 'https://www.readytalk.com/products-services/integrations/productivity/readytalk-desktop'


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
