### PR TITLE
Update google-play-music-desktop-player to 4.0.5

### DIFF
--- a/Casks/google-play-music-desktop-player.rb
+++ b/Casks/google-play-music-desktop-player.rb
@@ -1,11 +1,11 @@
 cask 'google-play-music-desktop-player' do
-  version '4.0.3'
-  sha256 '53d5b29dccb1b971b9cd057e83d86cab068596e71ecd7d0576963904e2e4cbe1'
+  version '4.0.5'
+  sha256 '12e4baae2f941e481346990c7e2f4bace7ba9b3313ce0ede24e41258d1cdeb8b'
 
   # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
   url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"
   appcast 'https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases.atom',
-          checkpoint: '2d13325b1e95df533cdcc36b1acbb4da8ab482ef8d64e7a96dcb4e6ebdce62ab'
+          checkpoint: '68ce60a4b41ad37bd6fe72df592bac9e4ae8ed2c934fc69b76912b654fdeeb94'
   name 'Google Play Music Desktop Player'
   homepage 'https://www.googleplaymusicdesktopplayer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.