### PR TITLE
Update pomodone to 1.5.856

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,10 +1,10 @@
 cask 'pomodone' do
-  version '1.5.806'
-  sha256 '0e934efef2f9832ff27616153c1d61962f321c16912794271c49ef5672f8516c'
+  version '1.5.856'
+  sha256 '4a51bf6f5b17493545d355101c2407e6b76be40a744a142d330c666636f7ee39'
 
   url "https://app.pomodoneapp.com/PomoDoneApp-#{version}.dmg"
   name 'PomoDone'
   homepage 'https://pomodoneapp.com/'
 
-  app 'PomoDone.app'
+  app 'PomoDoneApp.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.