### PR TITLE
Update older versions of Virtualbox

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,7 +1,10 @@
 cask 'virtualbox' do
   if MacOS.release <= :lion
-    version '4.3.32-103443'
-    sha256 'dcfbd1d3014ab393dc5944a9474eeabf8b33471e7d95cb4c94070dc7acab772c'
+    version '4.3.38-106717'
+    sha256 'f7229f9537dc2359e2f86b2d3623e5024f11d2ce9b075fe34a71b55995897463'
+  elsif MacOS.release == :mountain_lion
+    version '5.0.26-108824'
+    sha256 'e8836a98adea9350917a41e754dfec4fe2df7c4a0224fd8beca72cbc5d778437'
   else
     version '5.1.2-108956'
     sha256 '0e21615b6e1d1e2a030174b524939a34a91a268d436c3b913af14098acf23b44'
@@ -22,6 +25,10 @@ cask 'virtualbox' do
   zap delete: [
                 '/Library/Application Support/VirtualBox',
                 '~/Library/VirtualBox',
+                '~/Library/Preferences/org.virtualbox.app.VirtualBox.plist',
+                '~/Library/Preferences/org.virtualbox.app.VirtualBoxVM.plist',
+                '~/Library/Saved Application State/org.virtualbox.app.VirtualBox.savedState',
+                '~/Library/Saved Application State/org.virtualbox.app.VirtualBoxVM.savedState',
               ],
       rmdir:  '~/VirtualBox VMs'
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offences.

---

Lion version updated to 4.3.32. Added version 5.0.26 for Mountain Lion.
Expanded zap stanza.
