### PR TITLE
fixed sha256 for ship.rb

### DIFF
--- a/Casks/ship.rb
+++ b/Casks/ship.rb
@@ -1,6 +1,6 @@
 cask 'ship' do
   version '2.0'
-  sha256 '4cf4c0f7f369a1958a8e486b05fdd49dd575ad8f8a2ffc1be3b36d20e9c4b9a9'
+  sha256 '0422eef83b18e1f7e60f568b66750060857829b80d220e4ca9c96d50872f7649'
 
   url "https://www.realartists.com/builds/#{version}/Ship.app.zip"
   appcast "https://www.realartists.com/builds/#{version}/sparkle.xml",

--- a/Casks/ship.rb
+++ b/Casks/ship.rb
@@ -4,7 +4,7 @@ cask 'ship' do
 
   url "https://www.realartists.com/builds/#{version}/Ship.app.zip"
   appcast "https://www.realartists.com/builds/#{version}/sparkle.xml",
-          checkpoint: 'add1ec24702d46c77f294866507b13c6bc105cc34968bb7150371a9e62a5c6a4'
+          checkpoint: 'dd8ffc08a7a2d0b1d5dc24ffdfbdd6820a8f827897e7f18cb1170267fa4fbe7a'
   name 'Ship'
   homepage 'https://www.realartists.com/'
 


### PR DESCRIPTION
tried to re-download several times, seems like the SHA256 is indeed wrong..

```console
$ brew cask install ship
==> Downloading https://www.realartists.com/builds/2.0/Ship.app.zip
Already downloaded: /Users/carlos/Library/Caches/Homebrew/Cask/ship--2.0.zip
==> Verifying checksum for Cask ship
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 4cf4c0f7f369a1958a8e486b05fdd49dd575ad8f8a2ffc1be3b36d20e9c4b9a9
Actual: 0422eef83b18e1f7e60f568b66750060857829b80d220e4ca9c96d50872f7649
File: /Users/carlos/Library/Caches/Homebrew/Cask/ship--2.0.zip
To retry an incomplete download, remove the file above.
```