### PR TITLE
update yacreader to 8.5.0

### DIFF
--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -1,6 +1,6 @@
 cask 'yacreader' do
-  version '8.0.0'
-  sha256 '6e6e2f857a3f1ad4fa19c57550677e5e46c63ffaea955e353a832e51461d3e80'
+  version '8.5.0'
+  sha256 '13bfd484fb1e6e1ff29e9e2e63e2485fa9415f4f2d5186a5fc90c45cef394ef2'
 
   # bitbucket.org/luisangelsm/yacreader was verified as official when first introduced to the cask
   url "https://bitbucket.org/luisangelsm/yacreader/downloads/YACReader-#{version}-MacOSX-Intel.dmg"


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download yacreader` is error-free.
- [x] `brew cask style --fix yacreader` left no offenses.

didn't checked the last two ones because using repo in another directory (will do better next time). I hope the CI checks it.
