### PR TITLE
Update iterm2 to 3.0.12

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,11 +1,11 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.0.10'
-  sha256 '434f52c5d554005a94e1f471018d1480a029155205644dadd65377f5eeff3624'
+  version '3.0.12'
+  sha256 'd500c5e376a05df6896f92504961142b7721efb9e235232d39545c7a3c5b7507'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml',
-          checkpoint: 'd39bacce51180f1949aa3e1d75fd9149b03d08c6bd0aa9593221c2457b677cd8'
+          checkpoint: '1a760708aa5754e898f23cbb2c232033d09d2a0e1df53852e4f2cf81acbf33c4'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.