### PR TITLE
Update bitcoin-core to 0.13.2

### DIFF
--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -1,6 +1,6 @@
 cask 'bitcoin-core' do
-  version '0.13.1'
-  sha256 'ca063833ffcfe9ac5c8f0e213a39b90132f32eb408e675c1e40eeaf3fcb0404f'
+  version '0.13.2'
+  sha256 'dac105b49c159a3d8c9463d1f05afe4cf29ec40bbd145e8961132693b7eff953'
 
   # bitcoin.org was verified as official when first introduced to the cask
   url "https://bitcoin.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-osx.dmg"
@@ -18,10 +18,8 @@ cask 'bitcoin-core' do
   end
 
   postflight do
-    set_permissions "#{appdir}/Bitcoin Core.app", '0555'
+    set_permissions "#{appdir}/Bitcoin Core.app", '0755'
   end
 
-  zap delete: [
-                '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist',
-              ]
+  zap delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
 end

--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -17,9 +17,5 @@ cask 'bitcoin-core' do
     set_permissions "#{staged_path}/Bitcoin-Qt.app", '0755'
   end
 
-  postflight do
-    set_permissions "#{appdir}/Bitcoin Core.app", '0755'
-  end
-
   zap delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
 end


### PR DESCRIPTION
- Needed to change the postflight permissions to 0755 to be able to uninstall
- Then removed it completely because it doesn't seem relevant seeing as the source has already beed chmod

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.