### PR TITLE
Update gzdoom to 2.4.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,11 +1,11 @@
 cask 'gzdoom' do
-  version '2.3.2'
-  sha256 'b1db121cf75c1a6f9d56b30c66ed7e61681f7358cc101fb37ed0eba7beaca27b'
+  version '2.4.0'
+  sha256 '62a364b94d3bc792dc0ba902b2e173b5a1df7e2e857a9e05e014c3022122e846'
 
   # github.com/coelckers was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom',
-          checkpoint: 'a2b1a64ae7baad8671873448933e9cf7eafed7d0a62e4b96dd4371e21f709035'
+          checkpoint: 'b5b6b362b4c5cd34efb5a4d69719c2f44b7de07c366471c4741683ab136bf4cb'
   name 'gzdoom'
   homepage 'https://gzdoom.drdteam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.