### PR TITLE
Update hstracker to 0.19.1462

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '0.18.5.1367'
-  sha256 'e98417501ac6f1e38314a1a208326461bfb2a04fb4a2ec37d7afdc6c4870ff38'
+  version '0.19.1462'
+  sha256 'bf5fe3ed2b95ec4edb83cdb48fe09d720fa29b9bdaf39a2193f66874233c91d7'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: 'b86fdb031f5333a636556863898417a2e7a29bd13666d395a574a32197eee345'
+          checkpoint: 'b4b7e236a34ede43524224d3771d333ad4a3b65fe0a536806016fd061ff1e3bd'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.