### PR TITLE
Add Jettison.app v1.5

### DIFF
--- a/Casks/jettison.rb
+++ b/Casks/jettison.rb
@@ -1,0 +1,26 @@
+cask 'jettison' do
+  version '1.5'
+  sha256 'b502b1b0cd7730eea576fe7f524bd9914c0652dbbb631362300194cbc7f610ce'
+
+  url "https://stclairsoft.com/download/Jettison-#{version}.dmg"
+  appcast 'https://stclairsoft.com/cgi-bin/sparkle.cgi?JT',
+          checkpoint: 'fa83610c6373410e200e1cce210b5611575968e883aa33772bf91b17aaccdc7f'
+  name 'St. Clair Software Jettison'
+  name 'Jettison'
+  homepage 'https://stclairsoft.com/Jettison'
+  license :commercial
+
+  auto_updates true
+
+  app 'Jettison.app'
+
+  uninstall login_item: 'Jettison'
+
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.stclairsoft.jettison.sfl',
+                '~/Library/Application Support/Jettison',
+                '~/Library/Preferences/com.stclairsoft.Jettison.plist',
+                '~/Library/Preferences/com.stclairsoft.Jettison.AppStore.plist',
+                '~/Library/Caches/com.stclairsoft.Jettison',
+              ]
+end


### PR DESCRIPTION
Pull request [21875](https://github.com/caskroom/homebrew-cask/pull/21875) contains commit [716cb38](https://github.com/caskroom/homebrew-cask/pull/21875/commits/716cb38307073e48d3dfaf1915576aaf3bb8900b) "Removed jettison from the caskroom", which states "New versions of Jettison are only available in the App Store. This cask is very outdated.", but in fact the opposite appears to be the case - I'm therefore confused as to why this was removed in the first place.
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
