### PR TITLE
Update cryptomator (1.2.3)

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.2.2'
-  sha256 '2e6d302a7dc2839278483f60566e4f01e267103e936566677e846f3e5ec9f24c'
+  version '1.2.3'
+  sha256 '4e7b2baa97c0216ec1f9647dca5ade087a58f2bf22564e6395f5419f09bb7b55'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.