### PR TITLE
Update overture to 2.4.2

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.3.6'
-  sha256 '623355be84033257f3434d2f85a2a632f28f4adbeee4a897b92be53e147846a4'
+  version '2.4.2'
+  sha256 '45bd0385b6848c6ed5e9c9cb41ce32a76a955983dba80217693c73c68e5be724'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: 'bc8eff785ac9f781aeeee6f94a37447ff529439b53918de3d8487bdca855c046'
+          checkpoint: '996dae8fa422e98647a590fa5960ab11e73036427485800b786394f11e77b6c1'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.