### PR TITLE
Update smart-trash to 2.0.5

### DIFF
--- a/Casks/smart-trash.rb
+++ b/Casks/smart-trash.rb
@@ -2,7 +2,7 @@ cask 'smart-trash' do
   version '2.0.5'
   sha256 'c3e3dd27985446efb9874ea58818dd9c0d8a5a2f1a20ce0d91c0b30b875e91e6'
 
-  url 'https://www.hyperbolicsoftware.com/programs/SmartTrash2.zip'
+  url "https://www.hyperbolicsoftware.com/programs/SmartTrash#{version.major}.zip"
   appcast 'https://www.hyperbolicsoftware.com/Receipts/Smart_Trash/SmartTrashUpdate.xml',
           checkpoint: '6699bbe03e16dfc96ed4f6e638ceb74535d47e47fff9912785dbd630d7085927'
   name 'Smart Trash'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.