### PR TITLE
Update visualvm to 1.3.9

### DIFF
--- a/Casks/visualvm.rb
+++ b/Casks/visualvm.rb
@@ -1,10 +1,13 @@
 cask 'visualvm' do
-  version '1.3.8'
-  sha256 'dae23a7625f543f14f86f846e590dae308df4c27dd64eda4ab8d85b9078e35bd'
+  version '1.3.9'
+  sha256 '969708277eacfbaf1a0bc465110db454efd8225aa43db090109676bedff386b6'
 
-  url "https://java.net/downloads/visualvm/release138/VisualVM_#{version.no_dots}.dmg"
+  # github.com/visualvm was verified as official when first introduced to the cask
+  url "https://github.com/visualvm/visualvm.src/releases/download/#{version}/VisualVM_#{version.no_dots}.dmg"
+  appcast 'https://github.com/visualvm/visualvm.src/releases.atom',
+          checkpoint: 'dde5d93c09ce408c053b472040a2e2bfb0c283152722968c7da55985489cac41'
   name 'VisualVM'
-  homepage 'https://visualvm.java.net'
+  homepage 'https://visualvm.github.io'
 
   app 'VisualVM.app'
 

--- a/Casks/visualvm.rb
+++ b/Casks/visualvm.rb
@@ -2,7 +2,7 @@ cask 'visualvm' do
   version '1.3.9'
   sha256 '969708277eacfbaf1a0bc465110db454efd8225aa43db090109676bedff386b6'
 
-  # github.com/visualvm was verified as official when first introduced to the cask
+  # github.com/visualvm/visualvm.src was verified as official when first introduced to the cask
   url "https://github.com/visualvm/visualvm.src/releases/download/#{version}/VisualVM_#{version.no_dots}.dmg"
   appcast 'https://github.com/visualvm/visualvm.src/releases.atom',
           checkpoint: 'dde5d93c09ce408c053b472040a2e2bfb0c283152722968c7da55985489cac41'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

N.B.: VisualVM has moved sites from https://visualvm.java.net to https://visualvm.github.io/, as explained in https://visualvm.github.io/relnotes.html#changes.
