### PR TITLE
Update tower to 2.5.2-334-bc7e6fb8

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,11 +1,11 @@
 cask 'tower' do
-  version '2.5.1-329-2d945c27'
-  sha256 '309a334c11f3da29f7bbee88d52e38935fc7d2701cecc0f63c3c7b76b09dfc98'
+  version '2.5.2-334-bc7e6fb8'
+  sha256 '16f84397d3d323c1e810bf7421d429bde37c04e261aeaf6a35d1037c17d5607f'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.sub(%r{^[^\-]+\-}, '')}/Tower-#{version.major}-#{version.sub(%r{-[^-]+$}, '')}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable",
-          checkpoint: 'e6f8b40c3b27f552c30d74fa6528e4f249be4f899f2afb1e4e276aad57b6b982'
+          checkpoint: 'e3301dc2ed75b2d55109fb79e3e3fe83a0d3d88ce75b97ae8d6f559fd02a20e2'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
