### PR TITLE
Update godot to 2.1.1

### DIFF
--- a/Casks/godot.rb
+++ b/Casks/godot.rb
@@ -1,11 +1,11 @@
 cask 'godot' do
-  version '2.1'
-  sha256 '3ddb6c9835452d47b2ca5938dafa91dc494326ed86f9b85eeb15da0bb7830cd4'
+  version '2.1.1'
+  sha256 'acdf67b00f0fb283845caa869321f9aec680d20472d38c8eeacf8784f35e1fe2'
 
   # downloads.tuxfamily.org/godotengine was verified as official when first introduced to the cask
   url "https://downloads.tuxfamily.org/godotengine/#{version}/Godot_v#{version}-stable_osx.fat.zip"
   appcast 'https://github.com/godotengine/godot/releases.atom',
-          checkpoint: '8b2350fbd6f0bb87d745efa146aca9fb9941e272ab722a7876282c0cca440435'
+          checkpoint: '85890c85d5db44e8ff3bea4f0df4afb218bb20539eabba3bc36e88d721eaa003'
   name 'Godot Engine'
   homepage 'https://godotengine.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.