### PR TITLE
Update telegram to 2.27-51120

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.26-51005'
-  sha256 '76f8b4a989534b5720ac665a44242573e5b1e8a00863e20cf69e69dd12a2a6c3'
+  version '2.27-51120'
+  sha256 '4fda51a83b90134ad28dc9f652bd421d4e78d82f6ed52b22874a7d9120fa1f76'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '77a07fbbe09f33a659ea0ca14d899c14fd88dfd17225c55289d64206090a7883'
+          checkpoint: 'be255033b99e0ea72d0d0ef8f2f8b326ec87e81688bd5b19405ba148eb83ccaa'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
