### PR TITLE
Update mysql-connector-python to 2.1.5

### DIFF
--- a/Casks/mysql-connector-python.rb
+++ b/Casks/mysql-connector-python.rb
@@ -4,7 +4,7 @@ cask 'mysql-connector-python' do
 
   url "http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-macos10.12.dmg"
   name 'MySQL Connector for Python'
-  homepage 'https://dev.mysql.com/downloads/utilities/'
+  homepage 'https://dev.mysql.com/downloads/connector/python/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/mysql-connector-python.rb
+++ b/Casks/mysql-connector-python.rb
@@ -1,15 +1,12 @@
 cask 'mysql-connector-python' do
-  version '2.1.3'
-  sha256 '49655f970317383fc188ff48c777ade58be40d05d33be44c1c5e676546e41ba4'
+  version '2.1.5'
+  sha256 'd95dec32546fd7c3ca96bd3f65da374d2e9861ab3c145e2dddb80ac40acc1331'
 
-  if MacOS.version <= :mountain_lion
-    url "http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-osx10.8.dmg"
-  else
-    url "http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-osx10.9.dmg"
-  end
-
+  url "http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-macos10.12.dmg"
   name 'MySQL Connector for Python'
   homepage 'https://dev.mysql.com/downloads/utilities/'
+
+  depends_on macos: '>= :yosemite'
 
   pkg "mysql-connector-python-cext-#{version}.pkg"
 


### PR DESCRIPTION
They used to provide different download versions for different OSX versions, but with this release, the download is yosemite and up only.

I don't think it's a good idea to maintain older versions for a library so have updated accordingly. Happy to add the old 2.1.3 links back if someone thinks they should be maintained in the cask.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.