### PR TITLE
Update base to 2.4.11

### DIFF
--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -1,10 +1,10 @@
 cask 'base' do
-  version '2.4.10'
-  sha256 '1a23a8da1be9e9a681d57bb934ac1f2dc8ab569027ec357dbf9324d48fe4fded'
+  version '2.4.11'
+  sha256 '4c20edea4b4376fcd34aeecc6ea32488ba0f87a5521d37ae70146663e1bd189c'
 
   url "https://files.menial.co.uk/base/base_#{version}.zip"
   appcast 'https://update.menial.co.uk/software/base/',
-          checkpoint: '02f44fba8418545d1abdbcae6dd50fc20d8740eaac1f4b18a4d0aef23e5291ce'
+          checkpoint: 'c26db591f386eef06cd36c107a9c35528f56ee506c4cf639db5a0f00ed38a23c'
   name 'Menial Base'
   homepage 'https://menial.co.uk/base/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.