### PR TITLE
Update nylas-mail to 1.0.39-36e4906

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.32-89ced41'
-  sha256 'ac2017ffb098d156d71d31663dd9d0d2b40b3bd3ffd4222f0bf0ce9573b69e1f'
+  version '1.0.39-36e4906'
+  sha256 'c47951eebf2efb2468c3acb54ee5126d15a64771a9fbdcae69fe6311caeb3915'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '0202730be19c5f11cc3162adcf4379cd78f98cbf08c189f8c8bed4c60678be9b'
+          checkpoint: '8742f13aabbd3fb131fc4ff66ddb305c074a007e94f6dd118a3dc357150b3fe2'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.