### PR TITLE
Update kotori to 0.14

### DIFF
--- a/Casks/kotori.rb
+++ b/Casks/kotori.rb
@@ -1,10 +1,10 @@
 cask 'kotori' do
-  version '0.12.1'
-  sha256 'd436558722b35e8e86b24e67ea9e8655c3db238b8b8ecf2126c5b14952ad1550'
+  version '0.14'
+  sha256 '8ce83290e6705b32c285308b376a3f849675c3ff0f91b5c4448a4b4a6b1e79e8'
 
   url "https://github.com/Watson1978/kotori/releases/download/v#{version}/kotori_#{version}.dmg"
   appcast 'https://github.com/Watson1978/kotori/releases.atom',
-          checkpoint: 'df12b61dc857c7834a150e912cf8175f5925e61c89e516a324abd0e788ebe9e9'
+          checkpoint: '10dddbf3e6d44d33b12a6b02f2c4336a6a4036cc09cf3c6166062684b22b9d04'
   name 'kotori'
   name '小鳥'
   homepage 'https://github.com/Watson1978/kotori'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.