### PR TITLE
Update spillo to 142_1.9.8

### DIFF
--- a/Casks/spillo.rb
+++ b/Casks/spillo.rb
@@ -1,11 +1,11 @@
 cask 'spillo' do
-  version '141_1.9.7'
-  sha256 '1843b8efc0540b97b562d37f5549b6a8ba7079e36d09ce75dc61ca5185a3682e'
+  version '142_1.9.8'
+  sha256 'fb59347179b48b8a6f17090efe605966552472aefcba8a38a58d8616dfdb962c'
 
   # s3.amazonaws.com/bananafish-builds/spillo was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bananafish-builds/spillo/spillo_#{version}.zip"
   appcast 'https://bananafishsoftware.com/feeds/spillo.xml',
-          checkpoint: '7f2ca67505c011343ddf72efd684f1e3ba806d9f9429ca137dc53b045fb69f52'
+          checkpoint: '2f57f83464048b5e97a0b95cf76f37f090d1662e144b1e984fb24926d0413f68'
   name 'Spillo'
   homepage 'https://bananafishsoftware.com/products/spillo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.