### PR TITLE
Update redcine-x-pro to 42.0.0,41605

### DIFF
--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -1,12 +1,12 @@
 cask 'redcine-x-pro' do
-  version '39.40030'
-  sha256 '177c87dd1ccc5579b446020a5b5400a71f2713981afbc13f0fc202bf4270af99'
+  version '42.0.0,41605'
+  sha256 'ad0fe98b60a1997ff4e524a40925708c178a0f1f0af97c14f9bf0590f19e662a'
 
-  url "http://downloads.red.com/software/rcx/mac/release/#{version}/REDCINE-X_PRO_Build_#{version.major}.0.pkg"
+  url "http://downloads.red.com/software/rcx/mac/release/#{version.major}.#{version.after_comma}/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
   name 'REDCINE-X PRO'
   homepage 'http://www.red.com/'
 
-  pkg "REDCINE-X_PRO_Build_#{version.major}.0.pkg"
+  pkg "REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
 
   uninstall pkgutil: [
                        'com.red.pkg.REDCINE-X PRO',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.