### PR TITLE
Update deadbeef to 0.7.2

### DIFF
--- a/Casks/deadbeef.rb
+++ b/Casks/deadbeef.rb
@@ -1,5 +1,5 @@
 cask 'deadbeef' do
-  version '0.7.2-2'
+  version '0.7.2'
   sha256 '13efaf69691e579a95dc5394648766f533082cc8acd4fef094eb5d92f600e967'
 
   url 'https://downloads.sourceforge.net/deadbeef/travis/osx/master/deadbeef-devel-osx-x86_64.zip'

--- a/Casks/deadbeef.rb
+++ b/Casks/deadbeef.rb
@@ -1,10 +1,10 @@
 cask 'deadbeef' do
   version '0.7.2-2'
-  sha256 'cfac56c37d55ccebf934d3b8c0a2b0ae7acf809e9c5aa5dcf6ff0b5a281a4e5b'
+  sha256 '13efaf69691e579a95dc5394648766f533082cc8acd4fef094eb5d92f600e967'
 
-  url "https://downloads.sourceforge.net/deadbeef/deadbeef-static_#{version}_i686.tar.bz2"
+  url 'https://downloads.sourceforge.net/deadbeef/travis/osx/master/deadbeef-devel-osx-x86_64.zip'
   appcast 'https://sourceforge.net/projects/deadbeef/rss?path=/travis/osx/master',
-          checkpoint: 'ed8178e68dd11ce0d03d31f8864e4eaa95cf45112764691f0b82793fcbd4dcb2'
+          checkpoint: 'd9170ef09da3831c32f6cc4e2331cb67571738aa69c90dbf86d4554cc9bd3875'
   name 'DeaDBeeF'
   homepage 'http://deadbeef.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes [#28041](https://github.com/caskroom/homebrew-cask/issues/28041).