### PR TITLE
Add Halla.app v0.6.2

### DIFF
--- a/Casks/halla.rb
+++ b/Casks/halla.rb
@@ -1,0 +1,15 @@
+cask 'halla' do
+  version '0.6.2'
+  sha256 :no_check
+
+  url "https://github.com/rstacruz/halla/releases/download/v#{version}/halla-osx.zip"
+  appcast 'https://github.com/rstacruz/halla/releases.atom',
+          checkpoint: '44182d9e902fc0c5577758b119167e50829a253b2a12b504c5cba372694d3094'
+  name 'Halla'
+  homepage 'https://github.com/rstacruz/halla'
+  license :mit
+
+  app 'Halla.app'
+
+  caveats 'See https://github.com/rstacruz/halla/blob/master/README.md on creating your ~/.hallarc'
+end


### PR DESCRIPTION
About Halla "yet another "native" app for accessing your Slack teams. It tries to be more conservative with resources. Halla is built on nw.js, which takes less resources than Electron (most other wrapper apps) or MacGap (Slack official app)."

See more [here](https://github.com/rstacruz/halla/blob/master/README.md)
