### PR TITLE
Update jitsi to 2.10.5550

### DIFF
--- a/Casks/jitsi.rb
+++ b/Casks/jitsi.rb
@@ -1,10 +1,10 @@
 cask 'jitsi' do
-  version '2.8.5426'
-  sha256 '91980b803ba5c165c5ec109b784a7338bf5d1af2f866c513baf114bbda2953a4'
+  version '2.10.5550'
+  sha256 'd902af9dde7b1fde6f76af5f97e4f27d6b853bd9d3e83b2fec5292dda787a0da'
 
   url "https://download.jitsi.org/jitsi/macosx/jitsi-#{version}.dmg"
   appcast 'https://download.jitsi.org/jitsi/macosx/sparkle/updates.xml',
-          checkpoint: '0bc9e51570c27e6f5f2cd22ef44b673a6cd0968dc26ee961a07000215af929ab'
+          checkpoint: '240a8fc60ffcfb0ee41df2fada16c27a286ae3f91a49936509e2c2baaadde4bf'
   name 'Jitsi'
   homepage 'https://jitsi.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.