### PR TITLE
Fix vagrant: 'Vagrant.pkg' changed to 'vagrant.pkg'

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -9,7 +9,7 @@ cask 'vagrant' do
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 
-  pkg 'Vagrant.pkg'
+  pkg 'vagrant.pkg'
 
   uninstall script:  {
                        executable: 'uninstall.tool',


### PR DESCRIPTION
see https://github.com/caskroom/homebrew-cask/pull/31174#issuecomment-288486321

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
