### PR TITLE
Update hots-replay-uploader to 2.1.4

### DIFF
--- a/Casks/hots-replay-uploader.rb
+++ b/Casks/hots-replay-uploader.rb
@@ -1,10 +1,10 @@
 cask 'hots-replay-uploader' do
-  version '2.1.3'
-  sha256 '2a5e8f6414c3e60a2da573657614e05ce30005dc94b98cc0734c9e4c77368f13'
+  version '2.1.4'
+  sha256 '717b012359599efc6ccbbae3bbeb130c48ffc83c45885847fe0364bda8f37dcc'
 
   url "https://github.com/eivindveg/HotSUploader/releases/download/v#{version}/HotS.Replay.Uploader-#{version}.dmg"
   appcast 'https://github.com/eivindveg/HotSUploader/releases.atom',
-          checkpoint: 'db2c8e09acbc82472b7b4a907e628249b785e3b669327157a2984d9b36477649'
+          checkpoint: '470f8ede53d912c0f7b505bc13a71b53f45f7e98c3c929e7334cc9e20ca6d9c2'
   name 'HotS Replay Uploader'
   homepage 'https://github.com/eivindveg/HotSUploader/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.