### PR TITLE
Fix image2icon 2.7 sha256 mismatch

### DIFF
--- a/Casks/image2icon.rb
+++ b/Casks/image2icon.rb
@@ -1,6 +1,6 @@
 cask 'image2icon' do
   version '2.7'
-  sha256 '9db407556f0ff2921667fba61816dec29a45dde67b7d32b073693e3884c059a8'
+  sha256 '377399ee8f7fbb3fea16fa4da8bcd5cd6e9d7caf46d15e48212061eb627967ae'
 
   # sf-applications.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://sf-applications.s3.amazonaws.com/Image2Icon/app-releases/Image2icon#{version}.zip"


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
