### PR TITLE
Update remote-desktop-manager to 3.6.1.1

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager' do
-  version '3.5.2.0'
-  sha256 '8f4fb5737686f74ad01010a31dc93c259c48ae2babe07951652200f024debda1'
+  version '3.6.1.1'
+  sha256 'd46cd3ae3ad0e9e2d4d8da78508c380397fa36f12980eb7bddc991d2220f4ea7'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
