### PR TITLE
Update cocoaspell.rb to 2.5

### DIFF
--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -1,11 +1,10 @@
 cask 'cocoaspell' do
-  version '2.1'
-  sha256 '06d6cd7f2b04c47f553c5a3a33ebe6bc5651457521cbe7e3ead84a6cb218053c'
+  version '2.5'
+  sha256 'd8dd01e6471df86f55d5f272a33fdb421f49a2fb923a9858a8772ec4367d333c'
 
-  # people.ict.usc.edu/~leuski/cocoaspell was verified as official when first introduced to the cask
   url "http://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg"
   name 'cocoAspell'
-  homepage 'http://cocoaspell.leuski.net/'
+  homepage 'http://people.ict.usc.edu/~leuski/cocoaspell'
 
   pkg 'cocoAspell.pkg'
 

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -2,7 +2,7 @@ cask 'cocoaspell' do
   version '2.5'
   sha256 'd8dd01e6471df86f55d5f272a33fdb421f49a2fb923a9858a8772ec4367d333c'
 
-  url "http://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg"
+  url "http://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg", user_agent: :fake
   name 'cocoAspell'
   homepage 'http://people.ict.usc.edu/~leuski/cocoaspell'
 

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -6,6 +6,8 @@ cask 'cocoaspell' do
   name 'cocoAspell'
   homepage 'http://people.ict.usc.edu/~leuski/cocoaspell'
 
+  depends_on macos: '>= :el_capitan'
+
   pkg 'cocoAspell.pkg'
 
   uninstall pkgutil: 'net.leuski.cocoaspell.*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Thanks to @Numbermaniac for helping with this.