### PR TITLE
Update android-sdk

### DIFF
--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -7,6 +7,16 @@ cask 'android-sdk' do
   name 'android-sdk'
   homepage 'https://developer.android.com/index.html'
 
+  build_tools_version = '25.0.2'
+
+  binary "#{staged_path}/build-tools/#{build_tools_version}/aapt"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/aapt2"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/aidl"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/apksigner"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/dexdump"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/dx"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/llvm-rs-cc"
+  binary "#{staged_path}/build-tools/#{build_tools_version}/zipalign"
   binary "#{staged_path}/emulator/emulator"
   binary "#{staged_path}/emulator/emulator-check"
   binary "#{staged_path}/emulator/emulator64-arm"
@@ -27,7 +37,7 @@ cask 'android-sdk' do
   binary "#{staged_path}/tools/monitor"
 
   preflight do
-    system_command "#{staged_path}/tools/bin/sdkmanager", args: ['tools', 'platform-tools', 'build-tools;25.0.2'], input: 'y'
+    system_command "#{staged_path}/tools/bin/sdkmanager", args: ['tools', 'platform-tools', "build-tools;#{build_tools_version}"], input: 'y'
   end
 
   caveats <<-EOS.undent

--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -7,23 +7,26 @@ cask 'android-sdk' do
   name 'android-sdk'
   homepage 'https://developer.android.com/index.html'
 
-  binary "#{staged_path}/tools/bin/sdkmanager"
+  binary "#{staged_path}/emulator/emulator"
+  binary "#{staged_path}/emulator/emulator-check"
+  binary "#{staged_path}/emulator/emulator64-arm"
+  binary "#{staged_path}/emulator/emulator64-mips"
+  binary "#{staged_path}/emulator/emulator64-x86"
+  binary "#{staged_path}/platform-tools/adb"
+  binary "#{staged_path}/platform-tools/dmtracedump"
+  binary "#{staged_path}/platform-tools/etc1tool"
+  binary "#{staged_path}/platform-tools/fastboot"
+  binary "#{staged_path}/platform-tools/hprof-conv"
+  binary "#{staged_path}/platform-tools/sqlite3"
   binary "#{staged_path}/tools/android"
-  binary "#{staged_path}/tools/ddms"
-  binary "#{staged_path}/tools/draw9patch"
-  binary "#{staged_path}/tools/emulator"
-  binary "#{staged_path}/tools/emulator64-arm"
-  binary "#{staged_path}/tools/emulator-check"
-  binary "#{staged_path}/tools/emulator64-mips"
-  binary "#{staged_path}/tools/emulator64-x86"
-  binary "#{staged_path}/tools/hierarchyviewer"
-  binary "#{staged_path}/tools/lint"
+  binary "#{staged_path}/tools/bin/avdmanager"
+  binary "#{staged_path}/tools/bin/lint"
+  binary "#{staged_path}/tools/bin/monkeyrunner"
+  binary "#{staged_path}/tools/bin/sdkmanager"
   binary "#{staged_path}/tools/mksdcard"
   binary "#{staged_path}/tools/monitor"
-  binary "#{staged_path}/tools/monkeyrunner"
-  binary "#{staged_path}/tools/traceview"
 
-  postflight do
+  preflight do
     system_command "#{staged_path}/tools/bin/sdkmanager", args: ['tools', 'platform-tools', 'build-tools;25.0.2'], input: 'y'
   end
 


### PR DESCRIPTION
Correct the emulator binaries, which are moved from /tools to /emulator folder.
See announcement here: https://developer.android.com/studio/releases/emulator.html

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.


👋  Hello! My first MR here, please let me know if I missed anything from the contributing guideline I'll fix it ASAP.
