### PR TITLE
Update nylas-mail to 1.0.11-d1249b7

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.10-5e144cf'
-  sha256 '2ac7f49a00c8a195e1b983b11e808f66e1399e69b46f6761b3470ab23293abb7'
+  version '1.0.11-d1249b7'
+  sha256 '2065a5d26a73c1b9d3195b010fc8a17e0d3a8ae1f8b6945a72249ca403b5ac48'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '19732a7204b4e5840befa53277795bce8dab0d6244e20c995e2dbdff7ff87155'
+          checkpoint: 'a2be2bc86628622ab09ddbbc57e146487cfa2a701e2214f6dce51f79b7639b06'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.