### PR TITLE
Update trickster to 2.5

### DIFF
--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -3,13 +3,13 @@ cask 'trickster' do
     version '2.1.1'
     sha256 'cddc4a27c3c2a016f86d1688ef9708d3e8c605cfe06302470471309ccdc241db'
   else
-    version '2.4.2'
-    sha256 'afe5fcf0de994e6a993bf259da564783ed7c0619ad635c665ecf5d3067ba5049'
+    version '2.5'
+    sha256 '2faf93330c2081a0108d9ed62f0b1bb91232177ef7ec696a4cb238a79419f634'
   end
 
   url "https://dl.apparentsoft.com/Trickster_#{version}.zip"
   appcast 'https://dl.apparentsoft.com/trickster.rss',
-          checkpoint: '0a6c6015159cd8037e6e3f9464d3ed10c9ec05aa3ea063d012913b90be2aa218'
+          checkpoint: '7042bbbf9643323bd899d6a996e32949c602f069b1bcc4d14043d1f8b5794f1f'
   name 'Trickster'
   homepage 'https://www.apparentsoft.com/trickster/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.