### PR TITLE
Add stanza depends_on macos for tableau 10.1.0

### DIFF
--- a/Casks/tableau.rb
+++ b/Casks/tableau.rb
@@ -6,5 +6,7 @@ cask 'tableau' do
   name 'Tableau'
   homepage 'https://www.tableau.com/'
 
+  depends_on macos: '>= :yosemite'
+
   app 'Tableau.app'
 end


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

depends_on macos according to spec from official site [http://www.tableau.com/products/desktop](http://www.tableau.com/products/desktop)