### PR TITLE
Update actprinter to 3.2.4

### DIFF
--- a/Casks/actprinter.rb
+++ b/Casks/actprinter.rb
@@ -1,11 +1,13 @@
 cask 'actprinter' do
-  version '3.2.2'
-  sha256 '6e49ac75f8a660e33b3f0d3033bf9788cfeef5a0838faad93f06b21af0efb2ee'
+  version '3.2.4'
+  sha256 'c770888630b05faa53f3e3746765264b70a792d65077865f70101be0098b0835'
 
   # actprinter.com was verified as official when first introduced to the cask
   url "http://www.actprinter.com/mac/ACTPrinter%20for%20Mac%20#{version}.zip"
+  appcast 'https://www.houdah.com/ACTPrinter/releaseNotes.html',
+          checkpoint: 'b12e36299478a13dc633c97b76993055ba630a1b17b0bdf33850cd7e7fc4bc7b'
   name 'ACTPrinter'
   homepage 'https://www.houdah.com/ACTPrinter/'
 
-  app 'ACTPrinter for Mac.app'
+  app 'ACTPrinter Mac.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.