### PR TITLE
Update wordpresscom to 1.8.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '1.4.0'
-  sha256 'c1bcedae572caf6b5aaedeb9448f0ac4155b338d308f99d12ea449b9d9e43550'
+  version '1.8.0'
+  sha256 'd4d1bc63dc862d8c5e1fb59a6bcd348711f4e46377038e3e13d986362bbe8889'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: '67c301ee7c79b1c161c3d0a8691d267032489baf850ba8aecc4b9f5f3dcc3d87'
+          checkpoint: '960cd9d04fc8be4d43d8ade4e64236116b2f050db4a7ab15aed059f390a2865c'
   name 'WordPress.com'
   homepage 'https://desktop.wordpress.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
