### PR TITLE
Update qtox to 1.8.1

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.5.1'
-  sha256 '44c05f1768e120716b92c96e956523cdc0144ff37b4f68a3fc8556e382864df7'
+  version '1.8.1'
+  sha256 '9fd22b6fe650e610f8f539a4d440a5cf95ff9e2c186efce94e8a5a486bed639f'
 
   # github.com/tux3/qTox was verified as official when first introduced to the cask
   url "https://github.com/tux3/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/tux3/qtox/releases.atom',
-          checkpoint: 'e52d46cfa1c375744a0c5628f721c9ba9f91b967344d964d4122def35f42afd2'
+          checkpoint: '22955c01913765dc961d2959c3670ab0e37df11a1dd7b48909310f509436d962'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.