### PR TITLE
Thunder 2.7.2.2108

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '2.7.1.2006'
-  sha256 'cef50062e35fad33bce7eeef8a3c1dc5605cc74b0e496ff178ed2894af386d4c'
+  version '2.7.2.2108'
+  sha256 '6420e03a4604b62f3dfb2cfac8e73c57d86b6d40ac02017f8e9be748fe3bd9b3'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_dl#{version}_Beta.dmg"


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
