### PR TITLE
Update appserver to 1.1.3-200

### DIFF
--- a/Casks/appserver.rb
+++ b/Casks/appserver.rb
@@ -1,11 +1,11 @@
 cask 'appserver' do
-  version '1.1.2-188'
-  sha256 '4e35ab705e51d976071a9b5612da0a1c611fe628fb7daebfc93a2ec4ab729eeb'
+  version '1.1.3-200'
+  sha256 'dc7a94a1812356250b2cca7eb337c7fc7ad38c71745fc243492ec3113fac6c31'
 
   # github.com/appserver-io/appserver was verified as official when first introduced to the cask
   url "https://github.com/appserver-io/appserver/releases/download/#{version.sub(%r{-.*}, '')}/appserver-dist_#{version}_x86_64.pkg"
   appcast 'https://github.com/appserver-io/appserver/releases.atom',
-          checkpoint: 'aae37e43a351d3a37cffb369933b45ee9c3fc4127675ac48a76e333a3f31e229'
+          checkpoint: '5f1962c7d1468e71ec012ce91cdf6644ecef67af3aed1c27554cb8156d6cc5d8'
   name 'appserver.io'
   homepage 'http://www.appserver.io'
   license :oss


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
