### PR TITLE
Fix karabiner uninstall stanza

### DIFF
--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -12,12 +12,15 @@ cask 'karabiner' do
   auto_updates true
 
   pkg 'Karabiner.sparkle_guided.pkg'
-  binary '/Applications/Karabiner.app/Contents/Library/vendor/bin/blueutil'
-  binary '/Applications/Karabiner.app/Contents/Library/utilities/bin/warp-mouse-cursor-position'
+  binary '/Applications/Karabiner.app/Contents/Library/bin/karabiner'
 
-  uninstall quit:    'org.pqrs.Karabiner',
-            pkgutil: 'org.pqrs.driver.Karabiner',
-            kext:    'org.pqrs.driver.Karabiner'
+  uninstall early_script: '/Library/Application Support/org.pqrs/Karabiner/uninstall.sh',
+            script:       {
+                            executable:   '/usr/bin/killall',
+                            args:         ['Karabiner'],
+                            must_succeed: false,
+                            sudo:         false,
+                          }
 
   zap       delete: [
                       '~/Library/Application Support/Karabiner',


### PR DESCRIPTION
karabiner uninstall step was broken. Using uninstall script from author instead.
### Changes to a cask
#### Editing an existing cask
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
