### PR TITLE
Update studiolinkstandalone to 16.12.1-beta

### DIFF
--- a/Casks/studiolinkstandalone.rb
+++ b/Casks/studiolinkstandalone.rb
@@ -1,11 +1,11 @@
 cask 'studiolinkstandalone' do
-  version '16.12.0-beta'
-  sha256 '65a37884f47bdf2401ccf4fa0567196f1163c1b1dcc1d27ebaabab7a2ee3d40a'
+  version '16.12.1-beta'
+  sha256 '2840d9e3aba90bef9a1b672003c125d499d05ca23e660f933dc087c40741878e'
 
   # github.com/Studio-Link-v2/backend was verified as official when first introduced to the cask
   url "https://github.com/Studio-Link-v2/backend/releases/download/v#{version}/studio-link-standalone-osx.zip"
   appcast 'https://github.com/Studio-Link-v2/backend/releases.atom',
-          checkpoint: '36269f61a315e45e520ab68fbc3a06b5b6bfad10a671b81fa680b4420e651519'
+          checkpoint: '9e80271ad4e47265ce19b1f1438c476eb3a3bd014e3d9f35b0d770aef856b39d'
   name 'Studio Link Standalone'
   homepage 'https://doku.studio-link.de/standalone/installation-standalone.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.