### PR TITLE
Update polymail to 1.22

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.21'
-  sha256 'cc4e3637bd0f5223554c13f7a552060060c1f936cbea80379220aa596f187d7b'
+  version '1.22'
+  sha256 '62bd58476bc7052f665a93a1cbb78adf15bc9fd42f16346b80d30db7183f3436'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'f63977c7a9b614f8172580eb3b41330eae50411fa60d77693bbfe3577dc99f82'
+          checkpoint: '09d98ffd79ce80528ace3fe94d81b2e7ad6855c87504106dfc3473971ba53acd'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.