### PR TITLE
Update mailbutler to 6537

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6476'
-  sha256 'caf33e04484b49b82633caa348904e12b383da5521b4e6f67bc99fe202f1108a'
+  version '6537'
+  sha256 '5179c325c1e318ae7ed5d30241d7f031b98895b6d6daae0ed62b16d551b9656e'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '28df436c619b0fd0056da7d6521c59acb102a2b141f0800e97317c3f75facc77'
+          checkpoint: '2dc981c07e840dd08a7238da15c662e9e0160c74896e044b7c8fbd914163c3d4'
   name 'MailButler'
   homepage 'https://www.feingeist.io/mailbutler/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
