### PR TITLE
Update airtool to 1.4

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,11 +1,11 @@
 cask 'airtool' do
-  version '1.3.5'
-  sha256 '0e1aa4614e818e0ae579293d1997b5d85bbfefb7f349fed99ec366547fded9f0'
+  version '1.4'
+  sha256 '8c478e1018069dbfc409ecf6d3c955a87d688dad9773ba392c26f2552782ebc3'
 
   # amazonaws.com/adriangranados was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/adriangranados/airtool_#{version}.pkg"
   appcast 'https://www.adriangranados.com/appcasts/airtoolcast.xml',
-          checkpoint: '67f9a0be145410a24b2e6ab73b2b69e03d3e6d9396b240f1bd5e8c988028f171'
+          checkpoint: '3ae27f24c6a73ba242570adec45ea7cbf1b02b87c69494f02d978924b52c3a92'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.