### PR TITLE
Add fork steveschow-gfxcardstatus (v2.4.3i)

### DIFF
--- a/Casks/steveschow-gfxcardstatus.rb
+++ b/Casks/steveschow-gfxcardstatus.rb
@@ -1,0 +1,10 @@
+cask 'steveschow-gfxcardstatus' do
+  version '2.4.3i'
+  sha256 '511ebc665cff319186753213684bf44bb7d0517716e65bd19ffd8db2fac2113e'
+
+  url "https://github.com/steveschow/gfxCardStatus/releases/download/v#{version}/gfxCardStatus.app.zip"
+  name 'steveschow-gfxCardStatus'
+  homepage 'https://github.com/steveschow/gfxCardStatus'
+
+  app 'gfxCardStatus.app'
+end


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

macOS Sierra broke the old version of gfxcardstatus. This fork fixes
the issues in the original.

There doesn't seem to be any indication of time or whether the original repo is going to be fixed at all.  There's no PR open either.

If there's anything wrong with the formatting of the cask/commit messages let me know and I will do my best to correct them!
