### PR TITLE
Update webtorrent to 0.18.0

### DIFF
--- a/Casks/webtorrent.rb
+++ b/Casks/webtorrent.rb
@@ -1,11 +1,11 @@
 cask 'webtorrent' do
-  version '0.17.2'
-  sha256 'bf58a517fa212db860f1a8db99417ed82b730b2996109aa64cc2d450c8f47ebb'
+  version '0.18.0'
+  sha256 '561c11df5c3bdbff80754977af6ac33bfa3ffcda283deae16aa00293930f0e3d'
 
   # github.com/feross/webtorrent-desktop was verified as official when first introduced to the cask
   url "https://github.com/feross/webtorrent-desktop/releases/download/v#{version}/WebTorrent-v#{version}.dmg"
   appcast 'https://github.com/feross/webtorrent-desktop/releases.atom',
-          checkpoint: 'b1361dd58f810194aec58efc6566cbe5d29531b6e8261938f48c01817946e9fd'
+          checkpoint: 'af35a6f3a2c0dab9e46e0942c0168771aa36ea7c5b225500852b096689a82455'
   name 'WebTorrent Desktop'
   homepage 'https://webtorrent.io/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.