### PR TITLE
Update messenger-for-desktop to 2.0.6

### DIFF
--- a/Casks/messenger-for-desktop.rb
+++ b/Casks/messenger-for-desktop.rb
@@ -1,11 +1,11 @@
 cask 'messenger-for-desktop' do
-  version '2.0.4'
-  sha256 '3bf9d0668cdf9dd434150d6c87f8ff6de93846a4c77a0f3bb1e820afad1910c6'
+  version '2.0.6'
+  sha256 'cd013a62c919e960555b267402ef6f79c10973ec78222eeb3ab707a13f38d275'
 
   # github.com/Aluxian/Facebook-Messenger-Desktop was verified as official when first introduced to the cask
   url "https://github.com/Aluxian/Facebook-Messenger-Desktop/releases/download/v#{version}/messengerfordesktop-#{version}-osx.dmg"
   appcast 'https://github.com/Aluxian/Facebook-Messenger-Desktop/releases.atom',
-          checkpoint: 'd63acc80f778fa451fe48d9737408e41312577f39e672e0836b082f876ed0adb'
+          checkpoint: 'b26b01cc4a54ceae8f024c5e157b1bb4327338faf5768b4bc38707f02e9fc662'
   name 'Messenger for Desktop'
   homepage 'https://messengerfordesktop.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.