### PR TITLE
Update electron to 1.4.14

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.13'
-  sha256 'dd834906044dbfb24b5c6bc8bb325e89ba56e453fd2ff3ca52f7f8a056e64429'
+  version '1.4.14'
+  sha256 '7c3a5af7a9fe59f864a55d6217f28cebaf719d46d9eb18de2ea0f7ea1137383f'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '3fac69a8bb384c577eff470cf62784ad4d667080cbb4db0d18358f786bb8141b'
+          checkpoint: 'c0cc56aceb0e13f9601ef66b88396539a33f96362ce89d490cc3d19e430e4ea8'
   name 'Electron'
   homepage 'http://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.