### PR TITLE
Update beatport-pro to 2.3.0_169

### DIFF
--- a/Casks/beatport-pro.rb
+++ b/Casks/beatport-pro.rb
@@ -1,10 +1,10 @@
 cask 'beatport-pro' do
-  version '2.2.4_167'
-  sha256 '2039235b12e4ef90d9421c9689629a7304445380f5fdb0dc7a57b75fecb62104'
+  version '2.3.0_169'
+  sha256 '94155a9d2075e5c5a7023d13b9e3ec54ce92a4fa460e0e97fbd8df2e1130a888'
 
   url "https://pro.beatport.com/mac/#{version}/beatportpro_#{version}.zip"
   appcast 'https://pro.beatport.com/mac/appcast.xml',
-          checkpoint: 'ea3d3f35e508d63b3d58b50373d949f926c6bc2882ca21ab996e8a5ea2d94fc0'
+          checkpoint: '3692f8ca2ccaab6e7f812ea3c21bc9187575238e73349196e95bcc0be498d65c'
   name 'Beatport Pro'
   homepage 'https://pro.beatport.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
