### PR TITLE
Update kawasemi to 2.0.7

### DIFF
--- a/Casks/kawasemi.rb
+++ b/Casks/kawasemi.rb
@@ -1,26 +1,26 @@
 cask 'kawasemi' do
-  version :latest
-  sha256 :no_check
+  version '2.0.7'
+  sha256 '8b387f6177baf8aaaa6d5e650925b5e02b5c9a0605b769d2ec0755ee41950c84'
 
-  url 'https://store.monokakido.jp/download/Kawasemi2/Kawasemi2.dmg'
+  url "https://store.monokakido.jp/download/Kawasemi#{version.major}/Kawasemi#{version.major}.dmg"
   name 'Kawasemi'
   name 'かわせみ'
-  homepage 'https://www.monokakido.jp/mac/kawasemi2.html'
+  homepage 'http://www.monokakido.jp/mac/kawasemi2.html'
 
-  pkg 'Kawasemi2 Installer.app/Contents/Resources/Kawasemi2.pkg'
+  pkg "Kawasemi#{version.major} Installer.app/Contents/Resources/Kawasemi#{version.major}.pkg"
 
-  uninstall pkgutil:   'jp.monokakido.Kawasemi2.pkg',
+  uninstall pkgutil:   "jp.monokakido.Kawasemi#{version.major}.pkg",
             launchctl: [
-                         'jp.monokakido.Kawasemi2.Enabler',
-                         'jp.monokakido.Kawasemi2.Update.helper',
+                         "jp.monokakido.Kawasemi#{version.major}.Enabler",
+                         "jp.monokakido.Kawasemi#{version.major}.Update.helper",
                        ]
 
   zap delete: [
-                '/Library/Application Support/MONOKAKIDO/Kawasemi2',
-                '/Library/LaunchAgents/jp.monokakido.Kawasemi2.Enabler.plist',
-                '/Library/Preferences/jp.monokakido.inputmethod.Kawasemi2.registration.plist',
-                '~/Library/Preferences/jp.monokakido.Kawasemi2.Enabler.plist',
-                '~/Library/Preferences/jp.monokakido.inputmethod.Kawasemi2.registration.plist',
+                "/Library/Application Support/MONOKAKIDO/Kawasemi#{version.major}",
+                "/Library/LaunchAgents/jp.monokakido.Kawasemi#{version.major}.Enabler.plist",
+                "/Library/Preferences/jp.monokakido.inputmethod.Kawasemi#{version.major}.registration.plist",
+                "~/Library/Preferences/jp.monokakido.Kawasemi#{version.major}.Enabler.plist",
+                "~/Library/Preferences/jp.monokakido.inputmethod.Kawasemi#{version.major}.registration.plist",
               ]
 
   caveats do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.