### PR TITLE
Update stretchly to 0.4.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.3.0'
-  sha256 '331dd1c3c1b41dbfe48b8786e3d434cfccc2e199dcce04c43c698a2dc350676f'
+  version '0.4.0'
+  sha256 '19d8fd0920bec5221f85b3b2e7868805c8c493e994f9864ccf8ec9a6b1f5da50'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: 'af574f5126d75c782f81316ae110a3b76bb390f2c46dd90eb91b930d76c90f7e'
+          checkpoint: '1c4244355d721e8f05a3f9c451f742a9e3f6cf7e463d252e0a4b2da000ec524b'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.