### PR TITLE
Update waterfox to 50.0.2.1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '50.0.2'
-  sha256 'c7c70d211fd53425d981a4bb88364f1651edcc18b59f17ca41bbf26150266a1b'
+  version '50.0.2.1'
+  sha256 'e0b0212707449fd5b00647734f42f82587bf1a246f73d62a5bbad0a8b8187d87'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.