### PR TITLE
Update carbon-copy-cloner to 4.1.13.4496

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.12.4485'
-  sha256 '7f3aec364bbe77a166207523d40d313fcf37133df6202e629efac19e2ab46395'
+  version '4.1.13.4496'
+  sha256 'bdebeb3f168eb8ca793e2cd635609a9054af6c68c6952e0813b398a3100482c9'
 
   url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
   appcast "https://bombich.com/software/updates/ccc.php?os_minor=11&os_bugfix=#{version.major}&ccc=#{version.after_comma}&beta=0&locale=en",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.