### PR TITLE
Add globalSAN iSCSI Initiator v5.3.0.541

### DIFF
--- a/Casks/globalsan.rb
+++ b/Casks/globalsan.rb
@@ -1,0 +1,21 @@
+cask 'globalsan' do
+  version '5.3.0.541'
+  sha256 'f0fd88aefe931b4ba932ec2f9e7e8d9760668f903812f80c42172a74ce782971'
+
+  # snsftp.com was verified as official when first introduced to the cask
+  url "http://www.snsftp.com/public/globalsan/globalSAN-#{version}.dmg"
+  name 'globalSAN iSCSI Initiator'
+  homepage 'http://www.studionetworksolutions.com/globalsan-iscsi-initiator/'
+
+  pkg 'globalSAN.pkg'
+
+  uninstall script: {
+                      executable: 'Uninstall',
+                      input:      ['y'],
+                    }
+
+  zap       script: {
+                      executable: 'Uninstall',
+                      input:      ['n'],
+                    }
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
