### PR TITLE
Update blisk to 0.62.4925.237

### DIFF
--- a/Casks/blisk.rb
+++ b/Casks/blisk.rb
@@ -1,6 +1,6 @@
 cask 'blisk' do
-  version '0.61.2743.166'
-  sha256 '023d977bb17f54057c4b32986c9541af787058b2be7b7c5d7d93d5441f2a2616'
+  version '0.62.4925.237'
+  sha256 '0210522a727984d8b9274c4608fddd2d22c3c4c840e9942b6d61d827b64a9ffb'
 
   # bliskcloudstorage.blob.core.windows.net was verified as official when first introduced to the cask
   url "https://bliskcloudstorage.blob.core.windows.net/mac-installers/BliskInstaller_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
