### PR TITLE
Revert ".travis.yml: use xcode7.3 for 10.11"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode7.2
       rvm: system
     - env: OSX=10.10 HOMEBREW_RUBY=2.0.0
       os: osx


### PR DESCRIPTION
Reverts caskroom/homebrew-cask#20949

Reverting for now. Trying to figure out Travis’ issue.
