### PR TITLE
Update caret to 1.11.2

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.10.0'
-  sha256 'b43670a833840f1f590b97c3e275c0f88773f4563cdbe080afc6d88b3b25962d'
+  version '1.11.2'
+  sha256 '0097a9059bd66f1fc244d48d5e942c00cf2b097b43acc752efe74d4fbcdd5831'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'ebc58ab2af6e2880d9d26006215fabb5c8346ea818a61d1aeda97ee43cb82314'
+          checkpoint: 'fb2841ca280e9ea64aa17506c7ae586b85e7306adbf6ed5ca1df90acf192befa'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.