### PR TITLE
Update copyq to 2.8.2

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -1,11 +1,11 @@
 cask 'copyq' do
-  version '2.8.1'
-  sha256 'f599b647bdb39933697b3c989b64bb2433f8a64375a28cb45f7bdde38038fc83'
+  version '2.8.2'
+  sha256 '050dd898ffb2c68aad3d9a7163dd0b79ec126bded13249a69236985b69d01699'
 
   # github.com/hluk/CopyQ was verified as official when first introduced to the cask
   url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ.dmg"
   appcast 'https://github.com/hluk/CopyQ/releases.atom',
-          checkpoint: '59782e9ffbd154df25164c86833ebb4f287f3c0b4d5baf96acf35f84a5557843'
+          checkpoint: '2bca0baf7bb9ede52cd8ceb271fea4937043ca427aed43c8378fbc3852a51cd7'
   name 'CopyQ'
   homepage 'https://hluk.github.io/CopyQ/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.