### PR TITLE
Update istopmotion to 3.8.2-16057

### DIFF
--- a/Casks/istopmotion.rb
+++ b/Casks/istopmotion.rb
@@ -1,10 +1,12 @@
 cask 'istopmotion' do
-  version '3.6-15980'
-  sha256 '403f912d218da3868718cb1435bcd9919bfffbe587f37efca5182ef3a2770c62'
+  version '3.8.2-16057'
+  sha256 'eb31319488346e12d6f95b7be9d61d911eaaf0228f22b6053ee0be8f6902f520'
 
   url "https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_#{version}.app.zip"
+  appcast 'https://www.boinx.com/d/connect/histories/istopmotion',
+          checkpoint: '9234c3abcb9738d7bbfcc6098c5e6ae22f3cf0c742e6bbd395c3da94859e5ea3'
   name 'iStopMotion'
   homepage 'https://www.boinx.com/istopmotion/mac/'
 
-  app "iStopMotion #{version.major}.app"
+  app 'iStopMotion.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.