### PR TITLE
updated hots-replay-uploader (2.0.5)

### DIFF
--- a/Casks/hots-replay-uploader.rb
+++ b/Casks/hots-replay-uploader.rb
@@ -1,10 +1,10 @@
 cask 'hots-replay-uploader' do
-  version '2.0.3'
-  sha256 'adc3e36ece5c2bcfcedc515763edccdfa430b79835044c684712aa49642aa364'
+  version '2.0.5'
+  sha256 '1e817b826f39e2b4a61d0300e6b762fd9a90d175b6f77a08b9cdb5da6d0a7584'
 
   url "https://github.com/eivindveg/HotSUploader/releases/download/v#{version}/HotS.Replay.Uploader-#{version}.dmg"
   appcast 'https://github.com/eivindveg/HotSUploader/releases.atom',
-          checkpoint: 'a6b8613ffcff32aa4924d95f78f54e34d3f6a41aacd61a6aaa25be84f480d8e9'
+          checkpoint: 'bf10b65d7d029267f7246abaa4f57b5b479635253d1ccb2e695064c85ef1cdfd'
   name 'HotS Replay Uploader'
   homepage 'https://github.com/eivindveg/HotSUploader/'
   license :apache


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
