### PR TITLE
Update webcatalog to 3.4.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,13 +1,22 @@
 cask 'webcatalog' do
-  version '3.3.0'
-  sha256 '848ddc8eb98206d01907976cb3eedfb8c912f145e48ea23cce31a1dbff44b00a'
+  version '3.4.0'
+  sha256 '259defdb631646451c1edbda635e24227ba9c578017f8ddb65e303d3f5e31c2b'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '23ba7d52680f8ad3a0a2a2d0dc5a9d9ccebe657f2f30eeb0ef128d1c75b57ab4'
+          checkpoint: 'fb21aefc5e0fdb5c15fc19170cb4bb41316131998e17a665f74fbf8eaabbc9b0'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/'
 
   app 'WebCatalog.app'
+
+  zap delete: [
+                '~/Library/Application Support/WebCatalog',
+                '~/Library/Cookies/com.webcatalog.app.binarycookies',
+                '~/Library/Preferences/WebCatalog_Alt.plist',
+                '~/Library/Preferences/com.webcatalog.app.helper.plist',
+                '~/Library/Preferences/com.webcatalog.app.plist',
+                '~/Library/Saved Application State/com.webcatalog.app.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.