### PR TITLE
owasp-zap-250-update

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -1,6 +1,6 @@
 cask 'owasp-zap' do
-  version '2.4.3'
-  sha256 '581e1746384263a01a8d4def828d291e707fca3788d9302c1e57edb457db18ae'
+  version '2.5.0'
+  sha256 '56f99b77c57cdb1e84a9404b589c1d443d52877ee456c02cc7eae25105c18ae5'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/zaproxy/zaproxy/releases/download/#{version}/ZAP_#{version}_MAC_OS_X.dmg"


### PR DESCRIPTION
Cask: owasp-zap.rb

Updated version and checksum for 2.5.0
https://github.com/zaproxy/zaproxy/releases/tag/2.5.0
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.

I'm unable to complete the later 2 as I'm not on an OSX system, nor do I have access to one. However, I am part of the ZAP core team and am try to facilitate for our users :smiley:
