### PR TITLE
Update telegram to 2.28-51240

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.28-51237'
-  sha256 'e2efb5757cbd7fa535c5854e76af4cec5e5931bea3f2115562c9f7c30e630884'
+  version '2.28-51240'
+  sha256 '13da2ac429313ff8ae91990ef149918fb7fe8a355d140fc9beb3dde2789e11be'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '2a9f30a4be374f6515d4c13bf2122254b01e72f4c50436691133c6d1c6f1a6b3'
+          checkpoint: '5a478e37b4fd26c4520ed4623dfa19ccc6abb5ade968c367f6901de6a5db5e8e'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.