### PR TITLE
Update pikopixel to 1.0-b7

### DIFF
--- a/Casks/pikopixel.rb
+++ b/Casks/pikopixel.rb
@@ -1,8 +1,8 @@
 cask 'pikopixel' do
-  version '1.0b5'
-  sha256 '939c1ca666a0fa442e0f378e8bfe2f7b1946468b113bfef183d04b730fedf84f'
+  version '1.0-b7'
+  sha256 '6316f098a9f628fe195e56801dc688db8d27ee81eacc81e94c7b7635c08de20e'
 
-  url "http://twilightedge.com/downloads/PikoPixel#{version}.dmg",
+  url "http://twilightedge.com/downloads/PikoPixel.#{version}.dmg",
       user_agent: :fake
   name 'PikoPixel'
   homepage 'http://twilightedge.com/mac/pikopixel/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.