### PR TITLE
Update ganttproject to 2.8.4,r2134

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,8 +1,11 @@
 cask 'ganttproject' do
-  version '2.8.1-r2024'
-  sha256 'af54b01733505e9fe1c112078cb5b93f2b7cf43e496fc5d7130a3a7bd00ab76f'
+  version '2.8.4,r2134'
+  sha256 '1e42d88ac4122bdef7631aba589241ec431902859d7af18250891c486e5f242c'
 
-  url "https://dl.ganttproject.biz/ganttproject-#{version.sub(%r{-.*}, '')}/ganttproject-#{version}.dmg"
+  # github.com/bardsoftware/ganttproject/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"
+  appcast 'https://github.com/bardsoftware/ganttproject/releases.atom',
+          checkpoint: '6cb5f272592593f3fe23cacc2c7bb18d0a5fbfab18a8c87ec98c92db69252711'
   name 'GanttProject'
   homepage 'https://www.ganttproject.biz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.