### PR TITLE
stellarium.rb: added zap stanza

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -9,4 +9,6 @@ cask 'stellarium' do
   license :gpl
 
   app 'Stellarium.app'
+
+  zap delete: '~/Library/Preferences/Stellarium'
 end


### PR DESCRIPTION
Deleted user preferences folder for Stellarium as documented [here](http://www.stellarium.org/doc/head/fileStructure.html).
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
