### PR TITLE
Update bloodhound to 1.2.1

### DIFF
--- a/Casks/bloodhound.rb
+++ b/Casks/bloodhound.rb
@@ -1,10 +1,10 @@
 cask 'bloodhound' do
   version '1.2.1'
-  sha256 'dadf9b6c692693c628e8b51cf7d0657b14ef2e669daede5ceb6144484edc0f5e'
+  sha256 '63abbfb483811a004171a8680402e613ca6129c7bd152d67321e65d90b70810b'
 
   url "https://github.com/BloodHoundAD/BloodHound/releases/download/#{version}/BloodHound-darwin-x64.zip"
   appcast 'https://github.com/BloodHoundAD/BloodHound/releases.atom',
-          checkpoint: '2356a4e6a8274454e11cd014ce98cf9ef4365ce3348f1b7c16f7b39258e4cbc2'
+          checkpoint: '7d191f2c56d164380082cbbbfa75908947fd45bb943ee405d50ed9194eece955'
   name 'bloodhound'
   homepage 'https://github.com/BloodHoundAD/BloodHound'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.