### PR TITLE
Upgrade Litecoin-Qt.app to v0.13.2

### DIFF
--- a/Casks/litecoin.rb
+++ b/Casks/litecoin.rb
@@ -1,6 +1,6 @@
 cask 'litecoin' do
-  version '0.10.4.0'
-  sha256 '165452e7eefb36771002fdfc8e35b436f4af5280683c33ee6919282be5078f01'
+  version '0.13.2'
+  sha256 '5a86edc58c9bbc0ee059e933e5b94470f168caa76557bc8f255b35d3c8530954'
 
   url "https://download.litecoin.org/litecoin-#{version}/osx/litecoin-#{version}-osx.dmg"
   name 'Litecoin'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.