### PR TITLE
Update gpgtools.rb

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -26,9 +26,10 @@ cask 'gpgtools' do
 
   uninstall_postflight do
     system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
-    system_command '/bin/bash', args: ['-c', '[[ -f /usr/local/bin/gpg2      ]] && [[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg2']
-    system_command '/bin/bash', args: ['-c', '[[ -f /usr/local/bin/gpg       ]] && [[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg']
-    system_command '/bin/bash', args: ['-c', '[[ -f /usr/local/bin/gpg-agent ]] && [[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg-agent']
+
+    %w(gpg gpg2 gpg-agent).map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
+      File.rm(exec) if (File.exist?(exec) && File.readlink(exec))
+    end
   end
 
   uninstall script:    {

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -28,8 +28,8 @@ cask 'gpgtools' do
     # TODO: add kill to uninstall quit
     system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
 
-    %w(gpg gpg2 gpg-agent).map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
-      File.rm(exec) if (File.exist?(exec) && File.readlink(exec).include?('MacGPG2'))
+    %w[gpg gpg2 gpg-agent].map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
+      File.rm(exec) if File.exist?(exec) && File.readlink(exec).include?('MacGPG2')
     end
   end
 

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -25,6 +25,7 @@ cask 'gpgtools' do
   end
 
   uninstall_postflight do
+    # TODO: add kill to uninstall quit
     system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
 
     %w(gpg gpg2 gpg-agent).map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
@@ -35,7 +36,7 @@ cask 'gpgtools' do
   uninstall script:    {
                          executable: "#{staged_path}/Uninstall.app/Contents/Resources/GPG Suite Uninstaller.app/Contents/Resources/uninstall.sh",
                          sudo:       true,
-                       }
+                       },
             pkgutil:   'org.gpgtools.*',
             quit:      [
                          'com.apple.mail',

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -26,13 +26,16 @@ cask 'gpgtools' do
 
   uninstall_postflight do
     system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
-
-    %w(gpg gpg2 gpg-agent).map { |exec| "/usr/local/bin/#{exec}" }.each do |exec_location|
-      system_command '/bin/bash', args: ['-c', "[[ $(/usr/bin/readlink #{exec_location})      =~ MacGPG2 ]] && /bin/rm -f #{exec_location}"] if File.exist?(exec_location)
-    end
+    system_command '/bin/bash', args: ['-c', '[[ -f /usr/local/bin/gpg2      ]] && [[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg2']
+    system_command '/bin/bash', args: ['-c', '[[ -f /usr/local/bin/gpg       ]] && [[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg']
+    system_command '/bin/bash', args: ['-c', '[[ -f /usr/local/bin/gpg-agent ]] && [[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg-agent']
   end
 
-  uninstall pkgutil:   'org.gpgtools.*',
+  uninstall script:    {
+                         executable: "#{staged_path}/Uninstall.app/Contents/Resources/GPG Suite Uninstaller.app/Contents/Resources/uninstall.sh",
+                         sudo:       true,
+                       }
+            pkgutil:   'org.gpgtools.*',
             quit:      [
                          'com.apple.mail',
                          'org.gpgtools.gpgkeychainaccess',

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -26,9 +26,10 @@ cask 'gpgtools' do
 
   uninstall_postflight do
     system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
-    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg2']
-    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg']
-    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg-agent']
+
+    %w(gpg gpg2 gpg-agent).map { |exec| "/usr/local/bin/#{exec}" }.each do |exec_location|
+      system_command '/bin/bash', args: ['-c', "[[ $(/usr/bin/readlink #{exec_location})      =~ MacGPG2 ]] && /bin/rm -f #{exec_location}"] if File.exist?(exec_location)
+    end
   end
 
   uninstall pkgutil:   'org.gpgtools.*',

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -28,7 +28,7 @@ cask 'gpgtools' do
     system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
 
     %w(gpg gpg2 gpg-agent).map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
-      File.rm(exec) if (File.exist?(exec) && File.readlink(exec))
+      File.rm(exec) if (File.exist?(exec) && File.readlink(exec).include?('MacGPG2'))
     end
   end
 

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -25,39 +25,52 @@ cask 'gpgtools' do
   end
 
   uninstall_postflight do
-    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm -- /usr/local/bin/gpg2']
-    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm -- /usr/local/bin/gpg']
-    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm -- /usr/local/bin/gpg-agent']
+    system_command '/usr/bin/killall', args: ['-kill', 'gpg-agent']
+    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg2)"      =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg2']
+    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg)"       =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg']
+    system_command '/bin/bash', args: ['-c', '[[ "$(/usr/bin/readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && /bin/rm -f /usr/local/bin/gpg-agent']
   end
 
   uninstall pkgutil:   'org.gpgtools.*',
             quit:      [
                          'com.apple.mail',
                          'org.gpgtools.gpgkeychainaccess',
+                         'org.gpgtools.gpgkeychain',
                          'org.gpgtools.gpgservices',
                        ],
             launchctl: [
-                         'org.gpgtools.macgpg2.shutdown-gpg-agent',
                          'org.gpgtools.Libmacgpg.xpc',
-                         'org.gpgtools.gpgmail.enable-bundles',
-                         'org.gpgtools.gpgmail.user-uuid-patcher',
-                         'org.gpgtools.gpgmail.uuid-patcher',
+                         'org.gpgtools.gpgmail.patch-uuid-user',
                          'org.gpgtools.macgpg2.fix',
+                         'org.gpgtools.macgpg2.shutdown-gpg-agent',
                          'org.gpgtools.macgpg2.updater',
+                         'org.gpgtools.macgpg2.gpg-agent',
                        ],
             delete:    [
-                         '/Applications/GPG Keychain Access.app',
-                         '/Applications/GPG Keychain.app',
-                         '/usr/local/MacGPG2',
                          '/Library/Services/GPGServices.service',
                          '/Library/Mail/Bundles/GPGMail.mailbundle',
+                         '/Network/Library/Mail/Bundles/GPGMail.mailbundle',
+                         '/usr/local/MacGPG2',
+                         '/private/etc/paths.d/MacGPG2',
+                         '/private/etc/manpaths.d/MacGPG2',
+                         '/private/tmp/gpg-agent',
                          '/Library/PreferencePanes/GPGPreferences.prefPane',
+                         '/Applications/GPG Keychain Access.app',
+                         '/Applications/GPG Keychain.app',
+                         '/Library/Application Support/GPGTools',
+                         '/Library/Frameworks/Libmacgpg.framework',
                        ]
 
   zap delete: [
                 '~/Library/Services/GPGServices.service',
                 '~/Library/Mail/Bundles/GPGMail.mailbundle',
                 '~/Library/PreferencePanes/GPGPreferences.prefPane',
+                '~/Library/LaunchAgents/org.gpgtools.*',
+                '~/Library/Preferences/org.gpgtools.*',
+                '~/Library/Containers/com.apple.mail/Data/Library/Preferences/org.gpgtools.*',
+                '~/Library/Application Support/GPGTools',
+                '~/Library/Frameworks/Libmacgpg.framework',
+                '~/Containers/com.apple.mail/Data/Library/Frameworks/Libmacgpg.framework',
                 # TODO: expand/glob for ~/Library/Caches/org.gpgtools.gpg*
               ]
 


### PR DESCRIPTION
Closes https://github.com/caskroom/homebrew-cask/issues/28911.

I cannot test this, as I have `gpg` already installed via `brew`.

There is an `uninstall.sh` buried inside the `dmg` (I do not know why this is not used?), and these are the lines of the script I am attempting to reproduce:
```
***SNIP***

function rmv () {
	rm -f "$@"
}

***SNIP***

killall -kill gpg-agent

***SNIP***

[[ "$(readlink /usr/local/bin/gpg2)" =~ MacGPG2 ]] && rmv /usr/local/bin/gpg2
[[ "$(readlink /usr/local/bin/gpg)" =~ MacGPG2 ]] && rmv /usr/local/bin/gpg
[[ "$(readlink /usr/local/bin/gpg-agent)" =~ MacGPG2 ]] && rmv /usr/local/bin/gpg-agent

***SNIP***
```