### PR TITLE
Update principle to 2.1.4

### DIFF
--- a/Casks/principle.rb
+++ b/Casks/principle.rb
@@ -1,11 +1,11 @@
 cask 'principle' do
-  version '2.0.6'
-  sha256 '1820f400db72566698a3f4ce16c4ae6fc2ed7f6bc796ffe0158d328c6e5b54f5'
+  version '2.1.4'
+  sha256 '1f3110b4be955576dda6458a85de264ed5f05e227199211678da457853b92b96'
 
-  # dl.dropboxusercontent.com/u/13897407 was verified as official when first introduced to the cask
-  url "https://dl.dropboxusercontent.com/u/13897407/Principle_#{version.dots_to_underscores}.zip"
-  appcast 'https://dl.dropboxusercontent.com/u/13897407/buildTrain-601A6666-57A4-4C19-BDD3-1387B3CB9719.xml',
-          checkpoint: 'b29797807d5f46132632e0d92c23ee3e176afa43c12c0881f826bfc7eb2deace'
+  # principleformac.com.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'http://principleformac.com.s3.amazonaws.com/download/Principle_Latest.zip'
+  appcast 'http://principleformac.com/update2.xml',
+          checkpoint: '3db849e42e30663501a646b50cffa942f6ab482ec5bb63646f2e4452424083ca'
   name 'Principle'
   homepage 'http://principleformac.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.