### PR TITLE
Update sqlitebrowser to 3.9.1v2

### DIFF
--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -1,11 +1,11 @@
 cask 'sqlitebrowser' do
-  version '3.9.1'
-  sha256 'e4145eae9fb8457431894a3816ae5b90ca8e8122677fae392d18fcbab869afd4'
+  version '3.9.1v2'
+  sha256 '52c92282e70e9d7f328329e12682d8ab7e06456071465f63196f769d98d6e6d7'
 
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom',
-          checkpoint: 'ea975e8eef36bcbb334dfc015736c138c8e0b897e43ee11840c25c8d9f6a1620'
+          checkpoint: 'a43e7ac2a6707e523eb215e5e064a616f291d4fcabd97fa094b0fe542208845e'
   name 'SQLite Database Browser'
   homepage 'http://sqlitebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.