### PR TITLE
Update insync to 1.3.14.36131

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '1.3.12.36116'
-  sha256 '5439cd459776fdab9f285bdacead90fed199c398b1125b01e0c7b97db1e6b8d1'
+  version '1.3.14.36131'
+  sha256 'b19d6e43134e3630ec8b710742ee1a729d076ad9f19aa4cd22eaa3ae96965df3'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   name 'Insync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.