### PR TITLE
updated aqua-data-studio (17.0.6)

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,6 +1,6 @@
 cask 'aqua-data-studio' do
-  version '17.0.3'
-  sha256 'f3167e43d0be2d0cbf416749cc3cd77d8c4d52d8768ec831c2be6d96c8902c84'
+  version '17.0.6'
+  sha256 '94ef1e2e650a8b6773362127f079c1fd189c509c4e01c0422f89642e8fff21d8'
 
   url "http://www.aquafold.com/download/v#{version.major}.0.0/osx/ads-osx-#{version}.tar.gz"
   name 'Aquafold Aqua Data Studio'


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The download link for the current version (`17.0.3`) is broken.
