### PR TITLE
Update numi to 3.0b14,90:1478584117

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,9 +1,11 @@
 cask 'numi' do
-  version :latest
-  sha256 :no_check
+  version '3.0b14,90:1478584117'
+  sha256 'a9452e903169d3a735db1af2eb684521ff0828a2f39f1d34acda2c8602762627'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.dmitrynikolaev.numi/Numi.zip'
+  url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"
+  appcast 'http://updates.devmate.com/com.dmitrynikolaev.numi.xml',
+          checkpoint: 'd05068f1767ef5c8bd6ea5435737c347755799881b15ef43a49a2429635fb6ad'
   name 'Numi'
   homepage 'https://numi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.