### PR TITLE
Update dripcap to 0.6.0

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.5.6'
-  sha256 '294a6e17d84e1a1582bca17a2081fbfa8909722d02840cf783520ce2cde1c1c8'
+  version '0.6.0'
+  sha256 'f37e59dae325e3637ab6d2695860ce3b45961ae7ca01a46246d1428ef2ef006c'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '3fe41f8370c15299f79434db286740a84828fa0eae0f921f6220bc40713c16b0'
+          checkpoint: '2dd390aae4a7baff3c7464383e1a5f92d5101b53d482aa21c6f772febeb91813'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.