### PR TITLE
Update Seashore 0.5.1 `depends_on macos:` crashes on :Sierra

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -11,4 +11,8 @@ cask 'seashore' do
   depends_on macos: '<= :el_capitan'
 
   app 'Seashore.app'
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -7,6 +7,8 @@ cask 'seashore' do
           checkpoint: 'bcf60985cd8080b2d7d2df038b78e4eff30b60ce2e2d562cf91f2939cf4bb451'
   name 'Seashore'
   homepage 'http://seashore.sourceforge.net/'
-
+  
+  depends_on macos: '<= :el_capitain'
+  
   app 'Seashore.app'
 end

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -8,7 +8,7 @@ cask 'seashore' do
   name 'Seashore'
   homepage 'http://seashore.sourceforge.net/'
   
-  depends_on macos: '<= :el_capitain'
+  depends_on macos: '<= :el_capitan'
   
   app 'Seashore.app'
 end

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -7,8 +7,8 @@ cask 'seashore' do
           checkpoint: 'bcf60985cd8080b2d7d2df038b78e4eff30b60ce2e2d562cf91f2939cf4bb451'
   name 'Seashore'
   homepage 'http://seashore.sourceforge.net/'
-  
+
   depends_on macos: '<= :el_capitan'
-  
+
   app 'Seashore.app'
 end


### PR DESCRIPTION
As @neutric pointed out in `gittter` there is an active use of Seashore: 1000s of downloads per week, we have no idea of the cask usage for installation, but it makes sense so myself and @neutric to put a cap on the `depends_on macos:` for the cask until upstream is fixed.

https://sourceforge.net/p/seashore/discussion/244287/thread/5d38967a/?limit=25#3d54

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.