### PR TITLE
Update fluid to 1.8.6

### DIFF
--- a/Casks/fluid.rb
+++ b/Casks/fluid.rb
@@ -1,10 +1,10 @@
 cask 'fluid' do
-  version '1.8.5'
-  sha256 'aa644629b2f3ccf79e0fc88cd59d747d84e8ad330e5d6fc3d7e09f68214b67b5'
+  version '1.8.6'
+  sha256 '82a3e4d634383b2423adb16fbc15699c7c0927180f1ac58e223f6eaf524d99c0'
 
   url "http://fluidapp.com/dist/Fluid_#{version}.zip"
   appcast 'http://fluidapp.com/appcast/fluid1.rss',
-          checkpoint: 'a4f30ede491c600675f005416f7c76dd2945daeb71d5ecb1f7621bedc0416e30'
+          checkpoint: 'fbc75fb1251ce981acce75c680073b0e360b27e67dcf869d63ab5437387e015b'
   name 'Fluid'
   homepage 'http://fluidapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.