### PR TITLE
Update cocktail to 10.1

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -26,7 +26,7 @@ cask 'cocktail' do
 
     url "https://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
-            checkpoint: 'a3629f9c689818cf031fa873880eaff56a8a3a10dc70e60f59e6d67b81e993ae'
+            checkpoint: 'b094a58c5d390c3f02ebb8ae9ecb0c462cfab1b31091e7ca7ed97f809f075c7e'
   else
     version '10.1'
     sha256 'c87671e42f20646a981e69c8c5b8b502aee808367fe85f6a5709da129ed8eba6'

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -22,7 +22,7 @@ cask 'cocktail' do
             checkpoint: 'ffe079c9b71d0f356c8a4d45ecf4f5a50e1d284c972b0a1e5cf92234d7a1010e'
   elsif MacOS.version == :el_capitan
     version '9.4'
-    sha256 'e34a9d9fd7ec22e00e78d5627b5f2ad5c8dc4a6c8050ec2413d3cbc46c1812f2'
+    sha256 '19163c3d25c33b103da2b4b16fd829ea25a706f1644f38e52b3fb00ddefce5e7'
 
     url "https://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -1,19 +1,5 @@
 cask 'cocktail' do
-  if MacOS.version == :snow_leopard
-    version '5.1'
-    sha256 '630fc5236e95d5ec36c0de4b487f8ece76d8f02ecd00ec4b37124ddd0eed0f34'
-
-    url "https://www.maintain.se/downloads/sparkle/snowleopard/Cocktail_#{version}.zip"
-    appcast 'https://www.maintain.se/downloads/sparkle/snowleopard/snowleopard.xml',
-            checkpoint: '3fb0fdcd252f0d0898076a66c3ad3ef045590a82abc9c9789bc1d7fdd0dc21f0'
-  elsif MacOS.version == :lion
-    version '5.6'
-    sha256 '9fa8ff2ade1face0a1a36baf36cfa384535179b261716c18538b0102f281ee60'
-
-    url "https://www.maintain.se/downloads/sparkle/lion/Cocktail_#{version}.zip"
-    appcast 'https://www.maintain.se/downloads/sparkle/lion/lion.xml',
-            checkpoint: '81397ad4229e65572fb5386f445e7ecfdfc2161c51ce85747d2b4768b419984e'
-  elsif MacOS.version == :mountain_lion
+  if MacOS.version == :mountain_lion
     version '6.9'
     sha256 '309bac603a6ded301e9cc61b32bb522fc3a5208973cbd6c6f1a09d0e2c78d1e6'
 
@@ -35,12 +21,12 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml',
             checkpoint: 'ffe079c9b71d0f356c8a4d45ecf4f5a50e1d284c972b0a1e5cf92234d7a1010e'
   elsif MacOS.version == :el_capitan
-    version '9.3.5'
+    version '9.4'
     sha256 'e34a9d9fd7ec22e00e78d5627b5f2ad5c8dc4a6c8050ec2413d3cbc46c1812f2'
 
     url "https://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
-            checkpoint: 'a4d0e1719641e583255e63fc6d20aea2d910d77cdf9cb51ff5402d9a519109a1'
+            checkpoint: 'a3629f9c689818cf031fa873880eaff56a8a3a10dc70e60f59e6d67b81e993ae'
   else
     version '10.1'
     sha256 'c87671e42f20646a981e69c8c5b8b502aee808367fe85f6a5709da129ed8eba6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.