### PR TITLE
Update snapndrag to 4.2.2

### DIFF
--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -1,10 +1,10 @@
 cask 'snapndrag' do
-  version '4.2.1'
-  sha256 '4b768be224b6358b16f8555f3d5b82801a46afc87b1609d91108f71ed0ce93e2'
+  version '4.2.2'
+  sha256 'c06ec405df7bfaad46f8a515798f7092c557dc65a9faed6d1fff1a29b2d2e47f'
 
   url "http://yellowmug.com/download/SnapNDrag_#{version}.dmg"
   appcast 'http://yellowmug.com/snapndrag/appcast-1012.xml',
-          checkpoint: 'e850ffe995147b3a8ad8f73caaf067e60390a3dc3aa2fa000b1f93d664dcc81b'
+          checkpoint: 'f95d7fd7cc8e6ab7797be453e95bfb696db51bf5388fb53df16a1b233f5e73d8'
   name 'SnapNDrag'
   homepage 'http://www.yellowmug.com/snapndrag/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.