### PR TITLE
Update jabref to 3.8

### DIFF
--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -1,11 +1,11 @@
 cask 'jabref' do
-  version '3.7'
-  sha256 'd5833d9624c2a6f71a41b56bf82b300a5ee58cefc62dc2c29d6fdbe3ad7029c5'
+  version '3.8'
+  sha256 '12ab8a17f3dd809efea40d0f9b05a4bad2afacb8dfb89568582fc4ac45800aca'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
   url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: 'e9c5d2fa45eb53b586ba0afd00392ba74c09ad8587c70f4588eae82ff35bf9b9'
+          checkpoint: '812f5c928948e8eaf79da841c6eee460aa2681a0d8c0d6be98f17709a6fe68a9'
   name 'JabRef'
   homepage 'https://www.jabref.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.