### PR TITLE
Update navicat-premium-essentials to 11.2.16

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '11.2.15'
-  sha256 '6dded020e54bcc09054f6eb65cab8e26e6b57452439972d26ee42888f47ecfdd'
+  version '11.2.16'
+  sha256 'a0493442994c2c4f8bca81073f84305207da467c81b1d3563eb9f1c6b5b66c6b'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium Essentials'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download navicat-premium-essentials` is error-free.
- [x] `brew cask style --fix navicat-premium-essentials` reports no offenses.
- [x] The commit message includes the cask’s name and version.