### PR TITLE
Update typora to 0.9.9.8.4

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.8.2'
-  sha256 '9a59bf1068b0e5518f2159bc5a129043087799f7be06d31c4905a925a3654d7d'
+  version '0.9.9.8.4'
+  sha256 '35f46c0edca88b8e138b244a88aa82fd189d1b9b5db2bfd218a0e0b49566f2e2'
 
   url "https://www.typora.io/download/typora_#{version}.zip"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '475be3ae734a70e3f35203d35fdbb5f8054e56f850fc13d1d564f06ddf4db2af'
+          checkpoint: '31fff87c5e0d24d4e704e9eed012329a94e0cda5e0102bbb1be8be676ab02552'
   name 'Typora'
   homepage 'https://typora.io'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.