### PR TITLE
ostitarius: refuse to install on Sierra and later

### DIFF
--- a/Casks/ostiarius.rb
+++ b/Casks/ostiarius.rb
@@ -7,7 +7,7 @@ cask 'ostiarius' do
   name 'Ostiarius'
   homepage 'https://objective-see.com/products/ostiarius.html'
 
-  depends_on macos: '<= :sierra'
+  depends_on macos: '<= :el_capitan'
 
   app 'Ostiarius.app'
 

--- a/Casks/ostiarius.rb
+++ b/Casks/ostiarius.rb
@@ -7,9 +7,17 @@ cask 'ostiarius' do
   name 'Ostiarius'
   homepage 'https://objective-see.com/products/ostiarius.html'
 
+  depends_on macos: '<= :sierra'
+
   app 'Ostiarius.app'
 
   uninstall quit:   'com.objectiveSee.Ostiarius',
             kext:   'com.objective-see.OstiariusKext',
             delete: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.objectivesee.ostiarius.sfl'
+
+  caveats <<-EOS.undent
+    Apple fixed the Gatekeeper flaws the developer discovered and reported that Ostiarius protected against. As such, if you’re running macOS Sierra (10.12+), Ostiarius is no longer needed!
+
+    For that reason we’re making the cask refuse to install on Sierra and later.
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

See [homepage](https://objective-see.com/products/ostiarius.html) for confirmation.