### PR TITLE
Update julia to 0.5.1

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask 'julia' do
-  version '0.5.0'
-  sha256 '871dd1f309d0b8659980ef0db667a36cf84e5d0febb2d53b70859de3801bdf03'
+  version '0.5.1'
+  sha256 '201a7bfa19cb832beec10579c02dbbc069a8966b87a4c7d1f80b4937a7f5dc1b'
 
   # s3.amazonaws.com/julialang was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/julialang/bin/osx/x64/#{version.major_minor}/julia-#{version}-osx10.7+.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.