### PR TITLE
zulu: Update caveats for current Caskroom location

### DIFF
--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -48,14 +48,4 @@ cask 'zulu' do
                          ]
                        end,
                      ].keep_if { |v| !v.nil? }
-
-  caveats <<-EOS.undent
-    If this cask is upgraded, previous stale versions will be left under
-    'Caskroom/zulu/{version}'. Stale versions may also be left under
-    '/Library/Java/JavaVirtualMachines/zulu{version}.jdk'. Removing them may
-    require manual deletion, e.g.
-
-      rm -rf /usr/local/Caskroom/zulu/
-      rm -rf /Library/Java/JavaVirtualMachines/zulu*.jdk
-  EOS
 end

--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -55,7 +55,7 @@ cask 'zulu' do
     '/Library/Java/JavaVirtualMachines/zulu{version}.jdk'. Removing them may
     require manual deletion, e.g.
 
-      rm -rf /opt/homebrew-cask/Caskroom/zulu/
+      rm -rf /usr/local/Caskroom/zulu/
       rm -rf /Library/Java/JavaVirtualMachines/zulu*.jdk
   EOS
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.