### PR TITLE
Update x2goclient to 4.1.0.0

### DIFF
--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -1,8 +1,14 @@
 cask 'x2goclient' do
-  version :latest
-  sha256 :no_check
+  version '4.1.0.0'
 
-  url 'http://code.x2go.org/releases/X2GoClient_latest_macosx.dmg'
+  if MacOS.version < '10.9'
+    sha256 '8fbb806167461af5cfc15b5662a6a6ab5a4459c7f3c8efc61087ade80f919a4c'
+    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}-20170222_OSX_10_6.dmg"
+  else
+    sha256 'e0ba49333b0748dbe66a732435ecfe8f98b5c72f334b239d974f8bc58943606d'
+    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}-20170222_OSX_10_9.dmg"
+  end
+
   name 'X2Go Client'
   homepage 'http://wiki.x2go.org/doku.php'
 

--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -1,7 +1,7 @@
 cask 'x2goclient' do
   version '4.1.0.0'
 
-  if MacOS.version < '10.9'
+  if MacOS.version <= :mountain_lion
     sha256 '8fbb806167461af5cfc15b5662a6a6ab5a4459c7f3c8efc61087ade80f919a4c'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}-20170222_OSX_10_6.dmg"
   else


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.