### PR TITLE
Update freeplane to 1.5.18

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,10 +1,10 @@
 cask 'freeplane' do
-  version '1.5.17'
-  sha256 'cffb45c680943f05acf5800e829caf2d4d05bb640679bc9a5ebc50dd60f2cbe3'
+  version '1.5.18'
+  sha256 '8227c396ab9d580126d0d08da84ba6b859eb54116b7902b20b7d7dfd812bbbb0'
 
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable',
-          checkpoint: '1b1156a9db35677356923dc253b720995cc1ad9c021718b9512e33bb31a134df'
+          checkpoint: '18ffd999954ce5c856a46e3474487804445a3da40a0f4f209f54dfbffee34456'
   name 'Freeplane'
   homepage 'http://freeplane.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.