### PR TITLE
Update tableflip to 1.1.3

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,11 +1,11 @@
 cask 'tableflip' do
-  version '1.0.3'
-  sha256 'df0634628f0d451f0bbe8ae9b7efa7cadd51d815986a3866a60f85a161ca0e1b'
+  version '1.1.3'
+  sha256 '7670584f0177582b18f0f04ba483300639fa2d19cc1f30a5030646a1967f6014'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"
   appcast 'https://update.christiantietze.de/tableflip/v1/release.xml',
-          checkpoint: '97881da35c6d0e9e45d6d7acebcf487840c41ae9cf14aea6166dac0c7e16ce65'
+          checkpoint: 'df87f5df3dd31b2401c0510643dd811bf44ac5f63215cc87b411e4c1173fa4b4'
   name 'TableFlip'
   homepage 'http://tableflipapp.com'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.