### PR TITLE
Update vimr to 0.12.6-162

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.12.5-159'
-  sha256 'a32f6f73871e25fd1ab81238a6d56482cbbe30af3ab736e6ef3afebd4f335bfd'
+  version '0.12.6-162'
+  sha256 'b30571104ed858ae28cd4aef0d1f1457f57c96cbb25c2d5cfd6bfe5a1c1adcc1'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '4c1773073c09d3b1c45256979773dacda8d44ae4a6d8fa5018bf2b407058d9b6'
+          checkpoint: '5243dc7cf8df5c35aac65588c350e3e6d41c8674b37ac54e362f98a05485cd6c'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.