### PR TITLE
Add SafariSort.app Latest

### DIFF
--- a/Casks/safarisort.rb
+++ b/Casks/safarisort.rb
@@ -1,0 +1,11 @@
+cask 'safarisort' do
+  version :latest
+  sha256 :no_check
+
+  # macupdate.com was verified as official when first introduced to the cask
+  url 'https://www.macupdate.com/download/34101/SafariSort.dmg'
+  name 'SafariSort'
+  homepage 'http://www.safarisort.com'
+
+  app 'SafariSort.app'
+end


### PR DESCRIPTION
SafariSort does not appear to have a versioned download link, so Latest was chosen as the version.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
