### PR TITLE
Work around upstream bug in Vagrant 1.8.7

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -5,11 +5,20 @@ cask 'vagrant' do
   # hashicorp.com/vagrant was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}.dmg"
   appcast 'https://github.com/mitchellh/vagrant/releases.atom',
-          checkpoint: '5b1451672c9d60925f947f676d56250f5d5572462abcba4f8ef8fc043a4cb7fc'
+          checkpoint: '8d16ac5df154d7b39604d9f6505b17394cdc45205c6a75a1bac8d9ff39cc2f06'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 
   pkg 'Vagrant.pkg'
+
+  # Vagrant 1.8.7 ships with a broken embedded curl. Removing it causes vagrant
+  # to fall back to the system-installed curl, which works.
+  # https://github.com/mitchellh/vagrant/issues/7969
+  postflight do
+    system_command '/bin/rm',
+                   args: ['/opt/vagrant/embedded/bin/curl'],
+                   sudo: true
+  end
 
   uninstall script:  { executable: 'uninstall.tool', input: %w[Yes] },
             pkgutil: 'com.vagrant.vagrant'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

----

Upstream issue is documented here, and the workaround is tested and working on
OS X Sierra. I do not have an older machine to test on, but curl's invocation
has been relatively stable over the years.

https://github.com/mitchellh/vagrant/issues/7969

While I was working on this, Vagrant 1.9.0 was released. I'm not updating this
cask to 1.9.0 at this time to give it a few days for any potential issues to
shake out.