### PR TITLE
Update vimr to 0.12.0-150

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.11.1-140'
-  sha256 'bf171ffb0c47700194f5eb4f44df572f2be64ebb1e6e5fa79ce89b219f5b2244'
+  version '0.12.0-150'
+  sha256 '09e51b6c0d105e633b32da7de1209ec181cc11b2c17813b2f857332ca160889d'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '6ebdd0fc57647d4ffcf528d92deb1b5730b9a5d180cd8d0a73acaedc42d98cba'
+          checkpoint: 'f2144f5150e6cdd538cc4d617a0c99fff5d716569b277d0812ddbe012a2a4765'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.