### PR TITLE
Fix capitalisation typo in keybase.rb.

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -13,7 +13,7 @@ cask 'keybase' do
   app 'Keybase.app'
 
   postflight do
-    system_command "#{appdir}/Keybase.App/Contents/Resources/KeybaseInstaller.app/Contents/MacOS/Keybase",
+    system_command "#{appdir}/Keybase.app/Contents/Resources/KeybaseInstaller.app/Contents/MacOS/Keybase",
                    args: ["--app-path=#{appdir}/Keybase.app", '--run-mode=prod', '--timeout=10']
   end
 


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

---

Fixes the postflight failing on a case-sensitive filesystem because `Keybase.app` had a capital `A`.

(Is the version needed in the commit message in this case? Seems that point could do with clarification.)