### PR TITLE
Fix url to use official Adobe link

### DIFF
--- a/Casks/adobe-animate-cc.rb
+++ b/Casks/adobe-animate-cc.rb
@@ -2,19 +2,18 @@ cask 'adobe-animate-cc' do
   version '2015'
   sha256 'c4a0affca7c37884471b495a0c242ddb110c8591bc41da91ecab81d12da60590'
 
-  # prodesigntools.com was verified as official when first introduced to the cask
-  url 'http://prodesigntools.com/trials3/AdobeProducts/FLPR/15_1/osx10-64/Animate_15_LS20.dmg',
+  url 'http://trials3.adobe.com/AdobeProducts/FLPR/15_1/osx10-64/Animate_15_LS20.dmg',
       user_agent: :fake,
       cookies:    { 'MM_TRIALS' => '1234' }
   name 'Adobe Animate CC'
-  homepage 'https://www.adobe.com/products/animate.html'
+  homepage 'https://adobe.com/products/animate'
   license :commercial
 
-  installer script: "#{staged_path}/Adobe Animate CC 2015/Install.app/Contents/MacOS/Install",
-            args:   ['--mode=silent', "--deploymentFile=#{staged_path}/Adobe Animate CC 2015/deploy/en_US_Deployment.xml"]
+  installer script: "#{staged_path}/Adobe Animate CC #{version}/Install.app/Contents/MacOS/Install",
+            args:   ['--mode=silent', "--deploymentFile=#{staged_path}/Adobe Animate CC #{version}/deploy/en_US_Deployment.xml"]
 
   uninstall script: {
-                      executable: "#{staged_path}/Adobe Animate CC 2015/Install.app/Contents/MacOS/Install",
-                      args:       ['--mode=silent', "--deploymentFile=#{staged_path}/Adobe Animate CC 2015/deploy/uninstall.xml"],
+                      executable: "#{staged_path}/Adobe Animate CC #{version}/Install.app/Contents/MacOS/Install",
+                      args:       ['--mode=silent', "--deploymentFile=#{staged_path}/Adobe Animate CC #{version}/deploy/uninstall.xml"],
                     }
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download adobe-animate-cc` is error-free.
- [x] `brew cask style --fix adobe-animate-cc` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install adobe-animate-cc` worked successfully.
- [x] `brew cask uninstall adobe-animate-cc` worked successfully.

Signed-off-by: Daniel Bayley daniel.bayley@me.com
