### PR TITLE
Update porting-kit to 2.4.109

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,12 +1,12 @@
 cask 'porting-kit' do
-  version '2.4.108'
-  sha256 '5d54fb1a6033413f340c5b9d40b2db9eee9ddd2011fdf828312b05867784b895'
+  version '2.4.109'
+  sha256 '9937ae1d6a391eca416fc0f70e6657ce35c6e4d7dfa2fd708c9fa85c11490236'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '9260ad80921ccbcc6652556a7e3de9650212e52914369fbd0cad7b82073519f0'
+          checkpoint: 'a28eb59be546cddf76f114ec1b1c9fdb8dd07e7a951c1ea49d13f183d13d3182'
   name 'Porting Kit'
-  homepage 'http://portingkit.com/'
+  homepage 'http://portingkit.com/en/'
 
   auto_updates true
   conflicts_with cask: 'caskroom/versions/porting-kit-legacy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.