### PR TITLE
Update simple-hub to 4.5.8-1271

### DIFF
--- a/Casks/simple-hub.rb
+++ b/Casks/simple-hub.rb
@@ -1,10 +1,10 @@
 cask 'simple-hub' do
-  version '4.5.6-1227'
-  sha256 'e1dffd459300da8d64534298ee598f981898fa35db72a4508da78566661df175'
+  version '4.5.8-1271'
+  sha256 'e5fb63cb351f9b804b5d9fd5a7e5596efe59f914c7fce28e95596d6a9a5563b1'
 
   url "https://www.simplecontrol.com/b/SimpleHub-#{version.no_dots}.zip"
   appcast 'https://www.simplecontrol.com/b/Simple-HubAppcast.xml',
-          checkpoint: 'e20a1dbab073713ded48aee9a9c527584ae913bc723190359d3516027e1cac8f'
+          checkpoint: '930a2df33d838cbf49b4b1fcc082f5f0ccafd20e8cad165b4b5d9b456f4037fd'
   name 'Simple Hub'
   homepage 'https://store.simplecontrol.com/simple-sync.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.