### PR TITLE
Add TinkerTool.app Latest

### DIFF
--- a/Casks/TinkerTool.rb
+++ b/Casks/TinkerTool.rb
@@ -1,0 +1,11 @@
+cask 'TinkerTool' do
+  version :latest
+  sha256 :no_check
+
+  # webpack.de/bresink.eu was verified as official when first introduced to the cask
+  url 'https://ssl.webpack.de/bresink.eu/download3.php?PHPSESSID=0gc9kvq260r4brokt6o99nmuk1'
+  name 'TinkerTool'
+  homepage 'https://www.bresink.com/osx/TinkerTool.html'
+
+  app 'TinkerTool.app'
+end


### PR DESCRIPTION
TinkerTool has no versioned download URL, excluding legacy versions for previous OS's so have set version to latest.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
