### PR TITLE
New MongoChef version 3.6.0

### DIFF
--- a/Casks/mongochef.rb
+++ b/Casks/mongochef.rb
@@ -1,6 +1,6 @@
 cask 'mongochef' do
-  version '3.5.3'
-  sha256 '4c3afe4fefb048fc7979da7a0b858242b7df6a65d449f014b871f7f3e6bd8625'
+  version '3.6.0'
+  sha256 'cf089a5aabbb91846b8f73bcd61f507bff3a8dfd4b984ca070b7905c85cb6e66'
 
   url "https://cdn.3t.io/mongochef/mac/#{version}/MongoChef.dmg"
   name 'MongoChef'


### PR DESCRIPTION
#### Editing an existing cask
- [x] New MongoChef version 3.6.0
- [x] `brew cask audit --download mongochef` is error-free.
- [x] `brew cask style --fix mongochef` left no offenses.
