### PR TITLE
Update electron to 1.4.11

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.10'
-  sha256 'aeded1f57e2e23322e2cc8dddcdf4f80aca0607cbbffa16fe91f0d98170592b0'
+  version '1.4.11'
+  sha256 'bfd71f84e2fb2cda7cdaba868d06c34e608216ebb4a971bd973483e64baa5d80'
 
-  # github.com/atom/electron was verified as official when first introduced to the cask
-  url "https://github.com/atom/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
-  appcast 'https://github.com/atom/electron/releases.atom',
-          checkpoint: '59910136d4749469d17b6608c833b21d72c780ac414735fe717751758c34a561'
+  # github.com/electron/electron was verified as official when first introduced to the cask
+  url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
+  appcast 'https://github.com/electron/electron/releases.atom',
+          checkpoint: '6951b7662cb614db9b442c81235a3e05e57160bee884bc3ba039763e562e6d28'
   name 'Electron'
   homepage 'http://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.