### PR TITLE
Update framer to 78

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '76'
-  sha256 '963cd559cfb630d3b805025cbde3514c22db95aba175ad1e1c2862ee55f7cb07'
+  version '78'
+  sha256 '4642f7f9ff44a342e66a448a11b297cad9cd5bc5eaf3056d86f696b626d522d4'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: 'cdffcd827eed8cd3bbb03058438b0c024bd8129d59a1f3f1423cc772330c152a'
+          checkpoint: '2e00f8514e71435ce5f663df82a034ec091157271e1e452f22df24b5612d17f8'
   name 'Framer'
   homepage 'https://framerjs.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes [#28211](https://github.com/caskroom/homebrew-cask/issues/28211).