### PR TITLE
Update quik to 2.1.0.5334

### DIFF
--- a/Casks/quik.rb
+++ b/Casks/quik.rb
@@ -1,12 +1,10 @@
 cask 'quik' do
-  version '2.0.1.5076'
-  sha256 '5226e6e86a96eeeda88938763a1858e8e1fe29a1f6024ed280a6f5d912f1611d'
+  version '2.1.0.5334'
+  sha256 '960d14f1022ed13390a3f20ad9761317d82760cdb1c5a78e2e29e90ef2f75232'
 
   url "https://software.gopro.com/Mac/Quik-MacInstaller-#{version}.dmg"
   name 'GoPro Quik'
   homepage 'https://shop.gopro.com/softwareandapp/quik-%7C-desktop/Quik-Desktop.html'
-
-  conflicts_with cask: 'gopro-studio'
 
   pkg 'Quik.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.