### PR TITLE
Update jetbrains-toolbox to 1.1.2143

### DIFF
--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'jetbrains-toolbox' do
-  version '1.0.2095'
-  sha256 '3776ee7fc13e86eefc180c463d8e7ae2df1862847473cc454780bf0f6e35aa0e'
+  version '1.1.2143'
+  sha256 '2498a80625b858742a534d0e6b6ba2cea458bb1e7efe967f0e1b3721e11d5957'
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.dmg"
   name 'JetBrains Toolbox'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.