### PR TITLE
Upgrade bathyscaphe to 270-v937

### DIFF
--- a/Casks/bathyscaphe.rb
+++ b/Casks/bathyscaphe.rb
@@ -1,6 +1,6 @@
 cask 'bathyscaphe' do
-  version '270-v931'
-  sha256 'c27f02467f748662537a09128ffedd73a6ccace0ec28fcb5a86a6c2bfdde87c1'
+  version '270-v937'
+  sha256 '34900c805c30c697e2e0a4bc3fb5788a1ecdb9099fbc902c55158efe99c1815c'
 
   url "https://bitbucket.org/bathyscaphe/public/downloads/BathyScaphe-#{version}.dmg"
   name 'BathyScaphe'


### PR DESCRIPTION
##### Instructions
- Upgrade bathyscaphe to 270-v937
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
