### PR TITLE
Update polymail to 1.16

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.15'
-  sha256 '46193782f1d39ec28f293b85d8e2a5dcd1a9a8fb753448d1c9bc680244831796'
+  version '1.16'
+  sha256 'd258a5069d60da0b1fcc50d2d5b221a266afcaf478557c0c2f95d9779b8bf1ce'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '5c8929df7345145523b5f158caa1d683705027f33e0c915af39cf99385b82808'
+          checkpoint: '054058fe06bf143c32ccac853ad4acd6146179b9d88a9c7aeece0b7f8a272fea'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.