### PR TITLE
Update Docker to 1.12.0-a (11213)

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '1.12.0.10871'
-  sha256 'f170610d95c188dee8433eff33c84696c1c8a39421de548a71a1258a458e1b21'
+  version '1.12.0.11213'
+  sha256 'c6ec6c637efa347427e86168c8d963deb5770b1d67a99f64096c1554b635bd8b'
 
   url "https://download.docker.com/mac/stable/#{version}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: 'ee03f7c36b4192a64ba30e49a0fa1f8358cc3fe4a8a3af3def066c80f36b18bf'
+          checkpoint: '0fb1705e17e1946681c0ac6f2ebe60ae8316990dacff8822ade2fd95153a7a09'
   name 'Docker for Mac'
   homepage 'https://www.docker.com/products/docker'
   license :mit


### PR DESCRIPTION
The new version contains some important fixes for developers working with package management (apt, npm) or inotify events inside containers.
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
