### PR TITLE
Update broken binary in MacVim 8.0.129

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -12,7 +12,10 @@ cask 'macvim' do
   depends_on macos: '>= :mountain_lion'
 
   app 'MacVim.app'
+  binary "#{appdir}/MacVim.app/Contents/MacOS/MacVim"
+  binary "#{appdir}/MacVim.app/Contents/MacOS/macvim-askpass"
   binary "#{appdir}/MacVim.app/Contents/MacOS/mvim"
+  binary "#{appdir}/MacVim.app/Contents/MacOS/Vim"
 
   zap delete: [
                 '~/Library/Caches/org.vim.MacVim',

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,10 +1,10 @@
 cask 'macvim' do
-  version '8.0.128'
-  sha256 'e3763cf5978850eb85c8c333fc2b064c6ef1615c2d9f89445d4b385ca7fa916d'
+  version '8.0.129'
+  sha256 'a75d4999986f65b12b5adecde9dbdcf30ae04a19545a65b0131783c547897cf2'
 
   url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.patch}/MacVim.dmg"
   appcast 'https://github.com/macvim-dev/macvim/releases.atom',
-          checkpoint: '7f624738f4adf4fb2a6c19fe6d04dfb5577805140f05df0a9e512df8d2fdce73'
+          checkpoint: 'b94f207852bed3a9ece4d15be8163ed9a9b6abd18a751e0ae02123f42bb8b8c2'
   name 'MacVim'
   homepage 'https://github.com/macvim-dev/macvim'
 

--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -12,7 +12,7 @@ cask 'macvim' do
   depends_on macos: '>= :mountain_lion'
 
   app 'MacVim.app'
-  binary 'mvim'
+  binary "#{appdir}/MacVim.app/Contents/MacOS/mvim"
 
   zap delete: [
                 '~/Library/Caches/org.vim.MacVim',


### PR DESCRIPTION
- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} left no offenses.
- [x] The commit message includes the cask’s name and version.