### PR TITLE
Update borgbackup to 1.0.9rc1

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.0.8'
-  sha256 '9f74f984b362519c7fa8feb9662242bc8c6bf73175e2808e850ec662b62c8f30'
+  version '1.0.9rc1'
+  sha256 '926af3037808a017bd54c43d8d83e91ba2da68631b4321f253acedd704f200af'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '02c302ab17b35ef5cc66613a4e27733afff139fec6eed769bd22258e70e58205'
+          checkpoint: '18c47b4b9dec2deff4da88dfdbe1f833ae680143d5291305d034fe68083c86d7'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.io/en/stable/'
   gpg "#{url}.asc", key_id: '51F78E01'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.