### PR TITLE
Update remember-the-milk to 1.1.3

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.1.0'
-  sha256 '37b0af5f3e423d379702ee8a179ef67c83cab825e4a4d9a2d1e7cb83b2250ee7'
+  version '1.1.3'
+  sha256 '8817c88f395ca9d1d5ad74dbd69b01196ea27a46e4e691789fb0762a78886596'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   name 'Remember The Milk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.