### PR TITLE
Add pgAdmin4.app v1.0-beta1.

### DIFF
--- a/Casks/pgadmin4.rb
+++ b/Casks/pgadmin4.rb
@@ -1,0 +1,22 @@
+cask 'pgadmin4' do
+  # note: "4" is not a version number, but indicates a different app (vs pgadmin3)
+  version '1.0-beta1'
+  sha256 'ba004dcedff2a5d9bcc02ba50b3b0b429cd05a0f2ceba962a8afbea9120448f2'
+
+  # postgresql.org is the official download host per the vendor homepage
+  url "https://ftp.postgresql.org/pub/pgadmin3/pgadmin4/v#{version}/osx/pgadmin4-#{version}.dmg"
+  name 'pgAdmin4'
+  homepage 'http://pgadmin.org'
+  license :oss
+  gpg "#{url}.sig",
+      key_id: 'e0c4ceeb826b1fda4fb468e024adfaaf698f1519'
+
+  app 'pgAdmin 4.app'
+
+  zap delete: [
+                '~/.pgadmin',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.pgadmin.pgadmin4.sfl',
+                '~/Library/Preferences/org.pgadmin.pgAdmin 4.plist',
+                '~/Library/Saved Application State/org.pgadmin.pgAdmin4.savedState',
+              ]
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md). **Note that pgAdmin4 is a totally different app compared to pgAdmin3, so the 4 in the name must be retained. For the same reason, this app does not make pgAdmin3 obsolete (yet), and both apps may coexist.**
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download pgadmin4` is error-free.
- [x] `brew cask style --fix pgadmin4` left no offenses.
- [x] `brew cask install pgadmin4` worked successfully.
- [x] `brew cask uninstall pgadmin4` worked successfully.
