### PR TITLE
Update keystore-explorer to 5.2.2

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,10 +1,10 @@
 cask 'keystore-explorer' do
-  version '5.1.1'
-  sha256 'd4c8ce7acbe1e0fc1e05dfbe61fd6d6de083b4cd9bb30ee604b7a7775cb62332'
+  version '5.2.2'
+  sha256 'c6ab532a0e9ec41caf0177823b9ced256c9d241e77f3c39a6ad1070cfffe5a0f'
 
   url "https://downloads.sourceforge.net/keystore-explorer/KSE%20#{version}/kse-#{version.no_dots}.dmg"
   appcast 'https://sourceforge.net/projects/keystore-explorer/rss',
-          checkpoint: '8a65b0bf9eec051a535dd47b37d59657d46b74ade7b306feaffc30ce56ad2f7e'
+          checkpoint: '7b15fcaa57e590af43362b426bcc2dda8e06e020735351a637cfc1547c91759f'
   name 'KeyStore Explorer'
   homepage 'http://keystore-explorer.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.