### PR TITLE
Update preform to 2.10.2,454

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '2.10.0,404'
-  sha256 '180c3c3e73f0feca5b470aab960ae50ff3e6476c22346017168ebe9bdb8167d0'
+  version '2.10.2,454'
+  sha256 '690bd4c2f17d64e8e984eee1aba8896845e5d0f422aab4c44b0ec4b3c5561465'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.