### PR TITLE
Update karabiner-elements to 0.90.67

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '0.90.66'
-  sha256 'ffef3925ec2de2c04c91cd0ec76d39c93dd34295a4c6a173ee76ef56ead35cb8'
+  version '0.90.67'
+  sha256 '06c909e0f696bc5bcdc8a96b4135ba44e735066ae0a406bc6d569ef5dd65a7f7'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: '0fe4c7643700139ab817db8efdf3136d804281f8044b15cc672249606f4b9728'
+          checkpoint: '3600c2e64096314d78d94c163d2c2848f1c5b90de704ec4933440fa9a863d806'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.