### PR TITLE
Update adobe-dng-converter to 9.8

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -1,6 +1,6 @@
 cask 'adobe-dng-converter' do
-  version '9.7'
-  sha256 '240782398fb539e7e458f4031ce2d9cd07ca80eafbc7190263f59e4995d640be'
+  version '9.8'
+  sha256 'cc556216e5a14f77d249bd9c43c1e9ce1465945b963ba1e5f837097e1d41dbc6'
 
   url "http://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"
   name 'Adobe Camera Raw and DNG Converter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.