### PR TITLE
Update gcc-arm-embedded to 6_2-2016q4,20161216

### DIFF
--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -4,8 +4,10 @@ cask 'gcc-arm-embedded' do
 
   # armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm was verified as official when first introduced to the cask
   url "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/#{version.before_comma.sub(%r{_\d+}, '')}/gcc-arm-none-eabi-#{version.before_comma}-#{version.after_comma}-mac.tar.bz2"
+  appcast 'http://feeds.launchpad.net/gcc-arm-embedded/announcements.atom',
+          checkpoint: '5cc2b8a304f5810461b7f77040f9453919c12c9ef59945d6927dffc00fa2baed'
   name 'GCC ARM Embedded'
-  homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm'
+  homepage 'https://launchpad.net/gcc-arm-embedded'
 
   binary "gcc-arm-none-eabi-#{version.before_comma}/bin/arm-none-eabi-addr2line"
   binary "gcc-arm-none-eabi-#{version.before_comma}/bin/arm-none-eabi-ar"

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -1,10 +1,11 @@
 cask 'gcc-arm-embedded' do
-  version '5_4-2016q3,20160926'
-  sha256 '5656cdec40f99d5c054a85bbc694276e1c4a1488cdacbbc448bc6acd3bbe070d'
+  version '6_2-2016q4,20161216'
+  sha256 'cb52433610d0084ee85abcd1ac4879303acba0b6a4ecfe5a5113c09f0ee265f0'
 
-  url "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-#{version.before_comma}-#{version.after_comma}-mac.tar.bz2"
+  # armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm was verified as official when first introduced to the cask
+  url "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/#{version.before_comma.sub(%r{_\d+}, '')}/gcc-arm-none-eabi-#{version.before_comma}-#{version.after_comma}-mac.tar.bz2"
   name 'GCC ARM Embedded'
-  homepage 'https://launchpad.net/gcc-arm-embedded'
+  homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm'
 
   binary "gcc-arm-none-eabi-#{version.before_comma}/bin/arm-none-eabi-addr2line"
   binary "gcc-arm-none-eabi-#{version.before_comma}/bin/arm-none-eabi-ar"


### PR DESCRIPTION
Downloads have moved to new location, as noted on the [homepage](https://launchpad.net/gcc-arm-embedded).

I considered moving the homepage, but launchpad seems to still be the point of development as well as having a release announcement rss feed.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.