### PR TITLE
Update stretchly to 0.5.1

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.5.0'
-  sha256 '00ced334c9f1851738863097b6d3c5c57753ed4da1115295a59cffe3180bf658'
+  version '0.5.1'
+  sha256 '9b480ff99c23b91067598b573f7f94bbbc9a79703471a53e2c02a77f546042ac'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '196beefd3721b35d425280da73d1e58929f760eb1bb04b675a33e58f681bccd3'
+          checkpoint: '37bd240e647d53b8be14bbed20618f8dc1cf906d70a929cf841ffbc011f5e2d4'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.