### PR TITLE
Update ukelele to 3.2.2

### DIFF
--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -1,10 +1,10 @@
 cask 'ukelele' do
-  version '3.2.1'
-  sha256 'e56d8950fe422cedfc017d69c39e25762ffbde170cf1aa8092c22f910c3a440a'
+  version '3.2.2'
+  sha256 '3cd7bced5b0da8608460ff0296972c944c9f777c469e4190c72a03aa83b9929d'
 
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_#{version}&filename=Ukelele_#{version}.dmg"
   appcast 'https://dl.dropboxusercontent.com/u/60565698/Ukelele/Ukelele_appcast.xml',
-          checkpoint: '7843b4d5e4426629571910dfbe056dee2f67d92e3f9d3373b29ac2101429f643'
+          checkpoint: '6d81b38e0c3bc6b1f5ecbd85e66f7eb5866e0848f02903f9a0516c32a689af30'
   name 'Ukelele'
   homepage 'http://scripts.sil.org/ukelele'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.