### PR TITLE
Update toggldesktop to 7.4.18

### DIFF
--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop' do
-  version '7.4.7'
-  sha256 '6eeffced8ebd37e6f880197a03a70333eeac8c7d8614451591f9591112856796'
+  version '7.4.18'
+  sha256 'e0e6a2a44e91fb34fba9d7cb1e3a41a288ec55da9415efae18a83b396ab88287'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml',
-          checkpoint: '7328b779925803af3801f3528c3f191ee57412a3e72dbb9b73e2a6aa7a703b12'
+          checkpoint: 'c44ea9c0ffb7b43fad2d33c84e6716fd37cc16174a359e51c443bc0a847ecf74'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.