### PR TITLE
Add `IPA Manager.app` v2.2.1

### DIFF
--- a/Casks/ipa-manager.rb
+++ b/Casks/ipa-manager.rb
@@ -1,0 +1,10 @@
+cask 'ipa-manager' do
+  version '2.2.1'
+  sha256 '5cd8d2ae311f2d99b0e83e7e861ccdaf7156dab874b2e170d645791031509ffd'
+
+  url 'https://www.blugs.com/Downloads/IPAManager.dmg'
+  name 'IPA Manager'
+  homepage 'https://www.blugs.com/IPA/'
+
+  app 'IPA Manager.app'
+end

--- a/Casks/ipa-manager.rb
+++ b/Casks/ipa-manager.rb
@@ -8,5 +8,15 @@ cask 'ipa-manager' do
   name 'IPA Manager'
   homepage 'https://www.blugs.com/IPA/'
 
+  auto_updates true
+  depends_on macos: '>= :leopard'
+
+
   app 'IPA Manager.app'
+
+  zap delete: [
+  				'~/Library/Preferences/com.blugs.IPAManager.plist'
+				'~/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.blugs.ipamanager.sfl'
+      			'~/Library/Caches/com.blugs.IPAManager'
+              ]
 end

--- a/Casks/ipa-manager.rb
+++ b/Casks/ipa-manager.rb
@@ -4,7 +4,7 @@ cask 'ipa-manager' do
 
   url 'https://www.blugs.com/Downloads/IPAManager.dmg'
   appcast 'https://www.blugs.com/Appcasts/IPAPalette.xml',
-          checkpint: 'ea8fde774a46f69a2c4adac6e60f9ab4ccf4e4f5bc52c5cf706787a59999c0bf'
+          checkpoint: 'ea8fde774a46f69a2c4adac6e60f9ab4ccf4e4f5bc52c5cf706787a59999c0bf'
   name 'IPA Manager'
   homepage 'https://www.blugs.com/IPA/'
 

--- a/Casks/ipa-manager.rb
+++ b/Casks/ipa-manager.rb
@@ -3,6 +3,8 @@ cask 'ipa-manager' do
   sha256 '5cd8d2ae311f2d99b0e83e7e861ccdaf7156dab874b2e170d645791031509ffd'
 
   url 'https://www.blugs.com/Downloads/IPAManager.dmg'
+  appcast 'https://www.blugs.com/Appcasts/IPAPalette.xml',
+          checkpint: 'ea8fde774a46f69a2c4adac6e60f9ab4ccf4e4f5bc52c5cf706787a59999c0bf'
   name 'IPA Manager'
   homepage 'https://www.blugs.com/IPA/'
 

--- a/Casks/ipa-manager.rb
+++ b/Casks/ipa-manager.rb
@@ -1,4 +1,4 @@
-cask 'ipa-palette' do
+cask 'ipa-manager' do
   version '2.2.1'
   sha256 '5cd8d2ae311f2d99b0e83e7e861ccdaf7156dab874b2e170d645791031509ffd'
 

--- a/Casks/ipa-palette.rb
+++ b/Casks/ipa-palette.rb
@@ -1,11 +1,11 @@
-cask 'ipa-manager' do
+cask 'ipa-palette' do
   version '2.2.1'
   sha256 '5cd8d2ae311f2d99b0e83e7e861ccdaf7156dab874b2e170d645791031509ffd'
 
   url 'https://www.blugs.com/Downloads/IPAManager.dmg'
   appcast 'https://www.blugs.com/Appcasts/IPAPalette.xml',
           checkpoint: 'ea8fde774a46f69a2c4adac6e60f9ab4ccf4e4f5bc52c5cf706787a59999c0bf'
-  name 'IPA Manager'
+  name 'IPA Palette'
   homepage 'https://www.blugs.com/IPA/'
 
   auto_updates true

--- a/Casks/ipa-palette.rb
+++ b/Casks/ipa-palette.rb
@@ -11,12 +11,11 @@ cask 'ipa-palette' do
   auto_updates true
   depends_on macos: '>= :leopard'
 
-
   app 'IPA Manager.app'
 
   zap delete: [
-  				'~/Library/Preferences/com.blugs.IPAManager.plist'
-				'~/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.blugs.ipamanager.sfl'
-      			'~/Library/Caches/com.blugs.IPAManager'
+                '~/Library/Preferences/com.blugs.IPAManager.plist',
+                '~/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.blugs.ipamanager.sfl',
+                '~/Library/Caches/com.blugs.IPAManager',
               ]
 end


### PR DESCRIPTION
IPA Palette is a palette-class input method for OS X 10.5 and later.
It makes possible point-and-click input of International Phonetic
Alphabet symbols into Unicode-savvy applications.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download ipa-palette` is error-free.
- [x] `brew cask style --fix ipa-palette` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install ipa-palette` worked successfully.
- [x] `brew cask uninstall ipa-palette` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
