### PR TITLE
Add alternative bitcoin clients

### DIFF
--- a/Casks/bitcoin-classic.rb
+++ b/Casks/bitcoin-classic.rb
@@ -1,0 +1,23 @@
+cask 'bitcoin-classic' do
+  version '1.2.2'
+  sha256  'ee6eda8071e65a47b60a6d3a52c04ab8e75c53abfcca53da24599f572514dece'
+
+  url      "https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v#{version}/bitcoin-#{version}-osx.dmg"
+  name     'Bitcoin Classic'
+  homepage 'https://bitcoinclassic.com/'
+
+  conflicts_with cask: 'bitcoin-core',
+                 cask: 'bitcoin-unlimited',
+                 cask: 'bitcoin-xt'
+
+  depends_on     macos: '>= :mountain_lion'
+
+  app 'Bitcoin-Qt.app', target: 'Bitcoin Classic.app'
+
+  preflight do
+    set_permissions "#{staged_path}/Bitcoin-Qt.app", '0755'
+  end
+
+  # Bitcoin classic names it preferences file same as Bitcoin Core:
+  zap delete: '~/Library/Preferences/org.bitcoin.Bitcoin-Qt.plist'
+end

--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -7,7 +7,10 @@ cask 'bitcoin-core' do
   name 'Bitcoin Core'
   homepage 'https://bitcoincore.org/'
 
-  conflicts_with cask: 'bitcoin-xt'
+  conflicts_with cask: 'bitcoin-classic',
+                 cask: 'bitcoin-unlimited',
+                 cask: 'bitcoin-xt'
+
   depends_on macos: '>= :mountain_lion'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.

--- a/Casks/bitcoin-unlimited.rb
+++ b/Casks/bitcoin-unlimited.rb
@@ -1,0 +1,22 @@
+cask 'bitcoin-unlimited' do
+  version '1.0.1.1'
+  sha256  '47aa38b237d15112ea41e70341be3d2cbbc0edc431a2ddf2533bb34cbd359db9'
+
+  url      "https://www.bitcoinunlimited.info/downloads/bitcoinUnlimited-#{version}-osx.dmg"
+  name     'Bitcoin Unlimited'
+  homepage 'https://www.bitcoinunlimited.info'
+
+  conflicts_with cask: 'bitcoin-classic',
+                 cask: 'bitcoin-core',
+                 cask: 'bitcoin-xt'
+
+  depends_on     macos: '>= :mountain_lion'
+
+  app 'Bitcoin-Qt.app', target: 'Bitcoin Unlimited.app'
+
+  preflight do
+    set_permissions "#{staged_path}/Bitcoin-Qt.app", '0755'
+  end
+
+  zap delete: '~/Library/Preferences/info.bitcoinunlimited.Bitcoin-Qt.plist'
+end

--- a/Casks/bitcoin-xt.rb
+++ b/Casks/bitcoin-xt.rb
@@ -12,7 +12,9 @@ cask 'bitcoin-xt' do
   name 'Bitcoin XT'
   homepage 'https://bitcoinxt.software/'
 
-  conflicts_with cask: 'bitcoin-core'
+  conflicts_with cask: 'bitcoin-classic',
+                 cask: 'bitcoin-core',
+                 cask: 'bitcoin-unlimited'
 
   app 'Bitcoin-XT.app'
 


### PR DESCRIPTION
# Description

This adds casks for [Bitcoin Classic](https://bitcoinclassic.com/) and [Bitcoin Unlimited](https://www.bitcoinunlimited.info) clients to the existing Bitcoin Core and Bitcoin XT clients, and makes it so all 4 bitcoin-related casks are aware of conflicts with the other 4.

# Checklist
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
  (Rubocop is freaking out on me locally)
- [ ] The commit message includes the cask’s name and version.
  - See questions
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

# Questions

- Would you rather it be three commits like this - one for each of the new casks, one for the conflicts? Or squash some/all of them?
- Do you want versions for each of them in the commit msg, being new?
- Anything else?