### PR TITLE
Add GZDoom.app v0.6.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,0 +1,14 @@
+cask 'gzdoom' do
+  version '0.6.0'
+  sha256 '4a64aeeb831dd7a5d919d8ccd3a17b051ebd456b043c034c77329beb3863c482'
+
+  # github.com/alexey-lysiuk was verified as official when first introduced to the cask
+  url "https://github.com/alexey-lysiuk/gzdoom/releases/download/macOS-#{version}/GZDoom-macOS-#{version}.dmg"
+  appcast 'https://github.com/alexey-lysiuk/gzdoom/releases.atom',
+          checkpoint: 'fdf284e4bc993f222b95f4a8efbd114bb37b4b4423287de8a165941b8386d137'
+  name 'gzdoom'
+  homepage 'https://alexey-lysiuk.github.io/gzdoom/'
+  license :oss
+
+  app 'GZDoom.app'
+end


### PR DESCRIPTION
Add GZDoom.app 0.6.0

GZDoom is an advanced OpenGL source port for Doom, based on ZDoom. This version is marked as a pre-release but it is standard practice for windows GZDoom to use nightly builds because mods inevitably depend on features that aren't in the stable release.

I haven't tested the appcast stanza, it's not clear to me how to do so.
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
