### PR TITLE
Update boxcryptor to 2.7.778

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,11 +1,11 @@
 cask 'boxcryptor' do
-  version '2.6.775'
-  sha256 '42b1925d1257f5d95631e783070b6c77f72b64036a3cc7d52815a334eb62f3b4'
+  version '2.7.778'
+  sha256 '5147187c0434eb9736ef2ed2168e2142f97e55e55f5131c0ec6d7dcde51684a8'
 
   # d3k3ih5otj72mn.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3k3ih5otj72mn.cloudfront.net/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://rink.hockeyapp.net/api/2/apps/7fd6db3e51a977132e3b120c613eaea8',
-          checkpoint: 'e2a747a1e5641595b466da20a79f59e86255b63f4a0d3a75febc77c8177a4033'
+          checkpoint: '291babe1e979a31fbd5b756c5166a75f9ab06d109cfa38d06428301ce7db0bda'
   name 'Boxcryptor'
   homepage 'https://www.boxcryptor.com/en'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.