### PR TITLE
Update karabiner-elements to 0.90.61

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '0.90.58'
-  sha256 '0a7f75ec1c07102333d968ef071b46861ec3f422b76d7f098a533f03d8d97758'
+  version '0.90.61'
+  sha256 '7f1d73bcbfdafd119d2aa791923ba3133ffa219eebda06b2f3729bec1b3d5bf9'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: 'd15f2896a40b2b8551a24d635a37e151c69ca42318bbd5ee8bc0bd03382b2754'
+          checkpoint: '02dac0637664a1feb3488cd63f74a9008e566ed4e1a8a9d1629d423025180cc1'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
