### PR TITLE
Update eaglefiler to 1.7.4

### DIFF
--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,6 +1,6 @@
 cask 'eaglefiler' do
-  version '1.7.3'
-  sha256 '94b7467736a00f85d0a837233d5a566b4308dea207d45e70e9d2c50ea86a7d4d'
+  version '1.7.4'
+  sha256 '8b417c2f923bd3c6b5a4cb1c153679dd834f217a2d60ed7415d150ecb0d73daf'
 
   url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   name 'EagleFiler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #30668.