### PR TITLE
Update ctivo to 2.5.0

### DIFF
--- a/Casks/ctivo.rb
+++ b/Casks/ctivo.rb
@@ -1,10 +1,10 @@
 cask 'ctivo' do
-  version '2.4.4'
-  sha256 '7a3bfdc09d275360d868a2cc198aeb114705ba549e6eadb761a561991afc83fe'
+  version '2.5.0'
+  sha256 '34bb75805c558d150005364a2befb393fa84a014e710358dea23a08396b464d3'
 
   url "https://github.com/dscottbuch/cTiVo/releases/download/#{version}/cTiVo.zip"
   appcast 'https://github.com/dscottbuch/cTiVo/releases.atom',
-          checkpoint: '089829b42a2b46c8f41bd7efa3f2cc72658d2fb48d1f8f002dcdaa8d47803f6c'
+          checkpoint: 'ef9494b415aa0b8468866906e2a36eca9621cdb61e41f03ca5f642d7a2ef15a1'
   name 'cTiVo'
   homepage 'https://github.com/dscottbuch/cTiVo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.