### PR TITLE
Update filezilla to 3.24.1

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.24.0'
-    sha256 '6f57b0c91d0f20d545cd854855d35dcb1b088bc9e2c73cfaca4984bda93df5a9'
+    version '3.24.1'
+    sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '4b4bb69191e36ac2e2f36d306840e496435f345683d74bf348c9ef95ce818f3e'
+          checkpoint: '9aef92172bbc03270c5097accc8aa56af29a23ba59a8a7e5d19073f002f7824e'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,11 +1,6 @@
 cask 'filezilla' do
-  if MacOS.version <= :snow_leopard
-    version '3.8.1'
-    sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
-  else
-    version '3.24.1'
-    sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
-  end
+  version '3.24.1'
+  sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,6 +1,11 @@
 cask 'filezilla' do
-  version '3.24.1'
-  sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
+  if MacOS.version <= :snow_leopard
+    version '3.8.1'
+    sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
+  else
+    version '3.24.1'
+    sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
+  end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.