### PR TITLE
Update Bitmessage to 0.6.1

### DIFF
--- a/Casks/bitmessage.rb
+++ b/Casks/bitmessage.rb
@@ -1,8 +1,11 @@
 cask 'bitmessage' do
-  version '0.4.4'
-  sha256 'afef467644189c4783e673528665b09242526ba48841b16034a623d8dc553d78'
+  version '0.6.1'
+  sha256 '401571b671a75dfdc94587cb3790443165cff86a122b919ad08e51c2d088ad1f'
 
-  url "https://bitmessage.org/download/osx/Archive/bitmessage-v#{version}.dmg"
+  # github.com/Bitmessage/PyBitmessage was verified as official when first introduced to the cask
+  url "https://github.com/Bitmessage/PyBitmessage/releases/download/v#{version}/bitmessage-v#{version}.dmg"
+  appcast 'https://github.com/Bitmessage/PyBitmessage/releases.atom',
+          checkpoint: 'ff09661559521f36a3a2b74d3cadf48cf2f469db47f4a46d6be4639ad217c9da'
   name 'Bitmessage'
   homepage 'https://bitmessage.org/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
