### PR TITLE
Update qownnotes to 16.12.8,b2614-174708

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '16.12.6,b2604-191210'
-  sha256 '8621a23afc395a11649a7f44c8ef893bddd86fa7105f735eb5ac428894a1e8c3'
+  version '16.12.8,b2614-174708'
+  sha256 'decd7fccb832f08587112f81d4d079cc8790d59c9173a5a25f13e762396804fc'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '3e2138dd267e598c3dfc5f7cae14eef091f6d87febf17f6574edce0cb11cd387'
+          checkpoint: '9a11020c880876d7ceb09f99b5e00649a3c10268fee6a24a52ab5310ec1027e8'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.