### PR TITLE
Update avogadro to 1.90.0

### DIFF
--- a/Casks/avogadro.rb
+++ b/Casks/avogadro.rb
@@ -5,7 +5,7 @@ cask 'avogadro' do
   # sourceforge.net/avogadro/avogadro2 was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/avogadro/avogadro2/Avogadro2-#{version}-Darwin.dmg"
   appcast 'https://sourceforge.net/projects/avogadro/rss',
-          checkpoint: '86812f0880364b4a27a9f91cc64088181e6264e9793b4b5331a7317db60338cb'
+          checkpoint: '84f164280cc8b8c0749dc382dcd688cff57cc31eebf6ccb907fe4563b2d49152'
   name 'Avogadro'
   homepage 'https://avogadro.cc/wiki/Main_Page'
 

--- a/Casks/avogadro.rb
+++ b/Casks/avogadro.rb
@@ -1,13 +1,13 @@
 cask 'avogadro' do
-  version '1.2.0'
-  sha256 '8a9567a2f3ebf162eab8e375073ea84cd28483f004c7cd3cae33e21864615cc7'
+  version '1.90.0'
+  sha256 '71392555d2d38a486ea58d4a522304b59855fa8c3f71d88316bf3828f7a064da'
 
-  # sourceforge.net/avogadro was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avogadro/Avogadro-#{version}.dmg"
+  # sourceforge.net/avogadro/avogadro2 was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/avogadro/avogadro2/Avogadro2-#{version}-Darwin.dmg"
   appcast 'https://sourceforge.net/projects/avogadro/rss',
-          checkpoint: 'b4c194124e797b2c1962828bbbb16c54c624c9f38191bebcb6770259739208df'
+          checkpoint: '86812f0880364b4a27a9f91cc64088181e6264e9793b4b5331a7317db60338cb'
   name 'Avogadro'
   homepage 'https://avogadro.cc/wiki/Main_Page'
 
-  app 'Avogadro.app'
+  app 'Avogadro2.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.