### PR TITLE
Update audirvana-plus to 2.6.2

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,10 +1,10 @@
 cask 'audirvana-plus' do
-  version '2.6'
-  sha256 'a13aa827170dd0fc0d209cc6813847411e49dc566d193ddd843b242e964910f4'
+  version '2.6.2'
+  sha256 '0918e1c9cf632648aee38d3693fb1beb72f6c30900a0cfecb4f81dfefed5048b'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml",
-          checkpoint: 'a2223c00e95d702bb913a9359894e43927459487653c51efcceb4253a1a7e0be'
+          checkpoint: 'b7668aa0a055b297315eab0c12bf9e7d1cc4a87ccd1c3a2fedb82119bc931c62'
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.