### PR TITLE
Update hots-replay-uploader to 2.1.2

### DIFF
--- a/Casks/hots-replay-uploader.rb
+++ b/Casks/hots-replay-uploader.rb
@@ -1,10 +1,10 @@
 cask 'hots-replay-uploader' do
-  version '2.1.1'
-  sha256 'f338c76bdc2fb875d445ddeb4fe6734fedc932381268f228dcc6c2dfe02a6735'
+  version '2.1.2'
+  sha256 'a5e6dcb97ed05f74cbeb913b737bf70b19a02a8b9a6609f23fa5879bd6aa1f74'
 
   url "https://github.com/eivindveg/HotSUploader/releases/download/v#{version}/HotS.Replay.Uploader-#{version}.dmg"
   appcast 'https://github.com/eivindveg/HotSUploader/releases.atom',
-          checkpoint: 'bfe84d8cb453a9b75cb5ac94a4fbb2729b5d4c0983a4f0536535f9d93aa842c5'
+          checkpoint: 'edebb36c29afebbe206191bb9e7fcfaa05df864c86e0516e44038dbbd61ac51b'
   name 'HotS Replay Uploader'
   homepage 'https://github.com/eivindveg/HotSUploader/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.