### PR TITLE
Update tagspaces to 2.6.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,11 +1,11 @@
 cask 'tagspaces' do
-  version '2.5.0'
-  sha256 'cf668916519e0848b54c146796e57278a369edeacf26902ed08a166b5fc35559'
+  version '2.6.0'
+  sha256 '5eb5d99843bed186b9ba711794376c272922675be647671e9e5f18c82edceb31'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-#{version}-osx64.zip"
   appcast 'https://github.com/tagspaces/tagspaces/releases.atom',
-          checkpoint: 'd580c5cbfb066f3d80c174237cd3c8ebadd8b7007013b7a05df701a1e13bf7b7'
+          checkpoint: 'f2c08de8bc1a32b1617b46e2c88195bd11c984461d3a03c3412df3bffcf047d5'
   name 'TagSpaces'
   homepage 'https://www.tagspaces.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.