### PR TITLE
Update progressive-downloader to 2.7

### DIFF
--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -2,7 +2,7 @@ cask 'progressive-downloader' do
   version '2.7'
   sha256 'b893efec5e35fa889fcf25239108cd2b952562352104d96cc284a330d2cfbf48'
 
-  url "https://www.macpsd.net/update/#{version}/PSD.dmg"
+  url "http://www.macpsd.net/update/#{version}/PSD.dmg"
   name 'Progressive Downloader'
   homepage 'https://www.macpsd.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.