### PR TITLE
Update filezilla to 3.23.0.1

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.22.2.2'
-    sha256 'b43d52d441b0777439f36cecd4fc1888c18072b9c9381fa9be016fcef28954c2'
+    version '3.23.0.1'
+    sha256 'f7bb5af92df5317c2ff2076ea5052ae45dc22a75756de2a08b98938a9575b7d4'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: 'b518f15d722afb4a1a97be89d25a3cee20045d666a3968cafae654e8e3db6506'
+          checkpoint: '430d47e710c1f16aca123aec087771e9bf29d64209a82a70f2a1ebaa16ebb45c'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.