### PR TITLE
Update keeweb to 1.4.1

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,11 +1,11 @@
 cask 'keeweb' do
-  version '1.4.0'
-  sha256 '0a05d6ad6583d152fa7547c3f7788eed2da011025af5892cc1d5157e31e5c7c6'
+  version '1.4.1'
+  sha256 '447b584f90fe3d7111fd9f4ea52d20a1679aad30c1ba1d6f40c115b04fffd00d'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"
   appcast 'https://github.com/keeweb/keeweb/releases.atom',
-          checkpoint: '46f2cd53432b201d16e54138eb0fae8d8fd2216d3add6e54775c76c41e7cce49'
+          checkpoint: 'ff94c926ea2edefc63ece9cf2c2628526eed3f2d77a0ab1b2614496f0275e12e'
   name 'KeeWeb'
   homepage 'https://keeweb.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.