### PR TITLE
Update minikube to 0.12.2

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,6 +1,6 @@
 cask 'minikube' do
-  version '0.12.0'
-  sha256 'a96d6e1d53a7999503d00bcd41b4ccaa80f5d57f798608f03e3f4d63a42f9991'
+  version '0.12.2'
+  sha256 '5f818be5235d606ec5241ac1eea0dc92e6328d56841617c51e4595a0abc4300c'
 
   url "https://github.com/kubernetes/minikube/releases/download/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',

--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -4,7 +4,7 @@ cask 'minikube' do
 
   url "https://github.com/kubernetes/minikube/releases/download/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: 'c7afe3f8144af79a5e76615a6ac526196b1080bc62367d8e58481c4aefdd2e62'
+          checkpoint: '1bd94ecadb4c69469c347626fd78c3248df9bc9418dca9d77d1dec2890fcf6b1'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download minikube` is error-free.
- [x] `brew cask style --fix minikube` reports no offenses.
- [x] The commit message includes the cask’s name and version.