### PR TITLE
Update ncar-ncl.rb

### DIFF
--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -19,7 +19,7 @@ cask 'ncar-ncl' do
 
   depends_on cask: 'xquartz'
   depends_on formula: 'gcc'
-  depends_on macos: ['10.8', '10.9', '10.10']
+  depends_on macos: '>= 10.8'
   depends_on arch: :x86_64
 
   artifact 'include', target: '/usr/local/ncl-6.3.0/include'


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The 10.10 build of ncar-ncl works on OSX 10.11.  This update reflects that.
