### PR TITLE
Update postman to 4.8.0

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,11 +1,11 @@
 cask 'postman' do
-  version '4.7.2'
-  sha256 '37fe48d2a42559ce69520d089ca83a42c07a5057a18805f6a242e3841c28f562'
+  version '4.8.0'
+  sha256 'b66d3f74b95d5116b04345eb358b81e5615957caa1794b012d175fb21ff252e4'
 
   # s3.amazonaws.com/postman-electron-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/postman-electron-builds/mac/Postman-osx-#{version}.zip"
   appcast 'https://app.getpostman.com/api/electron_updates_auto',
-          checkpoint: 'fc712ff9a9720e2220a7630733ee589ede1bd26f685b3ccda454f4e3cbbeba75'
+          checkpoint: '5e127eb1fd7d0a137ddd33c6f7124e46af214964acf8837a432e4df63181b29d'
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download postman` is error-free.
- [x] `brew cask style --fix postman` reports no offenses.
- [x] The commit message includes the cask’s name and version.
