### PR TITLE
Update devcenter to 1.6.0

### DIFF
--- a/Casks/devcenter.rb
+++ b/Casks/devcenter.rb
@@ -1,6 +1,6 @@
 cask 'devcenter' do
   version '1.6.0'
-  sha256 '233b1ac58d509aa3a743b54658d8b35383e653765023278d5688d0dd13253639'
+  sha256 '2f803cdc700e3dd06d5bbad8d5c3039f6aa9a793baee42fc043439b495832ac3'
 
   url "https://downloads.datastax.com/devcenter/DevCenter-#{version}-macosx-x86_64.tar.gz"
   name 'DataStax DevCenter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.