### PR TITLE
Update devonthink to 2.9.6

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.5'
-  sha256 '445e1931d00f99e753c726c14cf1b4083e4edfba76c26828fe352da838fe3822'
+  version '2.9.6'
+  sha256 '91f482f87f52e24fb0f56725c1fef8296f5293cc9d341d1082a4d5686de2afc9'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: '94b758c197bd1b98fed3c09e5564395b7512cf604b683cc44af453c3b9ba647c'
+          checkpoint: '489254857e55a860ab6d9da9db145404ea6d2153a0521479f275f1585a76c187'
   name 'DEVONthink Personal'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
