### PR TITLE
Update MagicaVoxel to 0.98.1

### DIFF
--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,9 +1,9 @@
 cask 'magicavoxel' do
-  version '0.98'
-  sha256 '8fb7dc065ede34fa64203faf6da8bd9c54d65950177e0601225880d94010f83d'
+  version '0.98.1'
+  sha256 'd0876dd7f6603b220e74aa93d30aeb1e76f05df66c647f139ce8bd96a0b301aa'
 
   # 23.98.147.40 was verified as official when first introduced to the cask
-  url "http://23.98.147.40/uploads/MagicaVoxel-#{version}-win-mac.zip"
+  url "http://23.98.147.40/uploads/MagicaVoxel-#{version}-win-mac-beta.zip"
   name 'MagicaVoxel'
   homepage 'https://ephtracy.github.io/'
 


### PR DESCRIPTION
0.98.2 has been released but sadly not the Mac binary yet :(
