### PR TITLE
Fix homepages in 27 casks to use SSL

### DIFF
--- a/Casks/acslogo.rb
+++ b/Casks/acslogo.rb
@@ -4,7 +4,7 @@ cask 'acslogo' do
 
   url "http://www.alancsmith.co.uk/logo/ACSLogo#{version.no_dots}.dmg"
   name 'ACSLogo'
-  homepage 'http://www.alancsmith.co.uk/logo/'
+  homepage 'https://www.alancsmith.co.uk/logo/'
 
   app 'ACSLogo/ACSLogo.app'
 end

--- a/Casks/activity-audit.rb
+++ b/Casks/activity-audit.rb
@@ -6,7 +6,7 @@ cask 'activity-audit' do
   appcast 'https://version.dssw.co.uk/activityaudit/standard',
           checkpoint: 'b6f660015d4a8782fd78dfb75afb6242fc4c217d8c2e2954688f8e8c12263bf6'
   name 'Activity Audit'
-  homepage 'http://www.dssw.co.uk/activityaudit/'
+  homepage 'https://www.dssw.co.uk/activityaudit/'
 
   app 'Activity Audit.app'
 end

--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -11,7 +11,7 @@ cask 'amethyst' do
   appcast 'https://ianyh.com/amethyst/appcast.xml',
           checkpoint: '92d4615302d5e3ed68a3a187b6709e78080691550517f9b171b3631a6ca45d1c'
   name 'Amethyst'
-  homepage 'http://ianyh.com/amethyst/'
+  homepage 'https://ianyh.com/amethyst/'
 
   accessibility_access true
 

--- a/Casks/authbuddy.rb
+++ b/Casks/authbuddy.rb
@@ -4,7 +4,7 @@ cask 'authbuddy' do
 
   url 'https://www.dssw.co.uk/authbuddy/dsswauthbuddy.dmg'
   name 'authbuddy'
-  homepage 'http://www.dssw.co.uk/authbuddy/'
+  homepage 'https://www.dssw.co.uk/authbuddy/'
 
   pkg 'DssW authbuddy.pkg'
 

--- a/Casks/battery-guardian.rb
+++ b/Casks/battery-guardian.rb
@@ -6,7 +6,7 @@ cask 'battery-guardian' do
   appcast 'https://version.dssw.co.uk/batteryguardian/standard',
           checkpoint: '62cb80cfc4b5f02a4a4abea72aa36080b88d4ee73dd2841b9aa13af997df00ef'
   name 'Battery Guardian'
-  homepage 'http://www.dssw.co.uk/batteryguardian/'
+  homepage 'https://www.dssw.co.uk/batteryguardian/'
 
   app 'Battery Guardian.app'
 end

--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -6,7 +6,7 @@ cask 'battery-report' do
   appcast 'https://version.dssw.co.uk/batteryreport/standard',
           checkpoint: '18be1911eb53fa3d0a20abfaa0ba2a74992eed5bb9bb3fc39b64184537ffb674'
   name 'Battery Report'
-  homepage 'http://www.dssw.co.uk/batteryreport/'
+  homepage 'https://www.dssw.co.uk/batteryreport/'
 
   app 'Battery Report.app'
 end

--- a/Casks/bootxchanger.rb
+++ b/Casks/bootxchanger.rb
@@ -6,7 +6,7 @@ cask 'bootxchanger' do
   appcast 'http://swupdate.namedfork.net/bootxchanger.xml',
           checkpoint: '1c3c0913f51c0d8dd6b8320460e3be60f9541f62dab75f56e5befb690a7566dc'
   name 'BootXChanger'
-  homepage 'http://namedfork.net/bootxchanger/'
+  homepage 'https://namedfork.net/bootxchanger/'
 
   app 'BootXChanger.app'
 end

--- a/Casks/camerabag.rb
+++ b/Casks/camerabag.rb
@@ -5,7 +5,7 @@ cask 'camerabag' do
   # downloads.nevercenter.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://downloads.nevercenter.com.s3.amazonaws.com/CameraBag_Mac_#{version.dots_to_underscores}.dmg"
   name 'CameraBag'
-  homepage 'http://nevercenter.com/camerabag/photo/'
+  homepage 'https://nevercenter.com/camerabag/photo/'
 
   app "CameraBag #{version.major}.app"
 end

--- a/Casks/coolterm.rb
+++ b/Casks/coolterm.rb
@@ -4,7 +4,7 @@ cask 'coolterm' do
 
   url 'http://freeware.the-meiers.org/CoolTerm_Mac.zip'
   name 'CoolTerm'
-  homepage 'http://freeware.the-meiers.org/'
+  homepage 'https://freeware.the-meiers.org/'
 
   app 'CoolTermMac/CoolTerm.app'
 end

--- a/Casks/finderminder.rb
+++ b/Casks/finderminder.rb
@@ -6,7 +6,7 @@ cask 'finderminder' do
   appcast 'https://www.irradiatedsoftware.com/updates/profiles/finderminder.php',
           checkpoint: '5f07a947f8e34f2759bdf7073446973122c43680509bf67874ab495ff051c64f'
   name 'FinderMinder'
-  homepage 'http://www.irradiatedsoftware.com/labs/'
+  homepage 'https://www.irradiatedsoftware.com/labs/'
 
   accessibility_access true
 

--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -6,7 +6,7 @@ cask 'flash-ppapi' do
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',
           checkpoint: '50c4e19caa48710cf812e1549e5179124552b4bf760dc9aa719e09dd86d10fbe'
   name 'Adobe Flash Player PPAPI (plugin for Opera and Chromium)'
-  homepage 'http://get.adobe.com/flashplayer/otherversions/'
+  homepage 'https://get.adobe.com/flashplayer/otherversions/'
 
   pkg 'Install Adobe Pepper Flash Player.app/Contents/Resources/Adobe Flash Player.pkg'
 

--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -5,7 +5,7 @@ cask 'liclipse' do
   # googledrive.com/host/0BwwQN8QrgsRpLVlDeHRNemw3S1E was verified as official when first introduced to the cask
   url "https://googledrive.com/host/0BwwQN8QrgsRpLVlDeHRNemw3S1E/LiClipse%20#{version}/liclipse_#{version}_macosx.cocoa.x86_64.dmg"
   name 'LiClipse'
-  homepage 'http://www.liclipse.com/'
+  homepage 'https://www.liclipse.com/'
 
   app 'LiClipse.app'
 end

--- a/Casks/metagrowler.rb
+++ b/Casks/metagrowler.rb
@@ -4,7 +4,7 @@ cask 'metagrowler' do
 
   url "https://buttered-cat.com/downloads/get/12/MetaGrowler_#{version}.zip"
   name 'MetaGrowler'
-  homepage 'http://buttered-cat.com/products/view/MetaGrowler'
+  homepage 'https://buttered-cat.com/products/view/MetaGrowler'
 
   app 'MetaGrowler.app'
 end

--- a/Casks/mjolnir.rb
+++ b/Casks/mjolnir.rb
@@ -7,7 +7,7 @@ cask 'mjolnir' do
   appcast 'https://github.com/sdegutis/mjolnir/releases.atom',
           checkpoint: 'bcbd84dc837113b342a6f780109b23825f3d6c6c208c7b68a193560eab832d80'
   name 'Mjolnir'
-  homepage 'http://www.mjolnir.io/'
+  homepage 'https://www.mjolnir.io/'
 
   app 'Mjolnir.app'
 end

--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -4,7 +4,7 @@ cask 'mysqlworkbench' do
 
   url "https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-osx-x86_64.dmg"
   name 'MySQL Workbench'
-  homepage 'http://www.mysql.com/products/workbench/'
+  homepage 'https://www.mysql.com/products/workbench/'
   gpg "#{url}.asc",
       key_id: '8c718d3b5072e1f5'
 

--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -7,7 +7,7 @@ cask 'neofinder' do
   appcast 'https://www.wfs-apps.de/updates/neofinder-appcast-64.xml',
           checkpoint: 'dc7200a0207418ba7148ae3cff37fa3decd70bd911ce2f95c30cfd53ce484cdf'
   name 'NeoFinder'
-  homepage 'http://www.cdfinder.de'
+  homepage 'https://www.cdfinder.de/'
 
   app 'NeoFinder.app'
 end

--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -13,7 +13,7 @@ cask 'opensesame' do
   end
 
   name 'OpenSesame'
-  homepage 'http://osdoc.cogsci.nl/'
+  homepage 'https://osdoc.cogsci.nl/'
 
   app 'opensesame.app'
 end

--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -6,7 +6,7 @@ cask 'papers' do
   appcast 'https://appcaster.papersapp.com/apps/mac/production/appcast.xml',
           checkpoint: 'c35a04f02091fbcaf519185678a234c6e034d798561b19c7af4f0c590648450f'
   name 'Papers'
-  homepage 'http://papersapp.com/'
+  homepage 'https://papersapp.com/'
 
   app 'Papers.app'
 end

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -7,7 +7,7 @@ cask 'plover' do
   appcast 'https://github.com/openstenoproject/plover/releases.atom',
           checkpoint: '00552cb3716e36085af2c8ad44d0774d3e404e9ad86656bee7edb57721cd1d8c'
   name 'Plover'
-  homepage 'http://stenoknight.com/wiki/Main_Page'
+  homepage 'https://stenoknight.com/wiki/Main_Page'
 
   accessibility_access true
 

--- a/Casks/pokerth.rb
+++ b/Casks/pokerth.rb
@@ -7,7 +7,7 @@ cask 'pokerth' do
   appcast 'https://sourceforge.net/projects/pokerth/rss',
           checkpoint: '7a823751e557c8c38a4ae7ae0f4cfe502f140dbf84e433021280298c4413608d'
   name 'PokerTH'
-  homepage 'http://pokerth.net'
+  homepage 'https://pokerth.net/'
 
   app 'pokerth.app'
 end

--- a/Casks/power-manager.rb
+++ b/Casks/power-manager.rb
@@ -6,7 +6,7 @@ cask 'power-manager' do
   appcast 'https://version.dssw.co.uk/powermanager/application',
           checkpoint: 'bb2e3dca69a563292b36fbaa8aee38697085430e88cc3cc7fc75a6e56df89c8c'
   name 'Power Manager'
-  homepage 'http://www.dssw.co.uk/powermanager/'
+  homepage 'https://www.dssw.co.uk/powermanager/'
 
   auto_updates true
   depends_on macos: '>= :lion'

--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -5,7 +5,7 @@ cask 'remote-desktop-manager' do
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"
   name 'Remote Desktop Manager'
-  homepage 'http://mac.remotedesktopmanager.com/'
+  homepage 'https://mac.remotedesktopmanager.com/'
 
   app 'Remote Desktop Manager.app'
 end

--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -4,7 +4,7 @@ cask 'retroarch' do
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   name 'RetroArch'
-  homepage 'http://www.libretro.com/'
+  homepage 'https://www.libretro.com/'
 
   app 'RetroArch.app'
 end

--- a/Casks/sleep-monitor.rb
+++ b/Casks/sleep-monitor.rb
@@ -6,7 +6,7 @@ cask 'sleep-monitor' do
   appcast 'https://version.dssw.co.uk/sleepmonitor/standard',
           checkpoint: 'ce2f60062ef44a4e9ca411b903641bbc5b08568f6418a10c79f7409191fcd60f'
   name 'Sleep Monitor'
-  homepage 'http://www.dssw.co.uk/sleepmonitor/'
+  homepage 'https://www.dssw.co.uk/sleepmonitor/'
 
   app 'Sleep Monitor.app'
 end

--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -4,7 +4,7 @@ cask 'transmit' do
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   name 'Transmit'
-  homepage 'http://panic.com/transmit/'
+  homepage 'https://panic.com/transmit/'
 
   app 'Transmit.app'
 

--- a/Casks/trolcommander.rb
+++ b/Casks/trolcommander.rb
@@ -7,7 +7,7 @@ cask 'trolcommander' do
   appcast 'https://github.com/trol73/mucommander/releases.atom',
           checkpoint: '07a84626dfc65bc014a9c4cd9d76f44b3138b6a11ca3d891f4492aa32f65af55'
   name 'trolCommander'
-  homepage 'http://trolsoft.ru/en/soft/trolcommander'
+  homepage 'https://trolsoft.ru/en/soft/trolcommander'
 
   app 'trolCommander.app'
 end

--- a/Casks/whatpulse.rb
+++ b/Casks/whatpulse.rb
@@ -4,7 +4,7 @@ cask 'whatpulse' do
 
   url "http://amcdn.whatpulse.org/files/whatpulse-mac-#{version}.dmg"
   name 'WhatPulse'
-  homepage 'http://whatpulse.org/'
+  homepage 'https://whatpulse.org/'
 
   pkg "WhatPulse #{version}.mpkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
