### PR TITLE
Update hermes to 1.3.1

### DIFF
--- a/Casks/hermes.rb
+++ b/Casks/hermes.rb
@@ -1,11 +1,11 @@
 cask 'hermes' do
-  version '1.3.0'
-  sha256 '661544619346c83c586890a93e6b68af6e86e09b8605acc92d53921c2c160911'
+  version '1.3.1'
+  sha256 'f7c2949e4a44a9183eb6c937b250052867a0373f9de7a8ecbd63853d7df88dbd'
 
   # github.com/HermesApp/Hermes was verified as official when first introduced to the cask
   url "https://github.com/HermesApp/Hermes/releases/download/v#{version}/Hermes-#{version}.zip"
   appcast 'https://raw.githubusercontent.com/HermesApp/HermesApp.github.io/master/versions.xml',
-          checkpoint: 'b50dd357b9bc29039a83b1eba22065a300ee1a3d3bcb17933507ce1a2086dfd9'
+          checkpoint: '11e95c0584ac859fff5dd0782a85c46b38afa1c50076d3d8fd5c6f351cf1959f'
   name 'Hermes'
   homepage 'http://hermesapp.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.