### PR TITLE
Update ngrok to 2.1.14,4VmDzA7iaHb

### DIFF
--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -1,9 +1,16 @@
 cask 'ngrok' do
-  version '2.1.12,4VmDzA7iaHb'
-  sha256 '10812c02fb8450bb3b5726a50251e2d2615727875fb584764bbe38cfcc5dd68a'
+  version '2.1.14,4VmDzA7iaHb'
 
-  # bin.equinox.io was verified as official when first introduced to the cask
-  url "https://bin.equinox.io/c/#{version.after_comma}/ngrok-stable-darwin-amd64.zip"
+  if Hardware::CPU.is_32_bit?
+    sha256 '5f39f69ba742c9bdbdc8390aab5c8cb1ec209920ed14ea927c7c8b4e5e74850b'
+    # bin.equinox.io was verified as official when first introduced to the cask
+    url "https://bin.equinox.io/c/#{version.after_comma}/ngrok-stable-darwin-386.zip.zip"
+  else
+    sha256 '63c9aeee01956f2e9627581f78a2e498e3364455240d663ccf7184c86d0fe6e3'
+    # bin.equinox.io was verified as official when first introduced to the cask
+    url "https://bin.equinox.io/c/#{version.after_comma}/ngrok-stable-darwin-amd64.zip"
+  end
+
   name 'ngrok'
   homepage 'https://ngrok.com/'
   license :freemium


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Version was updated without URL being updated. Added in 32-bit for good measure

```
[~/Downloads] > ./ngrok --version
ngrok version 2.1.14
```
