### PR TITLE
Update data-integration to 7.0.0.0-25

### DIFF
--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -1,11 +1,11 @@
 cask 'data-integration' do
-  version '6.1.0.1-196'
-  sha256 'ef5076c09e8481d1ab4cfc5f7d4701437f80f2b97a3bf19dfa74821de9524495'
+  version '7.0.0.0-25'
+  sha256 '65f074a0ee087bedef0c09345853f6b807500250d7f3ba04e4c61dd3e2b3fa72'
 
   # sourceforge.net/pentaho was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/pentaho/pdi-ce-#{version}.zip"
-  appcast 'https://sourceforge.net/projects/pentaho/rss',
-          checkpoint: '70d19f1c19f8c6f11733c18ea3f8217f4514bd4e6aa50763bc05d1ab8ff97f72'
+  appcast 'https://sourceforge.net/projects/pentaho/rss?path=/Data%20Integration',
+          checkpoint: 'e65768e990d0aa7e0ebd91308fa13e30b046152541114b66273ad77ed133a5bf'
   name 'Pentaho Data Integration'
   homepage 'http://community.pentaho.com/'
 


### PR DESCRIPTION
* Updated the appcast url to be a little more targeted rather than all of the products.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.