### PR TITLE
Update endlesssky to 0.9.4

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -1,11 +1,11 @@
 cask 'endlesssky' do
-  version '0.9.2'
-  sha256 '73fd7c1f67318bd4b6f4dce952be16fef275988fd00e21c64efff5c4bf0c3845'
+  version '0.9.4'
+  sha256 '0f05a81aa3db2979328096f50e4d8391380eb8abbe93d42105988ece8359c4ca'
 
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom',
-          checkpoint: '95fdac50548fddf72f5c3f92ab847ed735bb5f82861ed11f9484cc1cc6abaafd'
+          checkpoint: '07b93c262346e01fe748c5af9c1069481bc0f39d6daef8ae66bb9faf660cbd7d'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.