### PR TITLE
Update gpgtools to 2016.10_v2

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -1,10 +1,10 @@
 cask 'gpgtools' do
-  version '2016.08_v2'
-  sha256 'f539601722597cef7710e6235fa343759944b4e39b456cb91104857007e9c10e'
+  version '2016.10_v2'
+  sha256 '8dbc5821876ca5c470d0127087f782ba02a842c52e6e19336cd935db7c5859ab'
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast 'https://gpgtools.org/releases/gka/appcast.xml',
-          checkpoint: '0c1cf1f2047fec41cf3af68106302f906fd593e8403b4a11b5877dbd1feb5091'
+          checkpoint: 'a5e963e76b0096573035e1c77860a1d65a312afde1b4354fc1e7c2dc31a0ab08'
   name 'GPG Suite'
   homepage 'https://gpgtools.org/'
   gpg "#{url}.sig",


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
