### PR TITLE
Update privatetunnel to 2.8

### DIFF
--- a/Casks/privatetunnel.rb
+++ b/Casks/privatetunnel.rb
@@ -1,6 +1,6 @@
 cask 'privatetunnel' do
   version '2.8'
-  sha256 '8abc331c8ab9d6805328bbc53f93f3bf9c94efbd8e609606ecbee9006851fbae'
+  sha256 '0ae1175dabe078a6776d483c53b760ae599099d00f954de724581ff94718a9b4'
 
   # swupdate.openvpn.org/privatetunnel was verified as official when first introduced to the cask
   url "https://swupdate.openvpn.org/privatetunnel/client/privatetunnel-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.