### PR TITLE
imagej, tinyumbrella: use depends_on_java caveat

### DIFF
--- a/Casks/imagej.rb
+++ b/Casks/imagej.rb
@@ -6,8 +6,11 @@ cask 'imagej' do
   name 'ImageJ'
   homepage 'https://imagej.nih.gov/ij/index.html'
 
-  depends_on cask: 'java'
   depends_on macos: '>= :mountain_lion'
 
   suite 'ImageJ'
+
+  caveats do
+    depends_on_java
+  end
 end

--- a/Casks/tinyumbrella.rb
+++ b/Casks/tinyumbrella.rb
@@ -7,7 +7,9 @@ cask 'tinyumbrella' do
   name 'TinyUmbrella'
   homepage 'https://www.firmwareumbrella.com/'
 
-  depends_on cask: 'java'
-
   app 'TinyUmbrella.app'
+
+  caveats do
+    depends_on_java
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
