### PR TITLE
Update stella urls

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -2,11 +2,12 @@ cask 'stella' do
   version '4.7.3'
   sha256 'b78cc81541830bc054318858e11dc07254bf1e7c64095f19479f8301b42aab77'
 
-  url "https://downloads.sourceforge.net/stella/stella/#{version}/Stella-#{version}-macosx.dmg"
-  appcast 'https://sourceforge.net/projects/stella/rss?path=/stella',
-          checkpoint: '880727ceb05e13b21bbd463ab9e090761e7ca74e17c15056e163c93263819a3c'
+  # github.com/stella-emu/stella/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/stella-emu/stella/releases/download/release-#{version}/Stella-#{version}-macosx.dmg"
+  appcast 'https://github.com/stella-emu/stella/releases.atom',
+          checkpoint: 'bed2f880db4e38155c5a5d730fbce423fe30b9ebacc0fd1eb1126644f1306440'
   name 'Stella'
-  homepage 'http://stella.sourceforge.net/'
+  homepage 'https://stella-emu.github.io/'
 
   app 'Stella.app'
 end


### PR DESCRIPTION
- download link was a redirect to sourceforge
- [sourceforge homepage](http://stella.sourceforge.net/) notes move to new url https://stella-emu.github.io/
- same page also notes move to github for source

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.