### PR TITLE
Change to HTTPS URL for Quitter.app cask

### DIFF
--- a/Casks/quitter.rb
+++ b/Casks/quitter.rb
@@ -2,7 +2,7 @@ cask 'quitter' do
   version :latest
   sha256 :no_check
 
-  url 'http://marco.org/appcasts/Quitter.zip'
+  url 'https://marco.org/appcasts/Quitter.zip'
   name 'Quitter'
   homepage 'https://marco.org/apps#quitter'
   license :gratis


### PR DESCRIPTION
Changed the download URL for Quitter.app to https per [instructions](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#https-urls-are-preferred).
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
