### PR TITLE
Add Axoloti Runtime v1.0.11

### DIFF
--- a/Casks/axoloti-runtime.rb
+++ b/Casks/axoloti-runtime.rb
@@ -1,0 +1,16 @@
+cask 'axoloti-runtime' do
+  version '1.0.11'
+  sha256 'b8c844c8668b0063ba177b7d87cfa278d288d8ea38a140f182a634ee2256ad0e'
+
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/axoloti/axoloti/releases/download/#{version}/axo_runtime_mac_#{version}.dmg"
+  appcast 'https://github.com/axoloti/axoloti/releases.atom',
+          checkpoint: 'b3e7756ec71f418f0a034460136fff898dcd539ff5f44b8a14c13401355eb515'
+  name 'Axoloti Runtime'
+  name 'axo-runtime'
+  homepage 'http://www.axoloti.com/'
+
+  depends_on java: '8'
+
+  app 'axoloti_runtime'
+end

--- a/Casks/axoloti-runtime.rb
+++ b/Casks/axoloti-runtime.rb
@@ -2,15 +2,16 @@ cask 'axoloti-runtime' do
   version '1.0.11'
   sha256 'b8c844c8668b0063ba177b7d87cfa278d288d8ea38a140f182a634ee2256ad0e'
 
-  # github.com was verified as official when first introduced to the cask
+  # github.com/axoloti/axoloti was verified as official when first introduced to the cask
   url "https://github.com/axoloti/axoloti/releases/download/#{version}/axo_runtime_mac_#{version}.dmg"
   appcast 'https://github.com/axoloti/axoloti/releases.atom',
           checkpoint: 'b3e7756ec71f418f0a034460136fff898dcd539ff5f44b8a14c13401355eb515'
   name 'Axoloti Runtime'
-  name 'axo-runtime'
   homepage 'http://www.axoloti.com/'
 
-  depends_on java: '8'
-
   app 'axoloti_runtime'
+
+  caveats do
+    depends_on_java('8')
+  end
 end

--- a/Casks/axoloti-runtime.rb
+++ b/Casks/axoloti-runtime.rb
@@ -9,7 +9,7 @@ cask 'axoloti-runtime' do
   name 'Axoloti Runtime'
   homepage 'http://www.axoloti.com/'
 
-  app 'axoloti_runtime'
+  suite 'axoloti_runtime'
 
   caveats do
     depends_on_java('8')


### PR DESCRIPTION
Adds Axoloti runtime, used by Axoloti Core (separate PR).

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
