### PR TITLE
Updated gpodder to 3.8.5

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,14 +1,12 @@
 cask 'gpodder' do
-  version '3.8.3_0'
-  sha256 '57fe1f006a691487452f80d924fa60fbadd865dbfb4cde2000aaf46db76d3065'
+  version '3.8.5_0'
+  sha256 '20e2ae8d5b703fa5b6e68495a33daed0a894efe408ef7f72b7f265e21718d7b9'
 
   # downloads.sourceforge.net/sourceforge/gpodder was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/sourceforge/gpodder/gPodder-#{version}.zip"
   name 'gPodder'
   homepage 'http://gpodder.org/'
   license :gpl
-
-  depends_on x11: true
 
   app 'gPodder.app'
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
#### Notes

X11 does not seem to be needed for this anymore. I was able to successfully install and run with and without XQuartz and didn't see any difference. Also the sourceforge page does not give any mention to X11 being needed therefore I believe it is no longer a necessary dependency.
