### PR TITLE
Update comma-chameleon to 0.5.0

### DIFF
--- a/Casks/comma-chameleon.rb
+++ b/Casks/comma-chameleon.rb
@@ -1,11 +1,11 @@
 cask 'comma-chameleon' do
-  version '0.4.8'
-  sha256 'f872ad9f95b9e303bac53636307374e591d2c61a7fd8600d7586c605065925ab'
+  version '0.5.0'
+  sha256 'b63d8a51ba8535555f28eda9ff82c9ff76afe9b4d649b3b8453a8802715220d7'
 
   # github.com/theodi/comma-chameleon was verified as official when first introduced to the cask
   url "https://github.com/theodi/comma-chameleon/releases/download/#{version}/comma-chameleon-darwin-x64.tar.gz"
   appcast 'https://github.com/theodi/comma-chameleon/releases.atom',
-          checkpoint: '6ec4b53671ef606c5cf28756cac4199a83c41e4d985b6b04bbbe01a1a7db922a'
+          checkpoint: '6db5403267c51a690ce811cc015391a3278eb8c8a062c537eb29a805a22a4c18'
   name 'Comma Chameleon'
   homepage 'https://comma-chameleon.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.