### PR TITLE
Update veusz to 1.25.1

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,6 +1,6 @@
 cask 'veusz' do
-  version '1.23.1'
-  sha256 '67cada3e84e8a4f4629bb70ffe2bcbb5dc3836fc91e862054ffda98e91759bb5'
+  version '1.25.1'
+  sha256 '38d4144babf3a07845b018af610cdf4b21a951a9b7c200c904509dbbe1d2b7a7'
 
   url "http://download.gna.org/veusz/Binaries-AppleOSX/veusz-#{version}-AppleOSX.dmg"
   name 'Veusz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
