### PR TITLE
Add stanza depends_on macos for RStudio 1.0.44

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -8,7 +8,8 @@ cask 'rstudio' do
   homepage 'https://www.rstudio.com/'
 
   depends_on formula: 'homebrew/science/r'
-  
+  depends_on macos: '>= :snow_leopard'
+
   app 'RStudio.app'
 
   zap delete: '~/.rstudio-desktop'


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

According to RStudio official site download section [https://www.rstudio.com/products/rstudio/download/](https://www.rstudio.com/products/rstudio/download/)