### PR TITLE
Add kk7ds-python-runtime v10.1

### DIFF
--- a/Casks/kk7ds-python-runtime.rb
+++ b/Casks/kk7ds-python-runtime.rb
@@ -1,0 +1,14 @@
+cask 'kk7ds-python-runtime' do
+  version '10.1'
+  sha256 '5cee8acb941e39f93a4df6a99ed29a14c48da0bc5beb3b31068852b1fad8b009'
+
+  url "http://www.d-rats.com/download/OSX_Runtime/KK7DS_Python_Runtime_R#{version.major}.pkg"
+  name 'KK7DS Python Runtime'
+  homepage 'http://www.d-rats.com/download/OSX_Runtime/'
+  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  pkg "KK7DS_Python_Runtime_R#{version.major}.pkg"
+
+  uninstall pkgutil: 'com.danplanet.python_runtime',
+            delete:  '/opt/kk7ds'
+end


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download kk7ds-python-runtime` is error-free.
- [x] `brew cask style --fix kk7ds-python-runtime` left no offenses.
- [x] `brew cask install kk7ds-python-runtime` worked successfully.
- [x] `brew cask uninstall kk7ds-python-runtime` worked successfully.

The KK7DS Python Runtime is required by CHIRP for programming radios.
