### PR TITLE
Update atom to 1.12.5

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -22,11 +22,15 @@ cask 'atom' do
 
   zap delete: [
                 '~/.atom',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
                 '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
                 '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Application Support/com.github.atom.ShipIt',
                 '~/Library/Caches/com.github.atom',
+                '~/Library/Caches/com.github.atom.ShipIt',
+                '~/Library/Preferences/com.github.atom.helper.plist',
                 '~/Library/Preferences/com.github.atom.plist',
+                '~/Library/Saved Application State/com.github.atom.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.