### PR TITLE
Update mysqlworkbench to 6.3.8

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -1,6 +1,6 @@
 cask 'mysqlworkbench' do
-  version '6.3.7'
-  sha256 '06e7c87483b8851fa3c9baa6f784d76a8f099878abebdb56e8c22637b784ca12'
+  version '6.3.8'
+  sha256 '8bcaad64d9971caae23edd018b90537975c615310105dc6b19f8036dca80eef9'
 
   url "https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-osx-x86_64.dmg"
   name 'MySQL Workbench'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
