### PR TITLE
Update caret to 1.14.2

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.14.0'
-  sha256 'df0b0eccf8e7890ba0b66f8f7146b3a9841ade60cc5ea915795c96be670c85cb'
+  version '1.14.2'
+  sha256 '019778f6bcd0ec4121e290576a931b0e97e0e7d004fdd3b770eb6859bc0e7c73'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'ce2ec8d1d450c701814c6912fbdba082b9b068e1bce4b63bb1d97ce124093aa8'
+          checkpoint: '278457f23557e4258b64f9a4decb33e8614afaeffcbe627b897050d296de51d3'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.