### PR TITLE
Update googleappengine to 1.9.49

### DIFF
--- a/Casks/googleappengine.rb
+++ b/Casks/googleappengine.rb
@@ -1,11 +1,11 @@
 cask 'googleappengine' do
-  version '1.9.40'
-  sha256 '24705f40ad689e6bf91c269489ef3aebfc0f41fe6de17b41cb66191591db3fac'
+  version '1.9.49'
+  sha256 '2186549547beadd7db2b6d4d5abd9ef56f087972707d9c0612e7198c4e8ca189'
 
   # storage.googleapis.com/appengine-sdks was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/appengine-sdks/featured/GoogleAppEngineLauncher-#{version}.dmg"
   appcast 'https://storage.googleapis.com/appengine-sdks',
-          checkpoint: '7918888a5ed9a499f939d5f9e2f433f768f12959dae32d0a1e174a4592b2876a'
+          checkpoint: '1bb10259a94fd2324be01d0d74dcdcf8ac523d32b014d3e0bec33cdb22d61bd1'
   name 'Google App Engine'
   homepage 'https://cloud.google.com/appengine/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.