### PR TITLE
Update privatetunnel to 2.8

### DIFF
--- a/Casks/privatetunnel.rb
+++ b/Casks/privatetunnel.rb
@@ -1,6 +1,6 @@
 cask 'privatetunnel' do
-  version '2.7'
-  sha256 '64ff83847f41cbdc857f616bff03477292c30e2283ce9617a59bb4bbba1058b4'
+  version '2.8'
+  sha256 '8abc331c8ab9d6805328bbc53f93f3bf9c94efbd8e609606ecbee9006851fbae'
 
   # swupdate.openvpn.org/privatetunnel was verified as official when first introduced to the cask
   url "https://swupdate.openvpn.org/privatetunnel/client/privatetunnel-mac-#{version}.dmg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
