### PR TITLE
update to minikube 0.17.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,6 +1,6 @@
 cask 'minikube' do
-  version '0.16.0'
-  sha256 '1de0dda591d23c01aa52f6e7b6c85bec7e4811a007a5a939eb2d1bed6fa84144'
+  version '0.17.0'
+  sha256 'd12fb4f8d9ff538c5563e1dcdf29495dc47b64a3fe108d7190fa37bf94a09a21'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download minikube` is error-free.
    - _(this didn't seem to work already.)_
- [x] `brew cask style --fix minikube` reports no offenses.
- [x] The commit message includes the cask’s name and version.
