### PR TITLE
Update java to 1.8.0_121-b13,e9e7ea248e2c4826b92b3f075a80e441

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,8 +1,8 @@
 cask 'java' do
-  version '1.8.0_112-b16'
-  sha256 'c9ebb729acb0ee8e6fbeda85751be20b024c45e3ebb83cc7c624908ffb8a466d'
+  version '1.8.0_121-b13,e9e7ea248e2c4826b92b3f075a80e441'
+  sha256 '82ff2493cd4b9ebdaeb9135abaffc9a37b71d341b007a83f73aa6ff3df1b6a3a'
 
-  url "http://download.oracle.com/otn-pub/java/jdk/#{version.sub(%r{^\d+\.(\d+).*?_(.*)$}, '\1u\2')}/jdk-#{version.sub(%r{^\d+\.(\d+).*?_(\d+)-.*$}, '\1u\2')}-macosx-x64.dmg",
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.sub(%r{^\d+\.(\d+).*?_(.*)$}, '\1u\2').split(',')[0]}/#{version.sub(%r{^\d+\.(\d+).*?_(.*)$}, '\1u\2').split(',')[1]}/jdk-#{version.sub(%r{^\d+\.(\d+).*?_(\d+)-.*$}, '\1u\2')}-macosx-x64.dmg",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.