### PR TITLE
Update keepassxc to 2.1.2

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,11 +1,11 @@
 cask 'keepassxc' do
-  version '2.1.1'
-  sha256 '3c29d5fc4f287e424fd38811f360ef03a9bf474980c8b6c9b27010a7c8865f15'
+  version '2.1.2'
+  sha256 '04af9a73cb8af055f209409c10a54bc82e06c8ad788d4ee431ff48757854a431'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-HTTP.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
   appcast 'https://github.com/keepassxreboot/keepassxc/releases.atom',
-          checkpoint: '741980d9622baef5c07fb37351dcfa6989720b65ba0904a3cc21a30e491824a2'
+          checkpoint: 'b4c39c3238663ed3a961552df7d77e30cfb107eb7e95b9f98833adebf2314c82'
   name 'KeePassXC'
   homepage 'https://keepassxc.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.