### PR TITLE
Update devonthink to 2.9.11

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.10'
-  sha256 '7f290e475a00cef898e768c08373f64a956f4050916c109e5460370eb3734caa'
+  version '2.9.11'
+  sha256 '041824169a78b9f8b53b533456f40bd9dacc5845822d9e32ed9f6a1b756b6575'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: 'e99ea34791e20fd443982ee8c14eb1d9e65a722d3dac59726dd7929f2a0b46a8'
+          checkpoint: '34224d20f95432db50fa2c7e74d045285b426b47ff33b52efa6e921a01a97244'
   name 'DEVONthink Personal'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.