### PR TITLE
Update dotnet caveats

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -14,9 +14,14 @@ cask 'dotnet' do
   uninstall pkgutil: 'com.microsoft.dotnet.*'
 
   caveats <<-EOS.undent
-    The latest version of OpenSS is required to use .NET Core.
-    It was already installed, but you may need to link it
+    The latest version of OpenSSL is required to use .NET Core.
+    It was already installed, but you may need to link it:
 
-      brew link --force openssl
+      ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
+      ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
+
+    Zsh users may need to symlink the dotnet binary:
+
+      ln -s /usr/local/share/dotnet/dotnet /usr/local/bin
   EOS
 end


### PR DESCRIPTION
Because

1) https://github.com/dotnet/cli/issues/2229#issuecomment-239621383
2) Microsoft even changed their install instructions: https://www.microsoft.com/net/core#macos
3) https://github.com/dotnet/core/blob/master/cli/known-issues.md#users-of-zsh-z-shell-dont-get-dotnet-on-the-path-after-install
#### Editing an existing cask
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
