### PR TITLE
Update pdfsam-basic to 3.2.5

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,11 +1,11 @@
 cask 'pdfsam-basic' do
-  version '3.2.4'
-  sha256 'bc016b4c59e9c8af2bdca337f6c2fc5b2ead25d8b23a8fbb8d7ff6c4350f5237'
+  version '3.2.5'
+  sha256 '6234d07be4e7d2a1a3d0362c4c1869a53b339bc827ae487b2ac216d2a8db5718'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}.RELEASE/PDFsam-#{version}.RELEASE.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom',
-          checkpoint: 'c3635fad8643f2fbb75ead16dd56a6ffc6b9426d68bb7d4e87ae15b16e533e03'
+          checkpoint: 'ef88c183a2a75bfded198a862cb7286685646767d45bfa8145b8ad408a2f2d41'
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.