### PR TITLE
Update spillo to 135_1.9.2

### DIFF
--- a/Casks/spillo.rb
+++ b/Casks/spillo.rb
@@ -1,11 +1,11 @@
 cask 'spillo' do
-  version '134_1.9.1'
-  sha256 '68ca7bc517d1d905b0aee1259519c39ee7dacb5411d279bcfe6b51ae7b54dd76'
+  version '135_1.9.2'
+  sha256 'eabd96229ed392bf392c50e6e6c1811642d0a0a3aa9413e726dd8018d3657723'
 
   # s3.amazonaws.com/bananafish-builds/spillo was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bananafish-builds/spillo/spillo_#{version}.zip"
   appcast 'https://bananafishsoftware.com/feeds/spillo.xml',
-          checkpoint: 'a62294387c0e83fee8e27278bfb78c8f353bccbe39f2780c101bc900d7826f86'
+          checkpoint: 'e44778a6413bc0ea36a07e2287b96079a992ccb299801d3f1d367b5956cdcb8b'
   name 'Spillo'
   homepage 'https://bananafishsoftware.com/products/spillo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.