### PR TITLE
Update tv-browser to 3.4.4

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -5,7 +5,7 @@ cask 'tv-browser' do
   # sourceforge.net/tvbrowser was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/tvbrowser/tvbrowser_#{version}_macjava.dmg"
   appcast 'https://sourceforge.net/projects/tvbrowser/rss',
-          checkpoint: '6c72cc25756e2a0d117c74692acb9515fc1a59933f469424d1409b36eee5449b'
+          checkpoint: 'b9f535f621475c9bc83836e269be9be5ec8dd375a33d6ebbd9bd76928aa35cb4'
   name 'TV-Browser'
   homepage 'http://www.tvbrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.