### PR TITLE
Update aquaskk to 4.4.2

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,10 +1,10 @@
 cask 'aquaskk' do
-  version '4.4.1'
-  sha256 '2f32925776f5ee57239f31df24f7edccf4bd9b6e8f997070ff4609b25e11dc6c'
+  version '4.4.2'
+  sha256 '745a864ac3682cfe9f94ad39f46ffbdd25c448f962647607c05bd3bb284bacef'
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom',
-          checkpoint: '8dce309c1b9a0c7ba2597b08cee0f5578a571ad37dfdfcb180cdcb55c0de6bff'
+          checkpoint: '1525cf3a5ea8a2d9ee540bb3e9320cf512061b95683bc73353b6694c1f3ed2c2'
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
