### PR TITLE
Update soundcast.rb

### DIFF
--- a/Casks/soundcast.rb
+++ b/Casks/soundcast.rb
@@ -1,8 +1,7 @@
 cask 'soundcast' do
   version '1.7'
   sha256 '39385f89007d65d3085720d8bbe4c4383d5ddedc60b6547e086122965618b7cd'
-
-  url "https://github.com/andresgottlieb/soundcast/releases/download/v#{version}/Soundcast_v#{version}.zip"
+  url "https://github.com/andresgottlieb/soundcast/archive/v#{version}.zip"
   appcast 'https://github.com/andresgottlieb/soundcast/releases.atom',
           checkpoint: 'ab04e3e3fb6927ccf9c59c5b0e09ed59909cdaac6a81a407fed4c605e2597be8'
   name 'Soundcast'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed

Soundcast has been discontinued, but the source code is still in the archive. Changed download URL to reflect this. soundcast.rb still points to v1.7