### PR TITLE
Update dbeaver-enterprise checksums

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,10 +1,10 @@
 cask 'dbeaver-enterprise' do
   version '3.8.2'
-  sha256 '0dcd609672e884874e6397652060697e29d7cf7b84030aadcac1dc0d812862ca'
+  sha256 '8061dfcebf357586938e0f89bbd774a0fc9cd501afa1cef218e5754b529d9f70'
 
   url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
   appcast 'http://dbeaver.jkiss.org/files/',
-          checkpoint: 'd12e3485499f7bc09a44a51424b0f51f844b58c94837d0a811fd15876b545af2'
+          checkpoint: '248a14eb2cac6358f84b3043f226f9a06125ae2c4a3a497d59fd133652a56842'
   name 'DBeaver Enterprise Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
It appears that jkiss performed a sneaky update of dbeaver's latest version without announcement and the files have changed. Updating both the package checksum as well as the appcast.

Please see the comments on #27991 for more information.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.