### PR TITLE
Upgrade jgrasp to v2.0.2_01

### DIFF
--- a/Casks/jgrasp.rb
+++ b/Casks/jgrasp.rb
@@ -1,11 +1,11 @@
 cask 'jgrasp' do
-  version '2.0.1_09'
-  sha256 '3b16bcc366a06d0a7765801814e02bd94837ee5e2e141ad0d5855ae4bd5b04ba'
+  version '2.0.2_01'
+  sha256 '17961e4407f5a6182c2548ccdfde4ec6815af3643080a3e9db945f3e12b0c7cc'
 
   url "http://www.jgrasp.org/dl4g/jgrasp/jgrasp#{version.no_dots}.pkg"
   name 'jgrasp'
   homepage 'http://jgrasp.org/index.html'
-  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :other # See http://www.jgrasp.org/license.html
 
   pkg "jgrasp#{version.no_dots}.pkg"
 


### PR DESCRIPTION
- Updated version number and SHA256 checksum; fixed license type and URL.
- Tested locally with brew-tap, installing and uninstalling.
