### PR TITLE
Update librecad to 2.1.3

### DIFF
--- a/Casks/librecad.rb
+++ b/Casks/librecad.rb
@@ -1,11 +1,11 @@
 cask 'librecad' do
-  version '2.1.2'
-  sha256 'b24e842629fa79b8404b2b09eddb9a6d3bcd6fa99b12bfad6ac8a39df38cb5fc'
+  version '2.1.3'
+  sha256 'e17f74be117c2cabbc9c5844ae459dd1d1e6f94b17d09f0e809ef23b936a8952'
 
   # sourceforge.net/librecad was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/librecad/OSX/#{version.major_minor}/#{version}/LibreCAD_#{version.dots_to_hyphens}.dmg"
   appcast 'https://sourceforge.net/projects/librecad/rss?path=/OSX',
-          checkpoint: 'a2463268ae3a532744db027bcdd154bfa4390dada1679dbea42d426e9d9b39cc'
+          checkpoint: '2d0cdc212c76bb751ee31bf6a3db0a4a34968a78ff7dd6d9870ead55d15e88f2'
   name 'LibreCAD'
   homepage 'http://librecad.org/cms/home.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.