### PR TITLE
Update and rename rabbitmq.rb to rabbitmq-app.rb

### DIFF
--- a/Casks/rabbitmq-app.rb
+++ b/Casks/rabbitmq-app.rb
@@ -1,4 +1,4 @@
-cask 'rabbitmq' do
+cask 'rabbitmq-app' do
   version '3.6.1-build.1'
   sha256 '1838afcece704ab1d23645d5d44953b809474f1f67ec4b18f3f98d440e5b5aad'
 


### PR DESCRIPTION
Part of https://github.com/caskroom/homebrew-cask/issues/15603.

From [the website](https://jpadilla.github.io/rabbitmqapp/), it seems indeed to be mostly a wrapper. If merged, we must also submit a fix to [the repo’s instructions](https://github.com/jpadilla/rabbitmqapp#installing-with-homebrew-cask).