### PR TITLE
Revert "Upgrade dropbox to v16.3.27"

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,6 +1,6 @@
 cask 'dropbox' do
-  version '16.3.27'
-  sha256 'b73f5b41c338727011212718c2a8e82333fc6f5c7853ed28b7b2be969c752e32'
+  version '15.4.22'
+  sha256 'a1569dfdea08b585ecb9f50569f4d26bf86434957d604d7bd18498606c7e6a56'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
Reverts caskroom/homebrew-cask#27661 as this is a [beta build](https://www.dropboxforum.com/t5/Desktop-client-builds/bd-p/101003016) and the stable build is still `15.4.22`.

I have updated the `dropbox-beta.rb` Cask in [caskroom/homebrew-versions](https://github.com/caskroom/homebrew-versions/blob/master/Casks/dropbox-beta.rb) to the latest beta version.

