### PR TITLE
Update kube-cluster to 0.5.2

### DIFF
--- a/Casks/kube-cluster.rb
+++ b/Casks/kube-cluster.rb
@@ -1,10 +1,10 @@
 cask 'kube-cluster' do
-  version '0.5.1'
-  sha256 '7f046d043a2371a552cdc8ee37bd15518c764eecce65ab5647e3732898049d17'
+  version '0.5.2'
+  sha256 'ccce60b70061bcf69bb9157df5cfa3c2511cbeca92d96143aa754a81b30e4198'
 
   url "https://github.com/TheNewNormal/kube-cluster-osx/releases/download/v#{version}/Kube-Cluster_v#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/kube-cluster-osx/releases.atom',
-          checkpoint: 'cc48edd6ed762e3645dc73ff720a070af067ba12f6db91a15989c3eae3d33712'
+          checkpoint: '20c656cac778020dcbee2a44c1a392cde990bc7a3445faa522ec0c33a72faa3e'
   name 'Kube-Cluster'
   homepage 'https://github.com/TheNewNormal/kube-cluster-osx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.