### PR TITLE
Update smartgit to 17.0.2

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,10 +1,10 @@
 cask 'smartgit' do
-  version '17.0.1'
-  sha256 '1eb0af3d6617c5f1f33b69f783decf833fde33f2c727217a8346bac8d17958f4'
+  version '17.0.2'
+  sha256 '85386cf20ed3bfa22a13e878086b1d074311d53f7bb60ff2efcd1e96f30211ea'
 
   url "https://www.syntevo.com/static/smart/download/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',
-          checkpoint: '02fe2bcdfbc8522324949e1f7dd44f90102639622c04108855ba8bc35758f01c'
+          checkpoint: 'cb9c326df8fb7c6111ba6b9d2241fe744ce182518e90ce8b3c808039f14fa18a'
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.