### PR TITLE
Update haskell-for-mac to 1.3.1,1226.1481263340

### DIFF
--- a/Casks/haskell-for-mac.rb
+++ b/Casks/haskell-for-mac.rb
@@ -1,11 +1,11 @@
 cask 'haskell-for-mac' do
-  version '1.3.0,1174.1473667413'
-  sha256 '01086dac60c42f113cf25df0ea5ec4adc013722c7634795033ff49d195dfff8f'
+  version '1.3.1,1226.1481263340'
+  sha256 'df7842930ea03c236c8c51f6775f66a69f3a9a7ff642da5ea0fc78c6d0831b75'
 
   # dl.devmate.com/com.haskellformac.Haskell.basic was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.haskellformac.Haskell.basic/#{version.after_comma.dots_to_slashes}/Haskell%E2%80%94FunctionalProgrammingLab-#{version.after_comma.major}.zip"
   appcast 'https://updates.devmate.com/com.haskellformac.Haskell.basic.xml',
-          checkpoint: '967c75ea27da3a1955b3ca288fa52d4814e8f419770d008025a005ab0157ee83'
+          checkpoint: '315adb1b8e64404705362dcf3c25adff14ff1a4fe85cbaa3f61a5597bd7dd7c8'
   name 'Haskell for Mac'
   homepage 'http://haskellformac.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.