### PR TITLE
Update postman to 4.10.2

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,11 +1,9 @@
 cask 'postman' do
-  version '4.9.3'
-  sha256 '51ef82eaa41928dbcfb7d4036600601bebe5e75f15d449035efa0eb195a927ea'
+  version '4.10.2'
+  sha256 '7d5db210802c925bfd114516db200e3c48e801bb4adf3476526e9d8b84c940dd'
 
-  # s3.amazonaws.com/postman-electron-builds was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/postman-electron-builds/mac/Postman-osx-#{version}.zip"
-  appcast 'https://app.getpostman.com/api/electron_updates_auto',
-          checkpoint: 'c041d1905eaa40104be76e0b21d799d089a5c12a5154a7240ca77b1b467eb931'
+  # dl.pstmn.io was verified as official when first introduced to the cask
+  url 'https://dl.pstmn.io/download/latest/osx'
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 

--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,8 +1,8 @@
 cask 'postman' do
-  version '4.10.2'
-  sha256 '7d5db210802c925bfd114516db200e3c48e801bb4adf3476526e9d8b84c940dd'
+  version :latest
+  sha256 :no_check
 
-  # dl.pstmn.io was verified as official when first introduced to the cask
+  # dl.pstmn.io/download/latest/osx was verified as official when first introduced to the cask
   url 'https://dl.pstmn.io/download/latest/osx'
   name 'Postman'
   homepage 'https://www.getpostman.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Unfortunately I can't find new appcast url.