### PR TITLE
Update synergy.rb URL

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -2,7 +2,7 @@ cask 'synergy' do
   version '1.8.8,c30301e'
   sha256 '9f9019b3c558bf0c05e558828ed282b29c316d9477c5f5169d3461e32dadb9b6'
 
-  url "https://symless.com/files/packages/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX-x86_64.dmg"
+  url "https://binaries.symless.com/v#{version.before_comma}/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX-x86_64.dmg"
   name 'Synergy'
   homepage 'https://symless.com/synergy/'
 


### PR DESCRIPTION
Reflect the new URL for Synergy binaries.
Synergy 1.8.8

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.