### PR TITLE
Convert casks to be multilingual.

### DIFF
--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -2,12 +2,21 @@ cask 'battle-net' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.battle.net/download/getInstallerForGame?os=mac&locale=enUS&version=LIVE&gameProgram=BATTLENET_APP'
-  name 'Blizzard Battle.net'
-  homepage 'https://us.battle.net/en/'
-  license :commercial
+  language 'en', default: true do
+    url 'https://www.battle.net/download/getInstallerForGame?os=mac&locale=enUS&version=LIVE&gameProgram=BATTLENET_APP'
+    homepage 'https://battle.net/'
 
-  installer manual: 'Battle.net-Setup.app'
+    installer manual: 'Battle.net-Setup.app'
+  end
+
+  language 'zh', 'CN' do
+    url 'https://www.battlenet.com.cn/download/getInstaller?os=mac&installer=Battle.net-Setup-zhCN.zip'
+    homepage 'http://www.battlenet.com.cn/zh/'
+
+    installer manual: 'Battle.net-Setup-zhCN.app'
+  end
+
+  name 'Blizzard Battle.net'
 
   uninstall delete: '/Applications/Battle.net.app'
 

--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,13 +1,81 @@
 cask 'firefox' do
   version '49.0.1'
-  sha256 '4a1b91c93aa3c0d2e530622c2d4203246446409bcc4d0155c2724bd21886669f'
 
-  url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
+  language 'de' do
+    sha256 'f7b1d7cb6c14a53e1857d3e6982ed63a00c97bf44051a67c9370f295b6d749da'
+    'de'
+  end
+
+  language 'en-GB' do
+    sha256 '84a9673fb922edb44d6d800b8c8f470964d939251d476de77c8426360595797c'
+    'en-GB'
+  end
+
+  language 'en', default: true do
+    sha256 '4a1b91c93aa3c0d2e530622c2d4203246446409bcc4d0155c2724bd21886669f'
+    'en-US'
+  end
+
+  language 'fr' do
+    sha256 'b553df6fde061caa7f7ae318455c7c8eca5acd5e119d75971c152d91489a5c62'
+    'fr'
+  end
+
+  language 'gl' do
+    sha256 '984cee045a7aefeb4e4adc4ba2e0056775a39a758a7fdea3597efbafc9eeac22'
+    'gl'
+  end
+
+  language 'it' do
+    sha256 '644b07f956ae169a5ad2bf5a7c1d57c4379ea91cd5089e207cd4348eeca1d3c2'
+    'it'
+  end
+
+  language 'ja' do
+    sha256 'f242598e4caced4d126f36acc1541ec2a9e19e3c82859a77935b12649b382e63'
+    'ja-JP-mac'
+  end
+
+  language 'nl' do
+    sha256 '29db6caf2633c43188306974edafcd2a951d1dcbe08aca37c017e5f95611c1fd'
+    'nl'
+  end
+
+  language 'pl' do
+    sha256 '81712bfaf0e167d1408fe2b23e27374892121616e4fc26c996cf2a56ae52416a'
+    'pl'
+  end
+
+  language 'pt' do
+    sha256 '70922d761d9a89a99686855f98a3b820faee7f75d8f289112061c37a5c3bfcb7'
+    'pt-PT'
+  end
+
+  language 'ru' do
+    sha256 'e77704feb0a60d3420440a2712f9cf4889a3911e86a3f63e65c43b07af4b860e'
+    'ru'
+  end
+
+  language 'uk' do
+    sha256 '7e6daa83a3f3ce5332722bf8024cbc41b40c5690391e1203b386db9a56bc945c'
+    'uk'
+  end
+
+  language 'zh-TW' do
+    sha256 'f7678356d09bad2ec1b85771476b87f0e7df4a67eb947db20319a96b53000ee0'
+    'zh-TW'
+  end
+
+  language 'zh' do
+    sha256 '1f35d8a1359757e210c2b01b2891627a6be7425d99ad4f9a7b0487bba129d971'
+    'zh-CN'
+  end
+
+  url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
           checkpoint: 'a159161411794fc6bb2e6fce6e57df6b99eb14499dde41c0ee4d0803d9277364'
   name 'Mozilla Firefox'
-  homepage 'https://www.mozilla.org/en-US/firefox/'
-  license :mpl
+  homepage 'https://www.mozilla.org/firefox/'
 
   auto_updates true
 

--- a/Casks/minecraft-server.rb
+++ b/Casks/minecraft-server.rb
@@ -27,7 +27,7 @@ cask 'minecraft-server' do
     system 'minecraft-server'
 
     eula_file = "#{staged_path}/eula.txt"
-    IO.write(eula_file, File.read(eula_file).gsub('false', 'TRUE'))
+    IO.write(eula_file, IO.read(eula_file).gsub('false', 'TRUE'))
   end
 
   caveats do

--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -1,14 +1,37 @@
 cask 'openoffice' do
-  version '4.1.2'
-  sha256 '4fe8e4b30989d0476fe3afc6d9d4374af57d38bd04f4a5e1947462bf5dde7699'
+  version '4.1.3'
+
+  language 'en', default: true do
+    sha256 '2eac3c6630ddbd6be771337001c8f877c2ff811620042e6071ef396788d480d8'
+    'en-US'
+  end
+
+  language 'fr' do
+    sha256 'a302fdff1deb65cc443a46884c37b3da5e29ae5679f9e36db038d0e0b9b40a3f'
+    'fr'
+  end
+
+  language 'gl' do
+    sha256 'f1db7dd745d7ed3b8ea01e459d0e2506e6e2fe39f0c498bdecdedb5f738260ec'
+    'gl'
+  end
+
+  language 'pt-BR' do
+    sha256 '31b6697151561d5d53134439e4bc18682626fe79a4d17cb8d309b4b02af84e45'
+    'pt-BR'
+  end
+
+  language 'pt' do
+    sha256 '3e53f8f842945e6a191e8863824f7d4a4cea7065bda5d7e88cf2c63522506380'
+    'pt'
+  end
 
   # sourceforge.net/openofficeorg.mirror was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_en-US.dmg"
+  url "https://downloads.sourceforge.net/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_#{language}.dmg"
   appcast 'https://sourceforge.net/projects/openofficeorg.mirror/rss',
-          checkpoint: '391656f2987abb760223ad7da9d186cc2bee9903e4b0d1c4cf686f8cc011a944'
+          checkpoint: '73cec0d3f0a0d7807a57960eb4147c7c0143870622b6ed7271b0e47c171c9f50'
   name 'Apache OpenOffice'
   homepage 'https://www.openoffice.org/'
-  license :apache
 
   app 'OpenOffice.app'
 

--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,13 +1,66 @@
 cask 'thunderbird' do
   version '45.3.0'
-  sha256 'd00599ab893f73cb74eafe58fae6135a5fd398b73d91822d5094831042af8061'
 
-  url "https://download.mozilla.org/?product=thunderbird-#{version}&os=osx&lang=en-US"
+  language 'de' do
+    sha256 'f4daf70019bee14db81dd286fca77e6cd22f13682fd6bd65242fe52c22f0b75d'
+    'de'
+  end
+
+  language 'en', default: true do
+    sha256 'd00599ab893f73cb74eafe58fae6135a5fd398b73d91822d5094831042af8061'
+    'en-US'
+  end
+
+  language 'fr' do
+    sha256 '4579c2d343a09d5a2ed0909455cc2a8d4ddc43a0760cabbf3cfa64cba871c222'
+    'fr'
+  end
+
+  language 'gl' do
+    sha256 'e55163af518cd04c5226adca7e7f7ab24d82c7ce78964e77ae931ca7d129c86b'
+    'gl'
+  end
+
+  language 'it' do
+    sha256 '9056799a7588480f2942ab5d7bc26608a8d7cc672b15acaf21aa8f2624cf9da6'
+    'it'
+  end
+
+  language 'ja' do
+    sha256 '0b7b46c00d56abcff68f6b8bbc89c40f267c2163c79f48e9fb01db2eedb840d4'
+    'ja-JP-mac'
+  end
+
+  language 'nl' do
+    sha256 '17dfec5caec0216dd5d2caefc2284c354514434ebae2117d2a9639d369a0668a'
+    'nl'
+  end
+
+  language 'pt' do
+    sha256 '52deef211b46c17b1184894b5313e27b963d99d2acf36229a97727549c68b680'
+    'pt-BR'
+  end
+
+  language 'ru' do
+    sha256 'a6f7da29d250085589ad2a3318f4035ddc29c1c4a5d219a09fbe38b6050bcf4e'
+    'ru'
+  end
+
+  language 'uk' do
+    sha256 '41ea1e0b5e168ce21a6eb07fe2989ff05c67312fbe8c47972b207beda91a1113'
+    'uk'
+  end
+
+  language 'zh' do
+    sha256 '1e426a8df0ff6ef185eea63814517f81c24be717357b4e2b648fd50000755ee2'
+    'zh-CN'
+  end
+
+  url "https://ftp.mozilla.org/pub/thunderbird/releases/#{version}/mac/#{language}/Thunderbird%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Thunderbird/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '28e0bfc5ee773a82e07809882874d5ad51ec035bf52445873bcfe400bd114c3b'
+          checkpoint: 'd879948f812a61892e6e65c7652d35a8b0cff009efa920ed62f6658cb86d75ba'
   name 'Mozilla Thunderbird'
-  homepage 'https://www.mozilla.org/en-US/thunderbird/'
-  license :mpl
+  homepage 'https://www.mozilla.org/thunderbird/'
 
   app 'Thunderbird.app'
 

--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,11 +1,89 @@
 cask 'torbrowser' do
   version '6.0.5'
-  sha256 'd79e18d691a407c9cc06ec508701bff2283d73b65d4321e254763b17d0a13a09'
 
-  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
+  language 'ar' do
+    sha256 'e9fdad13aec3679a00af0614474877b856e59c5b965bb88107ca4dcb3a9923c9'
+    'ar'
+  end
+
+  language 'de' do
+    sha256 '85663a210c0f8efb8f637e35fdfc0efa23f910ad8e4c4be2cfe097c0a3ee8429'
+    'de'
+  end
+
+  language 'es' do
+    sha256 'be7acf756ae9ee9e5af177f82689f739a2fecb6b37ee7d90107665c2765d5044'
+    'es-ES'
+  end
+
+  language 'en', default: true do
+    sha256 'd79e18d691a407c9cc06ec508701bff2283d73b65d4321e254763b17d0a13a09'
+    'en-US'
+  end
+
+  language 'fa' do
+    sha256 'c752d17676730059b32db9fc4f89df5b3c7c0bcffb2e41a70ea5695dcd12d768'
+    'fa'
+  end
+
+  language 'fr' do
+    sha256 '64296b0694753ff5ce44f95f3b6c357f4b00d38794d783ff5b18a74fe166f88d'
+    'fr'
+  end
+
+  language 'it' do
+    sha256 '088ea61fed53dbded627dc95ef1c4610e0dfbcb7ef365f7af8ec45af9723f833'
+    'it'
+  end
+
+  language 'ja' do
+    sha256 '6451028769dd8b8983f8f651cef540dad7f0d8d286bcee30ea33fd50d07947b2'
+    'ja'
+  end
+
+  language 'ko' do
+    sha256 '0505423cdf9e7ec91826ff126d943fe90810e2c359d535342b8fc3ac6823a5ba'
+    'ko'
+  end
+
+  language 'nl' do
+    sha256 'c7aa6cc8585465d4e598152260f52d2b3804a574c23e0b17a171d5eac8bd41ec'
+    'nl'
+  end
+
+  language 'pl' do
+    sha256 'ea00ef6da19f8c52c32af5b5b21f389610eaea2751f602ef9749a043de6a807a'
+    'pl'
+  end
+
+  language 'pt' do
+    sha256 '606f02e41eb1be0d345c80d1a462d8bfc21b1185ab268b134d69674f267106db'
+    'pt-PT'
+  end
+
+  language 'ru' do
+    sha256 '1f979d868335ac737f286a349c5c72ef2eb99e42b023751da9a6970af17b9710'
+    'ru'
+  end
+
+  language 'tr' do
+    sha256 '32b207fa9fbae37cc78b43eac4cef4c0966069dc94176ee035c0bf6390caee2a'
+    'tr'
+  end
+
+  language 'vi' do
+    sha256 'f2a8c9cc43727d44916aab74bdebeb43d66b5264e23ea900168f61988fc5e838'
+    'vi'
+  end
+
+  language 'zh' do
+    sha256 '9a4d96bfa614faa5df4b1e87e3623dd59f526be9fad09eec6427c8766fb22dcb'
+    'zh-CN'
+  end
+
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_#{language}.dmg"
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
-  license :oss
   gpg "#{url}.asc",
       key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
 

--- a/Casks/world-of-tanks.rb
+++ b/Casks/world-of-tanks.rb
@@ -1,22 +1,55 @@
 cask 'world-of-tanks' do
   version '1.0.34'
-  sha256 '22d96a5eea6cd60fb2e879d8af6bcf9b28958c0ddccb198e8a3388f191273211'
 
-  # wargaming.net was verified as official when first introduced to the cask
-  url 'http://redirect.wargaming.net/WoT/latest_mac_install_na'
-  appcast 'https://wot.gcdn.co/us/files/osx/WoT_OSX_update_na.xml',
-          checkpoint: '1e3ca625cca19f523265c07c2f2beef750b2b4dc22446d75ecb15e67964a5847'
-  name 'World Of Tanks'
-  homepage 'https://worldoftanks.com/'
-  license :gratis
+  # wot.gcdn.co was verified as official when first introduced to the cask
+  language 'AT', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LI', 'LT', 'LV', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR' do
+    sha256 '6c2a9c2ca507e5730a0494571ad58952bf655c8b3a9e963d4fcc5cdf6af7ab30'
+
+    url 'https://wot.gcdn.co/eu/files/osx/worldoftanks_eu.dmg'
+    appcast 'https://wot.gcdn.co/eu/files/osx/WoT_OSX_update_eu.xml',
+            checkpoint: '7a151d7884cc87d0a9d1dad524c7ca3dbf1da571183d971d7426e7a3e443bd72'
+    homepage 'http://worldoftanks.eu/'
+  end
+
+  language 'CA', 'US', default: true do
+    sha256 '38485f2c422f18e97403b2761082e38700adfa06eba92ec7f1b6e30acd07ba42'
+
+    url 'https://wot.gcdn.co/us/files/osx/worldoftanks_na.dmg'
+    appcast 'https://wot.gcdn.co/us/files/osx/WoT_OSX_update_na.xml',
+            checkpoint: '1e3ca625cca19f523265c07c2f2beef750b2b4dc22446d75ecb15e67964a5847'
+    homepage 'https://worldoftanks.com/'
+  end
+
+  language 'CN', 'ID', 'IN', 'JP', 'PH', 'SG', 'TH', 'TW', 'VN' do
+    sha256 'cd1730d62a6d6c2289074c53d11276db4cdc4a4c03b9d2526335ed25e5930192'
+
+    url 'https://wot.gcdn.co/sea/files/osx/worldoftanks_asia.dmg'
+    appcast 'https://wot.gcdn.co/sea/files/osx/WoT_OSX_update_asia.xml',
+            checkpoint: '0b4bad256188ed484b8e946e5ef80b74fadc717b39b1fdc747f2c95e938077bb'
+    homepage 'http://worldoftanks.asia/'
+  end
+
+  language 'KR' do
+    sha256 '9f57a2ffc0e5a7a76bd59438be5f73505f2508adf4b5ea4d119a0cf9ef453b2f'
+
+    url 'https://wot.gcdn.co/kr/files/osx/worldoftanks_kr.dmg'
+    appcast 'https://wot.gcdn.co/kr/files/osx/WoT_OSX_update_kr.xml',
+            checkpoint: '00fd089c9f73e92fa45a3b7f750a28a5479f0244e06132811ca7140814057833'
+    homepage 'http://worldoftanks.kr/'
+  end
+
+  language 'RU' do
+    sha256 '50c3892a49a19beeb5bf7b08bccbf94b657180e21ca5c4d2958a241f63370e01'
+
+    url 'https://wot.gcdn.co/ru/files/osx/worldoftanks_ru.dmg'
+    appcast 'https://wot.gcdn.co/ru/files/osx/WoT_OSX_update_ru.xml',
+            checkpoint: '482344ba173148844d943a0120764a5295fb050d4f321d7e4c484cd97f15cabe'
+    homepage 'http://worldoftanks.ru/'
+  end
+
+  name 'World of Tanks'
 
   app 'World of Tanks.app'
 
-  zap delete: '~/Documents/World_of_Tanks'
-
-  caveats <<-EOS.undent
-    #{token} is specific to North America; if you're in a different region, you'll need to find your version in caskroom/versions
-      brew tap caskroom/versions
-      brew search #{token}
-  EOS
+  zap trash: '~/Documents/World_of_Tanks'
 end

--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -70,6 +70,50 @@ else
 end
 ```
 
+### Switch Between Languages or Regions
+
+To switch between languages or regions based on the system locale, the `language` stanza should be used.
+
+The `language` stanza can match language codes ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) or [ISO 639-2](https://en.wikipedia.org/wiki/ISO_639-2)), [regional identifiers [ISO 3166-1 Alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) and script codes ([ISO 15924](https://en.wikipedia.org/wiki/ISO_15924)), or a combination thereof.
+
+The return value of the matching `language` block can be accessed by simply calling `language`.
+
+US English should always be used as the default language:
+
+```ruby
+language 'zh', 'CN' do
+  'zh_CN'
+end
+
+language 'de' do
+  'de_DE'
+end
+
+language 'en-GB' do
+  'en_GB'
+end
+
+language 'en', default: true do
+  'en_US'
+end
+```
+
+Note that the following are not the same:
+
+
+```ruby
+language 'en', 'GB' do
+  # matches all locales containing 'en' or 'GB'
+end
+
+language 'en-GB' do
+  # matches only locales containing 'en' and 'GB'
+end
+```
+
+
+Example: [Firefox](../../../../blob/master/Casks/firefox.rb).
+
 ## Arbitrary Ruby Methods
 
 In the exceptional case that the Cask DSL is insufficient, it is possible to define arbitrary Ruby variables and methods inside the Cask by creating a `Utils` namespace. Example:

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -208,7 +208,7 @@ When an App has a principal stable version, alternative versions should be submi
 
 ### Regional and Localized
 
-When an App exists in more than one language or has different regional editions, the US English one belongs in the main repo, and all the others in [caskroom/homebrew-versions](https://github.com/caskroom/homebrew-versions). When not already part of the name of the App, a [regional identifier](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) and a [language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) are to be appended to the Cask’s token (both when available, or just the appropriate one when not).
+When an App exists in more than one language or has different regional editions, [the `language` stanza should be used to switch between languages or regions](../../../cask_language_reference/readme.md#switch-between-languages-or-egions).
 
 ### Trial and Freemium Versions
 


### PR DESCRIPTION
_Sadly_, Firefox only offers [SHA512 checksums](http://releases.mozilla.org/pub/firefox/releases/48.0.2/SHA512SUMS) for their downloads, so maybe we should consider adding SHA512 support.

---

Closes https://github.com/caskroom/homebrew-cask/issues/24342.
