### PR TITLE
gnubg: no 'do' with EOS.undent

### DIFF
--- a/Casks/gnubg.rb
+++ b/Casks/gnubg.rb
@@ -18,10 +18,8 @@ cask 'gnubg' do
 
   app 'gnubg.app'
 
-  caveats do
-    <<-EOS.undent
-      #{token} only works if called from /Applications, so you may need to install it with
-        brew cask install #{token} --appdir=/Applications
-    EOS
-  end
+  caveats <<-EOS.undent
+    #{token} only works if called from /Applications, so you may need to install it with
+      brew cask install #{token} --appdir=/Applications
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.