### PR TITLE
Update macvim to 8.0.114

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,10 +1,10 @@
 cask 'macvim' do
-  version '8.0.113'
-  sha256 'b8843600253a497cb97bf422fdef1758fd67810758f380670fdd2c4bf775cc21'
+  version '8.0.114'
+  sha256 '22d260ee8d9ff65af26ff49ebe4360f09fa37911f482125c4d32e62f1582bd28'
 
   url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.patch}/MacVim.dmg"
   appcast 'https://github.com/macvim-dev/macvim/releases.atom',
-          checkpoint: '6a2fae38c03bad4d078a06fdadf300c4bd1c64517ef2eb2ee0e024d3480a0f66'
+          checkpoint: '03284c95779e49b17ad9d018988a598810a26be2b84fea5b8af4fe6ed6cac056'
   name 'MacVim'
   homepage 'https://github.com/macvim-dev/macvim'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
