### PR TITLE
Update navicat-for-postgresql to 11.2.16

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '11.2.15'
-  sha256 'b627e9d24e6eb3fead7b9cf7bad2285725051854558a5d2f0e41e90bbd56f1c1'
+  version '11.2.16'
+  sha256 'ce8a0277657c90210e0e9fadcc12a1d0593561ef85f700de84ca37e93cb17563'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   name 'Navicat for PostgreSQL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.