### PR TITLE
Update racket to 6.8

### DIFF
--- a/Casks/racket.rb
+++ b/Casks/racket.rb
@@ -1,6 +1,6 @@
 cask 'racket' do
-  version '6.7'
-  sha256 'abd6d9da0b09c3dc9d06e5a48ebb5e567f57ffa1584f4f262f9e6ecca9d8108a'
+  version '6.8'
+  sha256 '98303654b3c5bc1389e35fe8ca91f8b2ee749469796b2d80d864fb7dfdccc547'
 
   # cs.utah.edu/plt/installers was verified as official when first introduced to the cask
   url "https://www.cs.utah.edu/plt/installers/#{version}/racket-#{version}-x86_64-macosx.dmg"
@@ -30,13 +30,4 @@ cask 'racket' do
   binary "#{appdir}/Racket v#{version}/bin/slatex"
   binary "#{appdir}/Racket v#{version}/bin/slideshow"
   binary "#{appdir}/Racket v#{version}/bin/swindle"
-
-  caveats <<-EOS.undent
-    MacBook Pro with Touch Bar users:
-    To avoid a bug in this version that prevents programs from working with the Touch Bar, use the 32-bit version or try a snapshot build:
-      https://pre.racket-lang.org/installers/
-
-    More information on the download page:
-      https://download.racket-lang.org/
-  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The caveat for Touch Bar MBPs isn't needed any more -- that was fixed in this version according to the [release notes](https://download.racket-lang.org/v6.8.html) and my own test.