### PR TITLE
Update intensify-pro to 1.2.3_952

### DIFF
--- a/Casks/intensify-pro.rb
+++ b/Casks/intensify-pro.rb
@@ -1,11 +1,11 @@
 cask 'intensify-pro' do
-  version '1.2.2_867'
-  sha256 '6f259029ea928f92efdafe98706d341bd6418d8195374183758ab4cbc6a665c5'
+  version '1.2.3_952'
+  sha256 '147cc6db790e3ea6d7d51fbbcde5c27957cc4df24120b1ec79afde2d70d44dd5'
 
   # amazonaws.com/IntensifyCK was verified as official when first introduced to the cask
   url "https://creativekit.s3.amazonaws.com/IntensifyCK/IntensifyCK_Distribution_v#{version.dots_to_underscores}.zip"
   appcast 'http://cdn.macphun.com/updates/IntensifyPro/appcast.xml',
-          checkpoint: 'a617011d8dbc7e3223a1cefafbe1ab1a83ec9f7adea37827da2f8115519ec1f8'
+          checkpoint: 'dd6bc7a7e2b41782984ed47a7e4edc7af2898990bbdd5b9c61f85f6d63523ab0'
   name 'Intensify Pro'
   homepage 'https://macphun.com/intensify'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
