### PR TITLE
Update burn to 2.5.1

### DIFF
--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -2,9 +2,9 @@ cask 'burn' do
   version '2.5.1'
   sha256 'e82d2b7ef6a99e5a139706ff4e360659830d618ab8743e4b55ec80cdcdc97596'
 
-  url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn251.zip"
+  url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn#{version.no_dots}.zip"
   appcast 'https://sourceforge.net/projects/burn-osx/rss?path=/Burn',
-          checkpoint: 'beba57bd08a2204b74e12d2ef99768cfef0cbd9c605dee8befd527ec2d994510'
+          checkpoint: '647f9148eae77326d9868982b9ac03a0a0d08cb389b7dab8f431a5d6c64106a3'
   name 'Burn'
   homepage 'http://burn-osx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.