### PR TITLE
Update navicat-for-oracle to 11.2.16

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '11.2.15'
-  sha256 'c8a607c38cc0b93cab70931cceca71a2d2d08c1f616dd851173c704b1f744f33'
+  version '11.2.16'
+  sha256 'bbc1d84a75d67b9dc29c2ea3030d109d0b0087fbabd68f08dd95a380ae397e73'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   name 'Navicat for Oracle'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.