### PR TITLE
Update dungeon-crawl-stone-soup-tiles to 0.19.4

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,10 +1,10 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.19.1'
-  sha256 '4274e47ed18239ab73414be857c8a489d0acaf785467cffdc0b70d903a317402'
+  version '0.19.4'
+  sha256 '6c97a50ef9297580695606c2cbf14c8a778fe0ab8d9d6b7a89f1b9e72cbaacf1'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom',
-          checkpoint: '8e77d98e2f53d2d95fd2e2a2733f1032f8e5e81f99023b98d2e0b3a6531b60c4'
+          checkpoint: '0c90532523458c0c55ec1f5fb6077b1685ebd73b6615f5d45b60f7f6bc862932'
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.