### PR TITLE
Add AstroMenace v1.3.2

### DIFF
--- a/Casks/astromenace.rb
+++ b/Casks/astromenace.rb
@@ -1,0 +1,13 @@
+cask 'astromenace' do
+  version '1.3.2'
+  sha256 '8a298c84d5cfd24d01013eae94ded4cc4c6598c5cc8fc4b4c9ff85637f74cdef'
+
+  # downloads.sourceforge.net/openastromenace was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/openastromenace/astromenace-macosx-#{version}.dmg"
+  appcast 'https://sourceforge.net/projects/openastromenace/rss',
+          checkpoint: '1423a6e6ea44d0727b613493bea73f1fe2c9e8b87b3a4f509a6cc683ddc35ffd'
+  name 'AstroMenace'
+  homepage 'http://www.viewizard.com/'
+
+  app 'AstroMenace.app'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

AstroMenace is an astonishing hardcore scroll-shooter where brave space warriors may find a great opportunity to hone their combat skills