### PR TITLE
Update grip to 1.5.0-rc2

### DIFF
--- a/Casks/grip.rb
+++ b/Casks/grip.rb
@@ -1,11 +1,11 @@
 cask 'grip' do
-  version '1.4.0'
-  sha256 '9b51f8624d65b555c377ca382a53887f4fc8fe3f5021414cf4fb1b8beadf82b4'
+  version '1.5.0-rc2'
+  sha256 '8b2c9d08c9c36d0c0fb68765c03769a6366063c162add7945f0af21c19775a01'
 
   # github.com/WPIRoboticsProjects/GRIP was verified as official when first introduced to the cask
   url "https://github.com/WPIRoboticsProjects/GRIP/releases/download/v#{version}/GRIP-#{version}-x64.dmg"
   appcast 'https://github.com/WPIRoboticsProjects/GRIP/releases.atom',
-          checkpoint: '12cb4d50279babdf1bc6d6a65cd8906f69fdf0f12d8cf8f9c978cc9bac94e4bd'
+          checkpoint: '351ceeb68abdf0593404e7a01c0510f4fbc45e83dad0b7c6dbfbd4e18c458b1a'
   name 'GRIP Computer Vision Engine'
   name 'GRIP'
   homepage 'https://wpiroboticsprojects.github.io/GRIP/'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
