### PR TITLE
Fix Chatty to use Suite instead of App

### DIFF
--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -10,7 +10,8 @@ cask 'chatty' do
   homepage 'https://chatty.github.io'
   license :mit
 
-  app 'Chatty.jar'
+  # There is no sub-folder in the ZIP; the root *is* the folder
+  suite '.', target: 'Chatty'
 
   zap delete: '~/.chatty'
 


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offences.

With the change from symlinking to moving apps, the other files that the program requires weren't found by the jar. Changing this to a suite and moving the whole folder to /Applications solves this issue.

If this isn't an acceptable solution, I'm open to suggestion on how to improve it.
