### PR TITLE
Update gogs to 0.10.18

### DIFF
--- a/Casks/gogs.rb
+++ b/Casks/gogs.rb
@@ -1,11 +1,11 @@
 cask 'gogs' do
-  version '0.10.8'
-  sha256 '183bf709297231b5ca9490fa385f97e3ab9afd59ddeffe972d50bade68e1e20b'
+  version '0.10.18'
+  sha256 '2cff63d4ee55866325f4c581721825a9f5204b8dcae712179a87cd2fe1c9355d'
 
   # github.com/gogits/gogs was verified as official when first introduced to the cask
   url "https://github.com/gogits/gogs/releases/download/v#{version}/darwin_amd64.zip"
   appcast 'https://github.com/gogits/gogs/releases.atom',
-          checkpoint: '26caa92a196a2773f29c439c259d45bb72150c7be8c62fab0dbcd28982cacf7b'
+          checkpoint: '008541d957ba25e33febe14263d4ae20ee32b25c541b360d7639328c2c6b8dba'
   name 'Go Git Service'
   homepage 'https://gogs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.