### PR TITLE
Update bit-slicer to 1.7.8

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,11 +1,11 @@
 cask 'bit-slicer' do
-  version '1.7.7'
-  sha256 '2d99481186552c05ad3f3c53226c5a5193af1b96f28702794d940a74f1be4802'
+  version '1.7.8'
+  sha256 '8e9b9398240f37e7da16c1c7328a1bd8a8a19f7e376c3144304ef51ed587f1b8'
 
   # zgcoder.net was verified as official when first introduced to the cask
   url "https://zgcoder.net/software/bitslicer/dist/stable/Bit_Slicer_#{version}.zip"
   appcast 'https://zgcoder.net/bitslicer/update/appcast.xml',
-          checkpoint: '71d3b5ac6366b2ea61bb2e2ab2815fad8dbc335e9c2eb040f1445785623365c3'
+          checkpoint: 'dd69176f604029d5e98592880a448fb2a9f04f1d11eec3a965f84864e42efcc9'
   name 'Bit Slicer'
   homepage 'https://github.com/zorgiepoo/bit-slicer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.