### PR TITLE
wireshark 2.2.5: Run `dseditgroup` with sudo.

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -26,6 +26,7 @@ cask 'wireshark' do
   uninstall script:  {
                        executable: '/usr/sbin/dseditgroup',
                        args:       ['-o', 'delete', 'access_bpf'],
+                       sudo:       true,
                      },
             pkgutil: 'org.wireshark.*',
             delete:  [


### PR DESCRIPTION
Otherwise uninstall fails:
```
==> Running uninstall process for wireshark; your password may be necessary
==> Running uninstall script /usr/sbin/dseditgroup
==> Username and password must be provided.
Error: Command failed to execute!

==> Failed command:
#<Pathname:/usr/sbin/dseditgroup> -o delete access_bpf

==> Standard Output of failed command:


==> Standard Error of failed command:
Username and password must be provided.


==> Exit status of failed command:
#<Process::Status: pid 24757 exit 64>
```

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
