### PR TITLE
Fix MacUpdate Desktop v6.1

### DIFF
--- a/Casks/macupdate-desktop.rb
+++ b/Casks/macupdate-desktop.rb
@@ -1,6 +1,6 @@
 cask 'macupdate-desktop' do
   version '6.1'
-  sha256 '0f93e249074b7e49e6a7aacc4e69bc8c2a9a7e41e0004277299c74bd89f75bf9'
+  sha256 '68a5f05a865c04732fd84446f73ad69231a094f9db562485b2de6f0c98fd42be'
 
   url "http://cdn.macupdate.com/MacUpdateDesktop#{version}.zip"
   appcast 'http://www.macupdate.com/desktop/updates.xml',


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

``` bash
# brew cask install macupdate-desktop
==> Downloading http://cdn.macupdate.com/MacUpdateDesktop6.1.zip
######################################################################## 100.0%
==> Verifying checksum for Cask macupdate-desktop
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 0f93e249074b7e49e6a7aacc4e69bc8c2a9a7e41e0004277299c74bd89f75bf9
Actual: 68a5f05a865c04732fd84446f73ad69231a094f9db562485b2de6f0c98fd42be
File: /Library/Caches/Homebrew/macupdate-desktop-6.1.zip
To retry an incomplete download, remove the file above.
```
