### PR TITLE
Update Rodeo to version 2.0.0

### DIFF
--- a/Casks/rodeo.rb
+++ b/Casks/rodeo.rb
@@ -1,11 +1,11 @@
 cask 'rodeo' do
-  version '1.4.9'
-  sha256 '0e590fd0cc91153f971c56562cb4c2ae9b5209547c9e4043371ca03f53155b4c'
+  version '2.0.0'
+  sha256 'd9dfba1f62934e4ec7c80c4bfd0d4b77ddec63254f9d14b7cc867c0c20d5baf1'
 
   # github.com/yhat/rodeo was verified as official when first introduced to the cask
   url "https://github.com/yhat/rodeo/releases/download/v#{version}/Rodeo-#{version}.dmg"
   appcast 'https://github.com/yhat/rodeo/releases.atom',
-          checkpoint: '8a2cc3b31afd75edc1c9b3bb738bfb2f761c7a8d7f87c1f111550a6499ef1038'
+          checkpoint: '900acf0852da14c0d38a73345f82cfa37a951123af8dac9dce0cacb8a35b61fc'
   name 'Rodeo'
   homepage 'http://rodeo.yhat.com/'
   license :affero

--- a/Casks/rodeo.rb
+++ b/Casks/rodeo.rb
@@ -8,7 +8,7 @@ cask 'rodeo' do
           checkpoint: '8a2cc3b31afd75edc1c9b3bb738bfb2f761c7a8d7f87c1f111550a6499ef1038'
   name 'Rodeo'
   homepage 'http://rodeo.yhat.com/'
-  license :closed
+  license :affero
 
   app 'Rodeo.app'
 end


### PR DESCRIPTION
Rodeo 2.0.0 was [released yesterday](http://blog.yhat.com/posts/rodeo-2.0-release.html). This pull request reflects that, and includes a change to the licence (from `:closed` to `:affero`) to match the [app licence](https://github.com/yhat/rodeo/blob/5583fe7e14e633881ff5e8ff4b795c04868f3d76/LICENSE).
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
