### PR TITLE
Update namechanger to 3.3.0

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -1,10 +1,10 @@
 cask 'namechanger' do
-  version '3.2.1'
-  sha256 '3866310c60ed224d15d8cd6de864978e11d84d203e2bae6b9db4d77a46d4420f'
+  version '3.3.0'
+  sha256 '77a328f2947cd01c37a9181556c9e9d044b131075e72b514af0d01f7da35188d'
 
   url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.dots_to_underscores}.zip"
   appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
-          checkpoint: '427e9fe31bbd34d9ee9d6fb064f6d6c10b0634ec8a7a18ddfc8453b0498f2496'
+          checkpoint: '00cc536c81895136ea548eed2cf5cc5236089e1026f0dd99244db6ef7a4d9737'
   name 'NameChanger'
   homepage 'https://mrrsoftware.com/namechanger/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.