### PR TITLE
Update iina to 0.0.4

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -1,6 +1,6 @@
 cask 'iina' do
   version '0.0.4'
-  sha256 'c2847263dce7103d620be132c6004822f2197a330eb85b85bc49ecfd9eebf5f7'
+  sha256 '1c610b237b63e15d16eb551395c9bf3612b92cf4d365a5d23edd6eecd524f00b'
 
   # github.com/lhc70000/iina was verified as official when first introduced to the cask
   url "https://github.com/lhc70000/iina/releases/download/v#{version}/IINA.v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

It is a same version with a new build. The previous build has been renamed as 'IINA.v0.0.4-old.zip', which matches the sha256 in the outdated formula.