### PR TITLE
Update pritunl to 1.0.1177.2

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1075.52'
-  sha256 'd26f68e3d4acd6f793c2067e9a32f0b3bbcb265fe50a4193ecf73caf54cebd39'
+  version '1.0.1177.2'
+  sha256 '582f3c661ba00bacb057e0749bf317394ae6875e1c34b83fbdd2d866f876780e'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'abbfafa4acb850251becef5d320fe89e58bf955ab111c73d10386afe93c37fc0'
+          checkpoint: '1a98f5ea0efb1aed581e64130781d73e7295edfd245cf893c7846123059bb4f0'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.