### PR TITLE
Update helm to version 2.0.0-beta.2

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -1,11 +1,11 @@
 cask 'helm' do
-  version '2.0.0-beta.1'
-  sha256 '26a9aa7d04afed6f2fe71481bc6b66b7aab48e659e5ebd85682c138a29cef83e'
+  version '2.0.0-beta.2'
+  sha256 '0121ec7d7bf077c718cacf79d201a9d9e5c3b3e4ebecd907b41d5d383acc0aad'
 
   # storage.googleapis.com/kubernetes-helm/ was verified as official when first introduced to the cask
   url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
-          checkpoint: '2e716c3cd2469e7284be892bba510a77a5e3c8f83041f16aeef5a61a5369ad9c'
+          checkpoint: '1023bb1751f001a0696921a30043b33733eed9ee6173f613a7fc944d545e6f5d'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
