### PR TITLE
Update electron to 1.4.15

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.14'
-  sha256 '7c3a5af7a9fe59f864a55d6217f28cebaf719d46d9eb18de2ea0f7ea1137383f'
+  version '1.4.15'
+  sha256 '93a8e912ab0771b879d6959550f083fde3b643d2cb666e848aff334cb09f0f5d'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'c0cc56aceb0e13f9601ef66b88396539a33f96362ce89d490cc3d19e430e4ea8'
+          checkpoint: 'af42a3d933d70d264d5d400176d051211c06dcf21b7bc526104580d72fcfa1cb'
   name 'Electron'
   homepage 'http://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.