### PR TITLE
ISSUE_TEMPLATE.md: inform issue may be closed if rules are not followed

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,9 @@
 Before writing your issue, check our instructions for [reporting bugs](https://github.com/caskroom/homebrew-cask#reporting-bugs) or [making requests](https://github.com/caskroom/homebrew-cask#requests), as appropriate. Those will walk you through the process.
 
-If none of those is appropriate, then **delete all this pre-inserted template text** and tell us your issue in as much detail as possible. Thank you for taking the time to correctly report the issue.
+If none of those is appropriate, then **delete all this pre-inserted template text** and tell us your issue in as much detail as possible.
+
+Please note that if it is apparent you ignored the instructions for reporting issues, your issue may be closed without review. When the the guide isn‘t followed we get the same issues over and over. Having to repeatedly deal with the same solved and documented problems leads to maintainer burnout and a lot of wasted hours that could instead have been spent improving Homebrew-Cask itself and fixing real bugs.
+
+If the guide itself was unclear, open *first* an issue or pull request stating what you found was confusing *and only then* your other issue.
+
+Thank you for taking the time to make a correct report.


### PR DESCRIPTION
Pinging @caskroom/maintainers.

I, for one, am getting tired of people completely ignoring the guides (most of the time it’s pretty clear no attempt was made to read even part of it), even with a message asking them to when opening issues. It just goes to show that some human problems can’t be solved with technology.

I tried to be respectful with the message, and not at all forceful (if I failed, please let me know). The goal is to say “please respect our time”. If a user can’t take the time to make a correct report, I don’t see why we should take the time to solve their problem.

If accepted, will copy to the other repos.
