### PR TITLE
Update porting-kit to 2.4.91

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,10 +1,10 @@
 cask 'porting-kit' do
-  version '2.4.79'
-  sha256 '6f47b1eb365e26003c75641912a7147d1e1feae6d374acb10b78cc2a90b9d53f'
+  version '2.4.91'
+  sha256 'e156f59f344a95beb6a9d9dbce5c7f32bf0230c71b6d63c9648e1ae3a7f14263'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: 'cf58a8648931f04d89260b072501fbbb1c56c23ad365a46549eb53a399494d23'
+          checkpoint: 'f2913419f1689b2dd1315ab7cf82bfbca978814a2858dc529f1fb06cf1886c0d'
   name 'Porting Kit'
   homepage 'http://portingkit.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.