### PR TITLE
Update navicat-for-mysql to 11.2.15

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '11.2.14'
-  sha256 '1bda45092337abc050d05220ef72ab9cd99f34571b7f94912123aef4d75965b6'
+  version '11.2.15'
+  sha256 '590b5f9d39ba42fde79923ae39723cdbe39fc4a8da31308e8bdf17f7ceb0addd'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   name 'Navicat for MySQL'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
