### PR TITLE
Update xld to 2016.10.07

### DIFF
--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -1,11 +1,11 @@
 cask 'xld' do
-  version '2016.09.20'
-  sha256 '8a7c894cb28f10c08ab1d376da2c8ea7c454687a4cd5938af2d5159876ee10c4'
+  version '2016.10.07'
+  sha256 '2c862a0e3109563c7848b5d0ad671218ab57d56f2444af60be06e50ad30df76d'
 
   # sourceforge.net/xld was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/xld/xld-#{version.no_dots}.dmg"
   appcast 'https://svn.code.sf.net/p/xld/code/appcast/xld-appcast_e.xml',
-          checkpoint: '5fbc9772cb9c0c56244a42432f39d340d4d4aec49cc9e11c4b3c014a65329b29'
+          checkpoint: '0f95b97e04e14ef9e1cf4b695388024f2a66b47a41bdcc272fab4718b2746beb'
   name 'X Lossless Decoder'
   name 'XLD'
   homepage 'http://tmkk.undo.jp/xld/index_e.html'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
