### PR TITLE
Update microsoft-teams to 1.0.00.8201

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '0.7.00.5204'
-  sha256 '932ee1d3c5d072d5752918979105f3d1932a8df80c362d716c64df65dab372b1'
+  version '1.0.00.8201'
+  sha256 '01e8d6d19a1d50e7fe06dbfb1c4cd78df1657b361cec3751fa83a885bfef6909'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: '3396c9243e4d761c5f8941c7f1b66da5e7c069f7733cf49c66dd86953296c736'
+          checkpoint: 'd93cfc3109bab479ca409d6a1d9623acd4e33e7d116db6f693d19134b77c1d95'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.