### PR TITLE
Update art-of-illusion to 3.0.3

### DIFF
--- a/Casks/art-of-illusion.rb
+++ b/Casks/art-of-illusion.rb
@@ -1,11 +1,11 @@
 cask 'art-of-illusion' do
-  version '3.0.2'
-  sha256 '6ce23726cb1f97b7b493713fb2494e237b5947ba6711a0bd24b33eb2dfb4f52b'
+  version '3.0.3'
+  sha256 '855683968480ef24520e998d157bf94865232b3dddd7d8b2431f4dc8d6782984'
 
   # sourceforge.net/aoi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/aoi/ArtOfIllusion#{version.no_dots}-Mac.dmg"
   appcast 'https://sourceforge.net/projects/aoi/rss',
-          checkpoint: 'fae03e7c48c7884a973bf22bed829959c7b3cc314353939578aa4dea4ae958cf'
+          checkpoint: 'c34642e02f465fc46f2e02bf90f1e793499f6c8f2918a8f4d73a301a88e93d30'
   name 'Art of Illusion'
   homepage 'http://www.artofillusion.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.