### PR TITLE
Update istat-menus to 5.20

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus' do
-  version '5.30'
-  sha256 '41bf8f73727301ae40f014966fb7a2479ef5658ccfe520d609628921d664c04e'
+  version '5.20'
+  sha256 '4e73ab06e5224a53eab0e773f7c6d299f9a3a79aa358ef3c67979990f874d2b3'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
