### PR TITLE
Update mountain-duck to 1.8.1.6492

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.8.0.6480'
-  sha256 '6f073745f3d9e4faca9a94e8f83edccd6578d57783fba77ba87f26e4ad91be83'
+  version '1.8.1.6492'
+  sha256 '9ad62ef60f12940a3d17a18ece79e8b123eabe5e8b9c9d444eec9fe69e34b65a'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'e22e5466c30d24bf26e418f27149295f64a857b7a39ff2513974e188a7ae04c6'
+          checkpoint: '8f903d77378f0bed90781c16132e759846ea7fa35bc53fc849125014f7b02816'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.