### PR TITLE
Update riot to 0.9.5

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,6 +1,6 @@
 cask 'riot' do
-  version '0.9.2'
-  sha256 'e7e9f8df7958f9c28705aef8bd70950eb192d8c23ed0bff203cdc08059859b60'
+  version '0.9.5'
+  sha256 'd0a0717d08fe0a5f797bd079ced8894e68150f8aadb78f590d5b9bd30057666c'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   name 'Riot'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.