### PR TITLE
Update scap-workbench to 1.1.2

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,11 +1,11 @@
 cask 'scap-workbench' do
-  version '1.1.1'
-  sha256 '2d9cfea5e64e7585569bedb201ef9f76e376e24eeb16ce200f9f78cb7fa7a18e'
+  version '1.1.2'
+  sha256 '8b3a5faf1fadacba9d789a782d3c74fdd79e7cb2f0d0c9dbbbda75a66a89294f'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
   url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version}/scap-workbench-#{version}.dmg"
   appcast 'https://github.com/OpenSCAP/scap-workbench/releases.atom',
-          checkpoint: '7beb99e46af9aae7effb84245193d14564101f897ffbfce6bcf7250ade22bb70'
+          checkpoint: 'ab89a9ccba6ec34333295ced1186bdc091e16e35543eedb7473cae1e3d6de772'
   name 'scap-workbench'
   homepage 'https://www.open-scap.org/tools/scap-workbench/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.