### PR TITLE
zipeg.rb: update download url and homepage

### DIFF
--- a/Casks/zipeg.rb
+++ b/Casks/zipeg.rb
@@ -2,9 +2,9 @@ cask 'zipeg' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.zipeg.net/downloads/zipeg_mac.dmg'
+  url 'http://www.zipeg.com/downloads/zipeg_mac.dmg'
   name 'Zipeg'
-  homepage 'https://www.zipeg.net/'
+  homepage 'http://www.zipeg.com/'
   license :gratis
 
   app 'Zipeg.app'


### PR DESCRIPTION
Zipeg has changed their homepage to http://www.zipeg.com, therefore download url has been changed too. This commit updates zipeg.rb to correct urls. Please considering updating this cask. Thanks.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
