### PR TITLE
Update Cuda to 8.0.61

### DIFF
--- a/Casks/cuda.rb
+++ b/Casks/cuda.rb
@@ -1,8 +1,8 @@
 cask 'cuda' do
-  version '8.0.55'
-  sha256 'bd9f6a525916ab9c5774a67a89004bbd8e38334f66c37ff2ab4bc82003b7e57d'
+  version '8.0.61'
+  sha256 'b70a193cbe0a798d7363abab88ab5190409d237d7e13bf8682682fbbeac01847'
 
-  url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod/local_installers/cuda_#{version}_mac-dmg"
+  url "https://developer.nvidia.com/compute/cuda/#{version.major_minor}/Prod2/local_installers/cuda_#{version}_mac-dmg"
   name 'Nvidia CUDA'
   homepage 'https://developer.nvidia.com/cuda-zone'
 


### PR DESCRIPTION
Update Cuda to 8.0.61

After making all changes to the cask:

- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} left no offenses.
- [x] The commit message includes the cask’s name and version.
