### PR TITLE
Update prepros to 6.0.1

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,9 +1,11 @@
 cask 'prepros' do
-  version '5.10.2'
-  sha256 '45cdd9fb4b30cc2a26cdb211c713ef8c6f9ff3e9636131888ed796ae56262fa8'
+  version '6.0.1'
+  sha256 '9541c9561be11dfaebd5b682571a2e6f46edcc6186016ce9bdba6e16573834f1'
 
-  # prepros.io.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://prepros.io.s3.amazonaws.com/installers/Prepros-Mac-#{version}.zip"
+  # s3-us-west-2.amazonaws.com/ was verified as official when first introduced to the cask
+  url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
+  appcast 'https://prepros.io/changelog',
+          checkpoint: '1e4dfb8b73ea10880c0a158c5587368f07bc54f0f48e91770c096c1b5dbd0614'
   name 'Prepros'
   homepage 'https://prepros.io/'
 

--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -2,7 +2,7 @@ cask 'prepros' do
   version '6.0.1'
   sha256 '9541c9561be11dfaebd5b682571a2e6f46edcc6186016ce9bdba6e16573834f1'
 
-  # s3-us-west-2.amazonaws.com/ was verified as official when first introduced to the cask
+  # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
           checkpoint: '1e4dfb8b73ea10880c0a158c5587368f07bc54f0f48e91770c096c1b5dbd0614'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.