### PR TITLE
Add auto_update, uninstall and zap to hammerspoon

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -10,7 +10,19 @@ cask 'hammerspoon' do
   homepage 'http://www.hammerspoon.org/'
   license :mit
 
+  auto_updates true
   accessibility_access true
 
   app 'Hammerspoon.app'
+
+  uninstall quit:       'org.hammerspoon.Hammerspoon',
+            login_item: 'Hammerspoon'
+
+  zap delete: [
+                '~/.hammerspoon',
+                '~/Library/Application Support/com.crashlytics/org.hammerspoon.Hammerspoon',
+                '~/Library/Caches/org.hammerspoon.Hammerspoon',
+                '~/Library/Preferences/org.hammerspoon.Hammerspoon.plist',
+                '~/Library/Saved Application State/org.hammerspoon.Hammerspoon.savedState',
+              ]
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---
- Added `auto_update` because application comes with a _Check for updates..._ option
  ![check_for_updates_evidence](https://cloud.githubusercontent.com/assets/3751801/18605611/71c5dfde-7c96-11e6-801c-de25774b821d.png)
- Added uninstall `quit` and `login_items` to close app and then remove Hammerspoon item from mac startup application list if its enabled
  ![login_item_enabled](https://cloud.githubusercontent.com/assets/3751801/18605635/80c18604-7c97-11e6-949c-fcb3cffa7023.png)
- Created `zap` stanza to remove all the preferences, caches and config files related to hammerspoon. `~/.hammerspoon` path corresponds to the dir where hammerspoon stores its config files
