### PR TITLE
updated macbreakz (5.26)

### DIFF
--- a/Casks/macbreakz.rb
+++ b/Casks/macbreakz.rb
@@ -1,10 +1,10 @@
 cask 'macbreakz' do
   version '5.26'
-  sha256 'b161268d63709efb9e894572ac3945520e2a12fdd76b195adf930d8f4f807266'
+  sha256 'b40f25f56cd4968d15affebe74e25c5d600d04a5723d9d03ef59ec72431903a1'
 
   url "http://www.publicspace.net/download/MacBreakZ#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_mb#{version.major}.xml",
-          checkpoint: 'cbafe290b4ce6b94e04e744396d729b2b3453e69daee0fa536387858321da2c0'
+          checkpoint: 'dc30f7b8390c401431ecc54eb91ab7e06e0be9976a84bac1267dfbeb2547b48b'
   name 'MacBreakZ'
   homepage 'http://www.publicspace.net/MacBreakZ/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

 brew cask audit --download macbreakz                                                                                     (master)
==> Downloading http://www.publicspace.net/download/MacBreakZ5.dmg
Already downloaded: /Users/KyleWLawrence/Library/Caches/Homebrew/macbreakz-5.26.dmg
==> Verifying checksum for Cask macbreakz
==> Note: running "brew update" may fix sha256 checksum errors
audit for macbreakz: failed
- download not possible: sha256 mismatch
  Expected: b161268d63709efb9e894572ac3945520e2a12fdd76b195adf930d8f4f807266
  Actual: b40f25f56cd4968d15affebe74e25c5d600d04a5723d9d03ef59ec72431903a1
  File: /Users/KyleWLawrence/Library/Caches/Homebrew/macbreakz-5.26.dmg
  To retry an incomplete download, remove the file above.
- appcast checkpoint mismatch
  Expected: cbafe290b4ce6b94e04e744396d729b2b3453e69daee0fa536387858321da2c0
  Actual: dc30f7b8390c401431ecc54eb91ab7e06e0be9976a84bac1267dfbeb2547b48b
  Error: audit failed
