### PR TITLE
Update aquaskk to 4.4.4

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,10 +1,10 @@
 cask 'aquaskk' do
-  version '4.4.3'
-  sha256 'f9d481126c5b985ca80f74909da0c6c917747a8f391bcc27ec1b82e9b6cd3a00'
+  version '4.4.4'
+  sha256 '99febc55d2e7c923676a5bf1a9b9a2f38732f6ad4682a50b8090a0f177c981f8'
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom',
-          checkpoint: 'c4f7fd5793801a887b7c65f73472cda663b8d0aa30c33381fabe42518a905493'
+          checkpoint: '9337d63f73be4a88446eb530e85e31951d8eba61dca942a86138b9fb3357ffa5'
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.