### PR TITLE
Restore mysql-utilities cask (v1.6.5)

### DIFF
--- a/Casks/mysql-utilities.rb
+++ b/Casks/mysql-utilities.rb
@@ -1,0 +1,16 @@
+cask 'mysql-utilities' do
+  version '1.6.5'
+  sha256 '114658256e846b4eeff141065e18ef3f779bcbe59e5d2828ab920d905e693db7'
+
+  url "https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-utilities-#{version}-macos10.12.dmg"
+  name 'MySQL Utilities'
+  homepage 'https://dev.mysql.com/downloads/utilities/'
+
+  license :gpl
+
+  depends_on macos: '>= :sierra'
+
+  pkg "mysql-utilities-#{version}.pkg"
+
+  uninstall pkgutil: 'com.oracle.mysql.utilities'
+end


### PR DESCRIPTION
The latest update seems to have fixed the installer issues, meaning
this cask can be re-added.

Following up on #25061 and #24077.

I don't have access to anything running 10.11 or earlier to verify if the cask works on versions earlier than Sierra, so I've based the OS version requirement off of the file name provided by MySQL.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask