### PR TITLE
Update textmate to 2.0-rc.1

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,11 +1,11 @@
 cask 'textmate' do
-  version '2.0-beta.12.33'
-  sha256 '10752739b5a0af96d6a45ec7220f13e5452ff372bed7a9ef52452595f84e4da2'
+  version '2.0-rc.1'
+  sha256 '744228142e9359dd114233c6acb0b2bb87975b2adcbf073c3ada40117ccc5f0a'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
   appcast 'https://github.com/textmate/textmate/releases.atom',
-          checkpoint: 'b060d402f446bbcd4bf57b2680ccbea30b834a6eb7d377b8c6330703be91fe26'
+          checkpoint: 'ed404d0d0c4bb5895432f527ad5ecad1e000ae3aac1f4980eaf2af8246a2b3e4'
   name 'TextMate'
   homepage 'https://macromates.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.