### PR TITLE
Update sonic-pi to 2.11.1

### DIFF
--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -1,6 +1,6 @@
 cask 'sonic-pi' do
-  version '2.10.0'
-  sha256 '4539cbd70f1e0d347c27231f741a245551c0d50f10e987761b9b7567ba0d82fe'
+  version '2.11.1'
+  sha256 'fbe9d5939d296b9ffae69432dffb6a6b1b4e06d5d89754d3c110a5cfdd5cd954'
 
   url "http://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-v#{version}.dmg"
   name 'Sonic Pi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.