### PR TITLE
Update base to 2.4.12

### DIFF
--- a/Casks/base.rb
+++ b/Casks/base.rb
@@ -1,10 +1,10 @@
 cask 'base' do
-  version '2.4.11'
-  sha256 '4c20edea4b4376fcd34aeecc6ea32488ba0f87a5521d37ae70146663e1bd189c'
+  version '2.4.12'
+  sha256 '6b9ab469a04c647156d972109ff80dbb9c60d484654284e1c8f0319b7bbcced3'
 
   url "https://files.menial.co.uk/base/base_#{version}.zip"
   appcast 'https://update.menial.co.uk/software/base/',
-          checkpoint: 'c26db591f386eef06cd36c107a9c35528f56ee506c4cf639db5a0f00ed38a23c'
+          checkpoint: '13dec5059cd301d7d1b87d4c780ebd2c4c9a707895064d1f55852ee3592fdeb9'
   name 'Menial Base'
   homepage 'https://menial.co.uk/base/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.