### PR TITLE
Update balsamiq-mockups to 3.5.7

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -1,10 +1,10 @@
 cask 'balsamiq-mockups' do
-  version '3.5.6'
-  sha256 '52f4ec8d234b5aa9b43a34f56d00f507ea787ce0d73615cbe3db8f7a86606ce9'
+  version '3.5.7'
+  sha256 '6195e3ecd34709d454634bee9263c30ea250d00576201fea2c4bc3ee52f69535'
 
   url "https://builds.balsamiq.com/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"
   appcast 'https://builds.balsamiq.com/mockups-desktop/version.jsonp',
-          checkpoint: '8a5231223713a3e85fc302798f1646312ba65baece3a0f5595b7499df063bba6'
+          checkpoint: '99836870089ae0f6f5ac88ba6c529fe5f2b6922714e93f57ae964905f0889b17'
   name 'Balsamiq Mockups'
   homepage 'https://balsamiq.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.