### PR TITLE
Update healthi to 1.0.3

### DIFF
--- a/Casks/healthi.rb
+++ b/Casks/healthi.rb
@@ -2,9 +2,9 @@ cask 'healthi' do
   version '1.0.3'
   sha256 '06152346caae837a2fab3ab905de40e1919a88de73838c35bbcc5a31cf073dd4'
 
-  url "https://github.com/pablopunk/healthi/releases/download/#{version}/healthi.app.zip"
+  url "https://github.com/pablopunk/healthi/releases/download/{version}/healthi.app.zip"
   appcast 'https://github.com/pablopunk/healthi/releases.atom',
-          checkpoint: '3983b08ab2502f69485120bf646f9f5fa228cdd5e55f28c076681b3175af0295'
+          checkpoint: 'c91f3f15824cf2db2652de3b3ce3cf49f649e9fe678c29d1989886c55f6acfc2'
   name 'healthi'
   homepage 'https://github.com/pablopunk/healthi'
 

--- a/Casks/healthi.rb
+++ b/Casks/healthi.rb
@@ -2,7 +2,7 @@ cask 'healthi' do
   version '1.0.3'
   sha256 '06152346caae837a2fab3ab905de40e1919a88de73838c35bbcc5a31cf073dd4'
 
-  url "https://github.com/pablopunk/healthi/releases/download/{version}/healthi.app.zip"
+  url "https://github.com/pablopunk/healthi/releases/download/#{version}/healthi.app.zip"
   appcast 'https://github.com/pablopunk/healthi/releases.atom',
           checkpoint: 'c91f3f15824cf2db2652de3b3ce3cf49f649e9fe678c29d1989886c55f6acfc2'
   name 'healthi'

--- a/Casks/healthi.rb
+++ b/Casks/healthi.rb
@@ -1,10 +1,10 @@
 cask 'healthi' do
-  version '1.0.2'
-  sha256 'e519636ba2424c91806d26eefcd6a37cfbb6af47cfa4e02902ddfc8379034d72'
+  version '1.0.3'
+  sha256 '06152346caae837a2fab3ab905de40e1919a88de73838c35bbcc5a31cf073dd4'
 
-  url "https://github.com/pablopunk/healthi/releases/download/v#{version}/healthi.app.zip"
+  url "https://github.com/pablopunk/healthi/releases/download/#{version}/healthi.app.zip"
   appcast 'https://github.com/pablopunk/healthi/releases.atom',
-          checkpoint: '9af2a5dd2ca01556a71989dab2eb83ef1eb62127a0289701fd481d3767fd9905'
+          checkpoint: '3983b08ab2502f69485120bf646f9f5fa228cdd5e55f28c076681b3175af0295'
   name 'healthi'
   homepage 'https://github.com/pablopunk/healthi'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.