### PR TITLE
Update pydiosync to 1.2.8

### DIFF
--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -1,6 +1,6 @@
 cask 'pydiosync' do
-  version '1.2.7'
-  sha256 'a2c3f133940fb64e8dd915fe1750c914ad4289d6a18e3188696a676d175840f6'
+  version '1.2.8'
+  sha256 'da7ef2a6729b27bb9837d7637da6b7c2288a595b6bec52288b0f123f85e8021e'
 
   url "https://download.pydio.com/pub/pydio-sync/release/#{version}/PydioSync-MacOSX-Installer-v#{version}.dmg"
   name 'PydioSync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.