### PR TITLE
Update cleanapp.rb to 5.1.1

### DIFF
--- a/Casks/cleanapp.rb
+++ b/Casks/cleanapp.rb
@@ -6,8 +6,8 @@ cask 'cleanapp' do
     version '4.0.8'
     sha256 'e77359586731e1ae863351846afc9fd34a7b9774625122001c0d92593a340ff1'
   else
-    version '5.1'
-    sha256 'f605164571de8ef7fe08185f6c20e618f5ed6263bbea8b42dd527ac179c9f523'
+    version '5.1.1'
+    sha256 'c2839596edba012b823fd96dcc0b9073399d3128b1c47afcc9175ea566ac94df'
   end
 
   url "https://download.syniumsoftware.com/CleanApp/CleanApp%20#{version}.dmg"
@@ -16,4 +16,16 @@ cask 'cleanapp' do
   license :commercial
 
   app 'CleanApp.app'
+
+  zap delete: [
+                '/Library/Application Support/CleanApp',
+                '/Library/LaunchDaemons/com.syniumsoftware.CleanAppDaemon.plist',
+                '~/Library/Application Support/CleanApp',
+                '~/Library/Caches/com.syniumsoftware.CleanApp',
+                '~/Library/PreferencePanes/CleanApp Logging Service.prefPane',
+                '~/Library/Preferences/com.syniumsoftware.CleanApp.plist',
+                '~/Library/Preferences/com.syniumsoftware.CleanAppDaemon.plist',
+                '~/Library/Preferences/com.syniumsoftware.stats_config.plist',
+                '~/Library/Saved Application State/com.syniumsoftware.CleanApp.savedState',
+              ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update cleanapp.rb to 5.1.1
