### PR TITLE
Update astroimager to 2.6

### DIFF
--- a/Casks/astroimager.rb
+++ b/Casks/astroimager.rb
@@ -1,6 +1,6 @@
 cask 'astroimager' do
-  version '2.4'
-  sha256 '56d11b7fbc9937369677e708b88f5e7835ba31013c7f2deec45da8dc6823773e'
+  version '2.6'
+  sha256 'c2e5198ead29a41c5a5be649ba41b6578f80f2fed1c4625b8fdab7f2452fd320'
 
   url "http://download.cloudmakers.eu/AstroImager_#{version}.dmg"
   name 'AstroImager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.