### PR TITLE
Update 115browser.rb to 7.2.3.5

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,12 +1,19 @@
 cask '115browser' do
-  version '7.2.0.17'
-  sha256 '637bd783f324fb666cb040d7dfad82c7eb34cca59dae9cd35e01dcc235465144'
+  version '7.2.3.5'
+  sha256 '7f87490e0a4929bf6bbabf861540cfec0746e809f9b96fce7202146149ec9445'
 
   url "http://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'
   name '115浏览器'
-  homepage 'https://pc.115.com/mac.html'
+  homepage 'https://pc.115.com/'
   license :gratis
 
   app '115Browser.app'
+
+  zap delete: [
+                '~/Library/Application Support/115Browser',
+                '~/Library/Caches/115Browser',
+                '~/Library/Preferences/com.115.115browser.plist',
+                '~/Library/Saved Application State/com.115.115browser.savedState',
+              ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update 115browser.rb to 7.2.3.5
