### PR TITLE
little-flocker: Add minimum OS requirement

### DIFF
--- a/Casks/little-flocker.rb
+++ b/Casks/little-flocker.rb
@@ -6,6 +6,8 @@ cask 'little-flocker' do
   name 'Little Flocker'
   homepage 'https://www.littleflocker.com/'
 
+  depends_on macos: '>= :el_capitan'
+
   pkg 'Install Little Flocker.pkg'
 
   uninstall pkgutil: 'com.zdziarski.LittleFlockerDaemon'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. _- skipped because: Unable to activate rubocop-cask-0.10.6_ in style check
- [x] The commit message includes the cask’s name and version.