### PR TITLE
Update nylas-mail to 1.0.32-89ced41

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.30-a4ca416'
-  sha256 'e90f1653eef304d80cd398a7933be6764e3d2c9cbd685374175932bc81d7ca7a'
+  version '1.0.32-89ced41'
+  sha256 'ac2017ffb098d156d71d31663dd9d0d2b40b3bd3ffd4222f0bf0ce9573b69e1f'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '8c4b1dfb8625f5d7d6611ee3223cb8b7ccccc1efa1dde7885c1dd13d4a6f7cad'
+          checkpoint: '0202730be19c5f11cc3162adcf4379cd78f98cbf08c189f8c8bed4c60678be9b'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.