### PR TITLE
Add appcast to flycut

### DIFF
--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -3,6 +3,8 @@ cask 'flycut' do
   sha256 'f7fa218a4fee31208476ff400cd1044f3356bf2200a06e32731572498c7ce42a'
 
   url "https://github.com/TermiT/Flycut/releases/download/#{version}/Flycut.app.#{version}.zip"
+  appcast 'https://github.com/TermiT/Flycut/releases.atom',
+          checkpoint: '02bb24f0420441a85701adebe5e145497146bd9c4923b321df6974042cbbffa4'
   name 'Flycut'
   homepage 'https://github.com/TermiT/Flycut'
   license :mit


### PR DESCRIPTION
Follows the `flycut` cask update: https://github.com/caskroom/homebrew-cask/pull/21419#discussion_r64498593
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
