### PR TITLE
Update armory to 0.95.1

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -1,11 +1,11 @@
 cask 'armory' do
-  version '0.95.0'
-  sha256 '17e11d8aeb99feac42ad9fb89d202d5985a3fa031dd337de7f505918bee89b7a'
+  version '0.95.1'
+  sha256 '9ec3803b914660c5fbecfd5b2d6e907f64d16f920cd648678137d307399beb8d'
 
   # github.com was verified as official when first introduced to the cask
-  url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version.major_minor}_osx.tar.gz"
+  url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: '7bc57988822213c51e763ecc69fd0420cbc358380b44ebcb8fa2ce4e21d49b61'
+          checkpoint: 'd07ce0e7298475fc9a26b19ec5f525d987f6d245a9fc3e7050f1facf504f1d74'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.