### PR TITLE
fixed araxis-merge compatibility with 10.8 (2014.4459)

### DIFF
--- a/Casks/araxis-merge.rb
+++ b/Casks/araxis-merge.rb
@@ -1,14 +1,19 @@
 cask 'araxis-merge' do
-  version '2016.4750'
-
   name 'Araxis Merge'
-  if MacOS.release <= :mavericks
+  if MacOS.release <= :mountain_lion
+    version '2014.4459'
+    sha256 '7945e0fd583880bf4bbb65899c7184692d683f247764e73f435e0685954028f0'
+    url "http://www.araxis.com/download/Merge#{version}-OSX10.8.dmg"
+  elsif MacOS.release <= :mavericks
+    version '2016.4750'
     sha256 '9f3f4d3ba4931f69f75fd315e6823b19c5bb3938a5734b59b6aa92ec715ed00f'
     url "http://www.araxis.com/download/Merge#{version}-OSX10.9.dmg"
   elsif MacOS.release <= :yosemite
+    version '2016.4750'
     sha256 '18208f885f645347ae5956a81aa1d1ef78fbc5dd5f5da0ed5a02efab004293cf'
     url "http://www.araxis.com/download/Merge#{version}-OSX10.10.dmg"
   else
+    version '2016.4750'
     sha256 'efd2ec4fa98988022eaedda40c12fb7abd5d1720d8422f25ff279cd8daac8279'
     url "http://www.araxis.com/download/Merge#{version}-OSX10.11.dmg"
   end
@@ -16,7 +21,7 @@ cask 'araxis-merge' do
   homepage 'http://www.araxis.com/merge'
   license :commercial
 
-  depends_on macos: '>= :mavericks'
+  depends_on macos: '>= :mountain_lion'
 
   app 'Araxis Merge.app'
   binary 'Utilities/araxisgitdiff'


### PR DESCRIPTION
2014.4459 is a latest version that works on ML
