### PR TITLE
Update pusher to 0.7.4

### DIFF
--- a/Casks/pusher.rb
+++ b/Casks/pusher.rb
@@ -1,10 +1,10 @@
 cask 'pusher' do
-  version '0.7.3'
-  sha256 '3f9d530ef00e58affac74238de1a4f8a1462f229e1f811a0dcdcbe6e8b6117be'
+  version '0.7.4'
+  sha256 '58a6f828797da6cfefbd983a91e37dc8b1b4ad8bac263211b92d18afb84d7b94'
 
   url "https://github.com/noodlewerk/NWPusher/releases/download/#{version}/pusher.app.zip"
   appcast 'https://github.com/noodlewerk/NWPusher/releases.atom',
-          checkpoint: 'f713f4ee615887d908c0334aaa31ae499f9fb98fbfc4b3ed976f787646709ac6'
+          checkpoint: 'ca8d66b3aad9dcb79055592be038322b39e96b018e8e44b902fcd1fb5c4aea5d'
   name 'NWPusher'
   homepage 'https://github.com/noodlewerk/NWPusher'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.