### PR TITLE
Update mediathekview to 13.0.1

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,10 +1,10 @@
 cask 'mediathekview' do
-  version '13'
+  version '13.0.1'
   sha256 '96c8ba822f171dab19472ae4d8e2120014540c833ca28c767fc913b49a31144a'
 
-  url "https://downloads.sourceforge.net/zdfmediathk/Mediathek/Mediathek%20#{version}/MediathekView-#{version}.dmg"
+  url "https://downloads.sourceforge.net/zdfmediathk/Mediathek/Mediathek%20#{version.major}/MediathekView-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/zdfmediathk/rss?path=/Mediathek',
-          checkpoint: '74248bb4c74b544fa9cfc53eb13ce709ed7a937dd205691b5a808a459e622b86'
+          checkpoint: 'bec541062bdddfcea5b0ecd4f3e678f9fb0ecd0a00fb1c9b6ec6175b95b86f47'
   name 'MediathekView'
   homepage 'https://sourceforge.net/projects/zdfmediathk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.