### PR TITLE
Update torustrooper to 0.22.2

### DIFF
--- a/Casks/torustrooper.rb
+++ b/Casks/torustrooper.rb
@@ -4,7 +4,7 @@ cask 'torustrooper' do
 
   url "https://workram.com/downloads/TorusTrooper-for-OS-X-#{version}.dmg"
   appcast 'https://workram.com/games/',
-          checkpoint: '0099c96dfbcf566c5b80dee384bb73e788bb00042bcf33803c9aeb651f0603f4'
+          checkpoint: 'a53dea4e8dcc4e5486a920d1b73e53454811f3d8c54b19b25236eff3f8923030'
   name 'Torus Trooper'
   homepage 'https://workram.com/games/'
 

--- a/Casks/torustrooper.rb
+++ b/Casks/torustrooper.rb
@@ -3,6 +3,8 @@ cask 'torustrooper' do
   sha256 '39b188107620c58f4a60f2f24d01f39ab87d46655203f4bcfe97d3a6fa5b7b3e'
 
   url "https://workram.com/downloads/TorusTrooper-for-OS-X-#{version}.dmg"
+  appcast 'https://workram.com/games/',
+          checkpoint: 'a53dea4e8dcc4e5486a920d1b73e53454811f3d8c54b19b25236eff3f8923030'
   name 'Torus Trooper'
   homepage 'https://workram.com/games/'
 

--- a/Casks/torustrooper.rb
+++ b/Casks/torustrooper.rb
@@ -3,8 +3,6 @@ cask 'torustrooper' do
   sha256 '39b188107620c58f4a60f2f24d01f39ab87d46655203f4bcfe97d3a6fa5b7b3e'
 
   url "https://workram.com/downloads/TorusTrooper-for-OS-X-#{version}.dmg"
-  appcast 'https://workram.com/games/',
-          checkpoint: 'a53dea4e8dcc4e5486a920d1b73e53454811f3d8c54b19b25236eff3f8923030'
   name 'Torus Trooper'
   homepage 'https://workram.com/games/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.