### PR TITLE
Add i1Profiler.app v1.6.7

### DIFF
--- a/Casks/i1profiler.rb
+++ b/Casks/i1profiler.rb
@@ -6,7 +6,7 @@ cask 'i1profiler' do
   name 'i1Profiler'
   name 'Eye-One Profiler'
   name 'i1Publish'
-  homepage 'http://www.xrite.com/service-support/downloads/I/i1Profiler-i1Publish_V1_6_7'
+  homepage "http://www.xrite.com/service-support/downloads/I/i1Profiler-i1Publish_V#{version.dots_to_underscores}"
 
   pkg 'i1Profiler.pkg'
 

--- a/Casks/i1profiler.rb
+++ b/Casks/i1profiler.rb
@@ -1,0 +1,18 @@
+cask 'i1profiler' do
+  version '1.6.7'
+  sha256 'fe3a00123b6c9a1b60f7d2d42207770d1cffa23fe2e29410a308ee6dee40fda0'
+
+  url 'https://my.xrite.com/downloader.aspx?FileID=1672&Type=M'
+  name 'i1Profiler'
+  name 'Eye-One Profiler'
+  name 'i1Publish'
+  homepage 'http://www.xrite.com/service-support/downloads/I/i1Profiler-i1Publish_V1_6_7'
+
+  pkg 'i1Profiler.pkg'
+
+  uninstall pkgutil: 'com.xrite.i1profiler.*'
+
+  caveats do
+    reboot
+  end
+end


### PR DESCRIPTION
Adds current X-Rite color profiling application to homebrew-cask.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
