### PR TITLE
Update audirvana-plus to 2.6.4

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,10 +1,10 @@
 cask 'audirvana-plus' do
-  version '2.6.3'
-  sha256 '681f10515d43c4bde680ca9bc2b0e456b092538cc8a878a8bc78841763529482'
+  version '2.6.4'
+  sha256 '693d4e9af53a0eaa8a96a474c19f237ffa0387e8d0dfa6353f00140226fb72be'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml",
-          checkpoint: 'e3933264202fbbbb9cab1b9b46e7299291df1ce00fd6a7ad92db02bcae21f8d6'
+          checkpoint: 'b20274c82807b04f4613c3caf3778059f8b355defdab3b1ef4a8dbe54083cabf'
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.