### PR TITLE
Update buttercup to 0.8.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.7.1'
-  sha256 '3807c6fb545f2eb0f83d98b38cd1910669240ec85a2097587f47a912c1ebb9b3'
+  version '0.8.1'
+  sha256 '655b09cb004f0554bbc6948e8bec09750fe811b3814f51c5b3240944757b205d'
 
   # github.com/buttercup-pw/buttercup was verified as official when first introduced to the cask
-  url "https://github.com/buttercup-pw/buttercup/releases/download/#{version}-alpha/Buttercup-#{version}.dmg"
+  url "https://github.com/buttercup-pw/buttercup/releases/download/v#{version}-alpha/Buttercup-#{version}.dmg"
   appcast 'https://github.com/buttercup-pw/buttercup/releases.atom',
-          checkpoint: 'f9509aad18521511b24c814258977ba56c153a5314aadaf11d9f93f34416bbed'
+          checkpoint: '5b44f677b8deb75fa8bc40d67b5dce761a1d74d173d6768c3e321c4f83acf2f9'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.