### PR TITLE
Update neofinder to 7

### DIFF
--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,11 +1,11 @@
 cask 'neofinder' do
-  version '6.9.3'
-  sha256 '50f7148261298413a3249d6f1eb4d677346fd1ab2252301927b043e2ef875e1e'
+  version '7'
+  sha256 'b4a8b1f85216a7db62a72aa82cb53a127ea84953cae8f0f5d104d88033765417'
 
   # wfs-apps.de was verified as official when first introduced to the cask
   url "https://www.wfs-apps.de/updates/neofinder.#{version}.zip"
   appcast 'https://www.wfs-apps.de/updates/neofinder-appcast-64.xml',
-          checkpoint: 'dc7200a0207418ba7148ae3cff37fa3decd70bd911ce2f95c30cfd53ce484cdf'
+          checkpoint: 'd4b196c718780be1f55fa8d2544d68ed47e19b03c0f4496c7338b81a9a5cc2b7'
   name 'NeoFinder'
   homepage 'https://www.cdfinder.de/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.