### PR TITLE
Update MuseScore to v2.0.3.1

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,9 +1,9 @@
 cask 'musescore' do
-  version '2.0.3'
-  sha256 'ba50b2a8885d70ad9447154ef587f2496d21e474d90432be2db17e9cd29d951f'
+  version '2.0.3.1'
+  sha256 'a166a21bf6259331a42b3a5ed73cfb69f653095a27a676fbf94a747d98153b29'
 
   # ftp.osuosl.org/pub/musescore was verified as official when first introduced to the cask
-  url "http://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version}/MuseScore-#{version}.dmg"
+  url "http://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version}.dmg"
   name 'MuseScore'
   homepage 'https://musescore.org/'
 


### PR DESCRIPTION
Also updates `url` to better match their URL scheme.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
