### PR TITLE
Update postage to 3.1.1

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.1.0'
-  sha256 'c717a7e73ac5f0cdb7d5fe7be8282921bae2abb35bd9ea9e1231cca1b300d5cb'
+  version '3.1.1'
+  sha256 '10016205ab23965dc1576efdfb2c720d09bffbd9b08ff2b88ad44d1da594f01e'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: '544ff1a14f4daba819e0860350be35e137ec8041a7ed4262b8d986e409971399'
+          checkpoint: '3b1b4748d9a528e0abfdfcc8675d1f32cc0fc774012300002f1efc5d524ed3e1'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.