### PR TITLE
Audacity update url

### DIFF
--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,9 +1,17 @@
+require 'open-uri'
 cask 'audacity' do
   version '2.1.2'
   sha256 '2e4b7d608ecc0d2f79bf16663f085d383075e488f7d50bf7d74c0b69173defe7'
 
   # Current official URL as proposed on http://www.audacityteam.org/download/mac/
-  url "http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg"
+  # must be parsed to extract temporary url embedded in iframe
+  iframe_src_protected_url = nil
+  open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") { |io|
+    content = io.read
+    iframe_src_protected_url = /^\<iframe.*src=\"(http.*\.dmg)\".*>/.match(content)[1].to_s
+  }
+  url iframe_src_protected_url
+  
   name 'Audacity'
   homepage 'http://audacityteam.org'
   license :gpl

--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,4 +1,8 @@
+# Audacity does not provide a fixed URL
+# Their download URL points to a html page that generates a temporary URL embedded within an iframe
+# 'open-uri' is required to open that page and grab the temporary URL
 require 'open-uri'
+
 cask 'audacity' do
   version '2.1.2'
   sha256 '2e4b7d608ecc0d2f79bf16663f085d383075e488f7d50bf7d74c0b69173defe7'

--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -6,12 +6,11 @@ cask 'audacity' do
   # Current official URL as proposed on http://www.audacityteam.org/download/mac/
   # must be parsed to extract temporary url embedded in iframe
   iframe_src_protected_url = nil
-  open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") { |io|
+  open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") do |io|
     content = io.read
-    iframe_src_protected_url = /^\<iframe.*src=\"(http.*\.dmg)\".*>/.match(content)[1].to_s
-  }
+    iframe_src_protected_url = %r{^\<iframe.*src=\"(http.*\.dmg)\".*>}.match(content)[1].to_s
+  end
   url iframe_src_protected_url
-  
   name 'Audacity'
   homepage 'http://audacityteam.org'
   license :gpl

--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,9 +1,9 @@
 cask 'audacity' do
-  version '2.1.2-1453294898'
+  version '2.1.2'
   sha256 '2e4b7d608ecc0d2f79bf16663f085d383075e488f7d50bf7d74c0b69173defe7'
 
-  # oldfoss.com:81/download/Audacity was verified as official when first introduced to the cask
-  url "http://app.oldfoss.com:81/download/Audacity/audacity_macosx_ub_#{version.dots_to_underscores}.dmg"
+  # Current official URL as proposed on http://www.audacityteam.org/download/mac/
+  url "http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg"
   name 'Audacity'
   homepage 'http://audacityteam.org'
   license :gpl


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Changed Audacity download URL. 
Currently, the official website points to download URL leading to an HTML page, although seemingly pointing to a file. This HTML page is now parsed using open-uri to extract the temporary (protected) download URL that is embedded within an iframe. 
The previous download URL that was hardcoded (http://app.oldfoss.com:81/download/Audacity/audacity_macosx_ub_2_1_2-1453294898.dmg) seems not to be working anymore, so I'm proposing this fix.
