### PR TITLE
Update repo name in lib/hbc/utils.rb

### DIFF
--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -6,7 +6,7 @@ require "stringio"
 
 require "hbc/utils/tty"
 
-UPDATE_CMD = "brew uninstall --force brew-cask; brew untap phinze/cask; brew update; brew cleanup; brew cask cleanup".freeze
+UPDATE_CMD = "brew uninstall --force brew-cask; brew untap phinze/cask; brew untap caskroom/cask; brew update; brew cleanup; brew cask cleanup".freeze
 ISSUES_URL = "https://github.com/caskroom/homebrew-cask#reporting-bugs".freeze
 
 # TODO: temporary


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

For non-ancient installs of HBC, `brew untap phinze/cask` does not remove casks but `brew untap caskroom/cask` does.

Do we need to include both commands in case someone has a _really_ old installation?
