### PR TITLE
[WIP] Fixed Recognition of Compression Types in macOS Sierra

### DIFF
--- a/lib/hbc/container.rb
+++ b/lib/hbc/container.rb
@@ -14,6 +14,8 @@ require 'hbc/container/pkg'
 require 'hbc/container/seven_zip'
 require 'hbc/container/sit'
 require 'hbc/container/tar'
+require 'hbc/container/tar_bzip2'
+require 'hbc/container/tar_gzip'
 require 'hbc/container/ttf'
 require 'hbc/container/rar'
 require 'hbc/container/xar'
@@ -30,12 +32,14 @@ class Hbc::Container
       Hbc::Container::Dmg,
       Hbc::Container::SevenZip,
       Hbc::Container::Sit,
-      Hbc::Container::Tar,     # or compressed tar
       Hbc::Container::Rar,
       Hbc::Container::Zip,
+      Hbc::Container::TarBzip2,
+      Hbc::Container::TarGzip,
       Hbc::Container::Bzip2,
       Hbc::Container::Gzip,    # pure gzip, not tar/gzip
       Hbc::Container::Xar,
+      Hbc::Container::Tar,     # or compressed tar
     ]
     # for explicit use only (never autodetected):
     # Hbc::Container::Naked

--- a/lib/hbc/container/bzip2.rb
+++ b/lib/hbc/container/bzip2.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 
 class Hbc::Container::Bzip2 < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/x-bzip2;'
+    criteria.file.include?('application/x-bzip2;')
   end
 
   def extract

--- a/lib/hbc/container/criteria.rb
+++ b/lib/hbc/container/criteria.rb
@@ -43,10 +43,11 @@ class Hbc::Container::Criteria
     path.extname.sub(%r{\A\.}, '').downcase == test.downcase
   end
 
-  def magic_number(num, test)
-    File.open(path, "rb") do |file|
-      bytes = file.read(num).unpack('C*')
-      bytes == test
-    end
+  def magic_number(position, length, test, stream = nil)
+    stream = File.open(path, "rb") if stream.nil?
+    stream.read(position)
+    bytes = stream.read(length)
+    stream.close
+    bytes == test
   end
 end

--- a/lib/hbc/container/gzip.rb
+++ b/lib/hbc/container/gzip.rb
@@ -1,11 +1,8 @@
-
-# for pure gzip only, not tar-gzip (.tgz or .tar.gz)
-
 require 'tmpdir'
 
 class Hbc::Container::Gzip < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/x-gzip;'
+    criteria.file.include?('application/x-gzip;')
   end
 
   def extract

--- a/lib/hbc/container/pkg.rb
+++ b/lib/hbc/container/pkg.rb
@@ -1,7 +1,8 @@
 class Hbc::Container::Pkg < Hbc::Container::Naked
   def self.me?(criteria)
-    (criteria.extension 'pkg' or criteria.extension 'mpkg') and
-      (criteria.file.include? 'application/x-directory' or
-       criteria.magic_number(4, 'xar!'.unpack('C*')))
+    (criteria.extension('pkg') ||
+     criteria.extension('mpkg')) &&
+      (criteria.file.include?('application/x-directory') ||
+       criteria.magic_number(0, 4, 'xar!'))
   end
 end

--- a/lib/hbc/container/seven_zip.rb
+++ b/lib/hbc/container/seven_zip.rb
@@ -1,11 +1,11 @@
 class Hbc::Container::SevenZip < Hbc::Container::GenericUnar
   def self.me?(criteria)
     # todo: cover self-extracting archives
-    criteria.extension '7z' and
-      criteria.file.include? 'application/octet-stream;' and
-        criteria.magic_number(2, '7z'.unpack('C*')) and
-          ! criteria.lsar.nil? and
-            criteria.lsar.split("\n").first.split(':').last.include?('7-Zip') and
+    criteria.extension('7z') &&
+      criteria.file.include?('application/octet-stream;') &&
+        criteria.magic_number(0, 2, '7z') &&
+          !criteria.lsar.nil? &&
+            criteria.lsar.split("\n").first.split(':').last.include?('7-Zip') &&
               super
   end
 end

--- a/lib/hbc/container/tar.rb
+++ b/lib/hbc/container/tar.rb
@@ -2,7 +2,8 @@ require 'tmpdir'
 
 class Hbc::Container::Tar < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'application/x-tar'
+    criteria.file.include?('application/x-tar') ||
+      IO.popen(['/usr/bin/tar', '-tf', criteria.path.to_s], err: open('/dev/null').fileno) { |io| !io.read(1).nil? }
   end
 
   def extract

--- a/lib/hbc/container/tar_bzip2.rb
+++ b/lib/hbc/container/tar_bzip2.rb
@@ -1,0 +1,9 @@
+require 'hbc/container/tar'
+require 'hbc/container/bzip2'
+
+class Hbc::Container::TarBzip2 < Hbc::Container::Tar
+  def self.me?(criteria)
+    Hbc::Container::Bzip2.me?(criteria) &&
+      criteria.magic_number(257, 6, "ustar\0", IO.popen(['/usr/bin/bunzip2', '-c', criteria.path.to_s, :err => :out]))
+  end
+end

--- a/lib/hbc/container/tar_gzip.rb
+++ b/lib/hbc/container/tar_gzip.rb
@@ -1,0 +1,10 @@
+require 'hbc/container/tar'
+require 'hbc/container/gzip'
+require 'zlib'
+
+class Hbc::Container::TarGzip < Hbc::Container::Tar
+  def self.me?(criteria)
+    Hbc::Container::Gzip.me?(criteria) &&
+      criteria.magic_number(257, 6, "ustar\0", Zlib::GzipReader.open(criteria.path))
+  end
+end

--- a/lib/hbc/container/ttf.rb
+++ b/lib/hbc/container/ttf.rb
@@ -1,10 +1,9 @@
 class Hbc::Container::Ttf < Hbc::Container::Naked
   def self.me?(criteria)
-    (criteria.extension 'ttf' and
-     (criteria.file.include? 'application/x-font-ttf' or
-      criteria.magic_number(4, 'true'.unpack('C*')))) or
-
-    (criteria.extension 'ttc' and
-      criteria.magic_number(4, 'ttcf'.unpack('C*')))
+    (criteria.extension('ttf') &&
+     (criteria.file.include?('application/x-font-ttf') ||
+      criteria.magic_number(0, 4, 'true'))) ||
+      (criteria.extension('ttc') &&
+       criteria.magic_number(0, 4, 'ttcf'))
   end
 end

--- a/lib/hbc/container/xar.rb
+++ b/lib/hbc/container/xar.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 
 class Hbc::Container::Xar < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.magic_number(4, 'xar!'.unpack('C*'))
+    criteria.magic_number(0, 4, 'xar!')
   end
 
   def extract

--- a/lib/hbc/container/zip.rb
+++ b/lib/hbc/container/zip.rb
@@ -1,6 +1,6 @@
 class Hbc::Container::Zip < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/zip;'
+    criteria.file.include?('application/zip;')
   end
 
   def extract


### PR DESCRIPTION
### Changes to Detecting Package Compression Method, Fixes Errors in macOS Sierra
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

In macOS Sierra, recognising the packages compression with `criteria.file.include?`, yields the wonderful message `Error: Uh oh, could not figure out how to unpack '/Users/.../Library/Caches/Homebrew/filezilla-3.18.0.tar.bz2'`. This fix adds the ability to also recognise them by file extensions, which unless the packages extension does not match its type (unlikely), works all the time. The original detection method is still present, `or` statements are used between each detection method.
