### PR TITLE
Create shim script for LibreOffice's `soffice`

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -21,7 +21,9 @@ cask 'libreoffice' do
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/regmerge"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/regview"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/senddoc"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/soffice"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/sofficewrapper"
+  binary shimscript, target: 'soffice'
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/ui-previewer"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/uno"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/unoinfo"
@@ -29,6 +31,14 @@ cask 'libreoffice' do
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/urelibs"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/uri-encode"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/xpdfimport"
+
+  preflight do
+    File.open(shimscript, 'w') do |f|
+      f.puts '#!/usr/bin/env bash'
+      f.puts "#{Hbc.appdir}/LibreOffice.app/Contents/MacOS/soffice \"$@\""
+      FileUtils.chmod '+x', f
+    end
+  end
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl',

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -35,7 +35,7 @@ cask 'libreoffice' do
   preflight do
     File.open(shimscript, 'w') do |f|
       f.puts '#!/usr/bin/env bash'
-      f.puts "#{Hbc.appdir}/LibreOffice.app/Contents/MacOS/soffice \"$@\""
+      f.puts "#{appdir}/LibreOffice.app/Contents/MacOS/soffice \"$@\""
       FileUtils.chmod '+x', f
     end
   end

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -21,9 +21,6 @@ cask 'libreoffice' do
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/regmerge"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/regview"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/senddoc"
-  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/sofficewrapper"
-  binary shimscript, target: 'soffice'
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/ui-previewer"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/uno"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/unoinfo"
@@ -31,6 +28,9 @@ cask 'libreoffice' do
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/urelibs"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/uri-encode"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/xpdfimport"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/sofficewrapper"
+  binary shimscript, target: 'soffice'
 
   preflight do
     File.open(shimscript, 'w') do |f|


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

`soffice` depends on other files within the LibreOffice app.
Document conversion with the symlinked `soffice` would fail
with the following error:

```
... No Info.plist file in application bundle or no NSPrincipalClass in the Info.plist file, exiting
```

See also https://superuser.com/questions/1078968 and
https://gist.github.com/psjinx/3ad78df6290b5ba931c1.
