### PR TITLE
Update couchpotato to 3.0.1

### DIFF
--- a/Casks/couchpotato.rb
+++ b/Casks/couchpotato.rb
@@ -5,7 +5,7 @@ cask 'couchpotato' do
   # github.com/CouchPotato/CouchPotatoServer was verified as official when first introduced to the cask
   url "https://github.com/CouchPotato/CouchPotatoServer/releases/download/build%2F#{version}/CouchPotato-#{version}.macosx-10_6-intel.zip"
   appcast 'https://github.com/CouchPotato/CouchPotatoServer/releases.atom',
-          checkpoint: 'b61f00dafd9c9cbe596613d712055d2404d628121b8eaec7407f3344bf3afb4e'
+          checkpoint: '5ac2077dbad662df75bb50b160040d6d87862e171e32717bf9ef2b23ddb8089e'
   name 'CouchPotato'
   homepage 'https://couchpota.to/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.