### PR TITLE
Update qgroundcontrol to 3.1.0

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.0.2'
-  sha256 'bcbb0be65da45cfd7664ead51cc39a3156ee2a06d7f7e873b4a96996e2ad5e8e'
+  version '3.1.0'
+  sha256 'c75b08f9fb3b345aa8ee158559c7ae711322df70d0af4a781534c50f4c64e4c1'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: '528f423edb2b4616833954cbc2d556a8f2f058ec9c6182653a5c1eb3e0022c32'
+          checkpoint: '3447107ae1082a5556d5cd06eb7a926ca519d9d9642b7b991c8b70e624c75378'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.