### PR TITLE
add support for file-5.25 zip mimetype in macOS Sierra

### DIFF
--- a/lib/hbc/container/bzip2.rb
+++ b/lib/hbc/container/bzip2.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 
 class Hbc::Container::Bzip2 < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/x-bzip2;'
+    criteria.file.include? 'application/x-bzip2;'
   end
 
   def extract

--- a/lib/hbc/container/gzip.rb
+++ b/lib/hbc/container/gzip.rb
@@ -5,7 +5,7 @@ require 'tmpdir'
 
 class Hbc::Container::Gzip < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/x-gzip;'
+    criteria.file.include? 'application/x-gzip;'
   end
 
   def extract

--- a/lib/hbc/container/zip.rb
+++ b/lib/hbc/container/zip.rb
@@ -1,6 +1,6 @@
 class Hbc::Container::Zip < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/zip;'
+    criteria.file.include? 'application/zip;'
   end
 
   def extract


### PR DESCRIPTION
### Changes to the core

macOS Sierra's version of /usr/bin/file reports a different mimetype string for zip, bzip2 and gzip files:

```
$ /usr/bin/file -Izb -- /usr/local/Library/Taps/caskroom/homebrew-cask/spec/support/binaries/AppWithBinary.zip
application/zip; charset=binary
$ /usr/bin/file -Izb -- /usr/local/Library/Taps/caskroom/homebrew-cask/test/support/binaries/bzipped_asset.bz2
application/x-bzip2; charset=binary
$ /usr/bin/file -Izb -- /usr/local/Library/Taps/caskroom/homebrew-cask/test/support/binaries/gzipped_asset.gz
application/x-gzip; charset=binary
```
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).
