### PR TITLE
Update race-into-space to 1.1.0.286

### DIFF
--- a/Casks/race-into-space.rb
+++ b/Casks/race-into-space.rb
@@ -1,11 +1,11 @@
 cask 'race-into-space' do
   version '1.1.0.286'
-  sha256 'f22838888be4f456b107fd4d527474fdeae96ce5c3f3cfda623e736411e8c33c'
+  sha256 'fff9bd3a9410a44cd0e44ba18b60ad6d39f01a63c6c4267b53e5a10c5b76a328'
 
   # downloads.sourceforge.net/raceintospace was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/raceintospace/Race_Into_Space_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/raceintospace/rss',
-          checkpoint: '9a4ae7ec0dc399823bec3e9b24c808beab9889276360891bf382b3ef5eb56640'
+          checkpoint: '8f63391eac075c539902d03a772cea425ef059eca1c759d661f235551d1d62bc'
   name 'Race Into Space'
   homepage 'http://www.raceintospace.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.