### PR TITLE
Update airy to 3.1.161

### DIFF
--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -1,10 +1,10 @@
 cask 'airy' do
-  version '3.0.152'
-  sha256 'e6fb3c0a3b9d7fb824ba83fb9e6ddf54e0e03f556729a4eeeed009ad66f1b39d'
+  version '3.1.161'
+  sha256 '6e4e6e9d2518bb5e35ea068bb2b799662628820ba5b3a79ac35feac53740291c'
 
   url "http://www.eltima.com/download/airy-update/airy_#{version}.dmg"
   appcast 'http://mac.eltima.com/download/airy-update/airy.xml',
-          checkpoint: 'd257102427567379b8b4d40f1ef55cece284f24e2675a90c3650c5033ee1ffcc'
+          checkpoint: '8ed67f546cb45334b6fa69f5823527747514f3d81653708597c16934ada1876e'
   name 'Airy'
   homepage 'http://mac.eltima.com/youtube-downloader-mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.