### PR TITLE
Update docker-toolbox to 1.12.3

### DIFF
--- a/Casks/docker-toolbox.rb
+++ b/Casks/docker-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'docker-toolbox' do
-  version '1.12.2'
-  sha256 'f1654ba0456dbab97f3fce4df3458f3cf4d99e97bde47c17c76c55ee1ad4c966'
+  version '1.12.3'
+  sha256 'c09e0dea7805bd1a34076d46fce063911096af73db9e1467634769492148e09b'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: 'ff9aa60d8a337b81ef26761aad44727522b567306751ec59422372489eb798a0'
+          checkpoint: '02197247d526f9d9ba62dfc9d5d8a8d6147d2451cec5fd9e6d17278c650d9900'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/toolbox'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
