### PR TITLE
Updated Dropshare to 4-4223

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4-4222'
-  sha256 '7bf2443a68eda4f31b531bdfee1ad5dc1641ab99ad2c049bf4fe1164249bb63e'
+  version '4-4223'
+  sha256 '102c24a4cf995eb85431eb3ea2c2751b81a1d5834823dffaa2966463fa16969e'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version}.app.zip"
   appcast 'https://getdropsha.re/sparkle/Dropshare4.xml',
-          checkpoint: '407cbcd46b2edac456dc5331d57346f2424923bd46c66b2026e5d80e752bdd2f'
+          checkpoint: '2b9bbabecaee41a8fe0753cf93f78f96445334474874e47e7ac0f323e2f6eb20'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Updated Dropshare to 4-4223
