### PR TITLE
Update hawk-eye to 0.2.0

### DIFF
--- a/Casks/hawk-eye.rb
+++ b/Casks/hawk-eye.rb
@@ -1,10 +1,10 @@
 cask 'hawk-eye' do
-  version '0.1.0'
-  sha256 'f3a499f056f3a7e1f40dd60eda67503ae70b23bfc52c3bddd1befb16f02f1f08'
+  version '0.2.0'
+  sha256 'f62dbef8556a8b9d698ca0e10fb7aa550fc1a8a854c39f9417ddb158db9d2a09'
 
   url "https://github.com/harksys/HawkEye/releases/download/#{version}/hawkeye-#{version}-osx-x64.dmg"
   appcast 'https://github.com/harksys/HawkEye/releases.atom',
-          checkpoint: '150c01ef0b020ff10b357c7835db5f41d92cf5f0673f7bc22b60663307a6dd61'
+          checkpoint: 'cdb54347126b720f323668e929ff42e88a2795a32a0cfc7a0a86c8ba5752e009'
   name 'Hawk Eye'
   homepage 'https://github.com/harksys/HawkEye'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.