### PR TITLE
Add SQLPro for Postgres v43

### DIFF
--- a/Casks/sqlpro-for-postgres.rb
+++ b/Casks/sqlpro-for-postgres.rb
@@ -1,8 +1,8 @@
-cask 'sqlpropostgres' do
+cask 'sqlpro-for-postgres' do
   version '43'
   sha256 'ef510f2a7f69d0071872e9942f5f3cb967dadf1840e6ef978b38e8db3b019daf'
 
-  # cloudfront.net is the official download host per the vendor homepage
+  # d3fwkemdw8spx3.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/postgres/SQLProPostgres#{version}.app.zip"
   name 'SQLPro for Postgres'
   homepage 'http://www.macpostgresclient.com/SQLProPostgres'

--- a/Casks/sqlpropostgres.rb
+++ b/Casks/sqlpropostgres.rb
@@ -1,0 +1,17 @@
+cask 'sqlpropostgres' do
+  version '43'
+  sha256 'ef510f2a7f69d0071872e9942f5f3cb967dadf1840e6ef978b38e8db3b019daf'
+
+  # cloudfront.net is the official download host per the vendor homepage
+  url "https://d3fwkemdw8spx3.cloudfront.net/postgres/SQLProPostgres#{version}.app.zip"
+  name 'SQLPro for Postgres'
+  homepage 'http://www.macpostgresclient.com/SQLProPostgres'
+  license :commercial
+
+  app 'SQLPro for Postgres.app'
+
+  zap delete: [
+                '~/Library/Containers/com.hankinsoft.osx.SQLProPostgres',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.hankinsoft.osx.sqlpropostgres.sfl',
+              ]
+end


### PR DESCRIPTION
#### Adding a new cask
- [X] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [ ] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Commit message includes cask’s name.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.

Issues:
- This is by the same vendor as SQLPro for SQLite - I named the app after this but since the .app files are named differently there's some confusion there. I'm pinging the author on this so he's aware.
- Download URL was gotten from the homepage but it redirects to cloudfront.net
