### PR TITLE
Update eclipse-installer to 4.6.1,neon:1a

### DIFF
--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-installer' do
-  version :latest
-  sha256 :no_check
+  version '4.6.1,neon:1a'
+  sha256 '6dbfc18fa2fde0bc5fe497b5383f7e6029107f24240c35df74abfb66c0862ded'
 
-  url 'https://eclipse.org/downloads/download.php?file=/oomph/epp/neon/R1/eclipse-inst-mac64.tar.gz&r=1'
+  url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.after_comma.before_colon}/R1/eclipse-inst-mac64.tar.gz&r=1"
   name 'Eclipse Installer'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
