### PR TITLE
updated wwdc (4.2.1)

### DIFF
--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -1,10 +1,10 @@
 cask 'wwdc' do
-  version '4.1.3'
-  sha256 'a6f4e0e1a7a8aca193e8f71f2d5be04670df4b0eafe1621f3bf5af7747b8b2fa'
+  version '4.2.1'
+  sha256 'd1d75a70885bbf9da7b6c39aae146692672b7912f995a8d3b18fb5f2b5c23b33'
 
   url "https://github.com/insidegui/WWDC/releases/download/#{version}/WWDC_v#{version}.zip"
   appcast 'https://github.com/insidegui/WWDC/releases.atom',
-          checkpoint: 'c4590058344b062805fa729b74f7197ab7cc83e52f137839f0790da80b804dca'
+          checkpoint: '9925c90252904041fa07484b743008a8d1d7426df6bf10b9c9f36b87486461ed'
   name 'WWDC'
   homepage 'https://github.com/insidegui/WWDC'
   license :bsd


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

@vitorgalvao added auto_updates true in his merge yesterday. I don't know what this does (I'm new and didn't understand the explanation given of this stanza in #13201). I installed the app again and it still downloaded 4.1.3. So updated to a new version. Sorry if this is not needed anymore
