### PR TITLE
Update wmail to 2.3.0

### DIFF
--- a/Casks/wmail.rb
+++ b/Casks/wmail.rb
@@ -1,11 +1,11 @@
 cask 'wmail' do
-  version '2.2.0'
-  sha256 'dfd33d0c40d600043f507b64c027cf0f2f34ae189c31c33667aa63ff5b366b5c'
+  version '2.3.0'
+  sha256 '3fb07c1d4b5a2e386f687a4b1c1fe75795ae920f91e0aee61f1de4561fd9a358'
 
   # github.com/Thomas101/wmail was verified as official when first introduced to the cask
   url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/Thomas101/wmail/releases.atom',
-          checkpoint: '1287488a9a4d771b86ecb667eef9b44eb0a50a558ccfcc9fb8e76c137c73e2bd'
+          checkpoint: '8bdfc9efd95dffeb007621e2c8d8959f1f8eb490ff72694508bab598e8cbb1e5'
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.