### PR TITLE
Bump onionshare (TOR File Sharing) to 1.0

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,11 +1,11 @@
 cask 'onionshare' do
-  version '0.9.1'
-  sha256 '9721b9f60ab777d1b6a470d33108031814d6a0833909dc695e40c7b3d98279d1'
+  version '1.0'
+  sha256 '4586f3b2218188475610354f14c95e08b988d6d190eecc3f04258d25ca3543a6'
 
   # github.com/micahflee/onionshare was verified as official when first introduced to the cask
   url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom',
-          checkpoint: '5317a163350bbc2c380be9004831eeb12021e8a30a319d6424e3e2776ef0901a'
+          checkpoint: '72c38373f27461c9533ee32c87c2b13898f368779701213f0e625d51722337f9'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
   gpg "#{url}.sig",


### PR DESCRIPTION
Updated:
- version
- sha256
- checkpoint

passed audit, style, install, uninstall

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit -strict --fix {{cask_file}}` reports no offenses.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --strict --fix {{cask_file}}` reports no offenses.
- [X] `brew cask install {{cask_file}}` is error-free.
- [X] `brew cask uninstall {{cask_file}}` is error-free.
- [X] The commit message includes the cask’s name and version.