### PR TITLE
Update acorn to 5.6.2

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,10 +1,10 @@
 cask 'acorn' do
-  version '5.6.1'
-  sha256 '98d716aebb93e788f0ddda995734acba7923ba54cfac0cbda96a1bd50cb81454'
+  version '5.6.2'
+  sha256 '89b794eebbace2e81c6d1e4c9425f37d14f864e00fba30b1b4eb6f37ff635a8f'
 
   url 'https://secure.flyingmeat.com/download/Acorn.zip'
   appcast "http://www.flyingmeat.com/download/acorn#{version.major}update.xml",
-          checkpoint: 'f2cae39743280c31919bdd1262496776914d45815576c14d99ad4706b58eff1a'
+          checkpoint: '3362206a7a3a6b81d107918a92e606e99b3aa1b6cb2b38c0c73f3580b13220f0'
   name 'Acorn'
   homepage 'http://flyingmeat.com/acorn/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.