### PR TITLE
Update subtitles to 3.2.11

### DIFF
--- a/Casks/subtitles.rb
+++ b/Casks/subtitles.rb
@@ -1,10 +1,10 @@
 cask 'subtitles' do
-  version '3.2.9'
+  version '3.2.11'
   sha256 '72b68d998834ec3e6d5f03a1897766b7714cab712ccd5469ce9367b6cacd264c'
 
   url "https://subtitlesapp.com/download/Subtitles-mac-#{version}.zip"
   appcast 'https://subtitlesapp.com/updates.xml',
-          checkpoint: '1851499d9b99765244ec22db7faf583a82dd1d6e4e63aa04e7d0d1f28106c2ce'
+          checkpoint: '145d783869fd02ab9dd037199ecf8f6b1a1e0db41c087f7e2829c3bbf9c50127'
   name 'Subtitles'
   homepage 'https://subtitlesapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
The version 3.2.9 redirects to 3.2.11. This is why checksum not changed.