### PR TITLE
add sync_github_templates

### DIFF
--- a/developer/bin/sync_templates_and_ci
+++ b/developer/bin/sync_templates_and_ci
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+readonly caskroom_online='https://github.com/caskroom'
+readonly caskroom_repos_dir="$(mktemp -d)"
+readonly main_repo_dir="$(mktemp -d)" # From where files will be copied
+readonly caskroom_repos=(homebrew-versions homebrew-fonts homebrew-eid) # homebrew-cask is absent since it's the repo all the others are compared against'
+
+function message {
+  echo "${1}"
+}
+
+function get_main_repo {
+  curl --silent --location "${caskroom_online}/homebrew-cask/archive/master.zip" | ditto -xk - "${main_repo_dir}"
+  mv "${main_repo_dir}/homebrew-cask-master/"{*,.*} "${main_repo_dir}"
+  rmdir "${main_repo_dir}/homebrew-cask-master"
+}
+
+function get_repo {
+  local repo_name repo_dir
+
+  repo_name="${1}"
+  repo_dir="${caskroom_repos_dir}/${repo_name}"
+
+  cd "${caskroom_repos_dir}" || exit 1
+  message "Cloning ${repo_name}…"
+  git clone "${caskroom_online}/${repo_name}.git" --quiet
+  cd "${repo_dir}" || exit 1
+}
+
+function copy_templates_and_ci {
+  local repo_name
+
+  repo_name="${1}"
+  cp -R "${main_repo_dir}/.github" "${main_repo_dir}/.travis.yml" "${main_repo_dir}/ci" '.'
+  /usr/bin/sed -i '' -E "s:homebrew-cask/(pulls|issues):${repo_name}/\1:" '.github/PULL_REQUEST_TEMPLATE.md' # PULL_REQUEST_TEMPLATE has repo-specific links
+}
+
+function push_changes {
+  local is_repo_changed
+
+  is_repo_changed="$(git status --porcelain --ignore-submodules=dirty 2> /dev/null)"
+  if [[ -n "${is_repo_changed}" ]]; then
+    git add --all # Stage everything so 'git diff' does not miss aything (like new paths)
+    for modified_path in $(git diff --name-only --staged); do
+      echo -n "Detected changes to ${modified_path}. "
+      git commit "${modified_path}" --message "$(basename "${modified_path}"): update to match main repo" --quiet
+    done
+
+    echo 'Updating…'
+    git push origin master --quiet
+  fi
+}
+
+get_main_repo
+for repo in "${caskroom_repos[@]}"; do
+  get_repo "${repo}"
+  copy_templates_and_ci "${repo}"
+  push_changes
+done


### PR DESCRIPTION
We need only update the [issue and PR templates](https://github.com/caskroom/homebrew-cask/tree/master/.github) in the main repo and run this script to update it across all repos. The script takes into account repo-specific links, so it also saves from mistakes when copy-pasting.
