### PR TITLE
Update aws-vault to 3.5.0

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,13 +1,13 @@
 cask 'aws-vault' do
-  version '3.4.0'
-  sha256 'fa04d8593340f2b8b297a8b9728346aa0f83cc7c9b470c0b51cf26fb1db7fbeb'
+  version '3.5.0'
+  sha256 '76486ecee4543e1786891e29b8dc9c9eaaf281341821a10fa7a55bd628aafa69'
 
-  url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-Darwin-x86_64"
+  url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64"
   name 'aws-vault'
   homepage 'https://github.com/99designs/aws-vault'
   license :mit
 
   container type: :naked
 
-  binary 'aws-vault-Darwin-x86_64', target: 'aws-vault'
+  binary 'aws-vault-darwin-amd64', target: 'aws-vault'
 end


### PR DESCRIPTION
Updates aws-vault to 3.5.0
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
