### PR TITLE
Update kaku to 1.8.5

### DIFF
--- a/Casks/kaku.rb
+++ b/Casks/kaku.rb
@@ -1,11 +1,11 @@
 cask 'kaku' do
-  version '1.8.0'
-  sha256 '2843de576b2e7d2647eddea53f1ca6ed0e5c1b9293f7aec0829bc400fdd81f08'
+  version '1.8.5'
+  sha256 '7610ba4a10126127b919bb917fb5d1854286a9ae76e22df8660284857cdf781f'
 
   # github.com/EragonJ/Kaku was verified as official when first introduced to the cask
   url "https://github.com/EragonJ/Kaku/releases/download/#{version}/Kaku-#{version}.dmg"
   appcast 'https://github.com/EragonJ/Kaku/releases.atom',
-          checkpoint: 'ba0caf830db975e86fb14a85a2400fa91de98666c12dcef59afacb4cbd5533aa'
+          checkpoint: '39cfe15ddd86b8120075c0afba93d5f8befc63aff093f6d486efea97df03528c'
   name 'Kaku'
   homepage 'http://kaku.rocks/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.