### PR TITLE
Update postman to 4.9.1

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,11 +1,11 @@
 cask 'postman' do
-  version '4.8.3'
-  sha256 '57aa58f1779e844fff5b79a065e1fdceab5e83bfb76394ef3798f45cc41a3ebe'
+  version '4.9.1'
+  sha256 'acc7bb364384ba423986c85447d7c4b3b6effbd076351a5bd66ecc208597f522'
 
   # s3.amazonaws.com/postman-electron-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/postman-electron-builds/mac/Postman-osx-#{version}.zip"
   appcast 'https://app.getpostman.com/api/electron_updates_auto',
-          checkpoint: 'de268bc583e8f324ba2185cc7661c8e93f717b3c129154995070f9675447f3b5'
+          checkpoint: 'c01547e322e35aa95aa91e52520b556e5e778f542d059df184b3d12ac5c58c75'
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download postman` is error-free.
- [x] `brew cask style --fix postman` reports no offenses.
- [x] The commit message includes the cask’s name and version.
