### PR TITLE
Update astrotelescope to 1.12

### DIFF
--- a/Casks/astrotelescope.rb
+++ b/Casks/astrotelescope.rb
@@ -1,6 +1,6 @@
 cask 'astrotelescope' do
-  version '1.10'
-  sha256 'b294ced6a744c8048c6ce0df4a840f943120c418690b6eacf89a63d0a895c34a'
+  version '1.12'
+  sha256 'a417461c834b1d9a31fd3656e3ee1da2470cc9069df3a205949ef4cb46355e50'
 
   url "http://download.cloudmakers.eu/AstroTelescope_#{version}.dmg"
   name 'AstroTelescope'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.