### PR TITLE
Update smartgit to 17.0.3

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,10 +1,10 @@
 cask 'smartgit' do
-  version '17.0.2'
-  sha256 '85386cf20ed3bfa22a13e878086b1d074311d53f7bb60ff2efcd1e96f30211ea'
+  version '17.0.3'
+  sha256 '14460ddd755806ab6aa9ede4aa0ba8afbc7aa201834ace1be6d4279953b6035b'
 
   url "https://www.syntevo.com/static/smart/download/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',
-          checkpoint: 'cb9c326df8fb7c6111ba6b9d2241fe744ce182518e90ce8b3c808039f14fa18a'
+          checkpoint: '6f2b29ae7a8e53f106c74e8bbb535498e5a64b6dc713c6c4b15247a6f26cc7e0'
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.