### PR TITLE
Add MT32Emu 2.0.0

### DIFF
--- a/Casks/mt32emu.rb
+++ b/Casks/mt32emu.rb
@@ -2,7 +2,9 @@ cask 'mt32emu' do
   version '2.0.0'
   sha256 'b0a8434a6de660725723bd822c00a2bbb24c06ee9f2fd994961fa3dbb1b1bbd1'
 
-  url 'https://downloads.sourceforge.net/munt/munt/2.0.0/OS%20X/MT32Emu-qt-1.4.0.dmg'
+  url "https://downloads.sourceforge.net/munt/munt/#{version}/OS%20X/MT32Emu-qt-1.4.0.dmg"
+  appcast "https://sourceforge.net/projects/munt/rss?path=/munt/#{version}",
+          checkpoint: '84b7ecd3cafd0ff1e4ab1ec372e0e705bcde4eb9a9e3373d16a52c56d83c05a2'
   name 'MT32Emu'
   homepage 'https://sourceforge.net/projects/munt/'
 

--- a/Casks/mt32emu.rb
+++ b/Casks/mt32emu.rb
@@ -3,7 +3,7 @@ cask 'mt32emu' do
   sha256 'b0a8434a6de660725723bd822c00a2bbb24c06ee9f2fd994961fa3dbb1b1bbd1'
 
   url "https://downloads.sourceforge.net/munt/munt/#{version}/OS%20X/MT32Emu-qt-1.4.0.dmg"
-  appcast "https://sourceforge.net/projects/munt/rss?path=/munt/#{version}",
+  appcast "https://sourceforge.net/projects/munt/rss?path=/munt",
           checkpoint: '84b7ecd3cafd0ff1e4ab1ec372e0e705bcde4eb9a9e3373d16a52c56d83c05a2'
   name 'MT32Emu'
   homepage 'https://sourceforge.net/projects/munt/'

--- a/Casks/mt32emu.rb
+++ b/Casks/mt32emu.rb
@@ -1,0 +1,10 @@
+cask 'mt32emu' do
+  version '2.0.0'
+  sha256 'b0a8434a6de660725723bd822c00a2bbb24c06ee9f2fd994961fa3dbb1b1bbd1'
+
+  url 'https://downloads.sourceforge.net/munt/munt/2.0.0/OS%20X/MT32Emu-qt-1.4.0.dmg'
+  name 'MT32Emu'
+  homepage 'https://sourceforge.net/projects/munt/'
+
+  app 'MT32Emu.app'
+end

--- a/Casks/mt32emu.rb
+++ b/Casks/mt32emu.rb
@@ -3,8 +3,8 @@ cask 'mt32emu' do
   sha256 'b0a8434a6de660725723bd822c00a2bbb24c06ee9f2fd994961fa3dbb1b1bbd1'
 
   url "https://downloads.sourceforge.net/munt/munt/#{version}/OS%20X/MT32Emu-qt-1.4.0.dmg"
-  appcast "https://sourceforge.net/projects/munt/rss?path=/munt",
-          checkpoint: '84b7ecd3cafd0ff1e4ab1ec372e0e705bcde4eb9a9e3373d16a52c56d83c05a2'
+  appcast 'https://sourceforge.net/projects/munt/rss?path=/munt',
+          checkpoint: 'bec1a2eb6dd50e93a10a8f1e479860531cb1e61f7cd8f55a2992c774a995833c'
   name 'MT32Emu'
   homepage 'https://sourceforge.net/projects/munt/'
 


### PR DESCRIPTION
Hey guys, mt32emu is a [Roland MT-32](https://en.wikipedia.org/wiki/Roland_MT-32) emulator which has a Mac port also. The Mac port was not perfect on my tests, for example it doesn't detect input midi devices automatically but is working in combination with MidiKeys installable from cask. I found it useful and interesting for my use thats why I felt it would be good idea to share it with cask community. Cheers.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask