### PR TITLE
pre_bug_report: Modify commands

### DIFF
--- a/doc/reporting_bugs/pre_bug_report.md
+++ b/doc/reporting_bugs/pre_bug_report.md
@@ -7,9 +7,9 @@ Start by searching for your issue before posting a new one. If you find an open 
 If you did not find your particular bug, before reporting it make sure you have the latest versions of Homebrew, Homebrew-Cask, and all Taps by running the following commands. These will also fix some other issues:
 
 ```bash
+$ cd $(brew --repo); git fetch; git reset --hard origin/master; brew update
+$ brew untap phinze/cask; brew uninstall --force brew-cask
 $ brew update; brew cleanup; brew cask cleanup
-$ brew uninstall --force brew-cask; brew update
-$ brew untap phinze/cask; brew untap caskroom/cask; brew update
 ```
 
 Retry your failing command. If the issue persists, [go back](../../README.md#reporting-bugs) and pick the appropriate instructions for your problem.

--- a/doc/reporting_bugs/pre_bug_report.md
+++ b/doc/reporting_bugs/pre_bug_report.md
@@ -7,9 +7,9 @@ Start by searching for your issue before posting a new one. If you find an open 
 If you did not find your particular bug, before reporting it make sure you have the latest versions of Homebrew, Homebrew-Cask, and all Taps by running the following commands. These will also fix some other issues:
 
 ```bash
-$ cd $(brew --repo); git fetch; git reset --hard origin/master; brew update
-$ brew untap phinze/cask; brew uninstall --force brew-cask
-$ brew update; brew cleanup; brew cask cleanup
+$ cd $(brew --repo); git fetch; git reset --hard origin/master
+$ brew untap phinze/cask; brew untap caskroom/cask; brew uninstall --force brew-cask
+$ brew cleanup; brew cask cleanup; brew update
 ```
 
 Retry your failing command. If the issue persists, [go back](../../README.md#reporting-bugs) and pick the appropriate instructions for your problem.


### PR DESCRIPTION
Wasn't sure why `brew untap caskroom/cask` is a suggestion - that ends up killing the local repo.

Suggestions/feedback on a better order/is there anything we can further remove?

Pinging @reitermarkus @jawshooah for comments
