### PR TITLE
Show cached file location if download fails

### DIFF
--- a/lib/vendor/homebrew-fork/download_strategy.rb
+++ b/lib/vendor/homebrew-fork/download_strategy.rb
@@ -59,6 +59,7 @@ class Hbc::HbCurlDownloadStrategy < Hbc::AbstractDownloadStrategy
 
   def fetch
     ohai "Downloading #{@url}"
+    puts "The cache path for download: #{tarball_path}"
     unless tarball_path.exist?
       had_incomplete_download = temporary_path.exist?
       begin

--- a/lib/vendor/homebrew-fork/download_strategy.rb
+++ b/lib/vendor/homebrew-fork/download_strategy.rb
@@ -76,8 +76,7 @@ class Hbc::HbCurlDownloadStrategy < Hbc::AbstractDownloadStrategy
             msg = "File does not exist: #{@url.sub(%r[^file://], "")}"
           else
             msg = "Download failed: #{@url}"
-            msg << "\nThe desired cache filepath is #{tarball_path}, maybe you can download it by other tool,"
-            msg << "add move to the cache filepath, then run the install command again"
+            msg << "\nThe incomplete download is cached at #{tarball_path}"
           end
           raise Hbc::CurlDownloadStrategyError, msg
         end

--- a/lib/vendor/homebrew-fork/download_strategy.rb
+++ b/lib/vendor/homebrew-fork/download_strategy.rb
@@ -59,7 +59,6 @@ class Hbc::HbCurlDownloadStrategy < Hbc::AbstractDownloadStrategy
 
   def fetch
     ohai "Downloading #{@url}"
-    puts "The cache path for download: #{tarball_path}"
     unless tarball_path.exist?
       had_incomplete_download = temporary_path.exist?
       begin
@@ -77,6 +76,8 @@ class Hbc::HbCurlDownloadStrategy < Hbc::AbstractDownloadStrategy
             msg = "File does not exist: #{@url.sub(%r[^file://], "")}"
           else
             msg = "Download failed: #{@url}"
+            msg << "\nThe desired cache filepath is #{tarball_path}, maybe you can download it by other tool,"
+            msg << "add move to the cache filepath, then run the install command again"
           end
           raise Hbc::CurlDownloadStrategyError, msg
         end


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

When I install a cask , I hope the console can show the cache file's path, so  I can download the file by other download tool, and move it to the `brew --cache` directory after rename the filename as same as the cache file path.

My network is not good!!!
