### PR TITLE
audit.rb: always fake user agent when getting appcast

### DIFF
--- a/lib/hbc/audit.rb
+++ b/lib/hbc/audit.rb
@@ -104,7 +104,7 @@ class Hbc::Audit
 
   def check_appcast_http_code
     odebug "Verifying appcast returns 200 HTTP response code"
-    result = @command.run("curl", args: ["--compressed", "--location", "--output", "/dev/null", "--write-out", "%{http_code}", cask.appcast], print_stderr: false)
+    result = @command.run("curl", args: ["--compressed", "--location", "--user-agent", Hbc::URL::FAKE_USER_AGENT, "--output", "/dev/null", "--write-out", "%{http_code}", cask.appcast], print_stderr: false)
     if result.success?
       http_code = result.stdout.chomp
       add_warning "unexpected HTTP response code retrieving appcast: #{http_code}" unless http_code == "200"
@@ -115,7 +115,7 @@ class Hbc::Audit
 
   def check_appcast_checkpoint_accuracy
     odebug "Verifying appcast checkpoint is accurate"
-    result = @command.run("curl", args: ["--compressed", "--location", cask.appcast], print_stderr: false)
+    result = @command.run("curl", args: ["--compressed", "--location", "--user-agent", Hbc::URL::FAKE_USER_AGENT, cask.appcast], print_stderr: false)
     if result.success?
       processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}, "")
       # This step is necessary to replicate running `sed` from the command line


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Edited via the web interface and untested.

Closes https://github.com/caskroom/homebrew-cask/pull/22806. Refs https://github.com/caskroom/homebrew-cask/pull/22790#issuecomment-232815231. `checkpoint` should always be calculated in this manner, it was due to my lapse using the browsers headers isn’t documented (it’s just present in the scripts that interact with this).

Assigning @jawshooah to merge if everything is correct and you agree.
