### PR TITLE
music-manager.rb: do not move prefpane

### DIFF
--- a/Casks/music-manager.rb
+++ b/Casks/music-manager.rb
@@ -10,4 +10,6 @@ cask 'music-manager' do
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/4282
   app 'MusicManager.app', target: 'Music Manager.app'
+
+  uninstall delete: '~/Library/Preference Panes/MusicManager.prefPane'
 end

--- a/Casks/music-manager.rb
+++ b/Casks/music-manager.rb
@@ -10,5 +10,4 @@ cask 'music-manager' do
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/4282
   app 'MusicManager.app', target: 'Music Manager.app'
-  prefpane 'MusicManager.app/Contents/Helpers/MusicManager.prefPane'
 end


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Why would we be taking it? Presumably the app will take care of it.
