### PR TITLE
Updated natron to 2.1.3

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,8 +1,18 @@
 cask 'natron' do
-  version '1.2.1'
-  sha256 '39478124e8814dea23e8c2d47afb8862992ef5510b8776b441b04b8d1b7553cd'
+  version '2.1.3'
+  sha256 'dff5e382f7ba1c27c0a284b1bfde4c4fc080e267e76fcf8a3374135faf66da3c'
 
-  url "https://downloads.natron.fr/Mac/releases/Natron_MacOSX_x86-64bits_v#{version}.dmg"
+  download_url = "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg"
+
+  # this is an idea that doesn't work. i leave it here as a combination of documentation and wish
+  begin
+    url download_url
+  rescue
+    print "Try downloading #{download_url}\n"
+    print "Then move to cache:\n"
+    print "  mv ~/Downloads/Natron-#{version}.dmg /Users/Guest/Library/Caches/Homebrew/Cask/natron--#{version}.dmg\n"
+  end
+
   name 'Natron'
   homepage 'https://natron.fr/'
   license :mpl


### PR DESCRIPTION
The current natron cask is broken. This is a feeble effort to try to fix it.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
