### PR TITLE
Copied which_editor and exec_editor from brew utils to address #20074. …

### DIFF
--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -97,13 +97,31 @@ module Hbc::Utils
     return cmd_pn
   end
 
-  def self.exec_editor(*args)
-    editor = [
-              *ENV.values_at('HOMEBREW_EDITOR', 'VISUAL', 'EDITOR'),
-              *%w{mate edit vim /usr/bin/vim}.map{ |x| which(x) }
-             ].compact.first.to_s
-    exec(*editor.split.concat(args))
-  end
+def self.which_editor
+  editor = ENV.values_at("HOMEBREW_EDITOR", "VISUAL", "EDITOR").compact.first
+  return editor unless editor.nil?
+
+  # Find Textmate
+  editor = "mate" if which "mate"
+  # Find BBEdit / TextWrangler
+  editor ||= "edit" if which "edit"
+  # Find vim
+  editor ||= "vim" if which "vim"
+  # Default to standard vim
+  editor ||= "/usr/bin/vim"
+
+  opoo <<-EOS.undent
+    Using #{editor} because no editor was set in the environment.
+    This may change in the future, so we recommend setting EDITOR, VISUAL,
+    or HOMEBREW_EDITOR to your preferred text editor.
+  EOS
+
+  editor
+end
+
+def self.exec_editor(*args)
+  safe_exec(which_editor, *args)
+end
 
   # originally from Homebrew puts_columns
   def self.stringify_columns items, star_items=[]

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -97,12 +97,32 @@ module Hbc::Utils
     return cmd_pn
   end
 
+  # originally from Homebrew
+  def self.which_editor
+    editor = ENV.values_at("HOMEBREW_EDITOR", "VISUAL", "EDITOR").compact.first
+    return editor unless editor.nil?
+
+    # Find Textmate
+    editor = "mate" if which "mate"
+    # Find BBEdit / TextWrangler
+    editor ||= "edit" if which "edit"
+    # Find vim
+    editor ||= "vim" if which "vim"
+    # Default to standard vim
+    editor ||= "/usr/bin/vim"
+
+    opoo <<-EOS.undent
+      Using #{editor} because no editor was set in the environment.
+      This may change in the future, so we recommend setting EDITOR, VISUAL,
+      or HOMEBREW_EDITOR to your preferred text editor.
+    EOS
+
+    editor
+  end
+
+  # originally from Homebrew
   def self.exec_editor(*args)
-    editor = [
-              *ENV.values_at('HOMEBREW_EDITOR', 'VISUAL', 'EDITOR'),
-              *%w{mate edit vim /usr/bin/vim}.map{ |x| which(x) }
-             ].compact.first.to_s
-    exec(*editor.split.concat(args))
+    safe_exec(which_editor, *args)
   end
 
   # originally from Homebrew puts_columns


### PR DESCRIPTION
- Pulled the exec_editor and which_editor functions out of brew utils.rb so that the same warning message is echoed for brew cask edit when HOMEBREW_EDITOR isn't defined, as raised in #20074.  
- Tested with "bbedit" and "subl -w" ,  argument flags seem to be handled fine.  
- Code straight out of brew so not really my doing, I'm not familiar with the differences between safe_exec vs exec but it works. 

Closes #20074.
