### PR TITLE
Update boinc to 7.6.33

### DIFF
--- a/Casks/boinc.rb
+++ b/Casks/boinc.rb
@@ -16,5 +16,7 @@ cask 'boinc' do
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/edu.berkeley.boinc.*.sfl',
                 '~/Library/Application Support/BOINC',
                 '~/Library/Caches/edu.berkeley.boinc',
+                '~/Library/Preferences/BOINC Manager Preferences',
+                '~/Library/Preferences/edu.berkeley.boinc.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.