### PR TITLE
Revert "layout_test.rb: Add vendor to ignored dirs"

### DIFF
--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -18,7 +18,6 @@ describe "Repo layout" do
                     .rubocop_todo.yml
                     .ruby-version
                     coverage
-                    vendor
                    }
 
   # the developer has hopefully gitignored these


### PR DESCRIPTION
Reverts caskroom/homebrew-cask#20972

I think this can be reverted, as those Travis changes were rolled back
