### PR TITLE
Update brave to 0.12.5dev

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.12.4dev'
-  sha256 'e6cf20329fbbacaf96f433a47d89302b7422f54959df3952a0cc350111f55040'
+  version '0.12.5dev'
+  sha256 '20926723d628afa805de3146e820382e773223e599f7e804bf57a35670eb9cc4'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'adde91f3d0bc8c80019360e98b0fe05a1b9ddd6b597134217ee67924fecf5373'
+          checkpoint: '558bfc0a40b89f08c171cbc140a497d3a03fbceabaf3b2686f038d1e7d8b9105'
   name 'Brave'
   homepage 'https://brave.com'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
