### PR TITLE
Update standard-notes to 0.2.5

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.2.4'
-  sha256 '906885b96583c134ef76c388aa8913e0a1d84c10dbd16312279342097548cbd6'
+  version '0.2.5'
+  sha256 '0e5a6c5f2154e2e291089e00cc478d45178ab229de107cfed704d6cbee43f601'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'dfb068db85f61be7436290aa21c449b04275b0b58bccb5f0a2f95edcf000aa68'
+          checkpoint: 'b2da36af725cdd4241a973d308c985c7c7278f707e6d7439fa4909061c914302'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.