### PR TITLE
Update pester to 1.1b22

### DIFF
--- a/Casks/pester.rb
+++ b/Casks/pester.rb
@@ -1,10 +1,10 @@
 cask 'pester' do
-  version '1.1b21'
-  sha256 'a1923d0b330f9e054c1c7215b35322508f03c29294660df9b73bebf6411be283'
+  version '1.1b22'
+  sha256 '13d86be514a8fe8287e5bd073eeab0dfdd3d52d10337a082622b5e9b1f380ba8'
 
   url "https://sabi.net/nriley/software/Pester-#{version}.dmg"
   appcast 'https://sabi.net/nriley/software/Pester/updates.xml',
-          checkpoint: '80c01b621ac7672ce1866445703e2c11532f79b1c6120aa568b33af0bce9289e'
+          checkpoint: '585de88dbbbc6f29113b58a499287d45c9f31b1154364d4d9e2b4e2a926d4545'
   name 'Pester'
   homepage 'https://sabi.net/nriley/software/index.html#pester'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
