### PR TITLE
Update subler to 1.2.1

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.2'
-  sha256 'ad3c7b1b210e4760ebb319eaf6973432267409f390725250a0b3c4652ebf0d44'
+  version '1.2.1'
+  sha256 'f955ba61c4f9dba05e89c286c873f27aee2d5838613cd770cd33433290206bfe'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: '4c754b7a59b00695c4013a418b2e3daebbca476df5faab2f99a963ddce0298c7'
+          checkpoint: 'fe93ab507bdedc03aacee8ac6c38e5903ef0cbc5543d9f2e2d4784cca7f0e535'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.