### PR TITLE
Update sip to 0.9.5

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -1,10 +1,10 @@
 cask 'sip' do
-  version '0.9.4'
-  sha256 '32754b3a255377a67b72387425d59f9b2ea2094cc4c157a3b98e91da7a5cd018'
+  version '0.9.5'
+  sha256 '3735b97790ba10f0a070105d5452ca503c3f84a1edcf63226bce7d23c85fe34a'
 
   url 'http://sipapp.io/download/sip.dmg'
   appcast 'http://sipapp.io/sparkle/sip.xml',
-          checkpoint: '88734a57e970eaf72c5cfb7427cdba41f682e044668f7f4173144847496b26bd'
+          checkpoint: '985852e024717f0172fbef5107b83d8d855ff2a50a32ea21d042c73c3c28455e'
   name 'Sip'
   homepage 'http://sipapp.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.