### PR TITLE
Update qownnotes to 17.03.8,b2844-163619

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '16.12.9,b2621-183923'
-  sha256 'c320af940de2a7de71752752e5536afa6cdd55b29ea28202758a25de64209aa3'
+  version '17.03.8,b2844-163619'
+  sha256 'c25478d048b49b59ac3b2867a4c54ff37cc21867ad18fddc7da70e6c614cc025'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '8e06a38f0671d98de38d97911986195de0b8dd36089ec1cea3953aa6bde5c44f'
+          checkpoint: '90b5f1f9f9fabf278caafe8191da2e0a7b96e0c4e010993ab23e8ed378f9db98'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.