### PR TITLE
utils: remove install_gem_setup_path!

### DIFF
--- a/lib/hbc/cli/style.rb
+++ b/lib/hbc/cli/style.rb
@@ -24,7 +24,13 @@ class Hbc::CLI::Style < Hbc::CLI::Base
   RUBOCOP_CASK_VERSION = "~> 0.8.3".freeze
 
   def install_rubocop
-    Hbc::Utils.install_gem_setup_path! "rubocop-cask", RUBOCOP_CASK_VERSION, "rubocop"
+    Hbc::Utils.capture_stderr do
+      begin
+        Homebrew.install_gem_setup_path! "rubocop-cask", RUBOCOP_CASK_VERSION, "rubocop"
+      rescue SystemExit
+        raise Hbc::CaskError, $stderr.string.chomp.sub("#{::Tty.red}Error#{::Tty.reset}: ", "")
+      end
+    end
   end
 
   def cask_paths


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Use Homebrew's `install_gem_setup_path!` wrapped in a block to capture `stderr` and `SystemExit`.

Simplify `style_spec` so we aren't whitebox-testing Homebrew's `install_gem_setup_path!` code.

Refs #23603 
