### PR TITLE
Update soundcleod to 1.1.6

### DIFF
--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -1,11 +1,11 @@
 cask 'soundcleod' do
-  version '1.1.0'
-  sha256 '8647937bfdf807808612760f87df4cc66e64b3a2d861262b733889c4b504f737'
+  version '1.1.6'
+  sha256 'd097815eff0086dc92d48df043c78f573f7342dbc30e9cad45950f13bd847f7b'
 
   # github.com/salomvary/soundcleod was verified as official when first introduced to the cask
-  url "https://github.com/salomvary/soundcleod/releases/download/v#{version}/SoundCleod.dmg"
+  url "https://github.com/salomvary/soundcleod/releases/download/v#{version}/SoundCleod-#{version}.dmg"
   appcast 'https://github.com/salomvary/soundcleod/releases.atom',
-          checkpoint: '9fe007c0098bc5b7a0e9368209352e08089c848b7faaa02aab7b37654a00e389'
+          checkpoint: 'b8643e7b220e552615c71a136af27f373b7301144b5ddd19cc9d071e5cb17cd0'
   name 'SoundCleod'
   homepage 'https://soundcleod.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.