### PR TITLE
wine-staging.rb: no 'do' with EOS.undent

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -26,10 +26,8 @@ cask 'wine-staging' do
                      ],
             delete:  '/Applications/Wine Staging.app'
 
-  caveats do
-    <<-EOS.undent
-      #{token} installs support for running 64 bit applications in Wine, which is considered experimental.
-      If you do not want 64 bit support, you should download and install the #{token} package manually.
-    EOS
-  end
+  caveats <<-EOS.undent
+    #{token} installs support for running 64 bit applications in Wine, which is considered experimental.
+    If you do not want 64 bit support, you should download and install the #{token} package manually.
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.