### PR TITLE
Update overture to 2.4.6

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.4.4'
-  sha256 '112b331af0aa818d03a2605971923d7f403d5f0f32f81348e5c51beaac8929d0'
+  version '2.4.6'
+  sha256 'd766aea619b3185f318f22cefeba53e7f07db2bee551fc551bbff6b99fc5785a'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: '4f99d29cab642706752ca52eb86112da4e5b84f2da4d45d061c58d05bc84f66c'
+          checkpoint: '78269cfc592aff4bfdf33770d5bb12c598475c6526d0cf3904afe650704d0ec0'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.