### PR TITLE
Fixed path to uninstaller for logitech-options

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -12,7 +12,7 @@ cask 'logitech-options' do
   pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
 
   uninstall script:  {
-                       executable: '/Applications/Utilities/Logitech Options Uninstaller.app/Contents/Resources/Uninstaller',
+                       executable: '/Applications/Utilities/LogiMgr Uninstaller.app/Contents/Resources/Uninstaller',
                        sudo:       false,
                      },
             pkgutil: [


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

**as-is:**
$ brew cask uninstall logitech-options

```
==> Running uninstall process for logitech-options; your password may be necessary
==> Running uninstall script /Applications/Utilities/Logitech Options Uninstaller.app/Contents/Resources/Uninstaller
==> sh: /Applications/Utilities/Logitech Options Uninstaller.app/Contents/Resources/Uninstaller: No such file or directory
Error: Command failed to execute!

==> Failed command:
["/Applications/Utilities/Logitech\\\\ Options\\\\ Uninstaller.app/Contents/Resources/Uninstaller"]

==> Standard Output of failed command:


==> Standard Error of failed command:
sh: /Applications/Utilities/Logitech Options Uninstaller.app/Contents/Resources/Uninstaller: No such file or directory


==> Exit status of failed command:
#<Process::Status: pid 3561 exit 127>
```

**to-be:**
$ brew cask uninstall logitech-options

```
==> Running uninstall process for logitech-options; your password may be necessary
==> Running uninstall script /Applications/Utilities/LogiMgr Uninstaller.app/Contents/Resources/Uninstaller
==> Removing files from pkgutil Bill-of-Materials
```

`brew uninstall` didn't work due to wrong path to uninstaller.
