### PR TITLE
macvim.rb: remove extensive link renames

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -12,19 +12,7 @@ cask 'macvim' do
   depends_on macos: '>= :mountain_lion'
 
   app 'MacVim.app'
-
-  %w[
-    gview
-    gvim
-    gvimdiff
-    gvimex
-    mview
-    mvim
-    mvimdiff
-    mvimex
-  ].each do |link_name|
-    binary 'mvim', target: link_name
-  end
+  binary 'mvim'
 
   zap delete: [
                 '~/Library/Caches/org.vim.MacVim',


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

---

Closes #30953.