### PR TITLE
Update tableflip to 1.0.3

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,11 +1,11 @@
 cask 'tableflip' do
-  version '1.0.2'
-  sha256 '4178b77fb8b458560a191320e6009d1ac3c3e32eac95c0a2b05774edf0fcfaac'
+  version '1.0.3'
+  sha256 'df0634628f0d451f0bbe8ae9b7efa7cadd51d815986a3866a60f85a161ca0e1b'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"
   appcast 'https://update.christiantietze.de/tableflip/v1/release.xml',
-          checkpoint: '75935eb49c8ba7bde902f3bb7d10d94b80154143f880059d0844ee421c7d09c6'
+          checkpoint: '97881da35c6d0e9e45d6d7acebcf487840c41ae9cf14aea6166dac0c7e16ce65'
   name 'TableFlip'
   homepage 'http://tableflipapp.com'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
