### PR TITLE
`url.md`: point example to specific revision

### DIFF
--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -123,7 +123,7 @@ The block will be called immediately before downloading; its result value will b
 
 You can use the `url` stanza with either a direct argument or a block but not with both.
 
-Example for using the block syntax: [audacity.rb](https://github.com/caskroom/homebrew-cask/tree/master/Casks/audacity.rb)
+Example for using the block syntax: [audacity.rb](https://github.com/caskroom/homebrew-cask/blob/c389d9ccbb46d30b6ac1cbdbadf49591ca8ff6cd/Casks/audacity.rb#L5-L15)
 
 ### Mixing Additional URL Parameters With the Block Syntax
 


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

As [discussed](https://github.com/caskroom/homebrew-cask/pull/22014#discussion_r67345214) in #22014, this PR updates the docs in `url.md` to point to a [specific revision](https://github.com/caskroom/homebrew-cask/blob/c389d9ccbb46d30b6ac1cbdbadf49591ca8ff6cd/Casks/audacity.rb#L5-L15) for the `audacity.rb` example.
