### PR TITLE
Update min to 1.5.1

### DIFF
--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -1,11 +1,11 @@
 cask 'min' do
-  version '1.5.0'
-  sha256 'b143004d34f2d1f22b3e1bffc38fa5a53fce491e5ffe6639bceeaeaf5f04ede2'
+  version '1.5.1'
+  sha256 '702adc38b323ce68032fca433126248af55d08f6d73098a3b1ce89f4285528d0'
 
   # github.com/minbrowser/min was verified as official when first introduced to the cask
   url "https://github.com/minbrowser/min/releases/download/v#{version}/Min-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/minbrowser/min/releases.atom',
-          checkpoint: 'd9fe31b89a107bec70ad419961cfba3e7dc971ac3946bf67894b9fb99b4a36cc'
+          checkpoint: 'b4dd5cc128a8a80ea14a393f8457140ef4e5b2b4f2482df630a1e63b503f288f'
   name 'Min'
   homepage 'https://minbrowser.github.io/min/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.