### PR TITLE
packetsender cask update v5.3.1

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,11 +1,11 @@
 cask 'packetsender' do
-  version '5.3,2017-02-18'
-  sha256 '28f4f46fc0e8ec7584660376089f4f07f1626fac6775a954fc17e28154127418'
+  version '5.3.1,2017-02-21'
+  sha256 'de20dc2ef3ccf60823ff8a97461c30cd48f2cf1370c207531b4d6e4933b09c6a'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
   url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}/PacketSender_v#{version.before_comma.dots_to_underscores}_#{version.after_comma}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom',
-          checkpoint: 'b035e6238a22dae4ef736bc40315fc2cd6b81e5ac4ee1a5f02f3debdf41325b5'
+          checkpoint: 'd5ac4cc3e91163d8c70942b77218be2a6a97f70d54b0ffb8f323832ae24aa4d8'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'
 


### PR DESCRIPTION
Version bump Packet Sender for bug fix. 


- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
