### PR TITLE
Update provisionql to 1.3.0

### DIFF
--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -1,10 +1,10 @@
 cask 'provisionql' do
-  version '1.2.0'
-  sha256 'e159ecfb9acb6cd98149cf6b3b120d7782a1baa2578ede1f0f936b1b2d1017bb'
+  version '1.3.0'
+  sha256 '2b7ff935d8f4fa813f0cdac895ff9e4284e0090559e5f9c3f0bd7aadcd68e4b1'
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
   appcast 'https://github.com/ealeksandrov/ProvisionQL/releases.atom',
-          checkpoint: 'cb20def872e0bc63a71a1942abe2d3c767a3615416dd081d1178d199a3758bd0'
+          checkpoint: '8de3dd53a45de649968cc684f123d7172538dedb01f553fd078931b07717abc3'
   name 'ProvisionQL'
   homepage 'https://github.com/ealeksandrov/ProvisionQL'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.