### PR TITLE
Update qgroundcontrol to 3.0.2

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,9 +1,11 @@
 cask 'qgroundcontrol' do
-  version '2.5.2'
-  sha256 'b42f6e3de99250a86c9cb5860c8477ee449d5f81f06d32c04f564596198f0b83'
+  version '3.0.2'
+  sha256 'bcbb0be65da45cfd7664ead51cc39a3156ee2a06d7f7e873b4a96996e2ad5e8e'
 
-  # qgroundcontrol.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://qgroundcontrol.s3.amazonaws.com/QGroundControl-Stable-V#{version}.dmg"
+  # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
+  appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
+          checkpoint: '528f423edb2b4616833954cbc2d556a8f2f058ec9c6182653a5c1eb3e0022c32'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.