### PR TITLE
Only run keybase uninstall command if exists

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -21,7 +21,9 @@ cask 'keybase' do
     if system_command('launchctl', args: ['list']).stdout =~ %r{/^\d+.*keybase.Electron/}
       system_command 'killall', args: ['-kill', 'Keybase']
     end
-    system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
-                   args: ['uninstall']
+    if File.exist?("#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase")
+      system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
+                     args: ['uninstall']
+    end
   end
 end

--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -18,12 +18,7 @@ cask 'keybase' do
   end
 
   uninstall_preflight do
-    if system_command('launchctl', args: ['list']).stdout =~ %r{/^\d+.*keybase.Electron/}
-      system_command 'killall', args: ['-kill', 'Keybase']
-    end
-    if File.exist?("#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase")
-      system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
-                     args: ['uninstall']
-    end
+    system_command('killall', args: ['-kill', 'Keybase']) if system_command('launchctl', args: ['list']).stdout =~ %r{/^\d+.*keybase.Electron/}
+    system_command("#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase", args: ['uninstall']) if File.exist?("#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase")
   end
 end


### PR DESCRIPTION
Fixes #30145 

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

