### PR TITLE
Update lyn to 1.8.5

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,10 +1,10 @@
 cask 'lyn' do
-  version '1.8.4'
-  sha256 '899e6c37699f02ed0fe7c4abb09a27a5fdbf3f834ebfca1e661ec648495c4297'
+  version '1.8.5'
+  sha256 'a96766bee6e4350b096a5517c2bbb1170d018fc4016a0d67c67f71c4813a6f95'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: 'd4771771a079e5cfcb98e6767eee31349ea606837c4f5120ec19c2dab6fc9661'
+          checkpoint: '62aa93b5a77671a6028ec991884c80c8a4638e8674c853aabc679f6c0cda3a89'
   name 'Lyn'
   homepage 'http://www.lynapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.