### PR TITLE
Update avidemux to 2.6.16

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.6.15'
-  sha256 'b646cb9ceff19c96e771550ffd070dc8834427755ac962aad90efb11652c4667'
+  version '2.6.16'
+  sha256 'e9e8c8937f8039ba1eaa61c1b083e1262c29c5f7e27fa636a7f8a417c83ca66e'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: '37287b61c6efcc8ddea788b23cb0dd53422824ebb2d7d3ea68a386e46170bcc9'
+          checkpoint: '14cf1d7c8fb20c4dbec63cd7beaf403f623bf3c402010367b098220fae41a8d1'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.