### PR TITLE
Add wine-staging 2.0-rc1

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -9,11 +9,13 @@ cask 'wine-staging' do
   depends_on cask: 'xquartz'
 
   pkg "winehq-staging-#{version}.pkg",
-      choices: {
-                 'choiceIdentifier' => 'choice3',
-                 'choiceAttribute'  => 'selected',
-                 'attributeSetting' => 1,
-               }
+      choices: [
+                 {
+                   'choiceIdentifier' => 'choice3',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+               ]
 
   uninstall pkgutil: [
                        'org.winehq.wine-staging',

--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,0 +1,33 @@
+cask 'wine-staging' do
+  version '2.0-rc1'
+  sha256 'fd297e8f9288a0eace85d3c31b923618d215de3f0463703140893942f171e989'
+
+  url "https://repos.wine-staging.com/macosx/i686/winehq-staging-#{version}.pkg"
+  name 'WineHQ-staging'
+  homepage 'https://www.wine-staging.com/'
+
+  depends_on cask: 'xquartz'
+
+  pkg "winehq-staging-#{version}.pkg",
+      choices: {
+                 'choiceIdentifier' => 'choice3',
+                 'choiceAttribute'  => 'selected',
+                 'attributeSetting' => 1,
+               }
+
+  uninstall pkgutil: [
+                       'org.winehq.wine-staging',
+                       'org.winehq.wine-staging-deps',
+                       'org.winehq.wine-staging-deps64',
+                       'org.winehq.wine-staging32',
+                       'org.winehq.wine-staging64',
+                     ],
+            delete:  '/Applications/Wine Staging.app'
+
+  caveats do
+    <<-EOS.undent
+      #{token} installs support for running 64 bit applications in Wine, which is considered experimental.
+      If you do not want 64 bit support, you should download and install the #{token} package manually.
+    EOS
+  end
+end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked that the cask was not already refused in [closed issues].

Continuing [#27551](https://github.com/caskroom/homebrew-cask/pull/27551).

I have added the 64-bit Wine option as a default.

Ping @vitorgalvao for comments and approval.

