### PR TITLE
Update trailrunner to 3.8.821

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,10 +1,10 @@
 cask 'trailrunner' do
-  version '3.8.819'
-  sha256 'a6ac92c7a601cf870e95c62413effe7c8c9eaa633022fdb5af0d26272f46ad34'
+  version '3.8.821'
+  sha256 'd7d49f63acab5ec2cec6d0f6962ab2c32b45b4b16dffcb5532a343d6157e040f'
 
   url 'http://downloads.trailrunnerx.com/TrailRunner.app.zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610',
-          checkpoint: '969894c5a27db05780b68c077b2c591d1d16ec4ff27dc2b9233edc1482531b9f'
+          checkpoint: '854755a771b02a41e12af5f475a8a3a30190b8205f76c1a4b2a7bd5cea0dcf59'
   name 'TrailRunner'
   homepage 'http://trailrunnerx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.