### PR TITLE
Update little-flocker to 1.0.0

### DIFF
--- a/Casks/little-flocker.rb
+++ b/Casks/little-flocker.rb
@@ -1,6 +1,6 @@
 cask 'little-flocker' do
-  version '0.99.95'
-  sha256 'eac6662b5c85891ebbb7920f548a65257e2f708d70767bfc0a89b4025805546d'
+  version '1.0.0'
+  sha256 '83e44bdb5f941803a6627ad346616be32f9c12853072221c4028bcdba3cee795'
 
   # zdziarski.com/littleflocker was verified as official when first introduced to the cask
   url "https://www.zdziarski.com/littleflocker/LittleFlocker-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
