### PR TITLE
Update telegram to 2.30-51442

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.29-51395'
-  sha256 'a9c8170e162ef279e758bb21b82a4942b5176e9da1000bf96a5f9d150ff0e894'
+  version '2.30-51442'
+  sha256 'db28d47e8337eb417e4c75e6cc1650ccd3f34cd0ed6cffcebafd489f88336cac'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '0419c2359ef9ba9605501f77d6f84625773f5453553fafd80cf5ffbfc837eb27'
+          checkpoint: '3c1f0971cb334ae6b944fac8724d3e431b52965dcebde881939e5c91defb26f0'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.