### PR TITLE
Update ustream-producer to 7.3

### DIFF
--- a/Casks/ustream-producer.rb
+++ b/Casks/ustream-producer.rb
@@ -1,6 +1,6 @@
 cask 'ustream-producer' do
-  version '6.0.6'
-  sha256 'e3b38861fae0288fc717213b209766035c0507c90b4dc028cef9928af246df7b'
+  version '7.3'
+  sha256 'cc9f9f76dc7b600f671ab38d6ba07b8ca6175d005928a4407ab5787af81f5d0e'
 
   url "https://www.ustream.tv/producer/download/mac/free/#{version}"
   name 'Ustream Producer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.