### PR TITLE
Adds Telegram for macOS and renames Telegram Desktop

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -1,0 +1,13 @@
+cask 'telegram-desktop' do
+  version '0.9.51'
+  sha256 '7d898a6ddc2c9a2722d37867d22b422d63cf218f721dbb8942d67696b2f6aadd'
+
+  # tdesktop.com was verified as official when first introduced to the cask
+  url "https://updates.tdesktop.com/tmac/tsetup.#{version}.dmg"
+  name 'Telegram Desktop'
+  homepage 'https://desktop.telegram.org'
+  license :gpl
+
+  # Renamed to avoid conflict with telegram
+  app 'Telegram.app', target: 'Telegram Desktop.app'
+end

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,11 +1,10 @@
 cask 'telegram' do
-  version '0.9.51'
-  sha256 '7d898a6ddc2c9a2722d37867d22b422d63cf218f721dbb8942d67696b2f6aadd'
+  version :latest
+  sha256 :no_check
 
-  # tdesktop.com is the official download host per the vendor homepage
-  url "https://updates.tdesktop.com/tmac/tsetup.#{version}.dmg"
-  name 'Telegram Desktop'
-  homepage 'https://desktop.telegram.org/'
+  url 'https://osx.telegram.org/updates/telegram.dmg'
+  name 'Telegram for macOS'
+  homepage 'https://macos.telegram.org'
   license :gpl
 
   app 'Telegram.app'


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
### Some additional background to this commit

There are two different apps of Telegram for macOS:
- Telegram for macOS, called the native app (https://macos.telegram.org)
- Telegram Desktop (https://desktop.telegram.org)

Unfortunately both apps are installed with the same filename `Telegram.app`. To avoid a naming conflict, the app _Telegram Desktop_ is now installed as `Telegram Desktop.app` (like it's done if installed via the App Store). To reflect the new app name I also renamed the _Telegram Desktop_ recipe according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md) to `telegram-desktop.rb`.

So the new naming schema for the two apps is now:

| App Name on Homepage | App Name on Disk | Simplified App Name | Cask Token | Filename |
| --- | --- | --- | --- | --- |
| Telegram Desktop | `Telegram Desktop.app` | Telegram Desktop | telegram-desktop | `telegram-desktop.rb` |
| Telegram for macOS | `Telegram.app` | Telegram | telegram | `telegram.rb` |
