### PR TITLE
Update davmail to 4.7.3-2438

### DIFF
--- a/Casks/davmail.rb
+++ b/Casks/davmail.rb
@@ -1,10 +1,10 @@
 cask 'davmail' do
-  version '4.7.2-2427'
-  sha256 'd7f54f83bf1b757f09349dc8621a3d501ee7b14d7b51a806aaa7901e33c92724'
+  version '4.7.3-2438'
+  sha256 '94bfea44f9a94ccb7bb84516fe442cc6877427f7102f66a89d0ceb54ddda9cf3'
 
   url "https://downloads.sourceforge.net/davmail/DavMail-MacOSX-#{version}.app.zip"
   appcast 'https://sourceforge.net/projects/davmail/rss',
-          checkpoint: '81c159ec1957fb5e79cb145e60414cee9eb5c20745b5e7bf8fbd95b98728630f'
+          checkpoint: 'd318e221e5ac7623745f4a4b0e37dbd18f66e0b80cbe3dbf76c0f30f97d09be6'
   name 'DavMail'
   homepage 'http://davmail.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.