### PR TITLE
Update carmaintenance to 1.8.22

### DIFF
--- a/Casks/carmaintenance.rb
+++ b/Casks/carmaintenance.rb
@@ -4,7 +4,7 @@ cask 'carmaintenance' do
 
   url "http://www.traxxsoftware.com/downloads/CarMaintenance_#{version.dots_to_underscores}.zip"
   appcast 'http://www.traxxsoftware.com/download.html',
-          checkpoint: '99f9ae58fc6a4a6c4cf95f38f7531aa947b00aa21fb08ce6215f170b2232e13a'
+          checkpoint: 'e3d3a83c1bb9b237edce0adbb970e03d996d0712e45a5cfd1f545ada3149b82c'
   name 'CarMaintenance'
   homepage 'http://www.traxxsoftware.com/download.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.