### PR TITLE
Update devonthink-pro-office to 2.9.9

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro-office' do
-  version '2.9.8'
-  sha256 '83987e904c9b45a36c6f853c3ad74d3ca4d13d647aa67ed1ff5149dc56211e5f'
+  version '2.9.9'
+  sha256 'a4288f97e914fa247a2c907d3e0c68f46c3cb0c4dda31959202ef2d04a773fa7'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: '4cf18f27a4a3be7201f7e45760410d4e0a12882b459894fcf1ae13c065fe4722'
+          checkpoint: '977b84827318d6850d3c49bfb3623a7b06e4d2282da3bf0f6c65bd0c66809887'
   name 'DEVONthink Pro Office'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.