### PR TITLE
Update blue-jeans-launcher to 1.6.8

### DIFF
--- a/Casks/blue-jeans-launcher.rb
+++ b/Casks/blue-jeans-launcher.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans-launcher' do
-  version '1.5.8'
-  sha256 '0f9b668f6cbed26fee2b9174836c0a3ff56e8032be7ddc1b030decc41fe303d0'
+  version '1.6.8'
+  sha256 '9f76c386659697c11752b8e0c04d40c4a07c08733a6c928bbff11210303789db'
 
   url "https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_#{version.no_dots}.dmg"
   name 'Blue Jeans videoconferencing'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.