### PR TITLE
korean-spelling-checker.rb: no 'do' with EOS.undent

### DIFF
--- a/Casks/korean-spelling-checker.rb
+++ b/Casks/korean-spelling-checker.rb
@@ -13,12 +13,10 @@ cask 'korean-spelling-checker' do
 
   uninstall delete: '~/Library/Services/✔ 선택한 글의 한국어 맞춤법 검사하기.workflow'
 
-  caveats do
-    <<-EOS.undent
-      #{token} only works when you install it manually via Service Installer,
-      so you may need to run the installer with
+  caveats <<-EOS.undent
+    #{token} only works when you install it manually via Service Installer,
+    so you may need to run the installer with
 
-        open '~/Library/Services/✔ 선택한 글의 한국어 맞춤법 검사하기.workflow'
-    EOS
-  end
+      open '~/Library/Services/✔ 선택한 글의 한국어 맞춤법 검사하기.workflow'
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.