### PR TITLE
Update docker-toolbox to 1.12.5

### DIFF
--- a/Casks/docker-toolbox.rb
+++ b/Casks/docker-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'docker-toolbox' do
-  version '1.12.4'
-  sha256 '3e16e38f51196e3b250349908b1cfdc99826567c9205b8e35f5d2690657051ba'
+  version '1.12.5'
+  sha256 '602c7a1a48b830800dae7123bdad32c0d1fc3f10703c5665f368e6c05ffb4d06'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: '827357d60d7da6b3f53e21bbfb8b2f5f77374999079e9d775049720eff8dcef9'
+          checkpoint: '08a90af4a0cb4d85052ec1069de37d477e0cf4faa2797a3d9b81a6dfed949387'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/products/docker-toolbox'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.