### PR TITLE
Update pdfpenpro to 832.0,1487275504

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '831.0,1483740107'
-  sha256 '8edce0a326127243e93c7dd9029c15352b3d4e8ac07ca6817798ce41a448f042'
+  version '832.0,1487275504'
+  sha256 '6827c5f3ca6dc458b1b706a83d8dcb8c36a28f4281a6aefc5a8717cd455024f1'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '70d0e591bb0f201c5bf1f2202392c003da77272ae913b1a05d7e581649246097'
+          checkpoint: '15db456a13c45e7bba5e22a0ab10d6d5c51ba89c9ed0164649c727c1af566d71'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.