### PR TITLE
Update pyfa to 1.25.1,1.9

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.24.0,yc.118.8-1.4'
-  sha256 'c2d83aeac52508d3d6993280cc457c29170f856a034044987df090e6ccbcec4e'
+  version '1.25.1,1.9'
+  sha256 'd3d5bb635a5b95f64ef9e133e11f0717a214abf4a5e46c275a293549783ab8ac'
 
-  url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
+  url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-ascension-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '653940a68f7436506cba226e764094e783d5b9fdc6356678fe1b0b68c9898047'
+          checkpoint: '5a93c2b3880881738825b904a189b632147b2d5a9cc3a3a8fa75c8582048d0ba'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.