### PR TITLE
Update timely to 0.4.4

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,11 +1,11 @@
 cask 'timely' do
-  version '0.4.3'
-  sha256 '28e397b09767f1ab72e96827eee26a8d0fe2e1636420cc22f08ba89eafb890c2'
+  version '0.4.4'
+  sha256 '284c0171ba10dd62bd0e5ac447dfca35727a452eca998f350d04ea252c672290'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/osx64-v#{version}/Timely-#{version}.dmg"
   appcast 'https://github.com/Timely/desktop-releases/releases.atom',
-          checkpoint: '012cf46727c665a5b7a29f7e9223297c8d2a3c225f8f765cf6b91c2658f98982'
+          checkpoint: 'f50a2ff2f33ca35f1410975a6fdfba93546f7541d7a6ec8d5eb668c777242f02'
   name 'Timely'
   homepage 'https://timelyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.