### PR TITLE
Update tableflip to 1.1.4

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,6 +1,6 @@
 cask 'tableflip' do
-  version '1.1.3'
-  sha256 '7670584f0177582b18f0f04ba483300639fa2d19cc1f30a5030646a1967f6014'
+  version '1.1.4'
+  sha256 'feb5f11017e6983f1d4136ca31d251ddff86c42b0f5e990aeff6809fb85ce713'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.