### PR TITLE
Update texshop to 3.77

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,12 +1,14 @@
 cask 'texshop' do
-  version '3.75'
-  sha256 'f3d25dc4a7a8a3ccc17da13fddce19779ca51fa6d4069757dec0d92af6fc556a'
+  version '3.77'
+  sha256 'c6e167f496602dc5d1018f96e3ac50325e11256980fac53e14219d2af8be1ab2'
 
-  url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.sub('.', '')}.zip"
+  url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
-          checkpoint: '920914819ea0574c8fd896869b313aaeb597e6d592fd8de459cec5927991e04e'
+          checkpoint: 'bab042ce07e40d4dcba3d0eb408eb8a979fef1bbaaeddf6e9a74ceb5a6077e23'
   name 'TeXShop'
   homepage 'http://pages.uoregon.edu/koch/texshop/'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'TeXShop.app'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.