### PR TITLE
Fix helm 2.0.0-alpha.4 reference to tiller

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -10,5 +10,4 @@ cask 'helm' do
   license :apache
 
   binary 'darwin-amd64/helm'
-  binary 'darwin-amd64/tiller'
 end


### PR DESCRIPTION
### Checklist
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [X] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.

Helm no longer includes the tiller binary in the release, it is installed separately onto your kubernetes cluster.

This fix removes the reference to it so that the rest of the install will work.

Resolves #24507
