### PR TITLE
Update harmony to 0.4.7

### DIFF
--- a/Casks/harmony.rb
+++ b/Casks/harmony.rb
@@ -1,11 +1,11 @@
 cask 'harmony' do
-  version '0.4.6'
-  sha256 '19d5f0fcc2660947a68de98dba277ad14f475377e2c4536bb015e7d908a3e719'
+  version '0.4.7'
+  sha256 'b17649067dcb9f1810bdd684e08d70cf04289120945e34f271fdccd2db582fb2'
 
   # github.com/vincelwt/harmony was verified as official when first introduced to the cask
   url "https://github.com/vincelwt/harmony/releases/download/v#{version}/harmony-#{version}.dmg"
   appcast 'https://github.com/vincelwt/harmony/releases.atom',
-          checkpoint: '8cf4fd4fe82838ef8cc2b77272bfda6ec55e5d7c4d47b96cba83ba7abaa68d38'
+          checkpoint: 'c5f8e370155c76a02a08da9194809d405f5c257c1233628e0321c39b3f432970'
   name 'Harmony'
   homepage 'http://getharmony.xyz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.