### PR TITLE
man page: Fix spaces in path for ColorPickers and PreferencePanes

### DIFF
--- a/doc/man_page/brew-cask.1.md
+++ b/doc/man_page/brew-cask.1.md
@@ -152,10 +152,10 @@ in a future version.
     Target location for Applications. The default value is `/Applications`.
 
   * `--colorpickerdir=<path>`:
-    Target location for Color Pickers. The default value is `~/Library/Color Pickers`.
+    Target location for Color Pickers. The default value is `~/Library/ColorPickers`.
 
   * `--prefpanedir=<path>`:
-    Target location for Preference Panes. The default value is `~/Library/Preference Panes`.
+    Target location for Preference Panes. The default value is `~/Library/PreferencePanes`.
 
   * `--qlplugindir=<path>`:
     Target location for QuickLook Plugins. The default value is `~/Library/QuickLook`.

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -153,11 +153,11 @@ Target location for Applications\. The default value is \fB/Applications\fR\.
 .
 .TP
 \fB\-\-colorpickerdir=<path>\fR
-Target location for Color Pickers\. The default value is \fB~/Library/Color Pickers\fR\.
+Target location for Color Pickers\. The default value is \fB~/Library/ColorPickers\fR\.
 .
 .TP
 \fB\-\-prefpanedir=<path>\fR
-Target location for Preference Panes\. The default value is \fB~/Library/Preference Panes\fR\.
+Target location for Preference Panes\. The default value is \fB~/Library/PreferencePanes\fR\.
 .
 .TP
 \fB\-\-qlplugindir=<path>\fR


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

As noticed in comment https://github.com/caskroom/homebrew-cask/pull/21659#discussion_r65786306 by @tjanson .
