### PR TITLE
Update natron to 2.2.5

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.2.2'
-  sha256 '5b9b57a201206d534b885cfb2edf4d38816a3325d863b091c6c58652cb2a5088'
+  version '2.2.5'
+  sha256 'a6d5e7898fdc2a1ebd4ef427df3ec7402db51684eb5b12a64ef97024c7878d7d'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: '877111c56c7d4612d63dc5454402edcc2ef480632be03abadcfd4c06c61ee41f'
+          checkpoint: '8623d800936db165a0494334b9d655d40edb82a665480b2624f351a298458951'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.