### PR TITLE
Upgrade Eclipse Memory Analyzer to 1.6.0

### DIFF
--- a/Casks/mat.rb
+++ b/Casks/mat.rb
@@ -1,4 +1,4 @@
-cask 'memoryanalyzer' do
+cask 'mat' do
   version '1.6.0.20160531'
   sha256 '300e151bc6bc7e34b196fc50803269f3ce23ad49b0cda9d8335d8861d13ccb64'
 

--- a/Casks/memoryanalyzer.rb
+++ b/Casks/memoryanalyzer.rb
@@ -1,11 +1,11 @@
 cask 'memoryanalyzer' do
-  version '1.5.0.20150527'
-  sha256 'e7b2fbb156d8b61c449778756c20a6cf1567c48f7e446752b9fba8e479cd3d4e'
+  version '1.6.0.20160531'
+  sha256 '300e151bc6bc7e34b196fc50803269f3ce23ad49b0cda9d8335d8861d13ccb64'
 
-  url "http://www.eclipse.org/downloads/download.php?file=/mat/#{version.major_minor}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.x86_64.zip&r=1"
+  url "http://www.eclipse.org/downloads/download.php?r=1&file=/mat/#{version.major_minor}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.x86_64.zip"
   name 'Eclipse Memory Analyzer'
   homepage 'https://www.eclipse.org/mat/'
   license :eclipse
 
-  app 'mat/MemoryAnalyzer.app'
+  app 'mat.app'
 end


### PR DESCRIPTION
Eclipse MAT 1.6.0 was released a few weeks ago. This PR upgrades the dowloaded version.
Note that the app name changed in the zip, also for some reason the downloaded file had the `.zip&r=1` extension for this reason I moved the `r` query param before the `file` query param in the download URI.

**EDIT**: as suggested by @victorpopkov the cask is to be renamed to `mat` since the app name has changed.
### Changes to a cask
#### Editing an existing cask
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
