### PR TITLE
Update gpodder to 3.9.3_0

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,11 +1,11 @@
 cask 'gpodder' do
-  version '3.9.0_2'
-  sha256 'c5dafe2685057545cf6505d9492c429ab9c585e159c04bec62847c9ba9a40c2f'
+  version '3.9.3_0'
+  sha256 '6116f70e2db7bc37171762f7dd0bf8019a5518b6bb7c3e15b9dba573f5854c00'
 
   # sourceforge.net/gpodder was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpodder/gPodder-#{version}.zip"
-  appcast 'https://sourceforge.net/projects/gpodder/rss',
-          checkpoint: '2e66a10eb5778906af6dbcccc6a1e46d9d43e63bb3d8216c9c67a81a5de4e838'
+  appcast 'https://sourceforge.net/projects/gpodder/rss?path=/macosx',
+          checkpoint: 'cb0012d8251330c826ecb2ac16bdd1db728c8cdb7013d8e836a7dd0b8fec7bc9'
   name 'gPodder'
   homepage 'http://gpodder.org/'
 


### PR DESCRIPTION
* Updated appcast url to osx specific file releases

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.