### PR TITLE
Update digital-power-station uninstall

### DIFF
--- a/Casks/digital-power-station.rb
+++ b/Casks/digital-power-station.rb
@@ -8,6 +8,7 @@ cask 'digital-power-station' do
 
   pkg 'Bongiovi DPS.pkg'
 
-  uninstall pkgutil: 'com.bongiovi.pkg.DigitalPowerStation.*',
+  uninstall pkgutil: 'com.bongiovi.pkg.BongioviDPS.*',
+            kext:    'com.bongiovi.DPSReflector',
             delete:  '/Applications/Bongiovi DPS'
 end


### PR DESCRIPTION
* discovered that this app had left things on my system after testing so updating the uninstall stanzas

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.