### PR TITLE
Add "vscode" as an alias for Visual Studio Code

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -6,6 +6,7 @@ cask 'visual-studio-code' do
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"
   name 'Microsoft Visual Studio Code'
   name 'VS Code'
+  name 'vscode'
   homepage 'https://code.visualstudio.com/'
 
   auto_updates true


### PR DESCRIPTION
Not sure if this is accepted but I hoped brew guide me better when I wrote "brew cask install vscode" and I guessed this can help on that.