### PR TITLE
Update gns3 to 1.5.3

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '1.5.2'
-  sha256 'a6ef73ba5e018fb22ed88fc07d71597b993878d3cb88ba8f334226ddf23e2d16'
+  version '1.5.3'
+  sha256 '5c5498883a626563f50c7da7bf7ed7232d1937373bc6f2592a4cdd106505d926'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: '38d57e50a965264786265131c4fee2d397a31db5bbd51f9ed8188805d5b324f2'
+          checkpoint: '0de7220e36db7890c7a778248dac66c1fca4835387d2a28273cd698f2c180b69'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.