### PR TITLE
Update supersync to 6.1.2

### DIFF
--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,6 +1,6 @@
 cask 'supersync' do
-  version '6.1.1'
-  sha256 '43ca3fa8eebdba63bf9b8f2c17d26f0847e0ae55c114312f606240cbbbf88ce4'
+  version '6.1.2'
+  sha256 'fe5afaefc3a9803106a2f4f4decde36a45401fa384404185fd06ab747f72a31a'
 
   url "https://supersync.com/downloads/SuperSync_#{version}.dmg"
   name 'SuperSync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.