### PR TITLE
Revert "Updated Dropbox to 22.3.22 (#30803)"

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,6 +1,6 @@
 cask 'dropbox' do
-  version '22.3.22'
-  sha256 'a95302a1c03e3cace2b64eab74be0049f3717f435ccd57276d32a7022f8ed07b'
+  version '21.4.25'
+  sha256 'b6cc226f6264593ef3096beab68a2c08f54a845e5d35975d41e83d3dc7b060a5'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
This reverts commit df3c684faafb9c85aa45164ba6c41d4d863bdffd.

22.3.22 is a beta release, see my comment in #30803.