### PR TITLE
updated Veracrypt v1.18a

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,9 +1,9 @@
 cask 'veracrypt' do
-  version '1.17'
-  sha256 'fa62b0e84f993dc2c58966e4eef91d8fdd3710913f78d62aa352e12187259f89'
+  version '1.18a'
+  sha256 'b7c6b1a321a5f712b3bce13523c26f2fe7caa7a4062c01e5be9eba4779bd524b'
 
   # download-codeplex.sec.s-msft.com/Download/Release?ProjectName=veracrypt was verified as official when first introduced to the cask
-  url 'https://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=veracrypt&DownloadId=1537180&FileTime=130999181375130000&Build=21031'
+  url 'https://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=veracrypt&DownloadId=1601965&FileTime=131159523657700000&Build=21031'
   name 'VeraCrypt'
   homepage 'https://veracrypt.codeplex.com/'
   license :oss


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download veracrypt` is error-free.
- [x] `brew cask style --fix veracrypt` left no offenses.
