### PR TITLE
Remove `HOMEBREW_OSX_VERSION` environment variable from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
 
 matrix:
   include:
-    - env: OSX=10.11 HOMEBREW_RUBY=2.0.0 HOMEBREW_OSX_VERSION=$OSX
+    - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
       os: osx
       osx_image: xcode7.3
       rvm: system
-    - env: OSX=10.10 HOMEBREW_RUBY=2.0.0 HOMEBREW_OSX_VERSION=$OSX
+    - env: OSX=10.10 HOMEBREW_RUBY=2.0.0
       os: osx
       osx_image: xcode7.1
       rvm: system

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,9 +10,8 @@ end
 # just in case
 raise "brew-cask: Ruby 2.0 or greater is required." if RUBY_VERSION.to_i < 2
 
-# add homebrew to load path
-homebrew_repo = `brew --repository`.chomp
-$LOAD_PATH.unshift(File.expand_path("#{homebrew_repo}/Library/Homebrew"))
+# add Homebrew to load path
+$LOAD_PATH.unshift(File.expand_path("#{ENV['HOMEBREW_REPOSITORY']}/Library/Homebrew"))
 
 require "global"
 require "extend/pathname"


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Since test are now run using `brew cask-tests`, `HOMEBREW_OSX_VERSION` should already be exported.
