### PR TITLE
Get rid of cache symlinks.

### DIFF
--- a/lib/hbc/cli/audit.rb
+++ b/lib/hbc/cli/audit.rb
@@ -44,4 +44,8 @@ class Hbc::CLI::Audit < Hbc::CLI::Base
   def cask_tokens
     @cask_tokens ||= @args.reject { |a| a == "--download" }
   end
+
+  def self.needs_init?
+    true
+  end
 end

--- a/lib/hbc/cli/cleanup.rb
+++ b/lib/hbc/cli/cleanup.rb
@@ -43,12 +43,16 @@ class Hbc::CLI::Cleanup < Hbc::CLI::Base
     outdated_only && file && file.stat.mtime > OUTDATED_TIMESTAMP
   end
 
+  def incomplete?(file)
+    file.extname == ".incomplete"
+  end
+
   def cache_incompletes
-    cache_files.select { |file| file.extname == ".incomplete" }
+    cache_files.select(&method(:incomplete?))
   end
 
   def cache_completes
-    cache_files.reject { |file| file.extname == ".incomplete" }
+    cache_files.reject(&method(:incomplete?))
   end
 
   def disk_cleanup_size

--- a/lib/hbc/cli/doctor.rb
+++ b/lib/hbc/cli/doctor.rb
@@ -210,13 +210,13 @@ class Hbc::CLI::Doctor < Hbc::CLI::Base
 
   def self.render_cached_downloads
     cleanup = Hbc::CLI::Cleanup.default
-    files = cleanup.all_cache_files
+    files = cleanup.cache_files
     count = files.count
     size = cleanup.disk_cleanup_size
     size_msg = "#{number_readable(count)} files, #{disk_usage_readable(size)}"
     warn_msg = error_string('warning: run "brew cask cleanup"')
     size_msg << " #{warn_msg}" if count > 0
-    [HOMEBREW_CACHE, HOMEBREW_CACHE_CASKS, size_msg]
+    [Hbc.cache, size_msg]
   end
 
   def self.help

--- a/lib/hbc/cli/doctor.rb
+++ b/lib/hbc/cli/doctor.rb
@@ -211,7 +211,7 @@ class Hbc::CLI::Doctor < Hbc::CLI::Base
   def self.render_cached_downloads
     cleanup = Hbc::CLI::Cleanup.default
     files = cleanup.all_cache_files
-    count = files.size
+    count = files.count
     size = cleanup.disk_cleanup_size
     size_msg = "#{number_readable(count)} files, #{disk_usage_readable(size)}"
     warn_msg = error_string('warning: run "brew cask cleanup"')

--- a/lib/hbc/download.rb
+++ b/lib/hbc/download.rb
@@ -12,7 +12,6 @@ class Hbc::Download
   def perform
     clear_cache
     fetch
-    create_cache_symlink
     downloaded_path
   end
 
@@ -40,11 +39,5 @@ class Hbc::Download
     self.downloaded_path = downloader.fetch
   rescue StandardError => e
     raise Hbc::CaskError, "Download failed on Cask '#{cask}' with message: #{e}"
-  end
-
-  # this symlink helps track which downloads are ours
-  def create_cache_symlink
-    symlink_path = HOMEBREW_CACHE_CASKS.join(downloaded_path.basename)
-    FileUtils.ln_sf downloaded_path, symlink_path
   end
 end

--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -69,7 +69,7 @@ class Hbc::CurlDownloadStrategy < Hbc::AbstractDownloadStrategy
   end
 
   def tarball_path
-    @tarball_path ||= Pathname.new("#{HOMEBREW_CACHE}/#{name}-#{version}#{ext}")
+    @tarball_path ||= HOMEBREW_CACHE.join("#{name}-#{version}#{ext}")
   end
 
   def temporary_path

--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -69,7 +69,7 @@ class Hbc::CurlDownloadStrategy < Hbc::AbstractDownloadStrategy
   end
 
   def tarball_path
-    @tarball_path ||= Hbc.cache.join("#{name}-#{version}#{ext}")
+    @tarball_path ||= Hbc.cache.join("#{name}--#{version}#{ext}")
   end
 
   def temporary_path

--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -73,7 +73,7 @@ class Hbc::CurlDownloadStrategy < Hbc::AbstractDownloadStrategy
   end
 
   def temporary_path
-    @temporary_path ||= Pathname.new("#{tarball_path}.incomplete")
+    @temporary_path ||= tarball_path.sub(%r{$}, ".incomplete")
   end
 
   def cached_location

--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -35,7 +35,7 @@ class Hbc::HbVCSDownloadStrategy < Hbc::AbstractDownloadStrategy
   def initialize(cask, command = Hbc::SystemCommand)
     super
     @ref_type, @ref = extract_ref
-    @clone = HOMEBREW_CACHE.join(cache_filename)
+    @clone = Hbc.cache.join(cache_filename)
   end
 
   def extract_ref
@@ -69,7 +69,7 @@ class Hbc::CurlDownloadStrategy < Hbc::AbstractDownloadStrategy
   end
 
   def tarball_path
-    @tarball_path ||= HOMEBREW_CACHE.join("#{name}-#{version}#{ext}")
+    @tarball_path ||= Hbc.cache.join("#{name}-#{version}#{ext}")
   end
 
   def temporary_path

--- a/lib/hbc/locations.rb
+++ b/lib/hbc/locations.rb
@@ -37,6 +37,14 @@ module Hbc::Locations
       @caskroom = caskroom
     end
 
+    def legacy_cache
+      @legacy_cache ||= HOMEBREW_CACHE.join("Casks")
+    end
+
+    def cache
+      @cache ||= HOMEBREW_CACHE.join("Cask")
+    end
+
     attr_writer :appdir
 
     def appdir

--- a/lib/hbc/source/uri.rb
+++ b/lib/hbc/source/uri.rb
@@ -10,8 +10,8 @@ class Hbc::Source::URI
   end
 
   def load
-    HOMEBREW_CACHE_CASKS.mkpath
-    path = HOMEBREW_CACHE_CASKS.join(File.basename(uri))
+    Hbc.cache.mkpath
+    path = Hbc.cache.join(File.basename(uri))
     ohai "Downloading #{uri}"
     odebug "Download target -> #{path}"
     begin

--- a/spec/cask/cli/cleanup_spec.rb
+++ b/spec/cask/cli/cleanup_spec.rb
@@ -1,75 +1,45 @@
 require "spec_helper"
 
 describe Hbc::CLI::Cleanup do
-  let(:homebrew_cache_location) { Pathname(Dir.mktmpdir).realpath }
-  let(:cache_location) { homebrew_cache_location.join("Casks").tap(&:mkdir) }
+  let(:cache_location) { Pathname.new(Dir.mktmpdir).realpath }
   let(:cleanup_outdated) { false }
 
   subject { described_class.new(cache_location, cleanup_outdated) }
 
   after do
-    homebrew_cache_location.rmtree
+    cache_location.rmtree
   end
 
   describe "cleanup!" do
-    it "removes dead symlinks" do
-      bad_symlink = cache_location.join("bad_symlink")
-      bad_symlink.make_symlink("../does_not_exist")
-
-      expect {
-        subject.cleanup!
-      }.to output(<<-OUTPUT.undent).to_stdout
-        ==> Removing dead symlinks
-        #{bad_symlink}
-        ==> Removing cached downloads
-        Nothing to do
-      OUTPUT
-
-      expect(bad_symlink.symlink?).to eq(false)
-    end
-
     it "removes cached downloads" do
-      cached_download = homebrew_cache_location.join("SomeDownload.dmg")
+      cached_download = cache_location.join("SomeDownload.dmg")
       FileUtils.touch(cached_download)
 
-      cached_download_symlink = cache_location.join("SomeDownload.dmg")
-      cached_download_symlink.make_symlink(cached_download)
-
       expect {
         subject.cleanup!
       }.to output(<<-OUTPUT.undent).to_stdout
-        ==> Removing dead symlinks
-        Nothing to do
         ==> Removing cached downloads
         #{cached_download}
-        #{cached_download_symlink}
       OUTPUT
 
       expect(cached_download.exist?).to eq(false)
-      expect(cached_download_symlink.symlink?).to eq(false)
     end
 
     context "when cleanup_outdated is specified" do
       let(:cleanup_outdated) { true }
 
       it "does not remove cache files newer than 10 days old" do
-        cached_download = homebrew_cache_location.join("SomeNewDownload.dmg")
+        cached_download = cache_location.join("SomeNewDownload.dmg")
         FileUtils.touch(cached_download)
-
-        cached_download_symlink = cache_location.join("SomeNewDownload.dmg")
-        cached_download_symlink.make_symlink(cached_download)
 
         expect {
           subject.cleanup!
         }.to output(<<-OUTPUT.undent).to_stdout
-          ==> Removing dead symlinks
-          Nothing to do
           ==> Removing cached downloads older than 10 days old
           Nothing to do
         OUTPUT
 
         expect(cached_download.exist?).to eq(true)
-        expect(cached_download_symlink.symlink?).to eq(true)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,14 +47,13 @@ Hbc.homebrew_tapspath = nil
 Hbc.binarydir = Hbc.homebrew_prefix.join("binarydir", "bin")
 Hbc.appdir = Pathname.new(TEST_TMPDIR).join("appdir")
 
-# making homebrew's cache dir allows us to actually download Casks in tests
-HOMEBREW_CACHE = Pathname.new(TEST_TMPDIR).join("cache")
-HOMEBREW_CACHE.mkpath
-HOMEBREW_CACHE.join("Casks").mkpath
-
 # Look for Casks in testcasks by default.  It is elsewhere required that
 # the string "test" appear in the directory name.
 Hbc.default_tap = project_root.join("spec", "support")
+
+# create cache directory
+HOMEBREW_CACHE = Pathname.new(TEST_TMPDIR).join("cache")
+Hbc.cache.mkpath
 
 # our own testy caskroom
 Hbc.caskroom = Hbc.homebrew_prefix.join("TestCaskroom")

--- a/test/cask/installer_test.rb
+++ b/test/cask/installer_test.rb
@@ -141,7 +141,7 @@ describe Hbc::Installer do
 
       dest_path = Hbc.caskroom.join("bzipped-asset", asset.version)
       dest_path.must_be :directory?
-      file = Hbc.appdir.join("bzipped-asset-#{asset.version}")
+      file = Hbc.appdir.join("bzipped-asset--#{asset.version}")
       file.must_be :file?
     end
 
@@ -154,7 +154,7 @@ describe Hbc::Installer do
 
       dest_path = Hbc.caskroom.join("gzipped-asset", asset.version)
       dest_path.must_be :directory?
-      file = Hbc.appdir.join("gzipped-asset-#{asset.version}")
+      file = Hbc.appdir.join("gzipped-asset--#{asset.version}")
       file.must_be :file?
     end
 
@@ -170,7 +170,7 @@ describe Hbc::Installer do
 
       dest_path = Hbc.caskroom.join("xzipped-asset", asset.version)
       dest_path.must_be :directory?
-      file = Hbc.appdir.join("xzipped-asset-#{asset.version}")
+      file = Hbc.appdir.join("xzipped-asset--#{asset.version}")
       file.must_be :file?
     end
 
@@ -186,7 +186,7 @@ describe Hbc::Installer do
 
       dest_path = Hbc.caskroom.join("lzma-asset", asset.version)
       dest_path.must_be :directory?
-      file = Hbc.appdir.join("lzma-asset-#{asset.version}")
+      file = Hbc.appdir.join("lzma-asset--#{asset.version}")
       file.must_be :file?
     end
 

--- a/test/support/Casks/bzipped-asset.rb
+++ b/test/support/Casks/bzipped-asset.rb
@@ -5,5 +5,5 @@ test_cask 'bzipped-asset' do
   url TestHelper.local_binary_url('bzipped_asset.bz2')
   homepage 'http://example.com/bzipped-asset'
 
-  app 'bzipped-asset-1.2.3'
+  app 'bzipped-asset--1.2.3'
 end

--- a/test/support/Casks/gzipped-asset.rb
+++ b/test/support/Casks/gzipped-asset.rb
@@ -5,5 +5,5 @@ test_cask 'gzipped-asset' do
   url TestHelper.local_binary_url('gzipped_asset.gz')
   homepage 'http://example.com/gzipped-asset'
 
-  app 'gzipped-asset-1.2.3'
+  app 'gzipped-asset--1.2.3'
 end

--- a/test/support/Casks/lzma-asset.rb
+++ b/test/support/Casks/lzma-asset.rb
@@ -7,5 +7,5 @@ test_cask 'lzma-asset' do
 
   depends_on formula: 'lzma'
 
-  app 'lzma-asset-1.2.3'
+  app 'lzma-asset--1.2.3'
 end

--- a/test/support/Casks/xzipped-asset.rb
+++ b/test/support/Casks/xzipped-asset.rb
@@ -7,5 +7,5 @@ test_cask 'xzipped-asset' do
 
   depends_on formula: 'xz'
 
-  app 'xzipped-asset-1.2.3'
+  app 'xzipped-asset--1.2.3'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,11 +53,6 @@ at_exit do
   FileUtils.remove_entry(TEST_TMPDIR)
 end
 
-# making homebrew's cache dir allows us to actually download Casks in tests
-HOMEBREW_CACHE = Pathname.new(TEST_TMPDIR).join("cache")
-HOMEBREW_CACHE.mkpath
-HOMEBREW_CACHE.join("Casks").mkpath
-
 # must be called after testing_env so at_exit hooks are in proper order
 require "minitest/autorun"
 require "minitest/reporters"
@@ -79,6 +74,10 @@ Hbc.homebrew_tapspath = nil
 # Look for Casks in testcasks by default.  It is elsewhere required that
 # the string "test" appear in the directory name.
 Hbc.default_tap = "caskroom/homebrew-testcasks"
+
+# create cache directory
+HOMEBREW_CACHE = Pathname.new(TEST_TMPDIR).join("cache")
+Hbc.cache.mkpath
 
 # our own testy caskroom
 Hbc.caskroom = Hbc.homebrew_prefix.join("TestCaskroom")


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---
### Changes

The new cache directory is now at `HOMEBREW_CACHE`/`Cask`.

All symlinks in the old cache, `HOMEBREW_CACHE`/`Casks`, are checked, their sources moved to the new location, and then deleted. After this, `HOMEBREW_CACHE`/`Casks` is removed recursively.

When moving old cache files, they are also renamed according to a new naming convention, `#{token}--#{version}.#{ext}`, to allow for easier extraction of the token. The regular expression used for this should work for most cases, if it doesn't the worst case is that the file has to be re-downloaded.

---
### Todo
- [x] ~~Update Documentation~~ (there is none)

---

Fixes https://github.com/caskroom/homebrew-cask/issues/22727.
