### PR TITLE
Add Luyten.app version 0.4.7

### DIFF
--- a/Casks/luyten.rb
+++ b/Casks/luyten.rb
@@ -1,0 +1,13 @@
+cask 'luyten' do
+  version '0.4.7'
+  sha256 '612bd58de0d3ef23fbb9803d302f0af7d3f03e5fcf06cadd69521f0e57637045'
+
+  url "https://github.com/deathmarine/Luyten/releases/download/v#{version}/luyten-OSX-#{version}.zip"
+  appcast 'https://github.com/deathmarine/Luyten/releases.atom',
+          checkpoint: '9ecdaf5f2f3ace93eb6df32903e0e39db44fb4901ee761e8626f4cab3a6cf6fd'
+  name 'Luyten'
+  homepage 'https://deathmarine.github.io/Luyten/'
+  license :apache
+
+  app 'Luyten.app'
+end


### PR DESCRIPTION
The command-line version of luyten exists as a homebrew formula. This is the OS X app version.
- [X] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [X] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Commit message includes cask’s name.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
