### PR TITLE
Update visit to 2.12.1

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,6 +1,6 @@
 cask 'visit' do
-  version '2.12.0'
-  sha256 '060ada90328827aed9d5a175aade5e5e243ad99881749c9a360d980bd46d870d'
+  version '2.12.1'
+  sha256 '95c4dc58a9a6994c69e810dc264d7992addf1b19b6fbd6b4286302586462bff1'
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
   url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"

--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -5,7 +5,7 @@ cask 'visit' do
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
   url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables',
-          checkpoint: '732a92915a20a1edc31798b8b5a775761716a8665f28684b83ff517dedb9ad41'
+          checkpoint: '6d1f16f2a61085c04db7dea62820ffb8dd63306eb3930588b5a1c19a43b317cd'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.