### PR TITLE
Switch minikube-darwin-amd64 download to GCS from AWS

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -2,7 +2,8 @@ cask 'minikube' do
   version '0.16.0'
   sha256 '1de0dda591d23c01aa52f6e7b6c85bec7e4811a007a5a939eb2d1bed6fa84144'
 
-  url "https://github.com/kubernetes/minikube/releases/download/v#{version}/minikube-darwin-amd64"
+  # storage.googleapis.com/minikube was verified as official when first introduced to the cask
+  url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
           checkpoint: '30e9116a67824c129b5a28a458d8b2e57c01dbfb0912f8784d9d8c0d6712a250'
   name 'Minikube'


### PR DESCRIPTION
We release binaries on GCS as well. Github releases is backed by AWS. So do we want to switch to GCS?