### PR TITLE
Update comma-chameleon to 0.4.5

### DIFF
--- a/Casks/comma-chameleon.rb
+++ b/Casks/comma-chameleon.rb
@@ -1,11 +1,11 @@
 cask 'comma-chameleon' do
-  version '0.4.4'
-  sha256 'd91bf3d38344b2a7dc807a1c9714958280cd39ea531826492361498329b50ce5'
+  version '0.4.5'
+  sha256 '498b0e938e4bb3aa93ce47e7ab801219dbcacf1e1cb912dcf5924cc591a2a08e'
 
   # github.com/theodi/comma-chameleon was verified as official when first introduced to the cask
   url "https://github.com/theodi/comma-chameleon/releases/download/#{version}/comma-chameleon-darwin-x64.tar.gz"
   appcast 'https://github.com/theodi/comma-chameleon/releases.atom',
-          checkpoint: 'bb9c95c0aab908b897585e3fc80acab03ba185ec67d2ecb3f4e3917deed6e3d1'
+          checkpoint: 'c5b8f4dc7bfb7099036c6c23a139884537020f2b876eaf69eecb1ad1a130a770'
   name 'Comma Chameleon'
   homepage 'https://comma-chameleon.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.