### PR TITLE
travis: if merge base is older than 50 commits, unshallow the repo

### DIFF
--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -22,7 +22,10 @@ run 'env | sort'
 run export BRANCH_COMMIT="${TRAVIS_COMMIT_RANGE##*.}"
 run export TARGET_COMMIT="${TRAVIS_COMMIT_RANGE%%.*}"
 # shellcheck disable=SC2016
-run 'MERGE_BASE="$(git merge-base "${BRANCH_COMMIT}" "${TARGET_COMMIT}")"'
+if ! run 'MERGE_BASE="$(git merge-base "${BRANCH_COMMIT}" "${TARGET_COMMIT}")"'; then
+  run git fetch --unshallow
+  run 'MERGE_BASE="$(git merge-base "${BRANCH_COMMIT}" "${TARGET_COMMIT}")"'
+fi
 run export MERGE_BASE="${MERGE_BASE}"
 run export TRAVIS_COMMIT_RANGE="${MERGE_BASE}...${BRANCH_COMMIT}"
 


### PR DESCRIPTION
Should fix those pesky build errors we've been seeing when running `MERGE_BASE="$(git merge-base "${BRANCH_COMMIT}" "${TARGET_COMMIT}")"`.
