### PR TITLE
Update mongoChef to 4.5.1

### DIFF
--- a/Casks/mongochef.rb
+++ b/Casks/mongochef.rb
@@ -1,10 +1,10 @@
 cask 'mongochef' do
-  version '4.5.0'
-  sha256 '2b9ec5c84485bcf3f7df29766a642b444a4b6e302a3330c4c6968ef46c5af0a4'
+  version '4.5.1'
+  sha256 '8221b179fef6946244ff439cdadb55f408481690bcaec996c1d59c664f966590'
 
   url "https://cdn.3t.io/mongochef-core/mac/#{version}/MongoChef.dmg"
   appcast 'http://downloads.3t.io/mongochef-core/changelog.txt',
-          checkpoint: '475cc58f1530cb5592c4d8b9dd2b8d533986b4bc723acfa80e902d9855c9fb29'
+          checkpoint: '464de2612fe807d96e7f66fd967ce86cea55ceef013d593862f580bf9df1852f'
   name 'MongoChef'
   homepage 'https://3t.io/mongochef/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download mongochef` is error-free.
- [x] `brew cask style --fix mongochef` reports no offenses.
- [x] The commit message includes the cask’s name and version.