### PR TITLE
Move caveats for dotnet installer to postflight

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -11,15 +11,16 @@ cask 'dotnet' do
 
   pkg "dotnet-dev-osx-x64.#{version}.pkg"
 
+  postflight do
+    ohai 'Symlinking openssl libraries to /usr/local/lib to ensure crypto works'
+    system 'mkdir', '-p', '/usr/local/lib'
+    system 'ln', '-sfv', '/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib', '/usr/local/lib/'
+    system 'ln', '-sfv', '/usr/local/opt/openssl/lib/libssl.1.0.0.dylib', '/usr/local/lib/'
+  end
+
   uninstall pkgutil: 'com.microsoft.dotnet.*'
 
   caveats <<-EOS.undent
-    The latest version of OpenSSL is required to use .NET Core.
-    It was already installed, but you may need to link it:
-
-      ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
-      ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
-
     Zsh users may need to symlink the dotnet binary:
 
       ln -s /usr/local/share/dotnet/dotnet /usr/local/bin


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The dotnet crypto library must be able to find the openssl libraries in its
rpath, which by default includes /usr/local. If the 1.0.0 libs are not found,
dotnet does not work.
