### PR TITLE
Update rstudio to 1.0.44

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,6 +1,6 @@
 cask 'rstudio' do
-  version '0.99.903'
-  sha256 'cb7ac2b9ba2e0d4f4096b2dd2859c72742d12faf1461c68a6bfd3bce532ee1d6'
+  version '1.0.44'
+  sha256 'ec571ee4d1415cc031f8f55873ca15e75949038fe680520799934e115138066a'
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download rstudio` is error-free.
- [X] `brew cask style --fix rstudio` reports no offenses.
- [X] The commit message includes the cask’s name and version.