### PR TITLE
Update Impactor to 0.9.38

### DIFF
--- a/Casks/impactor.rb
+++ b/Casks/impactor.rb
@@ -1,6 +1,6 @@
 cask 'impactor' do
-  version '0.9.33'
-  sha256 '2f5e9278896b1a5d8c524dc24ff24b893cddb9d082951e17c4655c8327ba7c2d'
+  version '0.9.38'
+  sha256 '94ec97eeb86c75b68d9bfb3a51156fccb3390ea1037c40ac4e49e26875346aff'
 
   # cache.saurik.com/impactor was verified as official when first introduced to the cask
   url "https://cache.saurik.com/impactor/mac/Impactor_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Attempting to check the style segfaulted my Ruby interpreter. Not sure why, I need to dig into it further. Given that I only changed two lines, the style should be fine anyway.