### PR TITLE
Added Youtrack Workflow editor 40.3384

### DIFF
--- a/Casks/youtrack-workflow.rb
+++ b/Casks/youtrack-workflow.rb
@@ -1,0 +1,15 @@
+cask 'youtrack-workflow' do
+  version '3384fix'
+  sha256 '331bd2745696507da7ee3a6a193587fc53739face966c12736c16235211cda14'
+
+  url "https://download-cf.jetbrains.com/charisma/youtrack-workflow-editor-#{version}-macos.zip"
+  name 'JetBrains Youtrack Workflow Editor'
+  homepage 'https://www.jetbrains.com/youtrack/download/get_youtrack.html#materials=workflow-editor'
+  license :gratis
+
+  app 'youtrack-workflow.app'
+
+  caveats do
+    depends_on_java
+  end
+end


### PR DESCRIPTION
#### Adding a new cask Youtrack Workflow editor 40.3384
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download youtrack-workflow` is error-free.
- [x] `brew cask style --fix youtrack-workflow` left no offenses.
- [x] `brew cask install youtrack-workflow` worked successfully.
- [x] `brew cask uninstall youtrack-workflow` worked successfully.
