### PR TITLE
Add cask install-disk-creator

### DIFF
--- a/Casks/install-disk-creator.rb
+++ b/Casks/install-disk-creator.rb
@@ -1,0 +1,11 @@
+cask 'install-disk-creator' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://macdaddy.io/InstallDiskCreator.zip'
+  name 'Install Disk Creator'
+  homepage 'http://macdaddy.io/install-disk-creator/'
+  license :unknown
+
+  app 'Install Disk Creator.app'
+end


### PR DESCRIPTION
Just used this today because I got tired of looking up the terminal instructions for creating a bootable macOS USB installer.
### Checklist
- [x] The commit message includes the cask’s name and version (no version)
- [x] `brew cask audit --download install-disk-creator` is error-free.
- [x] `brew cask style --fix install-disk-creator` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install install-disk-creator` worked successfully.
- [x] `brew cask uninstall install-disk-creator` worked successfully.
