### PR TITLE
Update hab to 0.16.0-20170119214652

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.15.0-20161222215311'
-  sha256 'bf7066ef3a059b8d11099f7ef133d3123c4a0b0a1c1e40c18d2f99ac0cf74491'
+  version '0.16.0-20170119214652'
+  sha256 '81ac7209aca4573629a4c0e2ce73ff7fd93217c09b57ec9ef60b0edc323b8ca2'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'd1a116c68f18a5af0735c9a7d2651e0225ccec6751446841cd9a66ad26799afd'
+          checkpoint: 'eb6c98ff47cb2d9629a1a5dd4b862c8fdd99dbabccd37d2cb6151c4058e75457'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.