### PR TITLE
Update black-screen to 0.2.140

### DIFF
--- a/Casks/black-screen.rb
+++ b/Casks/black-screen.rb
@@ -1,10 +1,10 @@
 cask 'black-screen' do
-  version '0.2.93'
-  sha256 'f22217696997aa67833fd9bf6a888c748d4d743e18068d1bf4d8cc87e087a9bc'
+  version '0.2.140'
+  sha256 '701a3768f4d6954facd9dcf7ee50712a6ab7def39f1e680e62869f23c2626d2e'
 
   url "https://github.com/vshatskyi/black-screen/releases/download/v#{version}/black-screen-#{version}-mac.zip"
   appcast 'https://github.com/vshatskyi/black-screen/releases.atom',
-          checkpoint: 'ee18ae661108286d196dde79788ea2bc48a62c14f882a260319bd2670b9a6ae2'
+          checkpoint: '495f333af99d83359a752658e2e8957a6a31bad25377dbdf2fa3641ef506620d'
   name 'Black Screen'
   homepage 'https://github.com/vshatskyi/black-screen'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.