### PR TITLE
Update stay to 1.2.7

### DIFF
--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -1,10 +1,10 @@
 cask 'stay' do
-  version '1.2.6'
-  sha256 '70663d1964430c0ea06c00dc654cdde9fea06bb211afec1d4c5a552222aba70f'
+  version '1.2.7'
+  sha256 '332d7046630e0ed9367e635081f1eaadbecfb52e655448edc7f173d3c72c1ce5'
 
   url "https://cordlessdog.com/stay/versions/Stay%20#{version}.dmg"
   appcast 'https://cordlessdog.com/stay/appcast.xml',
-          checkpoint: 'cd7e295947892c42bfc9d3c89c229527200e20befaa7988f0b7416d3faeb650b'
+          checkpoint: '29ba88cd7fd5d9692b9d348f645daa94ea7d5c63fd0746478e3d7fc1cd0ea0e1'
   name 'Stay'
   homepage 'https://cordlessdog.com/stay/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.