### PR TITLE
Add cask avast-secureline-vpn

### DIFF
--- a/Casks/avast-mac-security.rb
+++ b/Casks/avast-mac-security.rb
@@ -1,4 +1,4 @@
-cask 'avast' do
+cask 'avast-mac-security' do
   version :latest
   sha256 :no_check
 

--- a/Casks/avast-secureline-vpn.rb
+++ b/Casks/avast-secureline-vpn.rb
@@ -1,0 +1,23 @@
+cask 'avast-secureline-vpn' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://mac.sl.d.avast.com/mac/avast_secureline.dmg'
+  name 'Avast SecureLine VPN'
+  homepage 'https://www.avast.com/secureline-vpn#mac'
+
+  pkg 'Avast SecureLine VPN.pkg'
+
+  uninstall script:   '/Applications/AvastSecureLine.app/Contents/Applications/AvastSecureLineUninstaller.app/Contents/MacOS/AvastSecureLineUninstaller',
+            pkgutil:   'com.avast.secureline',
+            launchctl: [
+                         'com.avast.secureline.userinit',
+                         'com.avast.secureline.update-agent',
+                         '*.com.avast.osx.secureline.avastsecurelinehelper',
+                       ]
+
+  zap delete: [
+                '~/Library/Cookies/com.avast.osx.secureline.binarycookies',
+                '~/Library/Caches/com.avast.osx.secureline',
+              ]
+end

--- a/Casks/avast-secureline-vpn.rb
+++ b/Casks/avast-secureline-vpn.rb
@@ -8,8 +8,7 @@ cask 'avast-secureline-vpn' do
 
   pkg 'Avast SecureLine VPN.pkg'
 
-  uninstall script:   '/Applications/AvastSecureLine.app/Contents/Applications/AvastSecureLineUninstaller.app/Contents/MacOS/AvastSecureLineUninstaller',
-            pkgutil:   'com.avast.secureline',
+  uninstall pkgutil:   'com.avast.secureline',
             launchctl: [
                          'com.avast.secureline.userinit',
                          'com.avast.secureline.update-agent',


### PR DESCRIPTION
I can't get the uninstall script to show me its arguments (if it has any), and additionally the user needs to restart their system immediately after the uninstall (because the script launches the GUI uninstaller, there is no other option for the user). Also, I included a commit in this pull request which changes the cask `avast` to `avast-mac-security` to avoid confusion between the two casks.