### PR TITLE
Update opera to 42.0.2393.517

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '42.0.2393.351'
-  sha256 '9a0baa36748fc0850dad66fa2738e5247f813b23152b3495ed2bb254b5248acf'
+  version '42.0.2393.517'
+  sha256 '3335ee75a54d9a0572e72a97d34d5189b777af1328a9d912dc294db80bbf19bb'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.