### PR TITLE
Remove empty MyHarmony.app on logitech-myharmony uninstall

### DIFF
--- a/Casks/logitech-myharmony.rb
+++ b/Casks/logitech-myharmony.rb
@@ -9,5 +9,6 @@ cask 'logitech-myharmony' do
   pkg 'MyHarmonySetup.pkg'
 
   uninstall quit:    'org.logitech.MyHarmony',
-            pkgutil: 'MyHarmony.pkg'
+            pkgutil: 'MyHarmony.pkg',
+            rmdir:   '/Applications/MyHarmony.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

**I didn't include the version because this is not a version-specific issue correction. Let me know if that is incorrect.**