### PR TITLE
Update little-flocker to 1.6.2

### DIFF
--- a/Casks/little-flocker.rb
+++ b/Casks/little-flocker.rb
@@ -1,6 +1,6 @@
 cask 'little-flocker' do
-  version '1.6.1'
-  sha256 'e07576974ec461f0b42e338b34f6763f61e38da7d128fa248ec16688b3274422'
+  version '1.6.2'
+  sha256 '646d20ee0584fc1b606287b3e7f7e556a7a4a6bbd234f68935b570c9572f9419'
 
   url "https://www.littleflocker.com/downloads/LittleFlocker-#{version}.dmg"
   name 'Little Flocker'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
