### PR TITLE
updated beaconscanner (1.11)

### DIFF
--- a/Casks/beacon-scanner.rb
+++ b/Casks/beacon-scanner.rb
@@ -1,13 +1,13 @@
-cask 'beaconscanner' do
-  version '1.1.8'
-  sha256 '85cc1c4d8ebec7f3c2e93ca2810c95de03bdc7996dc3431b6d3d85480d26bc39'
+cask 'beacon-scanner' do
+  version '1.11'
+  sha256 'd290eb9f83544eef42184f2ad3f0e8d48e4bea44e192bd3dc9fbf57aab45af14'
 
   url "https://github.com/mlwelles/BeaconScanner/releases/download/#{version}/BeaconScanner-#{version}.zip"
   appcast 'https://github.com/mlwelles/BeaconScanner/releases.atom',
-          checkpoint: '30fe0b1aa49f79e64712d6e1b72eff566685639aa58a45c9910768ffd3235e0f'
+          checkpoint: '9d54970c1dd5706a0206a65ea818d3940bb1f74cb31697a12fba974281a20dc7'
   name 'BeaconScanner'
   homepage 'https://github.com/mlwelles/BeaconScanner/'
   license :mit
 
-  app 'BeaconScanner.app'
+  app 'Beacon Scanner.app'
 end


### PR DESCRIPTION
The space character was added in app name since v1.11.
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
