### PR TITLE
Update karabiner-elements to 0.90.69

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,6 +1,6 @@
 cask 'karabiner-elements' do
-  version '0.90.68'
-  sha256 '2a83e118666492c8d48e3ead91455af7408625e828d1af4f18360f44a1b112a8'
+  version '0.90.69'
+  sha256 'b5d42e4839a9558c43d3285d45371b8b58fa1b483f1f031dbc46a5c362622d11'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.