### PR TITLE
Add VMware Remote Console (VMRC) v9.0

### DIFF
--- a/Casks/vmrc.rb
+++ b/Casks/vmrc.rb
@@ -13,6 +13,12 @@ cask 'vmrc' do
 
   app 'payload/VMware Remote Console.app'
 
+  postflight do
+    system_command "#{appdir}/VMware Remote Console.app/Contents/Library/Initialize VMRC.tool",
+                   args: ['set'],
+                   sudo: true
+  end
+
   uninstall_preflight do
     set_ownership "#{appdir}/VMware Remote Console.app"
   end

--- a/Casks/vmrc.rb
+++ b/Casks/vmrc.rb
@@ -1,0 +1,23 @@
+cask 'vmrc' do
+  version '9.0.0-4288332'
+  sha256 'b3adb7f0b2c19f98765710a0c6902f7d3d32ebf7e908886d4d6f687c4f8f6b2b'
+
+  url "https://softwareupdate.vmware.com/cds/vmw-desktop/vmrc/#{version.hyphens_to_slashes}/macos/com.vmware.vmrc.zip.tar"
+  appcast 'https://softwareupdate.vmware.com/cds/vmw-desktop/vmrc-macos.xml',
+          checkpoint: 'c2fcc80625919e460063b48a9fd6f93eb155f3b91b4f71050a492cdc465e6dbb'
+  name 'VMware Remote Console for Mac'
+  homepage 'https://www.vmware.com/support/pubs/vmrc_pubs.html'
+
+  auto_updates true
+  container nested: 'com.vmware.vmrc.zip'
+
+  app 'payload/VMware Remote Console.app'
+
+  uninstall_preflight do
+    set_ownership "#{appdir}/VMware Remote Console.app"
+  end
+
+  uninstall quit: 'com.vmware.vmrc'
+
+  zap delete: '/Library/Logs/VMRC Services.log'
+end

--- a/Casks/vmware-remote-console.rb
+++ b/Casks/vmware-remote-console.rb
@@ -1,4 +1,4 @@
-cask 'vmrc' do
+cask 'vmware-remote-console' do
   version '9.0.0-4288332'
   sha256 'b3adb7f0b2c19f98765710a0c6902f7d3d32ebf7e908886d4d6f687c4f8f6b2b'
 


### PR DESCRIPTION
Add a new Cask for VMware Remote Console 9.0.
NB: Download is from the vendor's software update repository, as otherwise user registration is required.

- [x] `brew cask audit --download vmrc` is error-free.
- [x] `brew cask style --fix vmrc` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install vmrc` worked successfully.
- [x] `brew cask uninstall vmrc` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
