### PR TITLE
Update timely to 0.4.5

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,11 +1,11 @@
 cask 'timely' do
-  version '0.4.4'
-  sha256 '284c0171ba10dd62bd0e5ac447dfca35727a452eca998f350d04ea252c672290'
+  version '0.4.5'
+  sha256 '732ca8669ce3390d5b9404bfb3ce06b30e0a20ef0a60da081624d22a1955c341'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/osx64-v#{version}/Timely-#{version}.dmg"
   appcast 'https://github.com/Timely/desktop-releases/releases.atom',
-          checkpoint: 'f50a2ff2f33ca35f1410975a6fdfba93546f7541d7a6ec8d5eb668c777242f02'
+          checkpoint: '10058dde6d53d6ab0fa626266ffbe9ee7ab53172ed41bde843d700ea9eb5a5d4'
   name 'Timely'
   homepage 'https://timelyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.