### PR TITLE
Update deltawalker to 2.3.1

### DIFF
--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -1,6 +1,6 @@
 cask 'deltawalker' do
-  version '2.3.0'
-  sha256 '567b17366dbc33518a6a914e140699485a37b840bf99acf8f7e5b1a86c83d664'
+  version '2.3.1'
+  sha256 '237d79ec8617a214c3616521795a76aecd775570a6b1e82a19b4f5b9bddb4a5b'
 
   # amazonaws.com/deltawalker was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/deltawalker/DeltaWalker-#{version}_64.dmg"
@@ -10,4 +10,11 @@ cask 'deltawalker' do
   depends_on macos: '>= :tiger'
 
   app 'DeltaWalker.app'
+
+  zap delete: [
+                '~/Library/Caches/com.deltopia.DeltaWalker',
+                '~/Library/Containers/com.deltopia.DeltaWalker',
+                '~/Library/Preferences/com.deltopia.DeltaWalker.plist',
+                '~/Library/Saved Application State/com.deltopia.DeltaWalker.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.