### PR TITLE
updated harvest (2.0.0)

### DIFF
--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -1,10 +1,10 @@
 cask 'harvest' do
   version '2.0.0'
-  sha256 '9cdd7353a0a66efb796483fd458d7e413335e4525df04977a74f935dba2a9b3d'
+  sha256 '57c806069dc3cc42522b07b65261a553e5ec725542ea803fedbba3512810b25d'
 
   url "https://www.getharvest.com/harvest/mac/Harvest.#{version}.zip"
   appcast 'https://www.getharvest.com/harvest/mac/appcast.xml',
-          checkpoint: '3e11300e8e201435d008737ca6f03a43229b90446d2318e5fe22f2575e4a6bc6'
+          checkpoint: '91f5f75d61635f6b395b42d6b261c7eddcdb4bc6625dc10d1266f6cae2fe6165'
   name 'Harvest'
   homepage 'https://www.getharvest.com/mac'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
- Existing harvest cask had incorrect sha256 value.  Users unable to install it.
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
