### PR TITLE
WIP: Add a cask for Docker for Mac

### DIFF
--- a/Casks/docker-for-mac.rb
+++ b/Casks/docker-for-mac.rb
@@ -8,6 +8,7 @@ cask 'docker-for-mac' do
   license :gratis
 
   auto_updates false
+
   app 'Docker.app'
 
   uninstall_preflight do

--- a/Casks/docker-for-mac.rb
+++ b/Casks/docker-for-mac.rb
@@ -1,0 +1,23 @@
+cask 'docker-for-mac' do
+  version :latest
+  sha256 "34320ebfdef2620c93fb6d959750ab527327b34405ab9f013edb96b8ad62dc54"
+
+  url 'https://dyhfha9j6srsj.cloudfront.net/Docker.dmg'
+  name 'Docker For Mac'
+  homepage 'https://beta.docker.com/docs/mac/'
+  license :gratis
+
+  auto_updates false
+  app 'Docker.app'
+
+  uninstall_preflight do
+    system "#{staged_path}/Docker.app/Contents/MacOS/Docker", '--uninstall'
+  end
+
+  uninstall pkgutil: 'com.docker.docker'
+
+  caveats <<-EOS.undent
+    #{token} needs an installer to be run after cask install:
+    sudo #{staged_path}/Docker.app/Contents/MacOS/Docker --token="your beta token"
+  EOS
+end

--- a/Casks/docker-for-mac.rb
+++ b/Casks/docker-for-mac.rb
@@ -1,6 +1,6 @@
 cask 'docker-for-mac' do
   version :latest
-  sha256 "34320ebfdef2620c93fb6d959750ab527327b34405ab9f013edb96b8ad62dc54"
+  sha256 :no_check
 
   url 'https://dyhfha9j6srsj.cloudfront.net/Docker.dmg'
   name 'Docker For Mac'


### PR DESCRIPTION
This provides a cask for the new Docker for Mac that is currently in beta release. This is usable now for people with a beta token, but shouldn't be merged until stable versions are released. 
## Adding a new cask
- [x] Checked there aren’t open pull requests for the same cask.
- [x] Checked there aren’t closed issues where that cask was already refused.
- [x] When naming the cask, followed the token reference.
- [x] Commit message includes cask’s name.
- [x] brew cask audit --download docker-for-mac is error-free.
- [x] brew cask style --fix docker-for-mac left no offenses.
- [x] brew cask install docker-for-mac worked successfully.
- [x] brew cask uninstall docker-for-mac worked successfully.
