### PR TITLE
Update near-lock to 4.0.0

### DIFF
--- a/Casks/near-lock.rb
+++ b/Casks/near-lock.rb
@@ -1,10 +1,10 @@
 cask 'near-lock' do
-  version '3.6.2'
-  sha256 '75a6ef10f26ff536dacad3eb1b8e27443133e302e9d94818d12dcb9ab22ab1e2'
+  version '4.0.0'
+  sha256 'cb2c849b9b941b609a6f2c8101d8fa6990bfce0714b790567b16af824cf10c12'
 
   url 'https://nearlock.me/downloads/nearlock.dmg'
   appcast 'https://nearlock.me/downloads/nearlock.xml',
-          checkpoint: '5a7892312aa20f9057a8e868d748f61a35397854893a7b80f6dfc11922923958'
+          checkpoint: '67628510f2a72f817fd0a66481324568ac961caef5de77f86f315d81ef0f764f'
   name 'Near Lock'
   homepage 'https://nearlock.me/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.