### PR TITLE
Update korean-spelling-checker to 1.7.1

### DIFF
--- a/Casks/korean-spelling-checker.rb
+++ b/Casks/korean-spelling-checker.rb
@@ -1,11 +1,11 @@
 cask 'korean-spelling-checker' do
-  version '1.7.0'
-  sha256 'a26723814722ef3c381f822321ca9ba9ef3885dab6071a1675bf12a9c0ad2142'
+  version '1.7.1'
+  sha256 'bbf7ebd57e29d83db827dbce46d8397d2de2eedd15ae1248a2d4bf556db5fc57'
 
   # github.com/miname/Korean-Spelling-Checker-Workflow was verified as official when first introduced to the cask
   url "https://github.com/miname/Korean-Spelling-Checker-Workflow/archive/#{version}.tar.gz"
   appcast 'https://github.com/miname/Korean-Spelling-Checker-Workflow/releases.atom',
-          checkpoint: '9c4a731a6084689385b3e57dc77ba4dd3b5ca2e969a4ad601c13bc27d8f450d4'
+          checkpoint: 'a51b690a1fa84faae276e0d7ba92837346d99a6824cd6863bdc2b99b4fe70599'
   name '한국어 맞춤법 검사기'
   homepage 'http://appletree.or.kr/google-chrome-extensions/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.