### PR TITLE
squirrelsql.rb: fix heredoc

### DIFF
--- a/Casks/squirrelsql.rb
+++ b/Casks/squirrelsql.rb
@@ -16,7 +16,7 @@ cask 'squirrelsql' do
   preflight do
     # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
     File.open(installoptions, 'w') do |f|
-      f.print <<EOS.undent
+      f.print <<-EOS.undent
         <?xml version="1.0" encoding="UTF-8" standalone="no"?>
         <AutomatedInstallation langpack="eng">
         <com.izforge.izpack.panels.HelloPanel id="UNKNOWN (com.izforge.izpack.panels.HelloPanel)"/>
@@ -67,7 +67,7 @@ cask 'squirrelsql' do
         <com.izforge.izpack.panels.InstallPanel id="UNKNOWN (com.izforge.izpack.panels.InstallPanel)"/>
         <com.izforge.izpack.panels.FinishPanel id="UNKNOWN (com.izforge.izpack.panels.FinishPanel)"/>
         </AutomatedInstallation>
-EOS
+      EOS
     end
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.