### PR TITLE
Update Eclipse platform to Neon release

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.5-201506032000'
-  sha256 '953b7ecacb3c84667c616e1b640240de8cf5c045f475d0aebc6179316ed083d6'
+  version '4.6-201606061100'
+  sha256 'd8c0b7b970581bbfab047375c0bf44243f5f4e528e950be2313e275451d684b6'
 
   url "http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.to_i}/R-#{version}/eclipse-SDK-#{version.sub(%r{-.*}, '')}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse SDK'


### PR DESCRIPTION
New version 4.6 of the Eclipse SDK as part of the [Neon release](https://www.eclipse.org/neon/).
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
