### PR TITLE
Update webcatalog to 3.3.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '3.2.7'
-  sha256 '90963049890a5189321701421262dce2fc11381dc3805df6cc51167fb7a396a5'
+  version '3.3.0'
+  sha256 '848ddc8eb98206d01907976cb3eedfb8c912f145e48ea23cce31a1dbff44b00a'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '8346d40a9e7ffed310c49332661e96e89ec08b9c93c6b10089aa2050ddd653da'
+          checkpoint: '23ba7d52680f8ad3a0a2a2d0dc5a9d9ccebe657f2f30eeb0ef128d1c75b57ab4'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.