### PR TITLE
Update flightgear to 2017.1.2

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -10,4 +10,9 @@ cask 'flightgear' do
   homepage 'http://www.flightgear.org/'
 
   app 'FlightGear.app'
+
+  zap delete: [
+                '/Library/Logs/DiagnosticReports/fgfs*',
+                '~/Library/Application Support/FlightGear',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.