### PR TITLE
Update Google Chrome depends_on

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -8,6 +8,7 @@ cask 'google-chrome' do
   license :gratis
 
   auto_updates true
+  depends_on macos: '>= :mavericks'
 
   app 'Google Chrome.app'
 


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download google-chrome` is error-free.
- [x] `brew cask style --fix google-chrome` left no offenses.

Because Google Chrome requires Mavericks and later
