### PR TITLE
Update aircall to 1.1.6

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,10 +1,10 @@
 cask 'aircall' do
-  version '1.1.5'
-  sha256 '5ac208d89f0448b18ce2cd4d395dc1bbc4e251174d39df3db1fc623737b27dbb'
+  version '1.1.6'
+  sha256 '29d1040a4fa30aafea783d4618c11377eb724992ea376b64a3ffb06ffe65e1c8'
 
   url "http://electron.aircall.io/download/#{version}/osx"
   appcast 'http://electron.aircall.io/update/osx/1.1.0',
-          checkpoint: '11e07a86a12d9363c75d65af1b27b16b80c04419aae8920bc8e6434874cc3db4'
+          checkpoint: 'f4be0f81b7b52dc0d28e2ad20da81a4e1dc64c42b627e073f059a79bf7bb5344'
   name 'Aircall'
   homepage 'https://aircall.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.