### PR TITLE
Fix vmware-horizon-client 4.0.1-3708485 download link

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -2,7 +2,7 @@ cask 'vmware-horizon-client' do
   version '4.0.1-3708485'
   sha256 '28d5a75194b57754391ebecc08311b3c81a587b9ed22a64685c1e0a51c136e48'
 
-  url "https://download3.vmware.com/software/view/viewclients/CART15Q4_3/VMware-Horizon-Client-#{version}.dmg"
+  url "https://download3.vmware.com/software/view/viewclients/CART16Q1_2/VMware-Horizon-Client-#{version}.dmg"
   name 'VMware Horizon Client'
   homepage 'https://www.vmware.com/'
   license :gratis


### PR DESCRIPTION
#### Editing an existing cask
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download Casks/vmware-horizon-client.rb` is error-free.
- [X] `brew cask style --fix Casks/vmware-horizon-client.rb` left no offenses.

Not sure how the audit download passed yesterday in #21106, unless they changed the link overnight...
