### PR TITLE
updated carbon-copy-cloner (4.1.9.4369)

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.9.4365'
-  sha256 '572143297bddcf526dfab9fae87716ac64abdb5fee77a92ead8a11166157b2f3'
+  version '4.1.9.4369'
+  sha256 '448d1a12b97fefe0549fff81df2e77a648e813cd1c8d827881bff046c6d704b8'
 
   url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
   appcast "https://bombich.com/software/updates/ccc.php?os_minor=11&os_bugfix=#{version.major}&ccc=#{version.after_comma}&beta=0&locale=en",


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
