### PR TITLE
Restore `cocoapods` Cask as `cocoapods-app`

### DIFF
--- a/Casks/cocoapods-app.rb
+++ b/Casks/cocoapods-app.rb
@@ -1,0 +1,25 @@
+cask 'cocoapods-app' do
+  version '1.0.0'
+  sha256 '92e41c869650cf46e42ad3011a75afa8c846cbbd7da552b85a43537061526067'
+
+  # github.com/CocoaPods/CocoaPods was verified as official when first introduced to the cask
+  url "https://github.com/CocoaPods/CocoaPods-app/releases/download/#{version}/CocoaPods.app-#{version}.tar.bz2"
+  appcast 'https://app.cocoapods.org/sparkle',
+          checkpoint: '1c438660a09e131d1c8fe292712cb2ff797fe60fc4fc283d0d7aa59f3a9a6792'
+  name 'CocoaPods.app'
+  homepage 'https://cocoapods.org/'
+  license :mit
+
+  app 'CocoaPods.app'
+  binary "#{appdir}/CocoaPods.app/Contents/Helpers/pod"
+
+  postflight do
+    # Because Homebrew-Cask symlinks the binstub directly, stop the app from asking the user to install the binstub.
+    system 'defaults', 'write', 'org.cocoapods.CocoaPods', 'CPDoNotRequestCLIToolInstallationAgain', '-bool', 'true'
+    suppress_move_to_applications
+  end
+
+  zap delete: [
+                '~/Library/Preferences/org.cocoapods.CocoaPods.plist',
+              ]
+end


### PR DESCRIPTION
See #23971 (cocoapods: migrate to Homebrew)
### Checklist
- [x] The commit message includes the cask’s name and version. (version remains the same; not applicable for commit message)
- [x] `brew cask audit --download cocoapods-app` is error-free.
- [x] `brew cask style --fix cocoapods-app` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install cocoapods-app` worked successfully.
- [x] `brew cask uninstall cocoapods-app` worked successfully.
