### PR TITLE
Update pdfsam-basic to 3.2.4

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,11 +1,11 @@
 cask 'pdfsam-basic' do
-  version '3.2.2'
-  sha256 'c57457fa03a943644ecf0b3ae189ccb1cdd4156157ac05be9d4846a29abcb08a'
+  version '3.2.4'
+  sha256 'bc016b4c59e9c8af2bdca337f6c2fc5b2ead25d8b23a8fbb8d7ff6c4350f5237'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}.RELEASE/PDFsam-#{version}.RELEASE.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom',
-          checkpoint: 'c50746704a30c294000a22a0acb4c7fea41e4b5f0f20fa8d961e4f0e5ca98893'
+          checkpoint: 'c3635fad8643f2fbb75ead16dd56a6ffc6b9426d68bb7d4e87ae15b16e533e03'
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.