### PR TITLE
Update bitscope-dso to 2.8.FE22H

### DIFF
--- a/Casks/bitscope-dso.rb
+++ b/Casks/bitscope-dso.rb
@@ -1,6 +1,6 @@
 cask 'bitscope-dso' do
-  version '2.8.FE22G'
-  sha256 'd32d924368bc8e093d4be9f1d2c90d7741d8347ac18f10db1d31c964cef44b16'
+  version '2.8.FE22H'
+  sha256 '487bd954c54740c9c9d2810db25ec7cfa2905b5808b068eb18db0d046ae574d1'
 
   url "http://bitscope.com/download/files/bitscope-dso_#{version}.app.tgz"
   name 'BitScope DSO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.