### PR TITLE
Update movelinks to 1.4.4

### DIFF
--- a/Casks/movelinks.rb
+++ b/Casks/movelinks.rb
@@ -1,11 +1,11 @@
 cask 'movelinks' do
-  version '1.4.3'
-  sha256 '8cb3cf46c18f3df45f35d72c39d1755d79955f77b32fb06d6c867b957bede473'
+  version '1.4.4'
+  sha256 '474ec979b4fb9b6c2319a61162e95ca895eb9949b3f2a72a7365561bcf651a8c'
 
   # d1c229iib3zm7m.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1c229iib3zm7m.cloudfront.net/mac/Moveslink2_#{version.dots_to_underscores}.dmg"
   appcast 'https://d1c229iib3zm7m.cloudfront.net/mac/appcast.xml',
-          checkpoint: '5cab6fe342d0d05df460b010eab2ba19491a2382f3decb6cb2b2d7803b7e6ef9'
+          checkpoint: 'c1d5f1b9a7c848fde84a61e12ed6232eb517126ad92be680ba4e37c76f902e14'
   name 'Movelinks'
   homepage 'https://www.movescount.com/connect/moveslinkmac/Suunto_Ambit'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
