### PR TITLE
Update mountain-duck to 1.6.3.5079

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.6.2.5061'
-  sha256 '52bf7a3878c7dbfc0834d4aae32c8e3b065f4604cf10c7a91a2d9f8e71ccaddc'
+  version '1.6.3.5079'
+  sha256 '652046c4003bdfdccb1dd8aebd68c4dc6e48eb16028a224a8f479e99eaa05f15'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'a6294d1557d2b077dd59a0757c2dea16866bb45fb872b76f5b5999b1b6a6fe85'
+          checkpoint: 'c5f444c8e14978645c62a3b30af904ec81a8ea1fcaf054ffdd3883c5aee95e6e'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.