### PR TITLE
Update dungeon-crawl-stone-soup-tiles to 0.19.1

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,8 +1,10 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.19.0'
-  sha256 'b2c9d2140c16069fd10d352162373180598a1b21dc493a8e3aa0843dec30af02'
+  version '0.19.1'
+  sha256 '4274e47ed18239ab73414be857c8a489d0acaf785467cffdc0b70d903a317402'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
+  appcast 'https://github.com/crawl/crawl/releases.atom',
+          checkpoint: '8e77d98e2f53d2d95fd2e2a2733f1032f8e5e81f99023b98d2e0b3a6531b60c4'
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.