### PR TITLE
Update orange to 3.3.9

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,8 +1,8 @@
 cask 'orange' do
-  version '3-3.3.8'
-  sha256 '11566c7233a0d9d64d115cebe6b1996358cba7a5ed2b37a5e82d85b32cb5c335'
+  version '3.3.9'
+  sha256 '4f10aac5a0233f5aaaa0a69d5de50c0c602565be7cd02a6070d1bb0eadb098ed'
 
-  url "http://orange.biolab.si/download/files/Orange#{version}.dmg"
+  url "http://orange.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
   name 'Orange'
   homepage 'http://orange.biolab.si/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.