### PR TITLE
Update outset to 2.0.4

### DIFF
--- a/Casks/outset.rb
+++ b/Casks/outset.rb
@@ -1,10 +1,10 @@
 cask 'outset' do
-  version '2.0.3'
-  sha256 '6e0e572bdd7b6d3c8378da3d13ed0ab0ea96db19251acbc4faa806926eefa9e4'
+  version '2.0.4'
+  sha256 '5eb8b302f18ca4e58bb72f1b453fb3f24b9e25edeb6919c7981b0107a6d3f51c'
 
   url "https://github.com/chilcote/outset/releases/download/v#{version}/outset-#{version}.pkg"
   appcast 'https://github.com/chilcote/outset/releases.atom',
-          checkpoint: 'd916798c95ff3d1190a5deb2a88179ca199b42d3352603aeb0d3ca0d6d383a0c'
+          checkpoint: '903c1a982566afa247ebef340359a4c8789ae40b45aa47b64ed6f63070830fac'
   name 'outset'
   homepage 'https://github.com/chilcote/outset'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.