### PR TITLE
Add Tifig Swift IDE v0.2.0

### DIFF
--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -1,0 +1,14 @@
+cask 'tifig' do
+  version '0.2.0-201606021314'
+  sha256 '83b1add057e8789349c2f55b28dcd1d8454c23e58b417339e6ffaa7b91e15563'
+
+  # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"
+  name 'Tifig'
+  homepage 'https://www.tifig.net'
+  license :gratis
+
+  depends_on arch: :x86_64
+
+  app 'Tifig.app'
+end


### PR DESCRIPTION
Add Tifig v0.2.0 (https://www.tifig.net)
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Tifig is an Eclipse-based Swift IDE. It is developed by the Institute
for Software at the University of Applied Sciences in Rapperswil, Switzerland (HSR).
