### PR TITLE
Update teamdrive to 4.3.0.1609

### DIFF
--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -3,7 +3,7 @@ cask 'teamdrive' do
   sha256 '3cbfebfdb93f4983a573f6718aef7c4c72b5285b851a7ef7cfa887d7e1b6b627'
 
   # s3download.teamdrive.net.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.')[-1]}/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"
+  url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"
   name 'TeamDrive'
   homepage 'https://www.teamdrive.com/'
 

--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -1,9 +1,9 @@
 cask 'teamdrive' do
-  version '4.3.0.1605'
-  sha256 '24249162a183c496203c1946fdbc0cbc5da915a056f4dbd36ad916d7c5961603'
+  version '4.3.0.1609'
+  sha256 '3cbfebfdb93f4983a573f6718aef7c4c72b5285b851a7ef7cfa887d7e1b6b627'
 
   # s3download.teamdrive.net.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://s3download.teamdrive.net.s3.amazonaws.com/4.3.1605/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"
+  url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.')[-1]}/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"
   name 'TeamDrive'
   homepage 'https://www.teamdrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.