### PR TITLE
Fix clementine on case-sensitive filesystem

### DIFF
--- a/Casks/clementine.rb
+++ b/Casks/clementine.rb
@@ -12,7 +12,7 @@ cask 'clementine' do
 
   conflicts_with cask: 'caskroom/versions/clementine-rc'
 
-  app 'Clementine.app'
+  app 'clementine.app'
 
   zap delete: [
                 '~/Library/Application Support/Clementine',


### PR DESCRIPTION
### Changes to a cask

Fixed clementine's app name so it won't fail when installing it on a case-sensitive filesystem:

``` sh
$ open ./clementine-1.3.1.dmg
$ cd /Volumes/Clementine/
$ ls
Applications    clementine.app
```
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
