### PR TITLE
Update vivaldi to 1.7.735.46

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,73 +1,73 @@
 cask 'thunderbird' do
-  version '45.7.0'
+  version '45.7.1'
 
   language 'de' do
-    sha256 '87af4fa81c50f830329897deb9d6b80c07837eda79d80697b605d09d14bbffc4'
+    sha256 '2a9f128bed773eafb28e1a17687e42319e2a6db22db1269b775e2821dd1f225c'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '4a9e0715887383487f05fe9bfd88d578239e0d15f50014e40aab0731975db07f'
+    sha256 'f0ea3365a434681e8da6df6d27651d3499297812c2e80263a9c94f3882598989'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '0a479d94e36bec5b240e461010faef2133b08c3071c2be7822f161358614e620'
+    sha256 '297aa21c91cf4b83d1bf88103a8c53a034452039f13c3a4da146a2668f7479cd'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '462181dc95468ecf2253912c1a68f680f8fbc3de758caaa9e0f28d698dd9430f'
+    sha256 '40446db3034bca40d2ee2f50bc80f2a34bd516df98aec2d15f02cc6e4ea81fbc'
     'fr'
   end
 
   language 'gl' do
-    sha256 'aad71bbe1a7b22dd1150ccb19613ccab2d80fd94565e73523a5923915049de40'
+    sha256 '2a6ff57bf80b9459ca4973eedc3edcdf1e45bb5d1d2075e19879f8522d244800'
     'gl'
   end
 
   language 'it' do
-    sha256 'c4e7911a4b7efb3efb945f2aefe7a71a3a8746da7d839dcf8ce46f4be46952bc'
+    sha256 'c96a7fe7e0662e067057ef185fd6083e8270432380640463abb39dc3f542d2d8'
     'it'
   end
 
   language 'ja' do
-    sha256 'd5925695268fe7dec27a921281d74597d1ff262e8bd5fe5808b274f8dc3c843f'
+    sha256 '925df210182d732e46e2f276e62f26a7e335f391e2206bd383d49f553b17418c'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '2c876863c2683e94a520081f071d238d3731e6c317cfb386441dd639e2fe159e'
+    sha256 '64d36ebb079971beeecbf76d439a051896b72389d1ab6f4b9a01e656db54711a'
     'nl'
   end
 
   language 'pl' do
-    sha256 '3ff4cb6a64014466f7411d27ac5e9f591715fe506f7e9bdcff12b0ba7c18dd66'
+    sha256 '34996c44da6786592dfcc24f405860131b3812891615f7e113b0db2a168a07f4'
     'pl'
   end
 
   language 'pt' do
-    sha256 '4e1560eb9173bde3a25acb702858b0f6704b27d992b9dc2361786da1702b53be'
+    sha256 'a3ccf168aa3fa2f8716a753b018793cc3dcaeef792ee71e162417aa10c93e31b'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '6808192874b34e8fb68fa5a1e36ddbbc5998399f22225a1d150241dfc39e4359'
+    sha256 '66dd4eb0884ec6422130879e83b3b042243bef2886c1236932534ef625201a80'
     'ru'
   end
 
   language 'uk' do
-    sha256 'ffde5d83b1592570889765371e85840c1368b8161a2c3f92ce86bb0994cddbc4'
+    sha256 '4ff1622fe6c4cd9ded23c21be4840e58b11f1a6b24a16860987ede041a683120'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '1b69f3c4cf0e2f3ec59bdff0c7b0b9f1fe9ed07bd8c018f7d0504ac004ada99a'
+    sha256 '08c112f9db690d27f2559b8290061a9433b13df6fa3553e56f600d953a040a47'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'e41392fe40f10f5ae0750176ecaefebe8e6023234b0ee3975c49d02b4f8f51a9'
+    sha256 'd11ab21c2dcb01c1e8b9e16fc56bf01d73af69da8f87835db9f67fc68a469ee2'
     'zh-CN'
   end
 

--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,73 +1,73 @@
 cask 'thunderbird' do
-  version '45.7.1'
+  version '45.7.0'
 
   language 'de' do
-    sha256 '2a9f128bed773eafb28e1a17687e42319e2a6db22db1269b775e2821dd1f225c'
+    sha256 '87af4fa81c50f830329897deb9d6b80c07837eda79d80697b605d09d14bbffc4'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'f0ea3365a434681e8da6df6d27651d3499297812c2e80263a9c94f3882598989'
+    sha256 '4a9e0715887383487f05fe9bfd88d578239e0d15f50014e40aab0731975db07f'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '297aa21c91cf4b83d1bf88103a8c53a034452039f13c3a4da146a2668f7479cd'
+    sha256 '0a479d94e36bec5b240e461010faef2133b08c3071c2be7822f161358614e620'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '40446db3034bca40d2ee2f50bc80f2a34bd516df98aec2d15f02cc6e4ea81fbc'
+    sha256 '462181dc95468ecf2253912c1a68f680f8fbc3de758caaa9e0f28d698dd9430f'
     'fr'
   end
 
   language 'gl' do
-    sha256 '2a6ff57bf80b9459ca4973eedc3edcdf1e45bb5d1d2075e19879f8522d244800'
+    sha256 'aad71bbe1a7b22dd1150ccb19613ccab2d80fd94565e73523a5923915049de40'
     'gl'
   end
 
   language 'it' do
-    sha256 'c96a7fe7e0662e067057ef185fd6083e8270432380640463abb39dc3f542d2d8'
+    sha256 'c4e7911a4b7efb3efb945f2aefe7a71a3a8746da7d839dcf8ce46f4be46952bc'
     'it'
   end
 
   language 'ja' do
-    sha256 '925df210182d732e46e2f276e62f26a7e335f391e2206bd383d49f553b17418c'
+    sha256 'd5925695268fe7dec27a921281d74597d1ff262e8bd5fe5808b274f8dc3c843f'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '64d36ebb079971beeecbf76d439a051896b72389d1ab6f4b9a01e656db54711a'
+    sha256 '2c876863c2683e94a520081f071d238d3731e6c317cfb386441dd639e2fe159e'
     'nl'
   end
 
   language 'pl' do
-    sha256 '34996c44da6786592dfcc24f405860131b3812891615f7e113b0db2a168a07f4'
+    sha256 '3ff4cb6a64014466f7411d27ac5e9f591715fe506f7e9bdcff12b0ba7c18dd66'
     'pl'
   end
 
   language 'pt' do
-    sha256 'a3ccf168aa3fa2f8716a753b018793cc3dcaeef792ee71e162417aa10c93e31b'
+    sha256 '4e1560eb9173bde3a25acb702858b0f6704b27d992b9dc2361786da1702b53be'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '66dd4eb0884ec6422130879e83b3b042243bef2886c1236932534ef625201a80'
+    sha256 '6808192874b34e8fb68fa5a1e36ddbbc5998399f22225a1d150241dfc39e4359'
     'ru'
   end
 
   language 'uk' do
-    sha256 '4ff1622fe6c4cd9ded23c21be4840e58b11f1a6b24a16860987ede041a683120'
+    sha256 'ffde5d83b1592570889765371e85840c1368b8161a2c3f92ce86bb0994cddbc4'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '08c112f9db690d27f2559b8290061a9433b13df6fa3553e56f600d953a040a47'
+    sha256 '1b69f3c4cf0e2f3ec59bdff0c7b0b9f1fe9ed07bd8c018f7d0504ac004ada99a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'd11ab21c2dcb01c1e8b9e16fc56bf01d73af69da8f87835db9f67fc68a469ee2'
+    sha256 'e41392fe40f10f5ae0750176ecaefebe8e6023234b0ee3975c49d02b4f8f51a9'
     'zh-CN'
   end
 

--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi' do
-  version '1.6.689.40'
-  sha256 '385171dc2f96d8dcde530564061773c256d8e1f103d8e98a23d18a6881e702e2'
+  version '1.7.735.46'
+  sha256 'e92346165841f38975eba46cd9ef7bd371c4090101f33d742069d07563d796f3'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '6ed839ec17f8facb6b6b3e0e01df0ee6bcede9e3fed255f59a6e9dfac3f26163'
+          checkpoint: '7f322b89efcdd172882b514cfc1b0674877a1181d61cfd7a215fd4d78ea3d6ec'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.