### PR TITLE
Update xtabulator to 2.004

### DIFF
--- a/Casks/xtabulator.rb
+++ b/Casks/xtabulator.rb
@@ -1,10 +1,10 @@
 cask 'xtabulator' do
-  version '2.003'
-  sha256 '041d8a415ebc4e2bba615d887f6ba3dcb17f34b59a779db2c592dbb45ad2037d'
+  version '2.004'
+  sha256 '7778fde457c0a091bcb403755e3e7094e2c7e5263029400ca4bfe24fd6bbd410'
 
   url "http://www.bartastechnologies.com/products/xtabulator/sparkleupdates/#{version}.zip"
   appcast 'http://www.bartastechnologies.com/products/xtabulator/sparkleupdates/xtappcast.php',
-          checkpoint: '9107d1169ca979ff224be09bf6981df865ad2d3666313afe2e72716eb882712d'
+          checkpoint: '748a1baa4bcb3118c037a581f08ac1dad96a6ca904ddecddc10a0c675d703d69'
   name 'XTabulator'
   homepage 'http://www.bartastechnologies.com/products/xtabulator/'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
