### PR TITLE
Update beatport-pro to 2.4.0_171

### DIFF
--- a/Casks/beatport-pro.rb
+++ b/Casks/beatport-pro.rb
@@ -1,10 +1,10 @@
 cask 'beatport-pro' do
-  version '2.3.0_169'
-  sha256 '94155a9d2075e5c5a7023d13b9e3ec54ce92a4fa460e0e97fbd8df2e1130a888'
+  version '2.4.0_171'
+  sha256 '39343bd1ca97b109bd5f566f9d6b7edac34f7dc8dad946cac635224aa27fa69d'
 
   url "https://pro.beatport.com/mac/#{version}/beatportpro_#{version}.zip"
   appcast 'https://pro.beatport.com/mac/appcast.xml',
-          checkpoint: '3692f8ca2ccaab6e7f812ea3c21bc9187575238e73349196e95bcc0be498d65c'
+          checkpoint: '2170cc2428a791bab031169ea7c11dcc16310cc7cf0824310ab6a0e6f6d050bb'
   name 'Beatport Pro'
   homepage 'https://www.beatport.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.