### PR TITLE
Update glyphs to 2.4.1-971

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.4.1-956'
-  sha256 '6acdd4765bfcecbaf8c709717e3c87092f4537c089882b7f2d0a29a19df981f4'
+  version '2.4.1-971'
+  sha256 '02842b3dd44c73ccfcdacb0714c0825e6cc459c31b7d9f2a5f5fe172e9207a54'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: '621a312f3c42b59ff86d55f88e802bfe6084f827e4890aed1cd722d029a4d5b7'
+          checkpoint: 'f54781e6536cd869faa6151a51c827937b2d3790532a51fc257c255fdf60780b'
   name 'Glyphs'
   homepage 'https://www.glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.