### PR TITLE
Fix osxfuse 3.5.3 to use the pkg choices: option

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -9,29 +9,12 @@ cask 'osxfuse' do
   name 'OSXFUSE'
   homepage 'https://osxfuse.github.io/'
 
-  installer script: '/usr/sbin/installer',
-            args:   [
-                      '-pkg', "#{staged_path}/Extras/FUSE for macOS #{version}.pkg",
-                      '-target', '/',
-                      '-applyChoiceChangesXML', "#{staged_path}/Extras/Choices.xml"
-                    ]
-
-  preflight do
-    IO.write "#{staged_path}/Extras/Choices.xml", <<-EOS.undent
-      <plist>
-        <array>
-        	<dict>
-        		<key>attributeSetting</key>
-        		<integer>1</integer>
-        		<key>choiceAttribute</key>
-        		<string>selected</string>
-        		<key>choiceIdentifier</key>
-        		<string>com.github.osxfuse.pkg.MacFUSE</string>
-        	</dict>
-        </array>
-      </plist>
-    EOS
-  end
+  pkg "Extras/FUSE for macOS #{version}.pkg",
+      choices: [
+                 'choiceIdentifier' => 'com.github.osxfuse.pkg.MacFUSE',
+                 'choiceAttribute'  => 'selected',
+                 'attributeSetting' => 1,
+               ]
 
   postflight do
     set_ownership ['/usr/local/include', '/usr/local/lib']


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Related to Homebrew/brew#1535 and #26964 

This won't work until Homebrew/brew#1535 is merged