### PR TITLE
Update lightning to 1.8.4

### DIFF
--- a/Casks/lightning.rb
+++ b/Casks/lightning.rb
@@ -1,8 +1,8 @@
 cask 'lightning' do
-  version '1.8.3'
-  sha256 '3ececcf522275b458257295d58738b48f98c6c2e66ea1d611952455c853dafb3'
+  version '1.8.4'
+  sha256 '98eca9d7ea7e8f35c213d646830f773f923b28abf13df81eb6560ba488d5d80f'
 
-  url "http://downloads.filewave.com/lightning/FileWave_Lightning-#{version}.dmg"
+  url "https://fwdl.filewave.com/lightning/FileWave_Lightning-#{version}.dmg"
   name 'FileWave Lightning'
   homepage 'https://www.filewave.com/products/imaging/lightning-thunderbolt'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.