### PR TITLE
Update libreoffice to 5.3.1

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '5.3.0'
-  sha256 '430f9b2d324e58de5b47f70be46ee2a4690e36c0612e04314f7a99c4fca7f059'
+  version '5.3.1'
+  sha256 '12003dac2c3b23e736f1c8500f47f99be0d5aaabc965e7a06fc2b695e2dd6d74'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.