### PR TITLE
Update unity-download-assistant to 5.4.3f1,01f4c123905a

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '5.3.5f1,960ebf59018a'
-  sha256 '4eda3cd17f145775c420edf44164e3f33cbb14ec0151b328bb249729635e7793'
+  version '5.4.3f1,01f4c123905a'
+  sha256 'f5f6f455a8da143ed54aaee8c812d03861435c681bb86b026f9ec0eea8e1ea42'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   name 'Unity'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.