### PR TITLE
Update spacemonkey (0.7.2,135)

### DIFF
--- a/Casks/spacemonkey.rb
+++ b/Casks/spacemonkey.rb
@@ -1,11 +1,11 @@
 cask 'spacemonkey' do
-  version '0.7.22,135'
-  sha256 '3890a4710782ff95b1f892548b9e7b95df06050b958c8c565e171d44752aec51'
+  version '0.7.24,138'
+  sha256 'aa36b50a076ade356c7c065721d4e9b0a529a785cac08d70cef73dd9612c6c6f'
 
   # hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c',
-          checkpoint: 'f2b61b62eea11d2c1d970740b4c6c04437d31469ac29160100d3fba723fdad4d'
+          checkpoint: '432e79d7e5cd77de36a1e250e6474cdbeccdb0e45cbe81520d32bc6e4ba63a3c'
   name 'Space Monkey'
   homepage 'https://www.spacemonkey.com'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
