### PR TITLE
Update parallels-desktop to 12.1.0-41489

### DIFF
--- a/Casks/parallels-desktop.rb
+++ b/Casks/parallels-desktop.rb
@@ -1,6 +1,6 @@
 cask 'parallels-desktop' do
-  version '12.0.2-41353'
-  sha256 'a815c1137589ffec00699b33acef545043de9d532ef8475dfa069352d45bae11'
+  version '12.1.0-41489'
+  sha256 'ec64f20b5f3553503cd8217814f8a74d51b97064eb51debc72894a130f3e9ec1'
 
   url "https://download.parallels.com/desktop/v#{version[%r{^\w+}]}/#{version}/ParallelsDesktop-#{version}.dmg"
   name 'Parallels Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.