### PR TITLE
powershell 6.0.0-alpha.12: add dependency on openssl and a note with …

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -9,6 +9,8 @@ cask 'powershell' do
   name 'PowerShell'
   homepage 'https://msdn.microsoft.com/powershell'
 
+  depends_on formula: 'openssl'
+
   pkg "powershell-#{version}.pkg"
 
   uninstall pkgutil: 'powershell'
@@ -24,4 +26,11 @@ cask 'powershell' do
                 '~/.local/share',
                 '~/.local',
               ]
+
+  caveats <<-EOS.undent
+    A OpenSSL-backed libcurl is required for custom handling of certificates.
+    This is rarely needed, but you can install it with
+      brew install curl --with-openssl
+    See https://github.com/PowerShell/PowerShell/issues/2211
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---
According to [official docs], Homebrew's `openssl` and `curl --with-openssl` are the prerequisites for PowerShell.

`openssl` is specified with `depends_on` because it is required for some commands such as `Invoke-WebRequest` (a PowerShell's parallel to wget and curl).

In contrast, `curl` is not specified but noted in caveats for the some reasons.
The OpenSSL-backed libcurl is difficult to depend on because it requires a non-standard option (`--with-openssl`).
Furthermore, the parts depending on it are hard to invoke from PowerShell (but #C).
For more infomation, see https://github.com/PowerShell/PowerShell/issues/2211

[official docs]: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl