### PR TITLE
add Voxengo SPAN 2.10 (VST)

### DIFF
--- a/Casks/voxengo-span-vst.rb
+++ b/Casks/voxengo-span-vst.rb
@@ -1,9 +1,9 @@
-cask 'voxengo-span' do
+cask 'voxengo-span-vst' do
   version '2.10'
   sha256 '09f5a195145b5dff81b095bae8af9f3d98e301debe8a0f7732684fd479b20185'
 
   url "http://www.voxengo.com/files/VoxengoSPAN_#{version.delete('.')}_Mac_VST_VST3_setup.dmg"
-  name 'Voxengo SPAN'
+  name 'Voxengo SPAN (VST)'
   homepage 'http://www.voxengo.com/product/span/'
   license :gratis
 

--- a/Casks/voxengo-span-vst.rb
+++ b/Casks/voxengo-span-vst.rb
@@ -2,7 +2,7 @@ cask 'voxengo-span-vst' do
   version '2.10'
   sha256 '09f5a195145b5dff81b095bae8af9f3d98e301debe8a0f7732684fd479b20185'
 
-  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.delete('.')}_Mac_VST_VST3_setup.dmg"
+  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_VST_VST3_setup.dmg"
   name 'Voxengo SPAN (VST)'
   homepage 'http://www.voxengo.com/product/span/'
   license :gratis

--- a/Casks/voxengo-span.rb
+++ b/Casks/voxengo-span.rb
@@ -1,0 +1,11 @@
+cask 'voxengo-span' do
+  version '2.10'
+  sha256 '09f5a195145b5dff81b095bae8af9f3d98e301debe8a0f7732684fd479b20185'
+
+  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.delete('.')}_Mac_VST_VST3_setup.dmg"
+  name 'Voxengo SPAN'
+  homepage 'http://www.voxengo.com/product/span/'
+  license :gratis
+
+  vst_plugin 'SPAN.vst'
+end


### PR DESCRIPTION
Voxengo SPAN is a widely used plug-in for spectrum analysis using FFT transform.
This is the VST version.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
