### PR TITLE
Update cyberduck to 5.3.3.23221

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '5.3.2.23205'
-  sha256 '24d4ac3a5a6ec5c03819fd93bd8100416373db2e01abc4d0ea65597dc73c4424'
+  version '5.3.3.23221'
+  sha256 'b647bbbe27f1796b99bf0eaf83ed07332f2ab141afe3bb885b25a1ae0017a110'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: 'b0cf91e75f09df32d0c64011f57674a87ffcd40dac76315068ddeea62ece76cf'
+          checkpoint: 'de1e882f7b9751eedbbdc3f00e9974bee45d421fafd60b615aa09ff3c2ac370d'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.