### PR TITLE
Update dragthing to 5.9.17

### DIFF
--- a/Casks/dragthing.rb
+++ b/Casks/dragthing.rb
@@ -1,6 +1,6 @@
 cask 'dragthing' do
-  version '5.9.12'
-  sha256 '4a351c593aff1c3214613d622a4e81f184e8ae238df6db921dd822efeefe27e6'
+  version '5.9.17'
+  sha256 '62d553878267d617aa2be48f09dfc401d08afce216cd42aef7441f4f95dd4cff'
 
   # amazonaws.com/tlasystems was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tlasystems/DragThing-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.