### PR TITLE
Update stretchly to 0.6.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.5.1'
-  sha256 '9b480ff99c23b91067598b573f7f94bbbc9a79703471a53e2c02a77f546042ac'
+  version '0.6.0'
+  sha256 '8bcacef9e79471340a27ab8ee5d143a16bd42d9d0421564a3a6457b50602de46'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '37bd240e647d53b8be14bbed20618f8dc1cf906d70a929cf841ffbc011f5e2d4'
+          checkpoint: '0ffc2cfe39b8988774ecdef0816562d433523ab92fde1f1a42445a5075ccae1c'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.