### PR TITLE
Renames Telegram Desktop recipe to telegram-desktop.

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -1,4 +1,4 @@
-cask 'telegram' do
+cask 'telegram-desktop' do
   version '0.9.51'
   sha256 '7d898a6ddc2c9a2722d37867d22b422d63cf218f721dbb8942d67696b2f6aadd'
 


### PR DESCRIPTION
This renaming is needed to avoid confusion with the native version of Telegram. I'll provide a new recipe for the nativ client as `telegram.rb` in an separate pull request once this one is merged.

The native version can be found here https://macos.telegram.org compared to the desktop version which can be found here https://desktop.telegram.org ...
