### PR TITLE
Update grip to 1.5.0-rc3

### DIFF
--- a/Casks/grip.rb
+++ b/Casks/grip.rb
@@ -1,11 +1,11 @@
 cask 'grip' do
-  version '1.5.0-rc2'
-  sha256 '8b2c9d08c9c36d0c0fb68765c03769a6366063c162add7945f0af21c19775a01'
+  version '1.5.0-rc3'
+  sha256 'da44a0184b296a8e26f9ef8098dc23f9496f16b8afb5a68573ebfd2743a56327'
 
   # github.com/WPIRoboticsProjects/GRIP was verified as official when first introduced to the cask
   url "https://github.com/WPIRoboticsProjects/GRIP/releases/download/v#{version}/GRIP-#{version}-x64.dmg"
   appcast 'https://github.com/WPIRoboticsProjects/GRIP/releases.atom',
-          checkpoint: '351ceeb68abdf0593404e7a01c0510f4fbc45e83dad0b7c6dbfbd4e18c458b1a'
+          checkpoint: 'e3e9e85b0fcc6b87e574b9bf524b9cee9af11ef4956a89e3a626ce380fc9f019'
   name 'GRIP Computer Vision Engine'
   name 'GRIP'
   homepage 'https://wpiroboticsprojects.github.io/GRIP/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.