### PR TITLE
Add NetBeans IDE for Java EE v8.2

### DIFF
--- a/Casks/netbeans-java-ee.rb
+++ b/Casks/netbeans-java-ee.rb
@@ -1,0 +1,33 @@
+cask 'netbeans-java-ee' do
+  version '8.2'
+  sha256 '5b897c3f1fa657749d5dcddbc3a95a1a15ec35e7cab08aad34befadd7ec3f1e7'
+
+  url "http://download.netbeans.org/netbeans/#{version}/final/bundles/netbeans-#{version}-javaee-macosx.dmg"
+  name 'NetBeans IDE for Java EE'
+  homepage 'https://netbeans.org/'
+
+  pkg "NetBeans #{version}.pkg"
+
+  # Theoretically this uninstall could conflict with a separate GlassFish
+  # installation.
+  #
+  # In practice, it appears that the normal GlassFish installation process does
+  # not use the macOS installer and so isn't in the pkgutil receipts database.
+  #
+  # https://glassfish.java.net/docs/4.0/installation-guide.pdf
+  #
+  # Arguably if the GlassFish installation by NetBeans inside its own target
+  # directory were to conflict with a standard GlassFish installation in the
+  # receipts database that would be a bug upstream with NetBeans not prefixing
+  # its GlassFish package with "org.netbeans."
+  #
+  # If this ever becomes an issue, pkgutil: 'glassfish.*' could be moved to a
+  # separate "zap" stanza.
+  #
+  # The NetBeans installer does some postflight unpacking of paths installed by
+  # the macOS installer, so it's insufficient to just delete the paths exposed
+  # by pkgutil, hence the additional ":delete" option below.
+
+  uninstall pkgutil: 'org.netbeans.ide.*|glassfish.*',
+            delete:  '/Applications/NetBeans'
+end


### PR DESCRIPTION
- [x] `brew cask audit --download netbeans-java-ee` is error-free.
- [x] `brew cask style --fix netbeans-java-ee` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install netbeans-java-ee` worked successfully.
- [x] `brew cask uninstall netbeans-java-ee` worked successfully.
- [x] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).

netbeans-php, netbeans-cpp and netbeans ('All' bundle) already exist.
The 'Java SE' and for 'Java EE' bundles are missing.
See https://netbeans.org/downloads/
