### PR TITLE
Update devonthink to 2.9.5

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.4'
-  sha256 '6600edb460099c338292bc160119bf1c08d6aaf6c95a4b889f1832fc9d642bc9'
+  version '2.9.5'
+  sha256 '445e1931d00f99e753c726c14cf1b4083e4edfba76c26828fe352da838fe3822'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: 'ea7be7476b53e4946cd02a6bdf344d1d78b2736bd5a779f3f39b556b0bf8aa91'
+          checkpoint: '94b758c197bd1b98fed3c09e5564395b7512cf604b683cc44af453c3b9ba647c'
   name 'DEVONthink Personal'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
