### PR TITLE
Update blocs to 2.2.2

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,11 +1,11 @@
 cask 'blocs' do
-  version '2.2.1'
-  sha256 'd10a06759af8868eb09381da71288c68f7400436155536e7c1a6efb53ec2d609'
+  version '2.2.2'
+  sha256 'bf90717419dd79edd3d6b18cdcc970c50d2110491b3abf4baadbacc7d430f917'
 
   # uistore.io was verified as official when first introduced to the cask
-  url 'http://downloads.uistore.io/blocs/version-2/Blocs.zip'
+  url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
   appcast 'https://uistore.io/blocs/2.0/info.xml',
-          checkpoint: '5b095d961e2a6177f4fdec510f423090ed962c96c3219901672d0745267d6413'
+          checkpoint: 'e3b76b5db084e39752548490c9f7a2f9567ff377a9d05a0ba5e20ce812e5c65c'
   name 'Blocs'
   homepage 'http://blocsapp.com/'
 

--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -4,7 +4,7 @@ cask 'blocs' do
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
-  appcast 'https://uistore.io/blocs/#{version.major}.0/info.xml',
+  appcast "https://uistore.io/blocs/#{version.major}.0/info.xml",
           checkpoint: 'e3b76b5db084e39752548490c9f7a2f9567ff377a9d05a0ba5e20ce812e5c65c'
   name 'Blocs'
   homepage 'http://blocsapp.com/'

--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -4,7 +4,7 @@ cask 'blocs' do
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
-  appcast 'https://uistore.io/blocs/2.0/info.xml',
+  appcast 'https://uistore.io/blocs/#{version.major}.0/info.xml',
           checkpoint: 'e3b76b5db084e39752548490c9f7a2f9567ff377a9d05a0ba5e20ce812e5c65c'
   name 'Blocs'
   homepage 'http://blocsapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.