### PR TITLE
Update thunder to 3.0.1.2548

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '2.7.8.2358'
-  sha256 'b99df5898a14744757884c6031ad508ad985131117348cee60279c3929199fc0'
+  version '3.0.1.2548'
+  sha256 '424f45b7e4de6d0855ec89b0bb3842b400447fd3b39301b1579e9aa6f84acc8e'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_dl#{version}_Beta.dmg"
@@ -8,21 +8,17 @@ cask 'thunder' do
   name '迅雷'
   homepage 'http://mac.xunlei.com/'
 
-  depends_on macos: '>= :mavericks'
+  depends_on macos: '>= :yosemite'
 
   app 'Thunder.app'
 
   zap delete: [
                 '~/Library/Application Support/Thunder',
-                '~/Library/Caches/com.Thunder.XLPlayer',
                 '~/Library/Caches/com.xunlei.Thunder',
-                '~/Library/Caches/com.xunlei.Thunder-Store',
-                '~/Library/Cookies/com.xunlei.Thunder-Store.binarycookies',
+                '~/Library/Caches/com.xunlei.swjsq',
                 '~/Library/Cookies/com.xunlei.Thunder.binarycookies',
-                '~/Library/Preferences/com.xunlei.Thunder-Store.plist',
                 '~/Library/Preferences/com.xunlei.Thunder.plist',
-                '~/Library/Saved Application State/com.Thunder.XLPlayer.savedState',
-                '~/Library/Saved Application State/com.xunlei.Thunder-Store.savedState',
                 '~/Library/Saved Application State/com.xunlei.Thunder.savedState',
+                '~/Library/Saved Application State/com.xunlei.XLPlayer.savedState',
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update thunder to 3.0.1.2548