### PR TITLE
Update ndm to 0.1.0

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '0.0.5-beta'
-  sha256 '61ca8bd11d297e075ae969b3222cd8e072dc4b615e3ec8797781d82a8e9be747'
+  version '0.1.0'
+  sha256 '3bf4a06f6449f086cb5247664509e833aa18e8e2607333362223b58f433d802d'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
-  url "https://github.com/720kb/ndm/releases/download/#{version}/ndm-#{version}.dmg"
+  url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '986240f18ce25bbb5bb42db29eeb5eaea52b1d1dc7dc01494eb4d802d2785e4d'
+          checkpoint: 'fbb83c6e59f353266ab87e3ec03a4a1fbd744d7a2dff3e76dde389ad806b2646'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.