### PR TITLE
Update wineskin-winery.rb for zap

### DIFF
--- a/Casks/wineskin-winery.rb
+++ b/Casks/wineskin-winery.rb
@@ -15,8 +15,9 @@ cask 'wineskin-winery' do
 
   zap delete: [
                 '~/Library/Application Support/Wineskin',
-                '~/Library/Preferences/com.urgesoftware.wineskin.wineskin.plist',
                 '~/Library/Caches/com.urgesoftware.wineskin.wineskinwinery',
+                '~/Library/Caches/Wine',
+                '~/Library/Preferences/com.urgesoftware.wineskin.wineskin.plist',
                 '~/Library/Saved Application State/com.urgesoftware.wineskin.wineskin.savedState',
               ],
       rmdir:  '~/Applications/Wineskin'

--- a/Casks/wineskin-winery.rb
+++ b/Casks/wineskin-winery.rb
@@ -18,7 +18,8 @@ cask 'wineskin-winery' do
                 '~/Library/Caches/com.urgesoftware.wineskin.wineskinwinery',
                 '~/Library/Caches/Wine',
                 '~/Library/Preferences/com.urgesoftware.wineskin.wineskin.plist',
-                '~/Library/Saved Application State/com.urgesoftware.wineskin.wineskin.savedState',
+                '~/Library/Saved Application State/com.urgesoftware.wineskin.wineskinwinery.savedState',
+                '~/Library/Saved Application State/*Wine.wineskin.prefs.savedState',
               ],
       rmdir:  '~/Applications/Wineskin'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update wineskin-winery.rb for zap

---

The applicantion which from `~/Applications/Wineskin` has its savedState `~/Library/Saved Application State/**Wine.wineskin.prefs.savedState`.
I don't know whether zap supports `*`.