### PR TITLE
Update Orange3 to Orange3-3.3.8

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,6 +1,6 @@
 cask 'orange' do
-  version '3-3.3.5'
-  sha256 'e6a839ef6488d8becf979750701c8f395a97155b379ff8b5f7f12ab90a0cdb01'
+  version '3-3.3.8'
+  sha256 '11566c7233a0d9d64d115cebe6b1996358cba7a5ed2b37a5e82d85b32cb5c335'
 
   url "http://orange.biolab.si/download/files/Orange#{version}.dmg"
   name 'Orange'


### PR DESCRIPTION
Changed version to current as found on [Orange3 download page](http://orange.biolab.si/download/), updated checksum and tested.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.



