### PR TITLE
bandage 0.8.0

### DIFF
--- a/Casks/bandage.rb
+++ b/Casks/bandage.rb
@@ -1,11 +1,11 @@
 cask 'bandage' do
-  version '0.7.1'
-  sha256 '29f88973388f27fa6456065c7659d5250dd0e825f184c3604621baacd440452f'
+  version '0.8.0'
+  sha256 '154863b16bc9ecdf7b53aa9ecc22e7b34b980959ceb1105b3aefbd229b29ee0b'
 
   # github.com/rrwick/Bandage was verified as official when first introduced to the cask
-  url "https://github.com/rrwick/Bandage/releases/download/v#{version}/Bandage_Mac_v#{version}.zip"
+  url "https://github.com/rrwick/Bandage/releases/download/v#{version}/Bandage_Mac_v#{version.gsub('.', '_')}.zip"
   appcast 'https://github.com/rrwick/Bandage/releases.atom',
-          checkpoint: 'db58afd366df0db3617e877dec3e018d1eb3f962f156d7047c8787208d6b7244'
+          checkpoint: '1a11b4ec58def73a31ca2f89638eecdc2eaf4e46d0f30416ab87a669138f5962'
   name 'Bandage'
   homepage 'https://rrwick.github.io/Bandage/'
   license :gpl


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
