### PR TITLE
Update pomotodo to 0.14.1,1473822170

### DIFF
--- a/Casks/pomotodo.rb
+++ b/Casks/pomotodo.rb
@@ -1,11 +1,11 @@
 cask 'pomotodo' do
-  version '0.13.3,1458914986'
-  sha256 '8ff2279ffd9e7efa7d3018df36ece019b2b6ca74d1e926f5c7a5a1ca12f436c6'
+  version '0.14.1,1473822170'
+  sha256 'a5b12ea1d088a784db5a9d33f001f7894b9932e55b757e2a188cc5bf06d6a5f1'
 
   # cdn.hackplan.com/theair was verified as official when first introduced to the cask
   url "http://cdn.hackplan.com/theair/#{version.after_comma}/Pomotodo_v#{version.before_comma}.dmg"
   appcast 'http://air.hackplan.com/projects/5455f382437315386000d4d5/versions/latest.xml',
-          checkpoint: '30f76b576eba5c4a718e3284dc3bbab396f9f384ea5b21f9349b5c56e02cc104'
+          checkpoint: '1063d1cd1e8a129f4bb5eaf9d2198c835b45162a65af1523f1e4416abaf5a6c7'
   name 'Pomodoro'
   homepage 'https://pomotodo.com'
   license :gratis


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
