### PR TITLE
Update downie to 2.7.9,1453

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.6.10,1440'
-  sha256 'f05b84eea6110cf55992f7a35ce99869a1ea9fa4d7ef7f50fee8de2138442624'
+  version '2.7.9,1453'
+  sha256 'c1e7ab4f47d8e4a81777255d465d0ad12475083445a52b3391cc41e512d60663'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '342f9333059e4a2e7f19b82baf1a5878671312b1d1c7dadb96a9dd28664e02b5'
+          checkpoint: '2e1fdf64425f79b4c532b80848ea4099dc58f624415a9a30cfa6f4189da6185f'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.