### PR TITLE
Change message passed to `CurlDownloadStrategyError`.

### DIFF
--- a/lib/hbc/download_strategy.rb
+++ b/lib/hbc/download_strategy.rb
@@ -109,12 +109,10 @@ class Hbc::CurlDownloadStrategy < Hbc::AbstractDownloadStrategy
           temporary_path.unlink
           had_incomplete_download = false
           retry
-        elsif @url =~ %r{^file://}
-          msg = "File does not exist: #{@url.sub(%r{^file://}, '')}"
-        else
-          msg = "Download failed: #{@url}"
-          msg << "\nThe incomplete download is cached at #{tarball_path}"
         end
+
+        msg = @url
+        msg.concat("\nThe incomplete download is cached at #{temporary_path}") if temporary_path.exist?
         raise CurlDownloadStrategyError, msg
       end
       ignore_interrupts { temporary_path.rename(tarball_path) }


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

The [`CurlDownloadStrategyError` class from Hombrew](https://github.com/Homebrew/brew/blob/81b034a577e9847b7d0db00b4f014216a4e06dae/Library/Homebrew/exceptions.rb#L431-L441) already has logic to detect `file://` links and output the approriate message.
