### PR TITLE
Update stretchly to 0.7.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.6.0'
-  sha256 '8bcacef9e79471340a27ab8ee5d143a16bd42d9d0421564a3a6457b50602de46'
+  version '0.7.0'
+  sha256 'b6958ccbb3e33afcd8b9484bdd25f3d15cfb204faa780b55783c6726c14e928e'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '0ffc2cfe39b8988774ecdef0816562d433523ab92fde1f1a42445a5075ccae1c'
+          checkpoint: 'dd45ca7702c61033305c5a750ca2afd55244c268598332279c8502ab9b45153d'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #.