### PR TITLE
Update boostnote to 0.8.3

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.2'
-  sha256 'a0eeddc8a16f43d31038e7f9261ae3cbef3b2acf19e5d2e3c9a1fd33f38f8093'
+  version '0.8.3'
+  sha256 '9f27d0451c94799d9cc05aaea52c1ef8a40892d5ddb180e4ab93e5f2c257f995'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: 'ed6319b0ee6d7d3e121f8475c9cb77f406fd791f7a21055886e8933350feceef'
+          checkpoint: 'd6168d65138979580968b99957ed7af91ce0eea0faff452b0bf553fd434d3ae2'
   name 'Boostnote'
   homepage 'https://b00st.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.