### PR TITLE
Add WiFiSpoof Latest

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,9 +1,11 @@
 cask 'wifispoof' do
-  version :latest
-  sha256 :no_check
+  version '3.0.2'
+  sha256 'ee0b4e0941f20f4cd71b7f6fa4f56da695cd1d6e1c4e49daec3a460463bd9946'
 
   # sweetpproductions.com was verified as official when first introduced to the cask
-  url 'https://sweetpproductions.com/products/wifispoof3/WiFiSpoof3.dmg'
+  url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"
+  appcast 'https://sweetpproductions.com/products/wifispoof3/appcast.xml',
+          checkpoint: 'e4a7cf391172f201bbd706624b22df970cb05e7b095b05a45713744c66e3b58a'
   name 'WiFiSpoof'
   homepage 'https://wifispoof.com/'
 

--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,0 +1,13 @@
+cask 'wifispoof' do
+  version :latest
+  sha256 :no_check
+
+  # sweetpproductions.com was verified as official when first introduced to the cask
+  url 'https://sweetpproductions.com/products/wifispoof3/WiFiSpoof3.dmg'
+  name 'WiFiSpoof'
+  homepage 'https://wifispoof.com/'
+
+  auto_updates true
+
+  app 'WiFiSpoof.app'
+end

--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -2,7 +2,7 @@ cask 'wifispoof' do
   version '3.0.2'
   sha256 'ee0b4e0941f20f4cd71b7f6fa4f56da695cd1d6e1c4e49daec3a460463bd9946'
 
-  # sweetpproductions.com was verified as official when first introduced to the cask
+  # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"
   appcast 'https://sweetpproductions.com/products/wifispoof3/appcast.xml',
           checkpoint: 'e4a7cf391172f201bbd706624b22df970cb05e7b095b05a45713744c66e3b58a'


### PR DESCRIPTION
Adds an initial cask for WiFiSpoof (latest Trial version).

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
