### PR TITLE
Update crashplan to 4.8.0

### DIFF
--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -1,6 +1,6 @@
 cask 'crashplan' do
-  version '4.7.0'
-  sha256 'ea138c87bb158fa47ba2aa5c7f5bcd43cccb9a7db9d83ace4a6954d1ae678d55'
+  version '4.8.0'
+  sha256 'fd0189c9ab40e77d5b3aee653ac052002754133fe4f361e0b7c088dae44ca271'
 
   # crashplan.com was verified as official when first introduced to the cask
   url "https://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_#{version}_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
