### PR TITLE
Update codekit (3.0.2)

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,12 +1,12 @@
 cask 'codekit' do
-  version '2.9.1-19142'
-  sha256 '8df162690d69ebb3f8995f06cc3e435ea6c0df15ceb6fb5f4b52c8e1d647f532'
+  version '3.0.2-25428'
+  sha256 '235f6184ef4015fece17e51b24eb4a74c5a8872cbd31e0820a0612b63eefd0bf'
 
-  url "https://incident57.com/codekit/files/codekit-#{version.sub(%r{.*-}, '')}.zip"
-  appcast 'https://incident57.com/codekit/appcast/ck2appcast.xml',
-          checkpoint: 'd7f6c068fa4e310e604ed8c3a41a1d41dff5b97f4db9aa9b0d41fe0964b11d8c'
+  url "https://codekitapp.com/binaries/codekit-#{version.sub(%r{.*-}, '')}.zip"
+  appcast 'https://codekitapp.com/api/3/appcast.xml',
+          checkpoint: 'e24539128c94a2c4558d0eb19252906d873ecc8ef379f86f47103bb84a63a543'
   name 'CodeKit'
-  homepage 'https://incident57.com/codekit/'
+  homepage 'https://codekitapp.com'
 
   auto_updates true
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Download link and home page changed domains - now hosted on codekitapp.com