### PR TITLE
Update eclipse-cpp to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-cpp' do
-  version '4.6.0'
-  sha256 '200144b4ca54d0e77572c66d249c3138e4186bb22f9404988c2cc6ea79d98f16'
+  version '4.6.1,neon:1a'
+  sha256 '1f4bcc0e1766b8441a11fc11e5bf8204a715d91dc818bfc481df8dc317a5c18b'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-cpp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse IDE for C/C++ Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
