### PR TITLE
Update munki to 2.8.2.2855

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,11 +1,11 @@
 cask 'munki' do
-  version '2.8.0.2810'
-  sha256 'f21e1c85bda04d703a1fcdc05c46a79bb32112c00ac43cfa2f50d782a85fb608'
+  version '2.8.2.2855'
+  sha256 '1a2221a5032921f7380f4d3517889ab52cc3a9f47a7cdeac16fbdb4a0e2279dd'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.sub(%r{^(\d+\.\d+.\d+).*}, '\1')}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: 'bb38df0b01ef55cf51bfc6ec6fff2750dc8740c6fc662ee6d118efeba82176ba'
+          checkpoint: '7daa2ae50f039d7cd9bc3a7b5688124878b8f845b79405041466c8fe6bc5b839'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
