### PR TITLE
Update liclipse to 3.5.0

### DIFF
--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -1,5 +1,5 @@
 cask 'liclipse' do
-  version '3.4.0'
+  version '3.5.0'
   sha256 '22099c6ff59c91670f1878bb6a8ca97e02f5ad6c76d66c0b64eced147adfe85a'
 
   # mediafire.com/file/pw05os9ewtfb35k was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.