### PR TITLE
Update dropshare to 4.5.1,4555

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4.4.5'
-  sha256 '779122019003f27b78e9792133902f18019d389cb93de45ce8b1c2670c60bd5c'
+  version '4.5.1,4555'
+  sha256 '1ecdea9e38c819d26377049e6d3138d4a1796ceefdf45ca034ce23185a15c6c0'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-latest.zip"
+  url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
-          checkpoint: 'f5a2dac4ec60a0cbd61a490091e62306692d686e6a3226cfd16ca2dcd1ae5f01'
+          checkpoint: '83b90981d5801fdf6e25ba2166c9f1f1306d8a587161f57bc9ab1b558837fde3'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.