### PR TITLE
Update firefox to 50.1.0

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,79 +1,79 @@
 cask 'firefox' do
-  version '50.0.2'
+  version '50.1.0'
 
   language 'de' do
-    sha256 'f0d357472ddc97644e3ceab9635261a8fad4ac1ce421324ecc3e7a23ca596bbb'
+    sha256 '2311ac796c0b4db8073a4de16d58303c63a1a0ce963729e2e2b341b4f6ffbf0a'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'aabfd7a6415c7be8244365258d7aee5b6faefe2e9ad6b32e39625956438c4f4c'
+    sha256 '7e673a023a9d4c125114147bc50c610dd70048a177522e66b6f4727e4af4732f'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '821e227a9fdde4d9f0b05e936abfb445cef36e98c22df1794027e60f8a502b0d'
+    sha256 'b41ece47d0ad891d8b9307c0f27b50d0daaaaa7495dfa007aa12968a8cc68a6e'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '0e4ce9449c81b9a6d0a6585ed05f39640b4b00f41835cefba3de8406f49f1e49'
+    sha256 '63c561051b1846f110ea60446a6578991a84d169e07dcfe1f4ea35aa4ca20e2a'
     'fr'
   end
 
   language 'gl' do
-    sha256 'f8b80dde9734271c2cec23f212d8c48bd624960a754e1fe5e3c6635bd71ad73d'
+    sha256 'd0a2d257d931a3616376a26171391f1fcfa08ad24bb8e099c70b547f202d903f'
     'gl'
   end
 
   language 'it' do
-    sha256 '871f4003a748820abc1e18ae333931d89e3f683fa9a7c9eb25b24f5b773960e4'
+    sha256 '44173c1a81b5f949650de034bc7b6e5dd433128def85769e474c0ce18bafd6f3'
     'it'
   end
 
   language 'ja' do
-    sha256 '2e2afc43b10cea6f3198b5a05c70e8c621b70c486ac965d86918bdd3303389e5'
+    sha256 'fb0d635e6fea19a721ec39ee46fdf9f5e2b139c349723b1fade3e1147027bef8'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '4e932720691ac3f7607cdd84d182f72aec27d587b972441adaebe21f91887fb0'
+    sha256 '5883c9ca4f2e084300772059235bf4118b7b9f21974dc8a2abd24648e296d74e'
     'nl'
   end
 
   language 'pl' do
-    sha256 'bea6513ec672edc2a904a29ce05d502b3932ae4170911fbe1aac737e92775022'
+    sha256 '0e98e5cce25c1ee8e127424d0afdc8dcc13cf687651afebfe2f8134537d872ea'
     'pl'
   end
 
   language 'pt' do
-    sha256 '620daaa9dfdf4996d012f6b7dbd836d2c5e913cef6d2df1d41cf8bbb3678d483'
+    sha256 'ddf88b221498a445036848821a8cbd87f25fbb3c3965718820f403cf977788e6'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '99eef5dd48ed39c3e8408f485a8ba8d4879b1331c6055da41188a94829d0b817'
+    sha256 '5888ebd9fc5fe9c5c54bc83e760cfe30852861bca30a0f92ddaf1ed8125df491'
     'ru'
   end
 
   language 'uk' do
-    sha256 '76157057b0dc52a2090753dff7a24de30fb0d781f2b4940e2bc3a591b650346b'
+    sha256 '00e50771f4fe7242c8f8abc0c47a9876d5804d33617dd2a1a87db5c3085d7b92'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'c29a101e3ec183437b4ac12ba7b5ad9e4d00332e460fb6e459a6d4051b245440'
+    sha256 'b46f7de33f5ad25d85cf67482b61a7a085af69e95caca96862d932242589fc3a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '18c7e910870358995eb6499dd60cf90cd6ac44278b48c5c4d3554432f50bca3d'
+    sha256 '1e71866df909ee353e0594a0863b9a6c1a8a3a5ea05df2dd9b51b91a5086c917'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '2bbba0fc24add1ba7a0c538a195cc5243292ee7cd5ede3d9fb2b49752ae44415'
+          checkpoint: '0888b8570c66c0225cf7515ec3f5afef8e0a752a88b4b9a77a54117722f769c6'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
