### PR TITLE
Update caret to 1.11.3

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.11.2'
-  sha256 '0097a9059bd66f1fc244d48d5e942c00cf2b097b43acc752efe74d4fbcdd5831'
+  version '1.11.3'
+  sha256 '30e7f3b177638b6212809ad5d2cb9a809c9c50a041fabfbec095294a458f8bf3'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'fb2841ca280e9ea64aa17506c7ae586b85e7306adbf6ed5ca1df90acf192befa'
+          checkpoint: '71fa511477d44249e92c5309b7b1bd7a7af6b2a03fc04945e864431e5b0d7d0b'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.