### PR TITLE
Update m3unify to 1.6.0

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,10 +1,10 @@
 cask 'm3unify' do
-  version '1.5.0'
-  sha256 '23192fcc84a65e1238940b3d6ae9267d2e77940aaea9fde12b210b46424438dc'
+  version '1.6.0'
+  sha256 '6fded03986ec51ac188b37e8f72c7bc350849028cb5096ceeccda6eff0af9c5b'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
-          checkpoint: 'eabdc7bbebf77d9733fb5c569e73585bad6fd5d23413e57dd8b5acf94b5095f3'
+          checkpoint: '5af8461250442d7751c91312c87cc7580845d74b4387daa6830195aa542a4272'
   name 'M3Unify'
   homepage 'https://dougscripts.com/apps/m3unifyapp.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.