### PR TITLE
Update qtspim to 9.1.18

### DIFF
--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -1,10 +1,10 @@
 cask 'qtspim' do
-  version '9.1.17'
-  sha256 '50f8fbc6c9385bd6a3aecbf80c91c3b5542052da0593f71a3c292cc7ab2bcaf7'
+  version '9.1.18'
+  sha256 'b66e026ac7ea99db67ba6e546cf50e78395395a58744a443793800cf9deb175d'
 
   url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.mpkg.zip"
   appcast 'https://sourceforge.net/projects/spimsimulator/rss',
-          checkpoint: '746e96427a6ac3af94e0207c64e46657f4bfbabcc8866a31b75a20b195972610'
+          checkpoint: '8655c6252572c0156d8dd1a5808d850affe99cba8856f11c42975677b60813c0'
   name 'QtSpim'
   homepage 'http://spimsimulator.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.