### PR TITLE
Add Setapp.app v1.1.2

### DIFF
--- a/Casks/setapp.rb
+++ b/Casks/setapp.rb
@@ -1,0 +1,22 @@
+cask 'setapp' do
+  version '1.1.2'
+  sha256 '02842ae2002e4549c87a225a3ad68458cbace60c22f0fe3f533a034e3d21cfe6'
+
+  # dl.devmate.com was verified as official when first introduced to the cask
+  url 'https://dl.devmate.com/com.setapp.DesktopClient/Setapp.zip'
+  appcast 'https://updates.devmate.com/com.setapp.DesktopClient.xml',
+          checkpoint: '08c1f419440f53b04c0deb7e3dff983f7201b73f1fa2695bf714f32c04cfbb7c'
+  name 'Setapp'
+  homepage 'https://setapp.com'
+
+  app 'Setapp.app'
+
+  zap delete: [
+                '~/Library/Application Support/Setapp',
+                '~/Library/LaunchAgents/com.setapp.DesktopClient.SetappAgent.plist',
+                '~/Library/LaunchAgents/com.setapp.DesktopClient.SetappUpdater.plist',
+                '~/Library/Logs/Setapp',
+                '~/Library/Preferences/com.setapp.DesktopClient.plist',
+                '~/Library/Preferences/com.setapp.DesktopClient.SetappAgent.plist',
+              ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

There's a previous closed PR https://github.com/caskroom/homebrew-cask/pull/27439 saying that it was walled, but now the download URL is not behind a login/registration form. I don't know if it should be considered walled reading the definition in [the correct repo] that states: 

> Walled: When the download URL is **both** behind a login/registration form and from a host that differs from the homepage.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask