### PR TITLE
Update hyper to 1.3.1

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.3.0'
-  sha256 '5854a2292dbb70fdbd0be7d35373d05c6b30b4b3f7393e8f89001891f9af374d'
+  version '1.3.1'
+  sha256 '00c622b181a83cb9e458f7d16704b32ce37a92d85a6dfe5fdac9356fb7fdc7d5'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: 'a58978a2f5af5eeee20178d28ec5591e95118a7e11e03854346e0cbd043f761a'
+          checkpoint: 'a47b64cf6d22b8e442b840fa6e7707873dd86139d23ad6d629974ec0644be26b'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.