### PR TITLE
Update cycling74 max (7.3.3 170301)

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '7.3.2_170214'
-  sha256 'ca2c584f88dc2627dfb9fe876513026477a64906b50c66cbe32229bb2ea91443'
+  version '7.3.3_170301'
+  sha256 '87095679f673b2d29c24a0229358f5c9153370d1a80b163497b749c932c6210b'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.