### PR TITLE
Added up-to-date check to cask-info

### DIFF
--- a/lib/hbc/cask.rb
+++ b/lib/hbc/cask.rb
@@ -82,6 +82,10 @@ class Hbc::Cask
     !versions.empty?
   end
 
+  def updated?
+    !versions.index{ |p| p.to_s == version }.nil?
+  end
+
   def to_s
     @token
   end

--- a/lib/hbc/cli/info.rb
+++ b/lib/hbc/cli/info.rb
@@ -30,6 +30,9 @@ class Hbc::CLI::Info < Hbc::CLI::Base
 
   def self.installation_info(cask)
     if cask.installed?
+      if !cask.updated?
+        puts "Not up-to-date"
+      end
       cask.versions.each do |version|
         versioned_staged_path = cask.caskroom_path.join(version)
 


### PR DESCRIPTION
### Changes to the core
- [x] Followed [hacking.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/hacking.md).

This adds a line to `brew cask info` if the cask is installed but the latest available version does not match any installed version. Example: 

<pre>
mono-mdk: 4.4.2.11
http://mono-project.com/
<b>Not up-to-date</b>
/opt/homebrew-cask/Caskroom/mono-mdk/4.2.1.102 (does not exist)
/opt/homebrew-cask/Caskroom/mono-mdk/4.4.0.142 (295.0M)
/opt/homebrew-cask/Caskroom/mono-mdk/4.4.1.0 (302.6M)
From: https://github.com/caskroom/homebrew-cask/blob/master/Casks/mono-mdk.rb
==> Name
Mono
==> Artifacts
MonoFramework-MDK-4.4.2.11.macos10.xamarin.universal.pkg (pkg)
</pre>


Not sure if this is in line with project plans, but I wanted a quick way to check for outdated casks, since recent changes to `brew cask info` broke my `cask-outdated` alias. Please see https://github.com/caskroom/homebrew-cask/issues/23762#issuecomment-239863238 for prior discussion. 
