### PR TITLE
Remove outdated config file from delete stanza of IDEA-based IDEs

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -12,7 +12,6 @@ cask 'appcode' do
   app 'AppCode.app'
 
   zap delete: [
-                "~/.Appcode#{version.major_minor}",
                 "~/Library/Preferences/AppCode#{version.major_minor}",
                 "~/Library/Application Support/AppCode#{version.major_minor}",
                 "~/Library/Caches/AppCode#{version.major_minor}",

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -12,7 +12,6 @@ cask 'clion' do
   app 'CLion.app'
 
   zap delete: [
-                "~/.CLion#{version.major_minor}",
                 "~/Library/Preferences/CLion#{version.major_minor}",
                 "~/Library/Application Support/CLion#{version.major_minor}",
                 "~/Library/Caches/CLion#{version.major_minor}",

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -12,7 +12,6 @@ cask 'datagrip' do
   app 'DataGrip.app'
 
   zap delete: [
-                "~/.DataGrip#{version.major_minor}",
                 "~/Library/Preferences/DataGrip#{version.major_minor}",
                 "~/Library/Application Support/DataGrip#{version.major_minor}",
                 "~/Library/Caches/DataGrip#{version.major_minor}",

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -14,7 +14,6 @@ cask 'intellij-idea' do
   uninstall delete: '/usr/local/bin/idea'
 
   zap delete: [
-                "~/.IntelliJIdea#{version.major_minor}",
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",
                 "~/Library/Application Support/IntelliJIdea#{version.major_minor}",

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -12,7 +12,6 @@ cask 'mps' do
   app "MPS #{version.major_minor}.app"
 
   zap delete: [
-                "~/.MPS#{version.major_minor.no_dots}",
                 "~/MPSSamples.#{version}",
                 "~/Library/Application Support/MPS#{version.major_minor.no_dots}",
                 "~/Library/Preferences/MPS#{version.major_minor.no_dots}",

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -12,7 +12,6 @@ cask 'phpstorm' do
   uninstall delete: '/usr/local/bin/pstorm'
 
   zap delete: [
-                "~/.PhpStorm#{version.major_minor}",
                 "~/Library/Preferences/PhpStorm#{version.major_minor}",
                 "~/Library/Caches/PhpStorm#{version.major_minor}",
                 "~/Library/Logs/PhpStorm#{version.major_minor}",

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -14,7 +14,6 @@ cask 'pycharm' do
   uninstall delete: '/usr/local/bin/charm'
 
   zap delete: [
-                "~/.PyCharm#{version.major_minor}",
                 "~/Library/Preferences/PyCharm#{version.major_minor}",
                 "~/Library/Application Support/PyCharm#{version.major_minor}",
                 "~/Library/Caches/PyCharm#{version.major_minor}",

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -16,7 +16,6 @@ cask 'rubymine' do
   zap delete: [
                 "~/Library/Application Support/RubyMine#{version.major_minor}",
                 "~/Library/Preferences/RubyMine#{version.major_minor}",
-                "~/.RubyMine#{version.major_minor}",
                 "~/Library/Caches/RubyMine#{version.major_minor}",
                 "~/Library/Logs/RubyMine#{version.major_minor}",
               ]

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -14,7 +14,6 @@ cask 'webstorm' do
   uninstall delete: '/usr/local/bin/wstorm'
 
   zap delete: [
-                "~/.WebStorm#{version.major_minor}",
                 "~/Library/Preferences/WebStorm#{version.major_minor}",
                 "~/Library/Application Support/WebStorm#{version.major_minor}",
                 "~/Library/Caches/WebStorm#{version.major_minor}",


### PR DESCRIPTION
- [ ] Commit message includes cask’s name (and new version, if applicable).
  - affects several casks, which are not explicitly listed
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

These configuration dotfiles in the home directory used to exist in older versions, but aren't used anymore.
See previous [discussion](https://github.com/caskroom/homebrew-versions/pull/2066#discussion-diff-63899190) in #2066 and [Jetbrains' documentation](https://www.jetbrains.com/help/idea/2016.1/directories-used-by-intellij-idea-to-store-settings-caches-plugins-and-logs.html?origin=old_help#d152420e69).

See also equivalent PR in [`caskroom/homebrew-versions`#2181](https://github.com/caskroom/homebrew-versions/pull/2181).
