### PR TITLE
Inaccurate info about Ruby syntax

### DIFF
--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -112,8 +112,6 @@ cask '<cask-token>' do
 [`<cask-token>`](token_reference.md) should match the Cask filename, without the `.rb` extension,
 enclosed in single quotes.
 
-The header line is not entirely strict Ruby: no comma is required after the Cask token.
-
 There are currently some arbitrary limitations on Cask tokens which are in the process of being removed. The Travis bot will catch any errors during the transition.
 
 


### PR DESCRIPTION
The language reference seems to imply that `cask 'foo' do ... end` isn't "strict" Ruby, whatever that means. But that's not true: in standard Ruby syntax, no comma is required between simple arguments and a `do` block. So I'm suggesting removing the sentence that claims that this is not strict Ruby.