### PR TITLE
upgrade filezilla to 3.24.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.23.0.2'
-    sha256 '18f9d4fe2441e6592559c11e62d442cea361ca9147be159b0cd73eb0573da61e'
+    version '3.24.0'
+    sha256 '6f57b0c91d0f20d545cd854855d35dcb1b088bc9e2c73cfaca4984bda93df5a9'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '55571dc40e4fb3b21b8f3f0ecba1f225208cc7774b7c42b256782bdb5a08b869'
+          checkpoint: '4b4bb69191e36ac2e2f36d306840e496435f345683d74bf348c9ef95ce818f3e'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
upgrade filezilla to 3.24.0 

---

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
