### PR TITLE
Update jubler to 5.1

### DIFF
--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -5,7 +5,7 @@ cask 'jubler' do
   # sourceforge.net/jubler was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jubler/Jubler-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/jubler/rss',
-          checkpoint: 'e53b10d79d2f486772e1293517212cdef19be67cf76244880dcba34d944343e3'
+          checkpoint: 'f9945f5e48daf05111b8249b781c944388fecfa7ebce5bd228ac508097b9f195'
   name 'Jubler'
   homepage 'http://www.jubler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.