### PR TITLE
Rename Flixster Desktop to Flixster Video as part of new upstream ver…

### DIFF
--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -1,16 +1,16 @@
-cask 'flixster-desktop' do
-  version '2.5.12.335'
-  sha256 '9b884410c07dd2f7f96b35b5dd0fcd9322b13b448cae69a494324cafa24deeb6'
+cask 'flixster-video' do
+  version '2.6.2.526'
+  sha256 'dd1115ad5ac28246bc74c3d46df5066fd8bd236830a89f1e22ea56fcdbf17788'
 
   # d1rtylazwb77ux.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
   appcast 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
-          checkpoint: '507f4bf227962190e023b4427d6a6c521a61b7db1a175467256546afd91a2240'
-  name 'Flixster Desktop for Mac'
+          checkpoint: '20c3667ff31a2e488951a235a9c61d031e154528fb172686759e0fd9b00eba43'
+  name 'Flixster Video'
   homepage 'https://www.flixster.com/about/ultraviolet/'
   license :gratis
 
-  app 'Flixster Desktop.app'
+  app 'Flixster Video.app'
 
   postflight do
     suppress_move_to_applications key: 'moveToApplicationsFolderAlertSuppress'


### PR DESCRIPTION
Flixster appears to have been partially acquired by Fandango, and the online video portion (which this app supports) has been spun out into Flixster Video.
