### PR TITLE
Update istat-menus to 5.30

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -3,14 +3,14 @@ cask 'istat-menus' do
   sha256 '421d1f962fbdc2369e10f5110d684dc3cf3105bcf6cbddd85613abd970d0ecea'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus#{version}.zip"
+  url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"
   name 'iStats Menus'
   homepage 'https://bjango.com/mac/istatmenus/'
 
   app 'iStat Menus.app'
 
   zap delete: [
-                '/Library/Application Support/iStat Menus #{version.major}',
+                "/Library/Application Support/iStat Menus #{version.major}",
                 '/Library/LaunchAgents/com.bjango.istatmenusagent.plist',
                 '/Library/LaunchAgents/com.bjango.istatmenusnotifications.plist',
                 '/Library/LaunchAgents/com.bjango.istatmenusstatus.plist',
@@ -18,7 +18,7 @@ cask 'istat-menus' do
                 '~/Library/Caches/com.bjango.istatmenus',
                 '~/Library/Caches/com.bjango.istatmenusstatus',
                 '~/Library/Logs/iStat Menus',
-                '~/Library/Preferences/com.bjango.istatmenus5.extras.plist',
+                "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
                 '~/Library/Preferences/com.bjango.istatmenusstatus.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.