### PR TITLE
Fix version interpolation in PolarClock 3.0

### DIFF
--- a/Casks/polar-clock.rb
+++ b/Casks/polar-clock.rb
@@ -6,5 +6,5 @@ cask 'polar-clock' do
   name 'PolarClock Screensaver'
   homepage 'http://blog.pixelbreaker.com/polarclock'
 
-  screen_saver 'PolarClock #{version}.saver'
+  screen_saver "PolarClock #{version}.saver"
 end


### PR DESCRIPTION
Correct version interpolation in screen_saver stanza to fix:

`Error: It seems the Screen Saver source is not there:
'/usr/local/Caskroom/polar-clock/3.0/PolarClock #{version}.saver'`.