### PR TITLE
Update sketchup to 2017

### DIFF
--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -1,6 +1,6 @@
 cask 'sketchup' do
-  version :latest
-  sha256 :no_check
+  version '2017'
+  sha256 'a61e7e55b42e8d2e4735c4e45f0d53435c8dfd4f6aaca7187b4f945a58acc858'
 
   # downloads can be found at https://www.sketchup.com/download/all
   # dl.trimble.com/sketchup was verified as official when first introduced to the cask
@@ -8,16 +8,16 @@ cask 'sketchup' do
   name 'SketchUp'
   homepage 'https://www.sketchup.com/'
 
-  suite 'SketchUp 2017'
+  suite "SketchUp #{version}"
 
   zap delete: [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sketchup.sketchup.2017.sfl',
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sketchup.stylebuilder.2017.sfl',
-                '~/Library/Application Support/SketchUp 2017',
-                '~/Library/Caches/com.sketchup.SketchUp.2017',
-                '~/Library/Cookies/com.sketchup.SketchUp.2017.binarycookies',
-                '~/Library/Preferences/com.sketchup.SketchUp.2017.plist',
-                '~/Library/Preferences/com.sketchup.SketchUp.2017.plist',
+                "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sketchup.sketchup.#{version}.sfl",
+                "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sketchup.stylebuilder.#{version}.sfl",
+                "~/Library/Application Support/SketchUp #{version}",
+                "~/Library/Caches/com.sketchup.SketchUp.#{version}",
+                "~/Library/Cookies/com.sketchup.SketchUp.#{version}.binarycookies",
+                "~/Library/Preferences/com.sketchup.SketchUp.#{version}.plist",
+                "~/Library/Preferences/com.sketchup.SketchUp.#{version}.plist",
                 '~/Library/Preferences/Trimble.SketchUp-Helper.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

This seems seldom updated, and hence fit to have a version.