### PR TITLE
Update losslesscut to 1.5.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,10 +1,10 @@
 cask 'losslesscut' do
-  version '1.4.0'
-  sha256 'f721a32381105f178f38c2daedb094244f4a72ba5ff5e84cb2a7e6be598fbb72'
+  version '1.5.0'
+  sha256 '98f972bd24c78142d847e5beb2529bcd0496c8c79ee919696329bf5bb2fbcb73'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-darwin-x64.zip"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom',
-          checkpoint: '7cb2aaac4723bba159f40fa4590daba8a1ff48ffe8832a5185d445d03654c722'
+          checkpoint: '4ef5a96c89e9f8f77a1c7902b4c3602bb3d96c06c32e4e66c093f1251ef46726'
   name 'Loslesscut'
   homepage 'https://github.com/mifi/lossless-cut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.