### PR TITLE
Update scap-workbench to 1.1.3

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,11 +1,11 @@
 cask 'scap-workbench' do
-  version '1.1.2'
-  sha256 '8b3a5faf1fadacba9d789a782d3c74fdd79e7cb2f0d0c9dbbbda75a66a89294f'
+  version '1.1.3'
+  sha256 '04a6c752aba3de1a76ae6c3a0e69c4e73f6601f073d2f24d48ee61cacab20330'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
   url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version}/scap-workbench-#{version}.dmg"
   appcast 'https://github.com/OpenSCAP/scap-workbench/releases.atom',
-          checkpoint: 'ab89a9ccba6ec34333295ced1186bdc091e16e35543eedb7473cae1e3d6de772'
+          checkpoint: '99c50028334b8ffa6333e9c97e0a3fdc449704f17ac89cefc4b6c0701c518363'
   name 'scap-workbench'
   homepage 'https://www.open-scap.org/tools/scap-workbench/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.