### PR TITLE
Update ndm to 0.1.3

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '0.1.2'
-  sha256 'b04b5646ab8192d8a2ca279d11b3fdf4b82854f25a550127630124da85956398'
+  version '0.1.3'
+  sha256 'bd066e0b833c99fd85562a1088144e0b68dbc7dedfe548d0510156397e91178b'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '12439fc6deea15e6fc49647ba274fb7d517751ea73d6b406edb558d6804cdb81'
+          checkpoint: '8a9ada6dd79cf6e995a79295bfa4fb3580052a78e0e4df1f2c505abe2fb204ab'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.