### PR TITLE
Update opera to 43.0.2442.1144

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '43.0.2442.991'
-  sha256 '8a13fa40182325d7f42fbb08777639461237594e7179c81199284a1169ff78f5'
+  version '43.0.2442.1144'
+  sha256 '4753feded98643b8b29a1ff35242f95374ee40779c4871ec64ef7037fac90015'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.