### PR TITLE
Update omnifocus to 2.7

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -8,8 +8,8 @@ cask 'omnifocus' do
     sha256 '3282eb7e41ec2638f68a92a6509eddd96a96c39b65b954dcedcc4e62289f22a9'
     url "https://downloads.omnigroup.com/software/MacOSX/10.9/OmniFocus-#{version}.dmg"
   else
-    version '2.6.2'
-    sha256 'cebddb0a4c04760be72443c1c4f816e5e6843bfedeef731d5d84566a2c93ad21'
+    version '2.7'
+    sha256 '5026c8ce1fe7e03b5085f0d3ad6df2d57d03e58d6391e4fec44d0c53882f5e62'
     url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
   end
 


### PR DESCRIPTION
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
