### PR TITLE
Fix stackato URL

### DIFF
--- a/Casks/stackato.rb
+++ b/Casks/stackato.rb
@@ -2,7 +2,7 @@ cask 'stackato' do
   version '3.2.4'
   sha256 'e1d940509d46bc1ec4829998c736b802f77c01971e661d43456fe7574b16e48f'
 
-  url "https://downloads.stackato.com/client/v#{version}/stackato-#{version}-macosx10.5-i386-x86_64.zip"
+  url "http://downloads.stackato.com/client/v#{version}/stackato-#{version}-macosx10.5-i386-x86_64.zip"
   name 'Stackato'
   homepage 'https://docs.stackato.com/user/client/'
   license :apache


### PR DESCRIPTION
Switch from https to http, stackato client available only via http:

```
brew cask install stackato
==> Downloading https://downloads.stackato.com/client/v3.2.4/stackato-3.2.4-macosx10.5-i386-x86_64.zip

curl: (7) Failed to connect to downloads.stackato.com port 443: Operation timed out
Error: Download failed on Cask 'stackato' with message: Download failed: https://downloads.stackato.com/client/v3.2.4/stackato-3.2.4-macosx10.5-i386-x86_64.zip
```
