### PR TITLE
Fix typo in android-sdk caveats

### DIFF
--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -29,6 +29,6 @@ cask 'android-sdk' do
 
   caveats <<-EOS.undent
     We will install android-sdk-tools, platform-tools, and build-tools for you.
-    You can contol android sdk packages via sdkmanager command.
+    You can control android sdk packages via the sdkmanager command.
   EOS
 end


### PR DESCRIPTION
"contol" -> "control"

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.