### PR TITLE
Update tnefs-enough to 3.7

### DIFF
--- a/Casks/tnefs-enough.rb
+++ b/Casks/tnefs-enough.rb
@@ -15,8 +15,8 @@ cask 'tnefs-enough' do
 
     url "http://www.joshjacob.com/mac-development/TNEF#{version}.dmg"
   else
-    version '3.6'
-    sha256 '75063d28eba5e436dbef8df9f9abbb095a32908830c13ea1363fb951ae5e4780'
+    version '3.7'
+    sha256 'fd8f0fa03b03fa0307a74694abed29e797b13e844d4d435c21f588fef5bb5d79'
 
     url "http://www.joshjacob.com/mac-development/TNEF#{version}.dmg"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.