### PR TITLE
Update kdiff3 to 0.9.98

### DIFF
--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -5,7 +5,7 @@ cask 'kdiff3' do
 
   url "https://downloads.sourceforge.net/kdiff3/kdiff3/#{version}/kdiff3-#{version}-MacOSX-64Bit.dmg"
   appcast 'https://sourceforge.net/projects/kdiff3/rss?path=/kdiff3',
-          checkpoint: 'ff44819d7794d2b61f2afcc381ed9cb01bf4e7f581b588e19e3a3300e04fd457'
+          checkpoint: 'ad2bf43d848e1abb7b421d02a754618c22d530d09a4b78e1be80f56f193c02ec'
   name 'KDiff3'
   homepage 'http://kdiff3.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.