### PR TITLE
OSXFUSE: Install MacFUSE compatibility layer by default.

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -10,13 +10,39 @@ cask 'osxfuse' do
   homepage 'https://osxfuse.github.io/'
   license :bsd
 
-  pkg "Extras/FUSE for macOS #{version}.pkg"
+  installer script: '/usr/sbin/installer',
+            args:   [
+                      '-pkg', "#{staged_path}/Extras/FUSE for macOS #{version}.pkg",
+                      '-target', '/',
+                      '-applyChoiceChangesXML', "#{staged_path}/Extras/Choices.xml"
+                    ]
+
+  preflight do
+    IO.write "#{staged_path}/Extras/Choices.xml", <<-EOS.undent
+      <plist>
+        <array>
+        	<dict>
+        		<key>attributeSetting</key>
+        		<integer>1</integer>
+        		<key>choiceAttribute</key>
+        		<string>selected</string>
+        		<key>choiceIdentifier</key>
+        		<string>com.github.osxfuse.pkg.MacFUSE</string>
+        	</dict>
+        </array>
+      </plist>
+    EOS
+  end
 
   postflight do
     set_ownership ['/usr/local/include', '/usr/local/lib']
   end
 
-  uninstall pkgutil: 'com.github.osxfuse.pkg.Core|com.github.osxfuse.pkg.PrefPane',
+  uninstall pkgutil: [
+                       'com.github.osxfuse.pkg.Core',
+                       'com.github.osxfuse.pkg.MacFUSE',
+                       'com.github.osxfuse.pkg.PrefPane',
+                     ],
             kext:    'com.github.osxfuse.filesystems.osxfusefs'
 
   caveats do

--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -13,12 +13,4 @@ cask 'veracrypt' do
   pkg 'VeraCrypt_Installer.pkg'
 
   uninstall pkgutil: 'com.idrix.pkg.veracrypt'
-
-  caveats <<-EOS.undent
-    #{token} requires osxfuse with "MacFUSE Compatibility Layer" enabled.
-    If you did not enable that option, #{token} will fail to install.
-
-    To enable the option, you need to install osxfuse manually (double-click the installer).
-    The installer should be located under #{Hbc.caskroom}/osxfuse
-  EOS
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Sort of closes https://github.com/caskroom/homebrew-cask/issues/25040.
