### PR TITLE
Update deadbeef to 0.7.2

### DIFF
--- a/Casks/deadbeef.rb
+++ b/Casks/deadbeef.rb
@@ -1,8 +1,8 @@
 cask 'deadbeef' do
   version '0.7.2'
-  sha256 '7dc688cca32bf1ef2efbfb4f93c7464b1f935ad71e3d2e35fb06513a615bd7e8'
+  sha256 'cfac56c37d55ccebf934d3b8c0a2b0ae7acf809e9c5aa5dcf6ff0b5a281a4e5b'
 
-  url 'https://downloads.sourceforge.net/deadbeef/deadbeef-devel-osx-x86_64.zip'
+  url 'https://downloads.sourceforge.net/deadbeef/deadbeef-static_0.7.2-2_i686.tar.bz2'
   appcast 'https://sourceforge.net/projects/deadbeef/rss?path=/travis/osx/master',
           checkpoint: 'ed8178e68dd11ce0d03d31f8864e4eaa95cf45112764691f0b82793fcbd4dcb2'
   name 'DeaDBeeF'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.