### PR TITLE
Update retroarch-cg to 1.5.0

### DIFF
--- a/Casks/retroarch-cg.rb
+++ b/Casks/retroarch-cg.rb
@@ -1,6 +1,6 @@
 cask 'retroarch-cg' do
-  version '1.3.6'
-  sha256 '79b536dde9348ecff66354cb97da28103e157a53c4d0c7276f32109aaacf469e'
+  version '1.5.0'
+  sha256 'e6278153ca77bb5445c134c41c42c95ff2d09309479c999ea8d8a968c9fddc7e'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch_CG.dmg"
   name 'RetroArch CG'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.