### PR TITLE
ship.rb: Remove SHA256 check

### DIFF
--- a/Casks/ship.rb
+++ b/Casks/ship.rb
@@ -1,10 +1,10 @@
 cask 'ship' do
   version '2.0'
-  sha256 '0422eef83b18e1f7e60f568b66750060857829b80d220e4ca9c96d50872f7649'
+  sha256 :no_check
 
   url "https://www.realartists.com/builds/#{version}/Ship.app.zip"
   appcast "https://www.realartists.com/builds/#{version}/sparkle.xml",
-          checkpoint: 'dd8ffc08a7a2d0b1d5dc24ffdfbdd6820a8f827897e7f18cb1170267fa4fbe7a'
+          checkpoint: '219ba2f439c96f4a6fe6ad0c67cd090c8e19bc359250a84e96835948d1f3d1fa'
   name 'Ship'
   homepage 'https://www.realartists.com/'
 


### PR DESCRIPTION
The developers are apparently pushing bugfix releases to the same URL. Current release according to the appcast is 2.0.2. I don’t think it makes sense to verify checksums for this cask.

Also see #29850 for the previous attempt at fixing this.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
