### PR TITLE
Update navicat-for-postgresql to 11.2.15

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '11.2.14'
-  sha256 '98fb9715f540ffb77bfe8de54cf99480b88434dd0ef077958b2be0ace5988c13'
+  version '11.2.15'
+  sha256 '36433d22ddfc9e463abe7b72ac4fb5a2e61e4e77c4a033e9f0365a8ca1ef6b5e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   name 'Navicat for PostgreSQL'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
