### PR TITLE
Update qownnotes to 16.12.4,b2595-105324

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '16.12.0,b2568-113120'
-  sha256 '226666a63124686b32a02d2ea145920659baa0fd4d9daed616566880fae79d84'
+  version '16.12.4,b2595-105324'
+  sha256 'd353c06ee8a2a82c42dda8cd6dc1b3b94eff330e4d2f033f453d6880022e6dda'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '81b0ed94ba7eebd8dfd1b8f890f383003e561ff0ba7e969581803222faf6d782'
+          checkpoint: '0b2a064392a8ea477addcd1a1c17b706fa219b17a5aa7416a544afd7b25c69a8'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.