### PR TITLE
Update postage to 3.1.3

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.1.2'
-  sha256 '991e666fe392030ebc2e3d82e910e7dc92f8e3cc486c80a7696dbb24dfe287a5'
+  version '3.1.3'
+  sha256 'ad6713f5246ecc0612da2f0062821e8eee175f42381264ab4c84126c4e7517a7'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: '0ef1dcb321c9b3e5c3ff4aa87430b02d27a3808645d99945affff9bbd5c47e7b'
+          checkpoint: '02c0f2495941b876d5b421bdc2123b63daa02475620a175408703e09c2ce66c0'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.