### PR TITLE
Update jin to 2.14.1

### DIFF
--- a/Casks/jin.rb
+++ b/Casks/jin.rb
@@ -5,7 +5,7 @@ cask 'jin' do
   # sourceforge.net/jin was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jin/jin/jin-#{version}/jin-#{version}-macosx-lion.dmg"
   appcast 'https://sourceforge.net/projects/jin/rss?path=/jin',
-          checkpoint: '16c958e1147a8a33c8b702c1aa2f6b112f31f8f93a0b6ec2c0c7b81dca2e32f7'
+          checkpoint: '71e7b29ab62ebcd3a8b823f43a289b95f93514d4a4b0936a03423e1a634394c6'
   name 'Jin'
   homepage 'http://www.jinchess.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.