### PR TITLE
Update vox to 2.8.10

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
   version '2.8.10'
-  sha256 '482a82625be1a98be9a0c4d7dff1d4d7b1bacedc5ff2417897b7380efc6880bd'
+  sha256 '5b5e7935ee1e9bf8552959169d0ca5675543df80564d832a7b90d19ffcca848b'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: '4344a16edd4c2eaab83e5f0332854f04a78c94e70b5ffbe5a8fa27cbb04b3d1d'
+          checkpoint: '9a4a9350db1220518aa6f768d27f912c24bcbd286072d9a4d99e7193c06013df'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.