### PR TITLE
Update caret to 1.13.4

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.13.0'
-  sha256 '302528ac9f2d59429d84dc3bafdb0539013ea40d07d71025eff6e6194a60fa5c'
+  version '1.13.4'
+  sha256 '0713abb9f580e66debdc01f29c8dcd671d9866a3d65fb84bcab7c7a98dd1e07d'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '328959312f1bbefe6d14814b38776a810012e4309ce44700797d9e2165829646'
+          checkpoint: '231d2003111ededfd466c91de687c27fbf8adeb52196ef7606a565fdc0f45a39'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.