### PR TITLE
Update doitim to 4.2.6

### DIFF
--- a/Casks/doitim.rb
+++ b/Casks/doitim.rb
@@ -1,10 +1,10 @@
 cask 'doitim' do
-  version '4.2.3'
-  sha256 'd9cc46729385cf94f7fc653e7e425baa33f3a7c193bfe386255b4afc88e685eb'
+  version '4.2.6'
+  sha256 'bf875f3b200540a708a8d4f404e98bc73b355b81a27183d091d31af73fe4f122'
 
   url "http://version.doit.im/dl/doit.im.#{version}.zip"
   appcast 'http://version.doit.im/mac/update.xml',
-          checkpoint: '4e1f29318d7adf08a0a39da28d53a36ae4389db20b2f005ddfb92effe953c6a6'
+          checkpoint: 'd8c81316e984d4a3e9071020c83dbbfcf8262b85a76d745966f2c0099102dc7e'
   name 'Doit.im'
   homepage 'https://doit.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.