### PR TITLE
Update popclip to 1.5.6

### DIFF
--- a/Casks/popclip.rb
+++ b/Casks/popclip.rb
@@ -3,8 +3,8 @@ cask 'popclip' do
     version '1.5.4'
     sha256 '8046452efc41988aa20ec0af31bc73aaceba5dd3d68bb4f56dc51959a2966349'
   else
-    version '1.5.5'
-    sha256 'e028c21c93c6632c85b63c5ea9b365ae76dd375455baec804506f0091b93a4be'
+    version '1.5.6'
+    sha256 '5cc5fed0281325b8121e3a26c181e5cbb34db75ba3cef351d6484a32844a611c'
   end
 
   # d20vhy8jiniubf.cloudfront.net was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
