### PR TITLE
Update maratis url and appcast

### DIFF
--- a/Casks/maratis.rb
+++ b/Casks/maratis.rb
@@ -2,7 +2,6 @@ cask 'maratis' do
   version '3.21-beta'
   sha256 '7ec6dd97f1ce1ce09e08df0947fcb6ceb7a9f63024998f44afed3d3965829707'
 
-  # maratis.googlecode.com was verified as official when first introduced to the cask
   url "http://maratis3d.org/download/archive/Maratis-#{version}-osx10.6.zip"
   appcast 'http://www.maratis3d.org/?page_id=57',
           checkpoint: '25042e2459b0727346e446c22c539bc64db4b322e273005a97956b52e7a0be39'

--- a/Casks/maratis.rb
+++ b/Casks/maratis.rb
@@ -3,7 +3,9 @@ cask 'maratis' do
   sha256 '7ec6dd97f1ce1ce09e08df0947fcb6ceb7a9f63024998f44afed3d3965829707'
 
   # maratis.googlecode.com was verified as official when first introduced to the cask
-  url "https://maratis.googlecode.com/files/Maratis-#{version}-osx10.6.zip"
+  url "http://maratis3d.org/download/archive/Maratis-#{version}-osx10.6.zip"
+  appcast 'http://www.maratis3d.org/?page_id=57',
+          checkpoint: '25042e2459b0727346e446c22c539bc64db4b322e273005a97956b52e7a0be39'
   name 'Maratis'
   homepage 'http://www.maratis3d.org/'
 


### PR DESCRIPTION
* original download link was 404
* also adding appcast as the checkpoint hasn't changed in a week

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] The commit message includes the cask’s name and version.