### PR TITLE
Update synergy to 1.8.6,2ab21aa

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,8 +1,8 @@
 cask 'synergy' do
-  version '1.8.5,a18eba7'
-  sha256 'b8023219e477603a6b07888ddf9388211ddd8bc9753b46ffd425feebddd917a5'
+  version '1.8.6,2ab21aa'
+  sha256 'f1ca271a56f0f42cc76dd3908c750d90cab7f51c329ac6fdebc04da7e64b5aef'
 
-  url "https://symless.com/files/packages/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX1011-x86_64.dmg"
+  url "https://symless.com/files/packages/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX-x86_64.dmg"
   name 'Synergy'
   homepage 'https://symless.com/synergy/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.