### PR TITLE
Update yujitach-menumeters to require El Capitan

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -6,9 +6,9 @@ cask 'yujitach-menumeters' do
   name 'MenuMeters El Capitan Port'
   homepage 'http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
   license :gpl
-  
-  depends_on macos: '>= :el_capitan'
 
+  depends_on macos: '>= :el_capitan'
+  
   prefpane 'MenuMeters.prefPane'
 
   zap delete: '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'

--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -6,6 +6,7 @@ cask 'yujitach-menumeters' do
   name 'MenuMeters El Capitan Port'
   homepage 'http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
   license :gpl
+  depends_on macos: '>= :el_capitan'
 
   prefpane 'MenuMeters.prefPane'
 

--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -6,6 +6,7 @@ cask 'yujitach-menumeters' do
   name 'MenuMeters El Capitan Port'
   homepage 'http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
   license :gpl
+  
   depends_on macos: '>= :el_capitan'
 
   prefpane 'MenuMeters.prefPane'


### PR DESCRIPTION
### Checklist
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download yujitach-menumeters is error-free.
- [x] `brew cask style --fix yujitach-menumeters left no offenses.

Single one line addition, as this fails on Yosemite:
  depends_on macos: '>= :el_capitan'

Verified by myself on 10.10.5
https://github.com/yujitach/MenuMeters/issues/10
