### PR TITLE
Update ax88179 to 2.8.0_20160912.

### DIFF
--- a/Casks/ax88179.rb
+++ b/Casks/ax88179.rb
@@ -1,10 +1,10 @@
 cask 'ax88179' do
-  version '2.8.0'
-  sha256 '4231136a1756f864dfad506497703dd48a2d95503a91914d98f9a12c129ef3a1'
+  version '2.8.0_20160912'
+  sha256 '91dc9e76f4808d515c6c764be1d03dddf820b4050eba83a1e1d139541f5bf027'
 
   module Utils
     def self.basename(version)
-      "AX88179_178A_Macintosh_10.6_to_10.11_Driver_Installer_v#{version}"
+      "AX88179_178A_Macintosh_10.6_to_10.12_Driver_Installer_v#{version}"
     end
   end
 
@@ -13,9 +13,17 @@ cask 'ax88179' do
   homepage 'http://www.asix.com.tw/download.php?sub=driverdetail&PItemID=131'
   license :gratis
 
-  container nested: "#{Utils.basename(version)}/AX88179_178A.dmg"
+  pkg "AX88179_178A_v#{version.sub(%r{_.*}, '')}.pkg"
 
-  pkg "AX88179_178A_v#{version}.pkg"
+  # HACK: DMG needs to be extracted manually because it is using an MBR partition table.
+  preflight do
+    begin
+      dmg_mount = `/usr/bin/hdiutil mount -readonly -noidme -nobrowse -mountrandom /tmp '#{staged_path.join(Utils.basename(version), 'AX88179_178A.dmg')}' | /usr/bin/cut -f3 -- - | /usr/bin/grep -- '.' -`.chop
+      FileUtils.cp(Dir.glob("#{dmg_mount}/AX*"), staged_path)
+    ensure
+      system "/usr/bin/hdiutil eject '#{dmg_mount}' >/dev/null 2>&1"
+    end
+  end
 
   postflight do
     system '/usr/bin/sudo', '-E', '--',


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

*Date is now added to the version number
*Upper Mac version upped to 10.12
*Sha256 hash updated
