### PR TITLE
Bump GraphiQL to 0.4.1

### DIFF
--- a/Casks/graphiql.rb
+++ b/Casks/graphiql.rb
@@ -1,10 +1,10 @@
 cask 'graphiql' do
-  version '0.4.0'
-  sha256 '7f4c775a0f740363c3dd2e3881cdaf8456b5c5a0b6dc517e44fc2f598c5fed86'
+  version '0.4.1'
+  sha256 '34946a4503a193d6ec8d9fc7c84324d1fd585cd86605f36c7701c809fd398d58'
 
   url "https://github.com/skevy/graphiql-app/releases/download/v#{version}/GraphiQL.app.zip"
   appcast 'https://github.com/skevy/graphiql-app/releases.atom',
-          checkpoint: '7f4c775a0f740363c3dd2e3881cdaf8456b5c5a0b6dc517e44fc2f598c5fed86'
+          checkpoint: '34946a4503a193d6ec8d9fc7c84324d1fd585cd86605f36c7701c809fd398d58'
   name 'GraphiQL App'
   homepage 'https://github.com/skevy/graphiql-app'
   license :mit


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

I discovered that one of the dependency changes in 0.4.0 was broken: https://github.com/skevy/graphiql-app/commit/bf0f4cbc655a0f486899e560d21d22bf0a4f7937

0.4.1 includes the fix. 
