### PR TITLE
Add Hyne.app v1.9.1

### DIFF
--- a/Casks/hyne.rb
+++ b/Casks/hyne.rb
@@ -1,0 +1,17 @@
+cask 'hyne' do
+  version '1.9.1'
+  sha256 'b71f9942a017b396a7f4e858ee1566ee50b0d7c1a9c560eecf723e161b9b0102'
+
+  url "https://github.com/myst6re/hyne/releases/download/#{version}/Hyne-#{version}-macos.zip"
+  name 'Hyne'
+  homepage 'https://github.com/myst6re/hyne'
+  license :oss
+
+  app 'Hyne.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.vin047.hyne.sfl',
+                '~/Library/Preferences/com.vin047.hyne.plist',
+                '~/Library/Saved Application State/com.vin047.hyne.savedState',
+              ]
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Add Hyne.app to Homebrew Cask. Hyne is a Final Fantasy 8 save editor
