### PR TITLE
Update mountain-duck to 1.8.2.6516

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.8.1.6492'
-  sha256 '9ad62ef60f12940a3d17a18ece79e8b123eabe5e8b9c9d444eec9fe69e34b65a'
+  version '1.8.2.6516'
+  sha256 '49912561f04c8b0660e2586e759591d70270d1fcc2cff872f64fec59770a1681'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '8f903d77378f0bed90781c16132e759846ea7fa35bc53fc849125014f7b02816'
+          checkpoint: '91dc850cd29646d247c414c1be6f1df33059ca80dde1cff73bfc3bfed623a1c7'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.