### PR TITLE
Update radiant-player to 1.11.3

### DIFF
--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -1,11 +1,11 @@
 cask 'radiant-player' do
-  version '1.11.2'
-  sha256 '53dbde2d2fefb6def1cb9ec9c83305cb5cc1ebaf10d0bed407900234df643681'
+  version '1.11.3'
+  sha256 'bc2ce000bd07b1c29638a861b128c08f26b9ba9ce29607d14530c2c9f7ded717'
 
   # github.com/radiant-player/radiant-player-mac was verified as official when first introduced to the cask
   url "https://github.com/radiant-player/radiant-player-mac/releases/download/v#{version}/radiant-player-v#{version}.zip"
   appcast 'https://github.com/radiant-player/radiant-player-mac/releases.atom',
-          checkpoint: '38863b628f4b5673196067e2ae484d9d5bbbab1252d302e9016f334fd9c94e75'
+          checkpoint: '210d8eca77faedc1251ae4e1d7a0ecd2e273e4fe6da42599327aac962d3c6586'
   name 'Radiant Player'
   homepage 'https://radiant-player.github.io/radiant-player-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.