### PR TITLE
Update nextiva to 21.5.0.813

### DIFF
--- a/Casks/nextiva.rb
+++ b/Casks/nextiva.rb
@@ -1,10 +1,10 @@
 cask 'nextiva' do
-  version '21.3.0.1311'
-  sha256 '1e5de7747db38e99cdc76e6b6194d24f44078d89eacc88843250a8fa13ce1466'
+  version '21.5.0.813'
+  sha256 '84d566d2eb996f74a76041310165e6dbad5e6c00aa981199e0f532bc03ebcd98'
 
   url "https://dm.nextiva.com/dms/bc/pc/Nextiva_App.bc-uc.osx-#{version}.dmg"
   name 'Nextiva'
-  homepage 'https://www.nextiva.com/support/nextiva-app-mac-setup.html'
+  homepage 'https://www.nextiva.com/support/articles/nextiva-app-mac-setup.html'
 
   app 'Nextiva App.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.