### PR TITLE
Update cakebrew.rb for depends_on and zap

### DIFF
--- a/Casks/cakebrew.rb
+++ b/Casks/cakebrew.rb
@@ -8,10 +8,13 @@ cask 'cakebrew' do
   name 'Cakebrew'
   homepage 'https://www.cakebrew.com/'
 
+  depends_on macos: '>= :mountain_lion'
+
   app 'Cakebrew.app'
 
   zap delete: [
                 '~/Library/Caches/com.brunophilipe.Cakebrew',
                 '~/Library/Preferences/com.brunophilipe.Cakebrew.plist',
+                '~/Library/Saved Application State/com.brunophilipe.Cakebrew.savedState',
               ]
 end


### PR DESCRIPTION
Update cakebrew.rb for depends_on and zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
