### PR TITLE
Update Launchpad Manager for both Yosemite and prior Yosemite ver.

### DIFF
--- a/Casks/launchpad-manager-yosemite.rb
+++ b/Casks/launchpad-manager-yosemite.rb
@@ -1,13 +1,18 @@
 cask 'launchpad-manager-yosemite' do
-  version '1.0.4'
-  sha256 '5edea718d385b222037f781932b9aa4097ff1a68133ab68d1ac4aa1de461ad8b'
+  if MacOS.release <= :mavericks
+    version :latest
+    sha256 :no_check
+    url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
+    app 'Launchpad Manager.app'
+  else
+    version :latest
+    sha256 :no_check
+    url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
 
-  url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
-  appcast 'http://launchpadmanager.com/appyos/sparkle.rss',
-          checkpoint: '9bd3cfb349d301c2e1e6316c250307d002cde68d1773daf757872f61580f9ff7'
+    app 'Launchpad Manager Yosemite.app'
+    end
+
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'
   license :commercial
-
-  app 'Launchpad Manager Yosemite.app'
 end

--- a/Casks/launchpad-manager-yosemite.rb
+++ b/Casks/launchpad-manager-yosemite.rb
@@ -10,7 +10,7 @@ cask 'launchpad-manager-yosemite' do
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
 
     app 'Launchpad Manager Yosemite.app'
-    end
+  end
 
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

As you may know, there are both version of Launchpad Manager, for both Yosemite and prior Yosemite.

I update this one to avoid conflict, duplicating a new cask, as suggested in #22736.

I also removed appcast and url check, since it made the software to be updated easier, no need to change the sha256 every time.
