### PR TITLE
Update ridibooks to 2.1.0

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,6 +1,6 @@
 cask 'ridibooks' do
-  version '2.0.0'
-  sha256 '929a114a862e5785f25507f5e94a9133fc01f4da5e34c5eb39270884c1282c56'
+  version '2.1.0'
+  sha256 '8bea09f4b21bf8d2475c50c4667b76f2121b1a4dc75a05921ec8b02666cd8ae0'
 
   # ridicorp.com was verified as official when first introduced to the cask
   url "https://cdn.ridicorp.com/app/mac/ridibooks-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.