### PR TITLE
README.md: do not show redirection in gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It’s implemented as a `homebrew` [external command](https://github.com/Homebre
 
 To start using Homebrew-Cask, you just need [Homebrew](http://brew.sh/) installed.
 
-<img src="https://i.imgur.com/oxHnF7I.gif" width="450px" alt="Installing Atom (animated gif)">
+<img src="https://i.imgur.com/IPSmy1y.gif" width="450px" alt="Installing Atom (animated gif)">
 
 Slower, now:
 


### PR DESCRIPTION
The old gif, before starting the download, would jump to 100% before starting the proper download. That is actually what happens with the cask, but it might be confusing to a new user and doesn’t actually add anything to the instructions.
