### PR TITLE
Update macports to 2.4.0

### DIFF
--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -1,35 +1,35 @@
 cask 'macports' do
-  version '2.3.5'
+  version '2.4.0'
 
   if MacOS.version <= :mountain_lion
-    sha256 'e77959840187054d31cbeb64bf33f311cf260973be7daf2a8c41e5753ecd8360'
+    sha256 '09200c9bf2c0d62f792647acf422e95a5799d43580d49e3fbc26ce87befdc483'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.8-MountainLion.pkg"
     pkg "MacPorts-#{version}-10.8-MountainLion.pkg"
   elsif MacOS.version <= :mavericks
-    sha256 'c0cd44d7f4820742a14dd35b9e5942da438adf0500044ba46c825f5ba44d6a47'
+    sha256 'f1977ba2b3553f405468dcf25d1a526976013b883a6ef537dae25ec6d38e150a'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.9-Mavericks.pkg"
     pkg "MacPorts-#{version}-10.9-Mavericks.pkg"
   elsif MacOS.version <= :yosemite
-    sha256 '12db5640b550f5c038edc2967d417334cdc0a8d8e619e145e1ed7352d274c07c'
+    sha256 '19747e613a7f6d74f26dae88dee9c204512a3ada9eb0070ee087658f54e789d9'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.10-Yosemite.pkg"
     pkg "MacPorts-#{version}-10.10-Yosemite.pkg"
   elsif MacOS.version <= :el_capitan
-    sha256 'a465c9364ecc24139c2a15a8613e2dbc8911f9eae96e3b5a7db4a8117f29db88'
+    sha256 'e4365a2c21f70c4f18496fdf5442e8f8e8d8adac0202981ba2c9d9f367f454b6'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.11-ElCapitan.pkg"
     pkg "MacPorts-#{version}-10.11-ElCapitan.pkg"
   else
-    sha256 '66cfda8d097038cb2786c8d73e3d85216d92f2afab00df97b8fe45d7a634242f'
+    sha256 '0ccf8a121df9277ad19ba215ca355f9f3bab3f1aca2d7fd542f1cfb67dd0e500'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.12-Sierra.pkg"
     pkg "MacPorts-#{version}-10.12-Sierra.pkg"
   end
 
   appcast 'https://github.com/macports/macports-base/releases.atom',
-          checkpoint: 'bb4a24db76cee5daec24c402a3c521881f5724b2725e20b6fd5610a53144853e'
+          checkpoint: 'b236fb8b470de6132694c44efa7df0ddafff4b5ed671eea71779ef9f27d2fb5d'
   name 'MacPorts'
   homepage 'https://www.macports.org/'
   gpg "#{url}.asc", key_id: '01ff673fb4aae6cd'


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.