### PR TITLE
Fix macOS requirement in Sierra Cache Cleaner.app Cask

### DIFF
--- a/Casks/sierra-cache-cleaner.rb
+++ b/Casks/sierra-cache-cleaner.rb
@@ -8,7 +8,7 @@ cask 'sierra-cache-cleaner' do
   homepage 'http://www.northernsoftworks.com/sierracachecleaner.html'
   license :commercial
 
-  depends_on macos: :sierra
+  depends_on macos: '<= :sierra'
 
   app 'Sierra Cache Cleaner.app'
 end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

This application is supported on OS X 10.4 and later, but is hard-coded to not work on anything newer than macOS Sierra.
