### PR TITLE
Update 1password to 6.6.2

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -16,8 +16,8 @@ cask '1password' do
 
     app "1Password #{version.major}.app"
   else
-    version '6.6.1'
-    sha256 '1891b56e0cd2a2c9467cc2e17e05f67d65e075473e683c509b09e1a212c683f9'
+    version '6.6.2'
+    sha256 'a2042ca1ddbf6bdf2a54e0064505013ca089197865d6a135fdb35201601f79df'
 
     # d13itkw33a7sus.cloudfront.net was verified as official when first introduced to the cask
     url "https://d13itkw33a7sus.cloudfront.net/dist/1P/mac4/1Password-#{version}.zip"
@@ -26,7 +26,7 @@ cask '1password' do
   end
 
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: '4559e30e1ed5757784d6a7ca9a77f08d10e9455c6073a13bec095911912052a4'
+          checkpoint: 'b11830f2e4d248da15bbf2de9ea319ed3b188683ea0d693d35792aff57b69f96'
   name '1Password'
   homepage 'https://1password.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.