### PR TITLE
Update aws-vault to 3.6.1

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,10 +1,10 @@
 cask 'aws-vault' do
-  version '3.6.0'
-  sha256 'aead4c87af8eb13fe9a28ba955d77760b774176f1b286dd5c4a94ebda7a071c3'
+  version '3.6.1'
+  sha256 'bc2ee3e8fb0a2c22af45daa5b9ab92fe5557821547de092eef198e52ba0974c7'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64"
   appcast 'https://github.com/99designs/aws-vault/releases.atom',
-          checkpoint: '72632fdb5d8302f33360e4d3dd65c0255679be1fc53e0a59f1d812a24ce3c988'
+          checkpoint: '5661f088104d39db0b333c124a5195b4eaaf111cd175fee6c8720a98e4027aa1'
   name 'aws-vault'
   homepage 'https://github.com/99designs/aws-vault'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
