### PR TITLE
Fix install of kindlegen

### DIFF
--- a/Casks/kindlegen.rb
+++ b/Casks/kindlegen.rb
@@ -7,7 +7,7 @@ cask 'kindlegen' do
   name 'KindleGen'
   homepage 'https://www.amazon.com/gp/feature.html?docId=1000765211'
 
-  binary "KindleGen_Mac_i386_v#{version.dots_to_underscores}/kindlegen"
+  binary 'kindlegen'
 
   caveats <<-EOS.undent
     Instructions on using KindleGen are available in


### PR DESCRIPTION
When migrating Kindlegen from homebrew-binary to homebrew-cask (#22194), the binary artifact was incorrectly named to be in a subdirectory that only exists when the downloaded zipfile is opened through the Finder archiver integration. When using `ditto` or `unzip`, `kindlegen` is extracted without a base directory.

Kindlegen would not install without this change on my machine.