### PR TITLE
Update codekit to 2.9.1-19142

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,10 +1,10 @@
 cask 'codekit' do
-  version '2.9-19137'
-  sha256 'fe5063f82cf657e97cf718743b3513ff2615255c4c4c52a9ab5d9cb80c9956ff'
+  version '2.9.1-19142'
+  sha256 '8df162690d69ebb3f8995f06cc3e435ea6c0df15ceb6fb5f4b52c8e1d647f532'
 
   url "https://incident57.com/codekit/files/codekit-#{version.sub(%r{.*-}, '')}.zip"
   appcast 'https://incident57.com/codekit/appcast/ck2appcast.xml',
-          checkpoint: '68c472683d62647414d8a607008db38af917110f37afef586e6036fc9d2945ec'
+          checkpoint: 'd7f6c068fa4e310e604ed8c3a41a1d41dff5b97f4db9aa9b0d41fe0964b11d8c'
   name 'CodeKit'
   homepage 'https://incident57.com/codekit/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
