### PR TITLE
Add Jriver Media Center 22.0.54

### DIFF
--- a/Casks/jriver-media-center.rb
+++ b/Casks/jriver-media-center.rb
@@ -1,0 +1,14 @@
+cask 'jriver-media-center' do
+  version '22.0.54'
+  sha256 'fc85bf66f75ce640936f1e21fc11c0786f2b43811f2082a4a4984b42676c337b'
+
+  url 'http://files.jriver.com/mediacenter/channels/v22/stable/MediaCenter220054.dmg'
+  name 'JRiver Media Center'
+  name 'JRiver'
+  name 'Media Center'
+  homepage 'https://www.jriver.com/'
+
+  app 'Media Center 22.app'
+
+  zap delete: '~/Library/Application Support/J River/'
+end

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -1,5 +1,5 @@
 cask 'media-center' do
-  version '22.0.54'
+  version '22.00.54'
   sha256 'fc85bf66f75ce640936f1e21fc11c0786f2b43811f2082a4a4984b42676c337b'
 
   url "http://files.jriver.com/mediacenter/channels/v#{version.major}/stable/MediaCenter#{version.no_dots}.dmg"

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -1,14 +1,12 @@
-cask 'jriver-media-center' do
+cask 'media-center' do
   version '22.0.54'
   sha256 'fc85bf66f75ce640936f1e21fc11c0786f2b43811f2082a4a4984b42676c337b'
 
-  url 'http://files.jriver.com/mediacenter/channels/v22/stable/MediaCenter220054.dmg'
+  url "http://files.jriver.com/mediacenter/channels/v22/stable/MediaCenter#{version.no_dots}.dmg"
   name 'JRiver Media Center'
-  name 'JRiver'
-  name 'Media Center'
   homepage 'https://www.jriver.com/'
 
-  app 'Media Center 22.app'
+  app "Media Center #{vesion.major}.app"
 
   zap delete: '~/Library/Application Support/J River/'
 end

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -6,7 +6,7 @@ cask 'media-center' do
   name 'JRiver Media Center'
   homepage 'https://www.jriver.com/'
 
-  app "Media Center #{vesion.major}.app"
+  app "Media Center #{version.major}.app"
 
   zap delete: '~/Library/Application Support/J River/'
 end

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -2,7 +2,7 @@ cask 'media-center' do
   version '22.0.54'
   sha256 'fc85bf66f75ce640936f1e21fc11c0786f2b43811f2082a4a4984b42676c337b'
 
-  url "http://files.jriver.com/mediacenter/channels/v22/stable/MediaCenter#{version.no_dots}.dmg"
+  url "http://files.jriver.com/mediacenter/channels/v#{version.major}/stable/MediaCenter#{version.no_dots}.dmg"
   name 'JRiver Media Center'
   homepage 'https://www.jriver.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

- [x] Named the cask according to the [token reference]. (not sure if I used the correct name according to your token reference. Jriver Media Center is full name mentioned at homepage. But appname is Media Center. But its very generic.)
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].