### PR TITLE
updated coteditor (2.5.0)

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -10,14 +10,14 @@ cask 'coteditor' do
     # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
     url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   else
-    version '2.4.4'
-    sha256 '9e64e47f44a2213d1974f0f1f220ebdc5448aeaf174759ee00cf2b8c20c1b1ee'
+    version '2.5.0'
+    sha256 '06dfa85f519d666165faae4b1b5cb99ed395d4b633602f72de621ea763871fea'
     # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
     url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   end
 
   appcast 'https://github.com/coteditor/CotEditor/releases.atom',
-          checkpoint: '1628004e59ec855cd21ba3a1164ade66c105eed940f839adefd23326ff17b719'
+          checkpoint: '5c0a27c1ae2bf56257c0e1a3227dd63062bac6e4f651b5a0ec33bd437db6273b'
   name 'CotEditor'
   homepage 'https://coteditor.com/'
   license :apache


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
