### PR TITLE
Update borgbackup to 1.0.8

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.0.7'
-  sha256 '4c3ac681e786f34f6de47efbf2dc0ecd2f0c615b6d8ff026639bf3317a4c5e5f'
+  version '1.0.8'
+  sha256 '9f74f984b362519c7fa8feb9662242bc8c6bf73175e2808e850ec662b62c8f30'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '957ad43f7646cd0227b030bd67359cd7403131fbf16505408a2899143515f119'
+          checkpoint: '02c302ab17b35ef5cc66613a4e27733afff139fec6eed769bd22258e70e58205'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.org/en/stable/'
   gpg "#{url}.asc",


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
