### PR TITLE
Update navicat-premium to 11.2.16

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '11.2.15'
-  sha256 '6a3843fb6aa88df52de1e564d07a9ee0b7435831be5ec7e6b306afe2e1badf28'
+  version '11.2.16'
+  sha256 '53210a7f61fc068cd871d71c3154c8199719e33fdf750ef1e35bd35f20a06a22'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download navicat-premium` is error-free.
- [x] `brew cask style --fix navicat-premium` reports no offenses.
- [x] The commit message includes the cask’s name and version.