### PR TITLE
Update darktable to 2.2.0

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,13 +1,15 @@
 cask 'darktable' do
-  version '2.0.7'
-  sha256 '0b341f3f753ae0715799e422f84d8de8854d8b9956dc9ce5da6d5405586d1392'
+  version '2.2.0'
+  sha256 '75d5f68fec755fefe6ccc82761d379b399f9fba9581c0f4c2173f6c147a0109f'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: '73af5565e5b7b288c2242b68309bc9e26e68ad3911feaa2835b825f7850e7cae'
+          checkpoint: 'ae7fffd947c8ed332a1e3e8d3a2daf06955d32bf455cd66cb518e4ef1617d20f'
   name 'darktable'
   homepage 'https://www.darktable.org/'
+
+  depends_on macos: '>= :lion'
 
   app 'darktable.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.