### PR TITLE
Update tortoisehg to 4.0.1

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.0.0'
-  sha256 'e16795c608b775cf6d755d4a5273214b65211891c2ac5b76907ecac3ff170717'
+  version '4.0.1'
+  sha256 '3b8833e308cb4916cc3adfb3c7a0267e37decd39472b8e3ea483a6ece4ce2be2'
 
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"
   name 'TortoiseHg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.