### PR TITLE
Update electron to 1.4.7

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.6'
-  sha256 '738fd6c9f7b274ffc92b634f518f9bd7d06d26dfec5dc4fb0d8de236fef2559c'
+  version '1.4.7'
+  sha256 'b57397ed14a694e94bb1db3e4a76b7873ad32a3053bf89f9859af7034d045185'
 
   # github.com/atom/electron was verified as official when first introduced to the cask
   url "https://github.com/atom/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/atom/electron/releases.atom',
-          checkpoint: 'b2d34af98fa037e07e5849d683a54eb7fbd72cb51d035275994edac783495b0a'
+          checkpoint: 'e08b321177ea2f5f257710bd3f8ce3f42b00ecba7a028c5589ae0b2719525579'
   name 'Electron'
   homepage 'http://electron.atom.io/'
 


### PR DESCRIPTION


- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
