### PR TITLE
Update opera to 42.0.2393.94

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '42.0.2393.85'
-  sha256 '76f50245d1ef06f1a702590ebd2b24bccb379370b45975d608a179cddec03e5b'
+  version '42.0.2393.94'
+  sha256 '7421382175f938883612d8ff61fc3086894472ccbfc39bad36547afce98a82c8'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.