### PR TITLE
Modify logitech-harmony to depend_on_java(6)

### DIFF
--- a/Casks/logitech-harmony.rb
+++ b/Casks/logitech-harmony.rb
@@ -8,6 +8,19 @@ cask 'logitech-harmony' do
 
   pkg 'LogitechRemoteSoftware.pkg'
 
+  postflight do
+    # Replace the hard-coded 1.4 requirement with an equally hard-coded 1.6 requirement
+    system_command '/usr/bin/sed',
+                   args: [
+                           '-E',
+                           '-i',
+                           '.bak',
+                           '-e',
+                           's|<string>1\.4\*</string>|<string>1.6*</string>|',
+                           '/Applications/Logitech Harmony Remote Software.app/Contents/Info.plist',
+                         ]
+  end
+
   uninstall quit:    'com.logitech.harmony.cappuccino.client.logitech',
             kext:    [
                        'com.RemoteControl.USBLAN.usbpart',
@@ -15,4 +28,8 @@ cask 'logitech-harmony' do
                        'com.Belcarra.iokit.USBLAN_usbpart',
                      ],
             pkgutil: 'com.logitech.harmony.logitechRemoteSoftware.*'
+
+  caveats do
+    depends_on_java('6')
+  end
 end


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Logitech Harmony remote is a 32-bit java application wrapped in an OS X application.  Therefore, it requires Java 6 (caskroom/versions/java6) which is the latest version of Java on OS X to ship with a 32-bit JVM.  The Info.plist file also needs to be modified (slightly) to use that version of java, rather than version 1.4 that the app is expecting.

The commit message does not contain the version, since the version is not changing.