### PR TITLE
Update macbreakz to 5.31

### DIFF
--- a/Casks/macbreakz.rb
+++ b/Casks/macbreakz.rb
@@ -1,10 +1,10 @@
 cask 'macbreakz' do
-  version '5.30'
-  sha256 '9b1aac4d1f7888c4cfe2043d937b6d8ee5cae610bc19cf545bcd7929c3d5ca46'
+  version '5.31'
+  sha256 '7ca1bf91ff2c018363f1dd74137077ebdd616beb5aa4d42aa732a64cf6761b8e'
 
   url "http://www.publicspace.net/download/MacBreakZ#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_mb#{version.major}.xml",
-          checkpoint: '23f424d150828f3bae58c422517ea2268fc6f8c7bfcccbec2b7e342292d1cfd4'
+          checkpoint: '54d830fe2ce391de55ed11509459748aae6bb6931ef477a364dce934eab60763'
   name 'MacBreakZ'
   homepage 'http://www.publicspace.net/MacBreakZ/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.