### PR TITLE
Automatically fix a few RuboCop warnings

### DIFF
--- a/Casks/adobe-after-effects-cc.rb
+++ b/Casks/adobe-after-effects-cc.rb
@@ -24,7 +24,6 @@ cask 'adobe-after-effects-cc' do
       cookies:    { 'MM_TRIALS' => '1234' }
   name 'Adobe After Effects CC 2015'
   homepage 'https://www.adobe.com/uk/products/aftereffects.html'
-  license :commercial
 
   media_signature = '147EC100-14BE-45EF-AB42-35BAEE7D02F0'
 

--- a/Casks/adobe-premiere-pro-cc.rb
+++ b/Casks/adobe-premiere-pro-cc.rb
@@ -24,7 +24,6 @@ cask 'adobe-premiere-pro-cc' do
       cookies:    { 'MM_TRIALS' => '1234' }
   name 'Adobe Premiere Pro CC 2015'
   homepage 'https://www.adobe.com/products/premierepro.html'
-  license :commercial
 
   media_signature = '38C72D42-0672-43B1-9E05-E7631684F9A1'
 

--- a/Casks/shadowsocksx-ng.rb
+++ b/Casks/shadowsocksx-ng.rb
@@ -4,7 +4,7 @@ cask 'shadowsocksx-ng' do
 
   url "https://github.com/shadowsocks/ShadowsocksX-NG/releases/download/#{version}/ShadowsocksX-NG-#{version}.dmg"
   appcast 'https://github.com/shadowsocks/ShadowsocksX-NG/releases.atom',
-          checkpoint: 'a04e2104c8823d27e4984fc05aa1a4948c7b6b7c7859c7f537081c72001a5b6f' 
+          checkpoint: 'a04e2104c8823d27e4984fc05aa1a4948c7b6b7c7859c7f537081c72001a5b6f'
   name 'ShadowsocksX-NG'
   homepage 'https://github.com/shadowsocks/ShadowsocksX-NG'
 

--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -46,7 +46,7 @@ cask 'wireshark-chmodbpf' do
   end
 
   postflight do
-    if Process.euid == 0
+    if Process.euid.zero?
       ohai 'Note:'
       puts <<-EOS.undent
         You executed 'brew cask' as the superuser.


### PR DESCRIPTION
I'm currently deep diving into audit/RuboCop and figured I should see if there were any warnings. And sure enough, `4615 files inspected, 805 offenses detected, 14 offenses corrected`. I'll tackle the easy ones that causes a lot of noise next (google fonts) so that the real ones show up.

_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [ ] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).
