### PR TITLE
Update synology-cloud-station-drive to 4.2.2-4379

### DIFF
--- a/Casks/synology-cloud-station-drive.rb
+++ b/Casks/synology-cloud-station-drive.rb
@@ -1,6 +1,6 @@
 cask 'synology-cloud-station-drive' do
-  version '4.1-4222'
-  sha256 '6a84d26a954ba134d8434b61ae24e4807479d8b0486a33a5a4b44769f123b3de'
+  version '4.2.2-4379'
+  sha256 '63c108164de7440cc7b3680e79a462c26a94f591f78380290a83782a30098f43'
 
   url "https://global.download.synology.com/download/Tools/CloudStationDrive/#{version}/Mac/Installer/synology-cloud-station-drive-#{version.sub(%r{.*-}, '')}.dmg"
   name 'Synology Cloud Station Drive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.