### PR TITLE
Bump rubocop-cask to 0.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :debug do
 end
 
 group :development do
-  gem 'rubocop-cask', '~> 0.7.0'
+  gem 'rubocop-cask', '~> 0.8.2'
 end
 
 group :release do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
+    public_suffix (2.0.2)
     rainbow (2.1.0)
     rake (10.4.2)
     rdiscount (2.1.8)
@@ -78,7 +79,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-cask (0.7.0)
+    rubocop-cask (0.8.2)
+      public_suffix (~> 2.0)
       rubocop (~> 0.41.1)
     ruby-progressbar (1.8.1)
     simplecov (0.11.1)
@@ -111,7 +113,7 @@ DEPENDENCIES
   rspec (~> 3.0.0)
   rspec-its
   rspec-wait
-  rubocop-cask (~> 0.7.0)
+  rubocop-cask (~> 0.8.2)
 
 BUNDLED WITH
    1.12.5

--- a/lib/hbc/cli/style.rb
+++ b/lib/hbc/cli/style.rb
@@ -19,7 +19,7 @@ class Hbc::CLI::Style < Hbc::CLI::Base
     $?.success?
   end
 
-  RUBOCOP_CASK_VERSION = '~> 0.7.0'
+  RUBOCOP_CASK_VERSION = '~> 0.8.2'
 
   def install_rubocop
     Hbc::Utils.install_gem_setup_path! 'rubocop-cask', RUBOCOP_CASK_VERSION, 'rubocop'


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

Update rubocop-cask to 0.8.2 with new `HomepageMatchesUrl` cop (caskroom/rubocop-cask#25).
