### PR TITLE
updated electron (1.1.0)

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -4,7 +4,7 @@ cask 'electron' do
 
   url "https://github.com/atom/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/atom/electron/releases.atom',
-          checkpoint: '4b692564c630075833d2086222cd3123baf1732b0b2bde9895f70677b60df5f3'
+          checkpoint: '535667359d6bd878fef8f16cf3e613a52cb9884604e149b869c7cd012919e243'
   name 'Electron'
   homepage 'http://electron.atom.io/'
   license :mit


### PR DESCRIPTION
Fixes checkpoint in https://github.com/caskroom/homebrew-cask/pull/21209.
