### PR TITLE
Update molotov to v1.3.1

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '1.2.2'
-  sha256 '6c32206e5a922d246e1a5a6b6462a5b531c37cdaceb05bd6f32f8c85e5c8b5ff'
+  version '1.3.1'
+  sha256 'ab2cf7e46e7e0b129ebcf99542de1bcf97a3443d610d712970054a9db3ceecaa'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download molotov.rb` is error-free.
- [X] `brew cask style --fix molotov.rb` reports no offenses.
- [X] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
