### PR TITLE
Update gmail-notifier to 2.1.0

### DIFF
--- a/Casks/gmail-notifier.rb
+++ b/Casks/gmail-notifier.rb
@@ -4,7 +4,7 @@ cask 'gmail-notifier' do
 
   url "https://github.com/jashephe/Gmail-Notifier/releases/download/v#{version}/Gmail.Notifier.v#{version}.zip"
   appcast 'https://github.com/jashephe/Gmail-Notifier/releases.atom',
-          checkpoint: 'd233f4257fe1131fafbe6b7387422b33e00e80d8bb75958ac113a6a20d40e0a4'
+          checkpoint: '51f64841bbabdf7fe727876dde08bbdf09ac4f4c025028270aead1d9e8910969'
   name 'Gmail Notifier'
   homepage 'https://github.com/jashephe/Gmail-Notifier'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.