### PR TITLE
Update soundcloud-downloader to 2.6.7

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
-  version '2.6.5'
-  sha256 '9bdb97b69dc28fd656de1d8d3f9d7fea5557f435417af6a8abf5126863ee2abe'
+  version '2.6.7'
+  sha256 '76501bdc629f06f2f548e30c76dda0ebc2b76d393a853bcef5e2d43a317641d6'
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
   appcast 'http://black-burn.ch/applications/scd/updates.php?hwni=1',
-          checkpoint: '0ec0399dd00efb723e161a4d0b26956a38d04e48cd7e7061ac29e1413546e430'
+          checkpoint: 'a0bbcf012158e1dcd00e8e5baa6e122012d9e527e67e0d38fd0bde8ecc252222'
   name 'SoundCloud Downloader'
   homepage 'http://black-burn.ch/scd/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.