### PR TITLE
Add discovered appcasts to 10 casks #9

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -3,6 +3,8 @@ cask 'nextcloud' do
   sha256 'b466cd8ec6c7d105e51019f49c31a1009068ae7fade787d7e7cab0ee469ae6ed'
 
   url "https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-#{version}.pkg"
+  appcast 'https://github.com/nextcloud/client_theming/releases.atom',
+          checkpoint: '47e4c47aba509566288c0ff028c453f2e2158abbb78b1abbcd5c2f42a2316427'
   name 'Nextcloud'
   homepage 'https://nextcloud.com/'
 

--- a/Casks/nisus-thesaurus.rb
+++ b/Casks/nisus-thesaurus.rb
@@ -3,6 +3,8 @@ cask 'nisus-thesaurus' do
   sha256 'ee9203ada1fa944ac4b7fc04f03ec58fd7c60ce1d73e6058321583f7dbf8ae5a'
 
   url "https://nisus.com/files/free/Thesaurus-v#{version.no_dots}.zip"
+  appcast 'https://nisus.com/Thesaurus/updates.php',
+          checkpoint: '08c437fa79d1ade081069f3d1bb0f8d0bce40abc66eeb3812e47f2f5259785fc'
   name 'Nisus Thesaurus'
   homepage 'https://nisus.com/Thesaurus/'
 

--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -3,6 +3,8 @@ cask 'noejectdelay' do
   sha256 'cfaeed50aa7ed9eac04716ab0e34c5ef10658802e691732f7589f9454e96aa94'
 
   url "https://pqrs.org/osx/karabiner/files/NoEjectDelay-#{version}.dmg"
+  appcast 'https://github.com/tekezo/NoEjectDelay/releases.atom',
+          checkpoint: '4475b83ad5927875fbc16e19c890dbaba1e466a758afcc0351ec86bb0e00468d'
   name 'NoEjectDelay'
   homepage 'https://pqrs.org/osx/karabiner/noejectdelay.html.en'
 

--- a/Casks/noiz2sa.rb
+++ b/Casks/noiz2sa.rb
@@ -3,6 +3,8 @@ cask 'noiz2sa' do
   sha256 'eb4d7f0a133b5e1541edb3b13209af58093f9a6a9fcc1296fec88552a967306d'
 
   url "https://workram.com/downloads/Noiz2sa-for-OS-X-#{version}.dmg"
+  appcast 'https://workram.com/games/noiz2sa/',
+          checkpoint: 'a6b2ed06deaa79e55249a0e6f105c3562391f1bad1f17006ded7d6bef06049cd'
   name 'Noiz2sa'
   homepage 'https://workram.com/games/noiz2sa/'
 

--- a/Casks/noobproof.rb
+++ b/Casks/noobproof.rb
@@ -3,6 +3,8 @@ cask 'noobproof' do
   sha256 '6e74a5aec8e9cf9102c160019990e90ae46486358959fa0d22517b4171f8209a'
 
   url "http://www.hanynet.com/noobproof-#{version}.zip"
+  appcast 'http://www.hanynet.com/noobproof/',
+          checkpoint: '7a559c6cdbea09410e04e52672a3c2216b8b6a24a8a4a3d696c3428dfb601f39'
   name 'NoobProof'
   homepage 'http://www.hanynet.com/noobproof/'
 

--- a/Casks/not-pacman.rb
+++ b/Casks/not-pacman.rb
@@ -3,6 +3,8 @@ cask 'not-pacman' do
   sha256 '4a2c4d84ad713f505a89a14eea5184e76ea5378eb08698da41afc6c4021ead13'
 
   url "http://stabyourself.net/dl.php?file=notpacman-#{version}/notpacman-osx.zip"
+  appcast 'http://stabyourself.net/notpacman',
+          checkpoint: '6f262fd3ae2a99d3f2cc0565fa94946d5d3b591903e5106368f3a4f9da4a5305'
   name 'Not Pacman'
   homepage 'http://stabyourself.net/notpacman/'
 

--- a/Casks/not-tetris.rb
+++ b/Casks/not-tetris.rb
@@ -3,6 +3,8 @@ cask 'not-tetris' do
   sha256 'ddb4df7f9169e1a03cb5f81e67b972cca4470e4925973af452f6e467830aaea8'
 
   url "http://stabyourself.net/dl.php?file=nottetris#{version}/nottetris#{version}-osx.zip"
+  appcast 'http://stabyourself.net/nottetris2/',
+          checkpoint: 'f84c9f10ea44b7625be3e76d7c5aedaac359f8ebd123beed0677b120f8eeb5c8'
   name 'Not Tetris'
   homepage 'http://stabyourself.net/nottetris2/'
 

--- a/Casks/ntfsmounter.rb
+++ b/Casks/ntfsmounter.rb
@@ -3,6 +3,8 @@ cask 'ntfsmounter' do
   sha256 'bfb8cfe17518513f8784f1a0389af8716b1ce319cc516cfc188de6226bbbbb4e'
 
   url "http://ntfsmounter.com/NTFS%20Mounter%20#{version}.dmg.zip"
+  appcast 'http://ntfsmounter.com/',
+          checkpoint: '617ad7431d12c751f518533b8c7b7f8b56decd2513d7f3ee49f2fa07f45739bc'
   name 'NTFS Mounter'
   homepage 'http://ntfsmounter.com/'
 

--- a/Casks/on-the-job.rb
+++ b/Casks/on-the-job.rb
@@ -4,6 +4,8 @@ cask 'on-the-job' do
 
   # stunt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://stunt.s3.amazonaws.com/onthejob_#{version}.zip"
+  appcast 'https://stuntsoftware.com/onthejob/',
+          checkpoint: '3e587991755623c8de6120bd07dae57209c6a3405044e8b90609f25d8505b471'
   name 'On The Job'
   homepage 'https://stuntsoftware.com/onthejob/'
 

--- a/Casks/yubikey-neo-manager.rb
+++ b/Casks/yubikey-neo-manager.rb
@@ -3,6 +3,8 @@ cask 'yubikey-neo-manager' do
   sha256 'b1af0f922bb8b6da285bf34bc012f48773c2529b4e128fe9a48f4ef768f70bd4'
 
   url "https://developers.yubico.com/yubikey-neo-manager/Releases/yubikey-neo-manager-#{version}-mac.pkg"
+  appcast 'https://developers.yubico.com/yubikey-neo-manager/Release_Notes.html',
+          checkpoint: '361b96775a4aa38325b8555bdb0ca0de3ea282831c5b9068b9a9f673fff29e37'
   name 'YubiKey NEO Manager'
   homepage 'https://developers.yubico.com/yubikey-neo-manager/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* nextcloud does not have a download available in github
* noejectdelay does not have a download available in github

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.