### PR TITLE
Update track-o-bot to 0.8.5

### DIFF
--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -1,11 +1,11 @@
 cask 'track-o-bot' do
-  version '0.8.3'
-  sha256 '44afc803cb49c3852d612c867824a716550076eabd80903cf3614d6e6532386d'
+  version '0.8.5'
+  sha256 '7e9185d980e3864feb67a8e60ba0c33ca53723a57b69115b0506f65f7a4ffc7e'
 
   # github.com/stevschmid/track-o-bot was verified as official when first introduced to the cask
   url "https://github.com/stevschmid/track-o-bot/releases/download/#{version}/Track-o-Bot_#{version}.dmg"
   appcast 'https://github.com/stevschmid/track-o-bot/releases.atom',
-          checkpoint: '50f779effdc72453fc06d6b2593dce301169fc0574d1ae68e7ad346cb948a651'
+          checkpoint: 'fc6fb048cf4efcf442067a33d079f08dc65948da01f4d9ac58b9761428a72408'
   name 'Track-o-Bot'
   homepage 'https://trackobot.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.