### PR TITLE
Upgrade FreeCAD.app to v0.16

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,11 +1,13 @@
 cask 'freecad' do
-  version '0.15.4671'
-  sha256 '47815ef591d084e1ac248302256d1af5cdf3bba3b3c8afc2c477362f1cc95fd6'
+  version '0.16-6704.0c449d7'
+  sha256 '2c996a31f37b8937ecfa31baa98b0f42e43549e66f959c36ecb6d1289d1a89b0'
 
-  url "http://downloads.sourceforge.net/sourceforge/free-cad/FreeCAD-#{version}_x64_osx.zip"
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/0.16/FreeCAD_#{version}-OSX-x86_64.dmg"
+  appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom',
+          checkpoint: '2ba5a313f5b3a3d186cc5f47f81067f1e5adb8b79d5821cf73aa6afe979c7b76'
   name 'FreeCAD'
-  homepage 'http://sourceforge.net/projects/free-cad/'
+  homepage 'http://www.freecadweb.org'
   license :gpl
 
-  app "FreeCAD-#{version}_x64_osx/FreeCAD.app"
+  app 'FreeCAD.app'
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Upgrade FreeCAD to v0.16.
Update sha256 stanza.
Add appcast stanza.
Update homepage to point to the new official URL.
Update app stanza to match .dmg content.
