### PR TITLE
Update p5 to 0.6.2

### DIFF
--- a/Casks/p5.rb
+++ b/Casks/p5.rb
@@ -1,12 +1,12 @@
 cask 'p5' do
   # note: "5" is not a version number, but an intrinsic part of the product name
-  version '0.6.1'
-  sha256 '608d54e6e18aee78b6292fdd56d7968821cb6b5a23567df9f452f9ce7e16231c'
+  version '0.6.2'
+  sha256 'd6688ad97708604b082332355aacdd24a2be28c14cc26ef452716be7d34fe255'
 
   # github.com/processing/p5.js-editor was verified as official when first introduced to the cask
   url "https://github.com/processing/p5.js-editor/releases/download/v#{version}/p5-mac.zip"
   appcast 'https://github.com/processing/p5.js-editor/releases.atom',
-          checkpoint: '219df1fa9cba52c93906de9018afc7657c809190a9abda6c0715a7aea28fa099'
+          checkpoint: 'be59b9f02d63c2c3ad02c6736566605dc0931d26d6d814c9187ed0f6f2c1bcf9'
   name 'p5.js Editor'
   homepage 'https://p5js.org/download/#editor'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.