### PR TITLE
Update filezilla to 3.22.2.2

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.22.1'
-    sha256 'c4980467797bc246047205b76be3efb6da08991d8045720439ed25c2bf4f5fe1'
+    version '3.22.2.2'
+    sha256 'b43d52d441b0777439f36cecd4fc1888c18072b9c9381fa9be016fcef28954c2'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '139fb1d6f257ca5bd78c6906248cbad6597f0c55db609982f833834ec0de7d9e'
+          checkpoint: 'b518f15d722afb4a1a97be89d25a3cee20045d666a3968cafae654e8e3db6506'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.