### PR TITLE
Update atom to 1.14.4

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,11 +1,11 @@
 cask 'atom' do
-  version '1.14.3'
-  sha256 'f43e71492a766b21546d0ae78df3386a3e20009f1c0b6bd7854b2f5f1ff9c602'
+  version '1.14.4'
+  sha256 'f0fdb9789730b91f7a62ed0db8ef8b9d135ab80101ef11199dd1432f2fd57eb0'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: 'a01ad847b1d124b9e8b10f370d3577cd0f3e4f8af4b47cb0d8091b02628d5c9c'
+          checkpoint: '1e2d5dca873aaf379d1b372de5b1f7799764b4c51ec78793e7409538f804a82a'
   name 'Github Atom'
   homepage 'https://atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.