### PR TITLE
Update textadept to 9.2

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,8 +1,10 @@
 cask 'textadept' do
-  version '8.3'
-  sha256 '25215aa18ce279fc312dd2a8e5b88eca32ce551991f5475cb12dbd491b24619d'
+  version '9.2'
+  sha256 '8fbc8f05ebbcd0118d72a2d1044415778aadc7a4c9bfba578f2964383797f66e'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
+  appcast 'https://foicica.com/textadept/feed',
+          checkpoint: '62e7aa917e28ee129b3942114bd18e635a6c0ed081a1ec71eecc75f661e44be4'
   name 'Textadept'
   homepage 'https://foicica.com/textadept/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.