### PR TITLE
Updated gnubg (1.04.000-1010-x86_64)

### DIFF
--- a/Casks/gnubg.rb
+++ b/Casks/gnubg.rb
@@ -24,14 +24,4 @@ cask 'gnubg' do
   depends_on x11: true
 
   app 'gnubg.app'
-
-  caveats do
-    <<-EOS.undent
-      #{token} only works if called from /Applications, so you may need to install it with
-        brew cask --appdir=/Applications install #{token}
-
-      Alternatively, you can create a symbolic link in /Applications after installing and upgrading:
-        ln -sf '#{staged_path}/gnubg.app' '/Applications/gnubg.app'
-    EOS
-  end
 end


### PR DESCRIPTION
Should this caveat be kept? (In case the user uses something else as `--appdir`)
