### PR TITLE
Update capture-one to 10.0.2

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -4,7 +4,7 @@ cask 'capture-one' do
 
   url "http://downloads.phaseone.com/9c7cb7b7-1525-4cfc-86a8-7d8f5a51f38e/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'
-  homepage 'https://www.phaseone.com/en/Products/Software/Capture-One-Pro/dot-release.aspx'
+  homepage 'https://www.phaseone.com/en/Products/Software/Capture-One-Pro/Whats-new.aspx'
 
   app "Capture One #{version.major}.app"
 end

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
   version '10.0.2'
-  sha256 ''
+  sha256 'ffd01fa5ee4a5ddfdcf74db0156f6ea8ea983c6b7b382d008b6da5204cdebe2b'
 
   url "http://downloads.phaseone.com/9c7cb7b7-1525-4cfc-86a8-7d8f5a51f38e/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,8 +1,8 @@
 cask 'capture-one' do
-  version '9.1.0'
-  sha256 '232cfdef4a096f3d97a7576198ebd1b4f320c2e81104b06cc2fccadf9394162d'
+  version '10.0.2'
+  sha256 ''
 
-  url "http://downloads.phaseone.com/International/CaptureOne.Mac.#{version}.dmg"
+  url "http://downloads.phaseone.com/9c7cb7b7-1525-4cfc-86a8-7d8f5a51f38e/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'
   homepage 'https://www.phaseone.com/en/Products/Software/Capture-One-Pro/dot-release.aspx'
 


### PR DESCRIPTION
Download URL changed

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.