### PR TITLE
fix(dotnet): use the right internal version during postflight

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,19 +1,19 @@
 cask 'dotnet' do
-  version '1.0.0-preview2-003148'
+  version '1.0.0-preview2-003148,1.0.2'
   sha256 '1209b0c7c07f46cc402fd087f1135b780f298daafe2e690b9251f1eea3bc93a7'
 
-  url "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-dev-osx-x64.#{version}.pkg"
+  url "https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-dev-osx-x64.#{version.before_comma}.pkg"
   name '.Net Core'
   homepage 'https://www.microsoft.com/net/core#macos'
 
   depends_on formula: 'openssl'
 
-  pkg "dotnet-dev-osx-x64.#{version}.pkg"
+  pkg "dotnet-dev-osx-x64.#{version.before_comma}.pkg"
 
   # Patch .NET Core to use the latest version of OpenSSL installed via Homebrew.
   # https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl
   postflight do
-    dotnet_core = '/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.2'
+    dotnet_core = "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/#{version.after_comma}"
     system '/usr/bin/sudo', '-E', '--', '/usr/bin/install_name_tool', "#{dotnet_core}/System.Security.Cryptography.Native.dylib", '-add_rpath', "#{HOMEBREW_PREFIX}/opt/openssl/lib"
     system '/usr/bin/sudo', '-E', '--', '/usr/bin/install_name_tool', "#{dotnet_core}/System.Net.Http.Native.dylib", '-change', '/usr/lib/libcurl.4.dylib', "#{HOMEBREW_PREFIX}/opt/curl/lib/libcurl.4.dylib"
   end

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -13,7 +13,7 @@ cask 'dotnet' do
   # Patch .NET Core to use the latest version of OpenSSL installed via Homebrew.
   # https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl
   postflight do
-    dotnet_core = '/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.1'
+    dotnet_core = '/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.2'
     system '/usr/bin/sudo', '-E', '--', '/usr/bin/install_name_tool', "#{dotnet_core}/System.Security.Cryptography.Native.dylib", '-add_rpath', "#{HOMEBREW_PREFIX}/opt/openssl/lib"
     system '/usr/bin/sudo', '-E', '--', '/usr/bin/install_name_tool', "#{dotnet_core}/System.Net.Http.Native.dylib", '-change', '/usr/lib/libcurl.4.dylib', "#{HOMEBREW_PREFIX}/opt/curl/lib/libcurl.4.dylib"
   end


### PR DESCRIPTION
if we install **dotnet**, a error occur during **postflight** with `/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.1` since #26011

The good version is `/usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.2`

Example of current `brew cask install dotnet`

```
==> Satisfying dependencies
==> Installing Formula dependencies from Homebrew
openssl ... already installed
complete
==> Downloading https://download.microsoft.com/download/1/0/C/10C868F3-EF61-47A7-95CF-FF2AE042D65F/dotnet-dev-osx-x64.1.0.0-preview2-003148.pkg
######################################################################## 100,0%
==> Verifying checksum for Cask dotnet
==> Running installer for dotnet; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
==> installer: Package name is Microsoft .NET Core 1.0.2 - SDK 1.0.0 Preview 2-003148 (x64)
==> installer: Installing at base path /
==> installer: The install was successful.
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open file: /usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.1/System.Security.Cryptography.Native.dylib (No such file or directory)
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open file: /usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.1/System.Net.Http.Native.dylib (No such file or directory)
🍺  dotnet was successfully installed!
```

this command don't work

```
$ sudo install_name_tool -add_rpath /usr/local/opt/openssl/lib /usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.1/System.Security.Cryptography.Native.dylib
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open file: /usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.1/System.Security.Cryptography.Native.dylib (No such file or directory)
```

this command work

```
sudo install_name_tool -add_rpath /usr/local/opt/openssl/lib /usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.0.2/System.Security.Cryptography.Native.dylib
```
