### PR TITLE
Update shimeike-formulatepro to 0.0.6

### DIFF
--- a/Casks/shimeike-formulatepro.rb
+++ b/Casks/shimeike-formulatepro.rb
@@ -2,7 +2,7 @@ cask 'shimeike-formulatepro' do
   version '0.0.6'
   sha256 '9a5c37bad02a9dea7448e4ebe6fc6b0887efa05b0530603b9be1e5b0b3db2542'
 
-  url 'https://github.com/shimeike/formulatepro/releases/download/v0.0.6a/FormulatePro-0.0.6.dmg'
+  url "https://github.com/shimeike/formulatepro/releases/download/v#{version}a/FormulatePro-#{version}.dmg"
   appcast 'https://github.com/shimeike/formulatepro/releases.atom',
           checkpoint: '5577b6aea342f35701fb94c0eff888f0536b01cdfe21978fded979d44835b082'
   name 'FormulatePro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.