### PR TITLE
Update prepros to 6.0.5

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.0.4'
-  sha256 '13780a321975ef2adebb615e6dd0e6a7d96f1a691833d47a269eae6966a7f652'
+  version '6.0.5'
+  sha256 '96814e1fc300dbcf24a09b288558a1113299bb7f78e5cc2c71367d2ad770ea16'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: '6b1d24132f67012a55e3785ce929756fe363613be0019665c7788b3b9dadebe6'
+          checkpoint: 'd8f662018c1f19ebb0f5debae948353c5ee76062f08f7db853a8b3f387235bad'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.