### PR TITLE
Update automatic to 2.4.8.394

### DIFF
--- a/Casks/automatic.rb
+++ b/Casks/automatic.rb
@@ -1,11 +1,11 @@
 cask 'automatic' do
-  version '2.4.7.392'
-  sha256 'b1d4b7b4a85eb81010b5863b439b978179f49c1c5d6522e481106bf93fbea94f'
+  version '2.4.8.394'
+  sha256 'f7902f27df769bdbf80cc15d234030ea64fbc507e53076c8aa0a0a863a3eb0b1'
 
   # com-codingcurious-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://com-codingcurious-downloads.s3.amazonaws.com/Automatic.#{version}.zip"
   appcast 'http://update.codingcurious.com/automatic/appcast2.xml',
-          checkpoint: '72d2e6e0c0ba0c4692f34e37e70da0ae4f4d54099e2a0618c237db03cf402c69'
+          checkpoint: '136d69f53b1873774a0bea357c570b1412f50034cda8909642ff8bb10ea75578'
   name 'Automatic'
   homepage 'http://codingcurious.com/automatic/'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
