### PR TITLE
Update google-adwords-editor to 11.7

### DIFF
--- a/Casks/google-adwords-editor.rb
+++ b/Casks/google-adwords-editor.rb
@@ -1,6 +1,6 @@
 cask 'google-adwords-editor' do
-  version '11.7'
-  sha256 'a87499d20ace9af9e47de5a91b6c34ea3b8c8918c2d691ad6f417f9952eecda9'
+  version :latest
+  sha256 :no_check
 
   url 'https://dl.google.com/adwords_editor/Google_AdWords_Editor.dmg'
   name 'Google AdWords Editor'

--- a/Casks/google-adwords-editor.rb
+++ b/Casks/google-adwords-editor.rb
@@ -1,8 +1,8 @@
 cask 'google-adwords-editor' do
-  version '11.5.9.0'
-  sha256 'f04ad235ebd7a4893623f5c26e8c073d8710b4bbaf918d437a9a118fe7bbb86f'
+  version '11.7'
+  sha256 'a87499d20ace9af9e47de5a91b6c34ea3b8c8918c2d691ad6f417f9952eecda9'
 
-  url "https://dl.google.com/adwords_editor/#{version}/Google_AdWords_Editor.dmg"
+  url 'https://dl.google.com/adwords_editor/Google_AdWords_Editor.dmg'
   name 'Google AdWords Editor'
   homepage 'https://adwords.google.com/home/tools/adwords-editor/?zd=1'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.