### PR TITLE
Update davmail to 4.8.0.3-2484

### DIFF
--- a/Casks/davmail.rb
+++ b/Casks/davmail.rb
@@ -1,10 +1,10 @@
 cask 'davmail' do
-  version '4.7.3-2438'
-  sha256 '94bfea44f9a94ccb7bb84516fe442cc6877427f7102f66a89d0ceb54ddda9cf3'
+  version '4.8.0.3-2484'
+  sha256 '412a5a5a8eff43b08851bf24a94df24faebee9b75e77351a7fa25e47a8d9ceeb'
 
   url "https://downloads.sourceforge.net/davmail/DavMail-MacOSX-#{version}.app.zip"
   appcast 'https://sourceforge.net/projects/davmail/rss',
-          checkpoint: 'd318e221e5ac7623745f4a4b0e37dbd18f66e0b80cbe3dbf76c0f30f97d09be6'
+          checkpoint: '4bd1e76733b1f6efe08e96968320d211e78acd2654b009bca51258786c74c23b'
   name 'DavMail'
   homepage 'http://davmail.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.