### PR TITLE
Update polymail to 1.13

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.12'
-  sha256 'd26a85d29caf178bf6989526a35bba8aac03e1286184e2995af7611fab1e2c62'
+  version '1.13'
+  sha256 '3a2642346813d2cccb7d540d7f5b7c52bd2198a082a69092fd5ea54cd68e3ea5'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'ac0081b9854d9d28aed7be9f734772e3c018ef3ee87371d0039d60d85d7764c2'
+          checkpoint: '07b3e01d07885583ae8a2446cf7d8e02b165a046b55484d5c3a3a36bb55c454e'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.