### PR TITLE
Updates to zap for Mactex 2016

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -27,9 +27,21 @@ cask 'mactex' do
 
   zap delete: [
                 '/usr/local/texlive/texmf-local',
-                '~/Library/texlive/2016',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/texshop.sfl',
+                '~/Library/Application Support/BibDesk',
                 '~/Library/Application Support/TeXShop',
                 '~/Library/Application Support/TeX Live Utility',
+                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/TeXShop.help',
+                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/edu.ucsd.cs.mmccrack.bibdesk.help',
+                '~/Library/Caches/edu.ucsd.cs.mmccrack.bibdesk',
+                '~/Library/Caches/fr.chachatelier.pierre.LaTeXiT',
+                '~/Library/Caches/TeXShop',
+                '~/Library/Preferences/edu.ucsd.cs.mmccrack.bibdesk.plist',
+                '~/Library/Preferences/Excalibur Preferences',
+                '~/Library/Preferences/fr.chachatelier.pierre.LaTeXiT.plist',
+                '~/Library/Preferences/TeXShop.plist',
+                '~/Library/Saved Application State/edu.bucknell.Excalibur.savedState',
+                '~/Library/texlive/2016',
                 '~/Library/TeXShop',
               ],
       rmdir:  [


### PR DESCRIPTION
After making all changes to the cask:
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

I didn't perform the first check, as the download is _huge_.
