### PR TITLE
Update warsow URL to www.warsow.net

### DIFF
--- a/Casks/warsow.rb
+++ b/Casks/warsow.rb
@@ -2,9 +2,9 @@ cask 'warsow' do
   version '2.1'
   sha256 '347c47b029dc706ab43b754ec7422c3766dde2b2ed9a3ce0f40cd0d52c64f94d'
 
-  url "https://www.warsow.gg/download?dl=warsow#{version.no_dots}mac"
+  url "https://www.warsow.net/download?dl=warsow#{version.no_dots}mac"
   name 'Warsow'
-  homepage 'https://www.warsow.gg/'
+  homepage 'https://www.warsow.net/'
 
   app 'Warsow.app'
 end


### PR DESCRIPTION
The old URL was failing to install due to an expired certificate.

www.warsow.gg redirects to www.warsow.net

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
