### PR TITLE
Update framer to 79

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '78'
-  sha256 '4642f7f9ff44a342e66a448a11b297cad9cd5bc5eaf3056d86f696b626d522d4'
+  version '79'
+  sha256 'e4074d4afc0fc212f74b2f5368c06685806deada1ce19ec9e3665a9be73833ca'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '2e00f8514e71435ce5f663df82a034ec091157271e1e452f22df24b5612d17f8'
+          checkpoint: 'affc460095434746d0f1ddc17c4a69564639276c66e6f8a35ca02f661743fba7'
   name 'Framer'
   homepage 'https://framerjs.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.