### PR TITLE
Update opencpn homepage and appcast

### DIFF
--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -4,8 +4,10 @@ cask 'opencpn' do
 
   # opencpn.navnux.org was verified as official when first introduced to the cask
   url "http://opencpn.navnux.org/#{version}/OpenCPN_#{version}.dmg"
+  appcast 'https://github.com/OpenCPN/OpenCPN/releases.atom',
+          checkpoint: '169b89252300cc760dab9f554ad9384183e3d3c7dbad746dfcdf44e69c2e6e93'
   name 'OpenCPN'
-  homepage 'https://opencpn.org/ocpn/'
+  homepage 'http://opencpn.org/'
 
   app 'OpenCPN.app'
 end


### PR DESCRIPTION
- homepage gave an error that certificates were for another domain, likely the hosting provider. Changing back to http.
- git based appcast does not have download links

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.