### PR TITLE
Update wordmark to 2.2.5

### DIFF
--- a/Casks/wordmark.rb
+++ b/Casks/wordmark.rb
@@ -1,11 +1,11 @@
 cask 'wordmark' do
-  version '2.1.7'
-  sha256 '0fa5a922cd9a860a004465abfb26265aa9e83b1ee4ddebad0928caf20a4c1b08'
+  version '2.2.5'
+  sha256 'd572b6dc97aeddcb9df6414ad12eb2e6c2b9ed7da85eb969c814d59fd349ccb3'
 
   # github.com/wordmark/wordmark was verified as official when first introduced to the cask
   url "https://github.com/wordmark/wordmark/releases/download/v#{version}/WordMark-darwin-x64.zip"
   appcast 'https://github.com/wordmark/wordmark/releases.atom',
-          checkpoint: 'ed6b36192e533e1f6ac518d2fbcfdbd483fdc64adc6dd79bc6e4386acbf9358b'
+          checkpoint: '0de99e8bc71d3e8c29ec350af6edc0c59faf2ed832fbe4864eecc75dd3073c55'
   name "WordMark #{version.major}"
   homepage 'http://wordmarkapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.