### PR TITLE
Update and rename maltego-chlorine-ce.rb to maltego-ce.rb

### DIFF
--- a/Casks/maltego-ce.rb
+++ b/Casks/maltego-ce.rb
@@ -1,10 +1,10 @@
-cask 'maltego-chlorine-ce' do
+cask 'maltego-ce' do
   version '4.0.11.9358'
   sha256 'eed48ed7d6a32cbb6d963c1af0c0fd7f9c78e89351aa746804889e521469ac3f'
 
   url "https://www.paterva.com/malv#{version.major}/community/MaltegoCE.v#{version}.dmg"
-  name 'Paterva Maltego'
+  name 'Maltego CE'
   homepage 'https://www.paterva.com/web7/buy/maltego-clients/maltego-ce.php'
 
-  app "Maltego Chlorine CE v#{version.major_minor_patch}.app"
+  app "Maltego CE v#{version.major_minor_patch}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Renamed cask to `maltego-ce` to be consistent with Paterva.

Corrected app stanza.