### PR TITLE
Update omnifocus to 2.8.2

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -12,8 +12,8 @@ cask 'omnifocus' do
     sha256 'bccd8d7c5698a9a3b3cee490baf9dbb6c5cf1d40a3f8fd2c69916a448cbe8b37'
     url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
   else
-    version '2.8.1'
-    sha256 'f6500513585cd6f9149b4e23814cef4579cd40c6c23ceba060181ce2b2f8f520'
+    version '2.8.2'
+    sha256 '5940245ecebc17e2954e2796c756ebdc678c49af7433b31d4f87bffecc6f4e8f'
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.