### PR TITLE
Updated file criteria

### DIFF
--- a/lib/hbc/container/bzip2.rb
+++ b/lib/hbc/container/bzip2.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 
 class Hbc::Container::Bzip2 < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/x-bzip2;'
+    criteria.file.include? 'application/x-bzip2'
   end
 
   def extract

--- a/lib/hbc/container/gzip.rb
+++ b/lib/hbc/container/gzip.rb
@@ -5,7 +5,7 @@ require 'tmpdir'
 
 class Hbc::Container::Gzip < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/x-gzip;'
+    criteria.file.include? 'application/x-gzip'
   end
 
   def extract

--- a/lib/hbc/container/zip.rb
+++ b/lib/hbc/container/zip.rb
@@ -1,6 +1,6 @@
 class Hbc::Container::Zip < Hbc::Container::Base
   def self.me?(criteria)
-    criteria.file.include? 'compressed-encoding=application/zip;'
+    criteria.file.include? 'application/zip'
   end
 
   def extract


### PR DESCRIPTION
`/usr/bin/file -Izb $FILENAME` doesn't return `compressed-encoding=`
prefix on MacOS 10.12b (16A201w)
