### PR TITLE
Update orange.rb to 3.3.5

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,11 +1,12 @@
 cask 'orange' do
-  version '3-3.2.dev0+2fc556d'
-  sha256 '9811008e071590c66abb2ac65355d55e466a59de2cd392b76fd328114094cf70'
+  version '3-3.3.5'
+  sha256 'e6a839ef6488d8becf979750701c8f395a97155b379ff8b5f7f12ab90a0cdb01'
 
   url "http://orange.biolab.si/download/files/Orange#{version}.dmg"
   name 'Orange'
   homepage 'http://orange.biolab.si/'
   license :gpl
 
-  app 'Orange.app'
+  app 'Orange3.app', target: 'Orange.app'
+  # Target for consistency, old versions did not include "3" in the App name and would not be overwritten.
 end

--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -7,6 +7,5 @@ cask 'orange' do
   homepage 'http://orange.biolab.si/'
   license :gpl
 
-  app 'Orange3.app', target: 'Orange.app'
-  # Target for consistency, old versions did not include "3" in the App name and would not be overwritten.
+  app 'Orange3.app'
 end


### PR DESCRIPTION
Changes to cask:

Update version, update sha256, update app stanza to include target because oddly they changed from Orange.app to Orange3.app between 3.3.2 and 3.3.5, which would cause two copies of the app to be installed. (This could also be due to using a "dev" version before which may lack a major version number.)

Audit performed, style check passed, install succeeded and replaced old version (when using --force).
