### PR TITLE
Update avogadro to 1.2.0

### DIFF
--- a/Casks/avogadro.rb
+++ b/Casks/avogadro.rb
@@ -1,9 +1,9 @@
 cask 'avogadro' do
-  version '1.1.1'
-  sha256 '8e63b7ec07555fd30ea2c22ed7f070e1b692fd2c9fbb60a3c8e0ddd411bb6477'
+  version '1.2.0'
+  sha256 '8a9567a2f3ebf162eab8e375073ea84cd28483f004c7cd3cae33e21864615cc7'
 
   # sourceforge.net/avogadro was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avogadro/Avogadro-#{version}.dmg.zip"
+  url "https://downloads.sourceforge.net/avogadro/Avogadro-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/avogadro/rss',
           checkpoint: 'b4c194124e797b2c1962828bbbb16c54c624c9f38191bebcb6770259739208df'
   name 'Avogadro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.