### PR TITLE
Update spillo to 136_1.9.3

### DIFF
--- a/Casks/spillo.rb
+++ b/Casks/spillo.rb
@@ -1,11 +1,11 @@
 cask 'spillo' do
-  version '135_1.9.2'
-  sha256 'eabd96229ed392bf392c50e6e6c1811642d0a0a3aa9413e726dd8018d3657723'
+  version '136_1.9.3'
+  sha256 'dbd910020f4d4cba03cfe434cfa123937f6e3be3947af801737a3e6abb001b3b'
 
   # s3.amazonaws.com/bananafish-builds/spillo was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bananafish-builds/spillo/spillo_#{version}.zip"
   appcast 'https://bananafishsoftware.com/feeds/spillo.xml',
-          checkpoint: 'e44778a6413bc0ea36a07e2287b96079a992ccb299801d3f1d367b5956cdcb8b'
+          checkpoint: 'a85c2858e7adb3d60252e30854e6cfda40558ac40cb63663507417dccf121607'
   name 'Spillo'
   homepage 'https://bananafishsoftware.com/products/spillo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.