### PR TITLE
Updated the Phoenix Slides to v1.4.2

### DIFF
--- a/Casks/phoenix-slides.rb
+++ b/Casks/phoenix-slides.rb
@@ -1,6 +1,6 @@
 cask 'phoenix-slides' do
-  version '1.4.0'
-  sha256 'ab65a2c2be1b8975f27cfed925c5d820e77e7089c0ab83c15d30bc930f1bf21f'
+  version '1.4.2'
+  sha256 'bde43c827972b8539198a0838e59e5d8f0fb3376a767eb04e467b584c832d239'
 
   url "http://blyt.net/phxslides/phoenix-slides-#{version.no_dots}.dmg"
   name 'Phoenix Slides'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated Phoenix Slides from version 1.4.0 to version 1.4.2
