### PR TITLE
Update Docker to stable channel and v1.12.0.10871

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '1.12.0.10404'
-  sha256 'ba458f4b568ca9f8395469f1cdc3030f3924bcfc166658ec3e29284af1a1d633'
+  version '1.12.0.10871'
+  sha256 'f170610d95c188dee8433eff33c84696c1c8a39421de548a71a1258a458e1b21'
 
-  url "https://download.docker.com/mac/beta/#{version}/Docker.dmg"
-  appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: 'dbdd029c3d6576232188b33148ff0aca12c68b329c6646fb3628e2c8e4bdb6cb'
+  url "https://download.docker.com/mac/stable/#{version}/Docker.dmg"
+  appcast 'https://download.docker.com/mac/stable/appcast.xml',
+          checkpoint: 'ee03f7c36b4192a64ba30e49a0fa1f8358cc3fe4a8a3af3def066c80f36b18bf'
   name 'Docker for Mac'
   homepage 'https://www.docker.com/products/docker'
   license :mit


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Note, there is now a stable and beta channel. Beta belongs in homebrew-versions, but the appcast is not yet available for this channel (as far as I can tell). I'll check again in the next day or so.
See https://blog.docker.com/2016/07/docker-for-mac-and-windows-production-ready/ for release announcement.
