### PR TITLE
Adding Simplenote (Electron version) v1.0.8

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,0 +1,19 @@
+cask 'simplenote' do
+  version '1.0.8'
+  sha256 '7bdc8d27b8936e53e1f2b9319d5a685ac85363db6fca5e566529ad36a22e5813'
+
+  url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.zip"
+  appcast 'https://github.com/Automattic/simplenote-electron/releases.atom',
+          checkpoint: 'c64f7c766c1225fd0eb4443ab72bd6656abe7e0f2028c514219a073ba7b7c3e4'
+  name 'Simplenote'
+  homepage 'https://github.com/Automattic/simplenote-electron'
+
+  app 'Simplenote.app'
+
+  zap delete: [
+                '~/Library/Application Support/Simplenote',
+                '~/Library/Caches/com.automattic.simplenote',
+                '~/Library/Caches/com.automattic.simplenote.ShipIt',
+                '~/Library/Saved Application State/com.automattic.simplenote.savedState',
+              ]
+end

--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -8,7 +8,7 @@ cask 'simplenote' do
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'
 
-  app 'Simplenote.app'
+  app 'Simplenote-darwin-x64/Simplenote.app'
 
   zap delete: [
                 '~/Library/Application Support/Simplenote',


### PR DESCRIPTION
The only question I have about this is what the correct name should be.

The developers called this a beta in their [blog post] announcing it, and there is an official macOS version that's different to this. However, the official macOS version is only available on the Mac App Store, so we don't have another cask whose name would conflict with this one.

Should the name be `simplenote`? This is what I've gone with, but I'm afraid it will cause confusion if someone expects to get the official app.

Should the name be `simplenote-beta`, since their blog calls it a beta?

Should the name be `simplenote-electron`, to match the [GitHub repo] name?

[blog post]: https://simplenote.com/2017/02/14/try-the-new-macos-beta/
[GitHub repo]: https://github.com/Automattic/simplenote-electron

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
