### PR TITLE
Update propresenter to 6.1.6_b16010

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.1.4_b15176'
-  sha256 '6fc35e92710de20417cc82e50dcc3c08c397625c9bd80592ee893882a7c9fa92'
+  version '6.1.6_b16010'
+  sha256 'e152be6197344962ce92242064d3f98e81a8d964e8dae5f9938131fafb824398'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: '68f9ca6d39542c61c4ae2e269a348bf30101effa1dcb197e147e4f8a40474273'
+          checkpoint: 'dcf7f904b59b81c63d5de618e34d4ab6125702a9088df9800f330b5770d3b090'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.