### PR TITLE
suspicious-package: use .dmg instead of .xip

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -2,7 +2,7 @@ cask 'suspicious-package' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.mothersruin.com/software/downloads/SuspiciousPackage.xip'
+  url 'http://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
   name 'Suspicious Package'
   homepage 'http://www.mothersruin.com/software/SuspiciousPackage/'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Suspicious Package is now distributed as .dmg since Apple has
removed support for .xip archives (except for those signed by
Apple) in Sierra.
