### PR TITLE
Update bathyscaphe to 280-v988

### DIFF
--- a/Casks/bathyscaphe.rb
+++ b/Casks/bathyscaphe.rb
@@ -1,8 +1,10 @@
 cask 'bathyscaphe' do
-  version '273-v966'
-  sha256 '5a0e8ce2305a8a1fb43e9851cdb046764e4a6d48204ec0c0b955d3dc69ecc969'
+  version '280-v988'
+  sha256 '12f1036e7881a9a8bd61cfe0493fe7c4684e7b139438018790b219e04e7b1c30'
 
   url "https://bitbucket.org/bathyscaphe/public/downloads/BathyScaphe-#{version}.dmg"
+  appcast 'https://api.bitbucket.org/2.0/repositories/bathyscaphe/public/downloads',
+          checkpoint: 'ddb893bb169ce5bb42f0f3f0ece5315e53606ba03054ab78452db18eebd53084'
   name 'BathyScaphe'
   homepage 'http://bathyscaphe.bitbucket.org/'
 

--- a/Casks/bathyscaphe.rb
+++ b/Casks/bathyscaphe.rb
@@ -3,8 +3,6 @@ cask 'bathyscaphe' do
   sha256 '12f1036e7881a9a8bd61cfe0493fe7c4684e7b139438018790b219e04e7b1c30'
 
   url "https://bitbucket.org/bathyscaphe/public/downloads/BathyScaphe-#{version}.dmg"
-  appcast 'https://api.bitbucket.org/2.0/repositories/bathyscaphe/public/downloads',
-          checkpoint: 'ddb893bb169ce5bb42f0f3f0ece5315e53606ba03054ab78452db18eebd53084'
   name 'BathyScaphe'
   homepage 'http://bathyscaphe.bitbucket.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.