### PR TITLE
update SublerCli to 0.32

### DIFF
--- a/Casks/sublercli.rb
+++ b/Casks/sublercli.rb
@@ -1,8 +1,8 @@
 cask 'sublercli' do
-  version :latest
-  sha256 :no_check
+  version '0.32'
+  sha256 'e5e99fb67944acffff9df5c6bf0a66805a7c696fb41df8a81fbfaf0068ce4c26'
 
-  url 'https://bitbucket.org/galad87/sublercli/downloads/SublerCLI-Test.zip'
+  url "https://bitbucket.org/galad87/sublercli/downloads/SublerCLI-#{version}.zip"
   name 'SublerCLI'
   homepage 'https://bitbucket.org/galad87/sublercli/'
   license :oss


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.

``` shell
$ brew cask audit --download Casks/sublercli.rb
==> Downloading https://bitbucket.org/galad87/sublercli/downloads/SublerCLI-0.32.zip
Already downloaded: /Users/Jon/Library/Caches/Homebrew/sublercli-0.32.zip
==> No checksum defined for Cask sublercli, skipping verification
audit for sublercli: passed
```
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

``` shell
$ brew cask style --fix Casks/sublercli.rb

1 file inspected, no offenses detected
```
