### PR TITLE
Update qgis to 2.18.0-1

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,6 +1,6 @@
 cask 'qgis' do
-  version '2.16.3-1'
-  sha256 'ed01b2f7f0212b548c2c5cd3d23d9baae0cbb603a7f2f7fbc2447b7339301711'
+  version '2.18.0-1'
+  sha256 'afbac1e61a363127c682d3d78a7d60f179e878cb4dc08c79b289006f6c8c797d'
 
   url "http://www.kyngchaos.com/files/software/qgis/QGIS-#{version}.dmg"
   name 'QGIS'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
