### PR TITLE
Update devonthink-pro-office to 2.9.5

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro-office' do
-  version '2.9.4'
-  sha256 'f24afec571a5f27b07db0f689596bdb08572ac69a906d24709e503162e03b66e'
+  version '2.9.5'
+  sha256 '5474dd72e9880fc34e5a510941c344c1542c34e7c2bcaf60a6d9f9f49606490c'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: '5315f2b52b0b98d7d3ba56d9cff1308f4e75f3ac0fb6e17be755749da19824ef'
+          checkpoint: '15575a8ea0390a0f4a863e73fe70f2fe5d916384fe5b9848432f9708fd306cc8'
   name 'DEVONthink Pro Office'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
