### PR TITLE
update to runescape NXT client

### DIFF
--- a/Casks/runescape.rb
+++ b/Casks/runescape.rb
@@ -2,7 +2,7 @@ cask 'runescape' do
   version :latest
   sha256 :no_check
 
-  url 'https://content.runescape.com/downloads/osx/RuneScape.dmg'
+  url 'https://content.runescape.com/downloads/osx/RuneScape.dmg?crc=2901131314'
   name 'RuneScape'
   homepage 'https://www.runescape.com'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

change URL to grab Runescape NXT v2.2.2 (13 Apr 2016) client
