### PR TITLE
added zap delete for a scheduler for cleanmymac v3.7.4,1488469864

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -67,6 +67,7 @@ cask 'cleanmymac' do
                   "~/Library/Caches/CleanMyMac #{version.major}",
                   "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}",
                   "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Menu",
+                  "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Scheduler",
                   "~/Library/Logs/CleanMyMac #{version.major}.log",
                   "~/Library/Logs/com.macpaw.CleanMyMac#{version.major}",
                   "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.major}-Helper.plist",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download cleanmymac` is error-free.
- [x] `brew cask style --fix cleanmymac` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
