### PR TITLE
Update libreoffice to 5.2.5

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '5.2.4'
-  sha256 '9359d8cf8aa5f1692894843fdd2ac0d166a0d173601b578e592498ab04f7c870'
+  version '5.2.5'
+  sha256 'cce4843e8bfe03cf1524eb4a994bb18254091671152a9ae9466dda55082f1319'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
