### PR TITLE
Fix airvpn 2.10 to use the new download link

### DIFF
--- a/Casks/airvpn.rb
+++ b/Casks/airvpn.rb
@@ -2,7 +2,7 @@ cask 'airvpn' do
   version '2.10'
   sha256 '2ab80137f9a80b0c8dcd549c56b66ca74c8aa6fd03156f6d665f18da949ce055'
 
-  url "https://airvpn.org/repository/#{version}/airvpn_osx_x64_installer.pkg"
+  url "https://airvpn.org/eddie/download/?platform=osx&arch=x64&format=installer.pkg&version=#{version}"
   name 'Air VPN'
   homepage 'https://airvpn.org/macosx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.