### PR TITLE
Update spectacle to 1.1.2

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -3,11 +3,11 @@ cask 'spectacle' do
     version '0.8.6'
     sha256 '3e367d2d7e6fe7d5f41d717d49cb087ba7432624b71ddd91c0cfa9d5a5459b7c'
   else
-    version '1.1.1'
-    sha256 '5277f226b494eea34bd94b11712aa0cf6205cd682830d95683c2362103c01a7a'
+    version '1.1.2'
+    sha256 '85624c4fbff0e3a7bb20a2ad724ec2a1246c7cd43217f6a0856743262163a756'
 
     appcast 'https://www.spectacleapp.com/updates/appcast.xml',
-            checkpoint: 'fc09f1ec4c33bc291b3ef504637f3e83d8be7198fa636ac70e73a5f0a51315cd'
+            checkpoint: 'e9634b0540816be0607d661c31d7ea7ae37a8d545030c4f88f70e1cd0d2852df'
   end
 
   # amazonaws.com/spectacle was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.