### PR TITLE
Update luyten (1.1.5)

### DIFF
--- a/Casks/luyten.rb
+++ b/Casks/luyten.rb
@@ -1,11 +1,11 @@
 cask 'luyten' do
-  version '0.4.8'
-  sha256 '5476171d2d0aa1b42f365dfe6372f816c9fbbc8232945f01418709c92e6ab9f5'
+  version '0.4.9'
+  sha256 'f5c37211501f00e5cb86623f7e2ab4ccaa07416bf2f5b067ac19846cad3b59c0'
 
   # github.com/deathmarine/Luyten was verified as official when first introduced to the cask
   url "https://github.com/deathmarine/Luyten/releases/download/v#{version}/luyten-OSX-#{version}.zip"
   appcast 'https://github.com/deathmarine/Luyten/releases.atom',
-          checkpoint: '1396a2f45a760d8515b942d2f68b7325da2715310d6e60ebc71993ead2fc6e0c'
+          checkpoint: 'a3088d3278005021feb872e4d0f14767da2d32d1db73e851e2d9b3bbadc16ee8'
   name 'Luyten'
   homepage 'https://deathmarine.github.io/Luyten/'
   license :apache


### PR DESCRIPTION
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
