### PR TITLE
Update URL of TuneInstructor v3.6

### DIFF
--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,6 +1,6 @@
 cask 'tuneinstructor' do
   version '3.6'
-  sha256 '7354d7423d19d75aa590f338596fc17da8d1c9f341c55bd7da592d5aa1b18a8e'
+  sha256 '9f68e5d1d31a7a7502f84e21f1d26cd8fd3a8eba7708f07386aa641551592d14'
 
   url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version}.dmg"
   name 'Tune•Instructor'

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,8 +1,8 @@
 cask 'tuneinstructor' do
   version '3.6'
-  sha256 '9f68e5d1d31a7a7502f84e21f1d26cd8fd3a8eba7708f07386aa641551592d14'
+  sha256 'f493a9361d9e14361cc38e684f4f9ab3dc772e58810120a7de518f64512bd9de'
 
-  url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version}.dmg"
+  url 'https://www.tune-instructor.de/resources/downloads/TuneInstructor.zip'
   name 'Tune•Instructor'
   homepage 'https://www.tune-instructor.de/com/start.html'
   license :commercial


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download tuneinstructor` is error-free.
- [x] `brew cask style --fix tuneinstructor` left no offenses.

I decided to open a new request instead of appending to #24836 
The real issue here was a change in the download URL.
