### PR TITLE
Update trailrunner to 3.8.832

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,10 +1,10 @@
 cask 'trailrunner' do
-  version '3.8.830'
-  sha256 'a53915cd8b5bbbe55fd96d0372b587e7ec165236f92589cf274ea55e380faa26'
+  version '3.8.832'
+  sha256 '8255753e931c9be2ae1c3852455b03a81556d7ff524ab8a0ddb89a6013211a41'
 
   url 'http://downloads.trailrunnerx.com/TrailRunner.app.zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610',
-          checkpoint: '60131a8205964387489144e2d94556d665b8b267fe984751d49eda26d375b31c'
+          checkpoint: '4113b19dfc7e425b67d781cfc496967235de7119cd4f8a2a30a1adf68eddfc92'
   name 'TrailRunner'
   homepage 'http://www.trailrunnerx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.