### PR TITLE
add Support for VST3 plug-ins

### DIFF
--- a/doc/cask_language_reference/all_stanzas.md
+++ b/doc/cask_language_reference/all_stanzas.md
@@ -32,7 +32,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install).
 | `service`          | yes                           | relative path to a Service that should be linked into the `~/Library/Services` folder on installation
 | `audio_unit_plugin`| yes                           | relative path to an Audio Unit plugin that should be linked into the `~/Library/Audio/Components` folder on installation
 | `vst_plugin`       | yes                           | relative path to a VST Plugin that should be linked into the `~/Library/Audio/VST` folder on installation
-| `vst3_plugin`       | yes                           | relative path to a VST3 Plugin that should be linked into the `~/Library/Audio/VST3` folder on installation
+| `vst3_plugin`      | yes                           | relative path to a VST3 Plugin that should be linked into the `~/Library/Audio/VST3` folder on installation
 | `suite`            | yes                           | relative path to a containing directory that should be linked into the `~/Applications` folder on installation (see also [Suite Stanza Details](stanzas/suite.md))
 | `artifact`         | yes                           | relative path to an arbitrary path that should be symlinked on installation. This is only for unusual cases. The `app` stanza is strongly preferred when linking `.app` bundles.
 | `installer`        | yes                           | describes an executable which must be run to complete the installation (see [Installer Stanza Details](stanzas/installer.md))

--- a/doc/cask_language_reference/all_stanzas.md
+++ b/doc/cask_language_reference/all_stanzas.md
@@ -32,6 +32,7 @@ Each Cask must declare one or more *artifacts* (i.e. something to install).
 | `service`          | yes                           | relative path to a Service that should be linked into the `~/Library/Services` folder on installation
 | `audio_unit_plugin`| yes                           | relative path to an Audio Unit plugin that should be linked into the `~/Library/Audio/Components` folder on installation
 | `vst_plugin`       | yes                           | relative path to a VST Plugin that should be linked into the `~/Library/Audio/VST` folder on installation
+| `vst3_plugin`       | yes                           | relative path to a VST3 Plugin that should be linked into the `~/Library/Audio/VST3` folder on installation
 | `suite`            | yes                           | relative path to a containing directory that should be linked into the `~/Applications` folder on installation (see also [Suite Stanza Details](stanzas/suite.md))
 | `artifact`         | yes                           | relative path to an arbitrary path that should be symlinked on installation. This is only for unusual cases. The `app` stanza is strongly preferred when linking `.app` bundles.
 | `installer`        | yes                           | describes an executable which must be run to complete the installation (see [Installer Stanza Details](stanzas/installer.md))

--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -153,6 +153,7 @@ screen_saver
 service
 audio_unit_plugin
 vst_plugin
+vst3_plugin
 artifact, target: # :target shown here as is required with `artifact`
 stage_only
 

--- a/doc/man_page/brew-cask.1.md
+++ b/doc/man_page/brew-cask.1.md
@@ -178,6 +178,9 @@ in a future version.
   * `--vst_plugindir=<path>`:
     Target location for VST Plugin links. The default value is `~/Library/Audio/Plug-Ins/VST`.
 
+  * `--vst3_plugindir=<path>`:
+    Target location for VST3 Plugin links. The default value is `~/Library/Audio/Plug-Ins/VST3`.
+
   * `--screen_saverdir=<path>`:
     Target location for Screen Saver links. The default value is `~/Library/Screen Savers`.
 

--- a/lib/hbc/artifact.rb
+++ b/lib/hbc/artifact.rb
@@ -15,6 +15,7 @@ require 'hbc/artifact/installer'
 require 'hbc/artifact/internet_plugin'
 require 'hbc/artifact/audio_unit_plugin'
 require 'hbc/artifact/vst_plugin'
+require 'hbc/artifact/vst3_plugin'
 require 'hbc/artifact/nested_container'
 require 'hbc/artifact/pkg'
 require 'hbc/artifact/postflight_block'
@@ -53,6 +54,7 @@ module Hbc::Artifact
       Hbc::Artifact::InternetPlugin,
       Hbc::Artifact::AudioUnitPlugin,
       Hbc::Artifact::VstPlugin,
+      Hbc::Artifact::Vst3Plugin,
       Hbc::Artifact::ScreenSaver,
       Hbc::Artifact::Uninstall,
       Hbc::Artifact::PostflightBlock,

--- a/lib/hbc/artifact/vst3_plugin.rb
+++ b/lib/hbc/artifact/vst3_plugin.rb
@@ -1,0 +1,3 @@
+class Hbc::Artifact::Vst3Plugin < Hbc::Artifact::Symlinked
+
+end

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -190,6 +190,9 @@ class Hbc::CLI
       opts.on("--vst_plugindir=MANDATORY") do |v|
         Hbc.vst_plugindir = Pathname(v).expand_path
       end
+      opts.on("--vst3_plugindir=MANDATORY") do |v|
+        Hbc.vst3_plugindir = Pathname(v).expand_path
+      end
       opts.on("--screen_saverdir=MANDATORY") do |v|
        Hbc.screen_saverdir = Pathname(v).expand_path
       end

--- a/lib/hbc/cli/internal_stanza.rb
+++ b/lib/hbc/cli/internal_stanza.rb
@@ -35,6 +35,7 @@ class Hbc::CLI::InternalStanza < Hbc::CLI::InternalUseBase
                        :internet_plugin,
                        :audio_unit_plugin,
                        :vst_plugin,
+                       :vst3_plugin,
                        :screen_saver,
                        :pkg,
                        :installer,

--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -33,7 +33,8 @@ class Hbc::DSL
     :service,
     :stage_only,
     :suite,
-    :vst_plugin
+    :vst_plugin,
+    :vst3_plugin
   ]
 
   ACTIVATABLE_ARTIFACT_TYPES = [:installer, *ORDINARY_ARTIFACT_TYPES] - [:stage_only]

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -100,6 +100,14 @@ module Hbc::Locations
       @vst_plugindir = _vst_plugindir
     end
 
+    def vst3_plugindir
+      @vst3_plugindir ||= Pathname.new('~/Library/Audio/Plug-Ins/VST3').expand_path
+    end
+
+    def vst3_plugindir=(_vst3_plugindir)
+      @vst3_plugindir = _vst3_plugindir
+    end
+
     def screen_saverdir
       @screen_saverdir ||= Pathname.new('~/Library/Screen Savers').expand_path
     end

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -188,6 +188,10 @@ Target location for Audio Unit Plugin links\. The default value is \fB~/Library/
 Target location for VST Plugin links\. The default value is \fB~/Library/Audio/Plug\-Ins/VST\fR\.
 .
 .TP
+\fB\-\-vst3_plugindir=<path>\fR
+Target location for VST3 Plugin links\. The default value is \fB~/Library/Audio/Plug\-Ins/VST3\fR\.
+.
+.TP
 \fB\-\-screen_saverdir=<path>\fR
 Target location for Screen Saver links\. The default value is \fB~/Library/Screen Savers\fR\.
 .


### PR DESCRIPTION
### Changes to the core
- [x] Add new stanza 'vst3_plugin'
- [x] Add new default directory/location for 'vst3_plugin': ~/Library/Audio/Plug-Ins/VST3
- [x] Add new command argument: --vst3-plugindir=PATH
- [x] Update doc for this command in [all_stanzas.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/all_stanzas.md), [readme.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/readme.md), [brew-cask.1.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/man_page/brew-cask.1.md) and [brew-cask.1](https://github.com/caskroom/homebrew-cask/blob/master/man/man1/brew-cask.1) .
- [x] Tested locally.
