### PR TITLE
Intel power gadget 303

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -3,7 +3,7 @@ cask 'intel-power-gadget' do
   version '3.0.3'
   sha256 '93f052f5c1306272fceab7af5740d2837656242ab879436a6ce9e573ed9a274e'
 
-  url "https://software.intel.com/file/501089/download"
+  url 'https://software.intel.com/file/501089/download'
   name 'Intel Power Gadget'
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
   license :gratis

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,14 +1,15 @@
+# coding: utf-8
 cask 'intel-power-gadget' do
-  version '3.0.1'
-  sha256 '538a792721604e2155b3a48caa4084db751a91b170e5fa62bf0331d3147f2239'
+  version '3.0.3'
+  sha256 '93f052f5c1306272fceab7af5740d2837656242ab879436a6ce9e573ed9a274e'
 
-  url "https://software.intel.com/sites/default/files/managed/59/39/IntelPowerGadgetMac#{version}.zip"
+  url "https://software.intel.com/file/501089/download"
   name 'Intel Power Gadget'
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
   license :gratis
 
   # this bogus-looking character accurately reflects an upstream error
-  container nested: 'IntelÆ Power Gadget.dmg'
+  container nested: "Intel® Power Gadget v#{version}.dmg"
 
   pkg 'Install Intel Power Gadget.pkg'
 

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 cask 'intel-power-gadget' do
   version '3.0.3'
   sha256 '93f052f5c1306272fceab7af5740d2837656242ab879436a6ce9e573ed9a274e'


### PR DESCRIPTION
### Changes to a cask

Upgrade Intel Power Gadget to v3.0.3
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download intel-power-gadget` is error-free.
- [x] `brew cask style --fix intel-power-gadget` left no offenses.
