### PR TITLE
Add GpsDump.app

### DIFF
--- a/Casks/gpsdump.rb
+++ b/Casks/gpsdump.rb
@@ -1,0 +1,11 @@
+cask 'gpsdump' do
+  version '0.4.1'
+  sha256 '6ded0b866d982dcc0a3ce984a3971fd38126e97622d154a81008b430cb4e8268'
+
+  url 'http://www.gpsdump.no/GpsDumpMac041.zip'
+  name 'GpsDump'
+  homepage 'http://www.gpsdump.no/body_mac.htm'
+  license :gratis
+
+  app 'GpsDump.app'
+end


### PR DESCRIPTION
This PR adds support for [GpsDump](http://www.gpsdump.no/body_mac.htm). GpsDump is a popular program for managing aviation GPSes.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
