### PR TITLE
Bump Armitage to '15.08.13'

### DIFF
--- a/Casks/armitage.rb
+++ b/Casks/armitage.rb
@@ -1,6 +1,6 @@
 cask 'armitage' do
-  version '14.11.20'
-  sha256 'b309fdef13c8a3a0d981ffc1ad2bfb4786a797f4e291dd4ef3bcc2806c1126f4'
+  version '15.08.13'
+  sha256 'f44af478248fd01e71ea7e7bcfa558e4c9b291a78b0d1df1ad245c34cabd896b'
 
   url "http://www.fastandeasyhacking.com/download/armitage#{version.no_dots}.dmg"
   name 'Armitage'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

---
tyr:~/Desktop/NEW benc$ brew cask audit --download ./armitage.rb
==> Downloading http://www.fastandeasyhacking.com/download/armitage150813.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask armitage
audit for armitage: passed
tyr:~/Desktop/NEW benc$ brew cask style --fix !$
brew cask style --fix ./armitage.rb

1 file inspected, no offenses detected

---

benc$ shasum -a 256 armitage150813.dmg 
f44af478248fd01e71ea7e7bcfa558e4c9b291a78b0d1df1ad245c34cabd896b  armitage150813.dmg

Current on: http://www.fastandeasyhacking.com/download/