### PR TITLE
Update telegram to 2.28-51237

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.27-51120'
-  sha256 '4fda51a83b90134ad28dc9f652bd421d4e78d82f6ed52b22874a7d9120fa1f76'
+  version '2.28-51237'
+  sha256 'e2efb5757cbd7fa535c5854e76af4cec5e5931bea3f2115562c9f7c30e630884'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'be255033b99e0ea72d0d0ef8f2f8b326ec87e81688bd5b19405ba148eb83ccaa'
+          checkpoint: '2a9f30a4be374f6515d4c13bf2122254b01e72f4c50436691133c6d1c6f1a6b3'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.