### PR TITLE
Update pastebot to 2.0.b13

### DIFF
--- a/Casks/pastebot.rb
+++ b/Casks/pastebot.rb
@@ -1,6 +1,6 @@
 cask 'pastebot' do
-  version '2.0.b12'
-  sha256 'dc7054ab271e77bcd3445f7634d68d0c9c6ba7055ef58b1c9af60f6b3fb67325'
+  version '2.0.b13'
+  sha256 '286fa510519f746cb2b7aa5b7240305cb2e950e07a4d9e64a5cbb3d368673675'
 
   # tapbots.net/pastebot was verified as official when first introduced to the cask
   url "https://tapbots.net/pastebot#{version.major}/PastebotBeta.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.