### PR TITLE
Update avidemux to 2.6.17

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.6.16'
-  sha256 'e9e8c8937f8039ba1eaa61c1b083e1262c29c5f7e27fa636a7f8a417c83ca66e'
+  version '2.6.17'
+  sha256 '7c9b652555eb1efd72df7a3b0d71b89c48fa3ae82b18d9c26ff15e1c8f4e41f5'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: '14cf1d7c8fb20c4dbec63cd7beaf403f623bf3c402010367b098220fae41a8d1'
+          checkpoint: 'c245e77888dd8c7610a289085c6f638fdca5136c8245f41b82e0860bb3f2164c'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.