### PR TITLE
Update pgweb to 0.9.6

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,10 +1,10 @@
 cask 'pgweb' do
-  version '0.9.5'
-  sha256 '677af53daac6c44f1bdc304bc6285245fef5a75b2a0f7a76d03213afb7268e3a'
+  version '0.9.6'
+  sha256 '7ae19e6fd93ef53cadd31ca623d2193f93b175be5cba0f0dfe80a84f1eeb09f4'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   appcast 'https://github.com/sosedoff/pgweb/releases.atom',
-          checkpoint: '9aee4e4f2d0ff344e9e255b8d82b8aec68cdcaf045e646ff223214789dc31a29'
+          checkpoint: '701b48686b44214fd068a789306029ff1ed66c7c0893852345b6b83ed0c91990'
   name 'pgweb'
   homepage 'https://github.com/sosedoff/pgweb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.