### PR TITLE
Update delicious-library to 3.6.1

### DIFF
--- a/Casks/delicious-library.rb
+++ b/Casks/delicious-library.rb
@@ -1,10 +1,10 @@
 cask 'delicious-library' do
-  version '3.6'
-  sha256 'dc672eb8087267caedb5e99d94a3c3c41a8256eff42ba3ac43d1e4f2c9395789'
+  version '3.6.1'
+  sha256 '4118b3c05dde652fcd27238f72b345b037d837f49cfe2226c62d2e2b109cd4ce'
 
   url "https://delicious-monster.com/downloads/DeliciousLibrary#{version.major}/v#{version}/DeliciousLibrary#{version.major}.zip"
-  appcast 'https://www.delicious-monster.com/downloads/DeliciousLibrary3.xml',
-          checkpoint: '23e6fdb006a046913b7843b89b023154dafb20912459598313c2b38bdd19fa95'
+  appcast "https://www.delicious-monster.com/downloads/DeliciousLibrary#{version.major}.xml",
+          checkpoint: '4fe1868f0ed078ecbfabfbdb041db8d7f2ca6146fb0ab8193c9a96c673bcb008'
   name 'Delicious Library'
   homepage 'https://delicious-monster.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.