### PR TITLE
Update eclipse-ptp to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-ptp' do
-  version '4.6.0'
-  sha256 '7eab1605dce524abb872185d184e8033b02e8a2c9fd23005a4c15224b4712803'
+  version '4.6.1,neon:1a'
+  sha256 '6bf6d6ceac99616a621f30b63ac720299d6264de439603b259148d7a2f61a311'
 
-  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/R/eclipse-parallel-neon-R-macosx-cocoa-x86_64.tar.gz&r=1'
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-parallel-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse for Parallel Application Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
