### PR TITLE
Update proxpn to 4.3.6.5

### DIFF
--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,10 +1,10 @@
 cask 'proxpn' do
-  version '4.3.6.2'
-  sha256 '5f4bf12371ccdf694a222ec8d966f6796e8d93a484934e674798385d60891370'
+  version '4.3.6.5'
+  sha256 '3c05b5f55ec416c167af536d34547a2d89828c31dd6d86f844ac6c316c18d10a'
 
   url "https://www.proxpn.com/updater/proXPN-MacOSX-10.7-#{version}.dmg"
   appcast 'https://www.proxpn.com/updater/appcast.rss',
-          checkpoint: 'ec65d9d281487212b1aba6ff55e4ec7802dff549d692941fb2f81a996b8485ab'
+          checkpoint: '5513dc0660f661331ad6361b962ef19a4780b52f6e34464f7e9da403853e9325'
   name 'proXPN'
   homepage 'https://www.proxpn.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
