### PR TITLE
Update sigil to 0.9.7

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,11 +1,11 @@
 cask 'sigil' do
-  version '0.9.6'
-  sha256 'fc71c79a920e022ae7a0eaccc5e1cfdc4fd116e2a0b8a3dfa27522605f943b59'
+  version '0.9.7'
+  sha256 '539801d7c35b0f3e7a393f5ce16bded49755bbe5f2fa4c7cfd23d653d8b0e968'
 
   # github.com/Sigil-Ebook/Sigil was verified as official when first introduced to the cask
   url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"
   appcast 'https://github.com/Sigil-Ebook/Sigil/releases.atom',
-          checkpoint: 'd5436acdc8e533bc0b2aea3e30a4cffdf513ec10f21e27cd3396f839780d39e6'
+          checkpoint: '72eec9fe9708e2704e8ea9e1dbf465b6475afbf7192df66fcfbe59b4e6b5b565'
   name 'Sigil'
   homepage 'https://sigil-ebook.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.