### PR TITLE
Update 4k-video-downloader to 4.2

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
   version '4.2'
-  sha256 'cd2651c0ff14cfadc8d36377951480da339ba0239cb08d6ba892dfe7685e624b'
+  sha256 '3d09b059952f54742a44877ac50e406ef47a93c26e3733605a0b42c109844db3'
 
   url "https://downloads.4kdownload.com/app/4kvideodownloader_#{version}.dmg"
   name '4K Video Downloader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Step by step:

1. Followed [`sha256 mismatch` error](https://github.com/caskroom/homebrew-cask/blob/master/doc/reporting_bugs/a_cask_fails_to_install.md#sha256-mismatch-error) instructions
2. Executed `cask-repair` with `--edit-cask` flag
3. Edited the cask with the expected checksum to make sure it will work
4. Successfully reinstalled the cask with `brew cask reinstall 4k-video-downloader`
5. Submitted the patch 😄 