### PR TITLE
thunderbird: add languages

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -6,6 +6,11 @@ cask 'thunderbird' do
     'de'
   end
 
+  language 'en-GB' do
+    sha256 '372193a0bff2ae0ecd5710f0f3321954b0c374e0df458d047a76df2a0a40354e'
+    'en-GB'
+  end
+
   language 'en', default: true do
     sha256 '2022553050c87afccacccf34709b01980c6228054492e03952cb2a135c20bdc3'
     'en-US'
@@ -36,6 +41,11 @@ cask 'thunderbird' do
     'nl'
   end
 
+  language 'pl' do
+    sha256 'abe9d1f702eb4e0e0b045bffb9af9feaa094010f5a05a01c317eac84858ed6ac'
+    'pl'
+  end
+
   language 'pt' do
     sha256 '9b3b0aa164b3a6013ebe7e0fa234523b5a9558d129412acad66429e17c948117'
     'pt-BR'
@@ -51,6 +61,11 @@ cask 'thunderbird' do
     'uk'
   end
 
+  language 'zh-TW' do
+    sha256 '4a4bb7f8ed810db4ae079fdaf78120ad20965d7de8fe44c39ff23933b45629f9'
+    'zh-TW'
+  end
+
   language 'zh' do
     sha256 '83f39422e6e85820da0d80e58624c90f9baa5967d28190db81b720b09c8b9986'
     'zh-CN'
@@ -61,6 +76,8 @@ cask 'thunderbird' do
           checkpoint: '8c0366217a03a7a63c4ec046321a74b8136069051804f58bab2b7e1c3e7c3f0e'
   name 'Mozilla Thunderbird'
   homepage 'https://www.mozilla.org/thunderbird/'
+
+  auto_updates true
 
   app 'Thunderbird.app'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

Add en-GB, pl, and zh-TW, which are present in the Firefox Cask but were missing here. The only remaining difference, the version of Portuguese chosen for the language `pt` (Firefox: `pt-PT`, Thunderbird: `pt-BR`), isn't touched to not change previous behavior.