### PR TITLE
Update astropad to 2.1.3

### DIFF
--- a/Casks/astropad.rb
+++ b/Casks/astropad.rb
@@ -1,10 +1,10 @@
 cask 'astropad' do
-  version '2.1.2'
-  sha256 'ae370241b8d4b2f66f935599be990e26ed61ed8ba55cd4e85720446cbcf30f50'
+  version '2.1.3'
+  sha256 'be1ef9e03810dda70bb5001cb2a8ca1e7b29ccbb58e7a243a228f0546816486a'
 
   url "http://astropad.com/downloads/Astropad-#{version}.zip"
   appcast 'http://astropad.com/downloads/sparkle.xml',
-          checkpoint: '45857cba40f2b4a8dae4d01317a887974150d4fc3087826e11433e24be5c8045'
+          checkpoint: '38749c3a42304c487957058be040a75c9305260a8723e8eb705c95c06567358e'
   name 'Astropad'
   homepage 'http://astropad.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.