### PR TITLE
Update caprine to 1.8.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '1.7.0'
-  sha256 '63fd671c29294eb8a6fc09c488eae3c0cfd83afef3e58023e9e719d63d1ad109'
+  version '1.8.0'
+  sha256 'ea94df271617b26a8e2583dd89d5c2b2e8f7f15da113c4edaa3f0e55e7b67176'
 
   url "https://github.com/sindresorhus/caprine/releases/download/#{version}/Caprine-osx-#{version}.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: 'fdbbaee4a9364e122ca5e1445eaedce4d6ace8048c4fc783650242242d4d12c8'
+          checkpoint: 'a24049d9b71e435ec7c4a4f12937bc72a340f39fd0d03c9e7c5507b42b46a630'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.