### PR TITLE
Update magicavoxel to 0.97.5

### DIFF
--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,6 +1,6 @@
 cask 'magicavoxel' do
-  version '0.97.4'
-  sha256 'a1c18356b2de57bcf99b356a5061c4903560956fd3a42ae4843730209f7799d9'
+  version '0.97.5'
+  sha256 'dc11b8ed8302557cdb2a62bc4dcbd041b4f9d106d80de502cb098eef8935d404'
 
   # 23.98.147.40 was verified as official when first introduced to the cask
   url "http://23.98.147.40/uploads/MagicaVoxel-#{version}-win-mac.zip"


### PR DESCRIPTION
Updated according to official download on homepage https://ephtracy.github.io/ 
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
