### PR TITLE
Update mailbutler to 6763

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6720'
-  sha256 '149f213d43f0810911b9e8a33cabbe9dce117f99e450c8200b030b0f5fb9aa8b'
+  version '6763'
+  sha256 '6a4cd033ba8244ddfa21adc62f34cc1a2df7b6f41ea96f4fbe3639cb67cb23c6'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: '7a6b9b12c076d5e07fd26ce67417be49f0b7ef8dad2f8f60991dd41e1086ff6d'
+          checkpoint: '01f2e150cbb8e87528fdd339431d421f12d277be83e4b4f8a7fac8d6aa8dc3b4'
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.