### PR TITLE
Update praat to 6.0.22

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,10 +1,10 @@
 cask 'praat' do
-  version '6.0.21'
-  sha256 '4c6c35f2c72b5862ac79e29989ac244618e1997e87c79b1bf7828360314b5f05'
+  version '6.0.22'
+  sha256 '21ca47f23a7f366bf56a8745d4171339d1e55c97c08b7bf36d65359554f7b964'
 
   url "http://www.fon.hum.uva.nl/praat/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom',
-          checkpoint: '3d74ff31449d5f37f3cca51c91e62ba828697e7e247ac60f8e62ca26f4a3ff8a'
+          checkpoint: 'd070c1558ef1f12db33da100192e4b2269f2c7194b395ce1049fee50c770dbc6'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.