### PR TITLE
Update luyten to 0.5.1

### DIFF
--- a/Casks/luyten.rb
+++ b/Casks/luyten.rb
@@ -1,11 +1,11 @@
 cask 'luyten' do
-  version '0.5.0'
-  sha256 '3317031309365498693a3a75661748c5c5b1a3425ef8458b9b244266282386e5'
+  version '0.5.1'
+  sha256 '7ed25aa4aac9a10096f02a1714784b82e1cd89ede51f8be01180e8d289717f4e'
 
   # github.com/deathmarine/Luyten was verified as official when first introduced to the cask
   url "https://github.com/deathmarine/Luyten/releases/download/v#{version}/luyten-OSX-#{version}.zip"
   appcast 'https://github.com/deathmarine/Luyten/releases.atom',
-          checkpoint: 'aff98b5d8de9ef034ff5093eb58e5d1ab3711e963a589067fbf35f6ed177fae5'
+          checkpoint: 'aa7c30606bdf06807a76ba9c789268e689664151e83cddc4ef30921b83207d2a'
   name 'Luyten'
   homepage 'https://deathmarine.github.io/Luyten/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.