### PR TITLE
menumeters doesn't work on el capitan

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -7,6 +7,8 @@ cask 'menumeters' do
   homepage 'http://www.ragingmenace.com/software/menumeters/'
   license :gpl
 
+  depends_on macos: '<= :yosemite'
+
   prefpane 'MenuMeters Installer.app/Contents/Resources/MenuMeters.prefPane'
 
   zap delete: '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

See http://www.ragingmenace.com/software/menumeters/#requirement — `yujitach-menumeters.rb` is presumably a [suitable replacement](https://github.com/caskroom/homebrew-cask/pull/14145).  I'd be open to a caveat here but I know that's a fairly political issue. 😉
