### PR TITLE
ApacheDirectoryStudio-2.0.0.v20161101-M12

### DIFF
--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -1,8 +1,8 @@
 cask 'apache-directory-studio' do
-  version '2.0.0.v20151221-M10'
-  sha256 'b27d116ea6b79268a74ae5057bd542813e186a888c2b4abedd6a2eb83fc2a0d5'
+  version '2.0.0.v20161101-M12'
+  sha256 '84b4ec5b529205d326d73f383430c41a2002f1fa3857fff8f93d76bfd0f28340'
 
-  url "http://www.us.apache.org/dist/directory/studio/#{version}/ApacheDirectoryStudio-#{version}-macosx.cocoa.x86_64.tar.gz"
+  url "http://www.us.apache.org/dist/directory/studio/#{version}/ApacheDirectoryStudio-#{version}-macosx.cocoa.x86_64.dmg"
   name 'Apache Directory Studio'
   homepage 'https://directory.apache.org/studio/'
 


### PR DESCRIPTION
This fixes the formula, which had been failing before with a 404 error, and updates to a newer version.

-----
- [✓] `brew cask audit --download Casks/apache-directory-studio.rb` is error-free.
```
$ brew cask audit --download Casks/apache-directory-studio.rb
==> Downloading http://www.us.apache.org/dist/directory/studio/2.0.0.v20161101-M12/ApacheDirectoryStudio-2.0.0.v20161101-M12-macosx.cocoa.x86_64.dmg
Already downloaded: /Users/marca/Library/Caches/Homebrew/Cask/apache-directory-studio--2.0.0.v20161101-M12.dmg
==> Verifying checksum for Cask apache-directory-studio
audit for apache-directory-studio: passed
```
- [✓] `brew cask style --fix Casks/apache-directory-studio.rb}` reports no offenses.
```
$ brew cask style --fix Casks/apache-directory-studio.rb

1 file inspected, no offenses detected
```
- [✓] The commit message includes the cask’s name and version.
-----

This formula had been previously failing with a 404:

```
$ brew cask install apache-directory-studio
==> Downloading http://www.us.apache.org/dist/directory/studio/2.0.0.v20151221-M10/ApacheDirectoryStudio-2.0.0.v20151221-M10-macosx.cocoa.x86_64.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'apache-directory-studio' with message: Download failed: http://www.us.apache.org/dist/directory/studio/2.0.0.v20151221-M10/ApacheDirectoryStudio-2.0.0.v20151221-M10-macosx.cocoa.x86_64.tar.gz
The incomplete download is cached at /Users/marca/Library/Caches/Homebrew/Cask/apache-directory-studio--2.0.0.v20151221-M10.tar.gz.incomplete
```

With this, it works:

```
$ brew cask install apache-directory-studio
==> Downloading http://www.us.apache.org/dist/directory/studio/2.0.0.v20161101-M12/ApacheDirectoryStudio-2.0.0.v20161101-M12-macosx.cocoa.x86_64.dmg
Already downloaded: /Users/marca/Library/Caches/Homebrew/Cask/apache-directory-studio--2.0.0.v20161101-M12.dmg
==> Verifying checksum for Cask apache-directory-studio
==> Moving App 'ApacheDirectoryStudio.app' to '/Applications/ApacheDirectoryStudio.app'
🍺  apache-directory-studio was successfully installed!
```