### PR TITLE
Update helm to version 2.1.0

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -1,11 +1,11 @@
 cask 'helm' do
-  version '2.0.2'
-  sha256 'd27bd7e40e12c0a5f08782a8a883166008565b28e0b82126d2089300ff3f8465'
+  version '2.1.0'
+  sha256 '1080267d1b4b7e0b5fe8dd192dcf8d83e817db396a3764d4be18d66e1434646c'
 
   # storage.googleapis.com/kubernetes-helm/ was verified as official when first introduced to the cask
   url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
-          checkpoint: '08098089f3eaeadb985f5431192df39b15a5017e83d2a844c48da64ca60ed135'
+          checkpoint: '7e053608498504e5aeb965a956f5d3d0934256c856fbbd608fcab72078837c40'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
