### PR TITLE
Unhide parallels-desktop application

### DIFF
--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -10,6 +10,9 @@ cask 'parallels-desktop' do
   app 'Parallels Desktop.app'
 
   postflight do
+    # Unhide the application
+    system '/usr/bin/sudo', '-E', '--', 'chflags', 'nohidden', "#{appdir}/Parallels Desktop.app"
+
     # Run the initialization script
     system '/usr/bin/sudo', '-E', '--',
            "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

It appears that the inittool no longer sets the "nohidden" flag on the target application anymore - because it is hidden in finder after this update.
