### PR TITLE
Update textsoap to 8.3.1

### DIFF
--- a/Casks/textsoap.rb
+++ b/Casks/textsoap.rb
@@ -1,11 +1,11 @@
 cask 'textsoap' do
-  version '8.3'
-  sha256 '6d4fdc5a3866d95d06c28135ae4c602d1bf2572d9bfe59fe335f4a9b8fa8768d'
+  version '8.3.1'
+  sha256 '33f6c3015d6389ba38a6691b6d306586f544c283aa4a43071168528983848351'
 
   # unmarked.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://unmarked.s3.amazonaws.com/textsoap#{version.major}.zip"
   appcast "https://unmarked.s3.amazonaws.com/appcast/textsoap#{version.major}.xml",
-          checkpoint: '91b001a03e3322296844a7ac66a3b6d8a7aa4553f1bebe38b2123d2149993245'
+          checkpoint: 'b7a7dd38ee4f6205c9f0842089c6e8e52d3735ba6076b48290e0ce1f0656b90e'
   name 'TextSoap'
   homepage 'https://www.unmarked.com/textsoap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.