### PR TITLE
Add Launchpad Manager 1.3.10

### DIFF
--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,0 +1,13 @@
+cask 'launchpad-manager' do
+  version '1.3.10'
+  sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'
+
+  url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
+  appcast 'http://launchpadmanager.com/appyos/sparkle.rss',
+          checkpoint: '9bd3cfb349d301c2e1e6316c250307d002cde68d1773daf757872f61580f9ff7'
+  name 'Launchpad Manager'
+  homepage 'http://launchpadmanager.com/'
+  license :commercial
+
+  app 'Launchpad Manager.app'
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download launchpad-manager` is error-free.
- [x] `brew cask style --fix launchpad-manager` left no offenses.
- [x] `brew cask install launchpad-manager` worked successfully.
- [x] `brew cask uninstall launchpad-manager` worked successfully.

As you may know there is a cask named launchpad-manager-yosemite. However, it is developed for Yosemite and later users. 

So I will add a new cask to Launchpad Manager for Mavericks and prior.
