### PR TITLE
Fix version in Dropbox.app v15.4.22

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,8 +1,11 @@
 cask 'dropbox' do
-  version :latest
-  sha256 :no_check
+  version '15.4.22'
+  sha256 'a1569dfdea08b585ecb9f50569f4d26bf86434957d604d7bd18498606c7e6a56'
 
-  url 'https://www.dropbox.com/download?plat=mac&full=1'
+  # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
+  url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"
+  appcast 'https://www.dropbox.com/release_notes/rss.xml',
+          checkpoint: 'e5f348f7f83a2c283a5e8bada332407fc200bbadaedc5f3a5d5ef7be39b25922'
   name 'Dropbox'
   homepage 'https://www.dropbox.com/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit —download {{cask_file}}` is error-free.
- [x] `brew cask style —fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

Fix checksum in Dropbox.app Cask
Add appcast in Dropbox.app Cask