### PR TITLE
Update timemill.rb appcast url

### DIFF
--- a/Casks/tilemill.rb
+++ b/Casks/tilemill.rb
@@ -4,7 +4,7 @@ cask 'tilemill' do
 
   # tilemill.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tilemill.s3.amazonaws.com/latest/TileMill-#{version}.zip"
-  appcast 'https://www.mapbox.com/tilemill/platforms/osx/appcast2.xml/',
+  appcast 'https://www.mapbox.com/tilemill/platforms/osx/appcast2.xml',
           checkpoint: '2a8c33291658fba8f69f408cf102ca063fa709e301f399b2f2b1a4a93b7516b5'
   name 'TileMill'
   homepage 'https://www.mapbox.com/tilemill/'


### PR DESCRIPTION
* The appcast url was 403, correcting. The checkpoint has not changed.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.