### PR TITLE
Update helm to 2.1.2

### DIFF
--- a/Casks/helm.rb
+++ b/Casks/helm.rb
@@ -1,11 +1,11 @@
 cask 'helm' do
-  version '2.1.0'
-  sha256 '1080267d1b4b7e0b5fe8dd192dcf8d83e817db396a3764d4be18d66e1434646c'
+  version '2.1.2'
+  sha256 '2b522dcfe27e987138f7826c79fb26a187075dd9be5c5a4c76fd6846bf109014'
 
   # storage.googleapis.com/kubernetes-helm/ was verified as official when first introduced to the cask
   url "http://storage.googleapis.com/kubernetes-helm/helm-v#{version}-darwin-amd64.tar.gz"
   appcast 'https://github.com/kubernetes/helm/releases.atom',
-          checkpoint: '7e053608498504e5aeb965a956f5d3d0934256c856fbbd608fcab72078837c40'
+          checkpoint: '894e3439c7fa23614115010d85529f1bae5156a7caaf86120bf387155a5b93a3'
   name 'Helm'
   homepage 'https://github.com/kubernetes/helm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.