### PR TITLE
Update gpodder to '3.9.0_2'

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,6 +1,6 @@
 cask 'gpodder' do
-  version '3.9.0_0'
-  sha256 'c8bbf5175b43d8def73f46c5d0d23950d12a524d686fdb9b8fe5d5a910dd6378'
+  version '3.9.0_2'
+  sha256 'c5dafe2685057545cf6505d9492c429ab9c585e159c04bec62847c9ba9a40c2f'
 
   # downloads.sourceforge.net/sourceforge/gpodder was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/sourceforge/gpodder/gPodder-#{version}.zip"


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
