### PR TITLE
Add duplicati v1.3.4

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -1,0 +1,10 @@
+cask 'duplicati' do
+  version '1.3.4'
+  sha256 'd97065d012fb929fa4e37b5efab2d246b6aef667f892a95301a1271f704963f2'
+
+  url "http://updates.duplicati.com/#{version.major_minor}.x/Duplicati%20#{version}.dmg"
+  name 'Duplicati'
+  homepage 'http://www.duplicati.com/'
+
+  app 'Duplicati.app'
+end

--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -3,6 +3,8 @@ cask 'duplicati' do
   sha256 'd97065d012fb929fa4e37b5efab2d246b6aef667f892a95301a1271f704963f2'
 
   url "http://updates.duplicati.com/#{version.major_minor}.x/Duplicati%20#{version}.dmg"
+  appcast 'https://github.com/duplicati/duplicati/releases.atom',
+          checkpoint: '5b228522bece130f042464271a9a9d49febd1e6935f9642653c12666d870af07'
   name 'Duplicati'
   homepage 'http://www.duplicati.com/'
 


### PR DESCRIPTION
Add back duplicati which was removed in #17338. Closes #30082.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
