### PR TITLE
Update pomotodo to 3.0.25,1487668760

### DIFF
--- a/Casks/pomotodo.rb
+++ b/Casks/pomotodo.rb
@@ -1,11 +1,11 @@
 cask 'pomotodo' do
-  version '0.14.3,1474212893'
-  sha256 '02acbed6a3a975c79799192fcdfdbc191a1ef3b80eba31a86ca61fe7bcfed18b'
+  version '3.0.25,1487668760'
+  sha256 'c0adcffc4e8c8c79a3e6bad9f5857d1059c71f5a837b62338a219e8454938a56'
 
   # cdn.hackplan.com/theair was verified as official when first introduced to the cask
   url "http://cdn.hackplan.com/theair/#{version.after_comma}/Pomotodo_v#{version.before_comma}.dmg"
   appcast 'http://air.hackplan.com/projects/5455f382437315386000d4d5/versions/latest.xml',
-          checkpoint: '29a7e720aada903ab887d8faeddb9ad6b68e53ddf8c0b4eb81ced2c0fc7090df'
+          checkpoint: '8f67471dd199a1fdaeda4e5aad44226e85e40c556f946bd141e7e691e45b7fcc'
   name 'Pomodoro'
   homepage 'https://pomotodo.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
