### PR TITLE
istat-menus checksum fix (5.20)

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus' do
   version '5.20'
-  sha256 'f1a30b49d4012fab3e431a1727fd335d0fe3f522028c8f597cdfac4999f199be'
+  sha256 :no_check # required as upstream package is updated in-place
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus#{version}.zip"


### PR DESCRIPTION
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.

The checksum in the previous cask for https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus5.20.zip was not correct.  It appears that they have updated an internal build (now they are serving build number 664 - but previously, it appeared that they were serving build number 657).
