### PR TITLE
Update wmail to 2.1.0

### DIFF
--- a/Casks/wmail.rb
+++ b/Casks/wmail.rb
@@ -1,11 +1,11 @@
 cask 'wmail' do
-  version '2.0.0'
-  sha256 '881013bf9808777fc1b773a6e94d3f33881b9ab431c19500d6bd53d18b0d455a'
+  version '2.1.0'
+  sha256 '1bbab3c8d6c2c99120258e484df883aa90f7737f246ddaa1ffac4dfd56137677'
 
   # github.com/Thomas101/wmail was verified as official when first introduced to the cask
-  url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_osx.dmg"
+  url "https://github.com/Thomas101/wmail/releases/download/#{version}/WMail_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/Thomas101/wmail/releases.atom',
-          checkpoint: 'ee718bdeba42a54b3a11e716dbc52027d98d7576cfcbeb20493ec40a746c9e0e'
+          checkpoint: '3f8d154cc47118f8070fb1a92f76b2c12928e5ad3a5d4019c788653209cedeec'
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.