### PR TITLE
Update udig to 2.0.0.RC1

### DIFF
--- a/Casks/udig.rb
+++ b/Casks/udig.rb
@@ -1,6 +1,6 @@
 cask 'udig' do
-  version '1.4.0'
-  sha256 '1364245d9e6f62a3ec4f21b5a0eb4046a0423ca778d3d550b348d5bb20706fa2'
+  version '2.0.0.RC1'
+  sha256 '72e5216ec754407b317f1e517f3a6fe6b04fc19e658ab4d09c1d4f9b6e040ee6'
 
   url "http://udig.refractions.net/files/downloads/udig-#{version}.macosx.cocoa.x86_64.dmg"
   name 'uDig'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.