### PR TITLE
Update hyne to 1.9.2c

### DIFF
--- a/Casks/hyne.rb
+++ b/Casks/hyne.rb
@@ -1,14 +1,14 @@
 cask 'hyne' do
-  version '1.9.1'
-  sha256 'b71f9942a017b396a7f4e858ee1566ee50b0d7c1a9c560eecf723e161b9b0102'
+  version '1.9.2c'
+  sha256 '74ddb3cee06e840849241da41e3fca32e4f20d4918e9786d9bb55b4643a59f95'
 
-  url "https://github.com/myst6re/hyne/releases/download/#{version}/Hyne-#{version}-macos.zip"
+  url "https://github.com/myst6re/hyne/releases/download/#{version}/Hyne-#{version}-osx64.tar.gz"
   appcast 'https://github.com/myst6re/hyne/releases.atom',
-          checkpoint: '66554e3611412debaf31ec9bba874b96b57d635b78a6b1d61c561c4db7e5ca72'
+          checkpoint: 'da938c2c2d76c46d384b6db7eb993d44b46a32cffd0eb99dfb09b958bf2fe5d1'
   name 'Hyne'
   homepage 'https://github.com/myst6re/hyne'
 
-  app 'Hyne.app'
+  app "hyne-#{version}-osx64/Hyne.app"
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.vin047.hyne.sfl',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.