### PR TITLE
update pinegrow web designer to 2.81

### DIFF
--- a/Casks/pinegrow-web-designer.rb
+++ b/Casks/pinegrow-web-designer.rb
@@ -1,6 +1,6 @@
 cask 'pinegrow-web-designer' do
-  version '2.2'
-  sha256 'c0d1b9595963b8080298261c4d9744237427e5d2ed02d38d38fbdbcbb43a7f1a'
+  version '2.81'
+  sha256 '76d14cc1947d97cfb58f9879956ffc8ee04582fbdff3131a6b11f4dabe7c2e25'
 
   # pinegrow.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://pinegrow.s3.amazonaws.com/PinegrowMac.#{version}.dmg"


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] brew cask audit --download pinegrow-web-designer is error-free.
- [x] brew cask style --fix pinegrow-web-designer left no offenses.
