### PR TITLE
Update captur to 3.2

### DIFF
--- a/Casks/captur.rb
+++ b/Casks/captur.rb
@@ -1,11 +1,23 @@
 cask 'captur' do
-  version '2.4'
-  sha256 '1f6f19806290c1c366701a8391fdc26cae3b1a54e3d54d715e420346eeb66648'
+  if MacOS.version <= :mavericks
+    version '2.4'
+    sha256 '1f6f19806290c1c366701a8391fdc26cae3b1a54e3d54d715e420346eeb66648'
 
-  # dropboxusercontent.com/u/27027504 was verified as official when first introduced to the cask
-  url "https://dl.dropboxusercontent.com/u/27027504/captur-#{version}.dmg.zip"
+    # dropboxusercontent.com/u/27027504 was verified as official when first introduced to the cask
+    url "https://dl.dropboxusercontent.com/u/27027504/captur-#{version}.dmg.zip"
+
+    app '64 Bit/Captur.app'
+  else
+    version '3.2'
+    sha256 '63c1881ba5ee8675f3f60135de0106dbe3948e3d8bb997c8d8f9557dd6c07834'
+
+    # dropboxusercontent.com/u/27027504 was verified as official when first introduced to the cask
+    url "https://dl.dropboxusercontent.com/u/27027504/captur-#{version}.zip"
+
+    container nested: "Captur #{version}.dmg"
+    app 'Captur.app'
+  end
+
   name 'Captur'
   homepage 'https://cambhlumbulunk.blogspot.com/p/captur.html'
-
-  app '64 Bit/Captur.app'
 end

--- a/Casks/captur.rb
+++ b/Casks/captur.rb
@@ -1,23 +1,14 @@
 cask 'captur' do
-  if MacOS.version <= :mavericks
-    version '2.4'
-    sha256 '1f6f19806290c1c366701a8391fdc26cae3b1a54e3d54d715e420346eeb66648'
+  version '3.2'
+  sha256 '63c1881ba5ee8675f3f60135de0106dbe3948e3d8bb997c8d8f9557dd6c07834'
 
-    # dropboxusercontent.com/u/27027504 was verified as official when first introduced to the cask
-    url "https://dl.dropboxusercontent.com/u/27027504/captur-#{version}.dmg.zip"
-
-    app '64 Bit/Captur.app'
-  else
-    version '3.2'
-    sha256 '63c1881ba5ee8675f3f60135de0106dbe3948e3d8bb997c8d8f9557dd6c07834'
-
-    # dropboxusercontent.com/u/27027504 was verified as official when first introduced to the cask
-    url "https://dl.dropboxusercontent.com/u/27027504/captur-#{version}.zip"
-
-    container nested: "Captur #{version}.dmg"
-    app 'Captur.app'
-  end
-
+  # dropboxusercontent.com/u/27027504 was verified as official when first introduced to the cask
+  url "https://dl.dropboxusercontent.com/u/27027504/captur-#{version}.zip"
   name 'Captur'
   homepage 'https://cambhlumbulunk.blogspot.com/p/captur.html'
+
+  depends_on macos: '>= :yosemite'
+  container nested: "Captur #{version}.dmg"
+
+  app 'Captur.app'
 end

--- a/Casks/captur.rb
+++ b/Casks/captur.rb
@@ -8,7 +8,6 @@ cask 'captur' do
   homepage 'https://cambhlumbulunk.blogspot.com/p/captur.html'
 
   depends_on macos: '>= :yosemite'
-  container nested: "Captur #{version}.dmg"
 
   app 'Captur.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.