### PR TITLE
Update aria-maestosa to 1.4.12

### DIFF
--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -1,6 +1,6 @@
 cask 'aria-maestosa' do
-  version '1.4.9'
-  sha256 '3a8d8bc625a6e27b2312ff1c008e78b64c94faa5ef263c85c6005e72a98ec1bf'
+  version '1.4.12'
+  sha256 '177f8d7befa7330b82386fd55b9289213928220faa2565c948804579867569a8'
 
   url "https://downloads.sourceforge.net/ariamaestosa/AriaMaestosa-osx-#{version}.zip"
   appcast 'https://sourceforge.net/projects/ariamaestosa/rss',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.