### PR TITLE
Update mediathekview to 13

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,10 +1,10 @@
 cask 'mediathekview' do
-  version '12'
-  sha256 'c0671283d2719028815adeb5380ad8d0991ea50f680b6a041b2852d542412c5e'
+  version '13'
+  sha256 '96c8ba822f171dab19472ae4d8e2120014540c833ca28c767fc913b49a31144a'
 
-  url "https://downloads.sourceforge.net/zdfmediathk/Mediathek/Mediathek%20#{version}/MediathekView_#{version}.dmg"
+  url "https://downloads.sourceforge.net/zdfmediathk/Mediathek/Mediathek%20#{version}/MediathekView-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/zdfmediathk/rss?path=/Mediathek',
-          checkpoint: 'cc32cbb6d7db3f56cf4c4739c54a7442677a748f93548217cbc9de439b7be25a'
+          checkpoint: '74248bb4c74b544fa9cfc53eb13ce709ed7a937dd205691b5a808a459e622b86'
   name 'MediathekView'
   homepage 'https://sourceforge.net/projects/zdfmediathk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.