### PR TITLE
Updated cevelop to v1.6.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,6 +1,6 @@
 cask 'cevelop' do
-  version '1.5.0-201607061232'
-  sha256 'c8b53ccd1123dc399e9733e085ba9aa92024596882eb45a7548e91305e7d1bc9'
+  version '1.6.0-201701201507'
+  sha256 'd6b9ad4657a3753290927ec451867ca4e43d441af9440c4653fa4424a66e8d23'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   name 'Cevelop'


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.6.0.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.