### PR TITLE
Fix cocoapacketanalyzer 1.50

### DIFF
--- a/Casks/cocoapacketanalyzer.rb
+++ b/Casks/cocoapacketanalyzer.rb
@@ -1,10 +1,10 @@
 cask 'cocoapacketanalyzer' do
   version '1.50'
-  sha256 'cd6549fb466fb73f5e22c82112d708513dfa903b151167f2d6112d9117efb017'
+  sha256 '8d99bbc6f51da98cf6466a1e8fef1d5e57211a2abee417a6ecb2e725a86982b2'
 
   url "http://tastycocoabytes.com/_downloads/CPA_#{version.no_dots}.dmg"
   appcast 'http://www.tastycocoabytes.com/cpa/updates/appcasting.php',
-          checkpoint: '7de1cd4c3d499c5ece7441cdc66c9c729ff12648c3528cd2fa7da907660f443e'
+          checkpoint: 'b84bef28c187d4e9dc3f47c80e2958d10ba170acb7771cde677c4499a0c26aa4'
   name 'Cocoa Packet Analyzer'
   homepage 'http://www.tastycocoabytes.com/cpa/'
   license :gratis


### PR DESCRIPTION
Vendor must've updated their 1.50 binary after c16da77? Not sure.
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.
