### PR TITLE
Update vox to 2.8.10

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '2.8.8'
-  sha256 '4f3c41c666a9bef6483b1706010a59e852b2b221e74dc01094b57d96e4e8d841'
+  version '2.8.10'
+  sha256 '482a82625be1a98be9a0c4d7dff1d4d7b1bacedc5ff2417897b7380efc6880bd'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: 'c942319fd75d1e38b7284ed37fb7051a1e434523a5d1494c9a287c3742268f8d'
+          checkpoint: '4344a16edd4c2eaab83e5f0332854f04a78c94e70b5ffbe5a8fa27cbb04b3d1d'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.