### PR TITLE
Update wechatwebdevtools to 0.11.112301,011112301a

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '0.10.102800,010102800'
-  sha256 '84dedd2680afc42a951579e4ca3278e69cfa27193eb0f288be7e9da73b5d3cd7'
+  version '0.11.112301,011112301a'
+  sha256 '035a9f921ee1d83bb19f87fc9512db2411e5610f67b175a112a8224ec09ec223'
 
   url "http://dldir1.qq.com/WechatWebDev/#{version.after_comma}/wechat_web_devtools_#{version.before_comma}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.