### PR TITLE
Add openpht 1.6.2.123-e23a7eef

### DIFF
--- a/Casks/openpht.rb
+++ b/Casks/openpht.rb
@@ -1,0 +1,13 @@
+cask 'openpht' do
+  version '1.6.2.123-e23a7eef'
+  sha256 '40b8e7e987d6a5551b4a8956afc37c06a9f67e30b2631305b4c658b3ae9403a8'
+
+  url "https://github.com/RasPlex/OpenPHT/releases/download/v#{version}/OpenPHT-#{version}-macosx-x86_64.zip"
+  appcast 'https://github.com/RasPlex/OpenPHT/releases.atom',
+          checkpoint: '209f89a2f9b9ae847e1ae60f21d58a974c114ce166fa4adfb935b4dc01097b2e'
+  name 'OpenPHT'
+  homepage 'https://github.com/RasPlex/OpenPHT'
+  license :gpl
+
+  app 'OpenPHT.app'
+end


### PR DESCRIPTION
#### Adding a new cask
- [X] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [X] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Commit message includes cask’s name.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.

OpenPHT is a built upon PlexHomeTheatre primarily built for RasPlex but also extended to Mac

https://github.com/RasPlex/OpenPHT
