### PR TITLE
Add NVIDIA Web Driver 346.03.15f03

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -7,7 +7,7 @@ cask 'nvidia-web-driver' do
   homepage 'http://www.nvidia.com/download/driverResults.aspx/107369/en-us'
   license :commercial
 
-  pkg 'WebDriver-346.03.15f03.pkg'
+  pkg "WebDriver-#{version}.pkg"
 
   uninstall pkgutil: 'com.nvidia.web-driver'
 

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,0 +1,17 @@
+cask 'nvidia-web-driver' do
+  version '346.03.15f03'
+  sha256 'd93be8e22ed3caf99b18b3bbab37fcc193df6def0dd451aecad5ff6b81ccc4d8'
+
+  url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
+  name 'NVIDIA Web Driver'
+  homepage 'http://www.nvidia.com/download/driverResults.aspx/107369/en-us'
+  license :commercial
+
+  pkg 'WebDriver-346.03.15f03.pkg'
+
+  uninstall pkgutil: 'com.nvidia.web-driver'
+
+  caveats do
+    reboot
+  end
+end


### PR DESCRIPTION
Nvidia's web driver is different from CUDA driver. It's an alternative to the driver for nvidia's graphics shipped by Apple. i.e. Nividia's own version of the graphics driver.
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
