### PR TITLE
audit: report exceptions as errors

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -18,6 +18,6 @@ fi
 
 if must_run_tests; then
   run bundle exec rake rubocop
-  run brew cask-tests
+  run brew cask-tests --coverage
   run bundle exec rake coveralls:push || true # in case of networking errors
 fi

--- a/cmd/brew-cask-tests.rb
+++ b/cmd/brew-cask-tests.rb
@@ -23,6 +23,12 @@ require "English"
     system "bundle", "install", "--path", "vendor/bundle"
   end
 
-  system "bundle", "exec", "rake", "test:coverage"
+  test_task = "test"
+  %w[rspec minitest coverage].each do |subtask|
+    next unless ARGV.flag?("--#{subtask}")
+    test_task = "test:#{subtask}"
+  end
+
+  system "bundle", "exec", "rake", test_task
   Homebrew.failed = !$CHILD_STATUS.success?
 end

--- a/lib/hbc/audit.rb
+++ b/lib/hbc/audit.rb
@@ -22,6 +22,10 @@ class Hbc::Audit
     check_generic_artifacts
     check_download
     self
+  rescue StandardError => e
+    odebug "#{e.message}\n#{e.backtrace.join("\n")}"
+    add_error "exception while auditing #{cask}: #{e.message}"
+    self
   end
 
   def success?

--- a/lib/hbc/cli/audit.rb
+++ b/lib/hbc/cli/audit.rb
@@ -4,11 +4,9 @@ class Hbc::CLI::Audit < Hbc::CLI::Base
   end
 
   def self.run(*args)
-    retval = new(args, Hbc::Auditor).run
-    # retval is ternary: true/false/nil
-
-    raise Hbc::CaskError, "audit failed" if retval.nil?
-    raise Hbc::CaskError, "some audits failed" unless retval
+    failed_casks = new(args, Hbc::Auditor).run
+    return if failed_casks.empty?
+    raise Hbc::CaskError, "audit failed for casks: #{failed_casks.join(' ')}"
   end
 
   def initialize(args, auditor)
@@ -17,11 +15,9 @@ class Hbc::CLI::Audit < Hbc::CLI::Base
   end
 
   def run
-    count = 0
-    casks_to_audit.each do |cask|
-      count += 1 if audit(cask)
+    casks_to_audit.each_with_object([]) do |cask, failed|
+      failed << cask unless audit(cask)
     end
-    count == 0 ? nil : count == casks_to_audit.length
   end
 
   def audit(cask)

--- a/spec/cask/audit_spec.rb
+++ b/spec/cask/audit_spec.rb
@@ -257,7 +257,7 @@ describe Hbc::Audit do
 
         context "when doing the audit" do
           it "evaluates the block" do
-            expect { subject }.to raise_error("Boom")
+            expect(subject).to fail_with(%r{Boom})
           end
         end
       end
@@ -295,6 +295,15 @@ describe Hbc::Audit do
 
         it { should fail_with(%r{#{error_msg}}) }
       end
+    end
+
+    context "when an exception is raised" do
+      let(:cask) { instance_double(Hbc::Cask) }
+      before do
+        cask.expects(:version).raises(StandardError.new)
+      end
+
+      it { should fail_with(%r{exception while auditing}) }
     end
   end
 end

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -18,6 +18,7 @@ describe "Repo layout" do
                    .rubocop_todo.yml
                    .ruby-version
                    coverage
+                   vendor
                  ].freeze
 
   # the developer has hopefully gitignored these

--- a/test/syntax_test.rb
+++ b/test/syntax_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 describe "Syntax check" do
   project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
-  backend_files = Dir[project_root.join("**", "*.rb")].reject { |f| f.match %r{/Casks/} }
+  backend_files = Dir[project_root.join("**", "*.rb")].reject { |f| f.match %r{/vendor/|/Casks/} }
   %w[2.0 2.1].each do |major_version|
     describe "under Ruby #{major_version}" do
       interpreter = Pathname.new("/System/Library/Frameworks/Ruby.framework/Versions/#{major_version}/usr/bin/ruby")


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Treat unexpected exceptions during an audit run as errors and proceed with the audit. Also report which casks failed after the audit is complete.

Refs #23472, #23463, #23442
