### PR TITLE
Update porthole to 1.7.10

### DIFF
--- a/Casks/porthole.rb
+++ b/Casks/porthole.rb
@@ -1,11 +1,11 @@
 cask 'porthole' do
-  version '1.7.9'
-  sha256 '805847cfec098073feabccd7f65f448c27c3db14574ac4a94b823458e525ebe3'
+  version '1.7.10'
+  sha256 '63b6d2a0a51a906413238770d1cd00180cc0105e210f44eb6131c2cbee298686'
 
   # getporthole.com was verified as official when first introduced to the cask
   url 'https://download.getporthole.com/Porthole-latest.zip'
   appcast 'https://update.getporthole.com/appcast.rss',
-          checkpoint: 'a3602cb1b9271bafaa09b607760da032f2bedaa6315238a339ae22c607510197'
+          checkpoint: 'c6aa8f34c57cd1d19454bf1ab7a6684f2c396b6b109a510431e55bc52ae3fff5'
   name 'Porthole'
   homepage 'https://www.dangercove.com/porthole/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.