### PR TITLE
Update nylas-mail to 1.0.48-5a0ce1c

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.45-a95f866'
-  sha256 '57610a9746a1cf3a4c471030abcd01b883cabf5c1611fba52be275ee9f6bb086'
+  version '1.0.48-5a0ce1c'
+  sha256 '4ab09bf095cab41c789536a99b30073ec154e02b51bf08a5ec911a66bc358f1c'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: 'aab4ec5de2ded71c72a29c04bca8fa3d176741ef9666174efa189e9dac5f8c81'
+          checkpoint: '119668734f2ea41c68dd97ad4372f1c54aea6fee0ebd614ccf9a042580d2ff1f'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.