### PR TITLE
A cask fails to install: put links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ Like most pieces of software, Homebrew-Cask has bugs — and we are busy fixing 
 
 If your issue persists, follow these instructions to the appropriate course of action:
 
-* [A cask fails to install](doc/reporting_bugs/a_cask_fails_to_install.md)
+* A cask fails to install:
+  * [`curl` error](doc/reporting_bugs/a_cask_fails_to_install.md#curl-error)
+  * [`Permission denied` error](doc/reporting_bugs/a_cask_fails_to_install.md#permission-denied-error)
+  * [`sha256 mismatch` error](doc/reporting_bugs/a_cask_fails_to_install.md#sha256-mismatch-error)
+  * [`source is not there` error](doc/reporting_bugs/a_cask_fails_to_install.md#source-is-not-there-error)
+  * [Unlisted reason](doc/reporting_bugs/a_cask_fails_to_install.md#unlisted-reason)
 * [`brew cask list` shows wrong information](doc/reporting_bugs/brew_cask_list_shows_wrong_information.md)
 * [`uninstall` wrongly reports cask as not installed](doc/reporting_bugs/uninstall_wrongly_reports_cask_as_not_installed.md)
 * [`Error: Unknown command: cask` error](doc/reporting_bugs/error_unknown_command_cask.md)

--- a/doc/reporting_bugs/a_cask_fails_to_install.md
+++ b/doc/reporting_bugs/a_cask_fails_to_install.md
@@ -2,13 +2,7 @@
 
 # A cask fails to install
 
-Possible reasons:
-
-* [`curl` error](#curl-error)
-* [`Permission denied` error](#permission-denied-error)
-* [`sha256 mismatch` error](#sha256-mismatch-error)
-* [`source is not there` error](#source-is-not-there-error)
-* [Unlisted reason](#unlisted-reason)
+Pick the issue closest to your case, and follow the links.
 
 ---
 


### PR DESCRIPTION
Looks to me like many people jump the instructions for not making the connection between their problem and “cask fails to install”. Hopefully this makes it harder to bypass that document.
