### PR TITLE
Update RawTherapee to 5.0

### DIFF
--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,31 +1,23 @@
 cask 'rawtherapee' do
-  if MacOS.version <= :mavericks
-    version '4.2.270'
-    sha256 '231f991cf43c92e21aace5ebc34c229542cbd3902633d091a8cd2c049216b29d'
+  if MacOS.version <= :lion
+    version '4.2.1'
+    sha256 'd553f04cab4e09a1d66d8811be5ec8468171abe584bdb541ff97d9fa0841e32f'
 
-    url "http://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.6_64_#{version}.zip"
-  elsif MacOS.version <= :yosemite
-    version '4.2.349'
-    sha256 'd88f4dc10740b9a105d0c6d72b8d8801957b5e3f2923912afc76b308ebb049bb'
-
-    url "http://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.10_64_#{version}.zip"
+    url "http://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.7_64_#{version}.zip"
   else
-    version '4.2.1025'
-    sha256 'e3e8f4b919528884c2e51dcb0cd0b746ea1ca32cae5317495bca80807648f84b'
-
-    url "http://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.11_64_#{version}.zip"
+    version '5.0-r1_gtk3'
+    sha256 '4a8c7d527d06e674e9a3d61dac3a45760c5ff1314db06b81e63f74bc8a3dff16'
+    
+    url "http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_#{version}.app.zip"
   end
 
   name 'RawTherapee'
   homepage 'http://rawtherapee.com/'
 
-  if MacOS.version <= :mavericks
-    container nested: "RawTherapee_OSX_10.6_64_#{version}.dmg"
-  elsif MacOS.version <= :yosemite
-    container nested: "RawTherapee_OSX_10.10_64_#{version}.dmg"
+  if MacOS.version <= :lion
+    container nested: "RawTherapee_OSX_10.7_64_#{version}/RawTherapee_OSX_10.7_64_#{version}__.dmg"
+    app 'RawTherapee.app'
   else
-    container nested: "RawTherapee_OSX_10.11_64_#{version}/RawTherapee_OSX_10.11_64__.dmg"
-  end
-
-  app 'RawTherapee.app'
+    app 'RawTherapee-gtk3.app'
+  end  
 end

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,23 +1,12 @@
 cask 'rawtherapee' do
-  if MacOS.version <= :lion
-    version '4.2.1'
-    sha256 'd553f04cab4e09a1d66d8811be5ec8468171abe584bdb541ff97d9fa0841e32f'
+  version '5.0-r1_gtk3'
+  sha256 '4a8c7d527d06e674e9a3d61dac3a45760c5ff1314db06b81e63f74bc8a3dff16'
 
-    url "http://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.7_64_#{version}.zip"
-  else
-    version '5.0-r1_gtk3'
-    sha256 '4a8c7d527d06e674e9a3d61dac3a45760c5ff1314db06b81e63f74bc8a3dff16'
-    
-    url "http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_#{version}.app.zip"
-  end
-
+  url "http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_#{version}.app.zip"
   name 'RawTherapee'
   homepage 'http://rawtherapee.com/'
 
-  if MacOS.version <= :lion
-    container nested: "RawTherapee_OSX_10.7_64_#{version}/RawTherapee_OSX_10.7_64_#{version}__.dmg"
-    app 'RawTherapee.app'
-  else
-    app 'RawTherapee-gtk3.app'
-  end  
+  depends_on macos: '>= 10.8'
+
+  app 'RawTherapee-gtk3.app'
 end


### PR DESCRIPTION
New packaging format and URL structure for the 5.0 releases
4.2.1:`http://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.7_64_4.2.1.zip`
5.0-r1:`http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_5.0-r1_gtk3.app.zip`

5.0 format has no `DMG` just a zipped `.app`. Also the 5.0 version is named `RawTherapee-gtk3.app`

As this is developer change, I left as is, but not sure if we need to nuke the old one as it won't over-write.
The other option is an `app 'RawTherapee-gtk3.app', target: 'RawTherapee.app'`

Either way we are left with possible duplicates of non-concurrent versions. Unless a zap (I think) is put in for the `pre-5.0` version.
---
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
---
Note on `Line 10`, no matter how many times I tried I keep ending up with 4 spaces on line 10 for no clear reason. Please delete, even pasting the:
`1 file inspected, 1 offense detected, 1 offense corrected`
code I ended up with the whitespace.
Sorry.