### PR TITLE
Update go-agent to 17.1.0-4511

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,10 +1,10 @@
 cask 'go-agent' do
-  version '16.12.0-4352'
-  sha256 'ec5446d45b4398b285bb8ca9ee7fed04c278aa112c1832d0944c87dffa8dbb28'
+  version '17.1.0-4511'
+  sha256 '66cad16c00d89113c7bd7b31a19cf56721334911fcdb9b98de786f2cfdcc8912'
 
   url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: '6539c8829706600fcd7c5b25ee83d46c90946cf06b66f053f789ad57ceb911e7'
+          checkpoint: 'a03aba1085c1682f406b2a113414328bb9d40231b0adde4b945ca81676fbec23'
   name 'Go Agent'
   homepage 'https://www.gocd.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.