### PR TITLE
Update chronycontrol to 1.1.6

### DIFF
--- a/Casks/chronycontrol.rb
+++ b/Casks/chronycontrol.rb
@@ -1,10 +1,10 @@
 cask 'chronycontrol' do
-  version '1.1.4'
-  sha256 '31fbe11a556befc2943f890d5786bd01270ba754c747b8507f862efe47e9089f'
+  version '1.1.6'
+  sha256 '8e60ee8176f62af4bc733a576c51d5f2cb9f3294cf167924e7ea6ac33d2b6916'
 
   url "https://www.whatroute.net/software/chronycontrol-#{version}.zip"
   appcast 'https://whatroute.net/chronycontrol.html',
-          checkpoint: '7d98fe2d5cc0741337a5e1e680928c6a631f5e048b14ed3c87d8647dca473d92'
+          checkpoint: 'ccecf5233d81787186f924b34ad1ee0ba7ed3cc4dcde82bb79b2f554c733edae'
   name 'ChronyControl'
   homepage 'https://whatroute.net/chronycontrol.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.