### PR TITLE
Update tableflip to 1.1.5

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,11 +1,11 @@
 cask 'tableflip' do
-  version '1.1.4'
-  sha256 'feb5f11017e6983f1d4136ca31d251ddff86c42b0f5e990aeff6809fb85ce713'
+  version '1.1.5'
+  sha256 '06ca0b955335c4b7ffdcdceeed7a3aecf6cef6cb996b6dc222636ec04ab92218'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"
   appcast "https://update.christiantietze.de/tableflip/v#{version.major}/release.xml",
-          checkpoint: 'df87f5df3dd31b2401c0510643dd811bf44ac5f63215cc87b411e4c1173fa4b4'
+          checkpoint: '0c5937b9dfa4b9cf2c0781d53b7f39e0f6385fedd9ebe8ef551dc26fb540ca3c'
   name 'TableFlip'
   homepage 'http://tableflipapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.