### PR TITLE
Update gnubg to fix an argument error

### DIFF
--- a/Casks/gnubg.rb
+++ b/Casks/gnubg.rb
@@ -21,7 +21,7 @@ cask 'gnubg' do
   caveats do
     <<-EOS.undent
       #{token} only works if called from /Applications, so you may need to install it with
-        brew cask --appdir=/Applications install #{token}
+        brew cask install #{token} --appdir=/Applications
     EOS
   end
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fixes `Error: Unknown command: --appdir=/Applications` when
trying to run the example command.