### PR TITLE
Use legacy Caskroom if it exists, but warn of change

### DIFF
--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -4,8 +4,30 @@ module Hbc::Locations
   end
 
   module ClassMethods
+    def legacy_caskroom
+      @@legacy_caskroom ||= Pathname.new('/opt/homebrew-cask/Caskroom')
+    end
+
+    def default_caskroom
+      @@default_caskroom ||= homebrew_repository.join('Caskroom')
+    end
+
     def caskroom
-      @@caskroom ||= homebrew_repository.join('Caskroom')
+      @@caskroom ||= begin
+        if Hbc::Utils.path_occupied?(legacy_caskroom)
+          opoo <<-EOS.undent
+            The default Caskroom location has moved to #{default_caskroom}.
+
+            Please migrate your Casks to the new location, or if you would like to keep your
+            Caskroom at #{legacy_caskroom}, add the following to your HOMEBREW_CASK_OPTS:
+
+              --caskroom=#{legacy_caskroom}
+          EOS
+          legacy_caskroom
+        else
+          default_caskroom
+        end
+      end
     end
 
     def caskroom=(caskroom)


### PR DESCRIPTION
If a Caskroom exists at the old location of /opt/homebrew-cask/Caskroom,
use it and warn the user that the default location has changed.

Refs #21858, #21857, #21894
