### PR TITLE
Assume Ruby 2.

### DIFF
--- a/cmd/brew-cask-tests.rb
+++ b/cmd/brew-cask-tests.rb
@@ -1,18 +1,3 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -W0 -EUTF-8:UTF-8
-# encoding: UTF-8
-
-# Ruby version check
-unless RUBY_VERSION.split(".").first.to_i >= 2
-  alt_ruby = which "ruby"
-  alt_ruby_version = `#{alt_ruby} --version`.chomp[%r{\d\.\d}, 0] if alt_ruby
-
-  unless alt_ruby && alt_ruby_version.split(".").first.to_i >= 2
-    abort "Ruby 2.0 or above is required. You can install it with `brew install ruby`."
-  end
-
-  exec alt_ruby, "-W0", "-I#{HOMEBREW_LIBRARY_PATH}", "-rglobal", __FILE__, *ARGV
-end
-
 require "English"
 
 repo_root = Pathname(__FILE__).realpath.parent.parent

--- a/cmd/brew-cask.rb
+++ b/cmd/brew-cask.rb
@@ -1,18 +1,3 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -W0 -EUTF-8:UTF-8
-# encoding: UTF-8
-
-# Ruby version check
-unless RUBY_VERSION.split(".").first.to_i >= 2
-  alt_ruby = which "ruby"
-  alt_ruby_version = `#{alt_ruby} --version`.chomp[%r{\d\.\d}, 0] if alt_ruby
-
-  unless alt_ruby && alt_ruby_version.split(".").first.to_i >= 2
-    abort "Ruby 2.0 or above is required. You can install it with `brew install ruby`."
-  end
-
-  exec alt_ruby, "-W0", "-I#{HOMEBREW_LIBRARY_PATH}", "-rglobal", __FILE__, *ARGV
-end
-
 require "pathname"
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", Pathname.new(__FILE__).realpath))

--- a/developer/bin/list_running_app_ids
+++ b/developer/bin/list_running_app_ids
@@ -21,8 +21,8 @@ $opt_test = nil
 ###
 
 def check_ruby
-  if RUBY_VERSION.to_f < 1.9
-    print "You are currently using Ruby ", RUBY_VERSION, ", but version 1.9 or above is required."
+  if RUBY_VERSION.to_f < 2.0
+    print "You are currently using Ruby ", RUBY_VERSION, ", but version 2.0 or above is required."
     exit 1
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,6 @@ if ENV["COVERAGE"]
   Coveralls.wear_merged!
 end
 
-# just in case
-raise "brew-cask: Ruby 2.0 or greater is required." if RUBY_VERSION.to_i < 2
-
 project_root = Pathname.new(File.expand_path("../..", __FILE__))
 
 # add Homebrew to load path

--- a/test/syntax_test.rb
+++ b/test/syntax_test.rb
@@ -3,23 +3,14 @@ require "test_helper"
 describe "Syntax check" do
   project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
   backend_files = Dir[project_root.join("**", "*.rb")].reject { |f| f.match %r{/vendor/|/Casks/} }
-  %w[2.0 2.1].each do |major_version|
-    describe "under Ruby #{major_version}" do
-      interpreter = Pathname.new("/System/Library/Frameworks/Ruby.framework/Versions/#{major_version}/usr/bin/ruby")
-      interpreter = Pathname.new(Dir["#{ENV['HOME']}/.rbenv/versions/#{major_version}*/bin/ruby"].first.to_s)  unless interpreter.exist?
-      interpreter = Pathname.new(Dir["#{ENV['HOME']}/.rvm/rubies/ruby-#{major_version}*/bin/ruby"].first.to_s) unless interpreter.exist?
-      interpreter = Pathname.new(Dir["/usr/local/bin/ruby{-,}#{major_version}*"].first.to_s)                   unless interpreter.exist?
-      interpreter = Pathname.new(Dir["/opt/local/bin/ruby{-,}#{major_version}*"].first.to_s)                   unless interpreter.exist?
-      flags = %w[-c]
-      flags.unshift "--disable-all"
-      backend_files.each do |file|
-        it "#{file} is valid Ruby" do
-          skip("Ruby #{major_version} not found") unless interpreter.exist?
-          args = flags + ["--", file]
-          shutup do
-            raise SyntaxError, "#{file} failed syntax check" unless system(interpreter, *args)
-          end
-        end
+  interpreter = RUBY_PATH
+  flags = %w[-c]
+  flags.unshift "--disable-all"
+  backend_files.each do |file|
+    it "#{file} is valid Ruby" do
+      args = flags + ["--", file]
+      shutup do
+        raise SyntaxError, "#{file} failed syntax check" unless system(interpreter, *args)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,6 @@ if ENV["COVERAGE"]
   Coveralls.wear_merged!
 end
 
-# just in case
-raise "brew-cask: Ruby 2.0 or greater is required." if RUBY_VERSION.to_i < 2
-
 project_root = Pathname.new(File.expand_path("../..", __FILE__))
 
 # add Homebrew to load path


### PR DESCRIPTION
Homebrew now always uses Ruby 2.0 so you no longer need to check in all these places for 2.0 or for 2.1 valid syntax.

Part of fixing issues for https://github.com/Homebrew/brew/pull/725
