### PR TITLE
Update hbuilder to 8.0.2

### DIFF
--- a/Casks/hbuilder.rb
+++ b/Casks/hbuilder.rb
@@ -1,6 +1,6 @@
 cask 'hbuilder' do
-  version '7.6.0'
-  sha256 '1f170037d3261b1b227c519e3f79b3de8a8b9b2066c2b269d566bacc4a4ace1c'
+  version '8.0.2'
+  sha256 '972e5614d66624306e52726e339842155064bc744148ef7eb54c8441c4c7a828'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "http://download.dcloud.net.cn/HBuilder.#{version}.macosx_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.