### PR TITLE
Update sqlpro-for-sqlite to 1.0.108

### DIFF
--- a/Casks/sqlpro-for-sqlite.rb
+++ b/Casks/sqlpro-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-sqlite' do
-  version '1.0.101'
-  sha256 '2f69c480ad534c3fc1841c87eb53023767c8e3c58404ec2b9a4042de4bcdc45b'
+  version '1.0.108'
+  sha256 'e8554683b3993f703b51a438d39d1439cb09e61e95f7fa2566b3304f841cde4a'
 
   # d3fwkemdw8spx3.cloudfront.net/sqlite was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/sqlite/SQLProSQLite.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.