### PR TITLE
Update pastebot to 2.0.b15

### DIFF
--- a/Casks/pastebot.rb
+++ b/Casks/pastebot.rb
@@ -1,5 +1,5 @@
 cask 'pastebot' do
-  version '2.0.b14'
+  version '2.0.b15'
   sha256 'f20df8b31d2ef47858a0fff216e300edfe34730572f61f062d737e708f8189a2'
 
   # tapbots.net/pastebot was verified as official when first introduced to the cask

--- a/Casks/pastebot.rb
+++ b/Casks/pastebot.rb
@@ -1,6 +1,6 @@
 cask 'pastebot' do
   version '2.0.b15'
-  sha256 'f20df8b31d2ef47858a0fff216e300edfe34730572f61f062d737e708f8189a2'
+  sha256 'ace5d843f9aaccdecafac628930a7d26f55ecbdeb6ac08f64e479769b6fb48a9'
 
   # tapbots.net/pastebot was verified as official when first introduced to the cask
   url "https://tapbots.net/pastebot#{version.major}/PastebotBeta.zip"
@@ -9,5 +9,8 @@ cask 'pastebot' do
 
   app 'Pastebot.app'
 
-  zap delete: "~/Library/Containers/com.tapbots.Pastebot#{version.major}Mac"
+  zap delete: [
+                "~/Library/Containers/com.tapbots.Pastebot#{version.major}Mac",
+                "~/Library/Preferences/com.tapbots.Pastebot#{version.major}Mac.plist",
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.