### PR TITLE
Update quiterss to 0.18.4

### DIFF
--- a/Casks/quiterss.rb
+++ b/Casks/quiterss.rb
@@ -1,8 +1,10 @@
 cask 'quiterss' do
-  version '0.17.7'
-  sha256 '7967cd729044152b1e876eba9492fbfc307104b259dbb2bb664d486836cda3dd'
+  version '0.18.4'
+  sha256 'f6d9dbf5817f94d5d7ddcae24a62aa5029ae4da2553728ecd81b745667d02353'
 
   url "https://quiterss.org/files/#{version}/QuiteRSS-#{version}.dmg"
+  appcast 'https://github.com/QuiteRSS/quiterss/releases.atom',
+          checkpoint: '5b373189915b31794b03dee3306ac6b238549647c64ddbf7f6d96c3f4df9d9c9'
   name 'QuiteRSS'
   homepage 'https://quiterss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.