### PR TITLE
Add --require-sha option for Issue #18831

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -170,6 +170,7 @@ $ brew cask install caskroom/fonts/font-symbola
 * `--version`: print version and exit
 * `--debug`: output debug information
 * `--no-binaries`: skip symlinking executable binaries into `/usr/local/bin`
+* `--require-sha`: abort installation of cask if no checksum is defined
 
 You can also modify the default installation locations used when issuing `brew cask install`:
 

--- a/doc/man_page/brew-cask.1.md
+++ b/doc/man_page/brew-cask.1.md
@@ -19,7 +19,7 @@ names, and other aspects of this manual are still subject to change.
 
 ## FREQUENTLY USED COMMANDS
 
-  * `install [--force] [--skip-cask-deps]` <token> [ <token> ... ]:
+  * `install [--force] [--skip-cask-deps] [--require-sha]` <token> [ <token> ... ]:
     Install Cask identified by <token>.
 
   * `uninstall [--force]` <token> [ <token> ... ]:
@@ -69,10 +69,11 @@ names, and other aspects of this manual are still subject to change.
   * `info` or `abv` <token> [ <token> ... ]:
     Display information about the given Cask.
 
-  * `install [--force] [--skip-cask-deps]` <token> [ <token> ... ]:
+  * `install [--force] [--skip-cask-deps] [--require-sha]` <token> [ <token> ... ]:
     Install the given Cask. With `--force`, re-install even if the Cask
     appears to be already present. With `--skip-cask-deps`, skip any Cask
-    dependencies.
+    dependencies. `--require-sha` will abort installation if the Cask does not
+    have a checksum defined.
 
     <token> is usually the ID of a Cask as returned by `brew cask search`,
     but see [OTHER WAYS TO SPECIFY A CASK][] for variations.
@@ -145,6 +146,9 @@ in a future version.
 
   * `--skip-cask-deps`:
     Skip Cask dependencies when installing.
+
+  *  `--require-sha`:
+    Abort Cask installation if the Cask does not have a checksum defined.
 
   * `--caskroom=<path>`:
     Location of the Caskroom, where all binaries are stored. The default value is: `$(brew --repository)/Caskroom`.

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -197,6 +197,9 @@ class Hbc::CLI
        Hbc.screen_saverdir = Pathname(v).expand_path
       end
 
+      opts.on("--require-sha") do |v|
+        Hbc.require_sha = true
+      end
       opts.on("--no-binaries") do |v|
         Hbc.no_binaries = true
       end

--- a/lib/hbc/cli/install.rb
+++ b/lib/hbc/cli/install.rb
@@ -28,6 +28,9 @@ class Hbc::CLI::Install < Hbc::CLI::Base
          count += 1
       rescue Hbc::CaskUnavailableError => e
         warn_unavailable_with_suggestion cask_token, e
+      rescue Hbc::CaskNoShasumError => e
+        opoo e.message
+        count += 1
       end
     end
     count == 0 ? nil : count == cask_tokens.length

--- a/lib/hbc/exceptions.rb
+++ b/lib/hbc/exceptions.rb
@@ -153,3 +153,17 @@ class Hbc::CaskSha256MismatchError < RuntimeError
       EOS
   end
 end
+
+class Hbc::CaskNoShasumError < Hbc::CaskError
+  attr_reader :token
+  def initialize(token)
+    @token = token
+  end
+
+  def to_s
+    <<-EOS.undent
+      #{token} does not have a sha256 checksum defined and was not be installed.
+      This means you have the "--require-sha" option set, perhaps in your HOMEBREW_CASK_OPTS.
+      EOS
+  end
+end

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -69,6 +69,7 @@ class Hbc::Installer
 
     begin
       satisfy_dependencies
+      verify_has_sha if Hbc.require_sha
       download
       verify
       extract_primary_container
@@ -98,6 +99,12 @@ class Hbc::Installer
     @downloaded_path = download.perform
     odebug "Downloaded to -> #{@downloaded_path}"
     @downloaded_path
+  end
+
+  def verify_has_sha
+    odebug "Checking cask has checksum"
+    return unless @cask.sha256 == :no_check
+    raise Hbc::CaskNoShasumError.new (@cask)
   end
 
   def verify

--- a/lib/hbc/options.rb
+++ b/lib/hbc/options.rb
@@ -43,5 +43,13 @@ module Hbc::Options
     def help=(_help)
       @help = _help
     end
+
+    def require_sha
+      @require_sha ||= false
+    end
+
+    def require_sha=(_require_sha)
+      @require_sha = _require_sha
+    end
   end
 end

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -18,7 +18,7 @@ Homebrew\-Cask works robustly enough that we welcome new users, but the project 
 .SH "FREQUENTLY USED COMMANDS"
 .
 .TP
-\fBinstall [\-\-force] [\-\-skip\-cask\-deps]\fR \fItoken\fR [ \fItoken\fR \.\.\. ]
+\fBinstall [\-\-force] [\-\-skip\-cask\-deps] [\-\-require\-sha]\fR \fItoken\fR [ \fItoken\fR \.\.\. ]
 Install Cask identified by \fItoken\fR\.
 .
 .TP
@@ -74,8 +74,8 @@ With no arguments, display the project page \fIhttp://caskroom\.io\fR\.
 Display information about the given Cask\.
 .
 .TP
-\fBinstall [\-\-force] [\-\-skip\-cask\-deps]\fR \fItoken\fR [ \fItoken\fR \.\.\. ]
-Install the given Cask\. With \fB\-\-force\fR, re\-install even if the Cask appears to be already present\. With \fB\-\-skip\-cask\-deps\fR, skip any Cask dependencies\.
+\fBinstall [\-\-force] [\-\-skip\-cask\-deps] [\-\-require\-sha]\fR \fItoken\fR [ \fItoken\fR \.\.\. ]
+Install the given Cask\. With \fB\-\-force\fR, re\-install even if the Cask appears to be already present\. With \fB\-\-skip\-cask\-deps\fR, skip any Cask dependencies\. \fB\-\-require\-sha\fR will abort installation if the Cask does not have a checksum defined\.
 .
 .IP
 \fItoken\fR is usually the ID of a Cask as returned by \fBbrew cask search\fR, but see \fIOTHER WAYS TO SPECIFY A CASK\fR for variations\.
@@ -142,6 +142,10 @@ Force an install to proceed even when a previously\-existing install is detected
 .TP
 \fB\-\-skip\-cask\-deps\fR
 Skip Cask dependencies when installing\.
+.
+.TP
+\fB\-\-require\-sha\fR
+Abort Cask installation if the Cask does not have a checksum defined\.
 .
 .TP
 \fB\-\-caskroom=<path>\fR

--- a/test/cask/cli/options_test.rb
+++ b/test/cask/cli/options_test.rb
@@ -124,6 +124,14 @@ describe Hbc::CLI do
     end
   end
 
+  describe "--require-sha" do
+    it "sets the Cask require_sha method to true" do
+        Hbc::CLI.process_options %w{foo --require-sha}
+        Hbc.require_sha.must_equal true
+        Hbc.require_sha = false
+    end
+  end
+
   after do
     ENV['HOMEBREW_CASK_OPTS'] = nil
   end


### PR DESCRIPTION
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

Implementation checklist from the issue #18831:
- [x] Add test for --require-sha to test/cask/cli/options_test.rb
- [x] Add option --require-sha to lib/hbc/cli.rb
- [x] Add new error Hbc::CaskNoShasumError to lib/hbc/exceptions.rb
- [ ] Check if sha256 :no_check in lib/hbc/cli/install.rb, and abort if --require-sha is present
- [x] Update documentation (USAGE.md, at a minimum)
- [x] Update man page

Regarding item 4, the change was to installer.rb instead of install.rb.
I also added an option to options.rb. I wasn't quite sure if this was the correct implementation.
