### PR TITLE
Update geany to 1.29

### DIFF
--- a/Casks/geany.rb
+++ b/Casks/geany.rb
@@ -1,8 +1,10 @@
 cask 'geany' do
-  version '1.27'
-  sha256 'ce629ba35aebbd71e054c3cd32984abc41f368f0d578864a2c1b3662f9b00ecc'
+  version '1.29'
+  sha256 '794d373a13287513608deb69b8eb012bdb904a9e8eb417055a1ff8794828b23a'
 
   url "https://download.geany.org/geany-#{version}_osx.dmg"
+  appcast 'https://github.com/geany/geany/releases.atom',
+          checkpoint: '5067d1c9d10d6630e280e9638cf303ee694f3ce48d233d905109fccefbf934bb'
   name 'Geany'
   homepage 'https://www.geany.org/'
 


### PR DESCRIPTION
* there is no github release download url available

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.