### PR TITLE
Update xerox-print-driver to 3.90.0_1788

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -15,8 +15,8 @@ cask 'xerox-print-driver' do
     sha256 'ed958701b6adca202f0b7936cfea0fac64c2161e228f35e00f341e29df36c18f'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx107/pt_BR/XeroxPrintDriver.#{version}.dmg"
   else
-    version '3.68.0_1623'
-    sha256 'da6a24cc2bf47e9c6d3a4549447c8e1f9701f120db6cbf5c7970d26de2423187'
+    version '3.90.0_1788'
+    sha256 'a630516d8b4a9d99fdfd4f4384bb8be3c7d3ef0a8bf19d71c253582ca293d587'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1010/ar/XeroxPrintDriver.#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.