### PR TITLE
Update grip to 1.5.1

### DIFF
--- a/Casks/grip.rb
+++ b/Casks/grip.rb
@@ -1,11 +1,11 @@
 cask 'grip' do
-  version '1.5.0'
-  sha256 '1b0e6f3e1d1b926ece83c47cfe3de99b4afbc60b7199893b35eba387e5e455b0'
+  version '1.5.1'
+  sha256 '1d0b1d21bfd5093c95ec63e42b71ed31eb0856c25b0c42d396a3682858da60b4'
 
   # github.com/WPIRoboticsProjects/GRIP was verified as official when first introduced to the cask
-  url "https://github.com/WPIRoboticsProjects/GRIP/releases/download/v#{version}/GRIP-#{version}-x64.dmg"
+  url "https://github.com/WPIRoboticsProjects/GRIP/releases/download/v#{version}/GRIP-v#{version}-x64.dmg"
   appcast 'https://github.com/WPIRoboticsProjects/GRIP/releases.atom',
-          checkpoint: '389751add1d0b6c8b07ea09e9b193e7651868049952113f502414dabfeda55ce'
+          checkpoint: '0240da58588de81cf34de5f6f3960f9223d8f3d307ab5b78d0818e374cf75220'
   name 'GRIP Computer Vision Engine'
   name 'GRIP'
   homepage 'https://wpiroboticsprojects.github.io/GRIP/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.