### PR TITLE
Update pocketcast to 1.30

### DIFF
--- a/Casks/pocketcast.rb
+++ b/Casks/pocketcast.rb
@@ -1,10 +1,10 @@
 cask 'pocketcast' do
-  version '1.26'
-  sha256 '9281179e3f1069470976dc8590e26e4f817142b1641094433e6b5c2806ee7d15'
+  version '1.30'
+  sha256 '9fee8fec0b5c5c3205a24c6b127064077dd6792ddf5d811b4df2dc84a34020da'
 
-  url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCast.zip"
+  url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCasts.zip"
   appcast 'https://github.com/mortenjust/PocketCastsOSX/releases.atom',
-          checkpoint: 'eecfbcc95b0d373b4c28aa39c3cd9dd8c9a4cb9f7acba7a8d1f597296b9ca4fd'
+          checkpoint: '503438969aa8948af77fdcf08d2ea57535301c837e4690413679f9c652015212'
   name 'Pocket Casts for Mac'
   homepage 'https://github.com/mortenjust/PocketCastsOSX'
 

--- a/Casks/pocketcasts.rb
+++ b/Casks/pocketcasts.rb
@@ -1,4 +1,4 @@
-cask 'pocketcast' do
+cask 'pocketcasts' do
   version '1.30'
   sha256 '9fee8fec0b5c5c3205a24c6b127064077dd6792ddf5d811b4df2dc84a34020da'
 
@@ -8,5 +8,5 @@ cask 'pocketcast' do
   name 'Pocket Casts for Mac'
   homepage 'https://github.com/mortenjust/PocketCastsOSX'
 
-  app 'PocketCast.app'
+  app 'PocketCasts.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.