### PR TITLE
pokerstars.rb: add region support

### DIFF
--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -2,21 +2,25 @@ cask 'pokerstars' do
   version :latest
   sha256 :no_check
 
-  language 'en', default: true do
-    %w[com]
+  language 'US', default: true do
+    %w[.com]
   end
 
+  language 'AU' do
+    %w[.eu/de EU]
+  end
+
+  launguage 'BE' do
+    %w[.be BE]
+  end
+  
   language 'PT' do
-    %w[pt PT]
+    %w[.pt PT]
   end
 
-  language 'eu' do
-    %w[eu EU]
-  end
-
-  url "https://www.pokerstars.#{language[0]}/PokerStars#{language[1]}.app.zip"
+  url "https://www.pokerstars#{language[0]}/PokerStars#{language[1]}.app.zip"
   name 'PokerStars'
-  homepage "https://www.pokerstars.#{language[0]}"
+  homepage "https://www.pokerstars#{language[0]}"
 
   auto_updates true
   container nested: "PokerStars#{language[1]}/PokerStars#{language[1]}.dmg"

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -6,11 +6,11 @@ cask 'pokerstars' do
     %w[.com]
   end
 
-  language 'AU' do
-    %w[.eu/de EU]
+  language 'AT' do
+    %w[.eu EU]
   end
 
-  launguage 'BE' do
+  language 'BE' do
     %w[.be BE]
   end
   

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -6,7 +6,7 @@ cask 'pokerstars' do
     %w[com]
   end
 
-  language 'pt' do
+  language 'PT' do
     %w[pt PT]
   end
 

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -2,17 +2,30 @@ cask 'pokerstars' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.pokerstars.com/PokerStars.app.zip'
+  language 'en', default: true do
+    %w[com]
+  end
+
+  language 'pt' do
+    %w[pt PT]
+  end
+
+  language 'eu' do
+    %w[eu EU]
+  end
+
+  url "https://www.pokerstars.#{language[0]}/PokerStars#{language[1]}.app.zip"
   name 'PokerStars'
-  homepage 'https://www.pokerstars.com/'
+  homepage "https://www.pokerstars.#{language[0]}"
 
   auto_updates true
+  container nested: "PokerStars#{language[1]}/PokerStars#{language[1]}.dmg"
 
-  app 'PokerStars.app'
+  app "PokerStars#{language[1]}.app"
 
   zap delete: [
-                '~/Library/Preferences/com.pokerstars.user.ini',
-                '~/Library/Preferences/com.pokerstars.PokerStars.plist',
-                '~/Library/Application Support/PokerStars',
+                "~/Library/Preferences/com.pokerstars#{language[1]}.user.ini",
+                "~/Library/Preferences/com.pokerstars.PokerStars#{language[1]}.plist",
+                "~/Library/Application Support/PokerStars#{language[1]}",
               ]
 end

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -13,7 +13,43 @@ cask 'pokerstars' do
   language 'BE' do
     %w[.be BE]
   end
-  
+
+  language 'BG' do
+    %w[.bg BG]
+  end
+
+  language 'DK' do
+    %w[.dk DK]
+  end
+
+  language 'EE' do
+    %w[.ee EE]
+  end
+
+  language 'ES' do
+    %w[.es ES]
+  end
+
+  language 'FR' do
+    %w[.fr FR]
+  end
+
+  language 'GR' do
+    %w[.gr GR]
+  end
+
+  language 'IT' do
+    %w[.it IT]
+  end
+
+  language 'RO' do
+    %w[.ro RO]
+  end
+
+  language 'UK' do
+    %w[.uk UK]
+  end
+
   language 'PT' do
     %w[.pt PT]
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

@reitermarkus Requesting some help here. I feel like this could be more elegant. There are a few things to consider:

+ PokerStars will only work if you have the correct version for your region. There used to be an `EU` version, but since now in Portugal it is `PT`, I’m guessing they have one for each country specifically.
  + Because of that, there really shouldn’t be a “default” version. Would it be possible to make it so that a user *has to* specify a region, else it would fail to install?
+ PokerStars redirects you like crazy. They seriously do not by any means want you visiting the the pages for the other regions, which makes verifying any region but yours a pain (which is why I only added one language).