### PR TITLE
Update DataGrip to 2016.3

### DIFF
--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -1,6 +1,6 @@
 cask 'datagrip' do
-  version '2016.2.6'
-  sha256 'a9466450233719fdbd83d6457533e72ad71e968da665066f7bb1878ff62651c1'
+  version '2016.3'
+  sha256 '998e037c295aa7849711163ef654d667cf1ef6e12f6530254f24d3d367df399c'
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version}.dmg"
   name 'DataGrip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.