### PR TITLE
Make auto_updates declarations consistent (3 casks changes)

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -6,7 +6,7 @@ cask 'airtame' do
   name 'Airtame'
   homepage 'https://airtame.com/'
 
-  auto_updates 'True'
+  auto_updates true
 
   app 'Airtame.app'
 end

--- a/Casks/flashlight.rb
+++ b/Casks/flashlight.rb
@@ -9,7 +9,7 @@ cask 'flashlight' do
   name 'Flashlight'
   homepage 'https://github.com/w0lfschild/Flashlight'
 
-  auto_updates
+  auto_updates true
   depends_on macos: '>= :yosemite'
   depends_on cask: 'mysimbl'
 

--- a/Casks/nuimo.rb
+++ b/Casks/nuimo.rb
@@ -8,7 +8,7 @@ cask 'nuimo' do
   name 'Nuimo'
   homepage 'https://www.senic.com/en/app'
 
-  auto_updates 'true'
+  auto_updates true
 
   app 'Nuimo.app'
 end


### PR DESCRIPTION
There are 3 casks that have an `auto_updates` declaration that is inconsistent with all other casks, and the documentation (which states that `auto_updates true` is the only correct value).

This PR updates those three casks to have an `auto_updates true` declaration, consistent with every other auto-updating cask.

***

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free. <ins>I'm on a very slow Internet connection right now, and will be leaving soon, so I'm creating this PR now and I'll update if this fails, since I can't imagine it would.</ins>
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
