### PR TITLE
Adding Netbeans HTML IDE v8.2

### DIFF
--- a/Casks/netbeans-html.rb
+++ b/Casks/netbeans-html.rb
@@ -1,0 +1,15 @@
+cask 'netbeans-html' do
+  version '8.2'
+  sha256 '084c34512db43a9027c0ee24bb1dc72364fc64ff6fa1b5ddeface07ba1c80c3b'
+
+  url "http://download.netbeans.org/netbeans/#{version}/final/bundles/netbeans-#{version}-html-macosx.dmg"
+  appcast 'https://netbeans.org/downloads/',
+          checkpoint: '01f76f4a3ce011fd416b18ce93c0219d06b2333ce146583181519c8458af014d'
+  name 'NetBeans IDE for HTML5/JavaScript'
+  homepage 'https://netbeans.org/'
+
+  pkg "NetBeans #{version}.pkg"
+
+  uninstall pkgutil: 'org.netbeans.ide.*|glassfish.*',
+            delete:  '/Applications/NetBeans'
+end


### PR DESCRIPTION
- Introducing a cask for Netbeans HTML IDE with version 8.2

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
