### PR TITLE
correct blisk sha256 for 2.0.136.192

### DIFF
--- a/Casks/blisk.rb
+++ b/Casks/blisk.rb
@@ -1,6 +1,6 @@
 cask 'blisk' do
   version '2.0.136.192'
-  sha256 '4760ef49a4fee184db5c6a9b28f17d282dead1ba936cd42cc32603f8a6bac10b'
+  sha256 'e4cf4958b6b6d7ae5b51375d0c3fc2e0b2adaafdffc93b0405ad4cd15d3f9d30'
 
   # bliskcloudstorage.blob.core.windows.net was verified as official when first introduced to the cask
   url "https://bliskcloudstorage.blob.core.windows.net/mac-installers/BliskInstaller_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.