### PR TITLE
Update thetube to 2.11.4

### DIFF
--- a/Casks/thetube.rb
+++ b/Casks/thetube.rb
@@ -1,6 +1,6 @@
 cask 'thetube' do
-  version '2.11.3'
-  sha256 '8ca81ca68d5ddca04a9fa8d53e9b8ba542e1b3c9806b3cd500172abd316bf277'
+  version '2.11.4'
+  sha256 '08136c0408ba1453db8d0728a9afcbc45db73c52bcc8da7b871eddbeb0da73e1'
 
   url "http://download2.equinux.com/files/other/TheTube_#{version}_Web.zip"
   name 'TheTube'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.