### PR TITLE
Update keeweb to 1.4.0

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,11 +1,11 @@
 cask 'keeweb' do
-  version '1.3.3'
-  sha256 '94c58fe6cc158ff901e0a0011cb97e33fc74bc1b051eb29c64c37898b1951a5c'
+  version '1.4.0'
+  sha256 '0a05d6ad6583d152fa7547c3f7788eed2da011025af5892cc1d5157e31e5c7c6'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"
   appcast 'https://github.com/keeweb/keeweb/releases.atom',
-          checkpoint: '67dbbf3ef00e3b891a8163f0dff154dd31e39e330f00e7a7c2fbd168c577f08f'
+          checkpoint: '46f2cd53432b201d16e54138eb0fae8d8fd2216d3add6e54775c76c41e7cce49'
   name 'KeeWeb'
   homepage 'https://keeweb.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.