### PR TITLE
Add discovered appcasts to 10 casks #5

### DIFF
--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -10,4 +10,3 @@ cask 'fritzing' do
 
   app 'Fritzing.app'
 end
-

--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -3,8 +3,11 @@ cask 'fritzing' do
   sha256 'a057ed849b842540b98a68ab2cb996e22b482278706dd2f8da21d1bccf70513f'
 
   url "http://fritzing.org/download/#{version}/mac-os-x-105/Fritzing#{version}.dmg"
+  appcast 'https://github.com/fritzing/fritzing-app/releases.atom',
+          checkpoint: 'a809ee3389e816cc81bd1053fabbb5da2cf82f093128db4fe8ddfa80a9b4a36d'
   name 'Fritzing'
   homepage 'http://fritzing.org/home/'
 
   app 'Fritzing.app'
 end
+

--- a/Casks/gifrocket.rb
+++ b/Casks/gifrocket.rb
@@ -3,6 +3,8 @@ cask 'gifrocket' do
   sha256 'c5407c9caad8c038f604d35da9a6554dede79611daaf5174116ea9517a704593'
 
   url "http://www.gifrocket.com/Gifrocket.#{version}.zip"
+  appcast 'http://www.gifrocket.com/',
+          checkpoint: '7852e6ef7cdcd9018b37c88bb7b343820bfa1d864e0fdad7fa242f5ada27d41c'
   name 'Gifrocket'
   homepage 'http://www.gifrocket.com/'
 

--- a/Casks/gogs.rb
+++ b/Casks/gogs.rb
@@ -3,6 +3,8 @@ cask 'gogs' do
   sha256 '281f107e5403374702f6080e7395f4728e5b978fc0484565fc46df3d367f8b80'
 
   url "https://cdn.gogs.io/gogs_v#{version}_darwin_amd64.zip"
+  appcast 'https://github.com/gogits/gogs/releases.atom',
+          checkpoint: '671ed3b027d5319b32029f8d95f787267bd7533b71ee72b9e640eb3a201cf50b'
   name 'Go Git Service'
   homepage 'https://gogs.io/'
 

--- a/Casks/gridwars.rb
+++ b/Casks/gridwars.rb
@@ -3,6 +3,8 @@ cask 'gridwars' do
   sha256 '39694d6d7f7af1a25818d10dbd811d0309562622f91f43f71d8b217bccdb03fb'
 
   url 'http://gridwars.marune.de/bin/gridwars_osx_x86.zip'
+  appcast 'http://gridwars.marune.de/',
+          checkpoint: '8cf5148b46ca27f4e6073b041b08040e3365b0a195cbc6dec98b1e2c02db4dfc'
   name 'GridWars'
   homepage 'http://gridwars.marune.de/'
 

--- a/Casks/gyazmail.rb
+++ b/Casks/gyazmail.rb
@@ -3,6 +3,8 @@ cask 'gyazmail' do
   sha256 '44660863538177d323702e2b952a38246dfe3ff82ed3899df0a5162fdd375c96'
 
   url "http://gyazsquare.com/gyazmail/GyazMail-#{version.no_dots}.dmg"
+  appcast 'http://gyazsquare.com/gyazmail/',
+          checkpoint: '30d8f8109aec27359a161c6b65a10d5f3d60371dae11ed32494a6e8eb1eea050'
   name 'GyazMail'
   homepage 'http://gyazsquare.com/gyazmail/'
 

--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -4,6 +4,8 @@ cask 'hab' do
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
+  appcast 'https://github.com/habitat-sh/habitat/releases.atom',
+          checkpoint: 'd1a116c68f18a5af0735c9a7d2651e0225ccec6751446841cd9a66ad26799afd'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 

--- a/Casks/haskell-platform.rb
+++ b/Casks/haskell-platform.rb
@@ -3,6 +3,8 @@ cask 'haskell-platform' do
   sha256 'f579f8f120998faba6a9158be7b6c218f73ce65bd041046f0a2677b8cc614129'
 
   url "https://haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%20Full%2064bit-signed-a.pkg"
+  appcast 'https://github.com/haskell/haskell-platform/releases.atom',
+          checkpoint: 'c5672590f584d967a46fcb20a2fcd24700eb9d9e2cc137bdc9ab0af3c599065e'
   name 'Haskell Platform'
   homepage 'https://www.haskell.org/platform/'
 

--- a/Casks/ibackup.rb
+++ b/Casks/ibackup.rb
@@ -3,6 +3,8 @@ cask 'ibackup' do
   sha256 '97e34fd79a16193161e873e2eb77c32597dedb5b63d44ed48a61c40af8aba8e2'
 
   url "http://www.grapefruit.ch/iBackup/versions/iBackup%20#{version.major}.x/iBackup%20#{version}.dmg"
+  appcast 'http://www.grapefruit.ch/iBackup/downloads.html',
+          checkpoint: '3f0bdd8f457ea60d548feda9c18e9dfedb74849470fa232dba8cb9e7dc4144a3'
   name 'iBackup'
   homepage 'http://www.grapefruit.ch/iBackup/'
 

--- a/Casks/ibored.rb
+++ b/Casks/ibored.rb
@@ -3,6 +3,8 @@ cask 'ibored' do
   sha256 'c507817d3b286f831e2ebb08e24b21e2183d166e3ef5e513f631b3f01bf6f495'
 
   url "http://files.tempel.org/iBored/iBored-Mac_#{version}.zip"
+  appcast 'http://apps.tempel.org/iBored/releasenotes.html',
+          checkpoint: '52c548b90bc50c31677c1dfb366f7d22f032017b173bb62feb01a4972e42d1b3'
   name 'iBored'
   homepage 'http://apps.tempel.org/iBored/'
 

--- a/Casks/icab.rb
+++ b/Casks/icab.rb
@@ -4,6 +4,8 @@ cask 'icab' do
 
   # icab.clauss-net.de was verified as official when first introduced to the cask
   url "http://icab.clauss-net.de/icab/iCab_#{version}_Intel.zip"
+  appcast 'http://www.icab.de/dl.php',
+          checkpoint: 'a2272b5ef213ca7cc65604012025e2bcd87c498cf1e251bf26c272e9525170ed'
   name 'iCab'
   homepage 'http://www.icab.de/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.