### PR TITLE
Add discovered appcasts to 10 casks #11

### DIFF
--- a/Casks/pliny.rb
+++ b/Casks/pliny.rb
@@ -3,6 +3,8 @@ cask 'pliny' do
   sha256 '1c263c181988e3cbbc110aa2802470272d7d3969cd6aa309af98b63a2680b215'
 
   url "http://pliny.cch.kcl.ac.uk/pliny-app-#{version}.tar.gz"
+  appcast 'http://pliny.cch.kcl.ac.uk/setup.html',
+          checkpoint: 'e91b521c5c361dca55ad9f0c1110cc53aa0ebe539726a06e6c2595e3cab0e88e'
   name 'Pliny'
   homepage 'http://pliny.cch.kcl.ac.uk/'
 

--- a/Casks/pngyu.rb
+++ b/Casks/pngyu.rb
@@ -3,6 +3,8 @@ cask 'pngyu' do
   sha256 'f853a3566236200391a40d12df9519b39f4d30053ab6ed6f60670b7eacca6217'
 
   url "https://nukesaq88.github.io/Pngyu/download/Pngyu_mac_#{version.no_dots}.zip"
+  appcast 'https://nukesaq88.github.io/Pngyu/',
+          checkpoint: 'ee455a313a8641564434acb35d81702d6e66be518c1bb5da1da3ec9f8eb00c26'
   name 'Pngyu'
   homepage 'https://nukesaq88.github.io/Pngyu/'
 

--- a/Casks/polycode.rb
+++ b/Casks/polycode.rb
@@ -3,6 +3,8 @@ cask 'polycode' do
   sha256 '9dfc56255fde79684376d5955142578f0ff7e36d1b59e97f58e243e27c24d698'
 
   url "http://polycode.org/download/content/PolycodeDarwin_#{version}.zip"
+  appcast 'https://github.com/ivansafrin/Polycode/releases.atom',
+          checkpoint: 'ad94328789b83f9fe37a6ff30f7ffa0b295a179511b9ca5e8651120152a00c68'
   name 'Polycode'
   homepage 'http://polycode.org/'
 

--- a/Casks/presentation.rb
+++ b/Casks/presentation.rb
@@ -3,6 +3,8 @@ cask 'presentation' do
   sha256 'ca13a2176a0d23f425c61c5d9172c160c4a0373b0080ca5d6b5e61355b31bb81'
 
   url "http://iihm.imag.fr/blanch/software/osx-presentation/releases/osx-presentation-#{version}.dmg"
+  appcast 'http://iihm.imag.fr/blanch/software/osx-presentation/',
+          checkpoint: '15e4ab5716488127d7785a7d5afa9a5e9154302080aeeade3a0649fb5ffb4765'
   name 'Présentation'
   homepage 'http://iihm.imag.fr/blanch/software/osx-presentation/'
 

--- a/Casks/profilemanager.rb
+++ b/Casks/profilemanager.rb
@@ -3,6 +3,8 @@ cask 'profilemanager' do
   sha256 'a46295851063d8a0630cace6720813e571e86a66734a8765f9706bab939b3f48'
 
   url "https://archive.mozilla.org/pub/mozilla.org/utilities/profilemanager/#{version}/profilemanager.mac.dmg"
+  appcast 'https://ftp.mozilla.org/pub/utilities/profilemanager/',
+          checkpoint: '97015dfa8a452cd44159385cf47f78683349ddd0cb0058ab129069d6796fc168'
   name 'Mozilla Profile Manager'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Profile_Manager'
 

--- a/Casks/programmer-dvorak.rb
+++ b/Casks/programmer-dvorak.rb
@@ -3,6 +3,8 @@ cask 'programmer-dvorak' do
   sha256 '36e51a0ee3ece99de99f2983e14beb415f74d9ae4726093cb60463cc206295e9'
 
   url "http://www.kaufmann.no/downloads/macos/ProgrammerDvorak-#{version.dots_to_underscores}.pkg.zip"
+  appcast 'http://kaufmann.no/roland/dvorak',
+          checkpoint: 'c08091bb0345b4376580e7ba19dd907ba78450a7180647b5b02a27c13e364a6d'
   name 'Programmer Dvorak'
   homepage 'http://kaufmann.no/roland/dvorak/'
 

--- a/Casks/protant.rb
+++ b/Casks/protant.rb
@@ -3,6 +3,8 @@ cask 'protant' do
   sha256 'db0a3b6af8034d622009fbfd0b44913c242d6e962a439610af3e0c4b64003272'
 
   url "http://www.laurenceanthony.net/software/protant/releases/ProtAnt#{version.no_dots}/ProtAnt.zip"
+  appcast 'http://www.laurenceanthony.net/software/protant/releases/',
+          checkpoint: '8e326bcde694d5f24eb20c0d1e0d7066543cf50782616b99afa3da0695daa62c'
   name 'ProtAnt'
   homepage 'http://www.laurenceanthony.net/software/protant/'
 

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -3,6 +3,8 @@ cask 'pycharm' do
   sha256 '20436a4faffe5d8251c3a41c59f0aa10548719a10f7052ccbf0ff236e5237838'
 
   url "https://download.jetbrains.com/python/pycharm-professional-#{version}.dmg"
+  appcast 'https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release',
+          checkpoint: '07878d7ff3f6c98608f0c7819c5b4ead2f1a6ac06cd57d60444f3b77e4015fab'
   name 'PyCharm'
   homepage 'https://www.jetbrains.com/pycharm/'
 

--- a/Casks/qrq.rb
+++ b/Casks/qrq.rb
@@ -3,6 +3,8 @@ cask 'qrq' do
   sha256 '76712d07f2d61b5d382c4c0c02a0c067e752c745db6b931717b3eb1e42e5076a'
 
   url "https://fkurz.net/ham/qrq/qrq-#{version}.dmg"
+  appcast 'https://fkurz.net/ham/qrq.html',
+          checkpoint: 'c36fba76c3c6323d61214e05f7bc18586f2220dda51fdb57d972ed14be62fde5'
   name 'qrq'
   homepage 'https://fkurz.net/ham/qrq.html'
 

--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -3,6 +3,8 @@ cask 'quassel' do
   sha256 'ac4e4e5f644f6fa9c1d7ed31f54060b3c676a6b327019d2e069d3172a362645d'
 
   url "http://quassel-irc.org/pub/QuasselMono_MacOSX-x86_64_#{version}.dmg"
+  appcast 'https://github.com/quassel/quassel/releases.atom',
+          checkpoint: '7a2bb5b73c8236569323678722040221cb28bd2e8a18d88a3c77bf89bb4b3b53'
   name 'Quassel IRC'
   homepage 'http://quassel-irc.org/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* polycode does not have a download available in github
* quassel does not have a download available in github

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.