### PR TITLE
Upgrade git to version 2.10.1, plus a fix to uninstall_preflight.

### DIFF
--- a/Casks/git.rb
+++ b/Casks/git.rb
@@ -6,12 +6,12 @@ cask 'git' do
     url "https://downloads.sourceforge.net/git-osx-installer/git-#{version}-intel-universal-snow-leopard.dmg"
     pkg "git-#{version}-intel-universal-snow-leopard.pkg"
   else
-    version '2.7.1'
-    sha256 '260b32e8877eb72d07807b26163aeec42e2d98c350f32051ab1ff0cc33626440'
+    version '2.10.1'
+    sha256 '6bad786bae098eaae0aa824e714d5a0b0fb3eb5d1412ed27c89743ddc1d3d209'
 
     url "https://downloads.sourceforge.net/git-osx-installer/git-#{version}-intel-universal-mavericks.dmg"
     appcast 'https://sourceforge.net/projects/git-osx-installer/rss',
-            checkpoint: '96f8b3facd8324ed75a2dc919d33519506b892f2b3bd8a84d16f2a6f93c9f6a5'
+            checkpoint: '56ba7834c0c58ff1b9f9ab9c7660d7a3228339e6114224a665b0285c5cc5d800'
 
     pkg "git-#{version}-intel-universal-mavericks.pkg"
   end
@@ -20,7 +20,7 @@ cask 'git' do
   homepage 'https://sourceforge.net/projects/git-osx-installer/'
 
   uninstall_preflight do
-    system "/usr/bin/yes yes | #{staged_path}/uninstall.sh"
+    system '/usr/bin/yes yes | /usr/local/git/uninstall.sh'
   end
 
   uninstall pkgutil: "GitOSX.Installer.git#{version.no_dots}Universal.*pkg"

--- a/Casks/git.rb
+++ b/Casks/git.rb
@@ -20,7 +20,7 @@ cask 'git' do
   homepage 'https://sourceforge.net/projects/git-osx-installer/'
 
   uninstall_preflight do
-    system '/usr/bin/yes yes | /usr/local/git/uninstall.sh'
+    system "/usr/bin/yes yes | #{staged_path}/uninstall.sh"
   end
 
   uninstall pkgutil: "GitOSX.Installer.git#{version.no_dots}Universal.*pkg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
