### PR TITLE
Update prizmo to 3.1.14

### DIFF
--- a/Casks/prizmo.rb
+++ b/Casks/prizmo.rb
@@ -1,10 +1,10 @@
 cask 'prizmo' do
-  version '3.1.13'
-  sha256 'c6edffd466ecfe6fd59ecb6bb855fca6426c22cb38485f390652a4a81f1bfb3b'
+  version '3.1.14'
+  sha256 'aaa2d86131c6ecddd026d5e8b5ecb63741b1d4de9cd497fb0a84d5676e922a14'
 
   url "https://www.creaceed.com/downloads/prizmo#{version.major}_#{version}.zip"
   appcast 'https://www.creaceed.com/appcasts/prizmo3.xml',
-          checkpoint: '2cf75bb8852c58cb3052c25a4e14d10aba836be5ce12d6b263087b9dee0be22d'
+          checkpoint: '823f040828c27187e031384e35b52d4154cc8eb05df0aeda5db18fae25b06747'
   name 'Prizmo'
   homepage 'https://www.creaceed.com/prizmo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.