### PR TITLE
Fix dash 3.4.2 checksum and appcast checkpoint

### DIFF
--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -1,10 +1,10 @@
 cask 'dash' do
   version '3.4.2'
-  sha256 '5254207b0416688e03633976e307f95bf74707c4bd8bae5fc7316cee1bba52b7'
+  sha256 '37b4552d7d5773054a914c512aa5db313c8a84c3da5e9756d0f374b695851bfc'
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
   appcast "https://kapeli.com/Dash#{version.major}.xml",
-          checkpoint: 'e4778350caededf3305e15e1cd05e51f402539e33f4d8ae6801d8bc50757f46a'
+          checkpoint: '48847cb6df60e630901982d45d6d71f9a214bc7c927520123b81b9536308478f'
   name 'Dash'
   homepage 'https://kapeli.com/dash'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.