### PR TITLE
Update keycue to 8.3

### DIFF
--- a/Casks/keycue.rb
+++ b/Casks/keycue.rb
@@ -2,7 +2,8 @@ cask 'keycue' do
   version '8.3'
   sha256 'a261dad0a1f0dde6624d4824a3d7843422d3466ad605ea2fbcf831ecd10d578e'
 
-  url "http://www.ergonis.com/downloads/products/keycue/KeyCue#{version.no_dots}-Install.dmg"
+  url "http://www.ergonis.com/downloads/products/keycue/KeyCue#{version.no_dots}-Install.dmg",
+      user_agent: :fake
   name 'KeyCue'
   homepage 'http://www.ergonis.com/products/keycue/'
 


### PR DESCRIPTION
- included user agent as the download fails in command line

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.