### PR TITLE
Update typora to 0.9.9.9.2

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,12 +1,20 @@
 cask 'typora' do
-  version '0.9.9.9.0'
-  sha256 '17a3781e33d045bfa59a8f6c976d5208d6b4a7e1b2d22a16e03bb02c74059fc9'
+  version '0.9.9.9.2'
+  sha256 '4d969cda4354d68eaa627257600a1a9adde006895576945cb652f1e64c4e9718'
 
   url "https://www.typora.io/download/typora_#{version}.zip"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '7218d417f1032bb4b89ba3239aafac2c1584848404fdf8e2737555265582e3fb'
+          checkpoint: '2f09a116fe42e9b9e74c803e51f7aea14a155c554608b1b943963f47bdf1d782'
   name 'Typora'
   homepage 'https://typora.io/'
 
   app 'Typora.app'
+
+  zap delete: [
+                '~/Library/Application Support/abnerworks.Typora',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/abnerworks.typora.sfl',
+                '~/Library/Caches/abnerworks.Typora',
+                '~/Library/Cookies/abnerworks.Typora.binarycookies',
+                '~/Library/Preferences/abnerworks.Typora.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.