### PR TITLE
Update moeditor to 0.2.0

### DIFF
--- a/Casks/moeditor.rb
+++ b/Casks/moeditor.rb
@@ -1,10 +1,10 @@
 cask 'moeditor' do
-  version '0.1.1'
-  sha256 '45dc7ac40675fa8c3c2170801450740701599f7a162a696c21f38bff4f04fc50'
+  version '0.2.0'
+  sha256 '5ce5605b0fd3ac360f6bd9c6538ded61bb33da5cd27e3d64810d03b6a5261bd2'
 
   url "https://github.com/Moeditor/Moeditor/releases/download/v#{version}-beta/Moeditor-#{version}-darwin-x64.zip"
   appcast 'https://github.com/Moeditor/Moeditor/releases.atom',
-          checkpoint: '3a0247fa7c01e7026c2fcf2d02cfc0ea4f2d073c4c39d2c0797f65ba919d41e1'
+          checkpoint: '24cdfe7506739ad20f9f5dd1f25c29504ca1b09fa2a7112f2e8405f57208f481'
   name 'Moeditor'
   homepage 'https://github.com/Moeditor/Moeditor'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.