### PR TITLE
Update suidguardng to 1.0.6

### DIFF
--- a/Casks/suidguardng.rb
+++ b/Casks/suidguardng.rb
@@ -2,9 +2,9 @@ cask 'suidguardng' do
   version '1.0.6'
   sha256 '47fcfbf2278cf23da46cb56f07b98647dc21b24d4e574a56713da371b688f7cd'
 
-  url "https://www.suidguard.com/downloads/SUIDGuardNG-#{version.no_dots}.pkg"
+  url "http://www.suidguard.com/downloads/SUIDGuardNG-#{version.no_dots}.pkg"
   name 'SUIDGuardNG'
-  homepage 'https://www.suidguard.com/'
+  homepage 'http://www.suidguard.com/'
 
   depends_on macos: '<= :yosemite'
 


### PR DESCRIPTION
- Removed SSL as it has expired several months ago

<img width="891" alt="ssl-suidguardng" src="https://cloud.githubusercontent.com/assets/450222/24427449/f03b49d8-13d8-11e7-9fb1-e863eabe7203.png">


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.