### PR TITLE
Update docker to 1.12.3.13776

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '1.12.1.12133'
-  sha256 '09570e4bca991cb5fc3b04d8f64835c910942c5b4b35366ffb6f1af90ad0f336'
+  version '1.12.3.13776'
+  sha256 '5e9676cedcd87dd0909bf7007bfba571354f61d728deb52a426a3be105ba3774'
 
   url "https://download.docker.com/mac/stable/#{version}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: '70ba05cde55d1499e124b2a164ff0256294a2ec1793ea1d38462b3a80738b489'
+          checkpoint: '1104809b02843215c4b7acf1108fb958d1491811912c8ef20ab4bc718e82cce2'
   name 'Docker for Mac'
   homepage 'https://www.docker.com/products/docker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.