### PR TITLE
Update name-mangler to 3.4

### DIFF
--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -3,8 +3,8 @@ cask 'name-mangler' do
   sha256 '460f802b90e0e0123d397199600b68adf609e656e51a7b23f38bdf9eec05c91e'
 
   url 'https://manytricks.com/download/namemangler'
-  appcast 'https://manytricks.com/namemangler/appcast.xml',
-          checkpoint: 'e2b10fede763493b3d336d082c4ab8fc12c8b74692f7f94585a5f2b3cd61a220'
+  appcast 'https://manytricks.com/namemangler/appcast/',
+          checkpoint: 'bd563ec5d011424d6f90b5b46a6d85e54fe1acc7ddb919ef96b5a3f96eb5f03b'
   name 'Name Mangler'
   homepage 'https://manytricks.com/namemangler/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.