### PR TITLE
Newest version is 20161009

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -6,7 +6,7 @@ cask 'mactex' do
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   appcast 'https://www.tug.org/mactex/downloading.html',
-          checkpoint: '14b52a4b06fa7259d2665c2a26f41dde0ee15fb61cb9b69c707ad916e9dd8073'
+          #checkpoint: '14b52a4b06fa7259d2665c2a26f41dde0ee15fb61cb9b69c707ad916e9dd8073'
   name 'MacTeX'
   homepage 'https://www.tug.org/mactex/'
   license :oss

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,6 +1,7 @@
 cask 'mactex' do
-  version '20160603'
-  sha256 '34e5c48846a674e0025e92bf1ab7bb43a1108f729b4c26c61edcda24fa5383e3'
+  version '20161009'
+  #sha256 '34e5c48846a674e0025e92bf1ab7bb43a1108f729b4c26c61edcda24fa5383e3'
+  md5 '5158d5e883dee3f17c7a98f6012706ed'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [ ] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).

Updated to the latest version, however I have not checked the hash.
The original website (https://tug.org/mactex/mactex-download.html) does give the md5 as '5158d5e883dee3f17c7a98f6012706ed'
