### PR TITLE
Fix qgis 2.18.2-1 per deprecation warning

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -7,7 +7,7 @@ cask 'qgis' do
   homepage 'http://www.kyngchaos.com/software/qgis'
 
   depends_on cask: 'gdal-framework'
-  depends_on formula: 'homebrew/python/matplotlib'
+  depends_on formula: 'homebrew/science/matplotlib'
 
   pkg '4 Install QGIS.pkg'
 


### PR DESCRIPTION
matplotlib formula has been moved to homebrew/science/matplotlib

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
