### PR TITLE
Update cyberduck to 5.3.9.23624

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '5.3.7.23440'
-  sha256 'd4893a669d413ff691167f0afdc73d6fe736753ace7c6990eda9d5ae00294d31'
+  version '5.3.9.23624'
+  sha256 'de2e7888c9e96c82996ac932e7a0075f86db1c5bda33cb626204e774d553e7e1'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: '8df61d456c80d69a15188136d45bda41b0b5f4cd05077131868204bdba1ed46c'
+          checkpoint: '06933ed8443c84a7f47c5a243052cc902f07b7bae2553053a9da44780882bbb0'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 

--- a/Casks/multibit-hd.rb
+++ b/Casks/multibit-hd.rb
@@ -1,0 +1,13 @@
+cask 'multibit-hd' do
+  version '0.4.1'
+  sha256 '12d230b723fd8d51fe6ea90a4ecdad25ee3eff6ebec6fc80295c55f54ea3c63a'
+
+  url "https://multibit.org/releases/multibit-hd/multibit-hd-#{version}/multibit-macos-#{version}-drag-install.dmg"
+  name 'MultiBit HD'
+  homepage 'https://multibit.org/'
+  gpg "#{url}.asc", key_id: '299c423c672f47f4756a6ba4c1972aed79f7c572'
+
+  app 'MultiBit HD.app'
+
+  uninstall quit: 'com.install4j.6925-4794-5772-4956.24'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.