### PR TITLE
Update Goofy to 2.2.6

### DIFF
--- a/Casks/goofy.rb
+++ b/Casks/goofy.rb
@@ -1,11 +1,11 @@
 cask 'goofy' do
-  version '2.2.5'
-  sha256 '392547a2d1ccb069e489453161f376449043921c1a158d3a2bc47169cab79c1d'
+  version '2.2.6'
+  sha256 '7408f4d5870d54c13a5557c7a403da39a3c1c71850c5d6b6cca9a840152374f1'
 
   # github.com/danielbuechele/goofy was verified as official when first introduced to the cask
   url "https://github.com/danielbuechele/goofy/releases/download/v#{version}/Goofy.app.zip"
   appcast 'https://github.com/danielbuechele/goofy/releases.atom',
-          checkpoint: '4acdaa73cad63003f14982b1b2658f610cac4392bf0211697fe70396c5408342'
+          checkpoint: '487c3d4a6f8520f7773e38341fc8fac04a556ce6ae5c3565d096a74ee5b96888'
   name 'Goofy'
   homepage 'http://www.goofyapp.com/'
   license :mit


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [ ] Commit message includes cask’s name (and new version, if applicable).
- [ ] `brew cask audit --download goofy` is error-free.
- [ ] `brew cask style --fix goofy` left no offenses.
