### PR TITLE
Update qcad to 3.15.5

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,6 +1,6 @@
 cask 'qcad' do
-  version '3.15.4'
-  sha256 '2bd86c5b3057a6dbcb1b471e167ab850030fdd496ceca45c0c0eb93f4c3c64ca'
+  version '3.15.5'
+  sha256 '70a96698259f9f07ca68ed6b2fa6cc5db1e28f9c83bd156d49a544afb34a8c6b'
 
   url "https://www.qcad.org/archives/qcad/qcad-#{version}-osx-10.6-10.11.dmg"
   name 'QCAD'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.