### PR TITLE
Update openra to 20161015

### DIFF
--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -1,11 +1,11 @@
 cask 'openra' do
-  version '20160508'
-  sha256 '2992357757c8882ebda97ae5239a4e8e435e06c58575f4230de45647414c6bd1'
+  version '20161015'
+  sha256 '9566f0404f03fde70e577eb0407a09fb95272f64c1c98a4cb019ceadf69189ce'
 
   # github.com/OpenRA/OpenRA was verified as official when first introduced to the cask
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
   appcast 'https://github.com/OpenRA/OpenRA/releases.atom',
-          checkpoint: 'e6787d8d0cafc3da4c192de3f532e331173134ac2cb043ba67be65e09cb66462'
+          checkpoint: '9e9f55215e33ba4b0bc688821a2efd1ec5338c784273d2ec891f92527078b88d'
   name 'OpenRA'
   homepage 'http://www.openra.net'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
