### PR TITLE
Update coconutbattery to 3.5.3

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -7,16 +7,16 @@ cask 'coconutbattery' do
     version '2.8'
     sha256 'fcfc81214ff26afff9f5c6c7cdc455b23ac898b6918f864b641a9e31526692d4'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
-  elsif MacOS.version <= :yosemite
+  elsif MacOS.version <= :mavericks
     version '3.3.4'
     sha256 '0edf6bdaf28fb3cc9c242fd916c348fbbae30a5356ddc1d6e5158d50f96d740d'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.dots_to_underscores}.zip"
   else
-    version '3.5.2'
-    sha256 '2d7331497961e14bc04fc03c3689c1b8057881a357d813f4dddcacbebf56adf0'
+    version '3.5.3'
+    sha256 'b5e27337be143908ce7d7e00d014d83184f8dbad6a918c6f42abbcbe194a1a18'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml',
-            checkpoint: 'b4dcb6a34af915e5fe4db413259d562b503eedf94e4c12540a5288c5d891ebe2'
+            checkpoint: '38b475a12488a9773876db0896fd4d1c31d41fe5a8fc5d3ab71c406503c33df3'
   end
 
   name 'coconutBattery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.