### PR TITLE
Update cloudera-hive-odbc to 2.5.21,1010

### DIFF
--- a/Casks/cloudera-hive-odbc.rb
+++ b/Casks/cloudera-hive-odbc.rb
@@ -1,8 +1,8 @@
 cask 'cloudera-hive-odbc' do
-  version '2.5.5'
-  sha256 'cf31ace79ca995e8b7b57f1b49761777168c9f4b103092a74f6cb111084d71d8'
+  version '2.5.21,1010'
+  sha256 'bf180972a6d4810648c5bdbc1e3a67f56cbfd884079660914ed7cffaf8b671e1'
 
-  url "https://downloads.cloudera.com/connectors/hive-#{version}.1006/MacOSX/ClouderaHiveODBC.dmg"
+  url "https://downloads.cloudera.com/connectors/hive_odbc_#{version.before_comma}.#{version.after_comma}/OSX/ClouderaHiveODBC.dmg"
   name 'Cloudera ODBC Driver for Hive'
   homepage 'https://www.cloudera.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.