### PR TITLE
Update donut to 2.4.0

### DIFF
--- a/Casks/donut.rb
+++ b/Casks/donut.rb
@@ -1,11 +1,11 @@
 cask 'donut' do
-  version '2.2.1'
-  sha256 '4ebfe99d10caf485f237ad9051a88579af582f2ebb223d39e53bd8f96d592e59'
+  version '2.4.0'
+  sha256 '03d46d2701cf340675cc57d1bd1b6c769ae67516fb33466d507142317f84bd10'
 
   # github.com/harshjv/donut was verified as official when first introduced to the cask
-  url "https://github.com/harshjv/donut/releases/download/v#{version}/donut-#{version}.dmg"
+  url "https://github.com/harshjv/donut/releases/download/#{version}/donut-#{version}.dmg"
   appcast 'https://github.com/harshjv/donut/releases.atom',
-          checkpoint: 'df886d7dde40b5ffa62c4d23df8514e2d4ed5b70b79acdd59f9cf36ed6752772'
+          checkpoint: '7d57c0616555224cdd707890102c283c3ea6daf3a557167b78fe75eed1bf53c0'
   name 'donut'
   homepage 'https://harshjv.github.io/donut/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.