### PR TITLE
Migrate jad 1.5.8g from homebrew-binary

### DIFF
--- a/Casks/jad.rb
+++ b/Casks/jad.rb
@@ -1,0 +1,17 @@
+cask 'jad' do
+  version '1.5.8g'
+  sha256 '8e9e4ea6c4177acce6d27325a036f10a72c170ed60e48c37c3483335319d07b9'
+
+  url "http://www.varaneckas.com/jad/jad#{version.no_dots}.mac.intel.zip"
+  name 'Jad - the fast Java Decompiler'
+  homepage 'http://www.varaneckas.com/jad/'
+
+  binary 'jad'
+  artifact 'jad.1', target: '/usr/local/share/man/man1/jad.1'
+
+  caveats <<-EOS.undent
+    Instructions on using cmucl are available in
+
+      #{staged_path}/Readme.txt
+  EOS
+end

--- a/Casks/jad.rb
+++ b/Casks/jad.rb
@@ -10,7 +10,7 @@ cask 'jad' do
   artifact 'jad.1', target: '/usr/local/share/man/man1/jad.1'
 
   caveats <<-EOS.undent
-    Instructions on using cmucl are available in
+    Instructions on using jad are available in
 
       #{staged_path}/Readme.txt
   EOS


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Ping @adidalal for review.