### PR TITLE
Update rejected_casks.md

### DIFF
--- a/doc/faq/rejected_casks.md
+++ b/doc/faq/rejected_casks.md
@@ -13,6 +13,8 @@ Common reasons to reject a Cask entirely:
 + The app has been rejected before due to an issue we cannot fix, and this new submission doesn’t fix that . An example would be [the first submission of `soapui`](https://github.com/caskroom/homebrew-cask/pull/4939), whose installation problems were not fixed in the two subsequent submissions ([#9969](https://github.com/caskroom/homebrew-cask/pull/9969), [#10606](https://github.com/caskroom/homebrew-cask/pull/10606)).
 + The Cask is a duplicate. These submissions mostly occur when the [token reference](../cask_language_reference/token_reference.md) was not followed.
 + The download URL for the app is both behind a login/registration form and from a host that differs from the homepage, meaning users can’t easily verify its authenticity. [alehouse/homebrew-unofficial](https://github.com/alehouse/homebrew-unofficial) is a sister repo where you may wish to submit your cask.
++ The Cask is for an app that is unmaintained (no releases in the last year, or [explicitly discontinued](https://github.com/caskroom/homebrew-cask/pull/22699)).
++ The Cask is too obscure (for example, for an app from a GitHub repository that is not [notable enough](https://github.com/caskroom/homebrew-cask/pull/28103) (< 10 forks)).
 + The author has [specifically asked us not to include it](https://github.com/caskroom/homebrew-cask/pull/5342).
 
 Common reasons to reject a Cask from the main repo:

--- a/doc/faq/rejected_casks.md
+++ b/doc/faq/rejected_casks.md
@@ -14,7 +14,7 @@ Common reasons to reject a Cask entirely:
 + The Cask is a duplicate. These submissions mostly occur when the [token reference](../cask_language_reference/token_reference.md) was not followed.
 + The download URL for the app is both behind a login/registration form and from a host that differs from the homepage, meaning users can’t easily verify its authenticity. [alehouse/homebrew-unofficial](https://github.com/alehouse/homebrew-unofficial) is a sister repo where you may wish to submit your cask.
 + The Cask is for an app that is unmaintained (no releases in the last year, or [explicitly discontinued](https://github.com/caskroom/homebrew-cask/pull/22699)).
-+ The Cask is too obscure (for example, for an app from a GitHub repository that is not [notable enough](https://github.com/caskroom/homebrew-cask/pull/28103) (< 10 forks)).
++ The Cask is too obscure (for example, for an app from a GitHub repository that is not [notable enough](https://github.com/caskroom/homebrew-cask/pull/28103) (< 10 stars)).
 + The author has [specifically asked us not to include it](https://github.com/caskroom/homebrew-cask/pull/5342).
 
 Common reasons to reject a Cask from the main repo:

--- a/doc/faq/rejected_casks.md
+++ b/doc/faq/rejected_casks.md
@@ -14,7 +14,7 @@ Common reasons to reject a Cask entirely:
 + The Cask is a duplicate. These submissions mostly occur when the [token reference](../cask_language_reference/token_reference.md) was not followed.
 + The download URL for the app is both behind a login/registration form and from a host that differs from the homepage, meaning users can’t easily verify its authenticity. [alehouse/homebrew-unofficial](https://github.com/alehouse/homebrew-unofficial) is a sister repo where you may wish to submit your cask.
 + The Cask is for an app that is unmaintained (no releases in the last year, or [explicitly discontinued](https://github.com/caskroom/homebrew-cask/pull/22699)).
-+ The Cask is too obscure (for example, for an app from a GitHub repository that is not [notable enough](https://github.com/caskroom/homebrew-cask/pull/28103) (< 10 stars)).
++ The Cask is too obscure (for example, a self-submitted app from a GitHub repository that is [not notable enough](https://github.com/caskroom/homebrew-cask/pull/28103) (< 10 stars)).
 + The author has [specifically asked us not to include it](https://github.com/caskroom/homebrew-cask/pull/5342).
 
 Common reasons to reject a Cask from the main repo:


### PR DESCRIPTION
Closes https://github.com/caskroom/homebrew-cask/issues/28220.

I think the third point in https://github.com/caskroom/homebrew-cask/issues/28220, namely:

> What maintainers feel is too much overhead for the value

is already covered by:

> The cask is so difficult to maintain, it constantly breaks. Happened only once so far, with Audacity, because it uses fosshub as a distribution site.
