### PR TITLE
Update neteasemusic to 1.5.0_520

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask 'neteasemusic' do
-  version '1.4.5_488'
-  sha256 '76146aaa091428ae79429b820b843fcce9163335e1ba40833e10e8d0a5d580ce'
+  version '1.5.0_520'
+  sha256 'a8a15afc900a1f42c746ce87f46cde3c4724e6983fc7182fb2b344e0b7537814'
 
   # s1.music.126.net was verified as official when first introduced to the cask
   url "http://s1.music.126.net/download/osx/NeteaseMusic_#{version}_web.dmg"
@@ -15,6 +15,7 @@ cask 'neteasemusic' do
   zap delete: [
                 '~/Library/Caches/com.netease.163music',
                 '~/Library/Containers/com.netease.163music',
+                '~/Library/Cookies/com.netease.163music.binarycookies',
                 '~/Library/Preferences/com.netease.163music.plist',
                 '~/Library/Saved Application State/com.netease.163music.savedState',
               ]


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update neteasemusic to 1.5.0_520