### PR TITLE
Update omnioutliner to 4.6.1

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,6 +1,6 @@
 cask 'omnioutliner' do
-  version '4.6'
-  sha256 'e5f4e589a2c1a3f1cb1e3059a763f063f73cdd591b01d312ee4f9b01188ceb61'
+  version '4.6.1'
+  sha256 '47652e8b46be40a5fc71eff16d7b621fa99bc07951f11f5445cacea5ee15ff2a'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniOutliner-#{version}.dmg"
   name 'OmniOutliner'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
