### PR TITLE
Add Mattermost

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,0 +1,12 @@
+cask 'mattermost' do
+  version '1.1.0'
+  sha256 '9f97b131209bb2daad6cf55be0faa20a461d5644284e556e48d1ca0707aa93c6'
+
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/mattermost/desktop/releases/download/v#{version}/mattermost-desktop-#{version}-osx.tar.gz"
+  name 'Mattermost'
+  homepage 'http://www.mattermost.org/'
+  license :mit
+
+  app "mattermost-desktop-#{version}-osx/Mattermost.app"
+end


### PR DESCRIPTION
[Mattermost](https://www.mattermost.org/) is an open source, self-hosted Slack-alternative.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
