### PR TITLE
Update lyn to 1.8.7

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,12 +1,18 @@
 cask 'lyn' do
-  version '1.8.5'
-  sha256 'a96766bee6e4350b096a5517c2bbb1170d018fc4016a0d67c67f71c4813a6f95'
+  version '1.8.7'
+  sha256 '9cecb54dad68d53432fa15134577662b9c2e7498c93ff52bc406c83f647facd6'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: '62aa93b5a77671a6028ec991884c80c8a4638e8674c853aabc679f6c0cda3a89'
+          checkpoint: '1334e552bbbce6ebb899cbe62cabef7d5fd798cbe18a71bb50d1bde3899b88f9'
   name 'Lyn'
   homepage 'https://www.lynapp.com/'
 
   app 'Lyn.app'
+
+  zap delete: [
+                '~/Library/Application Support/Lyn',
+                '~/Library/Caches/com.lynapp.lyn',
+                '~/Library/Preferences/com.lynapp.lyn.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.