### PR TITLE
All Jetbrains Tools' uninstall script updated

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -13,6 +13,10 @@ cask 'appcode' do
 
   app 'AppCode.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'appcode') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Preferences/AppCode#{version.major_minor}",
                 "~/Library/Application Support/AppCode#{version.major_minor}",

--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -14,7 +14,7 @@ cask 'appcode' do
   app 'AppCode.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'appcode') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'appcode') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -13,6 +13,10 @@ cask 'clion' do
 
   app 'CLion.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Preferences/CLion#{version.major_minor}",
                 "~/Library/Application Support/CLion#{version.major_minor}",

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -14,7 +14,7 @@ cask 'clion' do
   app 'CLion.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -13,6 +13,10 @@ cask 'datagrip' do
 
   app 'DataGrip.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'datagrip') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Preferences/DataGrip#{version.major_minor}",
                 "~/Library/Application Support/DataGrip#{version.major_minor}",

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -13,7 +13,12 @@ cask 'intellij-idea-ce' do
 
   app 'IntelliJ IDEA CE.app'
 
-  uninstall delete: '/usr/local/bin/idea'
+  uninstall script: {
+                      executable:   '/bin/rm',
+                      args:         [`which idea`.strip!],
+                      sudo:         false,
+                      must_succeed: false,
+                    }
 
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -13,12 +13,10 @@ cask 'intellij-idea-ce' do
 
   app 'IntelliJ IDEA CE.app'
 
-  uninstall script: {
-                      executable:   '/bin/rm',
-                      args:         [`which idea`.strip!],
-                      sudo:         false,
-                      must_succeed: false,
-                    }
+  uninstall_postflight do
+    launcher_path = `which idea`.strip!
+    FileUtils.rm(launcher_path) unless launcher_path.nil?
+  end
 
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -14,8 +14,7 @@ cask 'intellij-idea-ce' do
   app 'IntelliJ IDEA CE.app'
 
   uninstall_postflight do
-    launcher_path = `which idea`.strip!
-    FileUtils.rm(launcher_path) unless launcher_path.nil?
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.rm(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -14,7 +14,7 @@ cask 'intellij-idea-ce' do
   app 'IntelliJ IDEA CE.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -12,6 +12,10 @@ cask 'intellij-idea' do
 
   app 'IntelliJ IDEA.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -13,7 +13,7 @@ cask 'intellij-idea' do
   app 'IntelliJ IDEA.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -14,7 +14,7 @@ cask 'phpstorm' do
   app 'PhpStorm.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'pstorm') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'pstorm') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -13,7 +13,9 @@ cask 'phpstorm' do
 
   app 'PhpStorm.app'
 
-  uninstall delete: '/usr/local/bin/pstorm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'pstorm') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Preferences/PhpStorm#{version.major_minor}",

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -15,7 +15,7 @@ cask 'pycharm-ce' do
   app 'PyCharm CE.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -14,7 +14,9 @@ cask 'pycharm-ce' do
 
   app 'PyCharm CE.app'
 
-  uninstall delete: '/usr/local/bin/charm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/PyCharm#{version.major_minor}",

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -13,6 +13,10 @@ cask 'pycharm-edu' do
 
   app 'PyCharm Edu.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Preferences/PyCharmEdu#{version.major_minor.no_dots}",
                 "~/Library/Application Support/PyCharmEdu#{version.major_minor.no_dots}",

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -14,7 +14,7 @@ cask 'pycharm-edu' do
   app 'PyCharm Edu.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -14,7 +14,7 @@ cask 'pycharm' do
   app 'PyCharm.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -13,7 +13,9 @@ cask 'pycharm' do
 
   app 'PyCharm.app'
 
-  uninstall delete: '/usr/local/bin/charm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Preferences/PyCharm#{version.major_minor}",

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -14,7 +14,7 @@ cask 'rubymine' do
   app 'RubyMine.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mine') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mine') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -13,7 +13,9 @@ cask 'rubymine' do
 
   app 'RubyMine.app'
 
-  uninstall delete: '/usr/local/bin/mine'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mine') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/RubyMine#{version.major_minor}",

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -14,7 +14,7 @@ cask 'webstorm' do
   app 'WebStorm.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'wstorm') }.each { |path| File.rm(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'wstorm') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -13,7 +13,9 @@ cask 'webstorm' do
 
   app 'WebStorm.app'
 
-  uninstall delete: '/usr/local/bin/wstorm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'wstorm') }.each { |path| File.rm(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/WebStorm#{version.major_minor}",


### PR DESCRIPTION
As per #31867 and #31863, updated all the jetbrains' apps to use uninstall_postflight block to remove command liner launcher that exists.


- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
