### PR TITLE
Update eclipse-jee to 4.6.1

### DIFF
--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,10 +1,20 @@
 cask 'eclipse-jee' do
-  version '4.6.0'
-  sha256 'ec62c9734396fb99ae5fc8af8731bb87d19d4d40579aeac69b8fe1447c51a614'
+  version '4.6.1'
+  sha256 'c64da846dfb762ce6650e4d842c566a61836b14c0a77b1f5395f4f9842a66aad'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-jee-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  module Utils
+    def self.release
+      'neon'
+    end
+
+    def self.build
+      '1a'
+    end
+  end
+
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{Utils.release}/#{Utils.build}/eclipse-jee-#{Utils.release}-#{Utils.build}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse IDE for Java EE Developers'
-  homepage 'https://eclipse.org/'
+  homepage "http://www.eclipse.org/downloads/packages/release/#{Utils.release}/#{Utils.build}"
 
   depends_on macos: '>= :leopard'
   depends_on arch: :x86_64

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,20 +1,10 @@
 cask 'eclipse-jee' do
-  version '4.6.1'
+  version '4.6.1,neon:1a'
   sha256 'c64da846dfb762ce6650e4d842c566a61836b14c0a77b1f5395f4f9842a66aad'
 
-  module Utils
-    def self.release
-      'neon'
-    end
-
-    def self.build
-      '1a'
-    end
-  end
-
-  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{Utils.release}/#{Utils.build}/eclipse-jee-#{Utils.release}-#{Utils.build}-macosx-cocoa-x86_64.tar.gz&r=1"
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse IDE for Java EE Developers'
-  homepage "http://www.eclipse.org/downloads/packages/release/#{Utils.release}/#{Utils.build}"
+  homepage "http://www.eclipse.org/downloads/packages/release/#{version.after_comma.before_colon}/#{version.after_colon}"
 
   depends_on macos: '>= :leopard'
   depends_on arch: :x86_64


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
