### PR TITLE
Update sha256 for HackHands.app

### DIFF
--- a/Casks/hackhands.rb
+++ b/Casks/hackhands.rb
@@ -1,6 +1,6 @@
 cask 'hackhands' do
   version '1.4.11'
-  sha256 '915269b78f2f3fa25bfbd878cdbaccef69420b5c6d3b7f07a0b3219ead782dd7'
+  sha256 '638d4726d721592b4147403402b4b51bcdc848621f83d665320c03d44457c616'
 
   # desktop.hackhands.com.s3-website-us-west-1.amazonaws.com was verified as official when first introduced to the cask
   url "http://desktop.hackhands.com.s3-website-us-west-1.amazonaws.com/osx/#{version}/HackHands.zip"


### PR DESCRIPTION
There was a sha mismatch, I double checked the vendor site and it looks like the binary has been replaced without changing the version number.
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
