### PR TITLE
Update xiami to 3.0.2

### DIFF
--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -1,18 +1,20 @@
 cask 'xiami' do
-  version :latest
-  sha256 :no_check
+  version '3.0.2'
+  sha256 '6fe366c25bf53597dfc955a2581f22992ba0fef766461c23964c72ade9b6a9fb'
 
-  url 'http://www.xiami.com/software/download?app=music_mac'
+  # gxiami.alicdn.com/xiami-desktop was verified as official when first introduced to the cask
+  url "http://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"
   name 'Xiami'
+  name '虾米音乐'
   homepage 'http://www.xiami.com/'
 
-  app 'Xiami.app'
+  app '虾米音乐.app'
 
   uninstall quit: 'com.xiami.client'
 
   zap delete: [
-                '~/Library/Caches/com.xiami.client',
-                '~/Library/Containers/com.xiami.client',
+                '~/Library/Application Support/XIAMI-MUSIC',
+                '~/Library/Preferences/com.xiami.client.helper.plist',
                 '~/Library/Preferences/com.xiami.client.plist',
                 '~/Library/Saved Application State/com.xiami.client.savedState',
               ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.