### PR TITLE
Update komodo-ide to 10.1.4-89515

### DIFF
--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -1,6 +1,6 @@
 cask 'komodo-ide' do
-  version '10.0.1-89237'
-  sha256 'f08c9e995a8ef62805dc482c3ee654e48f96bf51352ecbe23f2cae755deb8a43'
+  version '10.1.4-89515'
+  sha256 '77866f74d34f76dc9328441fbeac1575d2df6cf57458fba421f899a628581122'
 
   # activestate.com/Komodo was verified as official when first introduced to the cask
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.