### PR TITLE
Update dropshare to 4.4.5

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,13 +1,13 @@
 cask 'dropshare' do
-  version '4-4226'
+  version '4.4.5'
   sha256 '779122019003f27b78e9792133902f18019d389cb93de45ce8b1c2670c60bd5c'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version}.app.zip"
-  appcast 'https://getdropsha.re/sparkle/Dropshare4.xml',
+  url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-latest.zip"
+  appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
           checkpoint: 'f5a2dac4ec60a0cbd61a490091e62306692d686e6a3226cfd16ca2dcd1ae5f01'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 
-  app 'Dropshare 4.app'
+  app "Dropshare #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.