### PR TITLE
Remove nested container after extracting.

### DIFF
--- a/lib/hbc/artifact/nested_container.rb
+++ b/lib/hbc/artifact/nested_container.rb
@@ -4,16 +4,19 @@ class Hbc::Artifact::NestedContainer < Hbc::Artifact::Base
   end
 
   def uninstall_phase
-    # no need to take action; we will get removed by rmtree of parent
+    # no need to take action; is removed after extraction
   end
 
   def extract(container_relative_path)
     source = @cask.staged_path.join(container_relative_path)
     container = Hbc::Container.for_path(source, @command)
+
     unless container
       raise Hbc::CaskError, "Aw dang, could not identify nested container at '#{source}'"
     end
+
     ohai "Extracting nested container #{source.basename}"
     container.new(@cask, source, @command).extract
+    FileUtils.remove_entry_secure(source)
   end
 end


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

There is no reason to keep a nested container after extraction, as we also wouldn't keep a non-nested container.
