### PR TITLE
Add discovered appcasts to 10 casks #12

### DIFF
--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -3,6 +3,8 @@ cask 'retro-virtual-machine' do
   sha256 '58e796a910a0f4079bd0189d92eced6b137ab55fe83ceff8e5b1fa587373031f'
 
   url "http://www.retrovirtualmachine.org/release/Retro%20Virtual%20Machine%20v#{version}.dmg"
+  appcast 'http://www.retrovirtualmachine.org/en/changelog',
+          checkpoint: 'e69d987db25ba33862ed219435d716e6e23ff8f66f3c6dfe3b476eb0b40eadc9'
   name 'Retro Virtual Machine'
   homepage 'http://www.retrovirtualmachine.org/'
 

--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -3,6 +3,8 @@ cask 'retroarch' do
   sha256 '12a9464880343a430e6bdbc330ea9f2c34628210eedbed59be1602280a915a51'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
+  appcast 'http://buildbot.libretro.com/stable/',
+          checkpoint: '1f193bd3be1c65306d7732695fd54a0077b43cb5d6997453c810848355d25b63'
   name 'RetroArch'
   homepage 'https://www.libretro.com/'
 

--- a/Casks/revisions.rb
+++ b/Casks/revisions.rb
@@ -3,6 +3,8 @@ cask 'revisions' do
   sha256 '56622f5f034fa7d5a759ce2db56635bee6382a1eb39d8154db8c724bcc416f07'
 
   url "https://revisionsapp.com/downloads/revisions-#{version}.dmg"
+  appcast 'https://revisionsapp.com/releases',
+          checkpoint: '8c3db32bb569e96b76c42df65d3aeb218cddb965d4a044c7bf9120c65c241ae3'
   name 'Revisions'
   homepage 'https://revisionsapp.com/'
 

--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -3,6 +3,8 @@ cask 'riot' do
   sha256 'd0a0717d08fe0a5f797bd079ced8894e68150f8aadb78f590d5b9bd30057666c'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
+  appcast 'https://github.com/vector-im/riot-web/releases.atom',
+          checkpoint: '41cfb0f40c28d10ae53e2f5294ee701154de518a91792d5bc3aa3d3c4ef41476'
   name 'Riot'
   homepage 'https://riot.im/'
 

--- a/Casks/riverflow.rb
+++ b/Casks/riverflow.rb
@@ -4,6 +4,8 @@ cask 'riverflow' do
 
   # amazonaws.com/sparkle-appcasts/riverflow was verified as official when first introduced to the cask
   url "https://s3-ap-northeast-1.amazonaws.com/sparkle-appcasts/riverflow/riverflow-#{version}.zip"
+  appcast 'http://questbe.at/riverflow/',
+          checkpoint: 'f31705d2fee50ef8e8bfc62ecb346f590ecfcc7d6222cdcfe4a9c4c609191325'
   name 'Riverflow'
   homepage 'http://questbe.at/riverflow/'
 

--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -3,6 +3,8 @@ cask 'robofont' do
   sha256 '923b0d7f72a4e155e86fc9afa1e657dc240662d7470f5d93162b13c2359dd936'
 
   url "http://robofont.com/downloads/RoboFont_#{version.after_comma}.dmg"
+  appcast 'http://robofont.com/downloads/',
+          checkpoint: 'a3ceaaa950defd4e2a878892b7486bfc788283d065459e1689b083911741f4eb'
   name 'RoboFont'
   homepage 'https://doc.robofont.com/'
 

--- a/Casks/rrootage.rb
+++ b/Casks/rrootage.rb
@@ -3,6 +3,8 @@ cask 'rrootage' do
   sha256 '466bec698ba02a38601e9de3e98373aea08e2f35ff7341cd0df35355cc03c134'
 
   url "https://workram.com/downloads/rRootage-for-OS-X-#{version}.dmg"
+  appcast 'https://workram.com/games/rrootage/',
+          checkpoint: '6168fdabbe02f823c92e0abe52216ecccb3d7fdbcc2815032f18b13fe516c6ff'
   name 'rRootage'
   homepage 'https://workram.com/games/rrootage/'
 

--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -3,6 +3,8 @@ cask 'screens' do
   sha256 '340fbcfee35b7eacd170e58cbcd2d9f3ca6078ef54371f245115d74c55e46ce3'
 
   url "https://download.edovia.com/screens/Screens_#{version}.zip"
+  appcast 'https://edovia.com/screens/',
+          checkpoint: 'afbc9761b0f6069adf295371727c6505eadc088aba11bec329c4af4fd25ed3f1'
   name 'Screens'
   homepage 'https://edovia.com/screens/#mac'
 

--- a/Casks/sharetool.rb
+++ b/Casks/sharetool.rb
@@ -3,6 +3,8 @@ cask 'sharetool' do
   sha256 '2990ecc1dd5f359fa25bd6c787f0efdd6b509919d00ef78c0d76fa83eef5c18e'
 
   url "https://files.bainsware.com/sharetool_#{version.no_dots}.dmg"
+  appcast 'https://www.bainsware.com/',
+          checkpoint: '53cec970caa95c1c056dd1673c981c3f644c47017eabc4d081c4975813601b9b'
   name 'ShareTool'
   homepage 'https://www.bainsware.com/'
 

--- a/Casks/shoes.rb
+++ b/Casks/shoes.rb
@@ -4,6 +4,8 @@ cask 'shoes' do
 
   # shoes.mvmanila.com/public/shoes was verified as official when first introduced to the cask
   url "https://shoes.mvmanila.com/public/shoes/shoes-#{version}-osx-10.9.tgz"
+  appcast 'http://shoesrb.com/downloads/',
+          checkpoint: '00ccd9ab19e9cab3568826ee0a0f336748dba891b10672fc050a4c1624039a14'
   name 'Shoes'
   homepage 'http://shoesrb.com/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* riot does not have a download available in github

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.