### PR TITLE
Update komodo-edit to 10.1.4-17456

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,6 +1,6 @@
 cask 'komodo-edit' do
-  version '10.1.1-17414'
-  sha256 'ff5f06fa202bb82b4e30f55f03a8ea657fcf4dbcc1af8dfd9c73660bf824a406'
+  version '10.1.4-17456'
+  sha256 'be6f046d0b12a6f5c5aa8badc730de25181d9f473f40f7f49dbd8e46057dc03a'
 
   # activestate.com/Komodo was verified as official when first introduced to the cask
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.