### PR TITLE
Update lazarus to 1.6.4

### DIFF
--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -1,6 +1,6 @@
 cask 'lazarus' do
   version '1.6.4-20170226'
-  sha256 '342c73a2481fb37b75ba95ef052b4a3bb734e19fd7fe7a2556f53b42e67f243c'
+  sha256 'd3af7a83e20732d268ea588be0037347f75392a9d0210e831b056279cc3d8c39'
 
   # sourceforge.net/lazarus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i386-macosx.dmg"

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -2,7 +2,7 @@ cask 'lazarus' do
   version '1.6.4-20170226'
   sha256 '342c73a2481fb37b75ba95ef052b4a3bb734e19fd7fe7a2556f53b42e67f243c'
 
-  # sourceforge.net/projects/lazarus was verified as official when first introduced to the cask
+  # sourceforge.net/lazarus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i686-macosx.dmg"
   appcast 'https://sourceforge.net/projects/lazarus/rss',
           checkpoint: 'ce6a7706e0ea9631ad9bc2e4a3d8d712459c79ea239fee34b7aace8cbe5ecd94'

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -3,7 +3,7 @@ cask 'lazarus' do
   sha256 '342c73a2481fb37b75ba95ef052b4a3bb734e19fd7fe7a2556f53b42e67f243c'
 
   # sourceforge.net/lazarus was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i686-macosx.dmg"
+  url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i386-macosx.dmg"
   appcast 'https://sourceforge.net/projects/lazarus/rss',
           checkpoint: 'ce6a7706e0ea9631ad9bc2e4a3d8d712459c79ea239fee34b7aace8cbe5ecd94'
   name 'Lazarus'

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -1,11 +1,11 @@
 cask 'lazarus' do
-  version '1.6.2'
-  sha256 'd0564cd255fb0612d1ed59c9a09f5e3733e43700e1e980caf5fd75a2b2529170'
+  version '1.6.4'
+  sha256 '342c73a2481fb37b75ba95ef052b4a3bb734e19fd7fe7a2556f53b42e67f243c'
 
-  # sourceforge.net/lazarus was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i686-macosx.dmg"
+  # sourceforge.net/projects/lazarus was verified as official when first introduced to the cask
+  url 'https://sourceforge.net/projects/lazarus/files/latest/download'
   appcast 'https://sourceforge.net/projects/lazarus/rss',
-          checkpoint: 'e52ea526cfb8b92e3dd7db6eb70eeafd87122259ca5b71a52367a61965201a77'
+          checkpoint: 'ce6a7706e0ea9631ad9bc2e4a3d8d712459c79ea239fee34b7aace8cbe5ecd94'
   name 'Lazarus'
   homepage 'http://www.lazarus-ide.org/'
 

--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -1,9 +1,9 @@
 cask 'lazarus' do
-  version '1.6.4'
+  version '1.6.4-20170226'
   sha256 '342c73a2481fb37b75ba95ef052b4a3bb734e19fd7fe7a2556f53b42e67f243c'
 
   # sourceforge.net/projects/lazarus was verified as official when first introduced to the cask
-  url 'https://sourceforge.net/projects/lazarus/files/latest/download'
+  url "https://downloads.sourceforge.net/lazarus/lazarus-#{version}-i686-macosx.dmg"
   appcast 'https://sourceforge.net/projects/lazarus/rss',
           checkpoint: 'ce6a7706e0ea9631ad9bc2e4a3d8d712459c79ea239fee34b7aace8cbe5ecd94'
   name 'Lazarus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.