### PR TITLE
Update wechatwebdevtools to 0.14.140900,014140900

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '0.13.140600,013140600'
-  sha256 '245af68e061dcdd61e511d44f7ef0e8ced0b0d3e103330108b564482a51fc976'
+  version '0.14.140900,014140900'
+  sha256 '64a6cade36208e1e60a70043bba899f15f97ededc3dbd6de7b84bfae4477e122'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.after_comma}/wechat_web_devtools_#{version.before_comma}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
