### PR TITLE
Update go-agent to 16.12.0-4352

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,10 +1,10 @@
 cask 'go-agent' do
-  version '16.10.0-4131'
-  sha256 '401a4757ba7caaf5bdbaac1ca5e5e1f7af6674dc15b586ee90f932d1eb7a63c4'
+  version '16.12.0-4352'
+  sha256 'ec5446d45b4398b285bb8ca9ee7fed04c278aa112c1832d0944c87dffa8dbb28'
 
-  url "https://download.go.cd/binaries/#{version}/osx/go-agent-#{version}-osx.zip"
+  url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"
   name 'Go Agent'
-  homepage 'https://www.go.cd/'
+  homepage 'https://gocd.io/'
 
   app 'Go Agent.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.