### PR TITLE
Update riot to 0.9.7

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,10 +1,10 @@
 cask 'riot' do
-  version '0.9.6'
-  sha256 '3433d33ac5e819a6642e79b3251b1d76f21aeb6b32fd42a831322ab50f12d8a1'
+  version '0.9.7'
+  sha256 '8586274e4e3a48b227884e170b9b626b4c662ddf6d808e189bf07f86fd86ae53'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-web/releases.atom',
-          checkpoint: '445549c3664843b6e8eddc8bb69df2ce4bc059808c061da1ac19e56a667f3957'
+          checkpoint: '16f57186dedac3c4c36adbfbe3464af71770d017b5d8fbc864634a0b4cb86f1b'
   name 'Riot'
   homepage 'https://riot.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.