### PR TITLE
Fix live-interior-3d-pro homepage

### DIFF
--- a/Casks/live-interior-3d-pro.rb
+++ b/Casks/live-interior-3d-pro.rb
@@ -5,7 +5,7 @@ cask 'live-interior-3d-pro' do
   # amazonaws.com/belightsoft was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/belightsoft/LiveInterior3DPro.dmg'
   name 'Live Interior 3D Pro'
-  homepage 'https://www.livehome3d.com/live-home-3d-pro'
+  homepage 'https://www.livehome3d.com/mac/live-home-3d-pro'
 
   app 'Live Interior 3D Pro.app'
 end


### PR DESCRIPTION
Homepage link was 404. Correcting.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.