### PR TITLE
Update rightfont to 3.3.0

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,10 +1,10 @@
 cask 'rightfont' do
-  version '3.2.5'
-  sha256 'd994c7907e3e68b7d7985cb52859d46d5ddfc261fc76d255a6b7b3a4b73b799f'
+  version '3.3.0'
+  sha256 '35a8af9d4e8489a0238c850dfd0adc144046cec4151144f174b5622a128c48c9'
 
   url "https://rightfontapp.com/downloads/#{version}/rightfont.zip"
   appcast 'https://rightfontapp.com/update/appcast.xml',
-          checkpoint: '2aeedf7f798fb76d5cbe5d992c6d9652072b2129d5e68eae06c11bc018c24247'
+          checkpoint: '717b0324b5609f4b51fe1851483a976f2e4d356a092ba470a6fa2a0873b2d51f'
   name 'RightFont'
   homepage 'https://rightfontapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.