### PR TITLE
update wechat-web-devtools to 0.9.092300

### DIFF
--- a/Casks/wechat-web-devtools.rb
+++ b/Casks/wechat-web-devtools.rb
@@ -1,11 +1,11 @@
 cask 'wechat-web-devtools' do
-  version '0.7.0'
-  sha256 '52e1015038e37ba1b6065de9e3e39c7de7a081ebc8c54ee254beb9ed248cded8'
+  version '0.9.092300,20160923'
+  sha256 '0c5c2038b30e7229b93bc4df574a45e438861fb4f430f99e063512cf01697693'
 
-  url "http://dldir1.qq.com/WechatWebDev/release/#{version}/wechat_web_devtools_#{version}.dmg"
+  url "http://dldir1.qq.com/WechatWebDev/mina/#{version.after_comma}/wechat_web_devtools_#{version.before_comma}.dmg"
   name 'wechat web devtools'
   name '微信web开发者工具'
-  homepage 'https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1455784140&token=&lang=zh_CN'
+  homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'
   license :commercial
 
   app '微信web开发者工具.app'


### PR DESCRIPTION
- [x] Commit message includes cask’s name and new version
- [x] `brew cask audit --download Casks/wechat-web-devtools.rb` is error-free.
- [x] `brew cask style --fix Casks/wechat-web-devtools.rb` left no offenses.
