### PR TITLE
Update electron to 1.4.6

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.5'
-  sha256 '39d45cb18bf639fadb2613af6750792b0f2e80531ea5455874e5494e7a1a7b83'
+  version '1.4.6'
+  sha256 '738fd6c9f7b274ffc92b634f518f9bd7d06d26dfec5dc4fb0d8de236fef2559c'
 
   # github.com/atom/electron was verified as official when first introduced to the cask
   url "https://github.com/atom/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/atom/electron/releases.atom',
-          checkpoint: 'ecf8e3716afb6ee1ff8005d18549fe8f2a516a5806fd520693a0d1d2c8bfd9e9'
+          checkpoint: 'b2d34af98fa037e07e5849d683a54eb7fbd72cb51d035275994edac783495b0a'
   name 'Electron'
   homepage 'http://electron.atom.io/'
 


### PR DESCRIPTION

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
