### PR TITLE
Update rhinoceros to 5.3.1

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceros' do
-  version '5.3'
-  sha256 '62fd0654f2ef3aa09a8b92aa9b90503023d5bffffb500a79a8a90512758ffdfd'
+  version '5.3.1'
+  sha256 '0973e54e9da5d3bb5218288ecdef4ad4d032644447c7568c205cb7115a1b8063'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/#{version.major}.0/Mac/Rhinoceros_#{version}.dmg"
   appcast "https://files.mcneel.com/rhino/#{version.major}.0/mac/#{version.major}CcommercialUpdates.xml",
-          checkpoint: '374e382692475e1951712e476a3c9f697b0c0cd960f82422e6b9e396d3c5d23a'
+          checkpoint: 'b4e600b807a804d5979bf02927d48eb6374781fc779f24a5ba2b85c574225710'
   name 'Rhinoceros'
   homepage 'https://www.rhino3d.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.