### PR TITLE
Update qtpass to 1.1.5

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -1,11 +1,11 @@
 cask 'qtpass' do
-  version '1.1.4'
-  sha256 '46b1ec021bd4defbd407e74cb35eaeb93f2cc12b1214987f3d58e3dfec790efd'
+  version '1.1.5'
+  sha256 'a8f35ff258a520795c9079dda837d3b1cbbdcd8528cec2ddae68573504f4883f'
 
   # github.com/IJHack/qtpass was verified as official when first introduced to the cask
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: 'ff499dc0c1c79de926d52e62cfb7e2f4a8c07a27d69b1c15df140bec9b0cf52f'
+          checkpoint: 'e2efc86af57d6fcda7802285b02ab279ee97e106d1aa9539f5f4aec0c317e319'
   name 'QtPass'
   homepage 'https://qtpass.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
