### PR TITLE
Fix Kivy 1.9.1 Script link Error

### DIFF
--- a/Casks/kivy.rb
+++ b/Casks/kivy.rb
@@ -10,5 +10,5 @@ cask 'kivy' do
 
   # Renamed as suggested by developer: https://kivy.org/docs/installation/installation-osx.html#installation-on-os-x
   app 'Kivy3.app', target: 'Kivy.app'
-  binary "#{appdir}/Kivy3.app/Contents/Resources/script", target: 'kivy'
+  binary "#{appdir}/Kivy.app/Contents/Resources/script", target: 'kivy'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`Error: It seems the symlink source is not there: '/Applications/Kivy3.app/Contents/Resources/script'`