### PR TITLE
Update eclipse-ide to 4.6.3,neon:3

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.6.2,neon:2'
-  sha256 'cbf26dcc7306e66d6f2c33814c8adefc85433a35dd87daa7b3651f25993d6089'
+  version '4.6.3,neon:3'
+  sha256 '0b194382d7a8058876e5c73cf1c110f2159cfc4a36332f8a4c84512f37e1bd32'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.tar.gz&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.