### PR TITLE
Update monolingual to 1.7.7

### DIFF
--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -15,14 +15,14 @@ cask 'monolingual' do
     version '1.7.3'
     sha256 '24fa5ff0a5903c0eb07cd58a15292e3adab97ea0823f304241dc4187f9252ffc'
   else
-    version '1.7.6'
-    sha256 'b0ab447ba49e98c468ee3c07ebf0f574d0df635277b1b12b821fc53547a3f3f6'
+    version '1.7.7'
+    sha256 'f76825d4cb36aef8c680c9f46d09d6be6d14b3622e59d82496781760548d3366'
   end
 
   # github.com/IngmarStein/Monolingual was verified as official when first introduced to the cask
   url "https://github.com/IngmarStein/Monolingual/releases/download/v#{version}/Monolingual-#{version}.dmg"
   appcast 'https://github.com/IngmarStein/Monolingual/releases.atom',
-          checkpoint: 'e0c4abfb696bace2721d6a928c9cbc7245e82122c98887d03c5f1a5d96b90306'
+          checkpoint: '4b69ae3f7e5bec46643887668be5a0db76fae14e92b2eb34ffb8f25a5263e90a'
   name 'Monolingual'
   homepage 'https://ingmarstein.github.io/Monolingual/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.