### PR TITLE
Update red to 0.6.2

### DIFF
--- a/Casks/red.rb
+++ b/Casks/red.rb
@@ -1,6 +1,6 @@
 cask 'red' do
-  version '0.6.1'
-  sha256 'afefaa392e5dbc1ec6d8805376ecffe86a1f6d1ce46d426800556f3c4f698693'
+  version '0.6.2'
+  sha256 'dc58bd3a264fbcc1aa3c54ea351ad0e2c14b6a2ecd4a299077d221b9958c4f90'
 
   url "http://static.red-lang.org/dl/mac/red-#{version.no_dots}"
   name 'Red Programming Language'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.