### PR TITLE
Update boom-recorder to 8.6.5

### DIFF
--- a/Casks/boom-recorder.rb
+++ b/Casks/boom-recorder.rb
@@ -1,6 +1,6 @@
 cask 'boom-recorder' do
-  version '8.6.2'
-  sha256 '1c7efe9f216d5d02490828215d6ed170c90097a6cca313c009946d76984d051f'
+  version '8.6.5'
+  sha256 'a8f2e9f4b6b7f68de40b625afc55d5424e0d503440e4b593c675b2083df5a675'
 
   url "http://www.vosgames.nl/media/downloads/Boom%20Recorder-#{version}.dmg"
   name 'Boom Recorder'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.