### PR TITLE
Update flightgear to 2017.1.2

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2016.4.4'
-  sha256 '01a79d6d0125ca26a36a1b9307851ab16eb9aa04c833ba448020bb630400783e'
+  version '2017.1.2'
+  sha256 'bd6270404515914c882f8a9c3be9073339d1dd998b7f88220ed15b9fe7d77dea'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: '6e65fda2c7dc92cfb997b405dacdea555990cb409c51a2a7f013d30119a1713d'
+          checkpoint: '4a83731f1a473aa983bc3c40b820cc212c5d2429eb39be63e391d57909790daf'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.