### PR TITLE
Update 1password to 6.3.4

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -16,8 +16,8 @@ cask '1password' do
 
     app "1Password #{version.major}.app"
   else
-    version '6.3.3'
-    sha256 '9b8c4c102c4459272865494158542456f18bc564ddc4776561a58bb95b5eb380'
+    version '6.3.4'
+    sha256 'cdede5056e7c60a09c65a15e2d9b4e4cd70488e95ead637be0881736508c246d'
 
     # d13itkw33a7sus.cloudfront.net was verified as official when first introduced to the cask
     url "https://d13itkw33a7sus.cloudfront.net/dist/1P/mac4/1Password-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
