### PR TITLE
Update airtool to 1.5

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,11 +1,11 @@
 cask 'airtool' do
-  version '1.4.1'
-  sha256 '3e3d03ae51f11d49f3248a7d57402add6896334665b1e571ba3560e4676496d5'
+  version '1.5'
+  sha256 'eeb72720d1288278430441f005204d3d622059ad29776b642076d63541f12b5d'
 
   # amazonaws.com/adriangranados was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/adriangranados/airtool_#{version}.pkg"
   appcast 'https://www.adriangranados.com/appcasts/airtoolcast.xml',
-          checkpoint: 'be5ebb845b2cf05c33c732a910e883d32ddf6209b32515dab83ea9ff5b873fa7'
+          checkpoint: '3e1c379598102166045827ca23e8c4b948803f21bbb9bc3de05c051facf095db'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.