### PR TITLE
Update zoom to 1.1.5

### DIFF
--- a/Casks/zoom.rb
+++ b/Casks/zoom.rb
@@ -3,8 +3,6 @@ cask 'zoom' do
   sha256 'ab9584758d922f3fa2c607ae6bf58841969fdd5740ff17af76f41ecfd7c6ae11'
 
   url "http://www.logicalshift.co.uk/mac/Zoom-#{version}.dmg"
-  appcast 'http://www.logicalshift.co.uk/unix/zoom/update.xml',
-          checkpoint: '100f800b8d8508447fd6e2690ef28f2dfe6e96d37d697583a6efcfbdf5dfc7fa'
   name 'Zoom'
   homepage 'https://www.logicalshift.co.uk/unix/zoom/'
 


### PR DESCRIPTION
- App Cast returns 404

<img width="531" alt="screen shot 2017-04-04 at 12 06 50 pm" src="https://cloud.githubusercontent.com/assets/450222/24666797/532b65ae-192f-11e7-8e0d-35e5ab1bf62c.png">


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.