### PR TITLE
Update Franz (0.9.10) to use the correct URL

### DIFF
--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -1,10 +1,9 @@
 cask 'franz' do
-  github_version '2.0'
   version '0.9.10'
   sha256 'bac5896e5cad84d4018e9486cd580a04548c0a0b350ade506b82192175306570'
 
   # github.com/imprecision/franz-app was verified as official when first introduced to the cask
-  url "https://github.com/imprecision/franz-app/releases/download/#{github_version}/Franz-darwin-x64-#{version}.dmg"
+  url "https://storage.googleapis.com/meetfranzdownloads/downloads/#{version}/Franz-darwin-x64-#{version}.dmg"
   appcast 'https://github.com/imprecision/franz-app/releases.atom',
           checkpoint: 'bfe803c6957cf9d530b954061370b590edebfc24eb3c6dd0afdce97fc1642e68'
   name 'Franz'

--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -1,9 +1,10 @@
 cask 'franz' do
+  github_version '2.0'
   version '0.9.10'
   sha256 'bac5896e5cad84d4018e9486cd580a04548c0a0b350ade506b82192175306570'
 
   # github.com/imprecision/franz-app was verified as official when first introduced to the cask
-  url "https://github.com/imprecision/franz-app/releases/download/#{version}/Franz-darwin-x64-#{version}.dmg"
+  url "https://github.com/imprecision/franz-app/releases/download/#{github_version}/Franz-darwin-x64-#{version}.dmg"
   appcast 'https://github.com/imprecision/franz-app/releases.atom',
           checkpoint: 'bfe803c6957cf9d530b954061370b590edebfc24eb3c6dd0afdce97fc1642e68'
   name 'Franz'

--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -2,7 +2,6 @@ cask 'franz' do
   version '0.9.10'
   sha256 'bac5896e5cad84d4018e9486cd580a04548c0a0b350ade506b82192175306570'
 
-  # github.com/imprecision/franz-app was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/meetfranzdownloads/downloads/#{version}/Franz-darwin-x64-#{version}.dmg"
   appcast 'https://github.com/imprecision/franz-app/releases.atom',
           checkpoint: 'bfe803c6957cf9d530b954061370b590edebfc24eb3c6dd0afdce97fc1642e68'

--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -2,9 +2,10 @@ cask 'franz' do
   version '0.9.10'
   sha256 'bac5896e5cad84d4018e9486cd580a04548c0a0b350ade506b82192175306570'
 
+  # storage.googleapis.com/meetfranzdownloads was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/meetfranzdownloads/downloads/#{version}/Franz-darwin-x64-#{version}.dmg"
   appcast 'https://github.com/imprecision/franz-app/releases.atom',
-          checkpoint: 'bfe803c6957cf9d530b954061370b590edebfc24eb3c6dd0afdce97fc1642e68'
+          checkpoint: 'e8032c13996ef3f39bda32345034a2c8d2ba4b03be678c20126e361e9d019f47'
   name 'Franz'
   homepage 'http://meetfranz.com'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Franz was recently updated to version '0.9.10'. However it is being advertised on github as version 2.0, meaning the dmg download has '0.9.10' but the github release is marked as 2.0. I added a new github_version and changed the url to use both properly.
