### PR TITLE
Update flightgear to 2016.4.4

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2016.4.3'
-  sha256 '305fbcf2cdab59a4073c6cff70818c4685c55a20f135b48ee198f22f4bf373e9'
+  version '2016.4.4'
+  sha256 '01a79d6d0125ca26a36a1b9307851ab16eb9aa04c833ba448020bb630400783e'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: 'f710d4fde29157f191348f278c5a192eaf5c91786e020aa3b3cc2fdeaf45e425'
+          checkpoint: '6e65fda2c7dc92cfb997b405dacdea555990cb409c51a2a7f013d30119a1713d'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.