### PR TITLE
Update proxpn to 4.3.6.6

### DIFF
--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,10 +1,10 @@
 cask 'proxpn' do
-  version '4.3.6.5'
-  sha256 '3c05b5f55ec416c167af536d34547a2d89828c31dd6d86f844ac6c316c18d10a'
+  version '4.3.6.6'
+  sha256 'dcb62b781b84a2dabfe77fb4e3a00e00cddf07ecc7ff5c5fcbedd12d86beb8c2'
 
   url "https://www.proxpn.com/updater/proXPN-MacOSX-10.7-#{version}.dmg"
   appcast 'https://www.proxpn.com/updater/appcast.rss',
-          checkpoint: '5513dc0660f661331ad6361b962ef19a4780b52f6e34464f7e9da403853e9325'
+          checkpoint: '0e4f4aef85ffe583d9fe32124aa0d8f2ede276b5095b5b961a21039643996e54'
   name 'proXPN'
   homepage 'https://www.proxpn.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.