### PR TITLE
bitcoin-core.rb: fix permission problems

### DIFF
--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -12,6 +12,14 @@ cask 'bitcoin-core' do
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app 'Bitcoin-Qt.app', target: 'Bitcoin Core.app'
 
+  preflight do
+    set_permissions "#{staged_path}/Bitcoin-Qt.app", '0755'
+  end
+
+  postflight do
+    set_permissions "#{appdir}/Bitcoin Core.app", '0555'
+  end
+
   zap delete: [
                 '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist',
               ]


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

They have limited permissions (to prevent tampering?), so this changes them just so we can rename, then sets them back.
