### PR TITLE
Update tiptyper to 2.7

### DIFF
--- a/Casks/tiptyper.rb
+++ b/Casks/tiptyper.rb
@@ -4,11 +4,11 @@ cask 'tiptyper' do
     sha256 '5f862ea7d68548569c9b038f8cc8e542e07ae21b26462e75442f28ba2d4088ad'
     url "https://www.brunophilipe.com/software/tiptyper/releases/releasen-#{version}.zip"
   else
-    version '2.6.4'
-    sha256 '76e14095a1816f9d1902d0aec390a724d2c10622c048e964ca46d854cfab71ca'
+    version '2.7'
+    sha256 'ec9b114764ce348c13407a672ea55489d2070ae5372fc9474f717ec0d943d8d9'
     url "https://www.brunophilipe.com/software/tiptyper/releases/releasen-#{version}.zip"
     appcast 'https://www.brunophilipe.com/software/tiptyper/versioninfo/appcast.php',
-            checkpoint: '2cf35f97bb203befea37d8161ebeb2535bc3bbc8464e39b60d5120d371767aae'
+            checkpoint: 'ac97ae5bfcb64305adf50b72484d70095993c6fc61b3a339f76f628bb4efed19'
   end
 
   name 'TipTyper'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.