### PR TITLE
Fix Google Music Manager (music-manager) pref pane

### DIFF
--- a/Casks/music-manager.rb
+++ b/Casks/music-manager.rb
@@ -7,6 +7,8 @@ cask 'music-manager' do
   homepage 'https://play.google.com/music/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
+  prefpane 'MusicManager.app/Contents/Helpers/MusicManager.prefPane'
+
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/4282
   app 'MusicManager.app', target: 'Music Manager.app'

--- a/Casks/music-manager.rb
+++ b/Casks/music-manager.rb
@@ -7,9 +7,8 @@ cask 'music-manager' do
   homepage 'https://play.google.com/music/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  prefpane 'MusicManager.app/Contents/Helpers/MusicManager.prefPane'
-
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/4282
   app 'MusicManager.app', target: 'Music Manager.app'
+  prefpane 'MusicManager.app/Contents/Helpers/MusicManager.prefPane'
 end


### PR DESCRIPTION
The app will copy the pref pane itself on first run (if it does not already exist), but then `brew uninstall` will not remove it.
By letting brew symlink the pref pane, it uninstalls properly.
