### PR TITLE
use secure (https://) URLs where supported (attempt #2)

### DIFF
--- a/Casks/0ad.rb
+++ b/Casks/0ad.rb
@@ -3,7 +3,7 @@ cask '0ad' do
   sha256 '5161cc784fc0a4e11bf48648cf09cb6f5b38afd13a6e32fa484497690e253f86'
 
   # wildfiregames.com was verified as official when first introduced to the cask
-  url "http://releases.wildfiregames.com/0ad-#{version}-osx64.dmg"
+  url "https://releases.wildfiregames.com/0ad-#{version}-osx64.dmg"
   name '0 A.D.'
   homepage 'http://www.play0ad.com/'
   license :oss

--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -5,7 +5,7 @@ cask '115browser' do
   url "http://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'
   name '115浏览器'
-  homepage 'http://pc.115.com/mac.html'
+  homepage 'https://pc.115.com/mac.html'
   license :gratis
 
   app '115Browser.app'

--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -3,7 +3,7 @@ cask '4k-youtube-to-mp3' do
   version '3.0'
   sha256 '29b65a99f64ba5d6a1924df989b3cc1e0b7354fface7b4cbedc02eac17f2bd33'
 
-  url "http://downloads.4kdownload.com/app/4kyoutubetomp3_#{version}.dmg"
+  url "https://downloads.4kdownload.com/app/4kyoutubetomp3_#{version}.dmg"
   name '4K YouTube to MP3'
   homepage 'https://www.4kdownload.com/products/product-youtubetomp3'
   license :oss

--- a/Casks/5kplayer.rb
+++ b/Casks/5kplayer.rb
@@ -2,9 +2,9 @@ cask '5kplayer' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.5kplayer.com/download/5kplayer.dmg'
+  url 'https://www.5kplayer.com/download/5kplayer.dmg'
   name '5KPlayer'
-  homepage 'http://www.5kplayer.com'
+  homepage 'https://www.5kplayer.com'
   license :closed
 
   app '5KPlayer.app'

--- a/Casks/abricotine.rb
+++ b/Casks/abricotine.rb
@@ -7,7 +7,7 @@ cask 'abricotine' do
   appcast 'https://github.com/brrd/Abricotine/releases.atom',
           checkpoint: '1ea84fd733feb1f4bf458b884fa6c3ec46240ee159f002877cc3c1242882e6b6'
   name 'abricotine'
-  homepage 'http://abricotine.brrd.fr'
+  homepage 'https://abricotine.brrd.fr'
   license :gpl
 
   app 'Abricotine-darwin-x64/Abricotine.app'

--- a/Casks/abyss.rb
+++ b/Casks/abyss.rb
@@ -2,9 +2,9 @@ cask 'abyss' do
   version 'x1'
   sha256 '63b0b8d6420a0f65899ea1fa7827f04c8c8b3fa444a9f6361054d6605cf13fed'
 
-  url 'http://www.aprelium.com/data/abwsx1.dmg'
+  url 'https://www.aprelium.com/data/abwsx1.dmg'
   name 'Abyss Web Server'
-  homepage 'http://www.aprelium.com/abyssws'
+  homepage 'https://www.aprelium.com/abyssws'
   license :gratis
 
   app 'Abyss Web Server/Abyss Web Server.app'

--- a/Casks/adware-removal-tool.rb
+++ b/Casks/adware-removal-tool.rb
@@ -2,7 +2,7 @@ cask 'adware-removal-tool' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.bitdefender.com/mac/tools/Adware%20Removal%20Tool.zip'
+  url 'https://download.bitdefender.com/mac/tools/Adware%20Removal%20Tool.zip'
   name 'Bitdefender Adware Removal Tool for Mac'
   homepage 'http://www.bitdefender.com'
   license :gratis

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -4,7 +4,7 @@ cask 'airmedia' do
 
   url "https://www.crestron.com/downloads/software/airmedia_guest_os_x_#{version}.dmg"
   name 'Crestron AirMedia'
-  homepage 'http://www.crestron.com/airmedia'
+  homepage 'https://www.crestron.com/microsites/airmedia-mobile-wireless-hd-presentations'
   license :gratis
 
   app 'AirMedia.app'

--- a/Casks/anytrans.rb
+++ b/Casks/anytrans.rb
@@ -2,9 +2,9 @@ cask 'anytrans' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/anytrans-mac.dmg'
+  url 'https://www.imobie.com/product/anytrans-mac.dmg'
   name 'AnyTrans'
-  homepage 'http://www.imobie.com/anytrans'
+  homepage 'https://www.imobie.com/anytrans'
   license :gratis
 
   app 'AnyTrans.app'

--- a/Casks/apptrans.rb
+++ b/Casks/apptrans.rb
@@ -2,9 +2,9 @@ cask 'apptrans' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/apptrans-mac.dmg'
+  url 'https://www.imobie.com/product/apptrans-mac.dmg'
   name 'AppTrans'
-  homepage 'http://www.imobie.com/apptrans/'
+  homepage 'https://www.imobie.com/apptrans/'
   license :gratis
 
   app 'AppTrans.app'

--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -3,10 +3,10 @@ cask 'appzapper' do
   sha256 'b7d0bdd05cf246a2f2ab18145b052824860cb74a6ae665fba9d403f6bb79fac4'
 
   url "http://www.appzapper.com/downloads/AppZapper#{version}.zip"
-  appcast 'http://www.appzapper.com/az2appcast.xml',
+  appcast 'https://www.appzapper.com/az2appcast.xml',
           checkpoint: 'b91ae47cbd23159ada1e03357647dc3140cd35ef509dfa44ed13e369aad07e88'
   name 'AppZapper'
-  homepage 'http://www.appzapper.com/'
+  homepage 'https://www.appzapper.com/'
   license :commercial
 
   auto_updates true

--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -2,7 +2,7 @@ cask 'appzapper' do
   version '2.0.1'
   sha256 'b7d0bdd05cf246a2f2ab18145b052824860cb74a6ae665fba9d403f6bb79fac4'
 
-  url "http://www.appzapper.com/downloads/AppZapper#{version}.zip"
+  url "https://www.appzapper.com/downloads/AppZapper#{version}.zip"
   appcast 'https://www.appzapper.com/az2appcast.xml',
           checkpoint: 'b91ae47cbd23159ada1e03357647dc3140cd35ef509dfa44ed13e369aad07e88'
   name 'AppZapper'

--- a/Casks/audiobookbinder.rb
+++ b/Casks/audiobookbinder.rb
@@ -2,8 +2,8 @@ cask 'audiobookbinder' do
   version '2.1'
   sha256 'ed0e722cbbbcad8ea305faa10e1f5f08c7719991118d015af132bb9d41f84170'
 
-  url "http://bluezbox.com/audiobookbinder/AudiobookBinder-#{version}.dmg"
-  appcast 'http://bluezbox.com/audiobookbinder/appcast.xml',
+  url "https://bluezbox.com/audiobookbinder/AudiobookBinder-#{version}.dmg"
+  appcast 'https://bluezbox.com/audiobookbinder/appcast.xml',
           checkpoint: '5513a6cc78863fd79e2779794a0767d241a066e1b4bd5cce19ecf5daa34c2306'
   name 'Audiobook Binder'
   homepage 'http://bluezbox.com/audiobookbinder.html'

--- a/Casks/audiobookbinder.rb
+++ b/Casks/audiobookbinder.rb
@@ -6,7 +6,7 @@ cask 'audiobookbinder' do
   appcast 'https://bluezbox.com/audiobookbinder/appcast.xml',
           checkpoint: '5513a6cc78863fd79e2779794a0767d241a066e1b4bd5cce19ecf5daa34c2306'
   name 'Audiobook Binder'
-  homepage 'http://bluezbox.com/audiobookbinder.html'
+  homepage 'https://bluezbox.com/audiobookbinder.html'
   license :oss
 
   app 'AudioBookBinder.app'

--- a/Casks/audiomate.rb
+++ b/Casks/audiomate.rb
@@ -3,7 +3,7 @@ cask 'audiomate' do
   sha256 '1be327d0d98d4884ccb9077f60ac9a6ff8cd10df3c3841fc85fde6866462a43e'
 
   # 9labs.io was verified as official when first introduced to the cask
-  url "http://backend.9labs.io/download/audiomate?version=#{version}"
+  url "https://backend.9labs.io/download/audiomate?version=#{version}"
   appcast 'https://backend.9labs.io/appcast/audiomate',
           checkpoint: '2af94fde8ad6c95ad8d87ebb6c2d6b14dd375917958d774e07b39ecb37685b1e'
   name 'AudioMate'

--- a/Casks/avibrazil-rdm.rb
+++ b/Casks/avibrazil-rdm.rb
@@ -3,7 +3,7 @@ cask 'avibrazil-rdm' do
   sha256 'eed11e9f5879cf67d306d314c266226463808f2c72d3a44fc874288c994ee9e7'
 
   # avi.alkalay.net/software/RDM was verified as official when first introduced to the cask
-  url "http://avi.alkalay.net/software/RDM/RDM-#{version}.pkg"
+  url "https://avi.alkalay.net/software/RDM/RDM-#{version}.pkg"
   name 'RDM'
   homepage 'https://github.com/avibrazil/RDM'
   license :gratis

--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -7,7 +7,7 @@ cask 'avidemux' do
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
           checkpoint: 'e6aa5bb57e6809631178c37bf241d59932eb3c87d904fee0722117968489e500'
   name 'Avidemux'
-  homepage 'http://www.avidemux.org/'
+  homepage 'https://www.avidemux.org/'
   license :gpl
 
   app "Avidemux#{version.major_minor}.app"

--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -4,7 +4,7 @@ cask 'avocode' do
 
   url "http://mediacdn.avocode.com/download/avocode-app/#{version}/avocode-app-mac-#{version}.zip"
   name 'Avocode'
-  homepage 'http://avocode.com/'
+  homepage 'https://avocode.com/'
   license :commercial
 
   app 'Avocode.app'

--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -2,8 +2,8 @@ cask 'base' do
   version '2.4.10'
   sha256 '1a23a8da1be9e9a681d57bb934ac1f2dc8ab569027ec357dbf9324d48fe4fded'
 
-  url "http://files.menial.co.uk/base/base_#{version}.zip"
-  appcast 'http://update.menial.co.uk/software/base/',
+  url "https://files.menial.co.uk/base/base_#{version}.zip"
+  appcast 'https://update.menial.co.uk/software/base/',
           checkpoint: '02f44fba8418545d1abdbcae6dd50fc20d8740eaac1f4b18a4d0aef23e5291ce'
   name 'Menial Base'
   homepage 'http://menial.co.uk/base/'

--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -6,7 +6,7 @@ cask 'base' do
   appcast 'https://update.menial.co.uk/software/base/',
           checkpoint: '02f44fba8418545d1abdbcae6dd50fc20d8740eaac1f4b18a4d0aef23e5291ce'
   name 'Menial Base'
-  homepage 'http://menial.co.uk/base/'
+  homepage 'https://menial.co.uk/base/'
   license :commercial
 
   app 'Base.app'

--- a/Casks/battery-guardian.rb
+++ b/Casks/battery-guardian.rb
@@ -2,7 +2,7 @@ cask 'battery-guardian' do
   version '1.1.0'
   sha256 'cc66f558559e322a84f9815bf5fd13c86815c2dd698336820b9c115746bacc5a'
 
-  url "http://www.dssw.co.uk/batteryguardian/dsswbatteryguardian-#{version.no_dots}.dmg"
+  url "https://www.dssw.co.uk/batteryguardian/dsswbatteryguardian-#{version.no_dots}.dmg"
   appcast 'https://version.dssw.co.uk/batteryguardian/standard',
           checkpoint: '62cb80cfc4b5f02a4a4abea72aa36080b88d4ee73dd2841b9aa13af997df00ef'
   name 'Battery Guardian'

--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -2,7 +2,7 @@ cask 'battery-report' do
   version '1.2.0'
   sha256 '1ad72dc7c73c2a9e0d85b7ee6836348714fe00b51bd6c49352b0c01e40425015'
 
-  url "http://www.dssw.co.uk/batteryreport/dsswbatteryreport-#{version.no_dots}.dmg"
+  url "https://www.dssw.co.uk/batteryreport/dsswbatteryreport-#{version.no_dots}.dmg"
   appcast 'https://version.dssw.co.uk/batteryreport/standard',
           checkpoint: '18be1911eb53fa3d0a20abfaa0ba2a74992eed5bb9bb3fc39b64184537ffb674'
   name 'Battery Report'

--- a/Casks/baygenie.rb
+++ b/Casks/baygenie.rb
@@ -4,7 +4,7 @@ cask 'baygenie' do
 
   url 'https://www.baygenie.com/Download/BayGenie4Mac.dmg'
   name 'BayGenie'
-  homepage 'http://www.baygenie.com/'
+  homepage 'https://www.baygenie.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'BayGenie.app'

--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -2,11 +2,11 @@ cask 'betterzip' do
   version '3.1.2'
   sha256 'eaf686e95876fd2b064cc1a6aba984c7b40b74710c5894c28130ed53a428f049'
 
-  url "http://macitbetter.com/dl/BetterZip-#{version}.zip"
-  appcast 'http://macitbetter.com/BetterZip3.rss',
+  url "https://macitbetter.com/dl/BetterZip-#{version}.zip"
+  appcast 'https://macitbetter.com/BetterZip3.rss',
           checkpoint: 'cc8f405304c66c96a64702a7806bef9e5c5a3f0b393560c95130e1730a38d79f'
   name 'BetterZip'
-  homepage 'http://macitbetter.com'
+  homepage 'https://macitbetter.com'
   license :commercial
 
   app 'BetterZip.app'

--- a/Casks/betterzipql.rb
+++ b/Casks/betterzipql.rb
@@ -2,9 +2,9 @@ cask 'betterzipql' do
   version :latest
   sha256 :no_check
 
-  url 'http://macitbetter.com/BetterZipQL.zip'
+  url 'https://macitbetter.com/BetterZipQL.zip'
   name 'BetterZipQL'
-  homepage 'http://macitbetter.com/BetterZip-Quick-Look-Generator/'
+  homepage 'https://macitbetter.com/BetterZip-Quick-Look-Generator/'
   license :gratis
 
   qlplugin 'BetterZipQL.qlgenerator'

--- a/Casks/bill.rb
+++ b/Casks/bill.rb
@@ -3,9 +3,9 @@ cask 'bill' do
   sha256 :no_check
 
   # myownapp.com was verified as official when first introduced to the cask
-  url 'http://myownapp.com/downloads/Bill2.zip'
+  url 'https://myownapp.com/downloads/Bill2.zip'
   name 'Bill'
-  homepage 'http://billtheapp.com/'
+  homepage 'https://billtheapp.com/'
   license :commercial
 
   app 'Bill 2.app'

--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -4,7 +4,7 @@ cask 'blackvue-viewer' do
 
   url "http://www.blackvue.com/en/common/downloadHIT.asp?downfile=BlackVue%20Viewer_#{version.major_minor}.app.zip&path=board&idx=2052"
   name 'BlackVue Viewer'
-  homepage 'http://blackvue.com'
+  homepage 'https://blackvue.com'
   license :closed
 
   app "BlackVue Viewer_#{version}.app"

--- a/Casks/bmglyph.rb
+++ b/Casks/bmglyph.rb
@@ -2,8 +2,8 @@ cask 'bmglyph' do
   version '2.2.0'
   sha256 'b4e42720274ec4825651d5e6376c7e9d80d62770edd5d9f4dc5dc8e24f3fe3fe'
 
-  url "http://www.bmglyph.com/application/bmGlyph.#{version}.zip"
-  appcast 'http://www.bmglyph.com/application/bmGlyphVersion.xml',
+  url "https://www.bmglyph.com/application/bmGlyph.#{version}.zip"
+  appcast 'https://www.bmglyph.com/application/bmGlyphVersion.xml',
           checkpoint: 'a758ecf728343284d3271c230483f31ba5c0165e79c0462c83690a9b7fe0039e'
   name 'bmGlyph'
   homepage 'http://www.bmglyph.com/'

--- a/Casks/bmglyph.rb
+++ b/Casks/bmglyph.rb
@@ -6,7 +6,7 @@ cask 'bmglyph' do
   appcast 'https://www.bmglyph.com/application/bmGlyphVersion.xml',
           checkpoint: 'a758ecf728343284d3271c230483f31ba5c0165e79c0462c83690a9b7fe0039e'
   name 'bmGlyph'
-  homepage 'http://www.bmglyph.com/'
+  homepage 'https://www.bmglyph.com/'
   license :commercial
 
   depends_on macos: '>= :mountain_lion'

--- a/Casks/brainworx-bxmegasingle.rb
+++ b/Casks/brainworx-bxmegasingle.rb
@@ -2,7 +2,7 @@ cask 'brainworx-bxmegasingle' do
   version '1.3'
   sha256 '92b6393ec946840cccfe3cfe06318629c3a467d608f67480bef7ebc272ba1071'
 
-  url "http://cdn.plugin-alliance.com/tl_files/products/installer/bx_megasingle_mac_#{version.dots_to_underscores}.zip"
+  url "https://cdn.plugin-alliance.com/tl_files/products/installer/bx_megasingle_mac_#{version.dots_to_underscores}.zip"
   name 'Brainworx bx_megasingle'
   homepage 'https://www.plugin-alliance.com/en/products/bx_megasingle.html'
   license :commercial

--- a/Casks/brow.rb
+++ b/Casks/brow.rb
@@ -2,9 +2,9 @@ cask 'brow' do
   version '1.0'
   sha256 'f646b89e63853edab7dfae701f10074b0b966f624d2c1e412f0c07cdeeff2eeb'
 
-  url 'http://www.timschroeder.net/brow/brow.zip'
+  url 'https://www.timschroeder.net/brow/brow.zip'
   name 'Brow'
-  homepage 'http://www.timschroeder.net/brow/'
+  homepage 'https://www.timschroeder.net/brow/'
   license :gratis
 
   app 'Brow.app'

--- a/Casks/busycal.rb
+++ b/Casks/busycal.rb
@@ -2,9 +2,9 @@ cask 'busycal' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.busymac.com/download/BusyCal.zip'
+  url 'https://www.busymac.com/download/BusyCal.zip'
   name 'BusyCal'
-  homepage 'http://busymac.com/busycal/index.html'
+  homepage 'https://busymac.com/busycal/index.html'
   license :commercial
 
   pkg 'BusyCal Installer.pkg'

--- a/Casks/busycontacts.rb
+++ b/Casks/busycontacts.rb
@@ -2,9 +2,9 @@ cask 'busycontacts' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.busymac.com/download/BusyContacts.zip'
+  url 'https://www.busymac.com/download/BusyContacts.zip'
   name 'BusyContacts'
-  homepage 'http://www.busymac.com/busycontacts/index.html'
+  homepage 'https://www.busymac.com/busycontacts/index.html'
   license :commercial
 
   pkg 'BusyContacts Installer.pkg'

--- a/Casks/butler.rb
+++ b/Casks/butler.rb
@@ -3,7 +3,7 @@ cask 'butler' do
   sha256 '067f39107d7b761f19216266fcea8109ddd3f666f31bab09651248d5414b5a9a'
 
   url 'https://manytricks.com/download/butler'
-  appcast 'http://manytricks.com/butler/butlercast.xml',
+  appcast 'https://manytricks.com/butler/butlercast.xml',
           checkpoint: 'd1174d6d7f7908cc657b52024197057f6eb5e4d63f332329703658ff315c04a5'
   name 'Butler'
   homepage 'https://manytricks.com/butler/'

--- a/Casks/butt.rb
+++ b/Casks/butt.rb
@@ -7,7 +7,7 @@ cask 'butt' do
   appcast 'https://sourceforge.net/projects/butt/rss',
           checkpoint: 'debc4e427e1f5c13678eb8301f23e13d07a75bb163216aa41e522c1f06816634'
   name 'Broadcast Using This Tool'
-  homepage 'http://danielnoethen.de/'
+  homepage 'https://danielnoethen.de/'
   license :gpl
 
   app 'butt.app'

--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -2,7 +2,7 @@ cask 'camtasia' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.techsmith.com/camtasiamac/enu/Camtasia.dmg'
+  url 'https://download.techsmith.com/camtasiamac/enu/Camtasia.dmg'
   name 'Camtasia'
   homepage 'https://www.techsmith.com/camtasia.html'
   license :commercial

--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -7,7 +7,7 @@ cask 'caret' do
   appcast 'https://github.com/careteditor/caret/releases.atom',
           checkpoint: 'cec541f4991c7b7ff7a5e437a61ae8c3227df5076397988481b3990ad1ace8b4'
   name 'Caret'
-  homepage 'http://caret.io/'
+  homepage 'https://caret.io/'
   license :commercial
 
   app 'Caret.app'

--- a/Casks/cashculator.rb
+++ b/Casks/cashculator.rb
@@ -2,8 +2,8 @@ cask 'cashculator' do
   version '1.3.7'
   sha256 '81b9be9131bcabd87a2c740028e5511b2f3db25abc15acc401cf7df62df12e30'
 
-  url "http://dl.apparentsoft.com/Cashculator_#{version}.dmg"
-  appcast 'http://dl.apparentsoft.com/cashculator.rss',
+  url "https://dl.apparentsoft.com/Cashculator_#{version}.dmg"
+  appcast 'https://dl.apparentsoft.com/cashculator.rss',
           checkpoint: 'c5f684fdba54e32ba054459ec44f052bc76db4943bd284086516f351f50f902d'
   name 'Cashculator'
   homepage 'http://www.apparentsoft.com/cashculator'

--- a/Casks/cashculator.rb
+++ b/Casks/cashculator.rb
@@ -6,7 +6,7 @@ cask 'cashculator' do
   appcast 'https://dl.apparentsoft.com/cashculator.rss',
           checkpoint: 'c5f684fdba54e32ba054459ec44f052bc76db4943bd284086516f351f50f902d'
   name 'Cashculator'
-  homepage 'http://www.apparentsoft.com/cashculator'
+  homepage 'https://www.apparentsoft.com/cashculator'
   license :freemium
 
   app 'Cashculator.app'

--- a/Casks/cellprofiler.rb
+++ b/Casks/cellprofiler.rb
@@ -3,7 +3,7 @@ cask 'cellprofiler' do
   sha256 :no_check
 
   # cellprofiler-org.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'http://cellprofiler-org.s3.amazonaws.com/CellProfiler.dmg'
+  url 'https://cellprofiler-org.s3.amazonaws.com/CellProfiler.dmg'
   name 'CellProfiler'
   homepage 'http://cellprofiler.org'
   license :oss

--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -2,7 +2,7 @@ cask 'choosy' do
   version '1.1'
   sha256 'c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c'
 
-  url "http://downloads.choosyosx.com/choosy_#{version}.zip"
+  url "https://downloads.choosyosx.com/choosy_#{version}.zip"
   appcast 'http://www.choosyosx.com/sparkle/feed',
           checkpoint: '588d73c48a23dc024ddd2b16029e989a731c7c53012bc87e46fb66fb8b807d95'
   name 'Choosy'

--- a/Casks/chronoagent.rb
+++ b/Casks/chronoagent.rb
@@ -2,7 +2,7 @@ cask 'chronoagent' do
   version :latest
   sha256 :no_check
 
-  url 'http://downloads.econtechnologies.com/CA_Mac_Download.dmg'
+  url 'https://downloads.econtechnologies.com/CA_Mac_Download.dmg'
   name 'ChronoAgent'
   homepage 'https://www.econtechnologies.com'
   license :commercial

--- a/Casks/chronosync.rb
+++ b/Casks/chronosync.rb
@@ -2,7 +2,7 @@ cask 'chronosync' do
   version :latest
   sha256 :no_check
 
-  url 'http://downloads.econtechnologies.com/CS4_Download.dmg'
+  url 'https://downloads.econtechnologies.com/CS4_Download.dmg'
   name 'ChronoSync'
   homepage 'https://www.econtechnologies.com'
   license :commercial

--- a/Casks/circle-wavetable-generator.rb
+++ b/Casks/circle-wavetable-generator.rb
@@ -4,7 +4,7 @@ cask 'circle-wavetable-generator' do
 
   url 'http://futureaudioworkshop.com/downloads/extras/Circle-Wavetable-Generator.dmg'
   name 'Future Audio Workshop Circle Wavetable Generator'
-  homepage 'http://www.futureaudioworkshop.com/circle/downloads/'
+  homepage 'https://www.futureaudioworkshop.com/circle/downloads/'
   license :commercial
 
   app 'Circle Wavetable Generator.app'

--- a/Casks/clarify.rb
+++ b/Casks/clarify.rb
@@ -3,7 +3,7 @@ cask 'clarify' do
   sha256 '454bff1e655bd8aee1c5bcb3c85339b2d09a386637b1cdb0246ab849c6283654'
 
   url "http://files.clarify-it.com/v#{version.major}/updaters/#{version}/Clarify.app.zip"
-  appcast 'http://www.bluemangolearning.com/download/clarify/2_0/auto_update/release/clarify_appcast.xml',
+  appcast 'https://www.bluemangolearning.com/download/clarify/2_0/auto_update/release/clarify_appcast.xml',
           checkpoint: 'f72c5dca89003ee282774a04865e98f0f8c02ba3e13913aa428ea3fa6b9a9adc'
   name 'Clarify'
   homepage 'http://www.clarify-it.com/'

--- a/Casks/cloudera-hive-odbc.rb
+++ b/Casks/cloudera-hive-odbc.rb
@@ -4,7 +4,7 @@ cask 'cloudera-hive-odbc' do
 
   url "https://downloads.cloudera.com/connectors/hive-#{version}.1006/MacOSX/ClouderaHiveODBC.dmg"
   name 'Cloudera ODBC Driver for Hive'
-  homepage 'http://www.cloudera.com'
+  homepage 'https://www.cloudera.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'ClouderaHiveODBC.pkg'

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -3,43 +3,43 @@ cask 'cocktail' do
     version '5.1'
     sha256 '630fc5236e95d5ec36c0de4b487f8ece76d8f02ecd00ec4b37124ddd0eed0f34'
 
-    url "http://www.maintain.se/downloads/sparkle/snowleopard/Cocktail_#{version}.zip"
-    appcast 'http://www.maintain.se/downloads/sparkle/snowleopard/snowleopard.xml',
+    url "https://www.maintain.se/downloads/sparkle/snowleopard/Cocktail_#{version}.zip"
+    appcast 'https://www.maintain.se/downloads/sparkle/snowleopard/snowleopard.xml',
             checkpoint: '3fb0fdcd252f0d0898076a66c3ad3ef045590a82abc9c9789bc1d7fdd0dc21f0'
   elsif MacOS.release == :lion
     version '5.6'
     sha256 '9fa8ff2ade1face0a1a36baf36cfa384535179b261716c18538b0102f281ee60'
 
     url "http://www.maintain.se/downloads/sparkle/lion/Cocktail_#{version}.zip"
-    appcast 'http://www.maintain.se/downloads/sparkle/lion/lion.xml',
+    appcast 'https://www.maintain.se/downloads/sparkle/lion/lion.xml',
             checkpoint: '81397ad4229e65572fb5386f445e7ecfdfc2161c51ce85747d2b4768b419984e'
   elsif MacOS.release == :mountain_lion
     version '6.9'
     sha256 '309bac603a6ded301e9cc61b32bb522fc3a5208973cbd6c6f1a09d0e2c78d1e6'
 
     url "http://www.maintain.se/downloads/sparkle/mountainlion/Cocktail_#{version}.zip"
-    appcast 'http://www.maintain.se/downloads/sparkle/mountainlion/mountainlion.xml',
+    appcast 'https://www.maintain.se/downloads/sparkle/mountainlion/mountainlion.xml',
             checkpoint: '916ed186f168a0ce5072beccb6e17f6f1771417ef3769aabff46d348f79b4c66'
   elsif MacOS.release == :mavericks
     version '7.9.1'
     sha256 'b8b5c37df3a2c44406f9fdf1295357d03b8fca6a9112b61401f0cca2b8e37033'
 
     url "http://www.maintain.se/downloads/sparkle/mavericks/Cocktail_#{version}.zip"
-    appcast 'http://www.maintain.se/downloads/sparkle/mavericks/mavericks.xml',
+    appcast 'https://www.maintain.se/downloads/sparkle/mavericks/mavericks.xml',
             checkpoint: '9a81f957ef6be7894a7ee7bd68ce37c4b5c6062560c9ef6c708c1cb3270793cc'
   elsif MacOS.release == :yosemite
     version '8.9.1'
     sha256 '13302ccdca9ebfdda6f15eba7a6782b9720a5573777f809c6ce9e80b799d15c8'
 
     url "http://www.maintain.se/downloads/sparkle/yosemite/Cocktail_#{version}.zip"
-    appcast 'http://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml',
+    appcast 'https://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml',
             checkpoint: '20bd5007e6c0280efd8e01b5cd4afa9020ab80abbf464273c5c47f8f9b591031'
   else
     version '9.3.3'
     sha256 '9033f7d1ef5ed40c4137786ea49cf0f20077ec21505e953392399a83b2f1afdf'
 
     url "http://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
-    appcast 'http://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
+    appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
             checkpoint: '67756ccd302bf64e08ab6383436558752a04f4d5e66bd22aa2e25c4c4404fa34'
   end
 

--- a/Casks/cog.rb
+++ b/Casks/cog.rb
@@ -4,8 +4,8 @@ cask 'cog' do
 
   # the stable package on sourceforge is a bzip-inside-bzip that we can't handle
 
-  url "http://cogx.org/nightly_builds/cog-#{version}.tbz"
-  appcast 'http://mamburu.net/cog/stable.xml',
+  url "https://cogx.org/nightly_builds/cog-#{version}.tbz"
+  appcast 'https://mamburu.net/cog/stable.xml',
           checkpoint: 'f5770d73ad0c4a19af24cf25195c01d1cc05b937a79416fe82ead0949beee62e'
   name 'Cog'
   homepage 'http://cogx.org'

--- a/Casks/cog.rb
+++ b/Casks/cog.rb
@@ -8,7 +8,7 @@ cask 'cog' do
   appcast 'https://mamburu.net/cog/stable.xml',
           checkpoint: 'f5770d73ad0c4a19af24cf25195c01d1cc05b937a79416fe82ead0949beee62e'
   name 'Cog'
-  homepage 'http://cogx.org'
+  homepage 'https://cogx.org/'
   license :gpl
 
   app 'Cog.app'

--- a/Casks/colortester.rb
+++ b/Casks/colortester.rb
@@ -3,9 +3,9 @@ cask 'colortester' do
   sha256 :no_check
 
   # alfasado.co.jp was verified as official when first introduced to the cask
-  url 'http://www.alfasado.co.jp/download/ColorTester_Mac.zip'
+  url 'https://www.alfasado.co.jp/download/ColorTester_Mac.zip'
   name 'ColorTester'
-  homepage 'http://alfasado.net/apps/colortester.html'
+  homepage 'https://alfasado.net/apps/colortester.html'
   license :gratis
 
   app 'ColorTester/ColorTester.app'

--- a/Casks/comma-chameleon.rb
+++ b/Casks/comma-chameleon.rb
@@ -7,7 +7,7 @@ cask 'comma-chameleon' do
   appcast 'https://github.com/theodi/comma-chameleon/releases.atom',
           checkpoint: 'c86edf15837b16ad7457a3be1388f5d7a5ba35dcdfdc12796a559fe8279f8ea1'
   name 'Comma Chameleon'
-  homepage 'http://comma-chameleon.io/'
+  homepage 'https://comma-chameleon.io/'
   license :mit
 
   app 'comma-chameleon-darwin-x64/comma-chameleon.app'

--- a/Casks/connectiq.rb
+++ b/Casks/connectiq.rb
@@ -2,7 +2,7 @@ cask 'connectiq' do
   version '1.2.1'
   sha256 '37461e01e41697c9abe794772649a9f144d358c6da56b1dd39f0c533f3a29198'
 
-  url "http://developer.garmin.com/downloads/connect-iq/sdks/connectiq-sdk-mac-#{version}.zip"
+  url "https://developer.garmin.com/downloads/connect-iq/sdks/connectiq-sdk-mac-#{version}.zip"
   name 'Garmin Connect IQ SDK'
   homepage 'http://developer.garmin.com/connect-iq'
   license :other

--- a/Casks/connectiq.rb
+++ b/Casks/connectiq.rb
@@ -4,7 +4,7 @@ cask 'connectiq' do
 
   url "https://developer.garmin.com/downloads/connect-iq/sdks/connectiq-sdk-mac-#{version}.zip"
   name 'Garmin Connect IQ SDK'
-  homepage 'http://developer.garmin.com/connect-iq'
+  homepage 'https://developer.garmin.com/connect-iq/overview'
   license :other
 
   app 'bin/ConnectIQ.app'

--- a/Casks/connector.rb
+++ b/Casks/connector.rb
@@ -2,8 +2,8 @@ cask 'connector' do
   version '2.2.3'
   sha256 'fa05fc0332ead81a16ad43ce64e67e645f6a73e98b845405bbcd827caec6834f'
 
-  url "http://update.mediaware.sk/numpad/connector-#{version}.zip"
-  appcast 'http://update.mediaware.sk/numpad.xml',
+  url "https://update.mediaware.sk/numpad/connector-#{version}.zip"
+  appcast 'https://update.mediaware.sk/numpad.xml',
           checkpoint: '5b1a1cf2f25f2eee0068ece16536ffe97337fbeae6315018e6842ee64a1bb7c5'
   name 'Connector'
   homepage 'http://mediaware.sk/connector'

--- a/Casks/connector.rb
+++ b/Casks/connector.rb
@@ -6,7 +6,7 @@ cask 'connector' do
   appcast 'https://update.mediaware.sk/numpad.xml',
           checkpoint: '5b1a1cf2f25f2eee0068ece16536ffe97337fbeae6315018e6842ee64a1bb7c5'
   name 'Connector'
-  homepage 'http://mediaware.sk/connector'
+  homepage 'https://mediaware.sk/connector'
   license :gratis
 
   app 'Connector.app'

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -4,10 +4,10 @@ cask 'controllermate' do
 
   # amazonaws.com/orderedbytes was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/orderedbytes/ControllerMate#{version.no_dots}.zip"
-  appcast 'http://www.orderedbytes.com/sparkle/appcast_cm460.xml',
+  appcast 'https://www.orderedbytes.com/sparkle/appcast_cm460.xml',
           checkpoint: '6d05b022c9c81d131733523dccd2c45997f33ff694d1d76fe4016f27f5c4938a'
   name 'ControllerMate'
-  homepage 'http://www.orderedbytes.com/controllermate/'
+  homepage 'https://www.orderedbytes.com/controllermate/'
   license :freemium
 
   pkg '#temp#/ControllerMate.pkg'

--- a/Casks/couchbase-server-community.rb
+++ b/Casks/couchbase-server-community.rb
@@ -14,6 +14,6 @@ cask 'couchbase-server-community' do
   end
 
   name 'Couchbase Server'
-  homepage 'http://www.couchbase.com/'
+  homepage 'https://www.couchbase.com/'
   license :apache
 end

--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -4,7 +4,7 @@ cask 'couchbase-server-enterprise' do
 
   url "http://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"
   name 'Couchbase Server'
-  homepage 'http://www.couchbase.com/'
+  homepage 'https://www.couchbase.com/'
   license :apache
 
   app 'couchbase-server-enterprise_4/Couchbase Server.app'

--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -3,7 +3,7 @@ cask 'cryptomator' do
   sha256 '9d0a8198575120c35448c831f2b9e7a869be593e8b4c0e671016a27e0bfb59fa'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
-  url "http://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
+  url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
   name 'Cryptomator'
   homepage 'https://cryptomator.org'
   license :oss

--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -2,8 +2,8 @@ cask 'cuppa' do
   version '1.7.9'
   sha256 '03172c74f887358bdb21678831f608226c6e17816befc11a8c01b16ec192e820'
 
-  url "http://www.nathanatos.com/software/downloads/Cuppa-#{version}.zip"
-  appcast 'http://www.nathanatos.com/software/cuppa.xml',
+  url "https://www.nathanatos.com/software/downloads/Cuppa-#{version}.zip"
+  appcast 'https://www.nathanatos.com/software/cuppa.xml',
           checkpoint: 'f01c77b88898d21e63f1fb75b9f00e182664d674a9b2b9f4d4daba61e14440e0'
   name 'Cuppa'
   homepage 'http://www.nathanatos.com/software'

--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -6,7 +6,7 @@ cask 'cuppa' do
   appcast 'https://www.nathanatos.com/software/cuppa.xml',
           checkpoint: 'f01c77b88898d21e63f1fb75b9f00e182664d674a9b2b9f4d4daba61e14440e0'
   name 'Cuppa'
-  homepage 'http://www.nathanatos.com/software'
+  homepage 'https://www.nathanatos.com/software'
   license :bsd
 
   app 'Cuppa.app'

--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -4,7 +4,7 @@ cask 'curio' do
 
   url 'http://zengobi.com/downloads/Curio.zip'
   name 'Curio'
-  homepage 'http://zengobi.com/products/curio/'
+  homepage 'https://zengobi.com/products/curio/'
   license :commercial
 
   app 'Curio.app'

--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -2,7 +2,7 @@ cask 'dash' do
   version '3.3.1'
   sha256 '6c5de63dc1ec34c56bd2704e409b4df6efcdfc5fab267f1eb785a8cc345b9937'
 
-  url "http://kapeli.com/downloads/v#{version.major}/Dash.zip"
+  url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
   appcast "https://kapeli.com/Dash#{version.major}.xml",
           checkpoint: '7ebd8e2c02a8c003e0fc7098fefc2313fc8bdd670a1ed711d2b89f05b163e0cc'
   name 'Dash'

--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -3,7 +3,7 @@ cask 'disk-drill' do
   sha256 'fdce1fc076289d3fb8be94bd3850a138c9bf9e556782b0b1fbae6efcdcb991c8'
 
   url "http://www.cleverfiles.com/releases/DiskDrill_#{version}.zip"
-  appcast 'http://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml',
+  appcast 'https://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml',
           checkpoint: 'dc4a2e03561b3d906015f4723ea529649c1ecce54612ca79345b6244cb982f7c'
   name 'Disk Drill'
   homepage 'http://www.cleverfiles.com/'

--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -6,7 +6,7 @@ cask 'disk-drill' do
   appcast 'https://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml',
           checkpoint: 'dc4a2e03561b3d906015f4723ea529649c1ecce54612ca79345b6244cb982f7c'
   name 'Disk Drill'
-  homepage 'http://www.cleverfiles.com/'
+  homepage 'https://www.cleverfiles.com/'
   license :freemium
 
   app 'Disk Drill.app'

--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -2,7 +2,7 @@ cask 'diskcatalogmaker' do
   version :latest
   sha256 :no_check
 
-  url 'http://diskcatalogmaker.com/download/zip/DiskCatalogMaker.zip'
+  url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   name 'DiskCatalogMaker'
   homepage 'http://diskcatalogmaker.com'
   license :freemium

--- a/Casks/diskwave.rb
+++ b/Casks/diskwave.rb
@@ -2,7 +2,7 @@ cask 'diskwave' do
   version '0.4'
   sha256 '976324e46e4ca4d54240de13cf2c6f0db9afdb703b0e6ef78e2b5b5d36d63e75'
 
-  url "http://diskwave.barthe.ph/download/DiskWave_#{version}.dmg"
+  url "https://diskwave.barthe.ph/download/DiskWave_#{version}.dmg"
   appcast 'https://diskwave.barthe.ph/sparkle/appcast_64bit.php',
           checkpoint: '8bc850c307554a6250a90dee47a0249810d7773abc33f772cd4f1de06b5b75b8'
   name 'DiskWave'

--- a/Casks/docear.rb
+++ b/Casks/docear.rb
@@ -2,7 +2,7 @@ cask 'docear' do
   version '1.2.0.0_stable_build291'
   sha256 '64b22b3e5529daff2fb9d929bdde5d6cfda364a6aa1acbbc80b249ef028f98df'
 
-  url 'http://docear.org/downloads/docear_macos.zip'
+  url 'https://docear.org/downloads/docear_macos.zip'
   name 'Docear'
   homepage 'https://docear.org'
   license :gpl

--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -6,7 +6,7 @@ cask 'downie' do
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
           checkpoint: '69c1ec419557f5101dfcca6b5036fede6b6ce7cd3da7ec9d95435b44ade45e15'
   name 'Downie'
-  homepage 'http://software.charliemonroe.net/downie.php'
+  homepage 'https://software.charliemonroe.net/downie.php'
   license :commercial
 
   depends_on macos: '>= :yosemite'

--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -3,7 +3,7 @@ cask 'downie' do
   sha256 'd8c56ed6707bb889a63147b1ea22bef9ef1c76725380e774d4f5ca3152516755'
 
   url "http://trial.charliemonroe.net/downie/Downie_#{version.patch}.zip"
-  appcast 'http://trial.charliemonroe.net/downie/updates_2.3.xml',
+  appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
           checkpoint: '69c1ec419557f5101dfcca6b5036fede6b6ce7cd3da7ec9d95435b44ade45e15'
   name 'Downie'
   homepage 'http://software.charliemonroe.net/downie.php'

--- a/Casks/doxygen.rb
+++ b/Casks/doxygen.rb
@@ -2,7 +2,7 @@ cask 'doxygen' do
   version '1.8.11'
   sha256 '81ce64ad3d9b72de1b6eebd0a316d364f7e97d43b604875b20fe444f12cfceab'
 
-  url "http://ftp.stack.nl/pub/users/dimitri/Doxygen-#{version}.dmg"
+  url "https://ftp.stack.nl/pub/users/dimitri/Doxygen-#{version}.dmg"
   appcast 'https://www.stack.nl/~dimitri/doxygen/manual/changelog.html',
           checkpoint: '47d68c2c457a2d6e3840bd189da9d6f4b4b71389e0bf17166a673d60703dd8dd'
   name 'Doxygen'

--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -6,13 +6,13 @@ cask 'dupin' do
     version '2.10.2'
     sha256 '060d469593e33e453eeeab46942f0a832042b32175e61377c99f19c2f11cbe57'
 
-    appcast 'http://dougscripts.com/itunes/itinfo/dupin_appcast.xml',
+    appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml',
             checkpoint: '2c663ac368987af0eca9b16cf3a4621227d894e362621b230c7b7bdeae0a59d9'
   end
 
   url "https://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"
   name 'Dupin'
-  homepage 'http://dougscripts.com/apps/dupinapp.php'
+  homepage 'https://dougscripts.com/apps/dupinapp.php'
   license :commercial
 
   depends_on macos: '>= :snow_leopard'

--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -10,7 +10,7 @@ cask 'dupin' do
             checkpoint: '2c663ac368987af0eca9b16cf3a4621227d894e362621b230c7b7bdeae0a59d9'
   end
 
-  url "http://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"
+  url "https://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"
   name 'Dupin'
   homepage 'http://dougscripts.com/apps/dupinapp.php'
   license :commercial

--- a/Casks/duplicate-annihilator.rb
+++ b/Casks/duplicate-annihilator.rb
@@ -2,7 +2,7 @@ cask 'duplicate-annihilator' do
   version :latest
   sha256 :no_check
 
-  url 'http://brattoo.com/propaganda/downloadDa.php'
+  url 'https://brattoo.com/propaganda/downloadDa.php'
   name 'Duplicate Annihilator'
   homepage 'http://brattoo.com/propaganda/'
   license :commercial

--- a/Casks/duplicate-annihilator.rb
+++ b/Casks/duplicate-annihilator.rb
@@ -4,7 +4,7 @@ cask 'duplicate-annihilator' do
 
   url 'https://brattoo.com/propaganda/downloadDa.php'
   name 'Duplicate Annihilator'
-  homepage 'http://brattoo.com/propaganda/'
+  homepage 'https://brattoo.com/propaganda/'
   license :commercial
 
   app 'Duplicate Annihilator.app'

--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -3,7 +3,7 @@ cask 'enpass' do
   sha256 '65a34eba1f231de0467a8953c761f37118d6a9c45b2f01af2e95cc34ad695bb5'
 
   # sinew.in was verified as official when first introduced to the cask
-  url "http://dl.sinew.in/mac/setup/Enpass-#{version}.dmg"
+  url "https://dl.sinew.in/mac/setup/Enpass-#{version}.dmg"
   name 'Enpass'
   homepage 'https://enpass.io'
   license :gratis

--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -5,7 +5,7 @@ cask 'etcher' do
   # resin-production-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://resin-production-downloads.s3.amazonaws.com/etcher/#{version}/Etcher-darwin-x64.dmg"
   name 'Etcher'
-  homepage 'http://www.etcher.io/'
+  homepage 'https://www.etcher.io/'
   license :apache
 
   app 'etcher.app'

--- a/Casks/exa.rb
+++ b/Casks/exa.rb
@@ -7,7 +7,7 @@ cask 'exa' do
   appcast 'https://github.com/ogham/exa/releases.atom',
           checkpoint: '77d34c77c2c3017137c276b6a3de91ffba51b4fe25f26c005382d934954a3e4f'
   name 'exa'
-  homepage 'http://bsago.me/exa/'
+  homepage 'https://bsago.me/exa/'
   license :mit
 
   binary 'exa-osx-x86_64', target: 'exa'

--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -2,7 +2,7 @@ cask 'expandrive' do
   version '5.3.2'
   sha256 'dc7f7b94f3f330dfd4c8ea8b8bf07def1fe57afb860fa14b3672a00d3e29bd62'
 
-  url "http://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
+  url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
   appcast 'http://updates.expandrive.com/appcast/expandrive.xml?version=3',
           checkpoint: '8adfd66ed23f4f41408a5c0fdb9188469278a8ba77335e7b1dd41419304ba103'
   name 'ExpanDrive'

--- a/Casks/faw-circle.rb
+++ b/Casks/faw-circle.rb
@@ -4,7 +4,7 @@ cask 'faw-circle' do
 
   url "http://futureaudioworkshop.com/downloads/Circle-#{version}-setup.dmg"
   name 'FAW Circle'
-  homepage 'http://futureaudioworkshop.com/circle'
+  homepage 'https://futureaudioworkshop.com/circle/'
   license :commercial
 
   pkg 'Circle².pkg'

--- a/Casks/fenics.rb
+++ b/Casks/fenics.rb
@@ -4,7 +4,7 @@ cask 'fenics' do
 
   url "http://www.fenicsproject.org/pub/software/fenics/fenics-#{version}-osx10.9.dmg"
   name 'FEniCS'
-  homepage 'http://fenicsproject.org/'
+  homepage 'https://fenicsproject.org/'
   license :gpl
 
   depends_on macos: '>= :mavericks'

--- a/Casks/festify.rb
+++ b/Casks/festify.rb
@@ -2,11 +2,11 @@ cask 'festify' do
   version '1.4.2'
   sha256 '07f3ad04bede2d6a622f3652382193e7024f6d1f308b6f1208a036d13c15413a'
 
-  url "http://getfestify.com/updates/mac/packages/#{version}/Festify.zip"
-  appcast 'http://getfestify.com/updates/mac/festify.xml',
+  url "https://getfestify.com/updates/mac/packages/#{version}/Festify.zip"
+  appcast 'https://getfestify.com/updates/mac/festify.xml',
           checkpoint: 'c38bc30efe3ecf2ac377a760cac281fbda793baf37949bbb331ad7359c082544'
   name 'Festify'
-  homepage 'http://getfestify.com/'
+  homepage 'https://getfestify.com/'
   license :gratis
 
   app 'Festify.app'

--- a/Casks/fetch.rb
+++ b/Casks/fetch.rb
@@ -4,7 +4,7 @@ cask 'fetch' do
 
   url "http://fetchsoftworks.com/fetch/download/Fetch_#{version}.dmg?direct=1"
   name 'Fetch'
-  homepage 'http://fetchsoftworks.com/fetch/'
+  homepage 'https://fetchsoftworks.com/fetch/'
   license :commercial
 
   app 'Fetch.app'

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -5,7 +5,7 @@ cask 'fiddler' do
   # ericlawrence.com was verified as official when first introduced to the cask
   url 'http://ericlawrence.com/dl/InstallFiddler.dmg'
   name 'Telerik Fiddler Proxy'
-  homepage 'http://www.telerik.com/fiddler'
+  homepage 'https://www.telerik.com/fiddler'
   license :commercial
 
   depends_on cask: 'mono-mdk'

--- a/Casks/fiji.rb
+++ b/Casks/fiji.rb
@@ -5,7 +5,7 @@ cask 'fiji' do
   # jenkins.imagej.net/job/Stable-Fiji-MacOSX was verified as official when first introduced to the cask
   url 'http://jenkins.imagej.net/job/Stable-Fiji-MacOSX/lastSuccessfulBuild/artifact/fiji-macosx.dmg'
   name 'Fiji'
-  homepage 'http://fiji.sc'
+  homepage 'https://fiji.sc'
   license :oss
 
   app 'Fiji.app'

--- a/Casks/filepane.rb
+++ b/Casks/filepane.rb
@@ -3,7 +3,7 @@ cask 'filepane' do
   sha256 :no_check
 
   # dl.devmate.com/com.mymixapps.FilePane was verified as official when first introduced to the cask
-  url 'http://dl.devmate.com/com.mymixapps.FilePane/FilePane.dmg'
+  url 'https://dl.devmate.com/com.mymixapps.FilePane/FilePane.dmg'
   name 'FilePane'
   homepage 'http://mymixapps.com/filepane'
   license :commercial

--- a/Casks/fish.rb
+++ b/Casks/fish.rb
@@ -2,9 +2,9 @@ cask 'fish' do
   version '2.3.1'
   sha256 'd42bfd0137043a7f372590b78354a6a0153987bad2ddfdd38401ef192b5bf6cd'
 
-  url "http://fishshell.com/files/#{version}/fish-#{version}.app.zip"
+  url "https://fishshell.com/files/#{version}/fish-#{version}.app.zip"
   name 'Fish App'
-  homepage 'http://fishshell.com'
+  homepage 'https://fishshell.com'
   license :gpl
 
   app 'fish.app'

--- a/Casks/flash.rb
+++ b/Casks/flash.rb
@@ -3,7 +3,7 @@ cask 'flash' do
   sha256 'ec1e880e0546d8cbfe7e585c02758387a555f0d04c2a09fff83f6c8a799a1354'
 
   # macromedia.com was verified as official when first introduced to the cask
-  url "http://fpdownload.macromedia.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
+  url "https://fpdownload.macromedia.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
           checkpoint: '54401f2d7472607f78e82281850b6285d7c711865009bc717e21bb4611b5fe3f'
   name 'Adobe Flash Player'

--- a/Casks/flexiglass.rb
+++ b/Casks/flexiglass.rb
@@ -2,8 +2,8 @@ cask 'flexiglass' do
   version '1.6.1-12795'
   sha256 'e929497301312054866b809fbe64ff06a33ad6bc188e4cb64da980aa6085496f'
 
-  url "http://downloads.nulana.com/flexiglass/Flexiglass-#{version}.zip"
-  appcast 'http://downloads.nulana.com/flexiglass/appcast.xml',
+  url "https://downloads.nulana.com/flexiglass/Flexiglass-#{version}.zip"
+  appcast 'https://downloads.nulana.com/flexiglass/appcast.xml',
           checkpoint: '9f2f95c38e5d941d943e25e0b4f5b6649005a33818299de43c28d98935152b48'
   name 'Flexiglass'
   homepage 'http://nulana.com/flexiglass/'

--- a/Casks/flexiglass.rb
+++ b/Casks/flexiglass.rb
@@ -6,7 +6,7 @@ cask 'flexiglass' do
   appcast 'https://downloads.nulana.com/flexiglass/appcast.xml',
           checkpoint: '9f2f95c38e5d941d943e25e0b4f5b6649005a33818299de43c28d98935152b48'
   name 'Flexiglass'
-  homepage 'http://nulana.com/flexiglass/'
+  homepage 'https://nulana.com/flexiglass/'
   license :commercial
 
   depends_on macos: '>= :snow_leopard'

--- a/Casks/flow.rb
+++ b/Casks/flow.rb
@@ -2,7 +2,7 @@ cask 'flow' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.getflow.com/mac/download'
+  url 'https://www.getflow.com/mac/download'
   name 'Flow'
   homepage 'https://www.getflow.com/'
   license :commercial

--- a/Casks/fmod-studio.rb
+++ b/Casks/fmod-studio.rb
@@ -4,7 +4,7 @@ cask 'fmod-studio' do
 
   url "http://www.fmod.org/download/fmodstudio/tool/Mac/fmodstudio#{version}mac-installer.dmg"
   name 'FMOD Studio'
-  homepage 'http://www.fmod.org/products/'
+  homepage 'https://www.fmod.org/products/'
   license :commercial
 
   app 'FMOD Studio/FMOD Studio.app'

--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -4,7 +4,7 @@ cask 'focuswriter' do
 
   url 'http://gottcode.org/focuswriter/download/?os=mac'
   name 'FocusWriter'
-  homepage 'http://gottcode.org/focuswriter/'
+  homepage 'https://gottcode.org/focuswriter/'
   license :gpl
 
   app 'FocusWriter.app'

--- a/Casks/fs-uae.rb
+++ b/Casks/fs-uae.rb
@@ -2,7 +2,7 @@ cask 'fs-uae' do
   version '2.6.2'
   sha256 '1c4e285ac82828d004c900e05b29dc6363eeb5f705524bfaa2bd4e6f57101ace'
 
-  url "http://fs-uae.net/stable/#{version}/fs-uae-suite_#{version}_macosx.tar.gz"
+  url "https://fs-uae.net/stable/#{version}/fs-uae-suite_#{version}_macosx.tar.gz"
   name 'FS-UAE'
   homepage 'http://fs-uae.net/'
   license :oss

--- a/Casks/fs-uae.rb
+++ b/Casks/fs-uae.rb
@@ -4,7 +4,7 @@ cask 'fs-uae' do
 
   url "https://fs-uae.net/stable/#{version}/fs-uae-suite_#{version}_macosx.tar.gz"
   name 'FS-UAE'
-  homepage 'http://fs-uae.net/'
+  homepage 'https://fs-uae.net/'
   license :oss
 
   app 'FS-UAE Arcade.app'

--- a/Casks/fstream.rb
+++ b/Casks/fstream.rb
@@ -2,7 +2,7 @@ cask 'fstream' do
   version '1.4.9'
   sha256 '50eb2abf24b5e09b42d66f07ca2145d13fa6d350932efd0fa3317ef41178000f'
 
-  url 'http://www.sourcemac.com/fstream_FStream.tgz'
+  url 'https://www.sourcemac.com/fstream_FStream.tgz'
   appcast 'http://www.sourcemac.com/sparkle.php?id=156&content=xml',
           checkpoint: 'b72e062b69d0a4bcf1a2a5f8acc4da87b09a849756bb2785d1435ab18d5579e1'
   name 'FStream'

--- a/Casks/geany.rb
+++ b/Casks/geany.rb
@@ -2,7 +2,7 @@ cask 'geany' do
   version '1.27'
   sha256 'ce629ba35aebbd71e054c3cd32984abc41f368f0d578864a2c1b3662f9b00ecc'
 
-  url "http://download.geany.org/geany-#{version}_osx.dmg"
+  url "https://download.geany.org/geany-#{version}_osx.dmg"
   name 'Geany'
   homepage 'http://www.geany.org'
   license :gpl

--- a/Casks/geany.rb
+++ b/Casks/geany.rb
@@ -4,7 +4,7 @@ cask 'geany' do
 
   url "https://download.geany.org/geany-#{version}_osx.dmg"
   name 'Geany'
-  homepage 'http://www.geany.org'
+  homepage 'https://www.geany.org/'
   license :gpl
 
   depends_on macos: '>= :lion'

--- a/Casks/geekbench.rb
+++ b/Casks/geekbench.rb
@@ -2,11 +2,11 @@ cask 'geekbench' do
   version '3.4.1'
   sha256 '9f2730472bba9fd39554290f465d37c32792debc5b20c9840efd1f79d40ca94c'
 
-  url "http://cdn.primatelabs.com/Geekbench-#{version}-Mac.zip"
-  appcast 'http://www.primatelabs.com/appcast/geekbench3.xml',
+  url "https://cdn.primatelabs.com/Geekbench-#{version}-Mac.zip"
+  appcast 'https://www.primatelabs.com/appcast/geekbench3.xml',
           checkpoint: '23877fa30558eada7e7beeefee4fa307c7a7ac3fad79b3c250fa09f4c68081c9'
   name 'Geekbench'
-  homepage 'http://www.primatelabs.com/geekbench/'
+  homepage 'https://www.primatelabs.com/geekbench/'
   license :commercial
 
   app 'Geekbench 3.app'

--- a/Casks/get-lyrical.rb
+++ b/Casks/get-lyrical.rb
@@ -2,7 +2,7 @@ cask 'get-lyrical' do
   version :latest
   sha256 :no_check
 
-  url 'http://shullian.com/files/getlyrical.zip'
+  url 'https://shullian.com/files/getlyrical.zip'
   name 'Get Lyrical'
   homepage 'http://shullian.com/get_lyrical.php'
   license :gratis

--- a/Casks/get-lyrical.rb
+++ b/Casks/get-lyrical.rb
@@ -4,7 +4,7 @@ cask 'get-lyrical' do
 
   url 'https://shullian.com/files/getlyrical.zip'
   name 'Get Lyrical'
-  homepage 'http://shullian.com/get_lyrical.php'
+  homepage 'https://shullian.com/get_lyrical.php'
   license :gratis
 
   app 'Get Lyrical/Get Lyrical.app'

--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -2,11 +2,11 @@ cask 'gitkraken' do
   version '1.5.1'
   sha256 '327606e536f6eb445a0e1b38a329efa53edda0616a6235ce8fa89d0dfe53ae82'
 
-  url "http://release.gitkraken.com/darwin/v#{version}.zip"
+  url "https://release.gitkraken.com/darwin/v#{version}.zip"
   appcast 'https://release.gitkraken.com/darwin/RELEASES',
           checkpoint: '7bd7202c2e753260f39adcdd8337ced6c271786510f7c976010b52373ac25f20'
   name 'GitKraken'
-  homepage 'http://www.gitkraken.com/'
+  homepage 'https://www.gitkraken.com/'
   license :gratis
 
   auto_updates true

--- a/Casks/go2shell.rb
+++ b/Casks/go2shell.rb
@@ -6,7 +6,7 @@ cask 'go2shell' do
   appcast 'http://appcast.zipzapmac.com/go2shell.xml',
           checkpoint: '80d5e9cc0a8c1a16116e34341d09a8d78b1aff5ce2a77c7fc0c0ff1f56b96235'
   name 'Go2Shell'
-  homepage 'http://zipzapmac.com/go2shell'
+  homepage 'https://zipzapmac.com/go2shell'
   license :gratis
 
   app 'Go2Shell.app'

--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -2,7 +2,7 @@ cask 'gog-galaxy' do
   version '1.1.12.113'
   sha256 'a09d73fac25017df7ac3b0dc0aafe1a08708c2a3be9729d9695a0fac84216df5'
 
-  url "http://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
+  url "https://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
   name 'GOG Galaxy Client'
   homepage 'https://www.gog.com/galaxy'
   license :gratis

--- a/Casks/google-trends.rb
+++ b/Casks/google-trends.rb
@@ -2,7 +2,7 @@ cask 'google-trends' do
   version :latest
   sha256 :no_check
 
-  url 'http://dl.google.com/dl/trends/screensaver/GoogleTrendsScreensaver.dmg'
+  url 'https://dl.google.com/dl/trends/screensaver/GoogleTrendsScreensaver.dmg'
   name 'Google Trends Screensaver'
   homepage 'https://www.google.com/trends/hottrends/visualize'
   license :gratis

--- a/Casks/gopro.rb
+++ b/Casks/gopro.rb
@@ -4,7 +4,7 @@ cask 'gopro' do
 
   url "https://software.gopro.com/Mac/GoPro-MacInstaller-#{version}.dmg"
   name 'GoPro Desktop'
-  homepage 'http://shop.gopro.com/softwareandapp/gopro-app-%7C-desktop/GoPro-Desktop-App.html'
+  homepage 'https://shop.gopro.com/softwareandapp/gopro-app-%7C-desktop/GoPro-Desktop-App.html'
   license :commercial
 
   conflicts_with cask: 'gopro-studio'

--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -3,11 +3,11 @@ cask 'graphicconverter' do
   sha256 'ae584e3e4d508eb4a6d99e8caa234466d0e88108465486ddd45cd641fc7d24df'
 
   # lemkesoft.info was verified as official when first introduced to the cask
-  url "http://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.minor}.zip"
+  url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.minor}.zip"
   appcast 'http://www.lemkesoft.org/files/graphicconverter/graphicconverter9.xml',
           checkpoint: 'eb62cdcced7681f47360d3b7c39e7b18db3a3cf96ffa8c93945bf5a0fe55151f'
   name 'GraphicConverter'
-  homepage 'http://www.lemkesoft.de/en/products/graphicconverter/'
+  homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
   license :commercial
 
   app "GraphicConverter #{version.major}.app"

--- a/Casks/hapu.rb
+++ b/Casks/hapu.rb
@@ -2,7 +2,7 @@ cask 'hapu' do
   version '2.4'
   sha256 '5a5a2d627b7862b43d231c00de849954340d00097bbab01c2615efefc0600be8'
 
-  url 'http://tars.mahdi.jp/squirrel/hapu.zip'
+  url 'https://tars.mahdi.jp/squirrel/hapu.zip'
   appcast 'https://mahdi.jp/apps/hapu/changelog',
           checkpoint: '16e15f67997b466f0a378a3ad1c1f0bebb0fe89392cb977589bc981a8aacca3d'
   name 'HAPU'

--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -4,7 +4,7 @@ cask 'hedgewars' do
 
   # download.gna.org/hedgewars was verified as official when first introduced to the cask
   url "http://download.gna.org/hedgewars/Hedgewars-#{version}.dmg"
-  appcast 'http://www.hedgewars.org/download/appcast.xml',
+  appcast 'https://www.hedgewars.org/download/appcast.xml',
           checkpoint: 'b568efa383a1243786b557c0d85dc0b3612afebcd310c77d91b5ec3c288a3264'
   name 'Hedgewars'
   homepage 'https://hedgewars.org/'

--- a/Casks/hockey.rb
+++ b/Casks/hockey.rb
@@ -6,7 +6,7 @@ cask 'hockey' do
   appcast 'https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1',
           checkpoint: '8802b612ed27a271b0c50c4b56c4882c6b24a9914b39d7b6058ec8b40ffc943f'
   name 'HockeyApp'
-  homepage 'http://hockeyapp.net/releases/mac/'
+  homepage 'https://hockeyapp.net/releases/mac/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'HockeyApp.app'

--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -2,7 +2,7 @@ cask 'horos' do
   version '2.0.0'
   sha256 '1af3252b5166bfb48769b93eeba64fc42f79bbf6a88625df96ec4a359d117f51'
 
-  url "http://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"
+  url "https://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"
   name 'Horos – Free, open medical image viewer'
   homepage 'http://www.horosproject.org'
   license :gpl

--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -4,7 +4,7 @@ cask 'horos' do
 
   url "https://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"
   name 'Horos – Free, open medical image viewer'
-  homepage 'http://www.horosproject.org'
+  homepage 'https://www.horosproject.org/'
   license :gpl
 
   app 'Horos.app'

--- a/Casks/htc-sync-manager.rb
+++ b/Casks/htc-sync-manager.rb
@@ -2,9 +2,9 @@ cask 'htc-sync-manager' do
   version '3.1.94'
   sha256 '416c0b656c13f9b878493eaabef2d02ea8c0888eeaf6efa5af092a714126990c'
 
-  url "http://dl4.htc.com/download/htc-sync-manager/setup_#{version}_htc.dmg"
+  url "https://dl4.htc.com/download/htc-sync-manager/setup_#{version}_htc.dmg"
   name 'HTC Sync Manager'
-  homepage 'http://www.htc.com/us/software/htc-sync-manager/'
+  homepage 'https://www.htc.com/us/software/htc-sync-manager/'
   license :gratis
 
   app 'HTC Sync Manager.app'

--- a/Casks/idisplay.rb
+++ b/Casks/idisplay.rb
@@ -3,7 +3,7 @@ cask 'idisplay' do
     version '1.1.12'
     sha256 'ea0f9dd2c488762169c0bab2218ee628b6eff658a814dfca583e4563b99b7c6c'
     # shape.ag was verified as official when first introduced to the cask
-    url 'http://www.shape.ag/freedownload/iDisplay/iDisplay.dmg'
+    url 'https://www.shape.ag/freedownload/iDisplay/iDisplay.dmg'
   else
     version '2.3.10'
     sha256 '6d87e0566e2e2693d89c4fdb1cddcfed9db6316f6f7b2bada24104ea18b996ae'

--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -4,7 +4,7 @@ cask 'igv' do
 
   url "https://data.broadinstitute.org/igv/projects/downloads/IGV_#{version}.app.zip"
   name 'Integrative Genomics Viewer (IGV)'
-  homepage 'http://www.broadinstitute.org/software/igv/'
+  homepage 'https://www.broadinstitute.org/software/igv/'
   license :mit
 
   app "IGV_#{version}.app"

--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -2,7 +2,7 @@ cask 'igv' do
   version '2.3.77'
   sha256 '042a9112c1e092fde69705d44c82b363b1c67ed713b4e91ce242b46ab47cdb0b'
 
-  url "http://data.broadinstitute.org/igv/projects/downloads/IGV_#{version}.app.zip"
+  url "https://data.broadinstitute.org/igv/projects/downloads/IGV_#{version}.app.zip"
   name 'Integrative Genomics Viewer (IGV)'
   homepage 'http://www.broadinstitute.org/software/igv/'
   license :mit

--- a/Casks/iholdem-indicator.rb
+++ b/Casks/iholdem-indicator.rb
@@ -2,9 +2,9 @@ cask 'iholdem-indicator' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.iholdemindicator.com/download/iHoldemIndicatorInstaller.pkg'
+  url 'https://www.iholdemindicator.com/download/iHoldemIndicatorInstaller.pkg'
   name 'iHoldem Indicator'
-  homepage 'http://www.iholdemindicator.com'
+  homepage 'https://www.iholdemindicator.com'
   license :commercial
 
   pkg 'iHoldemIndicatorInstaller.pkg'

--- a/Casks/imagej.rb
+++ b/Casks/imagej.rb
@@ -4,7 +4,7 @@ cask 'imagej' do
 
   url "http://imagej.nih.gov/ij/download/osx/ImageJ#{version.no_dots}.zip"
   name 'ImageJ'
-  homepage 'http://imagej.nih.gov/ij/index.html'
+  homepage 'https://imagej.nih.gov/ij/index.html'
   license :public_domain
 
   depends_on cask: 'java'

--- a/Casks/imageplay.rb
+++ b/Casks/imageplay.rb
@@ -7,7 +7,7 @@ cask 'imageplay' do
   appcast 'https://github.com/cpvrlab/ImagePlay/releases.atom',
           checkpoint: 'fb7eee5114029e3ce1cf0e40b01f6e99393fa6dd567e6d6df5de2cad56589d3b'
   name 'ImagePlay'
-  homepage 'http://imageplay.io/'
+  homepage 'https://imageplay.io/'
   license :gpl
 
   app 'ImagePlay.app'

--- a/Casks/interface-inspector.rb
+++ b/Casks/interface-inspector.rb
@@ -2,11 +2,11 @@ cask 'interface-inspector' do
   version '2.2'
   sha256 '2c365cffa8987a4e6f86f9381798e0066cd1c971824602cdefefc06d4bc704fe'
 
-  url "http://www.interface-inspector.com/download/Interface-Inspector-#{version}.zip"
-  appcast 'http://www.interface-inspector.com/download/feed.xml',
+  url "https://www.interface-inspector.com/download/Interface-Inspector-#{version}.zip"
+  appcast 'https://www.interface-inspector.com/download/feed.xml',
           checkpoint: 'bfb2eb4fb35aa4ce5db1124d7450af12915323d59b73161c9358e5c8f514d08e'
   name 'Interface Inspector'
-  homepage 'http://www.interface-inspector.com/'
+  homepage 'https://www.interface-inspector.com/'
   license :closed
 
   app 'Interface Inspector.app'

--- a/Casks/invisiblix.rb
+++ b/Casks/invisiblix.rb
@@ -4,10 +4,10 @@ cask 'invisiblix' do
 
   # sourceforge.net/invisiblix was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/invisiblix/invisibliX-#{version}.zip"
-  appcast 'http://www.read-write.fr/invisiblix/appcast.xml',
+  appcast 'https://www.read-write.fr/invisiblix/appcast.xml',
           checkpoint: 'f4ec5f8c4ef92d17aafde286acd8c3d35058da7e2bce93d2da8ee059dbdea4b6'
   name 'invisibliX'
-  homepage 'http://www.read-write.fr/invisiblix/'
+  homepage 'https://www.read-write.fr/invisiblix/'
   license :oss
 
   app 'invisibliX.app'

--- a/Casks/ioquake3.rb
+++ b/Casks/ioquake3.rb
@@ -5,7 +5,7 @@ cask 'ioquake3' do
 
   url "https://ioquake3.org/files/#{version}/ioquake3%20#{version}.dmg"
   name 'ioquake3'
-  homepage 'http://ioquake3.org/'
+  homepage 'https://ioquake3.org/'
   license :gpl
 
   suite 'ioquake3'

--- a/Casks/ioquake3.rb
+++ b/Casks/ioquake3.rb
@@ -3,7 +3,7 @@ cask 'ioquake3' do
   version '1.36'
   sha256 'ff310471aa641cc27980055691b3e3cf5496ac262f10967c9d5052fd3815a3fc'
 
-  url "http://ioquake3.org/files/#{version}/ioquake3%20#{version}.dmg"
+  url "https://ioquake3.org/files/#{version}/ioquake3%20#{version}.dmg"
   name 'ioquake3'
   homepage 'http://ioquake3.org/'
   license :gpl

--- a/Casks/ios-console.rb
+++ b/Casks/ios-console.rb
@@ -2,9 +2,9 @@ cask 'ios-console' do
   version :latest
   sha256 :no_check
 
-  url 'http://downloads.lemonjar.com/iosconsole_latest.zip'
+  url 'https://downloads.lemonjar.com/iosconsole_latest.zip'
   name 'iOS Console'
-  homepage 'http://lemonjar.com/iosconsole/'
+  homepage 'https://lemonjar.com/iosconsole/'
   license :gratis
 
   app 'iOS Console.app'

--- a/Casks/iphoto-library-manager.rb
+++ b/Casks/iphoto-library-manager.rb
@@ -2,7 +2,7 @@ cask 'iphoto-library-manager' do
   version '4.2.4'
   sha256 '4710def2d0a3f91152c08b128d03b38207455e43ff36fd5d337758cbeaa64309'
 
-  url 'http://www.fatcatsoftware.com/iplm/iPhotoLibraryManager.zip'
+  url 'https://www.fatcatsoftware.com/iplm/iPhotoLibraryManager.zip'
   appcast 'https://www.fatcatsoftware.com/iplm/iplm4_appcast.xml',
           checkpoint: 'd1a4cdb9ec10226113286433595506743481a2fb1d95bd3bb89256143d7dc2fd'
   name 'iPhoto Library Manager'

--- a/Casks/iphoto-library-manager.rb
+++ b/Casks/iphoto-library-manager.rb
@@ -3,10 +3,10 @@ cask 'iphoto-library-manager' do
   sha256 '4710def2d0a3f91152c08b128d03b38207455e43ff36fd5d337758cbeaa64309'
 
   url 'http://www.fatcatsoftware.com/iplm/iPhotoLibraryManager.zip'
-  appcast 'http://www.fatcatsoftware.com/iplm/iplm4_appcast.xml',
+  appcast 'https://www.fatcatsoftware.com/iplm/iplm4_appcast.xml',
           checkpoint: 'd1a4cdb9ec10226113286433595506743481a2fb1d95bd3bb89256143d7dc2fd'
   name 'iPhoto Library Manager'
-  homepage 'http://www.fatcatsoftware.com/iplm/'
+  homepage 'https://www.fatcatsoftware.com/iplm/'
   license :commercial
 
   app 'iPhoto Library Manager.app'

--- a/Casks/ireadfast.rb
+++ b/Casks/ireadfast.rb
@@ -2,9 +2,9 @@ cask 'ireadfast' do
   version '2.0'
   sha256 '0bc213c6da72a7917ceba8a9de46e307933608cd6d2bf397770517401ab3d98c'
 
-  url "http://www.gengis.net/downloads/iReadFast%20#{version}.dmg"
+  url "https://www.gengis.net/downloads/iReadFast%20#{version}.dmg"
   name 'iReadFast'
-  homepage 'http://www.gengis.net/prodotti/iReadFast_Mac/en/'
+  homepage 'https://www.gengis.net/prodotti/iReadFast_Mac/en/'
   license :gratis
 
   app 'iReadFast.app'

--- a/Casks/irip.rb
+++ b/Casks/irip.rb
@@ -3,7 +3,7 @@ cask 'irip' do
   sha256 '378130c09ed0b42eec738f755c9c29e3f26aa2f8f37d27cae2e95146038b468c'
 
   url 'https://files.thelittleappfactory.com/iRip2/iRip.zip'
-  appcast 'http://files.thelittleappfactory.com/iRip2/appcast.xml',
+  appcast 'https://files.thelittleappfactory.com/iRip2/appcast.xml',
           checkpoint: 'e934179f4e2cc9567565ae76ea1071cb735a2e92aa00893779f56aa31d6f7d5f'
   name 'iRip'
   homepage 'http://thelittleappfactory.com/irip/'

--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -7,7 +7,7 @@ cask 'jabref' do
   appcast 'https://github.com/JabRef/jabref/releases.atom',
           checkpoint: '5529a3b6efe55446a7621c7de9727fdcdcebf06cf4a078738ce12b70b1ba1312'
   name 'JabRef'
-  homepage 'http://www.jabref.org/'
+  homepage 'https://www.jabref.org/'
   license :gpl
 
   installer script: 'JabRef Installer.app/Contents/MacOS/JavaApplicationStub',

--- a/Casks/jansi.rb
+++ b/Casks/jansi.rb
@@ -3,7 +3,7 @@ cask 'jansi' do
   sha256 :no_check
 
   # dl.dropbox.com/u/43721500 was verified as official when first introduced to the cask
-  url 'http://dl.dropbox.com/u/43721500/JANSI-MacOSX10.4.zip'
+  url 'https://dl.dropbox.com/u/43721500/JANSI-MacOSX10.4.zip'
   name 'Japanese ANSI'
   name 'JANSI'
   homepage 'http://kenie33-jansi.blogspot.jp/'

--- a/Casks/jansi.rb
+++ b/Casks/jansi.rb
@@ -6,7 +6,7 @@ cask 'jansi' do
   url 'https://dl.dropbox.com/u/43721500/JANSI-MacOSX10.4.zip'
   name 'Japanese ANSI'
   name 'JANSI'
-  homepage 'http://kenie33-jansi.blogspot.jp/'
+  homepage 'https://kenie33-jansi.blogspot.jp/'
   license :unknown
 
   depends_on macos: '>= :tiger'

--- a/Casks/jasp.rb
+++ b/Casks/jasp.rb
@@ -2,7 +2,7 @@ cask 'jasp' do
   version '0.7.5.6'
   sha256 'd019f1699c5d185b5e367281e297ed55e11b0ffdf4770d8f455efc735f48060e'
 
-  url "http://static.jasp-stats.org/JASP-#{version}.dmg"
+  url "https://static.jasp-stats.org/JASP-#{version}.dmg"
   name 'JASP'
   homepage 'https://jasp-stats.org'
   license :gpl

--- a/Casks/jbrowse.rb
+++ b/Casks/jbrowse.rb
@@ -2,7 +2,7 @@ cask 'jbrowse' do
   version '1.12.1'
   sha256 '8b6921c2057f5ff11e5b9531cc848744aba932984fc3f408550f396a34afefe6'
 
-  url "http://jbrowse.org/releases/JBrowse-#{version}-desktop-osx.zip"
+  url "https://jbrowse.org/releases/JBrowse-#{version}-desktop-osx.zip"
   name 'jbrowse'
   homepage 'https://jbrowse.org/'
   license :oss

--- a/Casks/jing.rb
+++ b/Casks/jing.rb
@@ -2,8 +2,8 @@ cask 'jing' do
   version '2.7.0'
   sha256 '99fefbe732cb7afcc6956be58929f401a36ce9f406951e7ff0d127b7b958264a'
 
-  url 'http://download.techsmith.com/jing/mac/jing.dmg'
-  appcast 'http://download.techsmith.com/update/jing/enu/appcast.xml',
+  url 'https://download.techsmith.com/jing/mac/jing.dmg'
+  appcast 'https://download.techsmith.com/update/jing/enu/appcast.xml',
           checkpoint: '2bf893728361e8bf5a7a36af4a2c4299c0bd04274e51f6c89affdb1f6df02880'
   name 'Jing'
   homepage 'https://www.techsmith.com/jing.html'

--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -2,7 +2,7 @@ cask 'jitouch' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.jitouch.com/jitouch_el_capitan.zip'
+  url 'https://www.jitouch.com/jitouch_el_capitan.zip'
   name 'jitouch'
   homepage 'https://www.jitouch.com'
   license :commercial

--- a/Casks/join-together.rb
+++ b/Casks/join-together.rb
@@ -2,8 +2,8 @@ cask 'join-together' do
   version '7.6.1'
   sha256 '957a4c4a33be2afa6dcf6d706218aa86403100cb39b9db07f10577390c0e7e93'
 
-  url "http://dougscripts.com/itunes/scrx/jointogether#{version.no_dots}.zip"
-  appcast 'http://dougscripts.com/itunes/itinfo/jointogether_appcast.xml',
+  url "https://dougscripts.com/itunes/scrx/jointogether#{version.no_dots}.zip"
+  appcast 'https://dougscripts.com/itunes/itinfo/jointogether_appcast.xml',
           checkpoint: '388d83cd36ba376add48ffd5627cbfec629374e9555b96ea94a10727076c50a4'
   name 'Join Together'
   homepage 'http://dougscripts.com/itunes/itinfo/jointogether.php'

--- a/Casks/join-together.rb
+++ b/Casks/join-together.rb
@@ -6,7 +6,7 @@ cask 'join-together' do
   appcast 'https://dougscripts.com/itunes/itinfo/jointogether_appcast.xml',
           checkpoint: '388d83cd36ba376add48ffd5627cbfec629374e9555b96ea94a10727076c50a4'
   name 'Join Together'
-  homepage 'http://dougscripts.com/itunes/itinfo/jointogether.php'
+  homepage 'https://dougscripts.com/apps/jointogetherapp.php'
   license :commercial
 
   app 'Join Together.app'

--- a/Casks/key-codes.rb
+++ b/Casks/key-codes.rb
@@ -2,7 +2,7 @@ cask 'key-codes' do
   version '2.1'
   sha256 '60ec4c0cef5e97943c91e4ed317434bcaddd4cdbce93368d8bca9db9d45c60e2'
 
-  url 'http://manytricks.com/download/keycodes'
+  url 'https://manytricks.com/download/keycodes'
   appcast 'https://manytricks.com/keycodes/appcast.xml',
           checkpoint: 'c83453117309b3ee87694a729ce8ff72bb2d862fd33054fa8916af01e1a0adaa'
   name 'Key Codes'

--- a/Casks/keyaccess.rb
+++ b/Casks/keyaccess.rb
@@ -5,7 +5,7 @@ cask 'keyaccess' do
   url 'https://www.sassafras.com/links/K2Client.pkg'
   name 'Sassafras KeyAccess KeyServer Client'
   name 'K2 Client'
-  homepage 'http://www.sassafras.com/support/'
+  homepage 'https://www.sassafras.com/support/'
   license :gratis
 
   pkg 'K2Client.pkg'

--- a/Casks/keyaccess.rb
+++ b/Casks/keyaccess.rb
@@ -2,7 +2,7 @@ cask 'keyaccess' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.sassafras.com/links/K2Client.pkg'
+  url 'https://www.sassafras.com/links/K2Client.pkg'
   name 'Sassafras KeyAccess KeyServer Client'
   name 'K2 Client'
   homepage 'http://www.sassafras.com/support/'

--- a/Casks/keyboardcleantool.rb
+++ b/Casks/keyboardcleantool.rb
@@ -3,7 +3,7 @@ cask 'keyboardcleantool' do
   sha256 :no_check
 
   # bettertouchtool.net was verified as official when first introduced to the cask
-  url 'http://bettertouchtool.net/KeyboardCleanTool.zip'
+  url 'https://bettertouchtool.net/KeyboardCleanTool.zip'
   name 'KeyboardCleanTool'
   homepage 'https://blog.boastr.net/keyboardcleantool/'
   license :gratis

--- a/Casks/kivy.rb
+++ b/Casks/kivy.rb
@@ -4,7 +4,7 @@ cask 'kivy' do
 
   url "https://kivy.org/downloads/#{version}/Kivy-#{version}-osx-python3.7z"
   name 'Kivy'
-  homepage 'http://kivy.org'
+  homepage 'https://kivy.org'
   license :mit
 
   depends_on formula: 'unar'

--- a/Casks/lacona.rb
+++ b/Casks/lacona.rb
@@ -3,7 +3,7 @@ cask 'lacona' do
   sha256 'acc5b681774f9be2c702094d0d87baaa2728aee54529f6a27c6571342f8e13d3'
 
   # lacona-download.firebaseapp.com was verified as official when first introduced to the cask
-  url "http://lacona-download.firebaseapp.com/packages/#{version}/LaconaBeta.zip"
+  url "https://lacona-download.firebaseapp.com/packages/#{version}/LaconaBeta.zip"
   appcast 'https://lacona-download.firebaseapp.com/appcast.xml',
           checkpoint: '448b88e5ad9cd58e9f4d8cf7c5b58b9ac26c06b83539f7740538e15bf3882ca2'
   name 'Lacona'

--- a/Casks/lastfm.rb
+++ b/Casks/lastfm.rb
@@ -3,7 +3,7 @@ cask 'lastfm' do
   sha256 'dc46e58111f8555fc0b1d6d2bd11e8fd4e4c45c6c7e953d106e07be8d6d8b448'
 
   url "https://cdn.last.fm/client/Mac/Last.fm-#{version}.zip"
-  appcast 'http://cdn.last.fm/client/Mac/updates.xml',
+  appcast 'https://cdn.last.fm/client/Mac/updates.xml',
           checkpoint: '7a9b0239c6af0128a3eff20c46c3893cee1f3a57786f6c2fca8a8df8e8993280'
   name 'Last.fm Scrobbler'
   homepage 'https://www.last.fm/'

--- a/Casks/lastfm.rb
+++ b/Casks/lastfm.rb
@@ -2,11 +2,11 @@ cask 'lastfm' do
   version '2.1.37'
   sha256 'dc46e58111f8555fc0b1d6d2bd11e8fd4e4c45c6c7e953d106e07be8d6d8b448'
 
-  url "http://cdn.last.fm/client/Mac/Last.fm-#{version}.zip"
+  url "https://cdn.last.fm/client/Mac/Last.fm-#{version}.zip"
   appcast 'http://cdn.last.fm/client/Mac/updates.xml',
           checkpoint: '7a9b0239c6af0128a3eff20c46c3893cee1f3a57786f6c2fca8a8df8e8993280'
   name 'Last.fm Scrobbler'
-  homepage 'http://www.last.fm/'
+  homepage 'https://www.last.fm/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Last.fm.app'

--- a/Casks/launchy.rb
+++ b/Casks/launchy.rb
@@ -2,7 +2,7 @@ cask 'launchy' do
   version '2.5'
   sha256 '9a1112261c7f00d8600c2bf52abc98d5fabf89af56d5881a807b403b7c94e288'
 
-  url "http://www.launchy.net/downloads/mac/Launchy#{version}.dmg"
+  url "https://www.launchy.net/downloads/mac/Launchy#{version}.dmg"
   name 'Launchy'
   homepage 'http://www.launchy.net'
   license :gpl

--- a/Casks/launchy.rb
+++ b/Casks/launchy.rb
@@ -4,7 +4,7 @@ cask 'launchy' do
 
   url "https://www.launchy.net/downloads/mac/Launchy#{version}.dmg"
   name 'Launchy'
-  homepage 'http://www.launchy.net'
+  homepage 'https://www.launchy.net/'
   license :gpl
 
   app 'Launchy.app'

--- a/Casks/leap.rb
+++ b/Casks/leap.rb
@@ -4,7 +4,7 @@ cask 'leap' do
 
   url 'https://www.ironicsoftware.com/downloads/Leap.zip'
   name 'Ironic Software Leap'
-  homepage 'http://www.ironicsoftware.com/leap/'
+  homepage 'https://www.ironicsoftware.com/leap/'
   license :commercial
 
   app 'Leap.app'

--- a/Casks/leap.rb
+++ b/Casks/leap.rb
@@ -2,7 +2,7 @@ cask 'leap' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.ironicsoftware.com/downloads/Leap.zip'
+  url 'https://www.ironicsoftware.com/downloads/Leap.zip'
   name 'Ironic Software Leap'
   homepage 'http://www.ironicsoftware.com/leap/'
   license :commercial

--- a/Casks/leech.rb
+++ b/Casks/leech.rb
@@ -2,7 +2,7 @@ cask 'leech' do
   version '3.1'
   sha256 'e8553da6c6eaca569e87b0188b7c0bb6eab64dbc874c8c151768c6bf96c2470e'
 
-  url 'http://manytricks.com/download/leech'
+  url 'https://manytricks.com/download/leech'
   appcast 'https://manytricks.com/leech/appcast.xml',
           checkpoint: 'b0bc47dfb3d94fa3a2b7b4dad2538b2026803578283b3c106d48692b18d47c99'
   name 'Leech'

--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -2,7 +2,7 @@ cask 'livechat' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.livechatinc.com/download/Mac/LiveChat.dmg'
+  url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
   name 'LiveChat'
   homepage 'https://livechatinc.com'
   license :commercial

--- a/Casks/liya.rb
+++ b/Casks/liya.rb
@@ -4,7 +4,7 @@ cask 'liya' do
 
   url 'https://cutedgesystems.com/downloads/Liya.zip'
   name 'Liya'
-  homepage 'http://cutedgesystems.com/software/liya/'
+  homepage 'https://cutedgesystems.com/software/liya/'
   license :gratis
 
   app 'Liya.app'

--- a/Casks/loadmytracks.rb
+++ b/Casks/loadmytracks.rb
@@ -7,7 +7,7 @@ cask 'loadmytracks' do
   appcast 'https://www.cluetrust.com/AppCasts/LoadMyTracks.xml',
           checkpoint: 'bef86b055707d407eb2835db82e07d615968d344450417515cae5719fd97cefd'
   name 'LoadMyTracks'
-  homepage 'http://www.loadmytracks.com/'
+  homepage 'https://www.loadmytracks.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'LoadMyTracks.app'

--- a/Casks/logitech-control-center.rb
+++ b/Casks/logitech-control-center.rb
@@ -9,7 +9,7 @@ cask 'logitech-control-center' do
   else
     version '3.9.4'
     sha256 '0be19f691ad562cf143197bfd54c02183888c55842eb19a3bd644406acb3910d'
-    url "http://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
+    url "https://www.logitech.com/pub/techsupport/mouse/mac/lcc#{version}.zip"
   end
 
   name 'Logitech Control Center'

--- a/Casks/logitech-unifying.rb
+++ b/Casks/logitech-unifying.rb
@@ -4,7 +4,7 @@ cask 'logitech-unifying' do
 
   url "http://www.logitech.com/pub/controldevices/unifying/unifying#{version}_mac.zip"
   name 'Logitech Unifying Software'
-  homepage 'http://www.logitech.com/en-us/promotions/6072'
+  homepage 'https://www.logitech.com/en-us/promotions/6072'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   pkg 'Unifying Installer.app/Contents/Resources/Logitech Unifying Signed.mpkg'

--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -2,8 +2,8 @@ cask 'm3unify' do
   version '1.4.4'
   sha256 'f31041a4664b8158b3514571a9221fa8aa55d0af31817bca72f141fb86d5ed84'
 
-  url "http://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
-  appcast 'http://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
+  url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
+  appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
           checkpoint: '18a6929c547c19989a8ead8ead2bc8da131f45fe1e22639e6b2a8493b4ac30eb'
   name 'M3Unify'
   homepage 'http://dougscripts.com/itunes/itinfo/m3unify.php'

--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -6,7 +6,7 @@ cask 'm3unify' do
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
           checkpoint: '18a6929c547c19989a8ead8ead2bc8da131f45fe1e22639e6b2a8493b4ac30eb'
   name 'M3Unify'
-  homepage 'http://dougscripts.com/itunes/itinfo/m3unify.php'
+  homepage 'https://dougscripts.com/apps/m3unifyapp.php'
   license :commercial
 
   app 'M3Unify.app'

--- a/Casks/mac-informer.rb
+++ b/Casks/mac-informer.rb
@@ -4,7 +4,7 @@ cask 'mac-informer' do
 
   url 'http://files.informer.com/simac.dmg'
   name 'Mac Informer'
-  homepage 'http://macdownload.informer.com/landing/'
+  homepage 'https://macdownload.informer.com/landing/'
   license :gratis
 
   app 'Mac Informer.app'

--- a/Casks/macclean.rb
+++ b/Casks/macclean.rb
@@ -2,9 +2,9 @@ cask 'macclean' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/macclean-mac.dmg'
+  url 'https://www.imobie.com/product/macclean-mac.dmg'
   name 'MacClean'
-  homepage 'http://www.imobie.com/macclean/'
+  homepage 'https://www.imobie.com/macclean/'
   license :gratis
 
   app 'MacClean.app'

--- a/Casks/macpar-deluxe.rb
+++ b/Casks/macpar-deluxe.rb
@@ -2,9 +2,9 @@ cask 'macpar-deluxe' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.xs4all.nl/~gp/MacPAR_deLuxe/MacPARdeLuxe.dmg'
+  url 'https://www.xs4all.nl/~gp/MacPAR_deLuxe/MacPARdeLuxe.dmg'
   name 'MacPAR deLuxe'
-  homepage 'http://gp.home.xs4all.nl/Site/MacPAR_deLuxe.html'
+  homepage 'https://gp.home.xs4all.nl/Site/MacPAR_deLuxe.html'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'MacPAR deLuxe.app'

--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -2,11 +2,11 @@ cask 'mactracker' do
   version '7.5.6'
   sha256 '25d9d3b2e4807ab64141a4e7adcaffc79baf099f5afa92035e414cb062c6672b'
 
-  url "http://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
-  appcast 'http://update.mactracker.ca/appcast-b.xml',
+  url "https://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
+  appcast 'https://update.mactracker.ca/appcast-b.xml',
           checkpoint: '6b79b75ef700dca673faab2ac7df022b7f170012a5c0080793049b909fa1efc0'
   name 'Mactracker'
-  homepage 'http://mactracker.ca/'
+  homepage 'https://mactracker.ca/'
   license :gratis
 
   app 'Mactracker.app'

--- a/Casks/macx-youtube-downloader.rb
+++ b/Casks/macx-youtube-downloader.rb
@@ -2,9 +2,9 @@ cask 'macx-youtube-downloader' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.macxdvd.com/download/macx-youtube-downloader-free.dmg'
+  url 'https://www.macxdvd.com/download/macx-youtube-downloader-free.dmg'
   name 'MacX YouTube Downloader'
-  homepage 'http://www.macxdvd.com/free-youtube-video-downloader-mac'
+  homepage 'https://www.macxdvd.com/free-youtube-video-downloader-mac'
   license :gratis
 
   app 'MacX YouTube Downloader.app'

--- a/Casks/mailsmith.rb
+++ b/Casks/mailsmith.rb
@@ -2,11 +2,11 @@ cask 'mailsmith' do
   version '2.4_470'
   sha256 '5a599ceb64cb5d4410a26da3029e2e2ffa3eefd1efaf317cd33344ceccb059a2'
 
-  url "http://www.mailsmith.org/files/mailsmith-#{version.no_dots}.dmg"
-  appcast 'http://www.mailsmith.org/files/MailsmithSUFeed.xml',
+  url "https://www.mailsmith.org/files/mailsmith-#{version.no_dots}.dmg"
+  appcast 'https://www.mailsmith.org/files/MailsmithSUFeed.xml',
           checkpoint: '8a01c594f885a7e898f802707bdf105cec9aec3390138ba851353ca80d363bf5'
   name 'Mailsmith'
-  homepage 'http://www.mailsmith.org/'
+  homepage 'https://www.mailsmith.org/'
   license :gratis
 
   app 'Mailsmith.app'

--- a/Casks/makehuman.rb
+++ b/Casks/makehuman.rb
@@ -3,7 +3,7 @@ cask 'makehuman' do
   sha256 'ea74381b1fd9c0f699b2cf1a3476d7cf9447fad3beb3c48de0a4017032c44de9'
 
   # tuxfamily.org/makehuman was verified as official when first introduced to the cask
-  url "http://download.tuxfamily.org/makehuman/releases/#{version}/makehuman-#{version}-osx.dmg"
+  url "https://download.tuxfamily.org/makehuman/releases/#{version}/makehuman-#{version}-osx.dmg"
   name 'MakeHuman'
   homepage 'http://www.makehuman.org/'
   license :affero

--- a/Casks/manico.rb
+++ b/Casks/manico.rb
@@ -3,7 +3,7 @@ cask 'manico' do
   sha256 '14171ca3d2b0dcebdbc63f2c3b905f54b1134455d835f3ba1dfebeca8bfa0f1b'
 
   url "http://manico.im/static/Manico_#{version}.dmg"
-  appcast 'http://manico.im/static/manico-official-appcast.xml',
+  appcast 'https://manico.im/static/manico-official-appcast.xml',
           checkpoint: '0c20ba7f38321babd46cde6d61497690aa17068ebb5d03b8e678240413a04f97'
   name 'Manico'
   homepage 'http://manico.im/'

--- a/Casks/manico.rb
+++ b/Casks/manico.rb
@@ -6,7 +6,7 @@ cask 'manico' do
   appcast 'https://manico.im/static/manico-official-appcast.xml',
           checkpoint: '0c20ba7f38321babd46cde6d61497690aa17068ebb5d03b8e678240413a04f97'
   name 'Manico'
-  homepage 'http://manico.im/'
+  homepage 'https://manico.im/'
   license :commercial
 
   app 'Manico.app'

--- a/Casks/marsedit.rb
+++ b/Casks/marsedit.rb
@@ -2,7 +2,7 @@ cask 'marsedit' do
   version '3.7.7'
   sha256 'babe064e3e7871895fbcf5f163047782965fa7c1ac6d855988090994e6d08049'
 
-  url "http://www.red-sweater.com/marsedit/MarsEdit#{version}.zip"
+  url "https://www.red-sweater.com/marsedit/MarsEdit#{version}.zip"
   appcast 'https://www.red-sweater.com/marsedit/appcast3.php',
           checkpoint: '5b2b69a7d1ae90682f192f32b3849c288c800f4a9bae6a22277ab5c1a4d81b00'
   name 'MarsEdit'

--- a/Casks/master-key.rb
+++ b/Casks/master-key.rb
@@ -2,8 +2,8 @@ cask 'master-key' do
   version '5.6.4.3.611'
   sha256 'cfae689409eb520ef59c64a5bbe9ee321ea04d4485670cc723eb77b8b1c80dc5'
 
-  url 'http://macinmind.com/MasterKey.dmg'
-  appcast 'http://macinmind.com/pads/MasterKeyappcast.xml',
+  url 'https://macinmind.com/MasterKey.dmg'
+  appcast 'https://macinmind.com/pads/MasterKeyappcast.xml',
           checkpoint: '680e469511621b3f9dfb3976d6ef7c5518a322423fc1b4bf402945508660cf7d'
   name 'Master Key'
   homepage 'http://macinmind.com/?area=app&app=masterkey&pg=info'

--- a/Casks/master-key.rb
+++ b/Casks/master-key.rb
@@ -6,7 +6,7 @@ cask 'master-key' do
   appcast 'https://macinmind.com/pads/MasterKeyappcast.xml',
           checkpoint: '680e469511621b3f9dfb3976d6ef7c5518a322423fc1b4bf402945508660cf7d'
   name 'Master Key'
-  homepage 'http://macinmind.com/?area=app&app=masterkey&pg=info'
+  homepage 'https://macinmind.com/?area=app&app=masterkey&pg=info'
   license :commercial
 
   app 'Master Key.app'

--- a/Casks/max.rb
+++ b/Casks/max.rb
@@ -3,10 +3,10 @@ cask 'max' do
   sha256 '722bf714696d3d39329ba98ffddc9f117f8cc6863f71670507cd12f62a5e5f14'
 
   url "http://files.sbooth.org/Max-#{version}.tar.bz2"
-  appcast 'http://sbooth.org/Max/appcast.xml',
+  appcast 'https://sbooth.org/Max/appcast.xml',
           checkpoint: 'da0e3f2c4da860454e69657f5cbdf7b7866a68fa26cd456ae844e535981a4bc6'
   name 'Max'
-  homepage 'http://sbooth.org/Max/'
+  homepage 'https://sbooth.org/Max/'
   license :gpl
 
   app "Max-#{version}/Max.app"

--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -2,9 +2,9 @@ cask 'menumeters' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.ragingmenace.com/software/download/MenuMeters.dmg'
+  url 'https://www.ragingmenace.com/software/download/MenuMeters.dmg'
   name 'MenuMeters'
-  homepage 'http://www.ragingmenace.com/software/menumeters/'
+  homepage 'https://www.ragingmenace.com/software/menumeters/'
   license :gpl
 
   depends_on macos: '<= :yosemite'

--- a/Casks/messenger.rb
+++ b/Casks/messenger.rb
@@ -2,11 +2,11 @@ cask 'messenger' do
   version '0.1.8.1466363428-c3dc9b83f1dd0469'
   sha256 '84e8d4e5c5242ac3e277423a1ae54be6267d05c1eb47b79c77a6b5c0e548f7df'
 
-  url "http://fbmacmessenger.rsms.me/dist/Messenger-#{version}.zip"
+  url "https://fbmacmessenger.rsms.me/dist/Messenger-#{version}.zip"
   appcast 'https://fbmacmessenger.rsms.me/changelog.xml',
           checkpoint: '6b72f621e9f00b9cc4786cb7084a727d31bd91d5d34cf0191170c4a2e2b9c622'
   name 'Messenger'
-  homepage 'http://fbmacmessenger.rsms.me/'
+  homepage 'https://fbmacmessenger.rsms.me/'
   license :mit
 
   app 'Messenger.app'

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -2,7 +2,7 @@ cask 'microsoft-office' do
   version :latest
   sha256 :no_check
 
-  url 'http://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_2016_Installer.pkg'
+  url 'https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_2016_Installer.pkg'
   name 'Microsoft Office 2016'
   homepage 'https://www.microsoft.com/mac'
   license :commercial

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -7,7 +7,7 @@ cask 'middleclick' do
   appcast 'https://github.com/cl3m/MiddleClick/releases.atom',
           checkpoint: '56cc9aa7f59fd6d6db671678ff4b72a5289becb98dbe32ce1587cc746d411db9'
   name 'MiddleClick'
-  homepage 'http://rouge41.com/labs/'
+  homepage 'https://rouge41.com/labs/'
   license :gpl
 
   app 'MiddleClick.app'

--- a/Casks/mirador.rb
+++ b/Casks/mirador.rb
@@ -7,7 +7,7 @@ cask 'mirador' do
   appcast 'https://github.com/mirador/mirador/releases.atom',
           checkpoint: 'f170ed80b82bb18d60baca9c3310a9039ce8b88ee1c023f02a6a676bd0f6cdf6'
   name 'Mirador'
-  homepage 'http://fathom.info/mirador/'
+  homepage 'https://fathom.info/mirador/'
   license :gpl
 
   app 'Mirador.app'

--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -4,7 +4,7 @@ cask 'molotov' do
 
   url "http://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'
-  homepage 'http://www.molotov.tv/'
+  homepage 'https://www.molotov.tv/'
   license :unknown
 
   app 'Molotov.app'

--- a/Casks/moneydance.rb
+++ b/Casks/moneydance.rb
@@ -4,7 +4,7 @@ cask 'moneydance' do
 
   url 'https://infinitekind.com/stabledl/2015/Moneydance.zip'
   name 'Moneydance'
-  homepage 'http://infinitekind.com/moneydance'
+  homepage 'https://infinitekind.com/moneydance'
   license :commercial
 
   app 'Moneydance.app'

--- a/Casks/moneydance.rb
+++ b/Casks/moneydance.rb
@@ -2,7 +2,7 @@ cask 'moneydance' do
   version :latest
   sha256 :no_check
 
-  url 'http://infinitekind.com/stabledl/2015/Moneydance.zip'
+  url 'https://infinitekind.com/stabledl/2015/Moneydance.zip'
   name 'Moneydance'
   homepage 'http://infinitekind.com/moneydance'
   license :commercial

--- a/Casks/mountain.rb
+++ b/Casks/mountain.rb
@@ -2,11 +2,11 @@ cask 'mountain' do
   version '1.6.4'
   sha256 '7290dca93600e5c59cf797cae3f3bd874f2d9d79811969b9dad8586cf2a5c53f'
 
-  url 'http://appgineers.de/mountain/files/Mountain.zip'
-  appcast 'http://appgineers.de/mountain/files/mountaincast.xml',
+  url 'https://appgineers.de/mountain/files/Mountain.zip'
+  appcast 'https://appgineers.de/mountain/files/mountaincast.xml',
           checkpoint: '26376efb3510b4804c540a105616362ae6fc009dd1aa85f99ea943bb27e88945'
   name 'Mountain'
-  homepage 'http://appgineers.de/mountain/'
+  homepage 'https://appgineers.de/mountain/'
   license :commercial
 
   depends_on macos: '>= :snow_leopard'

--- a/Casks/movelinks.rb
+++ b/Casks/movelinks.rb
@@ -7,7 +7,7 @@ cask 'movelinks' do
   appcast 'https://d1c229iib3zm7m.cloudfront.net/mac/appcast.xml',
           checkpoint: '529dbb191756744a2304e8693f7044c6310d6d36a9b9b7a0196487fc10b80d4a'
   name 'Movelinks'
-  homepage 'http://www.movescount.com/connect/moveslinkmac/Suunto_Ambit'
+  homepage 'https://www.movescount.com/connect/moveslinkmac/Suunto_Ambit'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   auto_updates true

--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -7,7 +7,7 @@ cask 'mplayer-osx-extended' do
   appcast 'https://github.com/sttz/MPlayer-OSX-Extended/releases.atom',
           checkpoint: '97a7842a97b15d35ed296f0917e0c6ebdf9f5c54f978e15bf419134bac7bf232'
   name 'MPlayer OSX Extended'
-  homepage 'http://www.mplayerosx.ch/'
+  homepage 'https://mplayerosx.ch/'
   license :gpl
 
   app 'MPlayer OSX Extended.app'

--- a/Casks/multifirefox.rb
+++ b/Casks/multifirefox.rb
@@ -3,7 +3,7 @@ cask 'multifirefox' do
   sha256 '052148d029d5c4f0e9bc25ea56f1826f5491b36c18f595bd8639542c5a5eebbd'
 
   # amazonaws.com/mff_sparkle was verified as official when first introduced to the cask
-  url "http://s3.amazonaws.com/mff_sparkle/MultiFirefox_#{version}.zip"
+  url "https://s3.amazonaws.com/mff_sparkle/MultiFirefox_#{version}.zip"
   appcast 'https://s3.amazonaws.com/mff_sparkle/MultiFirefoxAppcast2.xml',
           checkpoint: 'fc4c1e122aa26f0f081158d044aa9dc51e70655b265682902e925f7c11782090'
   name 'MultiFirefox'

--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -10,7 +10,7 @@ cask 'mumble' do
   homepage 'https://www.mumble.info/'
   license :bsd
   gpg "#{url}.sig",
-      key_url: 'http://mumble.info/gpg/mumble-auto-build-2015.asc'
+      key_url: 'https://mumble.info/gpg/mumble-auto-build-2015.asc'
 
   app 'Mumble.app'
 end

--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -7,7 +7,7 @@ cask 'mumble' do
   appcast 'https://github.com/mumble-voip/mumble/releases.atom',
           checkpoint: 'a28725d6c33c456c81096d7c787eb90461e785d5213e11d98a010ff8625f9fd9'
   name 'Mumble'
-  homepage 'http://www.mumble.info/'
+  homepage 'https://www.mumble.info/'
   license :bsd
   gpg "#{url}.sig",
       key_url: 'http://mumble.info/gpg/mumble-auto-build-2015.asc'

--- a/Casks/narrative-uploader.rb
+++ b/Casks/narrative-uploader.rb
@@ -6,7 +6,7 @@ cask 'narrative-uploader' do
   appcast 'https://dl.getnarrative.com/appcast/osx.xml',
           checkpoint: 'db3fe560e55b1735cfeb457552ec724d95c75b72699bb28e2590c12b58972919'
   name 'Narrative Uploader'
-  homepage 'http://getnarrative.com'
+  homepage 'https://getnarrative.com/'
   license :gratis
 
   app 'Narrative Uploader.app'

--- a/Casks/narrative-uploader.rb
+++ b/Casks/narrative-uploader.rb
@@ -2,7 +2,7 @@ cask 'narrative-uploader' do
   version '201510131242'
   sha256 '1cc4cae7a1cfe43e3e35a2d49aa51a220925298f9628b2e2f84e900a1a82943b'
 
-  url "http://dl.getnarrative.com/appcast/osx/#{version}.zip"
+  url "https://dl.getnarrative.com/appcast/osx/#{version}.zip"
   appcast 'https://dl.getnarrative.com/appcast/osx.xml',
           checkpoint: 'db3fe560e55b1735cfeb457552ec724d95c75b72699bb28e2590c12b58972919'
   name 'Narrative Uploader'

--- a/Casks/ncmeta.rb
+++ b/Casks/ncmeta.rb
@@ -2,9 +2,9 @@ cask 'ncmeta' do
   version '1.0'
   sha256 '42e61202705784dbdb16d0842d8b499fb311c3947b3456fccd046edcfa1b9727'
 
-  url "http://www.timschroeder.net/ncMeta/ncMeta#{version}.zip"
+  url "https://www.timschroeder.net/ncMeta/ncMeta#{version}.zip"
   name 'ncMeta'
-  homepage 'http://www.timschroeder.net/ncMeta/'
+  homepage 'https://www.timschroeder.net/ncMeta/'
   license :mit
 
   app 'ncMeta.app'

--- a/Casks/nisus-thesaurus.rb
+++ b/Casks/nisus-thesaurus.rb
@@ -4,7 +4,7 @@ cask 'nisus-thesaurus' do
 
   url "https://nisus.com/files/free/Thesaurus-v#{version.no_dots}.zip"
   name 'Nisus Thesaurus'
-  homepage 'http://nisus.com/Thesaurus/'
+  homepage 'https://nisus.com/Thesaurus/'
   license :gratis
 
   depends_on macos: '>= :snow_leopard'

--- a/Casks/nisus-thesaurus.rb
+++ b/Casks/nisus-thesaurus.rb
@@ -2,7 +2,7 @@ cask 'nisus-thesaurus' do
   version '1.1.1'
   sha256 'ee9203ada1fa944ac4b7fc04f03ec58fd7c60ce1d73e6058321583f7dbf8ae5a'
 
-  url "http://nisus.com/files/free/Thesaurus-v#{version.no_dots}.zip"
+  url "https://nisus.com/files/free/Thesaurus-v#{version.no_dots}.zip"
   name 'Nisus Thesaurus'
   homepage 'http://nisus.com/Thesaurus/'
   license :gratis

--- a/Casks/notebooks.rb
+++ b/Casks/notebooks.rb
@@ -4,7 +4,7 @@ cask 'notebooks' do
 
   url 'https://www.notebooksapp.com/Download/Notebooks%20for%20Mac.dmg'
   name 'Notebooks'
-  homepage 'http://www.notebooksapp.com/mac/'
+  homepage 'https://www.notebooksapp.com/mac/'
   license :commercial
 
   app 'Notebooks.app'

--- a/Casks/notebooks.rb
+++ b/Casks/notebooks.rb
@@ -2,7 +2,7 @@ cask 'notebooks' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.notebooksapp.com/Download/Notebooks%20for%20Mac.dmg'
+  url 'https://www.notebooksapp.com/Download/Notebooks%20for%20Mac.dmg'
   name 'Notebooks'
   homepage 'http://www.notebooksapp.com/mac/'
   license :commercial

--- a/Casks/nwjs.rb
+++ b/Casks/nwjs.rb
@@ -11,13 +11,13 @@ cask 'nwjs' do
   else
     sha256 '416747be34ad3bbae008ac6121551fda1505dfac55169cbd025558b29a40faf4'
 
-    url "http://dl.nwjs.io/v#{version}/nwjs-v#{version}-osx-x64.zip"
+    url "https://dl.nwjs.io/v#{version}/nwjs-v#{version}-osx-x64.zip"
 
     binary "nwjs-v#{version}-osx-x64/nwjc"
     app "nwjs-v#{version}-osx-x64/nwjs.app"
   end
 
   name 'NW.js'
-  homepage 'http://nwjs.io'
+  homepage 'https://nwjs.io'
   license :mit
 end

--- a/Casks/nzbvortex.rb
+++ b/Casks/nzbvortex.rb
@@ -2,11 +2,11 @@ cask 'nzbvortex' do
   version '3.3.3'
   sha256 'e98104b8c4784f47b8923ea91722d94edd5373c845ead96cb471642d101917f0'
 
-  url "http://www.nzbvortex.com/downloads/NZBVortex-#{version}.zip"
+  url "https://www.nzbvortex.com/downloads/NZBVortex-#{version}.zip"
   appcast "https://www.nzbvortex.com/update/appcast_v#{version.major}.xml",
           checkpoint: '5e0d2970bee06d3fc90ddc6f35d1e91106641db616fd0094cfcdb4d2886e06f2'
   name 'NZBVortex'
-  homepage 'http://www.nzbvortex.com/'
+  homepage 'https://www.nzbvortex.com/'
   license :commercial
 
   app "NZBVortex #{version.major}.app"

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,7 +2,7 @@ cask 'ocenaudio' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.ocenaudio.com.br/downloads/ocenaudio64.dmg'
+  url 'https://www.ocenaudio.com.br/downloads/ocenaudio64.dmg'
   name 'ocenaudio'
   homepage 'http://www.ocenaudio.com.br/en'
   license :gratis

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -4,7 +4,7 @@ cask 'ocenaudio' do
 
   url 'https://www.ocenaudio.com.br/downloads/ocenaudio64.dmg'
   name 'ocenaudio'
-  homepage 'http://www.ocenaudio.com.br/en'
+  homepage 'https://www.ocenaudio.com/en'
   license :gratis
 
   app 'ocenaudio.app'

--- a/Casks/ocrkit.rb
+++ b/Casks/ocrkit.rb
@@ -5,7 +5,7 @@ cask 'ocrkit' do
   # exactcode.de was verified as official when first introduced to the cask
   url "http://dl.exactcode.de/tmp/#{version.after_comma}/OCRKit-#{version.before_comma}.dmg"
   name 'OCRKit'
-  homepage 'http://ocrkit.com/'
+  homepage 'https://ocrkit.com/'
   license :freemium
 
   app 'OCRKit.app'

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -2,7 +2,7 @@ cask 'omnioutliner' do
   version '4.5.3'
   sha256 'df2db6c5e79c28978a2471d68585b41219d4aa12ea142e66e0d67b62001c8da7'
 
-  url "http://downloads.omnigroup.com/software/MacOSX/10.10/OmniOutliner-#{version}.dmg"
+  url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniOutliner-#{version}.dmg"
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
   license :commercial

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -4,7 +4,7 @@ cask 'opera' do
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'
-  homepage 'http://www.opera.com/'
+  homepage 'https://www.opera.com/'
   license :gratis
 
   app 'Opera.app'

--- a/Casks/orbitum.rb
+++ b/Casks/orbitum.rb
@@ -4,7 +4,7 @@ cask 'orbitum' do
 
   url 'https://orbitum.com/orbitum.dmg'
   name 'Orbitum'
-  homepage 'http://orbitum.com/'
+  homepage 'https://orbitum.com/'
   license :gratis
 
   app 'Orbitum.app'

--- a/Casks/osu.rb
+++ b/Casks/osu.rb
@@ -2,7 +2,7 @@ cask 'osu' do
   version '20151017'
   sha256 '5677ee299ea9e271546e6ab56b9d3abe002d4295c9529a5b917f5af167dcd477'
 
-  url "http://m1.ppy.sh/osu%21-#{version}.dmg"
+  url "https://m1.ppy.sh/osu%21-#{version}.dmg"
   name 'osu!'
   homepage 'https://osu.ppy.sh'
   license :closed

--- a/Casks/outguess.rb
+++ b/Casks/outguess.rb
@@ -2,7 +2,7 @@ cask 'outguess' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.rbcafe.com/download/outguess.zip'
+  url 'https://www.rbcafe.com/download/outguess.zip'
   name 'Outguess'
   homepage 'http://www.rbcafe.com/softwares/outguess/'
   license :gratis

--- a/Casks/outguess.rb
+++ b/Casks/outguess.rb
@@ -4,7 +4,7 @@ cask 'outguess' do
 
   url 'https://www.rbcafe.com/download/outguess.zip'
   name 'Outguess'
-  homepage 'http://www.rbcafe.com/softwares/outguess/'
+  homepage 'https://www.rbcafe.com/softwares/outguess/'
   license :gratis
 
   depends_on macos: '>= :mountain_lion'

--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -18,6 +18,6 @@ cask 'p4merge' do
   caveats <<-EOS.undent
     git can be configured to use p4merge as a merge tool via
 
-      http://pempek.net/articles/2014/04/18/git-p4merge/
+      https://pempek.net/articles/2014/04/18/git-p4merge/
   EOS
 end

--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -4,7 +4,7 @@ cask 'paintcode' do
 
   url "https://www.paintcodeapp.com/content/versions/#{version}/paintcode-trial.zip"
   name 'PaintCode'
-  homepage 'http://www.paintcodeapp.com/'
+  homepage 'https://www.paintcodeapp.com/'
   license :commercial
 
   app 'PaintCode.app'

--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -2,7 +2,7 @@ cask 'paintcode' do
   version '2.4.1'
   sha256 'd3669953482e92c5a7ae35907d0273e22b801496d85ba1cadf02a310cb3a236f'
 
-  url "http://www.paintcodeapp.com/content/versions/#{version}/paintcode-trial.zip"
+  url "https://www.paintcodeapp.com/content/versions/#{version}/paintcode-trial.zip"
   name 'PaintCode'
   homepage 'http://www.paintcodeapp.com/'
   license :commercial

--- a/Casks/password-gorilla.rb
+++ b/Casks/password-gorilla.rb
@@ -3,7 +3,7 @@ cask 'password-gorilla' do
   sha256 '51c443fb58a3628c2a45bd3160096abb9b017f33e6a08628636168f996ad0414'
 
   # gorilla.dp100.com was verified as official when first introduced to the cask
-  url "http://gorilla.dp100.com/downloads/gorilla.mac.#{version.no_dots}.zip"
+  url "https://gorilla.dp100.com/downloads/gorilla.mac.#{version.no_dots}.zip"
   name 'Password Gorilla'
   homepage 'https://github.com/zdia/gorilla'
   license :gpl

--- a/Casks/perma.rb
+++ b/Casks/perma.rb
@@ -3,7 +3,7 @@ cask 'perma' do
   sha256 '7987bacb6852d9874d899beefed84f0f2dcbbbb2893e481a607a623c994eb62a'
 
   # perma-dl.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://perma-dl.s3.amazonaws.com/Perma-v#{version}.zip"
+  url "https://perma-dl.s3.amazonaws.com/Perma-v#{version}.zip"
   name 'Perma'
   homepage 'https://per.ma'
   license :unknown

--- a/Casks/pester.rb
+++ b/Casks/pester.rb
@@ -2,11 +2,11 @@ cask 'pester' do
   version '1.1b21'
   sha256 'a1923d0b330f9e054c1c7215b35322508f03c29294660df9b73bebf6411be283'
 
-  url "http://sabi.net/nriley/software/Pester-#{version}.dmg"
-  appcast 'http://sabi.net/nriley/software/Pester/updates.xml',
+  url "https://sabi.net/nriley/software/Pester-#{version}.dmg"
+  appcast 'https://sabi.net/nriley/software/Pester/updates.xml',
           checkpoint: '80c01b621ac7672ce1866445703e2c11532f79b1c6120aa568b33af0bce9289e'
   name 'Pester'
-  homepage 'http://sabi.net/nriley/software/index.html#pester'
+  homepage 'https://sabi.net/nriley/software/index.html#pester'
   license :bsd
 
   app 'Pester.app'

--- a/Casks/phonebrowse.rb
+++ b/Casks/phonebrowse.rb
@@ -2,9 +2,9 @@ cask 'phonebrowse' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/phonebrowse-mac.dmg'
+  url 'https://www.imobie.com/product/phonebrowse-mac.dmg'
   name 'PhoneBrowse'
-  homepage 'http://www.imobie.com/phonebrowse'
+  homepage 'https://www.imobie.com/phonebrowse'
   license :gratis
 
   app 'PhoneBrowse.app'

--- a/Casks/phoneclean.rb
+++ b/Casks/phoneclean.rb
@@ -2,9 +2,9 @@ cask 'phoneclean' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/phoneclean-mac.dmg'
+  url 'https://www.imobie.com/product/phoneclean-mac.dmg'
   name 'PhoneClean'
-  homepage 'http://www.imobie.com/phoneclean/'
+  homepage 'https://www.imobie.com/phoneclean/'
   license :commercial
 
   app 'PhoneClean.app'

--- a/Casks/phonerescue.rb
+++ b/Casks/phonerescue.rb
@@ -2,9 +2,9 @@ cask 'phonerescue' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/phonerescue-mac.dmg'
+  url 'https://www.imobie.com/product/phonerescue-mac.dmg'
   name 'PhoneRescue'
-  homepage 'http://www.imobie.com/phonerescue'
+  homepage 'https://www.imobie.com/phonerescue'
   license :gratis
 
   app 'PhoneRescue.app'

--- a/Casks/phonetrans.rb
+++ b/Casks/phonetrans.rb
@@ -2,9 +2,9 @@ cask 'phonetrans' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/phonetrans-mac.dmg'
+  url 'https://www.imobie.com/product/phonetrans-mac.dmg'
   name 'PhoneTrans'
-  homepage 'http://www.imobie.com/phonetrans'
+  homepage 'https://www.imobie.com/phonetrans'
   license :gratis
 
   app 'PhoneTrans.app'

--- a/Casks/phototrans.rb
+++ b/Casks/phototrans.rb
@@ -2,9 +2,9 @@ cask 'phototrans' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/phototrans-mac.dmg'
+  url 'https://www.imobie.com/product/phototrans-mac.dmg'
   name 'PhotoTrans'
-  homepage 'http://www.imobie.com/phototrans/'
+  homepage 'https://www.imobie.com/phototrans/'
   license :gratis
 
   app 'PhotoTrans.app'

--- a/Casks/pinta.rb
+++ b/Casks/pinta.rb
@@ -7,7 +7,7 @@ cask 'pinta' do
   appcast 'https://github.com/PintaProject/Pinta/releases.atom',
           checkpoint: 'd343ef21b0681259d7a8df250d61abf187a250cd34f54717c1d6130ec5767c28'
   name 'Pinta'
-  homepage 'http://pinta-project.com/'
+  homepage 'https://pinta-project.com/'
   license :mit
 
   depends_on cask: 'mono-mdk'

--- a/Casks/pixi-paint.rb
+++ b/Casks/pixi-paint.rb
@@ -3,7 +3,7 @@ cask 'pixi-paint' do
   sha256 :no_check
 
   # pixiecdn.com was verified as official when first introduced to the cask
-  url 'http://0.pixiecdn.com/PixiePaint-osx.zip'
+  url 'https://0.pixiecdn.com/PixiePaint-osx.zip'
   name 'Pixi Paint'
   homepage 'https://www.danielx.net/pixel-editor/docs/download'
   license :mit

--- a/Casks/playlist-assist.rb
+++ b/Casks/playlist-assist.rb
@@ -6,7 +6,7 @@ cask 'playlist-assist' do
   appcast 'https://dougscripts.com/itunes/itinfo/playlistassist_appcast.xml',
           checkpoint: '7324b771b62991def6574252bab947e3df630beae5351b7365ad8c9046f6fe29'
   name 'Playlist Assist'
-  homepage 'http://dougscripts.com/apps/playlistassistapp.php'
+  homepage 'https://dougscripts.com/apps/playlistassistapp.php'
   license :commercial
 
   app 'Playlist Assist.app'

--- a/Casks/playlist-assist.rb
+++ b/Casks/playlist-assist.rb
@@ -2,8 +2,8 @@ cask 'playlist-assist' do
   version '1.2.4'
   sha256 '85606254173bddf0c282affa24c9db3bce8c15d754a1d9ba3912932878260958'
 
-  url "http://dougscripts.com/itunes/scrx/playlistassistv#{version.no_dots}.zip"
-  appcast 'http://dougscripts.com/itunes/itinfo/playlistassist_appcast.xml',
+  url "https://dougscripts.com/itunes/scrx/playlistassistv#{version.no_dots}.zip"
+  appcast 'https://dougscripts.com/itunes/itinfo/playlistassist_appcast.xml',
           checkpoint: '7324b771b62991def6574252bab947e3df630beae5351b7365ad8c9046f6fe29'
   name 'Playlist Assist'
   homepage 'http://dougscripts.com/apps/playlistassistapp.php'

--- a/Casks/plistedit-pro.rb
+++ b/Casks/plistedit-pro.rb
@@ -2,9 +2,9 @@ cask 'plistedit-pro' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.fatcatsoftware.com/plisteditpro/PlistEditPro.zip'
+  url 'https://www.fatcatsoftware.com/plisteditpro/PlistEditPro.zip'
   name 'PlistEdit Pro'
-  homepage 'http://www.fatcatsoftware.com/plisteditpro/'
+  homepage 'https://www.fatcatsoftware.com/plisteditpro/'
   license :commercial
 
   app 'PlistEdit Pro.app'

--- a/Casks/podtrans.rb
+++ b/Casks/podtrans.rb
@@ -2,9 +2,9 @@ cask 'podtrans' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.imobie.com/product/podtrans-mac.dmg'
+  url 'https://www.imobie.com/product/podtrans-mac.dmg'
   name 'PodTrans'
-  homepage 'http://www.imobie.com/podtrans'
+  homepage 'https://www.imobie.com/podtrans'
   license :gratis
 
   app 'PodTrans.app'

--- a/Casks/polycom-realpresence-desktop.rb
+++ b/Casks/polycom-realpresence-desktop.rb
@@ -2,7 +2,7 @@ cask 'polycom-realpresence-desktop' do
   version '3.5.0_59579'
   sha256 '7b52d08b5be50e43b1f943201cbc9507983e19c44fa411f8a57c7b2adceab969'
 
-  url "http://downloads.polycom.com/video/realpresence_desktop/RPDMac-release_#{version}.dmg"
+  url "https://downloads.polycom.com/video/realpresence_desktop/RPDMac-release_#{version}.dmg"
   name 'Polycom RealPresence Desktop'
   homepage 'http://www.polycom.com/products-services/hd-telepresence-video-conferencing/realpresence-desktop/realpresence-desktop.html'
   license :commercial

--- a/Casks/pomello.rb
+++ b/Casks/pomello.rb
@@ -4,7 +4,7 @@ cask 'pomello' do
 
   url 'https://pomelloapp.com/download/mac'
   name 'Pomello'
-  homepage 'http://pomelloapp.com/'
+  homepage 'https://pomelloapp.com/'
   license :closed
 
   app 'Pomello.app'

--- a/Casks/pomello.rb
+++ b/Casks/pomello.rb
@@ -2,7 +2,7 @@ cask 'pomello' do
   version :latest
   sha256 :no_check
 
-  url 'http://pomelloapp.com/download/mac'
+  url 'https://pomelloapp.com/download/mac'
   name 'Pomello'
   homepage 'http://pomelloapp.com/'
   license :closed

--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -4,7 +4,7 @@ cask 'pomodone' do
 
   url 'https://app.pomodoneapp.com/PomoDone.dmg'
   name 'PomoDone'
-  homepage 'http://pomodoneapp.com/'
+  homepage 'https://pomodoneapp.com/'
   license :gratis
 
   app 'PomoDone.app'

--- a/Casks/porthole.rb
+++ b/Casks/porthole.rb
@@ -2,7 +2,7 @@ cask 'porthole' do
   version '1.7.8'
   sha256 'f59b618fcbd8135fdbbe58da6c87e9bc457d7e7a8f9aee11f460c5a86b49e09d'
 
-  url "http://download.getporthole.com/Porthole-v#{version}.zip"
+  url "https://download.getporthole.com/Porthole-v#{version}.zip"
   appcast 'https://update.getporthole.com/appcast.rss',
           checkpoint: '832694ca1715fbd74cac68b0c543084fdf67e7c1ebffc7e38be8f0f4d4f285cd'
   name 'Porthole'

--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -7,7 +7,7 @@ cask 'powerphotos' do
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
           checkpoint: '8e20c09bbffb0e07d275479375bc9ad7d851eec1377d397074bb6f427585e4ad'
   name 'PowerPhotos'
-  homepage 'http://www.fatcatsoftware.com/powerphotos/'
+  homepage 'https://www.fatcatsoftware.com/powerphotos/'
   license :commercial
 
   auto_updates true

--- a/Casks/private-eye.rb
+++ b/Casks/private-eye.rb
@@ -2,9 +2,9 @@ cask 'private-eye' do
   version :latest
   sha256 :no_check
 
-  url 'http://radiosilenceapp.com/downloads/Private_Eye_for_OS_X_10.9_and_later.pkg'
+  url 'https://radiosilenceapp.com/downloads/Private_Eye_for_OS_X_10.9_and_later.pkg'
   name 'Private Eye'
-  homepage 'http://radiosilenceapp.com/private-eye'
+  homepage 'https://radiosilenceapp.com/private-eye'
   license :oss
 
   pkg 'Private_Eye_for_OS_X_10.9_and_later.pkg'

--- a/Casks/prizmo.rb
+++ b/Casks/prizmo.rb
@@ -6,7 +6,7 @@ cask 'prizmo' do
   appcast 'http://www.creaceed.com/appcasts/prizmo3.xml',
           checkpoint: '7c791245da47c68259dd99f9fe0cd5962d51b5e1aa042b948f5090f8ec17520e'
   name 'Prizmo'
-  homepage 'http://www.creaceed.com/prizmo'
+  homepage 'https://www.creaceed.com/prizmo'
   license :freemium
 
   depends_on macos: '>= :yosemite'

--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -4,7 +4,7 @@ cask 'progressive-downloader' do
 
   url "https://www.macpsd.net/update/#{version}/PSD.dmg"
   name 'Progressive Downloader'
-  homepage 'http://www.macpsd.net'
+  homepage 'https://www.macpsd.net/'
   license :gratis
 
   app 'Progressive Downloader.app'

--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -2,7 +2,7 @@ cask 'progressive-downloader' do
   version '2.2.1'
   sha256 '7a27882727e54553eb553b2411bed45e73f36335eabb00b92a86c7a4a93b0aef'
 
-  url "http://www.macpsd.net/update/#{version}/PSD.dmg"
+  url "https://www.macpsd.net/update/#{version}/PSD.dmg"
   name 'Progressive Downloader'
   homepage 'http://www.macpsd.net'
   license :gratis

--- a/Casks/proximity.rb
+++ b/Casks/proximity.rb
@@ -3,7 +3,7 @@ cask 'proximity' do
   sha256 '836d209bb83cd144780e200aad7ea6dda2581b20c5be316208337996532f0d51'
 
   # kvraudio.com was verified as official when first introduced to the cask
-  url "http://static.kvraudio.com/files/1451/proximity_v#{version.dots_to_underscores}-mac.zip"
+  url "https://static.kvraudio.com/files/1451/proximity_v#{version.dots_to_underscores}-mac.zip"
   name 'Proximity'
   homepage 'http://www.tokyodawn.net/proximity/'
   license :gratis

--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -3,7 +3,7 @@ cask 'proxpn' do
   sha256 '5f4bf12371ccdf694a222ec8d966f6796e8d93a484934e674798385d60891370'
 
   url "https://www.proxpn.com/updater/proXPN-MacOSX-10.7-#{version}.dmg"
-  appcast 'http://www.proxpn.com/updater/appcast.rss',
+  appcast 'https://www.proxpn.com/updater/appcast.rss',
           checkpoint: 'ec65d9d281487212b1aba6ff55e4ec7802dff549d692941fb2f81a996b8485ab'
   name 'proXPN'
   homepage 'https://www.proxpn.com/'

--- a/Casks/qblocker.rb
+++ b/Casks/qblocker.rb
@@ -7,7 +7,7 @@ cask 'qblocker' do
   appcast 'https://updates.devmate.com/uk.co.wearecocoon.QBlocker.xml',
           checkpoint: '9e2b0dd2a34cf6bb9349ed7671a9fd1926f574e38aebbf95266663866f6708bf'
   name 'QBlocker'
-  homepage 'http://qblocker.com/'
+  homepage 'https://qblocker.com/'
   license :oss
 
   accessibility_access true

--- a/Casks/qupzilla.rb
+++ b/Casks/qupzilla.rb
@@ -2,7 +2,7 @@ cask 'qupzilla' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.qupzilla.com/startdownload?mac'
+  url 'https://www.qupzilla.com/startdownload?mac'
   name 'QupZilla'
   homepage 'http://www.qupzilla.com'
   license :gpl

--- a/Casks/qupzilla.rb
+++ b/Casks/qupzilla.rb
@@ -4,7 +4,7 @@ cask 'qupzilla' do
 
   url 'https://www.qupzilla.com/startdownload?mac'
   name 'QupZilla'
-  homepage 'http://www.qupzilla.com'
+  homepage 'https://www.qupzilla.com/'
   license :gpl
 
   app 'QupZilla.app'

--- a/Casks/radio-silence.rb
+++ b/Casks/radio-silence.rb
@@ -6,7 +6,7 @@ cask 'radio-silence' do
   appcast 'https://radiosilenceapp.com/update',
           checkpoint: 'b499bb832ce12d4e641ab1d69468dd1ddfc7d3871056a357a06d13610e9d2de8'
   name 'Radio Silence'
-  homepage 'http://radiosilenceapp.com'
+  homepage 'https://radiosilenceapp.com'
   license :commercial
 
   pkg "Radio_Silence_#{version}.pkg"

--- a/Casks/rdm.rb
+++ b/Casks/rdm.rb
@@ -7,7 +7,7 @@ cask 'rdm' do
   appcast 'https://github.com/uglide/RedisDesktopManager/releases.atom',
           checkpoint: '55c262996d7b3d7809ae543638792d70b6a1d2d26e817eeffe8a7ed6da3391fe'
   name 'Redis Desktop Manager'
-  homepage 'http://redisdesktop.com/'
+  homepage 'https://redisdesktop.com/'
   license :gpl
 
   app 'rdm.app'

--- a/Casks/recent-menu.rb
+++ b/Casks/recent-menu.rb
@@ -2,9 +2,9 @@ cask 'recent-menu' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.timschroeder.net/recentmenu/RecentMenu.zip'
+  url 'https://www.timschroeder.net/recentmenu/RecentMenu.zip'
   name 'Recent Menu'
-  homepage 'http://www.timschroeder.net/recentmenu/'
+  homepage 'https://www.timschroeder.net/recentmenu/'
   license :oss
 
   app 'Recent Menu.app'

--- a/Casks/repetier-host.rb
+++ b/Casks/repetier-host.rb
@@ -6,7 +6,7 @@ cask 'repetier-host' do
   appcast 'https://www.repetier.com/updates/rhm/rhm-appcast.xml',
           checkpoint: '465e0b22421fa56a9da4c564d409da1242eb5ceee6789c040ceb5e75db5ffe85'
   name 'Repetier-Host'
-  homepage 'http://www.repetier.com/'
+  homepage 'https://www.repetier.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Repetier-Host Mac.app'

--- a/Casks/repetier-host.rb
+++ b/Casks/repetier-host.rb
@@ -2,8 +2,8 @@ cask 'repetier-host' do
   version '0.56'
   sha256 '0d4b43ec7bec5ac85133d00e1a2cf61956ef90abc255c253029e0ef26160adfa'
 
-  url "http://www.repetier.com/updates/rhm/Repetier-Host-Mac_#{version.dots_to_underscores}.dmg"
-  appcast 'http://www.repetier.com/updates/rhm/rhm-appcast.xml',
+  url "https://www.repetier.com/updates/rhm/Repetier-Host-Mac_#{version.dots_to_underscores}.dmg"
+  appcast 'https://www.repetier.com/updates/rhm/rhm-appcast.xml',
           checkpoint: '465e0b22421fa56a9da4c564d409da1242eb5ceee6789c040ceb5e75db5ffe85'
   name 'Repetier-Host'
   homepage 'http://www.repetier.com/'

--- a/Casks/reveal.rb
+++ b/Casks/reveal.rb
@@ -2,11 +2,11 @@ cask 'reveal' do
   version '1.6.3'
   sha256 '61312d50b822c4f37460f61c17cb091d3c10dae5ab446abd27d402976e2ed539'
 
-  url "http://download.revealapp.com/Reveal.app-#{version}.zip"
-  appcast 'http://download.revealapp.com/reveal-release.xml',
+  url "https://download.revealapp.com/Reveal.app-#{version}.zip"
+  appcast 'https://download.revealapp.com/reveal-release.xml',
           checkpoint: '59912bbc29ae92bde4c523d54cc1a76babadc134b8a37c512bb32f72762eaa76'
   name 'Reveal'
-  homepage 'http://revealapp.com/'
+  homepage 'https://revealapp.com/'
   license :commercial
 
   app 'Reveal.app'

--- a/Casks/review-sherlock.rb
+++ b/Casks/review-sherlock.rb
@@ -2,7 +2,7 @@ cask 'review-sherlock' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.rbcafe.com/download/reviewsherlock.zip'
+  url 'https://www.rbcafe.com/download/reviewsherlock.zip'
   name 'Review Sherlock'
   homepage 'http://www.rbcafe.com/softwares/review-sherlock/'
   license :commercial

--- a/Casks/review-sherlock.rb
+++ b/Casks/review-sherlock.rb
@@ -4,7 +4,7 @@ cask 'review-sherlock' do
 
   url 'https://www.rbcafe.com/download/reviewsherlock.zip'
   name 'Review Sherlock'
-  homepage 'http://www.rbcafe.com/softwares/review-sherlock/'
+  homepage 'https://www.rbcafe.com/softwares/review-sherlock/'
   license :commercial
 
   depends_on macos: '>= :mountain_lion'

--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -3,10 +3,10 @@ cask 'rightfont' do
   sha256 '42dc554db588d81db7542c9b34376774459e67810033cc9151b5b761826147ab'
 
   url "http://rightfontapp.com/downloads/#{version}/rightfont.zip"
-  appcast 'http://rightfontapp.com/update/appcast.xml',
+  appcast 'https://rightfontapp.com/update/appcast.xml',
           checkpoint: 'cb332b6ef7e816b0770cb8b8dd7ffa684c24b1d0b1bc1130d5d3615480cb365e'
   name 'RightFont'
-  homepage 'http://rightfontapp.com/'
+  homepage 'https://rightfontapp.com/'
   license :commercial
 
   depends_on macos: '>= :yosemite'

--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -2,7 +2,7 @@ cask 'ringcentral' do
   version :latest
   sha256 :no_check
 
-  url 'http://downloads.ringcentral.com/sp/RingCentralForMac'
+  url 'https://downloads.ringcentral.com/sp/RingCentralForMac'
   name 'RingCentral for Mac'
   homepage 'https://www.ringcentral.com/office/features/desktop-apps/overview.html'
   license :closed

--- a/Casks/ringtones.rb
+++ b/Casks/ringtones.rb
@@ -3,7 +3,7 @@ cask 'ringtones' do
   sha256 '459119df8f7895fe427c95a541df7c94477962c19ff5884a450afb3e5b867bd0'
 
   url 'https://files.thelittleappfactory.com/ringtones/Ringtones.zip'
-  appcast 'http://files.thelittleappfactory.com/ringtones/appcast.xml',
+  appcast 'https://files.thelittleappfactory.com/ringtones/appcast.xml',
           checkpoint: 'b8bee0762970d4528aa5e9c4fc80ef569ec966afcad8c7a77ce74fc8373cc6a7'
   name 'Ringtones'
   homepage 'http://thelittleappfactory.com/ringtones/'

--- a/Casks/routebuddy.rb
+++ b/Casks/routebuddy.rb
@@ -5,7 +5,7 @@ cask 'routebuddy' do
   # objects.dreamhost.com/routebuddy was verified as official when first introduced to the cask
   url "https://objects.dreamhost.com/routebuddy/download/apps/RouteBuddy_#{version}.dmg"
   name 'RouteBuddy'
-  homepage 'http://routebuddy.com/'
+  homepage 'https://routebuddy.com/'
   license :commercial
 
   app 'RouteBuddy.app'

--- a/Casks/rubitrack.rb
+++ b/Casks/rubitrack.rb
@@ -3,10 +3,10 @@ cask 'rubitrack' do
   sha256 '1882f768befd9de165399efa52e460ea0fc883be442415da00e32aaccec9154c'
 
   url "http://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
-  appcast "http://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
+  appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
           checkpoint: 'd4e42f775f02e02c344b6119aa5995fa09fad6b78dda2c7d51ba307d21a38459'
   name 'rubiTrack'
-  homepage 'http://www.rubitrack.com/'
+  homepage 'https://www.rubitrack.com/'
   license :commercial
 
   depends_on macos: '>= :yosemite'

--- a/Casks/ryver.rb
+++ b/Casks/ryver.rb
@@ -5,7 +5,7 @@ cask 'ryver' do
   # d3vkb1nw20iqfq.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3vkb1nw20iqfq.cloudfront.net/mac/Ryver-#{version}.dmg"
   name 'Ryver'
-  homepage 'http://www.ryver.com'
+  homepage 'https://www.ryver.com/'
   license :unknown
 
   app 'Ryver.app'

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -17,7 +17,7 @@ cask 'sage' do
   end
 
   name 'Sage'
-  homepage 'http://www.sagemath.org/'
+  homepage 'https://www.sagemath.org/'
   license :gpl
 
   depends_on macos: '>= :lion'

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -3,11 +3,11 @@ cask 'scala-ide' do
 
   if Hardware::CPU.is_32_bit?
     # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-    url "http://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20160401/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
+    url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20160401/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86.zip"
     sha256 '271edecd517fe11cb34ca55fb2e654616daeb2cd84a1d7e47d9d622583182012'
   else
     # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-    url "http://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20160401/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+    url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20160401/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
     sha256 'c2b8a2d02fb6dd8586427cd171e3e3e8b55cf50afbb126e2bbf936052775e4b8'
   end
 

--- a/Casks/scansnap-manager-s1100.rb
+++ b/Casks/scansnap-manager-s1100.rb
@@ -5,7 +5,7 @@ cask 'scansnap-manager-s1100' do
   # origin.pfultd.com was verified as official when first introduced to the cask
   url "http://origin.pfultd.com/downloads/IMAGE/driver/ss/mgr/m-s1100/MacS1100ManagerV#{version.no_dots}WW.dmg"
   name 'ScanSnap Manager for Fujitsu ScanSnap s1100'
-  homepage 'http://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/s1100m-setup.html'
+  homepage 'https://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/s1100m-setup.html'
   license :gratis
 
   depends_on macos: '>= :lion'

--- a/Casks/scopebox.rb
+++ b/Casks/scopebox.rb
@@ -2,7 +2,7 @@ cask 'scopebox' do
   version '3.4.3'
   sha256 'abd8be8ec861e217c61bdc17dee60984da69d18409992dd5ef85d0966938e96e'
 
-  url "http://www.divergentmedia.com/filedownload/ScopeBox%20#{version}.dmg"
+  url "https://www.divergentmedia.com/filedownload/ScopeBox%20#{version}.dmg"
   name 'ScopeBox'
   homepage 'http://www.divergentmedia.com/scopebox'
   license :commercial

--- a/Casks/scopebox.rb
+++ b/Casks/scopebox.rb
@@ -4,7 +4,7 @@ cask 'scopebox' do
 
   url "https://www.divergentmedia.com/filedownload/ScopeBox%20#{version}.dmg"
   name 'ScopeBox'
-  homepage 'http://www.divergentmedia.com/scopebox'
+  homepage 'https://www.divergentmedia.com/scopebox'
   license :commercial
 
   app 'ScopeBox.app'

--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -3,7 +3,7 @@ cask 'screens-connect' do
   sha256 '18bb65623aadff7f931456598f12ba33f5c54bad9c1f7f2a3b10f9585f8bc771'
 
   # edovia.com was verified as official when first introduced to the cask
-  url "http://download.edovia.com/screensconnect/screensconnect%20#{version}.dmg"
+  url "https://download.edovia.com/screensconnect/screensconnect%20#{version}.dmg"
   name 'Screens Connect'
   homepage 'https://screensconnect.com'
   license :gratis

--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -2,7 +2,7 @@ cask 'screens' do
   version '3.6.11b4828'
   sha256 'c62417cb0b41cbd1122a24ec10e3c1d6706224527c6d20518b4c52b5be6d4568'
 
-  url "http://download.edovia.com/screens/Screens%20#{version}.zip"
+  url "https://download.edovia.com/screens/Screens%20#{version}.zip"
   name 'Screens'
   homepage 'https://edovia.com/screens/#mac'
   license :commercial

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -4,7 +4,7 @@ cask 'scummvm' do
 
   url "https://scummvm.org/frs/scummvm/#{version}/scummvm-#{version}-macosx.dmg"
   name 'ScummVM'
-  homepage 'http://scummvm.org/'
+  homepage 'https://scummvm.org/'
   license :gpl
 
   app 'ScummVM.app'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -2,7 +2,7 @@ cask 'scummvm' do
   version '1.8.1'
   sha256 'de493a74e0458401e35cce978d2b5ea5f443b3744931011bd67649be52c6ecf2'
 
-  url "http://scummvm.org/frs/scummvm/#{version}/scummvm-#{version}-macosx.dmg"
+  url "https://scummvm.org/frs/scummvm/#{version}/scummvm-#{version}-macosx.dmg"
   name 'ScummVM'
   homepage 'http://scummvm.org/'
   license :gpl

--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -5,7 +5,7 @@ cask 'seafile-client' do
   # bintray.com/artifact/download/seafile-org was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/seafile-org/seafile/seafile-client-#{version}.dmg"
   name 'Seafile Client'
-  homepage 'http://seafile.com/'
+  homepage 'https://seafile.com/'
   license :gpl
 
   app 'Seafile Client.app'

--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -2,7 +2,7 @@ cask 'securesafe' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.securesafe.com/en/assets/sync-client/SecureSafe.dmg'
+  url 'https://www.securesafe.com/en/assets/sync-client/SecureSafe.dmg'
   name 'SecureSafe'
   homepage 'https://www.securesafe.com/'
   license :gratis

--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -7,7 +7,7 @@ cask 'sequel-pro' do
   appcast 'https://github.com/sequelpro/sequelpro/releases.atom',
           checkpoint: 'dab1d8d845c8ced586958bc4ded12de724c9ec3013313ff3c2a4babc7cdd74fb'
   name 'Sequel Pro'
-  homepage 'http://www.sequelpro.com/'
+  homepage 'https://www.sequelpro.com/'
   license :mit
 
   depends_on macos: '>= :leopard'

--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -4,7 +4,7 @@ cask 'servetome' do
 
   url "http://downloads.zqueue.com/ServeToMe-v#{version}.dmg"
   name 'ServeToMe'
-  homepage 'http://zqueue.com/servetome/'
+  homepage 'https://zqueue.com/servetome/'
   license :gratis
 
   app 'ServeToMe.app'

--- a/Casks/shoes.rb
+++ b/Casks/shoes.rb
@@ -3,7 +3,7 @@ cask 'shoes' do
   sha256 'f30a01d1e5dadc7dd775d140de9f04bf12a5046e4f2d5931ea7b67372ebe56fa'
 
   # shoes.mvmanila.com/public/shoes was verified as official when first introduced to the cask
-  url "http://shoes.mvmanila.com/public/shoes/shoes-#{version}-osx-10.9.tgz"
+  url "https://shoes.mvmanila.com/public/shoes/shoes-#{version}-osx-10.9.tgz"
   name 'Shoes'
   homepage 'http://shoesrb.com/'
   license :oss

--- a/Casks/short-menu.rb
+++ b/Casks/short-menu.rb
@@ -5,7 +5,7 @@ cask 'short-menu' do
   # dl.devmate.com/com.floschliep.Short-Menu was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.floschliep.Short-Menu/ShortMenu.zip'
   name 'Short Menu'
-  homepage 'http://appiculous.com/short-menu-mac/'
+  homepage 'https://appiculous.com/short-menu-mac/'
   license :commercial
 
   app 'Short Menu.app'

--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -7,7 +7,7 @@ cask 'shotcut' do
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
           checkpoint: 'f9f9af0f09c04af5857e334f90c27f71dea99141723966608166f0b92e7c1522'
   name 'Shotcut'
-  homepage 'http://www.shotcut.org/'
+  homepage 'https://www.shotcut.org/'
   license :gpl
 
   app 'Shotcut.app'

--- a/Casks/silverback.rb
+++ b/Casks/silverback.rb
@@ -3,11 +3,11 @@ cask 'silverback' do
   sha256 'bee6233d3cc94ccd972b6c29f6777f329a4ac862dda5e699deab525491d82cae'
 
   # silverback.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://silverback.s3.amazonaws.com/silverback#{version.major}.zip"
+  url "https://silverback.s3.amazonaws.com/silverback#{version.major}.zip"
   appcast 'https://silverback.s3.amazonaws.com/release/appcast.xml',
           checkpoint: '87e80a6c66ebfc9ea8a683136686b4a80e45dc38d7dced8db4c4028bc59be0ba'
   name 'Silverback'
-  homepage 'http://silverbackapp.com/'
+  homepage 'https://silverbackapp.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Silverback.app'

--- a/Casks/simpless.rb
+++ b/Casks/simpless.rb
@@ -2,7 +2,7 @@ cask 'simpless' do
   version '1.4'
   sha256 '424b1b8b56f0568beef107bea2c81d4cc9576f850a3ba84f8b5b5abbc0715886'
 
-  url "http://wearekiss.com/files/SimpLESS-#{version}-mac.zip"
+  url "https://wearekiss.com/files/SimpLESS-#{version}-mac.zip"
   name 'SimpLESS'
   homepage 'http://wearekiss.com/simpless'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/simplifyextras.rb
+++ b/Casks/simplifyextras.rb
@@ -4,7 +4,7 @@ cask 'simplifyextras' do
 
   url "https://mmth.us/simplify/prefpane/updates/#{version}.zip"
   name 'Simplify Extras'
-  homepage 'http://mmth.us/simplify/extras/'
+  homepage 'https://mmth.us/simplify/extras/'
   license :gratis
 
   prefpane 'SimplifyExtras.prefPane'

--- a/Casks/simplifyextras.rb
+++ b/Casks/simplifyextras.rb
@@ -2,7 +2,7 @@ cask 'simplifyextras' do
   version '1.0'
   sha256 '03c940561d265c02ccc7782cf9b2a0be592b233d074bb691775656642fed9455'
 
-  url "http://mmth.us/simplify/prefpane/updates/#{version}.zip"
+  url "https://mmth.us/simplify/prefpane/updates/#{version}.zip"
   name 'Simplify Extras'
   homepage 'http://mmth.us/simplify/extras/'
   license :gratis

--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -2,11 +2,11 @@ cask 'sketch' do
   version '39.1'
   sha256 'da8582b6d67b0189d98dfa9aad441e6b68aa0048389aee44fa5acad4d014b127'
 
-  url "http://download.sketchapp.com/sketch-#{version}.zip"
-  appcast 'http://www.sketchapp.com/appcast3.xml',
+  url "https://download.sketchapp.com/sketch-#{version}.zip"
+  appcast 'https://www.sketchapp.com/appcast3.xml',
           checkpoint: 'b258be21946179f9b6e867585d139668af663428b80b5b0a84f21e35471543c9'
   name 'Sketch'
-  homepage 'http://www.sketchapp.com/'
+  homepage 'https://www.sketchapp.com/'
   license :commercial
 
   app 'Sketch.app'

--- a/Casks/smcfancontrol.rb
+++ b/Casks/smcfancontrol.rb
@@ -6,7 +6,7 @@ cask 'smcfancontrol' do
   appcast 'https://www.eidac.de/smcfancontrol/smcfancontrol.xml',
           checkpoint: '02ee10ec262f518ad8e099fe4230b78235d48ed26729c5ccd2241fe2d6291881'
   name 'smcFanControl'
-  homepage 'http://www.eidac.de/?cat=40'
+  homepage 'https://www.eidac.de/?cat=40'
   license :gpl
 
   app 'smcFanControl.app'

--- a/Casks/smcfancontrol.rb
+++ b/Casks/smcfancontrol.rb
@@ -2,8 +2,8 @@ cask 'smcfancontrol' do
   version '2.5.2'
   sha256 'e543b6a9fdb1bda6612699692f4dbaa9305007d451c987f2ae586950cbdf852b'
 
-  url "http://www.eidac.de/smcfancontrol/smcfancontrol_#{version.dots_to_underscores}.zip"
-  appcast 'http://www.eidac.de/smcfancontrol/smcfancontrol.xml',
+  url "https://www.eidac.de/smcfancontrol/smcfancontrol_#{version.dots_to_underscores}.zip"
+  appcast 'https://www.eidac.de/smcfancontrol/smcfancontrol.xml',
           checkpoint: '02ee10ec262f518ad8e099fe4230b78235d48ed26729c5ccd2241fe2d6291881'
   name 'smcFanControl'
   homepage 'http://www.eidac.de/?cat=40'

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -2,27 +2,27 @@ cask 'snagit' do
   if MacOS.release == :leopard
     version '1.0.4'
     sha256 'bfefc1c351485bffa01b7961685120306eb7624ec3ef63ba2b6d8049c846cd07'
-    url "http://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
+    url "https://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
   elsif MacOS.release <= :lion
     version '2.1.7'
     sha256 'c10e9eefc76addfe559809044bf47b600da2f19bb007ff0ed099a383fbd551a7'
-    url "http://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
+    url "https://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
   elsif MacOS.release == :mountain_lion
     version '3.2.3'
     sha256 '4fe9068e3bfafadb6f8760f381da0d89c9057ef0444ba726f7588676864807e2'
-    url "http://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
+    url "https://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
   elsif MacOS.release == :mavericks
     version '3.3.7'
     sha256 '4a0f3f9209011c70d5e3698e0b75d6cff73c0fb98d61d90aedd5884b0463ec3a'
-    url "http://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
+    url "https://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
   elsif MacOS.release == :yosemite
     version '4.0.3'
     sha256 '73dce90775e417933a30d2d625861b858410d3f14011909d702c97461078fc69'
-    url "http://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
+    url "https://download.techsmith.com/snagitmac/enu/#{version.no_dots}/snagit.dmg"
   else
     version :latest
     sha256 :no_check
-    url 'http://download.techsmith.com/snagitmac/enu/Snagit.dmg'
+    url 'https://download.techsmith.com/snagitmac/enu/Snagit.dmg'
   end
 
   name 'Snagit'

--- a/Casks/snippets.rb
+++ b/Casks/snippets.rb
@@ -6,7 +6,7 @@ cask 'snippets' do
   appcast 'https://snippets.me/mac/appcast.xml',
           checkpoint: 'b67b5cd59bfee4398a81f157dec126b982f120f757ec24a4ea1396f459ed19d0'
   name 'Snippets'
-  homepage 'http://snippets.me/'
+  homepage 'https://snippets.me/'
   license :gratis
 
   app 'Snippets.app'

--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -27,7 +27,7 @@ cask 'soapui' do
   #   /Applications/SoapUI-${version}.app/Contents/java/app/.install4j/response.varfile
   #
   # And refer to the install4j command line options for additional information
-  #   http://resources.ej-technologies.com/install4j/help/doc/index.html
+  #   https://resources.ej-technologies.com/install4j/help/doc/index.html
   #
   installer script: "SoapUI #{version} Installer.app/Contents/MacOS/JavaApplicationStub",
             args:   [

--- a/Casks/sonos.rb
+++ b/Casks/sonos.rb
@@ -4,7 +4,7 @@ cask 'sonos' do
 
   url 'http://www.sonos.com/redir/controller_software_mac'
   name 'Sonos'
-  homepage 'http://www.sonos.com/'
+  homepage 'https://www.sonos.com/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Sonos.app'

--- a/Casks/spark.rb
+++ b/Casks/spark.rb
@@ -4,7 +4,7 @@ cask 'spark' do
 
   url 'https://www.shadowlab.org/softwares/Spark/Spark.zip'
   name 'Spark'
-  homepage 'http://www.shadowlab.org/softwares/spark.php'
+  homepage 'https://www.shadowlab.org/softwares/spark.php'
   license :mit
 
   app 'Spark.app'

--- a/Casks/spark.rb
+++ b/Casks/spark.rb
@@ -2,7 +2,7 @@ cask 'spark' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.shadowlab.org/softwares/Spark/Spark.zip'
+  url 'https://www.shadowlab.org/softwares/Spark/Spark.zip'
   name 'Spark'
   homepage 'http://www.shadowlab.org/softwares/spark.php'
   license :mit

--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -7,7 +7,7 @@ cask 'sparkle' do
   appcast 'https://github.com/sparkle-project/Sparkle/releases.atom',
           checkpoint: 'a1192bf5b07dbc6d763bca7b5aa137e068a915ed53a462b7d87a73c9b66404ce'
   name 'Sparkle'
-  homepage 'http://sparkle-project.org/'
+  homepage 'https://sparkle-project.org/'
   license :mit
 
   app 'Sparkle Test App.app'

--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -5,7 +5,7 @@ cask 'sparkleshare' do
   # bitbucket.org/hbons/sparkleshare was verified as official when first introduced to the cask
   url "https://bitbucket.org/hbons/sparkleshare/downloads/sparkleshare-mac-#{version}.zip"
   name 'SparkleShare'
-  homepage 'http://sparkleshare.org/'
+  homepage 'https://sparkleshare.org/'
   license :gpl
 
   app 'SparkleShare.app'

--- a/Casks/spillo.rb
+++ b/Casks/spillo.rb
@@ -4,10 +4,10 @@ cask 'spillo' do
 
   # s3.amazonaws.com/bananafish-builds/spillo was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bananafish-builds/spillo/spillo_#{version}.zip"
-  appcast 'http://bananafishsoftware.com/feeds/spillo.xml',
+  appcast 'https://bananafishsoftware.com/feeds/spillo.xml',
           checkpoint: '3e0ca11991d5680afe8f75d37b92e76127ad3fe545acba6de6fe62dc0c46cf0b'
   name 'Spillo'
-  homepage 'http://bananafishsoftware.com/products/spillo/'
+  homepage 'https://bananafishsoftware.com/products/spillo/'
   license :commercial
 
   app 'Spillo.app'

--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -5,7 +5,7 @@ cask 'sqlpro-for-mysql' do
   # d3fwkemdw8spx3.cloudfront.net/mysql was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.app.zip"
   name 'SQLPro for MySQL'
-  homepage 'http://www.mysqlui.com'
+  homepage 'https://www.mysqlui.com'
   license :commercial
 
   app 'SQLPro for MySQL.app'

--- a/Casks/sqlpro-for-postgres.rb
+++ b/Casks/sqlpro-for-postgres.rb
@@ -5,7 +5,7 @@ cask 'sqlpro-for-postgres' do
   # d3fwkemdw8spx3.cloudfront.net/postgres was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/postgres/SQLProPostgres.#{version}.app.zip"
   name 'SQLPro for Postgres'
-  homepage 'http://www.macpostgresclient.com/SQLProPostgres'
+  homepage 'https://www.macpostgresclient.com/SQLProPostgres'
   license :commercial
 
   app 'SQLPro for Postgres.app'

--- a/Casks/sqlpro-studio.rb
+++ b/Casks/sqlpro-studio.rb
@@ -5,7 +5,7 @@ cask 'sqlpro-studio' do
   # d3fwkemdw8spx3.cloudfront.net/studio was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/studio/SQLProStudio.#{version}.app.zip"
   name 'SQLPro Studio'
-  homepage 'http://www.sqlprostudio.com'
+  homepage 'https://www.sqlprostudio.com'
   license :commercial
 
   app 'SQLPro Studio.app'

--- a/Casks/stack-exchange-notifier.rb
+++ b/Casks/stack-exchange-notifier.rb
@@ -2,9 +2,9 @@ cask 'stack-exchange-notifier' do
   version '1.1'
   sha256 '849b543bc724e735e9a951721159b45a5284fde44c4cd8caa74c0e7eefb7e30c'
 
-  url "http://hewgill.com/senotifier/stack-exchange-notifier-#{version}.dmg"
+  url "https://hewgill.com/senotifier/stack-exchange-notifier-#{version}.dmg"
   name 'Stack Exchange Notifier'
-  homepage 'http://hewgill.com/senotifier/'
+  homepage 'https://hewgill.com/senotifier/'
   license :bsd
 
   app 'Stack Exchange Notifier.app'

--- a/Casks/stremio.rb
+++ b/Casks/stremio.rb
@@ -2,7 +2,7 @@ cask 'stremio' do
   version '3.6.2'
   sha256 '1348304f7df32ae032b96809be7da8345755947078c9ba31fb60ff18166e9b79'
 
-  url "http://dl.strem.io/Stremio%20#{version}.dmg"
+  url "https://dl.strem.io/Stremio%20#{version}.dmg"
   name 'Stremio'
   homepage 'http://www.strem.io/'
   license :gratis

--- a/Casks/stremio.rb
+++ b/Casks/stremio.rb
@@ -4,7 +4,7 @@ cask 'stremio' do
 
   url "https://dl.strem.io/Stremio%20#{version}.dmg"
   name 'Stremio'
-  homepage 'http://www.strem.io/'
+  homepage 'https://www.strem.io/'
   license :gratis
 
   app 'Stremio.app'

--- a/Casks/subtitles.rb
+++ b/Casks/subtitles.rb
@@ -2,11 +2,11 @@ cask 'subtitles' do
   version '3.2.9'
   sha256 '72b68d998834ec3e6d5f03a1897766b7714cab712ccd5469ce9367b6cacd264c'
 
-  url "http://subtitlesapp.com/download/Subtitles-mac-#{version}.zip"
-  appcast 'http://subtitlesapp.com/updates.xml',
+  url "https://subtitlesapp.com/download/Subtitles-mac-#{version}.zip"
+  appcast 'https://subtitlesapp.com/updates.xml',
           checkpoint: '1851499d9b99765244ec22db7faf583a82dd1d6e4e63aa04e7d0d1f28106c2ce'
   name 'Subtitles'
-  homepage 'http://subtitlesapp.com'
+  homepage 'https://subtitlesapp.com'
   license :commercial
 
   app 'Subtitles.app'

--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -4,7 +4,7 @@ cask 'switchresx' do
 
   url "https://www.madrau.com/data/switchresx/SwitchResX#{version.major}.zip"
   name 'SwitchResX'
-  homepage 'http://www.madrau.com'
+  homepage 'https://www.madrau.com/'
   license :freemium
 
   prefpane 'SwitchResX.prefPane'

--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -2,7 +2,7 @@ cask 'switchresx' do
   version '4.5.3'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://www.madrau.com/data/switchresx/SwitchResX#{version.major}.zip"
+  url "https://www.madrau.com/data/switchresx/SwitchResX#{version.major}.zip"
   name 'SwitchResX'
   homepage 'http://www.madrau.com'
   license :freemium

--- a/Casks/synalyze-it-pro.rb
+++ b/Casks/synalyze-it-pro.rb
@@ -4,7 +4,7 @@ cask 'synalyze-it-pro' do
 
   # s3-us-west-2.amazonaws.com/synalysis was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/synalysis/SynalyzeItProTA_#{version}.zip"
-  appcast 'http://www.synalyze-it.com/SynalyzeItPro/appcast.xml',
+  appcast 'https://www.synalyze-it.com/SynalyzeItPro/appcast.xml',
           checkpoint: 'e74f18b3880f12d6e0a895948fc61949ea3e91fbb285421045f1aeab3c06db87'
   name 'Synalyze It! Pro'
   homepage 'https://www.synalysis.net/'

--- a/Casks/tag.rb
+++ b/Casks/tag.rb
@@ -7,7 +7,7 @@ cask 'tag' do
   appcast 'https://sourceforge.net/projects/tagosx/rss',
           checkpoint: 'b5357cef243912765a97a2fb4294dba43b823045143608244feb4afb3500785e'
   name 'Tag'
-  homepage 'http://sbooth.org/Tag/'
+  homepage 'https://sbooth.org/Tag/'
   license :gpl
 
   app "Tag-#{version}/Tag.app"

--- a/Casks/tap-bpm.rb
+++ b/Casks/tap-bpm.rb
@@ -2,9 +2,9 @@ cask 'tap-bpm' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.drumbot.com/resources/tap_bpm_mac.zip'
+  url 'https://www.drumbot.com/resources/tap_bpm_mac.zip'
   name 'Tap BPM'
-  homepage 'http://www.drumbot.com/projects/tap_bpm/'
+  homepage 'https://www.drumbot.com/projects/tap_bpm/'
   license :closed
 
   app 'Tap BPM.app'

--- a/Casks/taskwarrior-pomodoro.rb
+++ b/Casks/taskwarrior-pomodoro.rb
@@ -3,7 +3,7 @@ cask 'taskwarrior-pomodoro' do
   sha256 '72d83ed48f4fac4c9aa6b330392198118ec8038135370ae03cffeb9eafc74b43'
 
   # coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro was verified as official when first introduced to the cask
-  url "http://coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro/releases/taskwarrior-pomodoro-#{version}.dmg"
+  url "https://coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro/releases/taskwarrior-pomodoro-#{version}.dmg"
   appcast 'https://github.com/coddingtonbear/taskwarrior-pomodoro/releases.atom',
           checkpoint: '41aace18e70a1f810a265ce4c2592069501eed80cca5afa51036fb5dd1a0c750'
   name 'Taskwarrior-Pomodoro'

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -3,7 +3,7 @@ cask 'telegram' do
   sha256 'b59451effb2c0dbd599e03f21f27d8b31786b6f532ba9a4cbb1cf663f45ccb04'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
-  appcast 'http://osx.telegram.org/updates/versions.xml',
+  appcast 'https://osx.telegram.org/updates/versions.xml',
           checkpoint: '2e48e6b684fac637e997175a549dac1c214ddd11c4251f7213258b1d2476506c'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org'

--- a/Casks/temperature-monitor.rb
+++ b/Casks/temperature-monitor.rb
@@ -3,9 +3,9 @@ cask 'temperature-monitor' do
   sha256 :no_check
 
   # bresink.eu was verified as official when first introduced to the cask
-  url 'http://www.bresink.eu/Downloads/TemperatureMonitor.dmg'
+  url 'https://www.bresink.eu/Downloads/TemperatureMonitor.dmg'
   name 'Temperature Monitor'
-  homepage 'http://www.bresink.com/osx/LegacyProducts.html'
+  homepage 'https://www.bresink.com/osx/LegacyProducts.html'
   license :commercial
 
   # Renamed for consistency: app name is different in the Finder and in a shell.

--- a/Casks/the-tagger.rb
+++ b/Casks/the-tagger.rb
@@ -2,7 +2,7 @@ cask 'the-tagger' do
   version '1.6.1'
   sha256 '51ef8424ae4f6c7e53159e665d87067ce43dd9be3cfc2e7c18efd0f717375b9c'
 
-  url 'http://deadbeatsw.com/thetagger/TheTaggerLatest.zip'
+  url 'https://deadbeatsw.com/thetagger/TheTaggerLatest.zip'
   appcast 'https://deadbeatsw.com/thetagger/appcast.xml',
           checkpoint: 'dad3dd5d7fddb361fd75d449ada6982d291a204cf044fc0ac9172f225739fd18'
   name 'The Tagger'

--- a/Casks/the-tagger.rb
+++ b/Casks/the-tagger.rb
@@ -3,10 +3,10 @@ cask 'the-tagger' do
   sha256 '51ef8424ae4f6c7e53159e665d87067ce43dd9be3cfc2e7c18efd0f717375b9c'
 
   url 'http://deadbeatsw.com/thetagger/TheTaggerLatest.zip'
-  appcast 'http://deadbeatsw.com/thetagger/appcast.xml',
+  appcast 'https://deadbeatsw.com/thetagger/appcast.xml',
           checkpoint: 'dad3dd5d7fddb361fd75d449ada6982d291a204cf044fc0ac9172f225739fd18'
   name 'The Tagger'
-  homepage 'http://deadbeatsw.com/thetagger/'
+  homepage 'https://deadbeatsw.com/thetagger/'
   license :commercial
 
   app 'The Tagger.app'

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -2,7 +2,7 @@ cask 'tidal' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.tidal.com/desktop/TIDAL.dmg'
+  url 'https://download.tidal.com/desktop/TIDAL.dmg'
   name 'TIDAL'
   homepage 'http://tidal.com/us/download'
   license :closed

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -4,7 +4,7 @@ cask 'tidal' do
 
   url 'https://download.tidal.com/desktop/TIDAL.dmg'
   name 'TIDAL'
-  homepage 'http://tidal.com/us/download'
+  homepage 'https://tidal.com/us/download'
   license :closed
 
   app 'TIDAL.app'

--- a/Casks/tiny.rb
+++ b/Casks/tiny.rb
@@ -2,9 +2,9 @@ cask 'tiny' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.delightfuldev.com/assets/files/tiny/Tiny.zip'
+  url 'https://www.delightfuldev.com/assets/files/tiny/Tiny.zip'
   name 'Tiny'
-  homepage 'http://www.delightfuldev.com/tiny/'
+  homepage 'https://www.delightfuldev.com/tiny/'
   license :gratis
 
   depends_on macos: '>= 10.10'

--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -4,7 +4,7 @@ cask 'tinymediamanager' do
 
   url "http://release.tinymediamanager.org/dist/tmm_#{version}_mac.zip"
   name 'tinyMediaManager'
-  homepage 'http://www.tinymediamanager.org/'
+  homepage 'https://www.tinymediamanager.org/'
   license :apache
 
   app 'tinyMediaManager.app'

--- a/Casks/together.rb
+++ b/Casks/together.rb
@@ -2,11 +2,11 @@ cask 'together' do
   version '3.5.8'
   sha256 '2425411e6972a186d289c49b454041943fe6e594a445487cd42894166648b523'
 
-  url "http://reinventedsoftware.com/together/downloads/Together_#{version}.dmg"
+  url "https://reinventedsoftware.com/together/downloads/Together_#{version}.dmg"
   appcast "https://reinventedsoftware.com/together/downloads/Together#{version.major}.xml",
           checkpoint: '9d707f8da1a99bf4e85bdd61274b8310ee4578434146ba9d6fce778062aba7b9'
   name 'Together'
-  homepage 'http://reinventedsoftware.com/together/'
+  homepage 'https://reinventedsoftware.com/together/'
   license :commercial
 
   app "Together #{version.major}.app"

--- a/Casks/toneprint.rb
+++ b/Casks/toneprint.rb
@@ -4,7 +4,7 @@ cask 'toneprint' do
 
   url 'http://cdn-downloads.tcelectronic.com/media/5607727/toneprint-3100-r1373.dmg'
   name 'TonePrint Editor'
-  homepage 'http://www.tcelectronic.com/toneprint-editor/support/'
+  homepage 'https://www.tcelectronic.com/toneprint-editor/support/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'TonePrint.app'

--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -3,8 +3,8 @@ cask 'torguard' do
   sha256 'c3bf8d7e18f5f02ebb3182a59b5378ee47e981a641627bca0146f8a182b4e343'
 
   # torguard.biz was verified as official when first introduced to the cask
-  url "http://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"
-  appcast 'http://updates.torguard.biz/Software/MacOSX/checksums.sha256',
+  url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"
+  appcast 'https://updates.torguard.biz/Software/MacOSX/checksums.sha256',
           checkpoint: 'e7be5c13c0cca980b0ae1164f5e8a5ec932b261b822a63e840b20343a0b2b222'
   name 'TorGuard'
   homepage 'https://torguard.net'

--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -11,7 +11,7 @@ cask 'trickster' do
   appcast 'https://dl.apparentsoft.com/trickster.rss',
           checkpoint: '0a6c6015159cd8037e6e3f9464d3ed10c9ec05aa3ea063d012913b90be2aa218'
   name 'Trickster'
-  homepage 'http://www.apparentsoft.com/trickster/'
+  homepage 'https://www.apparentsoft.com/trickster/'
   license :commercial
 
   app 'Trickster.app'

--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -7,8 +7,8 @@ cask 'trickster' do
     sha256 'afe5fcf0de994e6a993bf259da564783ed7c0619ad635c665ecf5d3067ba5049'
   end
 
-  url "http://dl.apparentsoft.com/Trickster_#{version}.zip"
-  appcast 'http://dl.apparentsoft.com/trickster.rss',
+  url "https://dl.apparentsoft.com/Trickster_#{version}.zip"
+  appcast 'https://dl.apparentsoft.com/trickster.rss',
           checkpoint: '0a6c6015159cd8037e6e3f9464d3ed10c9ec05aa3ea063d012913b90be2aa218'
   name 'Trickster'
   homepage 'http://www.apparentsoft.com/trickster/'

--- a/Casks/tuck.rb
+++ b/Casks/tuck.rb
@@ -2,7 +2,7 @@ cask 'tuck' do
   version '1.0'
   sha256 '7e7822e3a7d7eb932f58e770aee31f778164784e151dbc36ab997be4107804ed'
 
-  url "http://www.irradiatedsoftware.com/downloads/Tuck_#{version}.zip"
+  url "https://www.irradiatedsoftware.com/downloads/Tuck_#{version}.zip"
   appcast 'https://www.irradiatedsoftware.com/updates/profiles/tuck.php',
           checkpoint: '9b7c8e54b14cf0c58f6c55fccdc7a553552045eb93fbfdda32311cf4c51c6084'
   name 'Tuck'

--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -6,7 +6,7 @@ cask 'typora' do
   appcast 'https://www.typora.io/download/dev_update.xml',
           checkpoint: '13d6c2b1722ac29bb43ec2bfea7f817f994d98aee13a31667111f5edfc055a0f'
   name 'Typora'
-  homepage 'http://typora.io'
+  homepage 'https://typora.io'
   license :gratis
 
   app 'Typora.app'

--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -3,7 +3,7 @@ cask 'ubar' do
   sha256 '185557b629c61cbb8ffa3f8111471de1540e4803a359e099246ed31460192680'
 
   url "http://www.brawersoftware.com/downloads/ubar/ubar#{version.no_dots}.zip"
-  appcast "http://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
+  appcast "https://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
           checkpoint: '1d54e5b404c005064cccef0caee02ce5e336d175adb99202c242e6281f7f0570'
   name 'uBar'
   homepage 'http://brawersoftware.com/products/ubar'

--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -6,7 +6,7 @@ cask 'ubar' do
   appcast "https://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
           checkpoint: '1d54e5b404c005064cccef0caee02ce5e336d175adb99202c242e6281f7f0570'
   name 'uBar'
-  homepage 'http://brawersoftware.com/products/ubar'
+  homepage 'https://brawersoftware.com/products/ubar'
   license :commercial
 
   depends_on macos: '>= :mavericks'

--- a/Casks/umsatz-standard.rb
+++ b/Casks/umsatz-standard.rb
@@ -2,9 +2,9 @@ cask 'umsatz-standard' do
   version :latest
   sha256 :no_check
 
-  url 'http://umsatz-programm.de/ladungen/UmsatzStandard2015.zip'
+  url 'https://umsatz-programm.de/ladungen/UmsatzStandard2015.zip'
   name 'Umsatz Standard 2015'
-  homepage 'http://umsatz-programm.de'
+  homepage 'https://umsatz-programm.de'
   license :freemium
 
   app 'Umsatz Standard 2015.app'

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -2,11 +2,11 @@ cask 'unicodechecker' do
   version '1.17'
   sha256 'cb474087e25c94deccac85ae2f973b70969a0241ee029cb0f198554b1997ed9c'
 
-  url 'http://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
-  appcast 'http://earthlingsoft.net/UnicodeChecker/appcast.xml',
+  url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
+  appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml',
           checkpoint: 'de148c37d18cc1903ecf5e11524b77671e848ed7074a4c2a5b51185352d692ad'
   name 'UnicodeChecker'
-  homepage 'http://earthlingsoft.net/UnicodeChecker/'
+  homepage 'https://earthlingsoft.net/UnicodeChecker/'
   license :gratis
 
   app "UnicodeChecker #{version}/UnicodeChecker.app"

--- a/Casks/voxengo-span-au.rb
+++ b/Casks/voxengo-span-au.rb
@@ -2,7 +2,7 @@ cask 'voxengo-span-au' do
   version '2.10'
   sha256 '48cf467a2d3b3be87b4b6ab725dd10f6ecf98cb8bceb090c4b2920989f33d413'
 
-  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_AU_AAX_setup.dmg"
+  url "https://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_AU_AAX_setup.dmg"
   name 'Voxengo SPAN (AU)'
   homepage 'http://www.voxengo.com/product/span/'
   license :gratis

--- a/Casks/voxengo-span-au.rb
+++ b/Casks/voxengo-span-au.rb
@@ -4,7 +4,7 @@ cask 'voxengo-span-au' do
 
   url "https://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_AU_AAX_setup.dmg"
   name 'Voxengo SPAN (AU)'
-  homepage 'http://www.voxengo.com/product/span/'
+  homepage 'https://www.voxengo.com/product/span/'
   license :gratis
 
   audio_unit_plugin 'SPAN.component'

--- a/Casks/voxengo-span-vst.rb
+++ b/Casks/voxengo-span-vst.rb
@@ -4,7 +4,7 @@ cask 'voxengo-span-vst' do
 
   url "https://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_VST_VST3_setup.dmg"
   name 'Voxengo SPAN (VST)'
-  homepage 'http://www.voxengo.com/product/span/'
+  homepage 'https://www.voxengo.com/product/span/'
   license :gratis
 
   vst_plugin 'SPAN.vst'

--- a/Casks/voxengo-span-vst.rb
+++ b/Casks/voxengo-span-vst.rb
@@ -2,7 +2,7 @@ cask 'voxengo-span-vst' do
   version '2.10'
   sha256 '09f5a195145b5dff81b095bae8af9f3d98e301debe8a0f7732684fd479b20185'
 
-  url "http://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_VST_VST3_setup.dmg"
+  url "https://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_VST_VST3_setup.dmg"
   name 'Voxengo SPAN (VST)'
   homepage 'http://www.voxengo.com/product/span/'
   license :gratis

--- a/Casks/vpaint.rb
+++ b/Casks/vpaint.rb
@@ -7,7 +7,7 @@ cask 'vpaint' do
   appcast 'https://github.com/dalboris/vpaint/releases.atom',
           checkpoint: '1acbd6f7b3b66e2e10fe2cc38a8a2051cd6d198e4a3593bfa2dc74d081dc009d'
   name 'VPaint'
-  homepage 'http://www.vpaint.org/'
+  homepage 'https://www.vpaint.org/'
   license :mit
 
   app 'vpaint.app'

--- a/Casks/wacom-intuos-pro-tablet.rb
+++ b/Casks/wacom-intuos-pro-tablet.rb
@@ -4,7 +4,7 @@ cask 'wacom-intuos-pro-tablet' do
 
   url "http://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   name 'Wacom Intuos Pro Tablet'
-  homepage 'http://www.wacom.com/'
+  homepage 'https://www.wacom.com/'
   license :gratis
 
   conflicts_with cask: 'wacom-intuos-tablet'

--- a/Casks/wacom-intuos-tablet.rb
+++ b/Casks/wacom-intuos-tablet.rb
@@ -4,7 +4,7 @@ cask 'wacom-intuos-tablet' do
 
   url "http://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_#{version}.dmg"
   name 'Wacom Intuos3/4/5 Tablet'
-  homepage 'http://www.wacom.com/'
+  homepage 'https://www.wacom.com/'
   license :gratis
 
   conflicts_with cask: 'wacom-intuos-pro-tablet'

--- a/Casks/warsow.rb
+++ b/Casks/warsow.rb
@@ -4,7 +4,7 @@ cask 'warsow' do
 
   url "https://www.warsow.gg/download?dl=warsow#{version.no_dots}mac"
   name 'Warsow'
-  homepage 'http://www.warsow.gg/'
+  homepage 'https://www.warsow.gg/'
   license :gpl
 
   app 'Warsow.app'

--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -4,7 +4,7 @@ cask 'whatroute' do
 
   url "http://www.whatroute.net/software/whatroute-#{version}.dmg"
   name 'WhatRoute'
-  homepage 'http://www.whatroute.net'
+  homepage 'https://www.whatroute.net'
   license :gratis
 
   app 'WhatRoute.app'

--- a/Casks/whatsize.rb
+++ b/Casks/whatsize.rb
@@ -2,7 +2,7 @@ cask 'whatsize' do
   version '6.5.2'
   sha256 '14abf2c48e321c63d21eb5e9adcf9f2d140859b3559d3120ffcd01df582b162e'
 
-  url 'http://www.whatsizemac.com/software/whatsize6/whatsize.dmg'
+  url 'https://www.whatsizemac.com/software/whatsize6/whatsize.dmg'
   appcast 'http://www.id-design.com/software/whatsize/release/notes.xml',
           checkpoint: 'a3939b96017d292cb2c10d7b3a024db78f734bf47d522b548c41e2ff71b74909'
   name 'WhatSize'

--- a/Casks/window-switch.rb
+++ b/Casks/window-switch.rb
@@ -4,7 +4,7 @@ cask 'window-switch' do
 
   url 'https://xpra.org/dists/osx/x86/Window-Switch.dmg'
   name 'Window Switch'
-  homepage 'http://xpra.org/'
+  homepage 'https://xpra.org/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Window-Switch.app'

--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -7,7 +7,7 @@ cask 'witch' do
     version '3.9.8'
     sha256 '6a290c9fcc6354044fb077d8ae3a6a7221cd5d4e19bf3a872ff09da95b9a7509'
 
-    url 'http://manytricks.com/download/witch'
+    url 'https://manytricks.com/download/witch'
     appcast 'https://manytricks.com/witch/appcast.xml',
             checkpoint: '239d72b3fac6a2c8ba69e8028cb3bed7de7d4065c5335f907183457a8db2e114'
   end

--- a/Casks/wondershare-player.rb
+++ b/Casks/wondershare-player.rb
@@ -4,7 +4,7 @@ cask 'wondershare-player' do
 
   url 'http://download.wondershare.com/mac-player_full1479.dmg'
   name 'Wondershare Player'
-  homepage 'http://www.wondershare.com/video-player/'
+  homepage 'https://www.wondershare.com/video-player/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Wondershare Player.app'

--- a/Casks/x-moto.rb
+++ b/Casks/x-moto.rb
@@ -2,7 +2,7 @@ cask 'x-moto' do
   version '0.5.10'
   sha256 '0b032d21fb0644db252fe9210f9c0a3f465616996aad6d50b20ead2123a3507a'
 
-  url "http://download.tuxfamily.org/xmoto/xmoto/#{version}/xmoto-#{version}-macosx.zip"
+  url "https://download.tuxfamily.org/xmoto/xmoto/#{version}/xmoto-#{version}-macosx.zip"
   name 'XMoto'
   homepage 'http://xmoto.tuxfamily.org'
   license :gpl

--- a/Casks/x-moto.rb
+++ b/Casks/x-moto.rb
@@ -4,7 +4,7 @@ cask 'x-moto' do
 
   url "https://download.tuxfamily.org/xmoto/xmoto/#{version}/xmoto-#{version}-macosx.zip"
   name 'XMoto'
-  homepage 'http://xmoto.tuxfamily.org'
+  homepage 'https://xmoto.tuxfamily.org/'
   license :gpl
 
   app 'X-Moto.app'

--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -7,7 +7,7 @@ cask 'xquartz' do
   appcast 'https://www.xquartz.org/releases/sparkle/release.xml',
           checkpoint: '74e4ffc811e99d388086551e256abc9259b9200d23a90eb380811516ae6f501a'
   name 'XQuartz'
-  homepage 'http://www.xquartz.org/'
+  homepage 'https://www.xquartz.org/'
   license :oss
 
   pkg 'XQuartz.pkg'

--- a/Casks/yep.rb
+++ b/Casks/yep.rb
@@ -4,7 +4,7 @@ cask 'yep' do
 
   url 'https://www.ironicsoftware.com/downloads/Yep.zip'
   name 'Yep'
-  homepage 'http://www.ironicsoftware.com/yep/'
+  homepage 'https://www.ironicsoftware.com/yep/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
   app 'Yep.app'

--- a/Casks/yep.rb
+++ b/Casks/yep.rb
@@ -2,7 +2,7 @@ cask 'yep' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.ironicsoftware.com/downloads/Yep.zip'
+  url 'https://www.ironicsoftware.com/downloads/Yep.zip'
   name 'Yep'
   homepage 'http://www.ironicsoftware.com/yep/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
##### Instructions
- Look for and complete the section relevant to your submission. Delete the others, including these `Instructions`.
- `{{cask_file}}` represents the cask file you’re submitting/editing (if applicable).
- If there’s a checkbox you can’t complete for any reason, that’s OK. Just explain in detail why you weren’t able to do so.
### Changes to a cask
#### Editing an existing cask
- [ ] Commit message includes cask’s name (and new version, if applicable).
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.

---

I've used a script to verify if a secure alternative is available:
    https://gist.github.com/vszakats/7bdb547e367338299d029140fd8208ed

Script updated to:
- handle more `#{version.*}` macros
- try harder to verify cases where content-length is not reported
- fix a minor issue in the automatic formula update code

The PR includes a second patch, that contains manually tracked/verified
URL changes, where the script detected certain patterns of ambiguity.

Ratio of secure/insecure URLs:

Before:
Secure: 4678
Insecure: 3453

After:
Secure: 5062
Insecure: 3076
