### PR TITLE
Update wordpresscom to 2.2.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '1.8.0'
-  sha256 'd4d1bc63dc862d8c5e1fb59a6bcd348711f4e46377038e3e13d986362bbe8889'
+  version '2.2.0'
+  sha256 '17e0c52cd2d157e56586d1f51f20c6ac073bf452e6cc49e55e2cf80078d2330a'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: '960cd9d04fc8be4d43d8ade4e64236116b2f050db4a7ab15aed059f390a2865c'
+          checkpoint: 'e38a213a734691af97f6e35d5326b87260fbfa7c3bf4fa43b720ab857d372659'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.