### PR TITLE
Add appcast url to enpass.rb

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -4,6 +4,8 @@ cask 'enpass' do
 
   # sinew.in was verified as official when first introduced to the cask
   url "https://dl.sinew.in/mac/setup/Enpass-#{version}.dmg"
+  appcast 'https://www.enpass.io/release-notes/macosx/',
+          checkpoint: 'e2fa3558bc9317f30f14428529f924a340d0501c69f5c6fdefaf7c9613780037'
   name 'Enpass'
   homepage 'https://www.enpass.io/'
 


### PR DESCRIPTION
Adding release notes URL as appcast url

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
