### PR TITLE
Update screencat to 4.2.0

### DIFF
--- a/Casks/screencat.rb
+++ b/Casks/screencat.rb
@@ -1,11 +1,11 @@
 cask 'screencat' do
-  version '2.0.0'
-  sha256 'd0587d3c7c926825019d296ad677c4469fa6cdf47ab434f556d74c372e5a18e6'
+  version '4.2.0'
+  sha256 '08230919e4efd3bf75900276f61810bfdea1c6fb6ff7026195a0004733c20d0e'
 
   # github.com/maxogden/screencat was verified as official when first introduced to the cask
-  url "https://github.com/maxogden/screencat/releases/download/#{version}/ScreenCat.zip"
+  url "https://github.com/maxogden/screencat/releases/download/v#{version}/ScreenCat.zip"
   appcast 'https://github.com/maxogden/screencat/releases.atom',
-          checkpoint: 'ab6d5b16172351803d8ad9bd1d3200abade4df0c9abc60341d5a07f0d5ec3488'
+          checkpoint: '5fdac9979072880ea612a383a066a2eaf6844181f578221d71d10a1604e69ead'
   name 'ScreenCat'
   homepage 'https://maxogden.github.io/screencat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.