### PR TITLE
Update consul-web-ui to 0.7.2

### DIFF
--- a/Casks/consul-web-ui.rb
+++ b/Casks/consul-web-ui.rb
@@ -1,15 +1,15 @@
 cask 'consul-web-ui' do
-  version '0.7.1'
-  sha256 '1b793c60e1af24cc470421d0411e13748f451b51d8a6ed5fcabc8d00bfb84264'
+  version '0.7.2'
+  sha256 'c9d2a6e1d1bb6243e5fd23338d92f5c71cdf0a4077f7fcc95fd81800fa1f42a9'
 
   # hashicorp.com was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/consul/#{version}/consul_#{version}_web_ui.zip"
   appcast 'https://github.com/hashicorp/consul/releases.atom',
-          checkpoint: '38ef0f44bc4072414cd2a95681f98bf84f2f14959fa505d4c71a86ccfb545653'
+          checkpoint: '13dd5b86c555de073de8513ce88735d28b8f057d8727c9208cd3814310a6e008'
   name 'Consul Web UI'
   homepage 'https://www.consul.io/intro/getting-started/ui.html'
 
-  depends_on cask: 'consul'
+  depends_on formula: 'consul'
 
   stage_only true
 


### PR DESCRIPTION
* Looks like this has been broken since #23413 because the cask dependency was no longer there? Do I have that right?

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.