### PR TITLE
Update hab to 0.19.0-20170311030920

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.18.0-20170302204108'
-  sha256 '115cb6bb52875a8232c1249b00f628f9786fca5ba5f92f1b9ed9edd412a104da'
+  version '0.19.0-20170311030920'
+  sha256 '81f86f83fc523fb4d666cd38ee1bd105874e10d078d219bd9042da58472e1758'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'c002f642118d263ed1188f9b8a6762e83772dd3fe8794b2cb44ee6efd420635d'
+          checkpoint: '24a0e5817e279933c2b956c8ff38e9d25203ea1fa7fb8210d2c10d847a84909f'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.