### PR TITLE
Update adguard to 1.4.0

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -1,10 +1,10 @@
 cask 'adguard' do
-  version '1.3.0'
-  sha256 'eb8f1fbb8e0ddf31f46eae39a571bee6d1237a1cdda0fa245bb21a85c2e32c25'
+  version '1.4.0'
+  sha256 'e8b0d47830b99d93412f09adee3d2396edb94b853e7a9ba25b1e8084a62a8ae7'
 
   url "https://static.adguard.com/mac/Adguard-#{version}.release.dmg"
   appcast 'https://static.adguard.com/mac/adguard-release-appcast.xml',
-          checkpoint: 'a934745bff30fa64ca202744b91a9c11dad69e60e84bf905aa4e118754fa993c'
+          checkpoint: '870fe28eba690c9b515da276db3aa6c0cd455ed91699ec3899a322de829cf1cf'
   name 'Adguard for Mac'
   homepage 'https://adguard.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.