### PR TITLE
Update Eclipse installer to Neon

### DIFF
--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -2,7 +2,7 @@ cask 'eclipse-installer' do
   version :latest
   sha256 :no_check
 
-  url 'https://eclipse.org/downloads/download.php?file=/oomph/epp/mars/R2/eclipse-inst-mac64.tar.gz&r=1'
+  url 'https://eclipse.org/downloads/download.php?file=/oomph/epp/neon/R/eclipse-inst-mac64.tar.gz&r=1'
   name 'Eclipse Installer'
   homepage 'https://eclipse.org/'
   license :eclipse


### PR DESCRIPTION
New Eclipse installer as part of the [Neon release](https://www.eclipse.org/neon/).
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
