### PR TITLE
Update stackato to 3.2.6

### DIFF
--- a/Casks/stackato.rb
+++ b/Casks/stackato.rb
@@ -1,8 +1,10 @@
 cask 'stackato' do
-  version '3.2.4'
-  sha256 'e1d940509d46bc1ec4829998c736b802f77c01971e661d43456fe7574b16e48f'
+  version '3.2.6'
+  sha256 'b0f2221957379f5e37c56da2818b6755d928b6f5b6a92e415a14098692e9b3ab'
 
   url "http://downloads.stackato.com/client/v#{version}/stackato-#{version}-macosx10.5-i386-x86_64.zip"
+  appcast 'http://downloads.stackato.com/client/',
+          checkpoint: '561b75d8736f901c2768fa1039f282de1a8dd1da7586166637b0bddc10ad117b'
   name 'Stackato'
   homepage 'https://docs.stackato.com/user/client/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.