### PR TITLE
Update silicon-labs-vcp-driver.rb

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -7,6 +7,8 @@ cask 'silicon-labs-vcp-driver' do
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx'
 
+  container nested: 'SiLabsUSBDriverDisk.dmg'
+
   pkg 'Silicon Labs VCP Driver.pkg'
 
   uninstall pkgutil: 'com.silabs.siliconLabsVcpDriver.*'


### PR DESCRIPTION
The change to remove `container nested:` in 3348a2b52b2dd348ff2e113069e552e1c8a16ef9 (#23322) seems to have broken this cask, which has a `.pkg` inside the `.dmg`. The autodetection didn't find the `.pkg`, causing "Error: pkg source file not found:"

After making all changes to the cask:

- [x] `brew cask audit --download silicon-labs-vcp-driver` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name but not version because it's an unversioned cask.
