### PR TITLE
Update coda to 2.6.1

### DIFF
--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -1,10 +1,10 @@
 cask 'coda' do
-  version '2.6'
-  sha256 '6ed66edaf471f54b55d781262df862a9ee85a1de0e59ead3d8f962a299197b79'
+  version '2.6.1'
+  sha256 '7403457c8a03b51579f7532e855849ce213a454cdf7b49b4ae935ea9064f770e'
 
   url "https://download.panic.com/coda/Coda%20#{version}.zip"
   appcast "https://www.panic.com/updates/update.php?appName=Coda%20#{version.major}",
-          checkpoint: 'a18425031d53a37f99cfb67a8351b15746bbdc6854aa24162e9bfc624c5ef069'
+          checkpoint: '57518b1b52efc789af936a62d71d4133323427dcdaa8e9eb09dd634823c0735a'
   name 'Panic Coda'
   homepage 'https://panic.com/coda/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.