### PR TITLE
Fixed Anki download and homepage links

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -1,15 +1,15 @@
 cask 'anki' do
   if MacOS.version <= :snow_leopard
-    version '2.0.38-alternate'
-    sha256 '75c3f0043c85dac19720ce27d81deda69544f0c0a6465bd4fb1970814b07b9b4'
+    version '2.0.40-alternate'
+    sha256 'a0087c85bbc27148a5e00bf40d5caad2ceb5ce09deac1f4385d87f54f0a36565'
   else
     version '2.0.40'
     sha256 '4089d1dfa5e94a161d9a2e8596f7622c9103046020b72590ab1d8be5f42687db'
   end
 
-  url "http://ankisrs.net/download/mirror/anki-#{version}.dmg"
+  url "https://apps.ankiweb.net/downloads/current/anki-#{version}.dmg"
   name 'Anki'
-  homepage 'https://apps.ankisrs.net/'
+  homepage 'https://apps.ankiweb.net/'
 
   app 'Anki.app'
 end


### PR DESCRIPTION
Also updated alternate `<= :snow_leopard` version

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
