### PR TITLE
Update nzbget to 17.1

### DIFF
--- a/Casks/nzbget.rb
+++ b/Casks/nzbget.rb
@@ -1,11 +1,11 @@
 cask 'nzbget' do
-  version '17.0'
-  sha256 '454408c32a652d569d23bf757aadb63dc16943ac69b4a8842eaaa9e2df67d67e'
+  version '17.1'
+  sha256 'cc7bd923974c56b59bab78025175a4a7248a495e8d514bd73c1d8ee4aba281d2'
 
   # github.com/nzbget/nzbget was verified as official when first introduced to the cask
   url "https://github.com/nzbget/nzbget/releases/download/v#{version}/nzbget-#{version}-bin-osx.zip"
   appcast 'https://github.com/nzbget/nzbget/releases.atom',
-          checkpoint: 'f84a8fe899e4ff163afdb81af13bb7572f8070b5b9289a6fca0606dcb624d326'
+          checkpoint: '40878b72afb95745be8ac09745b31d2bb72bdfe8d1a32b9778c07b436b64dcd8'
   name 'NZBGet'
   homepage 'http://nzbget.net'
 

--- a/Casks/nzbget.rb
+++ b/Casks/nzbget.rb
@@ -5,7 +5,7 @@ cask 'nzbget' do
   # github.com/nzbget/nzbget was verified as official when first introduced to the cask
   url "https://github.com/nzbget/nzbget/releases/download/v#{version}/nzbget-#{version}-bin-osx.zip"
   appcast 'https://github.com/nzbget/nzbget/releases.atom',
-          checkpoint: '40878b72afb95745be8ac09745b31d2bb72bdfe8d1a32b9778c07b436b64dcd8'
+          checkpoint: 'cc9ea4ea0bc52bb1f0cb11e01f32d79c4e90c85dda1e20f2fed81abde027fb40'
   name 'NZBGet'
   homepage 'http://nzbget.net'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.