### PR TITLE
Update eloston-chromium to 55.0.2883,95

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,8 +1,11 @@
 cask 'eloston-chromium' do
-  version '55.0.2883,95'
+  version '55.0.2883,95-1'
   sha256 'ce3059098bc77dcc298bf2f81c08bcb541495bdddc3d6a1cc0651fd39ab6f271'
 
-  url "https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases/download/#{version.before_comma}.#{version.after_comma}/ungoogled-chromium_#{version.before_comma}.#{version.after_comma}-1_macos.dmg"
+  # github.com/ungoogled-software/ungoogled-chromium-binaries was verified as official when first introduced to the cask
+  url "https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases/download/#{version.before_comma}.#{version.after_comma}/ungoogled-chromium_#{version.before_comma}.#{version.after_comma}_macos.dmg"
+  appcast 'https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases.atom',
+          checkpoint: 'dbb87319a87c7ccf876d7df29abf5dbbf95c97935855238aafe9daabd093fd9a'
   name 'Ungoogled Chromium'
   homepage 'https://github.com/Eloston/ungoogled-chromium'
 

--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -3,7 +3,7 @@ cask 'eloston-chromium' do
   sha256 'ce3059098bc77dcc298bf2f81c08bcb541495bdddc3d6a1cc0651fd39ab6f271'
 
   # github.com/ungoogled-software/ungoogled-chromium-binaries was verified as official when first introduced to the cask
-  url "https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases/download/#{version.before_comma}.#{version.after_comma}/ungoogled-chromium_#{version.before_comma}.#{version.after_comma}_macos.dmg"
+  url "https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases/download/#{version.before_comma}.#{version.after_comma.split('-')[0]}/ungoogled-chromium_#{version.before_comma}.#{version.after_comma}_macos.dmg"
   appcast 'https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases.atom',
           checkpoint: 'dbb87319a87c7ccf876d7df29abf5dbbf95c97935855238aafe9daabd093fd9a'
   name 'Ungoogled Chromium'

--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -7,7 +7,7 @@ cask 'eloston-chromium' do
   appcast 'https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases.atom',
           checkpoint: 'dbb87319a87c7ccf876d7df29abf5dbbf95c97935855238aafe9daabd093fd9a'
   name 'Ungoogled Chromium'
-  homepage 'https://github.com/Eloston/ungoogled-chromium'
+  homepage 'https://ungoogled-software.github.io/ungoogled-chromium-binaries/'
 
   app 'Chromium.app'
 

--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,10 +1,8 @@
 cask 'eloston-chromium' do
-  version '55.0.2883,75-1:9Morello'
-  sha256 'e19bedc98ec3b252a29468d1536a4f766570e60b68cdabf33cb158c140f26a90'
+  version '55.0.2883,95'
+  sha256 'ce3059098bc77dcc298bf2f81c08bcb541495bdddc3d6a1cc0651fd39ab6f271'
 
-  url "https://github.com/Eloston/ungoogled-chromium/releases/download/#{version.before_comma}.#{version.after_comma.before_colon}/ungoogled-chromium_#{version.before_comma}-#{version.after_comma.before_colon}_macos_#{version.after_colon}.dmg"
-  appcast 'https://github.com/Eloston/ungoogled-chromium/releases.atom',
-          checkpoint: 'e5d42e01d13de904ab33df77bb8d7ebd3432755fe13d7524bdcda988410a7cbe'
+  url "https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases/download/#{version.before_comma}.#{version.after_comma}/ungoogled-chromium_#{version.before_comma}.#{version.after_comma}-1_macos.dmg"
   name 'Ungoogled Chromium'
   homepage 'https://github.com/Eloston/ungoogled-chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.