### PR TITLE
Update copyq to 2.8.1

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -1,11 +1,11 @@
 cask 'copyq' do
-  version '2.7.1'
-  sha256 '39a95e01a127ab4fb0c40848b66486fd3f6c240cee7d744f72f3a73ee8c83603'
+  version '2.8.1'
+  sha256 'f599b647bdb39933697b3c989b64bb2433f8a64375a28cb45f7bdde38038fc83'
 
   # github.com/hluk/CopyQ was verified as official when first introduced to the cask
-  url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ-#{version}.dmg"
+  url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ.dmg"
   appcast 'https://github.com/hluk/CopyQ/releases.atom',
-          checkpoint: 'd1a625ac78d4a299c72917288794d89784bd8c8ada53c15404df009ac4f02d28'
+          checkpoint: '59782e9ffbd154df25164c86833ebb4f287f3c0b4d5baf96acf35f84a5557843'
   name 'CopyQ'
   homepage 'https://hluk.github.io/CopyQ/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.