### PR TITLE
Update mgba to 0.5.2

### DIFF
--- a/Casks/mgba.rb
+++ b/Casks/mgba.rb
@@ -1,11 +1,11 @@
 cask 'mgba' do
-  version '0.5.1,2016-10-05'
-  sha256 '6cb97fa813cd993afeb32cba542bc6dd9bc15fa5b3386692d257ef444f30d1c4'
+  version '0.5.2'
+  sha256 'ee0a934f05dff34938026314ddf2c8a9cb6bf2a3765e49bc4e3b2e1ce476b791'
 
   # github.com/mgba-emu/mgba was verified as official when first introduced to the cask
-  url "https://github.com/mgba-emu/mgba/releases/download/#{version.before_comma}/mGBA-#{version.before_comma}-osx.tar.xz"
+  url "https://github.com/mgba-emu/mgba/releases/download/#{version}/mGBA-#{version}-osx.tar.xz"
   appcast 'https://github.com/mgba-emu/mgba/releases.atom',
-          checkpoint: '2934c10a4f04b48941d67bda57114f96c3e24d9e9ba598004b960cb933912d9d'
+          checkpoint: '53679dc7990fb3512112228e27cf978e3e4b06700de52e484f0ee322f987d4cb'
   name 'mGBA'
   homepage 'https://mgba.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.