### PR TITLE
Update lyn to 1.8.1

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,10 +1,10 @@
 cask 'lyn' do
-  version '1.8'
-  sha256 '77cce0a0aa26fd83766d421c846b5abb2cadbc965998ec2a253ea83d07e11d74'
+  version '1.8.1'
+  sha256 '0785459c5777793c5e3808dca15240a1afc3e86cfd37dd73119121e85d43b636'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: '8e3c01bedb65e7061ab8c84d1e72cc5f93f21cfea78c3e6e57285a9a5a48f0a6'
+          checkpoint: '0a0b302988f4dae1ad0914a561deb127b9f036c3c424f213e5b9fd8e35e4fd0c'
   name 'Lyn'
   homepage 'http://www.lynapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
