### PR TITLE
adding_a_cask.md: Rephrase homebrew-versions criterion

### DIFF
--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -185,7 +185,7 @@ When an App is only available as beta, development, or unstable versions, or in 
 
 ### Beta, Unstable, Development, Nightly, Legacy, or Alternative Versions
 
-When an App’s principal stable version already exists in the main repo, alternative versions should be submitted to [caskroom/homebrew-versions](https://github.com/caskroom/homebrew-versions).
+When an App has a principal stable version, alternative versions should be submitted to [caskroom/homebrew-versions](https://github.com/caskroom/homebrew-versions).
 
 ### Regional and Localized
 


### PR DESCRIPTION
Follow up to the https://github.com/caskroom/homebrew-cask/pull/20171 vs https://github.com/caskroom/homebrew-versions/pull/1865 dispute.

Alternative versions of an app that has a principal stable version should always go into homebrew-versions, regardless of whether the principal stable version exists in the main repo or not. This covers edge cases like Safari whose principal stable version should not be vendored by homebrew-cask.
