### PR TITLE
Remove discontinued caveat from Unity Web Player Cask

### DIFF
--- a/Casks/unity-web-player.rb
+++ b/Casks/unity-web-player.rb
@@ -12,8 +12,4 @@ cask 'unity-web-player' do
 
   uninstall pkgutil: 'com.unity.UnityWebPlayer',
             delete:  '/Library/Internet Plug-Ins/Unity Web Player.plugin'
-
-  caveats do
-    discontinued
-  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.