### PR TITLE
Update gzdoom to 2.3.2

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,11 +1,11 @@
 cask 'gzdoom' do
-  version '2.3.1'
-  sha256 '5a58e49e9622d1ac6324b53c76c363bbd7a166965f4c4c4c4b0b7e2bc3819c21'
+  version '2.3.2'
+  sha256 'b1db121cf75c1a6f9d56b30c66ed7e61681f7358cc101fb37ed0eba7beaca27b'
 
   # github.com/coelckers was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom',
-          checkpoint: '672a5c9806126bfa8290ea4263f779b15678937074c735face96d5b1c6e49342'
+          checkpoint: 'a2b1a64ae7baad8671873448933e9cf7eafed7d0a62e4b96dd4371e21f709035'
   name 'gzdoom'
   homepage 'https://gzdoom.drdteam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.