### PR TITLE
Update chrome-devtools to 1.1.0

### DIFF
--- a/Casks/chrome-devtools.rb
+++ b/Casks/chrome-devtools.rb
@@ -4,7 +4,7 @@ cask 'chrome-devtools' do
 
   url "https://github.com/auchenberg/chrome-devtools-app/releases/download/v#{version}/chrome-devtools-app_#{version}.dmg"
   appcast 'https://github.com/auchenberg/chrome-devtools-app/releases.atom',
-          checkpoint: '0755195b9dd06139fe4043a3395df6b7ccab187d6c892ef473155f409f6478dd'
+          checkpoint: 'cdbba9426341e0ad1d5b7a01c5f007091cc1d41bce9b50923166837d85f6d943'
   name 'Chrome DevTools'
   homepage 'https://github.com/auchenberg/chrome-devtools-app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.