### PR TITLE
Update postgres to 9.6.1.1

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,11 +1,11 @@
 cask 'postgres' do
-  version '9.6.1'
-  sha256 '780ccd723baa52f7620471cb74d5cdd58040502f0f485ed667b5ccb6a649d3ac'
+  version '9.6.1.1'
+  sha256 '4924b956c30d1e3191277dcd72834dc43fc76f74c1cae5be18729af771b0da45'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/#{version}/Postgres-#{version}.zip"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
-          checkpoint: 'dd955be34d429304a39b3efa812eb87ad3e9df661aa5caf71443622765316397'
+          checkpoint: '84cfa62ebeaaa4cb156d4d89bcb392020c138f9838f29816685f563cb2b5454e'
   name 'Postgres'
   homepage 'https://postgresapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.