### PR TITLE
Update hirundo to 0.9.9

### DIFF
--- a/Casks/hirundo.rb
+++ b/Casks/hirundo.rb
@@ -1,10 +1,10 @@
 cask 'hirundo' do
-  version '0.9.7'
-  sha256 'd962b39cdd6626475d75e2c14a88a5495ef1760419ac8815ee66b4b3930f7d83'
+  version '0.9.9'
+  sha256 '5db56b8b09ac199174af5d11aa9f21495900ec7d483150462fc981dd454b3819'
 
   url "https://stylemac.com/hirundo/versions/#{version}/Hirundo-#{version}.tgz"
   appcast 'https://stylemac.com/hirundo/versions/current.json',
-          checkpoint: '9ddb3a38601017b621f4824953afb7271635a97d38b31c1b5c6b7782a6a31e60'
+          checkpoint: '5ec297365103f72748b17c82ac6b573ea1df85f0c31aa6ae967b056f7b894f78'
   name 'Hirundo'
   homepage 'https://stylemac.com/hirundo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.