### PR TITLE
Update bibdesk to 1.6.8

### DIFF
--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -1,10 +1,10 @@
 cask 'bibdesk' do
-  version '1.6.7'
-  sha256 'f9ba3a663f907d03326bcfa1741827ae4b639459020b5f3da14b5b17eb6562d6'
+  version '1.6.8'
+  sha256 'd59504a02a2192e7cd0d226a84bab1747da8404534dc459ee155421b0c0cacff'
 
   url "https://downloads.sourceforge.net/bibdesk/BibDesk/BibDesk-#{version}/BibDesk-#{version}.dmg"
   appcast 'http://bibdesk.sourceforge.net/bibdesk.xml',
-          checkpoint: '618bbe4ed7f37c05ec1e67fc4fc14b1feef2e63d8ba8ca7c6440715b662f59ff'
+          checkpoint: '35e43f002c6725809b3bfd6d413563fae2be6783265870ac12406c420b29114b'
   name 'BibDesk'
   homepage 'http://bibdesk.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.