### PR TITLE
Update glyphish-color-changer to 1.0-beta.3

### DIFF
--- a/Casks/glyphish-color-changer.rb
+++ b/Casks/glyphish-color-changer.rb
@@ -1,8 +1,8 @@
 cask 'glyphish-color-changer' do
-  version '1.0-beta.2'
-  sha256 '2fe6d7b5b056a67ca69c4f5cf477bc0c9ecf47a8d7aa95eefcb97c0fde0e75d8'
+  version '1.0-beta.3'
+  sha256 '4f6f7b4b3040c4caeda717393f2945ed6c844cbcd48b67f2c41269d27d676361'
 
-  url "https://github.com/glyphish/color-changer/releases/download/v#{version}/#{version}.zip"
+  url "https://github.com/glyphish/color-changer/releases/download/v#{version}/v#{version}.zip"
   appcast 'https://github.com/glyphish/color-changer/releases.atom',
           checkpoint: 'ae9964f5d451cb548f65709fb622e85d731a95ec1f4c47ac753472da98ebe7b5'
   name 'Glyphish Color Changer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.