### PR TITLE
Update twine to 2.1.0b5

### DIFF
--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -1,11 +1,11 @@
 cask 'twine' do
-  version '2.0.11'
-  sha256 '360d7b72b538d622e01d5fdac059bf6ddeac97619fdf5002fae736ca4b4eca19'
+  version '2.1.0b5'
+  sha256 '355b2ef4ecf82ff5e696f3b7337e9d8939d0625b5e35c0a9a2889f98d25cd435'
 
   # bitbucket.org/klembot/twinejs was verified as official when first introduced to the cask
   url "https://bitbucket.org/klembot/twinejs/downloads/twine_#{version}_osx.zip"
   name 'Twine'
   homepage 'https://twinery.org/'
 
-  app 'Twine.app'
+  app 'nw/Twine/osx64/Twine.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.