### PR TITLE
Update spriteilluminator to 1.3.1

### DIFF
--- a/Casks/spriteilluminator.rb
+++ b/Casks/spriteilluminator.rb
@@ -1,10 +1,10 @@
 cask 'spriteilluminator' do
-  version '1.3.0'
-  sha256 'f8eb5acc5abc7ecc5edcfc795f1018bf1ca974360f4dfa814cc829a036596f77'
+  version '1.3.1'
+  sha256 'e51941fbca6c4e9b9f0a347315e69e365b5f63902e1dd4271d4110e748a7f1eb'
 
   url "https://www.codeandweb.com/download/spriteilluminator/#{version}/SpriteIlluminator-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/SpriteIlluminator/appcast-mac-release.xml',
-          checkpoint: 'b295ea112a460f8f2217d40710412ba10b9756eae2d2579f39990949a982f0cf'
+          checkpoint: '997e662cfbe6d4b7e5e3ef5c7eee2bd17c32d91c3ee009949135197fbc8ed67b'
   name 'SpriteIlluminator'
   homepage 'https://www.codeandweb.com/spriteilluminator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.