### PR TITLE
Update zoc to 7.12.1

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.12.0'
-  sha256 'e4e07fe4dbcc86f90bc0adac896d5808bb7eaa8364a19232575289821824dbcd'
+  version '7.12.1'
+  sha256 '7ea57820b339a024966f81c99ab222b75c96af7d007def6a15d5f4fecc416c7e'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   name 'ZOC'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/29943.