### PR TITLE
Update vimr to 0.11.1-140

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.10.0-118'
-  sha256 'f4db5084565b08cfc78c171bfd479d5db0f467e3d77cefc51a0d7756fe68dc5c'
+  version '0.11.1-140'
+  sha256 'bf171ffb0c47700194f5eb4f44df572f2be64ebb1e6e5fa79ce89b219f5b2244'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '2800489c8892131df269efe614886bd72a691be647d61181c66cb3921e9b005d'
+          checkpoint: '6ebdd0fc57647d4ffcf528d92deb1b5730b9a5d180cd8d0a73acaedc42d98cba'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.