### PR TITLE
Update turbo-boost-switcher to 2.3.0

### DIFF
--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -1,9 +1,9 @@
 cask 'turbo-boost-switcher' do
-  version '2.2.0'
-  sha256 '60d78611a03e31d535e53545177d65c57f1f16dcee959ecabeb28a2e082698ae'
+  version '2.3.0'
+  sha256 'd8872ab5b3033d0889db0dec85b3bfa156fac7674eeb771663ae3b29596e06df'
 
   # s3.amazonaws.com/turbo-boost-switcher was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/turbo-boost-switcher/Turbo_Boost_Switcher_v#{version}.zip"
+  url "https://s3.amazonaws.com/turbo-boost-switcher/Turbo+Boost+Switcher_#{version}.zip"
   name 'Turbo Boost Switcher'
   homepage 'http://www.rugarciap.com/turbo-boost-switcher-for-os-x/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
