### PR TITLE
updated ngrok (2.1.12,4VmDzA7iaHb)

### DIFF
--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -1,6 +1,6 @@
 cask 'ngrok' do
-  version '2.1.3,4VmDzA7iaHb'
-  sha256 '863ebc05824329d288977d275d2ab90e554780a053019ae2bbadb317a1abf607'
+  version '2.1.12,4VmDzA7iaHb'
+  sha256 '10812c02fb8450bb3b5726a50251e2d2615727875fb584764bbe38cfcc5dd68a'
 
   # bin.equinox.io was verified as official when first introduced to the cask
   url "https://bin.equinox.io/c/#{version.after_comma}/ngrok-stable-darwin-amd64.zip"


### PR DESCRIPTION
Updates ngrok to version 2.1.12. File downloaded from ngrok website, and hash generated using `shasum -a 256 ngrok-stable-darwin-amd64.zip`.

`brew cask install ngrok` fails with:

```
==> Downloading https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip
######################################################################## 100.0%
==> Verifying checksum for Cask ngrok
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 863ebc05824329d288977d275d2ab90e554780a053019ae2bbadb317a1abf607
Actual: 10812c02fb8450bb3b5726a50251e2d2615727875fb584764bbe38cfcc5dd68a
File: /Users/timoram/Library/Caches/Homebrew/Cask/ngrok--2.1.3,4VmDzA7iaHb.zip
To retry an incomplete download, remove the file above.
```
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
