### PR TITLE
Update 115browser.rb to 8.0.0.52

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,19 +1,21 @@
 cask '115browser' do
-  version '7.2.5.15'
-  sha256 '949cc0870ab585ae6cce916485f6d4751831c4543f1de0cc57ceb7557a62408e'
+  version '8.0.0.52'
+  sha256 'b9fdce91f5320e9b287f6a958ac9c2c526fa19788ecb69c331f9b31f145e49d5'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'
 
+  depends_on macos: '>= :mountain_lion'
+
   app '115Browser.app'
 
   zap delete: [
                 '~/Library/Application Support/115Browser',
                 '~/Library/Caches/115Browser',
-                '~/Library/Caches/com.115.115browser',
-                '~/Library/Preferences/com.115.115browser.plist',
-                '~/Library/Saved Application State/com.115.115browser.savedState',
+                '~/Library/Caches/org.115Browser.115Browser',
+                '~/Library/Preferences/org.115Browser.115Browser.plist',
+                '~/Library/Saved Application State/org.115Browser.115Browser.savedState',
               ]
 end


### PR DESCRIPTION
Update 115browser.rb to 8.0.0.52

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
