### PR TITLE
Update caret to 2.0.8

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.7'
-  sha256 'e8a9446d2686f9a2fd32cf0a0e03cf9a1d43379367c2b8980ac6b3a747fd3597'
+  version '2.0.8'
+  sha256 '7d24156368ba7ae7f2fbd89583fe53783af44c6fa2add4d79640439e45fd2312'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '7a9e2cd101e55695392ca90e3ed55c71d8738444de43a65eabab506509212cc5'
+          checkpoint: 'bafbb6a15b2107268ecc61fd66969b1d1eaba391fa7f798d332557f60803f745'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.