### PR TITLE
chefdk.rb: fix macos dependendy

### DIFF
--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -2,7 +2,7 @@ cask 'chefdk' do
   if MacOS.version == :mountain_lion
     version '0.11.2-1'
     sha256 '56899eab322cacac7f445a24d3159af34fccb5910642f4535eff4ee47321fe56'
-  elsif MacOS.version >= :mavericks
+  else
     version '1.2.22-1'
     sha256 '5c435de289e90da45938a0f1a1f7e472e73a84f9b6bbe93e50342e11cc935458'
   end
@@ -13,6 +13,8 @@ cask 'chefdk' do
   name 'Chef Development Kit'
   name 'ChefDK'
   homepage 'https://downloads.chef.io/chefdk/'
+
+  depends_on macos: '>= :mountain_lion'
 
   pkg "chefdk-#{version}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.