### PR TITLE
Add WhichSpace.app v0.1.9

### DIFF
--- a/Casks/whichspace.rb
+++ b/Casks/whichspace.rb
@@ -1,0 +1,13 @@
+cask 'whichspace' do
+  version '0.1.9'
+  sha256 '4c1c0fb5f036cb1e11e2126ea5caaafb2ea9526523ed3a36a160793910529b57'
+
+  url "https://github.com/gechr/WhichSpace/releases/download/v#{version}/WhichSpace.app.zip"
+  name 'WhichSpace'
+  homepage 'https://github.com/gechr/WhichSpace'
+  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+
+  depends_on macos: '> :yosemite'
+
+  app 'WhichSpace.app'
+end

--- a/Casks/whichspace.rb
+++ b/Casks/whichspace.rb
@@ -3,6 +3,9 @@ cask 'whichspace' do
   sha256 '4c1c0fb5f036cb1e11e2126ea5caaafb2ea9526523ed3a36a160793910529b57'
 
   url "https://github.com/gechr/WhichSpace/releases/download/v#{version}/WhichSpace.app.zip"
+  appcast 'https://github.com/gechr/WhichSpace/releases.atom',
+          checkpoint: '100d2a27e92d419f26342e7c2389388e0812a59640d21203db0c8c81a8aa9b82'
+
   name 'WhichSpace'
   homepage 'https://github.com/gechr/WhichSpace'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder

--- a/Casks/whichspace.rb
+++ b/Casks/whichspace.rb
@@ -5,7 +5,6 @@ cask 'whichspace' do
   url "https://github.com/gechr/WhichSpace/releases/download/v#{version}/WhichSpace.app.zip"
   appcast 'https://github.com/gechr/WhichSpace/releases.atom',
           checkpoint: '100d2a27e92d419f26342e7c2389388e0812a59640d21203db0c8c81a8aa9b82'
-
   name 'WhichSpace'
   homepage 'https://github.com/gechr/WhichSpace'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download whichspace` is error-free.
- [x] `brew cask style --fix whichspace` left no offenses.
- [x] `brew cask install whichspace` worked successfully.
- [x] `brew cask uninstall whichspace` worked successfully.
