### PR TITLE
Update gqrx to 2.6-1

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,11 +1,11 @@
 cask 'gqrx' do
-  version '2.5.3'
-  sha256 'b5053b9a86c13d856137143a8215f48a85d3e57b4d867c317a666b1bc0e97d10'
+  version '2.6-1'
+  sha256 '3622b2e4f744afc21e1894f3c6b509d53c05072334934cad645b7cdd4cf9c76b'
 
   # github.com/csete/gqrx was verified as official when first introduced to the cask
-  url "https://github.com/csete/gqrx/releases/download/v#{version}/Gqrx-#{version}-2.dmg"
+  url "https://github.com/csete/gqrx/releases/download/v#{version.sub(%r{-.*}, '')}/Gqrx-#{version}.dmg"
   appcast 'https://github.com/csete/gqrx/releases.atom',
-          checkpoint: '686d4a577ad5eea69ae06269c07f215f0c8c90a6cfe89777808e5813d54b53cd'
+          checkpoint: '8a99dcbea1f93b049a49791a1d57ded257eb9e340bea070c144af1bfda2784ca'
   name 'Gqrx'
   homepage 'http://gqrx.dk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.