### PR TITLE
Fix qgis 2.18.0-1 to depend on the homebrew/python/matplotlib formula

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -7,7 +7,7 @@ cask 'qgis' do
   homepage 'http://www.kyngchaos.com/software/qgis'
 
   depends_on cask: 'gdal-framework'
-  depends_on formula: 'matplotlib'
+  depends_on formula: 'homebrew/python/matplotlib'
 
   pkg '4 Install QGIS.pkg'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.