### PR TITLE
Update gzdoom to 2.2.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,13 +1,12 @@
 cask 'gzdoom' do
-  version '0.6.0'
-  sha256 '4a64aeeb831dd7a5d919d8ccd3a17b051ebd456b043c034c77329beb3863c482'
+  version '2.2.0'
+  sha256 '38bb7569d05d436b7564a795677e707e573d101bfb3706b75a76fd66f96b2d2b'
 
-  # github.com/alexey-lysiuk was verified as official when first introduced to the cask
-  url "https://github.com/alexey-lysiuk/gzdoom/releases/download/macOS-#{version}/GZDoom-macOS-#{version}.dmg"
-  appcast 'https://github.com/alexey-lysiuk/gzdoom/releases.atom',
-          checkpoint: 'fdf284e4bc993f222b95f4a8efbd114bb37b4b4423287de8a165941b8386d137'
+  url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
+  appcast 'https://github.com/coelckers/gzdoom/releases.atom',
+          checkpoint: 'fef70e2e3a1fb43ffd48047dc6965896a3b7ccd778800205813b6b52787740e0'
   name 'gzdoom'
-  homepage 'https://alexey-lysiuk.github.io/gzdoom/'
+  homepage 'https://github.com/coelckers/gzdoom/'
 
   app 'GZDoom.app'
 end

--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -2,11 +2,12 @@ cask 'gzdoom' do
   version '2.2.0'
   sha256 '38bb7569d05d436b7564a795677e707e573d101bfb3706b75a76fd66f96b2d2b'
 
+  # github.com/coelckers was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom',
           checkpoint: 'fef70e2e3a1fb43ffd48047dc6965896a3b7ccd778800205813b6b52787740e0'
   name 'gzdoom'
-  homepage 'https://github.com/coelckers/gzdoom/'
+  homepage 'https://gzdoom.drdteam.org'
 
   app 'GZDoom.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.