### PR TITLE
Update brave to 0.13.2dev

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.13.1dev'
-  sha256 '1d9d3c6947b57194526a5d0a1ed4ebb95581cb6e9fd585fc23fb275903b8e2df'
+  version '0.13.2dev'
+  sha256 'c649a99ea24f54a539a73a0539cbc3e2b4a0e85d4facb754c42cf2499de64d29'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'b5f06098efdb2a15196c330b22d6bde25ab21d11e1e6ee96ec373d1fcd19623a'
+          checkpoint: 'edf0521552521c815bf3f53a5b6f6334fd9277b521fbc6bfebc0946a80fbfbad'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.