### PR TITLE
Update name-mangler to 3.4

### DIFF
--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -1,10 +1,10 @@
 cask 'name-mangler' do
-  version '3.3.7'
-  sha256 '27630a76e82f6426b802d43e94bc97eb84dfe426044343f0b9f4f440cfecda25'
+  version '3.4'
+  sha256 '460f802b90e0e0123d397199600b68adf609e656e51a7b23f38bdf9eec05c91e'
 
   url 'https://manytricks.com/download/namemangler'
   appcast 'https://manytricks.com/namemangler/appcast.xml',
-          checkpoint: '622b9edd29a3f31b34d0a1f9d3aa892ec2b71a5dfd7cb31769c4d41559357b05'
+          checkpoint: 'e2b10fede763493b3d336d082c4ab8fc12c8b74692f7f94585a5f2b3cd61a220'
   name 'Name Mangler'
   homepage 'https://manytricks.com/namemangler/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.