### PR TITLE
Revert AutoDMG 1.7.3 - Add binary stanza

### DIFF
--- a/Casks/autodmg.rb
+++ b/Casks/autodmg.rb
@@ -9,5 +9,4 @@ cask 'autodmg' do
   homepage 'https://github.com/MagerValp/AutoDMG'
 
   app 'AutoDMG.app'
-  binary "#{appdir}/AutoDMG.app/Contents/MacOS/AutoDMG"
 end


### PR DESCRIPTION
Reverts #31144.




Apologies @vitorgalvao @miccal , it seems symlinking inside the .app does not work.

When I was testing this I didn't realise I had the same alias to the autodmg .app in my dotfiles overriding the symlink.


Sorry for the inconvenience.



```
$ autodmg -h
ImportError: No module named main
2017-03-21 21:41:28.327 AutoDMG[49139:130893] UncaughtExceptionHandler:
2017-03-21 21:41:28.327 AutoDMG[49139:130893] Import of main.py failed
2017-03-21 21:41:28.327 AutoDMG[49139:130893] User info: (null)
2017-03-21 21:41:28.327 AutoDMG[49139:130893] Strack trace: (null)
2017-03-21 21:41:28.327 AutoDMG[49139:130893] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Import of main.py failed'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fffabb690db __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x00007fffc07faa2a objc_exception_throw + 48
	2   CoreFoundation                      0x00007fffabbe69c5 +[NSException raise:format:] + 197
	3   AutoDMG                             0x000000010cdbba2c AutoDMG + 10796
	4   libdyld.dylib                       0x00007fffc10dc255 start + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
[1]    49139 abort      autodmg -h
```
