### PR TITLE
couchbase-server-community 4.1.0 extraction directory fixed

### DIFF
--- a/Casks/couchbase-server-community.rb
+++ b/Casks/couchbase-server-community.rb
@@ -6,5 +6,5 @@ cask 'couchbase-server-community' do
   name 'Couchbase Server'
   homepage 'https://www.couchbase.com/'
 
-  app "couchbase-server-community_#{version}-macos_x86_64/Couchbase Server.app"
+  app "couchbase-server-community_#{version.major}/Couchbase Server.app"
 end


### PR DESCRIPTION
The 4.1.0 update ended up changing the directory for extracted files, so installation failed. I have changed it to the correct directory.

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
