### PR TITLE
Update freefilesync to 8.10

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '8.9'
-  sha256 'aa7972d8b6fa11f198bb78bb55128eca91be18d54fa57c84f25eeddfd9815996'
+  version '8.10'
+  sha256 '84497c6e395f1e9fa24ef9202bfadc81c00971caf8c6321f387c68ef877e0f25'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.