### PR TITLE
Update bit-slicer to 1.7.7

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,11 +1,11 @@
 cask 'bit-slicer' do
-  version '1.7.6'
-  sha256 '03e9125481bd4c6459e379b3b0df69a2eecbde80f7cb11d9be8dfc9c0f8d3a58'
+  version '1.7.7'
+  sha256 '2d99481186552c05ad3f3c53226c5a5193af1b96f28702794d940a74f1be4802'
 
   # zgcoder.net was verified as official when first introduced to the cask
   url "https://zgcoder.net/software/bitslicer/dist/stable/Bit_Slicer_#{version}.zip"
   appcast 'https://zgcoder.net/bitslicer/update/appcast.xml',
-          checkpoint: '98f4404442be353240a8e8f1c6172d008119e9d0ab1987cd973e9ebec3480bfa'
+          checkpoint: '71d3b5ac6366b2ea61bb2e2ab2815fad8dbc335e9c2eb040f1445785623365c3'
   name 'Bit Slicer'
   homepage 'https://github.com/zorgiepoo/bit-slicer/'
   license :bsd


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
