### PR TITLE
Fallback for audacity URL timeout.

### DIFF
--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -9,8 +9,8 @@ cask 'audacity' do
     require 'open-uri'
     # fosshub.com/Audacity.html was verified as official when first introduced to the cask
     open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") do |io|
-      content = io.read
-      %r{^\<iframe.*src=\"(http.*\.dmg)\".*>}.match(content)[1].to_s
+      content = io.read || ''
+      content.scan(%r{^\<iframe.*src=\"(http.*\.dmg)\".*>})[0].to_s
     end
   end
   name 'Audacity'

--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -2,22 +2,43 @@ cask 'audacity' do
   version '2.1.2'
   sha256 '2e4b7d608ecc0d2f79bf16663f085d383075e488f7d50bf7d74c0b69173defe7'
 
+  module Utils
+    require 'open3'
+
+    def self.phantomjs_script(url)
+      <<-EOF.undent
+        new WebPage().open('#{url}', function() {
+          console.log(this.evaluate(function(){try {
+            return document.querySelectorAll('[data^="https://"][data$="/#{File.basename(url)}"]')[0].getAttribute('data')
+          } catch (e) {
+            return ''
+          }}))
+          phantom.exit()
+        })
+      EOF
+    end
+
+    def self.fosshub_url(url)
+      Open3.capture2('phantomjs', '/dev/stdin', stdin_data: phantomjs_script(url))[0]
+    rescue
+      ''
+    end
+  end
+
   url do
     # Audacity does not provide a fixed URL
-    # Their download URL points to a html page that generates a temporary URL embedded within an iframe
-    # 'open-uri' is required to open that page and grab the temporary URL
-    require 'open-uri'
+    # Their download URL points to a html page that generates a temporary URL using JavaScript.
+    # 'phantomjs' is required to render that page
+
     # fosshub.com/Audacity.html was verified as official when first introduced to the cask
-    open("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg") do |io|
-      content = io.read || ''
-      content.scan(%r{^\<iframe.*src=\"(http.*\.dmg)\".*>})[0].to_s
-    end
+    Utils.fosshub_url("http://www.fosshub.com/Audacity.html/audacity-macosx-ub-#{version}.dmg")
   end
   name 'Audacity'
   homepage 'http://audacityteam.org'
   license :gpl
 
   depends_on macos: '>= :snow_leopard'
+  depends_on formula: 'phantomjs'
 
   suite 'Audacity'
 

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -16,6 +16,8 @@ run which bundle
 run bundle --version
 run bundle install --path="${GEM_HOME%/*/*}" --without=debug release test
 
+brew_install phantomjs
+
 if must_run_tests; then
   run bundle install --path="${GEM_HOME%/*/*}" --with=test
 


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

This of course only silences the audit error, but doesn't actually fix the URL. FossHub seems to be using JavaScript to generate the actual download link now.
