### PR TITLE
Update curb to 1.2.0

### DIFF
--- a/Casks/curb.rb
+++ b/Casks/curb.rb
@@ -1,10 +1,10 @@
 cask 'curb' do
-  version '1.1.1'
-  sha256 '832750d2a75272763c5c2f681b11670584626c9d93bf993d6b3af96234558f68'
+  version '1.2.0'
+  sha256 '577a18a69e097d149cc1f2a81d1a898c85d2d6e421478b1fbd4dc0a6e3633bd6'
 
   url "https://mrrsoftware.com/Downloads/Curb/Curb-#{version.dots_to_underscores}.zip"
   appcast 'https://www.mrrsoftware.com/Downloads/Curb/CurbSoftwareUpdates.xml',
-          checkpoint: '2141e205b0037e8e79d74564078cdaeb803b0dc2c1162e45477ebb9bcc72ae92'
+          checkpoint: '0e9a73e958a6be2158c2df7580acc0222f50b71d9c620dc89e2be848324a251f'
   name 'Curb'
   homepage 'https://mrrsoftware.com/curb/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.