### PR TITLE
Add versions and checksums to latest casks with appcasts

### DIFF
--- a/Casks/carmetal.rb
+++ b/Casks/carmetal.rb
@@ -1,10 +1,10 @@
 cask 'carmetal' do
-  version :latest
-  sha256 :no_check
+  version '3.8.2'
+  sha256 'ca91624b708b50428d4390ae2c21176d689d73f5e432061fc8922f43bc4d33b3'
 
   url 'http://db-maths.nuxit.net/CaRMetal/download/carmetal.dmg'
   appcast 'http://db-maths.nuxit.net/CaRMetal/telechargement_en.html',
-          checkpoint: '4caaf30e8385702176b6cb1358bdcb91187e3e5f9427b15f1fb661d2b13dd30f'
+          checkpoint: '27dc224170e577131722b1fda1c86db8cbfeb4915dfbc9ca463cb0aa35d8eb8c'
   name 'CaRMetal'
   homepage 'http://db-maths.nuxit.net/CaRMetal/index_en.html'
 

--- a/Casks/clipbuddy.rb
+++ b/Casks/clipbuddy.rb
@@ -1,6 +1,6 @@
 cask 'clipbuddy' do
-  version :latest
-  sha256 :no_check
+  version '2.10.26'
+  sha256 '2825f8748e86b96af8e56b8c534052aa027b90741caaa64c679c26961f8be84b'
 
   url 'http://www.ondesoft.com/download/odclipbuddy_mac.dmg'
   appcast 'http://www.ondesoft.com/clipbuddy_mac/release-history.html',

--- a/Casks/launchpad-manager-yosemite.rb
+++ b/Casks/launchpad-manager-yosemite.rb
@@ -1,7 +1,7 @@
 cask 'launchpad-manager-yosemite' do
   if MacOS.version <= :mavericks
-    version :latest
-    sha256 :no_check
+    version '1.3.11'
+    sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'
 
     url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
 

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -1,6 +1,6 @@
 cask 'onyx' do
-  version :latest
-  sha256 :no_check
+  version '3.2.2'
+  sha256 'c48b27710da5d4882241605a6179daf706be4cb287bcdcd18119d352cc64ef8a'
 
   macos_release = MacOS.version.to_s.delete('.')
 
@@ -12,7 +12,7 @@ cask 'onyx' do
   end
 
   appcast 'http://www.titanium.free.fr/release_onyx.html',
-          checkpoint: 'cce29a87371b8bb3059c32d9c28b2cdc20fe4f944b00fa8d3dd13b3de1c23e7c'
+          checkpoint: 'e77d30cd899aaa199351eb091ec477c580840b449880fb0808540e98ce96b913'
   name 'OnyX'
   homepage 'http://www.titanium.free.fr/onyx.html'
 

--- a/Casks/pi-filler.rb
+++ b/Casks/pi-filler.rb
@@ -1,6 +1,6 @@
 cask 'pi-filler' do
-  version :latest
-  sha256 :no_check
+  version '1.3'
+  sha256 '06179b365be0f86027f89ab634e98f5101899ccfe5378f44b4b9330aedf0a9b3'
 
   url 'http://ivanx.com/raspberrypi/files/PiFiller.zip'
   appcast 'http://ivanx.com/raspberrypi/',


### PR DESCRIPTION
There were 5 casks which had appcasts and still had version set to :latest. Updating them to the current reported versions.

```
> grep -l "appcast '" *|xargs grep 'version :latest'
carmetal.rb:  version :latest
clipbuddy.rb:  version :latest
launchpad-manager-yosemite.rb:    version :latest
onyx.rb:  version :latest
pi-filler.rb:  version :latest
```

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.