### PR TITLE
Updated tifig to v0.4.0

### DIFF
--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -1,6 +1,6 @@
 cask 'tifig' do
-  version '0.3.0-201607151151'
-  sha256 '694a1ae486b716e5afaf2ba5244987a672d7aa04432de82383002a43d74164c6'
+  version '0.4.0-201609230646'
+  sha256 '9835efb6d4e7931a83fe0eb860ab45cbdb8d3178815d7076212a6bc70af4ba0e'
 
   # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"


### PR DESCRIPTION
This pull request updates the cask for the Tifig Swift IDE to v0.4.0.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
