### PR TITLE
Update Near Lock to version 3.6 (again)

### DIFF
--- a/Casks/near-lock.rb
+++ b/Casks/near-lock.rb
@@ -1,10 +1,10 @@
 cask 'near-lock' do
   version '3.6'
-  sha256 '8118ae08ef0dd414244dfc436abad5f3648bc36e18a7ace5d8587dde896b52b3'
+  sha256 'd5f15c5da6e818ed467dead23a070ffd99af48d6265f5dbf3319ef6f336df530'
 
   url 'http://nearlock.me/downloads/nearlock.dmg'
   appcast 'http://nearlock.me/downloads/nearlock.xml',
-          checkpoint: '0d6cb95559b472c3e0b68f322310199311a74ebf915419607644b70e1a3d3917'
+          checkpoint: 'e0ca65379137858b4f565a9abd40195cd834829143575e800465096bf86a6a7c'
   name 'Near Lock'
   homepage 'http://nearlock.me/'
   license :gratis


### PR DESCRIPTION
Near Lock seems to have released a new version of the DMG, which breaks the checksums from the previous PR at #21960
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
