### PR TITLE
Update camunda-modeler to 1.6.0

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.5.1'
-  sha256 'f6562e511acde034ff96f6bedb527479de8a35882a2fd0d388d471606d2ffc16'
+  version '1.6.0'
+  sha256 'f10e9f898c05e42195d27227353c251cb5e91efa96068479e95fcd9f2fc56e0c'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.