### PR TITLE
Update coreos to 1.5.4

### DIFF
--- a/Casks/coreos.rb
+++ b/Casks/coreos.rb
@@ -1,10 +1,10 @@
 cask 'coreos' do
-  version '1.5.1'
-  sha256 '6f66821ec58451d7d9fb564082b7f33d1e2f1c3bad88869743c6952f7887fe33'
+  version '1.5.4'
+  sha256 '13cdeb14ef6c2efeba3e07f54873b6f6a25fb45c2d7b0e9d758c423b8a82f1a4'
 
   url "https://github.com/TheNewNormal/coreos-osx/releases/download/v#{version}/CoreOS_v#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/coreos-osx/releases.atom',
-          checkpoint: '734477a5e9f3742f55025f570fc394aaf93d96f7f4ce487ac1563aa661003223'
+          checkpoint: '00c7515b3d3e3e9fd868203a4b81688ff30015520cbb19f917a0c42caceb06fe'
   name 'CoreOS VM'
   homepage 'https://github.com/TheNewNormal/coreos-osx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.