### PR TITLE
Update conductor to 1.4.1

### DIFF
--- a/Casks/conductor.rb
+++ b/Casks/conductor.rb
@@ -1,10 +1,10 @@
 cask 'conductor' do
-  version '1.3.0'
-  sha256 'e1a63c988fbcc9de3307987b53799632de4101ab41c9215610f6c9a70c411816'
+  version '1.4.1'
+  sha256 'd0c467071f40a278b09fe3d82fa21745e86cec88246cd016b7a87bfa477a9c49'
 
   url "https://github.com/keith/conductor/releases/download/#{version}/Conductor.app.zip"
   appcast 'https://github.com/keith/conductor/releases.atom',
-          checkpoint: 'e9db5592440216e156b93dfe69a597508047dbda993e3ad8f528a5b54d448d00'
+          checkpoint: 'fb271592f0a88f92c680d2645a036b12da17d13d391b0bb6ce3641c4003723eb'
   name 'Conductor'
   homepage 'https://github.com/keith/conductor'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.