### PR TITLE
Update URL value in box-edit cask for latest version

### DIFF
--- a/Casks/box-edit.rb
+++ b/Casks/box-edit.rb
@@ -2,6 +2,7 @@ cask 'box-edit' do
   version :latest
   sha256 :no_check
 
+  # e3.boxcdn.net/box-installers/boxedit/mac/currentrelease was verified as official when first introduced to the cask
   url 'https://e3.boxcdn.net/box-installers/boxedit/mac/currentrelease/BoxToolsInstaller.dmg'
   name 'Box Edit'
   homepage 'https://www.box.com/resources/downloads'

--- a/Casks/box-edit.rb
+++ b/Casks/box-edit.rb
@@ -2,7 +2,7 @@ cask 'box-edit' do
   version :latest
   sha256 :no_check
 
-  url 'https://app.box.com/static/BoxEdit/BoxEditInstaller.dmg'
+  url 'https://e3.boxcdn.net/box-installers/boxedit/mac/currentrelease/BoxToolsInstaller.dmg'
   name 'Box Edit'
   homepage 'https://www.box.com/resources/downloads'
 


### PR DESCRIPTION
This afternoon I tried to install the box-edit cask but received 404 errors. After looking at Box's site for downloads it appears the URL to the disk image has changed.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [*] `brew cask audit --download {{cask_file}}` is error-free.
- [*] `brew cask style --fix {{cask_file}}` reports no offenses.
- [/] The commit message includes the cask’s name and version.
This is my first attempt to contribute to homebrew-cask and am not sure if I hit all these points exactly as you like but I'm happy to improve. 

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
