### PR TITLE
Update freesmug-chromium to 57.0.2987.110

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '57.0.2987.98'
-  sha256 'fc75350c1e2f4222a078e9784db7e34b029f87b5987c3b5edc57e71b944949bf'
+  version '57.0.2987.110'
+  sha256 '3342f3b3516eba019459a7c87111bfa464a54093dc0baaa9c44e0e298ffd4546'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '6323ca74531d5cc2cdc2e289772917ffc5431cd3aea98c062f588b6bfe8caeb4'
+          checkpoint: 'd7a820050d3c3ec8f7902b319dfb20b4fd62f6d5b215640c4804a6a357dba4f4'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
Changelog is [here](https://chromium.googlesource.com/chromium/src/+log/57.0.2987.98..57.0.2987.110?pretty=fuller&n=10000)

---

After making all changes to the cask:

- [x] `brew cask audit --download Casks/freesmug-chromium.rb` is error-free.
- [x] `brew cask style --fix Casks/freesmug-chromium.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.