### PR TITLE
add wiznote.rb back

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,0 +1,11 @@
+cask 'wiznote' do
+  version '2015-12-03'
+  sha256 'b1db69a400712c9e750bde91fab7382935ac6cb95d081c8cac1872b2e59e26a1'
+
+  url "http://release.wiz.cn/wiznote-macos-#{version}.dmg"
+  name 'WizNote'
+  homepage 'http://www.wiz.cn/wiznote-mac.html'
+  license :gratis
+
+  app 'WizNote.app'
+end


### PR DESCRIPTION
I asked for wiznote team, they said "there is always dmg download link":
http://tieba.baidu.com/p/4655608505?pid=93402615615&cid=93423872091#93423872091
![http://tieba.baidu.com/p/4655608505?pid=93402615615&cid=93423872091#93423872091](https://cloud.githubusercontent.com/assets/1926185/16678808/2ca7f332-4515-11e6-9be4-d22642077d23.jpg)
# Check list
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
