### PR TITLE
Update psychopy to 1.85.0

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,10 +1,10 @@
 cask 'psychopy' do
-  version '1.84.2'
-  sha256 '61d56a3c894fd75a8e23b4ca59af0bb7c172ee9b3713b1dd27f0169ccf186adb'
+  version '1.85.0'
+  sha256 'f14253facd263245dc36c51fb0318d7b8061d4bd145a802a0d7ead94400b4dac'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom',
-          checkpoint: 'f901e06f8e03c312d524c51a479c84e0939a1c6b75d62a7509af39ebab194a8a'
+          checkpoint: 'da63260b70b661fee5a17d94721ab01f6e6610a9334de39d073a97fcb56ab20c'
   name 'PsychoPy'
   homepage 'https://github.com/psychopy/psychopy'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.