### PR TITLE
Fix MacPorts Cask to support macOS Sierra

### DIFF
--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -13,10 +13,14 @@ cask 'macports' do
     sha256 '453125fffb358c9547aab70fa39dc5404acc037c18d7b1d7488256e9e4374138'
     url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.10-Yosemite.pkg"
     pkg "MacPorts-#{version}-10.10-Yosemite.pkg"
-  else
+  elsif MacOS.version <= :el_capitan
     sha256 '8c0b492032c796d766b76da3d1fda8dea732a6cc9056633a3509e3ff06b5e8d8'
     url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.11-ElCapitan.pkg"
     pkg "MacPorts-#{version}-10.11-ElCapitan.pkg"
+  else
+    sha256 '0fda4bfcbd922e20b489c762ee6d755d63df5a1e5f3666f71af95d96c9d398c8'
+    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.12-Sierra.pkg"
+    pkg "MacPorts-#{version}-10.12-Sierra.pkg"
   end
 
   name 'MacPorts'


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
