### PR TITLE
Update openshot-video-editor to 2.3.1

### DIFF
--- a/Casks/openshot-video-editor.rb
+++ b/Casks/openshot-video-editor.rb
@@ -1,11 +1,11 @@
 cask 'openshot-video-editor' do
-  version '2.2.0'
-  sha256 '1324b81f0bb2c3c756585df330af816bef8278cb8f5b7dc7a6c615b72701ce18'
+  version '2.3.1'
+  sha256 '735b1e511f97bceca0306f8afb0c81509f88b75f2334d2d0bbd1c289d393293d'
 
   # github.com/OpenShot/openshot-qt was verified as official when first introduced to the cask
   url "https://github.com/OpenShot/openshot-qt/releases/download/v#{version}/OpenShot-v#{version}-x86_64.dmg"
   appcast 'https://github.com/OpenShot/openshot-qt/releases.atom',
-          checkpoint: 'c745bfaef941e2a1c02f218203a80765b19fef9792e0325e9f8bae475d84f021'
+          checkpoint: '150d0dc218d3d53e4f30e45accc245d8b12c9951e55dd68f48f0bc445be0eee8'
   name 'OpenShot Video Editor'
   homepage 'http://openshot.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.