### PR TITLE
Add conflicts_with intellij-idea-eap stanza to intellij-idea

### DIFF
--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -8,6 +8,7 @@ cask 'intellij-idea' do
   license :commercial
 
   auto_updates true
+  conflicts_with cask: 'intellij-idea-eap'
 
   app 'IntelliJ IDEA.app'
 


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

RC build of Intellij IDEA 2016.2 and the current version of
IntelliJ IDEA both have the same app name.

See also caskroom/homebrew-versions#2302.
