### PR TITLE
Update dripcap to 0.6.1

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.6.0'
-  sha256 'f37e59dae325e3637ab6d2695860ce3b45961ae7ca01a46246d1428ef2ef006c'
+  version '0.6.1'
+  sha256 '8aeef72c32a76906feb5dc5d95e2195f06404225305d6bdbaff9477ca49b367e'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '2dd390aae4a7baff3c7464383e1a5f92d5101b53d482aa21c6f772febeb91813'
+          checkpoint: '25aa7d8fbacf558990e74d9d6caae648365facd3851e133fede5c1ade363adbc'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.