### PR TITLE
Add Papyrus.app v1.0

### DIFF
--- a/Casks/db-papyrus.rb
+++ b/Casks/db-papyrus.rb
@@ -1,0 +1,12 @@
+cask 'db-papyrus' do
+  version '1.0.0'
+  sha256 'cd88cd942504aa676879d86ba7c435ba8250db05525f0482a0c3812d069abf21'
+
+  url "https://github.com/morkro/papyrus/releases/download/#{version}/Papyrus-osx-#{version}.zip"
+  appcast 'https://github.com/morkro/papyrus/releases.atom',
+          checkpoint: '8c12e03261b6509c4f1c3269fa0ab07324095c829f7cff3cc309b77c60ecc0a8'
+  name 'Papyrus'
+  homepage 'https://github.com/morkro/papyrus'
+
+  app 'Papyrus.app'
+end

--- a/Casks/morkro-papyrus.rb
+++ b/Casks/morkro-papyrus.rb
@@ -1,4 +1,4 @@
-cask 'db-papyrus' do
+cask 'morkro-papyrus' do
   version '1.0.0'
   sha256 'cd88cd942504aa676879d86ba7c435ba8250db05525f0482a0c3812d069abf21'
 


### PR DESCRIPTION
Added the unofficial Dropbox Paper desktop app "Papyrus"

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download morkro-papyrus` is error-free.
- [x] `brew cask style --fix morkro-papyrus` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install morkro-papyrus` worked successfully.
- [x] `brew cask uninstall morkro-papyrus` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
