### PR TITLE
Update ndm to 0.0.4-beta

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '0.0.3-beta'
-  sha256 '19055224bbbc3dd36f272ef552142b49425d8a2fffda2b407045b8d8f6257ec6'
+  version '0.0.4-beta'
+  sha256 '204e2a3b769f4d9e215d85b6748ba2d8e8dff35b3be6cd3107540ad64d21f069'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '0db6ec7462676831c0922f595d653df6f903a49a540d41c81f0b6f5e1c2212b1'
+          checkpoint: '4d14881a991e3657c760486eca870685762f1347964713575719b96c3ce0369e'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.