### PR TITLE
Update ndm to 0.1.2

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '0.1.0'
-  sha256 '3bf4a06f6449f086cb5247664509e833aa18e8e2607333362223b58f433d802d'
+  version '0.1.2'
+  sha256 'b04b5646ab8192d8a2ca279d11b3fdf4b82854f25a550127630124da85956398'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: 'fbb83c6e59f353266ab87e3ec03a4a1fbd744d7a2dff3e76dde389ad806b2646'
+          checkpoint: '12439fc6deea15e6fc49647ba274fb7d517751ea73d6b406edb558d6804cdb81'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.