### PR TITLE
Update voxengo-span-au to 31

### DIFF
--- a/Casks/voxengo-span-au.rb
+++ b/Casks/voxengo-span-au.rb
@@ -1,6 +1,6 @@
 cask 'voxengo-span-au' do
-  version '3.0'
-  sha256 'fad219f7e9d0ca65d82b4e12d64b693c27367f5b3e903b7fdba8674e986fdab2'
+  version '31'
+  sha256 '025163dbecae1da3c6ca5984109f3b94ee8fcbc6153242a905fa1a202d133efd'
 
   url "https://www.voxengo.com/files/VoxengoSPAN_#{version.no_dots}_Mac_AU_AAX_setup.dmg"
   name 'Voxengo SPAN (AU)'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.