### PR TITLE
Updates boostnote to v0.7.1

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.7.0'
-  sha256 'd56242ce3c58d90502fa6fcd87f6096f80c449690c8ccc53c16b6c202aef0544'
+  version '0.7.1'
+  sha256 'f8fd7e2ec544a7fbc8bb627a7349555c00ee800f7ed7a522c1bacdf7af31962f'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '6409c85196d05b35a86505f0c20e89be7f2cb79d13f2a56162147bcba80f5a20'
+          checkpoint: '2aff9d48ba3431e3b0e22758a0720e873168709f7508bd4b9b7abb4f7bd62840'
   name 'Boostnote'
   homepage 'https://b00st.io'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
