### PR TITLE
Update baidunetdisk.rb for zap

### DIFF
--- a/Casks/baidunetdisk.rb
+++ b/Casks/baidunetdisk.rb
@@ -3,10 +3,20 @@ cask 'baidunetdisk' do
   sha256 '06a3477139a2c96fc8ceaa3a59c1a65dc0b57ec9a069f2f6356067778ae2014f'
 
   # baidupcs.com/issue/netdisk/MACguanjia was verified as official when first introduced to the cask
-  url "http://issuecdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
+  url "https://issuecdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
   name 'Baidu NetDisk'
   name '百度网盘'
-  homepage 'http://pan.baidu.com/download#pan'
+  homepage 'https://pan.baidu.com/download'
 
   app 'BaiduNetdisk_mac.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.baidu.BaiduNetdisk-mac',
+                '~/Library/Caches/com.baidu.BaiduNetdisk-mac',
+                '~/Library/Caches/com.plausiblelabs.crashreporter.data/com.baidu.BaiduNetdisk-mac',
+                '~/Library/Cookies/com.baidu.BaiduNetdisk-mac.binarycookies',
+                '~/Library/Preferences/com.baidu.BaiduNetdisk-mac.plist',
+                '~/Library/sapi/wappass.baidu.com',
+                '~/Library/Saved Application State/com.baidu.BaiduNetdisk-mac.savedState',
+              ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update baidunetdisk.rb for zap
