### PR TITLE
Fix qtspim v9.1.18 sha256 mismatch

### DIFF
--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -4,7 +4,7 @@ cask 'qtspim' do
 
   url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.mpkg.zip"
   appcast 'https://sourceforge.net/projects/spimsimulator/rss',
-          checkpoint: 'db926e1454e85c1f9d8e9336296c5cc6e44bc68eb52f7e7c9a909a5c44366abd'
+          checkpoint: 'eb3d8ed497f272fe2a6fd73fb6d53a39af4f25a03b552e3843ed4eab9f830aed'
   name 'QtSpim'
   homepage 'http://spimsimulator.sourceforge.net/'
 

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -1,6 +1,6 @@
 cask 'qtspim' do
   version '9.1.18'
-  sha256 'b66e026ac7ea99db67ba6e546cf50e78395395a58744a443793800cf9deb175d'
+  sha256 '5e51b50d0a497e3704808e03f314c15a501686aa7dc36b74c63cc7ae065e75d8'
 
   url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.mpkg.zip"
   appcast 'https://sourceforge.net/projects/spimsimulator/rss',


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
