### PR TITLE
Update zotero to 4.0.29.15

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '4.0.29.14'
-  sha256 '9af1d5149fc3dcdc7a836112b024e311b5e325a071f512e6db8f005678cd4df9'
+  version '4.0.29.15'
+  sha256 'a31fc874771ab9799ef3b23feb31a87dbed2d23b9c4c9cc44baad4294c34580d'
 
   url "https://download.zotero.org/standalone/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '676bc665177ff8a48e2b0afc7563ab11560f0159590d770a224bcc50386a91fe'
+          checkpoint: '767016f135332e3bebb815ab21b4ec54babb84de4f3d59b789bc55208945ef18'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
