### PR TITLE
Update docker-toolbox to 1.13.1a

### DIFF
--- a/Casks/docker-toolbox.rb
+++ b/Casks/docker-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'docker-toolbox' do
-  version '1.13.1'
-  sha256 'bd6920064116259c4fe01271e2eed33a0f1bb386cbdd7a575e3faacc5c512dda'
+  version '1.13.1a'
+  sha256 '44fa59b71f961056b255426fb9487933282d895d3920ba13a41f533b6c190e7c'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: '8cf0fa907b8f4844d07fafbf5d13687bd3d8fff051847f3bc18b8585af8624f6'
+          checkpoint: 'f36fe3efd4c54d75a8a9ef44a626c40ab00adecd46e213bdc1bfcce6be13df96'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/products/docker-toolbox'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.