### PR TITLE
Add standalone Microsoft OneDrive v17.3.6760.0105

### DIFF
--- a/Casks/onedrive.rb
+++ b/Casks/onedrive.rb
@@ -1,0 +1,13 @@
+cask 'onedrive' do
+  version '17.3.6760.0105'
+  sha256 '1b46614fe775aee48c9280430ab31af6d73a5b38b3e64fb1f6955c80c448aab1'
+
+  # oneclient.sfx.ms was verified as official when first introduced to the cask
+  url "https://oneclient.sfx.ms/Mac/Prod/#{version}/OneDrive.pkg"
+  name 'OneDrive'
+  homepage 'https://onedrive.live.com/'
+
+  pkg 'OneDrive.pkg'
+
+  uninstall pkgutil: 'com.microsoft.OneDrive'
+end


### PR DESCRIPTION
This request adds support for the standalone version of Microsoft OneDrive. Earlier versions of OneDrive were refused (#25356), because they were MAS-only, but the standalone version was [recently released](https://blogs.office.com/2017/01/24/onedrive-brings-new-file-collaboration-and-management-features-to-the-enterprise/).

Note that, although I attempted to use the [version convention](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/version.md) in the url stanza, I was unable to get the download to work when substituting `#{version}` for the actual version number:

`Error: Cask 'onedrive' definition is invalid: 'url' stanza failed with: bad URI(is not URI?): https://oneclient.sfx.ms/Mac/Prod/#{version}/OneDrive.pkg`

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask