### PR TITLE
Update qsyncthingtray to 0.5.6

### DIFF
--- a/Casks/qsyncthingtray.rb
+++ b/Casks/qsyncthingtray.rb
@@ -1,10 +1,10 @@
 cask 'qsyncthingtray' do
-  version '0.5.2'
-  sha256 '5419b2e4040f2fa347e9b173a54462a4885f9f145c72baefd988065cdd91fa7e'
+  version '0.5.6'
+  sha256 '30ffe15479173986c594677504eb6ba76cfdbf710cf7a2e52ad459f31d31d205'
 
   url "https://github.com/sieren/QSyncthingTray/releases/download/#{version}/QSyncthingTray_#{version}_MAC.dmg"
   appcast 'https://github.com/sieren/QSyncthingTray/releases.atom',
-          checkpoint: '05524e57a102be842841cb8f07504d742595fb63631bbef89e3dbe8c5fdfb251'
+          checkpoint: 'b71f1ff7715d8d10b2695d4202c33eb65da564c190a55e5601bb2f187a7500fb'
   name 'QSyncthingTray'
   homepage 'https://github.com/sieren/QSyncthingTray'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.