### PR TITLE
Windows, Linux, and WebGL build support for Unity, version 5.5.0f3

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,0 +1,14 @@
+cask 'unity-linux-support-for-editor' do
+  version '5.5.0f3,38b4efef76f0'
+  sha256 'fa76f2b509c825040a1466a3b9f2f7ae16eaea7124ad478a1b56d750d26e0cb5'
+
+  url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity Linux Build Support'
+  homepage 'https://unity3d.com/unity/'
+
+  depends_on cask: 'unity'
+
+  pkg "UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
+
+  uninstall pkgutil: 'com.unity3d.LinuxStandaloneSupport'
+end

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,0 +1,14 @@
+cask 'unity-webgl-support-for-editor' do
+  version '5.5.0f3,38b4efef76f0'
+  sha256 '17532ebcf73d74dec9b1403e6649697dfd39aafac87806a601b70bf713a7a270'
+
+  url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity WebGL Build Support'
+  homepage 'https://unity3d.com/unity/'
+
+  depends_on cask: 'unity'
+
+  pkg "UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
+
+  uninstall pkgutil: 'com.unity3d.WebGLSupport'
+end

--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,0 +1,14 @@
+cask 'unity-windows-support-for-editor' do
+  version '5.5.0f3,38b4efef76f0'
+  sha256 'f36f92e0b32c36a63540f7a1b6c03ad4aa4f94c849a8c12ec891c5c4298534a4'
+
+  url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity Windows Build Support'
+  homepage 'https://unity3d.com/unity/'
+
+  depends_on cask: 'unity'
+
+  pkg "UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
+
+  uninstall pkgutil: 'com.unity3d.WindowsStandaloneSupport'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask



(This pull request includes multiple casks; if that's not considered appropriate, please let me know and I can break them up.)

These casks (and the ones I based them on, `unity-ios-support-for-editor` and `unity-android-support-for-editor`) might more ideally be supported as installation options on the `unity` cask. Is that something that's possible? Even with these additions, we're still missing the Tizen, Xbox One, PS Vita, PS4, and Samsung TV support packages. Making a separate cask for each one doesn't really scale; as it is there are already multiple casks that will need to be updated when the core `unity` package gets a version bump. Any thoughts? 