### PR TITLE
Update ticktick to 1.6.31

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '1.6.20'
-  sha256 'e5aad9b01da4e9f08eb5355a189b669ff142002b445517c3280522d550a2f2b6'
+  version '1.6.31'
+  sha256 'b5fb9aa43ddd2a2ff6636cbf6feb274e2b10bce2330b23635624f06b9d37d770'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.