### PR TITLE
updated hachidori (1.1.8)

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,11 +1,11 @@
 cask 'hachidori' do
-  version '1.1.7.4'
-  sha256 '538e7f82705fca3e83fa063bca35978509a549747a2d204a5e9b924628b62092'
+  version '1.1.8'
+  sha256 'f97371c885af817177f4660232287176777e17092c0a25a9d1a74de8b31c0e52'
 
   # github.com/chikorita157/hachidori was verified as official when first introduced to the cask
   url "https://github.com/chikorita157/hachidori/releases/download/#{version}/Hachidori-#{version}.zip"
   appcast 'https://github.com/chikorita157/hachidori/releases.atom',
-          checkpoint: '7304aa9decf3283352b6a890053a465d9f5e93b601e3d964ec5140e0cad52888'
+          checkpoint: 'f72e2b4819b37d77f73496453f1d91398d2f677314c9492b9db3b3c927c8c0e5'
   name 'Hachidori'
   homepage 'http://hachidori.ateliershiori.moe'
   license :bsd


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
