### PR TITLE
Update comma-chameleon to 0.5.1

### DIFF
--- a/Casks/comma-chameleon.rb
+++ b/Casks/comma-chameleon.rb
@@ -1,11 +1,11 @@
 cask 'comma-chameleon' do
-  version '0.5.0'
-  sha256 'b63d8a51ba8535555f28eda9ff82c9ff76afe9b4d649b3b8453a8802715220d7'
+  version '0.5.1'
+  sha256 'd8508f4bc9b9f1fb61b354b3547b069ca8392a8ffa0d2ffcab5d98a178e8d20c'
 
   # github.com/theodi/comma-chameleon was verified as official when first introduced to the cask
   url "https://github.com/theodi/comma-chameleon/releases/download/#{version}/comma-chameleon-darwin-x64.tar.gz"
   appcast 'https://github.com/theodi/comma-chameleon/releases.atom',
-          checkpoint: '6db5403267c51a690ce811cc015391a3278eb8c8a062c537eb29a805a22a4c18'
+          checkpoint: '20cc20ba14e6170906a56a3d5dc5ffedad8c9cd104a8032157ac3ff4d8fbe67a'
   name 'Comma Chameleon'
   homepage 'https://comma-chameleon.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.