### PR TITLE
Update sweet-home3d to 5.3

### DIFF
--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -1,11 +1,11 @@
 cask 'sweet-home3d' do
-  version '5.2'
-  sha256 'd9450ac52ead59cd24a69616aa7d613a568d841295f56bee3a993c4ed066e2da'
+  version '5.3'
+  sha256 '4b3306e4dc0ffe1812b8d5fe0082e479dcc8450777f36d926608a2d641476b86'
 
   # sourceforge.net/sweethome3d was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/sweethome3d/SweetHome3D/SweetHome3D-#{version}/SweetHome3D-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/sweethome3d/rss?path=/SweetHome3D',
-          checkpoint: 'be55e729ad642b6f7886650d8c56eb653c74723052bce02ac8b6e2ec289663bb'
+          checkpoint: '7130d3dd86b0218c7ece2806fdf67458c7d2810c96437c63ecd365bccf583459'
   name 'Sweet Home 3D'
   homepage 'http://www.sweethome3d.com/'
 


### PR DESCRIPTION
Updates sweet-home3d to 5.3

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
