### PR TITLE
Update pdfpen to 821.5,1476995391

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,10 +1,10 @@
 cask 'pdfpen' do
-  version '820.3,1475632232'
-  sha256 'd1821d017719a188096f8f815c839ba48ac609f7c86c4a102caa7e58e33a6a1d'
+  version '821.5,1476995391'
+  sha256 'ffdc911d15c3f69b1b2e822bc73144db33832aff6b1b6d0dfc690f560c06b4de'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
-          checkpoint: '96b4784a02c764617a2625194816e63f227338bf7997a2cd5fc8342626a3fadb'
+          checkpoint: '6ade3bfe21c7b3bfdf8e3c4fdd21f9367d809ea2d168750927dcb46cafdc1294'
   name 'PDFpen'
   homepage 'https://smilesoftware.com/PDFpen/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
