### PR TITLE
Update fluor to 1.1

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,10 +1,10 @@
 cask 'fluor' do
-  version '1.0.1'
-  sha256 'b1f8e0d40e134f5cc3b321839e6fbfda0c4cabdd8876c0abd0befef20805444f'
+  version '1.1'
+  sha256 '89ce58822dbb2816bc6dd2fbb29acc6c6c1344d0c1f66011a2ee1c671f06b803'
 
   url "https://github.com/Pyroh/Fluor/releases/download/#{version}/Fluor.#{version}.dmg"
   appcast 'https://github.com/Pyroh/Fluor/releases.atom',
-          checkpoint: 'ec2d213ea59ab8a0cfe8431b5e8a655445dc7140c7489166b9a54573e5711b5b'
+          checkpoint: 'dbc24234d57bfa5e8c6483d6443f2cb24c4f75aa4f22a717d1c0e177a74587d8'
   name 'Fluor'
   homepage 'https://github.com/Pyroh/Fluor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.