### PR TITLE
Update little-flocker to 1.4.1

### DIFF
--- a/Casks/little-flocker.rb
+++ b/Casks/little-flocker.rb
@@ -1,6 +1,6 @@
 cask 'little-flocker' do
-  version '1.4'
-  sha256 '4fcc9d82b337a7bd30fe9f8b5ddbe1229af1c78af69d96c47b0b8e303845b784'
+  version '1.4.1'
+  sha256 'ad440cda69ab7ba09b4cba504673c125fd056e8543181a5db9b42a090127c742'
 
   # zdziarski.com/littleflocker was verified as official when first introduced to the cask
   url "https://www.zdziarski.com/littleflocker/LittleFlocker-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.