### PR TITLE
Update tankix to 535

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '532'
-  sha256 'f545d6ef9e9127dd2d4a65e57a054286a12150cdee2c216deb50a28cd5e54c29'
+  version '535'
+  sha256 '0ac40aa89a8ca9e18ecf051a283113965cdff2b894412aff0d12d45308290d99'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.