### PR TITLE
Updated gns3 v1.5.1

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,11 +1,11 @@
 cask 'gns3' do
-  version '1.4.6'
-  sha256 'a2d628213ffc7e234739e12e7ebb10c06bec78414355a2480fa00914826e417e'
+  version '1.5.1'
+  sha256 '4769c15ae372482369bebae6ebea3a356fdfe138fa8882a60708c8bbe7cd788a'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: '412d3b1b11530d7c3059a2d69055c42d19deedea76c40d300e7e11448c36e8c2'
+          checkpoint: 'ebe5570ab80918508ebe725264d04d98abe08127368addb6135534e68474e3f9'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
   license :gpl


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download gns3` is error-free.
- [x] `brew cask style --fix gns3` left no offenses.
