### PR TITLE
Upgrade Screens Connect to 4.1.2

### DIFF
--- a/Casks/screens-connect.rb
+++ b/Casks/screens-connect.rb
@@ -1,21 +1,32 @@
 cask 'screens-connect' do
-  version '3.6.1'
-  sha256 '18bb65623aadff7f931456598f12ba33f5c54bad9c1f7f2a3b10f9585f8bc771'
+  version '4.1.2'
+  sha256 'eea3db7530f5d0db7b60d3c633ebd6ff887d3d6fdaa23aceb989632b77677721'
 
   # edovia.com was verified as official when first introduced to the cask
-  url "https://download.edovia.com/screensconnect/screensconnect%20#{version}.dmg"
+  url "https://download.edovia.com/screensconnect/ScreensConnect_#{version}.zip"
+  appcast 'https://updates.edovia.com/com.edovia.screens.connect.4.mac/appcast.xml',
+          checkpoint: '0daebdac3a33c0983a11659087162e0229911b183304f9b37e43e9e52dfe8570'
   name 'Screens Connect'
   homepage 'https://screensconnect.com'
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :el_capitan'
 
-  pkg 'Screens Connect.pkg'
+  app 'Screens Connect.app'
 
   # Uninstall script can fail when trying to remove legacy PKGIDS
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/8833
-  uninstall script:  {
-                       executable:   'Uninstall Screens Connect.app/Contents/Resources/sc-uninstaller.tool',
-                       must_succeed: false,
-                     },
-            pkgutil: 'com.edovia.pkg.screens.connect.*'
+  uninstall quit:      'com.edovia.Screens-Connect',
+            launchctl: [
+                         'com.edovia.Screens-Connect.launcher',
+                         'com.edovia.screens.connect',
+                       ],
+            script:    {
+                         executable:   'Screens Connect.app/Contents/Resources/sc-uninstaller.tool',
+                         must_succeed: false,
+                       }
+
+  zap delete: [
+                '~/Library/Preferences/com.edovia.Screens-Connect.plist',
+                '~/Library/Preferences/com.edovia.ScreensConnect.Shared.plist',
+              ]
 end


### PR DESCRIPTION
Updates the screens-connect cask to the latest version (4.1.2). It's no longer a `pkg` installer and is instead an `app`.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
