### PR TITLE
Add discovered appcasts to 10 casks #14

### DIFF
--- a/Casks/steermouse.rb
+++ b/Casks/steermouse.rb
@@ -3,6 +3,8 @@ cask 'steermouse' do
   sha256 '1e918e321bf33cd0f678c8730d4ebc3da281bc59fc32420201ad831c4015a701'
 
   url "http://plentycom.jp/ctrl/files_sm/SteerMouse#{version}.dmg"
+  appcast 'http://plentycom.jp/en/steermouse/download.php',
+          checkpoint: '2f5eaebe70063f0559d233c46689671634e3ad16e8aece63410795101689b917'
   name 'SteerMouse'
   homepage 'http://plentycom.jp/en/steermouse/'
 

--- a/Casks/swikauthor.rb
+++ b/Casks/swikauthor.rb
@@ -3,6 +3,8 @@ cask 'swikauthor' do
   sha256 '5a891ed920678104f5afc80c8525ddca28265635af46893774d3d91c13b988c9'
 
   url "http://media.swikshare.com/download/SwikAuthorBeta_v#{version}.dmg"
+  appcast 'http://swikshare.com/',
+          checkpoint: 'ea6f92d0460639ec716f709c86ce16e784eb9b699a1e8be47342fac23404d0d6'
   name 'SwikAuthor'
   homepage 'http://swikshare.com/'
 

--- a/Casks/tapaal.rb
+++ b/Casks/tapaal.rb
@@ -3,6 +3,8 @@ cask 'tapaal' do
   sha256 '701fb0fbe22cae05162e435c95ffbf6b1a5760947ac0a5e116f80624c8d55038'
 
   url "http://www.tapaal.net/fileadmin/download/tapaal-#{version.major_minor}/tapaal-#{version}-mac64.dmg"
+  appcast 'http://www.tapaal.net/',
+          checkpoint: '3464ec18189f3b4326a2f56e2cbb29a2d264db87331389b6bdfbc43e8561e8e5'
   name 'TAPAAL'
   homepage 'http://www.tapaal.net/'
 

--- a/Casks/td-agent.rb
+++ b/Casks/td-agent.rb
@@ -4,6 +4,8 @@ cask 'td-agent' do
 
   # packages.treasuredata.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://packages.treasuredata.com.s3.amazonaws.com/2/macosx/td-agent-#{version}.dmg"
+  appcast 'https://td-agent-package-browser.herokuapp.com/2/macosx',
+          checkpoint: '0464c337583625e3604e30bbc6434f018cb7034c200710c2dd5965a8fa18ea47'
   name 'td-agent'
   homepage 'https://www.fluentd.org/'
 

--- a/Casks/teeworlds.rb
+++ b/Casks/teeworlds.rb
@@ -3,6 +3,8 @@ cask 'teeworlds' do
   sha256 'cb638bbe6f042262c4f8c25f913209e2c4b2d96efe9a8191d4acea6988572a6c'
 
   url "https://downloads.teeworlds.com/teeworlds-#{version}-osx.dmg"
+  appcast 'https://www.teeworlds.com/?page=downloads',
+          checkpoint: 'f6bee25b48abb654d415cea3513e353e4c374594c4f2af9a15012d9ae5d02e33'
   name 'Teeworlds'
   homepage 'https://www.teeworlds.com/'
 

--- a/Casks/texmacs.rb
+++ b/Casks/texmacs.rb
@@ -3,6 +3,8 @@ cask 'texmacs' do
   sha256 '6f560861a25439a3a4e314098ed096a3416581eab90ace89c7055e2eb34f7e2e'
 
   url "http://www.texmacs.org/Download/ftp/tmftp/macos/TeXmacs-#{version}.dmg"
+  appcast 'http://www.texmacs.org/tmweb/download/macosx.en.html',
+          checkpoint: '7e207b62277a2f1777c40e2d1c2405a5cb58718ad79a1ba6424a8291207a708c'
   name 'GNU TeXmacs'
   homepage 'http://www.texmacs.org/'
 

--- a/Casks/the-cheat.rb
+++ b/Casks/the-cheat.rb
@@ -3,6 +3,8 @@ cask 'the-cheat' do
   sha256 '24ed774cc21adc2355077123d04c2657295a41183fd5555c41a2342063c3dedc'
 
   url "https://chazmcgarvey.github.com/thecheat/thecheat-#{version}.dmg"
+  appcast 'https://github.com/chazmcgarvey/thecheat/releases.atom',
+          checkpoint: 'e38cb81d6d520a74e3b1e4271faa1d469020dbf76928937adb831cf6aae71796'
   name 'The Cheat'
   homepage 'https://github.com/chazmcgarvey/thecheat'
 

--- a/Casks/thumbsup.rb
+++ b/Casks/thumbsup.rb
@@ -4,6 +4,8 @@ cask 'thumbsup' do
 
   # s3.amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/freeware/thumbsup/#{version}/ThumbsUp.app.zip"
+  appcast 'http://www.devontechnologies.com/download/thank-you-for-downloading.html?productid=900000015',
+          checkpoint: '3934c9489e06ca477bde9eb225730f5e839d8933832c6981ba92a6908e16b53f'
   name 'ThumbsUp'
   homepage 'http://www.devontechnologies.com/products/freeware.html#c966'
 

--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -4,6 +4,8 @@ cask 'tifig' do
 
   # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"
+  appcast 'https://www.tifig.net/download/',
+          checkpoint: '5aade911f27a689391d5114b59a5c1a0d0cb42566fe916629728f405852d6b4f'
   name 'Tifig'
   homepage 'https://www.tifig.net/'
 

--- a/Casks/tigervnc-viewer.rb
+++ b/Casks/tigervnc-viewer.rb
@@ -4,6 +4,8 @@ cask 'tigervnc-viewer' do
 
   # bintray.com/tigervnc was verified as official when first introduced to the cask
   url "https://bintray.com/tigervnc/stable/download_file?file_path=TigerVNC-#{version}.dmg"
+  appcast 'https://github.com/TigerVNC/tigervnc/releases.atom',
+          checkpoint: '9a34d5ffb8a56e0fe4bb6101594b70775ca1749ce9ae03523c8a29cf2303bbac'
   name 'TigerVNC'
   homepage 'http://tigervnc.org/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* the-cheat does not have a download available in github
* tigervnc-viewer does not have a download available in github

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.