### PR TITLE
Update standard-notes to 0.2.6

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.2.5'
-  sha256 '0e5a6c5f2154e2e291089e00cc478d45178ab229de107cfed704d6cbee43f601'
+  version '0.2.6'
+  sha256 'a40f0fec1dd4e86ae57e16e8d3c308a419660220debfcc71100e30055048fa8c'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'b2da36af725cdd4241a973d308c985c7c7278f707e6d7439fa4909061c914302'
+          checkpoint: '7421d16a0413fcea9df2df4f6089b66c4f6e3b0d429af77ab767600b804b1678'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.