### PR TITLE
Update mist to 0.8.6

### DIFF
--- a/Casks/mist.rb
+++ b/Casks/mist.rb
@@ -1,10 +1,10 @@
 cask 'mist' do
-  version '0.8.4'
-  sha256 '50efcacfce0278269e8edd89aa91178c0ba00d9584fc019e25863939d0acf6ac'
+  version '0.8.6'
+  sha256 '3a66606aad465d8295e29e9711f5e76630c36bfd6064966ed6b7b4c194320acd'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: '2d7732efec4c6ae0075a4bb955750dc4fd8e78874abe2c5216e527c25aa3d9b9'
+          checkpoint: '4377f696a120458187946696684e3a39cac3e1ca9931069d36299c52f87e998e'
   name 'Mist'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
