### PR TITLE
Update antfileconverter to 1.2.1

### DIFF
--- a/Casks/antfileconverter.rb
+++ b/Casks/antfileconverter.rb
@@ -1,6 +1,6 @@
 cask 'antfileconverter' do
-  version '1.2.0'
-  sha256 '97080a3932ca46f604506da21fa7c0b4e6b1e1aaa1a02f926eb6bc9cc21b841c'
+  version '1.2.1'
+  sha256 'd981972789d48453ae0289c96f2b9679269114a4e6435ebf105e03d8837915d9'
 
   url "http://www.laurenceanthony.net/software/antfileconverter/releases/AntFileConverter#{version.no_dots}/AntFileConverter.zip"
   name 'AntFileConverter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.