### PR TITLE
aliwangwang.rb: remove appcast

### DIFF
--- a/Casks/aliwangwang.rb
+++ b/Casks/aliwangwang.rb
@@ -4,8 +4,6 @@ cask 'aliwangwang' do
 
   # dbison.alicdn.com was verified as official when first introduced to the cask
   url "https://dbison.alicdn.com/updates/macww-nosandbox-#{version}.dmg"
-  appcast 'https://update.labs.etao.com/macww/updates.xml',
-          checkpoint: '7178027350d87155dbcf2f2ebcc454262ae5d807fdf75f3688003ea5fccdb1b1'
   name 'Ali Wangwang'
   homepage 'https://wangwang.taobao.com'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Very outdated appcast. `Info.plist` suggests the new URL is `http://bison.labs.etao.com/MacWW_7_Internal/updates.json`, but trying to connect to it hangs, for me.
