### PR TITLE
boxcryptor 2.3.405.746

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,11 +1,11 @@
 cask 'boxcryptor' do
-  version '2.1.467.718'
-  sha256 '3859a2c0976a2fa1c280e4cea26a2037f125e066041f64cdbf4c47861aa39997'
+  version '2.3.405.746'
+  sha256 '0067dad6e70041f38076fd26fa674f337e51b6532bb8e35a2ac534e7e4fb858b'
 
   # d3k3ih5otj72mn.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3k3ih5otj72mn.cloudfront.net/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://rink.hockeyapp.net/api/2/apps/7fd6db3e51a977132e3b120c613eaea8',
-          checkpoint: 'c85906deda472e312cdd45f1892eb42db3f5c4a7adbbf737a407afbf756e8e9b'
+          checkpoint: '5d0f6c73dd0c2a0fc578c87268187306baaa610adb6f4a1d9cc7976b657659fc'
   name 'Boxcryptor'
   homepage 'https://www.boxcryptor.com/en'
   license :commercial


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Closing https://github.com/caskroom/homebrew-cask/pull/23564 in lieu of this PR.
