### PR TITLE
Update hyper to 1.3.0

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.2.1'
-  sha256 'eefd8e345c11cae8dbb0bfb99fba1aa30d35562fb425c27db1ca59917494f4c2'
+  version '1.3.0'
+  sha256 '5854a2292dbb70fdbd0be7d35373d05c6b30b4b3f7393e8f89001891f9af374d'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: 'cef5c590ab79abae9fcccea41aced83ebf9d6b67f5f89a87545e7301b166f181'
+          checkpoint: 'a58978a2f5af5eeee20178d28ec5591e95118a7e11e03854346e0cbd043f761a'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.