### PR TITLE
Update c3 to 0.6.18.8668

### DIFF
--- a/Casks/c3.rb
+++ b/Casks/c3.rb
@@ -1,10 +1,10 @@
 cask 'c3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '0.6.8.6120'
-  sha256 'ce8f1f18376b0c46bedca4853c5b51c3af973a12c8762522bad48c49a286b5d7'
+  version '0.6.18.8668'
+  sha256 'c36d5e08cdad3695dcd2ba933ef51e1091bc6c3ec4bb7dcefae012f6f77c37ff'
 
   # d2xj26462na9l3.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2xj26462na9l3.cloudfront.net/c3/C3-#{version}.dmg"
+  url "https://d2xj26462na9l3.cloudfront.net/c3/C3-Voice_Chat-#{version}.dmg"
   name 'C3'
   homepage 'https://www.downloadc3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.