### PR TITLE
Update world-of-tanks to 1.0.37

### DIFF
--- a/Casks/world-of-tanks.rb
+++ b/Casks/world-of-tanks.rb
@@ -7,7 +7,7 @@ cask 'world-of-tanks' do
 
     url 'https://wot.gcdn.co/eu/files/osx/worldoftanks_eu.dmg'
     appcast 'https://wot.gcdn.co/eu/files/osx/WoT_OSX_update_eu.xml',
-            checkpoint: 'd54b5dc41164a6dcb009b5322cbda681b0a0b46337fe7ba4ba13a359f1348771'
+            checkpoint: 'ff33b34e2e24f607ee0ed1d61381f735f1549a5f97efd4e8c58d3b815e59920d'
     homepage 'http://worldoftanks.eu/'
   end
 
@@ -16,7 +16,7 @@ cask 'world-of-tanks' do
 
     url 'https://wot.gcdn.co/us/files/osx/worldoftanks_na.dmg'
     appcast 'https://wot.gcdn.co/us/files/osx/WoT_OSX_update_na.xml',
-            checkpoint: '8fcc538b937d2c3a4fe17b85e7e4c59b609afe77056f6ce5d229618a67b08d09'
+            checkpoint: 'd2ec97babd465efc465a53aa68449d36e7b6c113d4580b1e93772fcc159bb564'
     homepage 'http://worldoftanks.com/'
   end
 
@@ -25,7 +25,7 @@ cask 'world-of-tanks' do
 
     url 'https://wot.gcdn.co/sea/files/osx/worldoftanks_asia.dmg'
     appcast 'https://wot.gcdn.co/sea/files/osx/WoT_OSX_update_asia.xml',
-            checkpoint: '086cd744b3b602f69b32c016599a465b153bf28b67f8dc6a057addef45ba192f'
+            checkpoint: 'ac623285e49b86445a21fa1d1fa252db3c64b8eb404dea8612bbe65d85ca46c3'
     homepage 'http://worldoftanks.asia/'
   end
 
@@ -34,7 +34,7 @@ cask 'world-of-tanks' do
 
     url 'https://wot.gcdn.co/kr/files/osx/worldoftanks_kr.dmg'
     appcast 'https://wot.gcdn.co/kr/files/osx/WoT_OSX_update_kr.xml',
-            checkpoint: '5fa09a65e22f1d42b00d052acc4abbb3cf4ce71d946a549fb5904427069d8a6e'
+            checkpoint: 'eebcac213b0780034b8592a30584d0022edf3ce611d45eff5d91b39b51e7127e'
     homepage 'http://worldoftanks.kr/'
   end
 
@@ -43,7 +43,7 @@ cask 'world-of-tanks' do
 
     url 'https://wot.gcdn.co/ru/files/osx/worldoftanks_ru.dmg'
     appcast 'https://wot.gcdn.co/ru/files/osx/WoT_OSX_update_ru.xml',
-            checkpoint: 'ff33b34e2e24f607ee0ed1d61381f735f1549a5f97efd4e8c58d3b815e59920d'
+            checkpoint: '00dcde02245e1b02259316adf06235a0cd67b94c6449e3798a814f10180a8c5e'
     homepage 'http://worldoftanks.ru/'
   end
 

--- a/Casks/world-of-tanks.rb
+++ b/Casks/world-of-tanks.rb
@@ -39,7 +39,7 @@ cask 'world-of-tanks' do
   end
 
   language 'RU' do
-    sha256 'd5ea883948ebc74c63d8684fbde36f6266e21296855af443f610464f661e0e23'
+    sha256 'e2e2750ff01fb00a5ca44244273c821c2564ed533543ecf16ef73cce3712bfb8'
 
     url 'https://wot.gcdn.co/ru/files/osx/worldoftanks_ru.dmg'
     appcast 'https://wot.gcdn.co/ru/files/osx/WoT_OSX_update_ru.xml',

--- a/Casks/world-of-tanks.rb
+++ b/Casks/world-of-tanks.rb
@@ -1,49 +1,49 @@
 cask 'world-of-tanks' do
-  version '1.0.34'
+  version '1.0.37'
 
   # wot.gcdn.co was verified as official when first introduced to the cask
   language 'AT', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LI', 'LT', 'LV', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR' do
-    sha256 '6c2a9c2ca507e5730a0494571ad58952bf655c8b3a9e963d4fcc5cdf6af7ab30'
+    sha256 '7caed20a567676b17d5518dfb6572683032b23b2060e919e77c0f6fd3d2eae75'
 
     url 'https://wot.gcdn.co/eu/files/osx/worldoftanks_eu.dmg'
     appcast 'https://wot.gcdn.co/eu/files/osx/WoT_OSX_update_eu.xml',
-            checkpoint: '7a151d7884cc87d0a9d1dad524c7ca3dbf1da571183d971d7426e7a3e443bd72'
+            checkpoint: 'd54b5dc41164a6dcb009b5322cbda681b0a0b46337fe7ba4ba13a359f1348771'
     homepage 'http://worldoftanks.eu/'
   end
 
   language 'CA', 'US', default: true do
-    sha256 '38485f2c422f18e97403b2761082e38700adfa06eba92ec7f1b6e30acd07ba42'
+    sha256 '90dca56188ff16623442996013181a46a3123a2dab319c0fbedfc29438891268'
 
     url 'https://wot.gcdn.co/us/files/osx/worldoftanks_na.dmg'
     appcast 'https://wot.gcdn.co/us/files/osx/WoT_OSX_update_na.xml',
-            checkpoint: '1e3ca625cca19f523265c07c2f2beef750b2b4dc22446d75ecb15e67964a5847'
+            checkpoint: '8fcc538b937d2c3a4fe17b85e7e4c59b609afe77056f6ce5d229618a67b08d09'
     homepage 'http://worldoftanks.com/'
   end
 
   language 'CN', 'ID', 'IN', 'JP', 'PH', 'SG', 'TH', 'TW', 'VN' do
-    sha256 'cd1730d62a6d6c2289074c53d11276db4cdc4a4c03b9d2526335ed25e5930192'
+    sha256 '7a2e737cf2951aec6b236a6bfabf483fac20b584935c4ac067aad55584ed4dfb'
 
     url 'https://wot.gcdn.co/sea/files/osx/worldoftanks_asia.dmg'
     appcast 'https://wot.gcdn.co/sea/files/osx/WoT_OSX_update_asia.xml',
-            checkpoint: '0b4bad256188ed484b8e946e5ef80b74fadc717b39b1fdc747f2c95e938077bb'
+            checkpoint: '086cd744b3b602f69b32c016599a465b153bf28b67f8dc6a057addef45ba192f'
     homepage 'http://worldoftanks.asia/'
   end
 
   language 'KR' do
-    sha256 '9f57a2ffc0e5a7a76bd59438be5f73505f2508adf4b5ea4d119a0cf9ef453b2f'
+    sha256 '9e94c6f0767a14dd42ba4890452d1ad397a687deaff457a47157fa7c472793b0'
 
     url 'https://wot.gcdn.co/kr/files/osx/worldoftanks_kr.dmg'
     appcast 'https://wot.gcdn.co/kr/files/osx/WoT_OSX_update_kr.xml',
-            checkpoint: '00fd089c9f73e92fa45a3b7f750a28a5479f0244e06132811ca7140814057833'
+            checkpoint: '5fa09a65e22f1d42b00d052acc4abbb3cf4ce71d946a549fb5904427069d8a6e'
     homepage 'http://worldoftanks.kr/'
   end
 
   language 'RU' do
-    sha256 '50c3892a49a19beeb5bf7b08bccbf94b657180e21ca5c4d2958a241f63370e01'
+    sha256 'd5ea883948ebc74c63d8684fbde36f6266e21296855af443f610464f661e0e23'
 
     url 'https://wot.gcdn.co/ru/files/osx/worldoftanks_ru.dmg'
     appcast 'https://wot.gcdn.co/ru/files/osx/WoT_OSX_update_ru.xml',
-            checkpoint: '482344ba173148844d943a0120764a5295fb050d4f321d7e4c484cd97f15cabe'
+            checkpoint: 'e2e2750ff01fb00a5ca44244273c821c2564ed533543ecf16ef73cce3712bfb8'
     homepage 'http://worldoftanks.ru/'
   end
 

--- a/Casks/world-of-tanks.rb
+++ b/Casks/world-of-tanks.rb
@@ -43,7 +43,7 @@ cask 'world-of-tanks' do
 
     url 'https://wot.gcdn.co/ru/files/osx/worldoftanks_ru.dmg'
     appcast 'https://wot.gcdn.co/ru/files/osx/WoT_OSX_update_ru.xml',
-            checkpoint: 'e2e2750ff01fb00a5ca44244273c821c2564ed533543ecf16ef73cce3712bfb8'
+            checkpoint: 'ff33b34e2e24f607ee0ed1d61381f735f1549a5f97efd4e8c58d3b815e59920d'
     homepage 'http://worldoftanks.ru/'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.