### PR TITLE
Update scala-ide to 4.5.0,2.11:20161213

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -10,5 +10,5 @@ cask 'scala-ide' do
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/2731
-  suite 'eclipse.app', target: 'Scala IDE.app'
+  app 'eclipse.app', target: 'Scala IDE.app'
 end

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -10,5 +10,5 @@ cask 'scala-ide' do
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/caskroom/homebrew-cask/pull/2731
-  suite 'eclipse', target: 'Scala IDE'
+  suite 'eclipse.app', target: 'Scala IDE.app'
 end

--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,9 +1,9 @@
 cask 'scala-ide' do
-  version '4.4.1,2.11:20160504'
-  sha256 'b3bd0907aec82e943de80df428839f08fca6823e99484bf28b50f878d1503d05'
+  version '4.5.0,2.11:20161213'
+  sha256 'acfd393b0c4d88049b470e5187acc75c3c95c586834ed58c74fc9e379eae927e'
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-  url "https://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-luna-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"
+  url "https://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-neon-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"
   name 'Scala IDE'
   homepage 'http://scala-ide.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.