### PR TITLE
New version MongoChef 4.4.2

### DIFF
--- a/Casks/mongochef.rb
+++ b/Casks/mongochef.rb
@@ -1,6 +1,6 @@
 cask 'mongochef' do
-  version '4.4.0'
-  sha256 '1dcf75c94827622902425a01e554055d3030befd6dfa05f74039fce5a44b110b'
+  version '4.4.2'
+  sha256 '1eb45bd6545decf5d4f6d1cc9af118d4f54c66a4543ad1590239771dd8d65fca'
 
   url "https://cdn.3t.io/mongochef-core/mac/#{version}/MongoChef.dmg"
   name 'MongoChef'


### PR DESCRIPTION
- [x] `brew cask audit --download mongochef` is error-free.
- [x] `brew cask style --fix mongochef` reports no offenses.
- [x] The commit message includes the cask’s name and version.