### PR TITLE
Update haroopad to 0.13.2

### DIFF
--- a/Casks/haroopad.rb
+++ b/Casks/haroopad.rb
@@ -1,9 +1,11 @@
 cask 'haroopad' do
-  version '0.13.1'
-  sha256 '97ea132dfb1efa5492d98ee3b7de4beda79796ac75ce293c57e8300e11b1f694'
+  version '0.13.2'
+  sha256 '97ef0a7df52daeace17ea01a1ca82dc974955c147593f251fb7c04ca0ff09064'
 
   # bitbucket.org/rhiokim/haroopad-download was verified as official when first introduced to the cask
   url "https://bitbucket.org/rhiokim/haroopad-download/downloads/Haroopad-v#{version}-x64.dmg"
+  appcast 'https://api.bitbucket.org/2.0/repositories/rhiokim/haroopad-download/downloads',
+          checkpoint: '18a1125d12b7dfed1a60b96a8f978947c4ab6b63c130d62f2686e22fab03a3ee'
   name 'Haroopad'
   homepage 'http://pad.haroopress.com/'
 

--- a/Casks/haroopad.rb
+++ b/Casks/haroopad.rb
@@ -4,8 +4,6 @@ cask 'haroopad' do
 
   # bitbucket.org/rhiokim/haroopad-download was verified as official when first introduced to the cask
   url "https://bitbucket.org/rhiokim/haroopad-download/downloads/Haroopad-v#{version}-x64.dmg"
-  appcast 'https://api.bitbucket.org/2.0/repositories/rhiokim/haroopad-download/downloads',
-          checkpoint: '18a1125d12b7dfed1a60b96a8f978947c4ab6b63c130d62f2686e22fab03a3ee'
   name 'Haroopad'
   homepage 'http://pad.haroopress.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.