### PR TITLE
Fix the sha-256

### DIFF
--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea' do
   version '2017.1'
-  sha256 '3a31fa83613e7c7e8d0fc4aee35bdb76aebc698c7b3ce9ffbd1e3c0db97d29e8'
+  sha256 'f37b3b63276d9e0cc9784506ea3257cbf6b843095546f5afef07e08a04dc74c0'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release',


### PR DESCRIPTION
Cask name: intellij-idea
version: '2017.1'
According to: https://download.jetbrains.com/idea/ideaIU-2017.1.dmg.sha256 the sha-256 is: f37b3b63276d9e0cc9784506ea3257cbf6b843095546f5afef07e08a04dc74c0

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
