### PR TITLE
Add wantedly-sync

### DIFF
--- a/Casks/sync-messenger.rb
+++ b/Casks/sync-messenger.rb
@@ -1,0 +1,16 @@
+cask 'sync-messenger' do
+  version '1.10.2'
+  sha256 'fb9f550d60fa21e91489f735f0c3f2fc3049118c698b2b3df35c4dad632fdb38'
+
+  url 'https://sync-download.s3-ap-northeast-1.amazonaws.com/releases/sync-darwin-production-1456814986.zip'
+  name 'Sync - a group chat app for business'
+  homepage 'https://www.wantedly.com/sync'
+  license :commercial
+
+  app 'Sync.app'
+
+  zap delete: [
+                '~/Library/Application Support/sync-messenger-electron',
+                '~/Library/Containers/com.wantedly.sync-desktop',
+              ]
+end

--- a/Casks/wantedly-sync.rb
+++ b/Casks/wantedly-sync.rb
@@ -3,7 +3,7 @@ cask 'wantedly-sync' do
   sha256 'fb9f550d60fa21e91489f735f0c3f2fc3049118c698b2b3df35c4dad632fdb38'
 
   url 'https://sync-download.s3-ap-northeast-1.amazonaws.com/releases/sync-darwin-production-1456814986.zip'
-  name 'Sync - a group chat app for business'
+  name 'Sync'
   homepage 'https://www.wantedly.com/sync'
   license :commercial
 

--- a/Casks/wantedly-sync.rb
+++ b/Casks/wantedly-sync.rb
@@ -1,4 +1,4 @@
-cask 'sync-messenger' do
+cask 'wantedly-sync' do
   version '1.10.2'
   sha256 'fb9f550d60fa21e91489f735f0c3f2fc3049118c698b2b3df35c4dad632fdb38'
 


### PR DESCRIPTION
## Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

``` sh
in ~g/wantedly/homebrew-cask on sync_messenger
❯ brew cask audit --download Casks/sync-messenger.rb
==> Downloading https://sync-download.s3-ap-northeast-1.amazonaws.com/releases/sync-darwin-production-1456814986.zip
######################################################################## 100.0%
==> Verifying checksum for Cask sync-messenger
audit for sync-messenger: passed

in ~g/wantedly/homebrew-cask on sync_messenger
❯ brew cask style --fix Casks/sync-messenger.rb
==> Installing or updating 'rubocop-cask' gem
Fetching: rainbow-2.1.0.gem (100%)
Successfully installed rainbow-2.1.0
Fetching: ast-2.2.0.gem (100%)
Successfully installed ast-2.2.0
Fetching: parser-2.3.1.0.gem (100%)
Successfully installed parser-2.3.1.0
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: ruby-progressbar-1.8.1.gem (100%)
Successfully installed ruby-progressbar-1.8.1
Fetching: unicode-display_width-1.0.5.gem (100%)
Successfully installed unicode-display_width-1.0.5
Fetching: rubocop-0.40.0.gem (100%)
Successfully installed rubocop-0.40.0
Fetching: rubocop-cask-0.6.0.gem (100%)
Successfully installed rubocop-cask-0.6.0
8 gems installed
== Casks/sync-messenger.rb ==
C:  6:  1: [Corrected] stanzas within the same group should have no lines between them
C: 14:  5: [Corrected] Align the elements of an array literal if they span more than one line.
C: 14:  5: [Corrected] Use 2 spaces for indentation in an array, relative to the position of the opening bracket.
C: 16:  3: [Corrected] Indent the right bracket the same as the left bracket.

1 file inspected, 4 offenses detected, 4 offenses corrected

in ~g/wantedly/homebrew-cask on sync_messenger *
❯ brew cask install Casks/sync-messenger.rb
==> Downloading https://sync-download.s3-ap-northeast-1.amazonaws.com/releases/sync-darwin-production-1456814986.zip
Already downloaded: /Library/Caches/Homebrew/sync-messenger-1.10.2.zip
==> Verifying checksum for Cask sync-messenger
==> Symlinking App 'Sync.app' to '/Users/ykiwng/Applications/Sync.app'
🍺  sync-messenger staged at '/opt/homebrew-cask/Caskroom/sync-messenger/1.10.2' (112 files, 107M)

in ~g/wantedly/homebrew-cask on sync_messenger *
❯ brew cask uninstall Casks/sync-messenger.rb
==> Removing App symlink: '/Users/ykiwng/Applications/Sync.app'
```
