### PR TITLE
Update mountain-duck to 1.6.1.5018

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.6.0.4947'
-  sha256 '46ddf9eb34607dfe9717b871957ec275ffd230d5bd2af7a4ce3c660e11764259'
+  version '1.6.1.5018'
+  sha256 '2d34cf06ba4180ec1e2476f0f1012f13f42799626db2e132c73d0796351936b5'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '31d74a9e3133ea63ce6f0ea536fbda5efc910792b6762b2e9ff8b0851017818c'
+          checkpoint: 'a9558f1e26ccacdb0b76566a5370c8cd2b11aa5b5b7763c6529f0044f1f4fd90'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
