### PR TITLE
Add ConcourseCI CLI fly v2.5.1

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,0 +1,18 @@
+cask 'fly' do
+  version '2.5.1'
+  sha256 '27ffb050b03ca815e9ffedd27cae08c69753389133ba8a256e7e1fec0b991d4c'
+
+  url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
+  appcast 'https://github.com/concourse/concourse/releases.atom',
+          checkpoint: '7f741af9ef4a64535bd83262068edec14a559bdcb78a3ba9217ee9a2c8f97805'
+  name 'fly'
+  homepage 'https://github.com/concourse/fly'
+
+  container type: :naked
+
+  binary 'fly_darwin_amd64', target: 'fly'
+
+  postflight do
+    set_permissions "#{staged_path}/fly_darwin_amd64", '0755'
+  end
+end


### PR DESCRIPTION
Adds the command line client for [ConcourseCI](https://concourse.ci).

Although there is an [official tap for concourse](https://github.com/concourse/homebrew-tap/issues/1), it's been [deprecated and scheduled for deletion](https://github.com/concourse/homebrew-tap/issues/1#issuecomment-128770275). The tracking issue for a better installer for concourse is [here](https://github.com/concourse/fly/issues/141).

Although the binary is open source, its build process is complicated to reproduce in homebrew itself. Since they do provide versioned, [up to date releases on github](https://github.com/concourse/concourse/releases), similar to [the onlabs cask](https://github.com/caskroom/homebrew-cask/blob/60531a2812005dd5f17dc92f3ce7419af3c5d019/Casks/onlabs.rb), this makes the`fly` binary installable.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
