### PR TITLE
Update framer to 86

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '85'
-  sha256 '8840011469fc6aad89273fce123951188c454b6fc5a0877d915973289dcfd7fb'
+  version '86'
+  sha256 '04200c0b3ee160355c0b055c0b7edb8111d4e5c29afa05937dce9568de665d86'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: 'a404c5edf55ef4795669c316cb7a89a2676692a3ec483647fe1833d612b533a6'
+          checkpoint: '44e01972dd1d2fa63eb158e8d3dd6810b5091f966b41556a54d7748c86210942'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.