### PR TITLE
Update real-vnc uninstall

### DIFF
--- a/Casks/real-vnc.rb
+++ b/Casks/real-vnc.rb
@@ -9,16 +9,8 @@ cask 'real-vnc' do
   pkg "VNC-#{version}-MacOSX-x86_64.pkg"
 
   uninstall_preflight do
-    IO.write "#{staged_path}/uninstall.sh", <<-EOS.undent
-      #!/bin/sh
-      "/Applications/RealVNC/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh" &> /dev/null
-      "/Applications/RealVNC/Uninstall VNC Viewer.app/Contents/Resources/uninstaller.sh" &> /dev/null
-    EOS
-
-    set_permissions "#{staged_path}/uninstall.sh", '0777'
-
-    system_command "#{staged_path}/uninstall.sh",
-                   sudo: true
+    system_command '/Applications/RealVNC/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh', print_stderr: false, sudo: true
+    system_command '/Applications/RealVNC/Uninstall VNC Viewer.app/Contents/Resources/uninstaller.sh', print_stderr: false, sudo: true
   end
 
   uninstall launchctl: [

--- a/Casks/real-vnc.rb
+++ b/Casks/real-vnc.rb
@@ -8,6 +8,19 @@ cask 'real-vnc' do
 
   pkg "VNC-#{version}-MacOSX-x86_64.pkg"
 
+  uninstall_preflight do
+    IO.write "#{staged_path}/uninstall.sh", <<-EOS.undent
+      #!/bin/sh
+      "/Applications/RealVNC/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh" &> /dev/null
+      "/Applications/RealVNC/Uninstall VNC Viewer.app/Contents/Resources/uninstaller.sh" &> /dev/null
+    EOS
+
+    set_permissions "#{staged_path}/uninstall.sh", '0777'
+
+    system_command "#{staged_path}/uninstall.sh",
+                   sudo: true
+  end
+
   uninstall launchctl: [
                          'com.realvnc.vncserver',
                          'com.realvnc.vncserver.peruser',


### PR DESCRIPTION
Suggested uninstall script execution, as discussed on #28657

I am unable to get two scripts to run via uninstall, so settled on this method. Preflight should mean the scripts have done their work and the uninstall stanzas should be cleanup only if it scripts fail to do so.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.