### PR TITLE
Update devonthink to 2.9.9

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.8'
-  sha256 '5c0038ce7088c0c83e3b33cabbaa7dc531904c9df1ccd5ced9ecc21e791f5ed2'
+  version '2.9.9'
+  sha256 '9b4d79d4b1b03669fc29f6c8f362fdac9ef4e0ecb279cd5ff74de851ae0a1b7a'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: '9c97727f49709539237dcf00bc520b13acbe9175a5c04b6273dfb183b30add21'
+          checkpoint: '26fd05eb4a3633c0f887be19532c05eaf9147796f3edbbaab91df0f0fb3d6669'
   name 'DEVONthink Personal'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.