### PR TITLE
Update microsoft-office (15.26.0_160910)

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -1,13 +1,15 @@
 cask 'microsoft-office' do
-  version :latest
-  sha256 :no_check
+  version '15.26.0_160910'
+  sha256 '0936d7c66a9f99c259b2b8e13329b503b44290e56ee8d2c2512bce5a5f3bf32a'
 
-  url 'https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_2016_Installer.pkg'
+  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_2016_#{version}_Installer.pkg"
   name 'Microsoft Office 2016'
   homepage 'https://www.microsoft.com/mac'
   license :commercial
 
-  pkg 'Microsoft_Office_2016_Installer.pkg'
+  auto_updates true
+
+  pkg "Microsoft_Office_2016_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
                          'com.microsoft.package.*',


### PR DESCRIPTION
When using `:latest` as the version and `:no_check` as the sum, it causes the file to be downloaded again - even if it is in cache.  Since MS Office in particular is quite a large application, this can be draining on network resources.  This also is the way that other casks are generally set up - specific versions are included in the cask where possible.

Also, the mechanism exists to flag certain applications as auto-updating (via the `auto_updates` stanza) so that was also added.
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
