### PR TITLE
Update qgroundcontrol to 3.1.2

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.1.1'
-  sha256 '94bf0c746a2a735362b72bac45f0c118e79837ff0afbd25e42df9b84d57c49ba'
+  version '3.1.2'
+  sha256 '6f7e0dfa7b9cf4eee37a10cb83caffedcab84651ee6e6b2fa46b65b4978b2813'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: '3853b894c09072a9a14faaae469281cf62b854fed38e61ee3c76540ad18cd790'
+          checkpoint: '75a58c85a559d9febabb5fc10f543d08754189e4598a0bf2a25598ffdc1b64eb'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.