### PR TITLE
Updating Anoncoin Cask

### DIFF
--- a/Casks/anoncoin.rb
+++ b/Casks/anoncoin.rb
@@ -2,11 +2,11 @@ cask 'anoncoin' do
   version '0.9.6.11'
   sha256 '8b4bb2d1b58e012d5f9b4f493c2f36bcd7bb75096fd70736c39f5d2b1aeaa94d'
 
-  url "https://anoncoin.net/downloads/#{version}/Anoncoin-#{version}.dmg"
-  appcast 'https://anoncoin.net/downloads/',
+  url "http://anoncoin.net/downloads/#{version}/Anoncoin-#{version}.dmg"
+  appcast 'http://anoncoin.net/downloads/',
           checkpoint: '7f2c0786d5cdbcde4d1001036fd954ecb2e38b49dc6404f67e11839bec7924cb'
   name 'Anoncoin'
-  homepage 'https://anoncoin.net/'
+  homepage 'http://anoncoin.net/'
 
   app 'Anoncoin.app'
 


### PR DESCRIPTION
- SSL certificate seems to be expired 2 months back

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].
