### PR TITLE
Update camed to 3.2.2

### DIFF
--- a/Casks/camed.rb
+++ b/Casks/camed.rb
@@ -1,10 +1,10 @@
 cask 'camed' do
-  version '3.2'
-  sha256 '7956c929a3518102a5364982e1ba978930228169d4d1eedb68c2db62fc4a86f1'
+  version '3.2.2'
+  sha256 '407e101a3a47566395606b03114388f94f48b488d3fa27041aecb937eb43bd12'
 
   url "https://downloads.sourceforge.net/camprocessor/CAMEd-#{version}-macosx-cocoa-x86_64.tar.gz"
   appcast 'https://sourceforge.net/projects/camprocessor/rss',
-          checkpoint: '1ec7ebc109fd8ebeb0e49f53a3339ef217e926b986ba48fe6d1ac76fc0f4787e'
+          checkpoint: '5ab59fb30e50bdc03d3c91c757fe001a1c1bc50ecd851efa6e4b45062156b7a5'
   name 'CAM Editor'
   homepage 'http://camprocessor.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.