### PR TITLE
Update thunder to 3.0.2.2636

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '3.0.1.2548'
-  sha256 '424f45b7e4de6d0855ec89b0bb3842b400447fd3b39301b1579e9aa6f84acc8e'
+  version '3.0.2.2636'
+  sha256 'cae90425a2affc47cdef16e50f7b2e833459d2b3f4662841cf8a060456d5c874'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_dl#{version}_Beta.dmg"
@@ -15,6 +15,7 @@ cask 'thunder' do
   zap delete: [
                 '~/Library/Application Support/Thunder',
                 '~/Library/Caches/com.xunlei.Thunder',
+                '~/Library/Caches/com.xunlei.XLPlayer',
                 '~/Library/Caches/com.xunlei.swjsq',
                 '~/Library/Cookies/com.xunlei.Thunder.binarycookies',
                 '~/Library/Preferences/com.xunlei.Thunder.plist',


### PR DESCRIPTION
Update thunder to 3.0.2.2636

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
