### PR TITLE
Update dfontsplitter to 0.4.2

### DIFF
--- a/Casks/dfontsplitter.rb
+++ b/Casks/dfontsplitter.rb
@@ -8,5 +8,5 @@ cask 'dfontsplitter' do
   name 'DfontSplitter'
   homepage 'https://peter.upfold.org.uk/projects/dfontsplitter'
 
-  app 'DfontSplitter.app'
+  app "#{version}/DfontSplitter.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Step by step:

1. Followed [`source is not there` error](https://github.com/caskroom/homebrew-cask/blob/master/doc/reporting_bugs/a_cask_fails_to_install.md#source-is-not-there-error) instructions
2. Executed `cask-repair` with `--edit-cask` flag
3. Edited the cask as needed
4. Successfully reinstalled the cask with `brew cask reinstall dfontsplitter`
5. Submitted the patch 😄 