### PR TITLE
oryoki 0.1.0

### DIFF
--- a/Casks/oryoki.rb
+++ b/Casks/oryoki.rb
@@ -1,11 +1,11 @@
 cask 'oryoki' do
-  version '0.0.5'
-  sha256 '320d6b57a0533f5167ad6b0574c9661e205a470e47224db2d28976f1d53a8814'
+  version '0.1.0'
+  sha256 '162d1f42ab4baadfa1eeb4a3607b4384b510e7b0cabd1e160c62544473847579'
 
   # github.com/thmsbfft/oryoki was verified as official when first introduced to the cask
   url "https://github.com/thmsbfft/oryoki/releases/download/#{version}/Oryoki-#{version}.zip"
   appcast 'https://github.com/thmsbfft/oryoki/releases.atom',
-          checkpoint: '03fb80bcfe6d5be99193c804add5dd4ecfb5383d6a35c3bae2dec8a5d3e6acd2'
+          checkpoint: 'a2f6d39a0d20f944954e8e5d865d51a8c6bdf2f32d28cff1d97253c4414b4762'
   name 'Oryoki'
   homepage 'http://oryoki.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

