### PR TITLE
Update aircall to 1.3.11

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,10 +1,10 @@
 cask 'aircall' do
-  version '1.3.0'
-  sha256 '49c2aa6bbdd9c6c579545ab5f89dd83e57469040008452f500a735cae0c32d0d'
+  version '1.3.11'
+  sha256 '7e0e4afb5f5232ea2c7c8bb6b0564c284c8349ae60183a10a001687957d06c44'
 
   url "https://electron.aircall.io/download/#{version}/osx"
   appcast 'https://electron.aircall.io/update/osx/1.1.0',
-          checkpoint: '43301a5ffe74fea9d4cf0271b110c80201e839a0af1b69c077057f3b192b898e'
+          checkpoint: '14292b0c3dab7db43901f9ff5e3b0fc5d22b5d7b6989b9574f60df261e610077'
   name 'Aircall'
   homepage 'https://aircall.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.