### PR TITLE
sublime-text: remove files_in_usr_local caveat

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -23,8 +23,4 @@ cask 'sublime-text' do
                 '~/Library/Preferences/com.sublimetext.3.plist',
                 '~/Library/Saved Application State/com.sublimetext.3.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fixes #29593