### PR TITLE
Update chatology to 1.1.1

### DIFF
--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,10 +1,10 @@
 cask 'chatology' do
-  version '1.1'
-  sha256 'cf5e9bf958b9cb62e3e194578a43d8c2d9c7bcb3138f0205c3b421f111566c73'
+  version '1.1.1'
+  sha256 '1867746333abce042f7306d0e1388e0454c053119d91307047f2ffca72e920e2'
 
   url "http://cdn.flexibits.com/Chatology_#{version}.zip"
   appcast 'https://flexibits.com/chatology/appcast.php',
-          checkpoint: '8de7c950c0f46d3649bd3b0b78c1e787fa302e048da00b0dc384f9cb86821357'
+          checkpoint: '81991574b1480ce01b901904abfa4a8b3ad0a99efe357f7b9fd208d181364366'
   name 'Chatology'
   homepage 'https://flexibits.com/chatology'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.