### PR TITLE
Update robomongo to 1.0.0-rc1,496f5c2

### DIFF
--- a/Casks/robomongo.rb
+++ b/Casks/robomongo.rb
@@ -1,6 +1,6 @@
 cask 'robomongo' do
-  version '0.9.0,0786489'
-  sha256 '35862af46635e33d89d5af3164f7cf445862add199a2645b0f246102df93691c'
+  version '1.0.0-rc1,496f5c2'
+  sha256 '7b2e0ee1effb36d548945fe668c2e584c1e2dde1e3b7786f2ee134dc419ed1ef'
 
   url "https://download.robomongo.org/#{version.before_comma}/osx/robomongo-#{version.before_comma}-darwin-x86_64-#{version.after_comma}.dmg"
   name 'Robomongo'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.