### PR TITLE
Update tagspaces to 2.7.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,11 +1,11 @@
 cask 'tagspaces' do
-  version '2.6.0'
-  sha256 '5eb5d99843bed186b9ba711794376c272922675be647671e9e5f18c82edceb31'
+  version '2.7.0'
+  sha256 'c1214f39732de3531bd4ccf9558ddb40d56b1dad3acef92a02c49cae1bfe4194'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-#{version}-osx64.zip"
   appcast 'https://github.com/tagspaces/tagspaces/releases.atom',
-          checkpoint: 'f2c08de8bc1a32b1617b46e2c88195bd11c984461d3a03c3412df3bffcf047d5'
+          checkpoint: 'fd5b21e6f3efe7295ab25b09e1eaa3cfc53f28798822839fc2df895df152b9cf'
   name 'TagSpaces'
   homepage 'https://www.tagspaces.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.