### PR TITLE
Update jedict to 5.0.3

### DIFF
--- a/Casks/jedict.rb
+++ b/Casks/jedict.rb
@@ -1,6 +1,6 @@
 cask 'jedict' do
-  version '5.0.1'
-  sha256 'e31f6b185e2aa326ba8b2981e668b751baf11b8e469d8e347f1da26488cc8000'
+  version '5.0.3'
+  sha256 '161d0c812010b4a9bfaa4abc6a2376dfe4b5260714efc2c0f77d3785eb9a2caf'
 
   url "http://jedict.com/Downloads/JEDict#{version.no_dots}.dmg"
   name 'Jedict'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.