### PR TITLE
Update thunder to 2.7.7.2318

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '2.7.6.2272'
-  sha256 'b7300bd2f530cc69c61465d5745989e73983cea8d481d7d574508ce128076f4c'
+  version '2.7.7.2318'
+  sha256 '8e456706c038eacbe1974a0b6be48eb1a43f74c7dbca7c05e8fa0525acaafdaa'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_dl#{version}_Beta.dmg"
@@ -15,8 +15,12 @@ cask 'thunder' do
   zap delete: [
                 '~/Library/Application Support/Thunder',
                 '~/Library/Caches/com.xunlei.Thunder',
+                '~/Library/Caches/com.xunlei.Thunder-Store',
                 '~/Library/Cookies/com.xunlei.Thunder.binarycookies',
+                '~/Library/Preferences/com.xunlei.Thunder-Store.plist',
                 '~/Library/Preferences/com.xunlei.Thunder.plist',
+                '~/Library/Saved Application State/com.Thunder.XLPlayer.savedState',
+                '~/Library/Saved Application State/com.xunlei.Thunder-Store.savedState',
                 '~/Library/Saved Application State/com.xunlei.Thunder.savedState',
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update thunder to 2.7.7.2318