### PR TITLE
Update slicer to 4.6.2,561385

### DIFF
--- a/Casks/slicer.rb
+++ b/Casks/slicer.rb
@@ -1,8 +1,11 @@
 cask 'slicer' do
-  version '4.5.0-1,461633'
-  sha256 '6159617cfae0bdf5d19fd7c7543806ae59393413cfdcd56f1db454e026f433c2'
+  version '4.6.2,561385'
+  sha256 '1b732c6901897707bc6edc568dadf1c7e79ee152ede400dd286b7b6290921041'
 
-  url "http://download.slicer.org/bitstream/#{version.after_comma}"
+  # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
+  url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"
+  appcast 'https://github.com/Slicer/Slicer/releases.atom',
+          checkpoint: '0ef602dd10c1c07f06e9ab6d168c2977b3fae564891e6d170498804eedd76f12'
   name '3D Slicer'
   homepage 'https://www.slicer.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.