### PR TITLE
Update securesafe to 2.2.4

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,8 +1,8 @@
 cask 'securesafe' do
-  version :latest
-  sha256 :no_check
+  version '2.2.4'
+  sha256 '403a009d56c3c9e891570ddf06f3499c86868a0ca9138f66b3a3718ad04742c0'
 
-  url 'https://www.securesafe.com/en/assets/sync-client/SecureSafe.dmg'
+  url "https://www.securesafe.com/downloads/SecureSafe_#{version}.dmg"
   name 'SecureSafe'
   homepage 'https://www.securesafe.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.