### PR TITLE
Fix homepages in 99 casks to include a bare domain slash

### DIFF
--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -5,7 +5,7 @@ cask 'dictionaries' do
   # dl.devmate.com was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/io.dictionaries.Dictionaries/Dictionaries.zip'
   name 'Dictionaries'
-  homepage 'https://dictionaries.io'
+  homepage 'https://dictionaries.io/'
 
   app 'Dictionaries.app'
 end

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -4,7 +4,7 @@ cask 'qiyimedia' do
 
   url 'http://mbdapp.iqiyi.com/j/ot/iQIYIMedia_003.dmg'
   name '爱奇艺视频'
-  homepage 'https://www.iqiyi.com'
+  homepage 'https://www.iqiyi.com/'
 
   app '爱奇艺.app'
 

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -4,7 +4,7 @@ cask 'scilab' do
 
   url "https://www.scilab.org/download/#{version}/scilab-#{version}-x86_64_yosemite.dmg"
   name 'Scilab'
-  homepage 'https://www.scilab.org'
+  homepage 'https://www.scilab.org/'
 
   app "scilab-#{version}.app"
 end

--- a/Casks/sdl-framework.rb
+++ b/Casks/sdl-framework.rb
@@ -4,7 +4,7 @@ cask 'sdl-framework' do
 
   url "https://www.libsdl.org/release/SDL-#{version}.dmg"
   name 'SDL.framework'
-  homepage 'https://www.libsdl.org'
+  homepage 'https://www.libsdl.org/'
 
   stage_only true
 end

--- a/Casks/sdl-ttf-framework.rb
+++ b/Casks/sdl-ttf-framework.rb
@@ -4,7 +4,7 @@ cask 'sdl-ttf-framework' do
 
   url "https://www.libsdl.org/projects/SDL_ttf/release/SDL_ttf-#{version}.dmg"
   name 'SDL_ttf.framework'
-  homepage 'https://www.libsdl.org'
+  homepage 'https://www.libsdl.org/'
 
   stage_only true
 end

--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -6,7 +6,7 @@ cask 'semulov' do
   appcast 'https://kainjow.com/updates/semulov.xml',
           checkpoint: '0764186f5017aac6f1adbaf2cdc1732f8038af7cd673909fd612ea9e255adff4'
   name 'Semulov'
-  homepage 'https://www.kainjow.com'
+  homepage 'https://www.kainjow.com/'
 
   app 'Semulov.app'
 end

--- a/Casks/sente.rb
+++ b/Casks/sente.rb
@@ -14,7 +14,7 @@ cask 'sente' do
   appcast 'https://www.thirdstreetsoftware.com/rss/Sente65.xml',
           checkpoint: '8b4ffee4f0379d9e1565166a6cecfa6a73260640ee8070e6abd8f58f3d26f754'
   name 'Sente'
-  homepage 'https://www.thirdstreetsoftware.com'
+  homepage 'https://www.thirdstreetsoftware.com/'
 
   app "Sente #{version.major}.app"
 end

--- a/Casks/sequential.rb
+++ b/Casks/sequential.rb
@@ -6,7 +6,7 @@ cask 'sequential' do
   appcast 'http://sequentialx.com/sequential.xml',
           checkpoint: '1fb8416920c90af57525b72c518fd89b0e6e29775d576720adf7535268ea510d'
   name 'Sequential'
-  homepage 'http://sequentialx.com'
+  homepage 'http://sequentialx.com/'
 
   app 'Sequential.app'
 end

--- a/Casks/servo.rb
+++ b/Casks/servo.rb
@@ -4,7 +4,7 @@ cask 'servo' do
 
   url 'https://download.servo.org/nightly/mac/servo-latest.dmg'
   name 'Servo'
-  homepage 'https://servo.org'
+  homepage 'https://servo.org/'
 
   app 'Servo.app'
 end

--- a/Casks/shapes.rb
+++ b/Casks/shapes.rb
@@ -6,7 +6,7 @@ cask 'shapes' do
   appcast "http://shapesapp.com/appcast/shapes#{version.major}.rss",
           checkpoint: '273c28c2c6030abfc48ef63eba711fcf86f36db4d31567b299ad95d5d90d4602'
   name 'Shapes'
-  homepage 'http://shapesapp.com'
+  homepage 'http://shapesapp.com/'
 
   depends_on macos: '>= :mountain_lion'
 

--- a/Casks/sharepod.rb
+++ b/Casks/sharepod.rb
@@ -5,7 +5,7 @@ cask 'sharepod' do
   # cdn.macroplant.com was verified as official when first introduced to the cask
   url "http://cdn.macroplant.com/release/Sharepod-#{version}.dmg"
   name 'Sharepod'
-  homepage 'https://www.getsharepod.com'
+  homepage 'https://www.getsharepod.com/'
 
   app 'Sharepod.app'
 end

--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -4,7 +4,7 @@ cask 'sharetool' do
 
   url "https://files.bainsware.com/sharetool_#{version.no_dots}.dmg"
   name 'ShareTool'
-  homepage 'https://www.bainsware.com'
+  homepage 'https://www.bainsware.com/'
 
   app 'ShareTool.app'
 end

--- a/Casks/ship.rb
+++ b/Casks/ship.rb
@@ -4,7 +4,7 @@ cask 'ship' do
 
   url 'https://www.realartists.com/Ship.app.zip'
   name 'Ship'
-  homepage 'https://www.realartists.com'
+  homepage 'https://www.realartists.com/'
 
   app 'Ship.app'
 

--- a/Casks/siilo.rb
+++ b/Casks/siilo.rb
@@ -6,7 +6,7 @@ cask 'siilo' do
   appcast 'https://api.siiloapp.com/versions/1/appcast.xml',
           checkpoint: 'd048385f246d0f8576533b61cc407c2ef6ac2a79e475695ffbd7588066c4af0a'
   name 'Siilo'
-  homepage 'https://siiloapp.com'
+  homepage 'https://siiloapp.com/'
 
   app 'Siilo.app'
 end

--- a/Casks/sketch-toolbox.rb
+++ b/Casks/sketch-toolbox.rb
@@ -6,7 +6,7 @@ cask 'sketch-toolbox' do
   appcast 'http://sketchtoolbox.com/updates/appcast.xml',
           checkpoint: '61636d433e619f4b56206366764c85f000715f7741d393ca30c214f36aad6c91'
   name 'Sketch Toolbox'
-  homepage 'http://sketchtoolbox.com'
+  homepage 'http://sketchtoolbox.com/'
 
   app 'Sketch Toolbox.app'
 end

--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -4,7 +4,7 @@ cask 'sketchbook' do
 
   url "https://cdn.sketchbook.com/mac/SketchBook_v#{version}_mac.dmg"
   name 'Autodesk Sketchbook'
-  homepage 'https://www.sketchbook.com'
+  homepage 'https://www.sketchbook.com/'
 
   pkg "SketchBook_v#{version}_mac.pkg"
 

--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -10,7 +10,7 @@ cask 'skype' do
   end
 
   name 'Skype'
-  homepage 'https://www.skype.com'
+  homepage 'https://www.skype.com/'
 
   auto_updates true
 

--- a/Casks/skypewebplugin.rb
+++ b/Casks/skypewebplugin.rb
@@ -4,7 +4,7 @@ cask 'skypewebplugin' do
 
   url "https://swx.cdn.skype.com/plugin/#{version}/SkypeWebPlugin.pkg"
   name 'Skype Web Plugin'
-  homepage 'https://www.skype.com'
+  homepage 'https://www.skype.com/'
 
   pkg 'SkypeWebPlugin.pkg'
 

--- a/Casks/slicer.rb
+++ b/Casks/slicer.rb
@@ -4,7 +4,7 @@ cask 'slicer' do
 
   url "http://download.slicer.org/bitstream/#{version.after_comma}"
   name '3D Slicer'
-  homepage 'https://www.slicer.org'
+  homepage 'https://www.slicer.org/'
 
   app 'Slicer.app'
 end

--- a/Casks/slingplayer-desktop.rb
+++ b/Casks/slingplayer-desktop.rb
@@ -7,7 +7,7 @@ cask 'slingplayer-desktop' do
   appcast 'https://qaautoupdate.sling.com/plugin_binary/downloads/SPD/Mac/DevAppcast/SlingPlayerDesktopAppcast.xml',
           checkpoint: 'f3e8f02a4af4671202a64777b3cc4e14f05865513a84b485eb797d7c48603574'
   name 'Slingplayer Desktop'
-  homepage 'http://www.slingbox.com'
+  homepage 'http://www.slingbox.com/'
 
   app 'Slingplayer Desktop.app'
 end

--- a/Casks/smoothmouse.rb
+++ b/Casks/smoothmouse.rb
@@ -6,7 +6,7 @@ cask 'smoothmouse' do
   appcast 'http://update.smoothmouse.com/appcast.xml',
           checkpoint: '5971898ce809ee4bad6a80918fc30d853f7dc98d88e35a05efa4f2c72b40b073'
   name 'SmoothMouse'
-  homepage 'http://smoothmouse.com'
+  homepage 'http://smoothmouse.com/'
 
   pkg 'SmoothMouse.pkg'
 

--- a/Casks/snappy.rb
+++ b/Casks/snappy.rb
@@ -4,7 +4,7 @@ cask 'snappy' do
 
   url 'http://go-snappy.com/Snappy.zip'
   name 'Snappy'
-  homepage 'http://go-snappy.com'
+  homepage 'http://go-snappy.com/'
 
   app 'Snappy.app'
 end

--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -5,7 +5,7 @@ cask 'soapui' do
   # downloads.smartbear.com/soapui-os was verified as official when first introduced to the cask
   url "https://downloads.smartbear.com/soapui-os/SoapUI-#{version}.dmg"
   name 'SmartBear SoapUI'
-  homepage 'https://www.soapui.org'
+  homepage 'https://www.soapui.org/'
 
   # Installer runs install4j from the distribution in quiet mode.
   #

--- a/Casks/sonoair.rb
+++ b/Casks/sonoair.rb
@@ -4,7 +4,7 @@ cask 'sonoair' do
 
   url "http://sonoair.mihosoft.eu/releases/#{version}/SonoAir.zip"
   name 'SonoAir'
-  homepage 'http://sonoair.mihosoft.eu'
+  homepage 'http://sonoair.mihosoft.eu/'
 
   app 'SonoAir.app'
 end

--- a/Casks/sookasa.rb
+++ b/Casks/sookasa.rb
@@ -7,7 +7,7 @@ cask 'sookasa' do
   appcast 'https://s3.amazonaws.com/sookasa-static-assets/mac-apps/appcats/appcast_mac_no_update.xml',
           checkpoint: '448360f2c1eec35b8b7ab5d6beaf5ecf25ea3f4a1f6d6f181f60aeb3bba3fcce'
   name 'Sookasa'
-  homepage 'https://www.sookasa.com'
+  homepage 'https://www.sookasa.com/'
 
   pkg "Sookasa_#{version}.pkg"
 

--- a/Casks/sopcast.rb
+++ b/Casks/sopcast.rb
@@ -5,7 +5,7 @@ cask 'sopcast' do
   # easetuner.com was verified as official when first introduced to the cask
   url "http://download.easetuner.com/download/SopCast-#{version}.dmg"
   name 'SopCast'
-  homepage 'http://www.sopcast.org'
+  homepage 'http://www.sopcast.org/'
 
   app 'SopCast.app'
   binary "#{appdir}/SopCast.app/Contents/Resources/binaries/m32/sp-sc-auth"

--- a/Casks/spacemonkey.rb
+++ b/Casks/spacemonkey.rb
@@ -7,7 +7,7 @@ cask 'spacemonkey' do
   appcast 'https://rink.hockeyapp.net/api/2/apps/aa33b6780fdfc71247b2995fa47b5d7c',
           checkpoint: '432e79d7e5cd77de36a1e250e6474cdbeccdb0e45cbe81520d32bc6e4ba63a3c'
   name 'Space Monkey'
-  homepage 'https://www.spacemonkey.com'
+  homepage 'https://www.spacemonkey.com/'
 
   auto_updates true
 

--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -4,7 +4,7 @@ cask 'speedify' do
 
   url 'https://downloads.speedify.com/speedify.php?platform=osx'
   name 'Speedify'
-  homepage 'https://speedify.com'
+  homepage 'https://speedify.com/'
 
   app 'Speedify.app'
 

--- a/Casks/spek.rb
+++ b/Casks/spek.rb
@@ -7,7 +7,7 @@ cask 'spek' do
   appcast 'https://github.com/alexkay/spek/releases.atom',
           checkpoint: '2ed5efa777cb07040d9d44e658bec267111b978d4701bbd8d6f6d3e1c1264f49'
   name 'Spek'
-  homepage 'http://spek.cc'
+  homepage 'http://spek.cc/'
 
   app 'Spek.app'
 end

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -4,7 +4,7 @@ cask 'spotify' do
 
   url 'https://download.spotify.com/Spotify.dmg'
   name 'Spotify'
-  homepage 'https://www.spotify.com'
+  homepage 'https://www.spotify.com/'
 
   auto_updates true
   depends_on macos: '>= :lion'

--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -7,7 +7,7 @@ cask 'sqlitebrowser' do
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom',
           checkpoint: 'ea975e8eef36bcbb334dfc015736c138c8e0b897e43ee11840c25c8d9f6a1620'
   name 'SQLite Database Browser'
-  homepage 'http://sqlitebrowser.org'
+  homepage 'http://sqlitebrowser.org/'
 
   app 'DB Browser for SQLite.app'
 end

--- a/Casks/sqlitestudio.rb
+++ b/Casks/sqlitestudio.rb
@@ -6,7 +6,7 @@ cask 'sqlitestudio' do
   appcast 'http://sqlitestudio.pl/rss.rvt',
           checkpoint: '20c2c66590f5f58f06c1da7197e7b418856c1a56c1abc3ebd5f30410458e51c2'
   name 'SQLiteStudio'
-  homepage 'http://sqlitestudio.pl'
+  homepage 'http://sqlitestudio.pl/'
 
   app 'SQLiteStudio.app'
 

--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -5,7 +5,7 @@ cask 'sqlpro-for-mysql' do
   # d3fwkemdw8spx3.cloudfront.net/mysql was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.app.zip"
   name 'SQLPro for MySQL'
-  homepage 'https://www.mysqlui.com'
+  homepage 'https://www.mysqlui.com/'
 
   app 'SQLPro for MySQL.app'
 

--- a/Casks/sqlpro-for-sqlite.rb
+++ b/Casks/sqlpro-for-sqlite.rb
@@ -5,7 +5,7 @@ cask 'sqlpro-for-sqlite' do
   # d3fwkemdw8spx3.cloudfront.net/sqlite was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/sqlite/SQLProSQLite.#{version}.app.zip"
   name 'SQLPro for SQLite'
-  homepage 'https://www.sqlitepro.com'
+  homepage 'https://www.sqlitepro.com/'
 
   app 'SQLPro for SQLite.app'
 

--- a/Casks/sqlpro-studio.rb
+++ b/Casks/sqlpro-studio.rb
@@ -5,7 +5,7 @@ cask 'sqlpro-studio' do
   # d3fwkemdw8spx3.cloudfront.net/studio was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/studio/SQLProStudio.#{version}.app.zip"
   name 'SQLPro Studio'
-  homepage 'https://www.sqlprostudio.com'
+  homepage 'https://www.sqlprostudio.com/'
 
   app 'SQLPro Studio.app'
 

--- a/Casks/sqlworkbenchj.rb
+++ b/Casks/sqlworkbenchj.rb
@@ -4,7 +4,7 @@ cask 'sqlworkbenchj' do
 
   url "http://www.sql-workbench.net/archive/Workbench-Build#{version}-MacJava8.tgz"
   name 'SQL Workbench/J'
-  homepage 'http://www.sql-workbench.net'
+  homepage 'http://www.sql-workbench.net/'
 
   app 'SQLWorkbenchJ.app'
 

--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -4,7 +4,7 @@ cask 'squeak' do
 
   url "http://files.squeak.org/#{version}/Squeak-#{version}-All-in-One.zip"
   name 'Squeak'
-  homepage 'http://squeak.org'
+  homepage 'http://squeak.org/'
 
   app "Squeak-#{version}-All-in-One/Squeak-#{version}-All-in-One.app"
 

--- a/Casks/squire.rb
+++ b/Casks/squire.rb
@@ -7,7 +7,7 @@ cask 'squire' do
   appcast 'http://www.sylion.com/squireapp/sparkle/SquireMac/appcastSquireMac.xml',
           checkpoint: '4f7ea01207cca2fa14f1b6c82e6eb35500715ddeaa15258a5dccdbb05f0edb72'
   name 'Squire'
-  homepage 'http://squireapp.com'
+  homepage 'http://squireapp.com/'
 
   app 'Squire.app'
 end

--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -6,7 +6,7 @@ cask 'stella' do
   appcast 'https://sourceforge.net/projects/stella/rss?path=/stella',
           checkpoint: '096a0719ee88287c5523ac52be377b76776d61bc9f6f4f018f68f177031833eb'
   name 'Stella'
-  homepage 'http://stella.sourceforge.net'
+  homepage 'http://stella.sourceforge.net/'
 
   app 'Stella.app'
 end

--- a/Casks/story-writer.rb
+++ b/Casks/story-writer.rb
@@ -4,7 +4,7 @@ cask 'story-writer' do
 
   url "http://soft.xiaoshujiang.com/version/Story-writer-v#{version}/Story-writer-osx64.zip"
   name 'Story Writer'
-  homepage 'http://soft.xiaoshujiang.com'
+  homepage 'http://soft.xiaoshujiang.com/'
 
   app 'Story-writer.app'
 end

--- a/Casks/strife.rb
+++ b/Casks/strife.rb
@@ -4,7 +4,7 @@ cask 'strife' do
 
   url "http://dl.strife.com/af1dfc2754268375727a3eec1749b27e/StrifeMac64-#{version}.zip"
   name 'Strife'
-  homepage 'https://strife.com'
+  homepage 'https://strife.com/'
 
   app 'Strife.app'
 end

--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -4,7 +4,7 @@ cask 'subsurface' do
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   name 'Subsurface'
-  homepage 'https://subsurface-divelog.org'
+  homepage 'https://subsurface-divelog.org/'
 
   app 'Subsurface.app'
 end

--- a/Casks/subtitles.rb
+++ b/Casks/subtitles.rb
@@ -6,7 +6,7 @@ cask 'subtitles' do
   appcast 'https://subtitlesapp.com/updates.xml',
           checkpoint: '1851499d9b99765244ec22db7faf583a82dd1d6e4e63aa04e7d0d1f28106c2ce'
   name 'Subtitles'
-  homepage 'https://subtitlesapp.com'
+  homepage 'https://subtitlesapp.com/'
 
   app 'Subtitles.app'
 

--- a/Casks/sunlogin-remote.rb
+++ b/Casks/sunlogin-remote.rb
@@ -5,7 +5,7 @@ cask 'sunlogin-remote' do
   url "https://download.oray.com/sunlogin/SunloginRemote_v#{version}.dmg"
   name 'Sunlogin Remote'
   name '向日葵控制端'
-  homepage 'https://sunlogin.oray.com'
+  homepage 'https://sunlogin.oray.com/'
 
   app 'Sunlogin Remote.app'
 end

--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -4,7 +4,7 @@ cask 'surge' do
 
   url 'http://dl.nssurge.com/mac/Surge-latest.zip'
   name 'Surge'
-  homepage 'https://nssurge.com'
+  homepage 'https://nssurge.com/'
 
   app 'Surge.app'
 end

--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -6,7 +6,7 @@ cask 'swinsian' do
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml',
           checkpoint: '0b2ca85ef37f4215353e0e795fd6d6d81725f0da2e2d8bbe7751a82af6302085'
   name 'Swinsian'
-  homepage 'https://swinsian.com'
+  homepage 'https://swinsian.com/'
 
   app 'Swinsian.app'
 end

--- a/Casks/sync-my-l2p.rb
+++ b/Casks/sync-my-l2p.rb
@@ -7,7 +7,7 @@ cask 'sync-my-l2p' do
   appcast 'https://github.com/Sync-my-L2P/Sync-my-L2P/releases.atom',
           checkpoint: '131d35c756edf86c9a5197973c41651749402e4a948699a98d1d7ff8bae6b3c2'
   name 'Sync-my-L2P'
-  homepage 'http://www.sync-my-l2p.de'
+  homepage 'http://www.sync-my-l2p.de/'
 
   app 'Sync-my-L2P.app'
 end

--- a/Casks/syncmate.rb
+++ b/Casks/syncmate.rb
@@ -6,7 +6,7 @@ cask 'syncmate' do
   appcast "http://www.eltima.com/download/syncmate-update/syncmate#{version.major}.xml",
           checkpoint: '36abb6bd0123ba9944961df59b58ef9de8fe72d6bc0d0ecc8daf5ff2d0f6a40f'
   name 'SyncMate'
-  homepage 'http://www.sync-mac.com'
+  homepage 'http://www.sync-mac.com/'
 
   app 'SyncMate.app'
 end

--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -4,7 +4,7 @@ cask 'synology-cloud-station-backup' do
 
   url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
   name 'Synology Cloud Station Backup'
-  homepage 'https://www.synology.com'
+  homepage 'https://www.synology.com/'
 
   pkg 'Install Cloud Station Backup.pkg'
 

--- a/Casks/synologyeiauthenticator.rb
+++ b/Casks/synologyeiauthenticator.rb
@@ -4,7 +4,7 @@ cask 'synologyeiauthenticator' do
 
   url "https://global.download.synology.com/download/Tools/EvidenceIntegrityAuthenticator/#{version}/Mac/SynologyEIAuthenticator-#{version}.dmg"
   name 'Synology Evidence Integrity Authenticator'
-  homepage 'https://www.synology.com'
+  homepage 'https://www.synology.com/'
 
   app 'SynologyEIAuthenticator.app'
 end

--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -7,7 +7,7 @@ cask 'tableflip' do
   appcast "https://update.christiantietze.de/tableflip/v#{version.major}/release.xml",
           checkpoint: 'df87f5df3dd31b2401c0510643dd811bf44ac5f63215cc87b411e4c1173fa4b4'
   name 'TableFlip'
-  homepage 'http://tableflipapp.com'
+  homepage 'http://tableflipapp.com/'
 
   auto_updates true
 

--- a/Casks/tamarin-prover.rb
+++ b/Casks/tamarin-prover.rb
@@ -5,7 +5,7 @@ cask 'tamarin-prover' do
   # github.com/tamarin-prover/bin-dists was verified as official when first introduced to the cask
   url 'https://github.com/tamarin-prover/bin-dists/archive/master.zip'
   name 'tamarin-prover'
-  homepage 'https://tamarin-prover.github.io'
+  homepage 'https://tamarin-prover.github.io/'
 
   depends_on macos: '>= :lion'
   depends_on arch: :x86_64

--- a/Casks/tapaal.rb
+++ b/Casks/tapaal.rb
@@ -4,7 +4,7 @@ cask 'tapaal' do
 
   url "http://www.tapaal.net/fileadmin/download/tapaal-3.1/tapaal-#{version}-mac64.dmg"
   name 'TAPAAL'
-  homepage 'http://www.tapaal.net'
+  homepage 'http://www.tapaal.net/'
 
   app 'Tapaal.app'
 end

--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -7,7 +7,7 @@ cask 'telegram-desktop' do
   appcast "https://tdesktop.com/mac/tupdates/current?version=#{version.no_dots}",
           checkpoint: '59522ad1ed2329bbc172b60587f7811fc1fa7cd2b23a3e67ade11f2576edc130'
   name 'Telegram Desktop'
-  homepage 'https://desktop.telegram.org'
+  homepage 'https://desktop.telegram.org/'
 
   # Renamed to avoid conflict with telegram
   app 'Telegram.app', target: 'Telegram Desktop.app'

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -6,7 +6,7 @@ cask 'telegram' do
   appcast 'https://osx.telegram.org/updates/versions.xml',
           checkpoint: '5a478e37b4fd26c4520ed4623dfa19ccc6abb5ade968c367f6901de6a5db5e8e'
   name 'Telegram for macOS'
-  homepage 'https://macos.telegram.org'
+  homepage 'https://macos.telegram.org/'
 
   auto_updates true
 

--- a/Casks/texts.rb
+++ b/Casks/texts.rb
@@ -6,7 +6,7 @@ cask 'texts' do
   appcast 'http://www.texts.io/appcast-osx.xml',
           checkpoint: '47e1ffeedbbc49ee19a70acf9aee9fe0a7df00ce60e23b427433fe5536add962'
   name 'Texts'
-  homepage 'http://www.texts.io'
+  homepage 'http://www.texts.io/'
 
   app 'Texts.app'
 end

--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -4,7 +4,7 @@ cask 'the-archive-browser' do
 
   url "https://wakaba.c3.cx/releases/TheArchiveBrowser/TheArchiveBrowser#{version}.zip"
   name 'The Archive Browser'
-  homepage 'https://archivebrowser.c3.cx'
+  homepage 'https://archivebrowser.c3.cx/'
 
   app 'The Archive Browser.app'
 end

--- a/Casks/the-ur-quan-masters.rb
+++ b/Casks/the-ur-quan-masters.rb
@@ -6,7 +6,7 @@ cask 'the-ur-quan-masters' do
   appcast 'https://sourceforge.net/projects/sc2/rss',
           checkpoint: '74e6fb7b18dc943aadb12bf7a5859788205790bc826b3decf39893dd0d3cf70e'
   name 'The Ur-Quan Masters'
-  homepage 'http://sc2.sourceforge.net'
+  homepage 'http://sc2.sourceforge.net/'
 
   app 'The Ur-Quan Masters.app'
 end

--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -5,7 +5,7 @@ cask 'tifig' do
   # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"
   name 'Tifig'
-  homepage 'https://www.tifig.net'
+  homepage 'https://www.tifig.net/'
 
   depends_on arch: :x86_64
 

--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -7,7 +7,7 @@ cask 'timely' do
   appcast 'https://github.com/Timely/desktop-releases/releases.atom',
           checkpoint: 'e4cb97258fa3ef5d9c4ac39ef80ad4bb3a96e11ad81beb1e674962292f270263'
   name 'Timely'
-  homepage 'https://timelyapp.com'
+  homepage 'https://timelyapp.com/'
 
   app 'Timely.app'
 end

--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -7,7 +7,7 @@ cask 'toggldesktop' do
   appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml',
           checkpoint: '0af9b4c523d6303ce4ccbeeb640733b7b1de9901d22b13acc8c2cb8c0d9376ed'
   name 'TogglDesktop'
-  homepage 'https://www.toggl.com'
+  homepage 'https://www.toggl.com/'
 
   app 'TogglDesktop.app'
 end

--- a/Casks/tongbu.rb
+++ b/Casks/tongbu.rb
@@ -5,7 +5,7 @@ cask 'tongbu' do
   # qd.appdown.info/qd/zsmacqd was verified as official when first introduced to the cask
   url "http://qd.appdown.info/qd/zsmacqd/Tongbu_mac_v#{version}_baidupinzhuan.dmg"
   name 'Tongbu'
-  homepage 'http://www.tongbu.com'
+  homepage 'http://www.tongbu.com/'
 
   app 'Tongbu.app'
 end

--- a/Casks/totalfinder.rb
+++ b/Casks/totalfinder.rb
@@ -4,7 +4,7 @@ cask 'totalfinder' do
 
   url "http://downloads.binaryage.com/TotalFinder-#{version}.dmg"
   name 'TotalFinder'
-  homepage 'http://totalfinder.binaryage.com'
+  homepage 'http://totalfinder.binaryage.com/'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/totalterminal.rb
+++ b/Casks/totalterminal.rb
@@ -4,7 +4,7 @@ cask 'totalterminal' do
 
   url "http://downloads.binaryage.com/TotalTerminal-#{version}.dmg"
   name 'TotalTerminal'
-  homepage 'http://totalterminal.binaryage.com'
+  homepage 'http://totalterminal.binaryage.com/'
 
   pkg 'TotalTerminal.pkg'
 

--- a/Casks/touch-unlock.rb
+++ b/Casks/touch-unlock.rb
@@ -4,7 +4,7 @@ cask 'touch-unlock' do
 
   url "https://releases.touchunlock.com/packages/Touch%20Unlock%20for%20Mac%20-%20v#{version}.dmg"
   name 'Touch Unlock for Mac'
-  homepage 'https://touchunlock.com'
+  homepage 'https://touchunlock.com/'
 
   app 'Touch Unlock for Mac.app'
 

--- a/Casks/tsprint.rb
+++ b/Casks/tsprint.rb
@@ -4,7 +4,7 @@ cask 'tsprint' do
 
   url 'http://www.terminalworks.com/downloads/tsprint/macosx/TSPrintClient.zip'
   name 'TSPrintClient'
-  homepage 'http://www.terminalworks.com'
+  homepage 'http://www.terminalworks.com/'
 
   pkg 'TSPrintClient.pkg'
 

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -9,7 +9,7 @@ cask 'tunnelblick' do
 
   url "https://www.tunnelblick.net/release/Tunnelblick_#{version}.dmg"
   name 'Tunnelblick'
-  homepage 'https://www.tunnelblick.net'
+  homepage 'https://www.tunnelblick.net/'
 
   auto_updates true
   depends_on macos: '>= :tiger'

--- a/Casks/twindocs.rb
+++ b/Casks/twindocs.rb
@@ -4,7 +4,7 @@ cask 'twindocs' do
 
   url 'https://www.twindocs.com/plugins/es/tools_mac/Twindocs%20tools.pkg.zip'
   name 'Twindocs tools'
-  homepage 'https://www.twindocs.com'
+  homepage 'https://www.twindocs.com/'
 
   pkg 'Twindocs tools.pkg'
 

--- a/Casks/twitch.rb
+++ b/Casks/twitch.rb
@@ -4,7 +4,7 @@ cask 'twitch' do
 
   url 'http://twitchapp.com/Twitch.app.zip'
   name 'Twitch'
-  homepage 'http://twitchapp.com'
+  homepage 'http://twitchapp.com/'
 
   app 'Twitch.app'
 end

--- a/Casks/typewriter.rb
+++ b/Casks/typewriter.rb
@@ -4,7 +4,7 @@ cask 'typewriter' do
 
   url 'https://typewriter.llllll.li/download/Typewriter.zip'
   name 'Typewriter'
-  homepage 'https://typewriter.llllll.li'
+  homepage 'https://typewriter.llllll.li/'
 
   app 'Typewriter.app'
 end

--- a/Casks/ultimate.rb
+++ b/Casks/ultimate.rb
@@ -4,7 +4,7 @@ cask 'ultimate' do
 
   url 'http://download.epubor.com/epubor_ultimate.zip'
   name 'Ultimate Converter'
-  homepage 'http://www.epubor.com'
+  homepage 'http://www.epubor.com/'
 
   container nested: "epubor_ultimate/Ultimate_v#{version}.dmg"
 

--- a/Casks/umsatz-standard.rb
+++ b/Casks/umsatz-standard.rb
@@ -4,7 +4,7 @@ cask 'umsatz-standard' do
 
   url 'https://umsatz-programm.de/ladungen/UmsatzStandard2015.zip'
   name 'Umsatz Standard 2015'
-  homepage 'https://umsatz-programm.de'
+  homepage 'https://umsatz-programm.de/'
 
   app 'Umsatz Standard 2015.app'
 end

--- a/Casks/unicorns.rb
+++ b/Casks/unicorns.rb
@@ -4,7 +4,7 @@ cask 'unicorns' do
 
   url 'http://cdn.unicorns.io/app/Unicorns.zip'
   name 'Unicorns'
-  homepage 'https://unicorns.io'
+  homepage 'https://unicorns.io/'
 
   app 'Unicorns.app'
 end

--- a/Casks/upeditor.rb
+++ b/Casks/upeditor.rb
@@ -4,7 +4,7 @@ cask 'upeditor' do
 
   url 'https://user.95516.com/ctrl/UPEditor_2.dmg'
   name 'UPEditor plugin'
-  homepage 'https://www.95516.com'
+  homepage 'https://www.95516.com/'
 
   internet_plugin 'UPEditorSafari.plugin'
 end

--- a/Casks/utox.rb
+++ b/Casks/utox.rb
@@ -7,7 +7,7 @@ cask 'utox' do
   appcast 'https://github.com/uTox/uTox/releases.atom',
           checkpoint: 'eee22a515c835b9a12c6dfc727a144227c27ec56d1b613a46362c8927b333a4a'
   name 'uTox'
-  homepage 'https://www.tox.chat'
+  homepage 'https://www.tox.chat/'
 
   app 'uTox.app'
 end

--- a/Casks/vectr.rb
+++ b/Casks/vectr.rb
@@ -4,7 +4,7 @@ cask 'vectr' do
 
   url "http://download.vectr.com/desktop/#{version}/mac/Vectr-#{version}.dmg"
   name 'Vectr'
-  homepage 'https://vectr.com'
+  homepage 'https://vectr.com/'
 
   app 'Vectr.app'
 end

--- a/Casks/veraport.rb
+++ b/Casks/veraport.rb
@@ -4,7 +4,7 @@ cask 'veraport' do
 
   url 'https://open.citibank.co.kr/3rdParty/wizvera/veraport/down/veraport.pkg'
   name 'VeraPort'
-  homepage 'https://open.citibank.co.kr'
+  homepage 'https://open.citibank.co.kr/'
 
   pkg 'veraport.pkg'
 

--- a/Casks/vessel.rb
+++ b/Casks/vessel.rb
@@ -7,7 +7,7 @@ cask 'vessel' do
   appcast 'https://github.com/awvessel/vessel/releases.atom',
           checkpoint: 'eed47ee87455b8096b127fc21903aface6f597750ed856d441569450adb4f38e'
   name 'Vessel'
-  homepage 'https://awvessel.github.io'
+  homepage 'https://awvessel.github.io/'
 
   app 'Vessel.app'
 end

--- a/Casks/viber.rb
+++ b/Casks/viber.rb
@@ -4,7 +4,7 @@ cask 'viber' do
 
   url 'https://download.viber.com/desktop/mac/Viber.dmg'
   name 'Viber'
-  homepage 'http://www.viber.com'
+  homepage 'http://www.viber.com/'
 
   app 'Viber.app'
 end

--- a/Casks/vico.rb
+++ b/Casks/vico.rb
@@ -6,7 +6,7 @@ cask 'vico' do
   appcast 'http://www.vicoapp.com/appcast.xml',
           checkpoint: 'b4ee7b48c746e73c1f75c20d4767e47997473ace4f14d32328962b2f4bbbf76a'
   name 'Vico'
-  homepage 'http://www.vicoapp.com'
+  homepage 'http://www.vicoapp.com/'
 
   app 'Vico.app'
   binary "#{appdir}/Vico.app/Contents/MacOS/vicotool", target: 'vico'

--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -7,7 +7,7 @@ cask 'vienna' do
   appcast 'https://viennarss.github.io/sparkle-files/changelog.xml',
           checkpoint: 'e16e5fb62571e6f28b5054a973716b9bfb2e253f319259f1a22156cd42883f72'
   name 'Vienna'
-  homepage 'http://www.vienna-rss.org'
+  homepage 'http://www.vienna-rss.org/'
 
   app 'Vienna.app'
 

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -12,7 +12,7 @@ cask 'virtualbox-extension-pack' do
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   name 'Oracle VirtualBox Extension Pack'
-  homepage 'https://www.virtualbox.org'
+  homepage 'https://www.virtualbox.org/'
 
   depends_on cask: 'virtualbox'
   container type: :naked

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -14,7 +14,7 @@ cask 'virtualbox' do
   appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',
           checkpoint: '779e6d24cb291ff605d93a3ec585cfa5589c1d4584ab7d9ee04a231d41ff5df3'
   name 'Oracle VirtualBox'
-  homepage 'https://www.virtualbox.org'
+  homepage 'https://www.virtualbox.org/'
 
   pkg 'VirtualBox.pkg'
 

--- a/Casks/visualvm.rb
+++ b/Casks/visualvm.rb
@@ -7,7 +7,7 @@ cask 'visualvm' do
   appcast 'https://github.com/visualvm/visualvm.src/releases.atom',
           checkpoint: 'dde5d93c09ce408c053b472040a2e2bfb0c283152722968c7da55985489cac41'
   name 'VisualVM'
-  homepage 'https://visualvm.github.io'
+  homepage 'https://visualvm.github.io/'
 
   app 'VisualVM.app'
 

--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -6,7 +6,7 @@ cask 'vivaldi' do
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
           checkpoint: '2fa69731030a1cce3f0000f17540865f3303502959e1cc526512874f35773230'
   name 'Vivaldi'
-  homepage 'https://vivaldi.com'
+  homepage 'https://vivaldi.com/'
 
   auto_updates true
 

--- a/Casks/wallpaper-wizard.rb
+++ b/Casks/wallpaper-wizard.rb
@@ -5,7 +5,7 @@ cask 'wallpaper-wizard' do
   # dl.devmate.com/com.wallwiz was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.wallwiz/WallpaperWizard.dmg'
   name 'Wallpaper Wizard'
-  homepage 'http://wallwiz.com'
+  homepage 'http://wallwiz.com/'
 
   app 'Wallpaper Wizard.app'
 end

--- a/Casks/wedge.rb
+++ b/Casks/wedge.rb
@@ -6,7 +6,7 @@ cask 'wedge' do
   appcast 'http://wedge.natestedman.com/appcast.xml',
           checkpoint: '2a2f34cb7ee8a7e61c0bb685aeba02aabd3b6681ef76730b8eb758913cddbf4d'
   name 'Wedge'
-  homepage 'http://wedge.natestedman.com'
+  homepage 'http://wedge.natestedman.com/'
 
   app 'Wedge.app'
 end

--- a/Casks/weibox.rb
+++ b/Casks/weibox.rb
@@ -6,7 +6,7 @@ cask 'weibox' do
   appcast 'https://weiboformac.sinaapp.com/appcast/wm2.xml',
           checkpoint: '7eb49b121dd6b425d75716b599bbf748e61b171a5924f2d6dba0b612f042d41d'
   name 'WeiboX'
-  homepage 'https://weiboformac.sinaapp.com'
+  homepage 'https://weiboformac.sinaapp.com/'
 
   depends_on macos: '>= :mountain_lion'
 

--- a/Casks/wireless-transfer.rb
+++ b/Casks/wireless-transfer.rb
@@ -4,7 +4,7 @@ cask 'wireless-transfer' do
 
   url 'http://www.wirelesstransferapp.com/wirelesstransferapp-intel.dmg'
   name 'Wireless Transfer App'
-  homepage 'http://www.wirelesstransferapp.com'
+  homepage 'http://www.wirelesstransferapp.com/'
 
   app 'Wireless Transfer App.app'
 end

--- a/Casks/wowdoge.rb
+++ b/Casks/wowdoge.rb
@@ -4,7 +4,7 @@ cask 'wowdoge' do
 
   url 'http://www.wowdoge.org/download/WowDoge.dmg'
   name 'WowDoge'
-  homepage 'http://www.wowdoge.org'
+  homepage 'http://www.wowdoge.org/'
 
   app 'WowDoge.app'
 end

--- a/Casks/xact.rb
+++ b/Casks/xact.rb
@@ -6,7 +6,7 @@ cask 'xact' do
   appcast 'http://xactupdate.scottcbrown.org/xACT.xml',
           checkpoint: '8d9d65d16c97d222254af173465ace91b959a73129773f8ba8b19e8ac16995d9'
   name 'xACT'
-  homepage 'http://xact.scottcbrown.org'
+  homepage 'http://xact.scottcbrown.org/'
 
   app "xACT #{version}/xACT.app"
 end

--- a/Casks/xmind.rb
+++ b/Casks/xmind.rb
@@ -4,7 +4,7 @@ cask 'xmind' do
 
   url "https://www.xmind.net/xmind/downloads/xmind-#{version}-macosx.dmg"
   name 'XMind'
-  homepage 'https://www.xmind.net'
+  homepage 'https://www.xmind.net/'
 
   depends_on macos: '>= :snow_leopard'
 

--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -4,7 +4,7 @@ cask 'xpra' do
 
   url 'https://www.xpra.org/dists/osx/x86/Xpra.dmg'
   name 'Xpra'
-  homepage 'https://www.xpra.org'
+  homepage 'https://www.xpra.org/'
 
   app 'Xpra.app'
 end

--- a/Casks/yahoo-messenger.rb
+++ b/Casks/yahoo-messenger.rb
@@ -5,7 +5,7 @@ cask 'yahoo-messenger' do
   # yimg.com was verified as official when first introduced to the cask
   url "https://s.yimg.com/jd/desktop/#{version}/yahoo-messenger-#{version}-osx.zip"
   name 'Yahoo Messenger'
-  homepage 'https://messenger.yahoo.com'
+  homepage 'https://messenger.yahoo.com/'
 
   app 'Yahoo Messenger.app'
 end

--- a/Casks/yummy-ftp.rb
+++ b/Casks/yummy-ftp.rb
@@ -6,7 +6,7 @@ cask 'yummy-ftp' do
   appcast 'http://www.yummysoftware.com/su/yummyftp/feed.xml',
           checkpoint: '70a3e488950656cf6b71fe10165d29b6af2c403e4023274dd084e544f61c49df'
   name 'Yummy FTP'
-  homepage 'http://www.yummysoftware.com'
+  homepage 'http://www.yummysoftware.com/'
 
   app 'Yummy FTP.app'
 end

--- a/Casks/zed.rb
+++ b/Casks/zed.rb
@@ -4,7 +4,7 @@ cask 'zed' do
 
   url "http://download.zedapp.org/zed-mac-v#{version}.tar.gz"
   name 'Zed'
-  homepage 'http://zedapp.org'
+  homepage 'http://zedapp.org/'
 
   app 'Zed.app'
 end

--- a/Casks/zerobranestudio.rb
+++ b/Casks/zerobranestudio.rb
@@ -4,7 +4,7 @@ cask 'zerobranestudio' do
 
   url "https://download.zerobrane.com/ZeroBraneStudioEduPack-#{version}-macos.dmg"
   name 'ZeroBrane Studio'
-  homepage 'https://studio.zerobrane.com'
+  homepage 'https://studio.zerobrane.com/'
 
   app 'ZeroBraneStudio.app'
 end

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -4,7 +4,7 @@ cask 'zoomus' do
 
   url 'https://zoom.us/client/latest/zoomusInstaller.pkg'
   name 'Zoom.us'
-  homepage 'https://www.zoom.us'
+  homepage 'https://www.zoom.us/'
 
   auto_updates true
 

--- a/Casks/zxpinstaller.rb
+++ b/Casks/zxpinstaller.rb
@@ -7,7 +7,7 @@ cask 'zxpinstaller' do
   appcast 'https://github.com/CreativeDo/ZXPInstaller/releases.atom',
           checkpoint: 'b90c69ba778b9321c00765c0d04e0e1d6aa38db8a88b49cf4ba86928108b020a'
   name 'ZXPInstaller'
-  homepage 'http://zxpinstaller.com'
+  homepage 'http://zxpinstaller.com/'
 
   app 'ZXPInstaller.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
Continuing https://github.com/caskroom/homebrew-cask/pull/27176. These are the last ones.