### PR TITLE
Update vimr to 0.12.4-157

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.12.3-156'
-  sha256 '689729075e82436750a1ba52bb3a5d9232abb7850e64dcdad725d2c07641de96'
+  version '0.12.4-157'
+  sha256 'e3cd0c7ef6f50419e82d60467331f580d58299a6cd80b9b000bf7b8f6fc488e6'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'caa3e003d1d120b961dcdd6cd9f98151ae640d4a63bacdff24af754adf66e4e9'
+          checkpoint: 'b4b6d9225509bb109d6821b9165c1030eb6fb95c90ec84e7b0565e8e325e73c4'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.