### PR TITLE
Update djview to 4.10.6

### DIFF
--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -1,10 +1,10 @@
 cask 'djview' do
   version '4.10.6'
-  sha256 '9b98acbd420eb10b3020b5d6e4ce144fe214461103a263c1d900f61797e92ef8'
+  sha256 '4585c41e9e856af702ab50ac345128e98aedc581d0d0c29ea8e7dac1ed0e7792'
 
-  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-intel64.dmg"
+  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-qt57-intel64.dmg"
   appcast 'https://sourceforge.net/projects/djvu/rss',
-          checkpoint: 'cf1aa92be5131c0e7c88841c5d3102a60f9d2ee4e6bb2cf6c858afa273068339'
+          checkpoint: '7cc16abf82300f400f18f9658f43280a5fc6c048797b0fba207b08ccb485202a'
   name 'DjView'
   homepage 'http://djvu.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.