### PR TITLE
hacking.md: Update instructions to force OS version

### DIFF
--- a/doc/development/hacking.md
+++ b/doc/development/hacking.md
@@ -59,13 +59,11 @@ This form can also be combined with a specific Ruby interpreter as above.
 
 ### Forcing a Specific macOS Release
 
-The environment variable `$MACOS_RELEASE` can be overridden at the command line for test purposes:
+The environment variable `$MACOS_VERSION` can be overridden at the command line for test purposes:
 
 ```bash
-$ MACOS_RELEASE=10.9 brew cask info <cask>
+$ MACOS_VERSION=10.9 brew cask info <cask>
 ```
-
-The environment variable `$MACOS_RELEASE_WITH_PATCHLEVEL` is also available, though not consulted directly. Use `$MACOS_RELEASE` for testing.
 
 ### Target Ruby Versions
 


### PR DESCRIPTION
Update instructions to force OS version to reflect Homebrew/brew#1883.

I removed the bit concerning `$MACOS_RELEASE_WITH_PATCHLEVEL` as I couldn't find the corresponding bits in the code (using GitHub's search).