### PR TITLE
Update darktable to 2.2.1

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,11 +1,11 @@
 cask 'darktable' do
-  version '2.2.0'
-  sha256 '75d5f68fec755fefe6ccc82761d379b399f9fba9581c0f4c2173f6c147a0109f'
+  version '2.2.1'
+  sha256 '9a86ed2cff453dfc0c979e802d5e467bc4974417ca462d6cbea1c3aa693b08de'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
-  url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
+  url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.3.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: 'ae7fffd947c8ed332a1e3e8d3a2daf06955d32bf455cd66cb518e4ef1617d20f'
+          checkpoint: '4f4d994ceb2d87d3b0c57e14beab7e69b10e938623b2e6d83b66e38ebb24727a'
   name 'darktable'
   homepage 'https://www.darktable.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.