### PR TITLE
Update polymail to 1.11

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.10'
-  sha256 '424c2c76fb90a2549c1beafba3f0ad92ffdc53b1494055e8f1f49b3c03e33f94'
+  version '1.11'
+  sha256 '3878022fb092d1916cb92c23cf630eed0117cbdcd205dd9512312cd66d1b0db5'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'a4b5d9383f754e13dd4a4d4a36ce3b6edfd5022712fd8e313a14e45534414e6c'
+          checkpoint: '70aa28877800cd5be16699be8e926e61fc5ca2aa26559f6ea50de0a78c37eaf7'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
