### PR TITLE
update firefox 47.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,10 +1,10 @@
 cask 'firefox' do
-  version '47.0'
-  sha256 'e8e068a8f87126d1e252a51bbd0d4b20314fef8dc015c70c21468deaab9c4d9d'
+  version '47.0.1'
+  sha256 '37f4b7b6a1fec3eb5225a0d1aed3c3d6979b5cf01748479313f6e384929cdc75'
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '9cce3ec6844e54c07b7870461fdad111af0c4ce9161dd24c8425885b4f62d372'
+          checkpoint: 'c03d2c0ce638c499da24232ddcdbce6b908fd718953440797924bd12b87552cf'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/en-US/firefox/'
   license :mpl


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
