### PR TITLE
Update URL of ldoce5-viewer

### DIFF
--- a/Casks/ldoce5-viewer.rb
+++ b/Casks/ldoce5-viewer.rb
@@ -2,9 +2,9 @@ cask 'ldoce5-viewer' do
   version :latest
   sha256 :no_check
 
-  url 'https://hakidame.net/ldoce5viewer/static/packages/LDOCE5%20Viewer.app.zip'
+  url 'https://forward-backward.co.jp/ldoce5viewer/static/packages/LDOCE5%20Viewer.app.zip'
   name 'LDOCE5 Viewer'
-  homepage 'https://hakidame.net/ldoce5viewer/'
+  homepage 'https://forward-backward.co.jp/ldoce5viewer/'
   license :gpl
 
   app 'LDOCE5 Viewer.app'


### PR DESCRIPTION
It looks like they've changed the download links

ref. https://forward-backward.co.jp/ldoce5viewer/download
