### PR TITLE
Update things to 2.8.8

### DIFF
--- a/Casks/things.rb
+++ b/Casks/things.rb
@@ -1,11 +1,11 @@
 cask 'things' do
-  version '2.8.7'
-  sha256 '05f871d70787543755829ee5ade6db7f569c985fb8f85ccbcf6af86ba8153cb5'
+  version '2.8.8'
+  sha256 '8a80e15eb33b5a2e35de4661dc9c2ea6807809756bfd6b2933f2d4aa3a755c09'
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/Things_#{version}.zip"
   appcast 'https://culturedcode.cachefly.net/things/sparkle/sparkle_en.xml',
-          checkpoint: '760a2436a621059a9baa6d64984a181ff5893af3fa1448c068f31b318523ec0c'
+          checkpoint: 'c8720881d183baea1601339cc80cf24c1ecab9c5d05b2d0735f784a46a5f98cc'
   name 'Things'
   homepage 'https://culturedcode.com/things/'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
