### PR TITLE
Update bzflag to 2.4.10

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -1,10 +1,10 @@
 cask 'bzflag' do
-  version '2.4.8'
-  sha256 '3b4bdd1b98565b998ff7b6915670cb30b81358203aed27423afb0a5f2bd3a5a9'
+  version '2.4.10'
+  sha256 '7e7147380f03e51acf5f12353454f539a25ccc3b90a853b8cf8fcabc11b0afc0'
 
   url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom',
-          checkpoint: '4662d8b609304cd7be193cfd5ef6504670d98d52fba4e3f6a0546db7d76a6451'
+          checkpoint: 'bf375854bf8e5da22b1c39a064f92c6f1cae3143f240342505c383e3ce18caf2'
   name 'BZFlag'
   homepage 'http://bzflag.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.