### PR TITLE
Upgrade Mongotron.app to 1.0.0-alpha.5

### DIFF
--- a/Casks/mongotron.rb
+++ b/Casks/mongotron.rb
@@ -1,11 +1,11 @@
 cask 'mongotron' do
-  version '1.0.0-alpha.4'
-  sha256 'b5f435ada45b3a09b6803074b5e2a50883349f2e6a3aa6dfa5bf7c23927d50a1'
+  version '1.0.0-alpha.5'
+  sha256 'b20d014ae3a9355a112f84d98d2f81c27d3f99fd2dd7dc3455be465b27ab1e20'
 
   # github.com/officert/mongotron was verified as official when first introduced to the cask
   url "https://github.com/officert/mongotron/releases/download/#{version}/Mongotron-darwin-x64.zip"
   appcast 'https://github.com/officert/mongotron/releases.atom',
-          checkpoint: 'acecea0dbfae6addd49f0e0456ba3a85fede5bdfe353f8cc1dff38403644e4d1'
+          checkpoint: 'c72d7d2bf8514e6f839b3fecd2a5240ed7fc976eee535a9e2905946c0227374f'
   name 'Mongotron'
   homepage 'http://mongotron.io/'
   license :mit


### PR DESCRIPTION
Upgrade Mongotron.app to 1.0.0-alpha.5
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
