### PR TITLE
mediathekview: Update project URL and related bits

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,12 +1,12 @@
 cask 'mediathekview' do
-  version '13.0.1'
+  version '13.0.0'
   sha256 '96c8ba822f171dab19472ae4d8e2120014540c833ca28c767fc913b49a31144a'
 
-  url "https://downloads.sourceforge.net/zdfmediathk/Mediathek/Mediathek%20#{version.major}/MediathekView-#{version}.dmg"
-  appcast 'https://sourceforge.net/projects/zdfmediathk/rss?path=/Mediathek',
-          checkpoint: 'bec541062bdddfcea5b0ecd4f3e678f9fb0ecd0a00fb1c9b6ec6175b95b86f47'
+  url "https://download.mediathekview.de/stabil/MediathekView-#{version}.dmg"
+  appcast 'https://mediathekview.de/changelog/index.xml',
+          checkpoint: '1b1ad0bd0cbef19a4f59e8707e0c87f38a2d8bc88cd293c79a1a13ffef6e37d3'
   name 'MediathekView'
-  homepage 'https://sourceforge.net/projects/zdfmediathk/'
+  homepage 'https://mediathekview.de'
 
   app 'MediathekView.app'
 end


### PR DESCRIPTION
Reflect project move from SF to own domain. Version downgrade since 13.0.1 was only released for Windows. "About" in the program shows 13.0.0, the file linked to as v13.0.1 on Sourceforge is just a renamed v13.0.0.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.