### PR TITLE
bitcoin-xt.rb: remove resetting permissions

### DIFF
--- a/Casks/bitcoin-xt.rb
+++ b/Casks/bitcoin-xt.rb
@@ -20,10 +20,6 @@ cask 'bitcoin-xt' do
     set_permissions "#{staged_path}/Bitcoin-Xt.app", '0755'
   end
 
-  postflight do
-    set_permissions "#{appdir}/Bitcoin-Xt.app", '0555'
-  end
-
   zap delete: [
                 '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist',
               ]


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.