### PR TITLE
generate_issue_template_urls: don't end in newline

### DIFF
--- a/developer/bin/generate_issue_template_urls
+++ b/developer/bin/generate_issue_template_urls
@@ -22,7 +22,7 @@ BASE_URL = "https://github.com/caskroom/homebrew-cask/issues/new".freeze
 def main(args)
   args.each do |file|
     File.read(file).scan(%r{(.*?)\n(.*)}m) do |title, body|
-      puts generate_url(title, body)
+      print generate_url(title, body)
     end
   end
 end


### PR DESCRIPTION
I usually run this script with `| pbocopy`. The copied newline is always annoying as it moves other text more than it should.
