### PR TITLE
Upgrade TagSpaces.app to 2.5.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,11 +1,11 @@
 cask 'tagspaces' do
-  version '2.4.0'
-  sha256 '41f89594069acea059e8878399072c38e5485edd94a60f40f3e45e063a246b7e'
+  version '2.5.0'
+  sha256 'cf668916519e0848b54c146796e57278a369edeacf26902ed08a166b5fc35559'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-#{version}-osx64.zip"
   appcast 'https://github.com/tagspaces/tagspaces/releases.atom',
-          checkpoint: '2ea4e29ed2132a8926c1cfae8de3f1f47724471f8ac21ee3a89c7f4deb5e340b'
+          checkpoint: 'd580c5cbfb066f3d80c174237cd3c8ebadd8b7007013b7a05df701a1e13bf7b7'
   name 'TagSpaces'
   homepage 'https://www.tagspaces.org/'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:
- [ ] Named the cask according to the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests](https://github.com/caskroom/homebrew-cask/pulls) for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues](https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed).
