### PR TITLE
Fix kitematic appcast hash

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -5,7 +5,7 @@ cask 'kitematic' do
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
-          checkpoint: '834ddbe5a9ae702ba925592d6fccf744edd2e4e3a2d3c7b1c65b48adab97a61d'
+          checkpoint: 'eec5e42824a67b64e2575b5bd1af8f1841d2bf4920d20aa21a5f363eec0e322b'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
