### PR TITLE
Update omnifocus to 2.8

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -7,10 +7,14 @@ cask 'omnifocus' do
     version '2.0.4'
     sha256 '3282eb7e41ec2638f68a92a6509eddd96a96c39b65b954dcedcc4e62289f22a9'
     url "https://downloads.omnigroup.com/software/MacOSX/10.9/OmniFocus-#{version}.dmg"
+  elsif MacOS.version <= :yosemite
+    version '2.7.2'
+    sha256 'bccd8d7c5698a9a3b3cee490baf9dbb6c5cf1d40a3f8fd2c69916a448cbe8b37'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
   else
     version '2.8'
     sha256 'ee72f19cbab9a955b87ab200beb1a389907910f5b61f2c0acf84f49cc5e7bfd9'
-    url 'http://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-2.8.dmg'
+    url "http://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
   end
 
   name 'OmniFocus'

--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -14,7 +14,7 @@ cask 'omnifocus' do
   else
     version '2.8'
     sha256 'ee72f19cbab9a955b87ab200beb1a389907910f5b61f2c0acf84f49cc5e7bfd9'
-    url "http://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
+    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
   end
 
   name 'OmniFocus'

--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -8,9 +8,9 @@ cask 'omnifocus' do
     sha256 '3282eb7e41ec2638f68a92a6509eddd96a96c39b65b954dcedcc4e62289f22a9'
     url "https://downloads.omnigroup.com/software/MacOSX/10.9/OmniFocus-#{version}.dmg"
   else
-    version '2.7.2'
-    sha256 'bccd8d7c5698a9a3b3cee490baf9dbb6c5cf1d40a3f8fd2c69916a448cbe8b37'
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
+    version '2.8'
+    sha256 'ee72f19cbab9a955b87ab200beb1a389907910f5b61f2c0acf84f49cc5e7bfd9'
+    url 'http://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-2.8.dmg'
   end
 
   name 'OmniFocus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.