### PR TITLE
Update inkdrop to 2.6.2

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,6 +1,6 @@
 cask 'inkdrop' do
-  version '0.11.0'
-  sha256 '23b47aa14a6531b3daf1ce96244b88255e43627a9b450b84220e1bfb70f095f5'
+  version '2.6.2'
+  sha256 'b6fb511c488dc8ca4d03489b1198e07445164a6066998af136a926ad8e5fe666'
 
   url "https://www.inkdrop.info/api/update/Inkdrop-#{version}-Mac.zip"
   name 'Inkdrop'

--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -2,9 +2,19 @@ cask 'inkdrop' do
   version '2.6.2'
   sha256 'b6fb511c488dc8ca4d03489b1198e07445164a6066998af136a926ad8e5fe666'
 
-  url "https://www.inkdrop.info/api/update/Inkdrop-#{version}-Mac.zip"
+  url "https://github.com/inkdropapp/releases/releases/download/v#{version}/Inkdrop-#{version}-Mac.zip"
+  appcast 'https://github.com/inkdropapp/releases/releases.atom',
+          checkpoint: '68889ce94c9b45b41713d4c2d85fce3a00590f0f1af10ff583b944582002172c'
   name 'Inkdrop'
   homepage 'https://www.inkdrop.info/'
 
-  app 'Inkdrop (Beta).app'
+  app 'Inkdrop.app'
+
+  zap delete: [
+                '~/Library/Application Support/inkdrop',
+                '~/Library/Saved Application State/info.pkpk.inkdrop.savedState',
+                '~/Library/Caches/info.pkpk.inkdrop',
+                '~/Library/Preferences/info.pkpk.inkdrop.plist',
+                '~/Library/Preferences/info.pkpk.inkdrop.helper.plist',
+              ]
 end

--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -2,6 +2,7 @@ cask 'inkdrop' do
   version '2.6.2'
   sha256 'b6fb511c488dc8ca4d03489b1198e07445164a6066998af136a926ad8e5fe666'
 
+  # github.com/inkdropapp was verified as official when first introduced to the cask
   url "https://github.com/inkdropapp/releases/releases/download/v#{version}/Inkdrop-#{version}-Mac.zip"
   appcast 'https://github.com/inkdropapp/releases/releases.atom',
           checkpoint: '68889ce94c9b45b41713d4c2d85fce3a00590f0f1af10ff583b944582002172c'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.