### PR TITLE
Update Paw to 3.0.12 and fix download link

### DIFF
--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -1,10 +1,10 @@
 cask 'paw' do
-  version '3.0.11'
-  sha256 'a0c4037cfacab81a780e69c16f496ff4e1a1b378b375e20ff56b90aca149d7d2'
+  version '3.0.12,1'
+  sha256 'e12e1d3233afdda71493238a7f45209248ac46d3a17e640e21de9367bb2ea117'
 
-  url "https://cdn-builds.paw.cloud/paw/Paw-#{version}-#{version.major}00#{version.minor}0#{version.patch}000.zip"
+  url "https://cdn-builds.paw.cloud/paw/Paw-#{version.major_minor_patch}-#{version.major}#{version.minor.rjust(3, '0')}#{version.patch.rjust(3, '0')}#{version.after_comma.rjust(3, '0')}.zip"
   appcast 'https://paw.cloud/api/v2/updates/appcast',
-          checkpoint: '956f65a45998969c17ed3a230e6f5f937c033387d35f78a19616645515f5740f'
+          checkpoint: 'd8c013df9507469ea98347619d54678373ecd83291174eadbaa40ad9330368c2'
   name 'Paw'
   homepage 'https://paw.cloud'
   license :commercial


### PR DESCRIPTION
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Download link seems to use a 3 digit padded version, and sometimes has a
final version field that is non-zero.
