### PR TITLE
Update caret to 1.12.2

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.12.1'
-  sha256 'cf730c7c6389714adb4fa5bbae1328d2a92824df07ff18408ef007d8996e83bc'
+  version '1.12.2'
+  sha256 '00c8e1e92a20f628b09e43ff63e23cdad05909a20640429b194b36ce54ae407d'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '203633db4b6b64d4c705aad237e4dbd2c6d9b51d67c0f307bb232cfbc049f7c2'
+          checkpoint: '267c807ba866eba090866572a12fa6c06ea241fbf19ed5e78de707a7da6b91b2'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.