### PR TITLE
fix yakyak v1.4.1 shasums

### DIFF
--- a/Casks/yakyak.rb
+++ b/Casks/yakyak.rb
@@ -1,10 +1,10 @@
 cask 'yakyak' do
   version '1.4.1'
-  sha256 'c16d4e5276a0a39742d5e9389967b5dcd180afb4db074ffa156a1f627b421671'
+  sha256 '25f8660c9987320e98f71ed741ff43a5565636ae8d2ac3cbb7666bd2b63eb7d3'
 
   url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx.zip"
   appcast 'https://github.com/yakyak/yakyak/releases.atom',
-          checkpoint: '50ab8f3dd67c702ce239d8e25d71ff391c4a2fca3cbd87ab2511e7b166f1ebb4'
+          checkpoint: 'c211df9625e8e4dc399226a1d72fd8095c949d2c7f2036119ff1684ecbfa73f7'
   name 'Yakyak'
   homepage 'https://github.com/yakyak/yakyak'
 


### PR DESCRIPTION
Just fixes the shasums for yakyak version 1.4.1

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.