### PR TITLE
Update touchosc-bridge to 1.4.0.1.

### DIFF
--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-bridge' do
-  version '1.3.0'
-  sha256 'cf6ae2a29e16a22e347b76fb02d2a524d143b958b9db1ea604a5ad49f9c55567'
+  version '1.4.0.1'
+  sha256 '7911ad9284aafb1ddd337af333d445de7ae57df5ca9b134bdf6881139a8795f4'
 
   url "http://hexler.net/pub/touchosc/touchosc-bridge-#{version}-osx.zip"
   name 'TouchOSC Bridge'


### PR DESCRIPTION
- [x] `brew cask audit --download touchosc-bridge` is error-free.
- [x] `brew cask style --fix touchosc-bridge` reports no offenses.
- [x] The commit message includes the cask’s name and version.
