### PR TITLE
Update fauxpas to 1.7.1

### DIFF
--- a/Casks/fauxpas.rb
+++ b/Casks/fauxpas.rb
@@ -1,10 +1,10 @@
 cask 'fauxpas' do
-  version '1.6.2'
-  sha256 '2723b5a420d2ec37debe1511ef058370f356ec3decfb6bd74c10e28de192028a'
+  version '1.7.1'
+  sha256 '504cec20886c05a6d69472d06f04a0e943f82a72ebb49b50cd506bdc92a3add8'
 
   url "http://files.fauxpasapp.com/FauxPas-#{version}.tar.bz2"
   appcast 'http://files.fauxpasapp.com/appcast.xml',
-          checkpoint: '4ed08adb98070de7a9889ed57106241b073b01fb107d2a22adfd86e995b1feb9'
+          checkpoint: 'd7ab51d8537cbaaf0bf5154057d5d705ee06eead6256f8d812df714f034e4575'
   name 'Faux Pas'
   homepage 'http://fauxpasapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.