### PR TITLE
Update IntelliJ IDEA to 2016.3.5 build 163.13906.18

### DIFF
--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -1,10 +1,10 @@
 cask 'intellij-idea-ce' do
-  version '2016.3.4'
-  sha256 'ef712348eac6a8e8d5a5bbae8328c1f433c6f3a31dd0ad1d8dbf8947c4f0b6e9'
+  version '2016.3.5'
+  sha256 '4b7a52afdd1fd8be6ea5a0116d23d8bbaf1d90337a78c4bbb8e24b0af19fbd57'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&type=release',
-          checkpoint: '7f5a48628654dc2631e7cbcd9732392fe47c8ab457f48f4d42da528042530b41'
+          checkpoint: '014262c41b97b40eaae10e1a1ba5cff15ea9545bdee1d861dcc78befece548bf'
   name 'IntelliJ IDEA Community Edition'
   name 'IntelliJ IDEA CE'
   homepage 'https://www.jetbrains.com/idea/'

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -1,10 +1,10 @@
 cask 'intellij-idea' do
   version '2016.3.5'
-  sha256 '136e679a751c4a098b2c7195efa526f8b3b51b010a96f568c875986b8eb11a71'
+  sha256 '4417df3aa9fba7c75af371b51d734759b2d555930404b2063866b4e869ae3b79'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release',
-          checkpoint: 'a725581302012d1dba4f2f26834e14992d21db3f725ce3f4933f7d1b9d10852c'
+          checkpoint: '96c427261ad1bea66b78cead640f843bf3808acef31b4ec05d43044d21f53233'
   name 'IntelliJ IDEA Ultimate'
   homepage 'https://www.jetbrains.com/idea/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

IntelliJ guys re-released IntelliJ IDEA 2016.3.5 what's why we  have to update checksums.