### PR TITLE
Update mcedit to 1.5.5.0

### DIFF
--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -1,11 +1,11 @@
 cask 'mcedit' do
-  version '1.5.4.1'
-  sha256 '29bde806dc415435296e14613f9052a38891e87189f63a30bd69494e13708953'
+  version '1.5.5.0'
+  sha256 '318fc9345e7630321f0ba993c68877713d423994f841c0086e23bfa6b062edae'
 
   # github.com/Khroki/MCEdit-Unified was verified as official when first introduced to the cask
   url "https://github.com/Khroki/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
   appcast 'https://github.com/Khroki/MCEdit-Unified/releases.atom',
-          checkpoint: '5006f92d219e88b424172f139c433f225ec4e6255010c59b6feef67420ee1b93'
+          checkpoint: '2b8f79fcdc2bfd57af1409324dc194d13e27b59659a695f947e9cc02d254a908'
   name 'MCEdit-Unified'
   homepage 'http://www.mcedit-unified.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.