### PR TITLE
Update sourcetree to 2.4e

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.4d'
-    sha256 '4dd8cb6f0162e9abaf1d4c1b40140d4bf178108e52f8ade647387c882a8b8b46'
+    version '2.4e'
+    sha256 '950357781de8cfd29377b8b8f356c5037c7480650e9d1bc1fed92db70217ea22'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.