### PR TITLE
Update vivaldi to 1.8.770.50

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi' do
-  version '1.7.735.46'
-  sha256 'e92346165841f38975eba46cd9ef7bd371c4090101f33d742069d07563d796f3'
+  version '1.8.770.50'
+  sha256 '1c61a4e6970163f6d262d082ff442acebeb3c7ffbe3d55e4816aa692e7e7084d'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'a12850c7dcbffa58f7c7db4a8a1ccd4c1cde240c71bf31c61605421918a5083b'
+          checkpoint: '286ade0553fc0b51f1fcc20de98c90e757803a7d856e29cf4045340054320c76'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.