### PR TITLE
Update lingon-x to 4.3.7

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '4.3.6'
-  sha256 '45d99926a089440c153462a7f2a56804b504c80aa3a4a30e5b2b4fda0ebcaabd'
+  version '4.3.7'
+  sha256 '2a108b6da46f1b4f30b9ef95412c6b806c7e92f2b4a28bff7bf67558a7ec9e7b'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '9ac359381e18499b0ddd76bf778045400aa1c1ba040bb2601fe1bee55004ac51'
+          checkpoint: '30913d1fd664606610ddb39899a1a3038340282d5a6aa86351bd795429ebdab1'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.