### PR TITLE
cuda.rb file edited for cuda toolkit 8.0.47

### DIFF
--- a/Casks/cuda.rb
+++ b/Casks/cuda.rb
@@ -2,7 +2,7 @@ cask 'cuda' do
   version '8.0.47'
   sha256 '6866465217e88f7d0c17c202c4aa21281bd56671b863d810efa870d2bbed0a54'
 
-  url "http://developer.download.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
+  url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'
   license :other

--- a/Casks/cuda.rb
+++ b/Casks/cuda.rb
@@ -1,6 +1,6 @@
 cask 'cuda' do
-  version '7.5.27'
-  sha256 'ff3699703a914ba6f71f76bc412cc4cc2cb8ce6fca435044d8780602b5a32e89'
+  version '8.0.47'
+  sha256 '6866465217e88f7d0c17c202c4aa21281bd56671b863d810efa870d2bbed0a54'
 
   url "http://developer.download.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac.dmg"
   name 'Nvidia CUDA'

--- a/Casks/cuda.rb
+++ b/Casks/cuda.rb
@@ -2,7 +2,7 @@ cask 'cuda' do
   version '8.0.47'
   sha256 '6866465217e88f7d0c17c202c4aa21281bd56671b863d810efa870d2bbed0a54'
 
-  url "http://developer.download.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac.dmg"
+  url "http://developer.download.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'
   license :other


### PR DESCRIPTION
CUDA toolkit 8.0 has been officially released. Version is 8.0.47
SHA256 checksum values of installer file for macOS 10.12 and 10.11 are identical as 6866465217e88f7d0c17c202c4aa21281bd56671b863d810efa870d2bbed0a54
