### PR TITLE
Update splice to 2.2.2-201701051612

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,11 +1,11 @@
 cask 'splice' do
-  version '2.2-201611251707'
-  sha256 '7f5cf850435c1b3dc75f6a26b8a7752d6f207eb2ff342d3e603b13cf9fd97667'
+  version '2.2.2-201701051612'
+  sha256 'de05ec24a6d14298888463d376189fcf059224760ea5fccc144c9e97c8b62d0f'
 
   # amazonaws.com/spliceosx was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/spliceosx/Splice.app-#{version}.zip"
   appcast 'https://splice.com/appcast.xml',
-          checkpoint: '267cb11f3ed988195e22bcf2c2a547ab79159256e60823b71fbad593419cfbc4'
+          checkpoint: 'ada6b14ef4fbc779f2fba277da11f09b4b87de6c593eacc79d9da1cd5254cea1'
   name 'Splice'
   homepage 'https://splice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.