### PR TITLE
Add Maltego Chlorine CE 3.6.0.app

### DIFF
--- a/Casks/maltego-chlorine-ce.rb
+++ b/Casks/maltego-chlorine-ce.rb
@@ -1,0 +1,11 @@
+cask 'maltego-chlorine-ce' do
+  version '3.6.0.6640'
+  sha256 '88bf739458868707da9ff5aad4761f38b998fe11163d643794e5533e8b6a6c3c'
+
+  url "https://www.paterva.com/malv#{version.major}#{version.minor}/community/MaltegoCE.v#{version}.dmg"
+  name 'Paterva Maltego'
+  homepage 'https://www.paterva.com/web7/buy/maltego-clients/maltego-ce.php'
+  license :closed
+
+  app "Maltego Chlorine CE v#{version.major_minor_patch}.app"
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

This is the community edition of Maltego Chlorine
that can be used for free with some limitations
as opposed to the commercial version called
Maltego Classic.
