### PR TITLE
vuze.rb: use explicit sudo on install

### DIFF
--- a/Casks/vuze.rb
+++ b/Casks/vuze.rb
@@ -8,7 +8,8 @@ cask 'vuze' do
   license :gpl
 
   installer script: 'Vuze Installer.app/Contents/MacOS/JavaApplicationStub',
-            args:   ['-q']
+            args:   ['-q'],
+            sudo:   true
 
   uninstall delete: '/Applications/Vuze.app'
 


### PR DESCRIPTION
Part of https://github.com/caskroom/homebrew-cask/issues/13608.
