### PR TITLE
FileBot 4.7: workaround MAS conflict

### DIFF
--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -8,8 +8,8 @@ cask 'filebot' do
   homepage 'https://www.filebot.net/'
   license :gpl
 
-  app 'FileBot.app'
-  binary "#{appdir}/FileBot.app/Contents/MacOS/filebot.sh", target: 'filebot'
+  app 'FileBot.app', target: 'FileBot-brew.app'
+  binary "#{appdir}/FileBot-brew.app/Contents/MacOS/filebot.sh", target: 'filebot'
 
   caveats do
     depends_on_java('8')


### PR DESCRIPTION
The brew cask version of FileBot and the MAS version seem to interfere with each other.

See https://github.com/caskroom/homebrew-cask/issues/21672
