### PR TITLE
Update mono-mdk to 4.6.2.16

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,8 +1,8 @@
 cask 'mono-mdk' do
-  version '4.6.2.7'
-  sha256 'e31963607d9eab70e5e0cece21773cc4be30484159f0b47b661b44b9d821ffd3'
+  version '4.6.2.16'
+  sha256 '466866fbf633e8853683543dd906b9773989bf5bb28366522d8309e3dde45e3e'
 
-  url "https://download.mono-project.com/archive/#{version.sub(%r{\.[^.]*$}, '')}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
+  url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.