### PR TITLE
Update vistrails to 2.2.4-1519abc0ae2b

### DIFF
--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -1,9 +1,9 @@
 cask 'vistrails' do
-  version '2.2.2-358e9a9fc33c'
-  sha256 'efee1669d3ba39985079e44a423f6e7b6b17493669c5945a3bbd70ec8659fc22'
+  version '2.2.4-1519abc0ae2b'
+  sha256 '61811b0f65fceaa4873fcf7fc6486376fb146a688d12af8e81a325cdb117ccac'
 
   # sourceforge.net/vistrails was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/vistrails/vistrails/v#{version.sub(%r{-.*}, '')}/vistrails-mac-10.6-intel-#{version}.dmg"
+  url "https://downloads.sourceforge.net/vistrails/vistrails-osx-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/vistrails/rss?path=/vistrails',
           checkpoint: '5b5470cbdb0773a980d33bdb4c56d44d4d1ccbc56961988faaccc9104174569c'
   name 'VisTrails'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.