### PR TITLE
Update dripcap to 0.4.0

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.3.10'
-  sha256 'da431b636ba7fa7d5d286ccfac2a940e4c7a426f436fe9f17e140531e70c5274'
+  version '0.4.0'
+  sha256 '9fc18f5f0ed54236eb407c0bd9eac1d2674d8d6893bdc329f33ed02ad2d463e6'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: 'eaf3729dcdc2a4e441028b803b20829963ef63b4809d0c753b148dd4f5bcf833'
+          checkpoint: '0364bf3db4d8fd226f7db588a4706f3469de230f49babee50e3092310c6ff58e'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
