### PR TITLE
travis: remove El Capitan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
     - os: osx
       osx_image: xcode8.2
       rvm: system
-    - os: osx
-      osx_image: xcode7.3
-      rvm: system
   fast_finish: true
 
 branches:
@@ -21,9 +18,6 @@ cache:
     - $HOME/.gem
 
 install: true # skip install step
-
-before_install: set -e # REMOVE AFTER EL CAPITAN IS NO LONGER NEEDED
-after_script: set +e # REMOVE AFTER EL CAPITAN IS NO LONGER NEEDED
 
 before_script:
   - . ci/travis/before_script.sh

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -11,7 +11,6 @@
 header 'Running before_script.sh...'
 
 # Required workarounds
-if ! run command -v gpg2 &>/dev/null; then run brew unlink gnupg && run brew install gpg2; fi # REMOVE AFTER EL CAPITAN IS NO LONGER NEEDED
 run gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 # Required by RVM: https://rvm.io/rvm/security
 run rvm get stable # Required due to Travis bug: https://github.com/travis-ci/travis-ci/issues/6307#issuecomment-233315824
 


### PR DESCRIPTION
Realistically, I don’t remember a single time when having casks being checked by CI in two macOS versions actually made a difference.

At the same time, the `shell_session_update` bug is getting infuriating, especially since it’s not reliably reproducible, it just happens when it feels like it (about half time, maybe more).

Sierra builds are fine, though, so unless any maintainer objects, lets just remove the El Capitan checks. When the new macOS version ([Farallon](https://www.macrumors.com/2014/04/24/future-os-x-names-california/)?) is out, we can again start checking two versions, if we deem necessary.