### PR TITLE
Update webcatalog to 3.2.7

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '3.2.6'
-  sha256 'ec91382cae0fa7ac5c0e290d058baa1f8cb7c3d659821fd4710041e33c082e9f'
+  version '3.2.7'
+  sha256 '90963049890a5189321701421262dce2fc11381dc3805df6cc51167fb7a396a5'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '21e3e3510cc26712ea04510ad0cd2778b1060feb59484e5000780170e4deba4a'
+          checkpoint: '8346d40a9e7ffed310c49332661e96e89ec08b9c93c6b10089aa2050ddd653da'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.