### PR TITLE
Update table-tool to 1.1.2

### DIFF
--- a/Casks/table-tool.rb
+++ b/Casks/table-tool.rb
@@ -1,10 +1,10 @@
 cask 'table-tool' do
-  version '1.1.1'
-  sha256 '044b3dae44221cab8f59b7e830ffa4c1d14fac0dcada20069db90c64bc4d3ff9'
+  version '1.1.2'
+  sha256 '7aa342aa3aaed6f6ecbf86c57a50de5f86add19b2ccb07c76c400f225fb828b9'
 
   url "https://github.com/jakob/TableTool/releases/download/v#{version}/tabletool-#{version}.zip"
   appcast 'https://github.com/jakob/TableTool/releases.atom',
-          checkpoint: '7392607502912d47225965601e76b31299b3491ff233e8a52ad4787135ff1a82'
+          checkpoint: '018d9b9ef2158e97203d26fd981e285e034b8fa9ce41d31496683216186a2879'
   name 'Table Tool'
   homepage 'https://github.com/jakob/TableTool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.