### PR TITLE
Update devonthink-pro to 2.9.11

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.10'
-  sha256 '948844e08b25f764ccaa9338b85e2d8b58eede5c2f5aa9add768eadcb51e34a7'
+  version '2.9.11'
+  sha256 '9a67d4319d7bf9ef50cb2f30f965a574ce666bc2db3bec10107fde759b65cbdd'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '2ebb936e76a586214ec01059877d6eff022852817950b78f3a6b293a6af3b103'
+          checkpoint: '55cbf5256021f8a7def23faec4bb551b747918df3f387599cd9280c92c53c60d'
   name 'DEVONthink Pro'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.