### PR TITLE
Update 115browser to 7.2.4.12

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -2,7 +2,7 @@ cask '115browser' do
   version '7.2.4.12'
   sha256 'bd2a578dc84b9fd719b0af004d010059a78de62d534999e722e2f5131eb3bd02'
 
-  url "https://down.115.com/client/mac/115br_v#{version}.dmg"
+  url "http://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'

--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,8 +1,8 @@
 cask '115browser' do
-  version '7.2.3.5'
-  sha256 '7f87490e0a4929bf6bbabf861540cfec0746e809f9b96fce7202146149ec9445'
+  version '7.2.4.12'
+  sha256 'bd2a578dc84b9fd719b0af004d010059a78de62d534999e722e2f5131eb3bd02'
 
-  url "http://down.115.com/client/mac/115br_v#{version}.dmg"
+  url "https://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update 115browser to 7.2.4.12
