### PR TITLE
Remove files_in_usr_local from casks that only have it due to `binary`

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -4,7 +4,7 @@ cask 'arduino' do
 
   url "https://downloads.arduino.cc/arduino-#{version}-macosx.zip"
   appcast 'https://www.arduino.cc/en/Main/ReleaseNotes',
-          checkpoint: 'bd0f51fb604bbbcddfc893b0631c2f5ec85c1477dd245bef7c0b6db042946153'
+          checkpoint: 'd50e794a44510130bfd4e08857a61bcbb338998aac7e564aa41c08ce7a44981e'
   name 'Arduino'
   homepage 'https://www.arduino.cc/'
 

--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -13,6 +13,5 @@ cask 'arduino' do
 
   caveats do
     depends_on_java
-    files_in_usr_local
   end
 end

--- a/Casks/genymotion.rb
+++ b/Casks/genymotion.rb
@@ -11,8 +11,4 @@ cask 'genymotion' do
   app 'Genymotion.app'
   app 'Genymotion Shell.app'
   binary "#{appdir}/Genymotion Shell.app/Contents/MacOS/genyshell"
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -21,8 +21,4 @@ cask 'golly' do
 
   name 'Golly'
   homepage 'http://golly.sourceforge.net/'
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -13,7 +13,7 @@ cask 'golly' do
 
     url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/golly-#{version}-mac.zip"
     appcast 'https://sourceforge.net/projects/golly/rss?path=/golly',
-            checkpoint: '2fa3e061bf65b9a057bc864604b4e4ffcd11c2c7238c61b0fb5cbd75fbe1acfb'
+            checkpoint: '7b50b7456e8709c9bee37c6808759288d61714c392eee7233660fd66d8c66bf6'
 
     app "golly-#{version}-mac/Golly.app"
     binary "golly-#{version}-mac/bgolly"

--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -25,8 +25,4 @@ cask 'kaleidoscope' do
                 '~/Library/Preferences/com.blackpixel.kaleidoscope.plist',
                 '~/Library/Saved Application State/com.blackpixel.kaleidoscope.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -4,7 +4,7 @@ cask 'kaleidoscope' do
 
   url "https://cdn.kaleidoscopeapp.com/releases/Kaleidoscope-#{version}.zip"
   appcast 'https://updates.blackpixel.com/updates?app=ks',
-          checkpoint: '7227f778900aa4f17dab7b1984cf58e19325d131e71a6e38cd19bb363812730a'
+          checkpoint: 'c49ed9d16dabc9279040e3891f727d8f0487b89ec9ef2df286ba684edde1352c'
   name 'Kaleidoscope'
   homepage 'http://www.kaleidoscopeapp.com/'
 

--- a/Casks/mailmate.rb
+++ b/Casks/mailmate.rb
@@ -9,8 +9,4 @@ cask 'mailmate' do
 
   app 'MailMate.app'
   binary "#{appdir}/MailMate.app/Contents/Resources/emate"
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/microsoft-r-open.rb
+++ b/Casks/microsoft-r-open.rb
@@ -30,8 +30,4 @@ cask 'microsoft-r-open' do
                       '~/Library/R',
                       '~/Library/Caches/org.R-project.R',
                     ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/oclint.rb
+++ b/Casks/oclint.rb
@@ -14,8 +14,4 @@ cask 'oclint' do
   binary "oclint-#{version.before_comma}/bin/oclint-xcodebuild"
   binary "oclint-#{version.before_comma}/lib/oclint", target: '/usr/local/lib/oclint'
   binary "oclint-#{version.before_comma}/include/c++", target: '/usr/local/include/c++'
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -30,8 +30,4 @@ cask 'sage' do
                 '~/Library/Logs/sage.log',
                 '~/Library/Preferences/org.sagemath.Sage.plist',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -10,8 +10,4 @@ cask 'smartgit' do
 
   app 'SmartGit.app'
   binary "#{appdir}/SmartGit.app/Contents/MacOS/SmartGit"
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -10,8 +10,4 @@ cask 'smartsynchronize' do
 
   app 'SmartSynchronize.app'
   binary "#{appdir}/SmartSynchronize.app/Contents/MacOS/SmartSynchronize"
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sopcast.rb
+++ b/Casks/sopcast.rb
@@ -11,8 +11,4 @@ cask 'sopcast' do
 
   app 'SopCast.app'
   binary "#{appdir}/SopCast.app/Contents/Resources/binaries/m32/sp-sc-auth"
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -36,8 +36,4 @@ cask 'sourcetree' do
                 '~/Library/Preferences/com.torusknot.SourceTreeNotMAS.LSSharedFileList.plist',
                 '~/Library/Saved Application State/com.torusknot.SourceTreeNotMAS.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -23,8 +23,4 @@ cask 'sublime-text' do
                 '~/Library/Preferences/com.sublimetext.3.plist',
                 '~/Library/Saved Application State/com.sublimetext.3.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -5,7 +5,7 @@ cask 'tower' do
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.sub(%r{^[^\-]+\-}, '')}/Tower-#{version.major}-#{version.sub(%r{-[^-]+$}, '')}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable",
-          checkpoint: '85f9fe9d7494acfbed27cd6abb5c323a633cff2cfc12d072a592e6519f79f6cc'
+          checkpoint: '08567549c704d9045c81ce24476d0212ee50a2bf485c0c6264bd9f1c83115fae'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -17,8 +17,4 @@ cask 'tower' do
                 "~/Library/Caches/com.fournova.Tower#{version.major}",
                 "~/Library/Preferences/com.fournova.Tower#{version.major}.plist",
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end


### PR DESCRIPTION
What the title says.

In this case, it shouldn’t be needed. If it turns out it is needed in some of them, we can always add it back.