### PR TITLE
Update subler to 1.2.7

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.2.6'
-  sha256 'cd67912ad62381288e4ce38c106b444bccc4ea97ac02cab3a5d08f678e306a32'
+  version '1.2.7'
+  sha256 'acb678a53632216badd34c3f938a1534cf47ebc7ac18e24daf03c2ecd7b67720'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: 'f83372b4af7dc447203cf356ca3e0fe761a26a863d84f725ae8472c4f7e8c629'
+          checkpoint: 'e388a2049cf12a7cf1a31a6f0080bc9e182503ebefea3543983f9aaa2672498c'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.