### PR TITLE
Update scythebill to 13.4.0

### DIFF
--- a/Casks/scythebill.rb
+++ b/Casks/scythebill.rb
@@ -1,6 +1,6 @@
 cask 'scythebill' do
-  version '13.2.5'
-  sha256 'f265663e302169b8e5f44e1ffcdecc356f66a5b4fd243ad43522ba924011284a'
+  version '13.4.0'
+  sha256 'a503abb08e9ad22bd90c8a1e3c5acbc011ff9c39c4cdf1fea736bb1aa4ba9730'
 
   # amazonaws.com/downloads.scythebill.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.scythebill.com/Scythebill-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.