### PR TITLE
Reinstate links to binaries in MacVim 8.0.129.

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -12,7 +12,17 @@ cask 'macvim' do
   depends_on macos: '>= :mountain_lion'
 
   app 'MacVim.app'
-  binary "#{appdir}/MacVim.app/Contents/bin/mvim"
+
+  %w[
+    gview
+    gvim
+    gvimdiff
+    mview
+    mvim
+    mvimdiff
+  ].each do |link_name|
+    binary "#{appdir}/MacVim.app/Contents/bin/mvim", target: link_name
+  end
 
   zap delete: [
                 '~/Library/Caches/org.vim.MacVim',


### PR DESCRIPTION
Those were removed in aa7bb6213e9f38f6e64a4ac4383dc24f4d269b94, apparently to fix https://github.com/caskroom/homebrew-cask/issues/30953.

But, according to https://github.com/caskroom/homebrew-cask/pull/30955, the real issue was in Homebrew, and it was fixed by https://github.com/Homebrew/brew/pull/2347.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
