### PR TITLE
Update fluxcenter to 1.2.3.44498

### DIFF
--- a/Casks/fluxcenter.rb
+++ b/Casks/fluxcenter.rb
@@ -1,6 +1,6 @@
 cask 'fluxcenter' do
-  version '1.1.15.43404'
-  sha256 '4d884fc23aa9b21959c63ba43009886bd618b38e817c1c121f1477961c22fde2'
+  version '1.2.3.44498'
+  sha256 '034d1da03515c23d2cf9d03873bc16f4e73658ed926fc24e33eec051b6398859'
 
   # files.flux.to was verified as official when first introduced to the cask
   url "http://files.flux.to/files/Center/MacOS/Flux_FluxCenter_MacOSX_Installer_(#{version}).dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.