### PR TITLE
Update trailrunner to 3.8.827

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,10 +1,10 @@
 cask 'trailrunner' do
-  version '3.8.824'
-  sha256 'b4cc1161f700b266d062ebb4cf5fc9053c5e7f55dedf2eb1f140c4ec673ee35d'
+  version '3.8.827'
+  sha256 'c9102ec6cc6af2fd10e5b8ad25a0aff54cb0c50ed46680b12df8a737f47bf045'
 
   url 'http://downloads.trailrunnerx.com/TrailRunner.app.zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610',
-          checkpoint: '3059e5b79286c9db9ce2a30701f73549e3c97d1872d8d194c2b1f0ceee8ca419'
+          checkpoint: '4c0ba04a57fee54d4ba9941e5bf0351e8a420419111f7409b0a35a20f0c3846c'
   name 'TrailRunner'
   homepage 'http://trailrunnerx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.