### PR TITLE
Update navicat-for-sqlite to 11.2.16

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '11.2.15'
-  sha256 'a04e84ae6ded5e6c5045ee3b2b88b568822a701f12924196097fba664c0073c4'
+  version '11.2.16'
+  sha256 '270f17e53ccf4443e02f67ce705388d55fb8d0ae3b0adbcb4bb1452f8d10d94e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   name 'Navicat for SQLite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.