### PR TITLE
Update dvdstyler to 3.0.3

### DIFF
--- a/Casks/dvdstyler.rb
+++ b/Casks/dvdstyler.rb
@@ -1,11 +1,11 @@
 cask 'dvdstyler' do
-  version '3.0.2'
-  sha256 '907ac4597652e0bfd38f563875030127e05e7ebb92175ca4e3adfd63263f0ccb'
+  version '3.0.3'
+  sha256 'c7e603a09e8455464d047ebb89b1aa2e4d81c49ade7bb38ed546170cf056b5a6'
 
   # sourceforge.net/dvdstyler was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dvdstyler/DVDStyler-#{version}-MacOSX.dmg"
   appcast 'https://sourceforge.net/projects/dvdstyler/rss',
-          checkpoint: 'd70dc1bd3e05c463d20e5cfd065acd593a2dfd7b044f02d18b211305ba02c341'
+          checkpoint: 'eeb09e1641cac1695a2ac136bea8a2bc21d9dab00bda98439806bbc86fe2f709'
   name 'DVDStyler'
   homepage 'http://www.dvdstyler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.