### PR TITLE
Update postico to 1.0.10

### DIFF
--- a/Casks/postico.rb
+++ b/Casks/postico.rb
@@ -1,6 +1,6 @@
 cask 'postico' do
-  version '1.0.9'
-  sha256 '19ef3bab73b5764e327e3d62c1c11894915ab9f00019dd6e6bd4427eb18812a1'
+  version '1.0.10'
+  sha256 'c746450e6decef04ab8ee193dd69524c951743718ca38bdaedef6c6f149c7300'
 
   # amazonaws.com/eggerapps-downloads was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/eggerapps-downloads/postico-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download postico` is error-free.
- [x] `brew cask style --fix postico` reports no offenses.
- [x] The commit message includes the cask’s name and version.
