### PR TITLE
Update colorport to 2.0.5

### DIFF
--- a/Casks/colorport.rb
+++ b/Casks/colorport.rb
@@ -2,7 +2,7 @@ cask 'colorport' do
   version '2.0.5'
   sha256 'ae176e3118ba55b4dd8a0716707d149a4e13827b30cdc3f1d29bc329a0ef4bd0'
 
-  url 'http://www.xrite.com/downloader.aspx?FileID=1168&Type=M&returnurl=%2fcolorport-utility-software%2fsupport%2fd1168'
+  url 'https://my.xrite.com/downloader.aspx?FileID=1168&Type=M'
   name 'ColorPort Utility Software'
   homepage 'http://www.xrite.com/colorport-utility-software/support/d1168'
 

--- a/Casks/fiery-express-mac-driver.rb
+++ b/Casks/fiery-express-mac-driver.rb
@@ -1,0 +1,12 @@
+class FieryExpressMacDriver < Cask
+  version '1.0.0.3'
+  sha256 '1585b1852d12246ef47b8bf0762c25fa16ffd435f21a5fbf1385f202a863a8da'
+
+  url 'https://d1m2uyedaojrqy.cloudfront.net/FSO/efi/MACOSX107/osx/all_lang/NA/Fiery%20Express%20Mac%20Driver.dmg.zip'
+  homepage 'http://w3.efi.com/fiery/fiery-support/download/download-drivers'
+  license :unknown
+
+  container :nested => 'Fiery Express Mac Driver.dmg'
+  pkg 'Fiery Express Mac Driver.pkg'
+  uninstall :pkgutil => 'EFI.COM.fieryExpressMacDriver.FieryExpressDrvFilesversion1.pkg'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.