### PR TITLE
Update tower to 2.5.1-329-2d945c27

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,11 +1,11 @@
 cask 'tower' do
-  version '2.5.0-327-cedf62ec'
-  sha256 '3b7803420ef379b07db09566aa3a2d20f2eb3423427802be6a6efd6d076ff4c8'
+  version '2.5.1-329-2d945c27'
+  sha256 '309a334c11f3da29f7bbee88d52e38935fc7d2701cecc0f63c3c7b76b09dfc98'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.sub(%r{^[^\-]+\-}, '')}/Tower-#{version.major}-#{version.sub(%r{-[^-]+$}, '')}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable",
-          checkpoint: '00618799a20d9cd61a71dd1ed4826d014e19fd65d848b1943187f1f8276f23fe'
+          checkpoint: 'e6f8b40c3b27f552c30d74fa6528e4f249be4f899f2afb1e4e276aad57b6b982'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
