### PR TITLE
Update detectx to 2.37

### DIFF
--- a/Casks/detectx.rb
+++ b/Casks/detectx.rb
@@ -1,11 +1,11 @@
 cask 'detectx' do
-  version '2.36'
-  sha256 '3be4ac1598fd582a4ae2fa932007e02b66d874ee2091386f682ad024c2a67a3b'
+  version '2.37'
+  sha256 '728f6e91035154046794f219db396160f636125eb3f1458c124645420b342f67'
 
   # amazonaws.com/sqwarq.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/sqwarq.com/PublicZips/DetectX.app.zip'
   appcast 'https://s3.amazonaws.com/sqwarq.com/AppCasts/detectx.xml',
-          checkpoint: 'a446cbfebba5e9f2b3a212865c638b279d45c047308e67d0da0e971612179e2b'
+          checkpoint: 'c7ddf9e1fe2d6b42bf5dcb9d451741a64bb78f86684a9c9e52dea1b3de0c8915'
   name 'DetectX'
   homepage 'https://sqwarq.com/detectx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.