### PR TITLE
Update devonthink-pro-office to 2.9.6

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro-office' do
-  version '2.9.5'
-  sha256 '5474dd72e9880fc34e5a510941c344c1542c34e7c2bcaf60a6d9f9f49606490c'
+  version '2.9.6'
+  sha256 '06c3d566aeb9568bbdcc24cd529d9c4f71ed329fc1d0948dedfafa35c1b21146'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: '15575a8ea0390a0f4a863e73fe70f2fe5d916384fe5b9848432f9708fd306cc8'
+          checkpoint: 'bc1ee5f4957bc2e41a06de2d243197662d28f45117a24fbd5da7cef008478425'
   name 'DEVONthink Pro Office'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
