### PR TITLE
Update pacifist to 3.5.12

### DIFF
--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -3,13 +3,13 @@ cask 'pacifist' do
     version '3.2.17'
     sha256 'd38e12293bc6087ddb09275e3c5ab34faa670e87e9dd41e04a587dd387f7b1d3'
   else
-    version '3.5.11'
-    sha256 'db03c766c2fc48675f3fe7fbd3eee3377c6cc06baa35e9b35afe2a345e57d415'
+    version '3.5.12'
+    sha256 '23a68a4834f799c3f90554e837e256734403ba3301f8c9c23e55b3d46207d7ff'
   end
 
   url "https://www.charlessoft.com/pacifist_download/Pacifist_#{version}.dmg"
   appcast 'https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi',
-          checkpoint: 'b7e5749bb2d009416a5a679a02a75453c7e1a641678cbb943e18712c45270e76'
+          checkpoint: '758b20da3f8f2a3e2c639d557b8f121f3432e7d71970441546ae6e054ca9de2b'
   name 'Pacifist'
   homepage 'https://www.charlessoft.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.