### PR TITLE
Fix Frappé cask version string

### DIFF
--- a/Casks/frappe.rb
+++ b/Casks/frappe.rb
@@ -1,5 +1,5 @@
 cask 'frappe' do
-  version 'v0.1.1'
+  version '0.1.1'
   sha256 'de5440f075dd8c93c92284158e2a44fbfc3747e00293739c3aba1aea31082433'
 
   url "https://github.com/niftylettuce/frappe/releases/download/v#{version}/v#{version}.zip"


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download frappe` is error-free.
- [x] `brew cask style --fix frappe` left no offenses.

The installation was not working because the URL was falsely expanded to ".../vv0.1.1/vv0.1.1".
