### PR TITLE
Update caret to 2.0.3

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.2'
-  sha256 '23a1aad15eeb8913a908519c34cfbdc337a5aff3c213f5a323cbc75d02c34b97'
+  version '2.0.3'
+  sha256 '410b1be6dc19be603faa21744d2010f7f4094af9a738313bc77081eaafa6a1f1'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '065248621dc6157f06a595d0563ba8660132f4f1815332b7d12c1c2f167f9335'
+          checkpoint: '83432c8840b3ce6488ae82e40588f410e630f49164e315170f37adc70952b834'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.