### PR TITLE
Enhance Airfoil 5.5.2 with zap stanza

### DIFF
--- a/Casks/airfoil.rb
+++ b/Casks/airfoil.rb
@@ -8,6 +8,26 @@ cask 'airfoil' do
   name 'Airfoil'
   homepage 'https://www.rogueamoeba.com/airfoil/mac/'
 
+  auto_updates true
+  depends_on macos: '>= :mavericks'
+
   app 'Airfoil/Airfoil Satellite.app'
   app 'Airfoil/Airfoil.app'
+
+  zap quit:       [
+                    'com.rogueamoeba.Airfoil',
+                    'com.rogueamoeba.AirfoilSpeakers',
+                  ],
+      login_item: 'Airfoil Satellite',
+      delete:     [
+                    '/Library/Audio/Plug-Ins/HAL/InstantOn.driver',
+                    '~/Library/Application Support/Airfoil',
+                    '~/Library/Application Support/Airfoil Satellite',
+                    '~/Library/Caches/com.rogueamoeba.Airfoil',
+                    '~/Library/Caches/com.rogueamoeba.AirfoilSpeakers',
+                    '~/Library/Preferences/com.rogueamoeba.Airfoil.plist',
+                    '~/Library/Preferences/com.rogueamoeba.AirfoilSpeakers.plist',
+                    '~/Library/Saved Application State/com.rogueamoeba.Airfoil.savedState',
+                    '~/Library/Saved Application State/com.rogueamoeba.AirfoilSpeakers.savedState',
+                  ]
 end


### PR DESCRIPTION
Add a zap stanza to the existing Airfoil 5.5.2 cask to allow full uninstall.

Note: is `uninstall quit` meant to be handled before `app`s are removed? I wanted to split logic between `uninstall` (e.g. `quit`, `login_item`, clear Caches) and `zap` (e.g. remove user settings), but found that when the app was running during an uninstall, that it warned that its `.app` package had been removed before it was sent the `quit` instruction via `osascript`. Is this expected behaviour? I couldn't find an open issue.

After making these changes to the cask:

- [x] `brew cask audit --download airfoil` is error-free.
- [x] `brew cask style --fix airfoil` reports no offenses.
- [x] The commit message includes the cask’s name and version.
