### PR TITLE
Updated QtPass to 1.1.3

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -1,10 +1,10 @@
 cask 'qtpass' do
-  version '1.1.1'
-  sha256 '4feb50fa56fb3d935bc9df598cc511da6168f91b926d20af3eef88b4dd96b051'
+  version '1.1.3'
+  sha256 'd2488cf342a7b470564481423dbf6b5a07789c41e7a39c7a44a027b6c2b0b054'
 
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: '708202c18c1b76e0ed3be809dff77457cbad1c3afbff329002e784db2260a0f9'
+          checkpoint: '5c020a503bcfad1407583e46b16bc2ee273622a136ba9a631002defc860125dd'
   name 'QtPass'
   homepage 'https://qtpass.org/'
   license :gpl


### PR DESCRIPTION
New upstream release number and sha256 hashes
