### PR TITLE
Update proxifier.rb for appcast and zap

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -1,10 +1,19 @@
 cask 'proxifier' do
-  version :latest
-  sha256 :no_check
+  version '2.16'
+  sha256 'de592e28198deb22edc522c7ef6785d1a83b5f21e683c0dc6b7ab838ebda50c7'
 
   url 'https://www.proxifier.com/distr/ProxifierMac.zip'
+  appcast 'https://www.proxifier.com/distr/last_versions/ProxifierMac.txt',
+          checkpoint: '5c316b2043de3d51392e3b60fc0894167c9b2c8abb5d1fe91ccf9d9c0a2056c9'
   name 'Proxifier'
   homepage 'https://www.proxifier.com/mac/'
 
   app 'Proxifier.app'
+
+  zap delete: [
+                '~/Library/Application Support/Proxifier',
+                '~/Library/Caches/com.initex.proxifier.macosx',
+                '~/Library/Preferences/com.initex.proxifier.macosx.plist',
+                '~/Library/Saved Application State/com.initex.proxifier.macosx.savedState',
+              ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update proxifier.rb for appcast and zap
