### PR TITLE
Update kode54-cog to 0.08,c291a488

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,a142a06'
-  sha256 '3e746e7f0c12ceea3abdf70b8c7a913aaecb17a885c4f9b31c9c9168013f2d83'
+  version '0.08,c291a488'
+  sha256 'a17c3fd7b8f79b1d073f9feb7139434ed28055edb27a5fc020320808ff799714'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.