### PR TITLE
Update mcedit to 1.5.4.1

### DIFF
--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -1,11 +1,11 @@
 cask 'mcedit' do
-  version '1.5.2.1'
-  sha256 '604d0f55a9a796f9758e4972c2f2819325b018f3b2ecf6cbe4d667e27ac0896c'
+  version '1.5.4.1'
+  sha256 '29bde806dc415435296e14613f9052a38891e87189f63a30bd69494e13708953'
 
   # github.com/Khroki/MCEdit-Unified was verified as official when first introduced to the cask
   url "https://github.com/Khroki/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
   appcast 'https://github.com/Khroki/MCEdit-Unified/releases.atom',
-          checkpoint: '496f5992c1dd033e1e4944a5c017ab81310446def236d8cded17725cededfd7e'
+          checkpoint: '5006f92d219e88b424172f139c433f225ec4e6255010c59b6feef67420ee1b93'
   name 'MCEdit-Unified'
   homepage 'https://khroki.github.io/MCEdit-Unified/'
 


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
