### PR TITLE
Update spectacle.rb for depends_on and zap

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -5,12 +5,13 @@ cask 'spectacle' do
   else
     version '1.2'
     sha256 '766d5bf3b404ec567110a25de1d221290bc829302283b28ed0fbe73b9557f30c'
+
+    appcast 'https://www.spectacleapp.com/updates/appcast.xml',
+            checkpoint: 'f6b3d6282b56296885c8e0dc3ff3218f12b6c045dfc946379a9322323dd85fac'
   end
 
   # amazonaws.com/spectacle was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/spectacle/downloads/Spectacle+#{version}.zip"
-  appcast 'https://www.spectacleapp.com/updates/appcast.xml',
-          checkpoint: 'f6b3d6282b56296885c8e0dc3ff3218f12b6c045dfc946379a9322323dd85fac'
   name 'Spectacle'
   homepage 'https://www.spectacleapp.com/'
 

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -5,25 +5,27 @@ cask 'spectacle' do
   else
     version '1.2'
     sha256 '766d5bf3b404ec567110a25de1d221290bc829302283b28ed0fbe73b9557f30c'
-
-    appcast 'https://www.spectacleapp.com/updates/appcast.xml',
-            checkpoint: 'f6b3d6282b56296885c8e0dc3ff3218f12b6c045dfc946379a9322323dd85fac'
   end
 
   # amazonaws.com/spectacle was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/spectacle/downloads/Spectacle+#{version}.zip"
+  appcast 'https://www.spectacleapp.com/updates/appcast.xml',
+          checkpoint: 'f6b3d6282b56296885c8e0dc3ff3218f12b6c045dfc946379a9322323dd85fac'
   name 'Spectacle'
   homepage 'https://www.spectacleapp.com/'
 
   accessibility_access true
+  depends_on macos: '>= :lion'
 
   app 'Spectacle.app'
 
   uninstall login_item: 'Spectacle'
 
   zap delete: [
+                '~/Library/Application Support/Spectacle',
                 '~/Library/Caches/com.divisiblebyzero.Spectacle',
                 '~/Library/Caches/com.plausiblelabs.crashreporter.data/com.divisiblebyzero.Spectacle',
+                '~/Library/Cookies/com.divisiblebyzero.Spectacle.binarycookies',
                 '~/Library/Preferences/com.divisiblebyzero.Spectacle.plist',
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update spectacle.rb for depends_on and zap