### PR TITLE
Update nodeclipse to 0.17

### DIFF
--- a/Casks/nodeclipse.rb
+++ b/Casks/nodeclipse.rb
@@ -5,7 +5,7 @@ cask 'nodeclipse' do
   # sourceforge.net/nodeclipse was verified as official when first introduced to the cask
   url 'https://downloads.sourceforge.net/nodeclipse/Enide-2015/7/Enide-2015-7-macosx-x64-20150706.zip'
   appcast 'https://sourceforge.net/projects/nodeclipse/rss',
-          checkpoint: 'a1066f2fca3aec174f2ba3bc32609868e4f7cf68f7218bcb0bcde620f2f54918'
+          checkpoint: 'fc3f1c9802ceb1fa0346e2f4a0b2a8f6bd1305d1cc0ec507a6481a9b5bcd60d9'
   name 'Nodeclipse'
   homepage 'http://www.nodeclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.