### PR TITLE
Add Messenger for Desktop v2.0.1

### DIFF
--- a/Casks/messenger-for-desktop.rb
+++ b/Casks/messenger-for-desktop.rb
@@ -1,0 +1,14 @@
+cask 'messenger-for-desktop' do
+  version '2.0.1'
+  sha256 'a1813dc526a1eb39099993e677632808372e82bb556cd694d0c2f043f80f4d0c'
+
+  # github.com/Aluxian/Facebook-Messenger-Desktop was verified as official when first introduced to the cask
+  url "https://github.com/Aluxian/Facebook-Messenger-Desktop/releases/download/v#{version}/messengerfordesktop-#{version}-osx.dmg"
+  appcast 'https://github.com/Aluxian/Facebook-Messenger-Desktop/releases.atom',
+          checkpoint: 'ffad9631c3186cb8bc9bdfa9c3a3a984e9981694ae4e3b72de29d27296088071'
+  name 'Messenger for Desktop'
+  homepage 'https://messengerfordesktop.com/'
+  license :mit
+
+  app 'Messenger for Desktop.app'
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [ ] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Note unmarked checkbox. This cask existed before under as `aluxian-messenger` but was removed, see https://github.com/caskroom/homebrew-cask/pull/18043. However the reason cited for removal was that it was unmaintained. It seems to have been maintained well enough and this is a very recent release, so I think it's worth having available again. (Also, I think it's worth removing [messenger-native](https://github.com/gaston23/MessengerNative) based on the same reasoning.)

Also note the difference between token name and app name. This is intentional and based on the following proposal for organizing the many FB messenger front-ends cropping up: 
- Rename and add 'messenger' type apps as `messenger-[author/project]` wherever possible. examples: 
  - Rename token [`goofy`](https://github.com/danielbuechele/goofy) to `messenger-goofy`
  - Rename token [`messenger`](https://github.com/rsms/fb-mac-messenger) to `messenger-rsms`
  - Add [Caprine](https://github.com/sindresorhus/caprine) as token `messenger-caprine`
  - Add [Messenger for Desktop](https://github.com/Aluxian/Facebook-Messenger-Desktop) as token `messenger-aluxian` (previously name `aluxian-messenger`)
  - (Remove `messenger-native` as outdated / unmaintained)

Obviously these would be largely exceptions to the token naming conventions. So this PR is only for adding back `messenger-aluxian` for now. 
