### PR TITLE
Upgrade Arq to 5.0.0.65

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,10 +1,10 @@
 cask 'arq' do
-  version '4.15.1'
-  sha256 '537d7872e2843a191bb1090e708bb48aedfa83dd2db616da25b792c013b8eb33'
+  version '5.0.0.65'
+  sha256 '9c37e55972bce74e2f4e01046bd98fbb19b70ce748cdf825c7e4e556879cb750'
 
   url "https://www.arqbackup.com/download/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arq#{version.major}.xml",
-          checkpoint: '537720fc6b4b69b44ccc36ff81198d378fedae8a2783589cbbd8d730a98396ea'
+          checkpoint: 'c8404b6c022aae522edac6cdeec521cdb1270409ee9d5b8eb94b77d6a765868e'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Release notes of Arq 5:
https://www.arqbackup.com/blog/arq-5-massively-faster-backup-and-restore/
