### PR TITLE
Update eyetv to 3.6.9_7416

### DIFF
--- a/Casks/eyetv.rb
+++ b/Casks/eyetv.rb
@@ -1,10 +1,13 @@
 cask 'eyetv' do
-  version '3.6.8_7407'
-  sha256 '7dea4cdd5f9feb643a45f60ccb93dcf5983dd13946b95621a86dd5b06b87e1d7'
+  version '3.6.9_7416'
+  sha256 '96d287b9f1fb5b3341105dd9f9e4cafbed2daf148133ee6b2d1c0cdd0c2ff258'
 
-  url "http://files.elgato.com/eyetvdownloads/support/eyetv_#{version.no_dots}.dmg"
+  # d2ax8v8radog32.cloudfront.net was verified as official when first introduced to the cask
+  url "http://d2ax8v8radog32.cloudfront.net/eyetv3/Geniatech_eyetv_#{version}.dmg"
+  appcast 'https://www.geniatech.eu/eyetv/support/eyetv-3-en/',
+          checkpoint: '3373d6a4a51b55666aa199aea5dc7e12f4d562bb6152c6a5cc276359b43b5add'
   name 'EyeTV'
-  homepage 'https://www.elgato.com/en/eyetv'
+  homepage 'https://www.geniatech.eu/eyetv/'
 
   app 'EyeTV.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.