### PR TITLE
Add SoundflowerBed 2.0.0

### DIFF
--- a/Casks/soundflowerbed.rb
+++ b/Casks/soundflowerbed.rb
@@ -3,6 +3,8 @@ cask 'soundflowerbed' do
   sha256 'b6946abb69bd0b154462181ed0c46fc5cbf6bb527b2f891ff97575382627d5d9'
 
   url 'https://github.com/mLupine/SoundflowerBed/releases/download/2.0.0-release/SoundflowerBed-2.0.0-release.dmg'
+  appcast 'https://github.com/mLupine/SoundflowerBed/releases.atom',
+          checkpoint: '60120402605c0241c7cfba987f2dd7cf8039ed3089ecb82e9fbf316fe1d101de'
   name 'SoundflowerBed'
   homepage 'https://github.com/mLupine/SoundflowerBed'
   license :mit

--- a/Casks/soundflowerbed.rb
+++ b/Casks/soundflowerbed.rb
@@ -1,0 +1,11 @@
+cask 'soundflowerbed' do
+  version '2.0.0'
+  sha256 'b6946abb69bd0b154462181ed0c46fc5cbf6bb527b2f891ff97575382627d5d9'
+
+  url 'https://github.com/mLupine/SoundflowerBed/releases/download/2.0.0-release/SoundflowerBed-2.0.0-release.dmg'
+  name 'SoundflowerBed'
+  homepage 'https://github.com/mLupine/SoundflowerBed'
+  license :mit
+
+  app 'SoundflowerBed.app'
+end


### PR DESCRIPTION
### Changes to a cask
#### Adding a new cask
- [X] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [X] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Commit message includes cask’s name.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.

---

Soundflower, after being abandoned and [picked up](https://github.com/mattingalls/Soundflower) by someone else, no longer includes Soundflowerbed, a menu bar app for quick configuration of Soundflower. It has similarly been [picked up](https://github.com/mLupine/SoundflowerBed) by someone else, now with a capital B.
