### PR TITLE
Update flightgear to 2016.4.3

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2016.2.1'
-  sha256 '86e0bdbe06a7e9660380060fc3e48f3e2d1ee5cf838af3573805db2560a5c720'
+  version '2016.4.3'
+  sha256 '305fbcf2cdab59a4073c6cff70818c4685c55a20f135b48ee198f22f4bf373e9'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: '924d166598e1d9b00b8ea57fe8c05aceb389f1612ac22f08b68296dada6050ed'
+          checkpoint: 'f710d4fde29157f191348f278c5a192eaf5c91786e020aa3b3cc2fdeaf45e425'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.