### PR TITLE
Update findings to 1.4.3,3551

### DIFF
--- a/Casks/findings.rb
+++ b/Casks/findings.rb
@@ -1,6 +1,6 @@
 cask 'findings' do
-  version '1.4.3.3551'
-  sha256 '55d94404139b7c0c3e303d208aba47b4f20bffcfef4cdcfc4535c55fbe2e021c'
+  version '1.4.4,3564'
+  sha256 '849c044139a6d35105020585169c01d9fd401f73dd44202cce4d1fe4fb0b2bed'
 
   url "http://downloads.findingsapp.com/Findings_#{version.after_comma}_#{version.before_comma}.zip"
   appcast 'http://downloads.findingsapp.com/appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.