### PR TITLE
brew-cask-tests: CD to repo root to enable testing in a dev repo

### DIFF
--- a/cmd/brew-cask-tests.rb
+++ b/cmd/brew-cask-tests.rb
@@ -15,7 +15,8 @@ end
 
 require "English"
 
-(HOMEBREW_LIBRARY / "Taps/caskroom/homebrew-cask").cd do
+repo_root = Pathname(__FILE__).realpath.parent.parent
+repo_root.cd do
   ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
 
   Homebrew.install_gem_setup_path! "bundler"

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -24,6 +24,7 @@ describe "Repo layout" do
   # the developer has hopefully gitignored these
   IGNORE_REGEXPS = [
                      %r{~$}, # emacs
+                     %r{.sublime-\w+}, # Sublime Text
                    ].freeze
 
   TOPLEVEL_DIRS = %w[


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Prior to this change, `brew cask-tests` would always `cd` to `/usr/local/Library/Taps/caskroom/homebrew-cask` before running the test suite, making it impossible to run tests in a dev repo with `developer/develop_brew_cask` enabled.
