### PR TITLE
Added ScreenSleeves screensaver v5.3

### DIFF
--- a/Casks/screensleeves.rb
+++ b/Casks/screensleeves.rb
@@ -1,9 +1,9 @@
 cask 'screensleeves' do
-  version '5.3'
-  sha256 'cc868a3ae9fcd6ddc2f47282a01823377ff3fa6696499ccbf0895423f2f542b8'
+  version :latest
+  sha256 :no_check
 
   url 'http://peacockmedia.software/mac/screensleeves/screensleeves.dmg'
-  name 'ScreenSleeves screensaver (free version)'
+  name 'ScreenSleeves screensaver'
   homepage 'http://peacockmedia.software/mac/screensleeves/'
 
   screen_saver 'ScreenSleeves.saver'

--- a/Casks/screensleeves.rb
+++ b/Casks/screensleeves.rb
@@ -1,0 +1,10 @@
+cask 'screensleeves' do
+  version '5.3'
+  sha256 'cc868a3ae9fcd6ddc2f47282a01823377ff3fa6696499ccbf0895423f2f542b8'
+
+  url 'http://peacockmedia.software/mac/screensleeves/screensleeves.dmg'
+  name 'ScreenSleeves screensaver (free version)'
+  homepage 'http://peacockmedia.software/mac/screensleeves/'
+
+  screen_saver 'ScreenSleeves.saver'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

ScreenSleeves is an album cover artwork screensaver for Mac OS. It
supports iTunes, Spotify, Snowtape, Ecoute, Rdio, Radium, Swinsian
and Hermes (Pandora client).