### PR TITLE
Update brave to 0.13.4dev

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.13.2dev'
-  sha256 'c649a99ea24f54a539a73a0539cbc3e2b4a0e85d4facb754c42cf2499de64d29'
+  version '0.13.4dev'
+  sha256 '36f7d822fae215e44189276ca27c8ffaa41b271f953e43fbad6df98e8f7b3c11'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}/Brave.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'edf0521552521c815bf3f53a5b6f6334fd9277b521fbc6bfebc0946a80fbfbad'
+          checkpoint: '840b16ee6491d3c8ab85310c98e59b3c49f902cdad2be6df2d1eece29d69e99d'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.