### PR TITLE
Add version and checksum to Dropbox.app - 11.4.20

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,8 +1,9 @@
 cask 'dropbox' do
-  version :latest
-  sha256 :no_check
+  version '11.4.20'
+  sha256 '61267a63616308bf9dd59db8c38298f25b9ea302bcbc57a1451f71c5dee2e905'
 
-  url 'https://www.dropbox.com/download?plat=mac&full=1'
+  # clientupdates.dropboxstatic.com/client was verified as official when first introduced to the cask
+  url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"
   name 'Dropbox'
   homepage 'https://www.dropbox.com/'
   license :gratis


### PR DESCRIPTION
### Checklist
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.

The dropbox cask does not need to be an unspecified latest with no checksum because the version number is readily available at from the OSX download page redirect.

The following curl shows the download location and version as a redirect from Dropbox within the Location header:

```
curl -sI "https://www.dropbox.com/download?plat=mac&full=1"
```

Latest and last version links to show that specific versions are readily available:
- https://clientupdates.dropboxstatic.com/client/Dropbox%2010.4.26.dmg
- https://clientupdates.dropboxstatic.com/client/Dropbox%2011.4.20.dmg
