### PR TITLE
Fix support for double extensions.

### DIFF
--- a/Casks/after-dark-classic.rb
+++ b/Casks/after-dark-classic.rb
@@ -7,8 +7,6 @@ cask 'after-dark-classic' do
   homepage 'http://en.infinisys.co.jp/product/afterdarkclassicset/index.shtml'
   license :commercial
 
-  container nested: "#{token}-#{version}.dmg"
-
   pkg 'ClassicSet.pkg'
 
   uninstall delete: [

--- a/Casks/after-dark-classic.rb
+++ b/Casks/after-dark-classic.rb
@@ -7,13 +7,9 @@ cask 'after-dark-classic' do
   homepage 'http://en.infinisys.co.jp/product/afterdarkclassicset/index.shtml'
   license :commercial
 
-  container nested: "after-dark-classic-#{version}.dmg"
+  container nested: "#{token}-#{version}.dmg"
 
   pkg 'ClassicSet.pkg'
-
-  preflight do
-    system '/bin/mv', '--', staged_path.join("after-dark-classic-#{version}"), staged_path.join("after-dark-classic-#{version}.dmg")
-  end
 
   uninstall delete: [
                       '/Library/Screen Savers/Boris.saver',

--- a/Casks/anonym.rb
+++ b/Casks/anonym.rb
@@ -7,7 +7,5 @@ cask 'anonym' do
   homepage 'http://www.hanynet.com/anonym/'
   license :oss
 
-  container nested: "Anonym #{version}.dmg"
-
   app 'Anonym.app'
 end

--- a/Casks/au-lab.rb
+++ b/Casks/au-lab.rb
@@ -7,7 +7,5 @@ cask 'au-lab' do
   homepage 'https://www.apple.com/itunes/mastered-for-itunes/'
   license :gratis
 
-  container nested: 'AU Lab Image.dmg'
-
   app 'AU Lab.app'
 end

--- a/Casks/avogadro.rb
+++ b/Casks/avogadro.rb
@@ -10,7 +10,5 @@ cask 'avogadro' do
   homepage 'http://avogadro.openmolecules.net/'
   license :gpl
 
-  container nested: "Avogadro-#{version}.dmg"
-
   app 'Avogadro.app'
 end

--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -14,7 +14,6 @@ cask 'bassjump' do
     # ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com was verified as official when first introduced to the cask
     url "http://ffe82a399885f9f28605-66638985576304cbe11c530b9b932f18.r24.cf2.rackcdn.com/BassJumpInstaller_#{version}.dmg.zip"
 
-    container nested: "BassJumpInstaller_#{version}.dmg"
     pkg 'BassJumpInstaller.pkg'
   end
 

--- a/Casks/beoplay-software-update.rb
+++ b/Casks/beoplay-software-update.rb
@@ -7,7 +7,5 @@ cask 'beoplay-software-update' do
   homepage 'http://www.beoplay.com/support/product%20support/beoplay%20updater'
   license :closed
 
-  container nested: "beoplay-product-updater_#{version}.dmg"
-
   app 'BeoPlay Software Update.app'
 end

--- a/Casks/calq.rb
+++ b/Casks/calq.rb
@@ -7,8 +7,6 @@ cask 'calq' do
   homepage 'http://www.katoemba.net/makesnosenseatall/calq/'
   license :gratis
 
-  container nested: "#{token}-#{version}.dmg"
-
   app 'Calq.app'
 
   zap delete: '~/Library/Preferences/com.katoemba.calq.plist'

--- a/Casks/calq.rb
+++ b/Casks/calq.rb
@@ -7,15 +7,9 @@ cask 'calq' do
   homepage 'http://www.katoemba.net/makesnosenseatall/calq/'
   license :gratis
 
-  container nested: "Calq-#{version}.dmg"
+  container nested: "#{token}-#{version}.dmg"
 
   app 'Calq.app'
-
-  # This is a horrible hack to force the file extension.  The
-  # backend code should be fixed so that this is not needed.
-  preflight do
-    system '/bin/mv', '--', staged_path.join("Calq-#{version}"), staged_path.join("Calq-#{version}.dmg")
-  end
 
   zap delete: '~/Library/Preferences/com.katoemba.calq.plist'
 end

--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -7,8 +7,6 @@ cask 'canon-imagerunner-printer-driver-ufrii' do
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
   license :gratis
 
-  container nested: "UFRII_v#{version}_MAC.dmg"
-
   pkg 'UFRII_LT_LIPS_LX_Installer.pkg'
 
   uninstall pkgutil: 'jp.co.canon.CUPSPrinter.*'

--- a/Casks/capsee.rb
+++ b/Casks/capsee.rb
@@ -7,7 +7,5 @@ cask 'capsee' do
   homepage 'http://www.threemagination.com/capsee/'
   license :gratis
 
-  container nested: "CapSee#{version.no_dots}.dmg"
-
   app 'CapSee.app'
 end

--- a/Casks/captur.rb
+++ b/Casks/captur.rb
@@ -8,7 +8,5 @@ cask 'captur' do
   homepage 'http://cambhlumbulunk.blogspot.co.uk/p/captur.html'
   license :gratis
 
-  container nested: "captur-#{version}.dmg"
-
   app '64 Bit/Captur.app'
 end

--- a/Casks/cockatrice.rb
+++ b/Casks/cockatrice.rb
@@ -10,8 +10,6 @@ cask 'cockatrice' do
   homepage 'http://www.woogerworks.com/'
   license :gpl
 
-  container nested: "Cockatrice_#{version.after_comma}_osx.dmg"
-
   app 'cockatrice.app'
   app 'oracle.app'
   app 'servatrice.app'

--- a/Casks/creepy.rb
+++ b/Casks/creepy.rb
@@ -10,7 +10,5 @@ cask 'creepy' do
   homepage 'http://www.geocreepy.com/'
   license :gpl
 
-  container nested: "cree.py #{version.major_minor}.dmg"
-
   app 'cree.py.app'
 end

--- a/Casks/duplicate-annihilator.rb
+++ b/Casks/duplicate-annihilator.rb
@@ -7,7 +7,5 @@ cask 'duplicate-annihilator' do
   homepage 'http://brattoo.com/propaganda/'
   license :commercial
 
-  container nested: 'Duplicate Annihilator.dmg'
-
   app 'Duplicate Annihilator.app'
 end

--- a/Casks/dupscanub.rb
+++ b/Casks/dupscanub.rb
@@ -7,7 +7,5 @@ cask 'dupscanub' do
   homepage 'http://www5.wind.ne.jp/miko/mac_soft/dup_scan/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  container nested: 'DupScanUB_241.dmg'
-
   app 'DupScan(UB).app'
 end

--- a/Casks/fenix.rb
+++ b/Casks/fenix.rb
@@ -10,7 +10,5 @@ cask 'fenix' do
   homepage 'http://fenixwebserver.com/'
   license :gpl
 
-  container nested: "Fenix_#{version}.dmg"
-
   app 'Fenix.app'
 end

--- a/Casks/fluxus.rb
+++ b/Casks/fluxus.rb
@@ -8,7 +8,5 @@ cask 'fluxus' do
   homepage 'http://www.pawfal.org/fluxus/'
   license :gpl
 
-  container nested: "fluxus-#{version}.mac_intel.10.5.dmg"
-
   app 'Fluxus.app'
 end

--- a/Casks/frappe.rb
+++ b/Casks/frappe.rb
@@ -9,7 +9,5 @@ cask 'frappe' do
   homepage 'https://github.com/niftylettuce/frappe'
   license :mit
 
-  container nested: 'Frappé.dmg'
-
   app 'Frappe.app'
 end

--- a/Casks/icefloor.rb
+++ b/Casks/icefloor.rb
@@ -7,7 +7,5 @@ cask 'icefloor' do
   homepage 'http://www.hanynet.com/icefloor/'
   license :oss
 
-  container nested: "IceFloor #{version}.dmg"
-
   app 'IceFloor.app'
 end

--- a/Casks/ilok-license-manager.rb
+++ b/Casks/ilok-license-manager.rb
@@ -1,13 +1,11 @@
 cask 'ilok-license-manager' do
   version '3.0.2_r33217'
-  sha256 '79a2d57359a117887af50356d6c10ace6d0889aa27865bf0ffe5728ea2f059e6'
+  sha256 '7dc4b7abdb5ee5cbcd0ff7cc42add6efbdce12253fabc4d12a9215072306a9de'
 
   url 'http://installers.ilok.com/iloklicensemanager/LicenseSupportInstallerMac.zip'
   name 'iLok License Manager'
   homepage 'https://ilok.com/#!license-manager'
   license :gratis
-
-  container nested: "LicenseSupportInstallerMac_v#{version}.dmg"
 
   pkg 'License Support.pkg'
 

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -7,9 +7,6 @@ cask 'intel-power-gadget' do
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
   license :gratis
 
-  # this bogus-looking character accurately reflects an upstream error
-  container nested: "Intel® Power Gadget v#{version}.dmg"
-
   pkg 'Install Intel Power Gadget.pkg'
 
   uninstall pkgutil: 'com.intel.pkg.PowerGadget.*'

--- a/Casks/jetphoto-studio.rb
+++ b/Casks/jetphoto-studio.rb
@@ -7,7 +7,5 @@ cask 'jetphoto-studio' do
   homepage 'http://www.jetphotosoft.com/web/home/'
   license :freemium
 
-  container nested: "JetPhoto Studio #{version}.dmg"
-
   app 'JetPhoto Studio.app'
 end

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -1,14 +1,12 @@
 cask 'klayout' do
-  version '0.24.7'
-  sha256 'c986ede1d0950294b1c3f94fe174927cfee2af82fe21ac03a5b15d5abc6b6385'
+  version '0.24.8'
+  sha256 '95b38f338b76636fc3fa840b747fc3a62dd9335a69163996fd741f289c62f40e'
 
   # klayout.org was verified as official when first introduced to the cask
   url "http://www.klayout.org/downloads/klayout-#{version}-MacOSX-Yosemite-1-Qt487mp.dmg.bz2"
   name 'KLayout'
   homepage 'http://www.klayout.de/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
-
-  container nested: "#{token}-#{version}.dmg"
 
   suite '.', target: 'KLayout'
 

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -8,7 +8,9 @@ cask 'klayout' do
   homepage 'http://www.klayout.de/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  pkg "klayout.#{version}.pkg"
+  container nested: "#{token}-#{version}.dmg"
+
+  suite '.', target: 'KLayout'
 
   uninstall pkgutil: 'klayout.de',
             quit:    'klayout.de'

--- a/Casks/macmoney.rb
+++ b/Casks/macmoney.rb
@@ -7,7 +7,5 @@ cask 'macmoney' do
   homepage 'http://www.devon.riceball.net/display.php?file=m01'
   license :commercial
 
-  container nested: "MacMoney_#{version}.dmg"
-
   app 'MacMoney.app'
 end

--- a/Casks/mailfollowup.rb
+++ b/Casks/mailfollowup.rb
@@ -30,8 +30,6 @@ cask 'mailfollowup' do
   homepage 'https://www.cs.unc.edu/~welch/MailFollowup/'
   license :gratis
 
-  container nested: "MailFollowUp_#{version}.dmg"
-
   pkg 'Install MailFollowUp.pkg'
 
   uninstall quit:    'com.apple.mail',

--- a/Casks/massreplaceit.rb
+++ b/Casks/massreplaceit.rb
@@ -7,7 +7,5 @@ cask 'massreplaceit' do
   homepage 'http://www.hexmonkeysoftware.com/'
   license :gratis
 
-  container nested: 'MassReplaceIt.dmg'
-
   app 'MassReplaceIt.app'
 end

--- a/Casks/menucalendarclock-ical.rb
+++ b/Casks/menucalendarclock-ical.rb
@@ -9,7 +9,7 @@ cask 'menucalendarclock-ical' do
   homepage 'http://www.objectpark.net/en/mcc.html'
   license :freemium
 
-  container nested: "menucalendarclock-ical-#{version}"
+  container nested: "#{token}-#{version}.dmg"
 
   app 'MenuCalendarClock iCal.app'
 end

--- a/Casks/menucalendarclock-ical.rb
+++ b/Casks/menucalendarclock-ical.rb
@@ -9,7 +9,5 @@ cask 'menucalendarclock-ical' do
   homepage 'http://www.objectpark.net/en/mcc.html'
   license :freemium
 
-  container nested: "#{token}-#{version}.dmg"
-
   app 'MenuCalendarClock iCal.app'
 end

--- a/Casks/menuola.rb
+++ b/Casks/menuola.rb
@@ -9,7 +9,5 @@ cask 'menuola' do
   homepage 'https://www.geocom.co.nz'
   license :gratis
 
-  container nested: 'Menuola.dmg'
-
   app 'Menuola.app'
 end

--- a/Casks/murus.rb
+++ b/Casks/murus.rb
@@ -8,7 +8,6 @@ cask 'murus' do
   license :freemium
 
   depends_on macos: '>= :mavericks'
-  container nested: "Murus #{version}.dmg"
 
   app 'Murus.app'
 end

--- a/Casks/nanostudio.rb
+++ b/Casks/nanostudio.rb
@@ -7,8 +7,6 @@ cask 'nanostudio' do
   homepage 'http://www.blipinteractive2.co.uk/'
   license :commercial
 
-  container nested: "NanoStudio-#{version}.dmg"
-
   app 'NanoStudio.app'
   app 'NanoStudio-Phone.app'
   app 'NanoStudio-Tablet.app'

--- a/Casks/nook.rb
+++ b/Casks/nook.rb
@@ -7,7 +7,5 @@ cask 'nook' do
   homepage 'http://www.barnesandnoble.com/u/nook-for-mac/379003592/'
   license :gratis
 
-  container nested: 'NOOK for Mac.dmg'
-
   app 'NookForMac.app'
 end

--- a/Casks/ntfsmounter.rb
+++ b/Casks/ntfsmounter.rb
@@ -7,7 +7,5 @@ cask 'ntfsmounter' do
   homepage 'http://ntfsmounter.com/'
   license :gratis
 
-  container nested: "NTFS Mounter #{version}.dmg"
-
   app 'ntfsMounter.app'
 end

--- a/Casks/people-plus-content-ip.rb
+++ b/Casks/people-plus-content-ip.rb
@@ -7,7 +7,5 @@ cask 'people-plus-content-ip' do
   homepage 'http://www.polycom.co.uk/products-services/hd-telepresence-video-conferencing/realpresence-accessories/people-content-ip.html#stab1'
   license :gratis
 
-  container nested: "PPCIPmac_v#{version}.dmg"
-
   app 'People + Content IP.app'
 end

--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -7,8 +7,5 @@ cask 'raw-photo-processor' do
   homepage 'https://www.raw-photo-processor.com/RPP/Overview.html'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  # note: this value changes with each version
-  container nested: 'RPP480_1703_64.dmg'
-
   app 'Raw Photo Processor 64.app'
 end

--- a/Casks/refresh-finder.rb
+++ b/Casks/refresh-finder.rb
@@ -7,7 +7,5 @@ cask 'refresh-finder' do
   homepage 'http://soderhavet.com/refresh/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  container nested: "Refresh_Finder_#{version}.dmg"
-
   app 'Refresh Finder.app'
 end

--- a/Casks/scythebill.rb
+++ b/Casks/scythebill.rb
@@ -8,8 +8,6 @@ cask 'scythebill' do
   homepage 'http://www.scythebill.com/'
   license :apache
 
-  container nested: "Scythebill #{version}.dmg"
-
   app 'Scythebill.app'
 
   caveats do

--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -7,7 +7,5 @@ cask 'sharetool' do
   homepage 'https://www.bainsware.com'
   license :gratis
 
-  container nested: "ShareTool #{version.major}.dmg"
-
   app 'ShareTool.app'
 end

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -8,8 +8,6 @@ cask 'silicon-labs-vcp-driver' do
   homepage 'https://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx'
   license :gratis
 
-  container nested: 'SiLabsUSBDriverDisk.dmg'
-
   pkg 'Silicon Labs VCP Driver.pkg'
 
   uninstall pkgutil: 'com.silabs.siliconLabsVcpDriver.*'

--- a/Casks/silo.rb
+++ b/Casks/silo.rb
@@ -7,7 +7,5 @@ cask 'silo' do
   homepage 'https://nevercenter.com/silo/'
   license :commercial
 
-  container nested: "Install_Silo_#{version.dots_to_underscores}_mac.dmg"
-
   app "Silo #{version.sub(%r{^(\d+\.\d+).*}, '\1')}.app"
 end

--- a/Casks/smart-trash.rb
+++ b/Casks/smart-trash.rb
@@ -1,6 +1,6 @@
 cask 'smart-trash' do
   version '2.0.5'
-  sha256 'ee1fa4ddfb954b024de02fc84ca8adb316242d0836edf904c0e22120cb7a6021'
+  sha256 'c3e3dd27985446efb9874ea58818dd9c0d8a5a2f1a20ce0d91c0b30b875e91e6'
 
   url 'https://www.hyperbolicsoftware.com/programs/SmartTrash2.zip'
   appcast 'https://www.hyperbolicsoftware.com/Receipts/Smart_Trash/SmartTrashUpdate.xml',
@@ -8,8 +8,6 @@ cask 'smart-trash' do
   name 'Smart Trash'
   homepage 'https://www.hyperbolicsoftware.com/SmartTrash.html'
   license :commercial
-
-  container nested: 'SmartTrash2.dmg'
 
   app 'Smart Trash.app'
 end

--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -8,7 +8,7 @@ cask 'snes9x' do
   homepage 'http://www.snes9x.com/'
   license :other
 
-  container nested: "snes9x-#{version}"
+  container nested: "#{token}-#{version}.dmg"
 
   app 'Snes9x.app'
 end

--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -8,7 +8,5 @@ cask 'snes9x' do
   homepage 'http://www.snes9x.com/'
   license :other
 
-  container nested: "#{token}-#{version}.dmg"
-
   app 'Snes9x.app'
 end

--- a/Casks/switch.rb
+++ b/Casks/switch.rb
@@ -7,7 +7,5 @@ cask 'switch' do
   homepage 'http://www.nch.com.au/switch/'
   license :closed
 
-  container nested: 'Switch_i.dmg'
-
   app 'Switch.app'
 end

--- a/Casks/thumbsup.rb
+++ b/Casks/thumbsup.rb
@@ -8,7 +8,5 @@ cask 'thumbsup' do
   homepage 'http://www.devontechnologies.com/products/freeware.html#c966'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  container nested: 'ThumbsUp.dmg'
-
   app 'ThumbsUp.app'
 end

--- a/Casks/timeedition.rb
+++ b/Casks/timeedition.rb
@@ -10,8 +10,6 @@ cask 'timeedition' do
   homepage 'https://www.timeedition.com/old/en/'
   license :gpl
 
-  container nested: "timeEdition#{version}-macosx.dmg"
-
   app "timeEdition #{version}/timeEdition.app"
 
   caveats do

--- a/Casks/timemachinescheduler.rb
+++ b/Casks/timemachinescheduler.rb
@@ -9,7 +9,5 @@ cask 'timemachinescheduler' do
   homepage 'http://www.klieme.com/TimeMachineScheduler.html'
   license :gratis
 
-  container nested: 'TimeMachineScheduler3_Installer.dmg'
-
   prefpane 'TimeMachineScheduler3_Installer.app/Contents/Resources/TimeMachineScheduler.prefPane'
 end

--- a/Casks/tn5250.rb
+++ b/Casks/tn5250.rb
@@ -7,7 +7,5 @@ cask 'tn5250' do
   homepage 'http://mochasoft.dk'
   license :commercial
 
-  container nested: 'tn5250.dmg'
-
   app 'tn5250.app'
 end

--- a/Casks/virtual-mix-rack.rb
+++ b/Casks/virtual-mix-rack.rb
@@ -7,7 +7,5 @@ cask 'virtual-mix-rack' do
   homepage 'http://www.slatedigital.com/products/virtual-mix-rack/'
   license :commercial
 
-  container nested: "Slate Digital - VMR Complete Bundle Installer - #{version} - Mac.dmg"
-
   pkg 'Install Virtual Mix Rack.pkg'
 end

--- a/Casks/waterroof.rb
+++ b/Casks/waterroof.rb
@@ -7,7 +7,5 @@ cask 'waterroof' do
   homepage 'http://www.hanynet.com/waterroof/'
   license :oss
 
-  container nested: "WaterRoof #{version}.dmg"
-
   app 'WaterRoof.app'
 end

--- a/lib/hbc/container/base.rb
+++ b/lib/hbc/container/base.rb
@@ -4,4 +4,15 @@ class Hbc::Container::Base
     @path = path
     @command = command
   end
+
+  def extract_nested(source)
+    container = Hbc::Container.for_path(source, @command)
+
+    return false unless container
+
+    ohai "Extracting nested container #{source.basename}"
+    container.new(@cask, source, @command).extract
+
+    true
+  end
 end

--- a/lib/hbc/container/bzip2.rb
+++ b/lib/hbc/container/bzip2.rb
@@ -8,8 +8,15 @@ class Hbc::Container::Bzip2 < Hbc::Container::Base
   def extract
     Dir.mktmpdir do |unpack_dir|
       @command.run!("/usr/bin/ditto",   args: ["--", @path, unpack_dir])
-      @command.run!("/usr/bin/bunzip2", args: ["-q", "--", Pathname(unpack_dir).join(@path.basename)])
-      @command.run!("/usr/bin/ditto",   args: ["--", unpack_dir, @cask.staged_path])
+      @command.run!("/usr/bin/bunzip2", args: ["--quiet", "--", Pathname.new(unpack_dir).join(@path.basename)])
+
+      src = Pathname.new(unpack_dir).children[0]
+
+      unless @cask.artifacts[:nested_container].empty? &&
+             extract_nested(src)
+        dest = @cask.staged_path.join(src.relative_path_from(Pathname.new(unpack_dir)))
+        FileUtils.mv(src, dest, force: true)
+      end
     end
   end
 end

--- a/lib/hbc/container/criteria.rb
+++ b/lib/hbc/container/criteria.rb
@@ -12,7 +12,7 @@ class Hbc::Container::Criteria
 
   def magic_number(regex)
     # 262: length of the longest regex (currently: Hbc::Container::Tar)
-    @magic_number ||= File.open(path, "rb") { |f| f.read(262) }
+    @magic_number ||= File.open(@path, "rb") { |f| f.read(262) }
     @magic_number =~ regex
   end
 end

--- a/lib/hbc/container/gzip.rb
+++ b/lib/hbc/container/gzip.rb
@@ -8,8 +8,15 @@ class Hbc::Container::Gzip < Hbc::Container::Base
   def extract
     Dir.mktmpdir do |unpack_dir|
       @command.run!("/usr/bin/ditto",  args: ["--", @path, unpack_dir])
-      @command.run!("/usr/bin/gunzip", args: ["-q", "--", Pathname(unpack_dir).join(@path.basename)])
-      @command.run!("/usr/bin/ditto",  args: ["--", unpack_dir, @cask.staged_path])
+      @command.run!("/usr/bin/gunzip", args: ["--quiet", "--", Pathname.new(unpack_dir).join(@path.basename)])
+
+      src = Pathname.new(unpack_dir).children[0]
+
+      unless @cask.artifacts[:nested_container].empty? &&
+             extract_nested(src)
+        dest = @cask.staged_path.join(src.relative_path_from(Pathname.new(unpack_dir)))
+        FileUtils.mv(src, dest, force: true)
+      end
     end
   end
 end

--- a/lib/hbc/container/zip.rb
+++ b/lib/hbc/container/zip.rb
@@ -4,6 +4,23 @@ class Hbc::Container::Zip < Hbc::Container::Base
   end
 
   def extract
-    @command.run!("/usr/bin/ditto", args: ["-x", "-k", "--", @path, @cask.staged_path])
+    Dir.mktmpdir do |unpack_dir|
+      @command.run!("/usr/bin/ditto", args: ["-x", "-k", "--", @path, unpack_dir])
+
+      children = Pathname.new(unpack_dir).children
+
+      nested_container = children[0]
+
+      unless children.count == 1 &&
+             !nested_container.directory? &&
+             @cask.artifacts[:nested_container].empty? &&
+             extract_nested(nested_container)
+        children.each do |src|
+          dest = @cask.staged_path.join(src.relative_path_from(Pathname.new(unpack_dir)))
+          FileUtils.rm_r(dest) if dest.exist?
+          FileUtils.mv(src, dest, force: true)
+        end
+      end
+    end
   end
 end

--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -174,9 +174,7 @@ class Hbc::CurlDownloadStrategy < Hbc::AbstractDownloadStrategy
   end
 
   def ext
-    # We need a Pathname because we've monkeypatched extname to support double
-    # extensions (e.g. tar.gz). -- todo actually that monkeypatch has been removed
-    Pathname.new(@url).extname[%r{[^?]+}]
+    Pathname.new(@url).extname
   end
 end
 

--- a/lib/hbc/extend/pathname.rb
+++ b/lib/hbc/extend/pathname.rb
@@ -1,6 +1,13 @@
 require "pathname"
 
 class Pathname
+  # extended to support common double extensions
+  def extname(path = to_s)
+    %r{(\.(dmg|tar|cpio|pax)\.(gz|bz2|lz|xz|Z|zip))$} =~ path
+    return Regexp.last_match(1) if Regexp.last_match(1)
+    File.extname(path)
+  end
+
   # https://bugs.ruby-lang.org/issues/9915
   if RUBY_VERSION == "2.0.0"
     prepend Module.new {


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---
### Changes

Added support to auto-detect nested containers. The most common ones are archived `.dmg`s (`.dmg.zip`, `.dmg.gz`, `.dmg.bz2`). If a cask has `container nested:` set, auto-detection is disabled.

---

This depends on https://github.com/caskroom/homebrew-cask/pull/23321, as otherwise the KLayout  `suite` will contain the `dmg`.
