### PR TITLE
Update to Codeship Jet v1.14.1

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,6 +1,6 @@
 cask 'jet' do
-  version '1.12.0'
-  sha256 'c0d4aeb21460974aad769d15113a8f51a05dc771f233d484cea0d52e0550e00e'
+  version '1.14.1'
+  sha256 '7665d7c62b9e89e42a733d8ef1567138b94df196947b73e7356c6b5252351fca'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.