### PR TITLE
Update meld to 3.16.0-r1,osx-9

### DIFF
--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -10,5 +10,5 @@ cask 'meld' do
   homepage 'https://yousseb.github.io/meld/'
 
   app 'Meld.app'
-  binary "#{appdir}/Contents/Resources/meld"
+  binary "#{appdir}/Contents/MacOS/Meld", target: 'meld'
 end

--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -10,5 +10,5 @@ cask 'meld' do
   homepage 'https://yousseb.github.io/meld/'
 
   app 'Meld.app'
-  binary "#{appdir}/Contents/MacOS/Meld", target: 'meld'
+  binary "#{appdir}/Meld.app/Contents/MacOS/Meld", target: 'meld'
 end

--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -5,9 +5,10 @@ cask 'meld' do
   # github.com/yousseb/meld was verified as official when first introduced to the cask
   url "https://github.com/yousseb/meld/releases/download/#{version.after_comma}/meldmerge.dmg"
   appcast 'https://github.com/yousseb/meld/releases.atom',
-          checkpoint: '4c9b17456ea505a7490456e40b96b980ae3295ad844fed7e71ac1c091787c250'
+          checkpoint: '4f8b54087e9218c1195f74c5a70bbcfc32803fbbd92a3a90257437d7300a4f27'
   name 'Meld for OSX'
   homepage 'https://yousseb.github.io/meld/'
 
   app 'Meld.app'
+  binary "#{appdir}/Contents/Resources/meld"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/29398