### PR TITLE
Update tomighty to 1.2

### DIFF
--- a/Casks/tomighty.rb
+++ b/Casks/tomighty.rb
@@ -1,11 +1,11 @@
 cask 'tomighty' do
-  version '1.1'
-  sha256 'e08afad7ccd3540fb7afd2957ad23809bf17b9812295eaf9b155beca74e3d916'
+  version '1.2'
+  sha256 '0ebee4c2c913a75b15fed071d68c22c866a3d8436ad359eb2ee66e27d39b2214'
 
   # github.com/tomighty/tomighty-osx was verified as official when first introduced to the cask
   url "https://github.com/tomighty/tomighty-osx/releases/download/#{version}/Tomighty-#{version}.dmg"
   appcast 'https://github.com/tomighty/tomighty-osx/releases.atom',
-          checkpoint: 'd840c6dbb9a016a8db3e4cd209d0ade84b13864dab3dff9df0f1cba93761fa8c'
+          checkpoint: 'f9f70f4d9e024d104d6783c6aa0633ef31a61300ff65412eb2a457b191914a57'
   name 'Tomighty'
   homepage 'http://tomighty.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.