### PR TITLE
update firefox to 49.0

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,10 +1,10 @@
 cask 'firefox' do
-  version '48.0.2'
-  sha256 '9328b33d62a2e95ffd2cc04ca0271c5cf137bc9a09860c527e8608c6ec715445'
+  version '49.0'
+  sha256 '62f2c0bf94522aa3788c6e139b37f707993ec71cabae788407f8f7acad8a716a'
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '9585e7dd7d365afd92f4514fc02f9ca4532ece60d44d04251426ecd1094bd6c5'
+          checkpoint: '04de504eabbbf9c24f3d9dcddba23b5bb8d89bb68290259e42d2f84601b636a9'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/en-US/firefox/'
   license :mpl


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
