### PR TITLE
rstudio.rb: replace depends_on with caveat

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -13,7 +13,7 @@ cask 'rstudio' do
 
   caveats <<-EOS.undent
     #{token} depends on R.
-    There are different ways to satisfy that dependency and we don’t want to impose one, so it is up to you to satify it.
+    There are different ways to satisfy that dependency and we don’t want to impose one, so it is up to you to satisfy it.
     We suggest you do so by running one of:
 
       brew install homebrew/science/r

--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -7,9 +7,16 @@ cask 'rstudio' do
   name 'RStudio'
   homepage 'https://www.rstudio.com/'
 
-  depends_on formula: 'homebrew/science/r'
-
   app 'RStudio.app'
 
   zap delete: '~/.rstudio-desktop'
+
+  caveats <<-EOS.undent
+    #{token} depends on R.
+    There are different ways to satisfy that dependency and we don’t want to impose one, so it is up to you to satify it.
+    We suggest you do so by running one of:
+
+      brew install homebrew/science/r
+      brew cask install r-app
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

Not the first time a user complains because this depends on the formula and they want the GUI. Most recently: https://github.com/caskroom/homebrew-cask/issues/28714.