### PR TITLE
Update jasper to 0.2.3

### DIFF
--- a/Casks/jasper.rb
+++ b/Casks/jasper.rb
@@ -1,11 +1,11 @@
 cask 'jasper' do
-  version '0.2.1'
-  sha256 'fdf38036aa77e018652d2ef9dd54249dec14b7c07904421f4d9d72e1c5140d8f'
+  version '0.2.3'
+  sha256 'ee8cee3e635994a00394ec0f815f8900f2e50a2a54800c292968544d053eb355'
 
   # github.com/jasperapp/jasper was verified as official when first introduced to the cask
   url "https://github.com/jasperapp/jasper/releases/download/v#{version}/jasper_v#{version}_mac.zip"
   appcast 'https://jasperapp.io/-/versions-mac.json',
-          checkpoint: '6ab49218c1d9d2897a96f897f83e94de4a931e4f594be91b294ee448c6267b34'
+          checkpoint: 'b88ca823b72545f2ffb62f652277b24f24de4cb2b5fa5dbd3811b20bee661393'
   name 'Jasper'
   homepage 'https://jasperapp.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.