### PR TITLE
Update phoneexpander to 1.1_325

### DIFF
--- a/Casks/phoneexpander.rb
+++ b/Casks/phoneexpander.rb
@@ -4,7 +4,7 @@ cask 'phoneexpander' do
 
   url "https://phoneexpander.com/downloads/PhoneExpander_#{version}.zip"
   appcast 'https://phoneexpander.com/appcast',
-          checkpoint: 'ebcdbc310920a916c79d4bc6041690a1dfc6799468ddc9c1e60173a4fa09dfd2'
+          checkpoint: '69e4a33ba8d1f2abd7ba5a5794a533506ccbecebfead08f94c35c3ce84bf3b38'
   name 'PhoneExpander'
   homepage 'https://phoneexpander.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.