### PR TITLE
Upgrade Vivaldi to v1.0.435.40

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,8 +1,8 @@
 cask 'vivaldi' do
-  version '1.0.435.38'
-  sha256 '6cadff6485beae7d3ec2186050a4c1d235258790866e7d21654b6d913429bf3a'
+  version '1.0.435.40'
+  sha256 '5231887cdcd72741c2b4eacabca4f373e64065c251f72eee670b7adc6bab43cc'
 
-  url "https://vivaldi.com/download/stable/Vivaldi.#{version}.dmg"
+  url "https://download.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   name 'Vivaldi'
   homepage 'https://vivaldi.com'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download vivaldi` is error-free.
- [x] `brew cask style --fix vivaldi` left no offenses.
