### PR TITLE
Add "Synology Cloud Station Backup.app" Cask

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -1,0 +1,16 @@
+cask 'synology-cloud-station-backup' do
+  version '4.1-4224'
+  sha256 '9e6e0ef536d4a19913bb9e1da3d3c38b3eb1852c4f08ad760318facd25bb4f78'
+
+  url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
+  name 'Synology Cloud Station Backup'
+  homepage 'https://www.synology.com'
+  license :gratis
+
+  pkg 'Install Cloud Station Backup.pkg'
+
+  uninstall pkgutil:   'com.synology.CloudStationBackup',
+            launchctl: 'com.synology.Synology Cloud Station Backup'
+
+  zap delete: '~/Library/Preferences/com.synology.CloudStationBackupUI.plist'
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name.
- [x] `brew cask audit --download synology-cloud-station-backup` is error-free.
- [x] `brew cask style --fix synology-cloud-station-backup` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install synology-cloud-station-backup` worked successfully.
- [x] `brew cask uninstall synology-cloud-station-backup` worked successfully.

---

Closes #24186.
