### PR TITLE
Update m3unify to 1.7.1

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,10 +1,10 @@
 cask 'm3unify' do
-  version '1.7.0'
-  sha256 'e302aeb18f02c591de1b5b48e473df13f199df129fed10ffeeeeed4f26e328a2'
+  version '1.7.1'
+  sha256 '29d67b2e0e584bb0472d219e36a77b587b6ff8fd76402eff60737a794e094650'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
-          checkpoint: 'd1ef8fcf53ba5a5c3924cf4f8bfe48125380afc69f11996862d00217ffa62251'
+          checkpoint: 'bc96f543e21d718b84ab6cfd1d977d5b2d54c6db122648abb2a520ded22af106'
   name 'M3Unify'
   homepage 'https://dougscripts.com/apps/m3unifyapp.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.