### PR TITLE
Update qt-creator to 4.2.1

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.2.0'
-  sha256 '5b9d7fda77b6d3e98bb65d1fb7a33552f4a2e0e8533930c6acc0fbbbeb60dc21'
+  version '4.2.1'
+  sha256 '0abe38936d0e6d5cadb3ba877053ad9177f380518ba6fc9571b51160e1ae0e25'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.