### PR TITLE
Update mavensmate to 0.0.11-beta.7

### DIFF
--- a/Casks/mavensmate.rb
+++ b/Casks/mavensmate.rb
@@ -1,10 +1,10 @@
 cask 'mavensmate' do
-  version '0.0.10'
-  sha256 'd79ae6e7297939e103d637574de0a9746862d25ce4bfac34a99412dfbf609ef7'
+  version '0.0.11-beta.7'
+  sha256 'ed657aef9ab474e42e0f4e28f9aaf7fe153e29f9505f673d2dbdbfafdd31b553'
 
-  url "https://github.com/joeferraro/MavensMate-Desktop/releases/download/v#{version}/MavensMate-app-v#{version}-osx-x64.zip"
+  url "https://github.com/joeferraro/MavensMate-Desktop/releases/download/v#{version}/MavensMate-Desktop-#{version}.dmg"
   appcast 'https://github.com/joeferraro/MavensMate-Desktop/releases.atom',
-          checkpoint: '98c2b494c56732080d04e2deed55a044bd1ce157a84906e10178ab4002d61e41'
+          checkpoint: 'f7091d612f879aff65a3a64effd370c2b72479748aece2f2dde1d250ae99b033'
   name 'MavensMate'
   homepage 'https://github.com/joeferraro/MavensMate-Desktop'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.