### PR TITLE
Update nvALT.app to support macOS Sierra

### DIFF
--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -7,12 +7,12 @@ cask 'nvalt' do
   else
     version '2.2b120'
     sha256 'e3ebdc012d5bba6e0e46173daa7c7548eca947958355b37d6ae6040e85b79153'
-    # abyss.designheresy.com/ was verified as official when first introduced to the cask
-    url "http://abyss.designheresy.com/nvALT#{version.sub(%r{b}, '')}.zip"
+    # abyss.designheresy.com was verified as official when first introduced to the cask
+    url "http://abyss.designheresy.com/nvALT#{version.delete('b')}.zip"
+    appcast "http://abyss.designheresy.com/nvalt#{version.major}/nvalt#{version.major}main.xml",
+            checkpoint: 'e9855b4e389ddce8ad13f5c9a325cd728c85a030f43b633e36bc31303910d34e'
   end
 
-  appcast 'http://abyss.designheresy.com/nvalt2/nvalt2main.xml',
-          checkpoint: 'e9855b4e389ddce8ad13f5c9a325cd728c85a030f43b633e36bc31303910d34e'
   name 'nvALT'
   homepage 'http://brettterpstra.com/project/nvalt/'
   license :bsd

--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -1,11 +1,18 @@
 cask 'nvalt' do
-  version '2.2b111'
-  sha256 'd787ddf92730bb03ba084e72bc6fb5f4fbd42731fa3531476af9eb3ce39e1cd0'
+  if MacOS.version <= :mavericks
+    version '2.2b111'
+    sha256 'd787ddf92730bb03ba084e72bc6fb5f4fbd42731fa3531476af9eb3ce39e1cd0'
+    # abyss.designheresy.com/nvaltb was verified as official when first introduced to the cask
+    url "http://abyss.designheresy.com/nvaltb/nvalt#{version}.zip"
+  else
+    version '2.2b120'
+    sha256 'e3ebdc012d5bba6e0e46173daa7c7548eca947958355b37d6ae6040e85b79153'
+    # abyss.designheresy.com/ was verified as official when first introduced to the cask
+    url "http://abyss.designheresy.com/nvALT#{version.sub(%r{b}, '')}.zip"
+  end
 
-  # abyss.designheresy.com/nvaltb was verified as official when first introduced to the cask
-  url "http://abyss.designheresy.com/nvaltb/nvalt#{version}.zip"
   appcast 'http://abyss.designheresy.com/nvalt2/nvalt2main.xml',
-          checkpoint: '0a7a6a0a27508d2de6ffcd7ebd5be5db54986ea9ba6694daacbe01c59cdea89d'
+          checkpoint: 'e9855b4e389ddce8ad13f5c9a325cd728c85a030f43b633e36bc31303910d34e'
   name 'nvALT'
   homepage 'http://brettterpstra.com/project/nvalt/'
   license :bsd


### PR DESCRIPTION
This is an update to the nvALT cask version 2.2120.

nvALT was updated to support macOS Sierra and this update is compatible
with versions of OS X >=10.9. The previous version os nvALT was
preserved for those users with OS X < 10.9.
