### PR TITLE
Update pki-io to 0.1.3-release1

### DIFF
--- a/Casks/pki-io.rb
+++ b/Casks/pki-io.rb
@@ -1,6 +1,6 @@
 cask 'pki-io' do
-  version '0.1.0-release1'
-  sha256 '7daf9349250c5da5f8bc1a126d704faf161977f82befb9f707bc1d788efbace4'
+  version '0.1.3-release1'
+  sha256 '4e9ea634d9038bdb0739eb13c16a324cccc7656d437297d4cb9fcb235610dc34'
 
   # github.com/pki-io/admin was verified as official when first introduced to the cask
   url "https://github.com/pki-io/admin/releases/download/#{version}/pki.io_#{version}_darwin_amd64.tar.gz"


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Update pki-io to 0.1.3-release1
