### PR TITLE
Update championify to 2.0.2

### DIFF
--- a/Casks/championify.rb
+++ b/Casks/championify.rb
@@ -1,10 +1,10 @@
 cask 'championify' do
-  version '2.0.1'
-  sha256 '28361881ce139fff709e8714842cc12ed396e32693a3bda99b9f4b36fc480237'
+  version '2.0.2'
+  sha256 'a48778cb9b15bf7b280445d0706087cd0eb920af40ccb2059a9e7c9f782a0d26'
 
   url "https://github.com/dustinblackman/Championify/releases/download/#{version}/Championify-OSX-#{version}.dmg"
   appcast 'https://github.com/dustinblackman/Championify/releases.atom',
-          checkpoint: '0b19f924de37bb8c9709cac2b436be798b05ac3c3c23023aa3b9cea744792832'
+          checkpoint: '89cdfdbaf8cf490ef6cb6be8fd5ad295a07ce1c217d1e5a9734469800f5fadb1'
   name 'Championify'
   homepage 'https://github.com/dustinblackman/Championify/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.