### PR TITLE
Move wasted.rb links

### DIFF
--- a/Casks/wasted.rb
+++ b/Casks/wasted.rb
@@ -4,7 +4,7 @@ cask 'wasted' do
 
   url 'http://wasted.werk01.de/Wasted.zip'
   appcast 'http://wasted.werk01.de/appcast.xml',
-          checkpoint: '2798524a4eb590c537dd46085528bb94a3717d6dd07572e93cb2241ed682f722'
+          checkpoint: '23a115ef319622d89f1b56f4b1ffea1ba10fd69e3b753e48344a4566687f04c6'
   name 'WASTED'
   homepage 'http://wasted.werk01.de'
 

--- a/Casks/wasted.rb
+++ b/Casks/wasted.rb
@@ -3,7 +3,7 @@ cask 'wasted' do
   sha256 '9802d9d9674145881f82ccd127ee49d64af4fd09f27a1199fe354a5fe57881ba'
 
   url 'http://wasted.werk01.de/Wasted.zip'
-  appcast 'http://werk01.de/wasted/appcast.xml',
+  appcast 'http://wasted.werk01.de/appcast.xml',
           checkpoint: '2798524a4eb590c537dd46085528bb94a3717d6dd07572e93cb2241ed682f722'
   name 'WASTED'
   homepage 'http://wasted.werk01.de'

--- a/Casks/wasted.rb
+++ b/Casks/wasted.rb
@@ -2,11 +2,11 @@ cask 'wasted' do
   version '3.0'
   sha256 '9802d9d9674145881f82ccd127ee49d64af4fd09f27a1199fe354a5fe57881ba'
 
-  url 'http://werk01.de/wasted/Wasted.zip'
+  url 'http://wasted.werk01.de/Wasted.zip'
   appcast 'http://werk01.de/wasted/appcast.xml',
-          checkpoint: '23a115ef319622d89f1b56f4b1ffea1ba10fd69e3b753e48344a4566687f04c6'
+          checkpoint: '2798524a4eb590c537dd46085528bb94a3717d6dd07572e93cb2241ed682f722'
   name 'WASTED'
-  homepage 'http://werk01.de/wasted/'
+  homepage 'http://wasted.werk01.de'
 
   app 'Wasted.app'
 end


### PR DESCRIPTION
All links for this cask were 404. Updated to locations that are responding.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.