### PR TITLE
navicat-premium-essentials - 11.2.10 Update sha256 of the installer file

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
   version '11.2.10'
-  sha256 'e6b5e065d84b8ba11df165faddb88c48d18e9e73c68645d8d3021d96a795dd47'
+  sha256 '556705265af0b09cb1bde5542c74dff9ea5b3bb5abfbfea040c3755b7edfaa7d'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium Essentials'


### PR DESCRIPTION
I'm not sure about the actual reason but it seems that Navicat changed the installer file `navicat-premium-essentials-11.2.10.dmg` so the hash is invalidated. The version is still 11.2.10 and the url is http://download.navicat.com/download/navicatess112_premium_en.dmg but the sha256 is changed. When I try to open the file `navicatess112_premium_en.dmg` in `(/Library/Caches/Homebrew/navicat-premium-essentials-11.2.10.dmg)` I can still Navicat without any problem.

cask audit previously fails with this output:

```
Buraks-MacBook-Pro:~ buremba$ brew cask audit --download navicat-premium-essentials
==> Downloading http://download.navicat.com/download/navicatess112_premium_en.dmg
Already downloaded: /Library/Caches/Homebrew/navicat-premium-essentials-11.2.10.dmg
==> Verifying checksum for Cask navicat-premium-essentials
==> Note: running "brew update" may fix sha256 checksum errors
audit for navicat-premium-essentials: failed
 - download not possible: sha256 mismatch
Expected: e6b5e065d84b8ba11df165faddb88c48d18e9e73c68645d8d3021d96a795dd47
Actual: 556705265af0b09cb1bde5542c74dff9ea5b3bb5abfbfea040c3755b7edfaa7d
File: /Library/Caches/Homebrew/navicat-premium-essentials-11.2.10.dmg
To retry an incomplete download, remove the file above.
Error: audit failed
Buraks-MacBook-Pro:~ buremba$
```

Now `brew cask audit --download navicat-premium-essentials` works as expected.
