### PR TITLE
Update bookwright to 1.1.147

### DIFF
--- a/Casks/bookwright.rb
+++ b/Casks/bookwright.rb
@@ -1,6 +1,6 @@
 cask 'bookwright' do
-  version '1.1.144'
-  sha256 'd1c65259d4e7aec0aa001b7375fd380619d991c8ef5ddfbe2cf89a34bdcd3b46'
+  version '1.1.147'
+  sha256 '850219dca84ec3e86cb9c8144b56fc9e0ad2862105e4d5f3feac9eddc597e719'
 
   url "http://downloads.blurb.com/bookwright_v2/#{version}/BookWright.dmg"
   name 'BookWright'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
