### PR TITLE
Update igetter to 2.9.5

### DIFF
--- a/Casks/igetter.rb
+++ b/Casks/igetter.rb
@@ -1,6 +1,6 @@
 cask 'igetter' do
-  version '2.9.4'
-  sha256 '9c564156b06583cd3f9de0f827cffa2e5f8cb59834926111d5dd9951a02409c5'
+  version '2.9.5'
+  sha256 '6e07dd6ba828b99a009bae254fe632897b492e489ae02da788728ec4b443ba2e'
 
   url "https://www.igetter.net/search/downloads/iGetter#{version}.dmg"
   name 'iGetter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.