### PR TITLE
Add Vysor Latest

### DIFF
--- a/Casks/vysor.rb
+++ b/Casks/vysor.rb
@@ -1,9 +1,11 @@
 cask 'vysor' do
-  version :latest
-  sha256 :no_check
+  version '1.6.7'
+  sha256 'c75f6c3f1e5b84141686c4214da91a409992f6c937521e821a77d83d6b548a2d'
 
-  # vysornuts.clockworkmod.com was verified as official when first introduced to the cask
-  url 'https://vysornuts.clockworkmod.com/download/osx.zip'
+  # github.com/koush/vysor.io was verified as official when first introduced to the cask
+  url "https://github.com/koush/vysor.io/releases/download/v#{version}/Vysor-mac.zip"
+  appcast 'https://github.com/koush/vysor.io/releases.atom',
+          checkpoint: '0d2caa485689d7473f12c206dc29f93837facca857a60276e44b632dfa290766'
   name 'Vysor'
   homepage 'https://www.vysor.io'
 

--- a/Casks/vysor.rb
+++ b/Casks/vysor.rb
@@ -1,0 +1,20 @@
+cask 'vysor' do
+  version :latest
+  sha256 :no_check
+
+  # vysornuts.clockworkmod.com was verified as official when first introduced to the cask
+  url 'https://vysornuts.clockworkmod.com/download/osx.zip'
+  name 'Vysor'
+  homepage 'https://www.vysor.io'
+
+  app 'Vysor.app'
+
+  zap delete: [
+                '~/Library/Application Support/Vysor',
+                '~/Library/Caches/com.electron.vysor',
+                '~/Library/Caches/com.electron.vysor.ShipIt',
+                '~/Library/Preferences/com.electron.vysor.plist',
+                '~/Library/Preferences/com.electron.vysor.helper.plist',
+                '~/Library/Saved Application State/com.electron.vysor.savedState',
+              ]
+end


### PR DESCRIPTION
Vysor was only available through Chrome app store, but a beta version
built on electron was published through a Google+ post from the author
(can be read here:
https://plus.google.com/110558071969009568835/posts/Ub7QKu2Pddu )

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
