### PR TITLE
Update filemaker-odbc sha and add appcast

### DIFF
--- a/Casks/filemaker-odbc.rb
+++ b/Casks/filemaker-odbc.rb
@@ -1,8 +1,10 @@
 cask 'filemaker-odbc' do
   version '14.0.10'
-  sha256 '68284d8556622081d90f2502b3785200090b8868f4b335b3512c5e0023102d8a'
+  sha256 '27aeca66ea4e82ac0dbdd538f42037611fefa4b7c6e461d3dba35cb10de20c18'
 
   url "http://fmdl.filemaker.com/UPDT/#{version.major}/FM#{version.major_minor}v1_xDBC_#{version}.dmg"
+  appcast 'https://www.filemaker.com/support/updaters/updater_json.txt',
+          checkpoint: '3936901fb3008befea96737250e1b2995894404938e83b1d431e1c7e6ec9f863'
   name 'FileMaker ODBC Client Drivers'
   homepage 'https://www.filemaker.com/'
 

--- a/Casks/filemaker-odbc.rb
+++ b/Casks/filemaker-odbc.rb
@@ -4,7 +4,7 @@ cask 'filemaker-odbc' do
 
   url "http://fmdl.filemaker.com/UPDT/#{version.major}/FM#{version.major_minor}v1_xDBC_#{version}.dmg"
   appcast 'https://www.filemaker.com/support/updaters/updater_json.txt',
-          checkpoint: '3936901fb3008befea96737250e1b2995894404938e83b1d431e1c7e6ec9f863'
+          checkpoint: '1fbc16bd48c0cb8be68fb074b7ffb5128f3e866ba77e5433527b27e50ffd7eb7'
   name 'FileMaker ODBC Client Drivers'
   homepage 'https://www.filemaker.com/'
 


### PR DESCRIPTION
* appcast stable for 7 days
* discovered that sha checksum had changed

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.