### PR TITLE
Update coda.rb for appcast and zap

### DIFF
--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -5,7 +5,7 @@ cask 'coda' do
   url "https://download.panic.com/coda/Coda%20#{version}.zip"
   appcast "https://www.panic.com/updates/update.php?appName=Coda%20#{version.major}",
           checkpoint: 'd8310a287cd373dad15ec242bf6b4e181dc5af358772f8030ed2b0c772aec2f8'
-  name "Coda #{version}"
+  name 'Coda'
   homepage 'https://panic.com/coda/'
 
   depends_on macos: '>= :lion'

--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -5,7 +5,7 @@ cask 'coda' do
   url "https://download.panic.com/coda/Coda%20#{version}.zip"
   appcast "https://www.panic.com/updates/update.php?appName=Coda%20#{version.major}",
           checkpoint: 'd8310a287cd373dad15ec242bf6b4e181dc5af358772f8030ed2b0c772aec2f8'
-  name 'Coda'
+  name 'Panic Coda'
   homepage 'https://panic.com/coda/'
 
   depends_on macos: '>= :lion'

--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -3,7 +3,9 @@ cask 'coda' do
   sha256 '5d734cdac6b47b07ca8ef9224611b0f7c8a57f1ec7b66eb7befdfcaf20896548'
 
   url "https://download.panic.com/coda/Coda%20#{version}.zip"
-  name 'Panic Coda'
+  appcast "https://www.panic.com/updates/update.php?appName=Coda%20#{version.major}",
+          checkpoint: 'd8310a287cd373dad15ec242bf6b4e181dc5af358772f8030ed2b0c772aec2f8'
+  name "Coda #{version}"
   homepage 'https://panic.com/coda/'
 
   depends_on macos: '>= :lion'
@@ -12,12 +14,10 @@ cask 'coda' do
 
   zap delete: [
                 "~/Library/Application Support/Coda #{version.major}",
-                "~/Library/Application Support/Growl/Tickets/Coda #{version.major}.growlTicket",
-                "~/Library/Caches/com.panic.Coda#{version.major}",
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.panic.coda2.sfl',
                 "~/Library/Caches/com.apple.helpd/Generated/com.panic.Coda#{version.major}.help",
+                "~/Library/Caches/com.panic.Coda#{version.major}",
                 "~/Library/Preferences/com.panic.Coda#{version.major}.plist",
-                "~/Library/Preferences/com.panic.Coda#{version.major}.LSSharedFileList.plist",
-                "~/Library/Preferences/com.panic.Coda#{version.major}.LSSharedFileList.plist.lockfile",
                 "~/Library/Saved Application State/com.panic.Coda#{version.major}.savedState",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update coda.rb for appcast and zap