### PR TITLE
Update relativewave-form to 1.4.1

### DIFF
--- a/Casks/relativewave-form.rb
+++ b/Casks/relativewave-form.rb
@@ -1,6 +1,6 @@
 cask 'relativewave-form' do
-  version '1.4.0'
-  sha256 '9369d1e468938da60fffa890b5c8d4ec2888dcde990b2d2763fb56bbae1825af'
+  version '1.4.1'
+  sha256 '1a0bcddf6e40e88dc1fb14116c8c76436b0f271263573252c3ca9e5c264907a5'
 
   # relativewave.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://relativewave.storage.googleapis.com/files/Form-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.