### PR TITLE
Fix and refactor `info`.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -117,12 +117,13 @@ Show details about a specific Cask:
 ```bash
 $ brew cask info caffeine
 caffeine: 1.1.1
-Caffeine
 http://lightheadsw.com/caffeine/
 Not installed
-https://github.com/caskroom/homebrew-cask/blob/master/Casks/caffeine.rb
-==> Contents
-  Caffeine.app (app)
+From: https://github.com/caskroom/homebrew-cask/blob/master/Casks/caffeine.rb
+==> Name
+Caffeine
+==> Artifacts
+Caffeine.app (app)
 ```
 
 ## Updating/Upgrading Casks

--- a/lib/hbc/dsl/caveats.rb
+++ b/lib/hbc/dsl/caveats.rb
@@ -31,9 +31,9 @@ class Hbc::DSL::Caveats < Hbc::DSL::Base
     localpath = "/usr/local"
     return unless Hbc.homebrew_prefix.to_s.downcase.start_with?(localpath)
     puts <<-EOS.undent
-    Cask #{@cask} installs files under "#{localpath}".  The presence of such
-    files can cause warnings when running "brew doctor", which is considered
-    to be a bug in Homebrew-Cask.
+      Cask #{@cask} installs files under "#{localpath}". The presence of such
+      files can cause warnings when running "brew doctor", which is considered
+      to be a bug in Homebrew-Cask.
 
     EOS
   end

--- a/test/cask/cli/info_test.rb
+++ b/test/cask/cli/info_test.rb
@@ -4,35 +4,38 @@ describe Hbc::CLI::Info do
   it "displays some nice info about the specified Cask" do
     lambda {
       Hbc::CLI::Info.run("local-caffeine")
-    }.must_output <<-CLIOUTPUT.undent
+    }.must_output <<-EOS.undent
       local-caffeine: 1.2.3
-      local-caffeine
       http://example.com/local-caffeine
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
-      ==> Contents
-        Caffeine.app (app)
-    CLIOUTPUT
+      From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+      ==> Name
+      None
+      ==> Artifacts
+      Caffeine.app (app)
+    EOS
   end
 
   describe "given multiple Casks" do
     before do
-      @expected_output = <<-CLIOUTPUT.undent
+      @expected_output = <<-EOS.undent
         local-caffeine: 1.2.3
-        local-caffeine
         http://example.com/local-caffeine
         Not installed
-        https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
-        ==> Contents
-          Caffeine.app (app)
+        From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+        ==> Name
+        None
+        ==> Artifacts
+        Caffeine.app (app)
         local-transmission: 2.61
-        local-transmission
         http://example.com/local-transmission
         Not installed
-        https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
-        ==> Contents
-          Transmission.app (app)
-      CLIOUTPUT
+        From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
+        ==> Name
+        None
+        ==> Artifacts
+        Transmission.app (app)
+      EOS
     end
 
     it "displays the info" do
@@ -51,14 +54,15 @@ describe Hbc::CLI::Info do
   it "should print caveats if the Cask provided one" do
     lambda {
       Hbc::CLI::Info.run("with-caveats")
-    }.must_output <<-CLIOUTPUT.undent
+    }.must_output <<-EOS.undent
       with-caveats: 1.2.3
-      with-caveats
       http://example.com/local-caffeine
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-caveats.rb
-      ==> Contents
-        Caffeine.app (app)
+      From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-caveats.rb
+      ==> Name
+      None
+      ==> Artifacts
+      Caffeine.app (app)
       ==> Caveats
       Here are some things you might want to know.
 
@@ -70,21 +74,22 @@ describe Hbc::CLI::Info do
 
         export PATH=/custom/path/bin:"$PATH"
 
-    CLIOUTPUT
+    EOS
   end
 
   it 'should not print "Caveats" section divider if the caveats block has no output' do
     lambda {
       Hbc::CLI::Info.run("with-conditional-caveats")
-    }.must_output <<-CLIOUTPUT.undent
+    }.must_output <<-EOS.undent
       with-conditional-caveats: 1.2.3
-      with-conditional-caveats
       http://example.com/local-caffeine
       Not installed
-      https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-conditional-caveats.rb
-      ==> Contents
-        Caffeine.app (app)
-    CLIOUTPUT
+      From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-conditional-caveats.rb
+      ==> Name
+      None
+      ==> Artifacts
+      Caffeine.app (app)
+    EOS
   end
 
   describe "when no Cask is specified" do


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

<details>
<summary>

sample output: `brew cask info tower` (newer version available than is installed)</summary>



``` text
tower 2.4.0-315-880ab34c
from https://github.com/caskroom/homebrew-cask/blob/master/Casks/tower.rb
==> Name
Tower
==> Homepage
https://www.git-tower.com/
==> Installation
/usr/local/Caskroom/tower/2.3.5-308-9f8ed9a3 (68B)
==> Artifacts
Tower.app (app)
/Applications/Tower.app/Contents/MacOS/gittower (binary)
==> Caveats
Cask tower installs files under "/usr/local". The presence of such
files can cause warnings when running "brew doctor", which is considered
to be a bug in Homebrew-Cask.

```

</details>

<details>
<summary>

sample output: `brew cask info hazel` (multiple versions installed)</summary>



``` text
hazel 4.0.5
from https://github.com/caskroom/homebrew-cask/blob/master/Casks/hazel.rb
==> Name
Hazel
==> Homepage
https://www.noodlesoft.com/hazel.php
==> Installation
/usr/local/Caskroom/hazel/4.0.3 (7 files, 277.1K)
/usr/local/Caskroom/hazel/4.0.5 (7 files, 277.1K)
==> Artifacts
Install Hazel.app/Contents/Resources/Hazel.prefPane (prefpane)
```

</details>

---

Fixes https://github.com/caskroom/homebrew-cask/issues/23565.
