### PR TITLE
Update sourcetree to 2.4c

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.3.2'
-    sha256 '5973cb419275cfb441ff3bb7e3228918d430ca13484ddd858c9df9f5720e7ca9'
+    version '2.4c'
+    sha256 '9d5d1fd44f39a757436405c79a551a896c5e421c6acf27a75de376e519664701'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.