### PR TITLE
Fixed broken pkg installer call in adobe-digital-editions 4.5.4

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -6,7 +6,7 @@ cask 'adobe-digital-editions' do
   name 'Adobe Digital Editions'
   homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
 
-  pkg "Digital Editions #{version} Installer.pkg"
+  pkg "Digital Editions #{version.major_minor} Installer.pkg"
 
   uninstall pkgutil: 'com.adobe.adobedigitaleditions.app'
 


### PR DESCRIPTION
- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} left no offenses.
- [x] The commit message includes the cask’s name and version.