### PR TITLE
Update prepros to 6.0.4

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.0.1'
-  sha256 '9541c9561be11dfaebd5b682571a2e6f46edcc6186016ce9bdba6e16573834f1'
+  version '6.0.4'
+  sha256 '13780a321975ef2adebb615e6dd0e6a7d96f1a691833d47a269eae6966a7f652'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: '1e4dfb8b73ea10880c0a158c5587368f07bc54f0f48e91770c096c1b5dbd0614'
+          checkpoint: '6b1d24132f67012a55e3785ce929756fe363613be0019665c7788b3b9dadebe6'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.