### PR TITLE
Update vox to 2.8.18

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '2.8.16'
-  sha256 '52d5bd6903675e1afc7163af36f05a231efc48804c8273a109990bf830714db3'
+  version '2.8.18'
+  sha256 '3534559b33b4bfd05a384f35986d7027d225971aac126a4556c3750ca13dea28'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: 'f7ae93b9daf4918507e9379dce4a568972c2ae7f609bfad9000da50e64e6cfca'
+          checkpoint: 'dc60a9a3fcbfe53b8186e6608f2f27e88185bd17bfd6d754323d7c67055d11b8'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.