### PR TITLE
Introduce block syntax for `url` stanza

### DIFF
--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,20 +1,18 @@
-# Audacity does not provide a fixed URL
-# Their download URL points to a html page that generates a temporary URL embedded within an iframe
-# 'open-uri' is required to open that page and grab the temporary URL
-require 'open-uri'
-
 cask 'audacity' do
   version '2.1.2'
   sha256 '2e4b7d608ecc0d2f79bf16663f085d383075e488f7d50bf7d74c0b69173defe7'
 
-  # Current official URL as proposed on http://www.audacityteam.org/download/mac/
-  # must be parsed to extract temporary url embedded in iframe
-  iframe_src_protected_url = nil
-  open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") do |io|
-    content = io.read
-    iframe_src_protected_url = %r{^\<iframe.*src=\"(http.*\.dmg)\".*>}.match(content)[1].to_s
+  url do
+    # Audacity does not provide a fixed URL
+    # Their download URL points to a html page that generates a temporary URL embedded within an iframe
+    # 'open-uri' is required to open that page and grab the temporary URL
+    require 'open-uri'
+    # fosshub.com/Audacity.html was verified as official when first introduced to the cask
+    open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") do |io|
+      content = io.read
+      %r{^\<iframe.*src=\"(http.*\.dmg)\".*>}.match(content)[1].to_s
+    end
   end
-  url iframe_src_protected_url
   name 'Audacity'
   homepage 'http://audacityteam.org'
   license :gpl

--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -1,9 +1,20 @@
+# Audacity does not provide a fixed URL
+# Their download URL points to a html page that generates a temporary URL embedded within an iframe
+# 'open-uri' is required to open that page and grab the temporary URL
+require 'open-uri'
+
 cask 'audacity' do
-  version '2.1.2-1453294898'
+  version '2.1.2'
   sha256 '2e4b7d608ecc0d2f79bf16663f085d383075e488f7d50bf7d74c0b69173defe7'
 
-  # oldfoss.com:81/download/Audacity was verified as official when first introduced to the cask
-  url "http://app.oldfoss.com:81/download/Audacity/audacity_macosx_ub_#{version.dots_to_underscores}.dmg"
+  # Current official URL as proposed on http://www.audacityteam.org/download/mac/
+  # must be parsed to extract temporary url embedded in iframe
+  iframe_src_protected_url = nil
+  open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") do |io|
+    content = io.read
+    iframe_src_protected_url = %r{^\<iframe.*src=\"(http.*\.dmg)\".*>}.match(content)[1].to_s
+  end
+  url iframe_src_protected_url
   name 'Audacity'
   homepage 'http://audacityteam.org'
   license :gpl

--- a/doc/cask_language_reference/all_stanzas.md
+++ b/doc/cask_language_reference/all_stanzas.md
@@ -8,7 +8,7 @@ Each of the following stanzas is required for every Cask.
 | ------------------ |------------------------------ | ----------- |
 | `version`          | no                            | application version; give value of `:latest`  if versioned downloads are not offered
 | `sha256`           | no                            | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`. Can be suppressed by using the special value `:no_check` (see also [Checksum Stanza Details](stanzas/sha256.md))
-| `url`              | no                            | URL to the `.dmg`/`.zip`/`.tgz`/`.tbz2` file that contains the application. A [comment](stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment) should be added if the hostnames in the `url` and `homepage` stanzas differ (see also [URL Stanza Details](stanzas/url.md))
+| `url`              | no                            | URL to the `.dmg`/`.zip`/`.tgz`/`.tbz2` file that contains the application.<br />A [comment](stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment) should be added if the hostnames in the `url` and `homepage` stanzas differ. Block syntax should be used for URLs that change on every visit.<br />See [URL Stanza Details](stanzas/url.md) for more information.
 | `name`             | yes                           | a string providing the full and proper name defined by the vendor (see also [Name Stanza Details](stanzas/name.md))
 | `homepage`         | no                            | application homepage; used for the `brew cask home` command
 | `license`          | no                            | a symbol identifying the license category for the application (see also [License Stanza Details](stanzas/license.md))

--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -84,8 +84,49 @@ Also make sure to give the URL for the binary download itself, rather than a pre
 
 ## Some Providers Block Command-line Downloads
 
-Some hosting providers actively block command-line HTTP clients (example: FossHub). Such URLs cannot be used in Casks.
+Some hosting providers actively block command-line HTTP clients. Such URLs cannot be used in Casks.
+
+Some providers do not actively block command-line HTTP clients but use URLs that change periodically, or even on each visit (example: FossHub). For those, see section [URLs that Change on Every Visit](#urls-that-change-on-every-visit).
 
 ## Vendor URLs Are Preferred
 
 When possible, it is best to use a download URL from the original developer or vendor, rather than an aggregator such as `macupdate.com`.
+
+## URLs that Change on Every Visit
+
+Some providers use disposable URLs, which a Cask author cannot know in advance. Such URLs may change daily, or on every visit, and sometimes need to be dynamically obtained from a landing site.
+
+### The Problem
+
+In theory, one can write arbitrary Ruby code right in the Cask definition to fetch and construct a disposable URL.
+
+However, this typically involves an HTTP/S round trip to a landing site, which may take a long time. Because of the way Homebrew-Cask loads and parses Casks, it is not acceptable that such expensive operations be performed directly in the body of a Cask definition.
+
+### Using a Block to Defer Code Execution
+
+Similar to the `preflight`, `postflight`, `uninstall_preflight`, and `uninstall_postflight` blocks, the `url` stanza offers an optional _block syntax_:
+
+```rb
+url do
+  # No known stable URL; fetching disposable URL from landing site
+  open('https://example.com/app/landing') do |landing_page|
+    content = landing_page.read
+    parse(content) # => https://example.com/download?23309800482283
+  end
+end
+```
+
+The block is only evaluated when needed, for example on download time or when auditing a Cask.
+Inside a block, you may safely do things such as HTTP/S requests that may take a long time to execute. You may also refer to the `@cask` instance variable, and invoke any method available on `@cask`.
+
+The block will be called immediately before downloading; its result value will be assumed to be a `String` and subsequently used as a download URL.
+
+You can use the `url` stanza with either a direct argument or a block but not with both.
+
+Example for using the block syntax: [audacity.rb](https://github.com/caskroom/homebrew-cask/tree/master/Casks/audacity.rb)
+
+### Mixing Additional URL Parameters With the Block Syntax
+
+In rare cases, you might need to set URL parameters like `cookies` or `referer` while also using the block syntax.
+
+This is possible by returning a two-element array as a block result. The first element of the array must be the download URL; the second element must be a `Hash` containing the parameters.

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -94,7 +94,7 @@ Fill in the following stanzas for your Cask:
 | ------------------ | ----------- |
 | `version`          | application version; give the value `:latest` if only an unversioned download is available
 | `sha256`           | SHA-256 checksum of the file downloaded from `url`, calculated by the command `shasum -a 256 <file>`. Can be suppressed by using the special value `:no_check`. (see [sha256](../cask_language_reference/stanzas/sha256.md))
-| `url`              | URL to the `.dmg`/`.zip`/`.tgz` file that contains the application. A [comment](../cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment) should be added if the hostnames in the `url` and `homepage` stanzas differ (see [URL Stanza Details](../cask_language_reference/stanzas/url.md))
+| `url`              | URL to the `.dmg`/`.zip`/`.tgz`/`.tbz2` file that contains the application.<br />A [comment](../cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment) should be added if the hostnames in the `url` and `homepage` stanzas differ. Block syntax should be used for URLs that change on every visit.<br />See [URL Stanza Details](../cask_language_reference/stanzas/url.md) for more information.
 | `name`             | the full and proper name defined by the vendor, and any useful alternate names (see [Name Stanza Details](../cask_language_reference/stanzas/name.md))
 | `homepage`         | application homepage; used for the `brew cask home` command
 | `license`          | a symbol identifying the license for the application. Valid category licenses include `:oss`, `:closed`, and `:unknown`. It is OK to leave as `:unknown`. (see [License Stanza Details](../cask_language_reference/stanzas/license.md))

--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -12,6 +12,7 @@ require 'hbc/dsl/installer'
 require 'hbc/dsl/license'
 require 'hbc/dsl/postflight'
 require 'hbc/dsl/preflight'
+require 'hbc/dsl/stanza_proxy'
 require 'hbc/dsl/uninstall_postflight'
 require 'hbc/dsl/uninstall_preflight'
 require 'hbc/dsl/version'
@@ -94,13 +95,14 @@ class Hbc::DSL
     @homepage ||= homepage
   end
 
-  def url(*args)
-    return @url if args.empty?
-    if @url && !args.empty?
+  def url(*args, &block)
+    url_given = !args.empty? || block_given?
+    return @url unless url_given
+    if @url && url_given
       raise Hbc::CaskInvalidError.new(self.token, "'url' stanza may only appear once")
     end
     @url ||= begin
-      Hbc::URL.new(*args)
+      Hbc::URL.from(*args, &block)
     rescue StandardError => e
       raise Hbc::CaskInvalidError.new(self.token, "'url' stanza failed with: #{e}")
     end

--- a/lib/hbc/dsl/stanza_proxy.rb
+++ b/lib/hbc/dsl/stanza_proxy.rb
@@ -1,0 +1,39 @@
+class Hbc::DSL::StanzaProxy
+  attr_reader :type
+
+  def self.once(type)
+    resolved = nil
+    new(type) { resolved ||= yield }
+  end
+
+  def initialize(type, &resolver)
+    @type = type
+    @resolver = resolver
+  end
+
+  def proxy?
+    true
+  end
+
+  def to_s
+    @resolver.call.to_s
+  end
+
+  # Serialization for dumpcask
+  def encode_with(coder)
+    coder['type'] = type
+    coder['resolved'] = @resolver.call
+  end
+
+  def respond_to?(symbol, include_private = false)
+    if %i{encode_with proxy? to_s, type}.include?(symbol)
+      return true 
+    end
+    return false if symbol == :to_ary
+    @resolver.call.respond_to?(symbol, include_private)
+  end
+
+  def method_missing(symbol, *args)
+    @resolver.call.send(symbol, *args)
+  end
+end

--- a/lib/hbc/url.rb
+++ b/lib/hbc/url.rb
@@ -8,6 +8,14 @@ class Hbc::URL
   extend Forwardable
   def_delegators :uri, :path, :scheme, :to_s
 
+  def self.from(*args, &block)
+    if block_given?
+      Hbc::DSL::StanzaProxy.once(self) { new(*block.call) }
+    else
+      new(*args)
+    end
+  end
+
   def initialize(uri, options={})
     @uri        = Hbc::UnderscoreSupportingURI.parse(uri)
     @user_agent = options[:user_agent]

--- a/spec/cask/audit_spec.rb
+++ b/spec/cask/audit_spec.rb
@@ -141,6 +141,24 @@ describe Hbc::Audit do
       end
     end
 
+    describe "url checks" do
+      context "given a block" do
+        let(:cask_token) { 'booby-trap' }
+
+        context "when loading the cask" do
+          it "does not evaluate the block" do
+            expect { cask }.to_not raise_error
+          end
+        end
+
+        context "when doing the audit" do
+          it "evaluates the block" do
+            expect { subject }.to raise_error("Boom")
+          end
+        end
+      end
+    end
+
     describe "audit of downloads" do
       let(:cask_token) { 'with-binary' }
       let(:cask) { Hbc.load(cask_token) }

--- a/spec/cask/dsl/stanza_proxy_spec.rb
+++ b/spec/cask/dsl/stanza_proxy_spec.rb
@@ -1,0 +1,32 @@
+describe Hbc::DSL::StanzaProxy do
+  let(:stanza_proxy) do
+    described_class.new(Array) { %i[foo bar cake] }
+  end
+
+  subject { stanza_proxy }
+  it { is_expected.to be_a_proxy }
+  it { is_expected.to respond_to(:pop) }
+  its(:pop) { is_expected.to eq(:cake) }
+  its(:type) { is_expected.to eq(Array) }
+  its(:to_s) { is_expected.to eq('[:foo, :bar, :cake]') }
+
+  describe 'when initialized' do
+    let(:initializing) do
+      proc { |b| described_class.new(Array, &b) }
+    end
+
+    it 'does not evaluate the block' do
+      expect(&initializing).not_to yield_control
+    end
+  end
+
+  describe 'when receiving a message' do
+    let(:receiving_a_message) do
+      proc { |b| described_class.new(Array, &b).to_s }
+    end
+
+    it 'evaluates the block' do
+      expect(&receiving_a_message).to yield_with_no_args
+    end
+  end
+end

--- a/spec/support/Casks/booby-trap.rb
+++ b/spec/support/Casks/booby-trap.rb
@@ -1,0 +1,8 @@
+cask 'booby-trap' do
+  version '0.0.7'
+
+  url do
+    # to be lazily evaluated
+    fail 'Boom'
+  end
+end


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---
## Issue

Some providers use disposable URLs, which need to be constructed from some sort of landing site ([recent example](https://github.com/caskroom/homebrew-cask/pull/21952#issuecomment-225855234)). Doing such expensive things in the middle of a Cask definition [has proven difficult](https://github.com/caskroom/homebrew-versions/pull/293#issuecomment-48755213) in the past. Loading a Cask would become unacceptably slow if HTTP/S requests were done in Cask definitions.
## Solution

Albeit rarely, such cases do pop up every now and then; so I decided to write this PR, which introduces an **optional block syntax** for the `url` stanza:

``` rb
url do
  # No known stable URL; fetching disposable URL from landing site
  open('https://example.com/app/landing') do |landing_page|
    content = landing_page.read
    parse(content) # => https://example.com/download?23309800482283
  end
end
```

The block is only evaluated when needed, for example on download time or when auditing a Cask. It is never evaluated when loading a Cask.

The return value of the block is either a `String`, or a `String, Hash` tuple; the latter case is for additional options such as `referrer`.
## Implementation note

For `stanza_proxy.rb`, I could have used `SimpleDelegator` but it turned out to be much faster to roll my own logic.

The proxy is designed to be easily reused for other stanzas if needed.
## Credits

Thanks @tobadia for contributing the regex/`open-uri` snippet in `audacity.rb`, which also triggered the idea for this PR.
## Feedback

Pinging @caskroom/maintainers for opinions (and for suggestions to improve my convoluted English in the docs). Thanks!
