### PR TITLE
Update invisionsync to 1.8.3-684

### DIFF
--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -1,10 +1,10 @@
 cask 'invisionsync' do
-  version '1.8.2-683'
-  sha256 '2e40d68390b2c1d72e32a50792a89f8ef80f6b34b0bfeefb4e480802cce4d55e'
+  version '1.8.3-684'
+  sha256 '17646577e2bf6be6ec96eeffe2bdb12853425673bc22c19946bf5b31a6f1a2fa'
 
   url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.sub(%r{^.*?-}, '')}.zip"
   appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml',
-          checkpoint: '3c142a877b1aa92ed471d0f2c83c09a0eb4954605f7230360259fd6901711b66'
+          checkpoint: 'bfd3c6b2e7746c0fbe2c89cdefc245e4d8daefc3592d263de299bb05969017fb'
   name 'InVision Sync'
   homepage 'https://www.invisionapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.