### PR TITLE
Update dripcap to 0.5.2

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.5.1'
-  sha256 '067567e6ab0be23e4899572e45b2549f6b4ef7ee230fb928d21278aa1b9642c5'
+  version '0.5.2'
+  sha256 'f2edaff7e8074114f8755ec3c4b57c1942cfdf4933165791c996ff5f86af3fe9'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: 'b70c95f5998afe00e0ed1874dfa4e493720caec7ae0d4b5b0647ff0ac0684613'
+          checkpoint: '7fb346513e6be63a962b40e97ed5f8d064ae27da7904b3ae047779f2ed8ce43a'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.