### PR TITLE
Update downie to 2.6.6,1383

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.6.5,1379'
-  sha256 '4b4c7ad3793338f6c4d6b45d25c1f15f98e15ccabbf2a1be0fb657b4b7bed9d1'
+  version '2.6.6,1383'
+  sha256 '1a3cf6f702707c092f3aeb224a248ef366553118f7c5298e30880734c8e310ab'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'b41b2600773d0eef3bcc8c3785a545011dbe086093fa2be016fca36362d79572'
+          checkpoint: 'a6ab19fc26c362ea2c326bf6e87f1c5e7f4cdf819dd1df2dd621b769e07c2b41'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.