### PR TITLE
Update fotowall download url

### DIFF
--- a/Casks/fotowall.rb
+++ b/Casks/fotowall.rb
@@ -2,8 +2,8 @@ cask 'fotowall' do
   version '0.8.2'
   sha256 'f49ad020eb6d36b9ad5492edd24ce608aef4466b727b5d0811ed4218b35d0c8c'
 
-  # fotowall.googlecode.com was verified as official when first introduced to the cask
-  url "https://fotowall.googlecode.com/files/Fotowall-#{version}-OSX.dmg"
+  # storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/fotowall was verified as official when first introduced to the cask
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/fotowall/Fotowall-#{version}-OSX.dmg"
   name 'Fotowall'
   homepage 'http://www.enricoros.com/opensource/fotowall/'
 


### PR DESCRIPTION
* download link was 404. Has been moved to google code archive link.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.