### PR TITLE
Update glyphs to 2.4.1-956

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.3.1-913'
-  sha256 'b7afabe338d617476d6077879b3c35547aeaba952ba3635b0ec47d4e61dca5d1'
+  version '2.4.1-956'
+  sha256 '6acdd4765bfcecbaf8c709717e3c87092f4537c089882b7f2d0a29a19df981f4'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: 'a00f114fc3cac79bcdd55fde37d4411ae7ebaa10116a17f3e13a68bca4bd87fa'
+          checkpoint: '621a312f3c42b59ff86d55f88e802bfe6084f827e4890aed1cd722d029a4d5b7'
   name 'Glyphs'
   homepage 'https://www.glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.