### PR TITLE
New cask: packetsender, PacketSender.app, version 5.1

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,9 +1,11 @@
 cask 'packetsender' do
-  version '5.1'
+  version '5.1,2016-10-13'
   sha256 '9ef8ee82b7d9a7987430a45e483b676db2c0a4ada1bb59b033538dbd1c9da520'
 
-  # github.com/dannagle was verified as official when first introduced to the cask
-  url 'https://github.com/dannagle/PacketSender/releases/download/v5.1-sierra1/PacketSender_2016-10-13.dmg'
+  # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
+  url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}-sierra1/PacketSender_#{version.after_comma}.dmg"
+  appcast 'https://github.com/dannagle/PacketSender/releases.atom',
+          checkpoint: '23639a7e3b2135f56c03a411d19ac81165cf4371dcc9e684d7ea644f83be3d86'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'
 

--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,0 +1,11 @@
+cask 'packetsender' do
+  version '5.1'
+  sha256 '9ef8ee82b7d9a7987430a45e483b676db2c0a4ada1bb59b033538dbd1c9da520'
+
+  # github.com/dannagle was verified as official when first introduced to the cask
+  url 'https://github.com/dannagle/PacketSender/releases/download/v5.1-sierra1/PacketSender_2016-10-13.dmg'
+  name 'Packet Sender'
+  homepage 'https://packetsender.com/'
+
+  app 'PacketSender.app'
+end


### PR DESCRIPTION
This is adding a new cask called "Packet Sender", an open source network utility for sending/receiving TCP and UDP packets. 

`brew cask install packetsender`

From the audit:

- [X ] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked that the cask was not already refused in [closed issues].

