### PR TITLE
Add cmd-eikana 1.1.1

### DIFF
--- a/Casks/cmd-eikana.rb
+++ b/Casks/cmd-eikana.rb
@@ -5,7 +5,7 @@ cask 'cmd-eikana' do
   url "https://ei-kana.appspot.com/download/eikana-#{version}.app.zip"
   appcast 'https://ei-kana.appspot.com',
           checkpoint: '72ae6ad7ab527ad4713dcca309d1485716a666ff8c2636434a2c17e2102e9092'
-  name 'cmd-eikana'
+  name '⌘英かな'
   homepage 'https://ei-kana.appspot.com'
   license :mit
 

--- a/Casks/cmd-eikana.rb
+++ b/Casks/cmd-eikana.rb
@@ -5,6 +5,7 @@ cask 'cmd-eikana' do
   url "https://ei-kana.appspot.com/download/eikana-#{version}.app.zip"
   appcast 'https://ei-kana.appspot.com',
           checkpoint: '72ae6ad7ab527ad4713dcca309d1485716a666ff8c2636434a2c17e2102e9092'
+  name 'cmd-eikana'
   name '⌘英かな'
   homepage 'https://ei-kana.appspot.com'
   license :mit

--- a/Casks/cmd-eikana.rb
+++ b/Casks/cmd-eikana.rb
@@ -1,0 +1,15 @@
+cask 'cmd-eikana' do
+  version '1.1.1'
+  sha256 'c61f82e1dfd6093272a1f441361c33da79ea29279d4de749dd31d2533d7ab18d'
+
+  url "https://ei-kana.appspot.com/download/eikana-#{version}.app.zip"
+  appcast 'https://ei-kana.appspot.com',
+          checkpoint: '72ae6ad7ab527ad4713dcca309d1485716a666ff8c2636434a2c17e2102e9092'
+  name 'cmd-eikana'
+  homepage 'https://ei-kana.appspot.com'
+  license :mit
+
+  app '⌘英かな.app'
+
+  zap delete: '~/Library/Preferences/io.github.imasanari.cmd-eikana.plist'
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download cmd-eikana` is error-free.
- [x] `brew cask style --fix cmd-eikana` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install cmd-eikana` worked successfully.
- [x] `brew cask uninstall cmd-eikana` worked successfully.
