### PR TITLE
Update abscissa to 3.4.6

### DIFF
--- a/Casks/abscissa.rb
+++ b/Casks/abscissa.rb
@@ -1,10 +1,10 @@
 cask 'abscissa' do
-  version '3.4.3'
-  sha256 '4ef1744451548aed19665cf71102e3ca8bb2af4ee02e45c6a18721a7b3c91a76'
+  version '3.4.6'
+  sha256 '319c6871e4f42eaf6b1925aff66859024241d5c11a542badeb6993d287da3da2'
 
   url "http://rbruehl.macbay.de/Abscissa/Downloads/Abscissa-#{version}.zip"
   name 'Abscissa'
   homepage 'http://rbruehl.macbay.de/Abscissa'
 
-  app 'Abscissa-#{version}/Abscissa.app'
+  app "Abscissa-#{version}/Abscissa.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.