### PR TITLE
Update gingr to 1.3

### DIFF
--- a/Casks/gingr.rb
+++ b/Casks/gingr.rb
@@ -1,11 +1,11 @@
 cask 'gingr' do
-  version '1.2'
-  sha256 '27ba08606ae3f743ffdbcb6d554048ab3a7560087577f10503a0f5cd0227f9d3'
+  version '1.3'
+  sha256 '2a7dd9307ce7dc69d68648c469f6d6fba2e411161332043af9477b08cb2406c6'
 
   # github.com/marbl/gingr was verified as official when first introduced to the cask
-  url "https://github.com/marbl/gingr/releases/download/v#{version}/gingr-OSX64-v#{version}.zip"
+  url "https://github.com/marbl/gingr/releases/download/v#{version}/gingr-OSX64-v#{version}.app.zip"
   appcast 'https://github.com/marbl/gingr/releases.atom',
-          checkpoint: '55307efb6bc20c741265ac4903825fc8fc49a35e2b6e3ef6a3a387cf2b69dbc1'
+          checkpoint: 'd9f1acde954eab6d308121d0665af8c4bf8206d5ad5fac2b272f36cb4f15fd6c'
   name 'Gingr'
   homepage 'https://harvest.readthedocs.io/en/latest/content/gingr.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.