### PR TITLE
Update onionshare to 0.9.1

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,11 +1,11 @@
 cask 'onionshare' do
-  version '0.9'
-  sha256 '9142dcce2aa313e628432408ffcfbd9928ddd5d50b529a7701f4f9e75e6df9a4'
+  version '0.9.1'
+  sha256 '9721b9f60ab777d1b6a470d33108031814d6a0833909dc695e40c7b3d98279d1'
 
   # github.com/micahflee/onionshare was verified as official when first introduced to the cask
   url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom',
-          checkpoint: '388c9b60d7dd35c10ef53856d832055cf3de414387b6977ea782dcf011d67c6c'
+          checkpoint: '5317a163350bbc2c380be9004831eeb12021e8a30a319d6424e3e2776ef0901a'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
   gpg "#{url}.sig",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.