### PR TITLE
Update and rename exponent-xde.rb to expo-xde.rb

### DIFF
--- a/Casks/expo-xde.rb
+++ b/Casks/expo-xde.rb
@@ -1,11 +1,11 @@
-cask 'exponent-xde' do
+cask 'expo-xde' do
   version :latest
   sha256 :no_check
 
   # exponentjs.com was verified as official when first introduced to the cask
   url 'https://xde-updates.exponentjs.com/download/mac'
-  name 'Exponent Development Environment (XDE)'
-  homepage 'https://getexponent.com/'
+  name 'Expo Development Environment (XDE)'
+  homepage 'https://expo.io/'
 
-  app 'Exponent XDE.app'
+  app 'Expo XDE.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. **NOTE** the version hasn't changed, it's just a rename.
