### PR TITLE
Update Codeship jet to v1.16.0

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,6 +1,6 @@
 cask 'jet' do
-  version '1.15.8'
-  sha256 'e37c4a88caf127bbc07fe366290dc739b6a58703e1f689517e009b90e1d61df1'
+  version '1.16.0'
+  sha256 '392ee5660e9c436465bdcf71610482300528dc9cfaa1e9c54e391b2781d48441'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

