### PR TITLE
Update tunnelblick to 3.7.0beta01,build_4780

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,11 +1,11 @@
 cask 'tunnelblick' do
-  version '3.6.10,build_4760'
-  sha256 '05f8f487a08f10f0b2558c27fde3aa37a8dbe609e0c7cf556f38d92cc49b18e0'
+  version '3.7.0beta01,build_4780'
+  sha256 'dc6da2b31ad8059fe19c9c243429e162f3ab9f0066e7d4264b5494c03b7a274e'
 
   # github.com/Tunnelblick/Tunnelblick/releases/download was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_#{version.after_comma}.dmg"
   appcast 'https://github.com/Tunnelblick/Tunnelblick/releases.atom',
-          checkpoint: 'eaec16a7880bb2105e2a2de1a342b7d77f6ad5b11dca085c94f04e28b071ae78'
+          checkpoint: '75358dcdd1aa63bcd68b2431598895c8681be1521a7581ce9e33a15d9a3f218b'
   name 'Tunnelblick'
   homepage 'https://www.tunnelblick.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.