### PR TITLE
Updated jdownloader (latest)

### DIFF
--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -16,8 +16,6 @@ cask 'jdownloader' do
 
   auto_updates true
 
-  app 'JDownloader 2.0/JDownloader2.app'
-
   preflight do
     system "\"#{staged_path}/JDownloader Installer.app/Contents/MacOS/JavaApplicationStub\" " \
            "-dir \"#{staged_path}\" " \
@@ -28,6 +26,8 @@ cask 'jdownloader' do
            '-VaddToDockAction\$Boolean=false ' \
            '> /dev/null 2>&1'
   end
+
+  uninstall delete: '/Applications/JDownloader2.app'
 
   caveats do
     depends_on_java


### PR DESCRIPTION
The installer creates a symlink at `/Applications/JDownloader2.app` automatically, thus no extra `app` stanza is required. Due to #13966 being merged a new warning is shown:

```
==> It seems there is already an App at '/Applications/JDownloader2.app'; not moving.
```

This update removes the unneeded `app` stanza and the warning.
(The `app` stanza was also not needed before #13966, but no warning was shown)
