### PR TITLE
Update vimr to 0.12.1-151

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.12.0-150'
-  sha256 '09e51b6c0d105e633b32da7de1209ec181cc11b2c17813b2f857332ca160889d'
+  version '0.12.1-151'
+  sha256 '792e86dfc50579c701841858775f595fe9322e0f5187016b4131a91bc541d89f'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'f2144f5150e6cdd538cc4d617a0c99fff5d716569b277d0812ddbe012a2a4765'
+          checkpoint: '61f6a66f902c1f3bbba344f25a3aa944252b0e5a25ecc5b1f6f9f833047da8f9'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.