### PR TITLE
Update telegram to 2.91-90444

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.91-90199'
-  sha256 '4f1806e7c72c6d2494612ae0972b348e85b8caeb5ee9406846a4d6af84096b9d'
+  version '2.91-90444'
+  sha256 'f5fb78350a9099c96a3306bccab8edc4c61c4a66cd67e7bab2357faa6125204e'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'cff68418229da26d5f6bbd5fe46764e4878fe183c4a4d02eedb77feabeba0a3b'
+          checkpoint: '300f3273a898608fb01522e21ba88def097b9144307c9e0b519d0adbd9e3e08e'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.