### PR TITLE
Add Skype for Business v16.0.0.3638

### DIFF
--- a/Casks/skype-for-business.rb
+++ b/Casks/skype-for-business.rb
@@ -1,0 +1,21 @@
+cask 'skype-for-business' do
+  version '16.0.0.3638'
+  sha256 '57236471924a67973e66fbe4e2e53e86cfe5e054318950d183a4e0e4df68a2be'
+
+  url "https://download.microsoft.com/download/D/0/5/D055DA17-C7B8-4257-89A1-78E7BBE3833F/SkypeForBusinessInstaller-#{version}.pkg"
+  name 'Skype for Business on Mac'
+  homepage 'https://www.microsoft.com/en-us/download/details.aspx?id=54108'
+
+  pkg 'SkypeForBusinessInstaller-#{version}.pkg'
+
+  uninstall pkgutil:  'com.microsoft.SkypeForBusiness'
+  uninstall login_item: 'Skype for Business'
+
+  zap delete: [
+                '/Library/Internet Plug-Ins/MeetingJoinPlugin.plugin',
+                '~/Library/Preferences/com.microsoft.SkypeForBusinessTAP.plist',
+                '~/Library/Preferences/com.microsoft.SkypeForBusinessTAP.debuglogging.plist',
+                '~/Library/Application Support/com.microsoft.SkypeForBusinessTAP',
+                '~/Library/Application Support/Skype for Business',
+              ]
+end

--- a/Casks/skype-for-business.rb
+++ b/Casks/skype-for-business.rb
@@ -3,13 +3,13 @@ cask 'skype-for-business' do
   sha256 '57236471924a67973e66fbe4e2e53e86cfe5e054318950d183a4e0e4df68a2be'
 
   url "https://download.microsoft.com/download/D/0/5/D055DA17-C7B8-4257-89A1-78E7BBE3833F/SkypeForBusinessInstaller-#{version}.pkg"
-  name 'Skype for Business on Mac'
+  name 'Skype for Business'
   homepage 'https://www.microsoft.com/en-us/download/details.aspx?id=54108'
 
   pkg 'SkypeForBusinessInstaller-#{version}.pkg'
 
-  uninstall pkgutil:  'com.microsoft.SkypeForBusiness'
-  uninstall login_item: 'Skype for Business'
+  uninstall pkgutil:  'com.microsoft.SkypeForBusiness',
+            login_item: 'Skype for Business'
 
   zap delete: [
                 '/Library/Internet Plug-Ins/MeetingJoinPlugin.plugin',

--- a/Casks/skype-for-business.rb
+++ b/Casks/skype-for-business.rb
@@ -8,7 +8,7 @@ cask 'skype-for-business' do
 
   pkg 'SkypeForBusinessInstaller-#{version}.pkg'
 
-  uninstall pkgutil:  'com.microsoft.SkypeForBusiness',
+  uninstall pkgutil:    'com.microsoft.SkypeForBusiness',
             login_item: 'Skype for Business'
 
   zap delete: [


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

I had an oddity with `brew cask uninstall skype-for-business`.  The uninstall completes, but leaves `/Applications/Skype for Business.app` behind.  I'm not sure why.
