### PR TITLE
Update frostwire to 6.4.6

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.4.5'
-  sha256 '7e0ff839625f149abf84f4cb786253db7a93e2138f6d56ef7f944226be5caf27'
+  version '6.4.6'
+  sha256 'edc23f818cf0a036003b3ca67bebd942c4f6af3098c35ce7e1f9b9cfcbed8e6e'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: 'bcd3340250a2d96f570b18c65f6af56c4d4ff6094c2873fcd1cba12c534e58bf'
+          checkpoint: '7bc2380d6e95de62112c532e5de887e47813766ac26739dfaab5109496519db9'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.