### PR TITLE
Update torguard to 0.3.55

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,11 +1,11 @@
 cask 'torguard' do
-  version '0.3.54'
-  sha256 '40af4c1ff05e1981c3bbc52efc5ae87dfa561770cc70c729d482dc8a1db60d0b'
+  version '0.3.55'
+  sha256 'ff38d516eda250d9c46adeeadedd542c54d0036c4c9bfaf0b2655585311b178c'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"
   appcast 'https://updates.torguard.biz/Software/MacOSX/checksums.sha256',
-          checkpoint: '5eeb07d71d1faec9dce4f2cdcc5e8d3790c7c26554f16ab5400f44967b7d1ab6'
+          checkpoint: '4dd3ec96038024d3636eb111933bbf3ec4fad3e9ffaf645a6f1d21c8f0f6f09e'
   name 'TorGuard'
   homepage 'https://torguard.net/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
