### PR TITLE
Update josm to 11826

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask 'josm' do
-  version '11639'
-  sha256 '1ecb13b8316397a2eaa2a9f7a141e278444e3cf2b17100827995b37d1d4c944c'
+  version '11826'
+  sha256 '26362eba2d00ab85d0b34367f592737a3a7412777a7bf26899467f89da51750d'
 
   url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
   name 'JOSM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.