### PR TITLE
update Airdroid to 3.3.5.1

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
-  version '3.3.5.0'
-  sha256 '20c3b9a7f1009ce5057ef24c61097ee5376f4c368c3416c266ca691aa735c2e1'
+  version '3.3.5.1'
+  sha256 '6e2e6e988071b4eec64ddc1e3e30c7f372fe31554f35a3f36d01984fbc6c33cd'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

