### PR TITLE
Update porting-kit to 2.4.171

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,10 +1,10 @@
 cask 'porting-kit' do
-  version '2.4.167'
-  sha256 '68fcee602deba7a471ba545b669eb5a953270467d19287cb57e4805a94da9135'
+  version '2.4.171'
+  sha256 'cba53106d07992f06d8360e8390510958fc668041987063d8c66ddb12d1acd0a'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '6132660ee2102d4989301dc2b03dd2161ae5f0ffbace66017accbee5366c312b'
+          checkpoint: '777d576f0b8e31de1a9bf2484b52658a312085f89de7b1bb9fb32c16332e20cf'
   name 'Porting Kit'
   homepage 'http://portingkit.com/en/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.