### PR TITLE
Update baidunetdisk.rb to 2.1.0

### DIFF
--- a/Casks/baidunetdisk.rb
+++ b/Casks/baidunetdisk.rb
@@ -1,12 +1,14 @@
 cask 'baidunetdisk' do
-  version '2.0.1'
-  sha256 '785cb6aa5525e1146d829baa5a861bda63caacf2b9239d6e317f36ed8b353d55'
+  version '2.1.0'
+  sha256 'd19738386adb0ab0d3eb196e4313978a025eaf70460be14789223a106f7b7458'
 
   # baidupcs.com/issue/netdisk/MACguanjia was verified as official when first introduced to the cask
   url "https://issuecdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
   name 'Baidu NetDisk'
   name '百度网盘'
   homepage 'https://pan.baidu.com/download'
+
+  depends_on macos: '>= :yosemite'
 
   app 'BaiduNetdisk_mac.app'
 
@@ -18,5 +20,10 @@ cask 'baidunetdisk' do
                 '~/Library/Preferences/com.baidu.BaiduNetdisk-mac.plist',
                 '~/Library/sapi/wappass.baidu.com',
                 '~/Library/Saved Application State/com.baidu.BaiduNetdisk-mac.savedState',
+              ],
+      rmdir:
+              [
+                '~/Library/Caches/com.plausiblelabs.crashreporter.data',
+                '~/Library/sapi',
               ]
 end


### PR DESCRIPTION
Update baidunetdisk.rb to 2.1.0

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
