### PR TITLE
add Voxengo SPAN 2.10 (AU)

### DIFF
--- a/Casks/voxengo-span-au.rb
+++ b/Casks/voxengo-span-au.rb
@@ -1,0 +1,11 @@
+cask 'voxengo-span-au' do
+  version '2.10'
+  sha256 '48cf467a2d3b3be87b4b6ab725dd10f6ecf98cb8bceb090c4b2920989f33d413'
+
+  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.delete('.')}_Mac_AU_AAX_setup.dmg"
+  name 'Voxengo SPAN (AU)'
+  homepage 'http://www.voxengo.com/product/span/'
+  license :gratis
+
+  audio_unit_plugin 'SPAN.component'
+end

--- a/Casks/voxengo-span-au.rb
+++ b/Casks/voxengo-span-au.rb
@@ -2,7 +2,7 @@ cask 'voxengo-span-au' do
   version '2.10'
   sha256 '48cf467a2d3b3be87b4b6ab725dd10f6ecf98cb8bceb090c4b2920989f33d413'
 
-  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.delete('.')}_Mac_AU_AAX_setup.dmg"
+  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_AU_AAX_setup.dmg"
   name 'Voxengo SPAN (AU)'
   homepage 'http://www.voxengo.com/product/span/'
   license :gratis


### PR DESCRIPTION
Voxengo SPAN is a widely used plug-in for spectrum analysis using FFT transform.
This is the AU version.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

I haven't checked uninstall yet but as soon as it is merged, i will check it.
