### PR TITLE
Update findings to 1.4.3,3551

### DIFF
--- a/Casks/findings.rb
+++ b/Casks/findings.rb
@@ -1,10 +1,10 @@
 cask 'findings' do
-  version '1.4.2,3539'
-  sha256 'a85915da38ac0d1d835083f4908ee39b69895c36e1ed8650fb1d65db09abe63a'
+  version '1.4.3,3551'
+  sha256 '9b44ffc10cb8965ce82b44bd410ab34cc96bc520d08911697a1bf5ff3e0596e7'
 
   url "http://downloads.findingsapp.com/Findings_#{version.after_comma}_#{version.before_comma}.zip"
   appcast 'http://downloads.findingsapp.com/appcast.xml',
-          checkpoint: '51548c6d2506ba1413967c96f183853facfef0cf4369fab6e069948340653397'
+          checkpoint: '646190d33cc190feaf35a2d7fdfedc60690f8423d2b287add00676222391d0af'
   name 'Findings'
   homepage 'http://findingsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.