### PR TITLE
Revert "Update libreoffice to 5.2.2" to "Update libreoffice to 5.2.1"

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '5.2.2'
-  sha256 '73b501e710a51016f80c38f4104021114a35c578b68ad48ac7e237a36bd015a4'
+  version '5.2.1'
+  sha256 '6e968525f849ac93572926118c3ac1b79abd3d0ee18ec870cb45abea34077503'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
Hi all,

It looks like LibreOffice 5.2.2 is disappeared:
http://download.documentfoundation.org/libreoffice/stable/
even we still can found 5.2.2.x [here](http://downloadarchive.documentfoundation.org/libreoffice/old/).

Maybe we should revert this PR: caskroom/homebrew-cask#25011
