### PR TITLE
Update audirvana-plus to 3.0.2

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,12 +1,20 @@
 cask 'audirvana-plus' do
-  version '2.6.6'
-  sha256 'fd2d0832f1257459991cc1e4008b2c154d86b7b518f66064096d78e885a5ac92'
+  version '3.0.2'
+  sha256 'bd0b19314e567ba0ca0f38eee9286925c3d31315d762598c7105bfe83ca096d8'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml",
-          checkpoint: '487036025712b4e5d8681666fb319408faa4177c749f3185386bf9d329d98f08'
+          checkpoint: '377d6d49236c794f858eddd352cc726ba03c4a7cf0aa9f351cc09a1a93081d3d'
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 
   app 'Audirvana Plus.app'
+
+  zap delete: [
+                '/Library/LaunchDaemons/com.audirvana.Audirvana-Plus.plist',
+                '/Library/PrivilegedHelperTools/com.audirvana.Audirvana-Plus',
+                '~/Library/Caches/com.audirvana.Audirvana-Plus',
+                '~/Library/Cookies/com.audirvana.Audirvana-Plus.binarycookies',
+                '~/Library/Preferences/com.audirvana.Audirvana-Plus.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.