### PR TITLE
wireshark-chmodbpf.rb: no puts for heredoc

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -50,7 +50,7 @@ cask 'wireshark-chmodbpf' do
                      ]
 
   caveats do
-    puts <<-EOS.undent
+    <<-EOS.undent
       This cask will install only the ChmodBPF package from the current Wireshark
       stable install package.
       An access_bpf group will be created and its members allowed access to BPF


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.