### PR TITLE
Update mjml to 1.6.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,11 +1,11 @@
 cask 'mjml' do
-  version '1.5.0'
-  sha256 '69a42d2243db23c114550e1f15b874a35b3d5106dadd404b7db9fbccc56d7264'
+  version '1.6.0'
+  sha256 '500dff72eb35fe7cad7fb88dc4ee6a4a7c61b300160a99db75acad7989634347'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-osx_#{version}.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom',
-          checkpoint: 'fa9260c1d0d298346f2465d358cd0c611fa05aba075b57a3b2984aebad3dd5ce'
+          checkpoint: 'e5c3c9d88b082d3a06270b18837726633a36eddd2d58aee84f76e6437eb3c41a'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.