### PR TITLE
Add Particle Dev Latest

### DIFF
--- a/Casks/particle-dev.rb
+++ b/Casks/particle-dev.rb
@@ -1,0 +1,16 @@
+cask 'particle-dev' do
+  version :latest
+  sha256 :no_check
+
+  # amazonaws.com/spark-website was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/spark-website/particle-dev-mac.zip'
+  name 'Particle Dev'
+  homepage 'https://www.particle.io/products/development-tools/particle-local-ide'
+
+  app 'Particle Dev.app'
+
+  zap delete: [
+                '~/.particle',
+                '~/.particledev',
+              ]
+end

--- a/Casks/particle-dev.rb
+++ b/Casks/particle-dev.rb
@@ -2,7 +2,7 @@ cask 'particle-dev' do
   version :latest
   sha256 :no_check
 
-  # amazonaws.com/spark-website was verified as official when first introduced to the cask
+  # s3.amazonaws.com/spark-website was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/spark-website/particle-dev-mac.zip'
   name 'Particle Dev'
   homepage 'https://www.particle.io/products/development-tools/particle-local-ide'


### PR DESCRIPTION
Particle Dev has been included in Caskroom before, and was most recently deleted in #19714. A downloads for the latest version is available from the vendor's website, rather than from GitHub Releases.

- [x] `brew cask audit --download particle-dev` is error-free.
- [x] `brew cask style --fix particle-dev` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install particle-dev` worked successfully.
- [x] `brew cask uninstall particle-dev` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

