### PR TITLE
Update veertu-desktop.rb

### DIFF
--- a/Casks/veertu-desktop.rb
+++ b/Casks/veertu-desktop.rb
@@ -6,13 +6,26 @@ cask 'veertu-desktop' do
   url "https://d2sje6b9huarvp.cloudfront.net/VeertuDesktop-#{version}.dmg"
   appcast 'https://d2sje6b9huarvp.cloudfront.net/vdoaupd.rss',
           checkpoint: 'fadbb21aa91efd48ebc69bf71a09cf13134dd1f7ea454d2e4df98d2b3c655611'
-  name 'Veertu'
+  name 'Veertu Desktop'
   homepage 'https://veertu.com/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'Veertu Desktop.app'
 
+  uninstall launchctl: 'com.veertu.vlaunch',
+            delete:    [
+                         '/Library/PrivilegedHelperTools/com.veertu.vlaunch',
+                         '/usr/local/bin/vdlaunch',
+                       ]
+
   zap delete: [
-                '~/Library/Containers/com.veertu.Veertu',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.veertu.veertu.sfl',
+                '~/Library/Caches/com.veertu.Veertu',
+                '~/Library/Containers/com.veertu.Veertu',
+                '~/Library/Preferences/com.veertu.Veertu.plist',
+                '~/Library/Saved Application State/com.veertu.Veertu.savedState',
+                '~/Library/Saved Application State/com.veertu.vmx.savedState',
+                '~/Library/WebKit/com.veertu.Veertu',
               ]
 end


### PR DESCRIPTION
Update veertu-desktop.rb for depends_on, uninstall and zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
