### PR TITLE
Update pphelper to 2.3.6

### DIFF
--- a/Casks/pphelper.rb
+++ b/Casks/pphelper.rb
@@ -1,10 +1,10 @@
 cask 'pphelper' do
-  version '2.3.5'
-  sha256 '229347cd7511fc24aaacdc4a059b20e98aeab8bf5dc35ff0f114de790fa5d764'
+  version '2.3.6'
+  sha256 '707fbcf66f1991c35265266da04fdd8e2070b3122419caae2ac943614693ce34'
 
   url 'https://ghost.25pp.com/soft/pp_mac.dmg'
   appcast 'https://liveupdate.25pp.com/macpc/Appcast.xml',
-          checkpoint: '80140597244d3ad36a2c6cc2a85de0c57002b086283f04c6e5c2ec087020b97c'
+          checkpoint: '5b2b6a6128f0f2c253cbb2a6286a84db184bbc7cd5e527b6ef2c6c66b45b3c16'
   name 'pphelper'
   name 'pp助手'
   homepage 'http://pro.25pp.com/pp_mac_ios'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.