### PR TITLE
Update citrix-receiver to 12.4.0

### DIFF
--- a/Casks/citrix-receiver.rb
+++ b/Casks/citrix-receiver.rb
@@ -1,6 +1,6 @@
 cask 'citrix-receiver' do
-  version '12.3.0'
-  sha256 'cd06f5fcb6c20f807318cf9b3eada887ac9e5e59e766f1310ad25b28caea3573'
+  version '12.4.0'
+  sha256 '9de4a268795bfcc1ccfcea5c41357ae518fad0bae8749bb0c96d5ff36df5f3fa'
 
   # downloadplugins.citrix.com.edgesuite.net was verified as official when first introduced to the cask
   url 'http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixReceiverWeb.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

Released Nov 6, 2016. Release notes at http://docs.citrix.com/en-us/receiver/mac/12-4.html.