### PR TITLE
Update tuneup to 2.10.1

### DIFF
--- a/Casks/tuneup.rb
+++ b/Casks/tuneup.rb
@@ -1,11 +1,11 @@
 cask 'tuneup' do
-  version '2.8.4'
-  sha256 'af67b5ac301c9aeb842b90b22402b144ba3d8d4c66f84eb12cb53919bf1e9eb8'
+  version '2.10.1'
+  sha256 '4332684d776c7e3114bc19357360b51fba69c77b8c4c641ed3a518ab9939fe86'
 
-  # dvk2ozaytrec6.cloudfront.net was verified as official when first introduced to the cask
-  url "https://dvk2ozaytrec6.cloudfront.net/mac4/Sparkle/TuneUp-#{version}.dmg"
-  appcast 'https://dvk2ozaytrec6.cloudfront.net/mac4/appcast.xml',
-          checkpoint: '64150d576a3291c6755d79e68b2e52e5d2fd71bee8e7627ac77bf57aca4f6f55'
+  # d2m5os1cpndbxq.cloudfront.net was verified as official when first introduced to the cask
+  url 'http://d2m5os1cpndbxq.cloudfront.net/mac4/Sparkle/TuneUp-Installer.dmg'
+  appcast 'https://d2m5os1cpndbxq.cloudfront.net/mac4/appcast.xml',
+          checkpoint: '2e1926411a6a93af80ce0d46b1a624acee03691d7cc1c48160bf958bfcef229d'
   name 'TuneUp'
   homepage 'https://www.tuneupmedia.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.