### PR TITLE
Add qiniu-devtools v3.1.20151125

### DIFF
--- a/Casks/qiniu-devtools.rb
+++ b/Casks/qiniu-devtools.rb
@@ -1,9 +1,9 @@
 cask 'qiniu-devtools' do
-  version 'v3.1.20151125'
+  version '3.1.20151125'
   sha256 '4a1ebcee5ea681e7d7e9f5544d7fe22e27240f70de9c0cd7cb790e8868a2b5f8'
 
   # devtools.qiniu.io was verified as official when first introduced to the cask
-  url "http://devtools.qiniu.io/qiniu-devtools-darwin_amd64-#{version}.tar.gz"
+  url "http://devtools.qiniu.io/qiniu-devtools-darwin_amd64-v#{version}.tar.gz"
   name 'Qiniu Developer Tools'
   homepage 'http://developer.qiniu.com/'
   license :unknown

--- a/Casks/qiniu-devtools.rb
+++ b/Casks/qiniu-devtools.rb
@@ -1,0 +1,16 @@
+cask 'qiniu-devtools' do
+  version 'v3.1.20151125'
+  sha256 '4a1ebcee5ea681e7d7e9f5544d7fe22e27240f70de9c0cd7cb790e8868a2b5f8'
+
+  # devtools.qiniu.io was verified as official when first introduced to the cask
+  url "http://devtools.qiniu.io/qiniu-devtools-darwin_amd64-#{version}.tar.gz"
+  name 'Qiniu Developer Tools'
+  homepage 'http://developer.qiniu.com/'
+  license :unknown
+
+  binary 'qetag'
+  binary 'qrsboxcli'
+  binary 'qrsctl'
+  binary 'qrsync'
+  binary 'qufopctl'
+end


### PR DESCRIPTION
### Changes to a cask
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
### Git commit message

Add qiniu-devtools v3.1.20151125

Qiniu devtools is a set of command line tools to operate to qiniu
cloud storage service. It is released officially by qiniu.

Qiniu Official Website: http://www.qiniu.com/
Qiniu devtools documentation: http://developer.qiniu.com/docs/v6/tools/qboxrsctl.html
