### PR TITLE
Armory 0.94.1

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -3,6 +3,8 @@ cask 'armory' do
   sha256 'e1a977de35840d969bdf4039a0d5ddb466866ee793e9c178b0650ebbbf93af5c'
 
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
+  appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
+          checkpoint: '50b50e2071c2cb4f05c0564cc0019d7fdd621ccc225953cdf4c1d93e40abba12'
   name 'Armory'
   homepage 'https://github.com/goatpig/BitcoinArmory'
   license :oss

--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -1,11 +1,11 @@
 cask 'armory' do
-  version '0.93.3'
-  sha256 'ecadb37e43f86a06815f0bc0cec8708b64fd3b53d9c01d7c939d2c941a5e8e91'
+  version '0.94.1'
+  sha256 'e1a977de35840d969bdf4039a0d5ddb466866ee793e9c178b0650ebbbf93af5c'
 
-  url "https://www.bitcoinarmory.com/downloads/bitcoinarmory-releases/armory_#{version}_osx.tar.gz"
+  url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   name 'Armory'
-  homepage 'https://bitcoinarmory.com/'
-  license :affero
+  homepage 'https://github.com/goatpig/BitcoinArmory'
+  license :oss
 
   app 'Armory.app'
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.

Armory has recently changed developers, and is now available from GitHub. It is also now under multiple licenses, so `oss` is more appropriate.

https://bitcointalk.org/index.php?topic=1351792 - old dev announces moving on
https://bitcointalk.org/index.php?topic=1351924.0 - new development anouncement
