### PR TITLE
Update multimarkdown-composer to 2.9

### DIFF
--- a/Casks/multimarkdown-composer.rb
+++ b/Casks/multimarkdown-composer.rb
@@ -5,7 +5,7 @@ cask 'multimarkdown-composer' do
   # files.fletcherpenney.net.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.fletcherpenney.net.s3.amazonaws.com/MultiMarkdown%20Composer-#{version}.zip"
   appcast 'http://multimarkdown.com/download/',
-          checkpoint: 'ae299940b699eeee3c47f2e6d32f82ae3057650c50c2c568f50f38577ff3ec5b'
+          checkpoint: 'a6abaa7faed9adabc0306f9cff4313a2cf42ed0c51482ef2b9b20b6fa0ff068e'
   name 'MultiMarkdown Composer'
   homepage 'http://multimarkdown.com/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.