### PR TITLE
Update mucommander to 0.9.1

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,11 +1,11 @@
 cask 'mucommander' do
-  version '0.9.0'
-  sha256 '24665a248bd0f027b399277c2e7096a57e75120048302f3ac2f89ce4f7f1acae'
+  version '0.9.1'
+  sha256 'e623a1ecdf198fae40d8f42a8898667f5fc38efbc158bfc01df6c0b746d22934'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
-  url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version.dots_to_underscores}.dmg"
+  url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"
   appcast 'https://github.com/mucommander/mucommander/releases.atom',
-          checkpoint: '8bd765c3f40255e49f6434a7a768cc459a4010ab73ed51c408868789576c1f37'
+          checkpoint: '2aded0eaec7e02ec75e1be9a3321cb3b142f9a798bba3d772facd626ac22d7bf'
   name 'muCommander'
   homepage 'http://www.mucommander.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
