### PR TITLE
malwarebytes-anti-malware.rb: Add uninstall launchctl, update zap stanza

### DIFF
--- a/Casks/malwarebytes-anti-malware.rb
+++ b/Casks/malwarebytes-anti-malware.rb
@@ -14,14 +14,27 @@ cask 'malwarebytes-anti-malware' do
 
   app 'Malwarebytes Anti-Malware.app'
 
+  uninstall launchctl:  'com.malwarebytes.HelperTool'
+
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.malwarebytes.antimalware.sfl',
                 '~/Library/Application Support/com.malwarebytes.antimalware',
+                '~/Library/Application Support/com.malware.antimalware',
                 '~/Library/Application Support/Malwarebytes',
+                '~/Library/Application Support/Malwarebytes Anti-Malware',
+                '~/Library/Application Support/com.malwarebytes.breachremediation',
                 '~/Library/Caches/com.malwarebytes.antimalware',
                 '~/Library/Caches/com.malwarebytes.Malwarebytes-Anti-Malware-Service',
                 '~/Library/Caches/com.malwarebytes.Malwarebytes-XPC-Service',
                 '~/Library/Preferences/com.malwarebytes.antimalware.plist',
+                '~/Library/Preferences/com.malwarebytes.Malwarebytes-Anti-Malware.plist',
+                '~/Library/Preferences/com.malwarebytes.breachremediation.plist',
                 '~/Library/Saved Application State/com.malwarebytes.antimalware.savedState',
+                '/Library/PrivilegedHelperTools/com.malwarebytes.MBAMHelperTool',
+                '/Library/PrivilegedHelperTools/com.malwarebytes.MBAMHelperTool.plist',
+                '/Library/PrivilegedHelperTools/com.malwarebytes.HelperTool',
+                '/Library/PrivilegedHelperTools/com.malwarebytes.HelperTool.plist',
+                '/Library/LaunchDaemons/com.malwarebytes.MBAMHelperTool.plist',
+                '/Library/LaunchDaemons/com.malwarebytes.HelperTool.plist',
               ]
 end

--- a/Casks/malwarebytes-anti-malware.rb
+++ b/Casks/malwarebytes-anti-malware.rb
@@ -14,7 +14,7 @@ cask 'malwarebytes-anti-malware' do
 
   app 'Malwarebytes Anti-Malware.app'
 
-  uninstall launchctl:  'com.malwarebytes.HelperTool'
+  uninstall launchctl: 'com.malwarebytes.HelperTool'
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.malwarebytes.antimalware.sfl',


### PR DESCRIPTION
Added an `uninstall launchctl` stanza and add more files to the `zap` stanza (found a file inside the app bundle which listed all the files that are removed during uninstallation – helpful!).