### PR TITLE
Update pomotodo to 3.1.1,1490104557

### DIFF
--- a/Casks/pomotodo.rb
+++ b/Casks/pomotodo.rb
@@ -1,6 +1,6 @@
 cask 'pomotodo' do
-  version '3.0.26,1488772232'
-  sha256 '64cc4414b3d7829dfb50d690cca4273f2c9385279fb33d0a63dd78ba6da14310'
+  version '3.1.1,1490104557'
+  sha256 '1da7df446d28386e4055d99ef29bdfdc3589a7adf30bbb5b1d712ff58e21fcc9'
 
   # cdn.hackplan.com/theair was verified as official when first introduced to the cask
   url "http://cdn.hackplan.com/theair/#{version.after_comma}/Pomotodo_v#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.