### PR TITLE
Add Livestreamer Twitch GUI v0.14.2

### DIFF
--- a/Casks/livestreamer-twitch-gui.rb
+++ b/Casks/livestreamer-twitch-gui.rb
@@ -1,0 +1,13 @@
+cask 'livestreamer-twitch-gui' do
+  version '0.14.2'
+  sha256 '8f23cdea09c3ab5f54dfab2f34304dd1ee9af1174dd4f227c6bdaf0d3847ddb5'
+
+  url "https://github.com/bastimeyer/livestreamer-twitch-gui/releases/download/v#{version}/livestreamer-twitch-gui-v#{version}-osx64.tar.gz"
+  appcast 'https://github.com/bastimeyer/livestreamer-twitch-gui/releases.atom',
+          checkpoint: '62fad10fd3c6c0fc19b9a7438314fd8950045a6ba3886e48819905cee12814be'
+  name 'Livestreamer Twitch GUI'
+  homepage 'https://github.com/bastimeyer/livestreamer-twitch-gui'
+  license :mit
+
+  app 'Livestreamer Twitch GUI.app'
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download livestreamer-twitch-gui` is error-free.
- [x] `brew cask style --fix livestreamer-twitch-gui` left no offenses.
- [x] `brew cask install livestreamer-twitch-gui` worked successfully.
- [x] `brew cask uninstall livestreamer-twitch-gui` worked successfully.
