### PR TITLE
Update synology-cloud-station-backup to 4.2.2-4379

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -1,6 +1,6 @@
 cask 'synology-cloud-station-backup' do
-  version '4.2.1-4374'
-  sha256 '6f4969a9f165d4b9ffe2b4c986a984b8e0a6529113fd0a604f859af98b086f2f'
+  version '4.2.2-4379'
+  sha256 '84a9cd61e49d22555b541fd8d90604e57091480d4180afe024d21d1dfc7f95b4'
 
   url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
   name 'Synology Cloud Station Backup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.