### PR TITLE
Update gimp to 2.8.18-x86_64-1

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,6 +1,6 @@
 cask 'gimp' do
-  version '2.8.18-x86_64'
-  sha256 '2430a1a1a12d146b5198175fa1878d9cf556a3903707e536a51c9429bf664ecc'
+  version '2.8.18-x86_64-1'
+  sha256 'e9f67f7a8b29871a977bb3d1c9129e473da2a52c3b46c2d42663cbbf939ded68'
 
   url "https://download.gimp.org/pub/gimp/v2.8/osx/gimp-#{version}.dmg"
   name 'GIMP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.