### PR TITLE
Update beatunes to 4.6.13

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,6 +1,6 @@
 cask 'beatunes' do
-  version '4.6.11'
-  sha256 '9e774d7113a9d14d7d2ccfa981bcd809c46b21ea9d49261bf0d1957c319e69c5'
+  version '4.6.13'
+  sha256 '66cccc073716efeddcc84b37f83bcdbdb27c5f01ee94b3d89c55acaf6d71dfba'
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   name 'beaTunes'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.