### PR TITLE
fix(dotnet): using the right package version (version after comma)

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,5 +1,5 @@
 cask 'dotnet' do
-  version '1.0.0-preview2-1-003177,1.0.3'
+  version '1.0.0-preview2-1-003177,1.1.0'
   sha256 'be009582107b6eb58196a1e417e02c11d7da182669cd47a4c2a42f512e112fea'
 
   url "https://download.microsoft.com/download/1/4/1/141760B3-805B-4583-B17C-8C5BC5A876AB/Installers/dotnet-dev-osx-x64.#{version.before_comma}.pkg"


### PR DESCRIPTION
Fixing #26826 to use the right package version. It was my mistake.

The correct is: /usr/local/share/dotnet/shared/Microsoft.NETCore.App/1.1.0
