### PR TITLE
Update lepton to 1.2.1

### DIFF
--- a/Casks/lepton.rb
+++ b/Casks/lepton.rb
@@ -1,11 +1,11 @@
 cask 'lepton' do
-  version '1.2.0'
-  sha256 '93609204d33dcb284693886ef406cebf3ddd6fdb2c7dbd9320d38e4e59b98902'
+  version '1.2.1'
+  sha256 '8b8487425b8a2e4649e860fa223500c7ea7894ae7f2774680eef99cc74c8899f'
 
   # github.com/hackjutsu/Lepton was verified as official when first introduced to the cask
   url "https://github.com/hackjutsu/Lepton/releases/download/v#{version}/Lepton-#{version}-mac.zip"
   appcast 'https://github.com/hackjutsu/Lepton/releases.atom',
-          checkpoint: '8452f00ddc67c72cf97a555020f93b9e8bbe4ae73701b6b6cfa5dc93e533b2ac'
+          checkpoint: '10612fabc575066085e1da2609be43562e70b1e18db8c1842bc6e80ac18fc817'
   name 'Lepton'
   homepage 'http://hackjutsu.com/Lepton/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.