### PR TITLE
Update go-server to 16.12.0-4352

### DIFF
--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -2,9 +2,9 @@ cask 'go-server' do
   version '16.12.0-4352'
   sha256 'f0b7f7f401e1a11022978c908f02409c0deec9c1cd5d80a6ae334bd82a7749e9'
 
-  url "https://download.go.cd/binaries/#{version}/osx/go-server-#{version}-osx.zip"
+  url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"
   name 'Go Server'
-  homepage 'https://www.go.cd/'
+  homepage 'https://gocd.io/'
 
   app 'Go Server.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.