### PR TITLE
Update postman to 4.8.1

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,11 +1,11 @@
 cask 'postman' do
-  version '4.8.0'
-  sha256 'b66d3f74b95d5116b04345eb358b81e5615957caa1794b012d175fb21ff252e4'
+  version '4.8.1'
+  sha256 'ed4e4c101b00eb43895d66d8510a98bfc21512542e393dde5346df105ac9b47c'
 
   # s3.amazonaws.com/postman-electron-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/postman-electron-builds/mac/Postman-osx-#{version}.zip"
   appcast 'https://app.getpostman.com/api/electron_updates_auto',
-          checkpoint: '5e127eb1fd7d0a137ddd33c6f7124e46af214964acf8837a432e4df63181b29d'
+          checkpoint: '21dcdef4cadfb47037b010020030e1dc8da8c0cca1ace5c328ffa3e74a26dde8'
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.