### PR TITLE
Update telegram to 2.92-91469

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.92-91328'
-  sha256 'c2348d76fa2033285d249889532401ee3084e43d5e7264b02953c60212571798'
+  version '2.92-91469'
+  sha256 '9d97f60391df4dbfe0c3e418ea9afd28e75019b60a94ba7600e6ac54d5d9857f'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'b0ccc1d72bc97d41d6e23674a8cf3c7a10666edaabb3ac85918317b39f1ad73b'
+          checkpoint: '6bbd8a701a7ca61f65b6b711bda1e5ebf8da494cf814f60613822ac5024de282'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.