### PR TITLE
updated carbon-copy-cloner (4.1.9.4365)

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,10 +1,10 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.8,4360'
-  sha256 'c1e4c13efb56814ae2ddfb954169747dfbb051d6704220ece8d4fb14a45a6d75'
+  version '4.1.9.4365'
+  sha256 '572143297bddcf526dfab9fae87716ac64abdb5fee77a92ead8a11166157b2f3'
 
-  url "http://bombich.com/software/files/ccc-#{version.before_comma}.#{version.after_comma}.zip"
+  url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
   appcast "https://bombich.com/software/updates/ccc.php?os_minor=11&os_bugfix=#{version.major}&ccc=#{version.after_comma}&beta=0&locale=en",
-          checkpoint: '61d5007912a0a979a8b1efd7693229cd7125fbca11c60e244e4114d285c32abe'
+          checkpoint: '1b64d38745f95986b8b0e0bf1b72341cc4a46616bd17226dec102a32b81c3b5a'
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
