### PR TITLE
Update geektool to version 3.1.9 and fix download URL

### DIFF
--- a/Casks/geektool.rb
+++ b/Casks/geektool.rb
@@ -1,8 +1,8 @@
 cask 'geektool' do
-  version '3.1.3'
-  sha256 'f881d212dff433b302146ce3325cdcc79e73b8a7e871f9de8cd6d69173e33ec7'
+  version '3.1.9'
+  sha256 'b8f4584b43816b3c96ac6f0224a679242f84999b06074f35500607874335ae6c'
 
-  url "http://download.tynsoe.org/GeekTool-#{version}.zip"
+  url 'https://dl.devmate.com/org.tynsoe.GeekTool/GeekTool.zip'
   name 'GeekTool'
   homepage 'http://projects.tynsoe.org/en/geektool/'
   license :mit


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Note that the Geektool author is now using a different host for file downloads and they are no longer versioned.

Also, the website still says 3.1.8, but when you actually run the application, it says 3.1.9. This is also reflected on the Geektool twitter:
https://twitter.com/geektool/status/707392894634737664
