### PR TITLE
Update vmware-horizon-client to 4.3.0-4698798

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -1,8 +1,8 @@
 cask 'vmware-horizon-client' do
-  version '4.2.0-4336768'
-  sha256 '1680232b2422a4ae5d381be8acb954050f6abcc3de14fb09cc1fcb3a84c4b0d7'
+  version '4.3.0-4698798'
+  sha256 'e90685948d134c8108a1c2f3e8252c402bbe1ddf220be94b9e5d67e719dd9740'
 
-  url "https://download3.vmware.com/software/view/viewclients/CART16Q3/VMware-Horizon-Client-#{version}.dmg"
+  url "https://download3.vmware.com/software/view/viewclients/CART16Q4/VMware-Horizon-Client-#{version}.dmg"
   name 'VMware Horizon Client'
   homepage 'https://www.vmware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes [#27917](https://github.com/caskroom/homebrew-cask/issues/27917).