### PR TITLE
Update parallels-virtualization-sdk to 12.1.1-41491

### DIFF
--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -1,6 +1,6 @@
 cask 'parallels-virtualization-sdk' do
-  version '11.1.3-32521'
-  sha256 'f6fda8d04dc14a0576762642195a6653384fb8718dbb1f313302c53b9169eb32'
+  version '12.1.1-41491'
+  sha256 '76bca1e1d0b74db5b43d81774674393771048bbca9e1c21e4ef60cbd5ca254e0'
 
   url "https://download.parallels.com/desktop/v#{version[%r{^\w+}]}/#{version}/ParallelsVirtualizationSDK-#{version}-mac.dmg"
   name 'Parallels Virtualization SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.