### PR TITLE
Update audirvana-plus to 2.6.5

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,10 +1,10 @@
 cask 'audirvana-plus' do
-  version '2.6.4'
-  sha256 '693d4e9af53a0eaa8a96a474c19f237ffa0387e8d0dfa6353f00140226fb72be'
+  version '2.6.5'
+  sha256 '1715966fcec1fffa9f5fc7d2c50a81fd3a029c9fa3348a071287f134a7920459'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml",
-          checkpoint: 'b20274c82807b04f4613c3caf3778059f8b355defdab3b1ef4a8dbe54083cabf'
+          checkpoint: 'bfbd74cd8c17b1c625d396c55b2eecc0a951451d50756399b7c0b47c863ac282'
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.