### PR TITLE
Update maltego-classic to 4.0.16.9722

### DIFF
--- a/Casks/maltego-classic.rb
+++ b/Casks/maltego-classic.rb
@@ -1,6 +1,6 @@
 cask 'maltego-classic' do
-  version '4.0.8.9246'
-  sha256 '9a36647f54760b0bba40634d19184470d5cdd073d3e4d772fdac3281c6b955fa'
+  version '4.0.16.9722'
+  sha256 '5915e6256a0f8a69dd7f8c9eca63f7a3856927d8bbb3d2fab6a3696c55fa7a24'
 
   url "https://www.paterva.com/malv#{version.major}/classic/Maltego.v#{version}.dmg"
   name 'Paterva Maltego'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.