### PR TITLE
komodo-edit: upgrade to 10.1.1-17414

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,6 +1,6 @@
 cask 'komodo-edit' do
-  version '10.0.1-17276'
-  sha256 '6ff89c1c0a43b16900889da6d7c6b7988f9aa82d04623bfc15c0b95b6e7fc591'
+  version '10.1.1-17414'
+  sha256 'ff5f06fa202bb82b4e30f55f03a8ea657fcf4dbcc1af8dfd9c73660bf824a406'
 
   # activestate.com/Komodo was verified as official when first introduced to the cask
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.