### PR TITLE
Update pgweb to 0.9.5

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,10 +1,10 @@
 cask 'pgweb' do
-  version '0.9.3'
-  sha256 'c96fedee07c6e79170f45b377912d51ba3f4ce479c48060adc48a32f3e472993'
+  version '0.9.5'
+  sha256 '677af53daac6c44f1bdc304bc6285245fef5a75b2a0f7a76d03213afb7268e3a'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   appcast 'https://github.com/sosedoff/pgweb/releases.atom',
-          checkpoint: 'ca68f8456b9b6ec147740771c4a2d84db150c630836b1b8f6e0293afd0e16431'
+          checkpoint: '9aee4e4f2d0ff344e9e255b8d82b8aec68cdcaf045e646ff223214789dc31a29'
   name 'pgweb'
   homepage 'https://github.com/sosedoff/pgweb'
   license :mit


### PR DESCRIPTION
Updates pgweb to latest release: 0.9.5
Release notes: https://github.com/sosedoff/pgweb/releases/tag/v0.9.5
