### PR TITLE
Update reactotron to 1.8.0

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,10 +1,10 @@
 cask 'reactotron' do
-  version '1.7.0'
-  sha256 '286663392d6f53f2de911380aee77c23fad04b05c285aed82d616b45f552dccd'
+  version '1.8.0'
+  sha256 '64790e7b199241b6923839709f5679c2c0a1e157f6fc85138a345facf3f90987'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron.app.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom',
-          checkpoint: 'c2a65f49ff4345bf46eaa0cef6d59f94df72f9cd819f1bb1ddd254d9041edc70'
+          checkpoint: '5a7cf84b2695661da635e9687598a84881a18fae9a409180706932f4733170e5'
   name 'Reactotron'
   homepage 'https://github.com/infinitered/reactotron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.