### PR TITLE
Update metabase to 0.21.0.1

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,10 +1,10 @@
 cask 'metabase' do
-  version '0.20.3.0'
-  sha256 '45804c178bdf46e6c60f45c709bc5af8eb978571bf1a28c4b99168f57f91e2e6'
+  version '0.21.0.1'
+  sha256 'bbede1f42e9c7722ca0aa54462de0dade717f662051a11548c8783a5ece4da14'
 
   url "http://downloads.metabase.com/v#{version.major_minor_patch}/Metabase.dmg"
   appcast 'http://downloads.metabase.com/appcast.xml',
-          checkpoint: 'c93852307774349a390d08f5f5d688aa7bbf40c90eaaccc3d91368678e33143a'
+          checkpoint: '4b8896312a1a79f0db75c454e4599332f0ceb54259bc7a3344cc47c0b909ad35'
   name 'Metabase'
   homepage 'http://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.