### PR TITLE
Update filezilla to 3.25.1

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.24.1'
     sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
   else
-    version '3.25.0'
-    sha256 '37b2b623d481e472e7d0a31a44aee7e2ffdfff1fbddd231963cd373176026e51'
+    version '3.25.1'
+    sha256 '76c1b583d2ddd1526bb5fa55f8c109b3172e5334cf5d848f04db039da35e5bc0'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '95412095423095b55575ff398e510f6bc6970b1a61e109423e5da8928682061f'
+          checkpoint: '0f23e3c46d6ac5c13761ffc1fa255ba0bcd163537f245efbd3907081078fc56c'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.