### PR TITLE
Add latest zeronet.

### DIFF
--- a/Casks/zeronet.rb
+++ b/Casks/zeronet.rb
@@ -1,0 +1,11 @@
+cask 'zeronet' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/HelloZeroNet/ZeroBundle was verified as official when first introduced to the cask
+  url 'https://github.com/HelloZeroNet/ZeroBundle/raw/master/dist/ZeroBundle-mac-osx.zip'
+  name 'ZeroNet'
+  homepage 'https://zeronet.io/'
+
+  suite 'ZeroBundle'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

- - -

You might say that the token must be `zerobundle` instead of `zeronet` because of the zipball name. But the app is widely known as zeronet.  

Related: #22155