### PR TITLE
Update processing to 3.2.3

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,10 +1,10 @@
 cask 'processing' do
-  version '3.2.2'
-  sha256 '206eb7954971561333b446a41397674454d435db9cd95162103617504a8c31f1'
+  version '3.2.3'
+  sha256 '55874bba8eb6404a19b2c32697438421f93c20715be92e4637c1a26cabd56da0'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: 'aa3e0e59bf5bd3a4abcb595fd1db75caa29d5ec24ec63f9b69f7e73f09cf4505'
+          checkpoint: 'b2000c13f2e7503048eb1ed3faedd0be414de16362217bee43e850402dd16483'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.