### PR TITLE
Update minikube to 0.16.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,10 +1,10 @@
 cask 'minikube' do
-  version '0.15.0'
-  sha256 'cc76cb68c9dfbe0317701e5d264ecf03cb3177a3a77906d901960c7adff6fc4a'
+  version '0.16.0'
+  sha256 '1de0dda591d23c01aa52f6e7b6c85bec7e4811a007a5a939eb2d1bed6fa84144'
 
   url "https://github.com/kubernetes/minikube/releases/download/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: '4facf8aca14f0a96adc1b3f32696938be460c8a66830c42ba3fa3242745acf95'
+          checkpoint: '30e9116a67824c129b5a28a458d8b2e57c01dbfb0912f8784d9d8c0d6712a250'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.