### PR TITLE
Update vistrails to 2.2.4-1519abc0ae2b

### DIFF
--- a/Casks/vistrails.rb
+++ b/Casks/vistrails.rb
@@ -5,7 +5,7 @@ cask 'vistrails' do
   # sourceforge.net/vistrails was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/vistrails/vistrails-osx-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/vistrails/rss?path=/vistrails',
-          checkpoint: '5b5470cbdb0773a980d33bdb4c56d44d4d1ccbc56961988faaccc9104174569c'
+          checkpoint: '4d1801bc601ba33f5b9ff5021fd449f340aacacec0ea824cf3166b7dfdf0d93a'
   name 'VisTrails'
   homepage 'https://www.vistrails.org/index.php/Main_Page'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.