### PR TITLE
Update smartgit to 17.0.1

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,8 +1,10 @@
 cask 'smartgit' do
-  version '17'
-  sha256 '6aa636471562f31f7b1c164910be2d039ce02674e682c2791a4c93475eb6fe27'
+  version '17.0.1'
+  sha256 '1eb0af3d6617c5f1f33b69f783decf833fde33f2c727217a8346bac8d17958f4'
 
   url "https://www.syntevo.com/static/smart/download/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
+  appcast 'https://www.syntevo.com/smartgit/changelog.txt',
+          checkpoint: '02fe2bcdfbc8522324949e1f7dd44f90102639622c04108855ba8bc35758f01c'
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.