### PR TITLE
Update studiolinkcomponent to 16.04.1-beta

### DIFF
--- a/Casks/studiolinkcomponent.rb
+++ b/Casks/studiolinkcomponent.rb
@@ -1,11 +1,11 @@
 cask 'studiolinkcomponent' do
-  version '16.02.2-beta'
-  sha256 '1ed7524c6cb7a4635eb8c27310ca894f56df6db335dc08c9bcda5843be64f87a'
+  version '16.04.1-beta'
+  sha256 '4b34beca575517d5d35d0b74479ebd36471903902eb770d5752d6ea6d4f7ace7'
 
   # github.com/Studio-Link-v2/backend was verified as official when first introduced to the cask
   url "https://github.com/Studio-Link-v2/backend/releases/download/v#{version}/studio-link-plugin-osx.zip"
   appcast 'https://github.com/Studio-Link-v2/backend/releases.atom',
-          checkpoint: 'f12e402194581d2fc3c8230faa2b2b069a3b57d6d5ad5df3df3c0b83d6103098'
+          checkpoint: '0ad259caf7f33deb8caf605b884a128e2e232285831ed938fc030ccce8b5252c'
   name 'Studio Link Plugin'
   homepage 'https://doku.studio-link.de/plugin/installation-plugin.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.