### PR TITLE
Update rhinoceros to 5.2.4

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceros' do
-  version '5.2.3'
-  sha256 'ffdd80773b787ee8d85cc7cc22a2c85814a7f262d16a9f5a2a3b15f31489906f'
+  version '5.2.4'
+  sha256 'fcaf19fb969608c5952b9b98771ba121f521362bab773fcba7c8831c04430aeb'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/#{version.major}.0/Mac/Rhinoceros_#{version}.dmg"
   appcast "https://files.mcneel.com/rhino/#{version.major}.0/mac/#{version.major}CcommercialUpdates.xml",
-          checkpoint: '037ccb00b5a0baf8788021c0222bd59921bd4ec6701584fb03221db4b1bb32d8'
+          checkpoint: '7eec993f342f384ef86530afe43c662e10553db89a4a42fba475f9b0b2fc73da'
   name 'Rhinoceros'
   homepage 'https://www.rhino3d.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.