### PR TITLE
Update track-o-bot to 0.8.6

### DIFF
--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -1,11 +1,11 @@
 cask 'track-o-bot' do
-  version '0.8.5'
-  sha256 '7e9185d980e3864feb67a8e60ba0c33ca53723a57b69115b0506f65f7a4ffc7e'
+  version '0.8.6'
+  sha256 '050ad7eda093d9eb3c44f9033291f0928512721162c8a2474b2fb55b52067eb2'
 
   # github.com/stevschmid/track-o-bot was verified as official when first introduced to the cask
   url "https://github.com/stevschmid/track-o-bot/releases/download/#{version}/Track-o-Bot_#{version}.dmg"
   appcast 'https://github.com/stevschmid/track-o-bot/releases.atom',
-          checkpoint: 'fc6fb048cf4efcf442067a33d079f08dc65948da01f4d9ac58b9761428a72408'
+          checkpoint: '1962fe0965f3939f91f2418a2c26967c99a2bd109dd9441454da612eedc176e6'
   name 'Track-o-Bot'
   homepage 'https://trackobot.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.