### PR TITLE
Update marked.rb for zap

### DIFF
--- a/Casks/marked.rb
+++ b/Casks/marked.rb
@@ -6,7 +6,7 @@ cask 'marked' do
   appcast 'https://updates.marked2app.com/marked.xml',
           checkpoint: 'caf003f39ca2a87922e2d1f6afe17df55bd6bb6f36dcfd16b52e257cf629f5e0'
   name 'Marked'
-  homepage 'https://marked2app.com/'
+  homepage 'http://marked2app.com/'
 
   auto_updates true
 

--- a/Casks/marked.rb
+++ b/Casks/marked.rb
@@ -1,12 +1,12 @@
 cask 'marked' do
-  version '2.5.9'
+  version '2.5.9925'
   sha256 '81bcbfbe51c1ec987f1d20695a2187fcd848bc46c33c054821fe120c7d82a5c0'
 
-  url 'http://marked2app.com/download/Marked.zip'
+  url "https://updates.marked2app.com/Marked#{version}.zip"
   appcast 'https://updates.marked2app.com/marked.xml',
           checkpoint: 'caf003f39ca2a87922e2d1f6afe17df55bd6bb6f36dcfd16b52e257cf629f5e0'
   name 'Marked'
-  homepage 'http://marked2app.com/'
+  homepage 'https://marked2app.com/'
 
   auto_updates true
 
@@ -15,10 +15,12 @@ cask 'marked' do
   uninstall quit: "com.brettterpstra.marked#{version.major}"
 
   zap delete: [
-                "~/Library/Application Support/Marked #{version.major}/paddata.padl",
-                "~/Library/Application Support/Marked #{version.major}/queue.pak",
-                "~/Library/Containers/com.brettterpstra.marked#{version.major}",
-                "~/Library/Preferences/com.brettterpstra.marked#{version.major}.LSSharedFileList.plist",
+                "~/Library/Application Support/Marked #{version.major}",
+                "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.brettterpstra.marked#{version.major}.sfl",
+                "~/Library/Caches/Marked #{version.major}",
+                "~/Library/Caches/com.brettterpstra.marked#{version.major}",
+                "~/Library/Logs/Marked #{version.major}",
+                "~/Library/Preferences/com.brettterpstra.marked#{version.major}.plist",
                 "~/Library/Saved Application State/com.brettterpstra.marked#{version.major}.savedState",
               ]
 end


### PR DESCRIPTION
Update marked.rb for zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
