### PR TITLE
Update qutebrowser to 0.10.0

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,8 @@
 cask 'qutebrowser' do
   version '0.10.0'
   sha256 'ba0202df8af6905d5b823bafdc04415853f897c06cdbbb6e40af9ed5e602c1d2'
+
+  # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
           checkpoint: 'ee0a69fe4e86f27d0d7127cd7492c01f98ad1120d9fa0bdaa1791937199aba41'

--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,11 +1,9 @@
 cask 'qutebrowser' do
-  version '0.8.4'
-  sha256 '2563a0f0152848b3e9eebe98746c34c1c3d9245bfc1540073d2707424fa7b64c'
-
-  # github.com/The-Compiler/qutebrowser was verified as official when first introduced to the cask
-  url "https://github.com/The-Compiler/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
-  appcast 'https://github.com/The-Compiler/qutebrowser/releases.atom',
-          checkpoint: 'ff2f6eadfe8540a0cb51f3852ce60769f5b7505f07f1b07bdfcee8affffdd9cc'
+  version '0.10.0'
+  sha256 'ba0202df8af6905d5b823bafdc04415853f897c06cdbbb6e40af9ed5e602c1d2'
+  url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
+  appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
+          checkpoint: 'ee0a69fe4e86f27d0d7127cd7492c01f98ad1120d9fa0bdaa1791937199aba41'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 


### PR DESCRIPTION
Update version 0.10.0
Update appcast checkpoint
Fix urls to qutebrowser/qutebrowser

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.