### PR TITLE
Update qbittorrent to 3.3.11

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,11 +1,11 @@
 cask 'qbittorrent' do
-  version '3.3.10'
-  sha256 '2ceece42dbb7e84a88496028c09e34edac5be8d9583d0475d494883b97a11a5f'
+  version '3.3.11'
+  sha256 'dda519484075ce455f91962d04ca57535c50604b30e886e5025ab97a4e5be1df'
 
   # sourceforge.net/qbittorrent was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/qbittorrent/rss?path=/qbittorrent-mac',
-          checkpoint: '80ba15210f3eb226e6f01848dd69298df7f42e7ee7dd849dfc2a2dc576dbb3e1'
+          checkpoint: '4bb8d28cf2ce7344b38fc0a40e82b74f94037cd30ac28893353da0a4f7babcea'
   name 'qBittorrent'
   homepage 'https://www.qbittorrent.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.