### PR TITLE
Update devonthink to 2.9.10

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.9'
-  sha256 '9b4d79d4b1b03669fc29f6c8f362fdac9ef4e0ecb279cd5ff74de851ae0a1b7a'
+  version '2.9.10'
+  sha256 '7f290e475a00cef898e768c08373f64a956f4050916c109e5460370eb3734caa'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: '26fd05eb4a3633c0f887be19532c05eaf9147796f3edbbaab91df0f0fb3d6669'
+          checkpoint: 'e99ea34791e20fd443982ee8c14eb1d9e65a722d3dac59726dd7929f2a0b46a8'
   name 'DEVONthink Personal'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.