### PR TITLE
Update thunder.rb to 2.7.6.2272

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '2.7.5.2200'
-  sha256 '2a9d2afee65c6ca508d66201045acfac7aa65122bf3bf5fb8b2a05ec483a575f'
+  version '2.7.6.2272'
+  sha256 'b7300bd2f530cc69c61465d5745989e73983cea8d481d7d574508ce128076f4c'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_dl#{version}_Beta.dmg"
@@ -8,5 +8,15 @@ cask 'thunder' do
   name '迅雷'
   homepage 'http://mac.xunlei.com/'
 
+  depends_on macos: '>= :mavericks'
+
   app 'Thunder.app'
+
+  zap delete: [
+                '~/Library/Application Support/Thunder',
+                '~/Library/Caches/com.xunlei.Thunder',
+                '~/Library/Cookies/com.xunlei.Thunder.binarycookies',
+                '~/Library/Preferences/com.xunlei.Thunder.plist',
+                '~/Library/Saved Application State/com.xunlei.Thunder.savedState',
+              ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update thunder.rb to 2.7.6.2272
