### PR TITLE
Update wmail to 2.0.0

### DIFF
--- a/Casks/wmail.rb
+++ b/Casks/wmail.rb
@@ -9,5 +9,5 @@ cask 'wmail' do
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 
-  app 'WMail-darwin-x64/WMail.app'
+  app 'WMail.app'
 end

--- a/Casks/wmail.rb
+++ b/Casks/wmail.rb
@@ -1,11 +1,11 @@
 cask 'wmail' do
-  version '1.3.1'
-  sha256 '2b8c14ed9b2616e1c32a33601293edc585e1fa0a1b16c1c07798ffdd590fbcfb'
+  version '2.0.0'
+  sha256 '881013bf9808777fc1b773a6e94d3f33881b9ab431c19500d6bd53d18b0d455a'
 
   # github.com/Thomas101/wmail was verified as official when first introduced to the cask
-  url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_osx.zip"
+  url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/Thomas101/wmail/releases.atom',
-          checkpoint: '88a65d3952c7868e1f5f5bdb974a2ac84dad1e55393a8751f170e95ae5d1ba1f'
+          checkpoint: 'ee718bdeba42a54b3a11e716dbc52027d98d7576cfcbeb20493ec40a746c9e0e'
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
