### PR TITLE
Create betterzip-latest.rb

### DIFF
--- a/Casks/betterzip-latest.rb
+++ b/Casks/betterzip-latest.rb
@@ -1,0 +1,15 @@
+cask 'betterzip-latest' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://macitbetter.com/BetterZip.zip'
+  name 'BetterZip'
+  homepage 'http://macitbetter.com'
+  license :commercial
+
+  depends_on macos: '>= mavericks'
+
+  app 'BetterZip.app'
+
+  zap delete: '~/Library/Preferences/com.macitbetter.betterzip.plist'
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download betterzip-latest` is error-free.
- [x] `brew cask style --fix betterzip-latest` left no offenses.
- [x] `brew cask install betterzip-latest` worked successfully.
- [x] `brew cask uninstall betterzip-latest` worked successfully.

Comparing to betterzip cask:
- Remove sha256, remove version check
- Download BetterZip straightaway from the home page
- Add depends: only support mavericks and above
- To avoid conflict with the current betterzip cask, I add a new cask
