### PR TITLE
racket.rb: caveat for MacBook Pro with Touch Bar users

### DIFF
--- a/Casks/racket.rb
+++ b/Casks/racket.rb
@@ -30,4 +30,13 @@ cask 'racket' do
   binary "#{appdir}/Racket v#{version}/bin/slatex"
   binary "#{appdir}/Racket v#{version}/bin/slideshow"
   binary "#{appdir}/Racket v#{version}/bin/swindle"
+
+  caveats <<-EOS.undent
+    MacBook Pro with Touch Bar users:
+    To avoid a bug in this version that prevents programs from working with the Touch Bar, use the 32-bit version or try a snapshot build:
+      https://pre.racket-lang.org/installers/
+
+    More information on the download page:
+      https://download.racket-lang.org/
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/28658.