### PR TITLE
Update freeze to 2.8-235

### DIFF
--- a/Casks/freeze.rb
+++ b/Casks/freeze.rb
@@ -1,10 +1,10 @@
 cask 'freeze' do
-  version '2.7-233'
-  sha256 '9d995ff91896d523854879fca756347d329a7be7feb058dc277608f1fea8af42'
+  version '2.8-235'
+  sha256 'a7e0823f2698a3a2547d8a0958458da9de443e38df2079fbde1e6c641c29e289'
 
   url "https://www.freezeapp.net/download/Freeze-#{version}.zip"
   appcast 'https://www.freezeapp.net/appcast.xml',
-          checkpoint: '10dbe8d09826aa2540d2206ab4f3ee2b5ed69f4a115120a125cc1a234bcc5f83'
+          checkpoint: 'cbbe7f0a9ad40f27c60f8fab8806154cefebb18a56e0688e5c74aa7d346f3311'
   name 'Freeze'
   homepage 'https://www.freezeapp.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.