### PR TITLE
macvim: add additional symlinks

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -14,6 +14,9 @@ cask 'macvim' do
   app 'MacVim.app'
   binary 'mvim'
 
+  executables = %w[mvimdiff mview mvimex gvim gvimdiff gview gvimex]
+  executables.each { |e| binary 'mvim', target: e }
+
   zap delete: [
                 '~/Library/Preferences/org.vim.MacVim.LSSharedFileList.plist',
                 '~/Library/Preferences/org.vim.MacVim.plist',


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

This adds the symlinks for `mvim` and `gvim` commands that [the macvim formula provides](https://github.com/Homebrew/homebrew-core/blob/44fa135/Formula/macvim.rb#L98-L101).
