### PR TITLE
Update avidemux to 2.6.19

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.6.18'
-  sha256 'bc4c1251103236a719a7d56a912bfffec4e333b4d625fc9037cd0c8220cb22c5'
+  version '2.6.19'
+  sha256 '606e239b7833fdb4e86422979189c31942ced034f8d8fd2cde0ee4cff7de13eb'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: '2125908587baf2bd9ee56e40a3882befcb56d69057f9b14bc2f3a3196da31312'
+          checkpoint: '48d5f951633deea796cee416eec784b6f338923abba559a74bed937cca40e5dd'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #.