### PR TITLE
Update bbedit to 11.6.4

### DIFF
--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -1,12 +1,14 @@
 cask 'bbedit' do
-  version '11.6.3'
-  sha256 'd386fa31418a14bae051096d5e3300ee7baffa54b19aa4bb2aec28879119762d'
+  version '11.6.4'
+  sha256 'c97b6a1804c051a28ef8a476518df608a6ee75e98a043d0284f53f818ca08989'
 
   url "http://pine.barebones.com/files/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml',
-          checkpoint: 'cf424efd4349932d32faece1f392d0078d6dad1159a8965c57c99f50c02730ce'
+          checkpoint: '867891de38a744b4c898ac0acf4b078b3062e18119a0c716b45e8b5b4cf8fe24'
   name 'BBEdit'
   homepage 'http://www.barebones.com/products/bbedit/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'BBEdit.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.