### PR TITLE
Update trailer to 1.5.2

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,10 @@
 cask 'trailer' do
-  version '1.5.1'
-  sha256 '440225079046bd412d1bf46f8f28e946969d1193d47fbad85d8ac076c79071bd'
+  version '1.5.2'
+  sha256 '275b6af5e5fd95e3f4d911def2fb85a37f2a46b5e715dece58f41f798edf4109'
 
   url "https://ptsochantaris.github.io/trailer/trailer#{version.no_dots}.zip"
   appcast 'https://ptsochantaris.github.io/trailer/appcast.xml',
-          checkpoint: '268413362de9da5989eee27099486f2558c4e3a320d061bb97399a55d2c56850'
+          checkpoint: '624edb1eed7b770f882ffc925f7270ab523afa78ab7d1d940c2e2c663211a6eb'
   name 'Trailer'
   homepage 'https://ptsochantaris.github.io/trailer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.