### PR TITLE
Update squeak to 5.1-16548

### DIFF
--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -1,12 +1,12 @@
 cask 'squeak' do
-  version '5.0'
-  sha256 '38fa71fac58770047636b7ee37d4c88989da90f6b748cb53667099edf07c3390'
+  version '5.1-16548'
+  sha256 'c78258c6cc0cb9e3a433230518b065fcf10b5710da7821ef335cf7d8b2fe2f8a'
 
-  url "http://files.squeak.org/#{version}/Squeak-#{version}-All-in-One.zip"
+  url "http://files.squeak.org/#{version.major_minor}/Squeak#{version}-32bit/Squeak#{version}-32bit-All-in-One.zip"
   name 'Squeak'
   homepage 'http://squeak.org/'
 
-  app "Squeak-#{version}-All-in-One/Squeak-#{version}-All-in-One.app"
+  app "Squeak#{version}-32bit-All-in-One/Squeak#{version}-32bit-All-in-One.app"
 
-  zap delete: '~/Library/Saved Application State/org.squeak.SqueakAllInOne45.savedState/'
+  zap delete: '~/Library/Saved Application State/org.squeak.Squeak#{version.major_minor}.32.All-in-One.savedState'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.