### PR TITLE
Codeship Jet, remove Docker dependency

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -8,7 +8,5 @@ cask 'jet' do
   homepage 'https://codeship.com/documentation/docker/'
   license :closed
 
-  depends_on formula: 'docker'
-
   binary 'jet'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name ~~and version~~. (The commit doesn't update the version)

With Docker 4 Mac there are other ways besides Homebrew to install Docker on macOS and they are not always compatible (e.g. `brew install docker` fails to link the binary if Docker for Mac is already installed).

Remove the dependency for now, as the documentation at http://documentation.codeship.com/docker/installation/#prerequisites already mentions Docker as a prerequisite.
