### PR TITLE
Update caret to 1.12.0

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.11.3'
-  sha256 '30e7f3b177638b6212809ad5d2cb9a809c9c50a041fabfbec095294a458f8bf3'
+  version '1.12.0'
+  sha256 '041d7fa5cb22d38749c9402557920d4519c2bbbbcd9fd2c602a507e75526c973'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '71fa511477d44249e92c5309b7b1bd7a7af6b2a03fc04945e864431e5b0d7d0b'
+          checkpoint: '9145c50d1c3ae4b4d9628df42d59d85168e9e81cb89c423623b8e037917f28f6'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.