### PR TITLE
Update avidemux to 2.6.18

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.6.17'
-  sha256 '7c9b652555eb1efd72df7a3b0d71b89c48fa3ae82b18d9c26ff15e1c8f4e41f5'
+  version '2.6.18'
+  sha256 'bc4c1251103236a719a7d56a912bfffec4e333b4d625fc9037cd0c8220cb22c5'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: 'c245e77888dd8c7610a289085c6f638fdca5136c8245f41b82e0860bb3f2164c'
+          checkpoint: '2125908587baf2bd9ee56e40a3882befcb56d69057f9b14bc2f3a3196da31312'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.