### PR TITLE
Fix rubitrack 4.3.5

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,4 +1,4 @@
-cask 'rubitrack' do
+cask 'rubitrack-pro' do
   version '4.3.5'
   sha256 'ff997eee5162b5edd5589d77c90560936a59fa2fb222582c7941ea6eb4dbb42d'
 

--- a/Casks/rubitrack.rb
+++ b/Casks/rubitrack.rb
@@ -11,5 +11,5 @@ cask 'rubitrack' do
   depends_on macos: '>= :yosemite'
   depends_on arch: :x86_64
 
-  app "rubiTrack #{version.major}.app"
+  app "rubiTrack #{version.major} Pro.app"
 end


### PR DESCRIPTION
Thanks @adidalal for #26938; I missed the fact that rubiTrack was already updated again.

The app name of rubiTrack has '` Pro`' suffix since version 4. Without it, the cask doesn't install properly (which would have been also the case for my PR #26937).

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
