### PR TITLE
Update black-screen to 0.2.85

### DIFF
--- a/Casks/black-screen.rb
+++ b/Casks/black-screen.rb
@@ -1,10 +1,10 @@
 cask 'black-screen' do
-  version '0.2.83'
-  sha256 'ef7b76567664e683b83d667c0090861327e9fecaffb1e958ded74ab549f9da07'
+  version '0.2.85'
+  sha256 '42e0856d79a38375e252aa66404e66f996f76ff94d7af0104c5466361950d1dd'
 
   url "https://github.com/shockone/black-screen/releases/download/v#{version}/black-screen-#{version}-mac.zip"
   appcast 'https://github.com/shockone/black-screen/releases.atom',
-          checkpoint: 'b21758f232c992ec7023305eda0fd244e29f39e187118330f3acaff74ae1456a'
+          checkpoint: '54164cf85208ee0231d29bafa0b21c5764070ec48f5d266a933bf4dee3c764b3'
   name 'Black Screen'
   homepage 'https://github.com/shockone/black-screen'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.