### PR TITLE
Update xerox-print-driver to 3.90.0_1788

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -20,7 +20,7 @@ cask 'xerox-print-driver' do
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1010/ar/XeroxPrintDriver.#{version}.dmg"
   end
 
-  pkg "Xerox Print Driver #{version.sub(%r{_.*}, '')}.pkg"
+  pkg "Xerox Print Driver #{version.major_minor_patch}.pkg"
 
   uninstall pkgutil: [
                        'com.xerox.installer.addprintqueue',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.