### PR TITLE
Update boostnote to 0.8.2

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.1'
-  sha256 'd9395bee5f703433bbd55fcb4e46473608bf08145918ea55fe57b712954ef41a'
+  version '0.8.2'
+  sha256 'a0eeddc8a16f43d31038e7f9261ae3cbef3b2acf19e5d2e3c9a1fd33f38f8093'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: 'e46d886c64463822339c3d0a066ab88bd7a3e254f59c89bdf08bd3a337080ad5'
+          checkpoint: 'ed6319b0ee6d7d3e121f8475c9cb77f406fd791f7a21055886e8933350feceef'
   name 'Boostnote'
   homepage 'https://b00st.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.