### PR TITLE
Add wireshark-chmodbpf

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,0 +1,89 @@
+cask 'wireshark-chmodbpf' do
+  version '2.0.3'
+  sha256 'a64dc77117a4408b48235297215032017e77822885ce3e19cd1065bfbea0ae57'
+
+  url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
+  name 'Wireshark-ChmodBPF'
+  homepage 'https://www.wireshark.org/'
+  license :gpl
+
+  installer script: '/usr/sbin/installer',
+            args:   [
+                      '-applyChoiceChangesXML',
+                      "#{staged_path}/chmodbpf_only.xml",
+                      '-package',
+                      "#{staged_path}/Wireshark #{version} Intel 64.pkg",
+                      '-target',
+                      '/',
+                    ]
+
+  preflight do
+    # shim script (https://github.com/caskroom/homebrew-cask/pull/21318)
+    FileUtils.touch "#{staged_path}/chmodbpf_only.xml"
+    chmodbpf_only = File.open "#{staged_path}/chmodbpf_only.xml", 'w'
+    chmodbpf_only.puts '<?xml version="1.0" encoding="UTF-8"?>'
+    chmodbpf_only.puts '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+    chmodbpf_only.puts '<plist version="1.0">'
+    chmodbpf_only.puts '<array>'
+    chmodbpf_only.puts '  <dict>'
+    chmodbpf_only.puts '    <key>attributeSetting</key>'
+    chmodbpf_only.puts '    <integer>0</integer>'
+    chmodbpf_only.puts '    <key>choiceAttribute</key>'
+    chmodbpf_only.puts '    <string>selected</string>'
+    chmodbpf_only.puts '    <key>choiceIdentifier</key>'
+    chmodbpf_only.puts '    <string>wireshark</string>'
+    chmodbpf_only.puts '  </dict>'
+    chmodbpf_only.puts '  <dict>'
+    chmodbpf_only.puts '    <key>attributeSetting</key>'
+    chmodbpf_only.puts '    <integer>0</integer>'
+    chmodbpf_only.puts '    <key>choiceAttribute</key>'
+    chmodbpf_only.puts '    <string>selected</string>'
+    chmodbpf_only.puts '    <key>choiceIdentifier</key>'
+    chmodbpf_only.puts '    <string>cli</string>'
+    chmodbpf_only.puts '  </dict>'
+    chmodbpf_only.puts '</array>'
+    chmodbpf_only.puts '</plist>'
+    chmodbpf_only.close
+  end
+
+  postflight do
+    if Process.euid == 0
+      ohai 'Note:'
+      puts <<-EOS.undent
+        You executed 'brew cask' as the superuser.
+
+        You must manually add users to group 'access_bpf' in order to use Wireshark
+      EOS
+    else
+      system '/usr/bin/sudo', '-E', '--',
+             '/usr/sbin/dseditgroup', '-o', 'edit', '-a', Etc.getpwuid(Process.euid).name, '-t', 'user', '--', 'access_bpf'
+    end
+  end
+
+  uninstall script:  {
+                       executable: '/usr/sbin/dseditgroup',
+                       args:       ['-o', 'delete', 'access_bpf'],
+                     },
+            pkgutil: 'org.wireshark.ChmodBPF.pkg',
+            delete:  [
+                       '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist',
+                     ],
+            rmdir:   [
+                       '/Library/Application Support/Wireshark/ChmodBPF',
+                       '/Library/Application Support/Wireshark',
+                     ]
+
+  caveats <<-EOS.undent
+    This cask will install only the ChmodBPF package from the current Wireshark
+    stable install package.
+    An access_bpf group will be created and its members allowed access to BPF
+    devices at boot to allow unpriviledged packet captures.
+    This cask is not required if installing the Wireshark cask. It is meant to
+    support Wireshark installed from homebrew or other cases where unpriviledged
+    access to OS X packet capture devices is desired without installing the binary
+    distribution of Wireshark.
+
+    The user account used to install this cask will be added to the access_bpf
+    group automatically.
+  EOS
+end


### PR DESCRIPTION
For some time now the homebrew wireshark formula has contained the following caveat:

> If your list of available capture interfaces is empty
> (default OS X behavior), try the following commands:
> 
>   curl https://bugs.wireshark.org/bugzilla/attachment.cgi?id=3373 -o ChmodBPF.tar.gz
>   tar zxvf ChmodBPF.tar.gz
>   open ChmodBPF/Install\ ChmodBPF.app
> 
> This adds a launch daemon that changes the permissions of your BPF
> devices so that all users in the 'admin' group - all users with
> 'Allow user to administer this computer' turned on - have both read
> and write access to those devices.
> 
> See bug report:
>   https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=3760

This seems like a good place to reference a cask. However, the file referenced in the caveat is an aging static attachment to an old bug id and not really suitable as the base of a cask.

This cask would install only 'org.wireshark.ChmodBPF.pkg' from the official Wireshark release pkg, but for it to work I need to write a temporary file containing:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<array>
 <dict>
  <key>attributeSetting</key>
  <integer>0</integer>
  <key>choiceAttribute</key>
  <string>selected</string>
  <key>choiceIdentifier</key>
  <string>wireshark</string>
 </dict>
 <dict>
  <key>attributeSetting</key>
  <integer>0</integer>
  <key>choiceAttribute</key>
  <string>selected</string>
  <key>choiceIdentifier</key>
  <string>cli</string>
 </dict>
</array>
</plist>
```

The temporary file would then be read in by the installer script. I attempted doing this with some sort of here document or stdin, but none of those attempts worked or looked like very good form for a cask. 

This pull-request contains a draft cask with everything but the logic to write the temporary file which is required by the installer script.

What would be the best way to accomplish this?
