### PR TITLE
Update syphon-virtual-screen to 1.3

### DIFF
--- a/Casks/syphon-virtual-screen.rb
+++ b/Casks/syphon-virtual-screen.rb
@@ -3,7 +3,7 @@ cask 'syphon-virtual-screen' do
   sha256 '0cf56d171f3427d623d4b12d55e0342a34cd8d12dd7082c7ed372b5effac8a46'
 
   # github.com/andreacremaschi/Syphon-virtual-screen was verified as official when first introduced to the cask
-  url 'https://github.com/andreacremaschi/Syphon-virtual-screen/releases/download/1.3/Syphon.Virtual.Screen.mpkg.zip'
+  url "https://github.com/andreacremaschi/Syphon-virtual-screen/releases/download/#{version}/Syphon.Virtual.Screen.mpkg.zip"
   appcast 'https://github.com/andreacremaschi/Syphon-virtual-screen/releases.atom',
           checkpoint: '99793e70b315957b663123c844fb442f2fffef84e7ec4731506b6324fc70fcca'
   name 'Syphon Virtual Screen'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.