### PR TITLE
Update dripcap to 0.5.1

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.5.0'
-  sha256 '00f2ddc25c11db471a578abeff85dfb632c37e0806d0c4fa5a292001da600ff9'
+  version '0.5.1'
+  sha256 '067567e6ab0be23e4899572e45b2549f6b4ef7ee230fb928d21278aa1b9642c5'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '1fa85ee2b4060af1ebdbcf383b67b284b27888930d211d2f4eb90133296861c6'
+          checkpoint: 'b70c95f5998afe00e0ed1874dfa4e493720caec7ae0d4b5b0647ff0ac0684613'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.