### PR TITLE
Update mattermost to 3.6.0

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,10 +1,10 @@
 cask 'mattermost' do
-  version '3.5.0'
-  sha256 'fb5d843fadef0dc2a18f95049951d21f09d5c822f8664bb8995507094f942f6c'
+  version '3.6.0'
+  sha256 '2422c261242106055534d9ee5689131a698351480a3b24d612178994fe44d988'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: '9e1033d791d7bcb6de41b302229fb8c867aa527700323c988e24acc594fa89d1'
+          checkpoint: '2b457d45458875bc53e941d74040dec76a298d34be9e2ec33d35115f487672a4'
   name 'Mattermost'
   homepage 'https://about.mattermost.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.