### PR TITLE
Update bassshapes to 01.2

### DIFF
--- a/Casks/bassshapes.rb
+++ b/Casks/bassshapes.rb
@@ -1,8 +1,8 @@
 cask 'bassshapes' do
   version '01.2'
-  sha256 '7f055b8114c9f5307bd1a0247532003b1e500974c5b60067e4770fcd24fae61e'
+  sha256 '69077a7ec35e39e1257b6957436b383e2af4176f2f9158360244d65dada9bc06'
 
-  url "http://yellquietly.com/downloads/BassShapes_v#{version.no_dots}.zip"
+  url "http://yellquietly.com/downloads/BassShapes_v#{version}.zip"
   name 'Bass Shapes'
   homepage 'http://yellquietly.com/bass-shapes/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.