### PR TITLE
Update scrivener to 2.81.2,106

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,9 +1,9 @@
 cask 'scrivener' do
-  version '2.8.1.2,106'
+  version '2.81.2,106'
   sha256 'b4a09047b4b7f7522d58fdd5736f7de9d7250447f3573fd993964bfb3b6be1e1'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://scrivener.s3.amazonaws.com/mac_updates/Scrivener_#{version.after_comma}_#{version.before_comma.gsub(%r{\.\d+\.}, '.' + version.minor)}.zip"
+  url "http://scrivener.s3.amazonaws.com/mac_updates/Scrivener_#{version.after_comma}_#{version.before_comma}.zip"
   appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
           checkpoint: '5ebdbf2cd82e1d644ad1a63fac21cbc02ca8d180295eea9ab944d91700f8052c'
   name 'Scrivener'

--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,11 +1,11 @@
 cask 'scrivener' do
-  version '2.8'
-  sha256 '752a689ca500a9b5ec8192790fd747671896e4f3ca4c8e14cc0b9943726cc36a'
+  version '2.8.1.2,106'
+  sha256 'b4a09047b4b7f7522d58fdd5736f7de9d7250447f3573fd993964bfb3b6be1e1'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
+  url "http://scrivener.s3.amazonaws.com/mac_updates/Scrivener_#{version.after_comma}_#{version.before_comma.gsub(%r{\.\d+\.}, '.' + version.minor)}.zip"
   appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
-          checkpoint: '79e3d31dd436e68082f47d8d3690967b250f6f810eca34b4e057f3255003cdde'
+          checkpoint: '5ebdbf2cd82e1d644ad1a63fac21cbc02ca8d180295eea9ab944d91700f8052c'
   name 'Scrivener'
   homepage 'https://literatureandlatte.com/scrivener.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.