### PR TITLE
Update processing to 3.2.2

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,10 +1,10 @@
 cask 'processing' do
-  version '3.2.1'
-  sha256 '5fd2310a39da1791a7a3b2a91f7cb8239dd575f1993380df1a2143cc8a134ca6'
+  version '3.2.2'
+  sha256 '206eb7954971561333b446a41397674454d435db9cd95162103617504a8c31f1'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: '02ad612ff327c10b61eda7c06329a9ba5d80db902ba673131ecce4c6d1505b88'
+          checkpoint: 'aa3e0e59bf5bd3a4abcb595fd1db75caa29d5ec24ec63f9b69f7e73f09cf4505'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.