### PR TITLE
Update ticktick to 1.6.20

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '1.0.1'
-  sha256 'be20a752e9fa696dcf0f8747752190d19f5910298fa6f5a74f9e364bdda1fe41'
+  version '1.6.20'
+  sha256 'e5aad9b01da4e9f08eb5355a189b669ff142002b445517c3280522d550a2f2b6'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.