### PR TITLE
Update dripcap to 0.6.7

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.6.6'
-  sha256 '6ff6f9ceff1e7bf05861f6d2d5ffb54fa7d2f33785832d2f456eaf0c3907c1a9'
+  version '0.6.7'
+  sha256 '71499b09d3f0292f921f90dff6b7d6cc1fbefef438a8e86fe33f948011b5e74d'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '71938cdeb112ca4f5dc4cdff2a59c2b0d79263382b53e3259633a6e7ca7be441'
+          checkpoint: '61aaf4db003cacb6de827e7d8002d4188a83f6e60a7967ba2d1e6f04817a2a6f'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.