### PR TITLE
Update fuse to 0.33.1.10445

### DIFF
--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -1,6 +1,6 @@
 cask 'fuse' do
-  version '0.32.0.9613'
-  sha256 'beaee654da3e561d8745205fe3f464a6524e82fd4342fb0f4352a94943c55afa'
+  version '0.33.1.10445'
+  sha256 '6a80042d91772dc610063f513376069dd72e29d73613f867f30db4bf4fbaeb0c'
 
   # fuse-dl.azureedge.net was verified as official when first introduced to the cask
   url "https://fuse-dl.azureedge.net/releaseartifacts/fuse_osx_#{version.dots_to_underscores}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.