### PR TITLE
Update free-download-manager to 5.1.24

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,6 +1,6 @@
 cask 'free-download-manager' do
-  version '5.1.23'
-  sha256 'a66b25b3271aeb4d0ab5ad5bba9ada775de966b1975057a039185b8695736fb6'
+  version '5.1.24'
+  sha256 'e33bd205b9f326e375ce5a354396324d80266afd2a76b79d35c8fa685a1493a3'
 
   url "http://files2.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
   name 'Free Download Manager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.