### PR TITLE
Update axoloti-runtime to 1.0.12

### DIFF
--- a/Casks/axoloti-runtime.rb
+++ b/Casks/axoloti-runtime.rb
@@ -1,11 +1,11 @@
 cask 'axoloti-runtime' do
-  version '1.0.11'
-  sha256 'b8c844c8668b0063ba177b7d87cfa278d288d8ea38a140f182a634ee2256ad0e'
+  version '1.0.12'
+  sha256 '5b3b484692a0afaca4663aee9456ed4836b1662881d0118c42e122cd1039bff8'
 
   # github.com/axoloti/axoloti was verified as official when first introduced to the cask
   url "https://github.com/axoloti/axoloti/releases/download/#{version}/axo_runtime_mac_#{version}.dmg"
   appcast 'https://github.com/axoloti/axoloti/releases.atom',
-          checkpoint: 'b3e7756ec71f418f0a034460136fff898dcd539ff5f44b8a14c13401355eb515'
+          checkpoint: '7e8428f250a591ed812f1f6cba4e91727230eff0d3aaab07c455f7a4c0245677'
   name 'Axoloti Runtime'
   homepage 'http://www.axoloti.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.