### PR TITLE
Update android-studio 2.2.0.12

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -18,8 +18,4 @@ cask 'android-studio' do
                 "~/Library/Caches/AndroidStudio#{version.major_minor}",
               ],
       rmdir:  '~/AndroidStudioProjects'
-
-  caveats do
-    depends_on_java
-  end
 end


### PR DESCRIPTION
### Reason

Android Studio 2.2 does not require Java as a dependency anymore.

> As of Android Studio 2.2, the IDE comes bundled with a custom OpenJDK build which contains a bunch of additional fixes to make the IDE work better (such as improved font rendering).

(from http://tools.android.com/tech-docs/configuration/osx-jdk)
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
