### PR TITLE
Update svgcleaner to 0.8.1

### DIFF
--- a/Casks/svgcleaner.rb
+++ b/Casks/svgcleaner.rb
@@ -1,10 +1,10 @@
 cask 'svgcleaner' do
-  version '0.8.0'
-  sha256 '544e75bd51b042e26183814720e656b787a6dd525c694314cf09ce0e6783f976'
+  version '0.8.1'
+  sha256 '3ea96e1882b303cc554438867da7e85f69dde1ab1b8af70c8287c2abb6c54db4'
 
   url "https://github.com/RazrFalcon/svgcleaner-gui/releases/download/v#{version}/svgcleaner_macos_#{version}.zip"
   appcast 'https://github.com/RazrFalcon/svgcleaner-gui/releases.atom',
-          checkpoint: 'b96f2dc4b73e545ef13efdaec64e238ca5b5edb5d58dcc53ea1218e94ebe5c8a'
+          checkpoint: '238f133ff682095cab4474b8871b538e5ade86912b1aa9d117073460cbb863a3'
   name 'SVG Cleaner'
   homepage 'https://github.com/RazrFalcon/svgcleaner-gui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.