### PR TITLE
Update soundcloud-downloader to 2.6.8

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
-  version '2.6.7'
-  sha256 '76501bdc629f06f2f548e30c76dda0ebc2b76d393a853bcef5e2d43a317641d6'
+  version '2.6.8'
+  sha256 'eeb09d781956764e7c7ee949b18cb0de30848b4473deba3083279c5ed4e1ee67'
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
   appcast 'http://black-burn.ch/applications/scd/updates.php?hwni=1',
-          checkpoint: 'a0bbcf012158e1dcd00e8e5baa6e122012d9e527e67e0d38fd0bde8ecc252222'
+          checkpoint: '9e6209368cd340dd0375d2b38b995d810853be80991e1db0f2602bb377ad0247'
   name 'SoundCloud Downloader'
   homepage 'http://black-burn.ch/scd/'
 

--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -4,7 +4,7 @@ cask 'soundcloud-downloader' do
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
   appcast 'http://black-burn.ch/applications/scd/updates.php?hwni=1',
-          checkpoint: '9e6209368cd340dd0375d2b38b995d810853be80991e1db0f2602bb377ad0247'
+          checkpoint: 'cdc2148baf8a3d61472eaac288b66b3cb297005979800fe990a08e8e36f078b4'
   name 'SoundCloud Downloader'
   homepage 'http://black-burn.ch/scd/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.