### PR TITLE
Update dropzone to 3.6.2

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,10 +1,10 @@
 cask 'dropzone' do
-  version '3.6.1'
-  sha256 '6cec10bcfccbca4d92fd1739bb6a5efaa10767909dae0366c7e70c9d9715516f'
+  version '3.6.2'
+  sha256 'c9f2df6979b4cdfd8c2040a47e1cfbd08634508e73321eaf797d1aef4221000a'
 
   url "https://aptonic.com/dropzone3/sparkle/Dropzone-#{version}.zip"
   appcast 'https://aptonic.com/sparkle/updates.xml',
-          checkpoint: '026d16213d31d1e4529d71b01d90112b7f76b1ffaf39627279cb2d55c93c9ca7'
+          checkpoint: '157cdc4b0ac7d8a9e5f1a19b2d20333fe3f780e3e8982636e51247bf83c73f47'
   name 'Dropzone'
   homepage 'https://aptonic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.