### PR TITLE
Update 1clipboard to 0.1.8

### DIFF
--- a/Casks/1clipboard.rb
+++ b/Casks/1clipboard.rb
@@ -3,7 +3,7 @@ cask '1clipboard' do
   sha256 'd1dee1594fa8b16a54bbcaf2d88b07e3bade0bb809416e535621ddb63b9e2b3d'
 
   url "http://1clipboard.io/download/darwin/#{version}/1Clipboard.zip"
-  appcast '1clipboard.io/download/darwin/',
+  appcast 'http://1clipboard.io/download/darwin/',
           checkpoint: '7dc172ad10ca0239253aff64fae7a09d4b082f6c11cbcfae95be1e2bacb60f9d'
   name '1Clipboard'
   homepage 'http://1clipboard.io/'

--- a/Casks/1clipboard.rb
+++ b/Casks/1clipboard.rb
@@ -1,8 +1,10 @@
 cask '1clipboard' do
-  version :latest
-  sha256 :no_check
+  version '0.1.8'
+  sha256 'd1dee1594fa8b16a54bbcaf2d88b07e3bade0bb809416e535621ddb63b9e2b3d'
 
-  url 'http://1clipboard.io/download/darwin/1Clipboard.dmg'
+  url "http://1clipboard.io/download/darwin/#{version}/1Clipboard.zip"
+  appcast '1clipboard.io/download/darwin/',
+          checkpoint: '7dc172ad10ca0239253aff64fae7a09d4b082f6c11cbcfae95be1e2bacb60f9d'
   name '1Clipboard'
   homepage 'http://1clipboard.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.