### PR TITLE
Update kotori to 0.19

### DIFF
--- a/Casks/kotori.rb
+++ b/Casks/kotori.rb
@@ -1,10 +1,10 @@
 cask 'kotori' do
-  version '0.14'
-  sha256 '8ce83290e6705b32c285308b376a3f849675c3ff0f91b5c4448a4b4a6b1e79e8'
+  version '0.19'
+  sha256 'bef610e408a529107b0c8f7fe0033d419ac62854a31de46d79e8764926c3052f'
 
   url "https://github.com/Watson1978/kotori/releases/download/v#{version}/kotori_#{version}.dmg"
   appcast 'https://github.com/Watson1978/kotori/releases.atom',
-          checkpoint: '10dddbf3e6d44d33b12a6b02f2c4336a6a4036cc09cf3c6166062684b22b9d04'
+          checkpoint: 'f09a8da6c45613b3432cf28e0eec6b49493bbd3cb11adfd3bac97cfb57b9d189'
   name 'kotori'
   name '小鳥'
   homepage 'https://github.com/Watson1978/kotori'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.