### PR TITLE
Update caret to 1.14.3

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.14.2'
-  sha256 '019778f6bcd0ec4121e290576a931b0e97e0e7d004fdd3b770eb6859bc0e7c73'
+  version '1.14.3'
+  sha256 'd69d2c5154dfba9c11e8fba93811def7a843bdc5a52731b22777fe3072fb5131'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '278457f23557e4258b64f9a4decb33e8614afaeffcbe627b897050d296de51d3'
+          checkpoint: '74061517283ccfa74a68dfba98396a5bcad952ce6d2a852b11eb4476a178286b'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.