### PR TITLE
Fix the dependency of the CoreOS to point to corectl-app

### DIFF
--- a/Casks/corectl-app.rb
+++ b/Casks/corectl-app.rb
@@ -1,8 +1,8 @@
 cask 'corectl-app' do
-  version '0.2.6'
-  sha256 '15485c6e898df6c8c2cf56562179b41906d8f1a71822f4190f97055569d8bf9d'
+  version '0.2.7'
+  sha256 '700c30151490969053835d56169b24011d2736c985c4d190bbcdf0054faf71f5'
 
-  url "https://github.com/TheNewNormal/corectl.app/releases/download/v#{version}/corectl_v#{version}.dmg"
+  url "https://github.com/TheNewNormal/corectl.app/releases/download/v#{version}/corectl_#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/corectl.app/releases.atom',
           checkpoint: '5538fe31af10ad0467017f143f95c74fca7a3ea176a11bccdc6c50aec04a6120'
   name 'Corectl'

--- a/Casks/coreos.rb
+++ b/Casks/coreos.rb
@@ -9,7 +9,7 @@ cask 'coreos' do
   homepage 'https://github.com/TheNewNormal/coreos-osx'
   license :apache
 
-  depends_on cask: 'corectl'
+  depends_on cask: 'corectl-app'
 
   app 'CoreOS.app'
 

--- a/Casks/coreos.rb
+++ b/Casks/coreos.rb
@@ -1,6 +1,6 @@
 cask 'coreos' do
-  version '1.4.9'
-  sha256 'c0ad06ebee3500ed7d5ad594c2017298e4717f3816f88440f8a0577e07429bab'
+  version '1.5.0'
+  sha256 'd1923f1a734b2ad634f2f7aef4f9fb593041be9529bebc892ef9c824025bd765'
 
   url "https://github.com/TheNewNormal/coreos-osx/releases/download/v#{version}/CoreOS_v#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/coreos-osx/releases.atom',


### PR DESCRIPTION
Update coreos to 1.5.0 and corectl-app to 0.2.7
### Checklist
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
