### PR TITLE
Update ibooksremote to 1.0.0

### DIFF
--- a/Casks/ibooksremote.rb
+++ b/Casks/ibooksremote.rb
@@ -2,7 +2,7 @@ cask 'ibooksremote' do
   version '1.0.0'
   sha256 '21c0d2102344b2286425ebad80d2ba32c9a4c7978f58a3519254fa514864d3e0'
 
-  url 'https://github.com/decapyre/iBookRemote/releases/download/v1.0.0/iBooksRemote-darwin-x64.zip'
+  url "https://github.com/decapyre/iBookRemote/releases/download/v#{version}/iBooksRemote-darwin-x64.zip"
   appcast 'https://github.com/decapyre/iBookRemote/releases.atom',
           checkpoint: '42f294c53eed32d814d0ca604468d05f58528c28e64badeec94f06a74b5db67b'
   name 'iBooks Remote'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.