### PR TITLE
Update wiznote to 2.4.3,2017-01-03

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,8 +1,8 @@
 cask 'wiznote' do
-  version '2.4.0,2016-11-18'
-  sha256 'aeb5363c751861036584beadfeab61a27be44f177c588941d55e4d2d6c14591b'
+  version '2.4.3,2017-01-03'
+  sha256 '399b7989bdc0e8ba3a646f409dd9ddd301cb34bb4a1cff8fc25d1f861909560d'
 
-  url "http://release.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
+  url "http://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   name 'WizNote'
   homepage 'http://www.wiz.cn/wiznote-mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.