### PR TITLE
Update iordning to 6.0.63

### DIFF
--- a/Casks/iordning.rb
+++ b/Casks/iordning.rb
@@ -1,10 +1,10 @@
 cask 'iordning' do
-  version '6.0.61'
-  sha256 'a8610e2a14148a57c129ba73bd7a1a26bad348f2fdb117612a273328386ca0a5'
+  version '6.0.63'
+  sha256 '68bc19dcbbb5485ab2505a5c9c38114be06bd1a8e0a00f71cb6fe6cc96ee2944'
 
   url "https://www.aderstedtsoftware.com/downloads/iOrdning#{version.major}.zip"
   appcast "https://www.aderstedtsoftware.com/economacs/v#{version.major}_appcast.xml",
-          checkpoint: '70e3ff5eef7e58d4b00eccf501a4e2a02a6be60502af808c81b239285eaa7951'
+          checkpoint: '60d2225ba97b22fd1b99f3409cd8c4f4130b55f0ea1f2524ea1e648987dae7e9'
   name 'iOrdning'
   name 'Economacs'
   homepage 'https://www.aderstedtsoftware.com/iordning/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.