### PR TITLE
Update eclipse-php to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-php' do
-  version '4.6.0'
-  sha256 '763b2e6f41277f61d377ed15aa7c6277f0a308c9b162ff00ffab46a823fc0865'
+  version '4.6.1,neon:1a'
+  sha256 '4126090e0c88f97eac863e75a2657a4b6d29e7dac724dba28e95c4e32ce948d3'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-php-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-php-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse for PHP Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
