### PR TITLE
fix install sketchup because of mismatch sha256

### DIFF
--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -1,6 +1,6 @@
 cask 'sketchup' do
   version '2017'
-  sha256 'a61e7e55b42e8d2e4735c4e45f0d53435c8dfd4f6aaca7187b4f945a58acc858'
+  sha256 '9a515fac2a3a4c0d32c90c2570e887395ae5c79511310d183624f24a6e436efa'
 
   # downloads can be found at https://www.sketchup.com/download/all
   # dl.trimble.com/sketchup was verified as official when first introduced to the cask


### PR DESCRIPTION
Install sketchup fail because of mismatch sha256:
```
$ brew cask install sketchup
==> Downloading https://dl.trimble.com/sketchup/SketchUpMake-en.dmg
######################################################################## 100,0%
==> Verifying checksum for Cask sketchup
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: a61e7e55b42e8d2e4735c4e45f0d53435c8dfd4f6aaca7187b4f945a58acc858
Actual: 9a515fac2a3a4c0d32c90c2570e887395ae5c79511310d183624f24a6e436efa
File: /Users/cyril.lakech/Library/Caches/Homebrew/Cask/sketchup--2017.dmg
To retry an incomplete download, remove the file above.

I just updated the sha256...

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
