### PR TITLE
Add Pale Moon version 26.5.0

### DIFF
--- a/Casks/newmoon.rb
+++ b/Casks/newmoon.rb
@@ -3,7 +3,7 @@ cask 'newmoon' do
   sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}-gstreamer.en-US.mac64.dmg"
-  name 'Pale Moon for Mac'
+  name 'Pale Moon'
   homepage 'https://www.palemoon.org/'
 
   app 'NewMoon.app'

--- a/Casks/newmoon.rb
+++ b/Casks/newmoon.rb
@@ -1,4 +1,4 @@
-cask 'palemoon' do
+cask 'newmoon' do
   version '26.5.0-131'
   sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
 

--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,0 +1,10 @@
+cask 'palemoon' do
+  version '26.5.0'
+  sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
+
+  url 'https://mac.palemoon.org/dist/palemoon-26.5.0-131-gstreamer.en-US.mac64.dmg'
+  name 'Pale Moon for Mac'
+  homepage 'https://www.palemoon.org/'
+
+  app 'NewMoon.app'
+end

--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,8 +1,8 @@
 cask 'palemoon' do
-  version '26.5.0'
+  version '26.5.0-131'
   sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
 
-  url 'https://mac.palemoon.org/dist/palemoon-26.5.0-131-gstreamer.en-US.mac64.dmg'
+  url "https://mac.palemoon.org/dist/palemoon-#{version}-gstreamer.en-US.mac64.dmg"
   name 'Pale Moon for Mac'
   homepage 'https://www.palemoon.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference]. (.app bundle is new moon, app is pale moon. named cask palemoon)
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

Adds the app Pale Moon (Newmoon.app) for MacOS. Would like to add version 27 seperately as it is a major rebase that breaks some features.