### PR TITLE
Update appzapper to 2.0.1

### DIFF
--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -3,7 +3,7 @@ cask 'appzapper' do
   sha256 'b7d0bdd05cf246a2f2ab18145b052824860cb74a6ae665fba9d403f6bb79fac4'
 
   url "https://www.appzapper.com/downloads/AppZapper#{version}.zip"
-  appcast 'https://www.appzapper.com/az2appcast.xml',
+  appcast "https://www.appzapper.com/az#{version.major}appcast.xml",
           checkpoint: 'b91ae47cbd23159ada1e03357647dc3140cd35ef509dfa44ed13e369aad07e88'
   name 'AppZapper'
   homepage 'https://www.appzapper.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.