### PR TITLE
update firefox to 49.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,10 +1,10 @@
 cask 'firefox' do
-  version '49.0'
-  sha256 '62f2c0bf94522aa3788c6e139b37f707993ec71cabae788407f8f7acad8a716a'
+  version '49.0.1'
+  sha256 '4a1b91c93aa3c0d2e530622c2d4203246446409bcc4d0155c2724bd21886669f'
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/en-US/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '04de504eabbbf9c24f3d9dcddba23b5bb8d89bb68290259e42d2f84601b636a9'
+          checkpoint: 'a159161411794fc6bb2e6fce6e57df6b99eb14499dde41c0ee4d0803d9277364'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/en-US/firefox/'
   license :mpl


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
