### PR TITLE
Update brave to 0.12.6dev

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.12.5dev'
-  sha256 '20926723d628afa805de3146e820382e773223e599f7e804bf57a35670eb9cc4'
+  version '0.12.6dev'
+  sha256 'c4c637116ad291ee56efb71bfd9639d7f648f9c0bd94abcd27c9939c3f806d1e'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '558bfc0a40b89f08c171cbc140a497d3a03fbceabaf3b2686f038d1e7d8b9105'
+          checkpoint: 'ee13ac95cf643a6b751c2f3109a7045b1243918bd09a417bfe667f412202f8d8'
   name 'Brave'
   homepage 'https://brave.com'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
