### PR TITLE
Update nzbget to 18.0

### DIFF
--- a/Casks/nzbget.rb
+++ b/Casks/nzbget.rb
@@ -1,11 +1,11 @@
 cask 'nzbget' do
-  version '17.1'
-  sha256 'cc7bd923974c56b59bab78025175a4a7248a495e8d514bd73c1d8ee4aba281d2'
+  version '18.0'
+  sha256 'eaf2f48155c12776a521504905e072ef6361c1b03da281e5fe16a4cafa70c0ef'
 
   # github.com/nzbget/nzbget was verified as official when first introduced to the cask
   url "https://github.com/nzbget/nzbget/releases/download/v#{version}/nzbget-#{version}-bin-osx.zip"
   appcast 'https://github.com/nzbget/nzbget/releases.atom',
-          checkpoint: 'cc9ea4ea0bc52bb1f0cb11e01f32d79c4e90c85dda1e20f2fed81abde027fb40'
+          checkpoint: 'ca0f3a3f225665ceef413a93c0b23ddedab6102e4746e60137231810017e9113'
   name 'NZBGet'
   homepage 'http://nzbget.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.