### PR TITLE
Add `uninstall :pkgutil` to SpiderOakOne.

### DIFF
--- a/Casks/spideroakone.rb
+++ b/Casks/spideroakone.rb
@@ -8,5 +8,6 @@ cask 'spideroakone' do
 
   pkg 'SpiderOakONE.pkg'
 
-  uninstall delete: '/Applications/SpiderOakONE.app'
+  uninstall delete:  '/Applications/SpiderOakONE.app',
+            pkgutil: 'org.python.python'
 end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

