### PR TITLE
Update homepage of 14 Casks

### DIFF
--- a/Casks/hiera.rb
+++ b/Casks/hiera.rb
@@ -2,9 +2,10 @@ cask 'hiera' do
   version '1.3.4'
   sha256 'f0c5342b09b6f48c727ded033e03d207313d3ebf12d41b50b0f2f71fd1c411e9'
 
+  # puppetlabs.com was verified as official when first introduced to the cask
   url "https://downloads.puppetlabs.com/mac/hiera-#{version}.dmg"
   name 'Puppet Labs Hiera'
-  homepage 'https://projects.puppetlabs.com/projects/hiera'
+  homepage 'https://docs.puppet.com/hiera/'
 
   pkg "hiera-#{version}.pkg"
 

--- a/Casks/intel-xdk-iot.rb
+++ b/Casks/intel-xdk-iot.rb
@@ -1,10 +1,11 @@
 cask 'intel-xdk-iot' do
-  version '1878'
-  sha256 '009bfc7b24a2eede47ff408a41ae2b57a9c4944d8b2fd5a00e377c06dcf656ef'
+  version '3491'
+  sha256 'ef4b9b3287790b2688ab17791b5737710bb07b9c634e19e42941a9c30e6deb46'
 
-  url "https://download.xdk.intel.com/iot-packages/iot_web_mac_master-iot_#{version}.dmg"
+  # xdk2-installers.s3.amazonaws.com/iot was verified as official when first introduced to the cask
+  url "https://xdk2-installers.s3.amazonaws.com/iot/xdk_web_mac_master_#{version}.dmg"
   name 'Intel XDK IoT Edition'
-  homepage 'https://software.intel.com/en-us/html5/xdk-iot'
+  homepage 'https://software.intel.com/iot/tools-ide/ide/xdk'
 
   pkg "xdk_full_#{version}.pkg"
 

--- a/Casks/librecad.rb
+++ b/Casks/librecad.rb
@@ -7,7 +7,7 @@ cask 'librecad' do
   appcast 'https://sourceforge.net/projects/librecad/rss?path=/OSX',
           checkpoint: 'a2463268ae3a532744db027bcdd154bfa4390dada1679dbea42d426e9d9b39cc'
   name 'LibreCAD'
-  homepage 'http://librecad.org/'
+  homepage 'http://librecad.org/cms/home.html'
 
   app 'LibreCAD.app'
 end

--- a/Casks/movelinks.rb
+++ b/Casks/movelinks.rb
@@ -7,7 +7,7 @@ cask 'movelinks' do
   appcast 'https://d1c229iib3zm7m.cloudfront.net/mac/appcast.xml',
           checkpoint: 'c1d5f1b9a7c848fde84a61e12ed6232eb517126ad92be680ba4e37c76f902e14'
   name 'Movelinks'
-  homepage 'http://www.movescount.com/connect/watch_sync_software?os=mac'
+  homepage 'http://www.movescount.com/connect?os=mac'
 
   auto_updates true
 

--- a/Casks/picturesque.rb
+++ b/Casks/picturesque.rb
@@ -2,9 +2,10 @@ cask 'picturesque' do
   version '2.4.5-937'
   sha256 'f1b91abcee428783de1bfe328aae36f1315741ee61ea62d05b35f1bbc8830f8a'
 
+  # acqualia.com was verified as official when first introduced to the cask
   url "http://www.acqualia.com/files/sparkle/picturesque_#{version}.zip"
   name 'Picturesque'
-  homepage 'http://www.acqualia.com/picturesque/'
+  homepage 'https://www.picturesqueapp.com/'
 
   app 'Picturesque.app'
 end

--- a/Casks/pivotalbooster.rb
+++ b/Casks/pivotalbooster.rb
@@ -2,9 +2,10 @@ cask 'pivotalbooster' do
   version '1.1.4.beta'
   sha256 'c32ca0eecd595340f255485ec6cff0c975d3549c2db58b3ddc7b736922a5e159'
 
+  # pivotalbooster.com was verified as official when first introduced to the cask
   url "http://pivotalbooster.com/downloads/releases/#{version}/PivotalBooster_#{version}.dmg"
   name 'PivotalBooster'
-  homepage 'http://pivotalbooster.com/'
+  homepage 'http://booster.railsware.com/'
 
   app 'PivotalBooster.app'
 end

--- a/Casks/stepmania.rb
+++ b/Casks/stepmania.rb
@@ -7,7 +7,7 @@ cask 'stepmania' do
   appcast 'https://github.com/stepmania/stepmania/releases.atom',
           checkpoint: '0b2d80a74aa81b15f01f0bc45ddfc6443e8422f3ca346b8c60ae9d55c1a853bd'
   name 'StepMania'
-  homepage 'http://www.stepmania.com/'
+  homepage 'https://www.stepmania.com/'
 
   app "StepMania-#{version}/Stepmania.app"
 end

--- a/Casks/tableau.rb
+++ b/Casks/tableau.rb
@@ -4,7 +4,7 @@ cask 'tableau' do
 
   url "https://downloads.tableau.com/tssoftware/TableauDesktop-#{version.dots_to_hyphens}.dmg"
   name 'Tableau'
-  homepage 'https://www.tableau.com/'
+  homepage 'https://public.tableau.com/s/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/web-sharing.rb
+++ b/Casks/web-sharing.rb
@@ -4,7 +4,7 @@ cask 'web-sharing' do
 
   url "http://dl.clickontyler.com/web-sharing/websharing_#{version}.zip"
   name 'Web Sharing'
-  homepage 'https://clickontyler.com/web-sharing/'
+  homepage 'https://clickontyler.com/web-sharing-mountain-lion/'
 
   prefpane 'Web Sharing.prefPane'
 end

--- a/Casks/wercker-cli.rb
+++ b/Casks/wercker-cli.rb
@@ -5,7 +5,7 @@ cask 'wercker-cli' do
   # amazonaws.com/downloads.wercker.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/downloads.wercker.com/cli/stable/darwin_amd64/wercker'
   name 'wercker'
-  homepage 'http://www.wercker.com/'
+  homepage 'http://www.wercker.com/wercker-cli'
 
   container type: :naked
 

--- a/Casks/wercker.rb
+++ b/Casks/wercker.rb
@@ -4,7 +4,7 @@ cask 'wercker' do
 
   url 'http://downloads.wercker.com/release/wercker-darwin-latest.tar.gz'
   name 'Wercker'
-  homepage 'http://www.wercker.com/downloads/'
+  homepage 'http://www.wercker.com/'
 
   app 'wercker.app'
 end

--- a/Casks/wifimasterkey.rb
+++ b/Casks/wifimasterkey.rb
@@ -2,10 +2,11 @@ cask 'wifimasterkey' do
   version :latest
   sha256 :no_check
 
+  # lianwifi.com was verified as official when first introduced to the cask
   url 'http://www.lianwifi.com/download/mac/WiFiMasterKey_Mac.dmg'
   name 'WiFi Master Key'
   name 'WiFi万能钥匙'
-  homepage 'http://www.lianwifi.com/'
+  homepage 'https://www.wifi.com/'
 
   app 'WiFiMasterKey.app'
 end

--- a/Casks/wondershare-pdf-editor-pro.rb
+++ b/Casks/wondershare-pdf-editor-pro.rb
@@ -4,7 +4,7 @@ cask 'wondershare-pdf-editor-pro' do
 
   url 'http://download.wondershare.com/mac-pdf-editor-pro_full841.dmg'
   name 'Wondershare PDF Editor for Mac'
-  homepage 'https://www.wondershare.com/mac-pdf-editor'
+  homepage 'https://pdf.wondershare.com/pdf-editor-mac/'
 
   app 'Wondershare PDF Editor Pro.app'
 end

--- a/Casks/xscope.rb
+++ b/Casks/xscope.rb
@@ -2,11 +2,12 @@ cask 'xscope' do
   version '4.2'
   sha256 'f976a94801caaccd445fa9a5afe6f794e4caa95cd39c5e1bf790931b1710adf8'
 
+  # iconfactory.com was verified as official when first introduced to the cask
   url "https://iconfactory.com/assets/software/xscope/xScope-#{version}.zip"
   appcast 'https://iconfactory.com/appcasts/xScope/appcast.xml',
           checkpoint: '6eec33a8cd45abf63e706e6292d25c0ae4cbbf273cafece2ffe3b73992c74cb0'
   name 'xScope'
-  homepage 'https://iconfactory.com/software/xscope'
+  homepage 'http://xscopeapp.com/'
 
   app 'xScope.app'
 end

--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -1,20 +1,17 @@
 cask 'yasu' do
-  if MacOS.version <= '10.11'
-    version '504'
-    sha256 'f1bd1e48a2ff0e9839f4b21c651e89a4e18d8aa85a9b9fa8642f333ef5b0053b'
-    url "https://yasuformac.com/appcasts/10.11/yasuformac_#{version}.zip"
+  if MacOS.version <= :snow_leopard
+    version '2.8.2'
+    sha256 '427672a45b8315c2f38d968ea5e0c35c21b91091a1fe0e750fcd2b0078644336'
   else
-    version '602'
-    sha256 'db0951295b8e9b9d8fc4dfd37795b8261bbd1c79b218d260c9532f78b47abc14'
-    url "https://yasuformac.com/appcasts/10.12/yasuformac_#{version}.zip"
+    version '2.9.1'
+    sha256 '597385cec59650cf5f5c9b54e22df5c0a87e4298e2164ceb09cf446b83646547'
   end
 
+  url "http://yasuapp.net/files/yasu_#{version}.zip"
   name 'Yasu'
-  homepage 'https://yasuformac.com/'
+  homepage 'http://yasuapp.net'
 
-  depends_on macos: '>= 10.11'
-
-  app 'Yasu for Mac.app'
+  app 'Yasu.app'
 
   zap delete: [
                 '~/Library/Caches/com.apple.helpd/Generated/net.yasuapp.yasu.help',
@@ -23,4 +20,8 @@ cask 'yasu' do
                 '~/Library/Preferences/net.yasuapp.yasu.plist',
                 '~/Library/Preferences/org.jimmitchell.yasu.plist',
               ]
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -23,5 +23,4 @@ cask 'yasu' do
                 '~/Library/Preferences/net.yasuapp.yasu.plist',
                 '~/Library/Preferences/org.jimmitchell.yasu.plist',
               ]
-
 end

--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -1,17 +1,20 @@
 cask 'yasu' do
-  if MacOS.version <= :snow_leopard
-    version '2.8.2'
-    sha256 '427672a45b8315c2f38d968ea5e0c35c21b91091a1fe0e750fcd2b0078644336'
+  if MacOS.version <= '10.11'
+    version '504'
+    sha256 'f1bd1e48a2ff0e9839f4b21c651e89a4e18d8aa85a9b9fa8642f333ef5b0053b'
+    url "https://yasuformac.com/appcasts/10.11/yasuformac_#{version}.zip"
   else
-    version '2.9.1'
-    sha256 '597385cec59650cf5f5c9b54e22df5c0a87e4298e2164ceb09cf446b83646547'
+    version '602'
+    sha256 'db0951295b8e9b9d8fc4dfd37795b8261bbd1c79b218d260c9532f78b47abc14'
+    url "https://yasuformac.com/appcasts/10.12/yasuformac_#{version}.zip"
   end
 
-  url "http://yasuapp.net/files/yasu_#{version}.zip"
   name 'Yasu'
-  homepage 'http://yasuapp.net'
+  homepage 'https://yasuformac.com/'
 
-  app 'Yasu.app'
+  depends_on macos: '>= 10.11'
+
+  app 'Yasu for Mac.app'
 
   zap delete: [
                 '~/Library/Caches/com.apple.helpd/Generated/net.yasuapp.yasu.help',
@@ -21,7 +24,4 @@ cask 'yasu' do
                 '~/Library/Preferences/org.jimmitchell.yasu.plist',
               ]
 
-  caveats do
-    discontinued
-  end
 end


### PR DESCRIPTION
Update homepage of 15 Casks.

Ping @victorpopkov 

This is from your updated list. After removing the ones that were simply local redirects and the ones you did in your PR [here](https://github.com/caskroom/homebrew-cask/pull/27086), there were 14 remaining.

I just swapped the two homepage in the `wercker` Casks.

The Cask `yasu` was a bit harder. There are versions for older MacOS's on their new website, but the app name (`Yasu.app` compared to `Yasu for Mac.app`) and download url's (see [here](https://yasuformac.com/download/)) are different, so I removed them. 