### PR TITLE
Fix broken Kivy v1.9.1

### DIFF
--- a/Casks/kivy.rb
+++ b/Casks/kivy.rb
@@ -10,6 +10,6 @@ cask 'kivy' do
   depends_on formula: 'unar'
 
   # Renamed as suggested by developer: https://kivy.org/docs/installation/installation-osx.html#installation-on-os-x
-  app 'Kivy2.app', target: 'Kivy.app'
-  binary 'Kivy2.app/Contents/Resources/script', target: 'kivy'
+  app 'Kivy3.app', target: 'Kivy.app'
+  binary 'Kivy3.app/Contents/Resources/script', target: 'kivy'
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

This cask is the python3 version of Kivy and the archive expands to Kivy3.app, not Kivy2.app.
Fixed app and binary stanzas.
