### PR TITLE
Handle broken symlinks on `install`, `install --force`

### DIFF
--- a/lib/hbc/artifact/moved.rb
+++ b/lib/hbc/artifact/moved.rb
@@ -22,7 +22,7 @@ class Hbc::Artifact::Moved < Hbc::Artifact::Base
     each_artifact do |artifact|
       load_specification(artifact)
       next unless preflight_checks
-      delete if File.exist?(target) && force
+      delete if Hbc::Utils.path_occupied?(target) && force
       move
     end
   end
@@ -64,7 +64,7 @@ class Hbc::Artifact::Moved < Hbc::Artifact::Base
   end
 
   def preflight_checks
-    if target.exist?
+    if Hbc::Utils.path_occupied?(target)
       if force
         ohai(warning_target_exists { |s| s << 'overwriting.' })
       else
@@ -96,7 +96,7 @@ class Hbc::Artifact::Moved < Hbc::Artifact::Base
       raise Hbc::CaskError.new(
         "Cannot remove undeletable #{english_name}")
     when force
-      Hbc::Utils.permissions_rmtree(target, command: @command)
+      Hbc::Utils.gain_permissions_remove(target, command: @command)
     else
       target.rmtree
     end

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -312,21 +312,23 @@ class Hbc::Installer
     purge_caskroom_path
   end
 
-  def permissions_rmtree(path)
-    Hbc::Utils.permissions_rmtree(path, command: @command)
+  def gain_permissions_remove(path)
+    Hbc::Utils.gain_permissions_remove(path, command: @command)
   end
 
   def purge_versioned_files
     odebug "Purging files for version #{@cask.version} of Cask #{@cask}"
 
     # versioned staged distribution
-    permissions_rmtree(@cask.staged_path)
+    gain_permissions_remove(@cask.staged_path)
 
     # Homebrew-cask metadata
     if @cask.metadata_versioned_container_path.respond_to?(:children) and
         @cask.metadata_versioned_container_path.exist?
       @cask.metadata_versioned_container_path.children.each do |subdir|
-        permissions_rmtree subdir unless PERSISTENT_METADATA_SUBDIRS.include?(subdir.basename)
+        unless PERSISTENT_METADATA_SUBDIRS.include?(subdir.basename)
+          gain_permissions_remove(subdir)
+        end
       end
     end
     Hbc::Utils.rmdir_if_possible(@cask.metadata_versioned_container_path)
@@ -338,6 +340,6 @@ class Hbc::Installer
 
   def purge_caskroom_path
     odebug "Purging all staged versions of Cask #{@cask}"
-    permissions_rmtree(@cask.caskroom_path)
+    gain_permissions_remove(@cask.caskroom_path)
   end
 end


### PR DESCRIPTION
While testing PR #21857 earlier today, I have found that `brew cask install` fails when it encounters a broken symlink, no matter if with or without `--force`:

![image](https://cloud.githubusercontent.com/assets/1239874/15992657/5f89f500-30d1-11e6-8f83-464d1762f34e.png)

Users _might_ run into this in the wake of PR #21857, e.&nbsp;g. trying to move their Caskrooms around in an attempt to get `brew cask list` back working, or to merge their Caskrooms. One could argue that users are not supposed to do this, but we all know they will do it anyway. The issue _will_ also bite unsuspecting users once PR #21858 is merged. Any legacy (pre-#13966) symlink pointing inside a custom Caskroom location is likely going to break.

I feel that while `install` needs to fail gracefully, `install --force` should do [exactly what it says on the tin](https://github.com/caskroom/homebrew-cask/pull/13966#issuecomment-220830387) and sweep broken symlinks out of the way.

**This PR fixes** both the `install` and `install --force` case.

Note that the `uninstall` and `zap` cases have similar issues; those remain unfixed for the time being. Those cases have additional issues anyway, require a bit more effort to be fixed, and thus deserve a PR on their own.
