### PR TITLE
Update lingon-x to 4.2.4

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '4.2.2'
-  sha256 'b8c11ecc456c63f22f8cf2a0abe27bcb453314458e36e7c6ba4a53c973c091f2'
+  version '4.2.4'
+  sha256 '8a8badc9b653ac59d6909df5fa782d0e2f04f2aacd7a44b70baadb7ce60596f0'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '451448d9b34721711926e5ec12d0cd79416858b149a0ed6ebdaacfe4181a59d6'
+          checkpoint: '16253916417aebe2d398a6d7b93e102bb41bfde3dae2604291b07b7214527ae0'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
