### PR TITLE
Update lightpaper to 1.4.1

### DIFF
--- a/Casks/lightpaper.rb
+++ b/Casks/lightpaper.rb
@@ -1,11 +1,11 @@
 cask 'lightpaper' do
-  version '1.3.1'
-  sha256 '4df2fa5a481fc7ed9e9b3afc548a78199b12c7a6006011f0642e93339d06bcc3'
+  version '1.4.1'
+  sha256 'fbd2ecc6128f60e44d9793edfc92355275f072e80049cbe109be5539ba42a5f0'
 
   # hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8?format=zip'
   appcast 'https://dl.dropboxusercontent.com/u/83257/LpMacUpdates/lightpaper_appcast.xml',
-          checkpoint: '82bbbb41cd12179fd15583927586a2a4a60d0237be095f30c795aad9a7aa85cd'
+          checkpoint: 'cbeaa1256456c7ee603079bd83085365f210fc6721b3ce6c260d3ec0a6120db8'
   name 'LightPaper'
   homepage 'http://lightpaper.42squares.in/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.