### PR TITLE
Update musictube to 1.7

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,10 +1,10 @@
 cask 'musictube' do
-  version '1.6'
-  sha256 'b86f46d2beb44ae7e2536f155b4f455f6f3fa63b05f6b591f79bc564b49aa6d5'
+  version '1.7'
+  sha256 '1aff1cc06d27f38dec72bd23e731d7cf5559db592502dc86be69ba747adc33b4'
 
   url 'http://flavio.tordini.org/files/musictube/musictube.dmg'
   appcast 'http://flavio.tordini.org/musictube-ws/appcast.xml',
-          checkpoint: '979ab554fea8ee4d2d66063f2ad49645dde118e2a1ecea7935c64f034883424d'
+          checkpoint: 'ab92e80f868ed53351e8c254f7d77aa6ec07e371126c139e4a99bca88ce6e031'
   name 'Musictube'
   homepage 'http://flavio.tordini.org/musictube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.