### PR TITLE
Add splashtop-personal.rb appcast

### DIFF
--- a/Casks/splashtop-personal.rb
+++ b/Casks/splashtop-personal.rb
@@ -4,6 +4,8 @@ cask 'splashtop-personal' do
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STP/Splashtop_Personal_v#{version}.dmg"
+  appcast 'http://www.splashtop.com/wp-content/themes/responsive/downloadx.php?product=stp&platform=mac-client',
+          checkpoint: '5c62995b415044d924c96f2fbf50b11ee0884af98355d7d8e9f17c6ba1e878fd'
   name 'Splashtop Personal'
   homepage 'https://www.splashtop.com/personal'
 


### PR DESCRIPTION
Appcast discovered while updating splashtop-streamer on #27933

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.