### PR TITLE
Update fldigi to 3.23.19

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '3.23.18'
-  sha256 '45ea2dd8a9874560881cc896d1a294fafeefde5c20c50a96f34afd01aebb08bc'
+  version '3.23.19'
+  sha256 'b44222a5982d148e654916a259a7ea74dd72ab082b58ed934e7c34ae917f6b77'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'acd7cbf6614894703042b9329656b59f5ef900731776dcc00ec563038aafcfeb'
+          checkpoint: '7fbfd51c00894bb8cd138a3ed6b650d95f706b6cc30446f012a1d4d5558d9262'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.