### PR TITLE
PULL_REQUEST_TEMPLATE.md: made instructions shorter and simpler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,19 @@
-### Instructions
+*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*
 
-Delete the parts of this template that are not relevant (including these `Instructions`) and fill out the rest.  
-If there’s a checkbox you can’t complete for any reason, that’s OK. Just explain in detail why you weren’t able to do so.  
-*Note:* `{{cask_file}}` represents the cask file you’re submitting/editing.
+After making all changes to the cask:
 
-### Checklist
-
-- [ ] The commit message includes the cask’s name and version.
 - [ ] `brew cask audit --download {{cask_file}}` is error-free.
-- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
+- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
+- [ ] The commit message includes the cask’s name and version.
 
-Additionally, when **adding a new cask**:
+Aditionally, **if adding a new cask**:
 
-- [ ] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
-- [ ] Checked there are no closed [issues](https://github.com/caskroom/homebrew-cask/issues) where that cask was already refused.
-- [ ] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
+- [ ] Named the cask according to the [token reference].
 - [ ] `brew cask install {{cask_file}}` worked successfully.
 - [ ] `brew cask uninstall {{cask_file}}` worked successfully.
+- [ ] Checked there are no [open pull requests] for the same cask.
+- [ ] Checked that the cask was not already refused in [closed issues].
+
+[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
+[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
+[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed


### PR DESCRIPTION
Many people still fill the “adding a new cask” part even when not adding a new cask, or do not delete parts of the instructions.

Apart from those who do those things by mistake, it must also be a bore for regular contributors to constantly be deleting parts of the template.

This new template aims to not make users delete any part of it (if they don’t want to), and instead just fill what’s relevant to their case. Instructions are also shorter, so they can be left without taking too much space.

If agreed upon, we’ll need to run the script to sync this to other repos.
