### PR TITLE
Update bitkeeper to 7.3.1ce

### DIFF
--- a/Casks/bitkeeper.rb
+++ b/Casks/bitkeeper.rb
@@ -1,8 +1,10 @@
 cask 'bitkeeper' do
-  version '7.2.1ce'
-  sha256 'ddc161d433ec963f35aca3619211bd3d0a02629ce697b02c954a6a002453a7d6'
+  version '7.3.1ce'
+  sha256 '25607370fbf3312e5f19785c438fb1db1b62f38eeb4ec1707acbe8bd85a21163'
 
   url "https://www.bitkeeper.org/downloads/#{version}/bk-#{version}-x86_64-macosx.pkg"
+  appcast 'https://www.bitkeeper.org/download.html',
+          checkpoint: '3ec320168eb53f3f1317b7ef2f9fefdf3633b40d18022c554b228eb1db50d8a8'
   name 'BitKeeper'
   homepage 'https://www.bitkeeper.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.