### PR TITLE
Add OpenMW 0.39.0

### DIFF
--- a/Casks/openmw.rb
+++ b/Casks/openmw.rb
@@ -1,0 +1,14 @@
+cask 'openmw' do
+  version '0.39.0'
+  sha256 '378d959f9e14b1f943bdd9edc45f1013904ec21632e73d98a745bcbbce0028ba'
+
+  # github.com/OpenMW/openmw was verified as official when first introduced to the cask
+  url "https://github.com/OpenMW/openmw/releases/download/openmw-#{version}/OpenMW-#{version}.dmg"
+  appcast 'https://github.com/OpenMW/openmw/releases.atom',
+          checkpoint: '592c69134e57dd382bc2f99520d27211b654ce19758aa9af3fab059dcd16c64e'
+  name 'OpenMW'
+  homepage 'https://openmw.org/'
+  license :gpl
+
+  suite 'OpenMW'
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download openmw` is error-free.
- [x] `brew cask style --fix openmw` left no offenses.
- [x] `brew cask install openmw` worked successfully.
- [x] `brew cask uninstall openmw` worked successfully.

---

From the [FAQ](https://openmw.org/faq/):

> OpenMW is a free, open source and modern engine based which reimplements and extends the one that runs the 2002 open-world RPG Morrowind.
> […]
> **NOTE:** Playing Morrowind with this engine still requires the Morrowind data files that you own.
