### PR TITLE
Update react-native-debugger (0.6.3)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.6.2'
-  sha256 '53ed983f2b436c5cc9a179f78d1b196089899e5a5cbec0102bcce594d1a184fa'
+  version '0.6.3'
+  sha256 'a4d740f17451c5a8b0c201c9e0f704c5fbab27e118ade0954acfd765b9b00d22'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: 'db9cbfe54f83be77d5ac47867bcf23cc09e6abbbc7813d6740c891286536ee53'
+          checkpoint: 'cf25e5bbe4e11ba4bc11f31cd8a02b4ea47e6b68d5288d2fc3b2329b53e9e915'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.