### PR TITLE
Add Adobe Bloodhound

### DIFF
--- a/Casks/adobe-bloodhound.rb
+++ b/Casks/adobe-bloodhound.rb
@@ -1,0 +1,14 @@
+cask 'adobe-bloodhound' do
+  version '3.1.1'
+  sha256 '37db031a52f9cb9c40b8ead08ee6247192b0c2853e5ce95407fc840c3c50d715'
+
+  # github.com/Adobe-Marketing-Cloud/mobile-services was verified as official when first introduced to the cask
+  url "https://github.com/Adobe-Marketing-Cloud/mobile-services/releases/download/Bloodhound-v#{version}-OSX/Bloodhound-#{version}-OSX.dmg"
+  appcast 'https://github.com/Adobe-Marketing-Cloud/mobile-services/releases.atom',
+          checkpoint: 'e9d0e8fda3066d6016404e9e1f60c25ba57c1d499cccc9926289d8e685c0a456'
+  name 'Adobe Bloodhound'
+  homepage 'https://marketing.adobe.com/resources/help/en_US/mobile/bloodhound/'
+  license :gratis
+
+  app 'Adobe Bloodhound.app'
+end


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download adobe-bloodhound.rb` is error-free.
- [x] `brew cask style --fix adobe-bloodhound.rb` left no offenses.
- [x] `brew cask install adobe-bloodhound.rb` worked successfully.
- [x] `brew cask uninstall adobe-bloodhound.rb` worked successfully.
