### PR TITLE
Update atom to 1.15.0

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,11 +1,11 @@
 cask 'atom' do
-  version '1.14.4'
-  sha256 'f0fdb9789730b91f7a62ed0db8ef8b9d135ab80101ef11199dd1432f2fd57eb0'
+  version '1.15.0'
+  sha256 '30458e0c7d94c735a6161b4b54ad4bb40c970dc686299c215eb79b4634f3c38a'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '1e2d5dca873aaf379d1b372de5b1f7799764b4c51ec78793e7409538f804a82a'
+          checkpoint: '0ed3175ca86a44825cf6cebeb09c42c2eee8f36cd0a750ec66ff313f36fb4d76'
   name 'Github Atom'
   homepage 'https://atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.