### PR TITLE
Update polymail to 1.21

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.20'
-  sha256 '8b2f551129a144b18dfcbb7187aa783fa0f99b4677da94074971a50386080d9c'
+  version '1.21'
+  sha256 'cc4e3637bd0f5223554c13f7a552060060c1f936cbea80379220aa596f187d7b'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'dea41f423f4680efec1e3dd0fd0bdec8f33c171a63bdd0fec9af0c36ff08f177'
+          checkpoint: 'f63977c7a9b614f8172580eb3b41330eae50411fa60d77693bbfe3577dc99f82'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.