### PR TITLE
Updating archi to V3.3.2

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,6 +1,6 @@
 cask 'archi' do
-  version '3.3.1'
-  sha256 '737d3287fdde718ed9a2363259efa814ff1c29feaf632bc6de594fdbe7c7af19'
+  version '3.3.2'
+  sha256 '77676360b17834e1bfca55d7d7df90c3104135c812aefc0946022b113b1d5be7'
 
   url "http://www.archimatetool.com/downloads/latest/Archi-mac64-#{version}.zip"
   name 'Archi'


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download archi` is error-free.
- [x] `brew cask style --fix archi` left no offenses.

Also fixing sha (as a byproduct), which was out of whack for v3.3.1
