### PR TITLE
bittorrent-sync/resilio-sync - latest - Update download URL and naming

### DIFF
--- a/Casks/bittorrent-sync.rb
+++ b/Casks/bittorrent-sync.rb
@@ -2,10 +2,10 @@ cask 'bittorrent-sync' do
   version :latest
   sha256 :no_check
 
-  url 'https://download-cdn.getsync.com/stable/osx/BitTorrent-Sync.dmg'
-  name 'BitTorrent Sync'
+  url 'https://download-cdn.getsync.com/stable/osx/Resilio-Sync.dmg'
+  name 'Resilio Sync'
   homepage 'https://www.getsync.com/'
   license :gratis
 
-  app 'BitTorrent Sync.app'
+  app 'Resilio Sync.app'
 end

--- a/Casks/resilio-sync.rb
+++ b/Casks/resilio-sync.rb
@@ -1,4 +1,4 @@
-cask 'bittorrent-sync' do
+cask 'resilio-sync' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
### Checklist
- [X] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:
- [X] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [X] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

The naming and URL changed from `bittorrent-sync` to `resilio-sync`. So maybe `bittorrent-sync` cask should point to a newly added `resilio-sync` cask? Not sure how you usually handle this case. I'm happy to improve this in any way. Just wanted to start a process here. I can also close this and open a separate issue for this.
