### PR TITLE
Update flycut to 1.8.1

### DIFF
--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -1,10 +1,10 @@
 cask 'flycut' do
-  version '1.8'
-  sha256 'f7fa218a4fee31208476ff400cd1044f3356bf2200a06e32731572498c7ce42a'
+  version '1.8.1'
+  sha256 '9b0bea415d1f86d4c992b3a8a3e283fae2d394e963f040cbaa8ec6fe70487d00'
 
   url "https://github.com/TermiT/Flycut/releases/download/#{version}/Flycut.app.#{version}.zip"
   appcast 'https://github.com/TermiT/Flycut/releases.atom',
-          checkpoint: '02bb24f0420441a85701adebe5e145497146bd9c4923b321df6974042cbbffa4'
+          checkpoint: '67597c9a346bfb4070c85b61817e7929a9b9734f0fa3761db5838f91534bb3c0'
   name 'Flycut'
   homepage 'https://github.com/TermiT/Flycut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.