### PR TITLE
Update hots-replay-uploader to 2.1.1

### DIFF
--- a/Casks/hots-replay-uploader.rb
+++ b/Casks/hots-replay-uploader.rb
@@ -1,10 +1,10 @@
 cask 'hots-replay-uploader' do
-  version '2.1.0'
-  sha256 '48a91ec1a73fee949ebe69c756b7de92aacd5d1315eeee41e56ae658e996da30'
+  version '2.1.1'
+  sha256 'f338c76bdc2fb875d445ddeb4fe6734fedc932381268f228dcc6c2dfe02a6735'
 
   url "https://github.com/eivindveg/HotSUploader/releases/download/v#{version}/HotS.Replay.Uploader-#{version}.dmg"
   appcast 'https://github.com/eivindveg/HotSUploader/releases.atom',
-          checkpoint: 'b701786f9df44f0fc4015c881df0abdfefb75912511abde5025d84346ae61477'
+          checkpoint: 'bfe84d8cb453a9b75cb5ac94a4fbb2729b5d4c0983a4f0536535f9d93aa842c5'
   name 'HotS Replay Uploader'
   homepage 'https://github.com/eivindveg/HotSUploader/'
   license :apache


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
