### PR TITLE
fixed bad appname for latest tor-messenger (0.2.0b2)

### DIFF
--- a/Casks/tor-messenger.rb
+++ b/Casks/tor-messenger.rb
@@ -4,8 +4,8 @@ cask 'tor-messenger' do
 
   url "https://dist.torproject.org/tormessenger/#{version}/TorMessenger-#{version}-osx64_en-US.dmg"
   name 'Tor Messenger'
-  homepage 'https://blog.torproject.org/blog/tor-messenger-010b6-released'
+  homepage 'https://trac.torproject.org/projects/tor/wiki/doc/TorMessenger'
   license :oss
 
-  app 'Tor Messenger.app'
+  app 'TorMessenger.app'
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
