### PR TITLE
Update virtualbox and virtualbox-extension-pack to 5.1.14-112924 and 5.0.32-112930

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -3,14 +3,16 @@ cask 'virtualbox-extension-pack' do
     version '4.3.40-110317a'
     sha256 '829812f9a94204cd206968a8b8c3ca14f719f9cc8e3e1c6825b68c2c3da13033'
   elsif MacOS.version == :mountain_lion
-    version '5.0.30-112061'
-    sha256 'f0880b7948bdc185d7e7be0fc98b551296ed9578f21e38d01b43771323a71a3d'
+    version '5.0.32-112930'
+    sha256 '3a0c45eb2471566787def7d73f8c01b03a806e5b2042c21911c2142dafdf9a44'
   else
-    version '5.1.12-112440'
-    sha256 '03111380afb06122a494595e966dffe3e2779840e8698e27e80f87342b291286'
+    version '5.1.14-112924'
+    sha256 'baddb7cc49224ecc1147f82d77fce2685ac39941ac9b0aac83c270dd6570ea85'
   end
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
+  appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',
+          checkpoint: '69ff967697383e82adfccadcc6e493391648adb709c427d4fef9ded116c08798'
   name 'Oracle VirtualBox Extension Pack'
   homepage 'https://www.virtualbox.org/'
 

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -3,16 +3,16 @@ cask 'virtualbox' do
     version '4.3.40-110317'
     sha256 'eb70fc0f36844ced6dc7deeb30397866fbaffb4a8dfb6071b047e943cae6a312'
   elsif MacOS.version == :mountain_lion
-    version '5.0.30-112061'
-    sha256 '030a054e49bf4edde7730fd7f5bbbc8be47d6ab06c345da70e1b5a124414f5d0'
+    version '5.0.32-112930'
+    sha256 'c693083f1df96a95d5faf794b22737df103973de3e0d89f04734d401962f81cf'
   else
-    version '5.1.12-112440'
-    sha256 '74b10d9af01b8eb7d987088ffe52c74646a479a27cba4f98dc5149f1f6b93c76'
+    version '5.1.14-112924'
+    sha256 'f12ed3b1f98c45074e52742d1006c418acd22d0d91e8a6fb6f7b3121c21ce998'
   end
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/VirtualBox-#{version}-OSX.dmg"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',
-          checkpoint: 'be267ff5adb254acf71b9e2dab4de6bd16d4b0e5bf085edd9156c2d7be1f585f'
+          checkpoint: '69ff967697383e82adfccadcc6e493391648adb709c427d4fef9ded116c08798'
   name 'Oracle VirtualBox'
   homepage 'https://www.virtualbox.org/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.