### PR TITLE
Correct resolume-avenue to 4.6.2

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,13 +1,13 @@
 cask 'resolume-avenue' do
-  version '5.0.4'
-  sha256 '44e668b89916d7a27498c269ee165a6796b78860f23f7815098fcb9e506aa2df'
+  version '4.6.2'
+  sha256 '0dfe3f28308c05dd180619071b87256333f00b2f3a19e1a2b9ea1fa649c74451'
 
   # d19j6z4lvv1vde.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d19j6z4lvv1vde.cloudfront.net/Resolume_Arena_#{version.dots_to_underscores}_Installer.dmg"
+  url "https://d19j6z4lvv1vde.cloudfront.net/Resolume_Avenue_#{version.dots_to_underscores}_Installer.dmg"
   name 'Resolume Avenue'
   homepage 'https://resolume.com/'
 
   pkg "Resolume Avenue #{version} Installer.pkg"
 
-  uninstall pkgutil: 'com.resolume.*'
+  uninstall pkgutil: 'com.resolume.pkg.ResolumeAvenue*'
 end


### PR DESCRIPTION
This cask was pointing to the wrong download and was broken. @vitorgalvao it looks like you got the wrong link off the download page in #22187 

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.