### PR TITLE
Update mp3tag to 2.81

### DIFF
--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -1,6 +1,6 @@
 cask 'mp3tag' do
-  version '2.80'
-  sha256 'a44dc798e0e49fffa1b1f28e173cdba12bcb8599621246c8b002083c214479a3'
+  version '2.81'
+  sha256 '961299e8227be3bc9d944237430e659331b83438ebe27f49517f2b765a56b914'
 
   url "http://download.mp3tag.de/mp3tagv#{version.no_dots}-MacOSX-Wine.zip"
   name 'MP3TAG'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.