### PR TITLE
Update openpht to 1.8.0.148-573b6d73

### DIFF
--- a/Casks/openpht.rb
+++ b/Casks/openpht.rb
@@ -1,10 +1,10 @@
 cask 'openpht' do
-  version '1.7.1.137-b604995c'
-  sha256 '9bb7a0c268a337a74f742877aa39cca8174cd44eb6760d0d826b160224b319ec'
+  version '1.8.0.148-573b6d73'
+  sha256 '153cbba8d9bb7f61c646fc4221f4ab107a15809d7bf5da41204dac49fbba0553'
 
   url "https://github.com/RasPlex/OpenPHT/releases/download/v#{version}/OpenPHT-#{version}-macosx-x86_64.zip"
   appcast 'https://github.com/RasPlex/OpenPHT/releases.atom',
-          checkpoint: '3ffa1bafac5989a356d7068beaa78589151adc2e16132c35c4f2760bdc6d7c5a'
+          checkpoint: '1263ce478e7c757b185488855a1a50f55bfd99b4170d3fbf226d647ef4606733'
   name 'OpenPHT'
   homepage 'https://github.com/RasPlex/OpenPHT'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.