### PR TITLE
Update prepros to 6.0.10

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.0.5'
-  sha256 '96814e1fc300dbcf24a09b288558a1113299bb7f78e5cc2c71367d2ad770ea16'
+  version '6.0.10'
+  sha256 'cfbc7062db0eb82080767af6123cc80b24d16089baaa2bc6f8d31e3ba5545243'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: 'd8f662018c1f19ebb0f5debae948353c5ee76062f08f7db853a8b3f387235bad'
+          checkpoint: '340e8db2f8cde0fd689f92ebbb145699123252d98a0752f67197216a5dd54049'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.