### PR TITLE
Update losslesscut to 1.4.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,10 +1,10 @@
 cask 'losslesscut' do
-  version '1.3.0'
-  sha256 'd44affab76fc4538a7968207742a2324a2cffb60b14360519650b0989b4049fb'
+  version '1.4.0'
+  sha256 'f721a32381105f178f38c2daedb094244f4a72ba5ff5e84cb2a7e6be598fbb72'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-darwin-x64.zip"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom',
-          checkpoint: '6a2fdf0e31250c613c097f5581f66be4e2c192e9a82425efffc0d86d135cdd8f'
+          checkpoint: '7cb2aaac4723bba159f40fa4590daba8a1ff48ffe8832a5185d445d03654c722'
   name 'Loslesscut'
   homepage 'https://github.com/mifi/lossless-cut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.