### PR TITLE
Bump SHA & vers to current Bose SoundTouch 13.0.11.16439

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,6 +1,6 @@
 cask 'bose-soundtouch' do
-  version '12.0.10.14848'
-  sha256 '333ac935131fb912b8b4de34e69db8a3dd451a04681bb5027f511a6e48565ae4'
+  version '13.0.11.16439'
+  sha256 'af75c51c01f004747d43cebf195fe337feeccaa6bd8e8e95b2b1ea019499c0da'
 
   # bose.com was verified as official when first introduced to the cask
   url "https://worldwide.bose.com/downloads/assets/updates/soundtouch/SoundTouch-#{version}-osx-10.9-installer.app.dmg"


### PR DESCRIPTION
### Checklist
- [X] The commit message includes the cask’s name and version.

The formula was failing silently as the it was serving the current version with the old filename, so had sha mismatch.
