### PR TITLE
Update syncthing to 0.14.2

### DIFF
--- a/Casks/syncthing.rb
+++ b/Casks/syncthing.rb
@@ -1,11 +1,11 @@
 cask 'syncthing' do
-  version '0.13.7'
-  sha256 '58c0063cecef9d2969b96223e4cacfabb91f2df0f7a7bf43860a50a344b487f7'
+  version '0.14.2'
+  sha256 'ca5d616cd4762d4f7b39f627c14dd35419d5146f89bde328cc71b9d1de0352c7'
 
   # github.com/syncthing/syncthing was verified as official when first introduced to the cask
   url "https://github.com/syncthing/syncthing/releases/download/v#{version}/syncthing-macosx-amd64-v#{version}.tar.gz"
   appcast 'https://github.com/syncthing/syncthing/releases.atom',
-          checkpoint: '85ca27e629ca442a77752696fcd65dd4ef789a7465ea83c6938ce398bc386d4c'
+          checkpoint: 'a89d1a18b6b6170a8f3bb3f714f41e2e55a814de4bc23b1881672b337470604c'
   name 'Syncthing'
   homepage 'https://syncthing.net/'
   license :mpl


### PR DESCRIPTION
I tried to use cask-repair but here is what I got

```
/usr/local/Library/Taps/caskroom/homebrew-cask/Casks master ⇣
❯ cask-repair --pull origin --push MoOx syncthing
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
cask 'syncthing' do
  version '0.13.7'
  sha256 '58c0063cecef9d2969b96223e4cacfabb91f2df0f7a7bf43860a50a344b487f7'

  # github.com/syncthing/syncthing was verified as official when first introduced to the cask
  url "https://github.com/syncthing/syncthing/releases/download/v#{version}/syncthing-macosx-amd64-v#{version}.tar.gz"
  appcast 'https://github.com/syncthing/syncthing/releases.atom',
          checkpoint: '85ca27e629ca442a77752696fcd65dd4ef789a7465ea83c6938ce398bc386d4c'
  name 'Syncthing'
  homepage 'https://syncthing.net/'
  license :mpl

  binary "syncthing-macosx-amd64-v#{version}/syncthing"

  zap delete: '~/Library/Application Support/Syncthing'
end
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Type the new version (or leave blank to use the current one)
> 0.14.2
==> Downloading external files for Cask ./syncthing.rb
==> Downloading https://github.com/syncthing/syncthing/releases/download/v0.14.2/syncthing-macosx-amd64-v0.14.2.tar.gz
######################################################################## 100.0%
==> No checksum defined for Cask syncthing, skipping verification
==> Success! Downloaded to -> /Users/moox/Library/Caches/Homebrew/syncthing-0.14.2.tar.gz
diff --git a/Casks/syncthing.rb b/Casks/syncthing.rb
index 815a2d6..a3e9540 100644
--- a/Casks/syncthing.rb
+++ b/Casks/syncthing.rb
@@ -1,11 +1,11 @@
 cask 'syncthing' do
-  version '0.13.7'
-  sha256 '58c0063cecef9d2969b96223e4cacfabb91f2df0f7a7bf43860a50a344b487f7'
+  version '0.14.2'
+  sha256 'ca5d616cd4762d4f7b39f627c14dd35419d5146f89bde328cc71b9d1de0352c7'

   # github.com/syncthing/syncthing was verified as official when first introduced to the cask
   url "https://github.com/syncthing/syncthing/releases/download/v#{version}/syncthing-macosx-amd64-v#{version}.tar.gz"
   appcast 'https://github.com/syncthing/syncthing/releases.atom',
-          checkpoint: '85ca27e629ca442a77752696fcd65dd4ef789a7465ea83c6938ce398bc386d4c'
+          checkpoint: 'a89d1a18b6b6170a8f3bb3f714f41e2e55a814de4bc23b1881672b337470604c'
   name 'Syncthing'
   homepage 'https://syncthing.net/'
   license :mpl
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Is everything correct? You can also make further manual edits (y/n/e) y
Submitting…

fatal: 'MoOx' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error: the requested upstream branch 'MoOx/cask-repair_update-syncthing' does not exist
hint: 
hint: If you are planning on basing your work on an upstream
hint: branch that already exists at the remote, you may need to
hint: run "git fetch" to retrieve it.
hint: 
hint: If you are planning to push out a new local branch that
hint: will track its remote counterpart, you may want to use
hint: "git push -u" to set the upstream config as you push.
Error creating pull request: Unprocessable Entity (HTTP 422)
Invalid value for "head"
Error creating pull request: Unprocessable Entity (HTTP 422)
Invalid value for "head"

There was an error submitting the pull request. Have you forked the repo and made sure the pull and push remotes exist?
```
