### PR TITLE
Update airserver to 7.0.2

### DIFF
--- a/Casks/airserver.rb
+++ b/Casks/airserver.rb
@@ -1,10 +1,10 @@
 cask 'airserver' do
-  version '7.0.1'
-  sha256 '933658798a5014e2cd33d2dfbfe76a2c2f3f4dd4a1646fe73547174832074a90'
+  version '7.0.2'
+  sha256 '637e574f2e7e09960db3bf47d71bcc72b21d4375365d36953266c3c9793c6a9f'
 
   url "http://dl.airserver.com/mac/AirServer-#{version}.dmg"
   appcast 'https://www.airserver.com/downloads/mac/appcast.xml',
-          checkpoint: '6050520478908e4e475468f8a8de1f5a194d9fa00eec5ff29f90f1927f6b1502'
+          checkpoint: '7336b8a1360c18d81499cac1c53c3e7c6757cf6f29437900ec1aa82bdc6af60d'
   name 'AirServer'
   homepage 'https://www.airserver.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.