### PR TITLE
Update Eclipse packages to Neon release

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-cpp' do
-  version '4.5.2'
-  sha256 '894726b6d85794af3a17b3d499c9143683a0a27074c9ff734146d81c5b4b631e'
+  version '4.6.0'
+  sha256 '200144b4ca54d0e77572c66d249c3138e4186bb22f9404988c2cc6ea79d98f16'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-cpp-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse IDE for C/C++ Developers'
   homepage 'https://eclipse.org/'
   license :eclipse

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-ide' do
-  version '4.5.2'
-  sha256 '70edececaf847a262e6bb5e5b952344155699adf8d267f98cb700f21e1f2c1e0'
+  version '4.6.0'
+  sha256 '8a8a07e3cd597ffc937f7074eb60713343217976a8f167645d1ed3bd543bcf97'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-committers-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-committers-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse IDE for Eclipse Committers'
   homepage 'https://eclipse.org/'
   license :eclipse

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-java' do
-  version '4.5.2'
-  sha256 'ecb79ad20548d65643d6c1b24992f900c7192cf8f3c54a1b38ed575835f2a6fe'
+  version '4.6.0'
+  sha256 'cc776030aac93ca313c2e7791f3368af399d595c6979e421ca7c36c180de3c96'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-java-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-java-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse IDE for Java Developers'
   homepage 'https://eclipse.org/'
   license :eclipse

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-jee' do
-  version '4.5.2'
-  sha256 'e5989046a9518b691b38fb718f7e60a4c4f593176115807579979e14ee7c15ad'
+  version '4.6.0'
+  sha256 'ec62c9734396fb99ae5fc8af8731bb87d19d4d40579aeac69b8fe1447c51a614'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-jee-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-jee-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse IDE for Java EE Developers'
   homepage 'https://eclipse.org/'
   license :eclipse

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-modeling' do
-  version '4.5.2'
-  sha256 'd413e761c3c009edce3c8aac0af6b4c63939623d41c2ab20228417d618e9f7d9'
+  version '4.6.0'
+  sha256 'dcd7ab2331f45b8c9df5324209bf304a7eb7de8e0f7eaa843009aba51ee62ca6'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-modeling-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-modeling-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse Modeling Tools'
   homepage 'https://eclipse.org/'
   license :eclipse

--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-php' do
-  version '4.5.2'
-  sha256 '8198b5826bba50ed93ed7dfbaa8f46bd30bbe06ec9817a4c0ebbcd2c196eea91'
+  version '4.6.0'
+  sha256 '763b2e6f41277f61d377ed15aa7c6277f0a308c9b162ff00ffab46a823fc0865'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-php-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-php-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse for PHP Developers'
   homepage 'https://eclipse.org/'
   license :eclipse

--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,9 +1,9 @@
 cask 'eclipse-ptp' do
-  version '4.5.2'
-  sha256 'ca5b762715346f2a40a5c64bf355d1f6916afe73c2ecf2e6070b2c380c2d0a34'
+  version '4.6.0'
+  sha256 '7eab1605dce524abb872185d184e8033b02e8a2c9fd23005a4c15224b4712803'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-parallel-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
-  name 'Eclipse Parallel Tools Platform'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-parallel-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  name 'Eclipse for Parallel Application Developers'
   homepage 'https://eclipse.org/'
   license :eclipse
 

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-rcp' do
-  version '4.5.2'
-  sha256 '1cfc4400582d94bf48ec5d8e91ec6d21fa2c664f541a97b7710e18abda80d38d'
+  version '4.6.0'
+  sha256 '5460e51dea3a58415f15cb59258aca067a95c958fb5a3e24b3bbf7a7fd7d616e'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/mars/2/eclipse-rcp-mars-2-macosx-cocoa-x86_64.tar.gz&r=1'
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-rcp-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
   name 'Eclipse for RCP and RAP Developers'
   homepage 'https://eclipse.org/'
   license :eclipse


### PR DESCRIPTION
New version 4.6 for the Eclipse packages as part of the [Neon release](https://www.eclipse.org/neon/).
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
