### PR TITLE
Correct cuttle appcast

### DIFF
--- a/Casks/cuttle.rb
+++ b/Casks/cuttle.rb
@@ -3,8 +3,8 @@ cask 'cuttle' do
   sha256 '7133beb24c3a37fe13f12d0b8110f1fcaf541d80e938cfaafb37a4d47bfcca15'
 
   url "https://github.com/oakmac/cuttle/releases/download/v#{version}/cuttle-v#{version}-mac.dmg"
-  appcast 'https://github.com/Swordfish90/cool-retro-term/releases.atom',
-          checkpoint: 'eb9ed3cb84563876d607d15d5d262e750d5d9210b6ee8ea1621ea0e261b0c646'
+  appcast 'https://github.com/oakmac/cuttle/releases.atom',
+          checkpoint: '9bcc9cf41d92b6c9470bdeaa80436b98b4016424d73c1f3561890770c36c5908'
   name 'CUTTLE'
   homepage 'https://github.com/oakmac/cuttle'
 


### PR DESCRIPTION
* was pointing to the wrong appcast url

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.