### PR TITLE
Update synergy to 1.8.8,c30301e

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '1.8.7,9799e96'
-  sha256 '7405758afdba9b0bdf5c01f4f7a01f2760382cda97b91171972ee065d64ba369'
+  version '1.8.8,c30301e'
+  sha256 '9f9019b3c558bf0c05e558828ed282b29c316d9477c5f5169d3461e32dadb9b6'
 
   url "https://symless.com/files/packages/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX-x86_64.dmg"
   name 'Synergy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.