### PR TITLE
Update opera to 43.0.2442.806

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '42.0.2393.517'
-  sha256 '3335ee75a54d9a0572e72a97d34d5189b777af1328a9d912dc294db80bbf19bb'
+  version '43.0.2442.806'
+  sha256 'f8d709ef1bc2db3080aca7a786d8cc6c6cf6346e2e8bcca3caf42c6a4f6b3ee5'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.