### PR TITLE
Update splice to 2.1.8-201610131641

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,11 +1,11 @@
 cask 'splice' do
-  version '2.1.7-201609221705'
-  sha256 'd68fb85daeb12bdad94d787faeb44c904947a070884a6cb637d7603c0cdb5399'
+  version '2.1.8-201610131641'
+  sha256 '7123768004fce6a259752f47c948e1309e53853391a8e562da7074e588df0dbd'
 
   # amazonaws.com/spliceosx was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/spliceosx/Splice.app-#{version}.zip"
   appcast 'https://splice.com/appcast.xml',
-          checkpoint: 'a26a85e731e4929366286e0ecf5c67d63cd3f9505720f0813ce5b37b6cf6031b'
+          checkpoint: '4fb3a1e2c86176252dfc9e7367df425e43bcfb132cdf590a4caaae3597b50949'
   name 'Splice'
   homepage 'https://splice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
