### PR TITLE
Fix the checkpoint for kitematic (0.12.0)

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -5,7 +5,7 @@ cask 'kitematic' do
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
-          checkpoint: '75e425c2b970eb5481b53aa1883abf2e0852015e379d8979f5af095257cc8d25'
+          checkpoint: '834ddbe5a9ae702ba925592d6fccf744edd2e4e3a2d3c7b1c65b48adab97a61d'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
   license :apache


### PR DESCRIPTION
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
