### PR TITLE
Add discovered appcasts to 10 casks #13

### DIFF
--- a/Casks/simbl.rb
+++ b/Casks/simbl.rb
@@ -13,6 +13,8 @@ cask 'simbl' do
     pkg "SIMBL-#{version}/SIMBL-#{version}.pkg"
   end
 
+  appcast 'http://www.culater.net/software/SIMBL/SIMBL.php',
+          checkpoint: 'fed90cb3904e03b0cba8d4f4869d9074e7954ce703c46404fc1a075124a4b468'
   name 'SIMBL'
   homepage 'http://www.culater.net/software/SIMBL/SIMBL.php'
 

--- a/Casks/simplesynth.rb
+++ b/Casks/simplesynth.rb
@@ -4,6 +4,8 @@ cask 'simplesynth' do
 
   # amazonaws.com/notahat was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/notahat/SimpleSynth-#{version}.zip"
+  appcast 'http://notahat.com/simplesynth/',
+          checkpoint: '3cb96e0949843a3f34dd8c0c605942cdeafc0379022684cc469174c5a0db085e'
   name 'SimpleSynth'
   homepage 'http://notahat.com/simplesynth/'
 

--- a/Casks/skyfonts.rb
+++ b/Casks/skyfonts.rb
@@ -4,6 +4,8 @@ cask 'skyfonts' do
 
   # cdn1.skyfonts.com was verified as official when first introduced to the cask
   url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
+  appcast 'https://www.fonts.com/other/skyfonts/getskyfontsclientdownloadinfo',
+          checkpoint: 'a549f8ab010f32f2f40bbcada5ac1e4097069dbfb82ce184e3e52638b5b2cdbe'
   name 'SkyFonts'
   homepage 'https://www.fonts.com/web-fonts/google'
 

--- a/Casks/softraid.rb
+++ b/Casks/softraid.rb
@@ -3,6 +3,8 @@ cask 'softraid' do
   sha256 '7060315cbb235fb029d5c3a122ef46df6d463fa8577224dc9e7b7327f6839513'
 
   url "https://softraid.com/updates/SoftRAID%20#{version}.dmg"
+  appcast 'https://www.softraid.com/updates/Latest_SoftRAID_Release.html',
+          checkpoint: '0ca79dffbd602b6c4fc129f3f57accbbd3af4042bf03903a83c4d94cdae7c312'
   name 'SoftRAID'
   homepage 'https://www.softraid.com/'
 

--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -3,6 +3,8 @@ cask 'sonic-pi' do
   sha256 'fbe9d5939d296b9ffae69432dffb6a6b1b4e06d5d89754d3c110a5cfdd5cd954'
 
   url "http://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-v#{version}.dmg"
+  appcast 'https://github.com/samaaron/sonic-pi/releases.atom',
+          checkpoint: 'de0a077ee24d16baa40620e5cabc991c2b8dcfabf71893b4d014c384a442ed9c'
   name 'Sonic Pi'
   homepage 'http://sonic-pi.net/'
 

--- a/Casks/sopcast.rb
+++ b/Casks/sopcast.rb
@@ -4,6 +4,8 @@ cask 'sopcast' do
 
   # download.sopcast.com/download was verified as official when first introduced to the cask
   url "http://download.sopcast.com/download/SopCastOSX-#{version}.zip"
+  appcast 'http://www.sopcast.org/download/mac.html',
+          checkpoint: '673096d87f25ade59b657b1b5e389b702b61440727f68db2337ab0730185def9'
   name 'SopCast'
   homepage 'http://www.sopcast.org/'
 

--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -4,6 +4,8 @@ cask 'sparkleshare' do
 
   # bitbucket.org/hbons/sparkleshare was verified as official when first introduced to the cask
   url "https://bitbucket.org/hbons/sparkleshare/downloads/sparkleshare-mac-#{version}.zip"
+  appcast 'https://github.com/hbons/SparkleShare/releases.atom',
+          checkpoint: '65e48f97e46f2c031347253bb72e60e23a4fe5ba7e9f874b536f4ddf49b994e6'
   name 'SparkleShare'
   homepage 'https://sparkleshare.org/'
 

--- a/Casks/spatterlight.rb
+++ b/Casks/spatterlight.rb
@@ -3,6 +3,8 @@ cask 'spatterlight' do
   sha256 '1729c51676f791149f4829454318f373eff43bf8d8388ecbe3b345308c669ba1'
 
   url "http://ccxvii.net/spatterlight/download/spatterlight-#{version}.zip"
+  appcast 'http://ccxvii.net/spatterlight/',
+          checkpoint: '2f5efdb5c866da041e7ae5a877a552a92baa4a08bf1704d49afcd601370527f9'
   name 'Spatterlight'
   homepage 'http://ccxvii.net/spatterlight/'
 

--- a/Casks/sputnik.rb
+++ b/Casks/sputnik.rb
@@ -3,6 +3,8 @@ cask 'sputnik' do
   sha256 'f35342dcb780647749631597990989bb55c3df03a57fd76457ddf40237fcf750'
 
   url "http://sputnik.szwacz.com/downloads/Sputnik-v#{version}.dmg"
+  appcast 'http://sputnik.szwacz.com/',
+          checkpoint: '2d8219b4370cd9fb3844a18282918b60f9d1a3132d01d28d8e4d7c2617f60869'
   name 'Sputnik'
   homepage 'http://sputnik.szwacz.com/'
 

--- a/Casks/stack-exchange-notifier.rb
+++ b/Casks/stack-exchange-notifier.rb
@@ -3,6 +3,8 @@ cask 'stack-exchange-notifier' do
   sha256 '849b543bc724e735e9a951721159b45a5284fde44c4cd8caa74c0e7eefb7e30c'
 
   url "https://hewgill.com/senotifier/stack-exchange-notifier-#{version}.dmg"
+  appcast 'https://hewgill.com/senotifier/',
+          checkpoint: '398a6bc54240d120edc773b81471ca4b58ad206a2690f7499b7b7462fae402a6'
   name 'Stack Exchange Notifier'
   homepage 'https://hewgill.com/senotifier/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* sonic-pi does not have a download available in github
* sparkleshare does not have a download available in github

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.