### PR TITLE
Update cubicsdr to 0.2.0

### DIFF
--- a/Casks/cubicsdr.rb
+++ b/Casks/cubicsdr.rb
@@ -1,11 +1,11 @@
 cask 'cubicsdr' do
-  version '0.2.0,rc4'
-  sha256 '981292e70ae0aad21cb86c780d53cee0a5b5f57e1e4f883d612af6d26ddb6015'
+  version '0.2.0'
+  sha256 '0ca38efcc5355585a1fdcb8f617bcc6bc4031513aa33d7117fe3c426892321bb'
 
   # github.com/cjcliffe/CubicSDR was verified as official when first introduced to the cask
-  url "https://github.com/cjcliffe/CubicSDR/releases/download/#{version.before_comma}-beta-#{version.after_comma}/CubicSDR-#{version.before_comma}-Darwin-#{version.after_comma}.dmg"
+  url "https://github.com/cjcliffe/CubicSDR/releases/download/#{version}/CubicSDR-#{version}-Darwin.dmg"
   appcast 'https://github.com/cjcliffe/CubicSDR/releases.atom',
-          checkpoint: '25e6bd2e65ae37f74f6659b8600bddad0bda93944f32308adc41339949dfd7de'
+          checkpoint: '6bc2d8513d0a7646888bd7760b10608567f16e030c2c7fa58498a48e1387749f'
   name 'CubicSDR'
   homepage 'http://cubicsdr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.