### PR TITLE
Update Beyond Compare to 4.1.9.21719

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,6 +1,6 @@
 cask 'beyond-compare' do
-  version '4.1.6.21095'
-  sha256 'ecbcf867986ab4244ca4b0c5345f087bbeb0cd84dbeb8e578145218d72d981c1'
+  version '4.1.9.21719'
+  sha256 '1576d3c7d07e2dac7a569e7e65631f0f706ec41f5e200ea2beaf977f45d3eccd'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   name 'Beyond Compare'


### PR DESCRIPTION
### Checklist
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download beyond-compare` is error-free.
- [X] `brew cask style --fix beyond-compare` left no offences.
