### PR TITLE
Update brave appcast checkpoint

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -5,7 +5,7 @@ cask 'brave' do
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'ecfc19fa397ed1c63024dba3412ac6c1c426fae035dc258a9f3500303901c877'
+          checkpoint: '528b81708ef877d7514cba576ef0eee854e8a4e061057908188149464b6e1487'
   name 'Brave'
   homepage 'https://brave.com'
 


### PR DESCRIPTION
_If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so._

After making all changes to the cask:
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

The commit message don't include the casks's version cause it's the same(0.12.7dev)

The appcast atom feed updated, cause a new testing release was published, but it's not available for macOS, so we can't update the cask to this version.
