### PR TITLE
Update cleartext to 2.45

### DIFF
--- a/Casks/cleartext.rb
+++ b/Casks/cleartext.rb
@@ -1,10 +1,10 @@
 cask 'cleartext' do
-  version '1.4'
-  sha256 '8a6873c20ef4157b31c3d56f96889c146f3b5556144923f1540d31f693a0c4cb'
+  version '2.45'
+  sha256 '4b3d44a0666c2bf2dd838c0f190e9a5678b2dc4d76e83d70fe091295d4cabdbc'
 
-  url "https://github.com/mortenjust/cleartext-mac/releases/download/#{version}/Cleartext#{version}.zip"
+  url "https://github.com/mortenjust/cleartext-mac/releases/download/#{version}/Cleartext.zip"
   appcast 'https://github.com/mortenjust/cleartext-mac/releases.atom',
-          checkpoint: '36cf6a4185c77ad9e0e00df9d4f46fc3851e77d7c95f0a7621818249c06a7f0c'
+          checkpoint: 'a97a4e71395b006d52aca725321b82d63b77aa75d5a4571daba06e9ecda0847c'
   name 'Cleartext'
   homepage 'https://github.com/mortenjust/cleartext-mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.