### PR TITLE
darktable 2.0.7

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,11 +1,11 @@
 cask 'darktable' do
-  version '2.0.6'
-  sha256 '8376ab1bb74f4a25998ff1a7f03c8498b57064bf27700c9af53a7356e5a2ee1e'
+  version '2.0.7'
+  sha256 '0b341f3f753ae0715799e422f84d8de8854d8b9956dc9ce5da6d5405586d1392'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: '132bcc2ab579209a8a630e928085e14cc514185c39ffdebd32e6192c3f067576'
+          checkpoint: '73af5565e5b7b288c2242b68309bc9e26e68ad3911feaa2835b825f7850e7cae'
   name 'darktable'
   homepage 'https://www.darktable.org/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[darktable 2.0.7 release notes](https://www.darktable.org/2016/10/darktable-2-0-7-released/).