### PR TITLE
Update nitroshare to 0.3.3

### DIFF
--- a/Casks/nitroshare.rb
+++ b/Casks/nitroshare.rb
@@ -1,8 +1,10 @@
 cask 'nitroshare' do
-  version '0.3.0'
-  sha256 '159f9ea92aff66f6123df8f0214c9c2e39b1ca347ce005efc2838ff6cde4b759'
+  version '0.3.3'
+  sha256 'a22ee3450f2dc8b72b98709fc44cc7cac4f43e95bb3a367b2b523331c82e0ba2'
 
-  url "https://launchpad.net/nitroshare/0.3/#{version}/+download/nitroshare-#{version}-osx.dmg"
+  url "https://launchpad.net/nitroshare/#{version.major_minor}/#{version}/+download/nitroshare-#{version}-osx.dmg"
+  appcast 'https://github.com/nitroshare/nitroshare-desktop/releases.atom',
+          checkpoint: '5e7923cad51870abc31d5adc65dedf76825b71f719a75ef05f3057ece9c62aff'
   name 'NitroShare'
   homepage 'https://launchpad.net/nitroshare'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.