### PR TITLE
Update sourcetree to 2.3.2

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,14 +6,14 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.3.1'
-    sha256 'ef1e9f76d9fc3679d915cdc2ae8b159a02367faacde6be860310f29575be0fea'
+    version '2.3.2'
+    sha256 '5973cb419275cfb441ff3bb7e3228918d430ca13484ddd858c9df9f5720e7ca9'
   end
 
   # atlassian.com was verified as official when first introduced to the cask
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcast.xml',
-          checkpoint: '096494e7aef3f14c99700663b0397571b19f2af17e18a8fa63c757409cf79708'
+          checkpoint: '6031bd143374559a84872d0b9ecef5420173e11fb3a0453cfaa092878c6bc908'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.