### PR TITLE
Fix checksum in adguard Cask

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -1,12 +1,22 @@
 cask 'adguard' do
   version '1.4.0'
-  sha256 '549f8a7f4f773bd04bb9c2f16a3817b7cb4b6acc4beab06aa6f930cd0797df28'
+  sha256 '328b0ade012ff2a483bf3c5033d07f8b7cf5e1bd021258655fe4d6e4aa0517d0'
 
   url "https://static.adguard.com/mac/Adguard-#{version}.release.dmg"
   appcast 'https://static.adguard.com/mac/adguard-release-appcast.xml',
-          checkpoint: '836f3f1161afdb22704e79aa54aa4930a56036b494cc8579a1ed041522fff864'
+          checkpoint: '99ff40a86559ad69a324d5cc421554874ee1851447b69088d3ac22de57151861'
   name 'Adguard for Mac'
   homepage 'https://adguard.com/'
 
   app 'Adguard.app'
+
+  zap delete: [
+                '/Library/Application Support/com.adguard.Adguard',
+                '~/Library/Application Support/Adguard',
+                '~/Library/Application Support/com.adguard.Adguard',
+                '~/Library/Caches/com.adguard.Adguard',
+                '~/Library/Cookies/com.adguard.Adguard.binarycookies',
+                '~/Library/Logs/Adguard',
+                '~/Library/Preferences/com.adguard.Adguard.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.