### PR TITLE
Update fly to 2.7.0

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '2.6.0'
-  sha256 '5da021282209ad09ac99844b506b8a6ea082837ef8917e0bc34686e892503aba'
+  version '2.7.0'
+  sha256 '038134e934ec8cc20f4e4477c1366ac2da484d5ff38ae94192f27efc86ce863d'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: '22601548e307a4713aa32765971955756f1052c5615187927a699b918e8da0fd'
+          checkpoint: 'b0b6d2bdd556ce34baed5f9201a9d97315e3eed59a7388b861c568afca00320a'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.