### PR TITLE
Update navicat-for-mariadb to 11.2.15

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '11.2.14'
-  sha256 '73f2b864cafbbeed2430d61b0463fdd9e68996215a72e1d900663a9922793803'
+  version '11.2.15'
+  sha256 '4d05fb39a67ab1a7f910e6a1215e1bcb29b0e54c834ed8a409a9e033858160cc'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   name 'Navicat for MariaDB'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
