### PR TITLE
Adding new jtool Cask

### DIFF
--- a/Casks/jtool.rb
+++ b/Casks/jtool.rb
@@ -6,8 +6,6 @@ cask 'jtool' do
   name 'jtool'
   homepage 'http://newosxbook.com/tools/jtool.html'
 
-  license :gratis
-
   binary 'jtool'
   artifact 'jtool.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/jtool.1"
 end

--- a/Casks/jtool.rb
+++ b/Casks/jtool.rb
@@ -1,0 +1,13 @@
+cask 'jtool' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.newosxbook.com/files/jtool.tar'
+  name 'jtool'
+  homepage 'http://newosxbook.com/tools/jtool.html'
+
+  license :gratis
+
+  binary 'jtool'
+  artifact 'jtool.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/jtool.1"
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

Submitting a new cask for [jtool](http://newosxbook.com/tools/jtool.html). I wasn't sure if there was a better way to handle linking a manpage. I opted to link it manually using `artifact` and `HOMEBREW_PREFIX`, similar to what [cargo does](https://github.com/caskroom/homebrew-cask/blob/master/Casks/cargo.rb).