### PR TITLE
Update kode54-cog to 0.08,89a2ab0

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,3ff4892'
-  sha256 '787c430f57188ff95d9b79b6122382a5b99329d02114bfb31a47757b85998901'
+  version '0.08,89a2ab0'
+  sha256 '959efb00c83f3bf3809806d2fa0d5dfda53b28f1415651cf115fcbb676499a31'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.