### PR TITLE
Update a-better-finder-attributes to 6.04

### DIFF
--- a/Casks/a-better-finder-attributes.rb
+++ b/Casks/a-better-finder-attributes.rb
@@ -1,10 +1,10 @@
 cask 'a-better-finder-attributes' do
-  version '6.03'
-  sha256 'fdc5e960faa943a78e0d9ecafb1c3ed0b0750035bc241cb78793c6b611c7493a'
+  version '6.04'
+  sha256 '6d1c36842cb33e022cfa254c0f9e59141e28e8fdb2135482f90c4540f57e8f07'
 
   url 'http://www.publicspace.net/download/ABFAX.dmg'
   appcast "http://www.publicspace.net/app/signed_abfa#{version.major}.xml",
-          checkpoint: 'd7de012c1ca68a42987836414036aca7e74a8ea7500b3675633e67489d1b5962'
+          checkpoint: '157b591920718041f5144b68312336449b90f961724d6fe841fbc1d5b0223b14'
   name 'A Better Finder Attributes'
   homepage 'http://www.publicspace.net/ABetterFinderAttributes/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.