### PR TITLE
Update droplr to 4.6.5,94

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version '4.6.4,91'
-  sha256 '41064cec1922fa76b15e940a747e3d12e720588fa3ab9a527b38ba3a683c531b'
+  version '4.6.5,94'
+  sha256 '8236d94a9ffd900fa35815c80fb1071c0f62211adb3a8840211115f01bea262e'
 
   # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.