### PR TITLE
Update scala-ide to 4.4.1

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,9 +1,15 @@
 cask 'scala-ide' do
-  version '4.4.0'
-  sha256 'c2b8a2d02fb6dd8586427cd171e3e3e8b55cf50afbb126e2bbf936052775e4b8'
+  version '4.4.1'
+  sha256 'b3bd0907aec82e943de80df428839f08fca6823e99484bf28b50f878d1503d05'
+
+  module Utils
+    def self.suffix
+      '20160401'
+    end
+  end
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20160401/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-#{Utils.suffix}/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
   name 'Scala IDE'
   homepage 'http://scala-ide.org/'
 

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -3,13 +3,13 @@ cask 'scala-ide' do
   sha256 'b3bd0907aec82e943de80df428839f08fca6823e99484bf28b50f878d1503d05'
 
   module Utils
-    def self.suffix
+    def self.build
       '20160401'
     end
   end
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-#{Utils.suffix}/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-#{Utils.build}/scala-SDK-#{build}-vfinal-2.11-macosx.cocoa.x86_64.zip"
   name 'Scala IDE'
   homepage 'http://scala-ide.org/'
 

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -4,17 +4,17 @@ cask 'scala-ide' do
 
   module Utils
     def self.build
-      '20160401'
+      '20160504'
     end
   end
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-#{Utils.build}/scala-SDK-#{build}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-#{Utils.build}/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
   name 'Scala IDE'
   homepage 'http://scala-ide.org/'
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/2731
-  app 'eclipse/Eclipse.app', target: 'Scala IDE.app'
+  app 'eclipse', target: 'Scala IDE'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
