### PR TITLE
pre_bug_report.md: remove steps relevant to old installs

### DIFF
--- a/doc/reporting_bugs/pre_bug_report.md
+++ b/doc/reporting_bugs/pre_bug_report.md
@@ -8,8 +8,7 @@ If you did not find your particular bug, before reporting it make sure you have 
 
 ```bash
 $ cd $(brew --repo); git fetch; git reset --hard origin/master
-$ brew untap phinze/cask; brew untap caskroom/cask; brew uninstall --force brew-cask
-$ brew cleanup; brew cask cleanup; brew update
+$ brew untap caskroom/cask; brew cleanup; brew cask cleanup; brew update
 ```
 
 Retry your failing command. If the issue persists, [go back](../../README.md#reporting-bugs) and pick the appropriate instructions for your problem.


### PR DESCRIPTION
Removed steps are the ones that are expected to fail and to only matter if you have a really old install. Likely safe to remove them already.