### PR TITLE
Update etcher to 1.0.0-beta.19

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,11 +1,11 @@
 cask 'etcher' do
-  version '1.0.0-beta.18'
-  sha256 '3573c73362557296b7dfa19604eeddfeecb4ee2baf4af9b60e46c49a253899e9'
+  version '1.0.0-beta.19'
+  sha256 'c8f01a62c0d5927b85e2f6ad9a69d6c712e857446ecede87d3297041ac66627b'
 
   # resin-production-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://resin-production-downloads.s3.amazonaws.com/etcher/#{version}/Etcher-#{version}-darwin-x64.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: '0de4565cc036df2e3a1cf93eba12b96607a61265a0749fbdde37ef108f2d5418'
+          checkpoint: '814b7e053ba2b60f94d0a5918489ca36b9b215b32c619ffe301ee865c33d139a'
   name 'Etcher'
   homepage 'https://etcher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.