### PR TITLE
Update pritunl to 1.0.1210.1

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1187.7'
-  sha256 'c954e10d48d15bc308d8e4a523a3fe4d597e944fdcd4c88fe3c3ddd0c4fb4255'
+  version '1.0.1210.1'
+  sha256 'efb11733636b22483b9331f976a559c41e53ffb0f641f6258a5cb601207306da'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: '9881fb6bf246fa62f1c63c387682af226c2fcea4f348b04f02b0714dd83b311a'
+          checkpoint: 'fc15aa703105fa8dd4e9c26266de2a783d340b47ae82dbaef493becfe742d9b7'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.