### PR TITLE
Update vinoteka to 3.5.1

### DIFF
--- a/Casks/vinoteka.rb
+++ b/Casks/vinoteka.rb
@@ -1,10 +1,10 @@
 cask 'vinoteka' do
   version '3.5.1'
-  sha256 '21b85c94f51d77e56a0dea29f619ee1a12191cfaa04c1d81b7b7113ae85cad19'
+  sha256 '9e347baab54b5f57bf9bf8d8f687a8ee4620007572718a6e1b301018c1955428'
 
   url 'http://download.vinotekasoft.com/Vinoteka.zip'
   appcast 'http://download.vinotekasoft.com/vinoteka_update.xml',
-          checkpoint: '7e65d66ceafa9deb3af5758197ede0f893b2858b1dd9272e870b64a24c887842'
+          checkpoint: '4c2f69fe8f8a2d46022eaff08797430d1db6628a5d6548cef579f6f3c5d85e87'
   name 'Vinoteka'
   homepage 'https://www.vinotekasoft.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.