### PR TITLE
Update vimr to 0.13.1-167

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.13.0-164'
-  sha256 '67932b57d8e13ccee4d1b5862404cde7f7d87dca7ed615896da9ee065291a943'
+  version '0.13.1-167'
+  sha256 '570ab8df069fa6a7bdd042144125ad56258f82f5aec46630cd880f044b60d9a6'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'f507e5628e040a7b90730257be1862ede95a961f1f059fccd7e61786b09a7fa6'
+          checkpoint: '51157cfc1b0ce5ca40e7a3c0092d281bf5bf5f9b55074b45c5d1676ef57af652'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.