### PR TITLE
Update lyn to 1.8.3

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,10 +1,10 @@
 cask 'lyn' do
-  version '1.8.2'
-  sha256 'df15aa097936b9d1ebca4f87559c9d33524cea5d630cc9a641828f97c0689caa'
+  version '1.8.3'
+  sha256 'f76ec277f153766b3be787e3a2a7d355f593cbf9f95653e31b974b36a6d4033e'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: '67cc250a8517383b307c406f31778de7e32c3172cb59b2b0d7d68d2092d19c47'
+          checkpoint: '893d026155f21ace185be5b8672cac5a66a3db45d43f861a3e2bfd70a5215c20'
   name 'Lyn'
   homepage 'http://www.lynapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.