### PR TITLE
updated gitup (1.0.5)

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,11 +1,11 @@
 cask 'gitup' do
-  version '1.0.4'
-  sha256 '756222e40bb125e5e0e3231b7a5ada035c73a0461e67ce09475fb0324dd7de76'
+  version '1.0.5'
+  sha256 'ca230886c4e808518b918530392ef2eb6aea5d11dcf4ea23a89a271d3d0ee3f1'
 
   # s3-us-west-2.amazonaws.com/gitup-builds was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/gitup-builds/stable/GitUp.zip'
   appcast 'https://github.com/git-up/GitUp/releases.atom',
-          checkpoint: '6d7967f3e3e93fce6596c760ed4ca3989b8c02077c7b0b18c4ff127e5723fda3'
+          checkpoint: '70b0baa99c73973227fc6a3a361e0b7bf6df59dbd77972400a028604e4d21ef9'
   name 'GitUp'
   homepage 'http://gitup.co'
   license :gpl


### PR DESCRIPTION
While I was trying to understand why gitup's SHA256 signature was wrong, I realized that a new version of it had been released.
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
