### PR TITLE
Update qtpass to 1.1.4

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -9,7 +9,5 @@ cask 'qtpass' do
   name 'QtPass'
   homepage 'https://qtpass.org/'
 
-  license :gpl
-
   app 'QtPass.app'
 end

--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -5,7 +5,7 @@ cask 'qtpass' do
   # github.com/IJHack/qtpass was verified as official when first introduced to the cask
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: '96b00beb82f888bbee5f39f9251b59a3fda77de19cc5adfc52caa43711a97f46'
+          checkpoint: 'ff499dc0c1c79de926d52e62cfb7e2f4a8c07a27d69b1c15df140bec9b0cf52f'
   name 'QtPass'
   homepage 'https://qtpass.org/'
 

--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -1,13 +1,14 @@
 cask 'qtpass' do
-  version '1.1.3'
-  sha256 'd2488cf342a7b470564481423dbf6b5a07789c41e7a39c7a44a027b6c2b0b054'
+  version '1.1.4'
+  sha256 '46b1ec021bd4defbd407e74cb35eaeb93f2cc12b1214987f3d58e3dfec790efd'
 
   # github.com/IJHack/qtpass was verified as official when first introduced to the cask
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: '5c020a503bcfad1407583e46b16bc2ee273622a136ba9a631002defc860125dd'
+          checkpoint: '96b00beb82f888bbee5f39f9251b59a3fda77de19cc5adfc52caa43711a97f46'
   name 'QtPass'
   homepage 'https://qtpass.org/'
+
   license :gpl
 
   app 'QtPass.app'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
