### PR TITLE
Update lingon-x to 4.3.5

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '4.3.4'
-  sha256 '276b00b96eefa35615efd8b4e6dc30aba82096bcd146d80468fdfd37b6cf6222'
+  version '4.3.5'
+  sha256 '5aa93c639114a3d30725709a0f924e26e264d5738e52154e690d557a5415bb56'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'f071d6ee29dfc8d8f683d854825bde984c015496fd730206deb1e9d095eaff14'
+          checkpoint: 'cb87c61e066a4a548e156770d9d4f56ebfd896354b4f5fcd61e4c300e67901c9'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.