### PR TITLE
Added more files to delete when zapping vmware-fusion

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -42,8 +42,17 @@ cask 'vmware-fusion' do
   zap delete: [
                 # note: '~/Library/Application Support/VMware Fusion' is not safe
                 # to delete. In older versions, VM images were located there.
+                '/Library/Preferences/VMware Fusion',
                 '~/Library/Caches/com.vmware.fusion',
                 '~/Library/Logs/VMware',
                 '~/Library/Logs/VMware Fusion',
+                '~/Library/Preferences/com.vmware.fusion.LSSharedFileList.plist',
+                '~/Library/Preferences/com.vmware.fusion.LSSharedFileList.plist.lockfile',
+                '~/Library/Preferences/com.vmware.fusion.plist',
+                '~/Library/Preferences/com.vmware.fusion.plist.lockfile',
+                '~/Library/Preferences/com.vmware.fusionDaemon.plist',
+                '~/Library/Preferences/com.vmware.fusionDaemon.plist.lockfile',
+                '~/Library/Preferences/com.vmware.fusionStartMenu.plist',
+                '~/Library/Preferences/com.vmware.fusionStartMenu.plist.lockfile',
               ]
 end


### PR DESCRIPTION
List of files extracted from [VMWare's knowledge base](https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1017838)
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
