### PR TITLE
Update waterfox to 52.0,2

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '51.0,1'
-  sha256 '1878cb6dd317b1e9483662117649e60012017eb28a51797b120d1a7ceb637a9a'
+  version '52.0,2'
+  sha256 'b54eb997d394944601f142f9bd277e2bbf9f974668594ef0ed863e061cf99fbd'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version.before_comma}%20Setup-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.