### PR TITLE
Update geneious to 10.0.7

### DIFF
--- a/Casks/geneious.rb
+++ b/Casks/geneious.rb
@@ -1,22 +1,12 @@
 cask 'geneious' do
-  version '9.1.2'
+  version '10.0.7'
+  sha256 'c20eb2199634ce03bd2032ff45ceb3e36e8b50b6092a876323962c7bcd12d261'
 
-  if MacOS.version <= '10.6'
-    sha256 '304afaac8251594d03379737e8263f45297da822b63b306d056057a950255ff2'
-
-    url "http://assets.geneious.com/installers/geneious/release/Geneious_mac64_#{version.dots_to_underscores}.dmg"
-
-    caveats do
-      depends_on_java('6')
-    end
-  else
-    sha256 '1e7da712b396e34c0f87d36745d7f23c4ae4d4557926e42e11d6def623be18b3'
-
-    url "http://assets.geneious.com/installers/geneious/release/Geneious_mac64_#{version.dots_to_underscores}_with_jre.dmg"
-  end
-
+  url "http://assets.geneious.com/installers/geneious/release/Geneious_mac64_#{version.dots_to_underscores}_with_jre.dmg"
   name 'Geneious'
   homepage 'https://www.geneious.com/'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'Geneious.app'
 end


### PR DESCRIPTION
- removed the older version because the latest version supports mountain lion and up anyway

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.