### PR TITLE
textwrangler: Mark as discontinued

### DIFF
--- a/Casks/textwrangler.rb
+++ b/Casks/textwrangler.rb
@@ -30,5 +30,4 @@ cask 'textwrangler' do
   caveats do
     discontinued
   end
-
 end

--- a/Casks/textwrangler.rb
+++ b/Casks/textwrangler.rb
@@ -26,4 +26,9 @@ cask 'textwrangler' do
   binary "#{appdir}/TextWrangler.app/Contents/Helpers/edit"
   binary "#{appdir}/TextWrangler.app/Contents/Helpers/twdiff"
   binary "#{appdir}/TextWrangler.app/Contents/Helpers/twfind"
+
+  caveats do
+    discontinued
+  end
+
 end


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

---

See [announcement](http://us11.campaign-archive1.com/?u=d7ffaa16f302eaf61e416e389&id=5c0940cf9b). Textwrangler will be replaced by BBEdit, which is free to use with reduced feature set after the evaluation period is over.