### PR TITLE
Update qbserve to 1.55

### DIFF
--- a/Casks/qbserve.rb
+++ b/Casks/qbserve.rb
@@ -1,10 +1,10 @@
 cask 'qbserve' do
-  version '1.53'
-  sha256 '2f1b76621a38be469fbcdc67fb7c3b007a8a5b8f5d64ac7ec7fcc65daff7f59e'
+  version '1.55'
+  sha256 '48dfe9b8d0fc5423071535ce57ba244d4425b28e8922f6040820acf93db24e98'
 
   url "https://qotoqot.com/qbserve/app/Qbserve-#{version}.zip"
   appcast 'https://qotoqot.com/qbserve/app/appcast.xml',
-          checkpoint: 'd03a53649d29ace37f3bc8a35de26aaa2c2c4d51f2cb99a6c590a2532cdff27f'
+          checkpoint: 'ffdec1a8a669e2ce3ec5f47019b4f168d3a84e475d67b20c98151022c40d9fdb'
   name 'Qbserve'
   homepage 'https://qotoqot.com/qbserve/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.