### PR TITLE
Update eclipse-ide to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-ide' do
-  version '4.6.0'
-  sha256 '8a8a07e3cd597ffc937f7074eb60713343217976a8f167645d1ed3bd543bcf97'
+  version '4.6.1,neon:1a'
+  sha256 '67eb608808e54011570d6b3c5f6ca0e360e397e80d92accc8f9e361ca7522125'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-committers-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse IDE for Eclipse Committers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
