### PR TITLE
Update lyn to 1.8.4

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,10 +1,10 @@
 cask 'lyn' do
-  version '1.8.3'
-  sha256 'f76ec277f153766b3be787e3a2a7d355f593cbf9f95653e31b974b36a6d4033e'
+  version '1.8.4'
+  sha256 '899e6c37699f02ed0fe7c4abb09a27a5fdbf3f834ebfca1e661ec648495c4297'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: '893d026155f21ace185be5b8672cac5a66a3db45d43f861a3e2bfd70a5215c20'
+          checkpoint: 'd4771771a079e5cfcb98e6767eee31349ea606837c4f5120ec19c2dab6fc9661'
   name 'Lyn'
   homepage 'http://www.lynapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.