### PR TITLE
Update gzdoom to 2.3.1

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,11 +1,11 @@
 cask 'gzdoom' do
-  version '2.3.0'
-  sha256 '39ca6342037551dec17c89b8428a9f76b96c6b278c0da49434df7a42b0d4f79b'
+  version '2.3.1'
+  sha256 '5a58e49e9622d1ac6324b53c76c363bbd7a166965f4c4c4c4b0b7e2bc3819c21'
 
   # github.com/coelckers was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom',
-          checkpoint: '0f15bb0072e6975877555a68d63ab811fab48778216ea7d23b3189de54cce9ce'
+          checkpoint: '672a5c9806126bfa8290ea4263f779b15678937074c735face96d5b1c6e49342'
   name 'gzdoom'
   homepage 'https://gzdoom.drdteam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.