### PR TITLE
Update tower to 2.6.1-347,121ed402

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,11 +1,11 @@
 cask 'tower' do
-  version '2.6.0-346,421e07c0'
-  sha256 '4d1fc9152c781f76b4d6c8846a728356acacc1c33e5c534f38cdb6ebbe6f0a75'
+  version '2.6.1-347,121ed402'
+  sha256 'acc31729627641973bbb49b101e076e78b9ec2e09d047eb46264119f98f51067'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.major}-#{version.before_comma}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable",
-          checkpoint: '08567549c704d9045c81ce24476d0212ee50a2bf485c0c6264bd9f1c83115fae'
+          checkpoint: '77b174635ffd454f42c88b8b8c243bb61784f68e6e19b37d073c93d03bc3b4b2'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.