### PR TITLE
zulu/1.8.0_112,8.19.0.1: add JNI as a capability of the JVM

### DIFF
--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -21,6 +21,9 @@ cask 'zulu' do
     system_command '/bin/ln',
                    args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
                    sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
 
     if MacOS.version <= :mavericks
       system_command '/bin/rm',


### PR DESCRIPTION
This is copying the behaviour found in the [java](https://github.com/caskroom/homebrew-cask/blob/master/Casks/java.rb#L21) cask and resolves an issue with node-java (as described [here](https://github.com/joeferner/node-java/issues/90#issuecomment-45613235)).

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
