### PR TITLE
Update istat-server to 3.02

### DIFF
--- a/Casks/istat-server.rb
+++ b/Casks/istat-server.rb
@@ -1,6 +1,6 @@
 cask 'istat-server' do
-  version '3.00'
-  sha256 'd28fcc1751e308ca81cdd5255e8c2be54eaa5dc06957ca099b050733b99765f9'
+  version '3.02'
+  sha256 '032a1f51bd34e850b0f930676361606a6b260cc0b7b35d9a1bca390a87d2bf41'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatserver#{version.major}/istatserver#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.