### PR TITLE
Updated to version 1.1.0.

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.0.5'
-  sha256 '3cbdc16ea6fb33406324f786e5305cd6fcf1d53a65d59be46333eea85e33fae3'
+  version '1.1.0'
+  sha256 '7ce23dda88728e92f5e35c5863f1bd54a288da0f32ee15a40290572fac46e903'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "http://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
- [y] Commit message includes cask’s name (and new version, if applicable).
- [y] `brew cask audit --download {{cask_file}}` is error-free.
- [y] `brew cask style --fix {{cask_file}}` left no offenses.

Updated Cryptomator to 1.1.0.
