### PR TITLE
Update black-ink to 1.6.6

### DIFF
--- a/Casks/black-ink.rb
+++ b/Casks/black-ink.rb
@@ -1,10 +1,10 @@
 cask 'black-ink' do
-  version '1.6.5'
-  sha256 '36bbc05292f8dc87edc0390b24ac459c7a4b7da20e7862775f9fc54c33e7bc8b'
+  version '1.6.6'
+  sha256 'e26188469a9179f695f58ed40c078935def34d51564d0dfa4b3e03038431c1e6'
 
   url "https://red-sweater.com/blackink/BlackInk#{version}.zip"
   appcast 'https://red-sweater.com/blackink/appcast1.php',
-          checkpoint: 'affea6547a2c90c4cd861f9bdbb770dc22bc2321d3853880afacc88b9cbebf61'
+          checkpoint: 'da630d54480b42a975eeded2cb432e887a73c07cd5065a5250ccbf946b274cde'
   name 'Black Ink'
   homepage 'https://red-sweater.com/blackink/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.