### PR TITLE
Update darktable to 2.2.3

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,11 +1,11 @@
 cask 'darktable' do
-  version '2.2.2'
-  sha256 '52fd0e9a8bb74c82abdc9a88d4c369ef181ef7fe2b946723c5706d7278ff2dfb'
+  version '2.2.3'
+  sha256 '1ebe9a9905b895556ce15d556e49e3504957106fe28f652ce5efcb274dadd41c'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: 'e8e9043d0e98339af2ed3e8a64a7c8b573c5b3979a3d8362b9cebda72dff1943'
+          checkpoint: 'f225149b844fe6a48ee77247f1542271354c0496bd91ed447e57543b6f180e31'
   name 'darktable'
   homepage 'https://www.darktable.org/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.