### PR TITLE
Update seamonkey to 2.46

### DIFF
--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -1,9 +1,9 @@
 cask 'seamonkey' do
-  version '2.40'
-  sha256 '51eb9ebc5578e81692d8c03cd2e7723f2279a4462c2afd2779b38c29bf12bd75'
+  version '2.46'
+  sha256 '167ae1fa1cd84006d1c85991b983dc9c9d00463f45ac480a3d6d41436bcb6f59'
 
   # mozilla.org was verified as official when first introduced to the cask
-  url "https://download.mozilla.org/?product=seamonkey-#{version}&os=osx&lang=en-US"
+  url "https://archive.mozilla.org/pub/seamonkey/releases/#{version}/mac/en-US/SeaMonkey%20#{version}.dmg"
   name 'SeaMonkey'
   homepage 'http://www.seamonkey-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.