### PR TITLE
Make cask `versions` method more robust.

### DIFF
--- a/lib/hbc/cask.rb
+++ b/lib/hbc/cask.rb
@@ -64,21 +64,15 @@ class Hbc::Cask
     subdir
   end
 
-  def version_comparator
-    proc do |x, y|
-      begin
-        x_version  =  Gem::Version.new(x)
-        x_version <=> Gem::Version.new(y)
-      rescue ArgumentError
-        x <=> y
-      end
-    end
+  def timestamped_versions
+    Pathname.glob(metadata_master_container_path.join("*", "*"))
+            .map { |p| p.relative_path_from(metadata_master_container_path) }
+            .sort_by(&:basename) # sort by timestamp
+            .map(&:split)
   end
 
   def versions
-    Pathname.glob(metadata_master_container_path.join("*"))
-            .map { |p| p.basename.to_s }
-            .sort(&version_comparator)
+    timestamped_versions.map(&:first).uniq
   end
 
   def installed?

--- a/lib/hbc/cli/list.rb
+++ b/lib/hbc/cli/list.rb
@@ -55,7 +55,7 @@ class Hbc::CLI::List < Hbc::CLI::Base
     if @options[:one]
       puts columns
     elsif @options[:versions]
-      installed_casks.each { |cask| puts "#{cask} #{cask.versions.reverse.join(', ')}" }
+      installed_casks.each { |cask| puts "#{cask} #{cask.versions.join(' ')}" }
     elsif @options[:long]
       puts Hbc::SystemCommand.run!("/bin/ls", args: ["-l", Hbc.caskroom]).stdout
     else


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Sorting versions by timestamp is more robust than a `semver` comparison with fallback.
