### PR TITLE
Update tableflip to 1.1.6

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,11 +1,11 @@
 cask 'tableflip' do
-  version '1.1.5'
-  sha256 '06ca0b955335c4b7ffdcdceeed7a3aecf6cef6cb996b6dc222636ec04ab92218'
+  version '1.1.6'
+  sha256 '6a2f67176bc545834c35eb247494373b14031c361189cd170933ea0a5ba6ca48'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"
   appcast "https://update.christiantietze.de/tableflip/v#{version.major}/release.xml",
-          checkpoint: '0c5937b9dfa4b9cf2c0781d53b7f39e0f6385fedd9ebe8ef551dc26fb540ca3c'
+          checkpoint: 'e881fb683ddad4ca7408759a2a59db55c08f775785d157e4ad6dde403d8d4a6c'
   name 'TableFlip'
   homepage 'http://tableflipapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.