### PR TITLE
Fixed the cli to include --skip-cask-deps to skip all casks dependencies

### DIFF
--- a/lib/hbc/cli/install.rb
+++ b/lib/hbc/cli/install.rb
@@ -3,7 +3,8 @@ class Hbc::CLI::Install < Hbc::CLI::Base
     cask_tokens = cask_tokens_from(args)
     raise Hbc::CaskUnspecifiedError if cask_tokens.empty?
     force = args.include? '--force'
-    retval = install_casks cask_tokens, force
+    skip_cask_deps = args.include? '--skip-cask-deps'
+    retval = install_casks cask_tokens, force, skip_cask_deps
     # retval is ternary: true/false/nil
     if retval.nil?
       raise Hbc::CaskError.new("nothing to install")
@@ -12,12 +13,12 @@ class Hbc::CLI::Install < Hbc::CLI::Base
     end
   end
 
-  def self.install_casks(cask_tokens, force)
+  def self.install_casks(cask_tokens, force, skip_cask_deps=false)
     count = 0
     cask_tokens.each do |cask_token|
       begin
         cask = Hbc.load(cask_token)
-        Hbc::Installer.new(cask).install(force)
+        Hbc::Installer.new(cask).install(force, skip_cask_deps)
         count += 1
        rescue Hbc::CaskAlreadyInstalledError => e
          opoo e.message

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -42,6 +42,16 @@ describe Hbc::CLI::Install do
     }, %r{==> Success! local-transmission staged at '#{Hbc.caskroom}/local-transmission/2.61' \(487 files, 11M\)})
   end
 
+  it "skip dependencies with --skip-cask-deps" do
+    shutup do
+      Hbc::CLI::Install.run('with-depends-on-cask-multiple', '--skip-cask-deps')
+    end
+    Hbc.load('with-depends-on-cask-multiple').must_be :installed?
+    Hbc.load('local-caffeine').wont_be :installed?
+    Hbc.load('local-transmission').wont_be :installed?
+  end
+
+
   it "properly handles Casks that are not present" do
     lambda {
       shutup do
@@ -83,6 +93,10 @@ describe Hbc::CLI::Install do
 
     describe "with --force" do
       with_options.call(['--force'])
+    end
+
+    describe "with --skip-cask-deps" do
+      with_options.call(['--skip-cask-deps'])
     end
 
     describe "with an invalid option" do


### PR DESCRIPTION
I changed the cli include --skip-cask-deps since the installer have this option to skip all casks dependencies
