### PR TITLE
Update itools to 2.9.1

### DIFF
--- a/Casks/itools.rb
+++ b/Casks/itools.rb
@@ -1,11 +1,13 @@
 cask 'itools' do
-  version '2.8.7'
-  sha256 'f49b075991705f57de4e46cdb6ae9ca5f7d995dba8d528c5c48f1cc31ff23dc3'
+  version '2.9.1'
+  sha256 '56e888c6c65784604ee3a48bbc0013bdf0c1f73e70e72e230699f45243f5f977'
 
   # dl2.itools.hk/dl was verified as official when first introduced to the cask
   url "http://dl2.itools.hk/dl/iTools64_#{version}.dmg"
   name 'iTools'
   homepage 'http://pro.itools.cn/mac/english'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'iTools.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.