### PR TITLE
Update messenger-for-desktop to 2.0.8

### DIFF
--- a/Casks/messenger-for-desktop.rb
+++ b/Casks/messenger-for-desktop.rb
@@ -1,11 +1,11 @@
 cask 'messenger-for-desktop' do
-  version '2.0.7'
-  sha256 '6aeaadd90cd02abf406bae927b78ab654543b7b2c83f19604a7df12e265a8ad4'
+  version '2.0.8'
+  sha256 'c86d3454f5bce8913bb6c26b6dcd682d718490cf5d4b7ddf8c155e41a8acf7a3'
 
   # github.com/aluxian/Messenger-for-Desktop was verified as official when first introduced to the cask
   url "https://github.com/aluxian/Messenger-for-Desktop/releases/download/v#{version}/messengerfordesktop-#{version}-osx.dmg"
   appcast 'https://github.com/aluxian/Messenger-for-Desktop/releases.atom',
-          checkpoint: '3f77603c5d2b79e63a66044fcbc9a11c309c692282e911eb2e209c418b72e56c'
+          checkpoint: 'f63d44651099d38a565f9368b05f1c4fc3cdfff2a322e865eb7a41cc63afd50f'
   name 'Messenger for Desktop'
   homepage 'https://messengerfordesktop.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.