### PR TITLE
Update jedict to 5.0.1

### DIFF
--- a/Casks/jedict.rb
+++ b/Casks/jedict.rb
@@ -1,8 +1,8 @@
 cask 'jedict' do
-  version '5.0'
-  sha256 'b18454ea99a410c38a20af354476572de21d5a0fe91795dfc399b605534b1ae0'
+  version '5.0.1'
+  sha256 'e31f6b185e2aa326ba8b2981e668b751baf11b8e469d8e347f1da26488cc8000'
 
-  url "http://jedict.com/Downloads/JEDict.#{version}.zip"
+  url "http://jedict.com/Downloads/JEDict#{version.no_dots}.dmg"
   name 'Jedict'
   homepage 'http://www.jedict.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.