### PR TITLE
Update slack to 2.3.4

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -1,6 +1,6 @@
 cask 'slack' do
-  version '2.3.3'
-  sha256 '3dd917164a0a4410b3f10f9c1ea2f1cdd899daa8c33e60fc7ba17095ed2c9b86'
+  version '2.3.4'
+  sha256 'f2ed659a8990330fbdd3564bc45cc2bba0ddaae784a1fdff83f68f6d0a8bc336'
 
   # downloads.slack-edge.com was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/mac_releases/Slack-#{version}-macOS.zip"

--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -4,8 +4,6 @@ cask 'slack' do
 
   # downloads.slack-edge.com was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/mac_releases/Slack-#{version}-macOS.zip"
-  appcast 'https://rink.hockeyapp.net/api/2/apps/38e415752d573e7e78e06be8daf5acc1',
-          checkpoint: '16fdeec6794f180b946510dab4b4a5d844182d2631c81219f4601a931db4d104'
   name 'Slack'
   homepage 'https://slack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.