### PR TITLE
Update ctivo to 2.5.1

### DIFF
--- a/Casks/ctivo.rb
+++ b/Casks/ctivo.rb
@@ -1,10 +1,10 @@
 cask 'ctivo' do
-  version '2.5.0'
-  sha256 '34bb75805c558d150005364a2befb393fa84a014e710358dea23a08396b464d3'
+  version '2.5.1'
+  sha256 '8ebef32944bcf98b7912d66b20cbc04f18386106203c1959c0e2089632d8d06d'
 
   url "https://github.com/dscottbuch/cTiVo/releases/download/#{version}/cTiVo.zip"
   appcast 'https://github.com/dscottbuch/cTiVo/releases.atom',
-          checkpoint: 'ef9494b415aa0b8468866906e2a36eca9621cdb61e41f03ca5f642d7a2ef15a1'
+          checkpoint: 'e0c8386ad0bfde5c29b0a953fcc1cdd16cc8e6787a44337006d9a535a0f8903b'
   name 'cTiVo'
   homepage 'https://github.com/dscottbuch/cTiVo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.