### PR TITLE
Update soundcloud-downloader to 2.6.5

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
-  version '2.6.4'
-  sha256 'eabb5f3f7ef0db45a804a720069fa98160ff51ca6ec6e0184423f1f4ef98e0af'
+  version '2.6.5'
+  sha256 '9bdb97b69dc28fd656de1d8d3f9d7fea5557f435417af6a8abf5126863ee2abe'
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
   appcast 'http://black-burn.ch/applications/scd/updates.php?hwni=1',
-          checkpoint: '69e4f358b3c260581c3d4da1d3cfc0285ed6b804e635457365382ec4ab17d7d8'
+          checkpoint: '0ec0399dd00efb723e161a4d0b26956a38d04e48cd7e7061ac29e1413546e430'
   name 'SoundCloud Downloader'
   homepage 'http://black-burn.ch/scd/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.