### PR TITLE
Update standard-notes to 0.2.4

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.2.2'
-  sha256 '02c04b39f3842cf1b26d3c36ed050a163331f1e3e0d3d6f052e45b8536768697'
+  version '0.2.4'
+  sha256 '906885b96583c134ef76c388aa8913e0a1d84c10dbd16312279342097548cbd6'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '619c2ba7710efe2fa43af66e31d2ed12d755c8711766608876bd92be3faa2d64'
+          checkpoint: 'dfb068db85f61be7436290aa21c449b04275b0b58bccb5f0a2f95edcf000aa68'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.