### PR TITLE
Update camunda-modeler to 1.5.1

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.5.0'
-  sha256 'cbd86a03aa32d2b6cbd0e23e8b99f212ef7c44db5ef73589d9e58552e11e8978'
+  version '1.5.1'
+  sha256 'f6562e511acde034ff96f6bedb527479de8a35882a2fd0d388d471606d2ffc16'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.