### PR TITLE
travis: fix CASK_TAP_DIR location

### DIFF
--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -62,7 +62,7 @@ run brew update
 run brew uninstall --force brew-cask
 
 # mirror the repo as a tap, then run the build from there
-run export CASK_TAP_DIR="/usr/local/Library/Taps/${TRAVIS_REPO_SLUG}"
+run export CASK_TAP_DIR="$(brew --repository)/Library/Taps/${TRAVIS_REPO_SLUG}"
 run mkdir -p "${CASK_TAP_DIR}"
 run rsync -az --delete "${TRAVIS_BUILD_DIR}/" "${CASK_TAP_DIR}/"
 run export TRAVIS_BUILD_DIR="${CASK_TAP_DIR}"


### PR DESCRIPTION
Don't assume the location of `brew --repository`.
