### PR TITLE
Update hots-replay-uploader to 2.1.0

### DIFF
--- a/Casks/hots-replay-uploader.rb
+++ b/Casks/hots-replay-uploader.rb
@@ -1,10 +1,10 @@
 cask 'hots-replay-uploader' do
-  version '2.0.5'
-  sha256 '1e817b826f39e2b4a61d0300e6b762fd9a90d175b6f77a08b9cdb5da6d0a7584'
+  version '2.1.0'
+  sha256 '48a91ec1a73fee949ebe69c756b7de92aacd5d1315eeee41e56ae658e996da30'
 
   url "https://github.com/eivindveg/HotSUploader/releases/download/v#{version}/HotS.Replay.Uploader-#{version}.dmg"
   appcast 'https://github.com/eivindveg/HotSUploader/releases.atom',
-          checkpoint: 'bf10b65d7d029267f7246abaa4f57b5b479635253d1ccb2e695064c85ef1cdfd'
+          checkpoint: 'b701786f9df44f0fc4015c881df0abdfefb75912511abde5025d84346ae61477'
   name 'HotS Replay Uploader'
   homepage 'https://github.com/eivindveg/HotSUploader/'
   license :apache


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
