### PR TITLE
Update runtastic-connect to 1.2.4

### DIFF
--- a/Casks/runtastic-connect.rb
+++ b/Casks/runtastic-connect.rb
@@ -1,10 +1,10 @@
 cask 'runtastic-connect' do
-  version '1.1.0'
-  sha256 '325e957b0b6cc8eba79e6a3fd01e13773dabfb13d2571c2feb9729f603c2a89f'
+  version '1.2.4'
+  sha256 '8ee506aaf8e61d476a9955b63f43babb0f064a78065ee97b7b411f4f1effd339'
 
   url "http://download.runtastic.com/connect/mac/Connect_#{version}.zip"
   appcast 'http://download.runtastic.com/connect/mac/appcast.xml',
-          checkpoint: '5a12c0d1453700ef2b9e284e3c5ea80649c2ef21aa0a6f8308629c91ea85fc8f'
+          checkpoint: '0cff0a9a0cc0a8a5952ff646aa86ddd180bb16000b1d3e0d6f58bcad45593f56'
   name 'Runtastic Connect'
   homepage 'https://www.runtastic.com/connect'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.