### PR TITLE
Update airtool to 1.4.1

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,11 +1,11 @@
 cask 'airtool' do
-  version '1.4'
-  sha256 '8c478e1018069dbfc409ecf6d3c955a87d688dad9773ba392c26f2552782ebc3'
+  version '1.4.1'
+  sha256 '3e3d03ae51f11d49f3248a7d57402add6896334665b1e571ba3560e4676496d5'
 
   # amazonaws.com/adriangranados was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/adriangranados/airtool_#{version}.pkg"
   appcast 'https://www.adriangranados.com/appcasts/airtoolcast.xml',
-          checkpoint: '3ae27f24c6a73ba242570adec45ea7cbf1b02b87c69494f02d978924b52c3a92'
+          checkpoint: 'be5ebb845b2cf05c33c732a910e883d32ddf6209b32515dab83ea9ff5b873fa7'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.