### PR TITLE
Update devonthink-pro to 2.9.5

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.4'
-  sha256 '15a16919cee3c02a804cd0f7485bf0a894f0170b7ca8383ef1e998a30c2f7a97'
+  version '2.9.5'
+  sha256 '818bb9d50064609feb365955cffa3a9de0c229f1d4064503e494267acb88eceb'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: 'e7abe60167421973d5412a2037efc8d983394402286bb930788684cf94357d81'
+          checkpoint: '4551a1304ab292db85c304dbb427d9399f7df83cbc721c3c3d8e3f9c39a7a432'
   name 'DEVONthink Pro'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
