### PR TITLE
Update navicat-for-sqlite to 11.2.17

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '11.2.16'
-  sha256 '270f17e53ccf4443e02f67ce705388d55fb8d0ae3b0adbcb4bb1452f8d10d94e'
+  version '11.2.17'
+  sha256 '4f9be16d5884f7cdd3b88be97173893598bf81f07e7fdeb1f4261eb496a29a0d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   name 'Navicat for SQLite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.