### PR TITLE
Update typora to 0.9.9.9.3

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.9.2'
-  sha256 '4d969cda4354d68eaa627257600a1a9adde006895576945cb652f1e64c4e9718'
+  version '0.9.9.9.3'
+  sha256 '0e976a080c840ac108f1b7bd4f6694ae2b89961106d5ff0eda32549594f32a1b'
 
   url "https://www.typora.io/download/typora_#{version}.zip"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '2f09a116fe42e9b9e74c803e51f7aea14a155c554608b1b943963f47bdf1d782'
+          checkpoint: 'c21c58bb3c851a8d68638ed943113a28b32a88356f28ec778327a90dd5415175'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.