### PR TITLE
Update wechat-web-devtools to 0.10.102800

### DIFF
--- a/Casks/wechat-web-devtools.rb
+++ b/Casks/wechat-web-devtools.rb
@@ -1,11 +1,10 @@
 cask 'wechat-web-devtools' do
-  version '0.9.092300,20160923'
-  sha256 '0c5c2038b30e7229b93bc4df574a45e438861fb4f430f99e063512cf01697693'
+  version '0.10.102800'
+  sha256 '84dedd2680afc42a951579e4ca3278e69cfa27193eb0f288be7e9da73b5d3cd7'
 
-  url "http://dldir1.qq.com/WechatWebDev/mina/#{version.after_comma}/wechat_web_devtools_#{version.before_comma}.dmg"
+  url 'http://dldir1.qq.com/WechatWebDev/010102800/wechat_web_devtools_0.10.102800.dmg'
   name 'wechat web devtools'
-  name '微信web开发者工具'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'
 
-  app '微信web开发者工具.app'
+  app 'wechatwebdevtools.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.