### PR TITLE
Add Noti 0.1.5

### DIFF
--- a/Casks/noti.rb
+++ b/Casks/noti.rb
@@ -4,8 +4,8 @@ cask 'noti' do
 
   # github.com/jariz/Noti was verified as official when first introduced to the cask
   url "https://github.com/jariz/Noti/releases/download/#{version}/Noti.dmg"
-  appcast 'https://rawgit.com/jariz/Noti-appcast/master/appcast.xml',
-          checkpoint: 'b2868e917e6b97a22e0d45de63b5d67dfe911b902cc8a4ee738b28012e9cce12'
+  appcast 'https://github.com/jariz/Noti/releases.atom',
+          checkpoint: 'c784b94965f932e1db3022eeccc17e0a75c99012db068ca30a9bc85ca8be3851'
   name 'Noti'
   homepage 'https://noti.center/'
 

--- a/Casks/noti.rb
+++ b/Casks/noti.rb
@@ -1,0 +1,15 @@
+cask 'noti' do
+  version '0.1.5'
+  sha256 '6c81afbee1146dffc543af6502b193e55a5b241b5cdd996f43016dce03c8a428'
+
+  # github.com/jariz/Noti was verified as official when first introduced to the cask
+  url "https://github.com/jariz/Noti/releases/download/#{version}/Noti.dmg"
+  appcast 'https://rawgit.com/jariz/Noti-appcast/master/appcast.xml',
+          checkpoint: 'b2868e917e6b97a22e0d45de63b5d67dfe911b902cc8a4ee738b28012e9cce12'
+  name 'Noti'
+  homepage 'https://noti.center/'
+
+  auto_updates true
+
+  app 'Noti.app'
+end


### PR DESCRIPTION
Noti is a pushbullet client for macOS. It allows you to see and act upon your Android notifications from macOS.
Homepage: https://noti.center/
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).
