### PR TITLE
Update macdown to 0.6.4

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -1,11 +1,11 @@
 cask 'macdown' do
-  version '0.6.2'
-  sha256 '33701539d252c29b1642b59fead311b86a05158854aa122ed286065e7f6fc85b'
+  version '0.6.4'
+  sha256 'fcc7950c69eca4428a2eb4c2705e032a747eacb2b657bc48195c3aee60d35f25'
 
-  # github.com/uranusjr/macdown was verified as official when first introduced to the cask
-  url "https://github.com/uranusjr/macdown/releases/download/v#{version}/MacDown.app.zip"
-  appcast 'https://github.com/uranusjr/macdown/releases.atom',
-          checkpoint: '0477e464f915b632bc05966556842fb76a64b67e39b35347249102ae24460618'
+  # github.com/MacDownApp/macdown was verified as official when first introduced to the cask
+  url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
+  appcast 'https://github.com/MacDownApp/macdown/releases.atom',
+          checkpoint: '494e6ec6883fd528a9b1905aa3270dfd0361143bfae5bec6b50284b22ef1f966'
   name 'MacDown'
   homepage 'http://macdown.uranusjr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

-----

The repo owner/organisation changed back in March, see [this commit by the author](https://github.com/MacDownApp/macdown/commit/8613582f9f0f5302a265b381bef91d16c98d7ba1).