### PR TITLE
Update trolcommander to 0.9.9

### DIFF
--- a/Casks/trolcommander.rb
+++ b/Casks/trolcommander.rb
@@ -1,11 +1,11 @@
 cask 'trolcommander' do
-  version '0.9.8'
-  sha256 'ce7a58046d2ed55ff92e8ab6990fa28c4db49db2075c51585616eee315aaccde'
+  version '0.9.9'
+  sha256 '143b62df9fa2ece807724b690692787cb10b3e42796faf6944f1f2d047db1d9e'
 
   # github.com/trol73/mucommander was verified as official when first introduced to the cask
   url "https://github.com/trol73/mucommander/releases/download/v#{version}/trolcommander-#{version.dots_to_underscores}.app.tar.gz?raw=true"
   appcast 'https://github.com/trol73/mucommander/releases.atom',
-          checkpoint: '07a84626dfc65bc014a9c4cd9d76f44b3138b6a11ca3d891f4492aa32f65af55'
+          checkpoint: 'ea64230d7f4a982b1da1c84371c4ca801d1031e105f266b64dd5f5d8aca96430'
   name 'trolCommander'
   homepage 'https://trolsoft.ru/en/soft/trolcommander'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.