### PR TITLE
Add NetBeans IDE for Java SE v8.2

### DIFF
--- a/Casks/netbeans-java-se.rb
+++ b/Casks/netbeans-java-se.rb
@@ -1,0 +1,13 @@
+cask 'netbeans-java-se' do
+  version '8.2'
+  sha256 '91652f03d8abba0ae9d76a612ed909c9f82e4f138cbd510f5d3679280323011b'
+
+  url "http://download.netbeans.org/netbeans/#{version}/final/bundles/netbeans-#{version}-javase-macosx.dmg"
+  name 'NetBeans IDE for Java SE'
+  homepage 'https://netbeans.org/'
+
+  pkg "NetBeans #{version}.pkg"
+
+  uninstall pkgutil: 'org.netbeans.ide.*',
+            delete:  '/Applications/NetBeans'
+end


### PR DESCRIPTION
- [x] `brew cask audit --download netbeans-java-se` is error-free.
- [x] `brew cask style --fix netbeans-java-se` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install netbeans-java-se` worked successfully.
- [x] `brew cask uninstall netbeans-java-se` worked successfully.
- [x] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).

netbeans-php, netbeans-cpp and netbeans ('All' bundle) already exist.
The 'Java SE' and for 'Java EE' bundles are missing.
See https://netbeans.org/downloads/
