### PR TITLE
Add wine-devel 2.1

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,0 +1,33 @@
+cask 'wine-devel' do
+  version '2.1'
+  sha256 '2a84e1d3aeaabf82ebab71f9a546909ce9b40bb4cffae062dc96545150bf930a'
+
+  url "https://dl.winehq.org/wine-builds/macosx/i686/winehq-devel-#{version}.pkg"
+  name 'WineHQ-devel'
+  homepage 'https://wiki.winehq.org/MacOS'
+
+  depends_on cask: 'xquartz'
+
+  pkg "winehq-devel-#{version}.pkg",
+      choices: [
+                 {
+                   'choiceIdentifier' => 'choice3',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+               ]
+
+  uninstall pkgutil: [
+                       'org.winehq.wine-devel',
+                       'org.winehq.wine-devel-deps',
+                       'org.winehq.wine-devel-deps64',
+                       'org.winehq.wine-devel32',
+                       'org.winehq.wine-devel64',
+                     ],
+            delete:  '/Applications/Wine Devel.app'
+
+  caveats <<-EOS.undent
+    #{token} installs support for running 64 bit applications in Wine, which is considered experimental.
+    If you do not want 64 bit support, you should download and install the #{token} package manually.
+  EOS
+end


### PR DESCRIPTION
The install logic is identical to the existing `wine-staging` formula. The difference is in content, where this package only includes features already endorsed and integrated into the Wine development branch, i.e. nothing experimental or out-of-branch. So, it's useful to get an official Wine binary build that is as close as possible to the stable development branch.

I'm unsure if the package will be updated in-place, but if it turns out to be, the hash can be removed.

Another option is to install Wine via `brew install wine`, but that method has the downside that it needs to keep rebuilding all its dependencies from source from the point of installation, making it very resource and time hungry and therefore unpractical in practice.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
