### PR TITLE
Update helm to version 2.0.0-beta.1

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -1,13 +1,15 @@
 cask 'helm' do
-  version '2.0.0-alpha.5'
-  sha256 '62b45875666fda9cfc837d7861e5b6d7e36cd9ebd9b62652e6969bbdf01752da'
+  version '2.0.0-beta.1'
+  sha256 '26a9aa7d04afed6f2fe71481bc6b66b7aab48e659e5ebd85682c138a29cef83e'
 
   # storage.googleapis.com/kubernetes-helm/ was verified as official when first introduced to the cask
   url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
-          checkpoint: '89bc384e94e30b530e8afce2db165db31c3e18465077de889255d166a9110d44'
+          checkpoint: '2e716c3cd2469e7284be892bba510a77a5e3c8f83041f16aeef5a61a5369ad9c'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
+
+  depends_on arch: :x86_64
 
   binary 'darwin-amd64/helm'
 end

--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -9,7 +9,5 @@ cask 'helm' do
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
 
-  depends_on arch: :x86_64
-
   binary 'darwin-amd64/helm'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
