### PR TITLE
Update duet (1.6.3.1)

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,11 +1,11 @@
 cask 'duet' do
-  version '1.6.2.8'
-  sha256 '7e491bebe011abab6330cab393e97cd8f61b5b8edb09f14e8a39867a573bb2ce'
+  version '1.6.3.1'
+  sha256 '35211d99080003fd378504a24ed7be3795381ffc781b872c2164fc0fd780e63c'
 
   # s3-us-west-1.amazonaws.com/duetmac/ was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/duetmac/#{version.major_minor_patch.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"
   appcast 'https://updates.duetdisplay.com/checkMacUpdates',
-          checkpoint: '118ed35f61dd63569722c55f9cfe1847b10407b6fb023b69a2ebd6e3530ed694'
+          checkpoint: '49aa9a81b1012d2524cc1a81e61502cea506299295703f1016da77dccb60cdfa'
   name 'Duet'
   homepage 'https://www.duetdisplay.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
