### PR TITLE
Update handylock to 1.2.10

### DIFF
--- a/Casks/handylock.rb
+++ b/Casks/handylock.rb
@@ -1,11 +1,11 @@
 cask 'handylock' do
-  version '1.2.9'
-  sha256 'f6052c4229613590be2916f68fbcb5c6b632488745fc6e9c1074bfe0452d11cf'
+  version '1.2.10'
+  sha256 '859a7a7c58388a35fd8ad7e287d0557ae69e3dfa8cc7b1416af37e7493a92aeb'
 
   # s3.amazonaws.com/netputing/handyLock was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/netputing/handyLock/handyLock+v#{version}.dmg"
+  url "https://s3.amazonaws.com/netputing/handyLock/handyLock+v#{version}.zip"
   name 'handyLock'
-  homepage 'https://www.netputing.com/applications/handylock/'
+  homepage 'http://www.netputing.com/applications/handylock/'
 
   app 'handyLock.app'
 end


### PR DESCRIPTION
* also adjusted homepage because the cert expired in November

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.