### PR TITLE
Update gzdoom to 2.3.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,11 +1,11 @@
 cask 'gzdoom' do
-  version '2.2.0'
-  sha256 '38bb7569d05d436b7564a795677e707e573d101bfb3706b75a76fd66f96b2d2b'
+  version '2.3.0'
+  sha256 '39ca6342037551dec17c89b8428a9f76b96c6b278c0da49434df7a42b0d4f79b'
 
   # github.com/coelckers was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom',
-          checkpoint: 'fef70e2e3a1fb43ffd48047dc6965896a3b7ccd778800205813b6b52787740e0'
+          checkpoint: '0f15bb0072e6975877555a68d63ab811fab48778216ea7d23b3189de54cce9ce'
   name 'gzdoom'
   homepage 'https://gzdoom.drdteam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.