### PR TITLE
Update nvalt to 2.2.5b123

### DIFF
--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -5,8 +5,8 @@ cask 'nvalt' do
     # abyss.designheresy.com/nvaltb was verified as official when first introduced to the cask
     url "http://abyss.designheresy.com/nvaltb/nvalt#{version}.zip"
   else
-    version '2.2b122'
-    sha256 'be6c4fd34f9023e4b4913bac5e5b6b4a56c75e3a5eba0eaa88a6877a70ccd2fb'
+    version '2.2.5b123'
+    sha256 '3bdefc9f60805ae8f1d0de538eda77a82bb63e50437247e65ae2dd05f3580af7'
     url "http://assets.brettterpstra.com/nvALT#{version.delete('b')}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.