### PR TITLE
Updated Pyfa from 1.21.1 to 1.23.1.

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,8 +1,8 @@
 cask 'pyfa' do
-  version '1.21.1'
-  sha256 '668046e0d79e868e55aee00e4d7350e2a2fa4eb1a18aee425f67f8c5641156a0'
+  version '1.23.1'
+  sha256 '4e0b4641a0824e99729278b9f077376a17628f685125bef5007587066e580c3f'
 
-  url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-#{version}-citadel-1.3-mac.zip"
+  url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-#{version}-yc.118.7-1.4-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
           checkpoint: '443b0342f7a4b5b342de546ecdc50a3145ac6191640a65b04ef1d0e5fcec3298'
   name 'pyfa'

--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -4,7 +4,7 @@ cask 'pyfa' do
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-#{version}-yc.118.7-1.4-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '443b0342f7a4b5b342de546ecdc50a3145ac6191640a65b04ef1d0e5fcec3298'
+          checkpoint: 'eea8bb24a425814f3a83bd27bf8a690c77ac4bf058ebeb9765ac1b4415abe13d'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
   license :gpl


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download pyfa.rb` is error-free.
- [x] `brew cask style --fix pyfa.rb` left no offenses.
