### PR TITLE
Update isubtitle to 3.0.4

### DIFF
--- a/Casks/isubtitle.rb
+++ b/Casks/isubtitle.rb
@@ -1,10 +1,10 @@
 cask 'isubtitle' do
-  version '3.0.3'
-  sha256 'c9cb7039a399becac657489c38003c071b0dbd601e7ce6558f451f53d6f17a16'
+  version '3.0.4'
+  sha256 '71692dd773fa2d128ac927c6521268364ff119a305d844f8fb33053a5505e1ff'
 
   url "http://www.bitfield.se/isubtitle#{version.major}/download/iSubtitle_#{version}.zip"
   appcast "http://www.bitfield.se/isubtitle#{version.major}/changelog.xml",
-          checkpoint: '8c7eb54f467c9e7dfe0557e6099455bfc331ddd036327b2f4382357b4dffd5aa'
+          checkpoint: '5a4d1b53448ffc6d8f2d992f5cb0434620df219ef11ae3e397269d04a937c76e'
   name 'iSubtitle'
   homepage 'http://www.bitfield.se/isubtitle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.