### PR TITLE
Update filezilla to 3.25.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.24.1'
-    sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
+    version '3.25.0'
+    sha256 '37b2b623d481e472e7d0a31a44aee7e2ffdfff1fbddd231963cd373176026e51'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '9aef92172bbc03270c5097accc8aa56af29a23ba59a8a7e5d19073f002f7824e'
+          checkpoint: '95412095423095b55575ff398e510f6bc6970b1a61e109423e5da8928682061f'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,14 +1,10 @@
 cask 'filezilla' do
-  if MacOS.version <= :snow_leopard
-    version '3.8.1'
-    sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
+  if MacOS.version <= :mavericks
+    version '3.24.1'
+    sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
   else
-    if MacOS.version <= :mavericks
-      version '3.24.1'
-      sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
-    else
-      version '3.25.0'
-      sha256 '37b2b623d481e472e7d0a31a44aee7e2ffdfff1fbddd231963cd373176026e51'
+    version '3.25.0'
+    sha256 '37b2b623d481e472e7d0a31a44aee7e2ffdfff1fbddd231963cd373176026e51'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,8 +3,12 @@ cask 'filezilla' do
     version '3.8.1'
     sha256 '86c725246e2190b04193ce8e7e5ea89d5b9318e9f20f5b6f9cdd45b6f5c2d283'
   else
-    version '3.25.0'
-    sha256 '37b2b623d481e472e7d0a31a44aee7e2ffdfff1fbddd231963cd373176026e51'
+    if MacOS.version <= :mavericks
+      version '3.24.1'
+      sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
+    else
+      version '3.25.0'
+      sha256 '37b2b623d481e472e7d0a31a44aee7e2ffdfff1fbddd231963cd373176026e51'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.