### PR TITLE
Update texworks to 0.6.1,201605010904:3614278

### DIFF
--- a/Casks/texworks.rb
+++ b/Casks/texworks.rb
@@ -1,9 +1,9 @@
 cask 'texworks' do
-  version '0.6.1'
+  version '0.6.1,201605010904:3614278'
   sha256 'd447ba603da349cb893fead53efcdc3bf9a5165c0ca22f5ad5611865deabc596'
 
   # github.com/TeXworks/texworks was verified as official when first introduced to the cask
-  url "https://github.com/TeXworks/texworks/releases/download/release-#{version}/TeXworks-osx-#{version}-201605010904-git_3614278.dmg"
+  url "https://github.com/TeXworks/texworks/releases/download/release-#{version.before_comma}/TeXworks-osx-#{version.before_comma}-#{version.after_comma.before_colon}-git_#{version.after_colon}.dmg"
   appcast 'https://github.com/TeXworks/texworks/releases.atom',
           checkpoint: '89401a7527b606e156e2bd8eb4ee4306dfcf599ef261be39c04ac530de727f9d'
   name 'TeXworks'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.