### PR TITLE
Update tabula to 1.1.0

### DIFF
--- a/Casks/tabula.rb
+++ b/Casks/tabula.rb
@@ -1,11 +1,11 @@
 cask 'tabula' do
-  version '1.0.1'
-  sha256 '85e75f120c450bc702c01aa88a4ca9c2d227ef2906ec7020e892e0f174a7d70b'
+  version '1.1.0c'
+  sha256 '70ec8a524e881ed66d6048776ed0ceb16a0c8b68d06e1295a39698e836274b04'
 
   # github.com/tabulapdf/tabula was verified as official when first introduced to the cask
-  url "https://github.com/tabulapdf/tabula/releases/download/v#{version}/tabula-mac-#{version}.zip"
+  url "https://github.com/tabulapdf/tabula/releases/download/v#{version.major_minor_patch}/tabula-mac-#{version}.zip"
   appcast 'https://github.com/tabulapdf/tabula/releases.atom',
-          checkpoint: '2e20dc186a93930ca4b59fe694ba278c4171776a19c6942273d1b6510d05755d'
+          checkpoint: '673874f3ec13bbf7ede5cb2930090ee49f1170cf95d43a578d0ba5f2d86ccee7'
   name 'Tabula'
   homepage 'http://tabula.technology/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.