### PR TITLE
Fix torguard.rb for new install method

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -9,5 +9,13 @@ cask 'torguard' do
   name 'TorGuard'
   homepage 'https://torguard.net/'
 
-  app 'TorGuard.app'
+  pkg 'Install TorGuard.pkg'
+
+  uninstall pkgutil: 'net.torguard.TorGuardDesktopQt',
+            delete:  '/Applications/TorGuard.app'
+
+  zap delete: [
+                '~/Library/Preferences/net.torguard.TorGuard*.plist',
+                '~/Library/Saved Application State/net.torguard.TorGuardDesktopQt.savedState',
+              ]
 end


### PR DESCRIPTION
Unfortunately when updating to 0.3.56 I missed that the packages has been moved to pkg instead of app and found it when I installed. Updating for pkg installs in future and fixing removals.

I haven't included the version number in the commit, assuming that this will be the install method for all future versions.

Also worth noting that the package uninstall works fine, but leaves an empty /Applications/TorGuard.app folder, thus the delete.

--- 

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
