### PR TITLE
Updated Doxie from 'latest' to 2.9.1

### DIFF
--- a/Casks/doxie.rb
+++ b/Casks/doxie.rb
@@ -1,8 +1,9 @@
 cask 'doxie' do
-  version :latest
-  sha256 :no_check
+  version '2.9.1'
+  sha256 '096d29dda008addb8fe5ba8e3b2c61f5ee392f9dadc1531cf7385b1d58dfc96b'
 
-  url 'http://www.getdoxie.com/resources/files/download_current_mac.php'
+  # cdn.getdoxie.com was verified as official when first introduced to the cask
+  url "http://cdn.getdoxie.com/resources/files/Doxie_#{version.dots_to_underscores}.dmg"
   name 'Doxie'
   homepage 'http://www.getdoxie.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Flexible URL scheme verified