### PR TITLE
Added Ethereum\ Mist.app v0.8.8

### DIFF
--- a/Casks/ethereum-mist.rb
+++ b/Casks/ethereum-mist.rb
@@ -1,0 +1,20 @@
+cask 'ethereum-mist' do
+  version '0.8.8'
+  sha256 '955b46059c6d65b5f2cdc824a642562eb7ec6442747fc1b5c4aafb6f42a7bad5'
+
+  url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
+  appcast 'https://github.com/ethereum/mist/releases.atom',
+          checkpoint: '63081a0ff5fcb43ec5670b82812ab60465e292f0a1de4e3ae956e93e47071def'
+  name 'Ethereum Mist'
+  homepage 'https://github.com/ethereum/mist'
+
+  app 'Mist.app', target: 'Ethereum Mist.app'
+
+  preflight do
+    set_permissions "#{staged_path}/Mist.app", '0755'
+  end
+
+  postflight do
+    set_permissions "#{appdir}/Ethereum Mist.app", '0555'
+  end
+end


### PR DESCRIPTION
The last Beta of the Ethereum\ Mist.app was v.0.8.7.
So it might be handy to an own ethereum-mist cask.

Both apps can be installed via corresponding casks.

  brew cask install ethereum-mist     (this one)

  and

  brew cask install ethereum-wallet   (exists)

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
