### PR TITLE
flash 24.0.0.194

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '24.0.0.186'
-  sha256 '3f1a4ad65cec4ee64660d81152a553df2bd4f77daea4c37bdaf49ff19136e6da'
+  version '24.0.0.194'
+  sha256 '54d7f2ff29fb2271064d25992d4595df81b9227a1a2e7db3caa130404d2c56c0'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,6 +1,6 @@
 cask 'flash-player' do
-  version '24.0.0.186'
-  sha256 'b5b2caf33b991ce200ada63ea8adbbbd59842231a2ce569a1c2c4fa9635cd8f0'
+  version '24.0.0.194'
+  sha256 '046142360fd0f528af0a6355428a00466f8e5f1ebb1ed2110a2b3f1730ca2b7b'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"

--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-ppapi' do
-  version '24.0.0.186'
-  sha256 'f08cdbb401dfaf7f1930f7a0dc4f0e9dc8aecbde8dabf026ba8d3908ce048692'
+  version '24.0.0.194'
+  sha256 '80cbbf9d78a6e7361fffdb886d4bc2418049a104b030a962dca7f0f25543e804'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
flash-player, flash-npapi, and flash-ppapi 24.0.0.194

Note that the appcast checkpoints are left unchanged intensionally, because somehow the appcasts are still showing the previous version instead of 24.0.0.194...