### PR TITLE
Update nvalt to 2.2.7b126

### DIFF
--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -1,15 +1,9 @@
 cask 'nvalt' do
-  if MacOS.version <= :mavericks
-    version '2.2b111'
-    sha256 'd787ddf92730bb03ba084e72bc6fb5f4fbd42731fa3531476af9eb3ce39e1cd0'
-    # abyss.designheresy.com/nvaltb was verified as official when first introduced to the cask
-    url "http://abyss.designheresy.com/nvaltb/nvalt#{version}.zip"
-  else
-    version '2.2.7b126'
-    sha256 '496e0fb87b255ac6b6746395ff676b788cc455eccd1e65b49a63d0e2812754c3'
-    url "http://updates.designheresy.com/nvalt/nvALT#{version.delete('b')}.dmg"
-  end
+  version '2.2.7-126'
+  sha256 '496e0fb87b255ac6b6746395ff676b788cc455eccd1e65b49a63d0e2812754c3'
 
+  # updates.designheresy.com/nvalt was verified as official when first introduced to the cask
+  url "http://updates.designheresy.com/nvalt/nvALT#{version.no_hyphens}.dmg"
   name 'nvALT'
   homepage 'http://brettterpstra.com/projects/nvalt/'
 

--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -5,9 +5,9 @@ cask 'nvalt' do
     # abyss.designheresy.com/nvaltb was verified as official when first introduced to the cask
     url "http://abyss.designheresy.com/nvaltb/nvalt#{version}.zip"
   else
-    version '2.2.7b125'
-    sha256 'efdab1c5fbf995c1adad9e65bb65438a39c9c6119205e578260ac49e576136c2'
-    url "http://assets.brettterpstra.com/nvALT#{version.delete('b')}.dmg"
+    version '2.2.7b126'
+    sha256 '496e0fb87b255ac6b6746395ff676b788cc455eccd1e65b49a63d0e2812754c3'
+    url "http://updates.designheresy.com/nvalt/nvALT#{version.delete('b')}.dmg"
   end
 
   name 'nvALT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.