### PR TITLE
Update netlogo to 6.0.1

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,10 +1,10 @@
 cask 'netlogo' do
-  version '6.0'
-  sha256 '7ed687afc901130a83019ecff45f40fa0576bfbe2beb470a400de48a2378f566'
+  version '6.0.1'
+  sha256 '081b34feb3357eaee21f3b91355efa9f9471e05029697c24c0f55a2e4d5af5f5'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml',
-          checkpoint: '5927e356270978f8366e6d0084b52ff2bb869fbba191e1928a0004d889408377'
+          checkpoint: '8f6e88b9ad1d1e73ee9e7c152ba03bf88f47706b59e95004033151fe5cb1f5c7'
   name 'NetLogo'
   homepage 'https://ccl.northwestern.edu/netlogo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.