### PR TITLE
Update manico to 2.2.1

### DIFF
--- a/Casks/manico.rb
+++ b/Casks/manico.rb
@@ -1,10 +1,10 @@
 cask 'manico' do
-  version '2.2'
-  sha256 'b5e82b984d6b6a9146375bb7a64c0d597fcfeccef1cb07956bda64f699adcd8b'
+  version '2.2.1'
+  sha256 'c8e8df0abf077c6ea6be2958d32bb42307500f959bb0c6dd3891b9f74646d6e3'
 
   url "https://manico.im/static/Manico_#{version}.dmg"
   appcast 'https://manico.im/static/manico-official-appcast.xml',
-          checkpoint: '7278b1933bf356865c61422e7702dc0f6b21b85a1e94ba5b7a2deb04f3a6875a'
+          checkpoint: 'bbd976faec21b9bdff9e6b953713dec94674e9b2be2369e191e79d384bc29061'
   name 'Manico'
   homepage 'https://manico.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.