### PR TITLE
basictex.rb: delete correct directories

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -1,17 +1,17 @@
 cask 'basictex' do
-  version '20161009'
+  version '2016.1009'
   sha256 '17f27a9c05f108b889b39d8ea2ff6236c1265f244e8e0376e9d14af4acf680bd'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
-  url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version}.pkg"
+  url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg"
   name 'BasicTeX'
   homepage 'https://www.tug.org/mactex/morepackages.html'
 
-  pkg "mactex-basictex-#{version}.pkg"
+  pkg "mactex-basictex-#{version.no_dots}.pkg"
 
-  uninstall pkgutil: 'org.tug.mactex.basictex2016',
+  uninstall pkgutil: "org.tug.mactex.basictex#{version.major}",
             delete:  [
-                       '/usr/local/texlive/2016',
+                       "/usr/local/texlive/#{version.major}basic",
                        '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
                        '/etc/paths.d/TeX',
                        '/etc/manpaths.d/TeX',
@@ -19,7 +19,7 @@ cask 'basictex' do
 
   zap delete: [
                 '/usr/local/texlive/texmf-local',
-                '~/Library/texlive/2016',
+                "~/Library/texlive/#{version.major}basic",
               ],
       rmdir:  [
                 '/usr/local/texlive',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

---

Also took the chance for some extra interpolation.