### PR TITLE
Update eclipse-platform to 4.6.1,201609071200

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -2,7 +2,7 @@ cask 'eclipse-platform' do
   version '4.6.1,201609071200'
   sha256 'eb089d46d0b772228a49cc813f965d036a47e1f15a283bd46d2e27880214a7be'
 
-  url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.tar.gz&r=1"
+  url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.tar.gz"
   name 'Eclipse SDK'
   homepage 'https://eclipse.org/eclipse/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.