### PR TITLE
Add Rclone Browser Version 1.2

### DIFF
--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -3,7 +3,7 @@ cask 'rclone-browser' do
   sha256 '542cd23eea128736999a7e512a9f2ff89be081c688d1581e6c78ab3d3ca118dd'
 
   # github.com/mmozeiko/RcloneBrowser was verified as official when first introduced to the cask
-  url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version.before_comma}/#{version.before_comma}-#{version.after_comma}.zip"
+  url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version.before_comma}/rclone-browser-#{version.before_comma}-#{version.after_comma}-macOS.zip"
   appcast 'https://github.com/mmozeiko/RcloneBrowser/releases.atom',
             checkpoint: 'a1156a045bcee8f66d1cab89598a1e35ce9e479c'
   name 'Rclone Browser'
@@ -11,7 +11,7 @@ cask 'rclone-browser' do
 
   depends_on formula: 'rclone'
 
-  app "#{version.before_comma}-#{version.after_comma}/Rclone Browser.app"
+  app "rclone-browser-#{version.before_comma}-#{version.after_comma}-macOS/Rclone Browser.app"
 
   zap delete: [
                 '~/Library/Preferences/Rclone Browser.plist',

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -2,7 +2,7 @@ cask 'rclone-browser' do
   version '1.2,a1156a0'
   sha256 '542cd23eea128736999a7e512a9f2ff89be081c688d1581e6c78ab3d3ca118dd'
 
-  # github.com was verified as official when first introduced to the cask
+  # github.com/mmozeiko/RcloneBrowser was verified as official when first introduced to the cask
   url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version.before_comma}/#{version.before_comma}-#{version.after_comma}.zip"
   name 'Rclone Browser'
   homepage 'https://mmozeiko.github.io/RcloneBrowser/'

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -4,6 +4,8 @@ cask 'rclone-browser' do
 
   # github.com/mmozeiko/RcloneBrowser was verified as official when first introduced to the cask
   url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version.before_comma}/#{version.before_comma}-#{version.after_comma}.zip"
+  appcast 'https://github.com/mmozeiko/RcloneBrowser/releases.atom',
+            checkpoint: 'a1156a045bcee8f66d1cab89598a1e35ce9e479c'
   name 'Rclone Browser'
   homepage 'https://mmozeiko.github.io/RcloneBrowser/'
 

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -1,0 +1,20 @@
+cask 'rclone-browser' do
+  version '1.2'
+  sha256 '542cd23eea128736999a7e512a9f2ff89be081c688d1581e6c78ab3d3ca118dd'
+
+  archive_name = 'rclone-browser-1.2-a1156a0-macOS'
+
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version}/#{archive_name}.zip"
+  name 'Rclone Browser'
+  homepage 'https://mmozeiko.github.io/RcloneBrowser/'
+
+  depends_on formula: 'rclone'
+
+  app "#{archive_name}/Rclone Browser.app"
+
+  zap delete: [
+                '~/Library/Preferences/Rclone Browser.plist',
+                '~/Library/Preferences/com.rclone-browser.rclone-browser.plist',
+              ]
+end

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -5,7 +5,7 @@ cask 'rclone-browser' do
   # github.com/mmozeiko/RcloneBrowser was verified as official when first introduced to the cask
   url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version.before_comma}/rclone-browser-#{version.before_comma}-#{version.after_comma}-macOS.zip"
   appcast 'https://github.com/mmozeiko/RcloneBrowser/releases.atom',
-            checkpoint: 'a1156a045bcee8f66d1cab89598a1e35ce9e479c'
+          checkpoint: '6c70233b86022aaa670af000d633ff4b2038037599511bfdfb1809c6ab863ff0'
   name 'Rclone Browser'
   homepage 'https://mmozeiko.github.io/RcloneBrowser/'
 

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -9,7 +9,7 @@ cask 'rclone-browser' do
 
   depends_on formula: 'rclone'
 
-  app "#{archive_name}/Rclone Browser.app"
+  app "#{version.before_comma}-#{version.after_comma}/Rclone Browser.app"
 
   zap delete: [
                 '~/Library/Preferences/Rclone Browser.plist',

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -1,11 +1,9 @@
 cask 'rclone-browser' do
-  version '1.2'
+  version '1.2,a1156a0'
   sha256 '542cd23eea128736999a7e512a9f2ff89be081c688d1581e6c78ab3d3ca118dd'
 
-  archive_name = 'rclone-browser-1.2-a1156a0-macOS'
-
   # github.com was verified as official when first introduced to the cask
-  url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version}/#{archive_name}.zip"
+  url "https://github.com/mmozeiko/RcloneBrowser/releases/download/#{version.before_comma}/#{version.before_comma}-#{version.after_comma}.zip"
   name 'Rclone Browser'
   homepage 'https://mmozeiko.github.io/RcloneBrowser/'
 


### PR DESCRIPTION
Adding a cask for [Rclone Browser](https://mmozeiko.github.io/RcloneBrowser/).

The only thing I'm unsure of is whether the `archive_name` line is permissible. It's only included to remove the duplication between `url` and `app`. Please let me know if there's a standard way to handle that, or if any other changes are required.

Thanks for reviewing!

***

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask