### PR TITLE
Fix homepages (and urls) in 7 casks that changed domains

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -26,7 +26,7 @@ cask '1password' do
   end
 
   name '1Password'
-  homepage 'https://agilebits.com/onepassword'
+  homepage 'https://1password.com/'
 
   auto_updates true
 

--- a/Casks/actprinter.rb
+++ b/Casks/actprinter.rb
@@ -2,9 +2,10 @@ cask 'actprinter' do
   version '3.2.2'
   sha256 '6e49ac75f8a660e33b3f0d3033bf9788cfeef5a0838faad93f06b21af0efb2ee'
 
+  # actprinter.com was verified as official when first introduced to the cask
   url "http://www.actprinter.com/mac/ACTPrinter%20for%20Mac%20#{version}.zip"
   name 'ACTPrinter'
-  homepage 'http://www.actprinter.com'
+  homepage 'https://www.houdah.com/ACTPrinter/'
 
   app 'ACTPrinter for Mac.app'
 end

--- a/Casks/chronocube.rb
+++ b/Casks/chronocube.rb
@@ -7,7 +7,7 @@ cask 'chronocube' do
   appcast 'https://github.com/pablopunk/chronocube/releases.atom',
           checkpoint: '0a834802763635f2efdd91bce9443d92abb1046e59cd241b611656c10e5fafea'
   name 'Chronocube'
-  homepage 'https://pablopunk.github.io/chronocube/'
+  homepage 'http://chronocube.live/'
 
   app 'Chronocube.app'
 end

--- a/Casks/etrecheck.rb
+++ b/Casks/etrecheck.rb
@@ -2,9 +2,9 @@ cask 'etrecheck' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.etresoft.com/download/EtreCheck.zip'
+  url 'https://etrecheck.com/download/EtreCheck.zip'
   name 'EtreCheck'
-  homepage 'https://www.etresoft.com/etrecheck'
+  homepage 'https://etrecheck.com/'
 
   app 'EtreCheck.app'
 

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -7,7 +7,7 @@ cask 'lazarus' do
   appcast 'https://sourceforge.net/projects/lazarus/rss',
           checkpoint: '56d06477a5cbba6f3669f864fc3b1573d9c01739ae04bc39d1145d7a7f84f888'
   name 'Lazarus'
-  homepage 'http://lazarus.freepascal.org/'
+  homepage 'http://www.lazarus-ide.org/'
 
   depends_on formula: 'fpc'
   depends_on cask: 'fpcsrc'

--- a/Casks/mosh.rb
+++ b/Casks/mosh.rb
@@ -2,9 +2,9 @@ cask 'mosh' do
   version '1.2.5'
   sha256 '8a590ba81edd6f706f2d0afe1cb882bd8ff8860e395b7c6ac7285306f4f12209'
 
-  url "https://mosh.mit.edu/mosh-#{version}.pkg"
+  url "https://mosh.org/mosh-#{version}.pkg"
   name 'Mosh'
-  homepage 'https://mosh.mit.edu/'
+  homepage 'https://mosh.org/'
 
   pkg "mosh-#{version}.pkg"
 

--- a/Casks/resilio-sync.rb
+++ b/Casks/resilio-sync.rb
@@ -2,9 +2,9 @@ cask 'resilio-sync' do
   version :latest
   sha256 :no_check
 
-  url 'https://download-cdn.getsync.com/stable/osx/Resilio-Sync.dmg'
+  url 'https://download-cdn.resilio.com/stable/osx/Resilio-Sync.dmg'
   name 'Resilio Sync'
-  homepage 'https://www.getsync.com/'
+  homepage 'https://www.resilio.com/'
 
   app 'Resilio Sync.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
Download URLs has been changed accordingly in 3 casks: **etrecheck**, **mosh**, **resilio-sync**.
