### PR TITLE
Fix coteditor 3.1.1 to zap the other files

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -29,5 +29,11 @@ cask 'coteditor' do
   app 'CotEditor.app'
   binary "#{appdir}/CotEditor.app/Contents/SharedSupport/bin/cot", target: 'cot'
 
-  zap delete: '~/Library/Containers/com.coteditor.CotEditor'
+  zap delete: [
+                '~/Library/Application Scripts/com.coteditor.CotEditor',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.coteditor.coteditor.sfl',
+                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/com.coteditor.CotEditor.help',
+                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/Japanese/HelpSDMIndexFile/com.coteditor.CotEditor.help',
+                '~/Library/Containers/com.coteditor.CotEditor',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.