### PR TITLE
Update ripit not to use SSL

### DIFF
--- a/Casks/ripit.rb
+++ b/Casks/ripit.rb
@@ -2,8 +2,8 @@ cask 'ripit' do
   version '1.6.9'
   sha256 '76a3450016db2ba93a4b74271327b19246794813b8ad5916752eb9817c2ad0bc'
 
-  url 'https://files.thelittleappfactory.com/ripit/RipIt.zip'
-  appcast 'https://files.thelittleappfactory.com/ripit/appcast.xml',
+  url 'http://files.thelittleappfactory.com/ripit/RipIt.zip'
+  appcast 'http://files.thelittleappfactory.com/ripit/appcast.xml',
           checkpoint: '689348dedb5f144b5195071b4ef1c03ba437986a6a1b58bebcb26e7006481979'
   name 'RipIt'
   homepage 'http://thelittleappfactory.com/ripit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.