### PR TITLE
fix path for 0ad;

### DIFF
--- a/Casks/0ad.rb
+++ b/Casks/0ad.rb
@@ -3,9 +3,9 @@ cask '0ad' do
   sha256 '4f616798252e4c814262e25b7d7e714619a6f0897c8a44a6a128766901d8b25d'
 
   # wildfiregames.com was verified as official when first introduced to the cask
-  url "https://releases.wildfiregames.com/0ad-#{version}-osx64.dmg"
+  url "http://releases.wildfiregames.com/0ad-#{version}-osx64.dmg"
   name '0 A.D.'
   homepage 'https://play0ad.com/'
 
-  app '0ad.app'
+  app '0 A.D..app'
 end


### PR DESCRIPTION
Fixes #27524
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.