### PR TITLE
Update dripcap to 0.6.6

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.6.3'
-  sha256 'c3995deb192266c1099407d7b00f824f28493691cb9d30b472fc73dfd652d191'
+  version '0.6.6'
+  sha256 '6ff6f9ceff1e7bf05861f6d2d5ffb54fa7d2f33785832d2f456eaf0c3907c1a9'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '8eabc4fab17a4dd5d84c1b38bcad6474ce4f4c9689592aa2173cfba57f0f0e56'
+          checkpoint: '71938cdeb112ca4f5dc4cdff2a59c2b0d79263382b53e3259633a6e7ca7be441'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.