### PR TITLE
Update voodoopad to 5.1.6

### DIFF
--- a/Casks/voodoopad.rb
+++ b/Casks/voodoopad.rb
@@ -2,7 +2,7 @@ cask 'voodoopad' do
   version '5.1.6'
   sha256 '5cfb9d420169ab72dba5bb8137b9f0b930e1f8943671d8f5d6a3c3a6fb96ea21'
 
-  url 'https://plausible.coop/static/download/VoodooPad-5.1.6.zip'
+  url "https://plausible.coop/static/download/VoodooPad-#{version}.zip"
   appcast 'https://plausible.coop/voodoopad/release_notes',
           checkpoint: 'e4993ba176c67aae1c4c053bee52bdd533fc133ab0b7456b733dff1c74c4d4ca'
   name 'VoodooPad'

--- a/Casks/voodoopad.rb
+++ b/Casks/voodoopad.rb
@@ -1,8 +1,10 @@
 cask 'voodoopad' do
-  version :latest
-  sha256 :no_check
+  version '5.1.6'
+  sha256 '5cfb9d420169ab72dba5bb8137b9f0b930e1f8943671d8f5d6a3c3a6fb96ea21'
 
-  url 'https://plausible.coop/static/download/VoodooPad.zip'
+  url 'https://plausible.coop/static/download/VoodooPad-5.1.6.zip'
+  appcast 'https://plausible.coop/voodoopad/release_notes',
+          checkpoint: 'e4993ba176c67aae1c4c053bee52bdd533fc133ab0b7456b733dff1c74c4d4ca'
   name 'VoodooPad'
   homepage 'https://plausible.coop/voodoopad/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.