### PR TITLE
Update pinegrow-web-designer to 2.951

### DIFF
--- a/Casks/pinegrow-web-designer.rb
+++ b/Casks/pinegrow-web-designer.rb
@@ -1,6 +1,6 @@
 cask 'pinegrow-web-designer' do
-  version '2.81'
-  sha256 '76d14cc1947d97cfb58f9879956ffc8ee04582fbdff3131a6b11f4dabe7c2e25'
+  version '2.951'
+  sha256 'ebad933a306fcf0b0848ece55950e17653799da49ed01100d5d0e5da2c87f69c'
 
   # pinegrow.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://pinegrow.s3.amazonaws.com/PinegrowMac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.