### PR TITLE
Update duet to 1.6.2.8

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,11 +1,11 @@
 cask 'duet' do
-  version '1.6.0.6'
-  sha256 '376bfaf0e10b841491b33f9105c24387da4e7c6e3dbda4348860eb199b825932'
+  version '1.6.2.8'
+  sha256 '7e491bebe011abab6330cab393e97cd8f61b5b8edb09f14e8a39867a573bb2ce'
 
-  # d2ycb980mbr5lq.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2ycb980mbr5lq.cloudfront.net/#{version.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"
+  # s3-us-west-1.amazonaws.com/duetmac/ was verified as official when first introduced to the cask
+  url "https://s3-us-west-1.amazonaws.com/duetmac/#{version.major_minor_patch.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"
   appcast 'https://updates.duetdisplay.com/checkMacUpdates',
-          checkpoint: 'effd1d216189a65c94a7307e9f55568df011564ddaa5393711f27717019e4b32'
+          checkpoint: '9530a79c68043d55ed87a039af0d6abd2c2f283bb9a4273a8e28344acf2f2582'
   name 'Duet'
   homepage 'http://www.duetdisplay.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.