### PR TITLE
Update burp-suite to 1.7.17

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,6 +1,6 @@
 cask 'burp-suite' do
-  version '1.7.16'
-  sha256 '9aa48e63d66e701a17db10bd47f12c899efc68213f4d32d29472e8ddd857fa07'
+  version '1.7.17'
+  sha256 '77740b44eebba7dce56cc866380a7cf94fca4536c22d14edb183d2f7f7a3177c'
 
   url "https://portswigger.net/Burp/Releases/Download?productId=100&version=#{version}&type=MacOsx"
   name 'Burp Suite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.