### PR TITLE
Add Frappé v0.1.1

### DIFF
--- a/Casks/frappe.rb
+++ b/Casks/frappe.rb
@@ -1,0 +1,14 @@
+# coding: utf-8
+cask 'frappe' do
+  version 'v0.1.1'
+  sha256 'de5440f075dd8c93c92284158e2a44fbfc3747e00293739c3aba1aea31082433'
+
+  url 'https://github.com/niftylettuce/frappe/releases/download/v0.1.1/v0.1.1.zip'
+  name 'Frappé'
+  homepage 'https://github.com/niftylettuce/frappe'
+  license :mit
+
+  container nested: 'Frappé.dmg'
+
+  app 'Frappe.app'
+end


### PR DESCRIPTION
#### Adding a new cask
- [X] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [X] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Commit message includes cask’s name.
- [X] `brew cask audit --download frappe` is error-free.
- [X] `brew cask style --fix frappe` left no offenses.
- [X] `brew cask install frappe` worked successfully.
- [X] `brew cask uninstall frappe` worked successfully.
