### PR TITLE
Update keytty to 1.2.1,1478523599

### DIFF
--- a/Casks/keytty.rb
+++ b/Casks/keytty.rb
@@ -1,11 +1,11 @@
 cask 'keytty' do
-  version '1.2.0,1476667481'
-  sha256 '20d6d6d3a8a935b9edee353b7f39a394c89ef9e2ab349b74c5a47d1b95af1c03'
+  version '1.2.1,1478523599'
+  sha256 'c10a61be158ade8d8505dd87fcfafb9577c4db1c746dc44f223710540d884dc2'
 
   # dl.devmate.com/com.keytty.Keytty was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.keytty.Keytty/#{version.before_comma}/#{version.after_comma}/keytty-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.keytty.Keytty.xml',
-          checkpoint: '387ed2865a3ac036f27bc112b012fd46d408f3a5ed035d708a567fef58ba58a9'
+          checkpoint: '7fd0b94dd90eab19e4be001ec520fb3ad5c1558c6d53acf8631639b561818b53'
   name 'Keytty'
   homepage 'http://keytty.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.