### PR TITLE
Update kindle to 44182

### DIFF
--- a/Casks/kindle.rb
+++ b/Casks/kindle.rb
@@ -1,6 +1,6 @@
 cask 'kindle' do
-  version '44033'
-  sha256 'f411c7ca8a7078c6fabb28884761101544208e658394e3fde313745382e66748'
+  version '44182'
+  sha256 '28dc21246a9c7cdedd2d6f0f4082e6bf7ef9db9ce9d485548e8a9e1d19eae2ac'
 
   url "http://kindleformac.amazon.com/#{version}/KindleForMac-#{version}.dmg"
   name 'Kindle for Mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.