### PR TITLE
Update gemini to 2.3.0

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,11 +1,11 @@
 cask 'gemini' do
-  version '2.2.5'
-  sha256 'd4a351010bdc0c88e8e4687b29f068d8872dcf0f9a97d1fb7d0efe4b7b3696c0'
+  version '2.3.0'
+  sha256 '26c9de9ba9b3e1b6866826f9db423e952cae3f1b1a6b54b9e861e28cc3c4d91c'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/Gemini#{version.major}.dmg"
   appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml",
-          checkpoint: 'fe8228534a39fa2db92f8fb7450fc01362a9a733d6540213c8390d6013661e7b'
+          checkpoint: 'a88afe489f4a8a438fb76c83d042834c3d7c0694431fdc30f543c7d65fdc7f6e'
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.