### PR TITLE
Update mono-mdk to 4.6.2.7

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk' do
-  version '4.6.1.5'
-  sha256 'f3796a14597d3886fa224a5c3b85adefd13bbd1a7ea0b4263aae5f5c23c1eadc'
+  version '4.6.2.7'
+  sha256 'e31963607d9eab70e5e0cece21773cc4be30484159f0b47b661b44b9d821ffd3'
 
   url "https://download.mono-project.com/archive/#{version.sub(%r{\.[^.]*$}, '')}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.