### PR TITLE
Update toggldesktop to 7.3.337

### DIFF
--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop' do
-  version '7.3.326'
-  sha256 'f2e85415b652fce729fbd703c387814d16168381087a7bb498a5a9117af8e000'
+  version '7.3.337'
+  sha256 '2699165bf65b3e8ee6f43cbd66d210eaa9546c74b26e898294a4f03520974819'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml',
-          checkpoint: '460f65668197a03b0b95a17d1a1f7d2c617321281eca6c7b6dd136de9511189d'
+          checkpoint: '0af9b4c523d6303ce4ccbeeb640733b7b1de9901d22b13acc8c2cb8c0d9376ed'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.