### PR TITLE
Update boostnote to 0.8.5

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.4'
-  sha256 '3998f998a666188298ade4fd233c28ddd3247a8ed405c6c3952b34119705e7cb'
+  version '0.8.5'
+  sha256 'ae026b80997ecdcb77d6c1151644303d90f5bb807c5ddffd3453ab2f9f9e24a2'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '2a3ab8c243b7377dffbfc927f883ac4392adbf328ef58bfa186aa840d63d0050'
+          checkpoint: '64ff760f4a20aedbb5a9870a3e96f341f4d87288f923e6182afd5f17c738b44d'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.