### PR TITLE
eclipse-installer.rb: Correct version and url

### DIFF
--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-installer' do
-  version '4.6.2,neon:2'
+  version '4.6.2,neon:2a'
   sha256 '8ff79e95be4bc8f88d75723cd068bc37545eb78f297eed0c544f9830b008fc3b'
 
-  url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.after_comma.before_colon}/R2a/eclipse-inst-mac64.tar.gz&r=1"
+  url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.after_comma.before_colon}/R#{version.after_colon}/eclipse-inst-mac64.tar.gz&r=1"
   name 'Eclipse Installer'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
 Correct `url` basing on `version`, so in future releases, just the `version` and `sha256` fields will need an update.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.