### PR TITLE
Update pyfa to 1.24.0,yc.118.8-1.4

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.23.1,yc.118.7-1.4'
-  sha256 '4e0b4641a0824e99729278b9f077376a17628f685125bef5007587066e580c3f'
+  version '1.24.0,yc.118.8-1.4'
+  sha256 'c2d83aeac52508d3d6993280cc457c29170f856a034044987df090e6ccbcec4e'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: 'eea8bb24a425814f3a83bd27bf8a690c77ac4bf058ebeb9765ac1b4415abe13d'
+          checkpoint: '653940a68f7436506cba226e764094e783d5b9fdc6356678fe1b0b68c9898047'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #27199.