### PR TITLE
Update webarchiveplayer to 1.4.7

### DIFF
--- a/Casks/webarchiveplayer.rb
+++ b/Casks/webarchiveplayer.rb
@@ -1,10 +1,10 @@
 cask 'webarchiveplayer' do
-  version '1.4.6'
-  sha256 'fb9e9d846ef85f1b626f0c29d6954e1b84732ccf18f467d01255420001ce6ca6'
+  version '1.4.7'
+  sha256 'a74f56e3c1b797c3c3063faa2555033a027f7122e21517d4acc1eed9825c0df9'
 
   url "https://github.com/ikreymer/webarchiveplayer/releases/download/#{version}/webarchiveplayer.dmg"
   appcast 'https://github.com/ikreymer/webarchiveplayer/releases.atom',
-          checkpoint: '7ddedc7687c1c3b2302ae2569f85b19a69ea91b3680a1b2b21bd89e27b099937'
+          checkpoint: 'a6041e53be0d61b346e14be9cef6109b46a9c207d6f809855605bf652a9e4ae3'
   name 'webarchiveplayer'
   homepage 'https://github.com/ikreymer/webarchiveplayer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.