### PR TITLE
Update scrivener to 2.8

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,10 +1,10 @@
 cask 'scrivener' do
-  version '2.80.3'
-  sha256 '9ea0910d950b36159d5e722ebcf04e8f1fff48ad667382a01e05edbbfb02fdb0'
+  version '2.8'
+  sha256 '752a689ca500a9b5ec8192790fd747671896e4f3ca4c8e14cc0b9943726cc36a'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://scrivener.s3.amazonaws.com/mac_updates/Scrivener_106_#{version}.zip"
-  appcast 'https://www.literatureandlatte.com/downloads/scrivener-2.xml',
+  url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
+  appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
           checkpoint: '79e3d31dd436e68082f47d8d3690967b250f6f810eca34b4e057f3255003cdde'
   name 'Scrivener'
   homepage 'https://literatureandlatte.com/scrivener.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.