### PR TITLE
Update gear-player to 2.2.31

### DIFF
--- a/Casks/gear-player.rb
+++ b/Casks/gear-player.rb
@@ -1,10 +1,10 @@
 cask 'gear-player' do
-  version '2.2.30'
-  sha256 '4723688e3c8a68dfc9079ca4692787051d69831b0f76a49fe6f78081f0c8ce04'
+  version '2.2.31'
+  sha256 '32a6aba48f4e1b5b5ef4e11e082637578b892affb77aa0b729a62308fc015ade'
 
   url 'https://dl.gearmusicplayer.com/gearupdate.zip'
   appcast 'https://dl.gearmusicplayer.com/gearcast.xml',
-          checkpoint: '3ad0ec6ab12d4818f3793ef615e4c716dd3411fe33652e391a55262239a21958'
+          checkpoint: '94ce3e99a213f01fc9d6cf68c8d5a6975d40fadcf0dc1f85e4fd4187c09c4d18'
   name 'Gear Player'
   homepage 'https://www.gearmusicplayer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.