### PR TITLE
Update vmware-appcatalyst (Update, June 2016)

### DIFF
--- a/Casks/vmware-appcatalyst.rb
+++ b/Casks/vmware-appcatalyst.rb
@@ -1,6 +1,6 @@
 cask 'vmware-appcatalyst' do
-  version 'August-2015'
-  sha256 '343e6259ee4f60e5c077a080d5d3a550ea105d25c6e2762c2eaa151820c8a4dd'
+  version 'Update' # June-2016
+  sha256 '6ed3d6d6fc2ff54105eccf3435c316b728fa5da8'
 
   url "http://getappcatalyst.com/downloads/VMware-AppCatalyst-Technical-Preview-#{version}.dmg"
   name 'VMware AppCatalyst'

--- a/Casks/vmware-appcatalyst.rb
+++ b/Casks/vmware-appcatalyst.rb
@@ -1,8 +1,8 @@
 cask 'vmware-appcatalyst' do
-  version 'Update' # June-2016
-  sha256 '6ed3d6d6fc2ff54105eccf3435c316b728fa5da8'
+  version :latest
+  sha256 'b8b99200e849079bbce4f8760950d6c4807d51a8c78ccccaca2bc3e04f467ddc'
 
-  url "http://getappcatalyst.com/downloads/VMware-AppCatalyst-Technical-Preview-#{version}.dmg"
+  url "http://getappcatalyst.com/downloads/VMware-AppCatalyst-Technical-Preview-Update.dmg"
   name 'VMware AppCatalyst'
   homepage 'http://getappcatalyst.com/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
   
Used `Update` and `June 2016` in the first commit, used `latest` in the revising commit

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

The license included in the previous version of VMware Appcatalyst has expired. http://blogs.vmware.com/cloudnative/appcatalyst-update/

The updated version includes a license that will expire in December 2016.