### PR TITLE
Update eclipse-rcp to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-rcp' do
-  version '4.6.0'
-  sha256 '5460e51dea3a58415f15cb59258aca067a95c958fb5a3e24b3bbf7a7fd7d616e'
+  version '4.6.1,neon:1a'
+  sha256 'f76df9e10f889b6ca2877e361717c847c3bbc0a3d69256df3583ee88ccb4068e'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-rcp-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-rcp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse for RCP and RAP Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
