### PR TITLE
Update keytty to 1.1.8,1475826505

### DIFF
--- a/Casks/keytty.rb
+++ b/Casks/keytty.rb
@@ -1,11 +1,11 @@
 cask 'keytty' do
-  version '1.1.7,1468903136'
-  sha256 'ec9387f7640b067283bea1f1b46117e1c369e7f34d40d4593462a6916b725b92'
+  version '1.1.8,1475826505'
+  sha256 '22abc07474dfdda74df3505ce4499b1e1cc4625196293a5783ab5387b4c8155b'
 
   # dl.devmate.com/com.keytty.Keytty was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.keytty.Keytty/#{version.before_comma}/#{version.after_comma}/keytty-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.keytty.Keytty.xml',
-          checkpoint: 'dc955a9d8cd12e3192300f4f66515de964e738a5141cc4d7466051df0e748aa8'
+          checkpoint: 'd4cdf07b530cce3260ac065c88a85a07d47fd8af9ff20e984e46866fb1968f99'
   name 'Keytty'
   homepage 'http://keytty.com/'
   license :closed


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
