### PR TITLE
Update electron to 1.3.14

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.6.2'
-  sha256 '6e2e9d3fa3197c00e243f3eba7e24e9c1ff318377422106d51ede6b63b814e86'
+  version '1.3.14'
+  sha256 '552412de7d1a0d1aa130a170306b803c00bdbbd48dcf928dc4d2de125e530ce7'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'db463e1ca5546a297361f79c9b9303d6034f78f115028a26fc3755eb09d5a31a'
+          checkpoint: 'b120faaa6253cee9b7ed811723ad61f3ecdb2ddba69db935e3330aa1b67721b4'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.