### PR TITLE
Update dripcap to 0.6.15

### DIFF
--- a/Casks/dripcap.rb
+++ b/Casks/dripcap.rb
@@ -1,11 +1,11 @@
 cask 'dripcap' do
-  version '0.6.9'
-  sha256 'eefe5bf38f63683104163c7ea15235b8014d928b9915503dfa548be727cf0dac'
+  version '0.6.15'
+  sha256 'a89f2eea194e6736b7ae2fa7d8668149c87a1c1378848460a6030b5fed9d187b'
 
   # github.com/dripcap was verified as official when first introduced to the cask
   url "https://github.com/dripcap/dripcap/releases/download/v#{version}/dripcap-darwin-amd64.dmg"
   appcast 'https://github.com/dripcap/dripcap/releases.atom',
-          checkpoint: 'abda84b525067460e5d82d74ca70a9617f50b3bc951d3d87f4ef3d0f6a8315db'
+          checkpoint: '54544b11d6daeb65f53b52af517ed4599144b055522cf7720c30c072b929a9c7'
   name 'Dripcap'
   homepage 'https://dripcap.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.