### PR TITLE
Update hyper to 1.0.0

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '0.8.3'
-  sha256 '11ecdfc72684c368d3f4d85c9f0893f8e95956e54d2293ba8217691f49955895'
+  version '1.0.0'
+  sha256 '1c91840607e7ca804f8710a21e5b159cfae2dca585a206aa4677b3f6cb5630a1'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '6cca58976de777655fa5675bf007780293a8f57bdf124e64bf825459dd1e84cf'
+          checkpoint: '50e92eb3acc7e55f04318fe4f56f5c36a5ab4ca74c10f93d6b1f0cbf4eaa75c6'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.