### PR TITLE
Update calibre to v2.70.0

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -3,10 +3,10 @@ cask 'calibre' do
     version '1.48.0'
     sha256 '0533283965fbc9a6618d0b27c85bdf3671fe75ff0e89eeff406fe1457ee61b14'
   else
-    version '2.69.0'
-    sha256 '6588e8723ce53944b80ee6bbb264e912500c617f543330652b61a9875cbbbb07'
+    version 'v2.70.0'
+    sha256 'fe84a144561af99f8103ec5f1ea68b53da7bf22883490a95668db7e1964b504d'
     appcast 'https://github.com/kovidgoyal/calibre/releases.atom',
-            checkpoint: '2d506c52541e006aa3dbe59bfc386806a4eceaa87c44fd7152cc2916d41f104f'
+            checkpoint: '67980993effbfe0d585b55a6a7a5cbd6209db5df3032db65e819b43be038f803'
   end
 
   url "https://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"

--- a/Casks/textwrangler.rb
+++ b/Casks/textwrangler.rb
@@ -5,14 +5,14 @@ cask 'textwrangler' do
 
     url "http://pine.barebones.com/files/TextWrangler_#{version}.dmg"
   else
-    version '5.5.1'
-    sha256 '000f69d1433886e31c9e12168e3d4d7cd0d9c06873016f487f8dbbb7bfba425a'
+    version '5.5.2'
+    sha256 '046aff569123d39782981f52d918a1b51f18caefca4ac0436dcc193edfd96c08'
 
     # amazonaws.com/BBSW-download was verified as official when first introduced to the cask
     url "https://s3.amazonaws.com/BBSW-download/TextWrangler_#{version}.dmg"
   end
   appcast 'https://versioncheck.barebones.com/TextWrangler.xml',
-          checkpoint: 'a5204efdb48776a1859abcb2bac6dd3f0d6dea65074b1ebdabd3a6d498f8d5cf'
+          checkpoint: 'f758c48e9e25d15e0d34310b000e1b0a3c90a4dfa200519a0e86f6e785f6d41c'
   name 'TextWrangler'
   homepage 'http://www.barebones.com/products/textwrangler/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
