### PR TITLE
Update flixster-video to 2.7.0.606

### DIFF
--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -1,11 +1,11 @@
 cask 'flixster-video' do
-  version '2.7.0.604'
-  sha256 'f5237ee6b762879959ef1c2bd6be63ef8aa6fc80aa7fce833a554b3096ffbedf'
+  version '2.7.0.606'
+  sha256 'f9b447fbb938d62eba39618c1f85473915fa20ca01154c10c57784010bb4ed72'
 
   # d1rtylazwb77ux.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
   appcast 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
-          checkpoint: '632ec893948fab75b406925d603b5637ead4dac2ddc89e2beeac4850e6394ef6'
+          checkpoint: '70d0513d0f9ccb486129b0a4aa6b728877aa9849adc57a4f3083b953c2598dc1'
   name 'Flixster Video'
   homepage 'https://www.flixster.com/about/ultraviolet/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.