### PR TITLE
Update avidemux to 2.6.15

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.6.14'
-  sha256 '9f9bc15e33bdf2e14f788d8017cfa7fc87d9f364186cdfc539ef1af8aeeba641'
+  version '2.6.15'
+  sha256 'b646cb9ceff19c96e771550ffd070dc8834427755ac962aad90efb11652c4667'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_EC_64Bits_Qt5.dmg"
+  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: 'a8205fa1028b0d77549b899ee33987cb57aaa94cf36e9c9953ef74eced55cd5e'
+          checkpoint: '37287b61c6efcc8ddea788b23cb0dd53422824ebb2d7d3ea68a386e46170bcc9'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.