### PR TITLE
Update cryptomator to 1.2.4

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,11 +1,11 @@
 cask 'cryptomator' do
-  version '1.2.3'
-  sha256 '4e7b2baa97c0216ec1f9647dca5ade087a58f2bf22564e6395f5419f09bb7b55'
+  version '1.2.4'
+  sha256 'f3753716ee69240d2904740c38a0c280bfca1e3b89fa5111b98db484a896d090'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
   appcast 'https://github.com/cryptomator/cryptomator/releases.atom',
-          checkpoint: '202fc07b3c9215458e6c2e31aa6de87b8e90bdea475794305f52343082fff836'
+          checkpoint: '9d77ffcb25ec02a5671b291264e64d61d6b2c3f08b94ba5e49f49f115c613550'
   name 'Cryptomator'
   homepage 'https://cryptomator.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.