### PR TITLE
Update Turbo Boost Switcher to 2.4.0

### DIFF
--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -1,13 +1,13 @@
 cask 'turbo-boost-switcher' do
-  version '2.3.0'
-  sha256 'd8872ab5b3033d0889db0dec85b3bfa156fac7674eeb771663ae3b29596e06df'
+  version '2.4.0'
+  sha256 'ae7cab0ecbf750becf438d45104e20b7332788d9479cc1bf7b1d1dc6a91a10d7'
 
   # s3.amazonaws.com/turbo-boost-switcher was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/turbo-boost-switcher/Turbo+Boost+Switcher_#{version}.zip"
   name 'Turbo Boost Switcher'
   homepage 'http://www.rugarciap.com/turbo-boost-switcher-for-os-x/'
 
-  app 'Turbo Boost Switcher.app'
+  app 'Turbo Boost Switcher (English).app'
 
   uninstall quit:       'rugarciap.com.Turbo-Boost-Switcher',
             kext:       'com.rugarciap.DisableTurboBoost',


### PR DESCRIPTION
Bumped version and shasum.

App name changed to: `Turbo Boost Switcher (English).app`

There is now a second app in the zip: `Turbo Boost Switcher (with beta translations).app`
Not sure if we have a switch for international?

---

After making all changes to the cask:
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.