### PR TITLE
Update chronycontrol to 1.1.4

### DIFF
--- a/Casks/chronycontrol.rb
+++ b/Casks/chronycontrol.rb
@@ -1,6 +1,6 @@
 cask 'chronycontrol' do
-  version '1.1.2'
-  sha256 'b171c2a201f3b9455668d2b283f5a7746b082ef28fcd04cc3aa266302606926c'
+  version '1.1.4'
+  sha256 '31fbe11a556befc2943f890d5786bd01270ba754c747b8507f862efe47e9089f'
 
   url "https://www.whatroute.net/software/chronycontrol-#{version}.zip"
   name 'ChronyControl'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.