### PR TITLE
Update aseprite to 1.1.12

### DIFF
--- a/Casks/aseprite.rb
+++ b/Casks/aseprite.rb
@@ -1,10 +1,10 @@
 cask 'aseprite' do
-  version '1.1.11'
-  sha256 'b131d47845b52dd56ea212c832f91208e5bbe16a7be2ac188e70ef40c553501e'
+  version '1.1.12'
+  sha256 '110b6603c2883506fe2a1b5e7d727f088be27e6ad2be1cce41c9a75952a25e33'
 
   url "http://www.aseprite.org/downloads/Aseprite-v#{version}-trial-MacOSX.dmg"
   appcast 'https://github.com/aseprite/aseprite/releases.atom',
-          checkpoint: 'a70760ec596a74b138ce410c9d3a396a8087b8201331893023c35ec1c03f2835'
+          checkpoint: 'c445ef96809cbd9dea2428bbc4a144fbdaa83556ea4b903b218ac682f72d4c91'
   name 'Aseprite'
   homepage 'https://www.aseprite.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.