### PR TITLE
Update rbtools to 0.7.7

### DIFF
--- a/Casks/rbtools.rb
+++ b/Casks/rbtools.rb
@@ -1,8 +1,10 @@
 cask 'rbtools' do
-  version '0.7.5'
-  sha256 'fd910542e24d067df3fe635e982ae5e3526a0036f79ff129c29cf66f02751bd6'
+  version '0.7.7'
+  sha256 '9f349490d82ce62c373c639437b14f81b40a36e6f06c7ec3c3154bc388d9defb'
 
-  url "https://downloads.reviewboard.org/releases/RBTools/#{version.sub(%r{\.\d+$}, '')}/RBTools-#{version}.pkg"
+  url "https://downloads.reviewboard.org/releases/RBTools/#{version.major_minor}/RBTools-#{version}.pkg"
+  appcast 'https://www.reviewboard.org/docs/releasenotes/rbtools/',
+          checkpoint: '8c04b3f5824596f4882606e02321e76d50646b606529ecec7ff671ea45d1e651'
   name 'RBTools'
   homepage 'https://www.reviewboard.org/docs/rbtools/0.7/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.