### PR TITLE
Update josm.rb to 11427

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask 'josm' do
-  version '11425'
-  sha256 'cf832e92f5886f30813b966ffca71e6cc62235d6dbe88995a54a7187eb54d68f'
+  version '11427'
+  sha256 'c2000ec4f0989181f6eadb434000e9429f04da00855dd7f329253e71ea2e0d98'
 
   url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
   name 'JOSM'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
