### PR TITLE
Update mailbutler to 6720

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6648'
-  sha256 '73599a7633e29477620749be6ba67e1ce0d2a70f11933caf212b0c07683a8f40'
+  version '6720'
+  sha256 '149f213d43f0810911b9e8a33cabbe9dce117f99e450c8200b030b0f5fb9aa8b'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: 'af50efdb68f342b65caf8f0136e7e11c5f40a22c4b366f8500ed533adb059bcd'
+          checkpoint: '7a6b9b12c076d5e07fd26ce67417be49f0b7ef8dad2f8f60991dd41e1086ff6d'
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.