### PR TITLE
Update qfinder-pro to 2.4.0.0316

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,10 +1,10 @@
 cask 'qfinder-pro' do
-  version '2.3.1.0124'
-  sha256 '04831a98d32b005136b22a68415a76f6666e8878f6cf6a87ad49178fa07b811c'
+  version '2.4.0.0316'
+  sha256 '379b6e6c6b8611cda3394ba34fb754b0a67a82694f0d935c270b0f746941eef2'
 
   url "http://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'http://update.qnap.com/SoftwareRelease.xml',
-          checkpoint: 'd6d10b87a31daffa00cc61e07bfed6fd2d822331bb9d090526bb5562ea917960'
+          checkpoint: '772710ef910a5786ba790ed6d963b7a9ae391d2459e18f65a631a4e0531935fd'
   name 'Qnap Qfinder Pro'
   homepage 'https://www.qnap.com/en/utilities#utliity_5'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.