### PR TITLE
Update hopper-disassembler to 4.0.17

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.0.16'
-  sha256 'c4950a3684bb375d93663d95a05d72223a4817a294fbd9b3de26c934b9ea1f69'
+  version '4.0.17'
+  sha256 '61ee9d7b0a6ca5a658e1e11c6d955e7dfaf7905a08271c650fecb282e1fb29f9'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}.zip"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '02b4a1edfc22be66b7d307b3fe2c5b14b2b4f30a3621be61f52b527afa35638d'
+          checkpoint: 'c1e3c75e9119ff34f4edfbab31526feee00f1b7e9afd90159f5b80e7d52377a9'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.