### PR TITLE
Update dungeon-crawl-stone-soup-tiles to 0.19.5

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,10 +1,10 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.19.4'
-  sha256 '6c97a50ef9297580695606c2cbf14c8a778fe0ab8d9d6b7a89f1b9e72cbaacf1'
+  version '0.19.5'
+  sha256 'cb6dbb50093c0e93124c3e52abb7440165a9312abe6535881742ca06a7057d77'
 
   url "https://crawl.develz.org/release/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom',
-          checkpoint: '0c90532523458c0c55ec1f5fb6077b1685ebd73b6615f5d45b60f7f6bc862932'
+          checkpoint: '4234b9bedc4b38b107b5ae7f46b41fc1c3f878ebe27e1ede96779b3a91b0cbc5'
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.