### PR TITLE
updated messenger (0.1.8.1466363428-c3dc9b83f1dd0469)

### DIFF
--- a/Casks/messenger.rb
+++ b/Casks/messenger.rb
@@ -1,10 +1,10 @@
 cask 'messenger' do
-  version '0.1.7.1459534376-b3a4a21fc7da0c8b'
-  sha256 'ba47eddc257d8e10bbfa426f01c1272b5a3bae9b4d3afdc354ca1284a78548e4'
+  version '0.1.8.1466363428-c3dc9b83f1dd0469'
+  sha256 '84e8d4e5c5242ac3e277423a1ae54be6267d05c1eb47b79c77a6b5c0e548f7df'
 
   url "http://fbmacmessenger.rsms.me/dist/Messenger-#{version}.zip"
   appcast 'https://fbmacmessenger.rsms.me/changelog.xml',
-          checkpoint: 'f56f4ab3fb85e6b6a0c71750d2e5195f0c526f2518211ba9465b434908c6580c'
+          checkpoint: '6b72f621e9f00b9cc4786cb7084a727d31bd91d5d34cf0191170c4a2e2b9c622'
   name 'Messenger'
   homepage 'http://fbmacmessenger.rsms.me/'
   license :mit


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
