### PR TITLE
Update papyrus to 2.0.2,neon

### DIFF
--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -1,6 +1,6 @@
 cask 'papyrus' do
-  version '2.0.1,neon'
-  sha256 '9527e06a93ba87f998a90c1729f53382b7c47ea337f6ff0f2b0f7c5789f3f85f'
+  version '2.0.2,neon'
+  sha256 '128c334e3cc41f3962347c633fe91f6d819893c66a07ffb843cf11e820cd830c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/modeling/mdt/papyrus/rcp/#{version.after_comma}/#{version.before_comma}/papyrus-#{version.after_comma}-#{version.before_comma}-macosx64.tar.gz&r=1"
   name 'Papyrus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.