### PR TITLE
updated spacemonkey (0.7.21)

### DIFF
--- a/Casks/spacemonkey.rb
+++ b/Casks/spacemonkey.rb
@@ -1,10 +1,11 @@
 cask 'spacemonkey' do
-  version '0.7.17'
-  sha256 '276c29a536e0a21539831dfbb6dd81f10dbd09a0e17bffeb11cd253c1dc78e57'
+  version '0.7.21,134'
+  sha256 'cf84059b32286feb14ee9d73c1c015c74e33c800548df817507e82c0803bd049'
 
-  url 'http://downloads.spacemonkey.com/client/mac/latest'
+  # hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c',
-          checkpoint: 'cfdb1a65ee5826ac97cb25af5d3cf55fa1af43c95ae3490f2737cd7063c3819d'
+          checkpoint: 'f6e6e143a5ec6f6a6d62e478f5e29ed08c1441ec73c3ed12a13ba498b0672b51'
   name 'Space Monkey'
   homepage 'https://www.spacemonkey.com'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder


### PR DESCRIPTION
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
