### PR TITLE
Update slicy to 1.1.7

### DIFF
--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -2,8 +2,9 @@ cask 'slicy' do
   version '1.1.7'
   sha256 '0a57becbcbb6d4de17ab27e7c011f07543c37277e2e6988f60f464c6483fee39'
 
-  url 'https://macrabbit.com/slicy/get/'
-  appcast 'https://update.macrabbit.com/slicy/1.1.3.xml',
+  # s3.amazonaws.com/macrabbit/downloads was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/macrabbit/downloads/Slicy+#{version}.zip"
+  appcast "https://update.macrabbit.com/slicy/#{version}.xml",
           checkpoint: '39d01f62bb6ab96fdee061a8077fd8cbffcafee6551d7be4bc0fe4dc20249e3d'
   name 'Slicy'
   homepage 'https://macrabbit.com/slicy/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.