### PR TITLE
Update docker-toolbox to 17.03.1-ce

### DIFF
--- a/Casks/docker-toolbox.rb
+++ b/Casks/docker-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'docker-toolbox' do
-  version '17.03.0-ce'
-  sha256 '5ff784a7915e47881e662ccbdd516eb6ab2cd48f29ec71868850845e586b3d5c'
+  version '17.03.1-ce'
+  sha256 '2496619f463da8b46bf7abf3838fa28a91efcd3870e683346ca7ca2d058f0f85'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: 'e08b1726112af6aa4a49a20d5f1b129f74f23363f748e095de86bb3d981ab0f4'
+          checkpoint: 'e8c3ce247e4d959a597e74c9cd8008c1da2123721d02cce2bb3241095796553e'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/products/docker-toolbox'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.