### PR TITLE
Update sqlectron to 1.17.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.16.0'
-  sha256 '2647354256efb8663bb28331235a0d02564102c410248b9bf6b855492fd969c9'
+  version '1.17.0'
+  sha256 '09792d9ed39e6595b02f0741bb2c18e2ae6f36bad8ab78e170c3b55aec6c843a'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: '201fa22f53e1d92036516f217556b85994499ce0248551915ef4a5a3554e0c43'
+          checkpoint: 'c7565ade7540397ee5bfdbfab8d75de14f3c8a15b9001eac4c7aae1bc031ca56'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.