### PR TITLE
Update citrix-receiver to 12.3.0

### DIFF
--- a/Casks/citrix-receiver.rb
+++ b/Casks/citrix-receiver.rb
@@ -1,6 +1,6 @@
 cask 'citrix-receiver' do
-  version '12.2.0'
-  sha256 '2401fdd57a20c2c4874b2d3da85bf89105c705f240ead4918591846c4904e8cb'
+  version '12.3.0'
+  sha256 'cd06f5fcb6c20f807318cf9b3eada887ac9e5e59e766f1310ad25b28caea3573'
 
   # downloadplugins.citrix.com.edgesuite.net was verified as official when first introduced to the cask
   url 'http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixReceiverWeb.dmg'


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

In running the last check here, I got a ruby error:

``` bash
$ brew cask style --fix citrix-receiver
dyld: lazy symbol binding failed: Symbol not found: _rb_ary_new_from_values
  Referenced from: /Users/joe/.rvm/gems/ruby-2.1.5/gems/psych-2.1.1/lib/psych.bundle
  Expected in: flat namespace

dyld: Symbol not found: _rb_ary_new_from_values
  Referenced from: /Users/joe/.rvm/gems/ruby-2.1.5/gems/psych-2.1.1/lib/psych.bundle
  Expected in: flat namespace

Error: style check failed
```

I don't think there are actually style problems with my PR, but if you have any suggestions for overcoming this error to run the style check successfully, I would be grateful. I am running macOS Sierra (10.12).

Released Sep 20, 2016. Release notes at https://www.citrix.com/downloads/citrix-receiver/mac/receiver-for-mac-latest.html.
