### PR TITLE
Update mailbutler to 6641

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6630'
-  sha256 'b8b46e9f2beacbefaefe2f1510cc818cf5b8850b6a4bd41934802e598fa2ddbf'
+  version '6641'
+  sha256 '115dbc2083c01eefdb1f4da27cba8d8ef7731bf5f0328c75cc06c40bb100059c'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '7a068342011c7e6255a2f9953f35a0aaf31d8298e97ab4efcac5afc11e2b87f3'
+          checkpoint: '959e0ed9cf044f26c4bcdae04085d1eb7fbbf6cd737009d551b30406c0b8ee5c'
   name 'MailButler'
   homepage 'https://www.feingeist.io/mailbutler/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.