### PR TITLE
Update tuxera-ntfs to 2016

### DIFF
--- a/Casks/tuxera-ntfs.rb
+++ b/Casks/tuxera-ntfs.rb
@@ -1,6 +1,6 @@
 cask 'tuxera-ntfs' do
-  version '2015.3'
-  sha256 'a263f405f8f3a7950e6c29e8d0ac511823a8b2e58f76211190ec179fbd62947a'
+  version '2016'
+  sha256 '29ae78a41fb79f8bec6f3dfd7878098300c79d24f9acda55db293c82aa235d03'
 
   url "https://www.tuxera.com/mac/tuxerantfs_#{version}.dmg"
   name 'Tuxera NTFS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.