### PR TITLE
Update controllermate to 4.10.1

### DIFF
--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,11 +1,11 @@
 cask 'controllermate' do
-  version '4.10.0'
-  sha256 '59590e5c9129ed62293f68bfc06cd430bbc57f34c430a1417f718e4f1e0aeb62'
+  version '4.10.1'
+  sha256 '472a2c6b7f5e8a3fa2ba0f0ce66eedc24cfe9cd361a539589cf2e6dec5904f0c'
 
   # amazonaws.com/orderedbytes was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/orderedbytes/ControllerMate#{version.no_dots}.zip"
   appcast 'https://www.orderedbytes.com/sparkle/appcast_cm460.xml',
-          checkpoint: 'f89ef55cc362d4c3a98dd523ea0655870127497460c774c8a0caaa720b2f5934'
+          checkpoint: '66464e45e21dd1e37c9465a1a4ca4ea06c355b26ca37fb3bf39955d4177a383e'
   name 'ControllerMate'
   homepage 'https://www.orderedbytes.com/controllermate/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.