### PR TITLE
Update downie to 2.6.1,1356

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.6,1353'
-  sha256 'e1f1e5bc118160899b4c5297c06067cf0ae88dfff411afe190e4b00f2b0fde41'
+  version '2.6.1,1356'
+  sha256 'a715f9dbb98b0e7e62486ef95f5b6d015608745682712b25e4c385cbc7f34ee9'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '337cfcc21942808adb2b1561c8e9ec3110a5714b2d66ffb4d576763bfd9c76e4'
+          checkpoint: '653b1a3d2a1292c9aa1469f39aa231b19c256e1991374663d62d63b2fd9e81e4'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.