### PR TITLE
Update robofont to 1.8.1,1612102134

### DIFF
--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -1,6 +1,6 @@
 cask 'robofont' do
-  version '1.6,1410152315'
-  sha256 'fb2fd390868a32fb9e89490081f3f052e65c1156ee32b39cac1c799b87abc4c7'
+  version '1.8.1,1612102134'
+  sha256 '923b0d7f72a4e155e86fc9afa1e657dc240662d7470f5d93162b13c2359dd936'
 
   url "http://robofont.com/downloads/RoboFont_#{version.after_comma}.dmg"
   name 'RoboFont'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.