### PR TITLE
Upgrade standard-notes to 0.2.2

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.1.2'
-  sha256 'c93bb4edafbe2b60e9b5cc78d261e6b5381772c2ff338af4e3c7d6ae462886e2'
+  version '0.2.2'
+  sha256 '02c04b39f3842cf1b26d3c36ed050a163331f1e3e0d3d6f052e45b8536768697'
 
   # github.com was verified as official when first introduced to the cask
-  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard.Notes-Mac-#{version}.dmg"
+  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'ba4ed2c7e86e4179f5cc0e7ef1db9e42cb048039921969e8ee2a7cfda25ef507'
+          checkpoint: '619c2ba7710efe2fa43af66e31d2ed12d755c8711766608876bd92be3faa2d64'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
The download URL pattern has changed slightly.

Checklist:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.