### PR TITLE
Make appdir method available inside *flight blocks

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -18,8 +18,8 @@ cask 'blender' do
     pythonversion = '3.4'
     File.open(shimscript, 'w') do |f|
       f.puts '#!/bin/bash'
-      f.puts "export PYTHONHOME=#{Hbc.appdir}/Blender.app/Contents/Resources/#{version}/python/lib/python#{pythonversion}"
-      f.puts "#{Hbc.appdir}/Blender.app/Contents/MacOS/blender $@"
+      f.puts "export PYTHONHOME=#{appdir}/Blender.app/Contents/Resources/#{version}/python/lib/python#{pythonversion}"
+      f.puts "#{appdir}/Blender.app/Contents/MacOS/blender $@"
       FileUtils.chmod '+x', f
     end
   end

--- a/Casks/cmpl.rb
+++ b/Casks/cmpl.rb
@@ -14,6 +14,6 @@ cask 'cmpl' do
   binary 'Cmpl/pyCmpl/scripts/Unix/pyCmpl'
 
   postflight do
-    system '/bin/rm', '-f', '--', "#{Hbc.appdir}/Cmpl/install", "#{Hbc.appdir}/Cmpl/deinstall"
+    system '/bin/rm', '-f', '--', "#{appdir}/Cmpl/install", "#{appdir}/Cmpl/deinstall"
   end
 end

--- a/Casks/dia.rb
+++ b/Casks/dia.rb
@@ -13,6 +13,6 @@ cask 'dia' do
   app 'Dia.app'
 
   postflight do
-    system '/usr/bin/sed', '-i', '--', 's/exec/exec env DISPLAY=:0/g', "#{Hbc.appdir}/Dia.app/Contents/Resources/bin/dia"
+    system '/usr/bin/sed', '-i', '--', 's/exec/exec env DISPLAY=:0/g', "#{appdir}/Dia.app/Contents/Resources/bin/dia"
   end
 end

--- a/Casks/gedit.rb
+++ b/Casks/gedit.rb
@@ -13,6 +13,6 @@ cask 'gedit' do
 
   postflight do
     library = Dir.glob("#{`brew --cellar`.chomp}/libxml2/**/libxml2.2.dylib").first
-    system 'cp', '-f', library, "#{Hbc.appdir}/gedit.app/Contents/Resources/lib/"
+    system 'cp', '-f', library, "#{appdir}/gedit.app/Contents/Resources/lib/"
   end
 end

--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -13,7 +13,7 @@ cask 'hex-fiend' do
   app 'Hex Fiend.app'
 
   postflight do
-    set_permissions "#{Hbc.appdir}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework", 'og=u'
+    set_permissions "#{appdir}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework", 'og=u'
   end
 
   zap delete: [

--- a/Casks/ibvpncom.rb
+++ b/Casks/ibvpncom.rb
@@ -11,6 +11,6 @@ cask 'ibvpncom' do
   app 'ibvpn.com.app'
 
   uninstall_preflight do
-    set_permissions "#{Hbc.appdir}/ibvpn.com.app", '0777'
+    set_permissions "#{appdir}/ibvpn.com.app", '0777'
   end
 end

--- a/Casks/jxplorer.rb
+++ b/Casks/jxplorer.rb
@@ -11,6 +11,6 @@ cask 'jxplorer' do
   app "jxplorer-#{version}.app"
 
   postflight do
-    set_permissions "#{Hbc.appdir}/jxplorer-#{version}.app/Contents/MacOS/jxplorer", 'a+x'
+    set_permissions "#{appdir}/jxplorer-#{version}.app/Contents/MacOS/jxplorer", 'a+x'
   end
 end

--- a/Casks/macfusion.rb
+++ b/Casks/macfusion.rb
@@ -15,7 +15,7 @@ cask 'macfusion' do
 
   # fix broken bundled sshfs, see https://github.com/osxfuse/osxfuse/wiki/SSHFS#macfusion
   postflight do
-    Dir.chdir("#{Hbc.appdir}/Macfusion.app/Contents/PlugIns/sshfs.mfplugin/Contents/Resources") do
+    Dir.chdir("#{appdir}/Macfusion.app/Contents/PlugIns/sshfs.mfplugin/Contents/Resources") do
       File.rename('sshfs-static', 'sshfs-static.orig')
       File.symlink('/usr/local/bin/sshfs', 'sshfs-static')
     end

--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -11,7 +11,7 @@ cask 'meshlab' do
 
   postflight do
     # workaround for bug which breaks the app on case-sensitive filesystems
-    Dir.chdir("#{Hbc.appdir}/meshlab.app/Contents/MacOS") do
+    Dir.chdir("#{appdir}/meshlab.app/Contents/MacOS") do
       File.symlink('meshlab', 'MeshLab') unless File.exist? 'MeshLab'
     end
   end

--- a/Casks/openarena.rb
+++ b/Casks/openarena.rb
@@ -10,6 +10,6 @@ cask 'openarena' do
   app "openarena-#{version}/OpenArena.app"
 
   postflight do
-    set_permissions "#{Hbc.appdir}/OpenArena.app/Contents/MacOS/openarena.ub", '755'
+    set_permissions "#{appdir}/OpenArena.app/Contents/MacOS/openarena.ub", '755'
   end
 end

--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -12,12 +12,12 @@ cask 'parallels-desktop' do
   postflight do
     # Run the initialization script
     system '/usr/bin/sudo', '-E', '--',
-           "#{Hbc.appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-           'init', '-b', "#{Hbc.appdir}/Parallels Desktop.app"
+           "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
+           'init', '-b', "#{appdir}/Parallels Desktop.app"
   end
 
   uninstall_preflight do
-    set_ownership "#{Hbc.appdir}/Parallels Desktop.app"
+    set_ownership "#{appdir}/Parallels Desktop.app"
   end
 
   uninstall delete: [

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -11,6 +11,6 @@ cask 'pd-extended' do
   app 'Pd-extended.app'
 
   postflight do
-    set_permissions "#{Hbc.appdir}/Pd-extended.app", 'u+w'
+    set_permissions "#{appdir}/Pd-extended.app", 'u+w'
   end
 end

--- a/Casks/pd.rb
+++ b/Casks/pd.rb
@@ -10,6 +10,6 @@ cask 'pd' do
   app "Pd-#{version}-64bit.app"
 
   postflight do
-    set_permissions "#{Hbc.appdir}/Pd-#{version}-64bit.app", 'u+w'
+    set_permissions "#{appdir}/Pd-#{version}-64bit.app", 'u+w'
   end
 end

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -19,7 +19,7 @@ cask 'vlc' do
   preflight do
     File.open(shimscript, 'w') do |f|
       f.puts '#!/bin/bash'
-      f.puts "#{Hbc.appdir}/VLC.app/Contents/MacOS/VLC \"$@\""
+      f.puts "#{appdir}/VLC.app/Contents/MacOS/VLC \"$@\""
       FileUtils.chmod '+x', f
     end
   end

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -36,7 +36,7 @@ cask 'vmware-fusion' do
   binary "#{appdir}/VMware Fusion.app/Contents/Library/VMware OVF Tool/ovftool"
 
   uninstall_preflight do
-    set_ownership "#{Hbc.appdir}/VMware Fusion.app"
+    set_ownership "#{appdir}/VMware Fusion.app"
   end
 
   zap delete: [

--- a/Casks/voicemac.rb
+++ b/Casks/voicemac.rb
@@ -12,6 +12,6 @@ cask 'voicemac' do
   app 'VoiceMac/VoiceMac.app'
 
   postflight do
-    set_permissions "#{Hbc.appdir}/VoiceMac.app/Contents/Info.plist", 'a+r'
+    set_permissions "#{appdir}/VoiceMac.app/Contents/Info.plist", 'a+r'
   end
 end

--- a/lib/hbc/dsl.rb
+++ b/lib/hbc/dsl.rb
@@ -281,10 +281,6 @@ class Hbc::DSL
     end
   end
 
-  def appdir
-    Hbc.appdir.sub(/\/$/, "")
-  end
-
   SPECIAL_ARTIFACT_TYPES.each do |type|
     define_method(type) do |*args|
       artifacts[type].merge(args)
@@ -300,5 +296,13 @@ class Hbc::DSL
   def method_missing(method, *args)
     Hbc::Utils.method_missing_message(method, self.token)
     return nil
+  end
+
+  def appdir
+    self.class.appdir
+  end
+
+  def self.appdir
+    Hbc.appdir.sub(/\/$/, "")
   end
 end

--- a/lib/hbc/dsl/base.rb
+++ b/lib/hbc/dsl/base.rb
@@ -23,4 +23,8 @@ class Hbc::DSL::Base
   def staged_path
     caskroom_path.join(@cask.version)
   end
+
+  def appdir
+    Hbc::DSL.appdir
+  end
 end

--- a/test/cask/dsl/preflight_test.rb
+++ b/test/cask/dsl/preflight_test.rb
@@ -1,12 +1,16 @@
 require "test_helper"
 
 describe Hbc::DSL::Preflight do
-  before do
-    cask = Hbc.load('basic-cask')
-    @dsl = Hbc::DSL::Preflight.new(cask, Hbc::FakeSystemCommand)
-  end
+  let(:cask) { Hbc.load('basic-cask') }
+  let(:dsl) { Hbc::DSL::Preflight.new(cask, Hbc::FakeSystemCommand) }
 
   it_behaves_like Hbc::Staged do
-    let(:staged) { @dsl }
+    let(:staged) { dsl }
+  end
+
+  it "supports the appdir method" do
+    result = dsl.instance_eval { appdir }
+
+    result.must_equal Hbc.appdir
   end
 end

--- a/test/cask/dsl/uninstall_postflight_test.rb
+++ b/test/cask/dsl/uninstall_postflight_test.rb
@@ -1,12 +1,8 @@
 require "test_helper"
 
-describe Hbc::DSL::Postflight do
+describe Hbc::DSL::UninstallPostflight do
   let(:cask) { Hbc.load('basic-cask') }
-  let(:dsl) { Hbc::DSL::Postflight.new(cask, Hbc::FakeSystemCommand) }
-
-  it_behaves_like Hbc::Staged do
-    let(:staged) { dsl }
-  end
+  let(:dsl) { Hbc::DSL::UninstallPostflight.new(cask, Hbc::FakeSystemCommand) }
 
   it "supports the appdir method" do
     result = dsl.instance_eval { appdir }

--- a/test/cask/dsl/uninstall_preflight_test.rb
+++ b/test/cask/dsl/uninstall_preflight_test.rb
@@ -1,12 +1,16 @@
 require "test_helper"
 
 describe Hbc::DSL::UninstallPreflight do
-  before do
-    cask = Hbc.load('basic-cask')
-    @dsl = Hbc::DSL::UninstallPreflight.new(cask, Hbc::FakeSystemCommand)
-  end
+  let(:cask) { Hbc.load('basic-cask') }
+  let(:dsl) { Hbc::DSL::UninstallPreflight.new(cask, Hbc::FakeSystemCommand) }
 
   it_behaves_like Hbc::Staged do
-    let(:staged) { @dsl }
+    let(:staged) { dsl }
+  end
+
+  it "supports the appdir method" do
+    result = dsl.instance_eval { appdir }
+
+    result.must_equal Hbc.appdir
   end
 end


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

This makes the `appdir` helper method available inside pre-flight, post-flight, etc. blocks in addition to the regular DSL stanzas.

Closes #22024.
