### PR TITLE
Update bandage to 0.8.1

### DIFF
--- a/Casks/bandage.rb
+++ b/Casks/bandage.rb
@@ -1,11 +1,11 @@
 cask 'bandage' do
-  version '0.8.0'
-  sha256 '154863b16bc9ecdf7b53aa9ecc22e7b34b980959ceb1105b3aefbd229b29ee0b'
+  version '0.8.1'
+  sha256 '13e90e5824b61bd4abe62afa8785a28627714bf7a3d4dad3edb4b8f9854d3b6d'
 
   # github.com/rrwick/Bandage was verified as official when first introduced to the cask
   url "https://github.com/rrwick/Bandage/releases/download/v#{version}/Bandage_Mac_v#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/rrwick/Bandage/releases.atom',
-          checkpoint: 'd70dfd9fbcd8219576c2ef2b68c53b85ef95c0fb3db13a5134cc50403d97776f'
+          checkpoint: 'f859465018f594b8e04978c946b9a05fdf3792897f51df9dc04047f35cfbfc4f'
   name 'Bandage'
   homepage 'https://rrwick.github.io/Bandage/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.