### PR TITLE
Add BRL-CAD / MGED.app v7.24.0

### DIFF
--- a/Casks/brl-cad-mged.rb
+++ b/Casks/brl-cad-mged.rb
@@ -4,8 +4,8 @@ cask 'brl-cad-mged' do
 
   # downloads.sourceforge.net/brlcad was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/#{version}/BRL-CAD%20#{version}.dmg"
-  appcast "https://sourceforge.net/projects/brlcad/rss?path=/BRL-CAD%20for%20Mac%20OS%20X",
-  	checkpoint: "b10ff43a62b9f9f66ed5ea4aa691603aedc8f65ea3370d08daeb641a807a0db5"
+  appcast 'https://sourceforge.net/projects/brlcad/rss?path=/BRL-CAD%20for%20Mac%20OS%20X',
+          checkpoint: 'b10ff43a62b9f9f66ed5ea4aa691603aedc8f65ea3370d08daeb641a807a0db5'
   name 'BRL-CAD'
   homepage 'http://brlcad.org/'
 

--- a/Casks/brl-cad-mged.rb
+++ b/Casks/brl-cad-mged.rb
@@ -4,6 +4,8 @@ cask 'brl-cad-mged' do
 
   # downloads.sourceforge.net/brlcad was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/#{version}/BRL-CAD%20#{version}.dmg"
+  appcast "https://sourceforge.net/projects/brlcad/rss?path=/BRL-CAD%20for%20Mac%20OS%20X",
+  	checkpoint: "b10ff43a62b9f9f66ed5ea4aa691603aedc8f65ea3370d08daeb641a807a0db5"
   name 'BRL-CAD'
   homepage 'http://brlcad.org/'
 

--- a/Casks/brl-cad-mged.rb
+++ b/Casks/brl-cad-mged.rb
@@ -1,4 +1,4 @@
-cask 'brl-cad' do
+cask 'brl-cad-mged' do
   version '7.24.0'
   sha256 '5fe9eb9f5a2eb5544cf459b02e7e880040e02d1312d04c2207b90a731ebd8f0f'
 

--- a/Casks/brl-cad.rb
+++ b/Casks/brl-cad.rb
@@ -3,7 +3,7 @@ cask 'brl-cad' do
   sha256 '5fe9eb9f5a2eb5544cf459b02e7e880040e02d1312d04c2207b90a731ebd8f0f'
 
   # downloads.sourceforge.net/brlcad was verified as official when first introduced to the cask
-  url 'https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/7.24.0/BRL-CAD%207.24.0.dmg'
+  url "https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/#{version}/BRL-CAD%20#{version}.dmg"
   name 'BRL-CAD'
   homepage 'http://brlcad.org/'
 

--- a/Casks/brl-cad.rb
+++ b/Casks/brl-cad.rb
@@ -1,0 +1,13 @@
+cask 'brl-cad' do
+  version '7.24.0'
+  sha256 '5fe9eb9f5a2eb5544cf459b02e7e880040e02d1312d04c2207b90a731ebd8f0f'
+
+  # downloads.sourceforge.net/brlcad was verified as official when first introduced to the cask
+  url 'https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/7.24.0/BRL-CAD%207.24.0.dmg'
+  name 'BRL-CAD'
+  homepage 'http://brlcad.org/'
+
+  depends_on x11: true
+
+  app "BRL-CAD : MGED #{version}.app"
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

`generate_cask_token` suggests "brl-cad-mged"; I've removed "mged" from the cask. From what I've experienced most people just refer to the software as brl-cad; mged is just a component of it. I'm not entirely sure, though.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
