### PR TITLE
Update vin047-abgx360 to 1.0.6

### DIFF
--- a/Casks/vin047-abgx360.rb
+++ b/Casks/vin047-abgx360.rb
@@ -4,7 +4,7 @@ cask 'vin047-abgx360' do
 
   url "https://github.com/vin047/abgx360gui/releases/download/#{version}/abgx360.dmg"
   appcast 'https://github.com/vin047/abgx360gui/releases.atom',
-          checkpoint: '66aa25afd5cb6052b881fe18a75af2bf2c2e042ac50da962114f5825ea7902b1'
+          checkpoint: '391a82bddb542f27bc187a4674d9c9ec6b4b8a4ac9f54839f737048fead95368'
   name 'vin047-abgx360'
   homepage 'https://github.com/vin047/abgx360gui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.