### PR TITLE
Update ipswdownloader to 2.6.6

### DIFF
--- a/Casks/ipswdownloader.rb
+++ b/Casks/ipswdownloader.rb
@@ -1,14 +1,8 @@
 cask 'ipswdownloader' do
-  if MacOS.version <= :snow_leopard
-    version '1.6.0'
-    sha256 '82a236f69d2b7acfa9b0c801b9df76372005d5aab3f399f0d10db71320bb0af3'
-    url 'http://www.igrsoft.com/wp-content/plugins/download-monitor/download.php?id=48'
-  else
-    version '2.6.6'
-    sha256 '00b6901c0e3d18f98a8dace757a56ad248914a9f7aaab24902e631c8d9f9259d'
-    url "http://downloads.igrsoft.com/downloads/ipswDownloader/ipswDownloader_#{version.no_dots}.zip"
-  end
+  version '2.6.6'
+  sha256 '00b6901c0e3d18f98a8dace757a56ad248914a9f7aaab24902e631c8d9f9259d'
 
+  url "http://downloads.igrsoft.com/downloads/ipswDownloader/ipswDownloader_#{version.no_dots}.zip"
   name 'ipswDownloader'
   homepage 'https://igrsoft.com/ipswdownloader/'
 

--- a/Casks/ipswdownloader.rb
+++ b/Casks/ipswdownloader.rb
@@ -4,9 +4,9 @@ cask 'ipswdownloader' do
     sha256 '82a236f69d2b7acfa9b0c801b9df76372005d5aab3f399f0d10db71320bb0af3'
     url 'http://www.igrsoft.com/wp-content/plugins/download-monitor/download.php?id=48'
   else
-    version '2.6.4'
-    sha256 'ba94d309c8c52b1bf2e58e2afc18eadb1a753e39ce180a255369c13a723e6018'
-    url 'http://www.igrsoft.com/wp-content/plugins/download-monitor/download.php?id=69'
+    version '2.6.6'
+    sha256 '00b6901c0e3d18f98a8dace757a56ad248914a9f7aaab24902e631c8d9f9259d'
+    url "http://downloads.igrsoft.com/downloads/ipswDownloader/ipswDownloader_#{version.no_dots}.zip"
   end
 
   name 'ipswDownloader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.