### PR TITLE
Update freefilesync to 8.6

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,9 +1,9 @@
 cask 'freefilesync' do
-  version '8.4'
-  sha256 '59cc3d42e16fbf5157d4af4fd7be66b02515c71cd673fbb160960152f746806c'
+  version '8.6'
+  sha256 'aaa1dd1e2dfcc39bf4673d8280cc6561ee8dc9921c4deb926ed336dd5aa1d57b'
 
-  url "http://www.freefilesync.org/download/FreeFileSync_#{version}_Mac_OS_X.zip",
-      referer: 'https://www.freefilesync.org/download.php'
+  # download2114.mediafire.com/dl0o9adlw80g/bzdxny1n7cxozkh was verified as official when first introduced to the cask.
+  url "https://download2114.mediafire.com/dl0o9adlw80g/bzdxny1n7cxozkh/FreeFileSync_#{version}_macOS.zip"
   name 'FreeFileSync'
   homepage 'http://www.freefilesync.org'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.