### PR TITLE
Add MailTags 5.0.3

### DIFF
--- a/Casks/mailtags.rb
+++ b/Casks/mailtags.rb
@@ -2,11 +2,11 @@ cask 'mailtags' do
   version '5.0.3'
   sha256 '5c618299dcbc742d7bc2287209eb8d902d512381f6cded596b0612e645e15870'
 
-  url 'https://smallcubed.com/download/mt/MailTags5.0.3.dmg'
+  url "https://smallcubed.com/download/mt/MailTags#{version}.dmg"
   name 'MailTags'
   homepage 'https://smallcubed.com/mt/'
 
-  installer manual: 'Install MailTags 5.app'
+  installer manual: "Install MailTags #{version.major}.app"
 
   zap delete: [
                 '~/Library/Mail/Bundles/MailTags.mailbundle',

--- a/Casks/mailtags.rb
+++ b/Casks/mailtags.rb
@@ -1,0 +1,15 @@
+cask 'mailtags' do
+  version '5.0.3'
+  sha256 '5c618299dcbc742d7bc2287209eb8d902d512381f6cded596b0612e645e15870'
+
+  url 'https://smallcubed.com/download/mt/MailTags5.0.3.dmg'
+  name 'MailTags'
+  homepage 'https://smallcubed.com/mt/'
+
+  installer manual: 'Install MailTags 5.app'
+
+  zap delete: [
+                '~/Library/Mail/Bundles/MailTags.mailbundle',
+                '~/Library/Application Support/Indev/MailTagsHelper.app',
+              ]
+end

--- a/Casks/mailtags.rb
+++ b/Casks/mailtags.rb
@@ -8,6 +8,8 @@ cask 'mailtags' do
 
   installer manual: 'Install MailTags 5.app'
 
+  uninstall pkgutil: 'ca.indev.MailTags*'
+
   zap delete: [
                 '~/Library/Mail/Bundles/MailTags.mailbundle',
                 '~/Library/Application Support/Indev/MailTagsHelper.app',


### PR DESCRIPTION
- This one is a bit tricky, as the app doesn't live in /Applications. I have
  also never used the 'installer' stanza in a cask, but the other examples and
  doc page doc/cask_language_reference/stanzas/installer.md appear to support
  this.
- The uninstaller for MailTags is also a manual option within the installer UI.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
