### PR TITLE
Update mailbutler to 6648

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6646'
-  sha256 'f1ba4d4e2a9aaf2ec7a7b960500033cc6e988b2b75a03630a8a9905e62e6ed63'
+  version '6648'
+  sha256 '73599a7633e29477620749be6ba67e1ce0d2a70f11933caf212b0c07683a8f40'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '76984a318c0a8ecf421d5c30e45df25c0fba1e82859b6a38c09513d31481570e'
+          checkpoint: 'af50efdb68f342b65caf8f0136e7e11c5f40a22c4b366f8500ed533adb059bcd'
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.