### PR TITLE
Update frostwire to 6.4.5

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.4.4'
-  sha256 '3500f01ac5a725f2cd469b8580bd7f6977a530dbd0aae4b4160465167159bdef'
+  version '6.4.5'
+  sha256 '7e0ff839625f149abf84f4cb786253db7a93e2138f6d56ef7f944226be5caf27'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: 'b48434b51bb0d38300c5b679fbf29aad6f5bb0452cfc037da04dc56015356c7b'
+          checkpoint: 'bcd3340250a2d96f570b18c65f6af56c4d4ff6094c2873fcd1cba12c534e58bf'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.