### PR TITLE
Fix homepages in 100 casks to include a bare domain slash

### DIFF
--- a/Casks/5kplayer.rb
+++ b/Casks/5kplayer.rb
@@ -4,7 +4,7 @@ cask '5kplayer' do
 
   url 'https://www.5kplayer.com/download/5kplayer.dmg'
   name '5KPlayer'
-  homepage 'https://www.5kplayer.com'
+  homepage 'https://www.5kplayer.com/'
 
   app '5KPlayer.app'
 end

--- a/Casks/abricotine.rb
+++ b/Casks/abricotine.rb
@@ -7,7 +7,7 @@ cask 'abricotine' do
   appcast 'https://github.com/brrd/Abricotine/releases.atom',
           checkpoint: 'b3422d90befd04546968b5063a92d50d91ce9fa390449c3e11d7e4537bc1c801'
   name 'abricotine'
-  homepage 'https://abricotine.brrd.fr'
+  homepage 'https://abricotine.brrd.fr/'
 
   app 'Abricotine-darwin-x64/Abricotine.app'
 end

--- a/Casks/actions-server.rb
+++ b/Casks/actions-server.rb
@@ -4,7 +4,7 @@ cask 'actions-server' do
 
   url 'http://getactionsapp.com/downloads/ActionsServer.dmg'
   name 'Actions Server'
-  homepage 'http://getactionsapp.com'
+  homepage 'http://getactionsapp.com/'
 
   app 'Actions Server.app'
 end

--- a/Casks/adware-removal-tool.rb
+++ b/Casks/adware-removal-tool.rb
@@ -4,7 +4,7 @@ cask 'adware-removal-tool' do
 
   url 'https://download.bitdefender.com/mac/tools/Adware%20Removal%20Tool.zip'
   name 'Bitdefender Adware Removal Tool for Mac'
-  homepage 'http://www.bitdefender.com'
+  homepage 'http://www.bitdefender.com/'
 
   app 'Adware Removal Tool.app'
 

--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -6,7 +6,7 @@ cask 'aircall' do
   appcast 'http://electron.aircall.io/update/osx/1.1.0',
           checkpoint: '25272934fa93d25ef834f9b4df1480ef14f33117adb2a2d86f53a0634e42f5cf'
   name 'Aircall'
-  homepage 'https://aircall.io'
+  homepage 'https://aircall.io/'
 
   auto_updates true
 

--- a/Casks/airserver.rb
+++ b/Casks/airserver.rb
@@ -6,7 +6,7 @@ cask 'airserver' do
   appcast 'https://www.airserver.com/downloads/mac/appcast.xml',
           checkpoint: '6050520478908e4e475468f8a8de1f5a194d9fa00eec5ff29f90f1927f6b1502'
   name 'AirServer'
-  homepage 'https://www.airserver.com'
+  homepage 'https://www.airserver.com/'
 
   app 'AirServer.app'
 end

--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -4,7 +4,7 @@ cask 'airtame' do
 
   url "https://us-1-downloads.airtame.com/application/ga/osx_x86/releases/airtame-application_#{version}.dmg"
   name 'Airtame'
-  homepage 'https://airtame.com'
+  homepage 'https://airtame.com/'
 
   auto_updates 'True'
 

--- a/Casks/alcatraz.rb
+++ b/Casks/alcatraz.rb
@@ -7,7 +7,7 @@ cask 'alcatraz' do
   appcast 'https://github.com/alcatraz/Alcatraz/releases.atom',
           checkpoint: '053f4ce6f085330611cfad0aacab07d2e3973233ff0b86881b22d0efee331914'
   name 'alcatraz'
-  homepage 'http://alcatraz.io'
+  homepage 'http://alcatraz.io/'
 
   artifact 'Alcatraz.xcplugin', target: "#{ENV['HOME']}/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin"
 

--- a/Casks/alchemy.rb
+++ b/Casks/alchemy.rb
@@ -4,7 +4,7 @@ cask 'alchemy' do
 
   url "http://al.chemy.org/files/Alchemy-#{version}.dmg"
   name 'Alchemy'
-  homepage 'http://al.chemy.org'
+  homepage 'http://al.chemy.org/'
 
   app 'Alchemy/Alchemy.app'
 end

--- a/Casks/algodoo.rb
+++ b/Casks/algodoo.rb
@@ -4,7 +4,7 @@ cask 'algodoo' do
 
   url "http://www.algodoo.com/download/Algodoo_#{version.dots_to_underscores}-MacOS.dmg"
   name 'Algodoo'
-  homepage 'http://www.algodoo.com'
+  homepage 'http://www.algodoo.com/'
 
   app 'Algodoo.app'
 end

--- a/Casks/aliwangwang.rb
+++ b/Casks/aliwangwang.rb
@@ -5,7 +5,7 @@ cask 'aliwangwang' do
   # dbison.alicdn.com was verified as official when first introduced to the cask
   url "https://dbison.alicdn.com/updates/macww-nosandbox-#{version}.dmg"
   name 'Ali Wangwang'
-  homepage 'https://wangwang.taobao.com'
+  homepage 'https://wangwang.taobao.com/'
 
   app 'AliWangwang.app'
 

--- a/Casks/aliworkbench.rb
+++ b/Casks/aliworkbench.rb
@@ -7,7 +7,7 @@ cask 'aliworkbench' do
   name 'AliWorkBench'
   name 'Qian Niu'
   name '千牛'
-  homepage 'https://qianniu.1688.com'
+  homepage 'https://qianniu.1688.com/'
 
   app 'AliWorkBench.app'
 end

--- a/Casks/ampps.rb
+++ b/Casks/ampps.rb
@@ -4,7 +4,7 @@ cask 'ampps' do
 
   url "http://files.ampps.com/AMPPS-#{version}.dmg"
   name 'AMPPS'
-  homepage 'http://www.ampps.com'
+  homepage 'http://www.ampps.com/'
 
   suite 'AMPPS'
 end

--- a/Casks/angband.rb
+++ b/Casks/angband.rb
@@ -4,7 +4,7 @@ cask 'angband' do
 
   url "http://rephial.org/downloads/#{version.major_minor}/Angband-#{version}-osx.dmg"
   name 'Angband'
-  homepage 'http://rephial.org'
+  homepage 'http://rephial.org/'
 
   app 'Angband.app'
 end

--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -7,7 +7,7 @@ cask 'angry-ip-scanner' do
   appcast 'https://github.com/angryziber/ipscan/releases.atom',
           checkpoint: '43039a9b361014d6b347f070687e4f815e7f56ed2bf40b48d793344117cb4eb7'
   name 'Angry IP Scanner'
-  homepage 'http://angryip.org'
+  homepage 'http://angryip.org/'
 
   app 'Angry IP Scanner.app'
 end

--- a/Casks/anoncoin.rb
+++ b/Casks/anoncoin.rb
@@ -4,7 +4,7 @@ cask 'anoncoin' do
 
   url "https://anoncoin.net/downloads/#{version}/Anoncoin-#{version}.dmg"
   name 'Anoncoin'
-  homepage 'https://anoncoin.net'
+  homepage 'https://anoncoin.net/'
 
   app 'Anoncoin.app'
 

--- a/Casks/antetype.rb
+++ b/Casks/antetype.rb
@@ -7,7 +7,7 @@ cask 'antetype' do
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ab08fb043a94f51c9109c216e295a50',
           checkpoint: '1c34ded90e4db5bd7cbec65b1e55fce4a28f0d014478f7a73fa7b60212eee20e'
   name 'Antetype'
-  homepage 'http://antetype.com'
+  homepage 'http://antetype.com/'
 
   app 'Antetype.app'
 end

--- a/Casks/anylogic.rb
+++ b/Casks/anylogic.rb
@@ -4,7 +4,7 @@ cask 'anylogic' do
 
   url "http://www.anylogic.com/files/anylogic-ple-#{version}.dmg"
   name 'AnyLogic'
-  homepage 'http://www.anylogic.com'
+  homepage 'http://www.anylogic.com/'
 
   depends_on arch: :x86_64
   depends_on macos: '>= :lion'

--- a/Casks/application-loader.rb
+++ b/Casks/application-loader.rb
@@ -4,7 +4,7 @@ cask 'application-loader' do
 
   url "https://itunesconnect.apple.com/apploader/ApplicationLoader_#{version}.dmg"
   name 'Application Loader'
-  homepage 'https://itunesconnect.apple.com'
+  homepage 'https://itunesconnect.apple.com/'
 
   pkg 'ApplicationLoader.pkg'
 

--- a/Casks/apptivate.rb
+++ b/Casks/apptivate.rb
@@ -4,7 +4,7 @@ cask 'apptivate' do
 
   url 'http://www.apptivateapp.com/resources/Apptivate.app.zip'
   name 'Apptivate'
-  homepage 'http://www.apptivateapp.com'
+  homepage 'http://www.apptivateapp.com/'
 
   app 'Apptivate.app'
 

--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -4,7 +4,7 @@ cask 'archi' do
 
   url "http://www.archimatetool.com/downloads/latest/Archi-mac64-#{version}.zip"
   name 'Archi'
-  homepage 'http://www.archimatetool.com'
+  homepage 'http://www.archimatetool.com/'
 
   app 'Archi/Archi.app'
 end

--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -6,7 +6,7 @@ cask 'aria-maestosa' do
   appcast 'https://sourceforge.net/projects/ariamaestosa/rss',
           checkpoint: '477668fd1065310b682c7ced2a01f4be95af808290674d9598ff2895122cad3a'
   name 'Aria Maestosa'
-  homepage 'http://ariamaestosa.sourceforge.net'
+  homepage 'http://ariamaestosa.sourceforge.net/'
 
   app "AriaMaestosa-#{version}/Aria Maestosa.app"
 end

--- a/Casks/arrsync.rb
+++ b/Casks/arrsync.rb
@@ -6,7 +6,7 @@ cask 'arrsync' do
   appcast 'https://sourceforge.net/projects/arrsync/rss',
           checkpoint: 'f7c57bd1384d7e7cac02ba47a2c0da78691f6045ff17c1b2c6f3642072658515'
   name 'arRsync'
-  homepage 'http://arrsync.sourceforge.net'
+  homepage 'http://arrsync.sourceforge.net/'
 
   app 'arRsync.app'
 end

--- a/Casks/art-of-illusion.rb
+++ b/Casks/art-of-illusion.rb
@@ -7,7 +7,7 @@ cask 'art-of-illusion' do
   appcast 'https://sourceforge.net/projects/aoi/rss',
           checkpoint: 'fae03e7c48c7884a973bf22bed829959c7b3cc314353939578aa4dea4ae958cf'
   name 'Art of Illusion'
-  homepage 'http://www.artofillusion.org'
+  homepage 'http://www.artofillusion.org/'
 
   depends_on macos: '>= :snow_leopard'
 

--- a/Casks/astrill.rb
+++ b/Casks/astrill.rb
@@ -4,7 +4,7 @@ cask 'astrill' do
 
   url 'http://download.astrill.com/astrill-setup-mac.dmg'
   name 'Astrill'
-  homepage 'https://www.astrill.com'
+  homepage 'https://www.astrill.com/'
 
   pkg 'Astrill Setup.mpkg'
 

--- a/Casks/astroguider.rb
+++ b/Casks/astroguider.rb
@@ -4,7 +4,7 @@ cask 'astroguider' do
 
   url "http://download.cloudmakers.eu/AstroGuider_#{version}.dmg"
   name 'AstroGuider'
-  homepage 'http://www.cloudmakers.eu'
+  homepage 'http://www.cloudmakers.eu/'
 
   app 'AstroGuider.app'
 end

--- a/Casks/astroimager.rb
+++ b/Casks/astroimager.rb
@@ -4,7 +4,7 @@ cask 'astroimager' do
 
   url "http://download.cloudmakers.eu/AstroImager_#{version}.dmg"
   name 'AstroImager'
-  homepage 'http://www.cloudmakers.eu'
+  homepage 'http://www.cloudmakers.eu/'
 
   app 'AstroImager.app'
 end

--- a/Casks/astrometry.rb
+++ b/Casks/astrometry.rb
@@ -4,7 +4,7 @@ cask 'astrometry' do
 
   url "http://download.cloudmakers.eu/Astrometry_#{version}.dmg"
   name 'Astrometry'
-  homepage 'http://www.cloudmakers.eu'
+  homepage 'http://www.cloudmakers.eu/'
 
   app 'Astrometry.app'
 end

--- a/Casks/astrotelescope.rb
+++ b/Casks/astrotelescope.rb
@@ -4,7 +4,7 @@ cask 'astrotelescope' do
 
   url "http://download.cloudmakers.eu/AstroTelescope_#{version}.dmg"
   name 'AstroTelescope'
-  homepage 'http://www.cloudmakers.eu'
+  homepage 'http://www.cloudmakers.eu/'
 
   app 'AstroTelescope.app'
 end

--- a/Casks/audioslicer.rb
+++ b/Casks/audioslicer.rb
@@ -6,7 +6,7 @@ cask 'audioslicer' do
   appcast 'https://sourceforge.net/projects/audioslicer/rss?path=/AudioSlicer',
           checkpoint: '6d9e32d6082008a24ad9d89b196e90ccda2a085eb5a0224e41ad11c63606a963'
   name 'AudioSlicer'
-  homepage 'http://audioslicer.sourceforge.net'
+  homepage 'http://audioslicer.sourceforge.net/'
 
   app 'AudioSlicer.app'
 end

--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -16,7 +16,7 @@ cask 'auristor-client' do
   end
 
   name 'AuriStor File System Client'
-  homepage 'https://www.auristor.com'
+  homepage 'https://www.auristor.com/'
 
   # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
   depends_on macos: [

--- a/Casks/authoxy.rb
+++ b/Casks/authoxy.rb
@@ -4,7 +4,7 @@ cask 'authoxy' do
 
   url "http://www.hrsoftworks.net/downloads/Authoxy#{version}.dmg"
   name 'Authoxy'
-  homepage 'http://www.hrsoftworks.net'
+  homepage 'http://www.hrsoftworks.net/'
 
   pkg 'Authoxy (double click me).pkg'
 

--- a/Casks/aware.rb
+++ b/Casks/aware.rb
@@ -7,7 +7,7 @@ cask 'aware' do
   appcast 'https://github.com/josh/Aware/releases.atom',
           checkpoint: '69d1a1fc0074d3e30dd3cb919be7a930907e690fdf733eb22d4c5bb4b9555986'
   name 'Aware'
-  homepage 'http://awaremac.com'
+  homepage 'http://awaremac.com/'
 
   app 'Aware.app'
 end

--- a/Casks/baiducloud.rb
+++ b/Casks/baiducloud.rb
@@ -7,7 +7,7 @@ cask 'baiducloud' do
   name 'Baidu Cloud'
   name 'Baidu Yun Tong Bu Pan'
   name '百度云同步盘'
-  homepage 'https://pan.baidu.com'
+  homepage 'https://pan.baidu.com/'
 
   app '百度云同步盘.app'
 

--- a/Casks/banshee.rb
+++ b/Casks/banshee.rb
@@ -5,7 +5,7 @@ cask 'banshee' do
   # gnome.org/pub/GNOME/binaries/mac/banshee was verified as official when first introduced to the cask
   url "https://ftp.gnome.org/pub/GNOME/binaries/mac/banshee/banshee-#{version}.macosx.intel.dmg"
   name 'Banshee'
-  homepage 'http://banshee.fm'
+  homepage 'http://banshee.fm/'
 
   app 'Banshee.app'
 end

--- a/Casks/bean.rb
+++ b/Casks/bean.rb
@@ -4,7 +4,7 @@ cask 'bean' do
 
   url 'http://www.bean-osx.com/releases/Bean-Install.zip'
   name 'Bean'
-  homepage 'http://www.bean-osx.com'
+  homepage 'http://www.bean-osx.com/'
 
   app 'Bean-Install/Bean.app'
 end

--- a/Casks/bearychat.rb
+++ b/Casks/bearychat.rb
@@ -4,7 +4,7 @@ cask 'bearychat' do
 
   url 'https://bearychat.com/apps/mac'
   name 'BearyChat'
-  homepage 'https://bearychat.com'
+  homepage 'https://bearychat.com/'
 
   app 'BearyChat.app'
 

--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -4,7 +4,7 @@ cask 'beatunes' do
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   name 'beaTunes'
-  homepage 'https://www.beatunes.com'
+  homepage 'https://www.beatunes.com/'
 
   depends_on macos: '>= :lion'
   depends_on arch: :x86_64

--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -6,7 +6,7 @@ cask 'betterzip' do
   appcast "https://macitbetter.com/BetterZip#{version.major}.rss",
           checkpoint: 'cc8f405304c66c96a64702a7806bef9e5c5a3f0b393560c95130e1730a38d79f'
   name 'BetterZip'
-  homepage 'https://macitbetter.com'
+  homepage 'https://macitbetter.com/'
 
   app 'BetterZip.app'
 

--- a/Casks/between.rb
+++ b/Casks/between.rb
@@ -4,7 +4,7 @@ cask 'between' do
 
   url 'http://assets-pc.between.us/downloads/between-latest.dmg'
   name 'Between'
-  homepage 'https://between.us'
+  homepage 'https://between.us/'
 
   app 'Between.app'
 end

--- a/Casks/bino.rb
+++ b/Casks/bino.rb
@@ -19,7 +19,7 @@ cask 'bino' do
   end
 
   name 'Bino'
-  homepage 'http://bino3d.org'
+  homepage 'http://bino3d.org/'
 
   app 'Bino.app'
 end

--- a/Casks/bitcasa.rb
+++ b/Casks/bitcasa.rb
@@ -4,7 +4,7 @@ cask 'bitcasa' do
 
   url "https://dist.bitcasa.com/update/InstallBitcasa.#{version}.pkg"
   name 'Bitcasa CloudFS'
-  homepage 'https://www.bitcasa.com'
+  homepage 'https://www.bitcasa.com/'
 
   pkg "InstallBitcasa.#{version}.pkg"
 

--- a/Casks/bitkeeper.rb
+++ b/Casks/bitkeeper.rb
@@ -4,7 +4,7 @@ cask 'bitkeeper' do
 
   url "https://www.bitkeeper.org/downloads/#{version}/bk-#{version}-x86_64-macosx.pkg"
   name 'BitKeeper'
-  homepage 'https://www.bitkeeper.org'
+  homepage 'https://www.bitkeeper.org/'
 
   pkg "bk-#{version}-x86_64-macosx.pkg"
 

--- a/Casks/bitlord.rb
+++ b/Casks/bitlord.rb
@@ -4,7 +4,7 @@ cask 'bitlord' do
 
   url "http://www.bitlord.com/osx/BitLord-Lion-#{version}.dmg"
   name 'BitLord'
-  homepage 'http://www.bitlord.com'
+  homepage 'http://www.bitlord.com/'
 
   app 'BitLord.app'
 end

--- a/Casks/bitscope-chart.rb
+++ b/Casks/bitscope-chart.rb
@@ -4,7 +4,7 @@ cask 'bitscope-chart' do
 
   url "http://bitscope.com/download/files/bitscope-chart_#{version}.app.tgz"
   name 'BitScope Chart'
-  homepage 'http://www.bitscope.com'
+  homepage 'http://www.bitscope.com/'
 
   app 'bitscope-chart.app'
 end

--- a/Casks/bitscope-dso.rb
+++ b/Casks/bitscope-dso.rb
@@ -4,7 +4,7 @@ cask 'bitscope-dso' do
 
   url "http://bitscope.com/download/files/bitscope-dso_#{version}.app.tgz"
   name 'BitScope DSO'
-  homepage 'http://www.bitscope.com'
+  homepage 'http://www.bitscope.com/'
 
   app 'bitscope-dso.app'
 end

--- a/Casks/bitscope-logic.rb
+++ b/Casks/bitscope-logic.rb
@@ -4,7 +4,7 @@ cask 'bitscope-logic' do
 
   url "http://bitscope.com/download/files/bitscope-logic_#{version}.app.tgz"
   name 'BitScope Logic'
-  homepage 'http://www.bitscope.com'
+  homepage 'http://www.bitscope.com/'
 
   app 'bitscope-logic.app'
 end

--- a/Casks/bitscope-meter.rb
+++ b/Casks/bitscope-meter.rb
@@ -4,7 +4,7 @@ cask 'bitscope-meter' do
 
   url "http://bitscope.com/download/files/bitscope-meter_#{version}.app.tgz"
   name 'BitScope Meter'
-  homepage 'http://www.bitscope.com'
+  homepage 'http://www.bitscope.com/'
 
   app 'bitscope-meter.app'
 end

--- a/Casks/bitsquare.rb
+++ b/Casks/bitsquare.rb
@@ -7,7 +7,7 @@ cask 'bitsquare' do
   appcast 'https://github.com/bitsquare/bitsquare//releases.atom',
           checkpoint: '04c4276419fe404f24206e3a9a222e4d9676b136a92ade78df95af0fec21bafc'
   name 'Bitsquare'
-  homepage 'https://bitsquare.io'
+  homepage 'https://bitsquare.io/'
   gpg "#{url}.asc",
       key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'
 

--- a/Casks/bittorrent.rb
+++ b/Casks/bittorrent.rb
@@ -5,7 +5,7 @@ cask 'bittorrent' do
   # utorrent.com was verified as official when first introduced to the cask
   url 'https://download-new.utorrent.com/os/osx/track/stable/endpoint/btmac'
   name 'BitTorrent'
-  homepage 'https://www.bittorrent.com'
+  homepage 'https://www.bittorrent.com/'
 
   installer manual: 'Bittorrent.app'
 

--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -4,7 +4,7 @@ cask 'bitwig-studio' do
 
   url "https://downloads.bitwig.com/stable/#{version}/Bitwig%20Studio%20#{version}.dmg"
   name 'Bitwig Studio'
-  homepage 'http://www.bitwig.com'
+  homepage 'http://www.bitwig.com/'
 
   app 'Bitwig Studio.app'
 end

--- a/Casks/blisk.rb
+++ b/Casks/blisk.rb
@@ -5,7 +5,7 @@ cask 'blisk' do
   # bliskcloudstorage.blob.core.windows.net was verified as official when first introduced to the cask
   url "https://bliskcloudstorage.blob.core.windows.net/mac-installers/BliskInstaller_#{version}.dmg"
   name 'Blisk Browser'
-  homepage 'https://blisk.io'
+  homepage 'https://blisk.io/'
 
   app 'Blisk.app'
 end

--- a/Casks/blobby-volley2.rb
+++ b/Casks/blobby-volley2.rb
@@ -4,7 +4,7 @@ cask 'blobby-volley2' do
 
   url "https://downloads.sourceforge.net/blobby/blobby2-macosx-#{version}.dmg"
   name 'Blobby Volley 2'
-  homepage 'http://blobby.sourceforge.net'
+  homepage 'http://blobby.sourceforge.net/'
 
   app 'Blobby Volley 2.app'
 end

--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -4,7 +4,7 @@ cask 'bluegriffon' do
 
   url "http://bluegriffon.org/freshmeat/#{version}/bluegriffon-#{version}.mac.dmg"
   name 'BlueGriffon'
-  homepage 'http://bluegriffon.org'
+  homepage 'http://bluegriffon.org/'
 
   app 'BlueGriffon.app'
 end

--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -4,7 +4,7 @@ cask 'bluej' do
 
   url "https://www.bluej.org/download/files/BlueJ-#{version.no_dots}.zip"
   name 'BlueJ'
-  homepage 'https://www.bluej.org'
+  homepage 'https://www.bluej.org/'
 
   app "BlueJ #{version}/BlueJ.app"
 end

--- a/Casks/bookends.rb
+++ b/Casks/bookends.rb
@@ -4,7 +4,7 @@ cask 'bookends' do
 
   url 'http://www.sonnysoftware.com/Bookends.dmg'
   name 'Bookends'
-  homepage 'http://www.sonnysoftware.com'
+  homepage 'http://www.sonnysoftware.com/'
 
   app 'Bookends.app'
 end

--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -7,7 +7,7 @@ cask 'boostnote' do
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
           checkpoint: '07df80006c9cfcf019787ce4629a4e0ac522c56845c5c4338a2a1958aa5de4f7'
   name 'Boostnote'
-  homepage 'https://b00st.io'
+  homepage 'https://b00st.io/'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/boot2docker-status.rb
+++ b/Casks/boot2docker-status.rb
@@ -7,7 +7,7 @@ cask 'boot2docker-status' do
   appcast 'https://github.com/nickgartmann/boot2docker-status/releases.atom',
           checkpoint: 'e399bad2bf54114275f4dbce07312b54338baca54d8489326405130501a02a0e'
   name 'Boot2Docker Status'
-  homepage 'http://boot2docker-status.nickgartmann.com'
+  homepage 'http://boot2docker-status.nickgartmann.com/'
 
   app 'Boot2Docker Status.app'
 

--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -7,7 +7,7 @@ cask 'brackets' do
   appcast 'https://github.com/adobe/brackets/releases.atom',
           checkpoint: 'f6eea3ff7a857c6c4039ac24662a9eab1de15dcc0464f1d33f8ac35efdaa4121'
   name 'Brackets'
-  homepage 'http://brackets.io'
+  homepage 'http://brackets.io/'
 
   app 'Brackets.app'
 

--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -7,7 +7,7 @@ cask 'brave' do
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
           checkpoint: '5fd92e5631b617190f6b70b2133dff1c8e93802e71a7ef7286893199cd7d6e06'
   name 'Brave'
-  homepage 'https://brave.com'
+  homepage 'https://brave.com/'
 
   app 'Brave.app'
 

--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -6,7 +6,7 @@ cask 'browser-chooserx' do
   appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
           checkpoint: 'cee64db6ef68bc2efb79a2ca91047eaa429800086f9797057ee86e6463c137b5'
   name 'Browser ChooserX'
-  homepage 'https://www.bdevapps.com'
+  homepage 'https://www.bdevapps.com/'
 
   auto_updates true
 

--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -4,7 +4,7 @@ cask 'camunda-modeler' do
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'
-  homepage 'https://camunda.org'
+  homepage 'https://camunda.org/'
 
   app 'camunda-modeler/Camunda Modeler.app'
 end

--- a/Casks/carlson-minot.rb
+++ b/Casks/carlson-minot.rb
@@ -4,7 +4,7 @@ cask 'carlson-minot' do
 
   url "https://www.carlson-minot.com/downloads/arm-#{version}-arm-none-linux-gnueabi.osx.intelx86.bin.pkg"
   name 'Carlson-Minot Toolchain'
-  homepage 'https://www.carlson-minot.com'
+  homepage 'https://www.carlson-minot.com/'
 
   pkg "arm-#{version}-arm-none-linux-gnueabi.osx.intelx86.bin.pkg"
 

--- a/Casks/cave-story.rb
+++ b/Casks/cave-story.rb
@@ -7,7 +7,7 @@ cask 'cave-story' do
   name 'Pixel Cave Story'
   name 'Doukutsu'
   name '洞窟物語'
-  homepage 'http://www.cavestory.org'
+  homepage 'http://www.cavestory.org/'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app 'Doukutsu.app', target: 'Cave Story.app'

--- a/Casks/cellprofiler.rb
+++ b/Casks/cellprofiler.rb
@@ -5,7 +5,7 @@ cask 'cellprofiler' do
   # cellprofiler-org.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://cellprofiler-org.s3.amazonaws.com/CellProfiler.dmg'
   name 'CellProfiler'
-  homepage 'http://cellprofiler.org'
+  homepage 'http://cellprofiler.org/'
 
   app 'CellProfiler.app'
 end

--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -7,7 +7,7 @@ cask 'chatty' do
   appcast 'https://github.com/chatty/chatty/releases.atom',
           checkpoint: 'ef6d8bab49e52d165104d7ac747e326240c7d069165bf2f4226ea4f9a1da8701'
   name 'Chatty'
-  homepage 'https://chatty.github.io'
+  homepage 'https://chatty.github.io/'
 
   suite 'Chatty'
 

--- a/Casks/cheetah3d.rb
+++ b/Casks/cheetah3d.rb
@@ -4,7 +4,7 @@ cask 'cheetah3d' do
 
   url 'http://cheetah3d.com/download/Cheetah3D.dmg'
   name 'Cheetah3D'
-  homepage 'http://www.cheetah3d.com'
+  homepage 'http://www.cheetah3d.com/'
 
   app 'Cheetah3D.app'
 end

--- a/Casks/chemdoodle.rb
+++ b/Casks/chemdoodle.rb
@@ -4,7 +4,7 @@ cask 'chemdoodle' do
 
   url "https://www.chemdoodle.com/downloads/ChemDoodle-osx-#{version}.dmg"
   name 'ChemDoodle'
-  homepage 'https://www.chemdoodle.com'
+  homepage 'https://www.chemdoodle.com/'
 
   suite 'ChemDoodle'
 end

--- a/Casks/chronoagent.rb
+++ b/Casks/chronoagent.rb
@@ -4,7 +4,7 @@ cask 'chronoagent' do
 
   url 'https://downloads.econtechnologies.com/CA_Mac_Download.dmg'
   name 'ChronoAgent'
-  homepage 'https://www.econtechnologies.com'
+  homepage 'https://www.econtechnologies.com/'
 
   pkg 'Install.pkg'
 

--- a/Casks/chronosync.rb
+++ b/Casks/chronosync.rb
@@ -4,7 +4,7 @@ cask 'chronosync' do
 
   url 'https://downloads.econtechnologies.com/CS4_Download.dmg'
   name 'ChronoSync'
-  homepage 'https://www.econtechnologies.com'
+  homepage 'https://www.econtechnologies.com/'
 
   pkg 'Install.pkg'
 

--- a/Casks/cinder.rb
+++ b/Casks/cinder.rb
@@ -6,7 +6,7 @@ cask 'cinder' do
   appcast 'https://github.com/cinder/cinder/releases.atom',
           checkpoint: '34a56a382e2a9712275ca7949028059987eb270356566e4e3599aebc856256a9'
   name 'Cinder'
-  homepage 'https://libcinder.org'
+  homepage 'https://libcinder.org/'
 
   suite "cinder_#{version}_mac"
 end

--- a/Casks/cliqz.rb
+++ b/Casks/cliqz.rb
@@ -5,7 +5,7 @@ cask 'cliqz' do
   # repository.cliqz.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://repository.cliqz.com.s3.amazonaws.com/dist/release/#{version}/de/CLIQZ-#{version}.de.mac.dmg"
   name 'CLIQZ'
-  homepage 'https://cliqz.com'
+  homepage 'https://cliqz.com/'
 
   app 'CLIQZ.app'
 

--- a/Casks/cloak.rb
+++ b/Casks/cloak.rb
@@ -6,7 +6,7 @@ cask 'cloak' do
   appcast 'https://www.getcloak.com/updates/osx/public/',
           checkpoint: 'b3d53389e79d941e79f60fe8f76f6ab95b89e3e76694f5f23662fd897c6f257a'
   name 'Cloak'
-  homepage 'https://www.getcloak.com'
+  homepage 'https://www.getcloak.com/'
 
   app 'Cloak.app'
 end

--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -4,7 +4,7 @@ cask 'cmake' do
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'
-  homepage 'https://cmake.org'
+  homepage 'https://cmake.org/'
 
   conflicts_with formula: 'cmake'
 

--- a/Casks/cocos-code-ide.rb
+++ b/Casks/cocos-code-ide.rb
@@ -4,7 +4,7 @@ cask 'cocos-code-ide' do
 
   url "http://www.cocos2d-x.org/filedown/cocos-code-ide-mac64-#{version}.dmg"
   name 'Cocos Code IDE'
-  homepage 'http://www.cocos2d-x.org'
+  homepage 'http://www.cocos2d-x.org/'
 
   app 'Cocos Code IDE.app'
 

--- a/Casks/codeblocks.rb
+++ b/Casks/codeblocks.rb
@@ -7,7 +7,7 @@ cask 'codeblocks' do
   appcast 'https://sourceforge.net/projects/codeblocks/rss?path=/Binaries',
           checkpoint: '4502ee0eada5102690fc1be210d2c23a3b580f21fc7aca847e0ddc7e353ad502'
   name 'Code::Blocks'
-  homepage 'http://www.codeblocks.org'
+  homepage 'http://www.codeblocks.org/'
 
   app 'CodeBlocks.app'
 end

--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -6,7 +6,7 @@ cask 'codekit' do
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml",
           checkpoint: '64dff7566f12ddacd9a5d6b7c669b63f0c09c4b2c1e7e48678c7a914bfe883f3'
   name 'CodeKit'
-  homepage 'https://codekitapp.com'
+  homepage 'https://codekitapp.com/'
 
   auto_updates true
 

--- a/Casks/colwiz-desktop.rb
+++ b/Casks/colwiz-desktop.rb
@@ -4,7 +4,7 @@ cask 'colwiz-desktop' do
 
   url 'https://www.colwiz.com/update?app=colwiz.installer.v2.mac'
   name 'Colwiz'
-  homepage 'https://www.colwiz.com'
+  homepage 'https://www.colwiz.com/'
 
   app 'Colwiz Desktop.app'
 end

--- a/Casks/contexts.rb
+++ b/Casks/contexts.rb
@@ -6,7 +6,7 @@ cask 'contexts' do
   appcast 'https://contexts.co/appcasts/stable.xml',
           checkpoint: 'be56bd036b79f7d3b7d05685f151db835e51802547695bf78e639ed899f0ef89'
   name 'Contexts'
-  homepage 'https://contexts.co'
+  homepage 'https://contexts.co/'
 
   app 'Contexts.app'
 

--- a/Casks/copay.rb
+++ b/Casks/copay.rb
@@ -7,7 +7,7 @@ cask 'copay' do
   appcast 'https://github.com/bitpay/copay/releases.atom',
           checkpoint: '10dd9c4b5ec7c252fe97d1dbb138bb3b50401b9c0d5b9ad7667ef59a520edebe'
   name 'Copay'
-  homepage 'https://copay.io'
+  homepage 'https://copay.io/'
   gpg "#{url}.sig",
       key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'
 

--- a/Casks/craftstudio.rb
+++ b/Casks/craftstudio.rb
@@ -4,7 +4,7 @@ cask 'craftstudio' do
 
   url 'http://craftstud.io/files/OSX/CraftStudio.pkg'
   name 'CraftStudio'
-  homepage 'http://craftstud.io'
+  homepage 'http://craftstud.io/'
 
   depends_on cask: 'mono-mre'
 

--- a/Casks/cross-web.rb
+++ b/Casks/cross-web.rb
@@ -4,7 +4,7 @@ cask 'cross-web' do
 
   url 'https://open.citibank.co.kr/3rdParty/initech/plugin/down/npCrossWeb_Mac.pkg'
   name 'Cross WEB'
-  homepage 'https://open.citibank.co.kr'
+  homepage 'https://open.citibank.co.kr/'
 
   pkg 'npCrossWeb_Mac.pkg'
 

--- a/Casks/crosswebex.rb
+++ b/Casks/crosswebex.rb
@@ -4,7 +4,7 @@ cask 'crosswebex' do
 
   url "https://open.shinhan.com/initech/extension/down/CrossWebEX.pkg?ver=#{version}"
   name 'Cross WEB EX'
-  homepage 'https://open.shinhan.com'
+  homepage 'https://open.shinhan.com/'
 
   pkg 'CrossWebEX.pkg'
 

--- a/Casks/crushftp.rb
+++ b/Casks/crushftp.rb
@@ -4,7 +4,7 @@ cask 'crushftp' do
 
   url 'https://www.crushftp.com/early7/CrushFTP7_OSX.zip'
   name 'CrushFTP7'
-  homepage 'https://www.crushftp.com'
+  homepage 'https://www.crushftp.com/'
 
   app 'CrushFTP7_OSX/CrushFTP7.app'
 

--- a/Casks/crypho.rb
+++ b/Casks/crypho.rb
@@ -4,7 +4,7 @@ cask 'crypho' do
 
   url 'https://www.crypho.com/downloads/Crypho.dmg'
   name 'Crypho'
-  homepage 'https://www.crypho.com'
+  homepage 'https://www.crypho.com/'
 
   app 'Crypho.app'
 end

--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -5,7 +5,7 @@ cask 'cryptomator' do
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
   name 'Cryptomator'
-  homepage 'https://cryptomator.org'
+  homepage 'https://cryptomator.org/'
 
   app 'Cryptomator.app'
 end

--- a/Casks/cuda-z.rb
+++ b/Casks/cuda-z.rb
@@ -6,7 +6,7 @@ cask 'cuda-z' do
   appcast 'https://sourceforge.net/projects/cuda-z/rss',
           checkpoint: 'be14076df6a9c950874f4f0740d66215ae7ad75ad52bdc64a76367f378f78ef8'
   name 'CUDA-Z'
-  homepage 'http://cuda-z.sourceforge.net'
+  homepage 'http://cuda-z.sourceforge.net/'
 
   app 'CUDA-Z.app'
 end

--- a/Casks/curse.rb
+++ b/Casks/curse.rb
@@ -5,7 +5,7 @@ cask 'curse' do
   # curseapp.net was verified as official when first introduced to the cask
   url 'https://updates.curseapp.net/osx/Curse.dmg'
   name 'Curse'
-  homepage 'https://www.curse.com'
+  homepage 'https://www.curse.com/'
 
   auto_updates true
 

--- a/Casks/dashcam-viewer.rb
+++ b/Casks/dashcam-viewer.rb
@@ -6,7 +6,7 @@ cask 'dashcam-viewer' do
   url "https://dl.dropboxusercontent.com/u/25150850/Dashcam_Viewer_v#{version}.dmg"
   name 'Dashcam Viewer'
   name 'Dashcam Viewer by Earthshine Software'
-  homepage 'https://dashcamviewer.com'
+  homepage 'https://dashcamviewer.com/'
 
   app 'Dashcam Viewer.app'
 end

--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -7,7 +7,7 @@ cask 'data-integration' do
   appcast 'https://sourceforge.net/projects/pentaho/rss',
           checkpoint: '70d19f1c19f8c6f11733c18ea3f8217f4514bd4e6aa50763bc05d1ab8ff97f72'
   name 'Pentaho Data Integration'
-  homepage 'http://community.pentaho.com'
+  homepage 'http://community.pentaho.com/'
 
   app 'data-integration/Data Integration.app'
 end

--- a/Casks/data-science-studio.rb
+++ b/Casks/data-science-studio.rb
@@ -4,7 +4,7 @@ cask 'data-science-studio' do
 
   url "https://downloads.dataiku.com/public/studio/#{version}/Data%20Science%20Studio%20#{version}.dmg"
   name 'Dataiku Data Science Studio'
-  homepage 'https://www.dataiku.com'
+  homepage 'https://www.dataiku.com/'
 
   app 'DataScienceStudio.app'
 end

--- a/Casks/davmail.rb
+++ b/Casks/davmail.rb
@@ -6,7 +6,7 @@ cask 'davmail' do
   appcast 'https://sourceforge.net/projects/davmail/rss',
           checkpoint: '81c159ec1957fb5e79cb145e60414cee9eb5c20745b5e7bf8fbd95b98728630f'
   name 'DavMail'
-  homepage 'http://davmail.sourceforge.net'
+  homepage 'http://davmail.sourceforge.net/'
 
   app 'DavMail.app'
 

--- a/Casks/deco.rb
+++ b/Casks/deco.rb
@@ -7,7 +7,7 @@ cask 'deco' do
   appcast 'https://github.com/decosoftware/deco-ide/releases.atom',
           checkpoint: 'c36536d79d0aefcaad1b366d4283387828b4ba1f30d418b8dc5a4888be60efe0'
   name 'Deco'
-  homepage 'https://www.decosoftware.com'
+  homepage 'https://www.decosoftware.com/'
 
   app 'Deco.app'
 

--- a/Casks/desktopstreamer.rb
+++ b/Casks/desktopstreamer.rb
@@ -4,7 +4,7 @@ cask 'desktopstreamer' do
 
   url 'http://www.elinasoft.com/Desktop_Streamer.dmg'
   name 'Desktop Streamer'
-  homepage 'http://www.elinasoft.com'
+  homepage 'http://www.elinasoft.com/'
 
   app 'DesktopStreamer.app'
 end

--- a/Casks/desktoputility.rb
+++ b/Casks/desktoputility.rb
@@ -4,7 +4,7 @@ cask 'desktoputility' do
 
   url 'https://sweetpproductions.com/products/desktoputility/DesktopUtility.dmg'
   name 'DesktopUtility'
-  homepage 'https://sweetpproductions.com'
+  homepage 'https://sweetpproductions.com/'
 
   app 'DesktopUtility.app'
 end

--- a/Casks/digikam.rb
+++ b/Casks/digikam.rb
@@ -5,7 +5,7 @@ cask 'digikam' do
   # kde.org/stable/digikam was verified as official when first introduced to the cask
   url "http://download.kde.org/stable/digikam/digiKam-#{version}-MacOS-x86-64.pkg"
   name 'digiKam'
-  homepage 'https://www.digikam.org'
+  homepage 'https://www.digikam.org/'
 
   pkg "digikam-#{version}-MacOS-x86-64.pkg"
 

--- a/Casks/diptrace.rb
+++ b/Casks/diptrace.rb
@@ -4,7 +4,7 @@ cask 'diptrace' do
 
   url 'http://diptrace.com/downloads/DipTrace.dmg'
   name 'diptrace'
-  homepage 'http://diptrace.com'
+  homepage 'http://diptrace.com/'
 
   depends_on x11: true
 

--- a/Casks/discord.rb
+++ b/Casks/discord.rb
@@ -4,7 +4,7 @@ cask 'discord' do
 
   url "https://cdn.discordapp.com/apps/osx/#{version}/Discord.dmg"
   name 'Discord'
-  homepage 'https://discordapp.com'
+  homepage 'https://discordapp.com/'
 
   app 'Discord.app'
 

--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -4,7 +4,7 @@ cask 'diskcatalogmaker' do
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   name 'DiskCatalogMaker'
-  homepage 'https://diskcatalogmaker.com'
+  homepage 'https://diskcatalogmaker.com/'
 
   app 'DiskCatalogMaker.app'
 end

--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -7,7 +7,7 @@ cask 'displaycal' do
   appcast 'https://sourceforge.net/projects/dispcalgui/rss?path=/release',
           checkpoint: '10f7fca2eaaa03dd2c057937be3832dd8c4af22c7d03cd3698a9d9e2719ad971'
   name 'DisplayCAL'
-  homepage 'https://displaycal.net'
+  homepage 'https://displaycal.net/'
 
   depends_on formula: 'argyll-cms'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
This thing has always bothered me. Since there has been done a lot of homepage cleaning recently, I would also suggest these small changes. Feel free to close this PR (or revert if merged), if someone from maintainers disagrees.

There are only 311 casks (including in this PR) at the moment that don't have a bare domain URL trailing slash. A good answer why it's needed you can find here: http://webmasters.stackexchange.com/a/35646

Basically from https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html:

> Note that the absolute path cannot be empty; if none is present in the original URI, it MUST be given as "/" (the server root).
