### PR TITLE
Fix package id for yubico-authenticator

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -9,5 +9,5 @@ cask 'yubico-authenticator' do
 
   pkg "yubioath-desktop-#{version}-mac.pkg"
 
-  uninstall pkgutil: 'com.yubico.pkg.YubicoAuthenticatoOSX'
+  uninstall pkgutil: 'com.yubico.pkg.YubicoAuthenticator'
 end


### PR DESCRIPTION
Package ID was wrong:

```
$ pkgutil --pkgs | grep -i yubi.*auth
com.yubico.pkg.YubicoAuthenticator
```
