### PR TITLE
Update synology-photo-station-uploader to 1.4-080

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -3,8 +3,6 @@ cask 'synology-photo-station-uploader' do
   sha256 '8b1e9477329d6f611df85ffcef715e289001a186e0f95ff0062b85104beaa83b'
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
-  appcast 'https://www.synology.com/en-global/releaseNote/PhotoStationUploader',
-          checkpoint: 'e438d9e1c4b182f1c59d661122c1a3bb2bf09eb1d72442acfb71be9aa3cb3cf4'
   name 'Synology Photo Station Uploader'
   homepage 'https://www.synology.com/'
 

--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,8 +1,10 @@
 cask 'synology-photo-station-uploader' do
-  version '1.3-056'
-  sha256 '515c01378d6cb660788c03a93be2bd509d977024184e9adbdb8414e6ad5c6bb9'
+  version '1.4-080'
+  sha256 '8b1e9477329d6f611df85ffcef715e289001a186e0f95ff0062b85104beaa83b'
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
+  appcast 'https://www.synology.com/en-global/releaseNote/PhotoStationUploader',
+          checkpoint: 'e438d9e1c4b182f1c59d661122c1a3bb2bf09eb1d72442acfb71be9aa3cb3cf4'
   name 'Synology Photo Station Uploader'
   homepage 'https://www.synology.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.