### PR TITLE
Update app-tamer to 2.3.1

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,10 +1,10 @@
 cask 'app-tamer' do
-  version '2.3'
-  sha256 '2be0baaf3d5b815e533fd8dd6da33c7174132b685ab74a819d8306e3c425a751'
+  version '2.3.1'
+  sha256 '59113f020f7a14186bcaa6befb2619ccd5700dbb0c804acf20960871a84f52de'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT',
-          checkpoint: 'd401efed1139b8a0916027bc711a647efcf474407cc9f9f41ce682a1a736a39b'
+          checkpoint: 'fc8109f439396e848fff1d4ecbe39240f677d5d6870189aa1c816b8095c8f1f2'
   name 'AppTamer'
   homepage 'https://www.stclairsoft.com/AppTamer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.