### PR TITLE
Transmission: switch URL to GitHub

### DIFF
--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -2,7 +2,7 @@ cask 'transmission' do
   version '2.92'
   sha256 '926a878cac007e591cfcea987048abc0689d77e7729a28255b9ea7b73f22d693'
 
-  url "https://download.transmissionbt.com/files/Transmission-#{version}.dmg"
+  url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://update.transmissionbt.com/appcast.xml',
           checkpoint: '24dcf232666db1aed41dae45c6a4fa9e7f52b98c10e69207cdd48baf83e114ac'
   name 'Transmission'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -1,8 +1,8 @@
 cask 'transmission' do
   version '2.92'
   sha256 '926a878cac007e591cfcea987048abc0689d77e7729a28255b9ea7b73f22d693'
-  
-  # https://github.com/transmission/transmission/releases/download/ was verified as official
+
+  # github.com/transmission/transmission/releases/download/ was verified as official
 
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://transmissionbt.com/appcast.xml',

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -2,7 +2,7 @@ cask 'transmission' do
   version '2.92'
   sha256 '926a878cac007e591cfcea987048abc0689d77e7729a28255b9ea7b73f22d693'
 
-  # github.com/transmission/transmission/releases/download/ was verified as official
+  # github.com/transmission/transmission/ was verified as official when first introduced to the cask
 
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://transmissionbt.com/appcast.xml',

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -3,7 +3,7 @@ cask 'transmission' do
   sha256 '926a878cac007e591cfcea987048abc0689d77e7729a28255b9ea7b73f22d693'
 
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
-  appcast 'https://update.transmissionbt.com/appcast.xml',
+  appcast 'https://transmissionbt.com/appcast.xml',
           checkpoint: '24dcf232666db1aed41dae45c6a4fa9e7f52b98c10e69207cdd48baf83e114ac'
   name 'Transmission'
   homepage 'https://www.transmissionbt.com/'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -1,7 +1,9 @@
 cask 'transmission' do
   version '2.92'
   sha256 '926a878cac007e591cfcea987048abc0689d77e7729a28255b9ea7b73f22d693'
-# github.com was verified as official
+  
+  # https://github.com/transmission/transmission/releases/download/ was verified as official
+
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://transmissionbt.com/appcast.xml',
           checkpoint: '78fb3a9cfd536d80d5a9a64da89e2e7e6281c18b8787b565450e501098bef83b'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -4,7 +4,7 @@ cask 'transmission' do
 
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://transmissionbt.com/appcast.xml',
-          checkpoint: 'a343a07672c7f4f7988dc2635b553d383e159a45942ba3e6a8c9fffcf9559b47'
+          checkpoint: '78fb3a9cfd536d80d5a9a64da89e2e7e6281c18b8787b565450e501098bef83b'
   name 'Transmission'
   homepage 'https://www.transmissionbt.com/'
   license :gpl

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -1,7 +1,7 @@
 cask 'transmission' do
   version '2.92'
   sha256 '926a878cac007e591cfcea987048abc0689d77e7729a28255b9ea7b73f22d693'
-
+# github.com was verified as official
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://transmissionbt.com/appcast.xml',
           checkpoint: '78fb3a9cfd536d80d5a9a64da89e2e7e6281c18b8787b565450e501098bef83b'

--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -4,7 +4,7 @@ cask 'transmission' do
 
   url "https://github.com/transmission/transmission/releases/download/#{version}/transmission-#{version}.dmg"
   appcast 'https://transmissionbt.com/appcast.xml',
-          checkpoint: '24dcf232666db1aed41dae45c6a4fa9e7f52b98c10e69207cdd48baf83e114ac'
+          checkpoint: 'a343a07672c7f4f7988dc2635b553d383e159a45942ba3e6a8c9fffcf9559b47'
   name 'Transmission'
   homepage 'https://www.transmissionbt.com/'
   license :gpl


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Safer download url because the project maintainers are incapable of securing a file server and don't know how to sign files with PGP. This is the 2nd time they have been hacked.
