### PR TITLE
utils cleanup from hb code

### DIFF
--- a/lib/hbc/cli/create.rb
+++ b/lib/hbc/cli/create.rb
@@ -18,7 +18,7 @@ class Hbc::CLI::Create < Hbc::CLI::Base
   # for mocking
   # TODO: add an :exec parameter to SystemCommand
   def self.exec_editor(*args)
-    Hbc::Utils.exec_editor(*args)
+    exec_editor(*args)
   end
 
   def self.template(cask_token)

--- a/lib/hbc/cli/edit.rb
+++ b/lib/hbc/cli/edit.rb
@@ -15,7 +15,7 @@ class Hbc::CLI::Edit < Hbc::CLI::Base
   # for mocking.
   # TODO: add an :exec parameter to SystemCommand
   def self.exec_editor(*args)
-    Hbc::Utils.exec_editor(*args)
+    exec_editor(*args)
   end
 
   def self.help

--- a/lib/hbc/cli/info.rb
+++ b/lib/hbc/cli/info.rb
@@ -16,7 +16,7 @@ class Hbc::CLI::Info < Hbc::CLI::Base
 
   def self.info(cask)
     installation = if cask.installed?
-                     "#{cask.staged_path} (#{Hbc::Utils.cabv(cask.staged_path)})"
+                     "#{cask.staged_path} (#{cask.staged_path.abv})"
                    else
                      "Not installed"
                    end

--- a/lib/hbc/cli/install.rb
+++ b/lib/hbc/cli/install.rb
@@ -1,3 +1,4 @@
+
 class Hbc::CLI::Install < Hbc::CLI::Base
   def self.run(*args)
     cask_tokens = cask_tokens_from(args)
@@ -44,7 +45,7 @@ class Hbc::CLI::Install < Hbc::CLI::Base
     if exact_match
       errmsg.concat(". Did you mean:\n#{exact_match}")
     elsif !partial_matches.empty?
-      errmsg.concat(". Did you mean one of:\n#{Hbc::Utils.stringify_columns(partial_matches.take(20))}\n")
+      errmsg.concat(". Did you mean one of:\n#{puts_columns(partial_matches.take(20))}\n")
     end
     onoe errmsg
   end

--- a/lib/hbc/cli/style.rb
+++ b/lib/hbc/cli/style.rb
@@ -24,7 +24,7 @@ class Hbc::CLI::Style < Hbc::CLI::Base
   RUBOCOP_CASK_VERSION = "~> 0.8.3".freeze
 
   def install_rubocop
-    Hbc::Utils.install_gem_setup_path! "rubocop-cask", RUBOCOP_CASK_VERSION, "rubocop"
+    Homebrew.install_gem_setup_path! "rubocop-cask", RUBOCOP_CASK_VERSION, "rubocop"
   end
 
   def cask_paths

--- a/lib/hbc/installer.rb
+++ b/lib/hbc/installer.rb
@@ -1,5 +1,6 @@
 require "rubygems"
 
+require "extend/pathname"
 require "hbc/cask_dependencies"
 require "hbc/staged"
 require "hbc/verify"
@@ -328,11 +329,11 @@ class Hbc::Installer
         end
       end
     end
-    Hbc::Utils.rmdir_if_possible(@cask.metadata_versioned_container_path)
-    Hbc::Utils.rmdir_if_possible(@cask.metadata_master_container_path)
+    @cask.metadata_versioned_container_path.rmdir_if_possible
+    @cask.metadata_master_container_path.rmdir_if_possible
 
     # toplevel staged distribution
-    Hbc::Utils.rmdir_if_possible(@cask.caskroom_path)
+    @cask.caskroom_path.rmdir_if_possible
   end
 
   def purge_caskroom_path

--- a/lib/hbc/utils.rb
+++ b/lib/hbc/utils.rb
@@ -43,11 +43,6 @@ def odebug(title, *sput)
   end
 end
 
-def puts_columns(items, star_items = [])
-  return if items.empty?
-  puts Hbc::Utils.stringify_columns(items, star_items)
-end
-
 module Hbc::Utils
   def self.which(cmd, path = ENV["PATH"])
     unless File.basename(cmd) == cmd.to_s
@@ -75,54 +70,6 @@ module Hbc::Utils
     end
     return nil unless cmd_pn.file?
     cmd_pn
-  end
-
-  # originally from Homebrew
-  def self.exec_editor(*args)
-    safe_exec(which_editor, *args)
-  end
-
-  # originally from Homebrew puts_columns
-  def self.stringify_columns(items, star_items = [])
-    return if items.empty?
-
-    if star_items && star_items.any?
-      items = items.map { |item| star_items.include?(item) ? "#{item}*" : item }
-    end
-
-    return items.join("\n").concat("\n") unless $stdout.tty?
-
-    # determine the best width to display for different console sizes
-    console_width = `/bin/stty size 2>/dev/null`.chomp.split(" ").last.to_i
-    console_width = 80 if console_width <= 0
-    longest = items.sort_by(&:length).last
-    optimal_col_width = (console_width.to_f / (longest.length + 2).to_f).floor
-    cols = optimal_col_width > 1 ? optimal_col_width : 1
-    Open3.popen2("/usr/bin/pr", "-#{cols}", "-t", "-w#{console_width}") do |stdin, stdout|
-      stdin.puts(items)
-      stdin.close
-      stdout.read
-    end
-  end
-
-  # originally from Homebrew
-  # children.empty? is slow to enumerate the whole directory just
-  # to see if it is empty
-  def self.rmdir_if_possible(dir)
-    dirpath = Pathname(dir)
-    begin
-      dirpath.rmdir
-      true
-    rescue Errno::ENOTEMPTY
-      if (ds_store = dirpath.join(".DS_Store")).exist? && dirpath.children.length == 1
-        ds_store.unlink
-        retry
-      else
-        false
-      end
-    rescue Errno::EACCES, Errno::ENOENT
-      false
-    end
   end
 
   def self.gain_permissions_remove(path, command: Hbc::SystemCommand)
@@ -175,21 +122,6 @@ module Hbc::Utils
 
   def self.current_user
     Etc.getpwuid(Process.euid).name
-  end
-
-  # originally from Homebrew abv
-  def self.cabv(dir)
-    output = ""
-    count = Hbc::SystemCommand.run!("/usr/bin/find",
-                                    args:         [dir, *%w[-type f -not -name .DS_Store -print0]],
-                                    print_stderr: false).stdout.count("\000")
-
-    size = Hbc::SystemCommand.run!("/usr/bin/du",
-                                   args:         ["-hs", "--", dir],
-                                   print_stderr: false).stdout.split("\t").first.strip
-
-    output << "#{count} files, " if count > 1
-    output << size
   end
 
   # paths that "look" descendant (textually) will still
@@ -253,37 +185,5 @@ module Hbc::Utils
 
   def self.size_in_bytes(files)
     Array(files).reduce(0) { |a, e| a + (File.size?(e) || 0) }
-  end
-
-  # originally from Homebrew
-  def self.install_gem_setup_path!(gem_name, version = nil, executable = gem_name)
-    require "rubygems"
-    ENV["PATH"] = "#{Gem.user_dir}/bin:#{ENV['PATH']}"
-
-    if Gem::Specification.find_all_by_name(gem_name, version).empty?
-      ohai "Installing or updating '#{gem_name}' gem"
-      install_args = %W[--no-ri --no-rdoc --user-install #{gem_name}]
-      install_args << "--version" << version if version
-
-      # Do `gem install [...]` without having to spawn a separate process or
-      # having to find the right `gem` binary for the running Ruby interpreter.
-      require "rubygems/commands/install_command"
-      install_cmd = Gem::Commands::InstallCommand.new
-      install_cmd.handle_options(install_args)
-      exit_code = 1 # Should not matter as `install_cmd.execute` always throws.
-      begin
-        install_cmd.execute
-      rescue Gem::SystemExitException => e
-        exit_code = e.exit_code
-      end
-      raise Hbc::CaskError, "Failed to install/update the '#{gem_name}' gem." if exit_code != 0
-    end
-
-    unless which executable
-      raise Hbc::CaskError, <<-EOS.undent
-        The '#{gem_name}' gem is installed but couldn't find '#{executable}' in the PATH:
-        #{ENV['PATH']}
-      EOS
-    end
   end
 end

--- a/spec/cask/cli/style_spec.rb
+++ b/spec/cask/cli/style_spec.rb
@@ -67,7 +67,7 @@ describe Hbc::CLI::Style do
 
     shared_examples "executable availability" do
       before do
-        allow(Hbc::Utils).to receive(:which).and_return(which_retval)
+        allow(Homebrew).to receive(:which).and_return(which_retval)
       end
 
       context "when rubocop is available on the PATH" do
@@ -106,7 +106,7 @@ describe Hbc::CLI::Style do
       let(:returned_specs) { [[]] }
 
       before do
-        allow(Hbc::Utils).to receive(:require)
+        allow(Homebrew).to receive(:require)
         allow(fake_gem_install_cmd_class).to receive(:new).and_return(fake_install_cmd)
         allow(fake_install_cmd).to receive(:handle_options)
         allow(fake_install_cmd).to receive(:execute).and_raise(fake_system_exit_exception)


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).
## 

_Do not merge_

Methods from homebrew are deleted from utils. 
_Problem:_ `install_gem_setup_path!` method from Homebrew doesn't throw an exception when can't find executable (like cask's one did), it exits immediately with error (SystemExit: exit). Cask specs contain tests checking that exception is thrown by this method but it is not any longer. What is more appropriate to do with these tests? I would remove them as I don't know ways to handle SystemExit properly and don't want to leave the duplicated method in utils either. But maybe there are some other ways.

cc @MikeMcQuaid 
