### PR TITLE
`Cask/` is redundant here

### DIFF
--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -170,7 +170,7 @@ You should also check stylistic details with `brew cask style`:
 
 ```bash
 $ cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask
-$ brew cask style Casks/my-new-cask.rb [--fix]
+$ brew cask style my-new-cask.rb [--fix]
 ```
 
 Keep in mind all of these checks will be made when you submit your PR, so by doing them in advance you’re saving everyone a lot of time and trouble.


### PR DESCRIPTION
causes a `Error: No such file or directory: ...` error

```bash
$ cd "$(brew --repository)"/Library/Taps/caskroom/homebrew-cask

$ brew cask style Casks/miniconda-two --fix
0 files inspected, no offenses detected
Error: No such file or directory: /usr/local/Homebrew/Library/Taps/caskroom/homebrew-cask/Casks/Casks/miniconda-two.rb
Error: style check failed

$ brew cask style miniconda-two --fix
1 file inspected, no offenses detected
```