### PR TITLE
Add cask for TouchSwitcher.app.

### DIFF
--- a/Casks/touchswitcher.rb
+++ b/Casks/touchswitcher.rb
@@ -1,0 +1,10 @@
+cask 'touchswitcher' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://hazeover.com/touchswitcher/TouchSwitcher.zip'
+  name 'TouchSwitcher'
+  homepage 'https://hazeover.com/touchswitcher.html'
+
+  app 'TouchSwitcher.app'
+end


### PR DESCRIPTION
Add [TouchSwitcher](https://hazeover.com/touchswitcher.html), an app that lets MBP 2016 users switch between recently-used apps using the touchbar. App is unversioned as of this PR.

After making all changes to the cask:

- [x] `brew cask audit --download touchswitcher` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

