### PR TITLE
Update sabnzbd to 1.2.1

### DIFF
--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -1,11 +1,11 @@
 cask 'sabnzbd' do
-  version '1.2.0'
-  sha256 'e0059a20afd1c37fb82caf9afd5e7c7945d68e2e559270e5e408a6d9f452ab78'
+  version '1.2.1'
+  sha256 '41bc37d0d6c4ce7f8123bcf98a2f65bf5fb036f778a8f6b8f7f8fd37f9546c78'
 
   # github.com/sabnzbd/sabnzbd was verified as official when first introduced to the cask
   url "https://github.com/sabnzbd/sabnzbd/releases/download/#{version}/SABnzbd-#{version}-osx.dmg"
   appcast 'https://github.com/sabnzbd/sabnzbd/releases.atom',
-          checkpoint: 'aff3949cf7e845bdd31324b749a6a7c73640af0256a7aaf53088a1926bc68b92'
+          checkpoint: 'e76f2bee5757f3c82e93c931029e7fe0e4d3f417eddbc112fd06362fb47153f7'
   name 'SABnzbd'
   homepage 'https://sabnzbd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.