### PR TITLE
Update deluge to 1.3.14

### DIFF
--- a/Casks/deluge.rb
+++ b/Casks/deluge.rb
@@ -1,8 +1,8 @@
 cask 'deluge' do
-  version '1.3.13'
-  sha256 '944b2e84ad38f5f31997cdb3b30d67ec7b77628c8fc6feb9acb365d2bc4775ff'
+  version '1.3.14'
+  sha256 'e431358d127ec5b3d70aeff3795e3a370b2e51fbf153a2be175a6d553855325f'
 
-  url "http://download.deluge-torrent.org/mac_osx/deluge-#{version}-osx-x64-0.dmg"
+  url "http://download.deluge-torrent.org/mac_osx/deluge-#{version}-macosx-x64.dmg"
   name 'Deluge'
   homepage 'http://deluge-torrent.org/'
 


### PR DESCRIPTION
- [X] `brew cask audit --download Casks/deluge.rb` is error-free.
- [X] `brew cask style --fix Casks/deluge.rb` reports no offenses.
- [X] The commit message includes the cask’s name and version.
