### PR TITLE
get dwarf-fortress runnable: just install and type `dwarf-fortress`

### DIFF
--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -35,4 +35,7 @@ cask 'dwarf-fortress' do
     end
   end
 
+  uninstall_preflight do
+    system 'cp', '-r', "#{staged_path}/df_osx/data/save", '/tmp/dwarf-fortress-save/'
+  end
 end

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -1,4 +1,15 @@
 cask 'dwarf-fortress' do
+  module Utils
+    def self.update_sdl(name, url, path)
+      ohai "Replacing #{name}.framework from libsdl.org"
+      system 'curl', '-ksL', "https://www.libsdl.org/#{url}", '-o', "/tmp/#{name}.dmg"
+      system 'hdiutil', 'attach', "/tmp/#{name}.dmg"
+      system 'rm', '-rf', "#{path}/df_osx/libs/#{name}.framework"
+      system 'cp', '-r', "/Volumes/#{name}/#{name}.framework", "#{path}/df_osx/libs"
+      system 'hdiutil', 'detach', "/Volumes/#{name}"
+    end
+  end
+
   version '0.43.01'
   sha256 '7fe378b7aeee67f10a1f88a2341b8724edbf91795fd928506f01dfb403304d43'
 
@@ -7,5 +18,20 @@ cask 'dwarf-fortress' do
   homepage 'http://www.bay12games.com/dwarves/'
   license :gratis
 
-  suite 'df_osx', target: 'Dwarf Fortress'
+  shimscript = "#{staged_path}/df_wrapper"
+  binary shimscript, target: Hbc.homebrew_prefix.join('bin/df_osx')
+
+  preflight do
+    File.open(shimscript, 'w') do |f|
+      f.puts '#!/bin/sh'
+      f.puts "cd '#{staged_path}/df_osx' && ./df \"$@\""
+      FileUtils.chmod '+x', f
+    end
+  end
+
+  postflight do
+    # http://dwarffortresswiki.org/index.php/DF2014:Installation#Mac
+    Utils.update_sdl 'SDL_ttf', 'projects/SDL_ttf/release/SDL_ttf-2.0.11.dmg', staged_path
+    Utils.update_sdl 'SDL', 'release/SDL-1.2.15.dmg', staged_path
+  end
 end

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -9,9 +9,10 @@ cask 'dwarf-fortress' do
 
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/df_wrapper"
-  binary shimscript, target: Hbc.homebrew_prefix.join('bin/df_osx')
   depends_on cask: 'sdl-framework'
   depends_on cask: 'sdl-ttf-framework'
+
+  binary shimscript, target: Hbc.homebrew_prefix.join('bin/dwarf-fortress')
 
   preflight do
     File.open(shimscript, 'w') do |f|

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -39,6 +39,7 @@ hdiutil detach /Volumes/#{name}
     # http://dwarffortresswiki.org/index.php/DF2014:Installation#Mac
     Utils.update_sdl 'SDL_ttf', 'projects/SDL_ttf/release/SDL_ttf-2.0.11.dmg', staged_path
     Utils.update_sdl 'SDL', 'release/SDL-1.2.15.dmg', staged_path
-    ohai "Run #{staged_path}/update_sdl to fetch and replace DF's SDL libraries"
   end
+
+  caveats "Run #{staged_path}/update_sdl to fetch and replace DF's SDL libraries"
 end

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -18,7 +18,7 @@ hdiutil detach /Volumes/#{name}
   version '0.43.01'
   sha256 '7fe378b7aeee67f10a1f88a2341b8724edbf91795fd928506f01dfb403304d43'
 
-  url "http://www.bay12games.com/dwarves/df_#{version.sub(%r{^0+\.}, '').gsub('.', '_')}_osx.tar.bz2"
+  url "http://www.bay12games.com/dwarves/df_#{version.minor}_#{version.patch}_osx.tar.bz2"
   name 'Dwarf Fortress'
   homepage 'http://www.bay12games.com/dwarves/'
   license :gratis

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -1,12 +1,17 @@
 cask 'dwarf-fortress' do
   module Utils
     def self.update_sdl(name, url, path)
-      ohai "Replacing #{name}.framework from libsdl.org"
-      system 'curl', '-ksL', "https://www.libsdl.org/#{url}", '-o', "/tmp/#{name}.dmg"
-      system 'hdiutil', 'attach', "/tmp/#{name}.dmg"
-      system 'rm', '-rf', "#{path}/df_osx/libs/#{name}.framework"
-      system 'cp', '-r', "/Volumes/#{name}/#{name}.framework", "#{path}/df_osx/libs"
-      system 'hdiutil', 'detach', "/Volumes/#{name}"
+      File.open("#{path}/update_sdl", 'a') do |f|
+        f.puts(<<-EOF)
+#!/bin/sh
+curl -ksL 'https://www.libsdl.org/#{url}' -o /tmp/#{name}.dmg
+hdiutil attach /tmp/#{name}.dmg
+rm -rf '#{path}/df_osx/libs/#{name}.framework'
+cp -r '/Volumes/#{name}/#{name}.framework' '#{path}/df_osx/libs'
+hdiutil detach /Volumes/#{name}
+        EOF
+        FileUtils.chmod '+x', f
+      end
     end
   end
 
@@ -33,5 +38,6 @@ cask 'dwarf-fortress' do
     # http://dwarffortresswiki.org/index.php/DF2014:Installation#Mac
     Utils.update_sdl 'SDL_ttf', 'projects/SDL_ttf/release/SDL_ttf-2.0.11.dmg', staged_path
     Utils.update_sdl 'SDL', 'release/SDL-1.2.15.dmg', staged_path
+    ohai "Run #{staged_path}/update_sdl to fetch and replace DF's SDL libraries"
   end
 end

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -24,13 +24,13 @@ cask 'dwarf-fortress' do
 
   postflight do
     Dir.chdir("#{staged_path}/df_osx/libs") do
-      [
-        ['SDL', 'sdl-framework'],
-        ['SDL_ttf', 'sdl-ttf-framework'],
-      ].each do |args|
-        name = "#{args[0]}.framework"
+      {
+        'SDL'     => 'sdl-framework',
+        'SDL_ttf' => 'sdl-ttf-framework',
+      }.each do |key, value|
+        name = "#{key}.framework"
         File.rename(name, "#{name}.orig")
-        File.symlink(Hbc.load(args[1]).staged_path.join(name), name)
+        File.symlink(Hbc.load(value).staged_path.join(name), name)
       end
     end
   end

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -23,6 +23,7 @@ hdiutil detach /Volumes/#{name}
   homepage 'http://www.bay12games.com/dwarves/'
   license :gratis
 
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/df_wrapper"
   binary shimscript, target: Hbc.homebrew_prefix.join('bin/df_osx')
 

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -12,7 +12,7 @@ cask 'dwarf-fortress' do
   depends_on cask: 'sdl-framework'
   depends_on cask: 'sdl-ttf-framework'
 
-  binary shimscript, target: Hbc.homebrew_prefix.join('bin/dwarf-fortress')
+  binary shimscript, target: 'dwarf-fortress'
 
   preflight do
     File.open(shimscript, 'w') do |f|

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -38,4 +38,6 @@ cask 'dwarf-fortress' do
   uninstall_preflight do
     system 'cp', '-r', "#{staged_path}/df_osx/data/save", '/tmp/dwarf-fortress-save/'
   end
+
+  caveats 'During uninstall, your save data will be copied to /tmp/dwarf-fortress-save'
 end

--- a/Casks/sdl-framework.rb
+++ b/Casks/sdl-framework.rb
@@ -1,0 +1,11 @@
+cask 'sdl-framework' do
+  version '1.2.15'
+  sha256 '49e228446599b1f77af812a6276dd7a3f230f8d7a02d1b7b62bb99a874262834'
+
+  url "https://www.libsdl.org/release/SDL-#{version}.dmg"
+  name 'SDL.framework'
+  homepage 'https://www.libsdl.org'
+  license :gpl
+
+  stage_only true
+end

--- a/Casks/sdl-ttf-framework.rb
+++ b/Casks/sdl-ttf-framework.rb
@@ -1,0 +1,11 @@
+cask 'sdl-ttf-framework' do
+  version '2.0.11'
+  sha256 '8c0c8eab34002dfff6695cec7066bd5e4aa56250b82dd9f5cd272f7e6f530dd4'
+
+  url "https://www.libsdl.org/projects/SDL_ttf/release/SDL_ttf-#{version}.dmg"
+  name 'SDL_ttf.framework'
+  homepage 'https://www.libsdl.org'
+  license :gpl
+
+  stage_only true
+end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
