### PR TITLE
Fing: Fix slash in `version`.

### DIFF
--- a/Casks/fing.rb
+++ b/Casks/fing.rb
@@ -1,14 +1,14 @@
 cask 'fing' do
-  version '3.0,2016/09'
+  version '3.0,2016-09'
   sha256 'a8497ce00d58609d8677c6c7850e479420516d94e9f37d681dbdc970359294c6'
 
   # 39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com/wp-content/uploads/#{version.after_comma}/overlook-fing-#{version.before_comma}.dmg_.zip"
+  url "https://39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com/wp-content/uploads/#{version.after_comma.hyphens_to_slashes}/overlook-fing-#{version.before_comma}.dmg_.zip"
   name 'Fing'
   homepage 'https://www.fing.io/'
   license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
 
-  pkg "overlook-fing-#{version}.pkg"
+  pkg "overlook-fing-#{version.before_comma}.pkg"
 
   uninstall pkgutil: 'com.Overlook.Fing'
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
## 

Fixes https://github.com/caskroom/homebrew-cask/issues/24872.
