### PR TITLE
Update sourcetree to 2.4.1a

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.4h'
-    sha256 '5b52e071da6b055367aaee963dd1cca45b3e59ef5d4040ed5749a677fd45ab68'
+    version '2.4.1a'
+    sha256 'cec67981d4b8ea8a8e46ac7190d6d4d16a2164427a5c0e2419b1af327fc24815'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.