### PR TITLE
Update privatetunnel to 2.7

### DIFF
--- a/Casks/privatetunnel.rb
+++ b/Casks/privatetunnel.rb
@@ -1,6 +1,6 @@
 cask 'privatetunnel' do
-  version '2.6'
-  sha256 '8a294d0bff57e0b5df41d613e1104a6f39483f3440dccd080022249f0b698460'
+  version '2.7'
+  sha256 '64ff83847f41cbdc857f616bff03477292c30e2283ce9617a59bb4bbba1058b4'
 
   # swupdate.openvpn.org/privatetunnel was verified as official when first introduced to the cask
   url "https://swupdate.openvpn.org/privatetunnel/client/privatetunnel-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.