### PR TITLE
Update mumble to 1.2.19

### DIFF
--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -1,11 +1,11 @@
 cask 'mumble' do
-  version '1.2.18'
-  sha256 'cd9d3124d76c15f5b77246d790a3f18346695c82c25c73fc9d6b2dd8e5ee94b9'
+  version '1.2.19'
+  sha256 '3784911cff35d1611c1aad1bdce74dda4d3a7f682cd83e256b1e4283d82bf368'
 
   # github.com/mumble-voip/mumble was verified as official when first introduced to the cask
   url "https://github.com/mumble-voip/mumble/releases/download/#{version}/Mumble-#{version}.dmg"
   appcast 'https://github.com/mumble-voip/mumble/releases.atom',
-          checkpoint: 'bcdca125e43adc1b3351c85ca43b0df5a58f21d42210ce7fe2300b267d1a9fe3'
+          checkpoint: '61bc39455db24130cde0266aa899c76c98848c3b1da56fe523ad76f813e59b4e'
   name 'Mumble'
   homepage 'https://wiki.mumble.info/wiki/Main_Page'
   gpg "#{url}.sig", key_id: '3bd0eca5925319af89c25865b585609c5a2be0c1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.