### PR TITLE
Fix sha256 for Inform 7 version 6M62

### DIFF
--- a/Casks/inform.rb
+++ b/Casks/inform.rb
@@ -1,6 +1,6 @@
 cask 'inform' do
   version '6M62'
-  sha256 'e3c9cbbd7fd3933e7585a0a89596c0c736e89d8bb5a9f297edfd6ad7d0f97c8c'
+  sha256 '5302213a92122a98167e8e2994fd465ed3400b16aa571139edc772616e72b8b9'
 
   url "http://inform7.com/download/content/#{version}/I7-#{version}-OSX.dmg"
   name 'Inform'


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

For some reason, the cask doesn't have the right sha256 for the file off their website.
