### PR TITLE
Updating squirrelsql-3.7.1 to use #{appdir}

### DIFF
--- a/Casks/squirrelsql.rb
+++ b/Casks/squirrelsql.rb
@@ -76,7 +76,7 @@ EOS
   end
 
   uninstall_postflight do
-    system_command 'java', args: ['-jar', '#{appdir}/SQuirreLSQL.app/Uninstaller/uninstaller.jar', '-f', '-c']
+    system_command 'java', args: ['-jar', "#{appdir}/SQuirreLSQL.app/Uninstaller/uninstaller.jar", '-f', '-c']
   end
 
   zap delete: '~/.squirrel-sql'

--- a/Casks/squirrelsql.rb
+++ b/Casks/squirrelsql.rb
@@ -22,7 +22,7 @@ cask 'squirrelsql' do
         <com.izforge.izpack.panels.HelloPanel id="UNKNOWN (com.izforge.izpack.panels.HelloPanel)"/>
         <com.izforge.izpack.panels.HTMLInfoPanel id="UNKNOWN (com.izforge.izpack.panels.HTMLInfoPanel)"/>
         <com.izforge.izpack.panels.TargetPanel id="UNKNOWN (com.izforge.izpack.panels.TargetPanel)">
-        <installpath>/Applications/SQuirreLSQL.app</installpath>
+        <installpath>#{appdir}/SQuirreLSQL.app</installpath>
         </com.izforge.izpack.panels.TargetPanel>
         <com.izforge.izpack.panels.PacksPanel id="UNKNOWN (com.izforge.izpack.panels.PacksPanel)">
         <pack index="0" name="Base" selected="true"/>
@@ -76,7 +76,7 @@ EOS
   end
 
   uninstall_postflight do
-    system_command 'java', args: ['-jar', '/Applications/SQuirreLSQL.app/Uninstaller/uninstaller.jar', '-f', '-c']
+    system_command 'java', args: ['-jar', '#{appdir}/SQuirreLSQL.app/Uninstaller/uninstaller.jar', '-f', '-c']
   end
 
   zap delete: '~/.squirrel-sql'


### PR DESCRIPTION
The squirrelsql cask has "/Applications" hardcoded in the paths. This PR changes the paths to use "#{appdir}" so that the install directory can be changed from the command line.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
