### PR TITLE
Update qgroundcontrol to 3.1.3

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.1.2'
-  sha256 '6f7e0dfa7b9cf4eee37a10cb83caffedcab84651ee6e6b2fa46b65b4978b2813'
+  version '3.1.3'
+  sha256 '20ad7970b14ff3286dc7b217b49420286b09a99c1244c95ca185870d8f3bca94'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: '75a58c85a559d9febabb5fc10f543d08754189e4598a0bf2a25598ffdc1b64eb'
+          checkpoint: '4b9d994643c4854fa1540ee06d4c26aff00172bf6aa734bc0da3f08925a4d781'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.