### PR TITLE
Update textsoap to 8.2.1

### DIFF
--- a/Casks/textsoap.rb
+++ b/Casks/textsoap.rb
@@ -1,11 +1,11 @@
 cask 'textsoap' do
-  version '8.2'
-  sha256 '84af657f6c2b3033228f245ff3b4487dfaac508ed228b5ab040852858b0f7ee1'
+  version '8.2.1'
+  sha256 '6c4ebdc255e0fdeb2dbc1ca57755df1f8d20bbe059a542a0927fa2dba9ff983f'
 
   # unmarked.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://unmarked.s3.amazonaws.com/textsoap#{version.major}.zip"
   appcast "https://unmarked.s3.amazonaws.com/appcast/textsoap#{version.major}.xml",
-          checkpoint: '06a133c9ba24c5e22b11658eace5c000128e675dccfc4f6532255054c8f59019'
+          checkpoint: '3b72c57964837673a3dbe0c011b5882d2cd227855f30d1f2e96d1c572fab39be'
   name 'TextSoap'
   homepage 'https://www.unmarked.com/textsoap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.