### PR TITLE
Update propresenter to 6.1.3_b15163

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.1.2_b15157'
-  sha256 '693a1ee058ed307a85ce0e7c09e4c9d44902bab52dc422465bc46ab7cd4a85c9'
+  version '6.1.3_b15163'
+  sha256 '0495619cb87574143d63fc46629ca75468643069fc1135278c5e92ad817b88fc'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: '8fbd91f023565ce9cffe855793fe29849812fda7710cb0224b5de8020d524b8a'
+          checkpoint: 'ab274baef50eafba2619b9303a8edf315b6af801e6501b2b28c3190cc5a75592'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.