### PR TITLE
parallels-desktop.rb: updated *flights to moving

### DIFF
--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -10,21 +10,14 @@ cask 'parallels-desktop' do
   app 'Parallels Desktop.app'
 
   postflight do
-    # Set the file to visible, since it was hidden in the dmg
-    system '/usr/bin/SetFile', '-a', 'v', staged_path.join('Parallels Desktop.app')
-
     # Run the initialization script
     system '/usr/bin/sudo', '-E', '--',
-           staged_path.join('Parallels Desktop.app/Contents/MacOS/inittool'),
-           'init', '-b', staged_path.join('Parallels Desktop.app')
-
-    # Set the correct permissions on the link - remove after #13201 is solved
-    system '/usr/bin/sudo', '-E', '--',
-           'chown', '-h', 'root:wheel', Hbc.appdir.join('Parallels Desktop.app')
+           "#{Hbc.appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
+           'init', '-b', "#{Hbc.appdir}/Parallels Desktop.app"
   end
 
   uninstall_preflight do
-    set_ownership staged_path.join('Parallels Desktop.app')
+    set_ownership "#{Hbc.appdir}/Parallels Desktop.app"
   end
 
   uninstall delete: [


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
