### PR TITLE
ableton-live 9.7.1

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live' do
-  version '9.2.1'
-  sha256 '30599a21a857be855e687e3d5a162cefb84ff98491bc2757d0580e811114295e'
+  version '9.7.1'
+  sha256 '6f6dfd07da7ab2a539293fc6591b9c4d9ef29daacf622aef17d2408328513b72'
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   name 'Ableton Live'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
