### PR TITLE
Update graphql-ide to 1.1.0

### DIFF
--- a/Casks/graphql-ide.rb
+++ b/Casks/graphql-ide.rb
@@ -1,10 +1,10 @@
 cask 'graphql-ide' do
-  version '0.1.5'
-  sha256 'fff77c227a9ea4991ef9cae356a9beede06c0bc8bd06d63007087cb22e2536ed'
+  version '1.1.0'
+  sha256 '697b1618d416c18a17bb6176eda88a1187588b6f95bafb0f559bb6b9fcca8775'
 
-  url "https://github.com/redound/graphql-ide/releases/download/#{version}/GraphQL.IDE.app.zip"
+  url "https://github.com/redound/graphql-ide/releases/download/v#{version}/GraphQL.IDE.app.zip"
   appcast 'https://github.com/redound/graphql-ide/releases.atom',
-          checkpoint: '972894e2e9f9abb69617e498fb406e0a92861d85c33dd61b44f8dfc4e917d3e4'
+          checkpoint: '303b735e0bceec72e00116ef27afd394686f2c1aa0cd133a4ec658b28d900555'
   name 'GraphQL IDE'
   homepage 'https://github.com/redound/graphql-ide'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.