### PR TITLE
Change PL2303 driver download url

### DIFF
--- a/Casks/pl2303.rb
+++ b/Casks/pl2303.rb
@@ -2,9 +2,9 @@ cask 'pl2303' do
   version '1.6.1_20160309'
   sha256 '14868e4a3c38904760d3445c37bbb5ca2f1024498547645147abbabfcb52eb87'
 
-  url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
+  url "http://prolificusa.com/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
   name 'Prolific USB-Serial Cable driver'
-  homepage 'http://www.prolific.com.tw/'
+  homepage 'http://prolificusa.com/'
 
   pkg "PL2303_MacOSX_#{version}.pkg"
 

--- a/Casks/pl2303.rb
+++ b/Casks/pl2303.rb
@@ -2,7 +2,7 @@ cask 'pl2303' do
   version '1.6.1_20160309'
   sha256 '14868e4a3c38904760d3445c37bbb5ca2f1024498547645147abbabfcb52eb87'
 
-  url "http://prolificusa.com/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
+  url "http://prolificusa.com/files/PL2303_MacOSX_#{version}.zip"
   name 'Prolific USB-Serial Cable driver'
   homepage 'http://prolificusa.com/'
 


### PR DESCRIPTION
The Download URL change. Prolific change web site.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
