### PR TITLE
Update fetch to 5.7.6

### DIFF
--- a/Casks/fetch.rb
+++ b/Casks/fetch.rb
@@ -1,6 +1,6 @@
 cask 'fetch' do
-  version '5.7.5'
-  sha256 '8f154a7e353dc6ab672d794b019fa5f298010a366379eda3cfa9a1c1c9d71e0d'
+  version '5.7.6'
+  sha256 '0687113cd0b94784a5cd6c1f9f609cada175aac0163f3bf104305e68da847e16'
 
   url "http://fetchsoftworks.com/fetch/download/Fetch_#{version}.dmg?direct=1"
   name 'Fetch'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.