### PR TITLE
Update jabref to 3.8.1

### DIFF
--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -1,11 +1,11 @@
 cask 'jabref' do
-  version '3.8'
-  sha256 '12ab8a17f3dd809efea40d0f9b05a4bad2afacb8dfb89568582fc4ac45800aca'
+  version '3.8.1'
+  sha256 'f38567286fce988c4431ee820b59e0e17cc861b91529e63117610e44b253eefd'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
   url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: '812f5c928948e8eaf79da841c6eee460aa2681a0d8c0d6be98f17709a6fe68a9'
+          checkpoint: 'b49423d0e6f035fc646372b494d98a31b6ef34c0dcdb1ae11a7c02898d559610'
   name 'JabRef'
   homepage 'https://www.jabref.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.