### PR TITLE
Update knuff to 1.1

### DIFF
--- a/Casks/knuff.rb
+++ b/Casks/knuff.rb
@@ -1,10 +1,10 @@
 cask 'knuff' do
-  version '1.0'
-  sha256 '4b5e88736e5d9443a84a204ba6c2a35faa7dfa6a6f94fb15286c70f07ef94744'
+  version '1.1'
+  sha256 'd954305fd0951d7d2697a55cd288c3d4af20b82293055ab0203f2a3518e92c27'
 
   url "https://github.com/KnuffApp/Knuff/releases/download/v#{version}/Knuff.app.zip"
   appcast 'https://github.com/KnuffApp/Knuff/releases.atom',
-          checkpoint: 'f8439225f5be2692f130847a8c1f15ca9303e5e9b6e76d959771bd938be29cad'
+          checkpoint: '4dbd515606ee39d27435503496353d109454c571ca2fe88ce4eed0a74deac0e1'
   name 'Knuff'
   homepage 'https://github.com/KnuffApp/Knuff'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.