### PR TITLE
Update kiwix.rb download url

### DIFF
--- a/Casks/kiwix.rb
+++ b/Casks/kiwix.rb
@@ -2,7 +2,6 @@ cask 'kiwix' do
   version '0.9'
   sha256 '98e677aee3c106c6ec5b16791d3be7c22274b3b32cc44a9cce1eeca6275b7bcc'
 
-  # mirror.netcologne.de/kiwix was verified as official when first introduced to the cask
   url "http://download.kiwix.org/bin/#{version}/kiwix-#{version}.dmg"
   name 'Kiwix'
   homepage 'http://www.kiwix.org/'

--- a/Casks/kiwix.rb
+++ b/Casks/kiwix.rb
@@ -3,7 +3,7 @@ cask 'kiwix' do
   sha256 '98e677aee3c106c6ec5b16791d3be7c22274b3b32cc44a9cce1eeca6275b7bcc'
 
   # mirror.netcologne.de/kiwix was verified as official when first introduced to the cask
-  url "https://mirror.netcologne.de/kiwix/bin/#{version}/kiwix-#{version}.dmg"
+  url "http://download.kiwix.org/bin/#{version}/kiwix-#{version}.dmg"
   name 'Kiwix'
   homepage 'http://www.kiwix.org/'
 


### PR DESCRIPTION
Original download link was 404, moved to new location.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] The commit message includes the cask’s name and version.