### PR TITLE
Update vectr to 0.1.14

### DIFF
--- a/Casks/vectr.rb
+++ b/Casks/vectr.rb
@@ -1,6 +1,6 @@
 cask 'vectr' do
-  version '0.1.12'
-  sha256 '73cad5c49f202d5b2b18b2ad813c2e7d4e4737107c3f1f95c77e66add7a77933'
+  version '0.1.14'
+  sha256 '67c440898f34ff34d8d61d07c3a5e3de8068f0182a080998cec5090bd7b90d97'
 
   url "http://download.vectr.com/desktop/#{version}/mac/Vectr-mac.dmg"
   name 'Vectr'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.