### PR TITLE
added cask dotnet-sdk 1.1.1

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,0 +1,36 @@
+cask 'dotnet-sdk' do
+  version '1.1.1'
+  sha256 '5b432bc4cf63ea63e8c28a089747feb8a10364e91dae734ca69942ea14188c81'
+
+  url "https://download.microsoft.com/download/8/F/9/8F9659B9-E628-4D1A-B6BF-C3004C8C954B/dotnet-#{version}-sdk-osx-x64.pkg"
+  name '.Net Core SDK'
+  homepage 'https://www.microsoft.com/net/core#macos'
+
+  depends_on formula: 'openssl'
+
+  pkg "dotnet-#{version}-sdk-osx-x64.pkg"
+
+  # Patch .NET Core to use the latest version of OpenSSL installed via Homebrew.
+  # https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl
+  postflight do
+    dotnet_core = "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/#{version}"
+    system_command '/usr/bin/install_name_tool',
+                   args: [
+                           "#{dotnet_core}/System.Security.Cryptography.Native.OpenSsl.dylib",
+                           '-add_rpath', "#{HOMEBREW_PREFIX}/opt/openssl/lib"
+                         ],
+                   sudo: true
+    system_command '/usr/bin/install_name_tool',
+                   args: [
+                           "#{dotnet_core}/System.Net.Http.Native.dylib",
+                           '-change', '/usr/lib/libcurl.4.dylib',
+                           "#{HOMEBREW_PREFIX}/opt/curl/lib/libcurl.4.dylib"
+                         ],
+                   sudo: true
+  end
+
+  uninstall pkgutil: 'com.microsoft.dotnet.*',
+            delete:  '/etc/paths.d/dotnet'
+
+  zap delete: '~/.nuget'
+end


### PR DESCRIPTION
Original dotnet cask installs only CLI, without SDK

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully. (Can't run this command)
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
