### PR TITLE
Update hopper to 4.0.35

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.0.33'
-  sha256 '40ef7a79eb832e8492e2bd75831d69a988e4ba9c41d1da52fce644fb78bced78'
+  version '4.0.35'
+  sha256 '152d85db87c69e2a4ad06976430beed4765a3732b144e85c4e3d14c5c9652da7'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '8e7864bcd003b0dcbc5e09663b6dabd7fde765ffce8eb7dd4a2d6082da65d402'
+          checkpoint: '2453ec14000e015092bd17548ca39f6cde0446958aa07af5aac7ad942d87d552'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
