### PR TITLE
Update standard-notes to 0.1.2

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.1.1'
+  version '0.1.2'
   sha256 '9b6a96ac9d00687f9fdd1ccd456ce36575228dd3a6b90662e8fe529bee04d955'
 
   # github.com was verified as official when first introduced to the cask
   url 'https://github.com/standardnotes/desktop/releases/download/v0.1.1/Standard.Notes-Mac-0.1.1.dmg'
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '727ba8f515d8c859bf0c05465a1be64d07951fd650b235460a8ef58e4f302954'
+          checkpoint: 'ba4ed2c7e86e4179f5cc0e7ef1db9e42cb048039921969e8ee2a7cfda25ef507'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -3,7 +3,7 @@ cask 'standard-notes' do
   sha256 '9b6a96ac9d00687f9fdd1ccd456ce36575228dd3a6b90662e8fe529bee04d955'
 
   # github.com was verified as official when first introduced to the cask
-  url 'https://github.com/standardnotes/desktop/releases/download/v0.1.1/Standard.Notes-Mac-0.1.1.dmg'
+  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard.Notes-Mac-#{version}.dmg"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
           checkpoint: 'ba4ed2c7e86e4179f5cc0e7ef1db9e42cb048039921969e8ee2a7cfda25ef507'
   name 'Standard Notes'

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
   version '0.1.2'
-  sha256 '9b6a96ac9d00687f9fdd1ccd456ce36575228dd3a6b90662e8fe529bee04d955'
+  sha256 'c93bb4edafbe2b60e9b5cc78d261e6b5381772c2ff338af4e3c7d6ae462886e2'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard.Notes-Mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.