### PR TITLE
Update textmate to 2.0-rc.7

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,11 +1,11 @@
 cask 'textmate' do
-  version '2.0-rc.4'
-  sha256 '8d956f079494c73a04750fc64018f3ce3680c2f7c6519cc3f67d2baf3943f0ff'
+  version '2.0-rc.7'
+  sha256 'cec681703045eae3d49fde2f94619256f089c1413b1750773dba5e6ca7bc1e20'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
   appcast 'https://github.com/textmate/textmate/releases.atom',
-          checkpoint: 'd844ca42e9860f5cd025dff173e586bb85a417e3eb5a45b87593d1936c179985'
+          checkpoint: '3b9a2f7f90cf9f46232fd530bf98fb0295ad749eb6bb03312391c70e33a5a6ae'
   name 'TextMate'
   homepage 'https://macromates.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.