### PR TITLE
Update mist to 0.8.8

### DIFF
--- a/Casks/mist.rb
+++ b/Casks/mist.rb
@@ -1,10 +1,10 @@
 cask 'mist' do
-  version '0.8.7'
-  sha256 'd8f5a442292b7a5faf4423a765fd34d4f08913ed59950c12c0c0f4447f64c278'
+  version '0.8.8'
+  sha256 '955b46059c6d65b5f2cdc824a642562eb7ec6442747fc1b5c4aafb6f42a7bad5'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: '4beac8a0d92cb0a142cb33444d28bc48d5634830725ccd95b9eb16820ca11548'
+          checkpoint: '63081a0ff5fcb43ec5670b82812ab60465e292f0a1de4e3ae956e93e47071def'
   name 'Mist'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.