### PR TITLE
OS X → macOS and added support for Sierra

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -21,7 +21,7 @@ cask 'deeper' do
     url 'http://joel.barriere.pagesperso-orange.fr/download/1011/Deeper.dmg'
   else
     # Unusual case: there is no fall-through.  The software will stop
-    # working, or is dangerous to run, on the next OS X release.
+    # working, or is dangerous to run, on the next macOS release.
   end
 
   name 'Deeper'

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -21,7 +21,7 @@ cask 'maintenance' do
     url 'http://joel.barriere.pagesperso-orange.fr/download/1011/Maintenance.dmg'
   else
     # Unusual case: there is no fall-through.  The software will stop
-    # working, or is dangerous to run, on the next OS X release.
+    # working, or is dangerous to run, on the next macOS release.
   end
 
   name 'Maintenance'

--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -13,7 +13,7 @@ cask 'netbeans' do
   # installation.
   #
   # In practice, it appears that the normal GlassFish installation process does
-  # not use the OS X installer and so isn't in the pkgutil receipts database.
+  # not use the macOS installer and so isn't in the pkgutil receipts database.
   #
   # https://glassfish.java.net/docs/4.0/installation-guide.pdf
   #
@@ -26,7 +26,7 @@ cask 'netbeans' do
   # to a separate "zap" stanza.
   #
   # The NetBeans installer does some postflight unpacking of paths installed by
-  # the OS X installer, so it's insufficient to just delete the paths exposed
+  # the macOS installer, so it's insufficient to just delete the paths exposed
   # by pkgutil, hence the additional ":delete" option below.
 
   uninstall pkgutil: 'org.netbeans.ide.*|glassfish-.*',

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -20,7 +20,7 @@ cask 'onyx' do
     url 'http://joel.barriere.pagesperso-orange.fr/download/1011/OnyX.dmg'
   else
     # Unusual case: there is no fall-through.  The software will stop
-    # working, or is dangerous to run, on the next OS X release.
+    # working, or is dangerous to run, on the next macOS release.
   end
   name 'OnyX'
   homepage 'http://www.titanium.free.fr/onyx.html'

--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -80,7 +80,7 @@ cask 'wireshark-chmodbpf' do
     devices at boot to allow unpriviledged packet captures.
     This cask is not required if installing the Wireshark cask. It is meant to
     support Wireshark installed from homebrew or other cases where unpriviledged
-    access to OS X packet capture devices is desired without installing the binary
+    access to macOS packet capture devices is desired without installing the binary
     distribution of Wireshark.
 
     The user account used to install this cask will be added to the access_bpf

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 _“To install, drag this icon…” no more!_
 
-Homebrew-Cask extends [Homebrew](http://brew.sh) and brings its elegance, simplicity, and speed to the installation and management of GUI Mac applications such as Google Chrome and Adium.
+Homebrew-Cask extends [Homebrew](http://brew.sh) and brings its elegance, simplicity, and speed to the installation and management of GUI macOS applications such as Google Chrome and Adium.
 
-We do this by providing a friendly Homebrew-style CLI workflow for the administration of Mac applications distributed as binaries.
+We do this by providing a friendly Homebrew-style CLI workflow for the administration of macOS applications distributed as binaries.
 
 It’s implemented as a `homebrew` [external command](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/External-Commands.md) called `cask`.
 

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -29,7 +29,7 @@ fi
 run export MERGE_BASE="${MERGE_BASE}"
 run export TRAVIS_COMMIT_RANGE="${MERGE_BASE}...${BRANCH_COMMIT}"
 
-# print detailed OSX version info
+# print detailed macOS version info
 run sw_vers
 
 # capture system ruby and gem locations

--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -78,8 +78,8 @@ REMOVE_TRAILING_PATS = [
                         %r{\bapp}i,
                         %r{\b(?:quick[\s-]*)?launcher}i,
 
-                        # "mac", "for mac", "for OS X".
-                        %r{\b(?:for)?[\s-]*mac(?:intosh)?}i,
+                        # "mac", "for mac", "for OS X", "macOS", "for macOS".
+                        %r{\b(?:for)?[\s-]*mac(?:intosh|OS)?}i,
                         %r{\b(?:for)?[\s-]*os[\s-]*x}i,
 
                         # hardware designations such as "for x86", "32-bit", "ppc"

--- a/developer/bin/list_url_attributes_on_file
+++ b/developer/bin/list_url_attributes_on_file
@@ -61,7 +61,7 @@ _list_url_attributes_on_file () {
 if [[ $1 =~ ^-+h(elp)?$ || -z "$1" ]]; then
     printf "list_url_attributes_on_file <file>
 
-Given a downloaded file, extract possible sources from OS X extended
+Given a downloaded file, extract possible sources from macOS extended
 attributes, which may be useful in a Cask url stanza.
 
 Currently the only attribute examined is

--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -57,7 +57,7 @@ if MacOS.release <= :mavericks     # symbolic name
 if MacOS.release <= '10.9'         # version string
 ```
 
-The available symbols for macOS versions are: `:cheetah`, `:puma`, `:jaguar`, `:panther`, `:tiger`, `:leopard`, `:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, `:yosemite`, and `:el_capitan`. The corresponding numeric version strings should given as major releases containing a single dot.
+The available symbols for macOS versions are: `:cheetah`, `:puma`, `:jaguar`, `:panther`, `:tiger`, `:leopard`, `:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, `:yosemite`, `:el_capitan`, and `:sierra`. The corresponding numeric version strings should given as major releases containing a single dot.
 
 ### Always Fall Through to the Newest Case
 

--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -57,7 +57,7 @@ if MacOS.release <= :mavericks     # symbolic name
 if MacOS.release <= '10.9'         # version string
 ```
 
-The available symbols for OS X versions are: `:cheetah`, `:puma`, `:jaguar`, `:panther`, `:tiger`, `:leopard`, `:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, `:yosemite`, and `:el_capitan`. The corresponding numeric version strings should given as major releases containing a single dot.
+The available symbols for macOS versions are: `:cheetah`, `:puma`, `:jaguar`, `:panther`, `:tiger`, `:leopard`, `:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, `:yosemite`, and `:el_capitan`. The corresponding numeric version strings should given as major releases containing a single dot.
 
 ### Always Fall Through to the Newest Case
 

--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -25,11 +25,11 @@ depends_on formula: 'unar'
 
 ## depends_on macos:
 
-### Requiring an Exact OS X Release
+### Requiring an Exact macOS Release
 
-The value for `depends_on macos:` may be a symbol, string, or an array, listing the exact compatible OS X releases.
+The value for `depends_on macos:` may be a symbol, string, or an array, listing the exact compatible macOS releases.
 
-The available values for OS X releases are:
+The available values for macOS releases are:
 
 | symbol             | corresponding string
 | -------------------|----------------------
@@ -46,7 +46,7 @@ The available values for OS X releases are:
 | `:yosemite`        | `'10.10'`
 | `:el_capitan`      | `'10.11'`
 
-Only major releases are covered (version numbers containing a single dot). The symbol form is preferred for readability. The following are all valid ways to enumerate the exact OS X release requirements for a Cask:
+Only major releases are covered (version numbers containing a single dot). The symbol form is preferred for readability. The following are all valid ways to enumerate the exact macOS release requirements for a Cask:
 
 ```ruby
 depends_on macos: :yosemite
@@ -55,9 +55,9 @@ depends_on macos: '10.9'
 depends_on macos: ['10.9', '10.10']
 ```
 
-### Setting a Minimum OS X Release
+### Setting a Minimum macOS Release
 
-`depends_on macos:` can also accept a string starting with a comparison operator such as `>=`, followed by an OS X release in the form above. The following are both valid expressions meaning “at least OS X 10.9”:
+`depends_on macos:` can also accept a string starting with a comparison operator such as `>=`, followed by an macOS release in the form above. The following are both valid expressions meaning “at least macOS 10.9”:
 
 ```ruby
 depends_on macos: '>= :mavericks'
@@ -102,7 +102,7 @@ depends_on arch: :x86_64
 | ---------- | ----------- |
 | `formula:` | a Homebrew Formula
 | `cask:`    | a Cask token
-| `macos:`   | a symbol, string, array, or comparison expression defining OS X release requirements
+| `macos:`   | a symbol, string, array, or comparison expression defining macOS release requirements
 | `arch:`    | a symbol or array defining hardware requirements
 | `x11:`     | a Boolean indicating a dependency on X11
 | `java:`    | *stub - not yet functional*

--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -45,6 +45,7 @@ The available values for macOS releases are:
 | `:mavericks`       | `'10.9'`
 | `:yosemite`        | `'10.10'`
 | `:el_capitan`      | `'10.11'`
+| `:sierra`          | `'10.12'`
 
 Only major releases are covered (version numbers containing a single dot). The symbol form is preferred for readability. The following are all valid ways to enumerate the exact macOS release requirements for a Cask:
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -61,7 +61,7 @@ $ ./developer/bin/list_pkg_ids_by_regexp <regular-expression>
 
 ## List Files Associated With a pkg Id
 
-Once you know the ID for an installed package, (above), you can list all files on your system associated with that package ID using the OS X command:
+Once you know the ID for an installed package, (above), you can list all files on your system associated with that package ID using the macOS command:
 
 ```bash
 $ pkgutil --files <package.id.goes.here>

--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -70,7 +70,7 @@ http://$STRING.osdn.jp/$PROJECTNAME/$RELEASEID/$FILENAME.$EXT
 
 `$STRING` is typically of the form `dl` or `$USER.dl`.
 
-If these formats are not available, and the application is Mac-exclusive (otherwise a command-line download defaults to the Windows version) we prefer the use of this format:
+If these formats are not available, and the application is macOS-exclusive (otherwise a command-line download defaults to the Windows version) we prefer the use of this format:
 
 ```
 http://sourceforge.net/projects/$PROJECTNAME/files/latest/download

--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -36,7 +36,7 @@ The comment doesn’t mean you should trust the source blindly, but we only appr
 
 ## Difficulty Finding a URL
 
-Web browsers may obscure the direct `url` download location for a variety of reasons. Homebrew-Cask supplies a script which can read extended file attributes to extract the actual source URL for most files downloaded by a browser on OS X. The script usually emits multiple candidate URLs; you may have to test each of them:
+Web browsers may obscure the direct `url` download location for a variety of reasons. Homebrew-Cask supplies a script which can read extended file attributes to extract the actual source URL for most files downloaded by a browser on macOS. The script usually emits multiple candidate URLs; you may have to test each of them:
 
 ```bash
 $ $(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_url_attributes_on_file <file>

--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -43,7 +43,7 @@ Details of software names and brands will inevitably be lost in the conversion t
 
 * Remove from the end: “Launcher”, “Quick Launcher”.
 
-* Remove from the end: strings such as “Mac”, “for Mac”, “for OS X”. These terms are generally added to ported software such as “MAME OS X.app”. Exception: when the software is not a port, and “Mac” is an inseparable part of the name, without which the name would be inherently nonsensical, as in [PlayOnMac.app](../../Casks/playonmac.rb).
+* Remove from the end: strings such as “Mac”, “for Mac”, “for OS X”, “macOS”, “for macOS”. These terms are generally added to ported software such as “MAME OS X.app”. Exception: when the software is not a port, and “Mac” is an inseparable part of the name, without which the name would be inherently nonsensical, as in [PlayOnMac.app](../../Casks/playonmac.rb).
 
 * Remove from the end: hardware designations such as “for x86”, “32-bit”, “ppc”.
 

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -177,7 +177,7 @@ We maintain separate Taps for different types of binaries. Our nomenclature is:
 
 ### Stable Versions
 
-Stable versions live in the main repository at [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask). They should run on the latest release of OS X or the previous point release (in 2015, for example, that meant El Capitan and Yosemite).
+Stable versions live in the main repository at [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask). They should run on the latest release of macOS or the previous point release (in 2015, for example, that meant El Capitan and Yosemite).
 
 ### But There Is No Stable Version!
 

--- a/doc/development/hacking.md
+++ b/doc/development/hacking.md
@@ -4,7 +4,7 @@ If you’d like to hack on the Ruby code that drives this project, please join u
 
 ## Goals, Design, and Philosophy
 
-Homebrew-Cask is an attempt to make a Linux-style package manager for precompiled OS X software. Homebrew-Cask is not yet as featureful as `apt` or `yum`, but we are trying to be as close as we can get to those tools from the user’s point of view.
+Homebrew-Cask is an attempt to make a Linux-style package manager for precompiled macOS software. Homebrew-Cask is not yet as featureful as `apt` or `yum`, but we are trying to be as close as we can get to those tools from the user’s point of view.
 
 We manage installed files via the “symlink farm” method, like [GNU Stow](http://www.gnu.org/software/stow/) and [Homebrew](http://brew.sh/). Similarly, we try to avoid `sudo` where possible.
 
@@ -100,7 +100,7 @@ $ brew cask /usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/info.rb g
 
 This form can also be combined with a specific Ruby interpreter as above.
 
-### Forcing a Specific OS X Release
+### Forcing a Specific macOS Release
 
 The environment variable `$MACOS_RELEASE` can be overridden at the command line for test purposes:
 

--- a/doc/man_page/brew-cask.1.md
+++ b/doc/man_page/brew-cask.1.md
@@ -1,4 +1,4 @@
-homebrew-cask(1) - A friendly binary installer for OS X
+homebrew-cask(1) - A friendly binary installer for macOS
 ========================================================
 
 ## SYNOPSIS
@@ -7,7 +7,7 @@ homebrew-cask(1) - A friendly binary installer for OS X
 
 ## DESCRIPTION
 
-Homebrew-Cask is a tool for installing precompiled OS X binaries (such as
+Homebrew-Cask is a tool for installing precompiled macOS binaries (such as
 Applications) from the command line. The user is never required to use the
 graphical user interface.
 

--- a/lib/hbc/caveats.rb
+++ b/lib/hbc/caveats.rb
@@ -120,7 +120,7 @@ class Hbc::CaveatsDSL
   def discontinued
     puts <<-EOS.undent
     #{@cask} has been officially discontinued upstream.
-    It may stop working correctly (or at all) in recent versions of OS X.
+    It may stop working correctly (or at all) in recent versions of macOS.
 
     EOS
   end

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -262,7 +262,7 @@ class Hbc::CLI
     def purpose
       puts <<-PURPOSE.undent
         brew-cask provides a friendly homebrew-style CLI workflow for the
-        administration of Mac applications distributed as binaries.
+        administration of macOS applications distributed as binaries.
 
       PURPOSE
     end

--- a/lib/hbc/cli/doctor.rb
+++ b/lib/hbc/cli/doctor.rb
@@ -1,7 +1,7 @@
 class Hbc::CLI::Doctor < Hbc::CLI::Base
   def self.run
-    ohai 'OS X Release:',                                    render_with_none_as_error( MacOS.release )
-    ohai 'OS X Release with Patchlevel:',                    render_with_none_as_error( MacOS.release_with_patchlevel )
+    ohai 'macOS Release:',                                   render_with_none_as_error( MacOS.release )
+    ohai 'macOS Release with Patchlevel:',                   render_with_none_as_error( MacOS.release_with_patchlevel )
     ohai "Hardware Architecture:",                           render_with_none_as_error( "#{Hardware::CPU.type}-#{Hardware::CPU.bits}" )
     ohai 'Ruby Version:',                                    render_with_none_as_error( "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" )
     ohai 'Ruby Path:',                                       render_with_none_as_error( RbConfig.ruby )

--- a/lib/hbc/dsl/depends_on.rb
+++ b/lib/hbc/dsl/depends_on.rb
@@ -56,15 +56,15 @@ class Hbc::DSL::DependsOn
 
   def self.coerce_os_release(arg)
 
-    @osx_symbols ||= MacOS::Release::SYMBOLS
-    @inverted_osx_symbols ||= @osx_symbols.invert
+    @macos_symbols ||= MacOS::Release::SYMBOLS
+    @inverted_macos_symbols ||= @macos_symbols.invert
 
     begin
       if arg.is_a?(Symbol)
-        Gem::Version.new(@osx_symbols.fetch(arg))
+        Gem::Version.new(@macos_symbols.fetch(arg))
       elsif arg =~ %r{^\s*:?([a-z]\S+)\s*$}i
-        Gem::Version.new(@osx_symbols.fetch($1.downcase.to_sym))
-      elsif @inverted_osx_symbols.has_key?(arg)
+        Gem::Version.new(@macos_symbols.fetch($1.downcase.to_sym))
+      elsif @inverted_macos_symbols.has_key?(arg)
         Gem::Version.new(arg)
       else
         raise

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -150,15 +150,15 @@ class Hbc::Installer
     if @cask.depends_on.macos.first.is_a?(Array)
       operator, release = @cask.depends_on.macos.first
       unless MacOS.release.send(operator, release)
-        raise Hbc::CaskError.new "Cask #{@cask} depends on OS X release #{operator} #{release}, but you are running release #{MacOS.release}."
+        raise Hbc::CaskError.new "Cask #{@cask} depends on macOS release #{operator} #{release}, but you are running release #{MacOS.release}."
       end
     elsif @cask.depends_on.macos.length > 1
       unless @cask.depends_on.macos.include?(Gem::Version.new(MacOS.release.to_s))
-        raise Hbc::CaskError.new "Cask #{@cask} depends on OS X release being one of: #{@cask.depends_on.macos(&:to_s).inspect}, but you are running release #{MacOS.release}."
+        raise Hbc::CaskError.new "Cask #{@cask} depends on macOS release being one of: #{@cask.depends_on.macos(&:to_s).inspect}, but you are running release #{MacOS.release}."
       end
     else
       unless MacOS.release == @cask.depends_on.macos.first
-        raise Hbc::CaskError.new "Cask #{@cask} depends on OS X release #{@cask.depends_on.macos.first}, but you are running release #{MacOS.release}."
+        raise Hbc::CaskError.new "Cask #{@cask} depends on macOS release #{@cask.depends_on.macos.first}, but you are running release #{MacOS.release}."
       end
     end
   end
@@ -259,7 +259,7 @@ class Hbc::Installer
     else
       opoo <<-EOS.undent
         Accessibility access was enabled for #{@cask}, but it is not safe to disable
-        automatically on this version of OS X.  See System Preferences.
+        automatically on this version of macOS.  See System Preferences.
       EOS
     end
   end

--- a/lib/hbc/macos/release.rb
+++ b/lib/hbc/macos/release.rb
@@ -7,6 +7,7 @@ module Hbc::MacOS
     include Comparable
 
     SYMBOLS = {
+               :sierra        => '10.12',
                :el_capitan    => '10.11',
                :yosemite      => '10.10',
                :mavericks     => '10.9',

--- a/lib/hbc/pkg.rb
+++ b/lib/hbc/pkg.rb
@@ -79,7 +79,7 @@ class Hbc::Pkg
 
   def _with_full_permissions(path, &block)
     original_mode = (path.stat.mode % 01000).to_s(8)
-    # todo: similarly read and restore OS X flags (cf man chflags)
+    # todo: similarly read and restore macOS flags (cf man chflags)
     @command.run!('/bin/chmod', :args => ['--', '777', path], :sudo => true)
     block.call
   ensure

--- a/lib/vendor/plist.rb
+++ b/lib/vendor/plist.rb
@@ -5,7 +5,7 @@
 # Distributed under the MIT License
 #
 
-# Plist parses Mac OS X xml property list files into ruby data structures.
+# Plist parses macOS xml property list files into ruby data structures.
 #
 # === Load a plist file
 # This is the main point of the library:

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -4,13 +4,13 @@
 .TH "HOMEBREW\-CASK" "1" "June 2016" "Homebrew-cask" "brew-cask"
 .
 .SH "NAME"
-\fBhomebrew\-cask\fR \- A friendly binary installer for OS X
+\fBhomebrew\-cask\fR \- A friendly binary installer for macOS
 .
 .SH "SYNOPSIS"
 \fBbrew cask\fR command [options] [\fItoken\fR \.\.\.]
 .
 .SH "DESCRIPTION"
-Homebrew\-Cask is a tool for installing precompiled OS X binaries (such as Applications) from the command line\. The user is never required to use the graphical user interface\.
+Homebrew\-Cask is a tool for installing precompiled macOS binaries (such as Applications) from the command line\. The user is never required to use the graphical user interface\.
 .
 .SH "ALPHA\-QUALITY SOFTWARE"
 Homebrew\-Cask works robustly enough that we welcome new users, but the project is still in early development\. That means command names, option names, and other aspects of this manual are still subject to change\.

--- a/spec/cask/cli/doctor_spec.rb
+++ b/spec/cask/cli/doctor_spec.rb
@@ -5,7 +5,7 @@ describe Hbc::CLI::Doctor do
   it 'displays some nice info about the environment' do
     expect {
       Hbc::CLI::Doctor.run
-    }.to output(/\A==> OS X Release:/).to_stdout
+    }.to output(/\A==> macOS Release:/).to_stdout
   end
 
   it "raises an exception when arguments are given" do


### PR DESCRIPTION
Some instances of `OS X` were kept. These were the cases where we fake a user agent and where we are specifically talking about old versions of the OS that will never include Sierra or the future ones.
