### PR TITLE
Update nylas-n1 to 0.4.402-74a7c7f

### DIFF
--- a/Casks/nylas-n1.rb
+++ b/Casks/nylas-n1.rb
@@ -1,11 +1,11 @@
 cask 'nylas-n1' do
-  version '0.4.52-5c342df'
-  sha256 '8d1d047a9ba9b186e59da8fcef15dda1b0bb552deea93f60b5c63fd40f12e6fa'
+  version '0.4.402-74a7c7f'
+  sha256 '2e0270e40df2cb21f2013714641ed3514bf2cc0a9a846853fffd68b0fc4eabcf'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/N1.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '6a61d15b714accbb4ba83adcd1e53634d0999f904e68088a673ca64a3c573e16'
+          checkpoint: '62e6f8ed3695f39f3796a1f5a4aced61c860d6833cfec711e8f1a16bbbca5270'
   name 'Nylas N1'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.