### PR TITLE
Update oscilloscope to 1.0.7

### DIFF
--- a/Casks/oscilloscope.rb
+++ b/Casks/oscilloscope.rb
@@ -1,10 +1,10 @@
 cask 'oscilloscope' do
-  version '1.0.6'
-  sha256 '41f9bd17d237fd2425fb81a68e42a6191f13e9ed1a781c8d6110918d16101eb3'
+  version '1.0.7'
+  sha256 '7da3fcbb84fcdb88c1eb09074d8af2028b9069487001dcf5f3d1f1b9c349b66c'
 
   url "https://github.com/kritzikratzi/Oscilloscope/releases/download/#{version}/oscilloscope-#{version}-osx.zip"
   appcast 'https://github.com/kritzikratzi/Oscilloscope/releases.atom',
-          checkpoint: '530377c02fef543f61895a50925a3becdc8784b881e30113b5d7b6813bdbc3a4'
+          checkpoint: '5d371197fb6937c8ba01fbec0bb2438e9ac3aeb0b07dd12eb5b6dec6f9991855'
   name 'Oscilloscope'
   homepage 'https://github.com/kritzikratzi/Oscilloscope'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.