### PR TITLE
Update iphoto-library-manager to 4.2.5

### DIFF
--- a/Casks/iphoto-library-manager.rb
+++ b/Casks/iphoto-library-manager.rb
@@ -1,10 +1,10 @@
 cask 'iphoto-library-manager' do
-  version '4.2.4'
-  sha256 '4710def2d0a3f91152c08b128d03b38207455e43ff36fd5d337758cbeaa64309'
+  version '4.2.5'
+  sha256 '797e14d8714c82d35e0a81e1dddb04117b9188e668aa453256f63f7faa816274'
 
   url 'https://www.fatcatsoftware.com/iplm/iPhotoLibraryManager.zip'
   appcast 'https://www.fatcatsoftware.com/iplm/iplm4_appcast.xml',
-          checkpoint: 'd1a4cdb9ec10226113286433595506743481a2fb1d95bd3bb89256143d7dc2fd'
+          checkpoint: 'd050807aec6efe87d4fa378e18000bc5292171c4488398702ffa181fadb99c1e'
   name 'iPhoto Library Manager'
   homepage 'https://www.fatcatsoftware.com/iplm/'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
