### PR TITLE
Update whatroute to 2.0.13

### DIFF
--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -4,13 +4,15 @@ cask 'whatroute' do
     sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a'
 
   else
-    version '2.0.12'
-    sha256 'd2186d8064eb851a9a6b1d3feafaf78959f0043e9a64317aa6c1a475d5d4125d'
+    version '2.0.13'
+    sha256 '920c088f9c0b80b78eb632c64119c81096497536ca62e4ce428516c3471be5c5'
   end
 
   url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   name 'WhatRoute'
   homepage 'https://www.whatroute.net/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'WhatRoute.app'
 end

--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,12 +1,6 @@
 cask 'whatroute' do
-  if MacOS.version <= :mavericks
-    version '1.13.3'
-    sha256 'bc8a4612dcd2d64758dbb2714de60dd95907744cc59dd771a0be29bd56d81e5a'
-
-  else
-    version '2.0.13'
-    sha256 '920c088f9c0b80b78eb632c64119c81096497536ca62e4ce428516c3471be5c5'
-  end
+  version '2.0.13'
+  sha256 '920c088f9c0b80b78eb632c64119c81096497536ca62e4ce428516c3471be5c5'
 
   url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   name 'WhatRoute'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.