### PR TITLE
Update astropad to 2.1.2

### DIFF
--- a/Casks/astropad.rb
+++ b/Casks/astropad.rb
@@ -1,10 +1,10 @@
 cask 'astropad' do
-  version '2.1'
-  sha256 'a021745e3d0630c3c05641be06b6e7b1fa2f527d0507ae5bcdd2b5e4f14f02af'
+  version '2.1.2'
+  sha256 'ae370241b8d4b2f66f935599be990e26ed61ed8ba55cd4e85720446cbcf30f50'
 
   url "http://astropad.com/downloads/Astropad-#{version}.zip"
   appcast 'http://astropad.com/downloads/sparkle.xml',
-          checkpoint: '8cf1d5f9491a234ba342e1dd162f9e427a581f93d38ae00950cb323d4daa14e0'
+          checkpoint: '45857cba40f2b4a8dae4d01317a887974150d4fc3087826e11433e24be5c8045'
   name 'Astropad'
   homepage 'http://astropad.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.