### PR TITLE
Update pdfpen to 833.3,1489545388

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,10 +1,10 @@
 cask 'pdfpen' do
-  version '831.0,1483740279'
-  sha256 'fc3ffc67a4c072e99534c6d0b2d3f89beb8830353b88bc1f852ab9f597acf594'
+  version '833.3,1489545388'
+  sha256 '787774f1f8f44eccce65c525426dc5b79e1c7bcdc198f844a84f3ff8fc1c3bcd'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
-          checkpoint: 'e9eb182b8d662af31ef78554fd3ec20a7d94850a81f0763a5a3135abb754b51e'
+          checkpoint: '7a1c84860de5ad3f72fedd1b5ad623deb458c3b91a6c2d1a9d09133d980e7894'
   name 'PDFpen'
   homepage 'https://smilesoftware.com/PDFpen'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.