### PR TITLE
Update keytty to 1.1.9,1476234897

### DIFF
--- a/Casks/keytty.rb
+++ b/Casks/keytty.rb
@@ -1,11 +1,11 @@
 cask 'keytty' do
-  version '1.1.8,1475826505'
-  sha256 '22abc07474dfdda74df3505ce4499b1e1cc4625196293a5783ab5387b4c8155b'
+  version '1.1.9,1476234897'
+  sha256 '9cfa4ab7d7567cb801df4c895ec92afff9903947977581a8c217d26545891bfe'
 
   # dl.devmate.com/com.keytty.Keytty was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.keytty.Keytty/#{version.before_comma}/#{version.after_comma}/keytty-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.keytty.Keytty.xml',
-          checkpoint: 'd4cdf07b530cce3260ac065c88a85a07d47fd8af9ff20e984e46866fb1968f99'
+          checkpoint: '311b96382866211a4ffe441d344746798b25764e17f47df98ac2a5b9eb9fd58a'
   name 'Keytty'
   homepage 'http://keytty.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
