### PR TITLE
Fix netbeans 8.2

### DIFF
--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -21,13 +21,13 @@ cask 'netbeans' do
   # receipts database that would be a bug upstream with NetBeans not prefixing
   # its GlassFish package with "org.netbeans."
   #
-  # If this ever becomes an issue, pkgutil: 'glassfish-.*' could be moved
-  # to a separate "zap" stanza.
+  # If this ever becomes an issue, pkgutil: 'glassfish.*' could be moved to a
+  # separate "zap" stanza.
   #
   # The NetBeans installer does some postflight unpacking of paths installed by
   # the macOS installer, so it's insufficient to just delete the paths exposed
   # by pkgutil, hence the additional ":delete" option below.
 
-  uninstall pkgutil: 'org.netbeans.ide.*|glassfish-.*',
+  uninstall pkgutil: 'org.netbeans.ide.*|glassfish.*',
             delete:  '/Applications/NetBeans'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download netbeans` is error-free.
- [x] `brew cask style --fix netbeans` reports no offenses.
- [x] The commit message includes the cask’s name and version.

NetBeans 8.2 installs the `glassfish.4.1.1` pkg, and the `glashfish-.*`
regexp (with the additional dash) in `netbeans.rb` won't match that.
