### PR TITLE
Update textsoap to 8.3

### DIFF
--- a/Casks/textsoap.rb
+++ b/Casks/textsoap.rb
@@ -1,11 +1,11 @@
 cask 'textsoap' do
-  version '8.2.1'
-  sha256 '6c4ebdc255e0fdeb2dbc1ca57755df1f8d20bbe059a542a0927fa2dba9ff983f'
+  version '8.3'
+  sha256 '6d4fdc5a3866d95d06c28135ae4c602d1bf2572d9bfe59fe335f4a9b8fa8768d'
 
   # unmarked.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://unmarked.s3.amazonaws.com/textsoap#{version.major}.zip"
   appcast "https://unmarked.s3.amazonaws.com/appcast/textsoap#{version.major}.xml",
-          checkpoint: '3b72c57964837673a3dbe0c011b5882d2cd227855f30d1f2e96d1c572fab39be'
+          checkpoint: '91b001a03e3322296844a7ac66a3b6d8a7aa4553f1bebe38b2123d2149993245'
   name 'TextSoap'
   homepage 'https://www.unmarked.com/textsoap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.