### PR TITLE
Dusty dependency conflict

### DIFF
--- a/Casks/dusty.rb
+++ b/Casks/dusty.rb
@@ -9,7 +9,7 @@ cask 'dusty' do
   homepage 'https://github.com/gamechanger/dusty'
   license :mit
 
-  depends_on cask: 'dockertoolbox'
+  depends_on cask: 'docker-toolbox'
   container type: :tar
 
   installer script:       'brew-install.sh',


### PR DESCRIPTION
When trying to install dusty it crashed due to an unmet dependency: `dockertoolbox`,
which has recently been renamed to `docker-toolbox` in this PR https://github.com/caskroom/homebrew-cask/pull/20540 

Here we fix that dependency that allows dusty to be installed without any problems.
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download dusty` is error-free.
- [x] `brew cask style --fix dusty` left no offenses.
