### PR TITLE
Update hands-off to 3.1.2

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,10 +1,10 @@
 cask 'hands-off' do
-  version '3.0.6'
-  sha256 '8c6b8b8f813e16378e5e6652d74c997cdf6ed3922aa6389d008af1efb2d77a09'
+  version '3.1.2'
+  sha256 'c3efcb883282055d1e51e9efa295d67d419b8c3c5427fc03bce70b36ac710673'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml",
-          checkpoint: 'e77c570a88756fa34f6c0a80df1cd7c239e223f34c827343b22edbd88430ee31'
+          checkpoint: '7bcc930a46fb9b9bccfce799a66bbbfe7131320209573337e15b1fa8ef1f7caf'
   name 'Hands Off!'
   homepage 'https://www.oneperiodic.com/products/handsoff/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.