### PR TITLE
Update inkdrop to 3.0.1

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,11 +1,11 @@
 cask 'inkdrop' do
-  version '3.0.0'
-  sha256 '00faf854c9a48b1419dceb3b22d5e924b9fc97915e22ddb6d012f037bd15662f'
+  version '3.0.1'
+  sha256 '2bc6326746785120bb3b12557df384fc29c3b99c3b8d01bc4e30b2481f38c06a'
 
   # github.com/inkdropapp was verified as official when first introduced to the cask
   url "https://github.com/inkdropapp/releases/releases/download/v#{version}/Inkdrop-#{version}-Mac.zip"
   appcast 'https://github.com/inkdropapp/releases/releases.atom',
-          checkpoint: '2f8f5018f2b7f8f8b992958143a52656103c6ee39a483784bd49a754330ada03'
+          checkpoint: '56b561993fc10c48b9ea1d880fdce4698e5ad1e8a1f68bb6241b4f77faa3ad34'
   name 'Inkdrop'
   homepage 'https://www.inkdrop.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.