### PR TITLE
Update hyper to 1.2.0

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -5,7 +5,7 @@ cask 'hyper' do
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '1a95bdccd4fb23f528b752726a27df7751afa8f1e252354905b78aafd909a613'
+          checkpoint: 'cef5c590ab79abae9fcccea41aced83ebf9d6b67f5f89a87545e7301b166f181'
   name 'Hyper'
   homepage 'https://hyper.is/'
 

--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.1.0'
-  sha256 '7bcc3c437e66ef183a9063a6586e7d301b1cd584a8212d58c984cd26be6d7804'
+  version '1.2.0'
+  sha256 '98e7fe598487f8e6a600a3e3424b7e0fe7196817044a2a1590942aa001808683'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '24cd4e7b79b778639476f323052420982f832b3b67745e5f417dc4320f5c1ff8'
+          checkpoint: '1a95bdccd4fb23f528b752726a27df7751afa8f1e252354905b78aafd909a613'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.