### PR TITLE
Update idefrag to 5.1.5

### DIFF
--- a/Casks/idefrag.rb
+++ b/Casks/idefrag.rb
@@ -1,10 +1,17 @@
 cask 'idefrag' do
-  version '5.1.2'
-  sha256 '65eddc90c80213069ad2fbfafa055ca948059b4f7b8889faa3a817ca7026718f'
+  if MacOS.version <= :el_capitan
+    version '5.1.3'
+    sha256 '4b695c04f491b8f9f60a1fb43836164960f7d95f82aaa38d1e3b7dd4eacd7d5c'
+  else
+    version '5.1.5'
+    sha256 'fef5403743b383cabacdb0636eb61f7d61f752a0a16592853a95bd100c1bf2ff'
+  end
 
   url "https://coriolis-systems.com/downloads/iDefrag-#{version}.dmg"
   name 'iDefrag'
   homepage 'https://coriolis-systems.com/iDefrag/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'iDefrag.app'
 end


### PR DESCRIPTION
* versions and depends updated based on the supported versions on [this page](https://coriolis-systems.com/support/2015/3/which-version-idefrag-do-i-need-os-x-10x)
---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.