### PR TITLE
Update scala-ide to 4.4.1,2.11:20160504

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,14 +1,14 @@
 cask 'scala-ide' do
-  version '4.4.0'
-  sha256 'c2b8a2d02fb6dd8586427cd171e3e3e8b55cf50afbb126e2bbf936052775e4b8'
+  version '4.4.1,2.11:20160504'
+  sha256 'b3bd0907aec82e943de80df428839f08fca6823e99484bf28b50f878d1503d05'
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-  url "https://downloads.typesafe.com/scalaide-pack/#{version}-vfinal-luna-211-20160401/scala-SDK-#{version}-vfinal-2.11-macosx.cocoa.x86_64.zip"
+  url "http://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-luna-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"
   name 'Scala IDE'
   homepage 'http://scala-ide.org/'
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/2731
-  app 'eclipse/Eclipse.app', target: 'Scala IDE.app'
+  suite 'eclipse', target: 'Scala IDE'
 end


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
