### PR TITLE
Update jira-client to 3.8.1

### DIFF
--- a/Casks/jira-client.rb
+++ b/Casks/jira-client.rb
@@ -1,6 +1,6 @@
 cask 'jira-client' do
-  version '3.8.0'
-  sha256 'c29f44b66c442583852adf658e5ca2ef5969b4a31a31551120c51530ce34012e'
+  version '3.8.1'
+  sha256 'c92bea86aa84c311ad202298a2232f15b8a268b5edb8f5e7450dc898a9221908'
 
   url "https://d1.almworks.com/.files/jiraclient-#{version.dots_to_underscores}.dmg"
   name 'JIRA Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.