### PR TITLE
updated gemini (2.2.2)

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,11 +1,11 @@
 cask 'gemini' do
-  version '2.1.0,1464094756'
-  sha256 '63453274fcda09cfa34b2032c1c779cf6d80f31209eaa115ac512b4631b90349'
+  version '2.2.2,1474365747'
+  sha256 'a99b18d1e07d35f414ffc9348a8f300590ea48a5e50ab41b27653d60cfab11c5'
 
   # devmate.com/com.macpaw.site.Gemini2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini2/#{version.before_comma}/#{version.after_comma}/Gemini2-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.macpaw.site.Gemini2.xml',
-          checkpoint: 'bd417aa8ad482c7ef89200581fc6f4a2abbd6f3ca0b09229327f1ca5ad1a9112'
+          checkpoint: '94818da12f213824999d9955518d9829071a973d763ddb911e09ccbdad786257'
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'
   license :commercial


### PR DESCRIPTION
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
