### PR TITLE
Update anki to 2.0.41

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -1,15 +1,12 @@
 cask 'anki' do
-  if MacOS.version <= :snow_leopard
-    version '2.0.40-alternate'
-    sha256 'a0087c85bbc27148a5e00bf40d5caad2ceb5ce09deac1f4385d87f54f0a36565'
-  else
-    version '2.0.40'
-    sha256 '4089d1dfa5e94a161d9a2e8596f7622c9103046020b72590ab1d8be5f42687db'
-  end
+  version '2.0.41'
+  sha256 '4837ce644eeae4252cbc5cf47bf3a998bad87ca244e49a52f050cba8f4826eb4'
 
   url "https://apps.ankiweb.net/downloads/current/anki-#{version}.dmg"
   name 'Anki'
   homepage 'https://apps.ankiweb.net/'
+
+  depends_on macos: '>= :lion'
 
   app 'Anki.app'
 end


### PR DESCRIPTION
* the normal version supports lion and up. Doesn't seem worthwhile to maintain and download check the alternate version so removing

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.