### PR TITLE
Fix checksum in Adguard.app

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -1,10 +1,10 @@
 cask 'adguard' do
   version '1.4.0'
-  sha256 'e8b0d47830b99d93412f09adee3d2396edb94b853e7a9ba25b1e8084a62a8ae7'
+  sha256 '549f8a7f4f773bd04bb9c2f16a3817b7cb4b6acc4beab06aa6f930cd0797df28'
 
   url "https://static.adguard.com/mac/Adguard-#{version}.release.dmg"
   appcast 'https://static.adguard.com/mac/adguard-release-appcast.xml',
-          checkpoint: '870fe28eba690c9b515da276db3aa6c0cd455ed91699ec3899a322de829cf1cf'
+          checkpoint: '836f3f1161afdb22704e79aa54aa4930a56036b494cc8579a1ed041522fff864'
   name 'Adguard for Mac'
   homepage 'https://adguard.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.