### PR TITLE
Update polymail to 1.19

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.17'
-  sha256 '9a97fa9fbf5f618f848869251aaee1c55c72fead2aad49ffabbc1df35843c3fc'
+  version '1.19'
+  sha256 'd5657afc93c3522c1fde0129605128c981cf78bd4012fc6f9a9181b27f934e7d'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'c192a3e748b427c7309524623cec6997f67dc60b4e228d8f7c61dc9f5b4b729f'
+          checkpoint: '05c514738478f81c83b979afa8c0557a6379ec36dca960070968c570c4013260'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.