### PR TITLE
Update mcedit to 1.5.6.0

### DIFF
--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -1,11 +1,11 @@
 cask 'mcedit' do
-  version '1.5.5.0'
-  sha256 '318fc9345e7630321f0ba993c68877713d423994f841c0086e23bfa6b062edae'
+  version '1.5.6.0'
+  sha256 'e2026de3589e3e65086a385ee4e02d607337bc9da11357d1b3ac106e2ee843d7'
 
   # github.com/Khroki/MCEdit-Unified was verified as official when first introduced to the cask
   url "https://github.com/Khroki/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
   appcast 'https://github.com/Khroki/MCEdit-Unified/releases.atom',
-          checkpoint: '2b8f79fcdc2bfd57af1409324dc194d13e27b59659a695f947e9cc02d254a908'
+          checkpoint: '4f2e24a6f33b62e24d538b879d16fce414771524787c44eac4ea6a7d88502366'
   name 'MCEdit-Unified'
   homepage 'http://www.mcedit-unified.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.