### PR TITLE
profilemanager - Update source URL

### DIFF
--- a/Casks/profilemanager.rb
+++ b/Casks/profilemanager.rb
@@ -2,7 +2,7 @@ cask 'profilemanager' do
   version '1.0'
   sha256 'a46295851063d8a0630cace6720813e571e86a66734a8765f9706bab939b3f48'
 
-  url "https://ftp.mozilla.org/pub/mozilla.org/utilities/profilemanager/#{version}/profilemanager.mac.dmg"
+  url "https://archive.mozilla.org/pub/mozilla.org/utilities/profilemanager/#{version}/profilemanager.mac.dmg"
   name 'Mozilla Profile Manager'
   homepage 'https://developer.mozilla.org/en-US/docs/Profile_Manager'
   license :mpl


### PR DESCRIPTION
Mozilla has changed their hosting structure, and will (eventually)
retire the old host names.
