### PR TITLE
Update sourcetree to 2.4h

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.4f'
-    sha256 '3e2e7fb4c1f2cbcf52028f32b07780d92d04a1a0d38422dc780d7ae26f68b4de'
+    version '2.4h'
+    sha256 '5b52e071da6b055367aaee963dd1cca45b3e59ef5d4040ed5749a677fd45ab68'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.