### PR TITLE
Update mplayerx to 1.1.4,1920

### DIFF
--- a/Casks/mplayerx.rb
+++ b/Casks/mplayerx.rb
@@ -1,11 +1,11 @@
 cask 'mplayerx' do
-  version '1.1.3-1913'
-  sha256 'd48abb4b42ecbde2ba99b6afcb0ae14cf3d5a160b758eeb3cb9c533ebe7bda58'
+  version '1.1.4,1920'
+  sha256 '9306b11acd9df45464fc3ddca1a3a757f50ef019ea6a09ce13ad3f51f1ef1592'
 
-  # sourceforge.net/mplayerx-osx was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/mplayerx-osx/MPlayerX-#{version}.zip"
+  # github.com/niltsh/MPlayerX-Deploy was verified as official when first introduced to the cask
+  url "https://github.com/niltsh/MPlayerX-Deploy/releases/download/#{version.before_comma}/MPlayerX-#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://raw.githubusercontent.com/niltsh/MPlayerX-Deploy/master/appcast.xml',
-          checkpoint: '7700102d2f188a738b2e3f2524a2fcbd510c25708ea58bb2e8953ef337bc7355'
+          checkpoint: '34bfae10cc1d8458ee908899a4a93d0f6ff2500b905f3d4458bfa0807cd1374a'
   name 'MPlayerX'
   homepage 'http://mplayerx.org/'
   license :oss


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Looks like GH releases are now being used: https://github.com/niltsh/MPlayerX-Deploy/commit/7011c9135a97c2a0b5d710af55572f6775c80fe5
