### PR TITLE
Update fldigi to v3.23.13

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,14 +1,14 @@
 cask 'fldigi' do
-  version '3.23.12'
-  sha256 '9c63ab88c280456c713c0e88fa42453529d08c761f47b18d5b8c535bcdbd13ee'
+  version '3.23.13'
+  sha256 '936ccb7d07eb70a3565c53fde77753b47d7fa8495e2adba04d48c7fcdf12b372'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'cf5589963f2f67d76bfe7f1fff77028d071fd026d4f30c9c031f7b34ba0deeef'
+          checkpoint: '2cddfc239be10e2acf1ab18d722f6cf296d04c4900ed46ed76ee91c6552434d9'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
   license :gpl
 
   app "fldigi-#{version}.app"
-  app 'flarq.app'
+  app 'flarq-4.3.6.app'
 end


### PR DESCRIPTION
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download fldigi` is error-free.
- [x] `brew cask style --fix fldigi` left no offenses.

Update fldigi to v3.23.13
Also resolve install error caused by flarq version number.
