### PR TITLE
Update devonthink-pro-office to 2.9.8

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro-office' do
-  version '2.9.7'
-  sha256 'a774bcdc293331baeaf7cbbab694197ca5faa4c20ced5625aedfe326109c29fa'
+  version '2.9.8'
+  sha256 '83987e904c9b45a36c6f853c3ad74d3ca4d13d647aa67ed1ff5149dc56211e5f'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: 'c57d6a31bb72ad29c4335d9c432e417591a5020e0b52118427fad669eac20090'
+          checkpoint: '4cf18f27a4a3be7201f7e45760410d4e0a12882b459894fcf1ae13c065fe4722'
   name 'DEVONthink Pro Office'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.