### PR TITLE
Fix `zap` regression introduced in 6500fa1; ref #21583

### DIFF
--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -304,7 +304,7 @@ class Hbc::Installer
     uninstall_artifacts
     if Hbc::Artifact::Zap.me?(@cask)
       ohai "Dispatching zap stanza"
-      Hbc::Artifact::Zap.new(@cask, @command).zap_phase
+      Hbc::Artifact::Zap.new(@cask, command: @command).zap_phase
     else
       opoo "No zap stanza present for Cask '#{@cask}'"
     end


### PR DESCRIPTION
<!--
### Changes to the core

- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

-->

This PR fixes an issue with 6500fa1, in which the (internal) installer API was refactored in preparation for the big change. That refactoring missed one case, causing `zap` to break; see #21583.

@caskroom/maintainers This is a one-line fix but please have a look nonetheless. Thanks!

Caveats:
- I did not include tests with this fix. The `zap` command seems to have test coverage issues. We do have a `cli/zap_test` case but [its main path is commented out](https://github.com/caskroom/homebrew-cask/commit/00921dd5137bcaba95ca816f8fb7a185d4bd220e#diff-7fe581fc0f85395ebffe41217d5bdc83R36). When I uncomment that test, it keeps failing and I can’t figure out why. Shall I open an issue for this on its own?
- # 13966 has exposed a few more (unrelated) issues with `uninstall` and `zap` in edge cases when the user has insufficient permissions. This is easily fixable (using methods from 9664b9f); I am preparing a PR right now.
