### PR TITLE
Fix `info` for casks that use `staged_path` as `suite`.

### DIFF
--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -10,8 +10,12 @@ cask 'chatty' do
   homepage 'https://chatty.github.io'
   license :mit
 
-  # There is no sub-folder in the ZIP; the root *is* the folder
-  suite '.', target: 'Chatty'
+  suite 'Chatty'
+
+  preflight do
+    # There is no sub-folder in the ZIP; the root *is* the folder
+    FileUtils.mv(staged_path.children, staged_path.join('Chatty').tap(&:mkpath))
+  end
 
   zap delete: '~/.chatty'
 

--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -12,8 +12,12 @@ cask 'displaycal' do
 
   depends_on formula: 'argyll-cms'
 
-  # There is no sub-folder in the DMG; the root *is* the folder
-  suite '.', target: 'DisplayCAL'
+  suite 'DisplayCAL'
+
+  preflight do
+    # There is no sub-folder in the DMG; the root *is* the folder
+    FileUtils.mv(staged_path.children, staged_path.join('DisplayCAL').tap(&:mkpath))
+  end
 
   zap delete: [
                 '~/Library/Application Support/dispcalGUI',

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -8,7 +8,12 @@ cask 'klayout' do
   homepage 'http://www.klayout.de/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  suite '.', target: 'KLayout'
+  suite 'KLayout'
+
+  preflight do
+    # There is no sub-folder in the DMG; the root *is* the folder
+    FileUtils.mv(staged_path.children, staged_path.join('KLayout').tap(&:mkpath))
+  end
 
   uninstall pkgutil: 'klayout.de',
             quit:    'klayout.de'

--- a/Casks/virtual-ii.rb
+++ b/Casks/virtual-ii.rb
@@ -13,8 +13,12 @@ cask 'virtual-ii' do
   homepage 'http://virtualii.com/'
   license :freemium
 
-  # There is no sub-folder in the DMG; the root *is* the folder
-  suite '.', target: 'Virtual ]['
+  suite 'Virtual ]['
+
+  preflight do
+    # There is no sub-folder in the DMG; the root *is* the folder
+    FileUtils.mv(staged_path.children, staged_path.join('Virtual ][').tap(&:mkpath))
+  end
 
   caveats <<-EOS.undent
     This app requires a ROM image, which must be downloaded and installed

--- a/lib/hbc/cli/info.rb
+++ b/lib/hbc/cli/info.rb
@@ -32,7 +32,11 @@ class Hbc::CLI::Info < Hbc::CLI::Base
     if cask.installed?
       cask.versions.each do |version|
         versioned_staged_path = cask.caskroom_path.join(version)
-        puts "#{versioned_staged_path} (#{versioned_staged_path.abv})"
+
+        puts versioned_staged_path.to_s
+          .concat(" (")
+          .concat(versioned_staged_path.exist? ? versioned_staged_path.abv : "#{Hbc::Utils::Tty.red}does not exist#{Hbc::Utils::Tty.reset}")
+          .concat(")")
       end
     else
       puts "Not installed"


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

---

Closes https://github.com/caskroom/homebrew-cask/issues/23762.
