### PR TITLE
Update nomachine (5.1.26_1)

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '5.1.9_16'
-  sha256 'ebd304097aeac41ebde64e364698e86ac529b2549b599f589bedbf3b561dab16'
+  version '5.1.26_1'
+  sha256 '837d4cc8049ddccef287ad9fec29c4c009f426f56a32b8c8b1396ced2e80b6f8'
 
   url "http://download.nomachine.com/download/#{version.split('.')[0..1].join('.')}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
