### PR TITLE
Update gas-mask to 0.8.5

### DIFF
--- a/Casks/gas-mask.rb
+++ b/Casks/gas-mask.rb
@@ -1,10 +1,10 @@
 cask 'gas-mask' do
-  version '0.8.4'
-  sha256 '2ad7dbb866f42a6adbda84ae454cefceab0df163602927e9936f26deb300b434'
+  version '0.8.5'
+  sha256 '23dba9a90432e060c144e9e35077a7dbd4b3bf1a9848807461dad9d8d8f3ae83'
 
   url "http://gmask.clockwise.ee/files/gas_mask_#{version}.zip"
   appcast 'http://gmask.clockwise.ee/check_update/',
-          checkpoint: '45971ba5209d41a4b67875dc31f487be0d1ac11af7f7e75e082dfb8681a7d785'
+          checkpoint: '257f5e44affa2eabe7e530f40ae8f7238e472dfe1da0f94c588dbb5a35a879ab'
   name 'Gas Mask'
   homepage 'http://clockwise.ee/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.