### PR TITLE
Update browser-chooserx to 1.2.8

### DIFF
--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -1,10 +1,10 @@
 cask 'browser-chooserx' do
-  version '1.2.7'
-  sha256 'a0d493968e2e31aa7d170643aeea4d5393c527f472d38071c65a4c223bb4492c'
+  version '1.2.8'
+  sha256 '1f63bb12099971af196fe7c718f424e833bf9a6911a10c19a3ceec160f07d811'
 
   url 'https://www.bdevapps.com/files/downloads/Browser%20ChooserX.zip'
   appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
-          checkpoint: 'ad8aa8420c32a0bbe2747081931538e84af3d062d41feb74f59acfcf1bdf6143'
+          checkpoint: '5da2717c910eadee567e9a65800c76af238ec44734bb269fefba7ca38294ef91'
   name 'Browser ChooserX'
   homepage 'https://bdevapps.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.