### PR TITLE
Update macfusion to 2.1-dev

### DIFF
--- a/Casks/macfusion.rb
+++ b/Casks/macfusion.rb
@@ -2,10 +2,10 @@ cask 'macfusion' do
   version '2.1-dev'
   sha256 'bc180bfe471fb41cbd5bf8d896dd38c0d4222436425970e090bcd36ad556e026'
 
-  # github.com/ElDeveloper/macfusion2 was verified as official when first introduced to the cask
-  url "https://github.com/ElDeveloper/macfusion2/releases/download/#{version}/Macfusion-#{version}.zip"
-  appcast 'https://github.com/ElDeveloper/macfusion2/releases.atom',
-          checkpoint: '66247c8e488caf39992d97b35481a7b24891eff9afb51a57b651dc68ff1190a8'
+  # github.com/ElDeveloper/macfusion was verified as official when first introduced to the cask
+  url "https://github.com/ElDeveloper/macfusion#{version.major}/releases/download/#{version}/Macfusion-#{version}.zip"
+  appcast "https://github.com/ElDeveloper/macfusion#{version.major}/releases.atom",
+          checkpoint: '1d723f056dc494253c55c5fa83f3f679ea9c4b421b2a97b806a70c08470aae08'
   name 'Macfusion'
   homepage 'http://macfusionapp.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.