### PR TITLE
Update beaker-electron to 1.7.1-0-g6dac09a

### DIFF
--- a/Casks/beaker-electron.rb
+++ b/Casks/beaker-electron.rb
@@ -1,9 +1,11 @@
 cask 'beaker-electron' do
-  version '1.6-0-gb7c81a9'
-  sha256 'd4c41c9341fc76e07b3f7733386bdd6cdaf111ab883d11cd7f5d2fdf2a0e04d8'
+  version '1.7.1-0-g6dac09a'
+  sha256 '09e40afd62ccc4541d37976c1846a0e4c242d0e0446544c3b59347b8156f4d8d'
 
   # d299yghl10frh5.cloudfront.net was verified as official when first introduced to the cask
   url "https://d299yghl10frh5.cloudfront.net/beaker-notebook-#{version}-electron-mac.dmg"
+  appcast 'https://github.com/twosigma/beaker-notebook/releases.atom',
+          checkpoint: '7ccfcec3abb78f9ae6fae09ae8f822801776331b2694a2a6d488d1b9b9f86265'
   name 'Beaker Electron'
   homepage 'http://beakernotebook.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.