### PR TITLE
Added appcast to Objective-See apps

### DIFF
--- a/Casks/blockblock.rb
+++ b/Casks/blockblock.rb
@@ -4,6 +4,8 @@ cask 'blockblock' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/BlockBlock_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'BlockBlock'
   homepage 'https://objective-see.com/products/blockblock.html'
 

--- a/Casks/kextviewr.rb
+++ b/Casks/kextviewr.rb
@@ -4,6 +4,8 @@ cask 'kextviewr' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/KextViewr_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'KextViewr'
   homepage 'https://objective-see.com/products/kextviewr.html'
 

--- a/Casks/knockknock.rb
+++ b/Casks/knockknock.rb
@@ -4,6 +4,8 @@ cask 'knockknock' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/KnockKnock_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'KnockKnock'
   homepage 'https://objective-see.com/products/knockknock.html'
 

--- a/Casks/lockdown.rb
+++ b/Casks/lockdown.rb
@@ -4,6 +4,8 @@ cask 'lockdown' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/Lockdown_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'Lockdown'
   homepage 'https://objective-see.com/products/lockdown.html'
 

--- a/Casks/ostiarius.rb
+++ b/Casks/ostiarius.rb
@@ -17,9 +17,7 @@ cask 'ostiarius' do
             kext:   'com.objective-see.OstiariusKext',
             delete: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.objectivesee.ostiarius.sfl'
 
-  caveats <<-EOS.undent
-    Apple fixed the Gatekeeper flaws the developer discovered and reported that Ostiarius protected against. As such, if you’re running macOS Sierra (10.12+), Ostiarius is no longer needed!
-
-    For that reason we’re making the cask refuse to install on Sierra and later.
-  EOS
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/ostiarius.rb
+++ b/Casks/ostiarius.rb
@@ -4,6 +4,8 @@ cask 'ostiarius' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/Ostiarius_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'Ostiarius'
   homepage 'https://objective-see.com/products/ostiarius.html'
 

--- a/Casks/oversight.rb
+++ b/Casks/oversight.rb
@@ -4,8 +4,6 @@ cask 'oversight' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/OverSight_#{version}.zip"
-  appcast 'https://objective-see.com/products.json',
-          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   appcast 'https://objective-see.com/products/versions/oversight.json',
           checkpoint: 'da8cba3af8fa83a106e23be6299fd286fe8377931906270bfdd885a609a1ae8b'
   name 'Oversight'

--- a/Casks/oversight.rb
+++ b/Casks/oversight.rb
@@ -4,6 +4,8 @@ cask 'oversight' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/OverSight_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   appcast 'https://objective-see.com/products/versions/oversight.json',
           checkpoint: 'da8cba3af8fa83a106e23be6299fd286fe8377931906270bfdd885a609a1ae8b'
   name 'Oversight'

--- a/Casks/ransomwhere.rb
+++ b/Casks/ransomwhere.rb
@@ -4,6 +4,8 @@ cask 'ransomwhere' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/RansomWhere_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'RansomWhere'
   homepage 'https://objective-see.com/products/ransomwhere.html'
 

--- a/Casks/taskexplorer.rb
+++ b/Casks/taskexplorer.rb
@@ -4,6 +4,8 @@ cask 'taskexplorer' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/TaskExplorer_#{version}.zip"
+  appcast 'https://objective-see.com/products.json',
+          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
   name 'TaskExplorer'
   homepage 'https://objective-see.com/products/taskexplorer.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

Yes, these all use the same appcast, which means some will trigger when there isn’t a new release. That said, these are all extremely focused apps with a clear scope, so they shouldn’t get too many updates (but those are important to get, since they deal with security of your system).

Also changed the caveat on Ostiarius. It makes it easier to identify and remove some day.