### PR TITLE
Update opensesame to 3.1.6

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -4,12 +4,12 @@ cask 'opensesame' do
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'
     url "https://files.cogsci.nl/software/opensesame/opensesame_#{version}-macos-2.zip"
   else
-    version '3.1.4'
-    sha256 '5beb72577afda123e7e2cb6fa887c4bd6dd17a92f208603325cabcc9af9476ff'
+    version '3.1.6'
+    sha256 '6b9bd3a88a09bfefdb1697a9524c508a7fa615792468f7f69ee25818f17ddc19'
     # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
     url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
     appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: 'd3ec8e64d2ac3afcef0735d9616ca48f0ba915c3f5cb935d68b7c565b9d8f1eb'
+            checkpoint: '27ce86920dfb1d7815fdae809f67a4c28b21448abcaa7a4a1878682f9a6331a2'
   end
 
   name 'OpenSesame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.