### PR TITLE
Update free-download-manager to 5.1.25

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,6 +1,6 @@
 cask 'free-download-manager' do
-  version '5.1.24'
-  sha256 'e33bd205b9f326e375ce5a354396324d80266afd2a76b79d35c8fa685a1493a3'
+  version '5.1.25'
+  sha256 '2cecfb18e98272bec8c0bc6974b53afdcdc4c08f9a25b912906762bfb05c0259'
 
   url "http://files2.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
   name 'Free Download Manager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.