### PR TITLE
Update Teamviewer to correct sha256

### DIFF
--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,6 +1,6 @@
 cask 'teamviewer' do
   version '12.0.72647'
-  sha256 '1dc2dda560dc8a70b6478e7e88b1c64d9b0f6a8db24c8d165c2b2e14e2de55ee'
+  sha256 '5570875f99f2be0fdc167366c11e80056fa9e3d617e9b731e7821a81e2e1df45'
 
   url "https://download.teamviewer.com/download/version_#{version.major}x/TeamViewer.dmg"
   name 'TeamViewer'


### PR DESCRIPTION
Fix the sha256.

08:42 $ brew cask install teamviewer
==> Downloading https://download.teamviewer.com/download/version_12x/TeamViewer.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask teamviewer
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 1dc2dda560dc8a70b6478e7e88b1c64d9b0f6a8db24c8d165c2b2e14e2de55ee
Actual: 5570875f99f2be0fdc167366c11e80056fa9e3d617e9b731e7821a81e2e1df45
File: /Users/jball/Library/Caches/Homebrew/Cask/teamviewer--12.0.72647.dmg
To retry an incomplete download, remove the file above.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
