### PR TITLE
Update hydrogen to 0.9.7

### DIFF
--- a/Casks/hydrogen.rb
+++ b/Casks/hydrogen.rb
@@ -1,11 +1,11 @@
 cask 'hydrogen' do
-  version '0.9.7-rc1'
-  sha256 'daeaa3e7a6fc5ee61a4c59116c90104d2393fd71c8782f136b48bed58d6082db'
+  version '0.9.7'
+  sha256 'f31d99cbb4e996a90ffc91de5002aaf8e62002ca900c169d4c387d69cadd4ce4'
 
   # downloads.sourceforge.net/hydrogen was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/hydrogen/hydrogen-#{version}.dmg"
+  url "https://downloads.sourceforge.net/hydrogen/Hydrogen-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/hydrogen/rss?path=/Hydrogen',
-          checkpoint: 'c472fb7218f40ece440782a1eff2da0fe1a677ebe05686185593380a1018d6cd'
+          checkpoint: 'dd41efb784551287f8a7314cd695a62b15827bbe9a36072cdeed82d837f75689'
   name 'Hydrogen'
   homepage 'http://www.hydrogen-music.org/hcms/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.