### PR TITLE
Update whale to 0.5.2

### DIFF
--- a/Casks/whale.rb
+++ b/Casks/whale.rb
@@ -1,10 +1,10 @@
 cask 'whale' do
-  version '0.5.1'
-  sha256 '53afc456c0f5fc2dca215439fd4ce556e96b95d70603ba9cbc7b18f254e3868f'
+  version '0.5.2'
+  sha256 'd473d9643d0fd74d624b91bf43bf4a4d381643fb2ff43816bc01b2566a9eb3d5'
 
   url "https://github.com/1000ch/whale/releases/download/v#{version}/Whale-macos-v#{version}.zip"
   appcast 'https://github.com/1000ch/whale/releases.atom',
-          checkpoint: '60355f839653f8711f096a12e22a3141999e682ebd4a2694464edd3277eebcdc'
+          checkpoint: '86e9d0c69c3eee59fbb0a568ecf226f48e7492c22eb49dfd890702841a468ad3'
   name 'Whale'
   homepage 'https://github.com/1000ch/whale'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.