### PR TITLE
Update mnemosyne to 2.4.1

### DIFF
--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -1,11 +1,11 @@
 cask 'mnemosyne' do
-  version '2.4'
-  sha256 'a1b107bfa61ea7b0f2d370446a324b56a742238f00d9a0f6ee1f6525e7f38222'
+  version '2.4.1'
+  sha256 'c302624b8652f397c18fe6cbdaf520c9898dd97a68b8a02f90b96cbe5177df8d'
 
   # sourceforge.net/mnemosyne-proj was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/mnemosyne-proj/mnemosyne/mnemosyne-#{version}/Mnemosyne-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/mnemosyne-proj/rss?path=/mnemosyne',
-          checkpoint: '6f8a58f877ca91c33af0d6e275d1e803d93a4e0dd93827954dfa352424fc4c04'
+          checkpoint: '0b5bd0a344a750820cb2ebce55dae58341670b395546cac3f8b3440c0e4ba602'
   name 'Mnemosyne'
   homepage 'http://mnemosyne-proj.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.