### PR TITLE
Update tunnelblick to 3.6.10,build_4760

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,13 +1,11 @@
 cask 'tunnelblick' do
-  if MacOS.version <= :snow_leopard
-    version '3.5.10_build_4270.4563'
-    sha256 '2219f7ffcf5a5be7fb5f55945a19f6b3966e73d500feb03d8c376a0e00640ade'
-  else
-    version '3.6.9_build_4685'
-    sha256 '215cfcedb534df5ab3855898ba7d3b052f0b77c8ca9d338d7a3a1b240d944c7e'
-  end
+  version '3.6.10,build_4760'
+  sha256 '05f8f487a08f10f0b2558c27fde3aa37a8dbe609e0c7cf556f38d92cc49b18e0'
 
-  url "https://www.tunnelblick.net/release/Tunnelblick_#{version}.dmg"
+  # github.com/Tunnelblick/Tunnelblick/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_#{version.after_comma}.dmg"
+  appcast 'https://github.com/Tunnelblick/Tunnelblick/releases.atom',
+          checkpoint: 'eaec16a7880bb2105e2a2de1a342b7d77f6ad5b11dca085c94f04e28b071ae78'
   name 'Tunnelblick'
   homepage 'https://www.tunnelblick.net/'
 


### PR DESCRIPTION
* Change to github download to match appcast
* Removed older version as it was snow leopard only to keep the cask simple rather than split urls

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.