### PR TITLE
Update VirtualHostX to 7.1.1

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,10 +1,11 @@
 cask 'virtualhostx' do
-  version '6.0.5'
-  sha256 'f54ec0eb8ca70e543ddf0c5cf3b5ef9dcf81173ae0fd32c055dd4ebdf6c9e43e'
+  version '7.1.2,7_11'
+  sha256 '116f279ff05d3be583a8b00d8cb753872dbb29f50a1ff3e82c79d18c42de48cb'
 
-  url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx60_#{version}.zip"
-  appcast 'https://shine.clickontyler.com/appcast.php?id=30',
-          checkpoint: '5c3afe742634cc3ff5510cf91255063f24efafe095966b2216e36bee758e7890'
+  # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
+  url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"
+  appcast 'https://shine.clickontyler.com/appcast.php?id=33',
+          checkpoint: '3c12d4345ecddc6977754c588a7ad604c1b05e44b777eac993ff3b9d0653fb21'
   name 'VirtualHostX'
   homepage 'https://clickontyler.com/virtualhostx/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Updated VirtualHostX to the most recent version (7.1.1). The download
URL no longer uses a consistent pattern as before, so I wasn't sure
what to do for easy versioning.
