### PR TITLE
Update sqlpro-for-mysql to 1.0.28

### DIFF
--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-mysql' do
-  version '1.0.20'
-  sha256 '078d78fad1d998b808f927715939bf343a13c4088c9c2ec6244ae33b62522186'
+  version '1.0.28'
+  sha256 '64b59b7a388d29f2ba6994636216bfb0eb5d37f2e08cd2b018c0c4d3ad39b5dc'
 
   # d3fwkemdw8spx3.cloudfront.net/mysql was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.