### PR TITLE
Update qfinder to 2.3.1.0124

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,4 +1,4 @@
-cask 'qfinder' do
+cask 'qfinder-pro' do
   version '2.3.1.0124'
   sha256 '04831a98d32b005136b22a68415a76f6666e8878f6cf6a87ad49178fa07b811c'
 

--- a/Casks/qfinder.rb
+++ b/Casks/qfinder.rb
@@ -1,12 +1,14 @@
 cask 'qfinder' do
-  version :latest
-  sha256 :no_check
+  version '2.3.1.0124'
+  sha256 '04831a98d32b005136b22a68415a76f6666e8878f6cf6a87ad49178fa07b811c'
 
-  url 'https://download.qnap.com/webstart/QNAPQfinder_Mac.dmg'
-  name 'Qnap Qfinder'
-  homepage 'https://www.qnap.com/i/in/utility/#block_1'
+  url "http://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
+  appcast 'http://update.qnap.com/SoftwareRelease.xml',
+          checkpoint: 'd6d10b87a31daffa00cc61e07bfed6fd2d822331bb9d090526bb5562ea917960'
+  name 'Qnap Qfinder Pro'
+  homepage 'https://www.qnap.com/en/utilities#utliity_5'
 
-  pkg 'Qfinder.pkg'
+  pkg 'Qfinder Pro.pkg'
 
   uninstall pkgutil: 'qnap.com.qfinder.*'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

About this update:

1. QNAP renamed this app to "Qfinder Pro" with the reason I don't know.
2. appcast URL has be found by using wireshark.
3. New homepage and download URL.