### PR TITLE
Update teamdrive to 4.3.1.1630

### DIFF
--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -1,6 +1,6 @@
 cask 'teamdrive' do
-  version '4.3.0.1609'
-  sha256 '3cbfebfdb93f4983a573f6718aef7c4c72b5285b851a7ef7cfa887d7e1b6b627'
+  version '4.3.1.1630'
+  sha256 'aab6d346123130befe5e418437dd14b0e4999b1b482a515f1805bdcf207d416c'
 
   # s3download.teamdrive.net.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.