### PR TITLE
Update mailbutler to 6545

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6537'
-  sha256 '5179c325c1e318ae7ed5d30241d7f031b98895b6d6daae0ed62b16d551b9656e'
+  version '6545'
+  sha256 'ada808a8b9671bc3cd3910ea2dbbd2301b587de2b01a48991354fa153be67503'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '2dc981c07e840dd08a7238da15c662e9e0160c74896e044b7c8fbd914163c3d4'
+          checkpoint: '3f7a5ead279f5b3fc5a20e52d19f3cd11a01527b37a4660e49581cbb4de538d7'
   name 'MailButler'
   homepage 'https://www.feingeist.io/mailbutler/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
