### PR TITLE
Update iOS App Signer to v1.9

### DIFF
--- a/Casks/ios-app-signer.rb
+++ b/Casks/ios-app-signer.rb
@@ -1,9 +1,11 @@
 cask 'ios-app-signer' do
-  version '1.8.2'
-  sha256 '5ae5e9ad1a5d97c858fdeda06ae7eb764f5abf1df75a7a8e0028c49689de8877'
+  version '1.9'
+  sha256 '5130b0748115d2d4b54f29a65b86e82f60f630124fec6bbd1fc5677eee6e6f08'
 
   # github.com/DanTheMan827/ios-app-signer was verified as official when first introduced to the cask
   url "https://github.com/DanTheMan827/ios-app-signer/releases/download/#{version}/iOS.App.Signer.app.zip"
+  appcast 'https://github.com/DanTheMan827/ios-app-signer/releases.atom',
+          checkpoint: '608bfbffa0f7cc8601db1c62802b1f3b61a3fa94e0bdd3387db0bf8869148c72'
   name 'iOS App Signer'
   homepage 'https://dantheman827.github.io/ios-app-signer/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.