### PR TITLE
Update synergy to 1.8.4,a6ff9079

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '1.8.3,db9181b'
-  sha256 '9c20556b79691ab45d4cd96ed56e4f67f223fee5d7763e29001e705b44c21b97'
+  version '1.8.4,a6ff9079'
+  sha256 '08a539fb7e258ece1e236807bd47fd2fd1be1b284c5b0c5576a797b10f7bd37b'
 
   url "https://symless.com/files/packages/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX1011-x86_64.dmg"
   name 'Synergy'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
