### PR TITLE
Scope require_sha to installer

### DIFF
--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -197,9 +197,6 @@ class Hbc::CLI
        Hbc.screen_saverdir = Pathname(v).expand_path
       end
 
-      opts.on("--require-sha") do |v|
-        Hbc.require_sha = true
-      end
       opts.on("--no-binaries") do |v|
         Hbc.no_binaries = true
       end

--- a/lib/hbc/cli/install.rb
+++ b/lib/hbc/cli/install.rb
@@ -4,7 +4,8 @@ class Hbc::CLI::Install < Hbc::CLI::Base
     raise Hbc::CaskUnspecifiedError if cask_tokens.empty?
     force = args.include? '--force'
     skip_cask_deps = args.include? '--skip-cask-deps'
-    retval = install_casks cask_tokens, force, skip_cask_deps
+    require_sha = args.include? '--require-sha'
+    retval = install_casks cask_tokens, force, skip_cask_deps, require_sha
     # retval is ternary: true/false/nil
     if retval.nil?
       raise Hbc::CaskError.new("nothing to install")
@@ -13,12 +14,13 @@ class Hbc::CLI::Install < Hbc::CLI::Base
     end
   end
 
-  def self.install_casks(cask_tokens, force, skip_cask_deps)
+  def self.install_casks(cask_tokens, force, skip_cask_deps, require_sha)
     count = 0
     cask_tokens.each do |cask_token|
       begin
         cask = Hbc.load(cask_token)
-        Hbc::Installer.new(cask, force: force, skip_cask_deps: skip_cask_deps).install
+        options = { force: force, skip_cask_deps: skip_cask_deps, require_sha: require_sha }
+        Hbc::Installer.new(cask, options).install
         count += 1
        rescue Hbc::CaskAlreadyInstalledError => e
          opoo e.message

--- a/lib/hbc/exceptions.rb
+++ b/lib/hbc/exceptions.rb
@@ -163,7 +163,7 @@ class Hbc::CaskNoShasumError < Hbc::CaskError
   def to_s
     <<-EOS.undent
       Cask '#{token}' does not have a sha256 checksum defined and was not installed.
-      This means you have the '--require-sha' option set, perhaps in your HOMEBREW_CASK_OPTS.
+      This means you have the "--require-sha" option set, perhaps in your HOMEBREW_CASK_OPTS.
     EOS
   end
 end

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -23,6 +23,7 @@ class Hbc::Installer
     @command = options.fetch(:command, Hbc::SystemCommand)
     @force = options.fetch(:force, false)
     @skip_cask_deps = options.fetch(:skip_cask_deps, false)
+    @require_sha = options.fetch(:require_sha, false)
   end
 
   def self.print_caveats(cask)
@@ -69,7 +70,7 @@ class Hbc::Installer
 
     begin
       satisfy_dependencies
-      verify_has_sha if Hbc.require_sha
+      verify_has_sha if @require_sha && !@force
       download
       verify
       extract_primary_container

--- a/lib/hbc/options.rb
+++ b/lib/hbc/options.rb
@@ -43,13 +43,5 @@ module Hbc::Options
     def help=(_help)
       @help = _help
     end
-
-    def require_sha
-      @require_sha ||= false
-    end
-
-    def require_sha=(_require_sha)
-      @require_sha = _require_sha
-    end
   end
 end

--- a/test/cask/cli/options_test.rb
+++ b/test/cask/cli/options_test.rb
@@ -124,14 +124,6 @@ describe Hbc::CLI do
     end
   end
 
-  describe "--require-sha" do
-    it "sets the Cask require_sha method to true" do
-        Hbc::CLI.process_options %w{foo --require-sha}
-        Hbc.require_sha.must_equal true
-        Hbc.require_sha = false
-    end
-  end
-
   after do
     ENV['HOMEBREW_CASK_OPTS'] = nil
   end

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -182,6 +182,21 @@ describe Hbc::Installer do
       no_checksum.must_be :installed?
     end
 
+    it "fails to install if sha256 :no_check is used with --require-sha" do
+      no_checksum = Hbc.load('no-checksum')
+      lambda {
+        Hbc::Installer.new(no_checksum, require_sha: true).install
+      }.must_raise(Hbc::CaskNoShasumError)
+    end
+
+    it "installs fine if sha256 :no_check is used with --require-sha and --force" do
+      no_checksum = Hbc.load('no-checksum')
+      shutup do
+        Hbc::Installer.new(no_checksum, require_sha: true, force: true).install
+      end
+      no_checksum.must_be :installed?
+    end
+
     it "prints caveats if they're present" do
       with_caveats = Hbc.load('with-caveats')
       TestHelper.must_output(self, lambda {


### PR DESCRIPTION
`--require-sha` is only relevant to `install`, so let's keep it there instead of polluting the global option space.

Also override `--require-sha` when used with `--force`.
