### PR TITLE
Update wesnoth to 1.12.6

### DIFF
--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -1,11 +1,11 @@
 cask 'wesnoth' do
-  version '1.12.4'
-  sha256 '1773d6d6441e121ed8e1a219acaa6cf0c7b24aefe58c5253fc71a16a165e350b'
+  version '1.12.6'
+  sha256 'c94fe7880b1ed0f52e31ad570d3f082412ffbeb9d7ddadf0c64d501dfc1f0589'
 
   # sourceforge.net/wesnoth was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/wesnoth/rss',
-          checkpoint: '3cefc3332267dc68bd9fb487ddb6a436360dc0d259507082a1fcba9ad94d3704'
+          checkpoint: 'f40c089c249d75fe9705712377818685f702500c34ae2d6aeab165dafac249f1'
   name 'The Battle for Wesnoth'
   homepage 'https://wesnoth.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
