### PR TITLE
Update intellij-idea-ce.rb

### DIFF
--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -13,7 +13,12 @@ cask 'intellij-idea-ce' do
 
   app 'IntelliJ IDEA CE.app'
 
-  uninstall delete: '/usr/local/bin/idea'
+  uninstall script: {
+                      executable:   '/bin/rm',
+                      args:         [`which idea`.strip!],
+                      sudo:         false,
+                      must_succeed: false,
+                    }
 
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",


### PR DESCRIPTION
Replacing uninstall 'delete:' key 'script:'
`/usr/local/bin/idea` file is not installed as part of this package.
This file is created by a user action in the application. As a result it could be present anywhere on path.
`uninstall delete:` key requires sudo, which may not be available.
Using uninstall script seems a better option.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
