### PR TITLE
Update weiyun to 3.0.1.315.28482

### DIFF
--- a/Casks/weiyun.rb
+++ b/Casks/weiyun.rb
@@ -1,6 +1,6 @@
 cask 'weiyun' do
-  version '2.0.002.20632'
-  sha256 'e219143abb8b5cbf1063a28f72398e8747bdec0cd95ad03369edbb16a8dd9043'
+  version '3.0.1.315.28482'
+  sha256 '80b7bd49f30bebcef5c501d78b7b2d4b118bb05cfc6fced73cffcce25ff9191c'
 
   # dldir1.qq.com/weiyun was verified as official when first introduced to the cask
   url "http://dldir1.qq.com/weiyun/Weiyun_Mac_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.