### PR TITLE
updated carbon-copy-cloner (4.1.8,4360)

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,10 +1,10 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.7,4285'
-  sha256 'ca8a081d35606c899745bb40a64a461e14a00de7dd6e3bb48da3a3c05f265de8'
+  version '4.1.8,4360'
+  sha256 'c1e4c13efb56814ae2ddfb954169747dfbb051d6704220ece8d4fb14a45a6d75'
 
   url "http://bombich.com/software/files/ccc-#{version.before_comma}.#{version.after_comma}.zip"
   appcast "https://bombich.com/software/updates/ccc.php?os_minor=11&os_bugfix=#{version.major}&ccc=#{version.after_comma}&beta=0&locale=en",
-          checkpoint: '9999510ec5d9c07a507c78b53d2a0ffd6f0457901e6d9ecd83325f3facb1947d'
+          checkpoint: '61d5007912a0a979a8b1efd7693229cd7125fbca11c60e244e4114d285c32abe'
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
