### PR TITLE
Add appcast url to plex-media-server.rb

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -3,6 +3,8 @@ cask 'plex-media-server' do
   sha256 '57f974ecf5186fedb9eeda3fb90b8e77659f6ef3cc0ee6da36c7ac7f99006ecf'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
+  appcast 'https://plex.tv/api/downloads/1.json',
+          checkpoint: 'd4f90ab6e1e17a7ccd3394d3b7f76363214e4eefbf9f02ee5e2401b5896f176b'
   name 'Plex Media Server'
   homepage 'https://www.plex.tv/'
 


### PR DESCRIPTION
Adding appcast url to plex-media-server, which list the available **free** version as opposed to the **plex pass member** version. I have seen this particular cask updated a few times with the non-free version (which cannot be used without membership), so hoping that this appcast will prevent that, as well as allow later automated updates.

If there is a call for it, I'll create another cask for the plex pass member version, but it's unclear that this is wanted.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
