### PR TITLE
Add reboot caveat to wireshark-chmodbpf cask

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -73,17 +73,21 @@ cask 'wireshark-chmodbpf' do
                        '/Library/Application Support/Wireshark',
                      ]
 
-  caveats <<-EOS.undent
-    This cask will install only the ChmodBPF package from the current Wireshark
-    stable install package.
-    An access_bpf group will be created and its members allowed access to BPF
-    devices at boot to allow unpriviledged packet captures.
-    This cask is not required if installing the Wireshark cask. It is meant to
-    support Wireshark installed from homebrew or other cases where unpriviledged
-    access to macOS packet capture devices is desired without installing the binary
-    distribution of Wireshark.
+  caveats do
+    puts <<-EOS.undent
+      This cask will install only the ChmodBPF package from the current Wireshark
+      stable install package.
+      An access_bpf group will be created and its members allowed access to BPF
+      devices at boot to allow unpriviledged packet captures.
+      This cask is not required if installing the Wireshark cask. It is meant to
+      support Wireshark installed from homebrew or other cases where unpriviledged
+      access to macOS packet capture devices is desired without installing the binary
+      distribution of Wireshark.
 
-    The user account used to install this cask will be added to the access_bpf
-    group automatically.
-  EOS
+      The user account used to install this cask will be added to the access_bpf
+      group automatically.
+
+    EOS
+    reboot
+  end
 end


### PR DESCRIPTION
A reboot is required before an admin user is able to access a BPF device.
