### PR TITLE
Update qgroundcontrol to 3.1.1

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.1.0'
-  sha256 'c75b08f9fb3b345aa8ee158559c7ae711322df70d0af4a781534c50f4c64e4c1'
+  version '3.1.1'
+  sha256 '94bf0c746a2a735362b72bac45f0c118e79837ff0afbd25e42df9b84d57c49ba'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: '3447107ae1082a5556d5cd06eb7a926ca519d9d9642b7b991c8b70e624c75378'
+          checkpoint: '3853b894c09072a9a14faaae469281cf62b854fed38e61ee3c76540ad18cd790'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.