### PR TITLE
Change default Caskroom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To start using Homebrew-Cask, you just need [Homebrew](http://brew.sh/) installe
 $ brew cask install google-chrome
 ==> Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
 ==> Moving App 'Google Chrome.app' to '/Applications/Google Chrome.app'
-🍺  google-chrome staged at '/opt/homebrew-cask/Caskroom/google-chrome/latest' (3 files, 288K)
+🍺  google-chrome staged at '/usr/local/Caskroom/google-chrome/latest' (3 files, 288K)
 ```
 
 And there we have it. Google Chrome installed with a few quick commands: no clicking, no dragging, no dropping.

--- a/doc/cask_language_reference/stanzas/app.md
+++ b/doc/cask_language_reference/stanzas/app.md
@@ -9,13 +9,13 @@ app 'Alfred 2.app'
 moves the source to:
 
 ```bash
-~/Applications/Alfred 2.app
+/Applications/Alfred 2.app
 ```
 
 from a source file such as:
 
 ```bash
-/opt/homebrew-cask/Caskroom/alfred/2.8.2_431/Alfred 2.app
+/usr/local/Caskroom/alfred/2.8.2_431/Alfred 2.app
 ```
 
 ## Renaming the Target

--- a/doc/cask_language_reference/stanzas/caveats.md
+++ b/doc/cask_language_reference/stanzas/caveats.md
@@ -9,8 +9,8 @@ When `caveats` is a string, it is evaluated at compile time. The following metho
 | `token`            | the Cask token
 | `version`          | the Cask version
 | `homepage`         | the Cask homepage
-| `caskroom_path`    | the containing directory for all staged Casks, typically `/opt/homebrew-cask/Caskroom` (only available with block form)
-| `staged_path`      | the staged location for this Cask, including version number, *eg* `/opt/homebrew-cask/Caskroom/adium/1.5.10` (only available with block form)
+| `caskroom_path`    | the containing directory for all staged Casks, typically `/usr/local/Caskroom` (only available with block form)
+| `staged_path`      | the staged location for this Cask, including version number, *eg* `/usr/local/Caskroom/adium/1.5.10` (only available with block form)
 
 Example:
 

--- a/doc/man_page/brew-cask.1.md
+++ b/doc/man_page/brew-cask.1.md
@@ -105,8 +105,8 @@ names, and other aspects of this manual are still subject to change.
     the `uninstall` instructions from *newest* Cask definition, even if
     the given Cask has changed since you installed it. The result is that
     `uninstall --force` will always succeed in removing relevant files
-    under `/opt/homebrew-cask`, but will sometimes fail to remove relevant
-    installed files outside of `/opt/homebrew-cask`. This issue is being
+    under `<Caskroom_path>`, but will sometimes fail to remove relevant
+    installed files outside of it. This issue is being
     addressed.
 
     `uninstall` without `--force` is also imperfect. It may be unable to
@@ -123,7 +123,7 @@ names, and other aspects of this manual are still subject to change.
     the Cask does not appear to be currently installed.
 
     Removes all staged versions of the Cask distribution found under
-    `/opt/homebrew-cask/Caskroom/<token>`.
+    `<Caskroom_path>/<token>`.
 
     If the Cask definition contains a `zap` stanza, performs additional
     `zap` actions as defined there, such as removing local preference
@@ -147,7 +147,7 @@ in a future version.
     Skip Cask dependencies when installing.
 
   * `--caskroom=<path>`:
-    Location of the Caskroom, where all binaries are stored. The default value is: `/opt/homebrew-cask/Caskroom`.
+    Location of the Caskroom, where all binaries are stored. The default value is: `$(brew --repository)/Caskroom`.
 
   * `--verbose`:
     Give additional feedback during installation.

--- a/lib/hbc.rb
+++ b/lib/hbc.rb
@@ -54,12 +54,12 @@ module Hbc
     HOMEBREW_CACHE.mkpath unless HOMEBREW_CACHE.exist?
     HOMEBREW_CACHE_CASKS.mkpath unless HOMEBREW_CACHE_CASKS.exist?
     unless caskroom.exist?
-      ohai "We need to make Caskroom for the first time at #{caskroom}"
-      ohai "We'll set permissions properly so we won't need sudo in the future"
+      ohai "Creating Caskroom at #{caskroom}"
       current_user = Hbc::Utils.current_user
       if caskroom.parent.writable?
         system '/bin/mkdir', '--', caskroom
       else
+        ohai "We'll set permissions properly so we won't need sudo in the future"
         toplevel_dir = caskroom
         toplevel_dir = toplevel_dir.parent until toplevel_dir.parent.root?
         unless toplevel_dir.directory?

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -5,7 +5,7 @@ module Hbc::Locations
 
   module ClassMethods
     def caskroom
-      @@caskroom ||= Pathname('/opt/homebrew-cask/Caskroom')
+      @@caskroom ||= homebrew_repository.join('Caskroom')
     end
 
     def caskroom=(caskroom)

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -104,7 +104,7 @@ Check the given Casks for correct style using RuboCop Cask \fIhttps://github\.co
 Uninstall the given Cask\. With \fB\-\-force\fR, uninstall even if the Cask does not appear to be present\.
 .
 .IP
-Note that \fBuninstall \-\-force\fR is currently imperfect\. It will follow the \fBuninstall\fR instructions from \fInewest\fR Cask definition, even if the given Cask has changed since you installed it\. The result is that \fBuninstall \-\-force\fR will always succeed in removing relevant files under \fB/opt/homebrew\-cask\fR, but will sometimes fail to remove relevant installed files outside of \fB/opt/homebrew\-cask\fR\. This issue is being addressed\.
+Note that \fBuninstall \-\-force\fR is currently imperfect\. It will follow the \fBuninstall\fR instructions from \fInewest\fR Cask definition, even if the given Cask has changed since you installed it\. The result is that \fBuninstall \-\-force\fR will always succeed in removing relevant files under \fB<Caskroom_path>\fR, but will sometimes fail to remove relevant installed files outside of it\. This issue is being addressed\.
 .
 .IP
 \fBuninstall\fR without \fB\-\-force\fR is also imperfect\. It may be unable to perform an \fBuninstall\fR operation if the given Cask has changed since you installed it\. This issue is being addressed\.
@@ -121,7 +121,7 @@ Unconditionally remove \fIall\fR files associated with the given Cask\.
 Implicitly performs all actions associated with \fBuninstall\fR, even if the Cask does not appear to be currently installed\.
 .
 .IP
-Removes all staged versions of the Cask distribution found under \fB/opt/homebrew\-cask/Caskroom/<token>\fR\.
+Removes all staged versions of the Cask distribution found under \fB<Caskroom_path>/<token>\fR\.
 .
 .IP
 If the Cask definition contains a \fBzap\fR stanza, performs additional \fBzap\fR actions as defined there, such as removing local preference files\. \fBzap\fR actions are variable, depending on the level of detail defined by the Cask author\.
@@ -145,7 +145,7 @@ Skip Cask dependencies when installing\.
 .
 .TP
 \fB\-\-caskroom=<path>\fR
-Location of the Caskroom, where all binaries are stored\. The default value is: \fB/opt/homebrew\-cask/Caskroom\fR\.
+Location of the Caskroom, where all binaries are stored\. The default value is: \fB$(brew \-\-repository)/Caskroom\fR\.
 .
 .TP
 \fB\-\-verbose\fR


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Closes https://github.com/caskroom/homebrew-cask/issues/21603.

Pinging @caskroom/maintainers. I’d like to merge this as soon as possible, so it still kind of fits inside the breaking changes of https://github.com/caskroom/homebrew-cask/pull/13966. Separated it in two commits, `core` and `docs`.
