### PR TITLE
1Password - Update to 6.5.4

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -16,8 +16,8 @@ cask '1password' do
 
     app "1Password #{version.major}.app"
   else
-    version '6.5.3'
-    sha256 '1771155ee1b7fc97db71d34d99ed906e6e37200b0ae4f6d310da00c8de5ec27a'
+    version '6.5.4'
+    sha256 'a49bc2a81eb9bdaba48f6dc4851af93e7ab167ce325349e37bba9eb1193c909a'
 
     # d13itkw33a7sus.cloudfront.net was verified as official when first introduced to the cask
     url "https://d13itkw33a7sus.cloudfront.net/dist/1P/mac4/1Password-#{version}.zip"
@@ -26,7 +26,7 @@ cask '1password' do
   end
 
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: '9944f1ff5b4d9157a82a680da6c47b7d3db9d9332afd8c18748eaad48a5ae56b'
+          checkpoint: 'f2058ad55c505f5344f33751398b5bad05e23b11d0a914b49d5d3759fb01fe6b'
   name '1Password'
   homepage 'https://1password.com/'
 


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Tested uninstalling and reinstalling locally without errors! Looks like a simple rebuild of v6.5.3:
https://app-updates.agilebits.com/product_history/OPM4#v654000

```
Good afternoon! This build is a re-release of 1Password 6.5.3 with a fix for the expired provisioning profile that was preventing 1Password from launching. Our apologies for the confusion!

FIXED
Updated the provisioning profile so 1Password will launch.
```