### PR TITLE
Update go-server to 17.1.0-4511

### DIFF
--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,10 +1,10 @@
 cask 'go-server' do
-  version '16.12.0-4352'
-  sha256 'f0b7f7f401e1a11022978c908f02409c0deec9c1cd5d80a6ae334bd82a7749e9'
+  version '17.1.0-4511'
+  sha256 'c59880d7a7f48000be201cad51699ab0dc99d8279e949d38bd6fe34d14e765fd'
 
   url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: '6539c8829706600fcd7c5b25ee83d46c90946cf06b66f053f789ad57ceb911e7'
+          checkpoint: 'a03aba1085c1682f406b2a113414328bb9d40231b0adde4b945ca81676fbec23'
   name 'Go Server'
   homepage 'https://www.gocd.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.