### PR TITLE
Add QuickTime Player 7 v7.6.6

### DIFF
--- a/Casks/quicktime-player7.rb
+++ b/Casks/quicktime-player7.rb
@@ -1,0 +1,15 @@
+cask 'quicktime-player7' do
+  # note: "7" is specified to differiante from the next iteration, QuickTime Player X
+  version '7.6.6'
+  sha256 '954c2376d2d747821614dc802249cf3c708a4792abed08945d7261de3894e759'
+
+  url 'http://support.apple.com/downloads/DL923/en_US/QuickTimePlayer7.6.6_SnowLeopard.dmg'
+  name 'QuickTime Player 7'
+  homepage 'https://support.apple.com/kb/dl923'
+
+  depends_on macos: '>= :snow_leopard'
+
+  pkg 'QuickTimePlayer7.6.6_SnowLeopard.pkg'
+
+  uninstall pkgutil: 'com.apple.pkg.QuickTimePlayer7.6.6_SnowLeopard'
+end


### PR DESCRIPTION
Despite a newer version of QuickTime Player, v10.4,
QuickTime Player 7 is still a requirement for many
professional media software.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
