### PR TITLE
Update vox to 2.8.16

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '2.8.14'
-  sha256 'e7b63f52e4a2e977266a360b6a9f08a1d2f9e7e9638628d522f35d26a9548d73'
+  version '2.8.16'
+  sha256 '52d5bd6903675e1afc7163af36f05a231efc48804c8273a109990bf830714db3'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: '18dfeb8851c0f7bb5379b3eb6aff25246705c01bbfad9c3ae8f986a2fe19d00f'
+          checkpoint: 'f7ae93b9daf4918507e9379dce4a568972c2ae7f609bfad9000da50e64e6cfca'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.