### PR TITLE
"staged at" message changed to "was successfully installed!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ complete
 ==> Moving App 'Atom.app' to '/Applications/Atom.app'
 ==> Symlinking Binary 'apm' to '/usr/local/bin/apm'
 ==> Symlinking Binary 'atom.sh' to '/usr/local/bin/atom'
-🍺  atom staged at '/usr/local/Caskroom/atom/1.8.0' (0B)
+🍺  atom was successfully installed!
 ```
 
 And there we have it. Atom installed with one quick command: no clicking, no dragging, no dropping.

--- a/USAGE.md
+++ b/USAGE.md
@@ -42,7 +42,7 @@ The command `brew cask install` accepts a Cask token as returned by `brew cask s
 $ brew cask install google-chrome
 ==> Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
 ==> Moving App 'Google Chrome.app' to '/Applications/Google Chrome.app'
-🍺  google-chrome staged at '/usr/local/Caskroom/google-chrome/latest' (3 files, 288K)
+🍺  google-chrome was successfully installed!
 ```
 
 ## Uninstalling Casks

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -88,7 +88,7 @@ class Hbc::Installer
         else
           "#{Tty.blue.bold}==>#{Tty.reset.bold} Success!#{Tty.reset} "
         end
-    s << "#{@cask} staged at '#{@cask.staged_path}' (#{Hbc::Utils.cabv(@cask.staged_path)})"
+    s << "#{@cask} was successfully installed!"
   end
 
   def download

--- a/test/cask/cli/install_test.rb
+++ b/test/cask/cli/install_test.rb
@@ -39,7 +39,7 @@ describe Hbc::CLI::Install do
 
     TestHelper.must_output(self, lambda {
       Hbc::CLI::Install.run('local-transmission', '--force')
-    }, %r{==> Success! local-transmission staged at '#{Hbc.caskroom}/local-transmission/2.61' \(0B\)})
+    }, %r{==> Success! local-transmission was successfully installed!})
   end
 
   it "skips dependencies with --skip-cask-deps" do


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

A user was just confused by this on Gitter. I agree it’s a bit of a weird message, especially in cases like atom where it says it was staged and then points out `(0B)`. `support files` seems to me generic enough to cover any cases, at the same time making clear you should likely not have to worry about it. It’s also arguable if the message should exist at all.

Submitting this as a suggestion to gather opinions/better solutions. Will only change the gif after the final decision (if we decide to change this).
