### PR TITLE
Update pritunl to 1.0.1187.7

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1177.2'
-  sha256 '582f3c661ba00bacb057e0749bf317394ae6875e1c34b83fbdd2d866f876780e'
+  version '1.0.1187.7'
+  sha256 'c954e10d48d15bc308d8e4a523a3fe4d597e944fdcd4c88fe3c3ddd0c4fb4255'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: '1a98f5ea0efb1aed581e64130781d73e7295edfd245cf893c7846123059bb4f0'
+          checkpoint: '9881fb6bf246fa62f1c63c387682af226c2fcea4f348b04f02b0714dd83b311a'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.