### PR TITLE
Update brave to 0.12.11dev

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.12.10dev'
-  sha256 'e2c706491d4037e695be5abb4be1024a7fa8c26cd733b1e21ee6179f5d1a4cb7'
+  version '0.12.11dev'
+  sha256 '06bf6eff55832f2e37571126cf87545121b11ab7905b8744352bdcd4c06449de'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '5fd92e5631b617190f6b70b2133dff1c8e93802e71a7ef7286893199cd7d6e06'
+          checkpoint: '664572153b76cf7816050bf9ea8016625b4e8293533e247a56fba6062b55b22a'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.