### PR TITLE
Update atom to 1.12.4

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,11 +1,11 @@
 cask 'atom' do
-  version '1.12.3'
-  sha256 'a00d33c892c836d72d1a4702ac884fdac4ad2434db821d362c2f8c3ca1253db4'
+  version '1.12.4'
+  sha256 '5e8910218ae1c5809100e842ee8a7664ccf0565f67ccb56fa8c18d8aea92800c'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '163f88fd056076530bee7baa396906810ffbafde617bd7703c8b6aa98168e321'
+          checkpoint: '5c7ba496b58ba302795f7368359cb5e446f3ff0ebb111b12b5974605e254b47e'
   name 'Github Atom'
   homepage 'https://atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.