### PR TITLE
Update svg-cleaner to 0.8.0

### DIFF
--- a/Casks/svg-cleaner.rb
+++ b/Casks/svg-cleaner.rb
@@ -1,10 +1,10 @@
 cask 'svg-cleaner' do
-  version '0.7.1'
-  sha256 '3eae7e6a3738f291d93d6ab029db55ffacfc795ecca8d23e1fe66de00ba703d4'
+  version '0.8.0'
+  sha256 '544e75bd51b042e26183814720e656b787a6dd525c694314cf09ce0e6783f976'
 
   url "https://github.com/RazrFalcon/svgcleaner-gui/releases/download/v#{version}/svgcleaner_macos_#{version}.zip"
   appcast 'https://github.com/RazrFalcon/svgcleaner-gui/releases.atom',
-          checkpoint: 'c6d3fc15b92224928961f3d87218a1306d2bb47c44b9c793ea1cff40c6251b41'
+          checkpoint: 'b96f2dc4b73e545ef13efdaec64e238ca5b5edb5d58dcc53ea1218e94ebe5c8a'
   name 'SVG Cleaner'
   homepage 'https://github.com/RazrFalcon/svgcleaner-gui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.