### PR TITLE
Fix git-it.rb app path

### DIFF
--- a/Casks/git-it.rb
+++ b/Casks/git-it.rb
@@ -8,7 +8,7 @@ cask 'git-it' do
   name 'Git-it'
   homepage 'https://github.com/jlord/git-it-electron'
 
-  app 'Git-it-Mac-x64/Git-it.app'
+  app 'Git-it-darwin-x64/Git-it.app'
 
   zap delete: [
                 '~/Library/Application Support/Git-it',


### PR DESCRIPTION
Another miss on my part while doing a bunch of updates which came up in later testing. The app path inside the zip had changed. I'm not including a version in the commit message, as I'm assuming it will stay this way going forward.

Will definitely be changing my update workflow after having two misses today.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.