### PR TITLE
Update frostwire to 6.4.4

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,8 +1,11 @@
 cask 'frostwire' do
-  version '5.7.2'
-  sha256 'c559d214576684a97cee0bea15c91caf8dd2c3609cc498039813724ea475642e'
+  version '6.4.4'
+  sha256 '3500f01ac5a725f2cd469b8580bd7f6977a530dbd0aae4b4160465167159bdef'
 
-  url "http://dl.frostwire.com/frostwire/#{version}/frostwire-#{version}.dmg"
+  # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
+  appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
+          checkpoint: 'b48434b51bb0d38300c5b679fbf29aad6f5bb0452cfc037da04dc56015356c7b'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
* found appcast, so also moved the download link to there to match
* [downloads page](http://www.frostwire.com/downloads) notes sourceforge as an official mirror

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.