### PR TITLE
Add Bossman v0.0.1

### DIFF
--- a/Casks/bossman.rb
+++ b/Casks/bossman.rb
@@ -1,0 +1,15 @@
+cask 'bossman' do  
+  version "0.0.1"
+  sha256 "ae33e81729aa9f014bbb02a295f0bbd5d145042f7e98f2d30baa5af8c8752f03"
+
+  name "Bossman"
+  app "Bossman.app"
+  homepage "https://github.com/ianclarksmith/Bossman"
+  url "https://github.com/ianclarksmith/Bossman/releases/download/0.0.1/Bossman.zip"
+
+  appcast "https://github.com/ianclarksmith/Bossman/releases.atom",
+          checkpoint: "fe7abd2bc606f39d8fb69029bd6bdc7e546598d1e7ceabd4c93496d6d52f72fb"
+
+  depends_on formula: "tmux"
+  depends_on macos: '>= :mavericks'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.  (Cannot run for some reason, /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:2007:in `raise_if_conflicts': Unable to activate rubocop-cask-0.10.6, because rubocop-0.47.1 conflicts with rubocop (~> 0.45.0) (Gem::LoadError))
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
