### PR TITLE
Update gnubg to 1.04.000,1010

### DIFF
--- a/Casks/gnubg.rb
+++ b/Casks/gnubg.rb
@@ -1,12 +1,14 @@
 cask 'gnubg' do
   if MacOS.version <= :mavericks
-    version '1.03.000-x86_64'
+    version '1.03.000'
     sha256 '90614e940a94515d265ccccabf05ae6610121207b6ba0b7ae656ac2e68c0f6ff'
-    url 'http://gnubg.org/media/macos/gnubg-1_03_000-mac-x86_64.dmg'
+
+    url "http://gnubg.org/media/macos/gnubg-#{version.major_minor_patch.dots_to_underscores}-mac-x86_64.dmg"
   else
-    version '1.04.000-1010-x86_64'
+    version '1.04.000,1010'
     sha256 '3f093856f18b0d47373d3be4094a4f127e654326438e7172c877b775764d7422'
-    url 'http://gnubg.org/media/macos/gnubg-1_04_000-mac-1010-x86_64.dmg'
+
+    url "http://gnubg.org/media/macos/gnubg-#{version.major_minor_patch.dots_to_underscores}-mac-#{version.after_comma}-x86_64.dmg"
   end
 
   name 'Gnu Backgammon'

--- a/Casks/gnubg.rb
+++ b/Casks/gnubg.rb
@@ -3,12 +3,12 @@ cask 'gnubg' do
     version '1.03.000'
     sha256 '90614e940a94515d265ccccabf05ae6610121207b6ba0b7ae656ac2e68c0f6ff'
 
-    url "http://gnubg.org/media/macos/gnubg-#{version.major_minor_patch.dots_to_underscores}-mac-x86_64.dmg"
+    url "http://gnubg.org/media/macos/gnubg-#{version.dots_to_underscores}-mac-x86_64.dmg"
   else
     version '1.04.000,1010'
     sha256 '3f093856f18b0d47373d3be4094a4f127e654326438e7172c877b775764d7422'
 
-    url "http://gnubg.org/media/macos/gnubg-#{version.major_minor_patch.dots_to_underscores}-mac-#{version.after_comma}-x86_64.dmg"
+    url "http://gnubg.org/media/macos/gnubg-#{version.before_comma.dots_to_underscores}-mac-#{version.after_comma}-x86_64.dmg"
   end
 
   name 'Gnu Backgammon'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.