### PR TITLE
Update CacheWarmer to 17

### DIFF
--- a/Casks/cachewarmer.rb
+++ b/Casks/cachewarmer.rb
@@ -1,9 +1,9 @@
 cask 'cachewarmer' do
-  version '16'
-  sha256 'cdbff051ac20e68e761ee73258059b47c4ef2864330dafbc46d2bfd407d4ad94'
+  version '17'
+  sha256 'f048be607937ca2884fd64dd5f324cb814ab3ae2e45de64e5978c09709b398ed'
 
-  # amazonaws.com/glencode_downloads was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/glencode_downloads/CacheWarmer-#{version}.pkg"
+  # s3.amazonaws.com/assetcache.io was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/assetcache.io/CacheWarmer-#{version}.pkg"
   name 'CacheWarmer'
   homepage 'https://assetcache.io/cachewarmer/'
   license :freemium


### PR DESCRIPTION
The download link changed slightly. I believe I have annotated it correctly since it comes from S3 not the app developer domain. Please let me know if anything needs correcting.
.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download cachewarmer` is error-free.
- [x] `brew cask style --fix cachewarmer` left no offenses.
