### PR TITLE
Update downie to 2.5.7,1333

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.5.6,1329'
-  sha256 '7bb3c7978d12d7176853aadf76f03a778a0b58ad3dfd211d4136bc018c66246f'
+  version '2.5.7,1333'
+  sha256 '7e1a229de1e0441dea133d30bc2df20645db67aaa0b36eef2209e51450a45b1b'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'e372e06630265daf9107bb52380333da0189100fdcde90768cad6f0323ea7655'
+          checkpoint: '6a0e14a68069f7f5bcb469d03e3bace664afad3ee3a5536f2d557520a36651e7'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.