### PR TITLE
Update bose-soundtouch to 13.0.13.16800

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,6 +1,6 @@
 cask 'bose-soundtouch' do
-  version '13.0.11.16439'
-  sha256 'af75c51c01f004747d43cebf195fe337feeccaa6bd8e8e95b2b1ea019499c0da'
+  version '13.0.13.16800'
+  sha256 '8e0bf45c017f074c449e4031a920b5344bc82a8e1ffac32beadd0274b8197f8d'
 
   # bose.com was verified as official when first introduced to the cask
   url "https://worldwide.bose.com/downloads/assets/updates/soundtouch/SoundTouch-#{version}-osx-10.9-installer.app.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.