### PR TITLE
Reintroduce iChm v1.4.3

### DIFF
--- a/Casks/ichm.rb
+++ b/Casks/ichm.rb
@@ -1,0 +1,12 @@
+cask 'ichm' do
+  version '1.4.3'
+  sha256 '2a00ab7fdfedd1dfea6a7a290af2eb791072812199e6d98cfdcafb9fd83e9697'
+
+  # ichm.googlecode.com was verified as official when first introduced to the cask
+  url "https://ichm.googlecode.com/files/iChm.#{version}.zip"
+  name 'iChm'
+  homepage 'http://www.robinlu.com/ichm'
+  license :oss
+
+  app 'iChm.app'
+end


### PR DESCRIPTION
Cask has been deleted during pull request #17270 with the following PR message:

``` bash
Seems to have rendering problems on OSX 10.7+ robin/ichm#1 and no current releases.

Tick #17075
```

I cannot reproduce the issue on OS X 10.11.4 and other .chm files seem to be displayed just fine as well.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
