### PR TITLE
Revert dockertoolbox.rb file name (Closes #23330)

### DIFF
--- a/Casks/dockertoolbox.rb
+++ b/Casks/dockertoolbox.rb
@@ -1,4 +1,4 @@
-cask 'docker-toolbox' do
+cask 'dockertoolbox' do
   version '1.12.0'
   sha256 'b06cfd858b805dd5e2bfd88cf780953ba6f326d69c4e689ad69c6d49e6cc694f'
 


### PR DESCRIPTION
Revert file-name changes introduced by https://github.com/caskroom/homebrew-cask/commit/1cfbf12dd8233f6e5720eba271e9aa8ff440a7c7

Only the file name and the relevant line in the `.rb` file were edited to remove the hyphen.
