### PR TITLE
Fix deadlock in `Hbc::SystemCommand`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,11 @@ group :release do
 end
 
 group :test do
-  gem 'coveralls', :require => false
+  gem 'coveralls', require: false
   gem 'minitest', '5.4.1'
   gem 'minitest-reporters'
-  gem 'mocha', '1.1.0', :require => false
+  gem 'mocha', '1.1.0', require: false
   gem 'rspec', '~> 3.0.0'
+  gem 'rspec-its', require: false
+  gem 'rspec-wait', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,9 +64,14 @@ GEM
     rspec-expectations (3.0.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.0.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
+    rspec-wait (0.0.8)
+      rspec (>= 2.11, < 3.5)
     rubocop (0.40.0)
       parser (>= 2.3.1.0, < 3.0)
       powerpack (~> 0.1)
@@ -104,6 +109,8 @@ DEPENDENCIES
   rake
   ronn (= 0.7.3)
   rspec (~> 3.0.0)
+  rspec-its
+  rspec-wait
   rubocop-cask (~> 0.6.1)
 
 BUNDLED WITH

--- a/lib/hbc/system_command.rb
+++ b/lib/hbc/system_command.rb
@@ -2,64 +2,112 @@ require 'open3'
 require 'shellwords'
 
 class Hbc::SystemCommand
+  attr_reader :command
+
   def self.run(executable, options={})
-    command = _process_options(executable, options)
-    processed_stdout = ''
-    processed_stderr = ''
-
-    command[0] = Shellwords.shellescape(command[0]) if command.size == 1
-
-    to_exec = command.map { |arg| arg.respond_to?(:to_path) ? File.absolute_path(arg) : String(arg) }
-
-    odebug "Executing: #{to_exec.utf8_inspect}"
-
-    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(*to_exec)
-
-    if options[:input]
-      Array(options[:input]).each { |line| raw_stdin.puts line }
-    end
-    raw_stdin.close_write
-
-    while line = raw_stdout.gets
-      processed_stdout << line
-      ohai line.chomp if options[:print_stdout]
-    end
-
-    while line = raw_stderr.gets
-      processed_stderr << line
-      ohai line.chomp if options[:print_stderr]
-    end
-
-    raw_stdout.close_read
-    raw_stderr.close_read
-
-    processed_status = raw_wait_thr.value
-
-    _assert_success(processed_status, command, processed_stdout) if options[:must_succeed]
-
-    Hbc::SystemCommand::Result.new(command, processed_stdout, processed_stderr, processed_status.exitstatus)
+    self.new(executable, options).run!
   end
 
   def self.run!(command, options={})
     run(command, options.merge(:must_succeed => true))
   end
 
-  def self._process_options(executable, options)
+  def run!
+    @processed_output = { stdout: '', stderr: '' }
+    odebug "Executing: #{ expanded_command.utf8_inspect }"
+
+    each_output_line do |type, line|
+      case type
+      when :stdout
+        processed_output[:stdout] << line
+        ohai line.chomp if options[:print_stdout]
+      when :stderr
+        processed_output[:stderr] << line
+        ohai line.chomp if options[:print_stderr]
+      end
+    end
+
+    assert_success if options[:must_succeed]
+    result
+  end
+
+  def initialize(executable, options)
+    @executable = executable
+    @options = options
+    process_options!
+  end
+
+  private
+
+  attr_reader :executable, :options,
+    :processed_output, :processed_status
+
+  def process_options!
     options.assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo, :bsexec
     sudo_prefix = %w{/usr/bin/sudo -E --}
     bsexec_prefix = [ '/bin/launchctl', 'bsexec',  options[:bsexec]  == :startup ? '/' : options[:bsexec] ]
-    command = [executable]
+    @command = [executable]
     options[:print_stderr] = true   if !options.key?(:print_stderr)
-    command.unshift(*bsexec_prefix) if  options[:bsexec]
-    command.unshift(*sudo_prefix)   if  options[:sudo]
-    command.concat(options[:args])  if  options.key?(:args) and !options[:args].empty?
-    command
+    @command.unshift(*bsexec_prefix) if  options[:bsexec]
+    @command.unshift(*sudo_prefix)   if  options[:sudo]
+    @command.concat(options[:args])  if  options.key?(:args) and !options[:args].empty?
+    if @command.size == 1
+      @command[0] = Shellwords.shellescape(@command[0])
+    end
+    nil
   end
 
-  def self._assert_success(status, command, output)
-    unless status and status.success?
-      raise Hbc::CaskCommandFailedError.new(command.utf8_inspect, output, status)
+  def assert_success
+    unless processed_status && processed_status.success?
+      raise Hbc::CaskCommandFailedError.new(
+        command.utf8_inspect,
+        processed_output[:stdout],
+        processed_status)
     end
+  end
+
+  def expanded_command
+    @expanded_command ||= command.map do |arg|
+      if arg.respond_to?(:to_path)
+        File.absolute_path(arg)
+      else
+        String(arg)
+      end
+    end
+  end
+
+  def each_output_line(&b)
+    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr =
+      Open3.popen3(*expanded_command)
+
+    write_input_to(raw_stdin) if options[:input]
+    raw_stdin.close_write
+    each_line_from [raw_stdout, raw_stderr], &b
+
+    @processed_status = raw_wait_thr.value
+  end
+
+  def write_input_to(raw_stdin)
+    Array(options[:input]).each { |line| raw_stdin.puts line }
+  end
+
+  def each_line_from(sources)
+    begin
+      readable_sources = IO.select(sources)[0]
+      readable_sources.delete_if(&:eof?).first(1).each do |source|
+        type = (source == sources[0] ? :stdout : :stderr)
+        yield(type, source.gets || '')
+      end
+    end until readable_sources.empty?
+    sources.each(&:close_read)
+  end
+
+  def result
+    Hbc::SystemCommand::Result.new(command,
+      processed_output[:stdout],
+      processed_output[:stderr],
+      processed_status.exitstatus
+    )
   end
 end
 

--- a/spec/cask/system_command_spec.rb
+++ b/spec/cask/system_command_spec.rb
@@ -2,16 +2,11 @@ require 'spec_helper'
 
 describe Hbc::SystemCommand do
   describe "when the exit code is 0" do
-    let(:command) { '/usr/bin/true' }
+    describe "its result" do
+      subject { described_class.run('/usr/bin/true') }
 
-    it "says the command was successful" do
-      result = described_class.run(command)
-      expect(result.success?).to eq(true)
-    end
-
-    it "says the exit status is 0" do
-      result = described_class.run(command)
-      expect(result.exit_status).to eq(0)
+      it { is_expected.to be_a_success }
+      its(:exit_status) { is_expected.to eq(0) }
     end
   end
 
@@ -27,32 +22,110 @@ describe Hbc::SystemCommand do
     end
 
     describe "and the command does not have to succeed" do
-      it "says the command failed" do
-        result = described_class.run(command)
-        expect(result.success?).to eq(false)
-      end
+      describe "its result" do
+        subject { described_class.run(command) }
 
-      it "says the exit status is 1" do
-        result = described_class.run(command)
-        expect(result.exit_status).to eq(1)
+        it { is_expected.not_to be_a_success }
+        its(:exit_status) { is_expected.to eq(1) }
       end
     end
   end
 
-  describe "args" do
+  describe "given a pathname" do
     let(:command) { '/bin/ls' }
     let(:path)    { Pathname(Dir.mktmpdir) }
 
-    before do
-      FileUtils.touch(path.join('somefile'))
+    before { FileUtils.touch(path.join('somefile')) }
+
+    describe "its result" do
+      subject { described_class.run(command, args: [path]) }
+
+      it { is_expected.to be_a_success }
+      its(:stdout) { is_expected.to eq("somefile\n") }
+    end
+  end
+
+  describe "with both STDOUT and STDERR output from upstream" do
+    let(:command) { '/bin/bash' }
+    let(:options) do
+      { args: [
+        '-c',
+        'for i in $(seq 1 2 5); do echo $i; echo $(($i + 1)) >&2; done'
+      ] }
     end
 
-    it "can be pathnames" do
-      result = described_class.run(command, args: [path])
+    shared_examples "it returns '1 2 3 4 5 6'" do
+      describe "its result" do
+        subject { shutup { described_class.run(command, options) } }
 
-      expect(result.success?).to eq(true)
-      expect(result.stdout).to eq("somefile\n")
+        it { is_expected.to be_a_success }
+        its(:stdout) { is_expected.to eq([1, 3, 5, nil].join("\n")) }
+        its(:stderr) { is_expected.to eq([2, 4, 6, nil].join("\n")) }
+      end
+    end
+
+    describe "with default options" do
+      it "echoes only STDERR" do
+        expected = [2, 4, 6].map { |i| "==> #{ i }\n" }.join('')
+        expect { described_class.run(command, options)
+          }.to output(expected).to_stdout
+      end
+
+      include_examples("it returns '1 2 3 4 5 6'")
+    end
+
+    describe "with print_stdout" do
+      before { options.merge!(print_stdout: true) }
+
+      it "echoes both STDOUT and STDERR" do
+        (1..6).each do |i|
+          expect { described_class.run(command, options)
+            }.to output(/==> #{ i }/).to_stdout
+        end
+      end
+
+      include_examples("it returns '1 2 3 4 5 6'")
+    end
+
+    describe "without print_stderr" do
+      before { options.merge!(print_stderr: false) }
+
+      it "echoes nothing" do
+        expect { described_class.run(command, options)
+          }.to output('').to_stdout
+      end
+
+      include_examples("it returns '1 2 3 4 5 6'")
+    end
+
+    describe "with print_stdout but without print_stderr" do
+      before do
+        options.merge!(print_stdout: true, print_stderr: false)
+      end
+
+      it "echoes only STDOUT" do
+        expected = [1, 3, 5].map { |i| "==> #{ i }\n" }.join('')
+        expect { described_class.run(command, options)
+          }.to output(expected).to_stdout
+      end
+
+      include_examples("it returns '1 2 3 4 5 6'")
+    end
+  end
+
+  describe "with a very long STDERR output" do
+    let(:command) { '/bin/bash' }
+    let(:options) do
+      { args: [
+        '-c',
+        'for i in $(seq 1 2 100000); do echo $i; echo $(($i + 1)) >&2; done'
+      ] }
+    end
+
+    it "returns without deadlocking" do
+      wait(10).for {
+        shutup { described_class.run(command, options) }
+      }.to be_a_success
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'pathname'
+require 'rspec/its'
+require 'rspec/wait'
 
 if ENV['COVERAGE']
   require 'coveralls'

--- a/test/support/fake_system_command.rb
+++ b/test/support/fake_system_command.rb
@@ -42,7 +42,7 @@ class Hbc::FakeSystemCommand
   end
 
   def self.run(command_string, options={})
-    command = Hbc::SystemCommand._process_options(command_string, options)
+    command = Hbc::SystemCommand.new(command_string, options).command
     unless responses.key?(command)
       fail("no response faked for #{command.inspect}, faked responses are: #{responses.inspect}")
     end


### PR DESCRIPTION
# Summary

The current implementation of `Hbc::SystemCommand` uses the `Open3` library **in a way that causes deadlocks.** In particular, a deadlock occurs whenever `STDERR` grows beyond a certain size (> 5000 lines) on the default OS&nbsp;X system Ruby.

This PR fixes the issue; it also provides failing tests to make the deadlock reproducible.

@caskroom/maintainers Please review! Thanks in advance :blush:
# Analysis

Apparently, the bug was well concealed; it was brought to my attention only today when user @winkelsdorf filed issue #18638 (thanks again!). The deadlock is triggered when `brew cask install parallels-desktop --force` is run with the app already installed; this triggers a `/bin/chmod -R -- u+rwx '/Applications/Parallels Desktop.app'`, producing an extremely long result on standard error, which in turn triggers the bug.
## Deadlock

The Ruby documentation, section Open3 [summarizes quite well why the deadlock occurs](http://ruby-doc.org/stdlib-2.0.0/libdoc/open3/rdoc/Open3.html#method-c-popen3):

> You should be careful to avoid deadlocks. Since pipes are fixed length buffer, ::popen3(“prog”) {|i, o, e, t| o.read } deadlocks if the program generates many output on stderr. You should be [sic] read stdout and stderr simultaneously (using thread or IO.select). However if you don’t need stderr output, ::popen2 can be used. If merged stdout and stderr output is not a problem, you can use ::popen2e. If you really needs stdout and stderr output as separate strings, you can consider ::capture3.
## Root cause

The offending code snippet from `system_command.rb` is:

``` ruby
raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(*to_exec)

…

while line = raw_stdout.gets # <-- deadlock occurs here
  processed_stdout << line
  ohai line.chomp if options[:print_stdout]
end

while line = raw_stderr.gets
  processed_stderr << line
  ohai line.chomp if options[:print_stderr]
end
```

The deadlock occurs during the first `while` loop when `raw_stderr` happens to grow beyond a certain size.

In that particular case, both `raw_stdout` and `raw_stderr` will block until someone reads from `raw_stderr`. In the code above, this condition is not met until the second `while` loop.

In other words: things go south because the first `while` loop waits on `raw_stdout`, which waits on `raw_stderr` to be consumed, which in turn waits for the `while` loop to finish; a deadlock.
## Triggering the failure

When Parallels Desktop.app is installed, the bundle is owned by `root` and read-only to everyone else. When `brew cask install --force` is subsequently called, HBC needs to remove the existing app. It is actually quite smart in handling this; as a first gentle attempt before escalating to `sudo`, it tries to make the app world-writeable:

```
/bin/chmod -R -- u+rwx '/Applications/Parallels Desktop.app'
```

In general, this particular `chmod` is expected to fail; it is only a first attempt to avoid `sudo` whenever possible. In our example however, the failing `chmod` causes a lot of noise on STDERR (> 5000 lines) which triggers the deadlock in `Hbc::SystemCommand`.
# The fix

Following the suggestion from the Ruby documentation, I have replaced the hard-coded order of streams in `Hbc::SystemCommand` by polling `IO.select`, which guarantees deadlock-free stream selection.

To clean up the code a bit, I also extracted a few methods and ivars while at it.
# Testing
## Failing specs

I have included a spec which should detect, and fail on, this particular deadlock when run with the default OS&nbsp;X system Ruby. For details, see `spec/cask/system_command_spec.rb`.

The new specs are **in a separate commit** within this PR. They be run against either the old and new implementation.
## Additional test dependencies

To make this case testable, and allow for the spec to be more expressive, I have added two new test dependencies: `rspec-its` and `rspec-wait`. Both gems are released under the MIT license ([1](https://github.com/rspec/rspec-its/blob/master/LICENSE.txt) [2](https://github.com/laserlemon/rspec-wait/blob/master/LICENSE.txt)). I strongly believe that the former package is going to benefit our specs greatly; the latter is needed for deadlock detecting. In my opinion, either package is well worth being included in our testing toolchain.
## Running the tests

To install the added test dependencies, you might want need to run `bundle install` once.

The quickest way to run the specs is:

``` sh
bundle exec rake test:rspec
```

If you want to **watch the spec fail,** simply `git reset` one commit back in history, and execute the specs there.
