### PR TITLE
Update downie to 2.6,1353

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.5.10,1345'
-  sha256 'a1ffeb14cbab15b778368060fde3ee6eb9bca93ca5097c9236a2ac45dc49edeb'
+  version '2.6,1353'
+  sha256 'e1f1e5bc118160899b4c5297c06067cf0ae88dfff411afe190e4b00f2b0fde41'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'b46b900f16f9e03a98380a718ecf3e071e46108b76df2487053fcfbac77e3152'
+          checkpoint: '337cfcc21942808adb2b1561c8e9ec3110a5714b2d66ffb4d576763bfd9c76e4'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.