### PR TITLE
Added mountain lion and mavericks version to daisydisk and itsycal

### DIFF
--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -2,9 +2,11 @@ cask 'daisydisk' do
   if MacOS.release <= :snow_leopard
     version '2.1.2'
     sha256 'd0a606dee19e524d6fa7b79fd48b3b9865123ca4126fb8805f8e96c317b57b31'
-    url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version}.dmg"
-    appcast 'https://daisydiskapp.com/downloads/appcastFeed.php',
-            checkpoint: '5f9960cd3d158636268aeae712f959bde3407efc4db59b7615e4ab08938d566a'
+    url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version.dots_to_underscores}.dmg"
+  elsif MacOS.release <= :mavericks
+    version '3.0.3.1'
+    sha256 'fe2aa86f2ea8a1f0c4791857a5b7991ecad295b5b969849bb7b15a890ab54b86'
+    url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version.dots_to_underscores}.zip"
   else
     version '4.2'
     sha256 'e60b9643d33fc0f10da0446f101b1ffb196c668f313ffeaf24ff5589a6cb2978'

--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -1,14 +1,25 @@
 cask 'itsycal' do
-  version '0.10.12'
-  sha256 '0ce81c7e932decb9faa8050fb6c6c713d5d30b57173b97dc51b5120d63fa7631'
+  if MacOS.release <= :mavericks
+    version '0.8.15'
+    sha256 '6470719a1f702c807f98a992880def5f499858231bf35924eaf3e0d5df48b436'
 
-  # s3.amazonaws.com/itsycal was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
-  appcast 'https://s3.amazonaws.com/itsycal/itsycal.xml',
-          checkpoint: '477514c570b5abeafcf1c5326b28d0cfe298033d78610b9d5d04d4efce263546'
+    # s3.amazonaws.com/itsycal was verified as official when first introduced to the cask
+    url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
+  else
+    version '0.10.12'
+    sha256 '0ce81c7e932decb9faa8050fb6c6c713d5d30b57173b97dc51b5120d63fa7631'
+
+    # s3.amazonaws.com/itsycal was verified as official when first introduced to the cask
+    url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
+    appcast 'https://s3.amazonaws.com/itsycal/itsycal.xml',
+            checkpoint: '477514c570b5abeafcf1c5326b28d0cfe298033d78610b9d5d04d4efce263546'
+  end
+
   name 'Itsycal'
   homepage 'http://www.mowglii.com/itsycal/'
   license :gratis
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'Itsycal.app'
 end


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Allows for older versions for `itsycal` and `daisydisk`.  In particular this fills in a weird gap in `daisydisk`, and notes that `itsycal` is 10.8+.  This is, of course, entirely self-serving.
