### PR TITLE
Update propresenter to 6.1.4_b15176

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.1.3_b15163'
-  sha256 '0495619cb87574143d63fc46629ca75468643069fc1135278c5e92ad817b88fc'
+  version '6.1.4_b15176'
+  sha256 '6fc35e92710de20417cc82e50dcc3c08c397625c9bd80592ee893882a7c9fa92'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: 'ab274baef50eafba2619b9303a8edf315b6af801e6501b2b28c3190cc5a75592'
+          checkpoint: '68f9ca6d39542c61c4ae2e269a348bf30101effa1dcb197e147e4f8a40474273'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.