### PR TITLE
Added Cask for Now Desktop

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,0 +1,12 @@
+cask 'now' do
+  version :latest
+  sha256 :no_check
+
+  # now-auto-updates.now.sh was verified as official when first introduced to the cask
+  url 'https://now-auto-updates.now.sh/download/macos'
+  name 'Now Desktop'
+  homepage 'https://zeit.co/desktop'
+
+  auto_updates true
+  app 'Now.app'
+end

--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -8,5 +8,6 @@ cask 'now' do
   homepage 'https://zeit.co/desktop'
 
   auto_updates true
+
   app 'Now.app'
 end


### PR DESCRIPTION
My team at @zeit and I decided to add the application [nevertheless](https://github.com/caskroom/homebrew-cask/pull/27397).

When looking over this PR, please keep in mind that the download isn't versioned and we're also not distributing over tools like Github Releases, so I also left the appcast away.

I carefully read the documentation and made sure to align with it.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed