### PR TITLE
Update aseprite to 1.1.10

### DIFF
--- a/Casks/aseprite.rb
+++ b/Casks/aseprite.rb
@@ -1,10 +1,10 @@
 cask 'aseprite' do
-  version '1.1.9'
-  sha256 'e76d7ceeab43625ceabbec7b3a3f81228a6855b68aa7835bea5677c92c38b4f5'
+  version '1.1.10'
+  sha256 'b1e25a66b7c23e0a07010bc1189d245144a631c80108a3c86621a27285c720df'
 
   url "http://www.aseprite.org/downloads/Aseprite-v#{version}-trial-MacOSX.dmg"
   appcast 'https://github.com/aseprite/aseprite/releases.atom',
-          checkpoint: '7e03d1fbeebc1c82311546e9f1a53a98609b30576c452df60eed23cbc9c921e6'
+          checkpoint: '4cf61fa2020f22b5eb6ee6bccd46fc82d5aff8a88963b593dfab5c1565845b57'
   name 'Aseprite'
   homepage 'https://www.aseprite.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.