### PR TITLE
Upgrade FileZilla to v3.18.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,8 +3,8 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.17.0.1'
-    sha256 '3488df6f4477817b076b0216a4eb9794582f4aad90e388bb0352f6ff35d116e3'
+    version '3.18.0'
+    sha256 '3003240707506959175938ab81de43d784caf9ed3cb95a6e068b09848008ecf5'
   end
 
   # sourceforge.net/project/filezilla was verified as official when first introduced to the cask


### PR DESCRIPTION
✔️ commit message includes cask’s name (and new version, if applicable).
✔️ `brew cask audit --download {{cask_file}}` is error-free.
✔️ `brew cask style --fix {{cask_file}}` left no offenses.
