### PR TITLE
Update helm to 2.0.2

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -1,11 +1,11 @@
 cask 'helm' do
-  version '2.0.0'
-  sha256 '1e654364fe7c2c28dd708ace0952c55e412af61621d0954cbe25e90df1180b3b'
+  version '2.0.2'
+  sha256 'd27bd7e40e12c0a5f08782a8a883166008565b28e0b82126d2089300ff3f8465'
 
   # storage.googleapis.com/kubernetes-helm/ was verified as official when first introduced to the cask
   url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
-          checkpoint: 'a7d693afb88348128a4dc5644a31aa95062cb874b12064ea904caeb0142ce0a3'
+          checkpoint: '08098089f3eaeadb985f5431192df39b15a5017e83d2a844c48da64ca60ed135'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.