### PR TITLE
Update flash-player-debugger-npapi to 25.0.0.127

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger-npapi' do
-  version '24.0.0.221'
-  sha256 '3fa7c70193efb98bbccab27ce4e646e79d108f15093fa79f3ff70ba294537e4d'
+  version '25.0.0.127'
+  sha256 '55a70ce13108d8f93f8ff624b5ef38cdffce05ee57b53517e885f9cd5d076752'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: 'b07017a15c35b22a55ddc34fe87200e707c39d98facfdde2b331860d2fe7916f'
+          checkpoint: '2b1fead2874fc8798351dec188583692bc626fdfd45585b0e4d40edbae70ceb1'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.