### PR TITLE
battle-net: update install filename

### DIFF
--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -7,7 +7,7 @@ cask 'battle-net' do
   homepage 'http://us.battle.net/en/'
   license :commercial
 
-  installer manual: 'Battle.net-Setup-enUS.app'
+  installer manual: 'Battle.net-Setup.app'
 
   uninstall delete: '/Applications/Battle.net.app'
 


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

On my machine, I end up with this:

```
$ ls /opt/homebrew-cask/Caskroom/battle-net/latest
Battle.net-Setup.app
```

Not sure if the installer name has just changed over time?
