### PR TITLE
Updated Droplr to 4.6.4 (Build 91)

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -4,8 +4,8 @@ cask 'droplr' do
 
   # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"
-  name "Droplr"
-  homepage "https://droplr.com/"
+  name 'Droplr'
+  homepage 'https://droplr.com/'
 
   auto_updates true
 

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,8 +1,8 @@
 cask 'droplr' do
-  version :latest
-  sha256 :no_check
+  version '4.6.4'
+  sha256 '41064cec1922fa76b15e940a747e3d12e720588fa3ab9a527b38ba3a683c531b'
 
-  url 'https://droplr.com/homebrew'
+  url 'https://s3.amazonaws.com/files.droplr.com/apps/mac/Droplr+91.zip'
   name 'Droplr'
   homepage 'https://droplr.com/'
 

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,10 +1,11 @@
 cask 'droplr' do
-  version '4.6.4'
-  sha256 '41064cec1922fa76b15e940a747e3d12e720588fa3ab9a527b38ba3a683c531b'
+  version "4.6.4,91"
+  sha256 "41064cec1922fa76b15e940a747e3d12e720588fa3ab9a527b38ba3a683c531b"
 
-  url 'https://s3.amazonaws.com/files.droplr.com/apps/mac/Droplr+91.zip'
-  name 'Droplr'
-  homepage 'https://droplr.com/'
+  # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"
+  name "Droplr"
+  homepage "https://droplr.com/"
 
   auto_updates true
 

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version "4.6.4,91"
-  sha256 "41064cec1922fa76b15e940a747e3d12e720588fa3ab9a527b38ba3a683c531b"
+  version '4.6.4,91'
+  sha256 '41064cec1922fa76b15e940a747e3d12e720588fa3ab9a527b38ba3a683c531b'
 
   # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Previous link (http://droplr.com/homebrew) links currently to an error
