### PR TITLE
Update jadengeller-helium to 1.9

### DIFF
--- a/Casks/jadengeller-helium.rb
+++ b/Casks/jadengeller-helium.rb
@@ -5,7 +5,7 @@ cask 'jadengeller-helium' do
   # github.com/JadenGeller/Helium was verified as official when first introduced to the cask
   url "https://github.com/JadenGeller/Helium/releases/download/#{version}/Helium.app.zip"
   appcast 'https://github.com/JadenGeller/Helium/releases.atom',
-          checkpoint: '875fb1cb7c6e18a330338c90a6cbabda82896e1e3699e2b8713c36fa073aa075'
+          checkpoint: '2fb1a80e559af39a44b95846c074775692bc31cab09507d988b762c1bd5d861f'
   name 'Helium'
   homepage 'http://heliumfloats.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.