### PR TITLE
Update vitamin-r to 2.43

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -7,25 +7,25 @@ cask 'vitamin-r' do
   elsif MacOS.version <= :snow_leopard
     version '1.85'
     sha256 'cf5676f710a9be0f290aa20c2b1f9feaf87f162b580987f7c08477a2f13b2705'
-    url 'http://www.publicspace.net/download/Vitamin_1_85.dmg'
+    url "http://www.publicspace.net/download/Vitamin_#{version.dots_to_underscores}.dmg"
     app 'Vitamin-R.app'
   elsif MacOS.version <= :lion
     version '2.06'
     sha256 'd6a5839f7a1bdf1b3767f1c48881048f6bee20bf9de55be3936bab3202ee2541'
-    url 'http://www.publicspace.net/download/Vitamin_2_06.dmg'
-    app 'Vitamin-R 2.app'
+    url "http://www.publicspace.net/download/Vitamin_#{version.dots_to_underscores}.dmg"
+    app "Vitamin-R #{version.major}.app"
   elsif MacOS.version <= :mavericks
     version '2.19'
     sha256 'cfc107e016e364ba1ed2ca091b6b03daf00d748852d06a4de7c421b8f4ece175'
-    url 'http://www.publicspace.net/download/Vitamin_2_19.dmg'
-    app 'Vitamin-R 2.app'
+    url "http://www.publicspace.net/download/Vitamin_#{version.dots_to_underscores}.dmg"
+    app "Vitamin-R #{version.major}.app"
   else
-    version '2.4.3'
+    version '2.43'
     sha256 'a08960027b32249e44d37ec30f1f6f78432f5f4eb116c24650b1a008b6fb7918'
     url "http://www.publicspace.net/download/signedVitamin#{version.major}.zip"
     appcast "http://www.publicspace.net/app/vitamin#{version.major}.xml",
             checkpoint: 'ddba0d4086693bc527ac9623936517dc265c6d44aabbf04145d40b9758250d7e'
-    app 'Vitamin-R 2.app'
+    app "Vitamin-R #{version.major}.app"
   end
 
   name 'Vitamin-R'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.