### PR TITLE
Update dripcap to 0.6.9

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.6.6'
-  sha256 '6ff6f9ceff1e7bf05861f6d2d5ffb54fa7d2f33785832d2f456eaf0c3907c1a9'
+  version '0.6.9'
+  sha256 'eefe5bf38f63683104163c7ea15235b8014d928b9915503dfa548be727cf0dac'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: '71938cdeb112ca4f5dc4cdff2a59c2b0d79263382b53e3259633a6e7ca7be441'
+          checkpoint: 'abda84b525067460e5d82d74ca70a9617f50b3bc951d3d87f4ef3d0f6a8315db'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.