### PR TITLE
Fix baiduhi cask latest

### DIFF
--- a/Casks/baiduhi.rb
+++ b/Casks/baiduhi.rb
@@ -1,11 +1,11 @@
 cask 'baiduhi' do
-  version '1.6.0.0'
-  sha256 '15de7fee8818b6ae9565a15e97fc0c3938041a129bc9cec1a359ddc8dc82590f'
+  version :latest
+  sha256 :no_check
 
-  url "https://bs.baidu.com/app-res/mac/machi_#{version}.dmg"
+  url 'http://hiupdate.baidu.com/machi_setup.dmg'
   name 'Baidu Hi'
   name '百度 Hi'
-  homepage 'https://im.baidu.com/'
+  homepage 'http://hi.baidu.com/'
 
   app '百度Hi.app'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Baidu Hi is currently provided on a non-versioned url
