### PR TITLE
Update poedit to 1.8.12

### DIFF
--- a/Casks/poedit.rb
+++ b/Casks/poedit.rb
@@ -5,12 +5,12 @@ cask 'poedit' do
 
     url "https://poedit.net/dl/poedit-#{version}.dmg"
   else
-    version '1.8.11'
-    sha256 'e6ae6b2c89edf636a53a1f71f7ab7c89737b554ec40b4bbad206a632139c740c'
+    version '1.8.12'
+    sha256 '0aa721a0733eb04635685d280093aeef56b28c0baddf0fc265e1c7d448dbc615'
 
     url "https://download.poedit.net/Poedit-#{version}.zip"
     appcast 'https://poedit.net/updates/osx/appcast',
-            checkpoint: '858efa613a533fa02c708e17020f3e2a8a08eb1e0db0113018857863d26bd0ab'
+            checkpoint: '4f5cec737829dd700e6fdace1af3a844d659e0edec28eba2f3345377ebcc3e3d'
   end
 
   name 'Poedit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.