### PR TITLE
Update symboliclinker to 2.1.1

### DIFF
--- a/Casks/symboliclinker.rb
+++ b/Casks/symboliclinker.rb
@@ -1,10 +1,10 @@
 cask 'symboliclinker' do
-  version '2.1'
-  sha256 '89c25ece463416ab9e66e090c1c2b0f1b9eb7a1f41e278e3ac20f6b2f6424d93'
+  version '2.1.1'
+  sha256 '58ed5a7992686f75981e4fe79678a9b9350267c487dd9cb4dc875ab6c87cfe08'
 
   url "https://github.com/nickzman/symboliclinker/releases/download/v#{version}/SymbolicLinker#{version}.dmg"
   appcast 'https://github.com/nickzman/symboliclinker/releases.atom',
-          checkpoint: 'c7ec74fb114ce3be79f7e71def4f02ada28e5485387696ffadd65631a4817537'
+          checkpoint: '593561fa2c0960a96517b10ec187d691240dbb326abe63d17b39ea3859629d52'
   name 'SymbolicLinker'
   homepage 'https://github.com/nickzman/symboliclinker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.