### PR TITLE
Update puppet-agent to 1.5.2, dynamize pkg name

### DIFF
--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -1,5 +1,5 @@
 cask 'puppet-agent' do
-  version '1.5.2'
+  version '1.5.2-1'
 
   if MacOS.release == :el_capitan
     sha256 '67613f23e6e7708fd1f8ddaa8528260cce176c4d46d7c3d666c236ea0edd1c8c'
@@ -10,12 +10,12 @@ cask 'puppet-agent' do
   end
 
   # downloads.puppetlabs.com was verified as official when first introduced to the cask
-  url "https://downloads.puppetlabs.com/mac/#{MacOS.release}/PC1/x86_64/puppet-agent-#{version}-1.osx#{MacOS.release}.dmg"
+  url "https://downloads.puppetlabs.com/mac/#{MacOS.release}/PC1/x86_64/puppet-agent-#{version}.osx#{MacOS.release}.dmg"
   name 'Puppet Agent'
   homepage 'https://docs.puppet.com/puppet/4.5/reference/about_agent.html'
   license :oss # all Apache 2 except for the vendored OpenSSL + Ruby
 
-  pkg 'puppet-agent-${version}-1-installer.pkg'
+  pkg 'puppet-agent-${version}-installer.pkg'
 
   uninstall launchctl: %w[puppet pxp-agent mcollective],
             pkgutil:   'com.puppetlabs.puppet-agent'

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -1,12 +1,12 @@
 cask 'puppet-agent' do
-  version '1.5.0'
+  version '1.5.2'
 
   if MacOS.release == :el_capitan
-    sha256 'd92a12ed3ab7aede17d21333c3bb92c3987559932291b4760210cf1e2ca64b07'
+    sha256 '67613f23e6e7708fd1f8ddaa8528260cce176c4d46d7c3d666c236ea0edd1c8c'
   elsif MacOS.release == :yosemite
-    sha256 'ee4ee7004c63a8a2cc4680bff6d76ee5bfab22449b60a05505a576e9a8042257'
+    sha256 'ba9d22b4992f96f6e100e689f92f81e4cabb0459730459d9b53fe54c59b392a4'
   elsif MacOS.release == :mavericks
-    sha256 'a56f1360616ab91bbd024658b536ada07083391747fb67c9874aa33effae5f80'
+    sha256 '67613f23e6e7708fd1f8ddaa8528260cce176c4d46d7c3d666c236ea0edd1c8c'
   end
 
   # downloads.puppetlabs.com was verified as official when first introduced to the cask
@@ -15,7 +15,7 @@ cask 'puppet-agent' do
   homepage 'https://docs.puppet.com/puppet/4.5/reference/about_agent.html'
   license :oss # all Apache 2 except for the vendored OpenSSL + Ruby
 
-  pkg 'puppet-agent-1.5.0-1-installer.pkg'
+  pkg 'puppet-agent-${version}-1-installer.pkg'
 
   uninstall launchctl: %w[puppet pxp-agent mcollective],
             pkgutil:   'com.puppetlabs.puppet-agent'


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

the version was stuck in the 'pkg' field, causing issues with "fancy" update techniques.

Sidenote: the download link on the website for the agent is different and produces a slightly different dmg with different shasum.

http://pm.puppetlabs.com/puppet-agent/2016.2.0/1.5.2/repos/apple/10.9/PC1/x86_64/puppet-agent-1.5.2-1.osx10.9.dmg

```
fe76f28b1764cf39ab649e6072e15f98d6c8daa0c5e2b6cf8d332b53c48c5c7f  puppet-agent-1.5.2-1.osx10.9.dmg
f24b60772f55f886d59043c39c7ccfeab224d742bbb951464e8b9cbc6b9eaeb0  puppet-agent-1.5.2-1.osx10.10.dmg
9e184b698f877530e3db7574d40233d7b51acf41f6dd2bbbda16bcd2e8825841  puppet-agent-1.5.2-1.osx10.11.dmg
```

https://downloads.puppetlabs.com/mac/10.9/PC1/x86_64/puppet-agent-1.5.2-1.osx10.9.dmg

```
bc75b261b2c1e5ed18599e63848e22fd4fca440242ba31391617a9a59806ef7a  puppet-agent-1.5.2-1.osx10.9.dmg
ba9d22b4992f96f6e100e689f92f81e4cabb0459730459d9b53fe54c59b392a4  puppet-agent-1.5.2-1.osx10.10.dmg
67613f23e6e7708fd1f8ddaa8528260cce176c4d46d7c3d666c236ea0edd1c8c  puppet-agent-1.5.2-1.osx10.11.dmg
```
