### PR TITLE
Update sdl-framework to 2.0.5

### DIFF
--- a/Casks/sdl-framework.rb
+++ b/Casks/sdl-framework.rb
@@ -1,8 +1,10 @@
 cask 'sdl-framework' do
-  version '1.2.15'
-  sha256 '49e228446599b1f77af812a6276dd7a3f230f8d7a02d1b7b62bb99a874262834'
+  version '2.0.5'
+  sha256 '09309e5af6739ce91e8e5db443604a0d0d85e0b728652423ba1a00e26363c30c'
 
-  url "https://www.libsdl.org/release/SDL-#{version}.dmg"
+  url "https://www.libsdl.org/release/SDL#{version.major}-#{version}.dmg"
+  appcast 'https://www.libsdl.org/release/',
+          checkpoint: '96be2bfa97cbeb863b64bf12cca8b658966907d94a227ccdd05853f0875a0338'
   name 'SDL.framework'
   homepage 'https://www.libsdl.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.