### PR TITLE
Add monity-helper package.

### DIFF
--- a/Casks/monity-helper.rb
+++ b/Casks/monity-helper.rb
@@ -1,0 +1,18 @@
+cask 'monity-helper' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.monityapp.com/download/MonityHelper.pkg'
+  name 'Monity Helper'
+  homepage 'http://www.monityapp.com'
+  license :closed
+
+  pkg 'MonityHelper.pkg'
+
+  uninstall pkgutil: [
+                       'com.Monity.Helper.monityHelper.com.Monity.Helper.pkg',
+                       'com.Monity.Helper.monityHelper.MonityHelper.pkg',
+                       'com.Monity.Helper.monityHelper.postflight.pkg',
+                       'com.Monity.Helper.monityHelper.preflight.pkg',
+                     ]
+end


### PR DESCRIPTION
Required package for [monity](http://www.monityapp.com/), an app available in the Mac App Store.
### Checklist
- [x] The commit message includes the cask’s name ~~and version~~. (no version)
- [x] `brew cask audit --download monity-helper` is error-free.
- [x] `brew cask style --fix monity-helper` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install monity-helper` worked successfully.
- [x] `brew cask uninstall monity-helper` worked successfully.
