### PR TITLE
Update ndm to 0.0.5-beta

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '0.0.4-beta'
-  sha256 '204e2a3b769f4d9e215d85b6748ba2d8e8dff35b3be6cd3107540ad64d21f069'
+  version '0.0.5-beta'
+  sha256 '61ca8bd11d297e075ae969b3222cd8e072dc4b615e3ec8797781d82a8e9be747'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '4d14881a991e3657c760486eca870685762f1347964713575719b96c3ce0369e'
+          checkpoint: '986240f18ce25bbb5bb42db29eeb5eaea52b1d1dc7dc01494eb4d802d2785e4d'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.