### PR TITLE
Update rstudio to 1.0.44

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -7,7 +7,6 @@ cask 'rstudio' do
   name 'RStudio'
   homepage 'https://www.rstudio.com/'
 
-  #requires an `r` package
   depends_on formula: 'homebrew/science/r'
   
   app 'RStudio.app'

--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,12 +1,15 @@
 cask 'rstudio' do
-  version '0.99.903'
-  sha256 'cb7ac2b9ba2e0d4f4096b2dd2859c72742d12faf1461c68a6bfd3bce532ee1d6'
+  version '1.0.44'
+  sha256 'ec571ee4d1415cc031f8f55873ca15e75949038fe680520799934e115138066a'
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/RStudio-#{version}.dmg"
   name 'RStudio'
   homepage 'https://www.rstudio.com/'
 
+  #requires an `r` package
+  depends_on formula: 'homebrew/science/r'
+  
   app 'RStudio.app'
 
   zap delete: '~/.rstudio-desktop'


### PR DESCRIPTION
After making all changes to the cask:
- [X] `brew cask audit --download rstudio.rb` is error-free.
- [X] `brew cask style --fix rstudio.rb` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Rev rstudio from: `version '0.99.903'` to `version '1.0.44'` with brewed `r` dependancy.

```
tyr:~/Code/Homebrew benc$ brew cask audit --download ./rstudio.rb 
==> Downloading https://download1.rstudio.org/RStudio-1.0.44.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask rstudio
audit for rstudio: passed
tyr:~/Code/Homebrew benc$ brew cask style --fix ./rstudio.rb 
==> Installing or updating 'rubocop-cask' gem
Fetching: rubocop-0.43.0.gem (100%)
Successfully installed rubocop-0.43.0
Fetching: rubocop-cask-0.10.4.gem (100%)
Successfully installed rubocop-cask-0.10.4
2 gems installed
== rstudio.rb ==
C:  4:  1: [Corrected] stanza groups should be separated by a single empty line

1 file inspected, 1 offense detected, 1 offense corrected
benc$ brew cask reinstall ./rstudio.rb 
==> Removing App: '/Applications/RStudio.app'
==> Satisfying dependencies
==> Installing Formula dependencies from Homebrew
homebrew/science/r ... ==> Warning: homebrew/science/r-3.3.2 already installed
done
complete
==> Downloading https://download1.rstudio.org/RStudio-1.0.44.dmg
Already downloaded: /Users/benc/Library/Caches/Homebrew/Cask/rstudio--1.0.44.dmg
==> Verifying checksum for Cask rstudio
==> Moving App 'RStudio.app' to '/Applications/RStudio.app'
🍺  rstudio was successfully installed!
```

This also closes #26308; I see all license files were nuked. Missed that discussion, but just for completeness rstudio is out under the `AGPL v3`