### PR TITLE
Update dhs to 1.3.1

### DIFF
--- a/Casks/dhs.rb
+++ b/Casks/dhs.rb
@@ -1,6 +1,6 @@
 cask 'dhs' do
-  version '1.2.0'
-  sha256 '8a9d15d5fd4cff113285fa53b2e4071fe9f7c9d2b8e7514f3ba907e657972405'
+  version '1.3.1'
+  sha256 '3fc293da9f4730790e8c07833e0225fa6b57d2455bec53dd8e5b1e50de41c8d4'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/DHS_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.