### PR TITLE
add pkgutil uninstall to karabiner v10.21.0

### DIFF
--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -14,7 +14,12 @@ cask 'karabiner' do
   pkg 'Karabiner.sparkle_guided.pkg'
   binary '/Applications/Karabiner.app/Contents/Library/bin/karabiner'
 
-  uninstall script: '/Library/Application Support/org.pqrs/Karabiner/uninstall.sh'
+  uninstall quit:    'org.pqrs.Karabiner',
+            pkgutil: 'org.pqrs.Karabiner',
+            script:  {
+                       executable: '/Library/Application Support/org.pqrs/Karabiner/uninstall.sh',
+                       sudo:       true,
+                     }
 
   zap       delete: [
                       '~/Library/Application Support/Karabiner',


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

After adding `karabiner-elements` in https://github.com/caskroom/homebrew-cask/pull/25165, I saw that `karabiner` could use a similar bit for uninstall.

Closes https://github.com/caskroom/homebrew-cask/issues/24990
