### PR TITLE
Update swimat to 1.3.2

### DIFF
--- a/Casks/swimat.rb
+++ b/Casks/swimat.rb
@@ -1,10 +1,10 @@
 cask 'swimat' do
-  version '1.3.1'
-  sha256 '88585d9c478e728838fb842dbd9187839bbc8e3e227a31e7bfb0502717da674c'
+  version '1.3.2'
+  sha256 'af7b8b17748848c96b2ad48a7493a4a6076f2cd3643da759346fe3aadc827f9d'
 
   url "https://github.com/Jintin/Swimat/releases/download/v#{version}/Swimat.zip"
   appcast 'https://github.com/Jintin/Swimat/releases.atom',
-          checkpoint: 'e2af280e708fb6d5e248f23240fed3968d52ac53c4d4b4023b027025ee254cfa'
+          checkpoint: '91ad576c11973d7023cff9aea04d2ea6cd28b0bd40062813e3369f8da78ee403'
   name 'Swimat'
   homepage 'https://github.com/Jintin/Swimat'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.