### PR TITLE
Keka 1.0.7 fix url

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -3,7 +3,7 @@ cask 'keka' do
   sha256 '92d05db46ba32e656992d2f9699e328b94dee058e573da3147865f3993bbe579'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
-  url "https://github.com/aonez/Keka/releases/download/#{version}/Keka-#{version}.dmg"
+  url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
           checkpoint: '6239d57ff44cec2f16c5f8546b61b891daa96a358b4b99481fc4de516cf00e57'
   name 'Keka'

--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -5,7 +5,7 @@ cask 'keka' do
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: '6239d57ff44cec2f16c5f8546b61b891daa96a358b4b99481fc4de516cf00e57'
+          checkpoint: '2abc192f8bc1572c7654d6eb4121c9f638ce405de61229ad09ec770a7c91deb2'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
Previous commit ca99ff9 change the way to dowload dmg file.
Github is now use but the url is not correct on the version part.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

