### PR TITLE
Update aws-vault to 3.7.0

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,10 +1,10 @@
 cask 'aws-vault' do
-  version '3.6.1'
-  sha256 'bc2ee3e8fb0a2c22af45daa5b9ab92fe5557821547de092eef198e52ba0974c7'
+  version '3.7.0'
+  sha256 'd17dfd93591efeaaceaca8d2eba8371f2ecc1543c4dc5d4441333c557330b04a'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64"
   appcast 'https://github.com/99designs/aws-vault/releases.atom',
-          checkpoint: '5661f088104d39db0b333c124a5195b4eaaf111cd175fee6c8720a98e4027aa1'
+          checkpoint: 'f1668dcf1b7e0b144d30ce76b3d1af473448bcc13579cf6a03a5419c41ecbe44'
   name 'aws-vault'
   homepage 'https://github.com/99designs/aws-vault'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
