### PR TITLE
Update devonthink-pro to 2.9.9

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.8'
-  sha256 '8cbf54ca7651b96fbef4ab6fb7996bc1875affb29e463a29ec63e02b8c13ae09'
+  version '2.9.9'
+  sha256 '665acc29ae0814f7fa6d2311e57636469cea32b09ed56eaed818358dd4ec85fc'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '8ac19c9384aecf656093ace77d527870718d7448339f55164d2548d270c6c8e8'
+          checkpoint: '3e624eeeef6347cb5c852db83a450a3328e5ff6bdac761561c5ff73ae1fe42f0'
   name 'DEVONthink Pro'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.