### PR TITLE
Update mountain-duck to 1.5.8.4906

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.5.5.4797'
-  sha256 '76e173b2fbc954334497a9c88c658a2b57dd3cba5edfde3b8aaa3455080e5281'
+  version '1.5.8.4906'
+  sha256 'a411968a710d06e487a26151d465c45935b6ddca6ce4221dd480e203cd0e13ec'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'c7f30408c9caab5a281857934febc781c278b2af4f1c258b42f091c796a447e5'
+          checkpoint: '875808506f655a7361e187a2b8e2e4c9ec9ab27e2b042edb7db42585cd67b227'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
