### PR TITLE
Update mosh to 1.2.6

### DIFF
--- a/Casks/mosh.rb
+++ b/Casks/mosh.rb
@@ -1,6 +1,6 @@
 cask 'mosh' do
-  version '1.2.5'
-  sha256 '8a590ba81edd6f706f2d0afe1cb882bd8ff8860e395b7c6ac7285306f4f12209'
+  version '1.2.6'
+  sha256 '5eb7797b0c3a5423da1c62f80f8e6268acd55b1b10a850e58fd7bb8f6bdb520d'
 
   url "https://mosh.org/mosh-#{version}.pkg"
   name 'Mosh'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.