### PR TITLE
Update duet to 1.6.3.6

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,11 +1,11 @@
 cask 'duet' do
-  version '1.6.3.4'
-  sha256 'bfd491368cb255d14f69fa055ffb7d0bc2ae9c4fee067384b17ae5601f0bddc2'
+  version '1.6.3.6'
+  sha256 'e8beb6d3c1bee14410d6602d9d6a263a33a76a1c6c5476734070a745e375d96e'
 
   # s3-us-west-1.amazonaws.com/duetmac/ was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/duetmac/#{version.major_minor_patch.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"
   appcast 'https://updates.duetdisplay.com/checkMacUpdates',
-          checkpoint: 'ead13c59711365f14dbf78817c8e9eac21c112735792ca1631166dc0ef3c5ea4'
+          checkpoint: '5ced264c2c1161b2226ab307ca8dd8a9a42ad3db2ea50f4283a8a4092f8cb882'
   name 'Duet'
   homepage 'https://www.duetdisplay.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.