### PR TITLE
Update metabase to 0.21.1.0

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,10 +1,10 @@
 cask 'metabase' do
-  version '0.21.0.3'
-  sha256 'a2f1df7bb5ef1f3ce0fa32971ae76bea404d976f6aa34c224c265825ee6479c9'
+  version '0.21.1.0'
+  sha256 'fdb7af70bfdf6a23a37397bd767efcb58a307f66f5251405eb09428e7c28fa54'
 
   url "http://downloads.metabase.com/v#{version.major_minor_patch}/Metabase.dmg"
   appcast 'http://downloads.metabase.com/appcast.xml',
-          checkpoint: '5f551b1788610008a6ac426110c838dfa097bc0bf5cb157585ff23ca9ecf7eac'
+          checkpoint: '88160499b40e01d174b0c98b641d50603ead9daf1b0268e75c0dcfe16dc2fbed'
   name 'Metabase'
   homepage 'http://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.