### PR TITLE
Update dripcap to 0.5.0

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.4.0'
-  sha256 '9fc18f5f0ed54236eb407c0bd9eac1d2674d8d6893bdc329f33ed02ad2d463e6'
+  version '0.5.0'
+  sha256 '00f2ddc25c11db471a578abeff85dfb632c37e0806d0c4fa5a292001da600ff9'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '0364bf3db4d8fd226f7db588a4706f3469de230f49babee50e3092310c6ff58e'
+          checkpoint: '1fa85ee2b4060af1ebdbcf383b67b284b27888930d211d2f4eb90133296861c6'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.