### PR TITLE
Add Reactotron.app v1.0.0

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -10,6 +10,6 @@ cask 'reactotron' do
   app 'Reactotron.app'
 
   zap delete: [
-                '~/Library/Application Support/Reactotron'
+                '~/Library/Application Support/Reactotron',
               ]
 end

--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -3,6 +3,8 @@ cask 'reactotron' do
   sha256 '31ef4f1291c5d05090cf2dd493da4dcfa081cb462a7f5d2774d287ae1b0436cb'
 
   url "https://github.com/reactotron/reactotron/releases/download/v#{version}/Reactotron.app.zip"
+  appcast 'https://github.com/reactotron/reactotron/releases.atom',
+          checkpoint: '8fd866834b9659cdd58912b531247bc3b9b3fc1092bee33fcc7d140ba2d15128'
   name 'Reactotron'
   homepage 'https://github.com/reactotron/reactotron'
   license :mit

--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,0 +1,15 @@
+cask 'reactotron' do
+  version '1.0.0'
+  sha256 '31ef4f1291c5d05090cf2dd493da4dcfa081cb462a7f5d2774d287ae1b0436cb'
+
+  url "https://github.com/reactotron/reactotron/releases/download/v#{version}/Reactotron.app.zip"
+  name 'Reactotron'
+  homepage 'https://github.com/reactotron/reactotron'
+  license :mit
+
+  app 'Reactotron.app'
+
+  zap delete: [
+                '~/Library/Application Support/Reactotron'
+              ]
+end


### PR DESCRIPTION
Add Reactotron.app v1.0.0

Reactotron is an OS X application for inspecting your React JS and React Native apps.
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
