### PR TITLE
Added Shiba v1.0.0, a rich markdown previewer

### DIFF
--- a/Casks/shiba.rb
+++ b/Casks/shiba.rb
@@ -1,0 +1,13 @@
+cask 'shiba' do
+  version '1.0.0'
+  sha256 '4600a765cd2a9b23b9fa1090b86b43f8c43f7b6d07e69c2c294c26f06a5cf0d3'
+
+  url "https://github.com/rhysd/Shiba/releases/download/v#{version}/Shiba-darwin-x64.zip"
+  appcast 'https://github.com/rhysd/Shiba/releases.atom',
+          checkpoint: '1c0cdb6cba3a6ee81b31b72dd17b02465d6b0b457fe276739585ea53fdf85235'
+  name 'Shiba'
+  homepage 'https://github.com/rhysd/Shiba'
+  license :mit
+
+  app 'Shiba-darwin-x64/Shiba.app'
+end


### PR DESCRIPTION
### Changes to a cask
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download shiba.rb` is error-free.
- [x] `brew cask style --fix shiba.rb` left no offenses.
- [x] `brew cask install shiba.rb` worked successfully.
- [x] `brew cask uninstall shiba.rb` worked successfully.

---

Shiba is a rich markdown preview application.

App: https://github.com/rhysd/Shiba
Documents: https://github.com/rhysd/Shiba/tree/master/docs
