### PR TITLE
Update porting-kit to 2.4.126

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,10 +1,10 @@
 cask 'porting-kit' do
-  version '2.4.125'
-  sha256 '9e914cf1b99a6dad0edc1abda5d038e77252d85948f8c4176dc486a3890fe213'
+  version '2.4.126'
+  sha256 '86574b573ac7a8b14c7d3bcbe13a3b768a53ab7991e4e3df1584617fe55cb652'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '44bd022e71a54ded19fe2bc79801e411baab9501814f0c4323e09e30f813bff5'
+          checkpoint: '1653fb7efa80e3daf03fb3c77dcc173bd74c83fe11d084f3b80df26a62ab1d6e'
   name 'Porting Kit'
   homepage 'http://portingkit.com/en/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.