### PR TITLE
Update pacifist to 3.5.11

### DIFF
--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -3,13 +3,13 @@ cask 'pacifist' do
     version '3.2.17'
     sha256 'd38e12293bc6087ddb09275e3c5ab34faa670e87e9dd41e04a587dd387f7b1d3'
   else
-    version '3.5.10'
-    sha256 '8905a66adcc75d33475cfa1e6789f83a1fd6da1952056671e95725d1b534143e'
+    version '3.5.11'
+    sha256 'db03c766c2fc48675f3fe7fbd3eee3377c6cc06baa35e9b35afe2a345e57d415'
   end
 
   url "https://www.charlessoft.com/pacifist_download/Pacifist_#{version}.dmg"
   appcast 'https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi',
-          checkpoint: '11541f9dbefb04099d97228a7104e7fa290ffe0db0c703c7c89f66a8220f85de'
+          checkpoint: 'b7e5749bb2d009416a5a679a02a75453c7e1a641678cbb943e18712c45270e76'
   name 'Pacifist'
   homepage 'https://www.charlessoft.com/'
 

--- a/Casks/textwrangler.rb
+++ b/Casks/textwrangler.rb
@@ -5,14 +5,14 @@ cask 'textwrangler' do
 
     url "http://pine.barebones.com/files/TextWrangler_#{version}.dmg"
   else
-    version '5.5.1'
-    sha256 '000f69d1433886e31c9e12168e3d4d7cd0d9c06873016f487f8dbbb7bfba425a'
+    version '5.5.2'
+    sha256 '046aff569123d39782981f52d918a1b51f18caefca4ac0436dcc193edfd96c08'
 
     # amazonaws.com/BBSW-download was verified as official when first introduced to the cask
     url "https://s3.amazonaws.com/BBSW-download/TextWrangler_#{version}.dmg"
   end
   appcast 'https://versioncheck.barebones.com/TextWrangler.xml',
-          checkpoint: 'a5204efdb48776a1859abcb2bac6dd3f0d6dea65074b1ebdabd3a6d498f8d5cf'
+          checkpoint: 'f758c48e9e25d15e0d34310b000e1b0a3c90a4dfa200519a0e86f6e785f6d41c'
   name 'TextWrangler'
   homepage 'http://www.barebones.com/products/textwrangler/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
