### PR TITLE
veracrypt: caveat about needing MacFUSE Compatibility Layer in osxfuse

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -13,4 +13,12 @@ cask 'veracrypt' do
   pkg 'VeraCrypt_Installer.pkg'
 
   uninstall pkgutil: 'com.idrix.pkg.veracrypt'
+
+  caveats <<-EOS.undent
+    #{token} requires osxfuse with "MacFUSE Compatibility Layer" enabled.
+    If you did not enable that option, #{token} will fail to install.
+
+    To enable the option, you need to install osxfuse manually (double-click the installer).
+    The installer should be located under #{Hbc.caskroom}/osxfuse
+  EOS
 end


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
