### PR TITLE
Update freefilesync to 8.9

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '8.8'
-  sha256 'f8a9878fed6b88eb7f0f48a105d2da771f2c203fae865776a3d581481b9a1f52'
+  version '8.9'
+  sha256 'aa7972d8b6fa11f198bb78bb55128eca91be18d54fa57c84f25eeddfd9815996'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.