### PR TITLE
Update coconutbattery to 3.5.1

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -13,7 +13,7 @@ cask 'coconutbattery' do
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.dots_to_underscores}.zip"
   else
     version '3.5.1'
-    sha256 '5cde42342ad09b8e75303ef0d9ec212e5592dcb52895b9db72c6375adcfaa0e7'
+    sha256 '8cadc6a1c1c1bc4f5ee0ce32a83ac6b74670fbd2ede62a1945988463d4ba6d66'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'http://updates.coconut-flavour.com/coconutBatteryIntel.xml',
             checkpoint: 'eff17e7bae73d67211dd178f3f17d81b44e37d281313886ee7017a7c6b1c8c4c'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.