### PR TITLE
Update metabase-app to 0.22.0.0

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,10 +1,10 @@
 cask 'metabase-app' do
-  version '0.21.1.0'
-  sha256 'fdb7af70bfdf6a23a37397bd767efcb58a307f66f5251405eb09428e7c28fa54'
+  version '0.22.0.0'
+  sha256 '4f84ba4ce30abd11ba8f5d74295a1e1fd432fe2bae59d3d9429d0f4e4d930f6c'
 
   url "http://downloads.metabase.com/v#{version.major_minor_patch}/Metabase.dmg"
   appcast 'http://downloads.metabase.com/appcast.xml',
-          checkpoint: '88160499b40e01d174b0c98b641d50603ead9daf1b0268e75c0dcfe16dc2fbed'
+          checkpoint: '9fc5043facfe18b6e7f79a1f95b51a04e8891db8c6d5acbf28fa4adb0730362d'
   name 'Metabase'
   homepage 'http://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.