### PR TITLE
Add discovered appcasts to 10 casks #15

### DIFF
--- a/Casks/torustrooper.rb
+++ b/Casks/torustrooper.rb
@@ -3,6 +3,8 @@ cask 'torustrooper' do
   sha256 '39b188107620c58f4a60f2f24d01f39ab87d46655203f4bcfe97d3a6fa5b7b3e'
 
   url "https://workram.com/downloads/TorusTrooper-for-OS-X-#{version}.dmg"
+  appcast 'https://workram.com/games/',
+          checkpoint: '0099c96dfbcf566c5b80dee384bb73e788bb00042bcf33803c9aeb651f0603f4'
   name 'Torus Trooper'
   homepage 'https://workram.com/games/'
 

--- a/Casks/trenchbroom.rb
+++ b/Casks/trenchbroom.rb
@@ -2,7 +2,9 @@ cask 'trenchbroom' do
   version '1.1.6_2759'
   sha256 '92eeb77b0a4b3be21421120d78e5996ff6d2e3f8c41afac6cbd8185f5798c67a'
 
-  url "http://kristianduske.com/trenchbroom/downloads/mac/TrenchBroom_Mac_#{version}.zip"
+  url "http://kristianduske.com/trenchbroom/downloads/macosx/stable/TrenchBroom_Mac_#{version}.zip"
+  appcast 'http://kristianduske.com/trenchbroom/downloads.php?platform=macosx',
+          checkpoint: '6210328d2de8336ad34e088d64f927a86e0db81655865ed9507bcfe5e8ae1b78'
   name 'TrenchBroom'
   homepage 'http://kristianduske.com/trenchbroom/'
 

--- a/Casks/ultimate-control.rb
+++ b/Casks/ultimate-control.rb
@@ -3,6 +3,8 @@ cask 'ultimate-control' do
   sha256 '8f26885d60c2afc502d97039c115f6bfcd22cee34ec9741017bc4d73bc3e5498'
 
   url "http://www.negusoft.com/downloads/ultimate_control_v#{version}_mac.dmg"
+  appcast 'http://www.negusoft.com/index.php/ultimate-control/downloads',
+          checkpoint: 'ea801f8d4087e94818cb165feef2d63127b349b7b0c59d9a648bbd04007a8527'
   name 'NEGU Soft Ultimate Control'
   homepage 'http://www.negusoft.com/index.php/ultimate-control'
 

--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -4,6 +4,8 @@ cask 'unetbootin' do
 
   # launchpad.net/unetbootin was verified as official when first introduced to the cask
   url "http://launchpad.net/unetbootin/trunk/#{version}/+download/unetbootin-mac-#{version}.dmg"
+  appcast 'https://github.com/unetbootin/unetbootin/releases.atom',
+          checkpoint: 'f9e92d09e934f9ed61ac373f7ec4a9659f8917dbe5370964185bf9a88c31ca86'
   name 'UNetbootin'
   homepage 'https://unetbootin.github.io/'
 

--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -9,10 +9,12 @@ cask 'unison' do
     version '2.48.15'
     sha256 '89894d14c9ff3c4d6195cb6a8065a2849e6ad55951799eedf8879e1a257d3e11'
 
-    # unison-binaries.inria.fr was verified as official when first introduced to the cask
-    url "http://unison-binaries.inria.fr/files/Unison-OS-X-#{version}.zip"
+    # github.com/bcpierce00/unison/releases/download was verified as official when first introduced to the cask
+    url "https://github.com/bcpierce00/unison/releases/download/#{version}/Unison-OS-X-#{version}.zip"
   end
 
+  appcast 'https://github.com/bcpierce00/unison/releases.atom',
+          checkpoint: '03df713ad77a41b0df51dea0474894d2dfa7dc55a63474735497bde71509e763'
   name 'Panic Unison'
   homepage 'https://www.cis.upenn.edu/~bcpierce/unison/'
 

--- a/Casks/universalmailer.rb
+++ b/Casks/universalmailer.rb
@@ -14,6 +14,8 @@ cask 'universalmailer' do
   end
 
   url "https://universalmailer.github.io/UniversalMailer/zips/UniversalMailer-v#{version.dots_to_underscores}.zip"
+  appcast 'https://universalmailer.github.io/UniversalMailer/download.html',
+          checkpoint: 'a4d338f1cb40ec31ba9ea26438d289f41cbdb84333a6f351b037ec620c4c46d0'
   name 'Universal Mailer'
   homepage 'https://universalmailer.github.io/UniversalMailer/'
 

--- a/Casks/viewit.rb
+++ b/Casks/viewit.rb
@@ -3,6 +3,8 @@ cask 'viewit' do
   sha256 '478d052bd9b7ad0e83fd61765b5ee097e143da37769efdd856b582b26c26d5b8'
 
   url "http://www.hexcat.com/downloads/ViewIt-#{version}.zip"
+  appcast 'http://www.hexcat.com/downloads.html',
+          checkpoint: '1094126ca908c7c2241a7d2da093d53ee7d05eb8c067b9f9fd92ef679d8ce486'
   name 'ViewIt'
   homepage 'http://www.hexcat.com/viewit/'
 

--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -4,6 +4,8 @@ cask 'visit' do
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
   url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
+  appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables',
+          checkpoint: '732a92915a20a1edc31798b8b5a775761716a8665f28684b83ff517dedb9ad41'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
 

--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -3,6 +3,8 @@ cask 'vuescan' do
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
+  appcast 'https://www.hamrick.com/old-versions.html',
+          checkpoint: 'd6e88549f481993c8bfe21a551c5a19e7d6fe83a7a0b5010ee5b3ff99ef49ca4'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 

--- a/Casks/wakeonlan.rb
+++ b/Casks/wakeonlan.rb
@@ -3,6 +3,8 @@ cask 'wakeonlan' do
   sha256 '00d86efd23e9d5de5451e26d6957f3af1a1a3bc66d11c50b8563454113fd5ab1'
 
   url "https://www.readpixel.com/downloads/files/WakeOnLan#{version}.zip"
+  appcast 'https://www.readpixel.com/wakeonlan/',
+          checkpoint: '071297f366dc484ab49cf01dfb531881f98fd404aebbb4a25e7956234a1b0be4'
   name 'WakeOnLan'
   homepage 'https://www.readpixel.com/wakeonlan/'
 


### PR DESCRIPTION
Adding discovered appcasts in lots of 10, as noted on #28873 

All appcast checkpoints have returned the same stable checksum for at least the last week

* unetbootin does not have a download available in github

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.