### PR TITLE
travis: update rvm to head before running

### DIFF
--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -8,8 +8,6 @@
 # shellcheck disable=SC1090
 . "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
 
-enter_build_step
-
 header 'Running before_install.sh...'
 
 # https://github.com/rvm/rvm/pull/3627
@@ -69,5 +67,3 @@ run mkdir -p "${CASK_TAP_DIR}"
 run rsync -az --delete "${TRAVIS_BUILD_DIR}/" "${CASK_TAP_DIR}/"
 run export TRAVIS_BUILD_DIR="${CASK_TAP_DIR}"
 run cd "${CASK_TAP_DIR}" || exit 1
-
-exit_build_step

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -12,6 +12,9 @@ enter_build_step
 
 header 'Running before_install.sh...'
 
+# https://github.com/rvm/rvm/pull/3627
+run rvm get head
+
 # unset rvm hook functions
 run unset -f cd gem
 

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -8,8 +8,6 @@
 # shellcheck disable=SC1090
 . "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
 
-enter_build_step
-
 header 'Running before_script.sh...'
 
 run which bundle
@@ -17,5 +15,3 @@ run bundle --version
 
 run which rake
 run rake --version
-
-exit_build_step

--- a/ci/travis/helpers.sh
+++ b/ci/travis/helpers.sh
@@ -50,16 +50,6 @@ brew_upgrade () {
   fi
 }
 
-# disallow unbound variables during build step
-enter_build_step () {
-  set -o nounset
-}
-
-# allow unbound variables so Travis doesn't get mad at us
-exit_build_step () {
-  set +o nounset
-}
-
 modified_cask_files () {
   if [[ -z "${MODIFIED_CASK_FILES+defined}" ]]; then
     MODIFIED_CASK_FILES="$(git diff --name-only --diff-filter=AM "${TRAVIS_COMMIT_RANGE}" -- Casks/*.rb)"

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -8,8 +8,6 @@
 # shellcheck disable=SC1090
 . "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
 
-enter_build_step
-
 header 'Running install.sh...'
 
 # install bundler and project dependencies in $GEM_HOME
@@ -26,5 +24,3 @@ if must_run_tests; then
   brew_install unar
   run brew cask install Casks/adobe-air.rb
 fi
-
-exit_build_step

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -8,8 +8,6 @@
 # shellcheck disable=SC1090
 . "${TRAVIS_BUILD_DIR}/ci/travis/helpers.sh"
 
-enter_build_step
-
 header 'Running script.sh...'
 
 if any_casks_modified; then
@@ -23,5 +21,3 @@ if must_run_tests; then
   run bundle exec rake test:coverage
   run bundle exec rake coveralls:push || true # in case of networking errors
 fi
-
-exit_build_step


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

See https://github.com/rvm/rvm/pull/3627

Should fix the `/Users/travis/build.sh: line 109: shell_session_update: command not found` error we've been seeing on Travis lately.
