### PR TITLE
Update keka to 1.0.8

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,11 +1,11 @@
 cask 'keka' do
-  version '1.0.7'
-  sha256 '92d05db46ba32e656992d2f9699e328b94dee058e573da3147865f3993bbe579'
+  version '1.0.8'
+  sha256 'ad6ab5e3baf98ab33d56022a844d5a37747bef9767cf9d3a2ed646f8a85630ee'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: '2abc192f8bc1572c7654d6eb4121c9f638ce405de61229ad09ec770a7c91deb2'
+          checkpoint: '3d0fc31334a2b913055f0d87a40f6060d778ea2a2b2713fd76cb1981709e9571'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.