### PR TITLE
Update qlab to 3.2.4

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,10 +1,10 @@
 cask 'qlab' do
-  version '3.1.23'
-  sha256 'bcea4d310f18895fbd94e902833cd2cbdc887d47f063214be568f8ca19d48120'
+  version '3.2.4'
+  sha256 '561904e8fcf56b035100a5a46a3abb6f717d0395f64acf8ce0e56cb87f57da38'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}.php",
-          checkpoint: 'dbdc85c3ec06dac60a1746c3cafb8c49d635fa24b21308c28ccb86b242b38f40'
+          checkpoint: '273773f4ab30e6148fccde6cf6bf87b68b59bfed2e9cafef4d1b8f5ec93ebf89'
   name 'QLab'
   homepage 'https://figure53.com/qlab/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.