### PR TITLE
Update dripcap to 0.6.3

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.6.1'
-  sha256 '8aeef72c32a76906feb5dc5d95e2195f06404225305d6bdbaff9477ca49b367e'
+  version '0.6.3'
+  sha256 'c3995deb192266c1099407d7b00f824f28493691cb9d30b472fc73dfd652d191'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '25aa7d8fbacf558990e74d9d6caae648365facd3851e133fede5c1ade363adbc'
+          checkpoint: '8eabc4fab17a4dd5d84c1b38bcad6474ce4f4c9689592aa2173cfba57f0f0e56'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.