### PR TITLE
Migrate eventstore.rb from homebrew/binary

### DIFF
--- a/Casks/eventstore.rb
+++ b/Casks/eventstore.rb
@@ -10,19 +10,19 @@ cask 'eventstore' do
   binary 'eventstore-testclient'
 
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  eventstore_shimscript = "#{staged_path}/eventstore"
-  testclient_shimscript = "#{staged_path}/eventstore-testclient"
+  eventstore_shimscript = "#{staged_path}/EventStore-OSS-MacOSX-v#{version}/eventstore"
+  testclient_shimscript = "#{staged_path}/EventStore-OSS-MacOSX-v#{version}/eventstore-testclient"
 
   preflight do
     IO.write eventstore_shimscript, <<-EOS.undent
       #!/bin/sh
-      cd "#{staged_path}"
-      exec "#{staged_path}/run-node.sh" "$@"
+      cd "#{staged_path}/EventStore-OSS-MacOSX-v#{version}"
+      exec "#{staged_path}/EventStore-OSS-MacOSX-v#{version}/run-node.sh" "$@"
     EOS
 
     IO.write testclient_shimscript, <<-EOS.undent
       #!/bin/sh
-      exec "#{staged_path}/testclient" "$@"
+      exec "#{staged_path}/EventStore-OSS-MacOSX-v#{version}/testclient" "$@"
     EOS
 
     set_permissions eventstore_shimscript, '+x'

--- a/Casks/eventstore.rb
+++ b/Casks/eventstore.rb
@@ -25,7 +25,7 @@ cask 'eventstore' do
       exec "#{staged_path}/testclient" "$@"
     EOS
 
-    FileUtils.chmod '+x', eventstore_shimscript
-    FileUtils.chmod '+x', testclient_shimscript
+    set_permissions eventstore_shimscript, '+x'
+    set_permissions testclient_shimscript, '+x'
   end
 end

--- a/Casks/eventstore.rb
+++ b/Casks/eventstore.rb
@@ -10,25 +10,22 @@ cask 'eventstore' do
   binary 'eventstore-testclient'
 
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/eventstore"
+  eventstore_shimscript = "#{staged_path}/eventstore"
+  testclient_shimscript = "#{staged_path}/eventstore-testclient"
 
   preflight do
-    IO.write shimscript, <<-EOS.undent
+    IO.write eventstore_shimscript, <<-EOS.undent
       #!/bin/sh
       cd "#{staged_path}"
       exec "#{staged_path}/run-node.sh" "$@"
     EOS
-    FileUtils.chmod '+x', shimscript
-  end
 
-  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/eventstore-testclient"
-
-  preflight do
-    IO.write shimscript, <<-EOS.undent
+    IO.write testclient_shimscript, <<-EOS.undent
       #!/bin/sh
       exec "#{staged_path}/testclient" "$@"
     EOS
-    FileUtils.chmod '+x', shimscript
+
+    FileUtils.chmod '+x', eventstore_shimscript
+    FileUtils.chmod '+x', testclient_shimscript
   end
 end

--- a/Casks/eventstore.rb
+++ b/Casks/eventstore.rb
@@ -1,0 +1,34 @@
+cask 'eventstore' do
+  version '3.9.3'
+  sha256 'a4ceca878a833e4f30235b08ce1764d5072935484c126c93fb05ab2188a2a9ee'
+
+  url "http://download.geteventstore.com/binaries/EventStore-OSS-MacOSX-v#{version}.tar.gz"
+  name 'Event Store'
+  homepage 'http://geteventstore.com'
+
+  binary 'eventstore'
+  binary 'eventstore-testclient'
+
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/eventstore"
+
+  preflight do
+    IO.write shimscript, <<-EOS.undent
+      #!/bin/sh
+      cd "#{staged_path}"
+      exec "#{staged_path}/run-node.sh" "$@"
+    EOS
+    FileUtils.chmod '+x', shimscript
+  end
+
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/eventstore-testclient"
+
+  preflight do
+    IO.write shimscript, <<-EOS.undent
+      #!/bin/sh
+      exec "#{staged_path}/testclient" "$@"
+    EOS
+    FileUtils.chmod '+x', shimscript
+  end
+end

--- a/Casks/eventstore.rb
+++ b/Casks/eventstore.rb
@@ -6,8 +6,8 @@ cask 'eventstore' do
   name 'Event Store'
   homepage 'http://geteventstore.com'
 
-  binary 'eventstore'
-  binary 'eventstore-testclient'
+  binary "EventStore-OSS-MacOSX-v#{version}/eventstore"
+  binary "EventStore-OSS-MacOSX-v#{version}/eventstore-testclient"
 
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   eventstore_shimscript = "#{staged_path}/EventStore-OSS-MacOSX-v#{version}/eventstore"


### PR DESCRIPTION
This is a work-in-progress and I need some help - I know that what I currently have is probably not correct.

The original formula from homebrew/binary is reproduced below:
```
class Eventstore < Formula
  desc "functional database with complex event processing"
  homepage "http://geteventstore.com"
  url "http://download.geteventstore.com/binaries/EventStore-OSS-MacOSX-v3.7.0.tar.gz"
  sha256 "e5902899d45aca6414fae01fff152ddc2df1495ad29d36ea3bcffbe33025e396"

  bottle :unneeded

  depends_on :macos => :mavericks

  def install
    prefix.install Dir["*"]

    (bin/"eventstore").write <<-EOS.undent
      #!/bin/sh
      cd "#{prefix}"
      exec "#{prefix}/run-node.sh" "$@"
    EOS

    (bin/"eventstore-testclient").write <<-EOS.undent
      #!/bin/sh
      exec "#{prefix}/testclient" "$@"
    EOS
  end

  test do
    assert_match  /#{version}/, shell_output("#{bin}/eventstore --version")
  end
end
```

Ping @adidalal and @vitorgalvao for some help with this one please.

Files inside the `tar.gz` for reference:

<img width="177" alt="screen shot 2017-01-20 at 20 09 26" src="https://cloud.githubusercontent.com/assets/6127163/22149031/73942c58-df4c-11e6-877b-768e46b5bb26.png">
