### PR TITLE
Update ramme to 3.0.3

### DIFF
--- a/Casks/ramme.rb
+++ b/Casks/ramme.rb
@@ -1,10 +1,10 @@
 cask 'ramme' do
-  version '2.3.0'
-  sha256 'f2da854e10422a5f9b6bf3c29eb07376c0ff6cc86b88520f279c2cca239c4517'
+  version '3.0.3'
+  sha256 '051a4d23e5e3b58c9e6ac1879baa15a4ca1230b85c1b5f2051cd871324d3889d'
 
-  url "https://github.com/terkelg/ramme/releases/download/#{version}/Ramme-osx-#{version}.zip"
+  url "https://github.com/terkelg/ramme/releases/download/v#{version}/Ramme-#{version}.dmg"
   appcast 'https://github.com/terkelg/ramme/releases.atom',
-          checkpoint: 'b526301e223e9a36aaebe375a984a28b5210a084a6d8dd2576761c95975196de'
+          checkpoint: '5d776a973b82369008f319d2cec1189c0114116abb62e54246174a62fc1ecb8c'
   name 'Ramme'
   homepage 'https://github.com/terkelg/ramme/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.