### PR TITLE
Update ndm to 1.1.0

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
   version '1.1.0'
-  sha256 'a4da54e09c944cf288a91d999f932daa4fa8102d63974c57caadeca35a187d2c'
+  sha256 '18bb22469f2804f5533a4b87159dedaf570be3fb6cb38ae40dbe26ef5d275170'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '31e8ea2c8c1748af0a3060313acf6319e313fc88ff5652d55de68c12910f67a9'
+          checkpoint: 'bc369e17fd3e6ef4421adfd4b86670c474f57ba37f1f9775427ac9b944fc6c46'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 

--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -5,7 +5,7 @@ cask 'ndm' do
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: 'bc369e17fd3e6ef4421adfd4b86670c474f57ba37f1f9775427ac9b944fc6c46'
+          checkpoint: '31e8ea2c8c1748af0a3060313acf6319e313fc88ff5652d55de68c12910f67a9'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 

--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -5,7 +5,7 @@ cask 'ndm' do
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: 'd7362aa520a1717deb489ce0e09f86274d70d352f0996384f479674bde9983c2'
+          checkpoint: '7a60a7052fa5a067d43d7aa0a7d0c6e439fb658262ad4288362e1ecf6543be0f'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 

--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -5,7 +5,7 @@ cask 'ndm' do
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '7a60a7052fa5a067d43d7aa0a7d0c6e439fb658262ad4288362e1ecf6543be0f'
+          checkpoint: 'bc369e17fd3e6ef4421adfd4b86670c474f57ba37f1f9775427ac9b944fc6c46'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 

--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '1.0.0'
-  sha256 'ed9c9c2af8abd382bee65d35124fd29399a1e43773dd05979022303b1fb83931'
+  version '1.1.0'
+  sha256 'a4da54e09c944cf288a91d999f932daa4fa8102d63974c57caadeca35a187d2c'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: 'f063615ef92ea1b9ba8d3157f24e968dcb36deb5c7223553b892899a3bdbea32'
+          checkpoint: 'd7362aa520a1717deb489ce0e09f86274d70d352f0996384f479674bde9983c2'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.