### PR TITLE
Update p4v (2015.2-20161101)

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,6 +1,6 @@
 cask 'p4v' do
-  version '2015.2-1312139'
-  sha256 '6f64cca4e84d344c5f420e58a72bd07c4fbf5f3eb9665b165acd8baa36c18eb9'
+  version '2015.2-1458499'
+  sha256 '2a77a8c0270a158432d6c571828c397ef3bd20b911bbbfb3db810845dc2995bc'
 
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*}, '\1')}/bin.macosx107x86_64/P4V.dmg"
   name 'Perforce Visual Client'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

New package was replaced in-directory on 2016-Nov-01 (see http://filehost.perforce.com/perforce/r15.2/bin.macosx107x86_64/).  Internal version is still the same (2015.2) but the revision number in the version used was changed.
