### PR TITLE
Update the-hit-list to 1.1.27,347

### DIFF
--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,10 +1,10 @@
 cask 'the-hit-list' do
-  version '1.1.26,345'
-  sha256 'a3b843d6156456330fce9746064996885b021cd4a876f0e6230c3e0ee5766ff0'
+  version '1.1.27,347'
+  sha256 '76d1dd3d441e1df6d7aa3a7708228853cd89ca3839a095f73c5cdb4d6d69749f'
 
   url "https://distrib.karelia.com/downloads/TheHitList-#{version.after_comma}.zip"
   appcast 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List',
-          checkpoint: '484546055de385df594a995cb3738b178f95a28a0da2a00b02c5a81612507b5c'
+          checkpoint: '2f9a1f6cc0fb28c0ff21b5e36211cad4d01acb4bcd9b0f97563cabce6c5657f5'
   name 'The Hit List'
   homepage 'https://www.karelia.com/products/the-hit-list/mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.