### PR TITLE
Update minikube to 0.15.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,10 +1,10 @@
 cask 'minikube' do
-  version '0.14.0'
-  sha256 '950805a1e1929dc41ef27698a0325b981f99f4a45df121521861fcd696e35f28'
+  version '0.15.0'
+  sha256 'cc76cb68c9dfbe0317701e5d264ecf03cb3177a3a77906d901960c7adff6fc4a'
 
   url "https://github.com/kubernetes/minikube/releases/download/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: '075362e43b0ce4d3262a1e2e4583c3916dac0851239d66283e91daddd4c23fa8'
+          checkpoint: '08c47fdf54bfb5bf62badf7685802bc107e4e7ba05b4d0440d71d14dad6f3c1e'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.