### PR TITLE
Update screenhero to 2.3.11.0

### DIFF
--- a/Casks/screenhero.rb
+++ b/Casks/screenhero.rb
@@ -1,10 +1,10 @@
 cask 'screenhero' do
-  version '2.3.10.0'
-  sha256 'ebe1d9922acb5703748c9cebab6e33b7af220e9a69d9bf38d294ce1794697518'
+  version '2.3.11.0'
+  sha256 '96a11bcb3886688fe01a683eca92606f275972ad498401decbd5a8a203525b51'
 
   url "https://secure.screenhero.com/update/screenhero/Screenhero-#{version}.dmg"
   appcast 'https://d3hb26arjl8wb7.cloudfront.net/jsherwani/public/update/mac/screenhero/sparkle.xml',
-          checkpoint: 'e9a3866e22348b5db011dcb375474359e09db7e34cb9c138f389050ab4e68d12'
+          checkpoint: '56640c847128ffba497aafe5f93fc4919ef41248899f5752eb354cdcb46711af'
   name 'Screenhero'
   homepage 'https://screenhero.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.