### PR TITLE
ioquake3-1.36: Use correct path in advice

### DIFF
--- a/Casks/ioquake3.rb
+++ b/Casks/ioquake3.rb
@@ -12,6 +12,6 @@ cask 'ioquake3' do
   caveats <<-EOS.undent
     To complete the installation of #{token}, you will have to copy the file
     'pak0.pk3' from your Quake 3 Arena installation support directory into
-    ~/Applications/ioquake3/baseq3/.
+    /Applications/ioquake3/baseq3/ or ~/Library/Application Support/Quake3/baseq3/.
   EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Current cask uses bad advice maybe due to historical reasons.
```
/Applications/ioquake3/ioquake3-1.36.app/Contents/MacOS/ioquake3.ub 
ioq3 1.36 macosx-i386 Apr 22 2009
----- FS_Startup -----
Current search path:
/Users/yurikoles/Library/Application Support/Quake3/baseq3
[...]
/Applications/ioquake3/baseq3
```
