### PR TITLE
Update fluid to 1.8.6

### DIFF
--- a/Casks/fluid.rb
+++ b/Casks/fluid.rb
@@ -1,10 +1,10 @@
 cask 'fluid' do
   version '1.8.6'
-  sha256 '82a3e4d634383b2423adb16fbc15699c7c0927180f1ac58e223f6eaf524d99c0'
+  sha256 'bbfa09a48563d89d5a1113527cd0a353f590b0f6811f270f12909ecfad8a2655'
 
   url "http://fluidapp.com/dist/Fluid_#{version}.zip"
   appcast "http://fluidapp.com/appcast/fluid#{version.major}.rss",
-          checkpoint: 'fbc75fb1251ce981acce75c680073b0e360b27e67dcf869d63ab5437387e015b'
+          checkpoint: 'db6db6a1f3cf7a8a4cb54b527e63a8b68108423292a10395bab3ddc4c290932f'
   name 'Fluid'
   homepage 'http://fluidapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.