### PR TITLE
Update jetphoto-studio to 5.6

### DIFF
--- a/Casks/jetphoto-studio.rb
+++ b/Casks/jetphoto-studio.rb
@@ -1,6 +1,6 @@
 cask 'jetphoto-studio' do
-  version '5.5'
-  sha256 'c583a173d018696d613545acacba4c43f641d770de4e5d5bbb0964c1cb2e9f7f'
+  version '5.6'
+  sha256 '71a626ea2e05cadc523797cb0c1d1569f5b9583af4a7c182f3cef2621b1d271c'
 
   url "http://www.jetphotosoft.com/web/download/JetPhoto_Studio_mac#{version}.zip"
   name 'JetPhoto Studio'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.