### PR TITLE
.travis.yml: Update osx_image versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,8 @@ env:
 
 matrix:
   include:
-    - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
-      os: osx
-      osx_image: xcode8
-      rvm: system
-    - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
-      os: osx
-      osx_image: xcode7.3
-      rvm: system
+    - osx_image: xcode8
+    - osx_image: xcode7.3
   fast_finish: true
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
   include:
     - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       rvm: system
-    - env: OSX=10.10 HOMEBREW_RUBY=2.0.0
+    - env: OSX=10.11 HOMEBREW_RUBY=2.0.0
       os: osx
-      osx_image: xcode7.1
+      osx_image: xcode7.3
       rvm: system
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ env:
 
 matrix:
   include:
-    - osx_image: xcode8
-    - osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode8
+      rvm: system
+    - os: osx
+      osx_image: xcode7.3
+      rvm: system
   fast_finish: true
 
 branches:


### PR DESCRIPTION
Ref:

In order to give users who explicitly use some of our less common Xcode versions some time to transition, we'll be maintaining all the current images through Monday, October 31st. On Oct. 31 we will be simplifying our image catalog to the following three available options:

osx_image: xcode6.4 (with 10.10)
osx_image: xcode7.3 (with 10.11 and default)
osx_image: xcode8 (currently 10.11, but tentatively planned to be 10.12 once we've done some vSphere compatibility testing)
