### PR TITLE
Add libreoffice-language-pack 5.2.3

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -557,7 +557,7 @@ cask 'libreoffice-language-pack' do
   stage_only true
 
   preflight do
-    system '/usr/bin/tar', '-C', '/Applications/LibreOffice.app/', '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"
-    system '/usr/bin/touch', '/Applications/LibreOffice.app/Contents/Resources/extensions'
+    system_command '/usr/bin/tar', args: ['-C', '/Applications/LibreOffice.app/', '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
+    system_command '/usr/bin/touch', args: ['/Applications/LibreOffice.app/Contents/Resources/extensions']
   end
 end

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -557,8 +557,8 @@ cask 'libreoffice-language-pack' do
   stage_only true
 
   preflight do
-    system_command '/usr/bin/tar', args: ['-C', '/Applications/LibreOffice.app/', '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
-    system_command '/usr/bin/touch', args: ['/Applications/LibreOffice.app/Contents/Resources/extensions']
+    system_command '/usr/bin/tar', args: ['-C', "#{appdir}/LibreOffice.app/", '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
+    system_command '/usr/bin/touch', args: ["#{appdir}/LibreOffice.app/Contents/Resources/extensions"]
   end
 
   caveats do

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -560,4 +560,10 @@ cask 'libreoffice-language-pack' do
     system_command '/usr/bin/tar', args: ['-C', '/Applications/LibreOffice.app/', '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
     system_command '/usr/bin/touch', args: ['/Applications/LibreOffice.app/Contents/Resources/extensions']
   end
+
+  caveats do
+    <<-EOS.undent
+      #{token} assumes LibreOffice is installed in #{appdir}. If it is not, you’ll need to run #{staged_path}/LibreOffice Language Pack.app manually.
+    EOS
+  end
 end

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,0 +1,563 @@
+cask 'libreoffice-language-pack' do
+  version '5.2.3'
+
+  language 'af' do
+    sha256 'd5009312d432832bc90c2564b1491c112b476330a45b3acd8699f1c6a8f3e1b6'
+    'af'
+  end
+
+  language 'am' do
+    sha256 'ff3431ebd29d2dbe8bbe39aeb6f6006041eeb7bf72d71eaac12b6186d99eee19'
+    'am'
+  end
+
+  language 'ar' do
+    sha256 '35070e52f6cae28a0e8e3911a24e3002d1af94b218e4d7dc9d616b2615d4031d'
+    'ar'
+  end
+
+  language 'as' do
+    sha256 'b4cf937e225722f4f72f1e87465400a17e1032c56bca1c738d8f53ffda9b66b7'
+    'as'
+  end
+
+  language 'ast' do
+    sha256 '77f2b61a0b6527410060d3301eef0bd4c77073aa6469bcaac6f0da31317fdd20'
+    'ast'
+  end
+
+  language 'be' do
+    sha256 '98465e1720f0f175f09eb9e0c5e9261ecf2ca93ba36683f852a510d5c4ef0094'
+    'be'
+  end
+
+  language 'bg' do
+    sha256 'c21539441f2c20d1d4ac2872bc8db8e9e4230b6d0c74d125bbcc74130d7c094f'
+    'bg'
+  end
+
+  language 'bn-IN' do
+    sha256 'e5536a6765668fa64831c2317e673c9dfb3a6ca676fe0a2288b3095c37f66699'
+    'bn-IN'
+  end
+
+  language 'bn' do
+    sha256 '4aea516aeb8241e3cde93b41e92319c39e6bea56342087c56c26850d6047f28c'
+    'bn'
+  end
+
+  language 'bo' do
+    sha256 '5f9b89303502d5c6dd16e632a47da525d5a6951b4732e0e4e7a6f7b83056d479'
+    'bo'
+  end
+
+  language 'br' do
+    sha256 '9ca5043328dfdab26a73a997718081271c1604643d5122d3c9dc820f6faa7f54'
+    'br'
+  end
+
+  language 'brx' do
+    sha256 '2f31173e18b12bc2e35ede6406cb6cb5d2f0ed6ff97f8b4f2f902d80e57f04b6'
+    'brx'
+  end
+
+  language 'bs' do
+    sha256 '2904d69b1b9349bfc306679349382b551bc9d77c924156c87c87a5c86e8277b8'
+    'bs'
+  end
+
+  language 'ca' do
+    sha256 'cf5cefe1318bb50c056703bb72eae9c9361c026b602dbc85a7060c1ef851e1f9'
+    'ca'
+  end
+
+  language 'cs' do
+    sha256 '288c419e633968eacff11594bcfb14f6bfa952584d994c4767dedf739f94e852'
+    'cs'
+  end
+
+  language 'cy' do
+    sha256 'c81557baf678f12eef6af6e9f99c89986ec79e61dba88ea254799d20bff911cd'
+    'cy'
+  end
+
+  language 'da' do
+    sha256 '71282a8a39e67003d9081c6c0fc3030fe7c84a384f1d8b59ee8fb8e18d25c27e'
+    'da'
+  end
+
+  language 'de' do
+    sha256 'cb7fe65c8532285e86633b138cc6da185f972da5c454ede793f186e17ffc9d48'
+    'de'
+  end
+
+  language 'dgo' do
+    sha256 'd647e194877b9963416d66094195bec7fbfc838a97cd9ea5917d4148b1aae00d'
+    'dgo'
+  end
+
+  language 'dz' do
+    sha256 '447ca2760b3aa30f48c4247509f2566c6ad38525ff422d50823dc804b978a5a0'
+    'dz'
+  end
+
+  language 'el' do
+    sha256 '225c28228cab01b34abded9bafcb4fca6d44cc7c5124ea7946b0ebaacaff319a'
+    'el'
+  end
+
+  language 'en-GB', default: true do
+    sha256 '82df20bdfc602a92019d8a404a2ab8980f751304bd19331d2e71f7b2c5284ff6'
+    'en-GB'
+  end
+
+  language 'en-ZA' do
+    sha256 'cdf3ab4de10b746e77b891816cafc2beaa6508d514f57ddeb9fa55ed725aa8c8'
+    'en-ZA'
+  end
+
+  language 'eo' do
+    sha256 'c17194be7bfb3356feb99b6e4571adc7b048e7cae3c47fb87673120e641c9c08'
+    'eo'
+  end
+
+  language 'es' do
+    sha256 'c377f416b57b97df2b7837e65887898cce37d07afb1c84fc9bf7e41ab30cf1f2'
+    'es'
+  end
+
+  language 'et' do
+    sha256 'a3012646b646af345a2867a98813755b661faf15a8060f43e0e3a06b9ccc0d82'
+    'et'
+  end
+
+  language 'eu' do
+    sha256 '49afdcb9c74d04d1688e7e72c88ad362b8a53ddab1582c89ecc3aeea1c465bae'
+    'eu'
+  end
+
+  language 'fa' do
+    sha256 'd5c7193678cef77b8919143d04bfefa02121fc816f6bdb4258b350070f129019'
+    'fa'
+  end
+
+  language 'fi' do
+    sha256 '3cc89a7eb0cbf2687e363f5e8494aae81043822a4cb740ab8307bebce28c2464'
+    'fi'
+  end
+
+  language 'fr' do
+    sha256 'd841458189b90ae5f3e208620707833b4def2e9d8c2be71ae395ec25bec1908c'
+    'fr'
+  end
+
+  language 'ga' do
+    sha256 'f7aa663be019e40a0bdc9ae356ca63b43d590be39b47edf1496542c185209c24'
+    'ga'
+  end
+
+  language 'gd' do
+    sha256 '52b31554f81384f0ccac76e77b884e48a9e6c32f09e06620e62745a3238dedb7'
+    'gd'
+  end
+
+  language 'gl' do
+    sha256 '743afa8db12737b556a48b330afba83878c20f5daf354c2794bfd90f08781cfd'
+    'gl'
+  end
+
+  language 'gu' do
+    sha256 '7e0e878248d7a396da93f3d814d6467724b42358c402d6b185bce690b557ce4d'
+    'gu'
+  end
+
+  language 'gug' do
+    sha256 '92e445a64e9c767c4369d201c2f68964a60b232c0814c415a6eac1b02240b7bb'
+    'gug'
+  end
+
+  language 'he' do
+    sha256 '15d9cd689454cd27a0dcf21ef6cd9f4e4151d5bc6e8f67fa19f5e156fcc3bfe6'
+    'he'
+  end
+
+  language 'hi' do
+    sha256 '39a25396f0314e20366d340b784a6672fbe183f8a54faac03eab60538383e1ba'
+    'hi'
+  end
+
+  language 'hr' do
+    sha256 'a89415a7f93ed8ce7ea9e1dfab6d562805838b817a1d0229a114258f8b3203db'
+    'hr'
+  end
+
+  language 'hu' do
+    sha256 '542b45a5f188c650e4c98a5e9424cf920d22a025cb9873dd7b71b29810efefa8'
+    'hu'
+  end
+
+  language 'id' do
+    sha256 '450e9ebff9a22e886c8aeb5c37727c1dfe90cb9668f5de7c7247d72c233c6076'
+    'id'
+  end
+
+  language 'is' do
+    sha256 '0fd35404f256b73ddbc8a3a59536971df9b256fa959ee476ce936e1e5cb15e92'
+    'is'
+  end
+
+  language 'it' do
+    sha256 'bc46c7917eabea915769f091a271b738a7d6659ea88b043137b31f67df122dd7'
+    'it'
+  end
+
+  language 'ja' do
+    sha256 'fc9bcbd84e46322dfc503efebd76785ac774e86ca3ec078151c2671637d76fdf'
+    'ja'
+  end
+
+  language 'ka' do
+    sha256 '0651e9b7a6e05869ebef1b78c20189721bdd48414f8bd38088dae8b6c19ff414'
+    'ka'
+  end
+
+  language 'kk' do
+    sha256 '6b5cd715ca325a7d35e91c0d50dd647c5a4b8cfd3c40465702e3bf086ac63c14'
+    'kk'
+  end
+
+  language 'km' do
+    sha256 'ef089970324ca25e2e5f7de63cf267d554d580b13bb39fb706cfa076cee7465b'
+    'km'
+  end
+
+  language 'kmr-Latn' do
+    sha256 '8ff30d162f859efe8da91c24ee9e6babfb8b909591a07b8b30fd0f2b172046bd'
+    'kmr-Latn'
+  end
+
+  language 'kn' do
+    sha256 '2802d4e0be0b675dd8605d2492ce9faca1044b4309f264bb98fe6ee4b1062d28'
+    'kn'
+  end
+
+  language 'ko' do
+    sha256 'ef1589600ffb46635316d69076d87e9d87f7085ac9ec3a78c43886d3c516b333'
+    'ko'
+  end
+
+  language 'kok' do
+    sha256 'fe80158e0abf52a39d7e88cdcb70abdead066ac455a12d8fc334071e1aa583c6'
+    'kok'
+  end
+
+  language 'ks' do
+    sha256 'ba653831d1d7a459b1cb4c5d79e0ecfd82dc010243a8907371a8550224a3a711'
+    'ks'
+  end
+
+  language 'lb' do
+    sha256 'd390a2a699c39c1262833940151b3e5003cf68916c2c22eacbb5a145d56d522e'
+    'lb'
+  end
+
+  language 'lo' do
+    sha256 '36564c618508a96d79fcf65ffaf22d8e739c8d32066cfaa334bc937cb4247f24'
+    'lo'
+  end
+
+  language 'lt' do
+    sha256 '555dbf57e97e138277b95696f80ee1e5318945961d802ac16f931f0398ddf4df'
+    'lt'
+  end
+
+  language 'lv' do
+    sha256 '70a7f2969c636364c4d1757c1da4f9f08938e0f8f303886c17d9abcdefd2d09a'
+    'lv'
+  end
+
+  language 'mai' do
+    sha256 '788dabe556015533c7d3eb52b19dc6c30f0ec228e0403020d4f986b2393db888'
+    'mai'
+  end
+
+  language 'mk' do
+    sha256 '851eac7769dcee0ef363dcae6c66c5218db676af2d774be71dcd0a64a462b9d6'
+    'mk'
+  end
+
+  language 'ml' do
+    sha256 '32c874e661e00e38392aae5dff16c6bf92d7f0a069db5e88d1e32001402635c0'
+    'ml'
+  end
+
+  language 'mn' do
+    sha256 '163a4db92bef94030b10ba5765c3a14fd9ace2123a9667893d006ad6e252a168'
+    'mn'
+  end
+
+  language 'mni' do
+    sha256 '049a73176f1f426a5c3aef439ac87c1051f8ff1848c5eeae4bde53e86870b5a7'
+    'mni'
+  end
+
+  language 'mr' do
+    sha256 'f6a15fa36086fb875f100d77cd32d06886ca762807f0285b6550970b6513b853'
+    'mr'
+  end
+
+  language 'my' do
+    sha256 '79bc7cf596b8e63521f72a94b5e06a6d88f8787e2249166c582635ca41239e64'
+    'my'
+  end
+
+  language 'nb' do
+    sha256 '8c1a63da3d911645683b9b2bcca24b34c5bccd37f82db572c565a6edbfe040f7'
+    'nb'
+  end
+
+  language 'ne' do
+    sha256 '60d2ad5a0183202a6afba4082fd1f18680a97fd023ac75fd34e5557aea58aa28'
+    'ne'
+  end
+
+  language 'nl' do
+    sha256 '3ef1a0c0ceb49a27c584dc5bfd5b384ac5397d2740e277d2e7e2b60c6e5dfc11'
+    'nl'
+  end
+
+  language 'nn' do
+    sha256 '0e6931c16538fdac46d295920904c4eb3bda8d761c8dd6bafbed6c9cafd9ea20'
+    'nn'
+  end
+
+  language 'nr' do
+    sha256 '09f7cb67a721938fd4c796b9745c33798c9659b650375ae92002a663d655a383'
+    'nr'
+  end
+
+  language 'nso' do
+    sha256 'f7622330a186076f65341381ac949b40841c96c72dbe88e6c95ef52463a3ab10'
+    'nso'
+  end
+
+  language 'oc' do
+    sha256 '7014d22eebcb9ec965a36516c2c0e2f4ff14c6cc859201b3ced7723daa19b135'
+    'oc'
+  end
+
+  language 'om' do
+    sha256 '56cb3e16178ef7ae6a49489eaa40a82c0c38820ea4ac705e258022dfa83554f8'
+    'om'
+  end
+
+  language 'or' do
+    sha256 '1e39fb17ce192006b66e15617188d31e4caf70814668e2e55eb39efaed6ee42c'
+    'or'
+  end
+
+  language 'pa-IN' do
+    sha256 '17517e12fa28e5f8ac9dfe00e3b86598225e06cd37e40ad61aaccf3fd94a0cc7'
+    'pa-IN'
+  end
+
+  language 'pl' do
+    sha256 '5b4c0e784facd5b2fe89677d719ac6de1aff44e89bc4f5fdc9eafd12fcf502c9'
+    'pl'
+  end
+
+  language 'pt-BR' do
+    sha256 '5075453c8cf3c27fbd36517fb2a26cf6ab8961d8f52316baa59a99cd1266d1ee'
+    'pt-BR'
+  end
+
+  language 'pt' do
+    sha256 '8a56305b4629af4694ab4181bfbedc07dbe72f33a88d1a286da4154278d1efb9'
+    'pt'
+  end
+
+  language 'ro' do
+    sha256 '0ee78fbc6ae00c84572d4f5b9d76e5d50fcfd1efaa792f10588171cccfeea0d7'
+    'ro'
+  end
+
+  language 'ru' do
+    sha256 '7e64b57acef1f801f7f292bf186d4638cedaf30f3b3641e8e558db33dd961a5e'
+    'ru'
+  end
+
+  language 'rw' do
+    sha256 '0c52879c16f358332b59becbb12f24f6d6fff7f45d03040264211690b8246053'
+    'rw'
+  end
+
+  language 'sa-IN' do
+    sha256 '0d751199a7b8d94bd5b1242043ea1ee7aebe17499fb68b4ce90872e9ce7b065e'
+    'sa-IN'
+  end
+
+  language 'sat' do
+    sha256 'e3153fad150a535e8863fd2ac5f85f2f30183065e1b24046c1a340b50931cde0'
+    'sat'
+  end
+
+  language 'sd' do
+    sha256 '3921b8210c3a623a908ad0e7157c9757f37467259c41fcdebaf58ab155222c27'
+    'sd'
+  end
+
+  language 'si' do
+    sha256 'a338dcbbf0fd5e468c84294ea89cbcf6c6ca27970df7daafffd64ba724359bfd'
+    'si'
+  end
+
+  language 'sid' do
+    sha256 'e8dc323cc34900ad8eff1889653411804fd5414eaf5e3131237c893ead213616'
+    'sid'
+  end
+
+  language 'sk' do
+    sha256 'f3185d509604bbde6a8f3e74c2239196c6eb485d1867bbd6fc9b65839bd2acb2'
+    'sk'
+  end
+
+  language 'sl' do
+    sha256 '528976a9f58cc727105c37aaa2d93aaad6e55b58833f16fd740dd9de4b7cf17b'
+    'sl'
+  end
+
+  language 'sq' do
+    sha256 '94c7c9de3ef6e988fdb5e23dbc6fdbeaf8c2b228fc6d598f2c08eebb38c3939a'
+    'sq'
+  end
+
+  language 'sr-Latn' do
+    sha256 '53d2b55c199b881e6346b45c538f5aa33479115e1c367cf071c62a6c8027511f'
+    'sr-Latn'
+  end
+
+  language 'sr' do
+    sha256 '4c1f7c337f5dc3fc223e81913582b4c85f682ca2de0166111ae263442b85d74b'
+    'sr'
+  end
+
+  language 'ss' do
+    sha256 '9ba622bc73df8ba41eb8e9a52396ab5f8fddc7d283845976eb18bfd840b29cd4'
+    'ss'
+  end
+
+  language 'st' do
+    sha256 'c7c49c0a552b2ee317800a6c5b4af4200a3cd6eb6fe9013ea99012c027b51fab'
+    'st'
+  end
+
+  language 'sv' do
+    sha256 'e34257318a33925d2300ad56df1e9dae4810417cac0118ce13c9634226216802'
+    'sv'
+  end
+
+  language 'sw-TZ' do
+    sha256 '04b8f433b24ec8b972428b43791d9ec00b44b25cdf1e7f40b7cf8aa31d2c9d15'
+    'sw-TZ'
+  end
+
+  language 'ta' do
+    sha256 '0dacd4a85aebfd63906ff7c4b39a0f4216637d32272e8f0be3f3bf172889dd23'
+    'ta'
+  end
+
+  language 'te' do
+    sha256 'c071feec32f8e75f4a471c63fa129cedb96960447d4c8e9463b1f10dadf83565'
+    'te'
+  end
+
+  language 'tg' do
+    sha256 '0640dc9d140b6579f69d7e0b7eae57fa0fbf43e77687e40733f5a69a4e04c28a'
+    'tg'
+  end
+
+  language 'th' do
+    sha256 'd7fe5f86765cb8a9273dedab39786f8faaa13fc330a37b0e42f95be4e33c3902'
+    'th'
+  end
+
+  language 'tn' do
+    sha256 '174563fa03cc5eae3d3e59c471d1e7c4602c0b166b2020b2ad2563319414d922'
+    'tn'
+  end
+
+  language 'tr' do
+    sha256 'b708810df7cb5381cf5ad017c4b2622124c02b4a32d4a7414a543a1b9fd1053f'
+    'tr'
+  end
+
+  language 'ts' do
+    sha256 '3f96277fb114b51a1eeb21b988d497a324f546cd9640bb055d2c2d5c6f1ea6e7'
+    'ts'
+  end
+
+  language 'tt' do
+    sha256 'd2651f3743548577cbc51dfeeb7b14be943df5eb9d94d9a340913de8008a62e7'
+    'tt'
+  end
+
+  language 'ug' do
+    sha256 '7837d6b623b87d49cf3a26c101ddbeb2ad4773ebad0c20524a61de115c88202c'
+    'ug'
+  end
+
+  language 'uk' do
+    sha256 '043cce4d8939106983dd61e56093eae2dd945e12d9cce991eb194a4066a0ef57'
+    'uk'
+  end
+
+  language 'uz' do
+    sha256 'f18b1112d37ab1740bcca49178a79e26d4faff4d5285d724d7c1b0c338347a79'
+    'uz'
+  end
+
+  language 've' do
+    sha256 'c525562b6b8169bc95e4b75f9cd72536a6e53815b3e6a936c23759432e7d6138'
+    've'
+  end
+
+  language 'vi' do
+    sha256 'c61014a9a5a5a7973d87654b11194a19b809745ad59e80833aa70841b61fcd29'
+    'vi'
+  end
+
+  language 'xh' do
+    sha256 '8c29a6ed054de06707b01bb2627a964380bc62fa29649a580c0f547498294895'
+    'xh'
+  end
+
+  language 'zh-CN' do
+    sha256 'dccb82fbbf17fb409dda0e9b1cd9b4e70862441c87fcb6e97ed6c22f0f7d8669'
+    'zh-CN'
+  end
+
+  language 'zh-TW' do
+    sha256 '69d078a007ba8a22ced33b66e84371ed6ea6773729b3d1b77709679d5e347832'
+    'zh-TW'
+  end
+
+  language 'zu' do
+    sha256 'cf898f1de9a4b66fc06049a4ccc1ec620debeea747fd4e2b80e4d380c1941604'
+    'zu'
+  end
+
+  # documentfoundation.org was verified as official when first introduced to the cask
+  url "http://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64_langpack_#{language}.dmg"
+  name 'LibreOffice Language Pack'
+  homepage 'https://www.libreoffice.org/'
+  gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
+
+  depends_on cask: 'libreoffice'
+
+  stage_only true
+
+  preflight do
+    system '/usr/bin/tar', '-C', '/Applications/LibreOffice.app/', '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"
+    system '/usr/bin/touch', '/Applications/LibreOffice.app/Contents/Resources/extensions'
+  end
+end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [X] Checked that the cask was not already refused in [closed issues].

Closes [#27193](https://github.com/caskroom/homebrew-cask/pull/27193).

@vitorgalvao I have removed the `sudo` requirement from the `preflight` block and successfully tested the Cask.

Please note that in the `preflight` block you have to use `/Applications` - I don't think you can use `#{appdir}` as it needs the `#{appdir}` of LibreOffice itself. I am not sure if there is an alternate way?

If there is not, I could add a `caveat` like so:
```
caveats do
 Requires LibreOffice.app to be installed in /Applications.
end
```