### PR TITLE
Update shotcut to 17.01.02

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '16.12.03'
-  sha256 '66afc1d321a4cfd457fbd6865734dfe792812f6356a62de77652d065b69db49f'
+  version '17.01.02'
+  sha256 '4dac35b32a3fdcfd3fdf9da50a4e6e6d974a5044b36859b9781a43f7876fdf51'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '87fe8c9a9ef4ef95357132b66912e869649c59e54e1dd2cca1db72afd5746920'
+          checkpoint: 'b6678c8dbe8af2c5394e1a6cbb55fd5a9651e6053bc6e9bf73d89deeee212c5c'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

`checkpoint:` will likely fail. That is normal.