### PR TITLE
Update shotcut to 17.03.02

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '17.02.05'
-  sha256 'f899f773164b23a0ad07d2efa9f129767534736005292044d9192e506b821edf'
+  version '17.03.02'
+  sha256 'e21f4072235bf732b3d6bdd62ee28be4f6de3ec4d46f4aecc42d12a4aa78fa76'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '10f1ea9cb4c11ef91a508ff88a29c9d2d68f75e25b99fc298f6d2c798d61ecb9'
+          checkpoint: '96e52ccbd0f26229b78a978daf3dafe97cf96d3b5d6db033b2583ce477b1e382'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.