### PR TITLE
Change Docker license from :mit to :gratis

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -7,7 +7,7 @@ cask 'docker' do
           checkpoint: '0fb1705e17e1946681c0ac6f2ebe60ae8316990dacff8822ade2fd95153a7a09'
   name 'Docker for Mac'
   homepage 'https://www.docker.com/products/docker'
-  license :mit
+  license :gratis
 
   auto_updates true
 


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

As per "DOCKER FOR MAC END USER LICENSE AGREEMENT" license text located at
`/Applications/Docker.app/Contents/Resources/LICENSE.rtf`.

License can't be found online, including first few paragraphs for reference:

```
DOCKER FOR MAC END USER LICENSE AGREEMENT

THIS DOCKER FOR MAC END USER LICENSE AGREEMENT (“AGREEMENT”) IS BY AND BETWEEN
DOCKER, INC., LOCATED AT 144 TOWNSEND STREET, SAN FRANCISCO, CA 94107 (“DOCKER”)
AND YOU OR THE ENTITY ON WHOSE BEHALF YOU ARE ENTERING INTO THIS AGREEMENT
(“YOU” OR “CUSTOMER”) AND GOVERNS YOUR USE OF DOCKER FOR MAC AND ANY RELATED
UPDATES MADE AVAILABLE BY DOCKER TO YOU (“LICENSED SOFTWARE”).
PLEASE READ THIS AGREEMENT CAREFULLY. BY CLICKING “I ACCEPT,” OR BY INSTALLING,
DOWNLOADING OR OTHERWISE USING THE LICENSED SOFTWARE YOU EXPRESSLY ACCEPT AND
AGREE TO THE TERMS OF THIS AGREEMENT.  IF YOU ARE AN INDIVIDUAL AGREEING TO THE
TERMS OF THIS AGREEMENT ON BEHALF OF AN ENTITY, SUCH AS YOUR EMPLOYER, YOU
REPRESENT THAT YOU HAVE THE LEGAL AUTHORITY TO BIND THAT ENTITY AND "CUSTOMER"
SHALL REFER HEREIN TO SUCH ENTITY.  IF YOU DO NOT HAVE SUCH AUTHORITY, OR IF YOU
DO NOT AGREE WITH THE TERMS OF THIS AGREEMENT, YOU MAY NOT USE THE LICENSED
SOFTWARE.
1.   License.
1.1. Licensed Software.  Subject to Customer’s compliance with the terms and
conditions of this Agreement, Docker hereby grants Customer a perpetual,
revocable, non-exclusive, non-transferable, non-sub-licensable license to
download, install and use the Licensed Software on a single computer, solely in
object code format, and solely for  Customer’s internal business purposes.
```
