### PR TITLE
Update ghostlab to 2.1.2

### DIFF
--- a/Casks/ghostlab.rb
+++ b/Casks/ghostlab.rb
@@ -1,12 +1,12 @@
 cask 'ghostlab' do
   version '2.1.2'
-  sha256 'ce2a1a6189fe226c59cd923717a5ae6f71621fcdd8a57e28f70efaaaf81f8d13'
+  sha256 'ad30b19c9190b0fa173e4cd3bc63a56afe2f2d7fc93b45296c21ea2a50c5316e'
 
-  url "https://awesome.vanamco.com/Ghostlab2/update/packages/mac/Ghostlab2-#{version}.zip"
-  appcast 'https://awesome.vanamco.com/Ghostlab2/update/ghostlab2-cast.xml?vco=trkd',
+  url "https://awesome.vanamco.com/Ghostlab#{version.major}/downloads/Ghostlab#{version.major}.dmg"
+  appcast "https://awesome.vanamco.com/Ghostlab2/update/ghostlab#{version.major}-cast.xml?vco=trkd",
           checkpoint: '243c77ba04b68fb6af58aed4467f7664d5bf79e88eff4726c48ca157d98a7490'
   name 'Ghostlab'
   homepage 'https://vanamco.com/ghostlab/'
 
-  app 'Ghostlab2.app'
+  app "Ghostlab#{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.