### PR TITLE
Fix sqlworkbenchj URL

### DIFF
--- a/Casks/sqlworkbenchj.rb
+++ b/Casks/sqlworkbenchj.rb
@@ -2,7 +2,7 @@ cask 'sqlworkbenchj' do
   version '119'
   sha256 '8565105504e517ca972b4f3c99f4436b13e7a3caaf8f53a97f44a71a7c71efc6'
 
-  url "http://www.sql-workbench.net/Workbench-Build#{version}-MacJava8.tgz"
+  url "http://www.sql-workbench.net/archive/Workbench-Build#{version}-MacJava8.tgz"
   name 'SQL Workbench/J'
   homepage 'http://www.sql-workbench.net'
   license :apache


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The download fails because a newer version was released and this version
was moved to the `archive` folder.

I've asked the maintainer for more durable download urls. In the
meantime, I figured it's better to have a working url than the latest
url which will break again when a new version is released.
