### PR TITLE
Update kollaborate-transfer to 1.4.3.1

### DIFF
--- a/Casks/kollaborate-transfer.rb
+++ b/Casks/kollaborate-transfer.rb
@@ -1,6 +1,6 @@
 cask 'kollaborate-transfer' do
-  version '1.3.0.0'
-  sha256 '3fcfd9bab9232133b2a78bcbfc6fecf1b4730adf014996d5bd2fdf57d2e5b734'
+  version '1.4.3.1'
+  sha256 '65ba2983e9f39c39895dc7613cc7c2c27c6aa75a789c0aae2cb7b6bcc55f55b6'
 
   # digitalrebellion.com was verified as official when first introduced to the cask
   url "http://www.digitalrebellion.com/download/kollabtransfer?version=#{version.no_dots}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.