### PR TITLE
Update airparrot to 2.6.2

### DIFF
--- a/Casks/airparrot.rb
+++ b/Casks/airparrot.rb
@@ -1,10 +1,10 @@
 cask 'airparrot' do
-  version '2.6.1'
-  sha256 'b1077f9c9eb6036451cce601798f566b0156bff7d5f1635ef60c915f7370efac'
+  version '2.6.2'
+  sha256 'fdc491ab964ac19d4f2b62e9f1f5c827941ce1c207a9eec6003f8aeaf7dc81bd'
 
   url "https://download.airsquirrels.com/AirParrot2/Mac/AirParrot-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/AirParrot2/Mac/AirParrot2.xml',
-          checkpoint: 'bf3c7a9f1f3aca05a01f79f3e3e2b43e6c596c8d1670352e7f8892a0da7ee9d4'
+          checkpoint: '92dc351a84122af35a424579d65fa9c842fb0a26d66625a729b21e243a49bffa'
   name 'AirParrot'
   homepage 'https://www.airsquirrels.com/airparrot/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
