### PR TITLE
Update universal-media-server to 6.5.3

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,11 +1,11 @@
 cask 'universal-media-server' do
-  version '6.5.2'
-  sha256 'cae3723dcd690b853fa20fd4a12e81f5374cf7120c7aaced34308df389b8e0da'
+  version '6.5.3'
+  sha256 '3da70e93852876f356e56bf2fec218c85e491df442b279da1afe5a930bc7b109'
 
   # sourceforge.net/unimediaserver was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/unimediaserver/Official%20Releases/OS%20X/UMS-#{version}-Java8.dmg"
   appcast 'https://sourceforge.net/projects/unimediaserver/rss?path=/Official%20Releases',
-          checkpoint: '1a3f35179536365a9b295c1b2f0b4a1c79f57e039a6da3633a7b5626effe96e5'
+          checkpoint: '67e49cd9b6212a0b70a2d5fdd4020af425696a264388b6bf17047431eec69d87'
   name 'Universal Media Server'
   homepage 'http://www.universalmediaserver.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.