### PR TITLE
Update letterfix to 2.5.2,66866

### DIFF
--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -1,14 +1,14 @@
 cask 'letterfix' do
-  version '2.5.1,66616'
-  sha256 '8baf373a4d7f95f7112b79bf46b6e4d859c1e9f59f0dd39d77c619840413aad5'
+  version '2.5.2,66866'
+  sha256 'd67d29760cb0cdc417d352ee029756cbec1f2cd7a37e262c67591c948a04cab8'
 
   url "http://dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
   appcast 'https://osdn.jp/projects/letter-fix/releases/rss',
-          checkpoint: '2572be16b41ee85378461d4a91e35f9796fdcfae4d9e4383782e47522dd3c1a9'
+          checkpoint: '2ee4d7d79be2178ed1e5f66bbe4bdfda5e5173d918bd7a545a9adf8c15844084'
   name 'LetterFix'
   homepage 'https://osdn.jp/projects/letter-fix/'
 
-  pkg "LetterFix-#{version}.pkg"
+  pkg "LetterFix-#{version.before_comma}.pkg"
 
   uninstall pkgutil: 'org.kuri.letterfix.LetterFix.pkg'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.