### PR TITLE
Update blisk to 2.0.136.192

### DIFF
--- a/Casks/blisk.rb
+++ b/Casks/blisk.rb
@@ -1,6 +1,6 @@
 cask 'blisk' do
-  version '1.0.125.166'
-  sha256 '76c9b1c6f71524bef2a35c5055eb36c1b96f42945e4fb324447525a7e7ee1c59'
+  version '2.0.136.192'
+  sha256 '4760ef49a4fee184db5c6a9b28f17d282dead1ba936cd42cc32603f8a6bac10b'
 
   # bliskcloudstorage.blob.core.windows.net was verified as official when first introduced to the cask
   url "https://bliskcloudstorage.blob.core.windows.net/mac-installers/BliskInstaller_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.