### PR TITLE
Update datagrip to 2016.3.4

### DIFF
--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -1,10 +1,10 @@
 cask 'datagrip' do
-  version '2016.3.3'
-  sha256 '3d7b52ad66275fd3d61d1338521ac61981d3b01924fd784c71036769192f014b'
+  version '2016.3.4'
+  sha256 '9a5fd58be9fb9e9144ee13df83590a869dda33f89a4b5cd7c0dc0a94b59e01ad'
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release',
-          checkpoint: 'ed14740685322fc685436779cff65bafa268cda4cd6fdb563b290375b4b1245d'
+          checkpoint: '5a5654769c64b370838a9e2b1412d12a417c8988e6c0e1324bc3013d0ca616df'
   name 'DataGrip'
   homepage 'https://www.jetbrains.com/datagrip/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.