### PR TITLE
Update iueditor to 2.0.5.13

### DIFF
--- a/Casks/iueditor.rb
+++ b/Casks/iueditor.rb
@@ -1,6 +1,6 @@
 cask 'iueditor' do
-  version '2.0.5.6'
-  sha256 'd4a4775c0c32b62645887d1afe9072cd04e9190731a7e2fcbf5e9be3212d2724'
+  version '2.0.5.13'
+  sha256 'b50a135f48d286e6fb7ec79c534155e524c18663803a88b04ae642f95d7df162'
 
   url "http://cdn.iueditor.org/release/IUEditorV#{version}.pkg"
   name 'JDLab IUEditor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.