### PR TITLE
Update webarchiveplayer to 1.4.5

### DIFF
--- a/Casks/webarchiveplayer.rb
+++ b/Casks/webarchiveplayer.rb
@@ -1,10 +1,10 @@
 cask 'webarchiveplayer' do
-  version '1.4.1'
+  version '1.4.5'
   sha256 'dc5bc702800c913c8781f9c23074156003bc991d4c3aeffdb5add0f51e05cdb6'
 
   url "https://github.com/ikreymer/webarchiveplayer/releases/download/#{version}/webarchiveplayer.dmg"
   appcast 'https://github.com/ikreymer/webarchiveplayer/releases.atom',
-          checkpoint: 'afa19ab62477ff8a21dde5e4704c78e1ae2d6ba027c43d53d13e6d970c3a38e6'
+          checkpoint: '83f4f76661fddb0fb06f946c43b1291ee57e51690430bbc77bd1f6d177ec2b70'
   name 'webarchiveplayer'
   homepage 'https://github.com/ikreymer/webarchiveplayer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #26415.