### PR TITLE
Upgraded Spotify Notifications to v0.6.0

### DIFF
--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -1,13 +1,11 @@
 cask 'spotify-notifications' do
-  version '0.5.2'
-  sha256 'c464da41ae084dfc208c94656e33465c86721a54391f2ee1ecba29e269296972'
+  version '0.6.0'
+  sha256 '136f676a4580a561ca08edf13a79a5cea5878f276ff6a38e3f2bb96aeca61031'
 
-  # github.com/citruspi/Spotify-Notifications was verified as official when first introduced to the cask
-  url "https://github.com/citruspi/Spotify-Notifications/releases/download/#{version}/Spotify.Notifications.-.#{version}.zip"
-  appcast 'https://github.com/citruspi/Spotify-Notifications/releases.atom',
-          checkpoint: '3ab1004774c7424ba472adbc993a95cd5cbbb424b45283470e11824556c269e7'
+  url "https://downloads.spotify-notifications.citruspi.io/#{version}-release.zip"
   name 'Spotify Notifications'
   homepage 'https://spotify-notifications.citruspi.io/'
+
   license :public_domain
 
   app 'Spotify Notifications.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.