### PR TITLE
Update overture to 2.4.4

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.4.2'
-  sha256 '45bd0385b6848c6ed5e9c9cb41ce32a76a955983dba80217693c73c68e5be724'
+  version '2.4.4'
+  sha256 '112b331af0aa818d03a2605971923d7f403d5f0f32f81348e5c51beaac8929d0'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: '996dae8fa422e98647a590fa5960ab11e73036427485800b786394f11e77b6c1'
+          checkpoint: '4f99d29cab642706752ca52eb86112da4e5b84f2da4d45d061c58d05bc84f66c'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.