### PR TITLE
Update imageplay to 6.1.0

### DIFF
--- a/Casks/imageplay.rb
+++ b/Casks/imageplay.rb
@@ -1,11 +1,11 @@
 cask 'imageplay' do
   version '6.1.0'
-  sha256 'b85bdff21dd8a569d84f3dcf25b2201b5c784ef06b8a5db8a6390897e2d7ed9d'
+  sha256 'afb57eee23f28c3b8bc45413fcdbc9d30c17267be929cfb9fb9918beff8d812e'
 
   # github.com/cpvrlab/ImagePlay was verified as official when first introduced to the cask
   url "https://github.com/cpvrlab/ImagePlay/releases/download/#{version}/ImagePlay-#{version}.dmg"
   appcast 'https://github.com/cpvrlab/ImagePlay/releases.atom',
-          checkpoint: 'df31de5607628dbc9cd4f6d842a6d3d077d30db480f8148212e7bab5c499a8c3'
+          checkpoint: 'e30fd8bb653449d1439fb4868a6717743ee43797d5e98d68bed5b8f0ffd2b7b1'
   name 'ImagePlay'
   homepage 'https://imageplay.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.