### PR TITLE
Update vimr to 0.12.2-153

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.12.1-151'
-  sha256 '792e86dfc50579c701841858775f595fe9322e0f5187016b4131a91bc541d89f'
+  version '0.12.2-153'
+  sha256 '85508ffff5b16353306ec56ad4436ac491cc3b01009137abbc16604249850e06'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '61f6a66f902c1f3bbba344f25a3aa944252b0e5a25ecc5b1f6f9f833047da8f9'
+          checkpoint: 'bdb4e17c16266b233f61e93273074625252ce2c433762e74bcccdde8e1195c9c'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.