### PR TITLE
Update mongodb-compass to 1.6.1

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.6.0'
-  sha256 '9b9ee6ce65bd7deaf3bdd3aff96ce29395da10f00d70b8d9d4d131f5a9664265'
+  version '1.6.1'
+  sha256 '406be840ea1962d8bbb5fc248f7ae432221bd12be8e2ed937d03603ea75f61a4'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.