### PR TITLE
Update timely to 0.4.1

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,11 +1,11 @@
 cask 'timely' do
-  version '0.3.4'
-  sha256 'e03507be08721055c1a761b3753bbf1932a22f75e424bb6ac3c179199982c9b9'
+  version '0.4.1'
+  sha256 'd021cb95b21ab526203bcf7073789011cc78e348c4bd6596b021e84da26d5518'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/osx64-v#{version}/Timely-#{version}.dmg"
   appcast 'https://github.com/Timely/desktop-releases/releases.atom',
-          checkpoint: 'e4cb97258fa3ef5d9c4ac39ef80ad4bb3a96e11ad81beb1e674962292f270263'
+          checkpoint: 'f431b778510451146b2eb1091ec4272b3da0c10c6e26a7aa3339cd39c7d0da0d'
   name 'Timely'
   homepage 'https://timelyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.