### PR TITLE
Update webarchiveplayer to 1.4.6

### DIFF
--- a/Casks/webarchiveplayer.rb
+++ b/Casks/webarchiveplayer.rb
@@ -1,10 +1,10 @@
 cask 'webarchiveplayer' do
-  version '1.4.5'
-  sha256 'dc5bc702800c913c8781f9c23074156003bc991d4c3aeffdb5add0f51e05cdb6'
+  version '1.4.6'
+  sha256 'fb9e9d846ef85f1b626f0c29d6954e1b84732ccf18f467d01255420001ce6ca6'
 
   url "https://github.com/ikreymer/webarchiveplayer/releases/download/#{version}/webarchiveplayer.dmg"
   appcast 'https://github.com/ikreymer/webarchiveplayer/releases.atom',
-          checkpoint: '83f4f76661fddb0fb06f946c43b1291ee57e51690430bbc77bd1f6d177ec2b70'
+          checkpoint: '7ddedc7687c1c3b2302ae2569f85b19a69ea91b3680a1b2b21bd89e27b099937'
   name 'webarchiveplayer'
   homepage 'https://github.com/ikreymer/webarchiveplayer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.