### PR TITLE
Update virtual-mix-rack to 1.6.6.2

### DIFF
--- a/Casks/virtual-mix-rack.rb
+++ b/Casks/virtual-mix-rack.rb
@@ -1,12 +1,10 @@
 cask 'virtual-mix-rack' do
-  version '1.6.4.1'
-  sha256 '687eed5f1d7f09623ca6322a222178149c6a73d98fa794beaecc1a228d891e80'
+  version '1.6.6.2'
+  sha256 'd0ae13f883c86069b78914320a1a9b3d6fc773a1bc44fc4c3e92d2f868a0cf99'
 
   url "http://download.slatedigital.com/vmr/VMR_#{version.no_dots}_Mac.zip"
   name 'Slate Digital Virtual Mix Rack'
   homepage 'https://slatedigital.com/'
-
-  container nested: "VMR_#{version.no_dots}_Mac.dmg"
 
   pkg 'Install Virtual Mix Rack.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.