### PR TITLE
Update helm to version 2.0.0-alpha.5

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -2,14 +2,12 @@ cask 'helm' do
   version '2.0.0-alpha.5'
   sha256 '6bd540611042665c78923fd722e9cd25d08e7381e982535a3a720458da163811'
 
-  # storage.googleapis.com/kubernetes-helm/helm-v was verified as official when first introduced to the cask (2016-10-11)
+  # storage.googleapis.com/kubernetes-helm/ was verified as official when first introduced to the cask
   url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
           checkpoint: '89bc384e94e30b530e8afce2db165db31c3e18465077de889255d166a9110d44'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
-
-  license :apache
 
   binary 'darwin-amd64/helm'
 end

--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -1,12 +1,15 @@
 cask 'helm' do
-  version '2.0.0-alpha.4'
-  sha256 'fcba539993b7b1459a5c2e02c93e87c7f2fdb5fea941b4a0bc3367e58f85c47b'
+  version '2.0.0-alpha.5'
+  sha256 '6bd540611042665c78923fd722e9cd25d08e7381e982535a3a720458da163811'
 
-  url "https://github.com/kubernetes/helm/releases/download/v#{version}/helm-v#{version}-darwin-amd64.tar.gz"
+  # storage.googleapis.com/kubernetes-helm/helm-v was verified as official when first introduced to the cask (2016-10-11)
+  url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
-          checkpoint: 'bc0b7ead6b44231cb9312dbec9a147b3c202387cdfd828cee0546f1b986d623c'
+          checkpoint: '89bc384e94e30b530e8afce2db165db31c3e18465077de889255d166a9110d44'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
+
+  license :apache
 
   binary 'darwin-amd64/helm'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
