### PR TITLE
Updated displaylink (2.5.1,573)

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,20 +1,16 @@
 cask 'displaylink' do
-  if MacOS.release <= :leopard
-    version '1.7'
-    sha256 'b35dc49fe286aa858d7f6f44fd3f6703de83fae2316d20b05e637a1134ba2440'
-  elsif MacOS.release <= :snow_leopard
-    version '2.2'
+  if MacOS.release <= :lion
+    version '2.2,121'
     sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
   else
-    version '2.4'
-    sha256 'e3972ca00836c5a7ae03f85f0e43b7069673b3f3d9d30d6c68175ea077045637'
+    version '2.5.1,573'
+    sha256 'b8eb10da99ce115a6649d79f23d4ee2c8ce32863b9139df285f3750d75eaa952'
   end
 
-  url 'http://www.displaylink.com/downloads/file.php',
+  url "http://www.displaylink.com/downloads/file?id=#{version.after_comma}",
       data:  {
-               'id'     => '420',
-               'file'   => "DisplayLink_OSX_#{version}.dmg",
-               'folder' => 'publicsoftware',
+               'fileId'        => version.after_comma,
+               'accept_submit' => 'Accept',
              },
       using: :post
   name 'DisplayLink USB Graphics Software'
@@ -50,6 +46,6 @@ cask 'displaylink' do
     Installing this Cask means you have AGREED to the DisplayLink
     Software License Agreement at
 
-      http://www.displaylink.com/support/sla.php?fileid=102
+      http://www.displaylink.com/downloads/file?id=#{version.after_comma}
   EOS
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download displaylink` is error-free.
- [x] `brew cask style --fix displaylink` left no offenses.

Fixes #20850 
