### PR TITLE
Update mqttfx to 1.3.1

### DIFF
--- a/Casks/mqttfx.rb
+++ b/Casks/mqttfx.rb
@@ -1,9 +1,9 @@
 cask 'mqttfx' do
-  version '1.3.0'
-  sha256 '96bb22596ac43ff79d0ef11324b36cc5d0668b506a5e89a367123cbf90cacc5d'
+  version '1.3.1'
+  sha256 'c9d4d1c862e5aab194338f3508f166d20a9116c9ba2be70e1e4341bad6c96070'
 
   # jensd.de/apps/mqttfx was verified as official when first introduced to the cask
-  url "http://www.jensd.de/apps/mqttfx/#{version}/mqttfx-#{version}.dmg"
+  url "http://www.jensd.de/apps/mqttfx/#{version}/mqttfx-#{version}-macos.dmg"
   name 'MQTT.fx'
   homepage 'http://mqttfx.jfx4ee.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.