### PR TITLE
Rename AppGate-Client to lowercase

### DIFF
--- a/Casks/appgate-client.rb
+++ b/Casks/appgate-client.rb
@@ -1,4 +1,4 @@
-cask 'AppGate-Client' do
+cask 'appgate-client' do
   version '11.2.3'
   sha256 'a9eb6ed2f46f33dfca21aea81ff163b99978aee27f78bbbc55200ed12728ae62'
 


### PR DESCRIPTION
`brew cask info` fails on the current version of this cask, and I'm pretty sure it's because of the casing. Hopefully this fixes that. (discovered this by accident when `cask _stanza` threw a warning)

```
>cask info AppGate-Client
Error: Cask 'appgate-client' definition is invalid: Bad header line: 'AppGate-Client' does not match file name
>cask info appgate-client
Error: Cask 'appgate-client' definition is invalid: Bad header line: 'AppGate-Client' does not match file name
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.