### PR TITLE
 New Cask Raven Lite 2.0 sound analysis software

### DIFF
--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -4,14 +4,14 @@ cask 'raven-lite' do
 
   url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version}_macosx.dmg"
   name 'Raven Lite'
-  homepage 'http://www.birds.cornell.edu/brp/RavenLite/RavenLiteReadMe.htm'
+  homepage 'http://www.birds.cornell.edu/brp/raven/RavenOverview.html'
 
   depends_on macos: '>= :mountain_lion'
   depends_on arch: :x86_64
 
-  installer manual: 'RavenLite-Installer.app'
-
-  uninstall trash: '/Applications/Raven Lite 2.0/'
+  installer script: './RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher',
+    sudo: false
+  uninstall delete: "/Applications/Raven Lite #{version.major_minor}/"
 
   caveats do
       depends_on_java('8+')

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -14,6 +14,6 @@ cask 'raven-lite' do
   uninstall delete: "/Applications/Raven Lite #{version.major_minor}/"
 
   caveats do
-      depends_on_java('8+')
+    depends_on_java('8+')
   end
 end

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -2,7 +2,7 @@ cask 'raven-lite' do
   version '2.0.0.0022'
   sha256 '84c8d97df6119605ff645c93d896d472a814246fb87128611225168459423532'
 
-  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version.major_minor_patch}_macosx.dmg"
+  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version}_macosx.dmg"
   name 'Raven Lite'
   homepage 'http://www.birds.cornell.edu/brp/RavenLite/RavenLiteReadMe.htm'
 

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -7,11 +7,10 @@ cask 'raven-lite' do
   homepage 'http://www.birds.cornell.edu/brp/raven/RavenOverview.html'
 
   depends_on macos: '>= :mountain_lion'
-  depends_on arch: :x86_64
 
   installer script: 'RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher', sudo: false
 
-  uninstall delete: "/Applications/Raven Lite #{version.major_minor}/"
+  uninstall delete: "/Applications/Raven Lite #{version.major_minor}"
 
   caveats do
     depends_on_java('8+')

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -9,8 +9,8 @@ cask 'raven-lite' do
   depends_on macos: '>= :mountain_lion'
   depends_on arch: :x86_64
 
-  installer script: './RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher',
-    sudo: false
+  installer script: './RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher', sudo: false
+  
   uninstall delete: "/Applications/Raven Lite #{version.major_minor}/"
 
   caveats do

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -8,7 +8,7 @@ cask 'raven-lite' do
 
   depends_on macos: '>= :mountain_lion'
 
-  installer script: 'RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher', sudo: false
+  installer manual: 'RavenLite-Installer.app'
 
   uninstall delete: "/Applications/Raven Lite #{version.major_minor}"
 

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -9,8 +9,8 @@ cask 'raven-lite' do
   depends_on macos: '>= :mountain_lion'
   depends_on arch: :x86_64
 
-  installer script: './RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher', sudo: false
-  
+  installer script: 'RavenLite-Installer.app/Contents/MacOS/JavaAppLauncher', sudo: false
+
   uninstall delete: "/Applications/Raven Lite #{version.major_minor}/"
 
   caveats do

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -1,0 +1,19 @@
+cask 'raven-lite' do
+  version '2.0.0.0022'
+  sha256 '84c8d97df6119605ff645c93d896d472a814246fb87128611225168459423532'
+
+  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version}_macosx.dmg"
+  name 'Raven Lite 2.0'
+  homepage 'http://www.birds.cornell.edu/brp/RavenLite/RavenLiteReadMe.htm'
+
+  depends_on macos: '>= :mountain_lion'
+  depends_on arch: :x86_64
+
+  installer manual: 'RavenLite-Installer.app'
+
+  uninstall trash: '/Applications/Raven Lite 2.0/'
+
+  caveats do
+    depends_on_java('6')
+  end
+end

--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -2,8 +2,8 @@ cask 'raven-lite' do
   version '2.0.0.0022'
   sha256 '84c8d97df6119605ff645c93d896d472a814246fb87128611225168459423532'
 
-  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version}_macosx.dmg"
-  name 'Raven Lite 2.0'
+  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version.major_minor_patch}_macosx.dmg"
+  name 'Raven Lite'
   homepage 'http://www.birds.cornell.edu/brp/RavenLite/RavenLiteReadMe.htm'
 
   depends_on macos: '>= :mountain_lion'
@@ -14,6 +14,6 @@ cask 'raven-lite' do
   uninstall trash: '/Applications/Raven Lite 2.0/'
 
   caveats do
-    depends_on_java('6')
+      depends_on_java('8+')
   end
 end


### PR DESCRIPTION
This adds the 64 bit Free version of the Cornell Lab of Ornithology Raven Lite 2.0 software used "for the acquisition, visualization, measurement, and analysis of sounds."
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked that the cask was not already refused in [closed issues].