### PR TITLE
Update docker to 1.13.0.15072

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '1.12.6.14937'
-  sha256 '06c37f809315855951f3d794c604c848abc1866662e5f3d85a0718b14fb57ec2'
+  version '1.13.0.15072'
+  sha256 '1ff2a59d36348c2e1df73318e366624b04d42861e81af3d1b72effd803402641'
 
   url "https://download.docker.com/mac/stable/#{version}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: '876fbc767ecc3c763e80c377e2b1cd9e6e0966b722a9f0f124a41fc16e95af4d'
+          checkpoint: 'df585a51327110755eb8d9aba8c42b559c91b41d98563604c8d448f3f2714906'
   name 'Docker for Mac'
   homepage 'https://www.docker.com/products/docker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.