### PR TITLE
Update caret to 2.0.5

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.3'
-  sha256 '410b1be6dc19be603faa21744d2010f7f4094af9a738313bc77081eaafa6a1f1'
+  version '2.0.5'
+  sha256 '84e3dcb448150261d54cdc14da0e62072bd89b12e93ae94f75736f11e96016a7'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '83432c8840b3ce6488ae82e40588f410e630f49164e315170f37adc70952b834'
+          checkpoint: 'f76e2cd28ec1936d2da7456efa809cb2eadb8ce93752e55a6512162316bc63ec'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.