### PR TITLE
Update time-out to 2.2.1

### DIFF
--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -6,8 +6,8 @@ cask 'time-out' do
     version '1.7.1'
     sha256 '3c9892344c8313b8ccf0a76cceb00834ddbe26e5114bcd674c4fd53aeb44e310'
   else
-    version '2.2'
-    sha256 'f2c0de432894d469533cc741e1edafd3a4fad46dbbd3a4ca2a67a1711c8e84fc'
+    version '2.2.1'
+    sha256 '1e99900cc0fac14dc226d450943e8af396c02bb054cfb0277fc204c9f554c5a0'
   end
 
   url "http://www.dejal.com/download/timeout-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.