### PR TITLE
Update qlab to 3.2.5

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,10 +1,10 @@
 cask 'qlab' do
-  version '3.2.4'
-  sha256 '561904e8fcf56b035100a5a46a3abb6f717d0395f64acf8ce0e56cb87f57da38'
+  version '3.2.5'
+  sha256 'e2d4f3af691e45b1b4585d979a3e6cdad030e99b5de2172610148baeb49d932c'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}.php",
-          checkpoint: '273773f4ab30e6148fccde6cf6bf87b68b59bfed2e9cafef4d1b8f5ec93ebf89'
+          checkpoint: 'da20cac6a998b60e92a498639b2ff7dd69e3840d65a1f80de75e88ed65c704d5'
   name 'QLab'
   homepage 'https://figure53.com/qlab/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.