### PR TITLE
Update nylas-mail to 1.0.29-e08ce58

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.27-7146d3f'
-  sha256 '0381382f0b3afa2f3f168a4da9d6b0a42eded09fa794c3c9b64487587f4e7fbb'
+  version '1.0.29-e08ce58'
+  sha256 '2ce6b1963f22e5e63e30d9d7113cccbf01003ab163fbef02f418eeb37b47a6b4'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '423ebd3731661164f7b7b1c6be8799d81507b2521795fb90eea6decc4136ff65'
+          checkpoint: 'f5ed43028f8b2216c804b4a72ca014075e7f3c17127fce4a57b9752e6ebf9365'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.