### PR TITLE
Fix incorrect google code archive urls

### DIFF
--- a/Casks/cronnix.rb
+++ b/Casks/cronnix.rb
@@ -2,7 +2,7 @@ cask 'cronnix' do
   version '3.0.2'
   sha256 'e61144dc7b489d581fea10bc5d04dab1c0ea590ba8a69ed5d3c4e4617f557cd2'
 
-  url "https://storage.googleapis.com/google-code-archive-downloads/v1/code.google.com/cronnix/CronniX_#{version}.app.zip"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cronnix/CronniX_#{version}.app.zip"
   name 'CronniX'
   homepage 'https://code.google.com/archive/p/cronnix/'
   license :gpl

--- a/Casks/epub-to-pdf.rb
+++ b/Casks/epub-to-pdf.rb
@@ -2,7 +2,7 @@ cask 'epub-to-pdf' do
   version '3.1'
   sha256 'dcfc59d57f756802e844614b7dae43bca67284ec85fe6b909f244e41f20987b3'
 
-  url "https://storage.googleapis.com/google-code-archive-downloads/v1/code.google.com/epub-2-pdf/e2p-#{version.major}.dmg"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/epub-2-pdf/e2p-#{version.major}.dmg"
   name 'epub-2-pdf'
   homepage 'https://code.google.com/archive/p/epub-2-pdf'
   license :oss


### PR DESCRIPTION
Hi,

I found an incorrect google code archive url when trying to install cronnix, leading to a 404.
I went through all casks and also found epub-to-pdf which was affected.

According to https://code.google.com/archive/schema, the v2 url should always be used.
