### PR TITLE
Update snapz-pro-x to 2.6.1

### DIFF
--- a/Casks/snapz-pro-x.rb
+++ b/Casks/snapz-pro-x.rb
@@ -3,10 +3,10 @@ cask 'snapz-pro-x' do
   sha256 'f979b464768bc2bf4e9fe9ed34e8914b0eba98af08f26c3a1ac298fde533541f'
 
   url "http://downloads3.ambrosiasw.com/snapzprox/essentials/SnapzProX#{version.major}.dmg"
-  appcast 'https://www.ambrosiasw.com/updates/profile.php/snapz_pro_x/release',
+  appcast 'http://www.ambrosiasw.com/updates/profile.php/snapz_pro_x/release',
           checkpoint: '0da65f1139e0e1fa8a17f1372dabb22af4873e4ff989f7acd6585749d1a03a0f'
   name 'Snapz Pro X'
-  homepage 'https://www.ambrosiasw.com/utilities/snapzprox/'
+  homepage 'http://www.ambrosiasw.com/utilities/snapzprox/'
 
   pkg 'Snapz Pro X.pkg'
 


### PR DESCRIPTION
- Developer site is not supporting SSL on APPcast

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.