### PR TITLE
Update google-play-music-desktop-player to 3.2.5

### DIFF
--- a/Casks/google-play-music-desktop-player.rb
+++ b/Casks/google-play-music-desktop-player.rb
@@ -1,11 +1,11 @@
 cask 'google-play-music-desktop-player' do
-  version '3.2.4'
-  sha256 '041b855b91a4ee889ed4dbdf87c202a0f972eb058b36720a6319a3fba83938b2'
+  version '3.2.5'
+  sha256 '4c577f9099ca6771cf460b1c0d58b2bb26f44fa83f75e2372a36a9e8eec7b675'
 
   # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
   url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"
   appcast 'https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases.atom',
-          checkpoint: 'ce7ebdd1679b95b71287b7d13fae3f9a555a446ac4e5d51927cc220177fa2734'
+          checkpoint: '280ecf9a9ec2457af4bd0697f8c4ef04c638764847ca94259507c818b8b91050'
   name 'Google Play Music Desktop Player'
   homepage 'http://www.googleplaymusicdesktopplayer.com/'
   license :mit


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Updating google-play-music-desktop-player to 3.2.5
