### PR TITLE
Update scratch to 2.0,453

### DIFF
--- a/Casks/scratch.rb
+++ b/Casks/scratch.rb
@@ -1,20 +1,22 @@
 cask 'scratch' do
-  version '450'
-  sha256 'bfe08081a5430a73cdc8b5d650decfbb3d71356d1e6599d942eaf73513918998'
+  version '2.0,453'
+  sha256 'a02759da55edb5209168e30cbb68545a06e9691417ebae2ea64f74d80b94ce4f'
 
-  url "https://scratch.mit.edu/scratchr2/static/sa/Scratch-#{version}.dmg"
+  url "https://scratch.mit.edu/scratchr2/static/sa/Scratch-#{version.after_comma}.dmg"
+  appcast 'https://scratch.mit.edu/scratchr2/static/sa/version.xml',
+          checkpoint: '1394a9c112ab300d9fc8c2ff4536979188f637e6b32b999379d1863e6dd136c2'
   name 'Scratch'
   homepage 'https://scratch.mit.edu/scratch2download/'
 
   depends_on cask: 'adobe-air'
 
-  installer script: 'Install Scratch 2.app/Contents/MacOS/Install Scratch 2',
+  installer script: "Install Scratch #{version.major}.app/Contents/MacOS/Install Scratch #{version.major}",
             args:   %w[-silent],
             sudo:   true
 
   uninstall script: {
                       executable: Hbc::Container::Air::INSTALLER_PATHNAME,
-                      args:       %w[-uninstall -silent /Applications/Scratch\ 2.app],
+                      args:       ['-uninstall', '-silent', "/Applications/Scratch\ #{version.major}.app"],
                       sudo:       true,
                     }
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.