### PR TITLE
Update polymail to 1.30

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.28'
-  sha256 '7ef0e504fbea42e1f7bdc52a26bf2f17845982f1282a4faaeb9468bfd1c9463c'
+  version '1.30'
+  sha256 'e9e1e8494e653ebc160af4af58eba1aafb6d73d4b016dceaa1b5a90caa8f0791'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '5cc48c3a3382f7c9c63f2456e20081277ca6b2cc96cb8ad2809580e6cc3789e5'
+          checkpoint: 'be7aa3378687ce8a34382f666cfdbd288658860736038a46f3491da3bf447e06'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.