### PR TITLE
Update electron-api-demos to 1.3.0

### DIFF
--- a/Casks/electron-api-demos.rb
+++ b/Casks/electron-api-demos.rb
@@ -1,10 +1,10 @@
 cask 'electron-api-demos' do
-  version '1.2.0'
-  sha256 '8786676a84ccb26671d08eb2c887ee777b616f7f966ff7125a43beada1ea4437'
+  version '1.3.0'
+  sha256 'd0b2fd3a3e0306f84f6734010b271cd1f2dc642e81a5a0b0b16cfc9b25814107'
 
   url "https://github.com/electron/electron-api-demos/releases/download/v#{version}/electron-api-demos-mac.zip"
   appcast 'https://github.com/electron/electron-api-demos/releases.atom',
-          checkpoint: '946f0f43ee3417ad0978e0e16ef43e3ffdcd3d6a698437632f6ebc89aec2326d'
+          checkpoint: '3183363297478ddd29e40ce54b36bd6af491431bc6daf84d6281dd76c74619eb'
   name 'Electron API Demos'
   homepage 'https://github.com/electron/electron-api-demos'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.