### PR TITLE
Fix gimp and hex-fiend with a+rx

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -9,6 +9,10 @@ cask 'gimp' do
 
   app 'GIMP.app'
 
+  postflight do
+    set_permissions "#{appdir}/GIMP.app/Contents/MacOS/GIMP", 'a+rx'
+  end
+
   zap delete: [
                 '~/Library/Application Support/GIMP',
                 '~/Library/Saved Application State/org.gnome.gimp.savedState',

--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -13,7 +13,7 @@ cask 'hex-fiend' do
   app 'Hex Fiend.app'
 
   postflight do
-    set_permissions "#{appdir}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework", 'og=u'
+    set_permissions "#{appdir}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework", 'a+rx'
   end
 
   zap delete: [


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

GIMP does not correctly set 'group' and 'other' permissions and will crash if a non-owner runs it. The buggy files are fixed by updating their 'group' and 'other' permissions to reflect the 'user' permissions: chmod a+rx. Before patch:

```
$ ls -l /Applications/GIMP.app/Contents/MacOS
total 16120
-rwxr--r--  1 Administrator  staff     2920 Dec 13  2015 GIMP
      ^~~~ lolwhoops
-rwxr-xr-x  1 Administrator  staff  8229340 Dec 13  2015 GIMP-bin
-rwxr-xr-x  1 Administrator  staff    13088 Dec 13  2015 python
```

Hex Fiend was previously patched with chmod og=u, which would give everyone write permission, as pointed out in this issue comment: https://github.com/ridiculousfish/HexFiend/issues/52#issuecomment-151438511. This PR also changes Hex Fiend to be patched with chmod a+rx.
