### PR TITLE
updated simpholders (2.2)

### DIFF
--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -2,9 +2,9 @@ cask 'simpholders' do
   version '2.2'
   sha256 '0f12b0076f2bef08cd3129916a6fbe6f92bd7601a96bc787bfc0c5feda4b4d4a'
 
-  url "https://simpholders.com/downloads/SimPholders_#{version}.dmg"
+  url "https://simpholders.com/site/assets/files/1968/simpholders_#{version.dots_to_underscores}.dmg"
   appcast 'https://simpholders.com/updates/releases.xml',
-          checkpoint: '582a16dc0509a7294f58ac01668342159bcdcb3edb01a61a172d7fe8376a96c1'
+          checkpoint: '5bf1c98cf80e24efdcb1fed5726780a58b9867d7b09e9f5c08fedcdd2f7897d8'
   name 'SimPholders'
   homepage 'https://simpholders.com/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Previous url doesn't exist anymore.
