### PR TITLE
Update colorport links

### DIFF
--- a/Casks/colorport.rb
+++ b/Casks/colorport.rb
@@ -2,9 +2,9 @@ cask 'colorport' do
   version '2.0.5'
   sha256 'ae176e3118ba55b4dd8a0716707d149a4e13827b30cdc3f1d29bc329a0ef4bd0'
 
-  url 'http://www.xrite.com/downloader.aspx?FileID=1168&Type=M&returnurl=%2fcolorport-utility-software%2fsupport%2fd1168'
+  url "http://downloads.xrite.com/downloads/software/ColorPort/v#{version}/ColorPort#{version.no_dots}.zip"
   name 'ColorPort Utility Software'
-  homepage 'http://www.xrite.com/colorport-utility-software/support/d1168'
+  homepage 'http://www.xrite.com/service-support/product-support/formulation-and-qc-software/ColorPort-Utility-Software'
 
   pkg "ColorPort#{version.sub(%r{^(\d+)\.(\d+).*}, '\1\2')}Distribution.mpkg"
 


### PR DESCRIPTION
* all links were 404. Updated

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] The commit message includes the cask’s name and version.