### PR TITLE
Add WhatsApp official 0.2.684

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,0 +1,11 @@
+cask 'whatsapp' do
+  version '0.2.684'
+  sha256 '728e1761d81e5d84a3fa9bc5f63383780f2830c7b10103c5791ffeccf016b842'
+
+  url 'https://web.whatsapp.com/desktop/mac/files/WhatsApp.zip'
+  name 'WhatsApp Official'
+  homepage 'https://www.whatsapp.com/'
+  license :closed # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  app 'WhatsApp.app'
+end


### PR DESCRIPTION
##### Instructions

Adding official desktop whatsapp 0.2.684
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [ ] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md). - it was suggested as `whats`
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).
