### PR TITLE
Update sparkle to 1.17.0

### DIFF
--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -1,11 +1,11 @@
 cask 'sparkle' do
-  version '1.16.0'
-  sha256 '8a928afa342062f433ab9e86fac02bca52ae3ce8352ed0ad2e803a76c19b2d87'
+  version '1.17.0'
+  sha256 'aa5024b76a1c76326115d114c96a6efc4b68e593dde22142a98d861dd44965b5'
 
   # github.com/sparkle-project/Sparkle was verified as official when first introduced to the cask
   url "https://github.com/sparkle-project/Sparkle/releases/download/#{version}/Sparkle-#{version}.tar.bz2"
   appcast 'https://github.com/sparkle-project/Sparkle/releases.atom',
-          checkpoint: '86802bf57ac0147277a048ae9b0a96146f36d7fb284b5ba2d3e0b1fe822bedda'
+          checkpoint: '472d80c2eccded64b98486f6cf166d69fdab88214056de4119b40f4924ea9851'
   name 'Sparkle'
   homepage 'https://sparkle-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.