### PR TITLE
tv-browser 3.4.4

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -1,6 +1,6 @@
 cask 'tv-browser' do
-  version '3.4.3'
-  sha256 '2b57c3e9d7d599045894b589c4c199f818336a46cffbde60f4565d8a035719cc'
+  version '3.4.4'
+  sha256 '53128cbebb2432ca254893453ea4f13fb16abdaf74d7d66355588d523162a086'
 
   # downloads.sourceforge.net/sourceforge/tvbrowser was verified as official when first introduced to the cask
   url "http://downloads.sourceforge.net/sourceforge/tvbrowser/tvbrowser_#{version}_macjava.dmg"


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
