### PR TITLE
Update shotcut to 16.12.03

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '16.10.01'
-  sha256 'b24bf7036df42be70b64f8905224568afaae04cd794d9898dfffda47ccad8db7'
+  version '16.12.03'
+  sha256 '66afc1d321a4cfd457fbd6865734dfe792812f6356a62de77652d065b69db49f'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '779aed1d63fae54c2801da15a9993d598e9cf7815b9328995ebbe1dac8debc66'
+          checkpoint: '87fe8c9a9ef4ef95357132b66912e869649c59e54e1dd2cca1db72afd5746920'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.