### PR TITLE
Update the-hit-list to 1.1.28,352

### DIFF
--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,10 +1,10 @@
 cask 'the-hit-list' do
-  version '1.1.27,347'
-  sha256 '76d1dd3d441e1df6d7aa3a7708228853cd89ca3839a095f73c5cdb4d6d69749f'
+  version '1.1.28,352'
+  sha256 '4262813521d6b0459d4580aebc7e3d4b1b6080731888d26c45253e4587e95952'
 
   url "https://distrib.karelia.com/downloads/TheHitList-#{version.after_comma}.zip"
   appcast 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List',
-          checkpoint: '2f9a1f6cc0fb28c0ff21b5e36211cad4d01acb4bcd9b0f97563cabce6c5657f5'
+          checkpoint: 'a4bc0e34599ed0ea03435c3db10011e0213d59957b4a8f8a0bdb8dab53234550'
   name 'The Hit List'
   homepage 'https://www.karelia.com/products/the-hit-list/mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.