### PR TITLE
Update qutebrowser to 0.8.2

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,11 +1,11 @@
 cask 'qutebrowser' do
-  version '0.8.1'
-  sha256 'e9541a90ad411be95e568ff16bcd083cf43496816bf41ee4ddc10e9fe808464c'
+  version '0.8.2'
+  sha256 'f8a646191577c2cd8f584ed72dff92381f89c265cd33f825c96183a82d653076'
 
   # github.com/The-Compiler/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/The-Compiler/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/The-Compiler/qutebrowser/releases.atom',
-          checkpoint: 'f43d2512e2ced0ecd3cfae96424c614fd7ca1370f4e07d49c191a413e7475aac'
+          checkpoint: 'a72cec31165988a3c8ad50e94818e6da163437f4a2d5f008ff99e4c9cf158740'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
