### PR TITLE
Update pocketcast to 1.26

### DIFF
--- a/Casks/pocketcast.rb
+++ b/Casks/pocketcast.rb
@@ -1,10 +1,10 @@
 cask 'pocketcast' do
-  version '1.25'
-  sha256 '01091dfc5f6819a800c5da51230e272dbecfdbac8a93d12124820a0cd0bb74b7'
+  version '1.26'
+  sha256 '9281179e3f1069470976dc8590e26e4f817142b1641094433e6b5c2806ee7d15'
 
-  url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCast#{version.no_dots}.zip"
+  url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCast.zip"
   appcast 'https://github.com/mortenjust/PocketCastsOSX/releases.atom',
-          checkpoint: '6f976b988d5d821d25489abdcaa28adc5193d8fec545f95821838a458f1e195e'
+          checkpoint: 'eecfbcc95b0d373b4c28aa39c3cd9dd8c9a4cb9f7acba7a8d1f597296b9ca4fd'
   name 'Pocket Casts for Mac'
   homepage 'https://github.com/mortenjust/PocketCastsOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.