### PR TITLE
Update meshlab to 2016.12

### DIFF
--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -1,12 +1,13 @@
 cask 'meshlab' do
-  version '1.3.3'
-  sha256 '7a19583ecd8282e9dc84e827e9e667f2139edd371b5f83a5c3fcbb88cb33923d'
+  version '2016.12'
+  sha256 '1a9d81f7bb7fb3da223e83768d13601b4728abde9276a415049bbb33b74baecf'
 
-  url "https://downloads.sourceforge.net/meshlab/meshlab/MeshLab%20v#{version}/MeshLabMac_v#{version.no_dots}.dmg"
-  appcast 'https://sourceforge.net/projects/meshlab/rss?path=/meshlab',
-          checkpoint: '6c7f4c0f099a5ee9ddca6a2cd2afb4c4c3c9a293bb06a4bb0f2a1b357f5de7a1'
+  # github.com/cnr-isti-vclab/meshlab was verified as official when first introduced to the cask
+  url "http://github.com/cnr-isti-vclab/meshlab/releases/download/v#{version}/MeshLab#{version}.dmg"
+  appcast 'http://github.com/cnr-isti-vclab/meshlab/releases.atom',
+          checkpoint: '77a82ca5a2c0050b6d3790364e35d0330423e6df854021bf9691a14e018029f2'
   name 'MeshLab'
-  homepage 'http://meshlab.sourceforge.net/'
+  homepage 'http://www.meshlab.net/'
 
   app 'meshlab.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #30783.