### PR TITLE
Update whatroute to 2.0.12

### DIFF
--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,16 +1,16 @@
 cask 'whatroute' do
   if MacOS.version <= :mavericks
-		version '1.13.3'
-		sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a' 	
-		url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
-	else
-		version '2.0.12'
-		sha256 'd2186d8064eb851a9a6b1d3feafaf78959f0043e9a64317aa6c1a475d5d4125d'
-		url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
-	end
-  
+    version '1.13.3'
+    sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a' 	
+
+  else
+    version '2.0.12'
+    sha256 'd2186d8064eb851a9a6b1d3feafaf78959f0043e9a64317aa6c1a475d5d4125d'
+  end
+
+  url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   name 'WhatRoute'
   homepage 'https://www.whatroute.net/'
-  
+
   app 'WhatRoute.app'
 end

--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,7 +1,7 @@
 cask 'whatroute' do
   if MacOS.version <= :mavericks
     version '1.13.3'
-    sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a' 	
+    sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a'
 
   else
     version '2.0.12'

--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,8 +1,14 @@
 cask 'whatroute' do
-  version '1.13.1'
-  sha256 '34a37acea1285b6a2c28bc18b81974b1214fbbf019c0ef9fad32844bb780cc56'
+  if MacOS.version <= :mavericks
+  	version '1.13.3'
+  	sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a'
+  	url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
+  else
+  	version '2.0.12'
+  	sha256 'd2186d8064eb851a9a6b1d3feafaf78959f0043e9a64317aa6c1a475d5d4125d'
+  	url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
+  end
 
-  url "https://www.whatroute.net/software/whatroute-#{version}.dmg"
   name 'WhatRoute'
   homepage 'https://www.whatroute.net/'
 

--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,16 +1,16 @@
 cask 'whatroute' do
   if MacOS.version <= :mavericks
-  	version '1.13.3'
-  	sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a'
-  	url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
-  else
-  	version '2.0.12'
-  	sha256 'd2186d8064eb851a9a6b1d3feafaf78959f0043e9a64317aa6c1a475d5d4125d'
-  	url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
-  end
-
+		version '1.13.3'
+		sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a' 	
+		url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
+	else
+		version '2.0.12'
+		sha256 'd2186d8064eb851a9a6b1d3feafaf78959f0043e9a64317aa6c1a475d5d4125d'
+		url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
+	end
+  
   name 'WhatRoute'
   homepage 'https://www.whatroute.net/'
-
+  
   app 'WhatRoute.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.