### PR TITLE
Update Horos to 1.1.7

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -1,9 +1,8 @@
 cask 'horos' do
-  version '1.1.6'
-  sha256 '140e7c8fc10a7732a24ef53f885b8929aac2e7e7ac5db71c78ce3b4605c13ed0'
+  version '1.1.7'
+  sha256 'd15e02d7678e0f41ad12910176307aeb6312e62d7386051bfe5a261a7feb004a'
 
-  # dev-horos-project.pantheon.io was verified as official when first introduced to the cask
-  url "http://dev-horos-project.pantheon.io/wp-content/uploads/downloads/Horos#{version}.dmg"
+  url "http://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"
   name 'Horos – Free, open medical image viewer'
   homepage 'http://www.horosproject.org'
   license :gpl


### PR DESCRIPTION
- Update Horos to current version 1.1.7.
- Use download url reflecting updated official homepage
