### PR TITLE
Update a-better-finder-rename to 10.14

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,10 +1,10 @@
 cask 'a-better-finder-rename' do
-  version '10.13'
-  sha256 '82252950fd35979af7a2543edab8086d6e71e94633261c2f732881deebd8525f'
+  version '10.14'
+  sha256 '64bee2a3e694f0da1e168eca17cc4d7537264228e578c067831609a844b1a149'
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml",
-          checkpoint: 'b1839b6d133ed202ffad1c1628fbf7413034163c8b592bdc56f9ec4f793bf0b9'
+          checkpoint: '9ee6035e6d1ef82f68cd8b353b8d5abe000a55354ae629c054fbce83f9706029'
   name 'A Better Finder Rename'
   homepage 'http://www.publicspace.net/ABetterFinderRename/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.