### PR TITLE
Update bitmessage to 0.6.2

### DIFF
--- a/Casks/bitmessage.rb
+++ b/Casks/bitmessage.rb
@@ -1,11 +1,11 @@
 cask 'bitmessage' do
-  version '0.6.1'
-  sha256 '401571b671a75dfdc94587cb3790443165cff86a122b919ad08e51c2d088ad1f'
+  version '0.6.2'
+  sha256 '79c02e7d42e0b313baacaee31a4d6df2650f83726fe759705cd88d1038256dcb'
 
   # github.com/Bitmessage/PyBitmessage was verified as official when first introduced to the cask
   url "https://github.com/Bitmessage/PyBitmessage/releases/download/v#{version}/bitmessage-v#{version}.dmg"
   appcast 'https://github.com/Bitmessage/PyBitmessage/releases.atom',
-          checkpoint: 'ff09661559521f36a3a2b74d3cadf48cf2f469db47f4a46d6be4639ad217c9da'
+          checkpoint: 'b27234668b54eae0824731a8326cae2aea1de0bf74b3b1d4251d5c4a5062a928'
   name 'Bitmessage'
   homepage 'https://bitmessage.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.