### PR TITLE
Update brackets to 1.8

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,11 +1,11 @@
 cask 'brackets' do
-  version '1.7'
-  sha256 '1631dd2603f69488171d29776fa6fad09266a6d22b4263b59ef7d1bc39d64ea8'
+  version '1.8'
+  sha256 '37a67ad7b8d87b878e672e0c14aa0d671c8dea59af2518b0119ae4f3498d2e89'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
   appcast 'https://github.com/adobe/brackets/releases.atom',
-          checkpoint: '065e17a16458bf2a795e1933bd59dd47c87a43b31989a31d1fcd3e3b4ddff8d8'
+          checkpoint: 'f6eea3ff7a857c6c4039ac24662a9eab1de15dcc0464f1d33f8ac35efdaa4121'
   name 'Brackets'
   homepage 'http://brackets.io'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.