### PR TITLE
Fix `gpgtools` sha256 and `soundflower` checkpoint.

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -1,6 +1,6 @@
 cask 'gpgtools' do
   version '2016.10_v2'
-  sha256 '8dbc5821876ca5c470d0127087f782ba02a842c52e6e19336cd935db7c5859ab'
+  sha256 'b0e18b27c8464ec73f909ad47ac60cf66dc65ba8a1d534d4a3258d2ce399bb1f'
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast 'https://gpgtools.org/releases/gka/appcast.xml',

--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -4,7 +4,7 @@ cask 'soundflower' do
 
   url "https://github.com/mattingalls/Soundflower/releases/download/#{version}/Soundflower-#{version}.dmg"
   appcast 'https://github.com/mattingalls/Soundflower/releases.atom',
-          checkpoint: '46ce87df41149532b2a9695224e6ff3060fffb6784e03c1703c315ac42674598'
+          checkpoint: '5782759ffb2d6994cb222c88476011dee82680de40bef5011adcc36df6cdca49'
   name 'Soundflower'
   homepage 'https://github.com/mattingalls/Soundflower'
 


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
