### PR TITLE
update sha for yakyak

### DIFF
--- a/Casks/yakyak.rb
+++ b/Casks/yakyak.rb
@@ -1,10 +1,10 @@
 cask 'yakyak' do
   version '1.4.1'
-  sha256 '84ea0423d7262df947a3ae9162c75ba7f0d5d5451fd05e6e13bd8c921c76bacb'
+  sha256 '8a65fbb2b15d9805341571a2d7aed60f68e2839932b77706fb6363b9bfc1c5e9'
 
   url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx.zip"
   appcast 'https://github.com/yakyak/yakyak/releases.atom',
-          checkpoint: 'fc6fcc04a790d974a656ebc58e4d232f16401ae6a9307e5703627468aad5bf3f'
+          checkpoint: 'e6b4c60c3e7bc88c55862e05282c35444e42e003d2e912372fb6d0ff3e69685a'
   name 'Yakyak'
   homepage 'https://github.com/yakyak/yakyak'
 


### PR DESCRIPTION
The released project binaries were wrongly updated and the `sha` changed.
This is the correct one as stated in https://github.com/yakyak/yakyak/issues/550.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.