### PR TITLE
Update navicat-for-sql-server to 11.2.17

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '11.2.16'
-  sha256 'e3529ae3df288d3da70a3b8805ca8a2bbe805402b3ff38f54994a02173d9f092'
+  version '11.2.17'
+  sha256 '84826b23b496dc809794c91ad77bce6deff9978c5ddb780999e9dd76ae776cc3'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   name 'Navicat for SQL Server'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.