### PR TITLE
Add Mail Unread Menu v3.4.6

### DIFF
--- a/Casks/mail-unread-menu.rb
+++ b/Casks/mail-unread-menu.rb
@@ -2,7 +2,7 @@ cask 'mail-unread-menu' do
   version '3.4.6'
   sha256 '869527e4a7ef34cd116856537f69f57a5c5775798c54615a9aae3e2060f166e9'
 
-  url 'http://loganrockmore.com/MailUnreadMenu/MailUnreadMenu_3.4.6.zip'
+  url "http://loganrockmore.com/MailUnreadMenu/MailUnreadMenu_#{version}.zip"
   name 'Mail Unread Menu'
   homepage 'http://loganrockmore.com/MailUnreadMenu/'
   license :gratis

--- a/Casks/mail-unread-menu.rb
+++ b/Casks/mail-unread-menu.rb
@@ -1,0 +1,17 @@
+cask 'mail-unread-menu' do
+  version '3.4.6'
+  sha256 '869527e4a7ef34cd116856537f69f57a5c5775798c54615a9aae3e2060f166e9'
+
+  url 'http://loganrockmore.com/MailUnreadMenu/MailUnreadMenu_3.4.6.zip'
+  name 'Mail Unread Menu'
+  homepage 'http://loganrockmore.com/MailUnreadMenu/'
+  license :gratis
+
+  app 'Mail Unread Menu.app'
+
+  zap delete: [
+                '~/Library/Preferences/com.loganrockmore.MailUnreadMenu.plist',
+                '~/Library/Application Support/Mail Unread Menu/',
+                '~/Library/Mail/Bundles/MailUnreadMenu.mailbundle',
+              ]
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download mail-unread-menu` is error-free.
- [x] `brew cask style --fix mail-unread-menu` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install mail-unread-menu` worked successfully.
- [x] `brew cask uninstall mail-unread-menu` worked successfully.
