### PR TITLE
fix music-manager prefPane path for uninstall

### DIFF
--- a/Casks/music-manager.rb
+++ b/Casks/music-manager.rb
@@ -11,5 +11,5 @@ cask 'music-manager' do
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/4282
   app 'MusicManager.app', target: 'Music Manager.app'
 
-  uninstall delete: '~/Library/Preference Panes/MusicManager.prefPane'
+  uninstall delete: '~/Library/PreferencePanes/MusicManager.prefPane'
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

amends #21659
