### PR TITLE
Update yubico-authenticator to 2.3.0

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,6 +1,6 @@
 cask 'yubico-authenticator' do
-  version '2.2.1'
-  sha256 '1c68b4589f377e6bae6f918e8018ed942172a4b71bcd3f907cdbca2b3f363313'
+  version '2.3.0'
+  sha256 '837d4e0d7255ffb5dc161c88fdc49feaa4a63d3004e2442509e80c6d0b62905e'
 
   url "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-#{version}-mac.pkg"
   name 'Yubico Authenticator'


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).

yubico-authenticator updated to 2.3.0
- [x] `brew cask audit --download {{cask_file}}` is error-free.

```
brew cask audit --download https://raw.githubusercontent.com/visualphoenix/homebrew-cask/update-yubi/Casks/yubico-authenticator.rb
==> Downloading https://raw.githubusercontent.com/visualphoenix/homebrew-cask/update-yubi/Casks/yubico-authenticator.rb
######################################################################## 100.0%
==> Downloading https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-2.3.0-mac.pkg
Already downloaded: /Library/Caches/Homebrew/yubico-authenticator-2.3.0.pkg
==> Verifying checksum for Cask yubico-authenticator
audit for yubico-authenticator: passed
==> Downloading https://raw.githubusercontent.com/visualphoenix/homebrew-cask/update-yubi/Casks/yubico-authenticator.rb
######################################################################## 100.0%
```
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

```
brew cask style --fix Casks/yubico-authenticator.rb

1 file inspected, no offenses detected
```
