### PR TITLE
Add poi.app v7.3.1.

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,0 +1,10 @@
+cask 'poi' do
+  version '7.2.1'
+  sha256 '4dffcb2790d22c2769f60f8615eff9421bc44320ed759ddd2458c46f6c716466'
+
+  url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}-macos-x64.dmg"
+  name 'poi'
+  homepage 'https://github.com/poooi/poi'
+
+  app 'poi.app'
+end

--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -2,9 +2,12 @@ cask 'poi' do
   version '7.2.1'
   sha256 '4dffcb2790d22c2769f60f8615eff9421bc44320ed759ddd2458c46f6c716466'
 
+  # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}-macos-x64.dmg"
+  appcast 'https://github.com/poooi/poi/releases.atom',
+          checkpoint: 'c4e14892affb593a9b76b68307a6fff9bd9a1fbe76f896c293313ee3929a71a6'
   name 'poi'
-  homepage 'https://github.com/poooi/poi'
+  homepage 'https://poi.io/'
 
   app 'poi.app'
 end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

The poi.app is an accessibility tool for browser game known as Kantai Collection.