### PR TITLE
Bump rubocop-cask dependency to 0.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ group :debug do
 end
 
 group :development do
-  gem 'rubocop', '~> 0.37.0'
-  gem 'rubocop-cask', '~> 0.5.0'
+  gem 'rubocop-cask', '~> 0.6.0'
 end
 
 group :release do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       metaclass (~> 0.0.1)
     mustache (1.0.2)
     netrc (0.11.0)
-    parser (2.3.0.2)
+    parser (2.3.1.0)
       ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -67,15 +67,15 @@ GEM
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    rubocop (0.37.0)
-      parser (>= 2.3.0.2, < 3.0)
+    rubocop (0.40.0)
+      parser (>= 2.3.1.0, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 0.3)
-    rubocop-cask (0.5.0)
-      rubocop (~> 0.37.0)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-cask (0.6.0)
+      rubocop (~> 0.40.0)
+    ruby-progressbar (1.8.1)
     simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -89,7 +89,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    unicode-display_width (0.3.1)
+    unicode-display_width (1.0.5)
 
 PLATFORMS
   ruby
@@ -104,8 +104,7 @@ DEPENDENCIES
   rake
   ronn (= 0.7.3)
   rspec (~> 3.0.0)
-  rubocop (~> 0.37.0)
-  rubocop-cask (~> 0.5.0)
+  rubocop-cask (~> 0.6.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/lib/hbc/cli/style.rb
+++ b/lib/hbc/cli/style.rb
@@ -19,7 +19,7 @@ class Hbc::CLI::Style < Hbc::CLI::Base
     $?.success?
   end
 
-  RUBOCOP_CASK_VERSION = '~> 0.5.0'
+  RUBOCOP_CASK_VERSION = '~> 0.6.0'
 
   def install_rubocop
     Hbc::Utils.install_gem_setup_path! 'rubocop-cask', RUBOCOP_CASK_VERSION, 'rubocop'


### PR DESCRIPTION
Closes #20806
