### PR TITLE
Update logic to 1.2.11

### DIFF
--- a/Casks/logic.rb
+++ b/Casks/logic.rb
@@ -1,10 +1,12 @@
 cask 'logic' do
-  version '1.2.10'
-  sha256 '02042d0527069581b4f4cf6d5dbd7d16312ae2219d2787d53ad677ddd6fa26b4'
+  version '1.2.11'
+  sha256 '35396fd72d0ed5b46119b512ca0681b3279cc1b2858e075081091ad123391b27'
 
   url "http://downloads.saleae.com/logic/#{version}/Logic-#{version}-Darwin.dmg"
   name 'Logic'
   homepage 'https://www.saleae.com/'
+
+  depends_on macos: '>= :lion'
 
   app 'Logic.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.