### PR TITLE
Update official source for wkhtmltopdf

### DIFF
--- a/Casks/wkhtmltopdf.rb
+++ b/Casks/wkhtmltopdf.rb
@@ -2,8 +2,7 @@ cask 'wkhtmltopdf' do
   version '0.12.4'
   sha256 '402209589279e092c94d17c76e6fdda6be5cadb21ce12e7c093c41f82b757506'
 
-  # download.gna.org/wkhtmltopdf was verified as official when first introduced to the cask
-  url "http://download.gna.org/wkhtmltopdf/#{version.major_minor}/#{version}/wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
+  url "http://downloads.wkhtmltopdf.org/#{version.major_minor}/#{version}/wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
   name 'wkhtmltopdf'
   homepage 'https://wkhtmltopdf.org/'
 


### PR DESCRIPTION
The GNA Project will be closing soon[1] and wkhtmltopdf decided to self-host[2] the binary files.
This commit update the cask source to the new official URL.

[1] https://mail.gna.org/public/project/2016-11/msg00001.html
[2] https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3390

(This PR doesn't change any version or hash)

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.