### PR TITLE
Update hypo to 0.5.6

### DIFF
--- a/Casks/hypo.rb
+++ b/Casks/hypo.rb
@@ -1,11 +1,11 @@
 cask 'hypo' do
-  version '0.5.5'
-  sha256 'efd4703fd13d8bf527f8b3965f200de7737673e26f63b5e831208f2d7fc6fbbd'
+  version '0.5.6'
+  sha256 'd18f2e44dd23265280fb8eb28015006c93c5bbf98794437fbd7acd4f531028ae'
 
   # hypo.github.io was verified as official when first introduced to the cask
   url "https://hypo.github.io/HypoAppPublic/hypo-#{version}.app.tbz"
   appcast 'https://hypo.github.io/HypoAppPublic/appcast.xml',
-          checkpoint: '3e4b2547c4e1f3fdcf9cfa52ad540f2df3ed1e60ae167eb6c9b8b9f19ec57850'
+          checkpoint: '8c662005d5f4ea9c75c0cbc53e5e0f432fedcf6d9dad6e8007ea8a12acccbe17'
   name 'hypo'
   homepage 'https://hypo.cc/mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
