### PR TITLE
Update stretchly to 0.3.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.2.1'
-  sha256 'f8b0d739862f4b087a00cd2bb60de63083a82fdf9b13c6e475d13f35e43219e2'
+  version '0.3.0'
+  sha256 '331dd1c3c1b41dbfe48b8786e3d434cfccc2e199dcce04c43c698a2dc350676f'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '398421aca0d3c9ccc31d1b19e8822b5c7e1a2e7e779411ce3e97b52c481017ff'
+          checkpoint: 'af574f5126d75c782f81316ae110a3b76bb390f2c46dd90eb91b930d76c90f7e'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
