### PR TITLE
Update ndm to 1.1.1

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,13 +1,20 @@
 cask 'ndm' do
-  version '1.1.0'
-  sha256 '77fa78d5aa51178e0a6e8c93a40ab4410d6330b48d0cc41338ca64b7f3132ae0'
+  version '1.1.1'
+  sha256 '561d370450f39713e29e42c3971e02c44f071de21402ff8533706afdda38302b'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: 'a80307035e4a461cca3b8b624d62327f4e40525abe41fd44a9a6262e67a1741e'
+          checkpoint: '5eb0a91feca304dc4980ed708a2db3096dfd822b4c5ebc630222b4293bb5b1af'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 
   app 'ndm.app'
+
+  zap delete: [
+                '~/Library/Application Support/ndm',
+                '~/Library/Preferences/net.720kb.ndm.helper.plist',
+                '~/Library/Preferences/net.720kb.ndm.plist',
+                '~/Library/Saved Application State/net.720kb.ndm.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.