### PR TITLE
Update beyond-compare.rb for appcast

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -3,6 +3,8 @@ cask 'beyond-compare' do
   sha256 '1576d3c7d07e2dac7a569e7e65631f0f706ec41f5e200ea2beaf977f45d3eccd'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
+  appcast "http://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx",
+          checkpoint: '491f6cbf38ca59aed9ceae04d0ffcbf93a460a8c342ee682ca92c277e6a144a9'
   name 'Beyond Compare'
   homepage 'http://www.scootersoftware.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update beyond-compare.rb for appcast