### PR TITLE
Update beatunes to 4.6.8

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,6 +1,6 @@
 cask 'beatunes' do
-  version '4.6.3'
-  sha256 '55e67e197bc47ea46f5f42c52600621716ae2854221013c77fa3cdab653b325a'
+  version '4.6.8'
+  sha256 'a59f76de6fbc4a5eb93296961fa587094a4d898b326746cbb520e6d3fdeddfc8'
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   name 'beaTunes'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
