### PR TITLE
Update abfr for depends_on and zap

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -9,11 +9,13 @@ cask 'a-better-finder-rename' do
   homepage 'http://www.publicspace.net/ABetterFinderRename/'
 
   auto_updates true
+  depends_on macos: '>= :lion'
 
   app "A Better Finder Rename #{version.major}.app"
 
   zap delete: [
                 "~/Library/Application Support/A Better Finder Rename #{version.major}",
+                "~/Library/Caches/com.apple.helpd/Generated/net.publicspace.abfr#{version.major}.help",
                 "~/Library/Caches/net.publicspace.abfr#{version.major}",
                 "~/Library/Cookies/net.publicspace.abfr#{version.major}.binarycookies",
                 "~/Library/Preferences/net.publicspace.abfr#{version.major}.plist",


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update a-better-finder-rename.rb for depends_on and zap