### PR TITLE
Update navicat-for-sql-server to 11.2.15

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '11.2.14'
-  sha256 'c60d1d493429b80cc380ff7ad880ed707fb005d428d46739de019b0085de468a'
+  version '11.2.15'
+  sha256 '45a967a43ba4f95a17a80d8fff2579bc17c81e17bb992db4055f7009b9575e6b'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   name 'Navicat for SQL Server'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
