### PR TITLE
add Referer header to free-telly mirrors request

### DIFF
--- a/Casks/free-telly.rb
+++ b/Casks/free-telly.rb
@@ -8,7 +8,13 @@ cask 'free-telly' do
     require 'json'
     # androidfilehost.com was verified as official when first introduced to the cask
     uri = URI('https://www.androidfilehost.com/libs/otf/mirrors.otf.php')
-    res = Net::HTTP.post_form(uri, 'submit' => 'submit', 'action' => 'getdownloadmirrors', 'fid' => '24588232905720770')
+    req = Net::HTTP::Post.new(uri)
+    file_id = '24588232905720770'
+    req.set_form_data('submit' => 'submit', 'action' => 'getdownloadmirrors', 'fid' => file_id)
+    req['Referer'] = "https://www.androidfilehost.com/?fid=#{file_id}"
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(req)
+    end
     JSON.parse(res.body)['MIRRORS'][0]['url']
   end
   name 'FreeTelly'

--- a/Casks/free-telly.rb
+++ b/Casks/free-telly.rb
@@ -12,9 +12,7 @@ cask 'free-telly' do
     file_id = '24588232905720770'
     req.set_form_data('submit' => 'submit', 'action' => 'getdownloadmirrors', 'fid' => file_id)
     req['Referer'] = "https://www.androidfilehost.com/?fid=#{file_id}"
-    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
-      http.request(req)
-    end
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http| http.request(req) }
     JSON.parse(res.body)['MIRRORS'][0]['url']
   end
   name 'FreeTelly'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
