### PR TITLE
Update context-free to 3.0.10

### DIFF
--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -1,8 +1,10 @@
 cask 'context-free' do
-  version '3.0.9'
-  sha256 '718719843a72f16f2e0706091141da0ce0f7c42afafb7564ca0551e5784a116a'
+  version '3.0.10'
+  sha256 '43fc99a9558393a726a04846eedca662d8c1cede68eddcb8aa91f7ee31bfa042'
 
   url "http://www.contextfreeart.org/download/ContextFree#{version}.dmg"
+  appcast 'https://github.com/MtnViewJohn/context-free/releases.atom',
+          checkpoint: '6c63e170204834cb906592d5591cfc70b88ff45532c9b20de315bf028aeb28b8'
   name 'Context Free'
   homepage 'https://www.contextfreeart.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.