### PR TITLE
Upgrade Ridibooks.app to v1.6.3b

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,6 +1,6 @@
 cask 'ridibooks' do
-  version '1.5.9b'
-  sha256 '27e06ef0625f8958a909c7801bfd0108d975164fec9b241d1a12ab083edea2e0'
+  version '1.6.3b'
+  sha256 '81cc774d9518a02050b0637c9da71f85a49afdb705c93ef334e3700e380dec21'
 
   # ridicorp.com was verified as official when first introduced to the cask
   url "https://cdn.ridicorp.com/app/mac/ridibooks-#{version}.dmg"


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download ridibooks` is error-free.
- [x] `brew cask style --fix ridibooks` left no offenses.
