### PR TITLE
Update bitwig-studio to 1.3.13

### DIFF
--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -1,6 +1,6 @@
-cask 'bitwig-studio' do
-  version '1.3.12'
-  sha256 'f862965cc568e9ad710ebf9572ec7389b1c95b33884320b532c9d3deabb5ae4b'
+  cask 'bitwig-studio' do
+  version '1.3.13'
+  sha256 '1b83cbe5b52b72d39c719491a53ae98857e8d6a14d75dfd3f1c75b173e4b267a'
 
   url "https://downloads.bitwig.com/stable/#{version}/Bitwig%20Studio%20#{version}.dmg"
   name 'Bitwig Studio'


### PR DESCRIPTION
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
