### PR TITLE
Update imageplay to 6.1.0

### DIFF
--- a/Casks/imageplay.rb
+++ b/Casks/imageplay.rb
@@ -1,11 +1,11 @@
 cask 'imageplay' do
-  version '6.0.0'
-  sha256 '669b56528cd8c8634c1d16f0fce0c0c450004705b55566922a4062974d7df01e'
+  version '6.1.0'
+  sha256 'b85bdff21dd8a569d84f3dcf25b2201b5c784ef06b8a5db8a6390897e2d7ed9d'
 
   # github.com/cpvrlab/ImagePlay was verified as official when first introduced to the cask
   url "https://github.com/cpvrlab/ImagePlay/releases/download/#{version}/ImagePlay-#{version}.dmg"
   appcast 'https://github.com/cpvrlab/ImagePlay/releases.atom',
-          checkpoint: 'fb7eee5114029e3ce1cf0e40b01f6e99393fa6dd567e6d6df5de2cad56589d3b'
+          checkpoint: 'df31de5607628dbc9cd4f6d842a6d3d077d30db480f8148212e7bab5c499a8c3'
   name 'ImagePlay'
   homepage 'https://imageplay.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.