### PR TITLE
Update noti to 0.2

### DIFF
--- a/Casks/noti.rb
+++ b/Casks/noti.rb
@@ -1,11 +1,11 @@
 cask 'noti' do
-  version '0.1.5'
-  sha256 '6c81afbee1146dffc543af6502b193e55a5b241b5cdd996f43016dce03c8a428'
+  version '0.2'
+  sha256 '2fcf8bb65f10fe2ad4dc68526f0a16acf0097d71f25eb24d30144ee92c17be47'
 
   # github.com/jariz/Noti was verified as official when first introduced to the cask
   url "https://github.com/jariz/Noti/releases/download/#{version}/Noti.dmg"
   appcast 'https://github.com/jariz/Noti/releases.atom',
-          checkpoint: 'c784b94965f932e1db3022eeccc17e0a75c99012db068ca30a9bc85ca8be3851'
+          checkpoint: 'db199fb032af8186bc2b1661a2e989668480ed3e505b9de667f33b546fb3fb5e'
   name 'Noti'
   homepage 'https://noti.center/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.