### PR TITLE
Update mirador to 1.4.1

### DIFF
--- a/Casks/mirador.rb
+++ b/Casks/mirador.rb
@@ -1,11 +1,11 @@
 cask 'mirador' do
-  version '1.4'
-  sha256 '4131c4114fba598e86b803d20ba1ef9732b7b92897b6c4b753ae62e892d9bdf1'
+  version '1.4.1'
+  sha256 '654288f08d66ae18372c422260b891d2d89126eca76ea51fea40205974c135c9'
 
   # github.com/mirador/mirador was verified as official when first introduced to the cask
   url "https://github.com/mirador/mirador/releases/download/#{version}/mirador-macosx-#{version}.zip"
   appcast 'https://github.com/mirador/mirador/releases.atom',
-          checkpoint: 'f170ed80b82bb18d60baca9c3310a9039ce8b88ee1c023f02a6a676bd0f6cdf6'
+          checkpoint: 'e28f3cb994524bbe25555c09e1298caf1992d676cbe4140017472f7de997dee5'
   name 'Mirador'
   homepage 'https://fathom.info/mirador/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.