### PR TITLE
updated mojibar (2.3.3)

### DIFF
--- a/Casks/mojibar.rb
+++ b/Casks/mojibar.rb
@@ -1,10 +1,10 @@
 cask 'mojibar' do
-  version '2.3.2'
-  sha256 'd92546c27155846a826cacace94fa3b20ab754079d985a06d05c5a278202a4b7'
+  version '2.3.3'
+  sha256 '907ec3285f56eb85d6ab462f0493ff839453c0ab2a274fcb7a6055838e70bdd1'
 
   url "https://github.com/muan/mojibar/releases/download/#{version}/mojibar.zip"
   appcast 'https://github.com/muan/mojibar/releases.atom',
-          checkpoint: '4aed1bf5a60456b1ff68d3b714027ea75ffeaff45074dd30be401b30de8852f5'
+          checkpoint: '3b1b56723ab897e45576e08bbe4e7bf05734e7d1b8d0eb7f7a5f69badda4ee8a'
   name 'Mojibar'
   homepage 'https://github.com/muan/mojibar'
 


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
