### PR TITLE
Update flycut to 1.8

### DIFF
--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -1,13 +1,13 @@
 cask 'flycut' do
-  version '1.5'
-  sha256 '0a0d3d91194ba8f4e53a9ad004452cb7b0bc5541322f849a203a75720f875908'
+  version '1.8'
+  sha256 'f7fa218a4fee31208476ff400cd1044f3356bf2200a06e32731572498c7ce42a'
 
-  url "https://github.com/downloads/TermiT/Flycut/flycut#{version}.pkg"
+  url "https://github.com/TermiT/Flycut/releases/download/#{version}/Flycut.app.#{version}.zip"
   name 'Flycut'
   homepage 'https://github.com/TermiT/Flycut'
   license :mit
 
-  pkg "flycut#{version}.pkg", allow_untrusted: true
+  app 'Flycut.app'
 
-  uninstall pkgutil: 'com.generalarcade.flycut'
+  zap delete: '~/Library/Preferences/com.generalarcade.flycut.plist'
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
