### PR TITLE
Update speedcrunch to 0.12

### DIFF
--- a/Casks/speedcrunch.rb
+++ b/Casks/speedcrunch.rb
@@ -1,6 +1,6 @@
 cask 'speedcrunch' do
-  version '0.11'
-  sha256 '1ce5ef9d167614a2e63daad43a23bd8df60b8ea641df6be9aabdf826bbb5a826'
+  version '0.12'
+  sha256 '1c513acd0db375e079f47055f5903b538361fdd2ebf62d09bd3e876cb7513a94'
 
   # bitbucket.org/heldercorreia/speedcrunch was verified as official when first introduced to the cask
   url "https://bitbucket.org/heldercorreia/speedcrunch/downloads/SpeedCrunch-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.