### PR TITLE
Add binary and zap stanzas for OpenSCAD (still 2015.03-3)

### DIFF
--- a/Casks/openscad.rb
+++ b/Casks/openscad.rb
@@ -9,4 +9,11 @@ cask 'openscad' do
   homepage 'http://www.openscad.org/'
 
   app 'OpenSCAD.app'
+  binary "#{appdir}/OpenSCAD.app/Contents/MacOS/OpenSCAD", target: 'openscad'
+
+  zap delete: [
+                '~/Library/Caches/org.openscad.OpenSCAD',
+                '~/Library/Preferences/org.openscad.OpenSCAD.plist',
+                '~/Library/Saved Application State/org.openscad.OpenSCAD.savedState',
+              ]
 end


### PR DESCRIPTION
This just adds the `openscad` command

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
