### PR TITLE
Update beersmith2 to 2.3.12

### DIFF
--- a/Casks/beersmith2.rb
+++ b/Casks/beersmith2.rb
@@ -1,6 +1,6 @@
 cask 'beersmith2' do
-  version '2.3.7'
-  sha256 '116b1f9f767a031bb6daa5432fad54b0318fec27c0e316ca4ed2485997686011'
+  version '2.3.12'
+  sha256 'd0ea232213d13ed18a1d49dfcd102824d85858618745274f4ff9a71559281e69'
 
   # amazonaws.com/beersmith2-3 was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/beersmith2-3/BeerSmith#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.