### PR TITLE
Updated utox (v0.9.8), fixed download url + appcast

### DIFF
--- a/Casks/utox.rb
+++ b/Casks/utox.rb
@@ -1,11 +1,11 @@
 cask 'utox' do
-  version '0.9.7'
-  sha256 'cec9cc990ad058159b843e3b6bd5e8e9fa7b33dbfd1b3895fbb1cfde8b9defc3'
+  version '0.9.8'
+  sha256 'a004c4bb1b01963fa910482bf6631a1f3a5c60ebf575259c168f5d95f38356eb'
 
-  # github.com/GrayHatter/uTox was verified as official when first introduced to the cask
-  url "https://github.com/GrayHatter/uTox/releases/download/v#{version}/uTox-#{version}.dmg"
-  appcast 'https://github.com/GrayHatter/uTox/releases.atom',
-          checkpoint: '9061a5db2d3ceb5c63d33c519a31f612d4d348ec2ec2a8e66983040151c23374'
+  # github.com/uTox/uTox was verified as official when first introduced to the cask
+  url "https://github.com/uTox/uTox/releases/download/v#{version}/uTox-#{version}.dmg"
+  appcast 'https://github.com/uTox/uTox/releases.atom',
+          checkpoint: 'eee22a515c835b9a12c6dfc727a144227c27ec56d1b613a46362c8927b333a4a'
   name 'uTox'
   homepage 'https://www.tox.chat'
   license :oss


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Previous download url was apparently obtained from the [tox wiki](https://wiki.tox.chat/binaries#mac_os_x), but the [GrayHatter repo](https://github.com/GrayHatter/uTox/releases) doesn't have any .dmg files available on the releases page. The [official download page](https://www.tox.chat/download.html) however provides the correct downloads from the [uTox repo](https://github.com/uTox/uTox/releases). 
