### PR TITLE
Update fraise to 3.7.7

### DIFF
--- a/Casks/fraise.rb
+++ b/Casks/fraise.rb
@@ -1,10 +1,10 @@
 cask 'fraise' do
-  version '3.7.3'
-  sha256 '48a5cf964188d01fb2115185403a96a8dd57f127d7fcb7480970266f5b0eb2e0'
+  version '3.7.7'
+  sha256 '22f127873db3546020660051c93a5b8ebe6fe5419f1918fc2b8d5fa9bb0385c2'
 
-  url "https://github.com/downloads/jfmoy/Fraise/Fraise%20#{version}.zip"
+  url 'https://github.com/abentele/Fraise/releases/download/3.7.7/Fraise-3.7.7.zip'
   name 'Fraise'
-  homepage 'https://github.com/jfmoy/Fraise'
+  homepage 'https://github.com/abentele/Fraise'
 
   app 'Fraise.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.