### PR TITLE
Update caret to 2.0.2

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.1'
-  sha256 '06e6c84204a4688508e8ca654e2e3d7cb10fa5baf6ff00ae541310cb18a4d35c'
+  version '2.0.2'
+  sha256 '23a1aad15eeb8913a908519c34cfbdc337a5aff3c213f5a323cbc75d02c34b97'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'afb9c3b3b16201d8a62d427c1e3b46fb69e49559377cf890e2e376c19a17857d'
+          checkpoint: '065248621dc6157f06a595d0563ba8660132f4f1815332b7d12c1c2f167f9335'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.