### PR TITLE
Update nylas-mail to 1.0.15-26c935f

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.11-d1249b7'
-  sha256 '2065a5d26a73c1b9d3195b010fc8a17e0d3a8ae1f8b6945a72249ca403b5ac48'
+  version '1.0.15-26c935f'
+  sha256 'fa2e676f2d6b0fe26c766fbf199c9ee522dff162cb758c04dc130cd60478bc3e'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: 'a2be2bc86628622ab09ddbbc57e146487cfa2a701e2214f6dce51f79b7639b06'
+          checkpoint: '1ff1044cc832f1fb662d91e3dd828c0fc8f423e79792cec628e3d57e282f51e5'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.