### PR TITLE
terminology: switch to artifact

### DIFF
--- a/Casks/terminology.rb
+++ b/Casks/terminology.rb
@@ -6,7 +6,9 @@ cask 'terminology' do
   name 'terminology'
   homepage 'https://agiletortoise.com/terminology/mac/'
 
-  installer script: 'Terminology-for-OS-X/Install.command', sudo: false
+  artifact 'Terminology-for-OS-X/Terminology.dictionary', target: "#{ENV['HOME']}/Library/Dictionaries/Terminology.dictionary"
 
-  uninstall delete: File.expand_path('~/Library/Dictionaries/Terminology.dictionary')
+  caveats <<-EOS.undent
+    To activate, open Dictionary.app and check "Terminology" in preferences.
+  EOS
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

As mentioned in #26029, the artefact is a nicer solution for standard accounts, where `sudo` would otherwise be required. There is no need to use the installation script anyway.
