### PR TITLE
Update minizincide to 2.1.3

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,11 +1,11 @@
 cask 'minizincide' do
-  version '2.1.2'
-  sha256 'a8c31cb362b1f8514f5a1a0516dcc41cefc2af5c1fa3cc54941422e65c42b921'
+  version '2.1.3'
+  sha256 'a4ec64bee9a04702f02bd82cdd182843f373d9f2986d11c580f3dc6e1dfd3d81'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"
   appcast 'https://github.com/MiniZinc/MiniZincIDE/releases.atom',
-          checkpoint: 'ed427dd915c7e01108d943422d495182c176542e56c420a27c27c5fc121ac6aa'
+          checkpoint: '9593f8dba4def26ae00a1ddb5e6eb11bca329a88b6b6ad199322a682187b6548'
   name 'MiniZincIDE'
   homepage 'https://www.minizinc.org/ide/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.