### PR TITLE
Update controlplane to 1.6.5

### DIFF
--- a/Casks/controlplane.rb
+++ b/Casks/controlplane.rb
@@ -3,11 +3,11 @@ cask 'controlplane' do
     version '1.2.3'
     sha256 '37f93d3a3a17a6e2f24447f0bc74c7e89ec1581ca52e5970960544858c86f909'
   else
-    version '1.6.4'
-    sha256 '5050f48212390aa7fd4d22677db3a5e1b14db1289ddef52867748a3e1a841ed5'
+    version '1.6.5'
+    sha256 '446da8ecb194f4a4c9e9d0a1984f1476cfcb7202a3415b6d36eff063f97db47c'
 
     appcast 'http://www.controlplaneapp.com/appcast.xml',
-            checkpoint: 'c9b44eb0ea2d2c7dd1cde14d60fd00a7cf8b4b6bc5b7b5b75cc4ec836b43aed3'
+            checkpoint: 'e8e01bc8f468b991f72c731ab00a15d676ca26a0ccbe75af237d17d223ac81a6'
   end
 
   url "http://www.controlplaneapp.com/download/#{version}"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
