### PR TITLE
Update caret to 2.0.1

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '1.15.1'
-  sha256 '68ba4ea961f5d5c57812d4df2a29136fe563f71a3ba6470a363b638fd321536a'
+  version '2.0.1'
+  sha256 '06e6c84204a4688508e8ca654e2e3d7cb10fa5baf6ff00ae541310cb18a4d35c'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '80b74eed8de527fb68f295c82e7873736e5c157d972130ab294e2ffc304ffd9d'
+          checkpoint: 'afb9c3b3b16201d8a62d427c1e3b46fb69e49559377cf890e2e376c19a17857d'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.