### PR TITLE
oryoki 0.0.5

### DIFF
--- a/Casks/oryoki.rb
+++ b/Casks/oryoki.rb
@@ -1,11 +1,11 @@
 cask 'oryoki' do
-  version '0.0.4'
-  sha256 '9936a9518e550297aec7add335cb56446b9eb447b5ae3bf9bf8da7492a42bd58'
+  version '0.0.5'
+  sha256 '320d6b57a0533f5167ad6b0574c9661e205a470e47224db2d28976f1d53a8814'
 
   # github.com/thmsbfft/oryoki was verified as official when first introduced to the cask
   url "https://github.com/thmsbfft/oryoki/releases/download/#{version}/Oryoki-#{version}.zip"
   appcast 'https://github.com/thmsbfft/oryoki/releases.atom',
-          checkpoint: '9e55a53a7930644516bb896ae8ea7be624586ebc08c8cb17d127ae3596a17107'
+          checkpoint: '03fb80bcfe6d5be99193c804add5dd4ecfb5383d6a35c3bae2dec8a5d3e6acd2'
   name 'Oryoki'
   homepage 'http://oryoki.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.