### PR TITLE
Update pdfsam-basic to 3.2.2

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,11 +1,11 @@
 cask 'pdfsam-basic' do
-  version '3.1.0'
-  sha256 'ccb2a8dfe6509111b66d89cfd6c0404f6d674f5e6e319a732adbaae7957b6daf'
+  version '3.2.2'
+  sha256 'c57457fa03a943644ecf0b3ae189ccb1cdd4156157ac05be9d4846a29abcb08a'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}.RELEASE/PDFsam-#{version}.RELEASE.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom',
-          checkpoint: '021f6c12c7e670d77fcd1497a728c8703fe069af99ecd3ce8cecdd0aba82e22a'
+          checkpoint: 'c50746704a30c294000a22a0acb4c7fea41e4b5f0f20fa8d961e4f0e5ca98893'
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.