### PR TITLE
Update devonthink-pro to 2.9.8

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.7'
-  sha256 '56705084f72c242a1277fc4fba01d995ff6aefe716d2280ee49f32a1d0b8cb0d'
+  version '2.9.8'
+  sha256 '8cbf54ca7651b96fbef4ab6fb7996bc1875affb29e463a29ec63e02b8c13ae09'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '90003251a95afcd0f47fd1fa9c54b398e5b193ed2a1bee4816754f02644fd916'
+          checkpoint: '8ac19c9384aecf656093ace77d527870718d7448339f55164d2548d270c6c8e8'
   name 'DEVONthink Pro'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.