### PR TITLE
Update Mumble to 1.2.18

### DIFF
--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -1,15 +1,14 @@
 cask 'mumble' do
-  version '1.2.17'
-  sha256 '169039aff011239f2aa5972a3e7c85b72d1f636ca30d349986f4d36cd3cd2077'
+  version '1.2.18'
+  sha256 'cd9d3124d76c15f5b77246d790a3f18346695c82c25c73fc9d6b2dd8e5ee94b9'
 
   # github.com/mumble-voip/mumble was verified as official when first introduced to the cask
   url "https://github.com/mumble-voip/mumble/releases/download/#{version}/Mumble-#{version}.dmg"
   appcast 'https://github.com/mumble-voip/mumble/releases.atom',
-          checkpoint: '7c0254c2fb4593a98d8609d2ba2eabcb6f4492428d4aea172e145c26ba184590'
+          checkpoint: 'bcdca125e43adc1b3351c85ca43b0df5a58f21d42210ce7fe2300b267d1a9fe3'
   name 'Mumble'
   homepage 'https://wiki.mumble.info/wiki/Main_Page'
-  gpg "#{url}.sig",
-      key_url: 'https://mumble.info/gpg/mumble-auto-build-2015.asc'
+  gpg "#{url}.sig", key_id: '3bd0eca5925319af89c25865b585609c5a2be0c1'
 
   app 'Mumble.app'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

GPG Key ID is listed here: https://github.com/mumble-voip/mumble-gpg-signatures/blob/master/gpg.txt