### PR TITLE
Update voxengo-span-vst to 3.0

### DIFF
--- a/Casks/voxengo-span-vst.rb
+++ b/Casks/voxengo-span-vst.rb
@@ -1,6 +1,6 @@
 cask 'voxengo-span-vst' do
-  version '2.10'
-  sha256 '09f5a195145b5dff81b095bae8af9f3d98e301debe8a0f7732684fd479b20185'
+  version '3.0'
+  sha256 'ce4b3e2e7e5aa015b6323976c42443d05127724bd3e78dbdddf0c9c26e04495c'
 
   url "https://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_VST_VST3_setup.dmg"
   name 'Voxengo SPAN (VST)'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.