### PR TITLE
Update acorn to 5.5.2

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -3,7 +3,7 @@ cask 'acorn' do
   sha256 'e8b1ca2ae886dca003f6cb43effd1f128a340dd08e952873da22178abed1231e'
 
   url 'https://secure.flyingmeat.com/download/Acorn.zip'
-  appcast 'http://www.flyingmeat.com/download/acorn5update.xml',
+  appcast "http://www.flyingmeat.com/download/acorn#{version.major}update.xml",
           checkpoint: 'fdd211ab0c3a91766a9b5c7a69371bb235b3877921022dba70d3ac8fd8ba7fea'
   name 'Acorn'
   homepage 'http://flyingmeat.com/acorn/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.