### PR TITLE
Update firestr to 0.11

### DIFF
--- a/Casks/firestr.rb
+++ b/Casks/firestr.rb
@@ -1,6 +1,6 @@
 cask 'firestr' do
-  version '0.10'
-  sha256 'a6d436a2095132382c059376e2d05a53390793abf3916a6a68c7e9d3d98cee26'
+  version '0.11'
+  sha256 '7d7d3740b2eb5a78bc8573b24cdc47c15bcd6536e21f0e8e82722b8a7e8e8cf3'
 
   url "https://mempko.com/firestr/build/#{version}/firestr_#{version}.dmg"
   name 'Firestar'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.