### PR TITLE
Update react-native-debugger (0.6.1)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.6.0'
-  sha256 '4fac01f0c3ff7390da224ab306363ab91c4fe656a258c6a843cba92f271ca727'
+  version '0.6.1'
+  sha256 '4736a41eeddba50f6d3d07cf92a9be4df6aa1cc419fff84bcb4f88fe69f7785f'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '3a28b0b4d270fe7100784b373192c947867053a8e3ab3db84903a7b69962462c'
+          checkpoint: '484994bcb382accf64d4898d7793cba5722aef9fd5e366e4abade3e9ad7ede26'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.