### PR TITLE
[New] Add Objective-See Dylib Hijack Scanner 1.3.1

### DIFF
--- a/Casks/dylib-hijack-scanner.rb
+++ b/Casks/dylib-hijack-scanner.rb
@@ -1,0 +1,11 @@
+cask 'dylib-hijack-scanner' do
+  version '1.3.1'
+  sha256 '3fc293da9f4730790e8c07833e0225fa6b57d2455bec53dd8e5b1e50de41c8d4'
+
+  # bitbucket.org/objective-see was verified as official when first introduced to the cask
+  url "https://bitbucket.org/objective-see/deploy/downloads/DHS_#{version}.zip"
+  name 'Dylib Hijack Scanner'
+  homepage 'https://objective-see.com/products/dhs.html'
+
+  app 'DHS.app'
+end


### PR DESCRIPTION
```
Dylib Hijack Scanner
Dylib Hijack Scanner or DHS, is a simple utility that will scan your computer for applications that are either susceptible to dylib hijacking or have been hijacked.
```

https://objective-see.com/products/dhs.html

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask audit --strict {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] `brew cask style --fix --strict {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
