### PR TITLE
Update trim-ios-screenshots to 1.0.2

### DIFF
--- a/Casks/trim-ios-screenshots.rb
+++ b/Casks/trim-ios-screenshots.rb
@@ -1,10 +1,12 @@
 cask 'trim-ios-screenshots' do
-  version '1.0.1'
-  sha256 '08be76899e40a99183cde27639ae44329096dd01f8c90619e4decc6243af6ed1'
+  version '1.0.2'
+  sha256 '3f30f05a6f3fd7adadb93e9da0cbe038d56c91d5380e674e13f9de3ebebf781c'
 
-  url "https://github.com/downloads/osteslag/trim-ios-screenshots/Trim_iOS_Screenshots-#{version}.zip"
+  url "https://github.com/osteslag/trim-ios-screenshots/releases/download/v#{version}/Trim_iOS_Screenshots-#{version}.zip"
+  appcast 'https://github.com/osteslag/trim-ios-screenshots/releases.atom',
+          checkpoint: 'bdc93d1552478ee4be878af55f80a4ac455d32ec8302bcb127f3392995e40174'
   name 'Trim iOS Screenshots'
   homepage 'https://github.com/osteslag/trim-ios-screenshots'
 
-  app 'Trim iOS Screenshots.app'
+  app "Trim_iOS_Screenshots-#{version}/Trim iOS Screenshots.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.