### PR TITLE
Update opera to 41.0.2353.46

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '40.0.2308.81'
-  sha256 '8b21d54227c13e074859f7f48f108944976c444f02b3e5da07628dbaf3093bda'
+  version '41.0.2353.46'
+  sha256 'a4b6c81e5c80699b256dd0c5f81ed67af89b040f041f8bd2812c2698401c53d9'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
