### PR TITLE
hex-fiend.rb: remove set_permissions

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -11,10 +11,6 @@ cask 'hex-fiend' do
 
   app 'Hex Fiend.app'
 
-  postflight do
-    set_permissions "#{appdir}/Hex Fiend.app/Contents/Frameworks/Sparkle.framework", 'a+rx'
-  end
-
   zap delete: [
                 '~/Library/Preferences/com.ridiculousfish.HexFiend.LSSharedFileList.plist',
                 '~/Library/Preferences/com.ridiculousfish.HexFiend.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

---

[Looks like it may no longer be needed](https://github.com/ridiculousfish/HexFiend/issues/52#issuecomment-260499083).