### PR TITLE
Update iterm2 to 3.0.13

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,11 +1,11 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.0.12'
-  sha256 'd500c5e376a05df6896f92504961142b7721efb9e235232d39545c7a3c5b7507'
+  version '3.0.13'
+  sha256 'b32cb66bf7fafd22c92adca4ea2d10c23e58d1398627aea5b15f1c396495b574'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml',
-          checkpoint: '1a760708aa5754e898f23cbb2c232033d09d2a0e1df53852e4f2cf81acbf33c4'
+          checkpoint: '277479a2ac0c31d3ed366c65db2d1e64898ca6b5afba78705b902aacd2d78059'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.