### PR TITLE
Update dropzone to 3.6.1

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,10 +1,10 @@
 cask 'dropzone' do
-  version '3.6.0'
-  sha256 '266ea1a8b14d2f4369a536289149588da111455e675e59ef1a777582a5ea39c8'
+  version '3.6.1'
+  sha256 '6cec10bcfccbca4d92fd1739bb6a5efaa10767909dae0366c7e70c9d9715516f'
 
   url "https://aptonic.com/dropzone3/sparkle/Dropzone-#{version}.zip"
   appcast 'https://aptonic.com/sparkle/updates.xml',
-          checkpoint: '5572a5a59d087717dcc4f3a44af1e772299d615122dfe8fe940d61ce8290e092'
+          checkpoint: '026d16213d31d1e4529d71b01d90112b7f76b1ffaf39627279cb2d55c93c9ca7'
   name 'Dropzone'
   homepage 'https://aptonic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.