### PR TITLE
Update freecol to 0.11.6

### DIFF
--- a/Casks/freecol.rb
+++ b/Casks/freecol.rb
@@ -1,6 +1,6 @@
 cask 'freecol' do
-  version '0.11.3'
-  sha256 'bf3dffc26689470f8a9c6fdccd079603ce86c4ed4360042db199b57e658e2de4'
+  version '0.11.6'
+  sha256 'f771f9e31876050281bddb3cc18cb3e5e7f10b32426730c59a9688e1f3496cb1'
 
   # sourceforge.net/freecol was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/freecol/freecol-#{version}-mac.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.