### PR TITLE
Update crypter to 3.0.0

### DIFF
--- a/Casks/crypter.rb
+++ b/Casks/crypter.rb
@@ -1,10 +1,10 @@
 cask 'crypter' do
-  version '2.0.0'
-  sha256 '51dea8a15d9d0cc3d5c32e9e175970b2208f5d1c1aa320819a370ae25eb34542'
+  version '3.0.0'
+  sha256 '72f2c6a2ab93b538865c59c8940376a9f475517e82e0c582e751f9732c06926d'
 
   url "https://github.com/HR/Crypter/releases/download/v#{version}/Crypter-#{version}.dmg"
   appcast 'https://github.com/HR/Crypter/releases.atom',
-          checkpoint: 'd0dbab1db97560147c7e706bd4dbadd8095d33937e8749d67f17bf13489f42ef'
+          checkpoint: 'c27754561a4ceaee39898c4eb5d52062c8d4b4237f32d55132a602fdfd884450'
   name 'Crypter'
   homepage 'https://github.com/HR/Crypter'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.