### PR TITLE
Update pastebot to 2.0.b8

### DIFF
--- a/Casks/pastebot.rb
+++ b/Casks/pastebot.rb
@@ -1,6 +1,6 @@
 cask 'pastebot' do
-  version '2.0.b7'
-  sha256 '01b0bfccd1904b8b087fe4aeb0a09d0791f0cf176e5090893381d4c42fb6904e'
+  version '2.0.b8'
+  sha256 'c9244e65a49f83d0062e651bbf2641e5aa7d02a6c2fbca6fb242928706838086'
 
   # tapbots.net/pastebot was verified as official when first introduced to the cask
   url "https://tapbots.net/pastebot#{version.major}/PastebotBeta.zip"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
