### PR TITLE
Add zap stanza for trusteer-rapport

### DIFF
--- a/Casks/trusteer-rapport.rb
+++ b/Casks/trusteer-rapport.rb
@@ -13,4 +13,6 @@ cask 'trusteer-rapport' do
                        sudo:       true,
                      },
             pkgutil: 'com.trusteer.ibmSecurityTrusteerEndpointProtection.*'
+
+  zap delete: '~/Library/Application\ Support/Rapport'
 end

--- a/Casks/trusteer-rapport.rb
+++ b/Casks/trusteer-rapport.rb
@@ -14,5 +14,5 @@ cask 'trusteer-rapport' do
                      },
             pkgutil: 'com.trusteer.ibmSecurityTrusteerEndpointProtection.*'
 
-  zap delete: '~/Library/Application\ Support/Rapport'
+  zap delete: '~/Library/Application Support/Rapport'
 end


### PR DESCRIPTION
Important: For some reason `brew cask zap trusteer-rapport` is ignoring the zap stanza and instead simply re-running the uninstall script. I don't understand why and have tried to resolve the issue, but to no avail. Am I missing something obvious?