### PR TITLE
Update vox-preferences-pane to 1.3.8

### DIFF
--- a/Casks/vox-preferences-pane.rb
+++ b/Casks/vox-preferences-pane.rb
@@ -1,11 +1,11 @@
 cask 'vox-preferences-pane' do
-  version '1.2.19'
-  sha256 '9f29732dd7441c5dd18024838ed46a968499ad39529ad41be1664ee315a20ee6'
+  version '1.3.8'
+  sha256 '27f3ca138f5360efa795cabd3961998acf52ad534257bd0655222409ef9d4498'
 
   # devmate.com/com.coppertino.VoxPrefs was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.VoxPrefs/VoxPrefs.dmg'
   appcast 'http://updateinfo.devmate.com/com.coppertino.VoxPrefs/updates.xml',
-          checkpoint: 'c5d5496d2f6dd7567cb3b32535847b5d8cb403289bcdce458b977cb2df496da3'
+          checkpoint: 'f0e62eb9fa14eda0bf00e5298ae4ccff8f1126eb42642d8e4cee341af93e9e16'
   name 'VOX Preferences'
   homepage 'https://vox.rocks/mac-music-player/control-extension-download'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.