### PR TITLE
Update vuescan to 9.5.68

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.64'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '9.5.68'
+  sha256 'f5178c545ef774fa3388151d91d450fe3d64d0072cabf0c193767d57eb5af1d5'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: 'd6e88549f481993c8bfe21a551c5a19e7d6fe83a7a0b5010ee5b3ff99ef49ca4'
+          checkpoint: 'b03bf18d13f1c6f90aa7b8eef0cfeac211eee8a922b9fee926c05d56a1eb0a34'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
* the file will change in place upstream, but there is now an appcast to support versioning, so adding checksum back

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.