### PR TITLE
Add Prince v11

### DIFF
--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -9,7 +9,10 @@ cask 'prince' do
   installer script: "prince-#{version}-macosx/install.sh",
             sudo:   false
 
-  uninstall delete: ['/usr/local/bin/prince', '/usr/local/lib/prince']
+  uninstall delete: [
+                      '/usr/local/bin/prince',
+                      '/usr/local/lib/prince',
+                    ]
 
   caveats do
     files_in_usr_local

--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -1,0 +1,17 @@
+cask 'prince' do
+  version '11'
+  sha256 'dac005d49c594b90b0933ffac0601997cee8c64c3e6190073dc1d024eb439553'
+
+  url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
+  name 'Prince'
+  homepage 'https://www.princexml.com'
+
+  installer script: "prince-#{version}-macosx/install.sh",
+            sudo:   false
+
+  uninstall delete: ['/usr/local/bin/prince', '/usr/local/lib/prince']
+
+  caveats do
+    files_in_usr_local
+  end
+end


### PR DESCRIPTION
Prince was previously in [homebrew-binary](https://github.com/Homebrew/homebrew-binary/blob/master/prince.rb).
Moving this here as homebrew-binary is deprecated and outdated.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
