### PR TITLE
Update evernote to 6.10_454267

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -4,11 +4,11 @@ cask 'evernote' do
     sha256 '06b6da6d74ccab08deabfdd4c9519b9bc7f7ef0f0db2a0e8b0cd72e781f2e0ed'
     url 'https://cdn1.evernote.com/mac/release/Evernote_402634.dmg'
   else
-    version '6.9.2_454158'
-    sha256 'b0c4be75463acdae6cc5ea629ecda8e0266064dcf6016082a896459cc9d38fec'
+    version '6.10_454267'
+    sha256 '44d44b402c547a01a8a4fe377558e95669bf5771387e2ddfe85e58ce5b122946'
     url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
     appcast 'https://update.evernote.com/public/ENMacSMD/EvernoteMacUpdate.xml',
-            checkpoint: 'b2185ad128355727aadd4a88c3e7bcbc5b15130de566b2f37b5028045885ac58'
+            checkpoint: '3f0be567b7dd63963674742bcfed9f970693da41069fc5de87b4c400f7b05efb'
   end
 
   name 'Evernote'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
