### PR TITLE
Added "Vega.app" (latest) cask

### DIFF
--- a/Casks/vega.rb
+++ b/Casks/vega.rb
@@ -1,6 +1,6 @@
 cask 'vega' do
   version :latest
-  sha256 '14f7eee1f41ef9241efeb2321731f8dda9ac0716805132c1a02f07994d86415f'
+  sha256 :no_check
 
   url 'https://dist.subgraph.com/downloads/Vega64.dmg'
   name 'Vega'

--- a/Casks/vega.rb
+++ b/Casks/vega.rb
@@ -1,0 +1,12 @@
+cask 'vega' do
+  version :latest
+  sha256 '14f7eee1f41ef9241efeb2321731f8dda9ac0716805132c1a02f07994d86415f'
+
+  url 'https://dist.subgraph.com/downloads/Vega64.dmg'
+  name 'Vega'
+  name 'Vega (64bit)'
+  homepage 'https://subgraph.com/vega/index.en.html'
+  license :unknown
+
+  app 'Vega.app'
+end

--- a/Casks/vega.rb
+++ b/Casks/vega.rb
@@ -2,9 +2,13 @@ cask 'vega' do
   version :latest
   sha256 :no_check
 
-  url 'https://dist.subgraph.com/downloads/Vega64.dmg'
+  if Hardware::CPU.is_32_bit?
+    url 'https://dist.subgraph.com/downloads/Vega.dmg'
+  else
+    url 'https://dist.subgraph.com/downloads/Vega64.dmg'
+  end
+
   name 'Vega'
-  name 'Vega (64bit)'
   homepage 'https://subgraph.com/vega/index.en.html'
   license :unknown
 


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download vega` is error-free.
- [x] `brew cask style --fix vega` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install vega` worked successfully.
- [x] `brew cask uninstall vega` worked successfully.

Added 64bit version of the latest release of "Vega.app" as new cask
vega.rb
