### PR TITLE
Update waterfox to 51.0,1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,9 +1,9 @@
 cask 'waterfox' do
-  version '50.1.0'
-  sha256 'f06d094e315e16496aafe55d39e57962614ce924742843499abdff37738621bf'
+  version '51.0,1'
+  sha256 '1878cb6dd317b1e9483662117649e60012017eb28a51797b120d1a7ceb637a9a'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"
+  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version.before_comma}%20Setup-#{version.after_comma}.dmg"
   name 'Waterfox'
   homepage 'https://www.waterfoxproject.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.