### PR TITLE
Deprecate `--binarydir` option.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -180,8 +180,6 @@ Default is `~/Library/PreferencePanes`
 Default is `~/Library/QuickLook`
 * `--fontdir=/my/path` changes the path for Fonts.
 Default is `~/Library/Fonts`
-* `--binarydir=/my/path` changes the path for Binary symlinks.
-Default is `/usr/local/bin`
 * `--input_methoddir=/my/path` changes the path for Input Methods.
 Default is `~/Library/Input Methods`
 * `--screen_saverdir=/my/path` changes the path for Screen Savers.

--- a/doc/man_page/brew-cask.1.md
+++ b/doc/man_page/brew-cask.1.md
@@ -195,9 +195,6 @@ in a future version.
   * `--no-binaries`:
     Do not link "helper" executables to `/usr/local/bin`.
 
-  * `--binarydir=<path>`:
-    Target location for "helper" executable links. The default value is `/usr/local/bin`.
-
   * `--debug`:
     Output debugging information of use to Cask authors and developers.
 

--- a/lib/hbc/cli.rb
+++ b/lib/hbc/cli.rb
@@ -176,8 +176,8 @@ class Hbc::CLI
       opts.on("--servicedir=MANDATORY") do |v|
         Hbc.servicedir = Pathname(v).expand_path
       end
-      opts.on("--binarydir=MANDATORY") do |v|
-        Hbc.binarydir = Pathname(v).expand_path
+      opts.on("--binarydir=MANDATORY") do
+        opoo "Option --binarydir is deprecated, Homebrew Cask now uses whatever your Hombrew install uses."
       end
       opts.on("--input_methoddir=MANDATORY") do |v|
         Hbc.input_methoddir = Pathname(v).expand_path

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -76,7 +76,7 @@ module Hbc::Locations
     attr_writer :binarydir
 
     def binarydir
-      @binarydir ||= Pathname.new("/usr/local/bin").expand_path
+      @binarydir ||= homebrew_prefix.join("bin")
     end
 
     attr_writer :input_methoddir

--- a/man/man1/brew-cask.1
+++ b/man/man1/brew-cask.1
@@ -208,10 +208,6 @@ Target location for Screen Savers\. The default value is \fB~/Library/Screen Sav
 Do not link "helper" executables to \fB/usr/local/bin\fR\.
 .
 .TP
-\fB\-\-binarydir=<path>\fR
-Target location for "helper" executable links\. The default value is \fB/usr/local/bin\fR\.
-.
-.TP
 \fB\-\-debug\fR
 Output debugging information of use to Cask authors and developers\.
 .

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ class Hbc::TestCask < Hbc::Cask; end
 Hbc.homebrew_prefix = Pathname.new(TEST_TMPDIR).join("prefix")
 Hbc.homebrew_repository = Hbc.homebrew_prefix
 Hbc.homebrew_tapspath = nil
-Hbc.binarydir = Hbc.homebrew_prefix.join("binarydir").join("bin")
+Hbc.binarydir = Hbc.homebrew_prefix.join("binarydir", "bin")
 Hbc.appdir = Pathname.new(TEST_TMPDIR).join("appdir")
 
 # making homebrew's cache dir allows us to actually download Casks in tests


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).
