### PR TITLE
Update typora to 0.9.9.9.4

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.9.3'
-  sha256 '0e976a080c840ac108f1b7bd4f6694ae2b89961106d5ff0eda32549594f32a1b'
+  version '0.9.9.9.4'
+  sha256 'a5f429ebe4e2f5704f4379fe28d8de1ee4857b3890fcc62122a3d39a45368863'
 
   url "https://www.typora.io/download/typora_#{version}.zip"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: 'c21c58bb3c851a8d68638ed943113a28b32a88356f28ec778327a90dd5415175'
+          checkpoint: 'a78f6fbe344669d90ff23a80c9e09b409a7711f4d4684842b682f580fba7d3be'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.