### PR TITLE
Update wxwork to 1.3.6.158

### DIFF
--- a/Casks/wxwork.rb
+++ b/Casks/wxwork.rb
@@ -1,6 +1,6 @@
 cask 'wxwork' do
-  version '1.3.5.1015'
-  sha256 '842734b7ca05605d9a4746d29ccb9889290eca9295e57c3d9b1cc2bd0fc56498'
+  version '1.3.6.158'
+  sha256 '307ebcb5546d262c9275f94b75eb3f36d63c03ec6040e7c19efddbc1396f605b'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   name 'Wechat Enterprise Version'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.