### PR TITLE
Update comment for URL & homepage mismatch

### DIFF
--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -31,7 +31,7 @@ cask 'gateblu' do
   version :latest
   sha256 :no_check
 
-  # amazonaws.com is the official download host per the vendor homepage
+  # amazonaws.com was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/gateblu/gateblu-ui/latest/Gateblu.dmg'
   name 'Gateblu'
   homepage 'https://gateblu.octoblu.com'


### PR DESCRIPTION
Updated comment explaining why URL and homepage domains don't match, as per https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment (previous code was failing checks)
