### PR TITLE
Update aquaskk to 4.4.5

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,10 +1,10 @@
 cask 'aquaskk' do
-  version '4.4.4'
-  sha256 '99febc55d2e7c923676a5bf1a9b9a2f38732f6ad4682a50b8090a0f177c981f8'
+  version '4.4.5'
+  sha256 'a0d3c21abc914da4b81a93b7af4a4c8d26a3afbc49bb7af3b24376356d3d0a18'
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom',
-          checkpoint: '9337d63f73be4a88446eb530e85e31951d8eba61dca942a86138b9fb3357ffa5'
+          checkpoint: 'f28054fe31c55e5b93cdd2e2f3515534e5225c74c2fbb960a221ad3983247f46'
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.