### PR TITLE
Update instead to 2.4.1

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,6 +1,6 @@
 cask 'instead' do
-  version '2.2.0'
-  sha256 'cde4a7d23ec3556baf98d73bfc5d2b8add3fad22cd5eb52a2d5c408ecc73aa73'
+  version '2.4.1'
+  sha256 'c9e7af048230da3f1390118a55ab13fa02a6915c0d15c1290cbb2d34a4ea176f'
 
   # sourceforge.net/instead was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/instead/instead/#{version}/Instead-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.