### PR TITLE
Update gramps to 4.2.5-1

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,11 +1,11 @@
 cask 'gramps' do
-  version '4.2.4-3'
-  sha256 '0b422840552e5da933feb69dd7964ed54002ecff8ef4813196fdb74c94cb72b3'
+  version '4.2.5-1'
+  sha256 'a1b7e57c9349bf4137ee0d932f23882ff461460dcf99e7f03e3620e0edbf8d58'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"
   appcast 'https://github.com/gramps-project/gramps/releases.atom',
-          checkpoint: 'febefb1931afcd9780aa2ec7bc4055c97be88aa01483aee452011e79074e1f19'
+          checkpoint: '98778e06cbb65bc14cc4f42ad301a9ef0f711f729a2ad5d4ae6492dac7a50ec9'
   name 'Gramps'
   homepage 'https://gramps-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.