### PR TITLE
pdftk-server 2.02 (new cask)

### DIFF
--- a/Casks/pdftk-server.rb
+++ b/Casks/pdftk-server.rb
@@ -1,0 +1,14 @@
+cask 'pdftk-server' do
+  version '2.02'
+  sha256 'c0679a7a12669480dd298c436b0e4d063966f95ed6a77b98d365bb8c86390d1b'
+
+  url "https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-#{version}-mac_osx-10.6-setup.pkg"
+  name 'PDFtk Server'
+  homepage 'https://www.pdflabs.com/tools/pdftk-server/'
+  license :gpl
+
+  pkg "pdftk_server-#{version}-mac_osx-10.6-setup.pkg"
+
+  uninstall pkgutil: 'com.pdflabs.pdftkThePdfToolkit.pdftk.pkg',
+            delete: '/opt/pdflabs/pdftk'
+end


### PR DESCRIPTION
#### Adding a new cask
- [ ] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [ ] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [ ] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Commit message includes cask’s name.
- [ ] `brew cask audit --download pdftk-server` is error-free.
- [ ] `brew cask style --fix pdftk-server` left no offenses.
- [ ] `brew cask install pdftk-server` worked successfully.
- [ ] `brew cask uninstall pdftk-server` worked successfully.
