### PR TITLE
Set rpath on dotnet cask's crypto lib to fix install failure

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -11,12 +11,13 @@ cask 'dotnet' do
 
   pkg "dotnet-dev-osx-x64.#{version}.pkg"
 
+  # the dotnet package ships with crypto libraries expecting to find openssl
+  # in /usr/local/lib, but it is installed keg only by homebrew
+  postflight do
+    system 'sudo', '-E', '--', 'install_name_tool', '-add_rpath',
+           '/usr/local/opt/openssl/lib',
+           '/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.0/System.Security.Cryptography.Native.dylib'
+  end
+
   uninstall pkgutil: 'com.microsoft.dotnet.*'
-
-  caveats <<-EOS.undent
-    The latest version of OpenSS is required to use .NET Core.
-    It was already installed, but you may need to link it
-
-      brew link --force openssl
-  EOS
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

This fixes https://github.com/dotnet/cli/issues/3964 properly

Note: I did not make the `/usr/local/opt/openssl/lib` interrogate brew to find the correct location for non `/usr/local` installs as I was not sure how to do this in the cask. It should be `"$(brew --prefix openssl)/lib`. I welcome a fix for this prior to merge.
