### PR TITLE
Update clipy to 1.1.3

### DIFF
--- a/Casks/clipy.rb
+++ b/Casks/clipy.rb
@@ -1,15 +1,15 @@
 cask 'clipy' do
-  version '1.1.2'
-  sha256 '21853e4bb4e3705edc0d61457d38016aac20166ab61579ad62a46c8f05566d8c'
+  version '1.1.3'
+  sha256 '688c137eab7a625e3582ccc23e9372740e505e1834f0598e21ebfad15ab130f8'
 
   # github.com/Clipy/Clipy was verified as official when first introduced to the cask
   url "https://github.com/Clipy/Clipy/releases/download/#{version}/Clipy_#{version}.dmg"
   appcast 'https://clipy-app.com/appcast.xml',
-          checkpoint: '77039d3fb2d280036ae72808ed465e9debfa0eb03dfea4967b8f62154328a011'
+          checkpoint: 'c5ae56a12075d8473a0c69f4d7adec5ce3a8caf9678a7f1b3f8b9297ed2ec7d8'
   name 'Clipy'
   homepage 'https://clipy-app.com/'
 
-  depends_on macos: '>= :mavericks'
+  depends_on macos: '>= :yosemite'
 
   app 'Clipy.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.