### PR TITLE
Update acslogo homepage and appcast

### DIFF
--- a/Casks/acslogo.rb
+++ b/Casks/acslogo.rb
@@ -3,8 +3,10 @@ cask 'acslogo' do
   sha256 'fcdab9679a9cc783d4b7912d611442faa1fe1293497c4cb649f6808a58d27082'
 
   url "http://www.alancsmith.co.uk/logo/ACSLogo#{version.no_dots}.dmg"
+  appcast 'http://www.alancsmith.co.uk/logo/release.html',
+          checkpoint: '827be82e4df2954df3dd3af536ad4a2db3a20fb6f19f078f9b23b87e52a9ac23'
   name 'ACSLogo'
-  homepage 'https://www.alancsmith.co.uk/logo/'
+  homepage 'http://www.alancsmith.co.uk/logo/'
 
   app 'ACSLogo/ACSLogo.app'
 end


### PR DESCRIPTION
- homepage gave an error that certificates were for another domain, likely the hosting provider. Changing back to http
- adding discovered appcast

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.