### PR TITLE
Update webcatalog to 3.4.4

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '3.4.0'
-  sha256 '259defdb631646451c1edbda635e24227ba9c578017f8ddb65e303d3f5e31c2b'
+  version '3.4.4'
+  sha256 '7bb7e3d58b0ab68d3a0be117d16b2d03349f91b00e242ca21dbfd42002507082'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: 'fb21aefc5e0fdb5c15fc19170cb4bb41316131998e17a665f74fbf8eaabbc9b0'
+          checkpoint: '041280020e5a1d1eeedc8ca6d1483a81e59fe564db74ad97869dff056ebd48c7'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.