### PR TITLE
Fix appcast in iTeleport Connect.app Cask

### DIFF
--- a/Casks/iteleport-connect.rb
+++ b/Casks/iteleport-connect.rb
@@ -1,10 +1,10 @@
 cask 'iteleport-connect' do
   version '6.0.0.2'
-  sha256 '2a845a052dfa04ae8a5c26da918944082f4a3a43ba3804cb8a078a77ad9f3b4c'
+  sha256 '834098a95c95183782e498de6427e3106b867a1f1793e4fe1306bb065baa732f'
 
-  url "http://www.iteleportmobile.com/download/iTeleport%20Installer.v#{version}.dmg"
-  appcast 'http://www.iteleportmobile.com/connect/mac/new',
-          checkpoint: 'e7df5301267b725512751f09ecd0a260586044e2b1330b4ac7ea3a8c8d5257ff'
+  url "http://www.iteleportmobile.com/download/iTeleport%20Connect.v#{version}.app.zip"
+  appcast 'http://www.iteleportmobile.com/download/sparkle.xml',
+          checkpoint: '892ff0a386d02d45828ce48baf1c761bd1b1b1091eeab70f28dbab4245e88aab'
   name 'iTeleport Connect'
   homepage 'http://www.iteleportmobile.com/connect'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit —download {{cask_file}}` is error-free.
- [x] `brew cask style —fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
  Version unchanged

Additionally, **if adding a new cask**:
- [ ] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).

Change URL to match appcast in iTeleport Connect.app Cask
