### PR TITLE
update cryptomator (1.2.0)

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.1.4'
-  sha256 '390bd9bd3ea950238600df41809d63e6b6a905260e3a5a47d14ec6fecca637ad'
+  version '1.2.0'
+  sha256 'fa743d7520467f6213e47a6fc058bb7ac7d28f8a3742d49f5bb01677b23df22f'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
