### PR TITLE
update steermouse (4.2.6f1)

### DIFF
--- a/Casks/steermouse.rb
+++ b/Casks/steermouse.rb
@@ -1,5 +1,5 @@
 cask 'steermouse' do
-  version '4.2.6'
+  version '4.2.6f1'
   sha256 '4bbe779fcbfc69d9ebb196e888789cb088459cd3f944c3978a55c061d7d9f819'
 
   url "http://plentycom.jp/ctrl/files_sm/SteerMouse#{version}.dmg"


### PR DESCRIPTION
URL changed, but contents (shasum) did not.
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download https://raw.githubusercontent.com/ptb/homebrew-cask/866789f5c74c8ecc90ab417f0b92275c93dc65c3/Casks/steermouse.rb` is error-free.
- [x] `brew cask style --fix steermouse.rb` left no offenses.
