### PR TITLE
Update electron to 1.4.8

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.7'
-  sha256 'b57397ed14a694e94bb1db3e4a76b7873ad32a3053bf89f9859af7034d045185'
+  version '1.4.8'
+  sha256 '948a13d6a61ff7bddb1f00b3d8fc5cdd3b7da4abf67966b8eaa862290212638c'
 
   # github.com/atom/electron was verified as official when first introduced to the cask
   url "https://github.com/atom/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/atom/electron/releases.atom',
-          checkpoint: 'e08b321177ea2f5f257710bd3f8ce3f42b00ecba7a028c5589ae0b2719525579'
+          checkpoint: '5de3f60cee90610008cfdb3afe9d2bb064e154436548ae2cc1fa3565e0b83cf8'
   name 'Electron'
   homepage 'http://electron.atom.io/'
 


### PR DESCRIPTION


- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
