### PR TITLE
update Airdroid to 3.3.5.0

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,8 +1,9 @@
 cask 'airdroid' do
-  version '3.3.2'
-  sha256 '81eb39bb434d10cd6611617fe77ba1f0218c9b01b449ca8fdbf79beee227b075'
+  version '3.3.5.0'
+  sha256 '20c3b9a7f1009ce5057ef24c61097ee5376f4c368c3416c266ca691aa735c2e1'
 
-  url "http://dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"
+  # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"
   name 'AirDroid'
   homepage 'https://www.airdroid.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

