### PR TITLE
add zap to android-studio

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -10,7 +10,7 @@ cask 'android-studio' do
   app 'Android Studio.app'
 
   zap delete: [
-                "~/Library/Android/sdk",
+                '~/Library/Android/sdk',
                 "~/Library/Application Support/AndroidStudio#{version.major_minor}",
                 "~/Library/Caches/AndroidStudio#{version.major_minor}",
                 "~/Library/Preferences/AndroidStudio#{version.major_minor}",

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -10,11 +10,12 @@ cask 'android-studio' do
   app 'Android Studio.app'
 
   zap delete: [
+                "~/Library/Android/sdk",
+                "~/Library/Application Support/AndroidStudio#{version.major_minor}",
+                "~/Library/Caches/AndroidStudio#{version.major_minor}",
                 "~/Library/Preferences/AndroidStudio#{version.major_minor}",
                 '~/Library/Preferences/com.google.android.studio.plist',
-                "~/Library/Application Support/AndroidStudio#{version.major_minor}",
                 "~/Library/Logs/AndroidStudio#{version.major_minor}",
-                "~/Library/Caches/AndroidStudio#{version.major_minor}",
               ],
       rmdir:  '~/AndroidStudioProjects'
 end

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -17,5 +17,8 @@ cask 'android-studio' do
                 '~/Library/Preferences/com.google.android.studio.plist',
                 "~/Library/Logs/AndroidStudio#{version.major_minor}",
               ],
-      rmdir:  '~/AndroidStudioProjects'
+      rmdir:  [
+                '~/AndroidStudioProjects',
+                '~/Library/Android',
+              ]
 end


### PR DESCRIPTION
It might just be possible to delete `~/Library/Android`, since it seems like `sdk` is the only folder in there. But just in case that folder is used by any other programs, I've added only the sdk folder.
<hr/>

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
