### PR TITLE
Update rodeo to 2.5.2

### DIFF
--- a/Casks/rodeo.rb
+++ b/Casks/rodeo.rb
@@ -1,11 +1,11 @@
 cask 'rodeo' do
-  version '2.4.10'
-  sha256 'd3fed43c0ed851fc3d7db3b5241f499bd27d63948fd8049fd1c305e017e106a1'
+  version '2.5.2'
+  sha256 '9e96d1966cc2a5159c4079312e30c1c20ad834fa766bc92dac938fb944c79d0d'
 
   # github.com/yhat/rodeo was verified as official when first introduced to the cask
   url "https://github.com/yhat/rodeo/releases/download/v#{version}/Rodeo-#{version}.dmg"
   appcast 'https://github.com/yhat/rodeo/releases.atom',
-          checkpoint: 'eba53abb38f96bd9e794891747a1b3dff390bd333bed2aef575eeb1ca44d6d25'
+          checkpoint: '11314607f359d744a2a1f03a11aef9528e71290df56645f146d9a9a94974c893'
   name 'Rodeo'
   homepage 'http://rodeo.yhat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.