### PR TITLE
cask: Add Bricklink Stud.io 1.0.0_21

### DIFF
--- a/Casks/studio.rb
+++ b/Casks/studio.rb
@@ -1,0 +1,13 @@
+cask 'studio' do
+  version :latest
+  sha256 :no_check
+
+  # amazonaws.com/blstudio was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/blstudio/Stud.io.pkg'
+  name 'Stud.io'
+  homepage 'http://studio.bricklink.com/v2/build/studio.page'
+
+  pkg 'Stud.io.pkg'
+
+  uninstall pkgutil: 'com.bricklink.pkg.Studio'
+end

--- a/Casks/studio.rb
+++ b/Casks/studio.rb
@@ -2,7 +2,7 @@ cask 'studio' do
   version :latest
   sha256 :no_check
 
-  # amazonaws.com/blstudio was verified as official when first introduced to the cask
+  # s3.amazonaws.com/blstudio was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/blstudio/Stud.io.pkg'
   name 'Stud.io'
   homepage 'http://studio.bricklink.com/v2/build/studio.page'


### PR DESCRIPTION
There is no appcast for this cask as the checksum for the page containing the changelog (same as the release page) changes every time audit is executed.