### PR TITLE
Add slash in homepage of 77 Casks

### DIFF
--- a/Casks/abscissa.rb
+++ b/Casks/abscissa.rb
@@ -4,7 +4,7 @@ cask 'abscissa' do
 
   url "http://rbruehl.macbay.de/Abscissa/Downloads/Abscissa-#{version}.zip"
   name 'Abscissa'
-  homepage 'http://rbruehl.macbay.de/Abscissa'
+  homepage 'http://rbruehl.macbay.de/Abscissa/'
 
   app "Abscissa-#{version}/Abscissa.app"
 end

--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -9,7 +9,7 @@ cask 'antconc' do
 
   url "http://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   name 'AntConc'
-  homepage 'http://www.laurenceanthony.net/software/antconc'
+  homepage 'http://www.laurenceanthony.net/software/antconc/'
 
   app 'AntConc.app'
 end

--- a/Casks/antpconc.rb
+++ b/Casks/antpconc.rb
@@ -4,7 +4,7 @@ cask 'antpconc' do
 
   url "http://www.laurenceanthony.net/software/antpconc/releases/AntPConc#{version.no_dots}/AntPConc.zip"
   name 'AntPConc'
-  homepage 'http://www.laurenceanthony.net/software/antpconc'
+  homepage 'http://www.laurenceanthony.net/software/antpconc/'
 
   app 'AntPConc.app'
 end

--- a/Casks/antwordprofiler.rb
+++ b/Casks/antwordprofiler.rb
@@ -4,7 +4,7 @@ cask 'antwordprofiler' do
 
   url "http://www.laurenceanthony.net/software/antwordprofiler/releases/AntWordProfiler#{version.no_dots}/AntWordProfiler.zip"
   name 'AntWordProfiler'
-  homepage 'http://www.laurenceanthony.net/software/antwordprofiler'
+  homepage 'http://www.laurenceanthony.net/software/antwordprofiler/'
 
   app 'AntWordProfiler.app'
 end

--- a/Casks/anypass.rb
+++ b/Casks/anypass.rb
@@ -4,7 +4,7 @@ cask 'anypass' do
 
   url "http://icyblaze.com/anypass/anypass_mac_#{version.sub(%r{^(\d+\.\d+).*}, '\1')}.zip"
   name 'Anypass'
-  homepage 'http://icyblaze.com/anypass'
+  homepage 'http://icyblaze.com/anypass/'
 
   app 'Anypass.app'
 end

--- a/Casks/anytrans.rb
+++ b/Casks/anytrans.rb
@@ -4,7 +4,7 @@ cask 'anytrans' do
 
   url 'https://www.imobie.com/product/anytrans-mac.dmg'
   name 'AnyTrans'
-  homepage 'https://www.imobie.com/anytrans'
+  homepage 'https://www.imobie.com/anytrans/'
 
   app 'AnyTrans.app'
 end

--- a/Casks/apptrap.rb
+++ b/Casks/apptrap.rb
@@ -6,7 +6,7 @@ cask 'apptrap' do
   appcast 'http://onnati.net/apptrap/ReleaseNotes.xml',
           checkpoint: '561cc83e41aea261c0472d73369c19b7c738b95b764eb346508a654643d651d5'
   name 'AppTrap'
-  homepage 'http://onnati.net/apptrap'
+  homepage 'http://onnati.net/apptrap/'
 
   prefpane 'AppTrap.prefPane'
 end

--- a/Casks/araxis-merge.rb
+++ b/Casks/araxis-merge.rb
@@ -22,7 +22,7 @@ cask 'araxis-merge' do
     url "https://www.araxis.com/download/Merge#{version}-macOS10.12.dmg"
   end
 
-  homepage 'https://www.araxis.com/merge'
+  homepage 'https://www.araxis.com/merge/'
 
   depends_on macos: '>= :mountain_lion'
 

--- a/Casks/banktivity.rb
+++ b/Casks/banktivity.rb
@@ -5,7 +5,7 @@ cask 'banktivity' do
   # iggsoft.com was verified as official when first introduced to the cask
   url 'https://www.iggsoft.com/banktivity/Banktivity5_Web.dmg'
   name 'Banktivity'
-  homepage 'https://www.iggsoftware.com/banktivity'
+  homepage 'https://www.iggsoftware.com/banktivity/'
 
   app 'Banktivity 5.app'
 end

--- a/Casks/black-light.rb
+++ b/Casks/black-light.rb
@@ -4,7 +4,7 @@ cask 'black-light' do
 
   url "https://littoral.michelf.ca/apps/black-light/black-light-#{version}.zip"
   name 'Black Light'
-  homepage 'https://michelf.ca/projects/black-light'
+  homepage 'https://michelf.ca/projects/black-light/'
 
   app 'Black Light.app'
 end

--- a/Casks/camranger.rb
+++ b/Casks/camranger.rb
@@ -4,7 +4,7 @@ cask 'camranger' do
 
   url "http://www.camranger.com/downloadFiles/CamRanger_#{version.dots_to_underscores}.dmg"
   name 'CamRanger'
-  homepage 'https://camranger.com/mac-downloads'
+  homepage 'https://camranger.com/mac-downloads/'
 
   app 'CamRanger.app'
 end

--- a/Casks/cathode.rb
+++ b/Casks/cathode.rb
@@ -7,7 +7,7 @@ cask 'cathode' do
   appcast 'http://store.secretgeometry.com/appcast.php?id=7',
           checkpoint: '9c9d24dd500bc58e625114c7e9c045ba41d86887e044c8f7441811b5bc237a94'
   name 'Cathode'
-  homepage 'http://www.secretgeometry.com/apps/cathode'
+  homepage 'http://www.secretgeometry.com/apps/cathode/'
 
   app 'Cathode.app'
 end

--- a/Casks/celestia.rb
+++ b/Casks/celestia.rb
@@ -6,7 +6,7 @@ cask 'celestia' do
   appcast 'https://sourceforge.net/projects/celestia/rss',
           checkpoint: '56994e2d3dcf5068e11639e2a32f6d76225cc54c077fc7811fad81cc2816a856'
   name 'Celestia'
-  homepage 'https://sourceforge.net/projects/celestia'
+  homepage 'https://sourceforge.net/projects/celestia/'
 
   app 'Celestia.app'
 end

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -4,7 +4,7 @@ cask 'clion' do
 
   url "https://download.jetbrains.com/cpp/CLion-#{version}.dmg"
   name 'CLion'
-  homepage 'https://www.jetbrains.com/clion'
+  homepage 'https://www.jetbrains.com/clion/'
 
   conflicts_with cask: 'clion-eap'
 

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -4,7 +4,7 @@ cask 'cocoaspell' do
 
   url "http://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg", user_agent: :fake
   name 'cocoAspell'
-  homepage 'http://people.ict.usc.edu/~leuski/cocoaspell'
+  homepage 'http://people.ict.usc.edu/~leuski/cocoaspell/'
 
   depends_on macos: '>= :el_capitan'
 

--- a/Casks/colorpicker-rcwebcolorpicker.rb
+++ b/Casks/colorpicker-rcwebcolorpicker.rb
@@ -4,7 +4,7 @@ cask 'colorpicker-rcwebcolorpicker' do
 
   url "http://www.rubicode.com/Downloads/RCWebColorPicker-#{version}.dmg"
   name 'RCWebColorPicker'
-  homepage 'http://www.rubicode.com/Software/RCWebColorPicker'
+  homepage 'http://www.rubicode.com/Software/RCWebColorPicker/'
 
   colorpicker 'RCWebColorPicker.colorPicker'
 end

--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -6,7 +6,7 @@ cask 'cuppa' do
   appcast 'https://www.nathanatos.com/software/cuppa.xml',
           checkpoint: 'f01c77b88898d21e63f1fb75b9f00e182664d674a9b2b9f4d4daba61e14440e0'
   name 'Cuppa'
-  homepage 'https://www.nathanatos.com/software'
+  homepage 'https://www.nathanatos.com/software/'
 
   app 'Cuppa.app'
 end

--- a/Casks/curb.rb
+++ b/Casks/curb.rb
@@ -6,7 +6,7 @@ cask 'curb' do
   appcast 'https://www.mrrsoftware.com/Downloads/Curb/CurbSoftwareUpdates.xml',
           checkpoint: '2141e205b0037e8e79d74564078cdaeb803b0dc2c1162e45477ebb9bcc72ae92'
   name 'Curb'
-  homepage 'https://mrrsoftware.com/curb'
+  homepage 'https://mrrsoftware.com/curb/'
 
   app 'Curb.app'
 end

--- a/Casks/cutesdr.rb
+++ b/Casks/cutesdr.rb
@@ -6,7 +6,7 @@ cask 'cutesdr' do
   appcast 'https://sourceforge.net/projects/cutesdr/rss',
           checkpoint: '5619e8fccaa00f7ecbcd8726ea4942698c15d8dd760756cdf43de7da08bf595a'
   name 'CuteSDR'
-  homepage 'https://sourceforge.net/projects/cutesdr'
+  homepage 'https://sourceforge.net/projects/cutesdr/'
 
   app 'cutesdr.app'
 end

--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -12,7 +12,7 @@ cask 'default-folder-x' do
 
   url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   name 'Default Folder X'
-  homepage 'https://www.stclairsoft.com/DefaultFolderX'
+  homepage 'https://www.stclairsoft.com/DefaultFolderX/'
 
   if MacOS.version <= :mavericks
     installer manual: 'Default Folder X Installer.app'

--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -4,7 +4,7 @@ cask 'diffmerge' do
 
   url "http://download.sourcegear.com/DiffMerge/#{version.sub(%r{\.\d+$}, '')}/DiffMerge.#{version}.intel.stable.pkg"
   name 'DiffMerge'
-  homepage 'https://www.sourcegear.com/diffmerge'
+  homepage 'https://www.sourcegear.com/diffmerge/'
 
   pkg "DiffMerge.#{version}.intel.stable.pkg"
 

--- a/Casks/displaperture.rb
+++ b/Casks/displaperture.rb
@@ -4,7 +4,7 @@ cask 'displaperture' do
 
   url 'http://manytricks.com/download/displaperture'
   name 'Displaperture'
-  homepage 'https://manytricks.com/displaperture'
+  homepage 'https://manytricks.com/displaperture/'
 
   app 'Displaperture.app'
 end

--- a/Casks/drop-to-gif.rb
+++ b/Casks/drop-to-gif.rb
@@ -7,7 +7,7 @@ cask 'drop-to-gif' do
   appcast 'https://github.com/mortenjust/droptogif/releases.atom',
           checkpoint: '6ac820bac52e7780d1aa24a31dd17e34c7c1253ae1c23f16dc77a91cfc77bab6'
   name 'Drop to GIF'
-  homepage 'https://mortenjust.github.io/droptogif'
+  homepage 'https://mortenjust.github.io/droptogif/'
 
   app 'Drop to GIF.app'
 end

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -4,7 +4,7 @@ cask 'eclipse-platform' do
 
   url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse SDK'
-  homepage 'https://eclipse.org/eclipse'
+  homepage 'https://eclipse.org/eclipse/'
 
   depends_on macos: '>= :leopard'
   depends_on arch: :x86_64

--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -7,7 +7,7 @@ cask 'flash-npapi' do
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
           checkpoint: '50c4e19caa48710cf812e1549e5179124552b4bf760dc9aa719e09dd86d10fbe'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox)'
-  homepage 'https://get.adobe.com/flashplayer'
+  homepage 'https://get.adobe.com/flashplayer/'
 
   pkg 'Install Adobe Flash Player.app/Contents/Resources/Adobe Flash Player.pkg'
 

--- a/Casks/garagebuy.rb
+++ b/Casks/garagebuy.rb
@@ -5,7 +5,7 @@ cask 'garagebuy' do
   # iwascoding.de was verified as official when first introduced to the cask
   url "https://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"
   name 'GarageBuy'
-  homepage 'https://www.iwascoding.com/GarageBuy'
+  homepage 'https://www.iwascoding.com/GarageBuy/'
 
   app 'GarageBuy.app'
 end

--- a/Casks/ghost.rb
+++ b/Casks/ghost.rb
@@ -7,7 +7,7 @@ cask 'ghost' do
   appcast 'https://github.com/TryGhost/Ghost-Desktop/releases.atom',
           checkpoint: 'e401dbb9d54f893e2330de2beb343aedd2146e3578cb7e5933fade5bb844a73c'
   name 'Ghost Desktop'
-  homepage 'https://ghost.org/downloads'
+  homepage 'https://ghost.org/downloads/'
 
   app 'Ghost.app'
 end

--- a/Casks/git.rb
+++ b/Casks/git.rb
@@ -17,7 +17,7 @@ cask 'git' do
   end
 
   name 'git-osx-installer'
-  homepage 'https://sourceforge.net/projects/git-osx-installer'
+  homepage 'https://sourceforge.net/projects/git-osx-installer/'
 
   depends_on macos: '>= :snow_leopard'
 

--- a/Casks/hackhands.rb
+++ b/Casks/hackhands.rb
@@ -5,7 +5,7 @@ cask 'hackhands' do
   # desktop.hackhands.com.s3-website-us-west-1.amazonaws.com was verified as official when first introduced to the cask
   url "http://desktop.hackhands.com.s3-website-us-west-1.amazonaws.com/osx/#{version}/HackHands.zip"
   name 'HackHands'
-  homepage 'https://hackhands.com/desktop'
+  homepage 'https://hackhands.com/desktop/'
 
   app 'HackHands.app'
 end

--- a/Casks/ibackup.rb
+++ b/Casks/ibackup.rb
@@ -4,7 +4,7 @@ cask 'ibackup' do
 
   url "http://www.grapefruit.ch/iBackup/versions/iBackup%20#{version.major}.x/iBackup%20#{version}.dmg"
   name 'iBackup'
-  homepage 'http://www.grapefruit.ch/iBackup'
+  homepage 'http://www.grapefruit.ch/iBackup/'
 
   app 'iBackup.app'
 end

--- a/Casks/icultus.rb
+++ b/Casks/icultus.rb
@@ -7,7 +7,7 @@ cask 'icultus' do
   appcast 'https://github.com/djyde/iCultus/releases.atom',
           checkpoint: '093578d94bc93c0dbbd6fbefd837faaf6824ad516add11ca6acc8b7f81a1fec8'
   name 'iCultus'
-  homepage 'https://djyde.github.io/iCultus'
+  homepage 'https://djyde.github.io/iCultus/'
 
   app 'iCultus.app'
 end

--- a/Casks/iloc.rb
+++ b/Casks/iloc.rb
@@ -4,7 +4,7 @@ cask 'iloc' do
 
   url "https://derailer.org/iloc/iloc-#{version}.tgz"
   name 'iloc'
-  homepage 'https://derailer.org/iloc'
+  homepage 'https://derailer.org/iloc/'
 
   binary "iloc-#{version}/iloc"
 end

--- a/Casks/keymo.rb
+++ b/Casks/keymo.rb
@@ -6,7 +6,7 @@ cask 'keymo' do
   appcast 'https://manytricks.com/keymo/appcast.xml',
           checkpoint: '382c704be6dbdc0bbeff5b01a661c227a9beabc487363bea91d63cf55ec0f8c7'
   name 'Keymo'
-  homepage 'https://manytricks.com/keymo'
+  homepage 'https://manytricks.com/keymo/'
 
   auto_updates true
 

--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -7,7 +7,7 @@ cask 'latexit' do
   appcast 'https://pierre.chachatelier.fr/latexit/downloads/latexit-sparkle-en.rss',
           checkpoint: '90d5bc582ecba92ccf740e0a9793fa8f08441d3c9586eeddcb8baf003cdc023c'
   name 'LaTeXiT'
-  homepage 'https://www.chachatelier.fr/latexit'
+  homepage 'https://www.chachatelier.fr/latexit/'
 
   app 'LaTeXiT.app'
 

--- a/Casks/licensed.rb
+++ b/Casks/licensed.rb
@@ -4,7 +4,7 @@ cask 'licensed' do
 
   url 'http://amarsagoo.info/licensed/Licensed.dmg'
   name 'Licensed'
-  homepage 'http://amarsagoo.info/licensed'
+  homepage 'http://amarsagoo.info/licensed/'
 
   app 'Licensed.app'
 end

--- a/Casks/macdrops.rb
+++ b/Casks/macdrops.rb
@@ -4,7 +4,7 @@ cask 'macdrops' do
 
   url "https://interfacelift.com/apps/macdrops/v1/Macdrops_v#{version}.dmg"
   name 'Macdrops'
-  homepage 'https://interfacelift.com/apps/macdrops/v1'
+  homepage 'https://interfacelift.com/apps/macdrops/v1/'
 
   app "Macdrops v#{version}.app"
 end

--- a/Casks/macx-youtube-downloader.rb
+++ b/Casks/macx-youtube-downloader.rb
@@ -4,7 +4,7 @@ cask 'macx-youtube-downloader' do
 
   url 'https://www.macxdvd.com/download/macx-youtube-downloader-free.dmg'
   name 'MacX YouTube Downloader'
-  homepage 'https://www.macxdvd.com/free-youtube-video-downloader-mac'
+  homepage 'https://www.macxdvd.com/free-youtube-video-downloader-mac/'
 
   app 'MacX YouTube Downloader.app'
 end

--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -7,7 +7,7 @@ cask 'min' do
   appcast 'https://github.com/minbrowser/min/releases.atom',
           checkpoint: 'd9fe31b89a107bec70ad419961cfba3e7dc971ac3946bf67894b9fb99b4a36cc'
   name 'Min'
-  homepage 'https://minbrowser.github.io/min'
+  homepage 'https://minbrowser.github.io/min/'
 
   app 'Min.app'
 

--- a/Casks/mini-vmac.rb
+++ b/Casks/mini-vmac.rb
@@ -4,7 +4,7 @@ cask 'mini-vmac' do
 
   url "http://www.gryphel.com/d/minivmac/minivmac-#{version}/minivmac-#{version}-imch.bin.tgz"
   name 'Mini vMac'
-  homepage 'http://www.gryphel.com/c/minivmac'
+  homepage 'http://www.gryphel.com/c/minivmac/'
 
   app 'Mini vMac.app'
 end

--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -4,7 +4,7 @@ cask 'mp3tag' do
 
   url "http://download.mp3tag.de/mp3tagv#{version.no_dots}-MacOSX-Wine.zip"
   name 'MP3TAG'
-  homepage 'http://www.mp3tag.de/en'
+  homepage 'http://www.mp3tag.de/en/'
 
   app "mp3tagv#{version.no_dots}-MacOSX-Wine/Mp3tag.app"
 end

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -4,7 +4,7 @@ cask 'mps' do
 
   url "https://download-cf.jetbrains.com/mps/#{version.major_minor.no_dots}/MPS-#{version}-macos-jdk-bundled.dmg"
   name 'JetBrains MPS'
-  homepage 'https://www.jetbrains.com/mps'
+  homepage 'https://www.jetbrains.com/mps/'
 
   conflicts_with cask: 'mps-eap'
 

--- a/Casks/multifirefox.rb
+++ b/Casks/multifirefox.rb
@@ -7,7 +7,7 @@ cask 'multifirefox' do
   appcast 'https://s3.amazonaws.com/mff_sparkle/MultiFirefoxAppcast2.xml',
           checkpoint: 'fc4c1e122aa26f0f081158d044aa9dc51e70655b265682902e925f7c11782090'
   name 'MultiFirefox'
-  homepage 'http://davemartorana.com/multifirefox'
+  homepage 'http://davemartorana.com/multifirefox/'
 
   app 'MultiFirefox.app'
 end

--- a/Casks/namely.rb
+++ b/Casks/namely.rb
@@ -4,7 +4,7 @@ cask 'namely' do
 
   url 'http://amarsagoo.info/namely/Namely.dmg'
   name 'Namely'
-  homepage 'http://amarsagoo.info/namely'
+  homepage 'http://amarsagoo.info/namely/'
 
   app 'Namely.app'
 end

--- a/Casks/nicecast.rb
+++ b/Casks/nicecast.rb
@@ -6,7 +6,7 @@ cask 'nicecast' do
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Nicecast&system=10114',
           checkpoint: 'cd857805b6f1290a2b1777b0b8e35d8876879323446e5a20fbd013160cc450a7'
   name 'Nicecast'
-  homepage 'https://rogueamoeba.com/nicecast'
+  homepage 'https://rogueamoeba.com/nicecast/'
 
   app 'Nicecast.app'
 end

--- a/Casks/noise-machine.rb
+++ b/Casks/noise-machine.rb
@@ -16,7 +16,7 @@ cask 'noise-machine' do
   appcast 'http://www.publicspace.net/app/nm.xml',
           checkpoint: '3fd8dc56e7655c3e15bb7937ec9cf30a51bc492f3481724a53bedeedec2e05fd'
   name 'Noise Machine'
-  homepage 'http://www.publicspace.net/NoiseMachine'
+  homepage 'http://www.publicspace.net/NoiseMachine/'
 
   app 'Noise Machine.app'
 end

--- a/Casks/omnidazzle.rb
+++ b/Casks/omnidazzle.rb
@@ -4,7 +4,7 @@ cask 'omnidazzle' do
 
   url "http://downloads2.omnigroup.com/software/MacOSX/10.6/OmniDazzle-#{version}.dmg"
   name 'OmniDazzle'
-  homepage 'https://support.omnigroup.com/omnidazzle-troubleshooting'
+  homepage 'https://support.omnigroup.com/omnidazzle-troubleshooting/'
 
   app 'OmniDazzle.app'
 

--- a/Casks/omnifocus-clip-o-tron.rb
+++ b/Casks/omnifocus-clip-o-tron.rb
@@ -4,7 +4,7 @@ cask 'omnifocus-clip-o-tron' do
 
   url "https://www.omnigroup.com/ftp/pub/software/MacOSX/10.10/OmniFocus-Clip-o-Tron-Installer-#{version}.dmg"
   name 'OmniFocus Clip-O-Tron'
-  homepage 'https://support.omnigroup.com/omnifocus-clip-o-tron'
+  homepage 'https://support.omnigroup.com/omnifocus-clip-o-tron/'
 
   installer manual: 'OmniFocus Clip-o-Tron.app'
 end

--- a/Casks/phoenix-slides.rb
+++ b/Casks/phoenix-slides.rb
@@ -4,7 +4,7 @@ cask 'phoenix-slides' do
 
   url "http://blyt.net/phxslides/phoenix-slides-#{version.no_dots}.dmg"
   name 'Phoenix Slides'
-  homepage 'http://blyt.net/phxslides'
+  homepage 'http://blyt.net/phxslides/'
 
   app 'Phoenix Slides.app'
 end

--- a/Casks/phonebrowse.rb
+++ b/Casks/phonebrowse.rb
@@ -4,7 +4,7 @@ cask 'phonebrowse' do
 
   url 'https://www.imobie.com/product/phonebrowse-mac.dmg'
   name 'PhoneBrowse'
-  homepage 'https://www.imobie.com/phonebrowse'
+  homepage 'https://www.imobie.com/phonebrowse/'
 
   app 'PhoneBrowse.app'
 end

--- a/Casks/phonerescue.rb
+++ b/Casks/phonerescue.rb
@@ -4,7 +4,7 @@ cask 'phonerescue' do
 
   url 'https://www.imobie.com/product/phonerescue-mac.dmg'
   name 'PhoneRescue'
-  homepage 'https://www.imobie.com/phonerescue'
+  homepage 'https://www.imobie.com/phonerescue/'
 
   app 'PhoneRescue.app'
 end

--- a/Casks/phonetrans.rb
+++ b/Casks/phonetrans.rb
@@ -4,7 +4,7 @@ cask 'phonetrans' do
 
   url 'https://www.imobie.com/product/phonetrans-mac.dmg'
   name 'PhoneTrans'
-  homepage 'https://www.imobie.com/phonetrans'
+  homepage 'https://www.imobie.com/phonetrans/'
 
   app 'PhoneTrans.app'
 end

--- a/Casks/pi-filler.rb
+++ b/Casks/pi-filler.rb
@@ -4,7 +4,7 @@ cask 'pi-filler' do
 
   url 'http://ivanx.com/raspberrypi/files/PiFiller.zip'
   name 'Pi Filler'
-  homepage 'http://ivanx.com/raspberrypi'
+  homepage 'http://ivanx.com/raspberrypi/'
 
   app 'Pi Filler.app'
 end

--- a/Casks/pixelpeeper.rb
+++ b/Casks/pixelpeeper.rb
@@ -4,7 +4,7 @@ cask 'pixelpeeper' do
 
   url 'https://www.irradiatedsoftware.com/download/PixelPeeper.zip'
   name 'PixelPeeper'
-  homepage 'https://www.irradiatedsoftware.com/labs'
+  homepage 'https://www.irradiatedsoftware.com/labs/'
 
   app 'PixelPeeper.app'
 end

--- a/Casks/plain-clip.rb
+++ b/Casks/plain-clip.rb
@@ -4,7 +4,7 @@ cask 'plain-clip' do
 
   url 'https://www.bluem.net/files/Plain-Clip.dmg'
   name 'Plain Clip'
-  homepage 'https://www.bluem.net/en/mac/plain-clip'
+  homepage 'https://www.bluem.net/en/mac/plain-clip/'
 
   app 'Plain Clip.app'
 end

--- a/Casks/podtrans.rb
+++ b/Casks/podtrans.rb
@@ -4,7 +4,7 @@ cask 'podtrans' do
 
   url 'https://www.imobie.com/product/podtrans-mac.dmg'
   name 'PodTrans'
-  homepage 'https://www.imobie.com/podtrans'
+  homepage 'https://www.imobie.com/podtrans/'
 
   app 'PodTrans.app'
 end

--- a/Casks/preference-manager.rb
+++ b/Casks/preference-manager.rb
@@ -6,7 +6,7 @@ cask 'preference-manager' do
   appcast 'https://www.digitalrebellion.com/rss/appcasts/pref_man.xml',
           checkpoint: '16d1e93f7fbdb16438f4fe44ae29079e63dbff5886965b707a72232371684d14'
   name 'Preference Manager'
-  homepage 'https://www.digitalrebellion.com/prefman'
+  homepage 'https://www.digitalrebellion.com/prefman/'
 
   app 'Preference Manager.app'
 end

--- a/Casks/protant.rb
+++ b/Casks/protant.rb
@@ -4,7 +4,7 @@ cask 'protant' do
 
   url "http://www.laurenceanthony.net/software/protant/releases/ProtAnt#{version.no_dots}/ProtAnt.zip"
   name 'ProtAnt'
-  homepage 'http://www.laurenceanthony.net/software/protant'
+  homepage 'http://www.laurenceanthony.net/software/protant/'
 
   app 'ProtAnt.app'
 end

--- a/Casks/qrfcview.rb
+++ b/Casks/qrfcview.rb
@@ -5,7 +5,7 @@ cask 'qrfcview' do
   # github.com/downloads/saghul/qrfcview-osx was verified as official when first introduced to the cask
   url "https://github.com/downloads/saghul/qrfcview-osx/qRFCView-#{version}-1.dmg"
   name 'qRFCView'
-  homepage 'https://saghul.github.io/qrfcview-osx'
+  homepage 'https://saghul.github.io/qrfcview-osx/'
 
   app 'qRFCView.app'
 end

--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -7,7 +7,7 @@ cask 'rapidweaver' do
   appcast "https://updates.devmate.com/com.realmacsoftware.rapidweaver#{version.major}.xml",
           checkpoint: '42a364ce0f07cb09d7b55024becee4acc42646a530673f5ae1d178fb13b40c1e'
   name 'RapidWeaver'
-  homepage 'https://realmacsoftware.com/rapidweaver'
+  homepage 'https://realmacsoftware.com/rapidweaver/'
 
   depends_on macos: '>= :leopard'
 

--- a/Casks/remote-buddy.rb
+++ b/Casks/remote-buddy.rb
@@ -4,7 +4,7 @@ cask 'remote-buddy' do
 
   url 'https://www.iospirit.com/static/objectfiles/file/101/RemoteBuddy.dmg'
   name 'Remote Buddy'
-  homepage 'https://www.iospirit.com/products/remotebuddy'
+  homepage 'https://www.iospirit.com/products/remotebuddy/'
 
   app 'Remote Buddy.app'
 end

--- a/Casks/segmentant.rb
+++ b/Casks/segmentant.rb
@@ -4,7 +4,7 @@ cask 'segmentant' do
 
   url "http://www.laurenceanthony.net/software/segmentant/releases/SegmentAnt#{version.no_dots}/SegmentAnt.zip"
   name 'SegmentAnt'
-  homepage 'http://www.laurenceanthony.net/software/segmentant'
+  homepage 'http://www.laurenceanthony.net/software/segmentant/'
 
   app 'SegmentAnt.app'
 end

--- a/Casks/soundmate.rb
+++ b/Casks/soundmate.rb
@@ -6,7 +6,7 @@ cask 'soundmate' do
   appcast 'http://www.icyarrow.com/soundmate/soundmatecast.xml',
           checkpoint: '5886a39685690a4a1526a6cd1909e40100faa353e552a3530383655bd707aa51'
   name 'soundmate'
-  homepage 'http://www.icyarrow.com/soundmate'
+  homepage 'http://www.icyarrow.com/soundmate/'
 
   app 'SoundMate.app'
 end

--- a/Casks/spacious.rb
+++ b/Casks/spacious.rb
@@ -4,7 +4,7 @@ cask 'spacious' do
 
   url 'https://www.iospirit.com/static/objectfiles/file/159/Spacious.zip'
   name 'Spacious'
-  homepage 'https://www.iospirit.com/products/spacious'
+  homepage 'https://www.iospirit.com/products/spacious/'
 
   app 'Spacious.app'
 end

--- a/Casks/sparkbox.rb
+++ b/Casks/sparkbox.rb
@@ -7,7 +7,7 @@ cask 'sparkbox' do
   appcast 'http://matrix.icyblaze.com/index.php/checkupdate/p/8',
           checkpoint: '6651d8423c428326e9b213812cd24b261f97f91b74574888afde249f34ed5333'
   name 'Sparkbox'
-  homepage 'http://www.icyblaze.com/sparkbox'
+  homepage 'http://www.icyblaze.com/sparkbox/'
 
   depends_on macos: '>= :lion'
 

--- a/Casks/spear.rb
+++ b/Casks/spear.rb
@@ -4,7 +4,7 @@ cask 'spear' do
 
   url 'http://www.klingbeil.com/spear/downloads/files/SPEAR_latest.dmg'
   name 'Spear'
-  homepage 'http://www.klingbeil.com/spear'
+  homepage 'http://www.klingbeil.com/spear/'
 
   app 'SPEAR.app'
 end

--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -7,7 +7,7 @@ cask 'stretchly' do
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
           checkpoint: '1c4244355d721e8f05a3f9c451f742a9e3f6cf7e463d252e0a4b2da000ec524b'
   name 'stretchly'
-  homepage 'https://hovancik.net/stretchly'
+  homepage 'https://hovancik.net/stretchly/'
 
   app 'stretchly.app'
 end

--- a/Casks/sysex-librarian.rb
+++ b/Casks/sysex-librarian.rb
@@ -6,7 +6,7 @@ cask 'sysex-librarian' do
   appcast 'https://www.snoize.com/SysExLibrarian/SysExLibrarian.xml',
           checkpoint: '5932ad75281f34f7ed7dda012b8cabb61b0c9c95acf4f0429c06fdc6a41e34aa'
   name 'SysEx Librarian'
-  homepage 'https://www.snoize.com/SysExLibrarian'
+  homepage 'https://www.snoize.com/SysExLibrarian/'
 
   depends_on macos: '>= :lion'
 

--- a/Casks/tagant.rb
+++ b/Casks/tagant.rb
@@ -4,7 +4,7 @@ cask 'tagant' do
 
   url "http://www.laurenceanthony.net/software/tagant/releases/TagAnt#{version.no_dots}/TagAnt.zip"
   name 'TagAnt'
-  homepage 'http://www.laurenceanthony.net/software/tagant'
+  homepage 'http://www.laurenceanthony.net/software/tagant/'
 
   app 'TagAnt.app'
 end

--- a/Casks/texmaker.rb
+++ b/Casks/texmaker.rb
@@ -4,7 +4,7 @@ cask 'texmaker' do
 
   url 'http://www.xm1math.net/texmaker/TexmakerMacosxLion.zip'
   name 'Texmaker'
-  homepage 'http://www.xm1math.net/texmaker'
+  homepage 'http://www.xm1math.net/texmaker/'
 
   app 'TexmakerMacosxLion/texmaker.app'
 end

--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -6,7 +6,7 @@ cask 'texshop' do
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
           checkpoint: '920914819ea0574c8fd896869b313aaeb597e6d592fd8de459cec5927991e04e'
   name 'TeXShop'
-  homepage 'http://pages.uoregon.edu/koch/texshop'
+  homepage 'http://pages.uoregon.edu/koch/texshop/'
 
   app 'TeXShop.app'
 end

--- a/Casks/tubbler.rb
+++ b/Casks/tubbler.rb
@@ -6,7 +6,7 @@ cask 'tubbler' do
   appcast 'https://ssl.webpack.de/celmaro.com/updates/tubbler/tubbler.xml',
           checkpoint: '332992e2232a2bfe6a207493f7ef6b97e1c5044d8d1e68b60bc9f9f2f0f5b26a'
   name 'Tubbler'
-  homepage 'http://www.celmaro.com/tubbler'
+  homepage 'http://www.celmaro.com/tubbler/'
 
   app 'Tubbler.app'
 end

--- a/Casks/ubersicht.rb
+++ b/Casks/ubersicht.rb
@@ -6,7 +6,7 @@ cask 'ubersicht' do
   appcast 'http://tracesof.net/uebersicht/updates.xml.rss',
           checkpoint: '156f6db16deb26544c11f1df36bbb4a53a61132f130f9c02ee8d9ce5cd6fb8a8'
   name 'Übersicht'
-  homepage 'http://tracesof.net/uebersicht'
+  homepage 'http://tracesof.net/uebersicht/'
 
   app 'Übersicht.app'
 

--- a/Casks/ui-browser.rb
+++ b/Casks/ui-browser.rb
@@ -4,7 +4,7 @@ cask 'ui-browser' do
 
   url "http://pfiddlesoft.com/uibrowser/downloads/UIBrowser#{version.no_dots}.dmg"
   name 'UI Browser'
-  homepage 'http://pfiddlesoft.com/uibrowser'
+  homepage 'http://pfiddlesoft.com/uibrowser/'
 
   pkg 'UI Browser.pkg'
 

--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -4,7 +4,7 @@ cask 'unifi-controller' do
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'
-  homepage 'https://www.ubnt.com/download/unifi'
+  homepage 'https://www.ubnt.com/download/unifi/'
 
   pkg 'UniFi.pkg'
 

--- a/Casks/webtorrent.rb
+++ b/Casks/webtorrent.rb
@@ -7,7 +7,7 @@ cask 'webtorrent' do
   appcast 'https://github.com/feross/webtorrent-desktop/releases.atom',
           checkpoint: 'b1361dd58f810194aec58efc6566cbe5d29531b6e8261938f48c01817946e9fd'
   name 'WebTorrent Desktop'
-  homepage 'https://webtorrent.io/desktop'
+  homepage 'https://webtorrent.io/desktop/'
 
   app 'WebTorrent.app'
 

--- a/Casks/yemuzip.rb
+++ b/Casks/yemuzip.rb
@@ -6,7 +6,7 @@ cask 'yemuzip' do
   appcast 'http://yellowmug.com/yemuzip/appcast.xml',
           checkpoint: '2ede15a2a242f583876e6e5f5957368819435adff6347431862c5a45ee7b2a42'
   name 'YemuZip'
-  homepage 'http://www.yellowmug.com/yemuzip'
+  homepage 'http://www.yellowmug.com/yemuzip/'
 
   app 'YemuZip.app'
 end

--- a/Casks/zooom.rb
+++ b/Casks/zooom.rb
@@ -4,7 +4,7 @@ cask 'zooom' do
 
   url 'http://software.coderage-software.com/zooom/Zooom_Latest.dmg'
   name 'Zooom/2'
-  homepage 'http://coderage-software.com/zooom'
+  homepage 'http://coderage-software.com/zooom/'
 
   depends_on macos: '>= :mavericks'
 


### PR DESCRIPTION
Update homepage for 77 Casks from the list [here](http://caskroom.victorpopkov.com/homebrew-cask/homepages.csv).

The only ones remaining from the above list are the ones with the warnings _domain_ and _redirect_ - those are much harder (mainly because I cannot think of a clever way to use `sed`!) and will (possibly) require comments added/edited above the `url` stanza.

Ping @victorpopkov.