### PR TITLE
Updated cevelop to v1.5.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,6 +1,6 @@
 cask 'cevelop' do
-  version '1.4.0-201603071314'
-  sha256 '9199a6e5978e608e51de95e165f13acfdec49d265fef4bf4df5b93973f6cf2ae'
+  version '1.5.0-201607061232'
+  sha256 'c8b53ccd1123dc399e9733e085ba9aa92024596882eb45a7548e91305e7d1bc9'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   name 'Cevelop'


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.5.0.
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
