### PR TITLE
Update slicy to 1.1.8

### DIFF
--- a/Casks/slicy.rb
+++ b/Casks/slicy.rb
@@ -1,11 +1,10 @@
 cask 'slicy' do
-  version '1.1.7'
-  sha256 '0a57becbcbb6d4de17ab27e7c011f07543c37277e2e6988f60f464c6483fee39'
+  version '1.1.8'
+  sha256 'bf1546bb9ab5b52a19438111531a75fb926dbb31522f72fec82adc81ac6c76f0'
 
-  # s3.amazonaws.com/macrabbit/downloads was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/macrabbit/downloads/Slicy+#{version}.zip"
+  url "http://macrabbit.com/slicy/downloads/Slicy%20#{version}.zip"
   appcast "https://update.macrabbit.com/slicy/#{version}.xml",
-          checkpoint: '39d01f62bb6ab96fdee061a8077fd8cbffcafee6551d7be4bc0fe4dc20249e3d'
+          checkpoint: 'bcd49586631479821ab8818e39ad749326d85a1ba62830ba0e7b09dd38c2ae99'
   name 'Slicy'
   homepage 'http://macrabbit.com/slicy/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.