### PR TITLE
Update deadbeef to 1.0

### DIFF
--- a/Casks/deadbeef.rb
+++ b/Casks/deadbeef.rb
@@ -1,10 +1,10 @@
 cask 'deadbeef' do
-  version '0.7.2'
-  sha256 '669daa26d5b347f332827ca75682b98cf14fd735b16cd0d4973746aa8a362323'
+  version '1.0'
+  sha256 '7e21c47d545d549bec998a9098c81b5a1f132af7207687c9af39e63c9aa6041b'
 
   url 'https://downloads.sourceforge.net/deadbeef/travis/osx/master/deadbeef-devel-osx-x86_64.zip'
   appcast 'https://sourceforge.net/projects/deadbeef/rss?path=/travis/osx/master',
-          checkpoint: 'dea19615860a038ef31c65a996ea380037ea255724e40eea21722fda10c0685c'
+          checkpoint: '3d74c7f0183363abd0275f7f70abf57ff2a28589bd6d84da5fb6a4ce13fd3e7c'
   name 'DeaDBeeF'
   homepage 'http://deadbeef.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

A new build is being advertising app's version as `1.0` for a while now.