### PR TITLE
Updates KeyCastr to v0.9.3

### DIFF
--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -1,10 +1,10 @@
 cask 'keycastr' do
-  version '0.9.2'
-  sha256 'c6664d87d52fbfde0f358cd412d07c4fd57ccd437dc2c1bb8d89259ed3ab75d2'
+  version '0.9.3'
+  sha256 '39ab0d77eb22bf62a473f17eaad077fa15ca25d7a0febb7de031dfc1145bd7db'
 
   url "https://github.com/keycastr/keycastr/releases/download/v#{version}/KeyCastr.app.zip"
   appcast 'https://github.com/keycastr/keycastr/releases.atom',
-          checkpoint: '5394902ffafbea8715673cab0837cb54dccfe9d8258067b94cfb10d009debf5f'
+          checkpoint: '3faa2926353705ebb671d2920c782c287f902d566af93f3ba54b8b71220de7d2'
   name 'KeyCastr'
   homepage 'https://github.com/keycastr/keycastr'
   license :bsd


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses. 

The last item failed but I don't believe it is related to this cask. More likely it has to do with the fact that I recently updated to macOS 10.12 Sierra. The instructions in the error message do not fix the issue:

```
brew cask style --fix https://raw.githubusercontent.com/akitchen/homebrew-cask/master/Casks/keycastr.rb
Error: undefined method `join' for nil:NilClassMost likely, this means you have an outdated version of Homebrew-Cask. Please run:

    brew uninstall --force brew-cask; brew untap phinze/cask; brew untap caskroom/cask; brew update; brew cleanup; brew cask cleanup

If this doesn’t fix the problem, please report this bug:

    https://github.com/caskroom/homebrew-cask#reporting-bugs

/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/locations.rb:145:in `path'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:44:in `block in cask_paths'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:44:in `map'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:44:in `cask_paths'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:22:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/style.rb:11:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:107:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:146:in `process'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/brew-cask.rb:8:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:105:in `<main>'
```
