### PR TITLE
Update NW.js to 0.17.5 and remove 32 bit version

### DIFF
--- a/Casks/nwjs.rb
+++ b/Casks/nwjs.rb
@@ -1,22 +1,12 @@
 cask 'nwjs' do
-  version '0.17.0'
+  version '0.17.5'
+  sha256 '559f2fe78be7b1a83cf5176fb583155037f0ed25a0fa2b6e8c2735db87f297d9'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '0170cb6acccb2329b4c31494a4bdb7e336e201204eba96e227e7b02546cc9ebb'
-
-    url "https://dl.nwjs.io/v#{version}/nwjs-v#{version}-osx-ia32.zip"
-
-    binary "nwjs-v#{version}-osx-ia32/nwjc"
-    app "nwjs-v#{version}-osx-ia32/nwjs.app"
-  else
-    sha256 '35e2bf24c31d27da96f32f00bfe2d4c74a83c43b58a7ac61222e128c494f7e5e'
-
-    url "https://dl.nwjs.io/v#{version}/nwjs-v#{version}-osx-x64.zip"
-
-    app "nwjs-v#{version}-osx-x64/nwjs.app"
-  end
-
+  url "https://dl.nwjs.io/v#{version}/nwjs-sdk-v#{version}-osx-x64.zip"
   name 'NW.js'
   homepage 'https://nwjs.io'
   license :mit
+
+  app "nwjs-sdk-v#{version}-osx-x64/nwjs.app"
+  binary "nwjs-sdk-v#{version}-osx-x64/nwjc"
 end


### PR DESCRIPTION
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

NW.js is only available for x64 as of v0.13. 32 bit version removed.

The docs suggest to use the SDK flavor rather than the standard (see
http://docs.nwjs.io/en/latest/For%20Users/Getting%20Started/#get-nwjs).
I'd envisage anyone wanting the standard ver should create a package in
homebrew/versions for this.

Added symlink to nwjc
