### PR TITLE
Update iridient-developer to 3.1.3

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.1.2'
-  sha256 '740aa73096d8729dcd0b457b6b76f5f8056347a3f8104112999283814a5bddc1'
+  version '3.1.3'
+  sha256 '7b28bfad2541e32b497a8816d489099189ec9b24dc9bfafa958ccd0cfbfb6208'
 
   url "http://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   name 'Iridient Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.