### PR TITLE
Update get-backup-pro to 3.3.3

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.3.2'
-  sha256 'bddece820707578ce640cd4b707a6c2cb88c2a3ba63b45e09741f5a0ce722a1b'
+  version '3.3.3'
+  sha256 'e454f031dd9cd417ad8065eba95bc125fcdc5978663588f2aba97faf65075fcf'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: '08b97dc2913b2a9c3d4153d26f9689cff91942b3c8d566ef34409d7d740afd9b'
+          checkpoint: '16bf6fe0fc9bde97bb1a3d34f0ddcc668007a68b7bc460d482a8235c4d25df95'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.