### PR TITLE
Update keepassxc to 2.1.3

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,11 +1,11 @@
 cask 'keepassxc' do
-  version '2.1.2'
-  sha256 '04af9a73cb8af055f209409c10a54bc82e06c8ad788d4ee431ff48757854a431'
+  version '2.1.3'
+  sha256 '1a31ed5236f1c69698b65c2360b7499ef9bc3c77a37a6b465672753625552b63'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
   appcast 'https://github.com/keepassxreboot/keepassxc/releases.atom',
-          checkpoint: 'b4c39c3238663ed3a961552df7d77e30cfb107eb7e95b9f98833adebf2314c82'
+          checkpoint: '13e80f21f311288d042402f0f3e7d5e8bfacefaaf649c2834014f9c56a856fe8'
   name 'KeePassXC'
   homepage 'https://keepassxc.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.