### PR TITLE
Upgrade Julia to 0.5.0

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask 'julia' do
-  version '0.4.7'
-  sha256 'ff6ed2950e7f8908818ec6ca953c9f0777c52999058f5dc5c1eb8793166b9253'
+  version '0.5.0'
+  sha256 '871dd1f309d0b8659980ef0db667a36cf84e5d0febb2d53b70859de3801bdf03'
 
   # s3.amazonaws.com/julialang was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/julialang/bin/osx/x64/#{version.sub(%r{\.\d+$}, '')}/julia-#{version}-osx10.7+.dmg"
@@ -10,8 +10,8 @@ cask 'julia' do
 
   depends_on macos: '>= :lion'
 
-  app "Julia-#{version}.app"
-  binary "#{appdir}/Julia-#{version}.app/Contents/Resources/julia/bin/julia"
+  app "Julia-#{version.sub(%r{[.][0]$}, '')}.app"
+  binary "#{appdir}/Julia-#{version.sub(%r{[.][0]$}, '')}.app/Contents/Resources/julia/bin/julia"
 
   zap delete: '~/.julia'
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Bump julia cask to 0.5.0. Note that version number is only '0.5' (not
'0.5.0') in some of the filenames, the cask has been modified to reflect
this.
