### PR TITLE
Update air-video-server-hd to 2.2.4-beta2

### DIFF
--- a/Casks/air-video-server-hd.rb
+++ b/Casks/air-video-server-hd.rb
@@ -1,11 +1,11 @@
 cask 'air-video-server-hd' do
-  version '2.2.4-beta1'
-  sha256 'e4444e0ed2c63cdb7aa45b38374ef166d70d98e7a4d06e4f4ea90f5e6fa6fcbb'
+  version '2.2.4-beta2'
+  sha256 'f3578a21f537a04756c0f8af8f8a5ca845baa034e75477f766d78be92977607f'
 
   # amazonaws.com/AirVideoHD was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/AirVideoHD/Download/Air+Video+Server+HD+#{version}.dmg"
   appcast 'https://s3.amazonaws.com/AirVideoHD/Download/appcast.xml',
-          checkpoint: 'e327ff4f0f6128267a1ef1af2e92086228a69d43203823ff4ce9cdb435bdeaf7'
+          checkpoint: '5bac1596a893cf4ac74db81a40404b6a98a0b8d14c3163cee14882b3557673f8'
   name 'Air Video Server HD'
   homepage 'http://www.inmethod.com/airvideohd'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.