### PR TITLE
Add lightkey 1.6.2.

### DIFF
--- a/Casks/lightkey.rb
+++ b/Casks/lightkey.rb
@@ -1,0 +1,19 @@
+cask 'lightkey' do
+  version '1.6.2'
+  sha256 '06cf4a9b9c609a91cff69f1fccbf73df0f81a4efdbf223aa92205aec74f43027'
+
+  url "http://lightkeyapp.com/content/06-download/Lightkey-#{version.dots_to_hyphens}/LightkeyInstaller.zip"
+  name 'Lightkey'
+  homepage 'http://lightkeyapp.com'
+  license :commercial
+
+  pkg 'LightkeyInstaller.pkg'
+
+  uninstall pkgutil: [
+                       'de.monospc.lightkey.pkg.App',
+                       'de.monospc.lightkey.pkg.Eurolite',
+                       'de.monospc.lightkey.pkg.OLA',
+                       'de.monospc.lightkey.pkg.Velleman',
+                       'de.monospc.lightkey.pkg.documentation',
+                     ]
+end


### PR DESCRIPTION
http://lightkeyapp.com/en/

Please note that the package also installs `com.FTDI.ftdiusbserialdriverinstaller.FTDIUSBSerialDriver.pkg`, however, this is used by other lighting software so I didn't want to add it to the uninstall clause. Maybe a comment in `lightkey.rb` would be appropriate?
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download lightkey` is error-free.
- [x] `brew cask style --fix lightkey` left no offenses.

Additionally, when **adding a new cask**:
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install lightkey` worked successfully.
- [x] `brew cask uninstall lightkey` worked successfully.
