### PR TITLE
Updated VisTrails to v2.2.4-1519abc0ae2b

### DIFF
--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -5,7 +5,7 @@ cask 'vistrails' do
   # sourceforge.net/project/vistrails has been verified as official
   url "https://downloads.sourceforge.net/project/vistrails/vistrails/v#{version.sub(%r{-.*}, '')}/vistrails-osx-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/vistrails/rss?path=/vistrails',
-    checkpoint: '2c87be9e8305cad6f23e74edbf88a0fd251cf8397f0f64d0e9c042be15b6e9c7'
+    checkpoint: '5b5470cbdb0773a980d33bdb4c56d44d4d1ccbc56961988faaccc9104174569c'
   name 'VisTrails'
   homepage 'https://www.vistrails.org'
 

--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -1,13 +1,13 @@
 cask 'vistrails' do
-  version '2.2.2-358e9a9fc33c'
-  sha256 'efee1669d3ba39985079e44a423f6e7b6b17493669c5945a3bbd70ec8659fc22'
+  version '2.2.4-1519abc0ae2b'
+  sha256 '61811b0f65fceaa4873fcf7fc6486376fb146a688d12af8e81a325cdb117ccac'
 
-  # sourceforge.net/vistrails was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/vistrails/vistrails/v#{version.sub(%r{-.*}, '')}/vistrails-mac-10.6-intel-#{version}.dmg"
+  # sourceforge.net/project/vistrails has been verified as official
+  url "https://downloads.sourceforge.net/project/vistrails/vistrails/v#{version.sub(%r{-.*}, '')}/vistrails-osx-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/vistrails/rss?path=/vistrails',
-          checkpoint: '5b5470cbdb0773a980d33bdb4c56d44d4d1ccbc56961988faaccc9104174569c'
+    checkpoint: '2c87be9e8305cad6f23e74edbf88a0fd251cf8397f0f64d0e9c042be15b6e9c7'
   name 'VisTrails'
-  homepage 'https://www.vistrails.org/index.php/Main_Page'
+  homepage 'https://www.vistrails.org'
 
   depends_on macos: '>= :snow_leopard'
 


### PR DESCRIPTION
- [ x ] `brew cask audit --download {{cask_file}}` is error-free.

One warning observed WRT SourceForge URL format, but review of reference reveals that URL format follows recommendation for MacOS-exclusive distributions.

- [ x ] `brew cask style --fix {{cask_file}}` reports no offenses.

One warning observed WRT the comment.  I am updating a pre-existing comment to be more relevant.

The 'rubocop' appears to incorrectly indent the 'checkpoint' parameter of appcast, which -- according to the documentation -- should be indented by 2-spaces and not "aligned with the method call" as it attempts to autofix.

- [ x ] The commit message includes the cask’s name and version.

Please let me know if you have any questions or concerns.

Cheers,
Scott
