### PR TITLE
Update championify to 2.0.4

### DIFF
--- a/Casks/championify.rb
+++ b/Casks/championify.rb
@@ -1,10 +1,10 @@
 cask 'championify' do
-  version '2.0.2'
-  sha256 'a48778cb9b15bf7b280445d0706087cd0eb920af40ccb2059a9e7c9f782a0d26'
+  version '2.0.4'
+  sha256 '9209be663ef541b49012356c2797b6b499235fa3ec1ee27d2eaa0f47cbfe6a64'
 
   url "https://github.com/dustinblackman/Championify/releases/download/#{version}/Championify-OSX-#{version}.dmg"
   appcast 'https://github.com/dustinblackman/Championify/releases.atom',
-          checkpoint: '89cdfdbaf8cf490ef6cb6be8fd5ad295a07ce1c217d1e5a9734469800f5fadb1'
+          checkpoint: 'abac4f5d49633034571c75bf18900ad2df0197de54eebab5ef4a0afcc6fd33c6'
   name 'Championify'
   homepage 'https://github.com/dustinblackman/Championify/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.