### PR TITLE
Update apple-events to 0.7

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,11 +1,11 @@
 cask 'atom' do
-  version '1.13.0'
-  sha256 'd7908ef3d38801518893612bc204c034a3ec75f1c981f8ba6d64ebaa494974ca'
+  version '0.7'
+  sha256 ''
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '6fea81a29e0117d5796ff2b9c4718d73f594d41d3bae7fd2ea400e63748baeb6'
+          checkpoint: 'ba93268748d1afb0b397d53ce22f1b42d14de91d54155343227d7c87abc72bff'
   name 'Github Atom'
   homepage 'https://atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.