### PR TITLE
android-sdk 25.2.3

### DIFF
--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -1,0 +1,34 @@
+cask 'android-sdk' do
+  version '25.2.3'
+  sha256 '593544d4ca7ab162705d0032fb0c0c88e75bd0f42412d09a1e8daa3394681dc6'
+
+  # google.com/android/repository/tools_r was verified as official when first introduced to the cask
+  url "https://dl.google.com/android/repository/tools_r#{version}-macosx.zip"
+  name 'android-sdk'
+  homepage 'https://developer.android.com/index.html'
+
+  binary "#{staged_path}/tools/bin/sdkmanager"
+  binary "#{staged_path}/tools/android"
+  binary "#{staged_path}/tools/ddms"
+  binary "#{staged_path}/tools/draw9patch"
+  binary "#{staged_path}/tools/emulator"
+  binary "#{staged_path}/tools/emulator64-arm"
+  binary "#{staged_path}/tools/emulator-check"
+  binary "#{staged_path}/tools/emulator64-mips"
+  binary "#{staged_path}/tools/emulator64-x86"
+  binary "#{staged_path}/tools/hierarchyviewer"
+  binary "#{staged_path}/tools/lint"
+  binary "#{staged_path}/tools/mksdcard"
+  binary "#{staged_path}/tools/monitor"
+  binary "#{staged_path}/tools/monkeyrunner"
+  binary "#{staged_path}/tools/traceview"
+
+  postflight do
+    system_command "#{staged_path}/tools/bin/sdkmanager", args: ['tools', 'platform-tools', 'build-tools;25.0.2'], input: 'y'
+  end
+
+  caveats <<-EOS.undent
+    We will install android-sdk-tools, platform-tools, and build-tools for you.
+    You can contol android sdk packages via sdkmanager command.
+  EOS
+end


### PR DESCRIPTION
This formulae is awaiting removal from Homebrew, so I`m porting it to cask.
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

Help wanted, there is command that should be run in order to complete installation. I have problem running command

```
system_command "/bin/echo y | /bin/bash #{staged_path}/tools/bin/sdkmanager tools platform-tools \"build-tools;25.0.2\""
```
Please note that quotes are necessary for last argument. Same command in Homebrew:
```
system "echo y | bash #{bin}/sdkmanager tools platform-tools \"build-tools;#{build_tools_version}\""
```
