### PR TITLE
Update mjml to 1.7.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,11 +1,11 @@
 cask 'mjml' do
-  version '1.6.0'
-  sha256 '500dff72eb35fe7cad7fb88dc4ee6a4a7c61b300160a99db75acad7989634347'
+  version '1.7.0'
+  sha256 '2011466db5b37cc2e06aec3412bf0a1e560fc59636a39e3b224bddb507818e80'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-osx_#{version}.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom',
-          checkpoint: 'e5c3c9d88b082d3a06270b18837726633a36eddd2d58aee84f76e6437eb3c41a'
+          checkpoint: '4debad94aeeb57ed7f2597d8f31e62990c7b6567fb1472af3f78f8dbf44d0d94'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.