### PR TITLE
Update keycue to 8.3

### DIFF
--- a/Casks/keycue.rb
+++ b/Casks/keycue.rb
@@ -1,6 +1,6 @@
 cask 'keycue' do
-  version '8.2'
-  sha256 'd0a455b983ef966b6e1741972cce25745410b0e639f5482c4e4696c9c649844e'
+  version '8.3'
+  sha256 'a261dad0a1f0dde6624d4824a3d7843422d3466ad605ea2fbcf831ecd10d578e'
 
   url "http://www.ergonis.com/downloads/products/keycue/KeyCue#{version.no_dots}-Install.dmg"
   name 'KeyCue'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.