### PR TITLE
Update wireshark-chmodbpf to 2.2.3

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,6 +1,6 @@
 cask 'wireshark-chmodbpf' do
-  version '2.0.5'
-  sha256 '9fe81f0738fb718cb7340ab4f08094d84cc6343d0f299df4dd56f153483446a5'
+  version '2.2.3'
+  sha256 '300195804c9545a75632c191fb1c5491f18e314b01178a2abe18faab78c8e150'
 
   url "https://www.wireshark.org/download/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
   name 'Wireshark-ChmodBPF'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.