### PR TITLE
Update rodeo to 2.4.10

### DIFF
--- a/Casks/rodeo.rb
+++ b/Casks/rodeo.rb
@@ -1,11 +1,11 @@
 cask 'rodeo' do
-  version '2.4.2'
-  sha256 '3aea0105c92f53066bd24e07aac28148882f0e7bdc1495e6324886286da12992'
+  version '2.4.10'
+  sha256 'd3fed43c0ed851fc3d7db3b5241f499bd27d63948fd8049fd1c305e017e106a1'
 
   # github.com/yhat/rodeo was verified as official when first introduced to the cask
   url "https://github.com/yhat/rodeo/releases/download/v#{version}/Rodeo-#{version}.dmg"
   appcast 'https://github.com/yhat/rodeo/releases.atom',
-          checkpoint: '661be9585dc69fa30fa3042b78631f52c453a6adcbba083e1b99f142f1d13832'
+          checkpoint: 'eba53abb38f96bd9e794891747a1b3dff390bd333bed2aef575eeb1ca44d6d25'
   name 'Rodeo'
   homepage 'http://rodeo.yhat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.