### PR TITLE
update: spectacle 1.1

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -3,11 +3,11 @@ cask 'spectacle' do
     version '0.8.6'
     sha256 '3e367d2d7e6fe7d5f41d717d49cb087ba7432624b71ddd91c0cfa9d5a5459b7c'
   else
-    version '1.0.6'
-    sha256 '189626c02986911ba8969f548ed1417ec59b5e1b4135f5978bc20553cf5317eb'
+    version '1.1'
+    sha256 'ead5000dd1c8fc45485498cec2ae7be1e682b2652a8791d537c8db0c6a13b7e9'
 
     appcast 'https://www.spectacleapp.com/updates/appcast.xml',
-            checkpoint: '6e6b8168ce612930a9982f1f9f33b40bca52219d5e44a531c5704005fa9c0002'
+            checkpoint: '24ec634b9fd9d3dfbba43702fa2a10fef892f5885a305f9dfb79456c98b3e341'
   end
 
   # amazonaws.com/spectacle was verified as official when first introduced to the cask


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The sha256 values came from the cask-repair update script, but it wasn't submitting so I just changed them on Github manually.
