### PR TITLE
Update lingon-x to 4.3.3

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '4.3.2'
-  sha256 'e565690b365cee46867abe3a3caebccd5c9bcea99e5c244001a5b658c1107fee'
+  version '4.3.3'
+  sha256 'a60e372828a75d0bd621c1692427ad0e89a5518f4344449d7393752417906016'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'dd006a1e3744447d6652a4b8b7c6a4ec7780ccca6ba5b5712236f4294a3feb44'
+          checkpoint: '9ffd18cd9a00e6e4bcdddaa552a5c6cc22b0374e80f1f292624950e8f19eef6e'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.