### PR TITLE
Repair provided apps and scripts for launching j 804

### DIFF
--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -11,7 +11,9 @@ cask 'j' do
     app "j64-#{version}/#{a}.app"
   end
 
-  %w[jconsole].each do |b|
-    binary "j64-#{version}/bin/#{b}"
+  # We have long provided jconsole on the path. However readme.txt specifies
+  # that jconsole is available under the name jcon. Just provide both names.
+  %w[jcon jconsole].each do |b|
+    binary "j64-#{version}/bin/jconsole", target: b
   end
 end

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -12,14 +12,16 @@ cask 'j' do
     app "j64-#{version}/#{a}.app"
   end
 
+  installer sudo: false, script: "j64-#{version}/updatejqt.sh"
+
   # We have long provided jconsole on the path. However readme.txt specifies
   # that jconsole is available under the name jcon. Just provide both names.
   %w[jcon jconsole].each do |b|
     binary "j64-#{version}/bin/jconsole", target: b
   end
 
-  # Provide jbrk and jhs on the path too, as readme.txt specifies.
-  %w[jbrk jhs].each do |b|
+  # Provide jbrk, jhs, and jqt on the path too, as readme.txt specifies.
+  %w[jbrk jhs jqt].each do |b|
     binary "j64-#{version}/bin/#{b}.command", target: b
   end
 
@@ -35,5 +37,11 @@ cask 'j' do
           #{'open' if cli} "#{@cask.staged_path}/j64-#{version}/bin/#{command}"
       EOF
     end
+
+    # jqt.command has a similar problem: it uses dirname $0 expecting to find
+    # J's binary directory, but will find the Homebrew binary directory instead
+    # if we use a symlink to jqt.command. Instead, use a symlink to the wrapper
+    # we just generated, which uses an absolute path.
+    FileUtils.ln_sf "#{@cask.appdir}/jqt.app/Contents/MacOS/apprun", "#{Hbc.binarydir}/jqt"
   end
 end

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -16,4 +16,9 @@ cask 'j' do
   %w[jcon jconsole].each do |b|
     binary "j64-#{version}/bin/jconsole", target: b
   end
+
+  # Provide jbrk and jhs on the path too, as readme.txt specifies.
+  %w[jbrk jhs].each do |b|
+    binary "j64-#{version}/bin/#{b}.command", target: b
+  end
 end

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -15,12 +15,10 @@ cask 'j' do
   installer script: "j64-#{version}/updatejqt.sh",
             sudo:   false
 
-  # We have long provided jconsole on the path. However readme.txt specifies
-  # that jconsole is available under the name jcon. Just provide both names.
+  # target names according to readme.txt
   %w[jcon jconsole].each do |b|
     binary "j64-#{version}/bin/jconsole", target: b
   end
-  # Provide jbrk, jhs, and jqt on the path too, as readme.txt specifies.
   commands = %w[jbrk jhs jqt]
   commands.each do |b|
     binary "j64-#{version}/bin/#{b}.command", target: b
@@ -30,7 +28,7 @@ cask 'j' do
     # Use `readlink` to get full path of symlinked commands.
     commands.each do |c|
       command = "#{staged_path}/j64-#{version}/bin/#{c}.command"
-      IO.write command, IO.read(command).gsub('$0', '$(readlink "$0" || echo "$0")')
+      IO.write command, IO.read(command).gsub('$0', '$(/usr/bin/readlink "$0" || /bin/echo "$0")')
     end
 
     # Fix relative paths inside App bundles.

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -7,7 +7,8 @@ cask 'j' do
   homepage 'http://www.jsoftware.com'
   license :gpl
 
-  %w[jbrk jcon jhs jqt].each do |a|
+  apps = %w[jbrk jcon jhs jqt]
+  apps.each do |a|
     app "j64-#{version}/#{a}.app"
   end
 
@@ -20,5 +21,19 @@ cask 'j' do
   # Provide jbrk and jhs on the path too, as readme.txt specifies.
   %w[jbrk jhs].each do |b|
     binary "j64-#{version}/bin/#{b}.command", target: b
+  end
+
+  postflight do
+    # All four of the Mac apps use a relative path to launch the underlying
+    # binaries, so none of them work after homebrew-cask moves them into
+    # /Applications.
+    apps.each do |a|
+      cli = %w[jcon jhs].include? a
+      command = a == 'jcon' ? 'jconsole' : a + '.command'
+      File.write "#{@cask.appdir}/#{a}.app/Contents/MacOS/apprun", <<-EOF.gsub(/^ +/, '')
+          #!/bin/sh
+          #{'open' if cli} "#{@cask.staged_path}/j64-#{version}/bin/#{command}"
+      EOF
+    end
   end
 end

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -32,7 +32,7 @@ cask 'j' do
     apps.each do |a|
       cli = %w[jcon jhs].include? a
       command = a == 'jcon' ? 'jconsole' : a + '.command'
-      File.write "#{@cask.appdir}/#{a}.app/Contents/MacOS/apprun", <<-EOF.gsub(/^ +/, '')
+      File.write "#{@cask.appdir}/#{a}.app/Contents/MacOS/apprun", <<-EOF.gsub(%r{^ +}, '')
           #!/bin/sh
           #{'open' if cli} "#{@cask.staged_path}/j64-#{version}/bin/#{command}"
       EOF


### PR DESCRIPTION
According to the readme.txt shipped with the J release, a J installation should add to PATH four commands: `jbrk`, `jcon`, `jhs`, and `jqt`. However none of these were being added to PATH previously, although `jcon` was available under the alternative name `jconsole`. This pull req adds the four specified binaries, preserving the original `jconsole` symlink for compatibility reasons.

Additionally, J provides four .app bundles which launch the four commands mentioned above. These all worked using relative paths, which means that when homebrew-cask moved them into /Applications they all broke. I have added a postflight section which updates the .app bundles on the fly, so that they use an absolute path and therefore work correctly again.

Finally I have added an installer stanza which invokes the `updatejqt.sh` script provided in the J distribution. This is required for jqt to work and indeed for homebrew-cask to generate a symlink to it properly. As this step takes a substantial amount of additional installation time, and jqt is far from required for working in J, I'd suggest we consider making jqt optional if possible. (If jqt is not required, then the script needn't run and neither the jqt command nor jqt.app need be installed.)
### Checklist
- [x] The commit message includes the cask’s name and version. (Note that these issues were _not_ caused by the upgrade to J804; the J802 cask had all the same problems.)
- [x] `brew cask audit --download j` is error-free.
- [x] `brew cask style --fix j` left no offenses.
