### PR TITLE
Update outset to 2.0.5

### DIFF
--- a/Casks/outset.rb
+++ b/Casks/outset.rb
@@ -1,10 +1,10 @@
 cask 'outset' do
-  version '2.0.4'
-  sha256 '5eb8b302f18ca4e58bb72f1b453fb3f24b9e25edeb6919c7981b0107a6d3f51c'
+  version '2.0.5'
+  sha256 'e4ed6a0398295ba44ee1588caebaa6c855aabaed052b3cf930d69c792f219f0d'
 
   url "https://github.com/chilcote/outset/releases/download/v#{version}/outset-#{version}.pkg"
   appcast 'https://github.com/chilcote/outset/releases.atom',
-          checkpoint: '903c1a982566afa247ebef340359a4c8789ae40b45aa47b64ed6f63070830fac'
+          checkpoint: '83da0d14e2858e696717362d7c51e4e470c9017fde80232f273a098d3a953a77'
   name 'outset'
   homepage 'https://github.com/chilcote/outset'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.