### PR TITLE
Update isubtitle to 3.0.3

### DIFF
--- a/Casks/isubtitle.rb
+++ b/Casks/isubtitle.rb
@@ -1,10 +1,10 @@
 cask 'isubtitle' do
-  version '3.0.2'
-  sha256 '77c3d7762e91e2b81eb702ab2a59ee0f372bfe77e419c24f2fb6566ce68946f4'
+  version '3.0.3'
+  sha256 'c9cb7039a399becac657489c38003c071b0dbd601e7ce6558f451f53d6f17a16'
 
   url "http://www.bitfield.se/isubtitle#{version.major}/download/iSubtitle_#{version}.zip"
   appcast "http://www.bitfield.se/isubtitle#{version.major}/changelog.xml",
-          checkpoint: 'ef6080d7af2993417d9a793965feba25ef0d0d1cdfcd4d67e42dd60d3e97f84a'
+          checkpoint: '8c7eb54f467c9e7dfe0557e6099455bfc331ddd036327b2f4382357b4dffd5aa'
   name 'iSubtitle'
   homepage 'http://www.bitfield.se/isubtitle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.