### PR TITLE
Update mattermost to 3.5.0

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,11 +1,11 @@
 cask 'mattermost' do
-  version '3.4.1'
-  sha256 'f34bfaa88901cecbea1a1fa5df97ce842b1f188f6e0083fcf63c0d1aef376006'
+  version '3.5.0'
+  sha256 'fb5d843fadef0dc2a18f95049951d21f09d5c822f8664bb8995507094f942f6c'
 
   # releases.mattermost.com was verified as official when first introduced to the cask
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: '83fffe005c17ee483f8e297417c0166a075b26145fbf01466de6a04d5571ea48'
+          checkpoint: '9e1033d791d7bcb6de41b302229fb8c867aa527700323c988e24acc594fa89d1'
   name 'Mattermost'
   homepage 'https://about.mattermost.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.