### PR TITLE
Add DBeaver Community Edition v3.7.6

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,0 +1,10 @@
+cask 'dbeaver-community' do
+  version '3.7.6'
+  sha256 '25f3508e47b77f039d89de090112908c1e50760885db307d9b930e1a94bb5d55'
+
+  url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
+  name 'DBeaver Community Edition'
+  homepage 'http://dbeaver.jkiss.org/'
+
+  app 'Dbeaver.app'
+end


### PR DESCRIPTION
Adding DBeaver at v3.7.6. Someone already upgrade the `dbeaver-enterprise` cask, and I was actually surprised that this wasn't already done.

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).
