### PR TITLE
Update porting-kit to 2.4.79

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,10 +1,10 @@
 cask 'porting-kit' do
-  version '2.4.63'
-  sha256 'c51c6f0904e48dc045d0c3471e2b5beea76550ce7fb5cdce0187a048f092654e'
+  version '2.4.79'
+  sha256 '6f47b1eb365e26003c75641912a7147d1e1feae6d374acb10b78cc2a90b9d53f'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '77e6b989ddd3913979d0f8ed6dd8abde452ed94285d1087fd2da36701289ef84'
+          checkpoint: 'cf58a8648931f04d89260b072501fbbb1c56c23ad365a46549eb53a399494d23'
   name 'Porting Kit'
   homepage 'http://portingkit.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
