### PR TITLE
Add Jietu.app v2.2.1

### DIFF
--- a/Casks/jietu.rb
+++ b/Casks/jietu.rb
@@ -1,16 +1,16 @@
 cask 'jietu' do
-  version '2.2.1'
+  version '2.2.1(10927)'
   sha256 '60cdd6a18092a4f889343595d64a35aa78dbd747f6f4dd9cd47c35f868d7e3d2'
 
-  url 'http://dldir1.qq.com/invc/tt/Jietu_2.2.1(10927).dmg'
+  url "http://dldir1.qq.com/invc/tt/Jietu_#{version}.dmg"
   name 'Jietu'
   name '截图'
   homepage 'http://jietu.qq.com/'
 
   app 'Jietu.app'
 
-  uninstall quit:      ['com.tencent.JietuMac'],
-            launchctl: ['com.tencent.JietuHelperMac']
+  uninstall quit:      'com.tencent.JietuMac',
+            launchctl: 'com.tencent.JietuHelperMac',
 
-  zap delete: ['~/Library/Preferences/com.tencent.JietuMac.plist']
+  zap delete: '~/Library/Preferences/com.tencent.JietuMac.plist'
 end

--- a/Casks/jietu.rb
+++ b/Casks/jietu.rb
@@ -1,0 +1,16 @@
+cask 'jietu' do
+  version '2.2.1'
+  sha256 '60cdd6a18092a4f889343595d64a35aa78dbd747f6f4dd9cd47c35f868d7e3d2'
+
+  url 'http://dldir1.qq.com/invc/tt/Jietu_2.2.1(10927).dmg'
+  name 'Jietu'
+  name '截图'
+  homepage 'http://jietu.qq.com/'
+
+  app 'Jietu.app'
+
+  uninstall quit:      ['com.tencent.JietuMac'],
+            launchctl: ['com.tencent.JietuHelperMac']
+
+  zap delete: ['~/Library/Preferences/com.tencent.JietuMac.plist']
+end

--- a/Casks/jietu.rb
+++ b/Casks/jietu.rb
@@ -10,7 +10,7 @@ cask 'jietu' do
   app 'Jietu.app'
 
   uninstall quit:      'com.tencent.JietuMac',
-            launchctl: 'com.tencent.JietuHelperMac',
+            launchctl: 'com.tencent.JietuHelperMac'
 
   zap delete: '~/Library/Preferences/com.tencent.JietuMac.plist'
 end


### PR DESCRIPTION
Jietu.app is also available on the Mac App Store with version 2.3.0, but it has fewer features due to sandboxing.

After making all changes to the cask:

- [x] `brew cask audit --download jietu` is error-free.
- [x] `brew cask style --fix jietu` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install jietu` worked successfully.
- [x] `brew cask uninstall jietu` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
