### PR TITLE
Update lazarus to 1.6.2

### DIFF
--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -1,11 +1,11 @@
 cask 'lazarus' do
-  version '1.6'
-  sha256 'f939418addf454b6d9835f48f079077b55905ba173f27a1bea4c1fae1467df56'
+  version '1.6.2'
+  sha256 'd0564cd255fb0612d1ed59c9a09f5e3733e43700e1e980caf5fd75a2b2529170'
 
   # sourceforge.net/lazarus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i686-macosx.dmg"
   appcast 'https://sourceforge.net/projects/lazarus/rss',
-          checkpoint: '56d06477a5cbba6f3669f864fc3b1573d9c01739ae04bc39d1145d7a7f84f888'
+          checkpoint: 'e52ea526cfb8b92e3dd7db6eb70eeafd87122259ca5b71a52367a61965201a77'
   name 'Lazarus'
   homepage 'http://www.lazarus-ide.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.