### PR TITLE
Update electron to 1.4.3

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.1'
-  sha256 'e60637e83775474d312a99592ae494d9ec627ad777868de8a2837ec7865d3816'
+  version '1.4.3'
+  sha256 '7bbd9260e499dc8acdc7f6056693ba6785d54778166f1ead93d339ea58c6eeaf'
 
   # github.com/atom/electron was verified as official when first introduced to the cask
   url "https://github.com/atom/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/atom/electron/releases.atom',
-          checkpoint: 'd417cb34e15ff2f0242f071acbc8921c7140ab1c63c7514737cae9b31ca73100'
+          checkpoint: '40af55bc4cc58b48ab71fd46d5f17d6b09ec2078df3a77137ee6ccc7432db487'
   name 'Electron'
   homepage 'http://electron.atom.io/'
   license :mit


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
