### PR TITLE
Update splice to 2.2-201611251707

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,11 +1,11 @@
 cask 'splice' do
-  version '2.1.8-201610131641'
-  sha256 '7123768004fce6a259752f47c948e1309e53853391a8e562da7074e588df0dbd'
+  version '2.2-201611251707'
+  sha256 '7f5cf850435c1b3dc75f6a26b8a7752d6f207eb2ff342d3e603b13cf9fd97667'
 
   # amazonaws.com/spliceosx was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/spliceosx/Splice.app-#{version}.zip"
   appcast 'https://splice.com/appcast.xml',
-          checkpoint: '4fb3a1e2c86176252dfc9e7367df425e43bcfb132cdf590a4caaae3597b50949'
+          checkpoint: '267cb11f3ed988195e22bcf2c2a547ab79159256e60823b71fbad593419cfbc4'
   name 'Splice'
   homepage 'https://splice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.