### PR TITLE
Update cryptomator to 1.2.1

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.2.0'
-  sha256 'fa743d7520467f6213e47a6fc058bb7ac7d28f8a3742d49f5bb01677b23df22f'
+  version '1.2.1'
+  sha256 '24aec5c60cc5c391eacf38c8c0096d3e6b5f743741331ad0c84c11c3d7e201e3'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.