### PR TITLE
Update redcine-x-pro to 39.40030

### DIFF
--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -1,14 +1,13 @@
 cask 'redcine-x-pro' do
-  version '31.0.0'
-  sha256 '9393f84d839214ef4b692434ced8f4f9ecd12f8f49d8230d84c1bef9fe44d4db'
+  version '39.40030'
+  sha256 '177c87dd1ccc5579b446020a5b5400a71f2713981afbc13f0fc202bf4270af99'
 
-  # amazonaws.com is the official download host per the vendor homepage
-  url "https://s3.amazonaws.com/red_3/downloads/software/rcx/REDCINE-X_PRO_Build_#{version.to_i}_OSX.zip"
+  url "http://downloads.red.com/software/rcx/mac/release/#{version}/REDCINE-X_PRO_Build_#{version.major}.0.pkg"
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'
   license :commercial
 
-  pkg "REDCINE-X_PRO_Build_#{version.to_i}.pkg"
+  pkg "REDCINE-X_PRO_Build_#{version.major}.0.pkg"
 
   uninstall pkgutil: [
                        'com.red.pkg.REDCINE-X PRO',


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Is there a special token I can use to just refer to the file that was just downloaded in the `pkg` stanza? (i.e. `pkg :downloaded_file`)

Thanks!
