### PR TITLE
Update caret to 1.12.1

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.12.0'
-  sha256 '041d7fa5cb22d38749c9402557920d4519c2bbbbcd9fd2c602a507e75526c973'
+  version '1.12.1'
+  sha256 'cf730c7c6389714adb4fa5bbae1328d2a92824df07ff18408ef007d8996e83bc'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '9145c50d1c3ae4b4d9628df42d59d85168e9e81cb89c423623b8e037917f28f6'
+          checkpoint: '203633db4b6b64d4c705aad237e4dbd2c6d9b51d67c0f307bb232cfbc049f7c2'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.