### PR TITLE
Update protege to 5.1.0

### DIFF
--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -1,11 +1,11 @@
 cask 'protege' do
-  version '5.0.0'
-  sha256 'cc5dc98cb41a59fb86a710a61249437f1f9d1b4b79eb989b1ff5055df0722540'
+  version '5.1.0'
+  sha256 '7d7f836236aca50b475111685ad868b86bb6628104af32b7cee1a085faf421f0'
 
   # github.com/protegeproject/protege-distribution was verified as official when first introduced to the cask
-  url "https://github.com/protegeproject/protege-distribution/releases/download/protege-#{version}/Protege-#{version}-os-x.zip"
+  url "https://github.com/protegeproject/protege-distribution/releases/download/v#{version}/Protege-#{version}-os-x.zip"
   appcast 'https://github.com/protegeproject/protege-distribution/releases.atom',
-          checkpoint: '85a7963eb388f3eaca03ab284323423a4c3659fa2939b183c1a46ef222c6293c'
+          checkpoint: '015b97cd269ea62c263f6e647b8a0b435af388ca3bc3fe84dd9b231c795247c7'
   name 'Protégé'
   homepage 'http://protege.stanford.edu/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.