### PR TITLE
Update dbeaver-community to 4.0.3

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -2,6 +2,7 @@ cask 'dbeaver-community' do
   version '4.0.3'
   sha256 '6324a964024653241ba41a25b2415a2c67ddeb8e4892740b6d78a3907207094d'
 
+  # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
           checkpoint: '15b3eb893d99309501e278bc76741e27d078d82e523e346b2f3d101595f26e87'

--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -2,9 +2,11 @@ cask 'dbeaver-community' do
   version '4.0.3'
   sha256 '6324a964024653241ba41a25b2415a2c67ddeb8e4892740b6d78a3907207094d'
 
-  url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
+  url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
+  appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
+          checkpoint: '15b3eb893d99309501e278bc76741e27d078d82e523e346b2f3d101595f26e87'
   name 'DBeaver Community Edition'
-  homepage 'http://dbeaver.jkiss.org/'
+  homepage 'https://github.com/serge-rider/dbeaver'
 
   app 'DBeaver.app'
 end

--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -6,7 +6,7 @@ cask 'dbeaver-community' do
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
           checkpoint: '15b3eb893d99309501e278bc76741e27d078d82e523e346b2f3d101595f26e87'
   name 'DBeaver Community Edition'
-  homepage 'https://github.com/serge-rider/dbeaver'
+  homepage 'http://dbeaver.jkiss.org/'
 
   app 'DBeaver.app'
 end


### PR DESCRIPTION
- Updating the Download & Homepage URL to github as http://dbeaver.jkiss.org/ is not accessiable

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.