### PR TITLE
Updating VLC appcast hash

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -4,7 +4,7 @@ cask 'vlc' do
 
   url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
   appcast 'http://update.videolan.org/vlc/sparkle/vlc-intel64.xml',
-          checkpoint: '473cf8f5c4d23aec6524e2d50b4b2e4ab736db718bb350f4decbf6dd969e2741'
+          checkpoint: '01543595515ba6449e20124ddf92dec314d5ef60a246af8d9460de01a0977b31'
   name 'VLC media player'
   homepage 'https://www.videolan.org/vlc/'
   license :oss


### PR DESCRIPTION
This PR is an extension of !20975. In that PR, VLC hadn't yet updated their appcast XML file. They have since updated it, so this PR just updates that value.
### Changes to a cask
#### Editing an existing cask
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
