### PR TITLE
Update shuttle to 1.2.9

### DIFF
--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -1,11 +1,11 @@
 cask 'shuttle' do
-  version '1.2.7'
-  sha256 '529f0c33d272a112aac3c99d023c615fbe704e6132377599c1eb1c38aaad80da'
+  version '1.2.9'
+  sha256 '0b80bf62922291da391098f979683e69cc7b65c4bdb986a431e3f1d9175fba20'
 
   # github.com/fitztrev/shuttle was verified as official when first introduced to the cask
   url "https://github.com/fitztrev/shuttle/releases/download/v#{version}/Shuttle.zip"
   appcast 'https://github.com/fitztrev/shuttle/releases.atom',
-          checkpoint: '7c389e357ae08cb0f7d9e20108fe239da609514d09c1fbcb94192998f570b6c5'
+          checkpoint: '450d58e7a2032148d809afe3bc6dd4cb7b0fd0bb807855fa17f452c57ace3a3b'
   name 'Shuttle'
   homepage 'https://fitztrev.github.io/shuttle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.