### PR TITLE
Update qownnotes to 16.12.0,b2568-113120

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '16.11.16,b2545-185156'
-  sha256 '98e6546870a8b1202d6839ba0d1819f27b9b7f3ab626840e50135f106f8fe099'
+  version '16.12.0,b2568-113120'
+  sha256 '226666a63124686b32a02d2ea145920659baa0fd4d9daed616566880fae79d84'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '8428e3522fe51de301d61cf8e98fbe42b1ddab9a07e3c4ba03508086b683d6c6'
+          checkpoint: '81b0ed94ba7eebd8dfd1b8f890f383003e561ff0ba7e969581803222faf6d782'
   name 'QOwnNotes'
   homepage 'http://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.