### PR TITLE
fixed depends_on macos that use version numbers

### DIFF
--- a/Casks/adobe-acrobat.rb
+++ b/Casks/adobe-acrobat.rb
@@ -8,7 +8,7 @@ cask 'adobe-acrobat' do
   name 'Adobe Acrobat Pro DC'
   homepage 'https://acrobat.adobe.com/us/en/acrobat/pdf-reader.html'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   pkg "Acrobat #{version}/Acrobat #{version} Installer.pkg"
 

--- a/Casks/adobe-reader.rb
+++ b/Casks/adobe-reader.rb
@@ -6,7 +6,7 @@ cask 'adobe-reader' do
   name 'Adobe Acrobat Reader DC'
   homepage 'https://acrobat.adobe.com/us/en/acrobat/pdf-reader.html'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   pkg "AcroRdrDC_#{version.no_dots}_MUI.pkg"
 

--- a/Casks/barmaid.rb
+++ b/Casks/barmaid.rb
@@ -8,7 +8,7 @@ cask 'barmaid' do
   name 'Barmaid'
   homepage 'https://github.com/zenonas/barmaid'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   app 'Barmaid.app'
 end

--- a/Casks/better-window-manager.rb
+++ b/Casks/better-window-manager.rb
@@ -8,7 +8,7 @@ cask 'better-window-manager' do
   name 'Better Window Manager'
   homepage 'https://www.gngrwzrd.com/better-window-manager/'
 
-  depends_on macos: '>= 10.10'
+  depends_on macos: '>= :yosemite'
 
   app 'Better Window Manager.app'
 end

--- a/Casks/carmaintenance.rb
+++ b/Casks/carmaintenance.rb
@@ -6,7 +6,7 @@ cask 'carmaintenance' do
   name 'CarMaintenance'
   homepage 'http://www.traxxsoftware.com/download.html'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   app "CarMaintenance_#{version.dots_to_underscores}/CarMaintenance.app"
 end

--- a/Casks/dyn-updater.rb
+++ b/Casks/dyn-updater.rb
@@ -1,13 +1,7 @@
 cask 'dyn-updater' do
-  if MacOS.version <= 10.6
-    version '3.0'
-    sha256 '737eeb00dd0fdb9eeae8401753593e055b1d64f2e287c6bdd98b68d433f0fe8b'
-    url 'http://cdn.dyn.com/dyndns-setup-mac.dmg'
-  else
-    version :latest
-    sha256 :no_check
-    url 'http://cdn.dyn.com/dynupdater/DynUpdater.dmg'
-  end
+  version :latest
+  sha256 :no_check
+  url 'http://cdn.dyn.com/dynupdater/DynUpdater.dmg'
 
   name 'Dyn Updater'
   homepage 'https://dyn.com/apps/updater/'

--- a/Casks/dyn-updater.rb
+++ b/Casks/dyn-updater.rb
@@ -1,8 +1,8 @@
 cask 'dyn-updater' do
   version :latest
   sha256 :no_check
-  url 'http://cdn.dyn.com/dynupdater/DynUpdater.dmg'
 
+  url 'http://cdn.dyn.com/dynupdater/DynUpdater.dmg'
   name 'Dyn Updater'
   homepage 'https://dyn.com/apps/updater/'
 

--- a/Casks/fog-burner.rb
+++ b/Casks/fog-burner.rb
@@ -6,7 +6,7 @@ cask 'fog-burner' do
   name 'Fog Burner'
   homepage 'http://fogburner.tofumatt.com/'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   app 'Fog Burner.app'
 end

--- a/Casks/garmin-virb-edit.rb
+++ b/Casks/garmin-virb-edit.rb
@@ -6,7 +6,7 @@ cask 'garmin-virb-edit' do
   name 'Garmin VIRB Edit'
   homepage 'https://buy.garmin.com/en-US/US/p/573412'
 
-  depends_on macos: '>= 10.10'
+  depends_on macos: '>= :yosemite'
 
   pkg 'Install VIRB Edit.pkg'
 

--- a/Casks/home-inventory.rb
+++ b/Casks/home-inventory.rb
@@ -6,7 +6,7 @@ cask 'home-inventory' do
   name 'Home Inventory'
   homepage 'https://binaryformations.com/products/home-inventory/'
 
-  depends_on macos: '>= 10.7'
+  depends_on macos: '>= :lion'
 
   app 'Home Inventory.app'
 

--- a/Casks/instasizer.rb
+++ b/Casks/instasizer.rb
@@ -6,7 +6,7 @@ cask 'instasizer' do
   name 'Instasizer'
   homepage 'http://www.tapgods.com/instasizer/'
 
-  depends_on macos: '>= 10.7'
+  depends_on macos: '>= :lion'
 
   app 'Instasizer.app'
 end

--- a/Casks/interarchy.rb
+++ b/Casks/interarchy.rb
@@ -1,5 +1,5 @@
 cask 'interarchy' do
-  if MacOS.version <= 10.9
+  if MacOS.version <= :mavericks
     version '10.0.5'
     sha256 'f2ee4d644dd423b6d3abad960db44af85ca9b8338030ecbea3a5d8665e7be33f'
   else

--- a/Casks/konica-minolta-bizhub-c220-c280-c360-driver.rb
+++ b/Casks/konica-minolta-bizhub-c220-c280-c360-driver.rb
@@ -7,7 +7,7 @@ cask 'konica-minolta-bizhub-c220-c280-c360-driver' do
   name 'Konica Minolta Bizhub C220/C280/C360 PostScript Printer Driver'
   homepage 'https://www.konicaminolta.eu/en/business-solutions/support/download-center.html'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   pkg 'bizhub_C360_109.pkg'
 

--- a/Casks/lightworks.rb
+++ b/Casks/lightworks.rb
@@ -6,7 +6,7 @@ cask 'lightworks' do
   name 'Lightworks'
   homepage 'https://www.lwks.com/'
 
-  depends_on macos: '>= 10.8'
+  depends_on macos: '>= :mountain_lion'
 
   app 'Lightworks.app'
 end

--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -18,7 +18,7 @@ cask 'ncar-ncl' do
 
   depends_on cask: 'xquartz'
   depends_on formula: 'gcc'
-  depends_on macos: '>= 10.8'
+  depends_on macos: '>= :mountain_lion'
   depends_on arch: :x86_64
 
   artifact 'include', target: '/usr/local/ncl-6.3.0/include'

--- a/Casks/noun-project.rb
+++ b/Casks/noun-project.rb
@@ -9,7 +9,7 @@ cask 'noun-project' do
   name 'Noun Project'
   homepage 'https://thenounproject.com/'
 
-  depends_on macos: '>= 10.9'
+  depends_on macos: '>= :mavericks'
 
   app 'Noun Project.app'
 end

--- a/Casks/photo-supreme-postgresql.rb
+++ b/Casks/photo-supreme-postgresql.rb
@@ -6,7 +6,7 @@ cask 'photo-supreme-postgresql' do
   name 'Photo Supreme with PostreSQL'
   homepage 'http://www.idimager.com/WP/?page_id=20'
 
-  depends_on macos: '>= 10.7'
+  depends_on macos: '>= :lion'
   depends_on formula: 'postgresql'
 
   pkg "PhotoSupremePostgreSQL_V#{version}.pkg"

--- a/Casks/tiny.rb
+++ b/Casks/tiny.rb
@@ -7,7 +7,7 @@ cask 'tiny' do
   name 'Tiny'
   homepage 'https://www.delightfuldev.com/tiny/'
 
-  depends_on macos: '>= 10.10'
+  depends_on macos: '>= :yosemite'
 
   app 'Tiny.app'
 end

--- a/Casks/yed.rb
+++ b/Casks/yed.rb
@@ -6,7 +6,7 @@ cask 'yed' do
   name 'yWorks yEd'
   homepage 'https://www.yworks.com/products/yed'
 
-  depends_on macos: '>= 10.8'
+  depends_on macos: '>= :mountain_lion'
 
   app 'yEd.app'
 end


### PR DESCRIPTION
We’ve always preferred this, so these slipped by.