### PR TITLE
Update freeplane to 1.5.17

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,10 +1,10 @@
 cask 'freeplane' do
-  version '1.5.13'
-  sha256 '15205e49b3d4f2e45f4bd4ae859df955783632dbe96737e69b5ae44960df705b'
+  version '1.5.17'
+  sha256 'cffb45c680943f05acf5800e829caf2d4d05bb640679bc9a5ebc50dd60f2cbe3'
 
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable',
-          checkpoint: '60fc48e1bc2033f5862ffb60ff689372bc9409406f254a39bb966ab833ee719a'
+          checkpoint: '1b1156a9db35677356923dc253b720995cc1ad9c021718b9512e33bb31a134df'
   name 'Freeplane'
   homepage 'http://freeplane.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.