### PR TITLE
Added appcast url for virtualbox

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -11,6 +11,8 @@ cask 'virtualbox' do
   end
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/VirtualBox-#{version}-OSX.dmg"
+  appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',
+          checkpoint: '0c9a9d43610d66f4cc3f42da08cae044483de25894a9daf9dc6a76ff75ca9327'
   name 'Oracle VirtualBox'
   homepage 'https://www.virtualbox.org'
   license :gpl


### PR DESCRIPTION
Virtualbox provides a "latest.txt" file, containing the version number of the
latest release. This should work as an appcast url.
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
