### PR TITLE
Update devonthink-pro to 2.9.10

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.9'
-  sha256 '665acc29ae0814f7fa6d2311e57636469cea32b09ed56eaed818358dd4ec85fc'
+  version '2.9.10'
+  sha256 '948844e08b25f764ccaa9338b85e2d8b58eede5c2f5aa9add768eadcb51e34a7'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '3e624eeeef6347cb5c852db83a450a3328e5ff6bdac761561c5ff73ae1fe42f0'
+          checkpoint: '2ebb936e76a586214ec01059877d6eff022852817950b78f3a6b293a6af3b103'
   name 'DEVONthink Pro'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.