### PR TITLE
Update folx to 5.1.13629

### DIFF
--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -1,10 +1,10 @@
 cask 'folx' do
-  version '5.1.13597'
-  sha256 '128c78aee54b195a23d6e1c8a730447b12ce6c30ec1852d6a5a11a7a69389677'
+  version '5.1.13629'
+  sha256 '3d2c9c7c80646b592bc8b6f2b012820661b57772d26c462a3ee71a9ac2f1e7fa'
 
   url "http://www.eltima.com/download/folx-update/downloader_mac_#{version}.dmg"
   appcast 'http://mac.eltima.com/download/folx-updater/folx.xml',
-          checkpoint: 'af8da469e29f9348247d26748f9ba6cadafee62fbc09606bf766974c1da920ae'
+          checkpoint: '73d28f32ff31be0564afd2a0b26d2f2dcba3a66a623843802458acacb925c9a4'
   name 'Folx'
   homepage 'http://mac.eltima.com/download-manager.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.