### PR TITLE
Update staruml to 2.8.0

### DIFF
--- a/Casks/staruml.rb
+++ b/Casks/staruml.rb
@@ -1,6 +1,6 @@
 cask 'staruml' do
-  version '2.7.0'
-  sha256 'a31f77ad71c0d3fed0b1729df4b23fcc76b47eb51695861546c053171c874a9f'
+  version '2.8.0'
+  sha256 'cdeb05bdcfb83d8182c419638faa32cebef2d5c3c9c639b336bb2f12d7cd473d'
 
   url "http://staruml.io/download/release/v#{version}/StarUML-v#{version}.dmg"
   name 'StarUML'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.