### PR TITLE
Update microsoft-teams to 0.7.00.5204

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '0.6.00.34901'
-  sha256 '2ae3687a2280117ff83f0bacbf8a08db1bee81ae26bc8eb82faa38436550a04b'
+  version '0.7.00.5204'
+  sha256 '932ee1d3c5d072d5752918979105f3d1932a8df80c362d716c64df65dab372b1'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: '9d8d5bc2d1a460e746f656038c637785126990e10fbf0709e3cadd8e83b7b750'
+          checkpoint: '3396c9243e4d761c5f8941c7f1b66da5e7c069f7733cf49c66dd86953296c736'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.