### PR TITLE
Add Browser ChooserX.app v1.0

### DIFF
--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -1,0 +1,19 @@
+cask 'browser-chooserx' do
+  version '1.0.16'
+  sha256 '9e14104b545a3d83d7f6cabe5bb762565618da6d6b0cdb90ddda8e902b9dcd99'
+
+  url 'https://www.bdevapps.com/files/downloads/Browser%20ChooserX.zip'
+  appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
+          checkpoint: '7f09f052c116ba0f351c14c115fabf494f5fd49848a8380c14710211dd1468fb'
+  name 'Browser ChooserX'
+  homepage 'https://www.bdevapps.com'
+
+  auto_updates true
+
+  app 'Browser ChooserX.app'
+
+  zap delete: [
+                '~/Library/Preferences/com.bdevapps.Browser-ChooserX.plist',
+                '~/Library/Saved Application State/com.bdevapps.Browser-ChooserX.savedState',
+              ]
+end


### PR DESCRIPTION
Sorry for the PR's duplication, I had some messes with git

After making all changes to the cask:
- [x] `brew cask audit --download browser-chooserx` is error-free.
- [x] `brew cask style --fix browser-chooserx` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install browser-chooserx` worked successfully.
- [x] `brew cask uninstall browser-chooserx` worked successfully.
- [x] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [x] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).
