### PR TITLE
Update ipe to 7.2.7

### DIFF
--- a/Casks/ipe.rb
+++ b/Casks/ipe.rb
@@ -1,6 +1,6 @@
 cask 'ipe' do
-  version '7.2.6'
-  sha256 '35e90434d635bb0c085c4447767ad746e61fc276b1f1dbe43a9d671327d5cfa1'
+  version '7.2.7'
+  sha256 '13bd32ecfb77d7c3e073436f4b7e8b8532706a80aeec9575172670dc91908b25'
 
   # bintray.com/otfried was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.