### PR TITLE
Update tankix to 577

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '576'
-  sha256 '8310acff9c8dc4236fbb7d1e808f5a86b7021f5bdbf11bfab07f2576fc80b069'
+  version '577'
+  sha256 '3e53defedf64963be4c696c38942fdc53c1b727ce36904c0cb31256bc937806f'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'
@@ -12,8 +12,8 @@ cask 'tankix' do
 
   zap delete: [
                 '/Library/Logs/DiagnosticReports/tankix*',
-                '~/Library/Application\ Support/CrashReporter/tankix*',
+                '~/Library/Application Support/CrashReporter/tankix*',
                 '~/Library/Preferences/unity.AlternativaPlatform.TankiX.plist',
-                '~/Library/Saved\ Application\ State/unity.AlternativaPlatform.TankiX.savedState',
+                '~/Library/Saved\ Application State/unity.AlternativaPlatform.TankiX.savedState',
               ]
 end

--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -14,6 +14,6 @@ cask 'tankix' do
                 '/Library/Logs/DiagnosticReports/tankix*',
                 '~/Library/Application Support/CrashReporter/tankix*',
                 '~/Library/Preferences/unity.AlternativaPlatform.TankiX.plist',
-                '~/Library/Saved\ Application State/unity.AlternativaPlatform.TankiX.savedState',
+                '~/Library/Saved Application State/unity.AlternativaPlatform.TankiX.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.