### PR TITLE
Add Meld for OSX v3.16.0 (r1)

### DIFF
--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -1,0 +1,12 @@
+cask 'meld' do
+  version '3.16.0 (r1)'
+  sha256 '324e096e0253e8ad4237f64a90cdda200fe427db8cf7ebc78143fc98e2d33ebc'
+
+  # github.com/yousseb/meld was verified as official when first introduced to the cask
+  url 'https://github.com/yousseb/meld/releases/download/osx-9/meldmerge.dmg'
+  name 'Meld for OSX'
+  homepage 'https://yousseb.github.io/meld/'
+  license :gpl
+
+  app 'Meld.app'
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download meld` is error-free.
- [x] `brew cask style --fix meld` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install meld` worked successfully.
- [x] `brew cask uninstall meld` worked successfully.
