### PR TITLE
Update fotomagico to 5.3-22548

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,10 +1,10 @@
 cask 'fotomagico' do
-  version '4.6.2-19829'
-  sha256 '7b92c77092a8467b1bcc2584e1d98c8e39819da0c3c37eeba53ad6b3e666d27c'
+  version '5.3-22548'
+  sha256 'f99311b87873a93e62a83e36f3426d327d3daa5b120534747bef75c4e78b10eb'
 
-  url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version}.app.zip"
+  url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   name 'FotoMagico'
   homepage 'https://www.boinx.com/fotomagico/'
 
-  app 'FotoMagico.app'
+  app "FotoMagico #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.