### PR TITLE
Update aria-maestosa to 1.4.13

### DIFF
--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -1,10 +1,10 @@
 cask 'aria-maestosa' do
-  version '1.4.12'
-  sha256 '177f8d7befa7330b82386fd55b9289213928220faa2565c948804579867569a8'
+  version '1.4.13'
+  sha256 'a3a04954ff7258141d4762659f49a204e42f24a06fab6ba318f47a749e6398c0'
 
   url "https://downloads.sourceforge.net/ariamaestosa/AriaMaestosa-osx-#{version}.zip"
   appcast 'https://sourceforge.net/projects/ariamaestosa/rss',
-          checkpoint: '477668fd1065310b682c7ced2a01f4be95af808290674d9598ff2895122cad3a'
+          checkpoint: '27ab42b1eaccdf79de35fa54c8dfd33c8e25b079a221e14d11e7d17efb64cac6'
   name 'Aria Maestosa'
   homepage 'http://ariamaestosa.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.