### PR TITLE
Update djview to 4.10.6

### DIFF
--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -1,10 +1,10 @@
 cask 'djview' do
   version '4.10.6'
-  sha256 '4585c41e9e856af702ab50ac345128e98aedc581d0d0c29ea8e7dac1ed0e7792'
+  sha256 '46b6042e9414e800d651d7dd484126737d379a7a4a79137a81a142cb35d5e5d0'
 
-  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-qt57-intel64.dmg"
+  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-qt57b-intel64.dmg"
   appcast 'https://sourceforge.net/projects/djvu/rss',
-          checkpoint: '7cc16abf82300f400f18f9658f43280a5fc6c048797b0fba207b08ccb485202a'
+          checkpoint: '5ad7e42269fd45af3efb843e42b2cebef42f145e26c1a99c09f8a6af41b3861f'
   name 'DjView'
   homepage 'http://djvu.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.