### PR TITLE
Update etcher to 1.0.0-beta.18

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,11 +1,11 @@
 cask 'etcher' do
-  version '1.0.0-beta.17'
-  sha256 '648ef2babbbaea6abdf7a680a76afe3f03dbc11780164e890d377c67aec124dc'
+  version '1.0.0-beta.18'
+  sha256 '3573c73362557296b7dfa19604eeddfeecb4ee2baf4af9b60e46c49a253899e9'
 
   # resin-production-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://resin-production-downloads.s3.amazonaws.com/etcher/#{version}/Etcher-#{version}-darwin-x64.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: 'd95cb8bd3494d8c9707618e1f111506f6f281ae6d5fe50694bac02e654f164da'
+          checkpoint: '0de4565cc036df2e3a1cf93eba12b96607a61265a0749fbdde37ef108f2d5418'
   name 'Etcher'
   homepage 'https://etcher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.