### PR TITLE
Add tanki-online version 3

### DIFF
--- a/Casks/tanki-online.rb
+++ b/Casks/tanki-online.rb
@@ -9,7 +9,7 @@ cask 'tanki-online' do
   app 'Tanki Online.app'
 
   zap delete: [
-                '~/Library/Application\ Support/TankiOnline/',
+                '~/Library/Application Support/TankiOnline/',
                 '~/Library/Caches/TankiOnline/',
               ]
 end

--- a/Casks/tanki-online.rb
+++ b/Casks/tanki-online.rb
@@ -1,0 +1,15 @@
+cask 'tanki-online' do
+  version '3'
+  sha256 '091b16df7f7a68bc0637c24923836d7965fd4c6feab7655013bb48beea6f51c4'
+
+  url "http://s.eu.tankionline.com/resources/client/#{version}/mac/tankionline_eu.dmg"
+  name 'Tanki Online'
+  homepage 'http://tankionline.com/'
+
+  app 'Tanki Online.app'
+
+  zap delete: [
+                '~/Library/Application\ Support/TankiOnline/',
+                '~/Library/Caches/TankiOnline/',
+              ]
+end


### PR DESCRIPTION
Not particularly sure if this cask has a version; however, I noticed that the number '3' in the URL can be replaced with a '2' and '1' and the download still works, which leads me to assume that this is the version number.

Passed `brew cask style tanki-online` and `brew cask audit --download tanki-online`.