### PR TITLE
Update Molotov to v1.2.2

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '1.1.2'
-  sha256 '634e811835e36261d4339e251d075914180a021497eab99aed0d64df08fa6662'
+  version '1.2.2'
+  sha256 '6c32206e5a922d246e1a5a6b6462a5b531c37cdaceb05bd6f32f8c85e5c8b5ff'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] The commit message includes the cask’s name and version.