### PR TITLE
Fix triumph.rb: Remove DDP Player.app artifact

### DIFF
--- a/Casks/triumph.rb
+++ b/Casks/triumph.rb
@@ -8,5 +8,4 @@ cask 'triumph' do
   license :commercial
 
   app 'Triumph.app'
-  app 'Triumph.app/Contents/Applications/DDP Player.app'
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
#### Rationale

Triumph.app contains in its bundle three helper tools. Those tools are meant to be accessed from the menu bar while using Triumph.

One of those tools, DDP Player.app, is defined as an artifact though. With upcoming PR #13966, `cask install` would rip out DDP Player.app from the bundle. As a consequence, invoking the _DDP Player_ menu item would cause Triumph to crash.

This commit fixes the issue by removing the artifact altogether. All the tools (including DDP Player) should be launched from the _Tools_ menu as intended, e. g.:

> Triumph » Tools » DDP Player
