### PR TITLE
Fix shim script in blender.rb

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -18,8 +18,8 @@ cask 'blender' do
     pythonversion = '3.4'
     File.open(shimscript, 'w') do |f|
       f.puts '#!/bin/bash'
-      f.puts "export PYTHONHOME=#{staged_path}/blender-#{version}-OSX_10.6-x86_64/blender.app/Contents/Resources/#{version}/python/lib/python#{pythonversion}"
-      f.puts "#{staged_path}/blender-#{version}-OSX_10.6-x86_64/blender.app/Contents/MacOS/blender $@"
+      f.puts "export PYTHONHOME=#{Hbc.appdir}/blender.app/Contents/Resources/#{version}/python/lib/python#{pythonversion}"
+      f.puts "#{Hbc.appdir}/blender.app/Contents/MacOS/blender $@"
       FileUtils.chmod '+x', f
     end
   end


### PR DESCRIPTION
#### Editing an existing cask
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.

The Blender app is now put in /Applications, so the shim script
needed to be updated to point to the correct location.
