### PR TITLE
brew-cask.rb: use 1.8-valid syntax

### DIFF
--- a/brew-cask.rb
+++ b/brew-cask.rb
@@ -1,8 +1,8 @@
 class BrewCask < Formula
   homepage "https://github.com/caskroom/homebrew-cask/"
-  url "https://github.com/caskroom/homebrew-cask.git", tag: "v0.60.1"
+  url "https://github.com/caskroom/homebrew-cask.git", :tag => "v0.60.1"
 
-  depends_on ruby: "2.0"
+  depends_on :ruby => "2.0"
 
   UNINSTALL_MSG = <<-EOS.undent
     You must uninstall this formula. It is no longer needed to stay up to date,


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

The `key: value` syntax wasn't introduced until 1.9.

Causing a failure here: https://travis-ci.org/Homebrew/homebrew-emacs/jobs/142633016#L284
