### PR TITLE
Update owncloud to 2.2.4.3709

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -3,6 +3,8 @@ cask 'owncloud' do
   sha256 'da05a0294754c2a6a45662f765d9352114980d108f34ceac7f7eee6202c4d65e'
 
   url "https://download.owncloud.com/desktop/stable/ownCloud-#{version}.pkg"
+  appcast 'https://github.com/owncloud/client/releases.atom',
+          checkpoint: 'c38f3b861f837704752d7fca3ad7de32be66a211aba6159944344997aa07b8df'
   name 'ownCloud'
   homepage 'https://owncloud.com/'
   license :gpl


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Added AppCast.
The version field just needs to be a valid older version. I think using `1.0.0` should always provide the latest version.
