### PR TITLE
Update jes to 5.020

### DIFF
--- a/Casks/jes.rb
+++ b/Casks/jes.rb
@@ -4,7 +4,7 @@ cask 'jes' do
 
   url "https://github.com/gatech-csl/jes/releases/download/#{version}/jes-#{version}-macosx.zip"
   appcast 'https://github.com/gatech-csl/jes/releases.atom',
-          checkpoint: '89cbf0688db38705320d068184ab288f79a4171edd257232ccaacda84f94f389'
+          checkpoint: '740b90e455acdd61965cb2d9db91b50cf2fdae7413e5445da011e028f0be242f'
   name 'JES'
   homepage 'https://github.com/gatech-csl/jes'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.