### PR TITLE
Update nylas-mail to 1.0.26-7ad07cf

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.21-b0e5dfb'
-  sha256 '170d00e126e72d891670de7f9b52aac1895d5165774ae80e6c7cca11bb3cb21c'
+  version '1.0.26-7ad07cf'
+  sha256 'a09c4ffd8fa066dcdb377de1b95d88bebc2a0ad729fa28ebcdc7f430edfc58fc'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: 'e95faadbac8f93123a1c28662667d23232a20bbc70d1f9931255e450fc898532'
+          checkpoint: '2acd27ffdb96c30cf00ecd0cb59b7eb59039cdd42873164b65c6753d5df6f6f3'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.