### PR TITLE
canon-imagerunner-printer-driver-ufrii.rb updated to v10.09.00

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -2,7 +2,7 @@ cask 'canon-imagerunner-printer-driver-ufrii' do
   version '10.09.00'
   sha256 '2811eb7c46a0011394d030a31d819466283aa3a5fb4dc79ce5e8c57d29820f6a'
 
-  url "http://downloads.canon.com/bisg2016/drivers/mac/UFRII_v#{version}_Mac.zip"
+  url "https://downloads.canon.com/bisg2016/drivers/mac/UFRII_v#{version}_Mac.zip"
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
   license :gratis

--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,10 +1,10 @@
 cask 'canon-imagerunner-printer-driver-ufrii' do
-  version '10.08.01'
-  sha256 '4255b1236bbf6b30b6b78db277fd2425d051ee58fd13a954068f5790ab7e2a28'
+  version '10.09.00'
+  sha256 '2811eb7c46a0011394d030a31d819466283aa3a5fb4dc79ce5e8c57d29820f6a'
 
-  url "https://downloads.canon.com/bisg2015/drivers/mac/UFRII_v#{version}_MAC.zip"
+  url "http://downloads.canon.com/bisg2016/drivers/mac/UFRII_v#{version}_Mac.zip"
   name 'Canon imageRUNNER UFRII Printer Driver'
-  homepage 'https://www.usa.canon.com/cusa/sna/office/color_imagerunner_advance/imagerunner_advance_c5030/imagerunner_advance_c5030#DriversAndSoftware'
+  homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
   license :gratis
 
   container nested: "UFRII_v#{version}_MAC.dmg"


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download canon-imagerunner-printer-driver-ufrii.rb` is error-free.
- [x] `brew cask style --fix canon-imagerunner-printer-driver-ufrii.rb` left no offenses.
