### PR TITLE
Add sickbeard 13.05.25

### DIFF
--- a/Casks/sickbeard.rb
+++ b/Casks/sickbeard.rb
@@ -1,0 +1,11 @@
+cask 'sickbeard' do
+  version '13.05.25'
+  sha256 'c6ce8b987447d074622d5ee0c96ee6a6da121f5a43252a552e0fc6f5d1cc0550'
+
+  url "http://sickbeard.lad1337.de/download.php?f=SickBeard-OSX-master-#{version}.dmg"
+  name 'SickBeard'
+  homepage 'http://sickbeard.lad1337.de/'
+  license :gpl
+
+  app 'SickBeard.app'
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -33,7 +33,6 @@
   "redis": "homebrew/core",
   "rust": "homebrew/core",
   "serf": "homebrew/core",
-  "sickbeard": "homebrew/core",
   "srclib": "homebrew/core",
   "sslmate": "homebrew/core",
   "swi-prolog": "homebrew/core",


### PR DESCRIPTION
[Sickbeard was removed for duplicating a homebrew formula](https://github.com/caskroom/homebrew-cask/issues/15603), but it has some major differences from the homebrew version.

While it still runs as a web server, it acts more like a native application. It can be added as a login item, keeps its settings & preference files in the standard OSX locations, and has a menu icon.

![image](https://cloud.githubusercontent.com/assets/416052/18223234/63ec78e6-7165-11e6-9930-eee31f622682.png)

![menu icon](https://cloud.githubusercontent.com/assets/416052/18223208/7051c02e-7164-11e6-8012-cc90c6b75eac.png)

I had to reinstall the application as part of [migrating to the new caskroom location](https://github.com/caskroom/homebrew-cask/issues/21913), and the standard homebrew version does not have any of my settings. Migrating the settings would probably be more work than this PR 😛 

Please consider adding this Cask back.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

This reverts commit b8feea7b9056689a081f781a0f0dba523c965eb5.
