### PR TITLE
Update audiobook-builder to 1.5.6

### DIFF
--- a/Casks/audiobook-builder.rb
+++ b/Casks/audiobook-builder.rb
@@ -1,10 +1,8 @@
 cask 'audiobook-builder' do
-  version '1.5.4'
-  sha256 '8ba09725221c44c991d934334d8e6562bcf7408a2faafdb42236ef4c9244def3'
+  version '1.5.6'
+  sha256 '1306fd3fac6f182e17c59a0fa423fd72b0edc4baf00dffdc3a760855774526fa'
 
   url "http://www.splasm.com/downloads/audiobookbuilder/Audiobook%20Builder%20#{version}.dmg"
-  appcast 'http://www.splasm.com/versions/audiobookbuilder_sparkle.xml',
-          checkpoint: 'e82ec1ee1623b4d41d69458b6af46fba041259f3cc2ed161c88c5cff6722c43f'
   name 'Audiobook Builder'
   homepage 'http://www.splasm.com/audiobookbuilder/'
 


### PR DESCRIPTION
- appcast removed because it has not been updated and still shows 1.5.4, but the download link for that was 404. Does not seem to reflect the versioning any more.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.