### PR TITLE
Update combine-pdfs to 5.2

### DIFF
--- a/Casks/combine-pdfs.rb
+++ b/Casks/combine-pdfs.rb
@@ -1,6 +1,6 @@
 cask 'combine-pdfs' do
-  version '5.1'
-  sha256 '993f46880b114de2f8f59f6ae1c96fb54370a07fe88bbf0a0db8ad63e2155faf'
+  version '5.2'
+  sha256 'da0defe99295660f26078ac1a9ac5894748451a3854a0a8f0c0c4fdbb3a8ab54'
 
   url 'https://www.monkeybreadsoftware.de/Freeware/CombinePDFs.dmg'
   appcast 'https://www.monkeybreadsoftware.de/Freeware/CombinePDFs/appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/30438.