### PR TITLE
Fix audit --download to correctly calculate appcast checkpoint

### DIFF
--- a/lib/hbc/audit.rb
+++ b/lib/hbc/audit.rb
@@ -118,6 +118,8 @@ class Hbc::Audit
     result = @command.run("curl", args: ["--compressed", "--location", cask.appcast], print_stderr: false)
     if result.success?
       processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}, "")
+      # This step is necessary to replicate running `sed` from the command line
+      processed_appcast_text << "\n" unless processed_appcast_text.end_with?("\n")
       expected = cask.appcast.checkpoint
       actual = Digest::SHA2.hexdigest(processed_appcast_text)
       add_warning <<-EOS.undent unless expected == actual

--- a/spec/cask/audit_spec.rb
+++ b/spec/cask/audit_spec.rb
@@ -157,7 +157,8 @@ describe Hbc::Audit do
 
           before do
             allow(fake_curl_result).to receive(:stdout).and_return(appcast_text)
-            allow(appcast_text).to receive(:gsub)
+            allow(appcast_text).to receive(:gsub).and_return(appcast_text)
+            allow(appcast_text).to receive(:end_with?).with("\n").and_return(true)
             allow(Digest::SHA2).to receive(:hexdigest).and_return(actual_checkpoint)
           end
 


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

`sed` seems to append a newline to the end of its output if one is not there already.

Ref #22734 
