### PR TITLE
Update brave to 0.13.1dev

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.13.0dev'
-  sha256 '9b6536e968b212971ab2e8d5518776d82967120a81137e22b8a317a1422ebcdc'
+  version '0.13.1dev'
+  sha256 '1d9d3c6947b57194526a5d0a1ed4ebb95581cb6e9fd585fc23fb275903b8e2df'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '18a9ec4234da958e40f6de76a9097c1d08b3fd9b2a92a08237b1d17f0d7f489a'
+          checkpoint: 'b5f06098efdb2a15196c330b22d6bde25ab21d11e1e6ee96ec373d1fcd19623a'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.