### PR TITLE
Update wifispoof to 3.0.4

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,11 +1,11 @@
 cask 'wifispoof' do
-  version '3.0.3'
-  sha256 '395a7fb451f2d7e968ee87545623e846d7f682eaaba5b27fccf5fb4a2cc27092'
+  version '3.0.4'
+  sha256 'cdcf7a8908de5c092349cea9fc9f4d608406a638e190792665fed0d0a810c720'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"
   appcast 'https://sweetpproductions.com/products/wifispoof3/appcast.xml',
-          checkpoint: 'dc0b638dce2b4c4386638e9065aba0d5d085c36b97c2bed65c12c7a040a188b1'
+          checkpoint: '0cf1f17460ff75966efb3e067048a21e18c75d19befc51fc0543a7746fd40b82'
   name 'WiFiSpoof'
   homepage 'https://wifispoof.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.