### PR TITLE
Update wiznote to 2.4.4,2017-03-14

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.4.3,2017-01-03'
-  sha256 '399b7989bdc0e8ba3a646f409dd9ddd301cb34bb4a1cff8fc25d1f861909560d'
+  version '2.4.4,2017-03-14'
+  sha256 '35090576e94ad67f84c213571818fe44cf45ebc0ad1a977a8a53b2a0d1f95ea6'
 
   url "http://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   name 'WizNote'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.