### PR TITLE
Update beaker to 1.7.1-0-g6dac09a

### DIFF
--- a/Casks/beaker.rb
+++ b/Casks/beaker.rb
@@ -1,9 +1,11 @@
 cask 'beaker' do
-  version '1.6-0-gb7c81a9'
-  sha256 '9c101935a6a715e9e396c7a8945bef38abf26ebcd5d510ddf70a137aa927f3ac'
+  version '1.7.1-0-g6dac09a'
+  sha256 '9fff2da8df616ce6e2a6bf8e8c4fff7aeeec0c875a197cb63558ae1a81f34035'
 
   # d299yghl10frh5.cloudfront.net was verified as official when first introduced to the cask
   url "https://d299yghl10frh5.cloudfront.net/beaker-notebook-#{version}-mac.dmg"
+  appcast 'https://github.com/twosigma/beaker-notebook/releases.atom',
+          checkpoint: 'aae840a5dd88e2e8f246c62d4310809d2b7c93fedeffbe55175106175e4c01c6'
   name 'Beaker'
   homepage 'http://beakernotebook.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.