### PR TITLE
Update cinch to 1.2.3

### DIFF
--- a/Casks/cinch.rb
+++ b/Casks/cinch.rb
@@ -1,10 +1,10 @@
 cask 'cinch' do
-  version '1.2.2'
-  sha256 'c8ff663bdc03329446db3ada84fa32aa0d382c7dbcd18a683712d1304ed914f1'
+  version '1.2.3'
+  sha256 '62589f8f7d08e537dcadea97a4cb35243db2b8a63efc25a21317814f732c5c11'
 
   url "https://www.irradiatedsoftware.com/downloads/Cinch_#{version}.zip"
   appcast 'https://www.irradiatedsoftware.com/updates/profiles/cinch.php',
-          checkpoint: '18e45489bf4ca68eaadfea51bc6ea38580ed00ac260bede0dd7b282778bf7a22'
+          checkpoint: '8f80771bd04590be0fe4e0e94f06635e96a04fd2777aaad4a558329f6bf98a38'
   name 'Cinch'
   homepage 'https://www.irradiatedsoftware.com/cinch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.