### PR TITLE
Update supercollider to 3.8.0

### DIFF
--- a/Casks/supercollider.rb
+++ b/Casks/supercollider.rb
@@ -1,11 +1,11 @@
 cask 'supercollider' do
-  version '3.7.1'
-  sha256 '35762e7a55b77e954412db0aaf2f0ad08a0f66292429e9bf0c34c61d2156e20f'
+  version '3.8.0'
+  sha256 '3ba38b061076004e4f567541059aa4633dfad537fd149dc64360584744191a3f'
 
   # github.com/supercollider/supercollider was verified as official when first introduced to the cask
-  url "https://github.com/supercollider/supercollider/releases/download/Version-#{version}/SuperCollider-OSX-#{version}.zip"
+  url "https://github.com/supercollider/supercollider/releases/download/Version-#{version}/SuperCollider-#{version}-OSX.zip"
   appcast 'https://github.com/supercollider/supercollider/releases.atom',
-          checkpoint: '792cf265121b3358432cd35be470055b7fdaa01ad547ef1b3d1618c61c0e689e'
+          checkpoint: '57e6bb2114243621c90a5c772d05d933bb3139e54fbfbd9bef5bba1df0e9f5ce'
   name 'SuperCollider'
   homepage 'https://supercollider.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.