### PR TITLE
Update shazzlemailclient to 2.8.0

### DIFF
--- a/Casks/shazzlemailclient.rb
+++ b/Casks/shazzlemailclient.rb
@@ -1,6 +1,6 @@
 cask 'shazzlemailclient' do
-  version '2.0.0'
-  sha256 '6891feff8bf6141f8d05ccffd1d033f164e9cc063dd714b6580fba65bcebf953'
+  version '2.8.0'
+  sha256 'd3d9d5307f75d2ea785143696b24e6c9a8d258b9ac40e813c1085f6c8048b4cd'
 
   url "https://shazzlemail.com/files/client/mac/ShazzleMailClient-#{version}.dmg"
   name 'ShazzleMail Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.