### PR TITLE
Update navicat-for-oracle to 11.2.15

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '11.2.14'
-  sha256 '25d9ef96d35f2a01bc5da652bac5c099cd9ef4a46edadeb90c757df4fd97771d'
+  version '11.2.15'
+  sha256 '4a179a71fe41c1202ddee3e976944e5592b90a2c2f5fe4ef2d1a516cdb25ff27'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   name 'Navicat for Oracle'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
