### PR TITLE
Update m3unify to 1.7.0

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,10 +1,10 @@
 cask 'm3unify' do
-  version '1.6.0'
-  sha256 '6fded03986ec51ac188b37e8f72c7bc350849028cb5096ceeccda6eff0af9c5b'
+  version '1.7.0'
+  sha256 'e302aeb18f02c591de1b5b48e473df13f199df129fed10ffeeeeed4f26e328a2'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
-          checkpoint: '5af8461250442d7751c91312c87cc7580845d74b4387daa6830195aa542a4272'
+          checkpoint: 'd1ef8fcf53ba5a5c3924cf4f8bfe48125380afc69f11996862d00217ffa62251'
   name 'M3Unify'
   homepage 'https://dougscripts.com/apps/m3unifyapp.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.