### PR TITLE
Update together to 3.8.1

### DIFF
--- a/Casks/together.rb
+++ b/Casks/together.rb
@@ -1,10 +1,10 @@
 cask 'together' do
-  version '3.7.3'
-  sha256 'c9fd27e685aa0c91cdbe47366fb49014b9ab40a454a9b6b925c7f8aefe2ef9ac'
+  version '3.8.1'
+  sha256 '8cd067232792c6267939af5d895baac6560cce3eb5a0826e936303b241b61d3b'
 
   url "https://reinventedsoftware.com/together/downloads/Together_#{version}.dmg"
   appcast "https://reinventedsoftware.com/together/downloads/Together#{version.major}.xml",
-          checkpoint: 'fa6f75869fe9c96c9760dc7d523cde54353ca855844897aa5fcc0b3e835c3d55'
+          checkpoint: 'a6a9e45f2be85c4a0074cb6ce6de82ab032ba3cbc4d06e166600e00686a13a4f'
   name 'Together'
   homepage 'https://reinventedsoftware.com/together/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.