### PR TITLE
Update sts to 3.8.3.RELEASE

### DIFF
--- a/Casks/sts.rb
+++ b/Casks/sts.rb
@@ -1,10 +1,10 @@
 cask 'sts' do
-  version '3.8.2.RELEASE'
-  sha256 '8857035e065b9a8f8a26beaeda863f9315fe4afa4f9d17b5cbea5607c9450439'
+  version '3.8.3.RELEASE'
+  sha256 '74ec8913bd247eab095f38d7a9629d2b8557ded11a8f36179c713a4515ae25ac'
 
   module Utils
     def self.eclipse_version
-      '4.6.1' # find eclipse version at https://spring.io/tools/sts/all
+      '4.6.2' # find eclipse version at https://spring.io/tools/sts/all
     end
 
     def self.eclipse_version_major_minor
@@ -12,8 +12,8 @@ cask 'sts' do
     end
   end
 
-  # springsource.com was verified as official when first introduced to the cask
-  url "https://dist.springsource.com/release/STS/#{version}/dist/e#{Utils.eclipse_version_major_minor}/spring-tool-suite-#{version}-e#{Utils.eclipse_version}-macosx-cocoa-x86_64.tar.gz"
+  # download.springsource.com/release/STS was verified as official when first introduced to the cask
+  url "http://download.springsource.com/release/STS/#{version}/dist/e#{Utils.eclipse_version_major_minor}/spring-tool-suite-#{version}-e#{Utils.eclipse_version}-macosx-cocoa-x86_64.tar.gz"
   name 'Spring Tool Suite'
   homepage 'https://spring.io/tools/sts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.