### PR TITLE
Update eve-launcher to 1104888

### DIFF
--- a/Casks/eve-launcher.rb
+++ b/Casks/eve-launcher.rb
@@ -1,10 +1,12 @@
 cask 'eve-launcher' do
-  version '1045952'
-  sha256 '9ed265c3968f01ca608484a1146c22303bdfa0c1af6ff906fe469354c8640864'
+  version '1104888'
+  sha256 '7bbb94efe41638e222d0cbfb6cb13803b07a6df6f075a0586e91669c9efde3fc'
 
   url "https://binaries.eveonline.com/EveLauncher-#{version}.dmg"
   name 'Eve Online'
   homepage 'https://www.eveonline.com/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'EVE Launcher.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.