### PR TITLE
Update servetome to 4.0.0144

### DIFF
--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -1,8 +1,10 @@
 cask 'servetome' do
-  version '3.9.0.3101'
-  sha256 '507987377436f80f985e3c46e1f5ffaecea933d8fbe36c23a5eb09f11c77567a'
+  version '4.0.0144'
+  sha256 '32e9ab67641a22051e4e879f8aeb6d723fa2e7ac5aee961c155bacb735d59be7'
 
   url "http://downloads.zqueue.com/ServeToMe-v#{version}.dmg"
+  appcast 'https://www.zqueue.com/servetome/changehistory.html',
+          checkpoint: 'e94a01c4410b8d1bfe8fce5feb9dc465e9fbbf1dc5510ac80fb0bdce886156ab'
   name 'ServeToMe'
   homepage 'https://www.zqueue.com/servetome/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.