### PR TITLE
Update google-play-music-desktop-player to 4.0.3

### DIFF
--- a/Casks/google-play-music-desktop-player.rb
+++ b/Casks/google-play-music-desktop-player.rb
@@ -1,11 +1,11 @@
 cask 'google-play-music-desktop-player' do
-  version '4.0.1'
-  sha256 '6735d0952512d3716cc693cb25c0097cf21f5b0ce3c696f9ef37d70db9588c56'
+  version '4.0.3'
+  sha256 '53d5b29dccb1b971b9cd057e83d86cab068596e71ecd7d0576963904e2e4cbe1'
 
   # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
   url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"
   appcast 'https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases.atom',
-          checkpoint: 'cde8c847769f73286912e15685787a67990870a9b05fdb9e40a6d01cfeda8844'
+          checkpoint: '2d13325b1e95df533cdcc36b1acbb4da8ab482ef8d64e7a96dcb4e6ebdce62ab'
   name 'Google Play Music Desktop Player'
   homepage 'https://www.googleplaymusicdesktopplayer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.