### PR TITLE
updated devonthink-pro-office (2.8.11)

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,17 +1,16 @@
 cask 'devonthink-pro-office' do
-  version '2.8.9'
-  sha256 '3fd65975ceed5abc3df0248d3c2b8c5df1979caf3c01b5cf41e5548b1de140c8'
+  version '2.8.11'
+  sha256 '82a443cc2aa1e6c94f0b3865790d07ef0fef35d92f19ef8e0f537b259b8f34e9'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.dmg.zip"
+  url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: 'dcff8944a25e070e6ea9629b3c6e4794e7322dd6777ae07e3fd1b35b6d00ff94'
+          checkpoint: 'b84e8b09f53bfb37f2bf23322bf7c22318b7688622f80cfb30cf9f231246a8ff'
   name 'DEVONthink Pro Office'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
   license :commercial
 
   depends_on macos: '>= :mountain_lion'
-  container nested: 'DEVONthink_Pro_Office.dmg'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/3838


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
