### PR TITLE
Update jet to 1.17.0

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,6 +1,6 @@
 cask 'jet' do
-  version '1.16.0'
-  sha256 '392ee5660e9c436465bdcf71610482300528dc9cfaa1e9c54e391b2781d48441'
+  version '1.17.0'
+  sha256 'b728fb6070081d81e6c1c58a504426c3cd554d408ab80779b18b133873f413fe'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.