### PR TITLE
Updated tableau reader to 10.1.3

### DIFF
--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -1,8 +1,8 @@
 cask 'tableau-reader' do
-  version :latest
-  sha256 :no_check
+  version '10.1.3'
+  sha256 '4e6eb5fe6275c8373dcfe3d264f64cbfdd9d6736a46c73c2a50482d48632511b'
 
-  url 'https://downloads.tableau.com/tssoftware/TableauReader.dmg'
+  url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
   name 'Tableau Reader'
   homepage 'https://www.tableau.com/products/reader'
 


### PR DESCRIPTION
previous cask was pulling v9 of the reader