### PR TITLE
Update openzfs to 1.6.1

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -1,20 +1,23 @@
 cask 'openzfs' do
-  version '1.5.2'
-  sha256 '185d20242bacd14cd609ccfb8f89736e1ea0ca6dec6475fd9eb7703c17ab5413'
+  version '1.6.1,f8'
+  sha256 '126ce9215ec060b2eb60db0609b29acad334f0d1c30c5ef2ab97cb251f374c39'
 
-  url "https://openzfsonosx.org/w/images/6/6b/OpenZFS_on_OS_X_#{version}.dmg"
+  url "https://openzfsonosx.org/w/images/#{version.after_comma[0]}/#{version.after_comma}/OpenZFS_on_OS_X_#{version.before_comma}.dmg"
   name 'OpenZFS on OS X'
   homepage 'https://openzfsonosx.org/'
 
-  # OpenZFS on OS X has no version below Mountain Lion.
+  depends_on macos: '>= :mountain_lion'
+
   if MacOS.version == :mountain_lion
-    pkg "OpenZFS on OS X #{version.sub(%r{-.*}, '')} Mountain Lion.pkg"
+    pkg "OpenZFS on OS X #{version.before_comma} Mountain Lion.pkg"
   elsif MacOS.version == :mavericks
-    pkg "OpenZFS on OS X #{version.sub(%r{-.*}, '')} Mavericks.pkg"
+    pkg "OpenZFS on OS X #{version.before_comma} Mavericks.pkg"
   elsif MacOS.version == :yosemite
-    pkg "OpenZFS on OS X #{version.sub(%r{-.*}, '')} Yosemite.pkg"
-  elsif MacOS.version >= :el_capitan
-    pkg "OpenZFS on OS X #{version.sub(%r{-.*}, '')} El Capitan or higher.pkg"
+    pkg "OpenZFS on OS X #{version.before_comma} Yosemite.pkg"
+  elsif MacOS.version == :el_capitan
+    pkg "OpenZFS on OS X #{version.before_comma} El Capitan.pkg"
+  elsif MacOS.version >= :sierra
+    pkg "OpenZFS on OS X #{version.before_comma} Sierra.pkg"
   end
 
   uninstall pkgutil: 'net.lundman.openzfs.*'


### PR DESCRIPTION
Add new part to version to ease interpolation in other stanzas. Remove
part of interpolation accomodating version numbers with '-X' in them as
that was only needed once so far.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. _- skipped because: Unable to activate rubocop-cask-0.10.6 in style check_
- [x] The commit message includes the cask’s name and version.