### PR TITLE
Update downie to 2.8,1455

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.7.9,1453'
-  sha256 'c1e7ab4f47d8e4a81777255d465d0ad12475083445a52b3391cc41e512d60663'
+  version '2.8,1455'
+  sha256 'c6a7a247f804ebe7ead0fb77d5412596d928b61126563a3d5fbe65367975a36e'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '2e1fdf64425f79b4c532b80848ea4099dc58f624415a9a30cfa6f4189da6185f'
+          checkpoint: '39d946b861ff1a1d929908c6c26c81558002a0f10a50d36b71d87a46ec804b78'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.