### PR TITLE
Update sogouinput.rb to 3.7.0.1459

### DIFF
--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -1,8 +1,8 @@
 cask 'sogouinput' do
-  version '3.6.0.1303'
-  sha256 'f2eb401f37fd964688a9c605895841c33c68fb7a2aea044855f6d78434743c69'
+  version '3.7.0.1459'
+  sha256 '1f738c14235fa5bfd079788c23d07b4827f4091c4ab2ba6017d387535ee563aa'
 
-  url 'http://cdn1.ime.sogou.com/SogouInput_V3.6.0.1303.dmg'
+  url "http://cdn1.ime.sogou.com/SogouInput_V#{version}.dmg"
   name 'Sogou Input Method'
   name '搜狗输入法'
   homepage 'http://pinyin.sogou.com/mac/'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update sogouinput.rb to 3.7.0.1459
