### PR TITLE
Update wiring to 1.0,0101

### DIFF
--- a/Casks/wiring.rb
+++ b/Casks/wiring.rb
@@ -1,8 +1,8 @@
 cask 'wiring' do
-  version '1.0-101'
+  version '1.0,0101'
   sha256 'ff593ccfc8a1ef988b86f7610141c9bd0e5d3763b64e04f28257a374042830a8'
 
-  url 'http://wiring.org.co/download/wiring-0101-macosx.zip'
+  url "http://wiring.org.co/download/wiring-#{version.after_comma}-macosx.zip"
   name 'Wiring'
   homepage 'http://wiring.org.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.