### PR TITLE
Update keytty to 1.2.0,1476667481

### DIFF
--- a/Casks/keytty.rb
+++ b/Casks/keytty.rb
@@ -1,11 +1,11 @@
 cask 'keytty' do
-  version '1.1.9,1476234897'
-  sha256 '9cfa4ab7d7567cb801df4c895ec92afff9903947977581a8c217d26545891bfe'
+  version '1.2.0,1476667481'
+  sha256 '20d6d6d3a8a935b9edee353b7f39a394c89ef9e2ab349b74c5a47d1b95af1c03'
 
   # dl.devmate.com/com.keytty.Keytty was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.keytty.Keytty/#{version.before_comma}/#{version.after_comma}/keytty-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.keytty.Keytty.xml',
-          checkpoint: '311b96382866211a4ffe441d344746798b25764e17f47df98ac2a5b9eb9fd58a'
+          checkpoint: '387ed2865a3ac036f27bc112b012fd46d408f3a5ed035d708a567fef58ba58a9'
   name 'Keytty'
   homepage 'http://keytty.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
