### PR TITLE
Update typora to 0.9.9.8.5

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.8.4'
-  sha256 '35f46c0edca88b8e138b244a88aa82fd189d1b9b5db2bfd218a0e0b49566f2e2'
+  version '0.9.9.8.5'
+  sha256 '6edbd210cc166d46d8a8e9f3de6a4ee20f6bbaf647330491a2192690d07c6853'
 
   url "https://www.typora.io/download/typora_#{version}.zip"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '31fff87c5e0d24d4e704e9eed012329a94e0cda5e0102bbb1be8be676ab02552'
+          checkpoint: '44f938414da0269e0f11181a46bf69722ce03286046c5c2b3fb7032652b97e40'
   name 'Typora'
   homepage 'https://www.typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.