### PR TITLE
Add discovered appcasts to 10 casks #7

### DIFF
--- a/Casks/kepler.rb
+++ b/Casks/kepler.rb
@@ -3,6 +3,8 @@ cask 'kepler' do
   sha256 '8b6b793b7ba95d1a26184d25b89fe531d8a291b75f1bfc62e7dbcf41a8bc05fb'
 
   url "https://code.kepler-project.org/code/kepler/releases/installers/#{version}/Kepler-#{version}.dmg"
+  appcast 'https://kepler-project.org/users/downloads',
+          checkpoint: 'f2961afc71cd84d2f41d992c1fd73e3d60bd41a6c5ba6adf9916522d41080248'
   name 'Kepler'
   homepage 'https://kepler-project.org/'
 

--- a/Casks/kk7ds-python-runtime.rb
+++ b/Casks/kk7ds-python-runtime.rb
@@ -3,6 +3,8 @@ cask 'kk7ds-python-runtime' do
   sha256 '5cee8acb941e39f93a4df6a99ed29a14c48da0bc5beb3b31068852b1fad8b009'
 
   url "http://www.d-rats.com/download/OSX_Runtime/KK7DS_Python_Runtime_R#{version.major}.pkg"
+  appcast 'http://www.d-rats.com/download/OSX_Runtime/',
+          checkpoint: '076ef6eff11fc08dbacfc577635b29af98c3e9bb11c0173dcd7b688c5a9611e0'
   name 'KK7DS Python Runtime'
   homepage 'http://www.d-rats.com/download/OSX_Runtime/'
 

--- a/Casks/kylo.rb
+++ b/Casks/kylo.rb
@@ -2,8 +2,10 @@ cask 'kylo' do
   version '1.0.1.76141'
   sha256 '5c5f1c3aedba9aa2807cffbc3aec448f0f51e16e1039c0314cf6394ddbe391b1'
 
-  # kylo.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://kylo.s3.amazonaws.com/update/public/kylo-setup-#{version.dots_to_underscores}.dmg"
+  # github.com/teamkylo/kylo-browser/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/teamkylo/kylo-browser/releases/download/v#{version}/kylo-setup-#{version.dots_to_underscores}.dmg"
+  appcast 'https://github.com/teamkylo/kylo-browser/releases.atom',
+          checkpoint: 'e5a8bad8a4356c16dc1d79126c49e8905b2ea44c390fdeba1089f9b11005a2f3'
   name 'Kylo'
   homepage 'http://kylo.tv/'
 

--- a/Casks/liquifile.rb
+++ b/Casks/liquifile.rb
@@ -3,6 +3,8 @@ cask 'liquifile' do
   sha256 '81e8a0583af77fe9a2fbafa3433e73a5cb8567fdd53e37119b431c4ea6ce242d'
 
   url 'http://www.liquifile.info/Liquifile.dmg'
+  appcast 'http://www.liquifile.info/',
+          checkpoint: 'c15e603a4ef343df45c22eea78b2035685b6b1f9a5f1ae0c884b8d1e01c24fba'
   name 'Liquifile'
   homepage 'http://www.liquifile.info/'
 

--- a/Casks/macswear.rb
+++ b/Casks/macswear.rb
@@ -3,6 +3,8 @@ cask 'macswear' do
   sha256 'a113fa7a73adac2bb153d49d6d7d1ba15ac1ae5ca78a8d24861900b8664bdd52'
 
   url "https://wakaba.c3.cx/releases/Swear/MacSwear#{version}.zip"
+  appcast 'https://wakaba.c3.cx/s/games/macswear',
+          checkpoint: '674535c4feadcaea75bf623df674892dac6a17cd18d08e9ab64b36a72db75abc'
   name 'MacSwear'
   homepage 'https://wakaba.c3.cx/s/games/macswear'
 

--- a/Casks/marble.rb
+++ b/Casks/marble.rb
@@ -3,6 +3,8 @@ cask 'marble' do
   sha256 '6d1bf3e02c34ef0df0d5d0311d580bfae1d5259e3db45036163a5330dc139c04'
 
   url "https://files.kde.org/marble/downloads/MacOSX/Marble-#{version}.dmg"
+  appcast 'https://marble.kde.org/install.php',
+          checkpoint: '2e380a4e00b3dd33424238e3f263c594baa4b5baf4c26ef51141bd9f94cf3fce'
   name 'Marble'
   homepage 'https://marble.kde.org/'
 

--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -3,6 +3,8 @@ cask 'mediaelch' do
   sha256 'f82d4c157ef64e25529744fb962771ce678a9e2e3a94b18b3d398dfa5b8b9452'
 
   url "http://www.kvibes.de/releases/mediaelch/#{version}/MediaElch-#{version}.dmg"
+  appcast 'https://github.com/Komet/MediaElch/releases.atom',
+          checkpoint: 'ed0fc59d36c76777a9245ef278968e979e7f6ee0b35250a770fcbca34ed851e1'
   name 'MediaElch'
   homepage 'http://www.kvibes.de/en/mediaelch/'
 

--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -4,6 +4,8 @@ cask 'meld' do
 
   # github.com/yousseb/meld was verified as official when first introduced to the cask
   url "https://github.com/yousseb/meld/releases/download/#{version.after_comma}/meldmerge.dmg"
+  appcast 'https://github.com/yousseb/meld/releases.atom',
+          checkpoint: '4c9b17456ea505a7490456e40b96b980ae3295ad844fed7e71ac1c091787c250'
   name 'Meld for OSX'
   homepage 'https://yousseb.github.io/meld/'
 

--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -3,6 +3,8 @@ cask 'netlogo' do
   sha256 '7ed687afc901130a83019ecff45f40fa0576bfbe2beb470a400de48a2378f566'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
+  appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml',
+          checkpoint: '5927e356270978f8366e6d0084b52ff2bb869fbba191e1928a0004d889408377'
   name 'NetLogo'
   homepage 'https://ccl.northwestern.edu/netlogo/'
 

--- a/Casks/r-app.rb
+++ b/Casks/r-app.rb
@@ -11,6 +11,8 @@ cask 'r-app' do
     pkg "R-#{version}.pkg"
   end
 
+  appcast 'https://www.r-project.org/',
+          checkpoint: '97043eed2b030ed4fa7ffd3509b6f9edc2ce9aaa1608ea3bd35ab421ab98f843'
   name 'R'
   homepage 'https://www.r-project.org/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* note that mediaelch.rb does not have a github download source

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.