### PR TITLE
updated logitech-gaming-software (8.79.45)

### DIFF
--- a/Casks/logitech-gaming-software.rb
+++ b/Casks/logitech-gaming-software.rb
@@ -1,13 +1,13 @@
 cask 'logitech-gaming-software' do
-  version '8.60.313'
-  sha256 'f83d5c573fc4236454471158d88153cb970996211b1cbd27180f906fccc7d9c1'
+  version '8.79.45'
+  sha256 '7385e438a7bf3956f05e8420b723b5e1a0b0502c308b075419dde5552c593f55'
 
   url "http://download01.logitech.com/web/ftp/pub/techsupport/gaming/LogitechSetup_#{version}.zip"
   name 'Logitech Gaming Software'
   homepage 'http://support.logitech.com/en_us/downloads'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  pkg 'LogiGamingSetup.mpkg'
+  pkg 'LogitechGamingInstaller.app/Contents/Resources/LogiGamingSetup.mpkg'
 
   uninstall script:  '/Applications/Logitech/Uninstaller.app/Contents/Resources/UninstallScript.sh',
             pkgutil: [


### PR DESCRIPTION
### Changes to a cask

Now packaged as an `app` instead of `mpkg`. Simply wraps original `mpkg`.
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
