### PR TITLE
Fix url and app in Pingendo3.app Cask

### DIFF
--- a/Casks/pingendo.rb
+++ b/Casks/pingendo.rb
@@ -2,9 +2,9 @@ cask 'pingendo' do
   version :latest
   sha256 :no_check
 
-  url 'http://pingendo.com/Pingendo.dmg'
+  url 'http://download.pingendo.com/v3/Pingendo.dmg'
   name 'Pingendo'
   homepage 'https://pingendo.com/'
 
-  app 'Pingendo.app'
+  app 'Pingendo3.app'
 end

--- a/Casks/pingendo.rb
+++ b/Casks/pingendo.rb
@@ -1,10 +1,10 @@
 cask 'pingendo' do
-  version :latest
-  sha256 :no_check
+  version '3'
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url 'http://download.pingendo.com/v3/Pingendo.dmg'
+  url "http://download.pingendo.com/v#{version}/Pingendo.dmg"
   name 'Pingendo'
   homepage 'https://pingendo.com/'
 
-  app 'Pingendo3.app'
+  app "Pingendo#{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
