### PR TITLE
Update airdroid to 3.3.5.3

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
-  version '3.3.5.1'
-  sha256 '6e2e6e988071b4eec64ddc1e3e30c7f372fe31554f35a3f36d01984fbc6c33cd'
+  version '3.3.5.3'
+  sha256 '325b282641410e2f7d62ca70d03a1d1de3c31519d3660cfd1e501eda596d8286'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.