### PR TITLE
Remove caveats from google-chrome and firefox

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -17,10 +17,4 @@ cask 'firefox' do
                 '~/Library/Application Support/Firefox',
                 '~/Library/Caches/Firefox',
               ]
-
-  caveats <<-EOS.undent
-  The Mac App Store version of 1Password won't work with a Homebrew-cask-linked Mozilla Firefox. To bypass this limitation, you need to either:
-    + Move Mozilla Firefox to your /Applications directory (the app itself, not a symlink).
-    + Install 1Password from outside the Mac App Store (licenses should transfer automatically, but you should contact AgileBits about it).
-  EOS
 end

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -25,11 +25,4 @@ cask 'google-chrome' do
                 '~/Library/Caches/Google',
                 '~/Library/Google',
               ]
-
-  caveats <<-EOS.undent
-    The Mac App Store version of 1Password won't work with a Homebrew-Cask-linked Google Chrome. To bypass this limitation, you need to either:
-
-      + Move Google Chrome to your /Applications directory (the app itself, not a symlink).
-      + Install 1Password from outside the Mac App Store (licenses should transfer automatically, but you should contact AgileBits about it).
-  EOS
 end


### PR DESCRIPTION
With the change to moving artifacts to `/Applications`, it seems that the previously necessary caveats should removed, so as to not cause confusion.
