### PR TITLE
dotnet 1.1.1 version.after_comma is empty string

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -13,7 +13,7 @@ cask 'dotnet' do
   # Patch .NET Core to use the latest version of OpenSSL installed via Homebrew.
   # https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl
   postflight do
-    dotnet_core = "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/#{version.after_comma}"
+    dotnet_core = "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/#{version}"
     system_command '/usr/bin/install_name_tool',
                    args: [
                            "#{dotnet_core}/System.Security.Cryptography.Native.OpenSsl.dylib",


### PR DESCRIPTION
`version '1.1.1'` does not have any value after comma, therefore `version.after_comma` will point to empty string.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free. (Editing file from GitHub)
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. (Editing file from GitHub)
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask