### PR TITLE
Fix url in mono-mdk Cask (4.6.2.16)

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -2,7 +2,8 @@ cask 'mono-mdk' do
   version '4.6.2.16'
   sha256 '466866fbf633e8853683543dd906b9773989bf5bb28366522d8309e3dde45e3e'
 
-  url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
+  # mono-project.azureedge.net was verified as official when first introduced to the cask
+  url "https://mono-project.azureedge.net/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 

--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -2,7 +2,7 @@ cask 'mono-mdk' do
   version '4.6.2.16'
   sha256 '466866fbf633e8853683543dd906b9773989bf5bb28366522d8309e3dde45e3e'
 
-  # mono-project.azureedge.net was verified as official when first introduced to the cask
+  # mono-project.azureedge.net/archive was verified as official when first introduced to the cask
   url "https://mono-project.azureedge.net/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
   homepage 'http://www.mono-project.com/'


### PR DESCRIPTION
#### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Fixed download url, as the original one first produces a certificate warning and then a 404 not found.
The updated url has been copied from the project's homepage.
http://www.mono-project.com/download/#download-mac
