### PR TITLE
Update downie to 2.5.8,1336

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.5.7,1333'
-  sha256 '7e1a229de1e0441dea133d30bc2df20645db67aaa0b36eef2209e51450a45b1b'
+  version '2.5.8,1336'
+  sha256 '51dc2ba14b213a12294c738d6eb787e1ea9518f7d5cd8c8aef9dbf197be625e1'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '6a0e14a68069f7f5bcb469d03e3bace664afad3ee3a5536f2d557520a36651e7'
+          checkpoint: 'ef9da41ac56a1e6369d013d74f7cf7d996918d526e339bba7f86409e780047ea'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.