### PR TITLE
Update bzflag to 2.4.8

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -1,10 +1,10 @@
 cask 'bzflag' do
-  version '2.4.6'
-  sha256 '718b520498294e0083dcff7faf277dcda8fa512a11bf2b852ffc7617f01bfb3e'
+  version '2.4.8'
+  sha256 '3b4bdd1b98565b998ff7b6915670cb30b81358203aed27423afb0a5f2bd3a5a9'
 
-  url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-MacOSX.zip"
+  url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom',
-          checkpoint: 'f6f94afd10f51ff5510ceb84f4d04c707e5a74aa722f0443267d694c9a7c32c0'
+          checkpoint: 'dd2c052f3c22f8d0a64fa2230c80fa0113e9a8611963e279d7b6c48cdf908541'
   name 'BZFlag'
   homepage 'https://bzflag.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
