### PR TITLE
Update reveal version, sha256 and link.

### DIFF
--- a/Casks/reveal.rb
+++ b/Casks/reveal.rb
@@ -2,10 +2,7 @@ cask 'reveal' do
   version '4'
   sha256 '2e8f4c1a20c355d540de2aab3552114059ab7d63b987e0a116e9a02fee1fe426'
 
-  # dl.devmate.com/com.ittybittyapps.Reveal was verified as official when first introduced to the cask
   url "https://download.revealapp.com/Reveal.app-#{version}.zip"
-  appcast 'https://download.revealapp.com/reveal-release.xml',
-          checkpoint: '45f5abc7f69aa58300ad63786eabe2b5b4c6c4f6c90599e770d6eb50466231cf'
   name 'Reveal'
   homepage 'https://revealapp.com/'
 

--- a/Casks/reveal.rb
+++ b/Casks/reveal.rb
@@ -1,9 +1,9 @@
 cask 'reveal' do
-  version '2'
-  sha256 'ab62f33440072f283717cd2557b235f8241dbbef9c2e66ee0ab6d540bd4905f7'
+  version '4'
+  sha256 '2e8f4c1a20c355d540de2aab3552114059ab7d63b987e0a116e9a02fee1fe426'
 
   # dl.devmate.com/com.ittybittyapps.Reveal was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.ittybittyapps.Reveal#{version}/Reveal.zip"
+  url "https://download.revealapp.com/Reveal.app-#{version}.zip"
   appcast 'https://download.revealapp.com/reveal-release.xml',
           checkpoint: '45f5abc7f69aa58300ad63786eabe2b5b4c6c4f6c90599e770d6eb50466231cf'
   name 'Reveal'


### PR DESCRIPTION
I rolled back https://github.com/caskroom/homebrew-cask/pull/26282 and updated to version 4.
Though https://dl.devmate.com/com.ittybittyapps.Reveal2/Reveal.zip is the official link used on https://revealapp.com/download/ but it does not respect version number (2 is not a version but a part of application id). For example Reveal 5 will have the same link. On the other hand https://download.revealapp.com/Reveal.app-4.zip is still working and giving the same zip archive and it respects version number (you can place 2 or 3 instead of 4 to get previous versions).
So I suggest to stay with this link as long as it works.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
