### PR TITLE
updated KeePassXC to 2.1.1

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,11 +1,11 @@
 cask 'keepassxc' do
-  version '2.1.0'
-  sha256 '44f126aebd0993a8c2b200595c37ee0d864eacc7cb3a61abd4ecd89a546e81d6'
+  version '2.1.1'
+  sha256 '3c29d5fc4f287e424fd38811f360ef03a9bf474980c8b6c9b27010a7c8865f15'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-HTTP.dmg"
   appcast 'https://github.com/keepassxreboot/keepassxc/releases.atom',
-          checkpoint: '1f990f1b8e6092f28e2209a93c8b58a90c4f84eba8f2b5d365c64a43b5a044ce'
+          checkpoint: '741980d9622baef5c07fb37351dcfa6989720b65ba0904a3cc21a30e491824a2'
   name 'KeePassXC'
   homepage 'https://keepassxc.org/'
 


### PR DESCRIPTION
Updated KeePassXC to 2.1.1 (introducing the http server build)
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.