### PR TITLE
Adding Papyrus App Version 1.0.2

### DIFF
--- a/Casks/papyrus-osx.rb
+++ b/Casks/papyrus-osx.rb
@@ -1,0 +1,12 @@
+cask 'papyrus-osx' do
+  version '1.0.2'
+  sha256 '56224eadffc9be30a240790487919406fb6ffc8e952c1446de696850b209bca8'
+
+  url "https://github.com/morkro/papyrus/releases/download/1.0.2/Papyrus-osx-#{version}.zip"
+  appcast 'https://github.com/morkro/papyrus/releases.atom',
+          checkpoint: 'ff73e8d692001f894192ce94aa67352fcae9a43f6fce5313852a39e63762586a'
+  name 'Papyrus'
+  homepage 'https://github.com/morkro/papyrus/'
+
+  app 'Papyrus.app'
+end


### PR DESCRIPTION
- Including Cask for Papyrus App ~ Unofficial Dropbox Paper desktop app

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].