### PR TITLE
Add ManDrake.app v3.0

### DIFF
--- a/Casks/mandrake.rb
+++ b/Casks/mandrake.rb
@@ -1,0 +1,13 @@
+cask 'mandrake' do
+  version '3.0'
+  sha256 '42be0986d5ae47ffa10e27d5dea04d5fb519884deb1236d5bb8b36c62e899d77'
+
+  url "http://sveinbjorn.org/files/software/mandrake/ManDrake-#{version}.zip"
+  appcast 'http://sveinbjorn.org/files/appcasts/ManDrakeAppcast.xml',
+          checkpoint: '823a16ee9b605408873ddac7c801b6df98fd4cf847a6edbdbd89457d3072f433'
+  name 'ManDrake'
+  homepage 'http://sveinbjorn.org/mandrake'
+  license :bsd
+
+  app 'ManDrake.app'
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

---

Quoting http://sveinbjorn.org/mandrake:

> ManDrake is a native, open-source man page editor for Mac OS X. It has
> syntax highlighting, mdoc syntax validation and a live-updating
> rendered preview.

The homepage and download URL are HTTP-only. The software itself is pretty nice.
