### PR TITLE
updated firefox (48.0)

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,10 +1,10 @@
 cask 'firefox' do
-  version '47.0.1'
-  sha256 '37f4b7b6a1fec3eb5225a0d1aed3c3d6979b5cf01748479313f6e384929cdc75'
+  version '48.0'
+  sha256 '2e5d2dac667345a5c640c2026beafde22ab05ce05fa3183bc37998da4c43a5b1'
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: 'c03d2c0ce638c499da24232ddcdbce6b908fd718953440797924bd12b87552cf'
+          checkpoint: '3bcddb4a768718aa1c44067092cefd5b4e0c456dd6a95a236bf4e438f2d7b8d8'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/en-US/firefox/'
   license :mpl


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
