### PR TITLE
Update vmware-fusion to initialize itself before first-launch

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -36,6 +36,12 @@ cask 'vmware-fusion' do
   binary "#{appdir}/VMware Fusion.app/Contents/Library/vmware-vmx-stats"
   binary "#{appdir}/VMware Fusion.app/Contents/Library/VMware OVF Tool/ovftool"
 
+  postflight do
+    system_command "#{appdir}/VMware Fusion.app/Contents/Library/Initialize VMware Fusion.tool",
+                   args: ['set'],
+                   sudo: true
+  end
+
   uninstall_preflight do
     set_ownership "#{appdir}/VMware Fusion.app"
   end


### PR DESCRIPTION
As description: run the Initialize VMware Fusion script after install to avoid being prompted for credentials on first launch.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
