### PR TITLE
Update monodraw to b94

### DIFF
--- a/Casks/monodraw.rb
+++ b/Casks/monodraw.rb
@@ -1,10 +1,10 @@
 cask 'monodraw' do
-  version 'b93'
-  sha256 'c9fd0903694dd71ed3103afdf54d5941cc8b6a9362282afbf0cc8a7164e70853'
+  version 'b94'
+  sha256 '2e0dc71d06c9f6a56b7a6c8f31c9fe3689c53ec4bd28c9ff175c6065e7565970'
 
   url "https://updates.helftone.com/monodraw/downloads/Monodraw-#{version}.zip"
   appcast 'https://updates.helftone.com/monodraw/appcast-beta.xml',
-          checkpoint: 'a03fdd2a7856dc04af59224a7a06f02bddbe6a5387be4a6a10696eae01d67031'
+          checkpoint: '396a457a8e3a7d22e75960aeb983dae5a9f425c427ac3684750d1f48addc300d'
   name 'Monodraw'
   homepage 'http://monodraw.helftone.com'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
