### PR TITLE
busycal: uninstall - delete BusyCal.app

### DIFF
--- a/Casks/busycal.rb
+++ b/Casks/busycal.rb
@@ -11,6 +11,7 @@ cask 'busycal' do
   pkg 'BusyCal Installer.pkg'
 
   uninstall pkgutil: 'com.busymac.busycal3.pkg',
+            delete:  '/Applications/BusyCal.app',
             quit:    [
                        'com.busymac.busycal3',
                        'N4RA379GBW.com.busymac.busycal3.alarm',


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
