### PR TITLE
Update mountain-duck to 1.8.0.6480

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.7.1.6290'
-  sha256 'cdc753359863a628ce804766cc5daeae7ce2841853535600801011916c1049cd'
+  version '1.8.0.6480'
+  sha256 '6f073745f3d9e4faca9a94e8f83edccd6578d57783fba77ba87f26e4ad91be83'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '934e083df0d5e6936e8805eef30f06c2d62f96e03816ca143f0e90762feb07f0'
+          checkpoint: 'e22e5466c30d24bf26e418f27149295f64a857b7a39ff2513974e188a7ae04c6'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.