### PR TITLE
Update spamsieve to 2.9.27

### DIFF
--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -10,7 +10,7 @@ cask 'spamsieve' do
 
     url "https://c-command.com/downloads/SpamSieve-#{version}-leopard.dmg"
   else
-    version '2.9.26'
+    version '2.9.27'
     sha256 '95c1c3726ba260c25a8ae9b4482237639aee4e2e5e174c28c3cc287ba619c647'
 
     url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"

--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -11,7 +11,7 @@ cask 'spamsieve' do
     url "https://c-command.com/downloads/SpamSieve-#{version}-leopard.dmg"
   else
     version '2.9.26'
-    sha256 '2b25241dd355ed3d2c868e626fb766587d68ca6cd3704fe9fe6b302ddcac02ff'
+    sha256 '95c1c3726ba260c25a8ae9b4482237639aee4e2e5e174c28c3cc287ba619c647'
 
     url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.