### PR TITLE
Update renamer to 5.0.3

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
   version '5.0.3'
-  sha256 '4d37b7c0d8b0a3fdf32f54caa1ae85a516213a3212b72bd006c8b7f45c7ba1ca'
+  sha256 '59e9d52740d5ff04003f195ef5ffe582d7f9db5c1a7ad53c5264185e27497c6f'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.