### PR TITLE
Update torguard to 0.3.56

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,11 +1,11 @@
 cask 'torguard' do
-  version '0.3.55'
-  sha256 'ff38d516eda250d9c46adeeadedd542c54d0036c4c9bfaf0b2655585311b178c'
+  version '0.3.56'
+  sha256 'c690049b491797e7c4581e2e0ec46f405012cdf3e40dbdcb9af84d48f0130e4f'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"
   appcast 'https://updates.torguard.biz/Software/MacOSX/checksums.sha256',
-          checkpoint: '4dd3ec96038024d3636eb111933bbf3ec4fad3e9ffaf645a6f1d21c8f0f6f09e'
+          checkpoint: '34aa55c736deead09779382dc667ae8d1002fa1ef2259828778a3946a426f4cb'
   name 'TorGuard'
   homepage 'https://torguard.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.