### PR TITLE
Update lazarus.rb files on v1.6

### DIFF
--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -10,8 +10,8 @@ cask 'lazarus' do
   homepage 'http://lazarus.freepascal.org/'
   license :gpl
 
-  depends_on cask: 'fpc'
-  depends_on cask: 'fpcsrc'
+  # depends_on cask: 'fpc'
+  # depends_on cask: 'fpcsrc'
 
   pkg 'lazarus.pkg'
 

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -10,8 +10,8 @@ cask 'lazarus' do
   homepage 'http://lazarus.freepascal.org/'
   license :gpl
 
-  # depends_on cask: 'fpc'
-  # depends_on cask: 'fpcsrc'
+  depends_on formula: 'fpc'
+  depends_on cask: 'fpcsrc'
 
   pkg 'lazarus.pkg'
 


### PR DESCRIPTION
There's a dependency cask for both fpc, meanwhile there's no fpc cask inside Caskroom/cask tap :))

Temporarily, I commented out the "depends_on cask:" line

EDIT:
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
