### PR TITLE
Update vimr to v0.9.0-SNAPSHOT-20161017.2152-107

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,14 +1,15 @@
 cask 'vimr' do
-  version 'v0.9.0-SNAPSHOT-20161017.2152-107'
+  version '0.9.0-SNAPSHOT-20161017.2152-107'
   sha256 '0ef84f2f2dddce3d0a4ab1c7578bf28d3ecd24d12e9554b7cac610974e4af447'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
-  url "https://github.com/qvacua/vimr/releases/download/snapshot%2f#{version}/VimR-#{version}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/snapshot%2fv#{version}/VimR-#v{version}.tar.bz2"
   appcast 'https://raw.githubusercontent.com/qvacua/vimr/master/appcast.xml',
           checkpoint: 'ee806d0b9294d6a886dc659f951a250fe3d4bbfcb75d919a8cc7768d922dd1b4'
-  auto_updates true
   name 'VimR'
   homepage 'http://vimr.org/'
+
+  auto_updates true
 
   app 'VimR.app'
   binary "#{appdir}/VimR.app/Contents/Resources/vimr"

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -3,7 +3,7 @@ cask 'vimr' do
   sha256 '0ef84f2f2dddce3d0a4ab1c7578bf28d3ecd24d12e9554b7cac610974e4af447'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
-  url "https://github.com/qvacua/vimr/releases/download/snapshot%2fv#{version}/VimR-#v{version}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/snapshot%2fv#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
           checkpoint: 'ee806d0b9294d6a886dc659f951a250fe3d4bbfcb75d919a8cc7768d922dd1b4'
   name 'VimR'

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -4,7 +4,7 @@ cask 'vimr' do
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/snapshot%2fv#{version}/VimR-#v{version}.tar.bz2"
-  appcast 'https://raw.githubusercontent.com/qvacua/vimr/master/appcast.xml',
+  appcast 'https://github.com/qvacua/vimr/releases.atom',
           checkpoint: 'ee806d0b9294d6a886dc659f951a250fe3d4bbfcb75d919a8cc7768d922dd1b4'
   name 'VimR'
   homepage 'http://vimr.org/'

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.8.0-32'
-  sha256 '8660e7d5157b3165faab8a228f67a1bd63016c51bc300af131b90edc18dda678'
+  version 'v0.9.0-SNAPSHOT-20161017.2152-107'
+  sha256 '0ef84f2f2dddce3d0a4ab1c7578bf28d3ecd24d12e9554b7cac610974e4af447'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
-  url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-#{version.sub(%r{-.*}, '')}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/snapshot%2f#{version}/VimR-#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'cfd99e9ff5feb321bde77647d980df524d1522c8203df977f7a245254020c250'
+          checkpoint: 'e4d44a53c967f8fc2e23d0d674bbc0e55875312431d6bc0944f5fff3a9cf7918'
   name 'VimR'
   homepage 'http://vimr.org/'
 

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -4,8 +4,9 @@ cask 'vimr' do
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/snapshot%2f#{version}/VimR-#{version}.tar.bz2"
-  appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'e4d44a53c967f8fc2e23d0d674bbc0e55875312431d6bc0944f5fff3a9cf7918'
+  appcast 'https://raw.githubusercontent.com/qvacua/vimr/master/appcast.xml',
+          checkpoint: 'ee806d0b9294d6a886dc659f951a250fe3d4bbfcb75d919a8cc7768d922dd1b4'
+  auto_updates true
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
