### PR TITLE
Maltego Classic. Version 4.0.0.8846

### DIFF
--- a/Casks/maltego-classic.rb
+++ b/Casks/maltego-classic.rb
@@ -1,4 +1,4 @@
-cask 'maltego' do
+cask 'maltego-classic' do
   version '4.0.0.8846'
   sha256 '1fd90f884f40a6b2a7530b8e081b6b9f7d21cdaf53a52a6dc800034a85af84be'
 

--- a/Casks/maltego-classic.rb
+++ b/Casks/maltego-classic.rb
@@ -2,10 +2,11 @@ cask 'maltego-classic' do
   version '4.0.0.8846'
   sha256 '1fd90f884f40a6b2a7530b8e081b6b9f7d21cdaf53a52a6dc800034a85af84be'
 
-  url "https://www.paterva.com/malv#{version.sub(%r{^(\d+)\..*}, '\1\2')}/classic/Maltego.v#{version}.dmg"
+  url "https://www.paterva.com/malv#{version.major}/classic/Maltego.v#{version}.dmg"
   name 'Paterva Maltego'
   homepage 'https://www.paterva.com/web7/buy/maltego-clients/maltego.php'
   license :closed
 
-  app "Maltego Classic v#{version.sub(%r{\.\d+$}, '')}.app"
+  app "Maltego Classic v#{version.major_minor_patch}.app"
+
 end

--- a/Casks/maltego-classic.rb
+++ b/Casks/maltego-classic.rb
@@ -8,5 +8,4 @@ cask 'maltego-classic' do
   license :closed
 
   app "Maltego Classic v#{version.major_minor_patch}.app"
-
 end

--- a/Casks/maltego.rb
+++ b/Casks/maltego.rb
@@ -1,11 +1,11 @@
 cask 'maltego' do
-  version '3.6.0.6526'
-  sha256 'cda838e27afd3c73dd33705f0448f7e63918a3e65df0274928a9c87fe3340d00'
+  version '4.0.0.8846'
+  sha256 '1fd90f884f40a6b2a7530b8e081b6b9f7d21cdaf53a52a6dc800034a85af84be'
 
-  url "https://www.paterva.com/malv#{version.sub(%r{^(\d+)\.(\d+)\..*}, '\1\2')}/commercial/Maltego.v#{version}.dmg"
+  url "https://www.paterva.com/malv#{version.sub(%r{^(\d+)\..*}, '\1\2')}/classic/Maltego.v#{version}.dmg"
   name 'Paterva Maltego'
-  homepage 'https://www.paterva.com/web6/products/maltego.php'
+  homepage 'https://www.paterva.com/web7/buy/maltego-clients/maltego.php'
   license :closed
 
-  app "Maltego Chlorine v#{version.sub(%r{\.\d+$}, '')}.app"
+  app "Maltego Classic v#{version.sub(%r{\.\d+$}, '')}.app"
 end


### PR DESCRIPTION
New version - Maltego Classic. Version 4.0.0.8846
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download maltego` is error-free.
- [x] `brew cask style --fix maltego` left no offenses.
