### PR TITLE
Update downie to 2.6.5,1379

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.6.1,1356'
-  sha256 'a715f9dbb98b0e7e62486ef95f5b6d015608745682712b25e4c385cbc7f34ee9'
+  version '2.6.5,1379'
+  sha256 '4b4c7ad3793338f6c4d6b45d25c1f15f98e15ccabbf2a1be0fb657b4b7bed9d1'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '653b1a3d2a1292c9aa1469f39aa231b19c256e1991374663d62d63b2fd9e81e4'
+          checkpoint: 'b41b2600773d0eef3bcc8c3785a545011dbe086093fa2be016fca36362d79572'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.