### PR TITLE
Update libreoffice-language-pack to 5.3.0

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,553 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '5.2.4'
+  version '5.3.0'
 
   language 'af' do
-    sha256 '987b6e82d7b2bced2d21fc72fbf9f25fce5512a5ad4b29fbe6f0cd76c26643c8'
+    sha256 '272ff3bffab9589c789b6f0a74ebec6266bfa1b18d1f062ee9a4e5d943f444e8'
     'af'
   end
 
   language 'am' do
-    sha256 '64236a9548e2ccfab83fe2328cb35a5350f60788f83b084edbdca8da58b29ed4'
+    sha256 '1180376083f15091dca616764b28d2d7682951c31e26ea88bd29d612ce684e21'
     'am'
   end
 
   language 'ar' do
-    sha256 'd185c5127043918158d889e444f972e929c5a7ff0cd851a445218b02a0d26d8c'
+    sha256 'e3f77a476ac06593d47cc66ea51ab16c3de62bbfcf4517396f22942ce12fa739'
     'ar'
   end
 
   language 'as' do
-    sha256 '7ef0d459c92eb07b4cade347d1cda2670c37c9af5cdc3d8000b38acef9c06f7b'
+    sha256 '5ea9648f9c80fb0481900dd9d54e4e6bc7151410c7eee007882c41e3d2db031f'
     'as'
   end
 
   language 'ast' do
-    sha256 '25a150e5a021300451f79b23d13585dfd353ae6b3c821c8d1268cd57272f7391'
+    sha256 '9448009b9aa95a8ed0c9666e153bd03a410b51c57e5f05096421a675c2c701f9'
     'ast'
   end
 
   language 'be' do
-    sha256 '6ddc4bb2e9762cc5d497cf896df2ef6188b0621c03ae847df864cfe3a45cbb1d'
+    sha256 'dc62de54eeeb659fad326ecd765172bbda0afff0635d41f58f184f06b1aeb627'
     'be'
   end
 
   language 'bg' do
-    sha256 '5cf5b97bf97b2ad976e130fd3a3f8cdf7fd9382b3f0fb556f965b90ad9fb2156'
+    sha256 'e9c863abc4861375bfd8f4b0e8ab31da5be4650bdc1b7e4c4a5956e14421bd15'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '68986d381dcd52f5ece4376c3ffd6401fb697d8d08960498e533d116c8de8741'
+    sha256 '4737ed87e5ed92fbc3d8931241c3ccd142de3c108e94b2ccf5e39dff51a2cae5'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 'a0f4d9e7c9b83a461e716e5cb04b603cb61a2939f62f4ae71a8b9fcdf8070639'
+    sha256 '6a7ec673fff23aad7288cc5076163613fef96fa30fada3429000ae099aa86932'
     'bn'
   end
 
   language 'bo' do
-    sha256 '16da06484b9e33f4bf96c4cf6cbd74fd736870909b5bc547a98be63d18e5e5f0'
+    sha256 'a9356174f15b6de82e61f1dad8e8bdde6c0db5a254e1251816d89d16b2d266bf'
     'bo'
   end
 
   language 'br' do
-    sha256 '227089e481fe00df0aa289f4c59c04ef200eb6fbb7de666b18aaa7f561a518e7'
+    sha256 'c42a598affe360ab08a2bd0043e3f6acce8f49219a1386217899f9e17a686e7a'
     'br'
   end
 
   language 'brx' do
-    sha256 'b97178acd6821afe0cf0c5a5abb9b0a7b8cfc118cc0681f1e78fa856a50bf3da'
+    sha256 '947596f1891531eb8d74c1e256949fa55917dbe1738b04c977aedbef91caf76f'
     'brx'
   end
 
   language 'bs' do
-    sha256 '7c10130ac2157041209b9fd1068cdbca9043db3c7519959a8f4382418ead0d43'
+    sha256 '551437baa1b683fb551221be24fcdaa909fd1eeb5e32c2458c0b578ba71b6bd2'
     'bs'
   end
 
+  language 'ca-valencia' do
+    sha256 '9eeb67532bc1387b036b815df70d8c917c5cf536c425558855be94a228819539'
+    'ca-valencia'
+  end
+
   language 'ca' do
-    sha256 'e90d89698ed6bbcdc2e06795a28bed3073f9648f1fdaeae63a38a53b8aea94b4'
+    sha256 '12923ef29be84b66438bef3a2efdac7d6fd2ec6a5dd3629250cf5b16f2b813c2'
     'ca'
   end
 
   language 'cs' do
-    sha256 'a5bd49785a609e46998d99a43a7d3ff8a9632b43c7e5d3fb7c381227f232516c'
+    sha256 'a872fa98badef455c95616db01f9b54304265050d773e66adf701fa7acde53b5'
     'cs'
   end
 
   language 'cy' do
-    sha256 'db44cc4a058fdb800954b10a6c84f56244c9a9c9e84bc632155fd6402cf22658'
+    sha256 'ceeed6ab9020db725795d9d666fd49df0d79f57e5118f09df2cfc2b9d2d4b630'
     'cy'
   end
 
   language 'da' do
-    sha256 'b7fe87bd77a7a81cefd5927060f5c22ed10f6f08dd3e2e2e51ed1ebda1cf6e2a'
+    sha256 'f5b385dec212b80855504a739d96b1a71ea6e4ee2e22fa58bc1d0b531259c6e8'
     'da'
   end
 
   language 'de' do
-    sha256 'fe3222341b071ccaa330b48a29c70e747647e572dec5b4ceadb907f01fa899ca'
+    sha256 '52b39f08a6fde03d71abbcc114521cc90a10f82d10be501d15383f562fb5716d'
     'de'
   end
 
   language 'dgo' do
-    sha256 '5dd3643ddd3adc661fd2ca0c3cea27af39cbbc0bf41f598826b14a05a7260c49'
+    sha256 'fa4ad24a9da278beaf77193eb033d4263b00c71eb7c445985c4b4a6c86f8a236'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '928b9ba269debee929fe1181fe1c0ca4df0ee7d6d1717b704d66e17dbf0e6e3a'
+    sha256 'c9b3e98d259642333096b05ba342270ed8c69236aa43fc2976bb012dfdd2638b'
     'dz'
   end
 
   language 'el' do
-    sha256 '63fe95f55fd3cf373b8815add935b5e5959072f8c25ce89bf69f9301c811f877'
+    sha256 '12cde16038a6a4a4059f7f4ee3f66dc4a66a7f8079d579b803e5a3a24990947c'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '0774a1a698fec402e17f6b53d8d8e9fc238668e93c084444132a76defa4b4e03'
+    sha256 '44dc392a187cd11b5aaac5cf9f2eb788207a2d5a69f6830ed077b12f04269cb7'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '04e6cee888bddb68b0c21ae1c8c2ed4b56b4ebd3ceb59fa5ade4223c7033fd69'
+    sha256 'ef3f89ae6ed474f57b5b934b32927823e8e26468f411abbc8eaae8f375fbcd01'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '080263f3c09903a3dba030cf3fa109a40ae395bf62c020136aad4d47000d25a8'
+    sha256 '4375f9eb39e33d70441f38f56cdde4ea27b41a1ac3dec8bedece7ee08b148db4'
     'eo'
   end
 
   language 'es' do
-    sha256 'f6a84a0e8273576a7bb3094a20d9529d3700551f40a5896810ca2dbe4aa1a395'
+    sha256 '09e72b25eb2f61e62120168915038f1c7689011de495517f7fc91c783e5cea86'
     'es'
   end
 
   language 'et' do
-    sha256 '3a623bca9ee0c9ed7afc7928715dd8c8eb10b6ed715eb424af9873474db87c40'
+    sha256 '9bb77a47c46937283fc8d305ebfeab02e7f56568b4d8e7d6b8e3f19db59ad61d'
     'et'
   end
 
   language 'eu' do
-    sha256 'ef5026a638d88886b7797e1f45bdf23ea4e793de329cdacd518d151006068a69'
+    sha256 '022e788ce23abb2167bcf1e9d6798562096af431adfea1c700e892fa60d1256b'
     'eu'
   end
 
   language 'fa' do
-    sha256 '00612fc843d612d2a4e29c06478dfffceefea40b6a569fb81d817e2a2895e0f2'
+    sha256 '78adc39e360e0b97b155b54a966424220212e25db4289ccb1a38a43153c70f05'
     'fa'
   end
 
   language 'fi' do
-    sha256 '2ab640b7724d9a93c9561705a3ba083a069fd009aa7d4c2e80a21bb450a23f0a'
+    sha256 '74adf229b3633c8f3fbb40b964a5c19d0117f3c2ad5b3d3d5b2f300324ff02e6'
     'fi'
   end
 
   language 'fr' do
-    sha256 '3c0d7cf4e1c4f474e6f4561466e7fe3fdf6a0685865493c4653fe0360ce0e12b'
+    sha256 'ad83edd7b4158f0220de35e10270554f4e71d54410d270d8395ed62af6a27ccf'
     'fr'
   end
 
   language 'ga' do
-    sha256 '8413760a80e35cff6494258fa9b858bdef7b4375acea33c6ef87e35a8d1f2d3d'
+    sha256 'f1b3d9ce06655c1f28b3cd0f17142ba8f10c2f7b5ab1430e57f1ee600e35196a'
     'ga'
   end
 
   language 'gd' do
-    sha256 'c6c17b6ff685a971ce419f72d2657ecd1b63e72b6f47871290784d41574d33a0'
+    sha256 '3bd64dffa29518b1ac56588e7b48bc1b3d77716cb1ef34a7a22d95d1d4ab4293'
     'gd'
   end
 
   language 'gl' do
-    sha256 '68affad15763b1411244241529368a569d89d30ad1a55fe22399f3b785d05fbc'
+    sha256 '69cb7196345a0691537fe61216d7de93f6de78e7cb14046d9a446a08804dd572'
     'gl'
   end
 
   language 'gu' do
-    sha256 'fd326d32383b3261a6d644832d29c1a3aefd1cbe866f99664be779851e98ebbc'
+    sha256 '116733c561fc7ea9c71f10849842a0d953df6b924ea02e0efe39970286928030'
     'gu'
   end
 
   language 'gug' do
-    sha256 'b49c126c3ecf92e51a63e70c16ce9746a7a5138b79a6f2ea66082c0a7e24fc6c'
+    sha256 '3c695dbc7bc94be052d02b66e7e60209086b50144b483e231d14ee4592102d49'
     'gug'
   end
 
   language 'he' do
-    sha256 '47e3df8da24d8328fe2fcbb19155b1c9318bc28d188ef1e0d1fb83ed37ff6abb'
+    sha256 '43100ee2a51010ec20e5e3560ae42b378ff322e712a6cfa18c2d4e65f196802c'
     'he'
   end
 
   language 'hi' do
-    sha256 'c0e87f50b14db7fb3d788817d31af4734eac74cf42fc72daee62396ff246014d'
+    sha256 '93809a904e49234c5d57e55c619fb471d207117633e0ff91ea613203c4269c9f'
     'hi'
   end
 
   language 'hr' do
-    sha256 'f3c97c2524c3d03d70e8d03595654601249e83da56befa96f8685628998bb72e'
+    sha256 '75ee51abcf6024a6a51cfa8a22e199a66662223b07a27ca24ee981eeebbd8383'
     'hr'
   end
 
   language 'hu' do
-    sha256 '2ed2c15007321201526b766ef2e1a4165cf521de3661e5abaa93c49c4d51a65b'
+    sha256 'c815d0002dae066503dd82fa6340f6fe3442d10a88f77564eb5f21765c4f4611'
     'hu'
   end
 
   language 'id' do
-    sha256 'db8caf99494a86b255d82af49c28e3e7cd052b77d8ac310e28ca3081cc4d5516'
+    sha256 'ef88d1dfbe5e2958433299501e98eabcfff9bac0ac9999ab8541d7b032c4fbb3'
     'id'
   end
 
   language 'is' do
-    sha256 '8eea4031cd4cf9d8904454234126f0ea8ecedd3b8b13488e52321ad8e364c459'
+    sha256 '63b07946b254ef2da95358041b756a5b63d5dd7ac5b976284f9970bebfffa685'
     'is'
   end
 
   language 'it' do
-    sha256 '7c0e21e4f85d8823cdec1b79a69d81d6ed24cf9fd5163d2c3e8103c23326df8a'
+    sha256 'd10436193ed6834b89a469f2aa299173ecf845de44e1b0d2575b49dc7e164d24'
     'it'
   end
 
   language 'ja' do
-    sha256 '9e33105526ed0ff1f74164b4de9d26363cca223b6e9b6c250ed9f70c17c0967d'
+    sha256 '351724c42d303155cdde6760acd352bc1755c67664e9e3b8336b5ba8335d9f0f'
     'ja'
   end
 
   language 'ka' do
-    sha256 '5377faef06a2c34250645125993ff489e5a14c6de4c76c7c12dcc849a9977403'
+    sha256 '641ebed9f3d26afb45164f14a3298b59fc87c2e9ec066a92cef6886703698d95'
     'ka'
   end
 
   language 'kk' do
-    sha256 '64a1ebab8d90b57ba9e47f77640971af2bd00c1986d5665218539717ea2bc6d3'
+    sha256 'faa8e317dbbcc277cf5a2a1160453a3e1bb6e57e4f65862729dc21969c3cf7ad'
     'kk'
   end
 
   language 'km' do
-    sha256 '32b1069c6bf0c273449a485993731b63727ab6f9c30d0fe2d63aec4a4061bd49'
+    sha256 '6f8a6dd268d56b0873ba9cdbce3876bd0705e69d52016aa6615ef2ae1ee2a639'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '692db25bb1cbb68bc4579f3ae6f762c945b9418acb7b9b8b60f51efba3cf1397'
+    sha256 '56bead7724cc6dbb7f54c722a1d3807469bd0d9fece101e0ae70a7ed42df7325'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 '99b0f8ee5b1eadfc4debeb7e30e6cff1d7112129970273a6513e016f1505102d'
+    sha256 '646a42004d46bd43b58ba8c345c5cf3d61c289af5ece12250634c3137754aea5'
     'kn'
   end
 
   language 'ko' do
-    sha256 '5244909a75fa22c444aa9cb26ac3d96090e4a211c68551b41d2f1fe4407a6d5f'
+    sha256 '540654d42c13da7c05f56928e181e3c45c46024d6abd033c0a7b85b043447151'
     'ko'
   end
 
   language 'kok' do
-    sha256 '1237723fcf6afef6a660aaad094c02449643d811b88697ddf8a90ad86b1dc21e'
+    sha256 '14751153451769f8cc55028fa14de5f5e0108201bf73203a7db8eee8d5167d08'
     'kok'
   end
 
   language 'ks' do
-    sha256 'c4986a031a63374ad1381150fc55a7d8f7fd8b62cd9ba11ada52ac8cabef83d5'
+    sha256 '19bec14e3c3b71ae142215955f1bf4481d839e7f3b5330ff272367c4f00d89f7'
     'ks'
   end
 
   language 'lb' do
-    sha256 '1c56d2b30110b12a082d72929d2ee7e55ad28455df8ca1539b8b987960f5b3f9'
+    sha256 'a5db943a3dafeeb142e147af129660abb2704c86964642c2baa79396b1299bae'
     'lb'
   end
 
   language 'lo' do
-    sha256 '5c51b05332b2c60944931104796695e64904af9385e781c6d06f0eb07853901f'
+    sha256 '5f353375caf754071c3177e381a050e030fe2686a1e08bfe9b206443ece2668e'
     'lo'
   end
 
   language 'lt' do
-    sha256 '8a1a90f3274a81c12eb918f2909fb7e601fb3d56dd764f65c7b82e9f37e95bfe'
+    sha256 '68f26491a3c2596bc578a35525705eaf938770c31988a2128d3281f439a820fa'
     'lt'
   end
 
   language 'lv' do
-    sha256 '51919d9a5393b9995e2871eb7f3401bea3de5d5c1b90fb2b342c0a8bfe7c12ab'
+    sha256 '1b2b7828f3bf2ec275d7d5d1bff3b87268c15d4fda75e648ff58b28dfd1cf830'
     'lv'
   end
 
   language 'mai' do
-    sha256 '125ef24390899c6eaf4529188aaceec38d3148d19b4ac96e05dcb63a07ffc040'
+    sha256 'a27cde2799ca77666e34e3d2668c85751d36eb2b2d70508c3f8dda1af743da51'
     'mai'
   end
 
   language 'mk' do
-    sha256 'd0ff0864958779db06089a8ed140e82e355ea1257b32edd78c875413e982ad91'
+    sha256 'a88e3b0841c5443a42063822999f1def6461b97e27be4ee29b28a26c6f71a7a0'
     'mk'
   end
 
   language 'ml' do
-    sha256 '7199f9dd087f22648a8128f5c058fcd6d743bf642d9238023be1bab73b1f66fb'
+    sha256 'a796186f61130fca8199e0bef208cef9ac9761bdc507f35392401787a4ec5d86'
     'ml'
   end
 
   language 'mn' do
-    sha256 '76f5f097cb7b390bde48f926d9d7d307ad0bdb19e225f07aac73e8bff0267e5b'
+    sha256 '08c0c361d9cd6d02f699ef16e7b44a2142f33e55bfcc6947ffbafa0b077083b9'
     'mn'
   end
 
   language 'mni' do
-    sha256 '745cd39c79142850e010723b7768c515fa6ff01623f85461aaabc0879d087fda'
+    sha256 'e999d11220b2a3d68cb61b8324c8ea99845f6cad3d7a404951714fd13e82c69b'
     'mni'
   end
 
   language 'mr' do
-    sha256 '6b63a740d6ba2c247b6a26469cbe4c6958911a3231f57c048756aead0727fa0b'
+    sha256 '8c03b39411276144ce2f7a15461eeb7cbac9fddc4a3f053837f1fc2b86c522bd'
     'mr'
   end
 
   language 'my' do
-    sha256 '981dc0371e653aeada2afeee4ce4219bf48db4dd141cff526296b09a32ec2bc8'
+    sha256 '4364902dbd3c3432edec7e2a58443782c87d7cd5d11ede3ec2a5ba8ecec87d6b'
     'my'
   end
 
   language 'nb' do
-    sha256 '51ca00fde878fb5a5e57d5861523c4488530864f6f9476ce455a72595a00e71f'
+    sha256 'bba45af7d92d1a809c4500926ab7a86acb4f6ee1de890119fb6606abaa39bd4e'
     'nb'
   end
 
   language 'ne' do
-    sha256 '2c59bcbb9c9bfd71f8f126f27729ff073fd8a1e3ef3ed64a881e1fce4924a593'
+    sha256 '9d916c3ab821f26828c502ff6806cbc9229a35af33adaacc939c76e9936a7e26'
     'ne'
   end
 
   language 'nl' do
-    sha256 '4d6bda111ef79992c614308fc9014c8b8373fe52a0285e02ae91b07b79142fe7'
+    sha256 'c311e6716d99add14571f183f71be8ed61f0eb819653b2b39d51b2d41159ba2c'
     'nl'
   end
 
   language 'nn' do
-    sha256 'd2f1110c4fa1ee128a674fa8c188d046fbdece67a660c763e56a2be6e0aa4d5e'
+    sha256 '02379da3049b91c5beb4de07b0e9cdd72afb36c21aa0c73de5b7018ff5249b16'
     'nn'
   end
 
   language 'nr' do
-    sha256 'e26b8900db5e8895ad967aa53e389f8d63459e5f6c85081cbff1cd0915789562'
+    sha256 'e1fca3f5a122276e1448d7a34d89f3c199a60c7511309a9982451b4be4556142'
     'nr'
   end
 
   language 'nso' do
-    sha256 '1d20f6ed7db8a8c35bd045e7ee6a291b4e1df853c9c4673e1d08e29a0011c657'
+    sha256 'a98bfcdae795795eac62f45eb5a00e0796beec3e15dfb767f31ddd109a84bdec'
     'nso'
   end
 
   language 'oc' do
-    sha256 '13d6f86592340a0050dd6d71c6f196677e3d5ffffccd4d3468a593f8d11d9e8b'
+    sha256 'e4781f895568b8dcdff133bd502504b3185e9a5cfb43658d4814f3e640b7214a'
     'oc'
   end
 
   language 'om' do
-    sha256 '0edf097441e76f779dbe0d7e474216eadd17c4c52bbe30fa4641cdd2b1521ff3'
+    sha256 '545db4da4fed1e51a81773953b7b55e62b3e70d06cc4b4a5cf28e74ad9471667'
     'om'
   end
 
   language 'or' do
-    sha256 '5e4092853972ca689fdf7fa0548bebaaa27e3cdc4db4855777a9db26049e6bb1'
+    sha256 '55e83355b4c56763e39eebaa9c68285bb457a1cffcecb718075d2f91857a6ed3'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '86daffbda877b37d4fdbc816703d859603f5910925a5e13ffd4cce5737816598'
+    sha256 '2cbcb96d6978a5e90a6763d5460c5971ad6f6abcc85dd80a9ca67867a2cdef23'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '236d913f61bf6f4e92d0f8a695dfbb2f617d9288d12c27d6a539b904a6b01946'
+    sha256 'accba41dff505c1f1cf82f812bd7ac7d70017284fd175dd90dbcf4a6c6707f35'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '7ed724c19cb9950e01a6182d4dc4f110dfdf423205cc97fe4d88c13c6fc1dd19'
+    sha256 '5aa6f1d477e10bb4a46139a9276e8c5569bbab9c5ba5780c327472c563cc0a2e'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '1a47cb952e7b2b061593c0ad9894f3501256079ba39b9361857e92258f535223'
+    sha256 'f2f5fda9c50e85076301b0cbc6ea5fecd8287d5de2f7f92e3ed38c0c496dc9d0'
     'pt'
   end
 
   language 'ro' do
-    sha256 '638df781ceb1292de1ee8e7d3e8b05411b5d07db0c46bb36f405bbe984c550ba'
+    sha256 'f43925260d90a305cc680ccfee8eb694c89e6b229e83f051adcc6dbbdb9f544c'
     'ro'
   end
 
   language 'ru' do
-    sha256 'd7373d60b51f7c93fae0e71308b2e06c30917b13b02da19485a8ba178759f60b'
+    sha256 'a64aa10c477f9bbfc0efb374e01b45577950a772d1a636434b81e59a6d57a1bf'
     'ru'
   end
 
   language 'rw' do
-    sha256 '2866f43841180a7830ca95d6ec34983ded7931b8802923a00fc75996fe83a912'
+    sha256 '06128893c706be3c28ff2e6b472fd7f1975a738ab536d1c63a8a0649f8483839'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '94188c422c9b37bcdff9b31b9fdcd0a4fc533fbe1482497c7a44cc5a5efce57b'
+    sha256 '46520d9c7d9ca04838c47eb3bd786dee48947ec6600aad772478a8e7d8e9aec1'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 'c275129c67516f1b282632775e7058b669d45f58591426e0eed8dc14e27cecf7'
+    sha256 'e2675c5864241fd011320339e5529aa324cea1f0fea96062555494a371d3db92'
     'sat'
   end
 
   language 'sd' do
-    sha256 'ba7c260103709e5d0cf0232c2e64abbbb3d2ea2bb95d6b16881862e0cf47e891'
+    sha256 'db265ba8624c831ef9bcf5e01f86328a4e0dafec24d34b81ff18134c4072b563'
     'sd'
   end
 
   language 'si' do
-    sha256 '91699299c64bc7a008be8733f846a4fc026b0e5ba1026c70e4147cb43a14d909'
+    sha256 '354de7d896bb92730919135937c9b74482892c46ffc06cedbe38078a1f65bead'
     'si'
   end
 
   language 'sid' do
-    sha256 'ab3f957d5071a6d786781348daa36b9dff79550f60a2ec92c819f43dc017826e'
+    sha256 'cb5bdcf2920a91cc4168109ac34f5bc6f98a248910a9899b56e40e452bf72aa2'
     'sid'
   end
 
   language 'sk' do
-    sha256 '9bedcda76832ec5f508b243e0b558fdc6458b05f8c1c7a253775f2d3e87ce7c0'
+    sha256 '9b2b00faba590940264cd6e07f654b6769986b902ea80280365c1ea9f08479f8'
     'sk'
   end
 
   language 'sl' do
-    sha256 'c79f00aef28363bea61e60b48de7cd910756e8bac03db12410ef8b7ea5123697'
+    sha256 'aac6d33af93da40cb2ec5306c010b7c5eea3dd9b5634de78e4713d1652431ea4'
     'sl'
   end
 
   language 'sq' do
-    sha256 'cd36f25892338a0e3b958b59b3a304d706a1762baf0b65579e447b61c9dfe627'
+    sha256 'be55dd9d43b1ff0e331bbd6d1d4c3fbd6328e10e086cbf034817a930287cf4b5'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 'e099832e1f0f3625d700e0d1ae0351e265db90be0a10a7a27577563f1d55b8a1'
+    sha256 'f4f6e27d6565cb3819ac18cebafd47e1db3ed5baf02ba206787419fad53ad607'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 '0a0af0586aae6ca94e82205457996863917705538bb3468f4d6e4cd3d57dec06'
+    sha256 '77933b3de6ad8a9f925866edacf7e9d751808e7515b8bfa783549c13c20b4b28'
     'sr'
   end
 
   language 'ss' do
-    sha256 '0ee66c01f800f51499bb933436b490255383d844bcf8e3d5fcc7a4fbddcd62e8'
+    sha256 '71563aef59329ba0da6582c3d4a8364be24ced3c0ae4e533242327238bc19217'
     'ss'
   end
 
   language 'st' do
-    sha256 '00a9ed34ae45c863a964ef45c6cbb543ec0809126f3f21bd595269e7694a2c78'
+    sha256 'da6717d014ea5c3f868f2be94b7793c7c10daa1b17622ebc4d53694736b2f9ec'
     'st'
   end
 
   language 'sv' do
-    sha256 '1fc792ba78f70c6c66c1be8f3f08e818aec76b4b7452186afedcc9e955887b7f'
+    sha256 'b0228741b5e570aaa30abb1a51721981a67f5266ec437cddbe75034a739ff146'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'e2b86a79be8e88183ae9fe45cb5773433e9414a4032729f4d800f36367df3e80'
+    sha256 '80793f0fe1e5215f1e97f978316ca1e2291a6d6ceb16c9fb4c07f384199e0228'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '4cf3cc7242c45bba30222cad06d38cae38a4bdb1a944fb7f28f932176dd14fd7'
+    sha256 'ec11c876ac62fb6d02e5ec32f25571e0c65a9d51d79740fe3a458a18aef7deb3'
     'ta'
   end
 
   language 'te' do
-    sha256 '76fb2aa8707e9a92ae5a0090356351c6d1065f98ef3670c2e92a6eea8dc35eaa'
+    sha256 'e8a17d80070044e888f5099c32619a5b84e1e653df042b1994050bff4012b287'
     'te'
   end
 
   language 'tg' do
-    sha256 '7330b3e1d3c2c40a6ce880a70742cdf20609af33b2d458c5ac020a32afa97d2e'
+    sha256 '204f9cd9d2c33b1610ef2932b424dcb68971a606a22221740e5f9d114ab1d57b'
     'tg'
   end
 
   language 'th' do
-    sha256 'b7d239cb94e7aacf6bb7aeb472714692e99044b8211296574272daa74835ed91'
+    sha256 '057690ef60f8ea6154f172731b88daef561631e66467ca85964a171d9dbaafc7'
     'th'
   end
 
   language 'tn' do
-    sha256 '9d815c2d3e1d33ce24116ccbf4b599114760bca0b05e76e9297fc27d8f428534'
+    sha256 '64d90663393d5dcb97876293773ebb739def396e2013733f2ea4f61a71f6b0e6'
     'tn'
   end
 
   language 'tr' do
-    sha256 '929e9ecc18c6531131ec323245ee2508be2a0164abd7461631fba26e11750836'
+    sha256 '443b673399e613d6c683c67e3d1e571611005e8554638c6bb8e149839fe4e1ec'
     'tr'
   end
 
   language 'ts' do
-    sha256 'b892a880b32f912c88519ce255f0780db3d8e91bdb0dac3c03f6f4301660970f'
+    sha256 'd7e91f1e6cbc18c963fb4943378141746aa1de712e7e3c80a019cbb15d07ea81'
     'ts'
   end
 
   language 'tt' do
-    sha256 '72b4eb11dae315a60701db179a0f4fbc77709186e03cbde14d1878298eb3ad52'
+    sha256 '1f95e3ad80ceab884019d85e19d89ff2a1650466c232b7e917c47750da58123e'
     'tt'
   end
 
   language 'ug' do
-    sha256 '68819036dd33a1aa47f5378fee1a833b17737bacbe21359d42200f9f3b9a092c'
+    sha256 'bea0f5ddd6030f91635ac2c7501eae67d250039911aa2cf381955e27b96fce40'
     'ug'
   end
 
   language 'uk' do
-    sha256 '2feeda0d3f950e05b971ebfd6639da67926f75274a0f87880c5bf077d039356a'
+    sha256 'dbf028d712d98f99a54c9b3ae63a4efd89c863c24ca5de5cfa7615bf41e2ef9d'
     'uk'
   end
 
   language 'uz' do
-    sha256 'b4a913160c39ee3b1e85866de48c1fc0b4c699e1a90673a78bf73f9fef489939'
+    sha256 'e3c6f79abe2b6969c4ef5ad3a56aaf37b07a8d1dd6470ed73837c9e51e339bb4'
     'uz'
   end
 
   language 've' do
-    sha256 'e831cd76da1360666129a51d3edb48d5970deed48a9b5574745e4e40d2bd46c0'
+    sha256 '8af61d595baac8823f150f3e4efbf8e0f177c4b72e09d8dd0a364e08090e4f6c'
     've'
   end
 
   language 'vec' do
-    sha256 '7179b634698ed90e5442663ba58018656ec1335ff80576aef94e2561f628b687'
+    sha256 '8202bacf10fe7b1cb8f6cf9a02029ed89c022efca11321f1f460047b09bf78ba'
     'vec'
   end
 
   language 'vi' do
-    sha256 '985fdceff434b31650a4a836121b8da6d2496018b6cc8f035e46ff7ec2d90476'
+    sha256 '3a5d3075f1443d069b9e9578624296f255d011271bedc7c548120e6c54cd47ec'
     'vi'
   end
 
   language 'xh' do
-    sha256 '0e782ce03156656ee212a0072b1954e0d961a6639abfbab11cbe95dfc2001645'
+    sha256 'cd65959f5056b2f936b419d3fef4c2aaca02b361afb9d6a32a089d7b40fa6f7c'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'f897ff33346b6c0b9df6ee8718d3fb7365ccd8a31a0e6ed368100fe77d579bbc'
+    sha256 '937b4fa01d3aad2185ca199a219285f23741a6c5006d6cf34ed370858943dccd'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '1cae7e32c35f9a90739ad5a174fdbb19f6ac21865043ef6c15913b707907bd0f'
+    sha256 '1dddde7d1b844078dde6a02a5d2c85211dd63621dc4d156d49b20c22d8ff14b6'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '2c1fe88092fe626eadee307ca7f1eac4113acb84f4bfa8ef04a296f3d647c65c'
+    sha256 'd20f5c35f2d9f26b484ddc8065d8de223240aa4cd8c35e5668ebbff48e3e53a6'
     'zu'
   end
 

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -66,11 +66,6 @@ cask 'libreoffice-language-pack' do
     'bs'
   end
 
-  language 'ca-valencia' do
-    sha256 '9eeb67532bc1387b036b815df70d8c917c5cf536c425558855be94a228819539'
-    'ca-valencia'
-  end
-
   language 'ca' do
     sha256 '12923ef29be84b66438bef3a2efdac7d6fd2ec6a5dd3629250cf5b16f2b813c2'
     'ca'


### PR DESCRIPTION
Update libreoffice-language-pack to 5.3.0

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
