### PR TITLE
Update opera to 42.0.2393.351

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '42.0.2393.137'
-  sha256 'b0f6668cc37906b7b5126bcda6cec5cb9349290856296b82e9d73d7ff166cd3a'
+  version '42.0.2393.351'
+  sha256 '9a0baa36748fc0850dad66fa2738e5247f813b23152b3495ed2bb254b5248acf'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.