### PR TITLE
Update mountain-duck to 1.6.2.5061

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.6.1.5018'
-  sha256 '2d34cf06ba4180ec1e2476f0f1012f13f42799626db2e132c73d0796351936b5'
+  version '1.6.2.5061'
+  sha256 '52bf7a3878c7dbfc0834d4aae32c8e3b065f4604cf10c7a91a2d9f8e71ccaddc'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'a9558f1e26ccacdb0b76566a5370c8cd2b11aa5b5b7763c6529f0044f1f4fd90'
+          checkpoint: 'a6294d1557d2b077dd59a0757c2dea16866bb45fb872b76f5b5999b1b6a6fe85'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.