### PR TITLE
Update downie to 2.5.10,1345

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.5.9,1339'
-  sha256 '0d3b4e023a71ed72913b170acfc58deff95317cbb96fae0409ea1e7b836060c4'
+  version '2.5.10,1345'
+  sha256 'a1ffeb14cbab15b778368060fde3ee6eb9bca93ca5097c9236a2ac45dc49edeb'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '7c1dc04de430a72a1da7eee9281b2a0472edd605973dace2d918889e4a2e0502'
+          checkpoint: 'b46b900f16f9e03a98380a718ecf3e071e46108b76df2487053fcfbac77e3152'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.