### PR TITLE
Fix uninstall stanza in Xquartz.app v2.7.11

### DIFF
--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -21,10 +21,16 @@ cask 'xquartz' do
     system_command '/bin/launchctl', args: ['load', '/Library/LaunchAgents/org.macosforge.xquartz.startx.plist']
   end
 
-  uninstall quit:      'org.macosforge.xquartz.X11',
-            launchctl: 'org.macosforge.xquartz.startx',
-            pkgutil:   'org.macosforge.xquartz.pkg',
-            delete:    '/opt/X11/'
+  uninstall_preflight do
+    system_command '/bin/launchctl', args: ['unload', '/Library/LaunchAgents/org.macosforge.xquartz.startx.plist']
+
+    system_command '/bin/launchctl', args: ['unload', '/Library/LaunchDaemons/org.macosforge.xquartz.privileged_startx.plist']
+
+    system_command 'rm', args: ['-rf', '/opt/X11* /Library/Launch*/org.macosforge.xquartz.* /Applications/Utilities/XQuartz.app /etc/*paths.d/*XQuartz']
+  end
+
+  uninstall quit:    'org.macosforge.xquartz.X11',
+            pkgutil: 'org.macosforge.xquartz.pkg'
 
   zap       delete: [
                       '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.macosforge.xquartz.x11.sfl',


### PR DESCRIPTION
May fix #26551 and #13823.  Based on [uninstall guide published by Xquartz](https://www.xquartz.org/FAQs.html#uninstall-snow-leopard-or-later).

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

