### PR TITLE
Add discovered appcasts to 10 casks #6

### DIFF
--- a/Casks/icecat.rb
+++ b/Casks/icecat.rb
@@ -3,6 +3,8 @@ cask 'icecat' do
   sha256 '895340df6baf3640d8d7fbb9e690edc2b1d14bf59082ad5f01d310f81e318e31'
 
   url "https://ftp.gnu.org/gnu/gnuzilla/#{version}/icecat-#{version}.en-US.mac64.dmg"
+  appcast 'http://ftp.gnu.org/gnu/gnuzilla/',
+          checkpoint: '466422b8746c3f0fce6c75b29c9c768a3ab3e6d2931b9b6d58345e3fb7a76deb'
   name 'IceCat'
   homepage 'https://www.gnu.org/software/gnuzilla/'
 

--- a/Casks/icefloor.rb
+++ b/Casks/icefloor.rb
@@ -3,6 +3,8 @@ cask 'icefloor' do
   sha256 'b326bab20c022c12be9ed01c3aa0e5f072853ce7dc5fb756bddebc2c3abddf64'
 
   url "http://www.hanynet.com/icefloor-#{version}.zip"
+  appcast 'http://www.hanynet.com/icefloor/',
+          checkpoint: 'dcb770af43ce81eec5851c87a7c683403e81ffdbb2aadb0f167ae362a052fc0b'
   name 'IceFloor'
   homepage 'http://www.hanynet.com/icefloor/'
 

--- a/Casks/iconping.rb
+++ b/Casks/iconping.rb
@@ -3,6 +3,8 @@ cask 'iconping' do
   sha256 '9f02c99b360ed2a0a424e1bdeb4f810ffb120a3cf78b6889b8a6c5b29b06d0c9'
 
   url "http://antirez.com/iconping/iconping-#{version}.app.dmg"
+  appcast 'http://antirez.com/iconping/',
+          checkpoint: '9b5e31372e075a6c6422b63e21c9cce3a578d530ba0955551d1e1c4df86209fe'
   name 'Icon Ping'
   homepage 'http://antirez.com/iconping/'
 

--- a/Casks/iloc.rb
+++ b/Casks/iloc.rb
@@ -3,6 +3,8 @@ cask 'iloc' do
   sha256 '3c9909b73ba4a17aef20cdc7efea2333d94f23fca2c87bc6c402bc4f17ce9ef3'
 
   url "https://derailer.org/iloc/iloc-#{version}.tgz"
+  appcast 'https://derailer.org/iloc/',
+          checkpoint: '345ea8840b83e082750936c2462e1bd4a72590f95d480d5a93f6426ece9604cc'
   name 'iloc'
   homepage 'https://derailer.org/iloc/'
 

--- a/Casks/image-tool.rb
+++ b/Casks/image-tool.rb
@@ -3,6 +3,8 @@ cask 'image-tool' do
   sha256 '66ef0c6cdf2e90981bc8bd0d1131e6e0f141744406997712550b8b5a05022d39'
 
   url "http://www.jimmcgowan.net/diskimages/ImageTool#{version}.dmg"
+  appcast 'http://www.jimmcgowan.net/Site/ImageTool.html',
+          checkpoint: 'f272e04488b986737e525bdc825b525fe0f698f0e67ed025d09510934c8949c6'
   name 'Image Tool'
   homepage 'http://www.jimmcgowan.net/Site/ImageTool.html'
 

--- a/Casks/inform.rb
+++ b/Casks/inform.rb
@@ -3,6 +3,8 @@ cask 'inform' do
   sha256 '5302213a92122a98167e8e2994fd465ed3400b16aa571139edc772616e72b8b9'
 
   url "http://inform7.com/download/content/#{version}/I7-#{version}-OSX.dmg"
+  appcast 'http://inform7.com/download/',
+          checkpoint: '3fbbfa135f012ac8009b67422e0b98178c630ab2f95f902f1400d98a6149385a'
   name 'Inform'
   homepage 'http://inform7.com/'
 

--- a/Casks/ipe.rb
+++ b/Casks/ipe.rb
@@ -4,6 +4,8 @@ cask 'ipe' do
 
   # bintray.com/otfried was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac.dmg"
+  appcast 'http://ipe.otfried.org/',
+          checkpoint: 'bd56cea213718b2f59da8fb146cd3f120e70d3b908c7364d230db6235c7b25ae'
   name 'Ipe'
   homepage 'http://ipe.otfried.org/'
 

--- a/Casks/ireadfast.rb
+++ b/Casks/ireadfast.rb
@@ -3,6 +3,8 @@ cask 'ireadfast' do
   sha256 '0bc213c6da72a7917ceba8a9de46e307933608cd6d2bf397770517401ab3d98c'
 
   url "https://www.gengis.net/downloads/iReadFast%20#{version}.dmg"
+  appcast 'https://www.gengis.net/prodotti/iReadFast_Mac/en/index.php',
+          checkpoint: '85acb65eb5e61cb2f9031d827bf3314e99934813b1b97867b28d1e98658db92a'
   name 'iReadFast'
   homepage 'https://www.gengis.net/prodotti/iReadFast_Mac/en/'
 

--- a/Casks/iridium-extra.rb
+++ b/Casks/iridium-extra.rb
@@ -3,6 +3,8 @@ cask 'iridium-extra' do
   sha256 'b0de307fef0bc1ac1123ac8f480c4a2178b6ba2849578f38d6c10dad35c04d6d'
 
   url "https://downloads.iridiumbrowser.de/macosx/#{version}/iridium_browser_extra_#{version}_osx_x64.dmg"
+  appcast 'https://downloads.iridiumbrowser.de/macosx/',
+          checkpoint: '0a338c863d60192ea9b00df8b50aa90fc4b7d298b7e895284fab5b19d29888ca'
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'
 

--- a/Casks/isteg.rb
+++ b/Casks/isteg.rb
@@ -3,6 +3,8 @@ cask 'isteg' do
   sha256 '5f385efce3416c9df75c6d97a35de82b76d9c829c2956461dd2fc95ca843702d'
 
   url "http://www.hanynet.com/isteg-#{version}.zip"
+  appcast 'http://www.hanynet.com/isteg/',
+          checkpoint: 'c0a0d7f43bb66f02369da2938c41dbe8a46f41464017c4b3340df5dc72cf7a11'
   name 'iSteg'
   homepage 'http://www.hanynet.com/isteg/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.