### PR TITLE
Update neo11-chitchat to 2.5.2

### DIFF
--- a/Casks/neo11-chitchat.rb
+++ b/Casks/neo11-chitchat.rb
@@ -1,10 +1,10 @@
 cask 'neo11-chitchat' do
-  version '2.3'
-  sha256 'c56ad3d84a1dbb01de45f2148c83ee6007d6e18e94817de8a23a42743f381247'
+  version '2.5.2'
+  sha256 '803f91fe294d232af74fbe37abe4acaea068427c5b10cdc9a774fe0be49c7809'
 
   url "https://github.com/Neo11/ChitChat/releases/download/v#{version}/ChitChat.zip"
   appcast 'https://github.com/Neo11/ChitChat/releases.atom',
-          checkpoint: '1d331c02c9dbecc82e852ae9069473b63ad1384c46b183be5d0e83259a954383'
+          checkpoint: '3611f0ed560142a9cb0db52ec1cb8c68ff203686140dbe3ca17efbaa625e3326'
   name 'ChitChat'
   homepage 'https://github.com/Neo11/ChitChat'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.