### PR TITLE
Update nylas-mail to 1.0.30-a4ca416

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.29-e08ce58'
-  sha256 '2ce6b1963f22e5e63e30d9d7113cccbf01003ab163fbef02f418eeb37b47a6b4'
+  version '1.0.30-a4ca416'
+  sha256 'e90f1653eef304d80cd398a7933be6764e3d2c9cbd685374175932bc81d7ca7a'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: 'f5ed43028f8b2216c804b4a72ca014075e7f3c17127fce4a57b9752e6ebf9365'
+          checkpoint: '8c4b1dfb8625f5d7d6611ee3223cb8b7ccccc1efa1dde7885c1dd13d4a6f7cad'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.