### PR TITLE
Update mountain-duck to 1.6.0.4947

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.5.8.4906'
-  sha256 'a411968a710d06e487a26151d465c45935b6ddca6ce4221dd480e203cd0e13ec'
+  version '1.6.0.4947'
+  sha256 '46ddf9eb34607dfe9717b871957ec275ffd230d5bd2af7a4ce3c660e11764259'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '875808506f655a7361e187a2b8e2e4c9ec9ab27e2b042edb7db42585cd67b227'
+          checkpoint: '31d74a9e3133ea63ce6f0ea536fbda5efc910792b6762b2e9ff8b0851017818c'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
