### PR TITLE
Update abricotine to 0.5.0

### DIFF
--- a/Casks/abricotine.rb
+++ b/Casks/abricotine.rb
@@ -1,11 +1,11 @@
 cask 'abricotine' do
-  version '0.4.0'
-  sha256 '59c00ed450f75fc1cc0bc9fc36ac4e7a86088cf6b2eddc60863fd115486a11c7'
+  version '0.5.0'
+  sha256 '4f133bc46da91b7bc8f6f94370f3b7e63b1fb52acebeb6798d55025713971a20'
 
   # github.com/brrd/Abricotine was verified as official when first introduced to the cask
   url "https://github.com/brrd/Abricotine/releases/download/#{version}/Abricotine-osx-x64.zip"
   appcast 'https://github.com/brrd/Abricotine/releases.atom',
-          checkpoint: 'b3422d90befd04546968b5063a92d50d91ce9fa390449c3e11d7e4537bc1c801'
+          checkpoint: 'b68be4c95fd5f87d83e28659227518a6295167ce4781b91779d7e46758443239'
   name 'abricotine'
   homepage 'https://abricotine.brrd.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.