### PR TITLE
cask packetsender version v5.3

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -3,7 +3,7 @@ cask 'packetsender' do
   sha256 '28f4f46fc0e8ec7584660376089f4f07f1626fac6775a954fc17e28154127418'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
-  url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}/PacketSender_v#{version.before_comma.to_s.sub('.', '_')}_#{version.after_comma}.dmg"
+  url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}/PacketSender_v#{version.before_comma.dots_to_underscores}_#{version.after_comma}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom',
           checkpoint: 'b035e6238a22dae4ef736bc40315fc2cd6b81e5ac4ee1a5f02f3debdf41325b5'
   name 'Packet Sender'

--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,11 +1,11 @@
 cask 'packetsender' do
-  version '5.1,2016-10-13'
-  sha256 '9ef8ee82b7d9a7987430a45e483b676db2c0a4ada1bb59b033538dbd1c9da520'
+  version '5.3,2017-02-18'
+  sha256 '28f4f46fc0e8ec7584660376089f4f07f1626fac6775a954fc17e28154127418'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
-  url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}-sierra1/PacketSender_#{version.after_comma}.dmg"
+  url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}/PacketSender_v#{version.before_comma.to_s.sub('.', '_')}_#{version.after_comma}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom',
-          checkpoint: '23639a7e3b2135f56c03a411d19ac81165cf4371dcc9e684d7ea644f83be3d86'
+          checkpoint: 'b035e6238a22dae4ef736bc40315fc2cd6b81e5ac4ee1a5f02f3debdf41325b5'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'
 


### PR DESCRIPTION
New version of Packet Sender released. 

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
