### PR TITLE
Update macports to 2.3.5

### DIFF
--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -28,6 +28,8 @@ cask 'macports' do
     pkg "MacPorts-#{version}-10.12-Sierra.pkg"
   end
 
+  appcast 'https://github.com/macports/macports-base/releases.atom',
+          checkpoint: 'bb4a24db76cee5daec24c402a3c521881f5724b2725e20b6fd5610a53144853e'
   name 'MacPorts'
   homepage 'https://www.macports.org/'
   gpg "#{url}.asc", key_id: '01ff673fb4aae6cd'

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -1,25 +1,30 @@
 cask 'macports' do
-  version '2.3.4'
+  version '2.3.5'
 
   if MacOS.version <= :mountain_lion
-    sha256 '43c9b56dda623f897854d88c3f7747bd9ae4287fa12b16b1d5eb32f45417b2da'
-    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.8-MountainLion.pkg"
+    sha256 'e77959840187054d31cbeb64bf33f311cf260973be7daf2a8c41e5753ecd8360'
+    # github.com/macports/macports-base was verified as official when first introduced to the cask
+    url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.8-MountainLion.pkg"
     pkg "MacPorts-#{version}-10.8-MountainLion.pkg"
   elsif MacOS.version <= :mavericks
-    sha256 '4b0fd713e3887c5a0f2fa975f90b6818aeb35ec909931d0905c181085abef7f4'
-    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.9-Mavericks.pkg"
+    sha256 'c0cd44d7f4820742a14dd35b9e5942da438adf0500044ba46c825f5ba44d6a47'
+    # github.com/macports/macports-base was verified as official when first introduced to the cask
+    url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.9-Mavericks.pkg"
     pkg "MacPorts-#{version}-10.9-Mavericks.pkg"
   elsif MacOS.version <= :yosemite
-    sha256 '453125fffb358c9547aab70fa39dc5404acc037c18d7b1d7488256e9e4374138'
-    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.10-Yosemite.pkg"
+    sha256 '12db5640b550f5c038edc2967d417334cdc0a8d8e619e145e1ed7352d274c07c'
+    # github.com/macports/macports-base was verified as official when first introduced to the cask
+    url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.10-Yosemite.pkg"
     pkg "MacPorts-#{version}-10.10-Yosemite.pkg"
   elsif MacOS.version <= :el_capitan
-    sha256 '8c0b492032c796d766b76da3d1fda8dea732a6cc9056633a3509e3ff06b5e8d8'
-    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.11-ElCapitan.pkg"
+    sha256 'a465c9364ecc24139c2a15a8613e2dbc8911f9eae96e3b5a7db4a8117f29db88'
+    # github.com/macports/macports-base was verified as official when first introduced to the cask
+    url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.11-ElCapitan.pkg"
     pkg "MacPorts-#{version}-10.11-ElCapitan.pkg"
   else
-    sha256 '0fda4bfcbd922e20b489c762ee6d755d63df5a1e5f3666f71af95d96c9d398c8'
-    url "https://distfiles.macports.org/MacPorts/MacPorts-#{version}-10.12-Sierra.pkg"
+    sha256 'a465c9364ecc24139c2a15a8613e2dbc8911f9eae96e3b5a7db4a8117f29db88'
+    # github.com/macports/macports-base was verified as official when first introduced to the cask
+    url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.12-Sierra.pkg"
     pkg "MacPorts-#{version}-10.12-Sierra.pkg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.