### PR TITLE
Updated TortoiseHG to v. 4.0.0

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '3.9.2'
-  sha256 'f2be4c32f6a2084523d532c6bed35ace574c7862c17a3c4ec9128b3b31b1a5c5'
+  version '4.0.0'
+  sha256 'e16795c608b775cf6d755d4a5273214b65211891c2ac5b76907ecac3ff170717'
 
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"
   name 'TortoiseHg'


### PR DESCRIPTION
Updated TortoiseHG to version 4.0.0

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.