### PR TITLE
Update Xbox 360 Controller Driver to 0.16.1

### DIFF
--- a/Casks/xbox360-controller-driver.rb
+++ b/Casks/xbox360-controller-driver.rb
@@ -1,10 +1,10 @@
 cask 'xbox360-controller-driver' do
-  version '0.16'
-  sha256 '16d1e9790469fe1f71ec01b417ea9839bbd0b1c614e5b01d9691588c083a8d4d'
+  version '0.16.1'
+  sha256 '676ace81cd91da316433eae915c4755941864ee0ea20f331ed4c1fd952385fee'
 
   url "https://github.com/360Controller/360Controller/releases/download/v#{version}/360ControllerInstall_#{version}.dmg"
   appcast 'https://github.com/360Controller/360Controller/releases.atom',
-          checkpoint: '941793641fb8345a0fd8e699b3647965011c618d56c2aee890a3649a635fe620'
+          checkpoint: '9aab5799b0f3b8983fa65f31c89326549a342f47b00421c0d0738351b6e217ad'
   name 'TattieBogle Xbox 360 Controller Driver (with improvements)'
   homepage 'https://github.com/360Controller/360Controller'
   license :gpl


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download xbox360-controller-driver` is error-free.
- [x] `brew cask style --fix xbox360-controller-driver` left no offenses.
