### PR TITLE
dotnet 1.0.0-preview2-003148,1.0.2: uninstall /etc/paths.d/dotnet

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -18,7 +18,8 @@ cask 'dotnet' do
     system '/usr/bin/sudo', '-E', '--', '/usr/bin/install_name_tool', "#{dotnet_core}/System.Net.Http.Native.dylib", '-change', '/usr/lib/libcurl.4.dylib', "#{HOMEBREW_PREFIX}/opt/curl/lib/libcurl.4.dylib"
   end
 
-  uninstall pkgutil: 'com.microsoft.dotnet.*'
+  uninstall pkgutil: 'com.microsoft.dotnet.*',
+            delete:  '/etc/paths.d/dotnet'
 
   zap delete: '~/.nuget'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---
Bill-of-Materials does not includes `/etc/paths.d/dotnet`.