### PR TITLE
Update writefull to latest (3.0.0-beta12)

### DIFF
--- a/Casks/writefull.rb
+++ b/Casks/writefull.rb
@@ -1,13 +1,11 @@
 cask 'writefull' do
-  version '3.0.0-beta10-patch2'
-  sha256 'a6690158f67ff3e107c37f92995b5f3cb4757d306025c352bcbb39dca7549cdb'
+  version :latest
+  sha256 :no_check
 
-  # github.com/paraphrase-ai/writefull-releases was verified as official when first introduced to the cask
-  url "https://github.com/paraphrase-ai/writefull-releases/releases/download/#{version}/Writefull.dmg"
-  appcast 'https://github.com/paraphrase-ai/writefull-releases/releases.atom',
-          checkpoint: '7c9ae4a6c5ebb22eb50af62f4167c813c76da523a9743fd266fb45bff0a810c6'
+  # d3aw1w08kaciwn.cloudfront.net was verified as official when first introduced to the cask
+  url 'https://d3aw1w08kaciwn.cloudfront.net/Writefull.dmg'
   name 'Writefull'
   homepage 'https://writefullapp.com/'
 
-  app "Writefull_#{version.major}beta.app"
+  app 'Writefull.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

It seems they won't release their app at github anymore.