### PR TITLE
Update musictube to 1.7

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,10 +1,10 @@
 cask 'musictube' do
   version '1.7'
-  sha256 '1aff1cc06d27f38dec72bd23e731d7cf5559db592502dc86be69ba747adc33b4'
+  sha256 'dc2b3fe32262e09e7080f522e03b796e6f589e4281f100c9f80023a58ac56f59'
 
   url 'http://flavio.tordini.org/files/musictube/musictube.dmg'
   appcast 'http://flavio.tordini.org/musictube-ws/appcast.xml',
-          checkpoint: 'ab92e80f868ed53351e8c254f7d77aa6ec07e371126c139e4a99bca88ce6e031'
+          checkpoint: '67f33a5811f49c447808f92ece2884842657aa4e947c08e5df6f575bb41b5f0b'
   name 'Musictube'
   homepage 'http://flavio.tordini.org/musictube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.