### PR TITLE
Update dupin to 2.11.1

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,11 +3,11 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.11.0'
-    sha256 '57bbc2247a806fc1bcc83e0abcdf7ea078203c205bd1717955d25b485fd3e83e'
+    version '2.11.1'
+    sha256 '1cb909a9e49ece636bfcd1a56827fb5ed89bd9089200bd8a56937787677da7d1'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml',
-            checkpoint: '4c3f8d66bae375c1cd896ead741f4c5aa90c0295687cbb116b3ddb306b3d31fc'
+            checkpoint: '4fb8b05a84b3e8929fae6e7afa071de4ed51c26139f4c25c160d03cf74623d15'
   end
 
   url "https://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.