### PR TITLE
Update pritunl to 1.0.1212.27

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1210.1'
-  sha256 'efb11733636b22483b9331f976a559c41e53ffb0f641f6258a5cb601207306da'
+  version '1.0.1212.27'
+  sha256 '6a282d89b7e3e10367e25e684199852266ed44dedbf4e93ba28dbae2ba2b32f8'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'fc15aa703105fa8dd4e9c26266de2a783d340b47ae82dbaef493becfe742d9b7'
+          checkpoint: 'd61acf8a1ee9d8e016770660d24a06da97ff9281d044a8946af7cca23612ffea'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.