### PR TITLE
Update dropshare to 4.5.2,4558

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4.5.1,4555'
-  sha256 '1ecdea9e38c819d26377049e6d3138d4a1796ceefdf45ca034ce23185a15c6c0'
+  version '4.5.2,4558'
+  sha256 '4c0d5d73eb003684ab9b0f1e543f5bd8bb5d733f853c97b357d4d3250a3fa9aa'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
-          checkpoint: '83b90981d5801fdf6e25ba2166c9f1f1306d8a587161f57bc9ab1b558837fde3'
+          checkpoint: '18b2b7d72d2c911ee76b4aa98747d5592d93a5fef11ae84035e1d8c64d614fea'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.