### PR TITLE
Update minishift 0.9.0 download url

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -2,11 +2,11 @@ cask 'minishift' do
   version '0.9.0'
   sha256 '885251315ba9e3e7e3cb2687c8cbf534d8cfffd6c860140c739bbc37a6f78621'
 
-  url "https://github.com/jimmidyson/minishift/releases/download/v#{version}/minishift-darwin-amd64"
-  appcast 'https://github.com/jimmidyson/minishift/releases.atom',
-          checkpoint: 'b6e67eb191a8d05cf419858ce1f51b4840aae11ca8fd877113e6e44da760868d'
+  url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-darwin-amd64"
+  appcast 'https://github.com/minishift/minishift/releases.atom',
+          checkpoint: '98ed8bd13a92b9ef0c2179154a9ba6d7347a2d883c455068f3b3f5343b9d22d2'
   name 'Minishift'
-  homepage 'https://github.com/jimmidyson/minishift'
+  homepage 'https://github.com/minishift/minishift'
 
   depends_on arch: :x86_64
   container type: :naked


### PR DESCRIPTION
Minishift has now a new organisation https://github.com/minishift, so I've updated the formula to download binary from the new repository.
 
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
