### PR TITLE
Update debookee to 5.2.3

### DIFF
--- a/Casks/debookee.rb
+++ b/Casks/debookee.rb
@@ -1,11 +1,11 @@
 cask 'debookee' do
-  version '5.2.2'
-  sha256 '521afdc999dae84fc5a1660c1ad918244b0254566be45e857cec4dc6d69daff3'
+  version '5.2.3'
+  sha256 '6adb304cd2c8fc232a13c8596a2ba2a311207024a9bc201b9cb37fcd04fd80e9'
 
   # iwaxx.com/debookee/ was verified as official when first introduced to the cask
   url 'https://www.iwaxx.com/debookee/debookee.zip'
   appcast 'https://www.iwaxx.com/debookee/appcast.php',
-          checkpoint: '345e8e107a056c423f6546c7322bbc451af54d9e937494391cdaf73f0b011433'
+          checkpoint: 'e604e18bc376cc0561f6ccc875f45b79f4f17a207c4faa93960e53fda4f413ac'
   name 'Debookee'
   homepage 'https://debookee.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.