### PR TITLE
Update kube-solo to 1.0.3

### DIFF
--- a/Casks/kube-solo.rb
+++ b/Casks/kube-solo.rb
@@ -4,7 +4,7 @@ cask 'kube-solo' do
 
   url "https://github.com/TheNewNormal/kube-solo-osx/releases/download/v#{version}/Kube-Solo_v#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/kube-solo-osx/releases.atom',
-          checkpoint: '011276cb76066f9e5503493ff92ce386bd4024ac4b825b6c1491c0582484db2f'
+          checkpoint: '6ba282b8234da950f8d0f4c3a9c7c86793b2cf0fa760e0a8c235ac6b64852987'
   name 'Kube-Solo'
   homepage 'https://github.com/TheNewNormal/kube-solo-osx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.