### PR TITLE
Update freac to 20161129

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,11 +1,11 @@
 cask 'freac' do
-  version '20151122'
-  sha256 'd8078a5cc44e3aca10ecd06bf746c5a09866d26a9cbef6465aab0e32a501ac77'
+  version '20161129'
+  sha256 '8bd1e20a8e5f11971a446c359008545e5c123a7639402f3abfa874b4d00d1913'
 
   # sourceforge.net/bonkenc was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/bonkenc/rss',
-          checkpoint: '128279d3629dc59eaee4eced8ceb8d2ece59f7c761c22e5b9820aa03403ae9a7'
+          checkpoint: '618073cc7d75292e113725f9044e5b9aa001aa83a2ef007e260b621270b68fa1'
   name 'fre:ac'
   homepage 'https://www.freac.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.