### PR TITLE
Update mojibar to 2.3.3

### DIFF
--- a/Casks/mojibar.rb
+++ b/Casks/mojibar.rb
@@ -1,10 +1,10 @@
 cask 'mojibar' do
-  version '2.3.2'
-  sha256 'd92546c27155846a826cacace94fa3b20ab754079d985a06d05c5a278202a4b7'
+  version '2.3.3'
+  sha256 '907ec3285f56eb85d6ab462f0493ff839453c0ab2a274fcb7a6055838e70bdd1'
 
   url "https://github.com/muan/mojibar/releases/download/#{version}/mojibar.zip"
   appcast 'https://github.com/muan/mojibar/releases.atom',
-          checkpoint: '4aed1bf5a60456b1ff68d3b714027ea75ffeaff45074dd30be401b30de8852f5'
+          checkpoint: 'd231ce6091701aba5f03fb1c31591a3c1b8c44f49c59db996a14e7439596c5ad'
   name 'Mojibar'
   homepage 'https://github.com/muan/mojibar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.