### PR TITLE
Update mailbutler to 6646

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,13 +1,13 @@
 cask 'mailbutler' do
-  version '6641'
-  sha256 '115dbc2083c01eefdb1f4da27cba8d8ef7731bf5f0328c75cc06c40bb100059c'
+  version '6646'
+  sha256 'f1ba4d4e2a9aaf2ec7a7b960500033cc6e988b2b75a03630a8a9905e62e6ed63'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '959e0ed9cf044f26c4bcdae04085d1eb7fbbf6cd737009d551b30406c0b8ee5c'
+          checkpoint: '76984a318c0a8ecf421d5c30e45df25c0fba1e82859b6a38c09513d31481570e'
   name 'MailButler'
-  homepage 'https://www.feingeist.io/mailbutler/'
+  homepage 'https://www.mailbutler.io/'
 
   app 'MailButler.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.