### PR TITLE
Update karabiner-elements to 0.90.83

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '0.90.82'
-  sha256 '685f511d3ae14a8f86d057950ff26bb99a5695228916d129a14c7d45a753e334'
+  version '0.90.83'
+  sha256 'a545f4cc8d48618e4fccb1974e6b3e488a3839a1abbdcd5ed455db955aacee4b'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: '50b672616730009e73999ce6f1d77a9a8aa97c17110e40ab209fce2179c314fb'
+          checkpoint: 'f541bccac480ac8ca83f570b3f202847d1e8b0cb585df43599154763c86d354f'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.