### PR TITLE
Update security-growler to 2.3

### DIFF
--- a/Casks/security-growler.rb
+++ b/Casks/security-growler.rb
@@ -1,10 +1,10 @@
 cask 'security-growler' do
-  version '2.2'
-  sha256 '6e0a7a36745e1003177db4d419ec4502fb4a1ccbbf6766ba7ea8a69cad863593'
+  version '2.3'
+  sha256 'ef00c7effca5fb1001498c3490190f9c923bbefa2a0dd2c21df15374bd23c962'
 
   url "https://github.com/pirate/security-growler/releases/download/v#{version}/Security.Growler.app.zip"
   appcast 'https://github.com/pirate/security-growler/releases.atom',
-          checkpoint: 'f871b12f5e054e01460055a896e6fce7117c2c647b5cfef8acd7a1ae39ec25be'
+          checkpoint: '8e66d2ad02cdecc2728c20c7cf6352614d7b3b5de218a3adc4e496728b72f396'
   name 'Security Growler'
   homepage 'https://github.com/pirate/security-growler'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.