### PR TITLE
Update irip not to use SSL

### DIFF
--- a/Casks/irip.rb
+++ b/Casks/irip.rb
@@ -2,8 +2,8 @@ cask 'irip' do
   version '2.1.8'
   sha256 '378130c09ed0b42eec738f755c9c29e3f26aa2f8f37d27cae2e95146038b468c'
 
-  url "https://files.thelittleappfactory.com/iRip#{version.major}/iRip.zip"
-  appcast "https://files.thelittleappfactory.com/iRip#{version.major}/appcast.xml",
+  url "http://files.thelittleappfactory.com/iRip#{version.major}/iRip.zip"
+  appcast "http://files.thelittleappfactory.com/iRip#{version.major}/appcast.xml",
           checkpoint: 'e934179f4e2cc9567565ae76ea1071cb735a2e92aa00893779f56aa31d6f7d5f'
   name 'iRip'
   homepage 'http://thelittleappfactory.com/irip/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.