### PR TITLE
Corrected wireshark-chmodbpf url and updated it to version 2.0.4

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,8 +1,8 @@
 cask 'wireshark-chmodbpf' do
-  version '2.0.3'
-  sha256 'a64dc77117a4408b48235297215032017e77822885ce3e19cd1065bfbea0ae57'
+  version '2.0.4'
+  sha256 'b78531be77099f4d4b08a1a0fea6dbb777b739ee82255cc83f7de47137ef1627'
 
-  url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
+  url "https://www.wireshark.org/download/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
   name 'Wireshark-ChmodBPF'
   homepage 'https://www.wireshark.org/'
   license :gpl


### PR DESCRIPTION
Installation of wireshark-chmodbpf 2.0.3 does not work:

==> Downloading https://www.wireshark.org/download/osx/Wireshark%202.0.3%20Intel%2064.dmg

curl: (22) The requested URL returned error: 404 Not Found
