### PR TITLE
Update get-backup-pro to 3.3.2

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.3'
-  sha256 'b17cf71cba6d2910089cc0bf087b2eb5f0e069b8fa59211d67f8524f8a90291a'
+  version '3.3.2'
+  sha256 'bddece820707578ce640cd4b707a6c2cb88c2a3ba63b45e09741f5a0ce722a1b'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: '69e44682725cd00c49ead1ce0bf173fb4325940d01eef17a07889004c97e3be9'
+          checkpoint: '08b97dc2913b2a9c3d4153d26f9689cff91942b3c8d566ef34409d7d740afd9b'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.