### PR TITLE
Remove conflicts_with stanza from intellij-idea

### DIFF
--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -7,8 +7,6 @@ cask 'intellij-idea' do
   homepage 'https://www.jetbrains.com/idea/'
   license :commercial
 
-  conflicts_with cask: 'intellij-idea-eap'
-
   app 'IntelliJ IDEA.app'
 
   uninstall delete: '/usr/local/bin/idea'


### PR DESCRIPTION
There is no conflict between `intellij-idea` and `intellij-idea-eap`.
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
