### PR TITLE
Update caret to 1.14.0

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.13.4'
-  sha256 '0713abb9f580e66debdc01f29c8dcd671d9866a3d65fb84bcab7c7a98dd1e07d'
+  version '1.14.0'
+  sha256 'df0b0eccf8e7890ba0b66f8f7146b3a9841ade60cc5ea915795c96be670c85cb'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '231d2003111ededfd466c91de687c27fbf8adeb52196ef7606a565fdc0f45a39'
+          checkpoint: 'ce2ec8d1d450c701814c6912fbdba082b9b068e1bce4b63bb1d97ce124093aa8'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.