### PR TITLE
Update keybase to 1.0.18-20170130165558,0fcd377

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -3,8 +3,8 @@ cask 'keybase' do
   sha256 'b871ee5bf7af5f3194ae4c679e7cf98c260262638005b7851090a08093d5b103'
 
   url "https://prerelease.keybase.io/darwin/Keybase-#{version.before_comma}%2B#{version.after_comma}.dmg"
-  appcast 'https://github.com/keybase/client/releases.atom',
-          checkpoint: 'e52341b2c47ad7ebf202812221116c9bb4eda1f938de97225584bf7ebeff0d6d'
+  appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json',
+          checkpoint: '6a8df98fc9fc4abbd8931ba82f17bc6e60732646a88fcbe243b0ca6f9922fb8e'
   name 'Keybase'
   homepage 'https://keybase.io/'
 

--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,8 +1,8 @@
 cask 'keybase' do
-  version '1.0.18-20170120152345'
-  sha256 '896ebeab741c4f4abfc848aef771488d2b5bbb08388c2ff6237284e22e23bb82'
+  version '1.0.18-20170130165558,0fcd377'
+  sha256 'b871ee5bf7af5f3194ae4c679e7cf98c260262638005b7851090a08093d5b103'
 
-  url 'https://prerelease.keybase.io/Keybase.dmg'
+  url "https://prerelease.keybase.io/darwin/Keybase-#{version.before_comma}%2B#{version.after_comma}.dmg"
   appcast 'https://github.com/keybase/client/releases.atom',
           checkpoint: 'e52341b2c47ad7ebf202812221116c9bb4eda1f938de97225584bf7ebeff0d6d'
   name 'Keybase'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.