### PR TITLE
Update sysex-librarian to 1.3.1

### DIFF
--- a/Casks/sysex-librarian.rb
+++ b/Casks/sysex-librarian.rb
@@ -4,7 +4,7 @@ cask 'sysex-librarian' do
 
   url "https://www.snoize.com/SysExLibrarian/SysExLibrarian_#{version.dots_to_underscores}.zip"
   appcast 'https://www.snoize.com/SysExLibrarian/SysExLibrarian.xml',
-          checkpoint: '5932ad75281f34f7ed7dda012b8cabb61b0c9c95acf4f0429c06fdc6a41e34aa'
+          checkpoint: 'a349dd3b6dc82daf740319832f0ee72c1380ecb244a791df50a462c5537bfed8'
   name 'SysEx Librarian'
   homepage 'https://www.snoize.com/SysExLibrarian/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.