### PR TITLE
Update sqleditor to 3.1.6

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,10 +1,10 @@
 cask 'sqleditor' do
-  version '3.1.5'
-  sha256 'cdad154b848b964961dc91aa904b6148db158793cb0e939465cf62f2648c20ad'
+  version '3.1.6'
+  sha256 'e1e937818ec956e9835704a911aedd526d7c6e97dd118c0872353a5364608898'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml',
-          checkpoint: '3f980b1d7aa0db76040ea0354595a571a1256456e9b253d4a1aed090da2ebb99'
+          checkpoint: '1b4cfc7a5d073c659e3f7b10308bda31456b43c10008169d330585c43fb50c24'
   name 'SQLEditor'
   homepage 'https://www.malcolmhardie.com/sqleditor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.