### PR TITLE
Deal with HazelHelper when uninstalling Hazel

### DIFF
--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -11,8 +11,11 @@ cask 'hazel' do
 
   prefpane 'Install Hazel.app/Contents/Resources/Hazel.prefPane'
 
+  uninstall quit: 'com.noodlesoft.HazelHelper'
+
   zap delete: [
                 '~/Library/Application Support/Hazel',
                 '~/Library/Preferences/com.noodlesoft.Hazel.plist',
+                '~/Library/Preferences/com.noodlesoft.HazelHelper.plist',
               ]
 end


### PR DESCRIPTION
- Make sure that HazelHelper quits on uninstall.
- Delete HazelHelper.plist on zap.
