### PR TITLE
Mou is not macOS Sierra compatible

### DIFF
--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -9,7 +9,7 @@ cask 'mou' do
   homepage 'http://25.io/mou/'
   license :commercial
 
-  depends_on macos: '< :sierra'
+  depends_on macos: '<= :el_capitan'
 
   app 'Mou.app'
 

--- a/Casks/mou.rb
+++ b/Casks/mou.rb
@@ -9,6 +9,8 @@ cask 'mou' do
   homepage 'http://25.io/mou/'
   license :commercial
 
+  depends_on macos: '< :sierra'
+
   app 'Mou.app'
 
   zap delete: [


### PR DESCRIPTION
### Instructions
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Mou won't run on macOS Sierra:
objc[20930]: Objective-C garbage collection is no longer supported.
