### PR TITLE
Update eclipse-java to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-java' do
-  version '4.6.0'
-  sha256 'cc776030aac93ca313c2e7791f3368af399d595c6979e421ca7c36c180de3c96'
+  version '4.6.1,neon:1a'
+  sha256 'a9ab1f02baf01f50b2601ed9d4cf2489e68bec41c1909d7905e68c149792a543'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-java-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz"
   name 'Eclipse IDE for Java Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
