### PR TITLE
Fix Silverlight uninstall

### DIFF
--- a/Casks/silverlight.rb
+++ b/Casks/silverlight.rb
@@ -9,7 +9,8 @@ cask 'silverlight' do
 
   pkg 'silverlight.pkg'
 
-  uninstall pkgutil: 'com.microsoft.SilverlightInstaller'
+  uninstall pkgutil: 'com.microsoft.silverlight.plugin',
+            delete:  '/Library/Internet Plug-Ins/Silverlight.plugin'
 
   zap       delete: [
                       '~/Library/Application Support/Microsoft/Silverlight',


### PR DESCRIPTION
The bundle id was wrong. Even after fixing it there were some files
leftover that weren't included in the receipt data. Turns out these
leftover "*.ni.dll" files are compiled during the installation process,
so the only way to get rid of the plugin completely is to delete the
entire Silverlight.plugin package.
