### PR TITLE
Update retroarch to 1.5.0

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,10 +1,10 @@
 cask 'retroarch' do
-  version '1.3.6'
-  sha256 '12a9464880343a430e6bdbc330ea9f2c34628210eedbed59be1602280a915a51'
+  version '1.5.0'
+  sha256 'd62fcd6cd6cd8ca42efae8aec24fb71104de55b9e3450f18ad83776c2d9d3f50'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   appcast 'https://buildbot.libretro.com/stable/',
-          checkpoint: '3518326c4c798a21f2c4e9e0c85cc6b602344bd9eab48af36eb6790d2ecdef94'
+          checkpoint: '7b75c088adb25dcc880685cd6792b0054afe91e9f27f4c56f19cb475b02dec20'
   name 'RetroArch'
   homepage 'https://www.libretro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.