### PR TITLE
Update secure-pipes to 0.99.10,74ba1dcf08a3a62

### DIFF
--- a/Casks/secure-pipes.rb
+++ b/Casks/secure-pipes.rb
@@ -1,6 +1,6 @@
 cask 'secure-pipes' do
-  version '0.99.8,15e8a5ef38260ea'
-  sha256 'ea52611b251ecd03cf0ccb0127ed6a9032a4d48d6faf6053b1459cc1930cbaf8'
+  version '0.99.10,74ba1dcf08a3a62'
+  sha256 '4aad61805b83ca12077d09648cd787e093042240ee53f68a41a2254f94ae7c23'
 
   url "https://www.opoet.com/pyro/index.php/files/download/#{version.after_comma}"
   name 'Secure Pipes'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.