### PR TITLE
Fix Little Flocker 1.4.5 hash

### DIFF
--- a/Casks/little-flocker.rb
+++ b/Casks/little-flocker.rb
@@ -1,6 +1,6 @@
 cask 'little-flocker' do
   version '1.4.5'
-  sha256 '3a64a2e287eedb631d374ca5478f10a8379715dca4aa7956d80a8ebf79f2c09f'
+  sha256 '309cb8dfdbdf1ee8a0498a351926629b6128b099b4a20d3ecdca50bb5b71859e'
 
   url "https://www.littleflocker.com/downloads/LittleFlocker-#{version}.dmg"
   name 'Little Flocker'


### PR DESCRIPTION
After the change in #28941 I'm getting a sha256 mismatch. Maybe Little Flocker re-released with the same version number?

```
$ brew update && brew cask install little-flocker >/dev/null
Error: sha256 mismatch
Expected: 3a64a2e287eedb631d374ca5478f10a8379715dca4aa7956d80a8ebf79f2c09f
Actual: 309cb8dfdbdf1ee8a0498a351926629b6128b099b4a20d3ecdca50bb5b71859e
File: /Users/rick/Library/Caches/Homebrew/Cask/little-flocker--1.4.5.dmg
To retry an incomplete download, remove the file above.
```

The "Actual" checksum above does seem correct:

```
$ curl -s https://www.littleflocker.com/downloads/LittleFlocker-1.4.5.dmg | shasum -a 256
309cb8dfdbdf1ee8a0498a351926629b6128b099b4a20d3ecdca50bb5b71859e  -
```