### PR TITLE
updated syncthing-bar (0.0.11, repackaged)

### DIFF
--- a/Casks/syncthing-bar.rb
+++ b/Casks/syncthing-bar.rb
@@ -1,10 +1,10 @@
 cask 'syncthing-bar' do
   version '0.0.11'
-  sha256 '1b918bd0bd08bddd93165782dbc1b98b049b8ee11671297c1f2dc05977ab438c'
+  sha256 'eb81af00838561cfd1cb3a1b01b28ae6131730d11031fe1863b5a4189a359a6e'
 
   url "https://github.com/m0ppers/syncthing-bar/releases/download/#{version}/syncthing-bar-#{version}.pkg"
   appcast 'https://github.com/m0ppers/syncthing-bar/releases.atom',
-          checkpoint: '85ff4420f74580ef04f71ce5900979d779a9de86d2b8218745f5324e8d9cd077'
+          checkpoint: '2409480b802299ae5ba438d16bc26a6d50beb2eda61622225f424ffe4fe95fca'
   name 'Syncthing bar'
   homepage 'https://github.com/m0ppers/syncthing-bar'
   license :oss


### PR DESCRIPTION
There was a problem with packaging, and `syncthing-bar` was repackaged without a new release. Hence only the checksum changed.
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
