### PR TITLE
Add discovered appcasts to 10 Casks

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -25,6 +25,8 @@ cask '1password' do
     app "1Password #{version.major}.app"
   end
 
+  appcast 'https://app-updates.agilebits.com/product_history/OPM4',
+          checkpoint: '9944f1ff5b4d9157a82a680da6c47b7d3db9d9332afd8c18748eaad48a5ae56b'
   name '1Password'
   homepage 'https://1password.com/'
 

--- a/Casks/abscissa.rb
+++ b/Casks/abscissa.rb
@@ -3,6 +3,8 @@ cask 'abscissa' do
   sha256 '319c6871e4f42eaf6b1925aff66859024241d5c11a542badeb6993d287da3da2'
 
   url "http://rbruehl.macbay.de/Abscissa/Downloads/Abscissa-#{version}.zip"
+  appcast 'http://rbruehl.macbay.de/Abscissa/Downloads/',
+          checkpoint: 'a5b279ad4abd26be9934916a946d708517383bc459d3edcbe248bfc354ae6c99'
   name 'Abscissa'
   homepage 'http://rbruehl.macbay.de/Abscissa/'
 

--- a/Casks/alice.rb
+++ b/Casks/alice.rb
@@ -3,6 +3,8 @@ cask 'alice' do
   sha256 '0d6259bdff7fd0309b532188445d0dd4f7ea4d50f5570e9b46d282fbade74ce1'
 
   url "https://www.ps.uni-saarland.de/alice/download/Alice-#{version}-4-i386.dmg"
+  appcast 'https://www.ps.uni-saarland.de/alice/download.html',
+          checkpoint: '732e2eca0a1f81d70e7988eb8bcb8909de3613c6cff80363707d3eb2eb66d6cc'
   name 'Alice'
   homepage 'https://www.ps.uni-saarland.de/alice/'
 

--- a/Casks/anoncoin.rb
+++ b/Casks/anoncoin.rb
@@ -3,6 +3,8 @@ cask 'anoncoin' do
   sha256 '8b4bb2d1b58e012d5f9b4f493c2f36bcd7bb75096fd70736c39f5d2b1aeaa94d'
 
   url "https://anoncoin.net/downloads/#{version}/Anoncoin-#{version}.dmg"
+  appcast 'https://anoncoin.net/downloads/',
+          checkpoint: '7f2c0786d5cdbcde4d1001036fd954ecb2e38b49dc6404f67e11839bec7924cb'
   name 'Anoncoin'
   homepage 'https://anoncoin.net/'
 

--- a/Casks/antpconc.rb
+++ b/Casks/antpconc.rb
@@ -3,6 +3,8 @@ cask 'antpconc' do
   sha256 '3b8f25e876f4c3c6d5e9765b0891a377aae277e1a76adb8183b1ec948a23771c'
 
   url "http://www.laurenceanthony.net/software/antpconc/releases/AntPConc#{version.no_dots}/AntPConc.zip"
+  appcast 'http://www.laurenceanthony.net/software/antpconc/releases/',
+          checkpoint: '0129809d06241c8972b6741beb652af0a8fc26c8b316fa54ecc45369428a9774'
   name 'AntPConc'
   homepage 'http://www.laurenceanthony.net/software/antpconc/'
 

--- a/Casks/antwordprofiler.rb
+++ b/Casks/antwordprofiler.rb
@@ -3,6 +3,8 @@ cask 'antwordprofiler' do
   sha256 'b7cea938e38001b54fce28d1efb1336bbfe4f5af37559c7b3ffd3a14a8aed608'
 
   url "http://www.laurenceanthony.net/software/antwordprofiler/releases/AntWordProfiler#{version.no_dots}/AntWordProfiler.zip"
+  appcast 'http://www.laurenceanthony.net/software/antwordprofiler/releases/',
+          checkpoint: 'e90c95c59a2d69fe1bc13b2a3b8a16adb72c6c3d767660c51eee418a24db20fd'
   name 'AntWordProfiler'
   homepage 'http://www.laurenceanthony.net/software/antwordprofiler/'
 

--- a/Casks/anypass.rb
+++ b/Casks/anypass.rb
@@ -3,6 +3,8 @@ cask 'anypass' do
   sha256 '364d108736eddfdb6e7db56430806d790b79e9f8561aedc544fc78d7e41bac54'
 
   url "http://icyblaze.com/anypass/anypass_mac_#{version.sub(%r{^(\d+\.\d+).*}, '\1')}.zip"
+  appcast 'http://icyblaze.com/anypass/',
+          checkpoint: 'e438ed63fbe147117168c65645e79c5068b5ad10d2f0cf6ade97d29228723b8a'
   name 'Anypass'
   homepage 'http://icyblaze.com/anypass/'
 

--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -4,6 +4,8 @@ cask 'apache-couchdb' do
 
   # bintray.com/apache/couchdb was verified as official when first introduced to the cask
   url "https://dl.bintray.com/apache/couchdb/mac/#{version}/Apache-CouchDB-#{version}.zip"
+  appcast 'https://github.com/apache/couchdb/releases.atom',
+          checkpoint: 'ea86b147b24603481fdc95f2a365cc24dbb9ff2b54b0b04c70f2033880edf132'
   name 'Apache CouchDB'
   homepage 'https://couchdb.apache.org/'
 

--- a/Casks/astah-community.rb
+++ b/Casks/astah-community.rb
@@ -3,6 +3,8 @@ cask 'astah-community' do
   sha256 'b2736dc7b980b6e617b5bc49bdcc986581a91a80644bf737759f9da54fed6297'
 
   url "http://cdn.astah.net/downloads/astah-community-#{version.before_comma.dots_to_underscores}-#{version.after_comma}-MacOs.dmg"
+  appcast 'http://astah.net/release-notes/community',
+          checkpoint: 'e2575a4b0a049bd7e5e044dd8cc68b518de49dc91c6f0873ab925d586a971f55'
   name 'Change Vision Astah Community'
   homepage 'http://astah.net/editions/community'
 

--- a/Casks/atlantis.rb
+++ b/Casks/atlantis.rb
@@ -3,6 +3,8 @@ cask 'atlantis' do
   sha256 '52957a5b92b1fd3612aa7a3a07f5238236dad4397a6a256a03355c331433e540'
 
   url "http://www.riverdark.net/atlantis/downloads/Atlantis-#{version}.dmg"
+  appcast 'http://www.riverdark.net/atlantis/downloads/',
+          checkpoint: '73d865e7bb2de4cc3a5157bfd5d28c1d6a23bf4b85b4ef873ce78e8c2167adba'
   name 'Atlantis'
   homepage 'http://www.riverdark.net/atlantis/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.