### PR TITLE
Upgrade pencil to 2.0.18 and use maintained fork

### DIFF
--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -1,16 +1,11 @@
 cask 'pencil' do
-  version '2.0.6'
-  sha256 'dacd76c658b12101457d17a4ade0b3f9c6a012f8eddacd379c41e372545ffac6'
+  version '2.0.18'
+  sha256 'dfddc7a5b7b781eed0cd8dc998656421e2d86eddb1068fe227cc85e04c7ab520'
 
-  # storage.googleapis.com is the official download host per the vendor homepage
-  url "https://storage.googleapis.com/google-code-archive-downloads/v1/code.google.com/evoluspencil/Pencil-#{version}-mac.tar.bz2"
+  url "https://github.com/prikhi/pencil/releases/download/v#{version}/Pencil-#{version}-mac-osx.zip"
   name 'Pencil'
-  homepage 'http://pencil.evolus.vn'
+  homepage 'https://github.com/prikhi/pencil'
   license :gpl
 
   app 'Pencil.app'
-
-  caveats do
-    discontinued
-  end
 end


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The current version of pencil in caskroom points to a release from 2013.  The project is hosted on google code and has been abandoned for years.  However, there is a fork on github that has an active community over at https://github.com/prikhi/pencil . This PR points pencil to the new repo.
