### PR TITLE
Update ndm to 0.1.4

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '0.1.3'
-  sha256 'bd066e0b833c99fd85562a1088144e0b68dbc7dedfe548d0510156397e91178b'
+  version '0.1.4'
+  sha256 'd8b33b688128650521f5d80718cbab87499f15b82536b208c3ee9f7c60352612'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '8a9ada6dd79cf6e995a79295bfa4fb3580052a78e0e4df1f2c505abe2fb204ab'
+          checkpoint: '234338ed5321bab24e1b6c5b4c982e2b4d003cf1c8a6292248dbf2146e3a0af1'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.