### PR TITLE
Update scap-workbench to 1.1.4

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,11 +1,11 @@
 cask 'scap-workbench' do
-  version '1.1.3'
-  sha256 '04a6c752aba3de1a76ae6c3a0e69c4e73f6601f073d2f24d48ee61cacab20330'
+  version '1.1.4'
+  sha256 '506ea96f69f1c67cc1b836c357d1b7accf616ffb676c19713ebdc8c379a713e7'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
   url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version}/scap-workbench-#{version}.dmg"
   appcast 'https://github.com/OpenSCAP/scap-workbench/releases.atom',
-          checkpoint: '99c50028334b8ffa6333e9c97e0a3fdc449704f17ac89cefc4b6c0701c518363'
+          checkpoint: 'b3d63d0ee9e295b11fe80731a57057b5e4def157812e16033ea0a29520ee7413'
   name 'scap-workbench'
   homepage 'https://www.open-scap.org/tools/scap-workbench/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.