### PR TITLE
Update karabiner to 10.22.0

### DIFF
--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -1,10 +1,10 @@
 cask 'karabiner' do
-  version '10.21.0'
-  sha256 '4b4815e139ef2579144b66f33f20a6ab57c6bf76b06f217cd23b5d2482261636'
+  version '10.22.0'
+  sha256 'b05560f26b16c19eea076f5589b58124dc9346c69be3df25a23c65c77f6d9554'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/appcast.xml',
-          checkpoint: '291a5570aeda093e72ab0948ae70790a964887fcf03b156402ff0daf3768f58f'
+          checkpoint: '38438b15c3af9c23215ac7d23af13c0b32cbc7b06e96ed02f7b50c29b65924b2'
   name 'Karabiner'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.