### PR TITLE
Cask repari gmvault fix

### DIFF
--- a/Casks/gmvault.rb
+++ b/Casks/gmvault.rb
@@ -8,5 +8,5 @@ cask 'gmvault' do
   homepage 'http://gmvault.org'
   license :gpl
 
-  binary "gmvault-v#{version}/bin/gmvault"
+  binary "gmvault-v#{version}/gmvault"
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

There is no bin subfolder in the latest 1.9.1 release, so this commit is to fix the installation of 1.9.1, which otherwise results in

```
Error: It seems the symlink source is not there: '/opt/homebrew-cask/Caskroom/gmvault/1.9.1/gmvault-v1.9.1/bin/gmvault'
```
