### PR TITLE
Update pibakery to 0.3.2

### DIFF
--- a/Casks/pibakery.rb
+++ b/Casks/pibakery.rb
@@ -1,11 +1,11 @@
 cask 'pibakery' do
-  version '0.2.3'
-  sha256 '655c01afafdd3012332ad3a68f0388f5f838cf826dc49b7d645b5b0928e01f50'
+  version '0.3.2'
+  sha256 '1b7ac4a3d9890185a838fd1566aa1809e6dfad24fd9dfbd0fe482b80edbbb6c5'
 
   # github.com/davidferguson was verified as official when first introduced to the cask
   url "https://github.com/davidferguson/pibakery/releases/download/v#{version}/PiBakery.pkg"
   appcast 'https://github.com/davidferguson/pibakery/releases.atom',
-          checkpoint: '32c4b18e7d1986179ac634944e4e5093267ad1e1ada80f6065a9384a966ea3eb'
+          checkpoint: '1a8b804fb29d35abeb58731dcd32ce025c744fa114c7992cc8bb46773f77c269'
   name 'PiBakery'
   homepage 'http://www.pibakery.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.