### PR TITLE
unison.rb: add version for older OS release

### DIFF
--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -5,6 +5,12 @@ cask 'unison' do
 
     # unison-binaries.inria.fr was verified as official when first introduced to the cask
     url "https://unison-binaries.inria.fr/files/Unison-#{version}_x64.dmg"
+  elsif MacOS.version <= :yosemite
+    version '2.48.3'
+    sha256 'd578196d8b38f35c1e0410a1c86ff4e115a91f7eb211201db7a940a3a3e0f099'
+
+    # github.com/bcpierce00/unison/releases/download was verified as official when first introduced to the cask
+    url "https://github.com/bcpierce00/unison/releases/download/#{version}/Unison-OS-X-#{version}.zip"
   else
     version '2.48.15'
     sha256 '89894d14c9ff3c4d6195cb6a8065a2849e6ad55951799eedf8879e1a257d3e11'


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free. _=> not tested_
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. _=> not tested_
- [x] The commit message includes the cask’s name and version.