### PR TITLE
Add Ansible DK 1.2.0

### DIFF
--- a/Casks/ansible-dk.rb
+++ b/Casks/ansible-dk.rb
@@ -1,0 +1,15 @@
+cask 'ansible-dk' do
+  version '1.2.0-3'
+  sha256 '70fe9e4b8f27e8961c992de3ed1e30bb39c43319af28aae73c177f9530352a49'
+
+  url 'https://github.com/omniti-labs/ansible-dk/releases/download/1.2.0/ansible-dk-1.2.0-3.dmg'
+  appcast 'https://github.com/omniti-labs/ansible-dk/releases.atom',
+          checkpoint: 'e4ff73165aeb8fbb73bf77422ce1ee68c80e8569d695ece740865aa121fce931'
+  name 'ansible-dk'
+  homepage 'https://github.com/omniti-labs/ansible-dk'
+  license :bsd
+
+  pkg 'ansible-dk-1.2.0-1.pkg'
+
+  uninstall pkgutil: 'com.omniti.labs.ansible-dk'
+end


### PR DESCRIPTION
#### Adding a new cask
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Just like the Chef Development Kit (DK), there is an omnibus-based DK
for Ansible maintained by OmniTI.  This adds that.
