### PR TITLE
[merge 16 April] Revert "Only initialize Homebrew-Cask when necessary"

### DIFF
--- a/lib/hbc.rb
+++ b/lib/hbc.rb
@@ -50,6 +50,9 @@ module Hbc
   ::Hardware = Hbc::Hardware
 
   def self.init
+    # todo: Creating directories should be deferred until needed.
+    #       Currently this fire and even asks for sudo password
+    #       if a first-time user simply runs "brew cask --help".
     odebug 'Creating directories'
     HOMEBREW_CACHE.mkpath unless HOMEBREW_CACHE.exist?
     HOMEBREW_CACHE_CASKS.mkpath unless HOMEBREW_CACHE_CASKS.exist?

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -73,10 +73,6 @@ class Hbc::CLI
     raise unless e.to_s.include? path
   end
 
-  def self.should_init?(command)
-    (command.is_a? Class) && (command < Hbc::CLI::Base) && command.needs_init?
-  end
-
   def self.run_command(command, *rest)
     if command.respond_to?(:run)
       # usual case: built-in command verb
@@ -116,8 +112,8 @@ class Hbc::CLI
   def self.process(arguments)
     command_string, *rest = *arguments
     rest = process_options(rest)
+    Hbc.init
     command = Hbc.help ? 'help' : lookup_command(command_string)
-    Hbc.init if should_init?(command)
     run_command(command, *rest)
   rescue Hbc::CaskError, Hbc::CaskSha256MismatchError => e
     msg = e.message

--- a/lib/hbc/cli/base.rb
+++ b/lib/hbc/cli/base.rb
@@ -14,8 +14,4 @@ class Hbc::CLI::Base
   def self.help
     "No help available for the #{command_name} command"
   end
-
-  def self.needs_init?
-    false
-  end
 end

--- a/lib/hbc/cli/install.rb
+++ b/lib/hbc/cli/install.rb
@@ -46,8 +46,4 @@ class Hbc::CLI::Install < Hbc::CLI::Base
   def self.help
     "installs the given Cask"
   end
-
-  def self.needs_init?
-    true
-  end
 end


### PR DESCRIPTION
@adidalal @jawshooah @ilovezfs Any objections with reverting this? I’d rather have the old behaviour (a minor annoyance) than [buggy behaviour](https://github.com/caskroom/homebrew-cask/issues/18606).

Closes https://github.com/caskroom/homebrew-cask/issues/18606. If there are no valid objections or a fix in a week, lets merge this.
