### PR TITLE
Add Opera Neon, first release

### DIFF
--- a/Casks/opera-neon.rb
+++ b/Casks/opera-neon.rb
@@ -8,6 +8,8 @@ cask 'opera-neon' do
 
   app 'Opera Neon.app'
 
-  zap delete: '~/Library/Application Support/Opera Neon'
-  zap delete: '~/Library/Caches/Opera Neon'
+  zap delete: [
+                '~/Library/Application Support/Opera Neon',
+                '~/Library/Caches/Opera Neon',
+              ]
 end

--- a/Casks/opera-neon.rb
+++ b/Casks/opera-neon.rb
@@ -1,0 +1,13 @@
+cask 'opera-neon' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://get.geo.opera.com/.private/OperaNeon.dmg'
+  name 'Opera Neon'
+  homepage 'http://www.opera.com/computer/neon'
+
+  app 'Opera Neon.app'
+
+  zap delete: '~/Library/Application Support/Opera Neon'
+  zap delete: '~/Library/Caches/Opera Neon'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. Caveat: Opera Neon doesn't seem to be versioned explicitly, so in the commit version, I just noted "first release"

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
