### PR TITLE
Add miniconda2 for python 2.x, a lightweight alternative to anaconda f…

### DIFF
--- a/Casks/miniconda-two.rb
+++ b/Casks/miniconda-two.rb
@@ -1,0 +1,21 @@
+cask 'miniconda-two' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
+  name 'Continuum Analytics Miniconda'
+  homepage 'https://www.continuum.io/why-anaconda'
+
+  auto_updates true
+  depends_on macos: '>= :lion'
+  container type: :naked
+
+  installer script: 'Miniconda2-latest-MacOSX-x86_64.sh',
+            args:   ['-b']
+
+  uninstall delete: '~/miniconda2'
+
+  caveats do
+    path_environment_variable '~/miniconda2/bin'
+  end
+end


### PR DESCRIPTION
…or python 2.x

Adds miniconda2 by Continuum Analytics. The full anaconda install is massive and often unnecessary. This is a supported and valid alternative.

This differs from @drzax's [miniconda](https://github.com/caskroom/homebrew-cask/blob/master/Casks/miniconda.rb) in that it is for python 3.x. miniconda2 is for python 2.x.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
