### PR TITLE
Update mailbutler to 6630

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6562'
-  sha256 'fd4e5e40108d57c5bcd4013f21d7f68534a4d01d7232a3f3f1a3f6b5bb536933'
+  version '6630'
+  sha256 'b8b46e9f2beacbefaefe2f1510cc818cf5b8850b6a4bd41934802e598fa2ddbf'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '523c96f4846fb59eaef5fbf93ba36c41daf9c8a38b77e3bc1ce83a275546af4c'
+          checkpoint: '7a068342011c7e6255a2f9953f35a0aaf31d8298e97ab4efcac5afc11e2b87f3'
   name 'MailButler'
   homepage 'https://www.feingeist.io/mailbutler/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.