### PR TITLE
Update psequel to 1.5.1

### DIFF
--- a/Casks/psequel.rb
+++ b/Casks/psequel.rb
@@ -1,6 +1,6 @@
 cask 'psequel' do
-  version '1.5.0'
-  sha256 '79052e701eebb63bd8b89c307da4b7e58bc286a7a9d7ceee00f8acbb2aee10fd'
+  version '1.5.1'
+  sha256 '46c1c392e4947ce6fe13e78883c71a596c725fb775ed4d7586d679ef3d0b7fb6'
 
   url "http://www.psequel.com/download?version=#{version}"
   name 'PSequel'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.