### PR TITLE
Update postgres to 2.0.1

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,11 +1,11 @@
 cask 'postgres' do
-  version '9.6.1.1'
-  sha256 '4924b956c30d1e3191277dcd72834dc43fc76f74c1cae5be18729af771b0da45'
+  version '2.0.1'
+  sha256 'bc8e40df78eab5fcc95eb749c79f03310d32a34d681b049507157d66872ce4ed'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
-          checkpoint: '84cfa62ebeaaa4cb156d4d89bcb392020c138f9838f29816685f563cb2b5454e'
+          checkpoint: '658a38a0aa9191a6918c922042d8e05f3b37eb78f83df7e2082bbd09092644a0'
   name 'Postgres'
   homepage 'https://postgresapp.com/'
 

--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -3,7 +3,7 @@ cask 'postgres' do
   sha256 '4924b956c30d1e3191277dcd72834dc43fc76f74c1cae5be18729af771b0da45'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
-  url "https://github.com/PostgresApp/PostgresApp/releases/download/#{version}/Postgres-#{version}.zip"
+  url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
           checkpoint: '84cfa62ebeaaa4cb156d4d89bcb392020c138f9838f29816685f563cb2b5454e'
   name 'Postgres'

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -3,11 +3,11 @@ cask 'spectacle' do
     version '0.8.6'
     sha256 '3e367d2d7e6fe7d5f41d717d49cb087ba7432624b71ddd91c0cfa9d5a5459b7c'
   else
-    version '1.1.2'
-    sha256 '85624c4fbff0e3a7bb20a2ad724ec2a1246c7cd43217f6a0856743262163a756'
+    version '1.2'
+    sha256 '766d5bf3b404ec567110a25de1d221290bc829302283b28ed0fbe73b9557f30c'
 
     appcast 'https://www.spectacleapp.com/updates/appcast.xml',
-            checkpoint: 'e9634b0540816be0607d661c31d7ea7ae37a8d545030c4f88f70e1cd0d2852df'
+            checkpoint: 'f6b3d6282b56296885c8e0dc3ff3218f12b6c045dfc946379a9322323dd85fac'
   end
 
   # amazonaws.com/spectacle was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.