### PR TITLE
Fix error on 'require "english"' when running on a case-sensitive filesystem

### DIFF
--- a/lib/hbc/cli/style.rb
+++ b/lib/hbc/cli/style.rb
@@ -1,4 +1,4 @@
-require "english"
+require "English"
 
 class Hbc::CLI::Style < Hbc::CLI::Base
   def self.help

--- a/spec/cask/cli/style_spec.rb
+++ b/spec/cask/cli/style_spec.rb
@@ -1,4 +1,4 @@
-require 'english'
+require 'English'
 require 'spec_helper'
 
 describe Hbc::CLI::Style do


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

See Issue #22595 
