### PR TITLE
Update freeze to 2.8.1-237

### DIFF
--- a/Casks/freeze.rb
+++ b/Casks/freeze.rb
@@ -1,10 +1,10 @@
 cask 'freeze' do
-  version '2.8-235'
-  sha256 'a7e0823f2698a3a2547d8a0958458da9de443e38df2079fbde1e6c641c29e289'
+  version '2.8.1-237'
+  sha256 '0deed04568a00066e146da3d35316a422fd764e1c8eaa459feb945ecd5ec27f1'
 
   url "https://www.freezeapp.net/download/Freeze-#{version}.zip"
   appcast 'https://www.freezeapp.net/appcast.xml',
-          checkpoint: 'cbbe7f0a9ad40f27c60f8fab8806154cefebb18a56e0688e5c74aa7d346f3311'
+          checkpoint: '02a642497df16099b0035e80e13ea4af5b231df9582cf75b2290419803f94b46'
   name 'Freeze'
   homepage 'https://www.freezeapp.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.