### PR TITLE
updated textmate (2.0-beta.12.14)

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,11 +1,11 @@
 cask 'textmate' do
-  version '2.0-beta.12.12'
-  sha256 '478563b0c70c0dbe18d99da1c191a2736a7d75ee5b369e76193b77d1827f9f80'
+  version '2.0-beta.12.14'
+  sha256 '20becdd4b8ff6a375b9bf8c934170eaf3866c583edc82d37a44195f0fce39dce'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
   appcast 'https://github.com/textmate/textmate/releases.atom',
-          checkpoint: 'd1d8e577b2e872e28be2f4a1b38a57ce2243297ff208295008449b2a1588379d'
+          checkpoint: '9f817207ebcec4453c5153b64b396d993534096f0b8fc257edd233a7f6d1b8d0'
   name 'TextMate'
   homepage 'https://macromates.com/'
   license :gpl


### PR DESCRIPTION
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
