### PR TITLE
Update iojs to 3.3.1

### DIFF
--- a/Casks/iojs.rb
+++ b/Casks/iojs.rb
@@ -1,8 +1,10 @@
 cask 'iojs' do
-  version '2.4.0'
-  sha256 '7d842eb47b4208f8eb1e9fd7d34e8c1d8b5cde70ba731c2d7565c76f2629b98f'
+  version '3.3.1'
+  sha256 'b440c0f48fc8a435f2af6793a8e9c2ce1b9d2d4912d8a268b9c17c872fda10ba'
 
   url "https://iojs.org/dist/v#{version}/iojs-v#{version}.pkg"
+  appcast 'https://iojs.org/dist/latest/',
+          checkpoint: '7fd29711bfd040011093143752f10dfe7b4e5b631df8dba5b18b85b0f6677025'
   name 'io.js'
   homepage 'https://iojs.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.