### PR TITLE
Update commander-one to 1.7.1

### DIFF
--- a/Casks/commander-one.rb
+++ b/Casks/commander-one.rb
@@ -1,10 +1,10 @@
 cask 'commander-one' do
-  version '1.7'
-  sha256 '8e33f2fca68b3b7e445f86ee3b4cae8c180b18f28d9a11faf7133843f81b0e0c'
+  version '1.7.1'
+  sha256 '3a241ddf99654c5eace926a958ae239494fe20db3eed97489203947940a7433c'
 
   url 'http://mac.eltima.com/download/commander.dmg'
   appcast 'http://www.eltima.com/download/commander-update/settings.xml',
-          checkpoint: '73f40a368b723490bad6cac5f8d02c133df810cbded3b51ff7d6dbe2eb7896e2'
+          checkpoint: '591064c625131d29700702cfd2587de5620a648c16e8c159fbd589742682ea78'
   name 'Commander One'
   homepage 'http://mac.eltima.com/file-manager.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.