### PR TITLE
Update gear-player to 2.2.32

### DIFF
--- a/Casks/gear-player.rb
+++ b/Casks/gear-player.rb
@@ -1,10 +1,10 @@
 cask 'gear-player' do
-  version '2.2.31'
-  sha256 '32a6aba48f4e1b5b5ef4e11e082637578b892affb77aa0b729a62308fc015ade'
+  version '2.2.32'
+  sha256 '6d12b4318e7a965ff31893d244bb8c0f614417d7c45a6d912d83e6ea5d7f2454'
 
   url 'https://dl.gearmusicplayer.com/gearupdate.zip'
   appcast 'https://dl.gearmusicplayer.com/gearcast.xml',
-          checkpoint: '94ce3e99a213f01fc9d6cf68c8d5a6975d40fadcf0dc1f85e4fd4187c09c4d18'
+          checkpoint: '925dafce924b93bafed67f306b28bd5e8e2a464b029e474c6fb9b5688ad0817d'
   name 'Gear Player'
   homepage 'https://www.gearmusicplayer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.