### PR TITLE
Update lightpaper to 1.4.2

### DIFF
--- a/Casks/lightpaper.rb
+++ b/Casks/lightpaper.rb
@@ -1,11 +1,11 @@
 cask 'lightpaper' do
-  version '1.4.1'
-  sha256 'fbd2ecc6128f60e44d9793edfc92355275f072e80049cbe109be5539ba42a5f0'
+  version '1.4.2'
+  sha256 '7e1f7f8304bd2b299e7973a34d55e9c5b6b57b9987f51c3e2200897150c06923'
 
   # hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8?format=zip'
-  appcast 'https://dl.dropboxusercontent.com/u/83257/LpMacUpdates/lightpaper_appcast.xml',
-          checkpoint: 'cbeaa1256456c7ee603079bd83085365f210fc6721b3ce6c260d3ec0a6120db8'
+  appcast 'http://links.ashokgelal.com/lp-mac-update-feed',
+          checkpoint: 'a69ba60cca5db29c7f0fb60b4cc54ccc197aa53e4795a1f0af2209d6a1a726b6'
   name 'LightPaper'
   homepage 'http://lightpaper.42squares.in/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.