### PR TITLE
Fixed docs/wiki: Adding a cask: style check

### DIFF
--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -173,7 +173,7 @@ You should also check stylistic details with `brew cask style`:
 
 ```bash
 $ cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
-$ brew cask style Casks/my-new-cask.rb [--fix]
+$ brew cask style my-new-cask [--fix]
 ```
 
 Keep in mind all of these checks will be made when you submit your PR, so by doing them in advance you’re saving everyone a lot of time and trouble.


### PR DESCRIPTION
Changed `brew cask style Casks/my-new-cask.rb` to working `brew cask style my-new-cask`
