### PR TITLE
Add Together.app v3.5.8 as 'together' cask

### DIFF
--- a/Casks/together.rb
+++ b/Casks/together.rb
@@ -1,0 +1,22 @@
+cask 'together' do
+  version '3.5.8'
+  sha256 '2425411e6972a186d289c49b454041943fe6e594a445487cd42894166648b523'
+
+  url "http://reinventedsoftware.com/together/downloads/Together_#{version}.dmg"
+  appcast 'http://reinventedsoftware.com/together/downloads/',
+          checkpoint: 'a83aba19c678378af423f1f93c57e67272f8c657439500d2492172b44d3079b8'
+  name "Together #{version.major}"
+  homepage 'http://reinventedsoftware.com/together/'
+  license :commercial
+
+  app "Together #{version.major}.app"
+
+  zap delete: [
+                "~/Library/Application Support/Together #{version.major}",
+                '~/Library/Caches/Together',
+                "~/Library/Caches/com.reinvented.Together#{version.major}",
+                "~/Library/Preferences/com.reinvented.Together#{version.major}.shared.plist",
+                "~/Library/Preferences/com.reinvented.Together#{version.major}.plist",
+                "~/Library/Saved Application State/com.reinvented.Together#{version.major}.savedState",
+              ]
+end


### PR DESCRIPTION
### Changes to a cask
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download together` is error-free.
- [x] `brew cask style --fix together` left no offenses.
- [x] `brew cask install together` worked successfully.
- [x] `brew cask uninstall together` worked successfully.

The Together.app is trial, with the possibility to be bought outside the App Store.
