### PR TITLE
Update launchcontrol to 1.28.3

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -1,10 +1,10 @@
 cask 'launchcontrol' do
-  version '1.28.2'
-  sha256 '5ad184e2b91690093afb8dadd7663a60d4b32f4c628f2b5874811c1caaa6e580'
+  version '1.28.3'
+  sha256 'd5f08263c615846df220528e267e6b251627c894d6501ae4ad568756cc4ea17b'
 
   url "http://www.soma-zone.com/download/files/LaunchControl_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/LaunchControl/a/appcast.xml',
-          checkpoint: '48f8c0a98e698b53fc185a4a78c2e4d0489aaff0ba5e68ecd889e341b9319bcd'
+          checkpoint: '0fdbb5083496bdb5b2e4ccf1192af5be0316f24022d22c0b31aba7b9a6263505'
   name 'LaunchControl'
   homepage 'http://www.soma-zone.com/LaunchControl/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.