### PR TITLE
Update synergy to 1.8.5,a18eba7

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '1.8.4,a6ff907'
-  sha256 '897d35998c9f537fd6916a43c4c461c63db2d7611444f6bc27d91d0557e4621f'
+  version '1.8.5,a18eba7'
+  sha256 'b8023219e477603a6b07888ddf9388211ddd8bc9753b46ffd425feebddd917a5'
 
   url "https://symless.com/files/packages/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX1011-x86_64.dmg"
   name 'Synergy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.