### PR TITLE
Update eclipse-platform to 4.6.3,201703010400

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.6.2,201611241400'
-  sha256 '37044a75ae992dccfbd2eaf4dac1a8858322d4ef071ec05949643db9490beace'
+  version '4.6.3,201703010400'
+  sha256 '59e4e3eeffdce26894f270ec1fa660f63e4dc9b57b0eda6f4692348bd7547160'
 
   url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.tar.gz"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.