### PR TITLE
Update fromscratch to 1.2.0

### DIFF
--- a/Casks/fromscratch.rb
+++ b/Casks/fromscratch.rb
@@ -1,11 +1,11 @@
 cask 'fromscratch' do
-  version '1.1.1'
-  sha256 'eb39b0ba128fe9352ceb4d2cb2701a4cd7ef772083ad97ce7de62a2f14bdad02'
+  version '1.2.0'
+  sha256 'b9d69e6e29f9569b3c96d3343d5f4f082d70846d6e0a166625b21b3263f64222'
 
   # github.com/Kilian/fromscratch was verified as official when first introduced to the cask
   url "https://github.com/Kilian/fromscratch/releases/download/v#{version}/FromScratch-darwin-x64-#{version}.zip"
   appcast 'https://github.com/Kilian/fromscratch/releases.atom',
-          checkpoint: 'bc6fd4aea1849757ce946f7daaeaf22a1f47c838346af321cdb877e9b256f47e'
+          checkpoint: 'c6ce7f224a03ae7f7a9891b25cb2f247465602f77edcd770984d0834f6757595'
   name 'FromScratch'
   homepage 'https://fromscratch.rocks/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.