### PR TITLE
Update ndm to 1.1.0

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '1.0.0'
-  sha256 'ed9c9c2af8abd382bee65d35124fd29399a1e43773dd05979022303b1fb83931'
+  version '1.1.0'
+  sha256 '77fa78d5aa51178e0a6e8c93a40ab4410d6330b48d0cc41338ca64b7f3132ae0'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: 'a2c7307a110e61c4cbaa2e2a5a65f75cffe5e42d70bb897ed18d64044e5f8d7a'
+          checkpoint: 'a80307035e4a461cca3b8b624d62327f4e40525abe41fd44a9a6262e67a1741e'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.