### PR TITLE
Update dockertoolbox to 1.11.1

### DIFF
--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -1,11 +1,11 @@
 cask 'dockertoolbox' do
-  version '1.11.0'
-  sha256 'be1629bfec6854cf170f0e635858661105d8e0bb1f7656ac510676f5fcc82897'
+  version '1.11.1'
+  sha256 '05b0d13b94a8a637023eacb2657c30d7ee66026f7f28e97c8a83c6fee0c0f0df'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: '12d86cd293f7dba682b15ead4d2529cc5fe159ba8e751386559795e5efa88efd'
+          checkpoint: '5dc74ad4c56f796e7dd32846ecbf0c1839a63fa2b1ecef6ac72b3b7256a4474a'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/toolbox'
   license :apache


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download dockertoolbox` is error-free.
- [x] `brew cask style --fix dockertoolbox` left no offenses.
