### PR TITLE
updated messenger (0.1.9.1471449462-ee2d21f7e322294f)

### DIFF
--- a/Casks/messenger.rb
+++ b/Casks/messenger.rb
@@ -1,10 +1,10 @@
 cask 'messenger' do
-  version '0.1.8.1466363428-c3dc9b83f1dd0469'
-  sha256 '84e8d4e5c5242ac3e277423a1ae54be6267d05c1eb47b79c77a6b5c0e548f7df'
+  version '0.1.9.1471449462-ee2d21f7e322294f'
+  sha256 '1a4b49b860b9ae14c6f6b3e0190484b0572299f40f95f798d330838e4c9c17f4'
 
   url "https://fbmacmessenger.rsms.me/dist/Messenger-#{version}.zip"
   appcast 'https://fbmacmessenger.rsms.me/changelog.xml',
-          checkpoint: '6b72f621e9f00b9cc4786cb7084a727d31bd91d5d34cf0191170c4a2e2b9c622'
+          checkpoint: '0e38e45168998342254958575d9127c2a1509f2290d1c7c8efc9e534d0ffb968'
   name 'Messenger'
   homepage 'https://fbmacmessenger.rsms.me/'
   license :mit


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
