### PR TITLE
Update browser-chooserx to 1.2.6

### DIFF
--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -1,10 +1,10 @@
 cask 'browser-chooserx' do
-  version '1.2.5'
-  sha256 'ceb0d92493a42264d6fff765b49b45eaa1ddb2cafb169c552b619605ccd32c68'
+  version '1.2.6'
+  sha256 'c0a7f5e17bb3093c9be573d65133600dafc3ab30e04b016b7e39a4c236bdeae9'
 
   url 'https://www.bdevapps.com/files/downloads/Browser%20ChooserX.zip'
   appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
-          checkpoint: '59db5bb7da1a5b614925fb5521ec61f50258ce87996d1b22ca1f22f68c08bb50'
+          checkpoint: '0ec97bcb8a3d22dda757171b8427b2c22d81349ecc434eed986b0688b13d9f0c'
   name 'Browser ChooserX'
   homepage 'https://bdevapps.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.