### PR TITLE
Squire 1.5.7 - corrected sha256

### DIFF
--- a/Casks/squire.rb
+++ b/Casks/squire.rb
@@ -1,6 +1,6 @@
 cask 'squire' do
   version '1.5.7'
-  sha256 'a543f006ee04630397f1316a5599d5944445f0bf232239fa50c791a33cc387c9'
+  sha256 '36b5b895c287f3579839c42a20bc85b1ef2489d630881c533b440020f6a30375'
 
   # amazonaws.com/squire was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/squire/builds/Squire.dmg'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated sha256 with correct value (probably due to a new version of the file, for the same app version [1.5.7]).