### PR TITLE
Exclude `**/vendor/**/*` from RuboCop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
   Exclude:
     - '**/Casks/**/*'
     - 'developer/**/*'
-    - 'lib/vendor/**/*'
+    - '**/vendor/**/*'
 
 Metrics/AbcSize:
   Enabled: false


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

When running `brew cask-tests`, `bundler` installs to `./vendor/bundle` and RuboCop goes rogue after that.
