### PR TITLE
Update splashtop-streamer to 3.1.2.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,9 +1,11 @@
 cask 'splashtop-streamer' do
-  version '3.0.8.3'
-  sha256 'c23d0e8b865cf88e2ce39e8be3b1b366883839b280a284a24fae891e3aacaedb'
+  version '3.1.2.0'
+  sha256 'e1ee59c52dbb7c478e324d0b0d883bd5dcadadc396a2d8103b0c00543c273fdb'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_MAC_v#{version}.dmg"
+  url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_v#{version}.dmg"
+  appcast 'http://www.splashtop.com/wp-content/themes/responsive/downloadx.php?platform=mac',
+          checkpoint: 'c5c866f9c2b1fb7de154a03449a5dfd8afdb960957c15631e460aadaaaced493'
   name 'Splashtop Streamer'
   homepage 'https://www.splashtop.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.