### PR TITLE
Update balsamiq-mockups to 3.5.6

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -1,8 +1,10 @@
 cask 'balsamiq-mockups' do
-  version '3.5.5'
-  sha256 'b08819effb63fa3361e2286d4e580bc67edf30c16962c34453e191ccbcfc482e'
+  version '3.5.6'
+  sha256 '52f4ec8d234b5aa9b43a34f56d00f507ea787ce0d73615cbe3db8f7a86606ce9'
 
   url "https://builds.balsamiq.com/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"
+  appcast 'https://builds.balsamiq.com/mockups-desktop/version.jsonp',
+          checkpoint: '8a5231223713a3e85fc302798f1646312ba65baece3a0f5595b7499df063bba6'
   name 'Balsamiq Mockups'
   homepage 'https://balsamiq.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.