### PR TITLE
Update hsang to 1.8.2

### DIFF
--- a/Casks/hsang.rb
+++ b/Casks/hsang.rb
@@ -1,6 +1,6 @@
 cask 'hsang' do
-  version '1.6.1'
-  sha256 'e747d0549630c24a81b3b74b9382cd47ecb594af123f7471a4f9753c3bf4b1ba'
+  version '1.8.2'
+  sha256 'a1e54fc34b5ca82ed1b3e24f4618b832ef2df8e9d1bdb918573ac6f3d339e449'
 
   # nie.gdl.netease.com/lushi was verified as official when first introduced to the cask
   url "http://nie.gdl.netease.com/lushi/HSAng_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.