### PR TITLE
Update tabula to 1.1.1

### DIFF
--- a/Casks/tabula.rb
+++ b/Casks/tabula.rb
@@ -1,11 +1,11 @@
 cask 'tabula' do
-  version '1.1.0c'
-  sha256 '70ec8a524e881ed66d6048776ed0ceb16a0c8b68d06e1295a39698e836274b04'
+  version '1.1.1'
+  sha256 '7b02fa0cc00719316332785c116cdae815b33c5dab2157da27cec44ccacf7593'
 
   # github.com/tabulapdf/tabula was verified as official when first introduced to the cask
   url "https://github.com/tabulapdf/tabula/releases/download/v#{version.major_minor_patch}/tabula-mac-#{version}.zip"
   appcast 'https://github.com/tabulapdf/tabula/releases.atom',
-          checkpoint: '673874f3ec13bbf7ede5cb2930090ee49f1170cf95d43a578d0ba5f2d86ccee7'
+          checkpoint: '8d9dad810499164269a195e9c8b0e4ea3a2ce60daf638762056a7d5ae91bc624'
   name 'Tabula'
   homepage 'http://tabula.technology/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.