### PR TITLE
Update mediainfo to 0.7.93

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,10 +1,10 @@
 cask 'mediainfo' do
-  version '0.7.92.1'
-  sha256 '8ae9e6bc3e25efa56ecc170d0a744559d06fd5d5e2d739b4ebbbd67dc14a6642'
+  version '0.7.93'
+  sha256 '88025567e517825a34d626d2b39370dc6f9289cb09ce6f3664ecd871576c760f'
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   appcast 'https://mediaarea.net/rss/mediainfo_updates.xml',
-          checkpoint: 'a175aa24917dfa35edbf56625b4b8a839600b1ab753f4384d710c36b9a3f2422'
+          checkpoint: '239841c19e101ac144948117ad8f29cbda885fb2d9ba61c024bd8face292a33e'
   name 'MediaInfo'
   homepage 'https://mediaarea.net/en/MediaInfo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.