### PR TITLE
updated logitech-harmony (7.8.1)

### DIFF
--- a/Casks/logitech-harmony.rb
+++ b/Casks/logitech-harmony.rb
@@ -2,10 +2,9 @@ cask 'logitech-harmony' do
   version '7.8.1'
   sha256 '13a100211fb18569563c9d9bbe6c231cbfaa50989df0b471703ec942be2ecafb'
 
-  # navisite.net is the official download host per the vendor homepage
-  url "http://logitech-sjca.navisite.net/web/ftp/pub/techsupport/harmony/LogitechHarmonyRemoteSoftware#{version}-OSX.dmg"
+  url "https://cdn-cx-images.dynamite.myharmony.com/software/LogitechHarmonyRemoteSoftware#{version}-OSX.dmg"
   name 'Logitech Harmony Remote Software'
-  homepage 'http://www.logitech.com/en-us/support/universal-remotes'
+  homepage 'https://www.myharmony.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'LogitechRemoteSoftware.pkg'


### PR DESCRIPTION
No vendor comment is needed anymore since new official homepage and download URL are available.
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
