### PR TITLE
Update p4v to version 2017.1

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,13 +1,15 @@
 cask 'p4v' do
-  version '2015.2-1458499'
-  sha256 '2a77a8c0270a158432d6c571828c397ef3bd20b911bbbfb3db810845dc2995bc'
+  version '2017.1'
+  sha256 'b015a82a7c0bd492edb972dc542b377a7633bad2148e4b3e2d800f7df0c9297a'
 
-  url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*}, '\1')}/bin.macosx107x86_64/P4V.dmg"
+  url "http://cdist2.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*}, '\1')}/bin.macosx1011x86_64/P4V.dmg"
   name 'Perforce Visual Client'
   name 'P4V'
   homepage 'https://www.perforce.com/product/components/perforce-visual-client'
 
   app 'p4v.app'
+  app 'p4admin.app'
+  app 'p4merge.app'
   binary 'p4vc'
 
   zap delete: [


### PR DESCRIPTION
This updates the p4v cask to the latest version and adds all the tools that come from the dmg (p4v, p4merge, p4admin).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
