### PR TITLE
Update hopper-disassembler to 3.11.23

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '3.11.20'
-  sha256 'fee6fb596a21d0ee33d929a298926a8f8308946ca9d8821cb97390b9a2a478e7'
+  version '3.11.23'
+  sha256 '63e3f3a34f58bb24ec3446143271c90637ea2b375cc73fbbd62a6df60cf7be8b'
 
   # d1f8bh81yd16yv.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1f8bh81yd16yv.cloudfront.net/Hopper-#{version}.zip"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '9f654ee8423fe4337d66ba2d242e8ab6350926be1f74a5adbb3df380bd444c65'
+          checkpoint: '1c313cc8e78a21ec980c3032c06954e2394a994c39463d48c202a430af47acda'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
   license :commercial


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
