### PR TITLE
Update universal-media-server to 6.6.0

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,11 +1,11 @@
 cask 'universal-media-server' do
-  version '6.5.3'
-  sha256 '3da70e93852876f356e56bf2fec218c85e491df442b279da1afe5a930bc7b109'
+  version '6.6.0'
+  sha256 'bff9c419c5089030ac15881b37f83890e7482dc7636ac4b8c80d3f03844772b4'
 
   # sourceforge.net/unimediaserver was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/unimediaserver/Official%20Releases/OS%20X/UMS-#{version}-Java8.dmg"
   appcast 'https://sourceforge.net/projects/unimediaserver/rss?path=/Official%20Releases',
-          checkpoint: '67e49cd9b6212a0b70a2d5fdd4020af425696a264388b6bf17047431eec69d87'
+          checkpoint: '30aae405c758df9ac847221144dfb8e9615ef9111afa5976584a304a73f70560'
   name 'Universal Media Server'
   homepage 'http://www.universalmediaserver.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.