### PR TITLE
Update grip to 1.5.0

### DIFF
--- a/Casks/grip.rb
+++ b/Casks/grip.rb
@@ -1,11 +1,11 @@
 cask 'grip' do
-  version '1.5.0-rc3'
-  sha256 'da44a0184b296a8e26f9ef8098dc23f9496f16b8afb5a68573ebfd2743a56327'
+  version '1.5.0'
+  sha256 '1b0e6f3e1d1b926ece83c47cfe3de99b4afbc60b7199893b35eba387e5e455b0'
 
   # github.com/WPIRoboticsProjects/GRIP was verified as official when first introduced to the cask
   url "https://github.com/WPIRoboticsProjects/GRIP/releases/download/v#{version}/GRIP-#{version}-x64.dmg"
   appcast 'https://github.com/WPIRoboticsProjects/GRIP/releases.atom',
-          checkpoint: 'e3e9e85b0fcc6b87e574b9bf524b9cee9af11ef4956a89e3a626ce380fc9f019'
+          checkpoint: '389751add1d0b6c8b07ea09e9b193e7651868049952113f502414dabfeda55ce'
   name 'GRIP Computer Vision Engine'
   name 'GRIP'
   homepage 'https://wpiroboticsprojects.github.io/GRIP/'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.