### PR TITLE
Update opensesame to 3.1.4

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -4,12 +4,12 @@ cask 'opensesame' do
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'
     url "https://files.cogsci.nl/software/opensesame/opensesame_#{version}-macos-2.zip"
   else
-    version '3.1.2'
-    sha256 'f82fd0daf576784b04152e239bfaa633d5933af6273721c01d31ffa9b715353e'
+    version '3.1.4'
+    sha256 '5beb72577afda123e7e2cb6fa887c4bd6dd17a92f208603325cabcc9af9476ff'
     # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
     url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
     appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: '958aa1f4116709f5caf4a8e8bae48b5866a28a23a6c544a15042cbf81f431b8f'
+            checkpoint: 'd3ec8e64d2ac3afcef0735d9616ca48f0ba915c3f5cb935d68b7c565b9d8f1eb'
   end
 
   name 'OpenSesame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.