### PR TITLE
Update whatroute to 2.0.17

### DIFF
--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,6 +1,6 @@
 cask 'whatroute' do
-  version '2.0.16'
-  sha256 '3f871a70be24332ba6a37f9a5c09da905182c34026fd53a1afb402508af7660a'
+  version '2.0.17'
+  sha256 '63a13c326a41b4652c291aa0f441d608522a9ab1346e4dcfc5154576e7a47186'
 
   url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   name 'WhatRoute'
@@ -9,4 +9,12 @@ cask 'whatroute' do
   depends_on macos: '>= :yosemite'
 
   app 'WhatRoute.app'
+
+  zap delete: [
+                '/Library/LaunchDaemons/net.whatroute.whatroute2helper.plist',
+                '/Library/PrivilegedHelperTools/net.whatroute.whatroute2helper',
+                '~/Library/Caches/net.whatroute.whatroute2',
+                '~/Library/Logs/net.whatroute.whatroute2',
+                '~/Library/Preferences/net.whatroute.whatroute2.plist',
+              ]
 end

--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,6 +1,6 @@
 cask 'whatroute' do
-  version '2.0.13'
-  sha256 '920c088f9c0b80b78eb632c64119c81096497536ca62e4ce428516c3471be5c5'
+  version '2.0.16'
+  sha256 '3f871a70be24332ba6a37f9a5c09da905182c34026fd53a1afb402508af7660a'
 
   url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   name 'WhatRoute'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.