### PR TITLE
Update camerabag-photo to 3.0.1

### DIFF
--- a/Casks/camerabag-photo.rb
+++ b/Casks/camerabag-photo.rb
@@ -1,4 +1,4 @@
-cask 'camerabag' do
+cask 'camerabag-photo' do
   version '3.0.1'
   sha256 '5fd4bad30ae1d84d179c0b10a38ea9df3f89d7c450e1c8f912da2f8f37949c9d'
 

--- a/Casks/camerabag.rb
+++ b/Casks/camerabag.rb
@@ -1,11 +1,11 @@
 cask 'camerabag' do
-  version '2.7.01'
-  sha256 'e120208a17692ebcc5ad7c7c3fc27125fe9870530174b2872a2a3b3fdaff6163'
+  version '3.0.1'
+  sha256 '5fd4bad30ae1d84d179c0b10a38ea9df3f89d7c450e1c8f912da2f8f37949c9d'
 
   # downloads.nevercenter.com.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://downloads.nevercenter.com.s3.amazonaws.com/CameraBag_Mac_#{version.dots_to_underscores}.dmg"
+  url "http://downloads.nevercenter.com.s3.amazonaws.com/CameraBag_Photo_Mac_#{version.dots_to_underscores}.dmg"
   name 'CameraBag'
   homepage 'https://nevercenter.com/camerabag/photo/'
 
-  app "CameraBag #{version.major}.app"
+  app 'CameraBag Photo.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.