### PR TITLE
Update endlesssky to 0.9.5

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -1,11 +1,11 @@
 cask 'endlesssky' do
-  version '0.9.4'
-  sha256 '0f05a81aa3db2979328096f50e4d8391380eb8abbe93d42105988ece8359c4ca'
+  version '0.9.5'
+  sha256 '368516912dae6760b6107ee7b79dd598d50e7039deaa381e411687c186a27d48'
 
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom',
-          checkpoint: '07b93c262346e01fe748c5af9c1069481bc0f39d6daef8ae66bb9faf660cbd7d'
+          checkpoint: '665d15ac54bfc5af79e671fe4dc20569f02aebdb74193c7dbf1a01642b9f40c6'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.