### PR TITLE
Update liri-browser to 0.3

### DIFF
--- a/Casks/liri-browser.rb
+++ b/Casks/liri-browser.rb
@@ -2,12 +2,11 @@ cask 'liri-browser' do
   version '0.3'
   sha256 'cdb39c6470f9e0a7b74e42dc31787172d2dacec6b074b2c3ecbce1b7b79dee7b'
 
-  # github.com/liri-project/liri-browser was verified as official when first introduced to the cask
   url "https://github.com/liri-project/liri-browser/releases/download/v#{version}/liri-browser-#{version}-osx.zip"
   appcast 'https://github.com/liri-project/liri-browser/releases.atom',
           checkpoint: '45f8016ad9e5023a21ed430111f62701cc24699a51276d814a98c575488b6597'
   name 'Liri Browser'
-  homepage 'http://liriproject.me/browser/'
+  homepage 'https://github.com/liri-project/liri-browser'
 
   app 'Liri Browser.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.