### PR TITLE
Update splashtop-personal to 2.6.8.0

### DIFF
--- a/Casks/splashtop-personal.rb
+++ b/Casks/splashtop-personal.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-personal' do
-  version '2.6.4.1'
-  sha256 'df738c2067e99fac4aed16ab79b0a659aa0787ac6c68e195fab4e5d1c9f02820'
+  version '2.6.8.0'
+  sha256 '8c867a3969399db29b4f7aa6abb2f70f06535503f35db7eb5ff58358f3cb91dd'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STP/Splashtop_Personal_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.