### PR TITLE
Add depends_on for Adobe Creative Cloud 3.9.1.335

### DIFF
--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -6,5 +6,7 @@ cask 'adobe-creative-cloud' do
   name 'Adobe Creative Cloud'
   homepage 'https://creative.adobe.com/products/creative-cloud'
 
+  depends_on macos: '>= :mavericks'
+
   installer manual: 'Creative Cloud Installer.app'
 end


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

According to system requirements from Adobe official site
[https://helpx.adobe.com/creative-cloud/system-requirements.html](https://helpx.adobe.com/creative-cloud/system-requirements.html)