### PR TITLE
macdown 0.6.4: add artifact to zap & update appcast url

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -4,18 +4,22 @@ cask 'macdown' do
 
   # github.com/MacDownApp/macdown was verified as official when first introduced to the cask
   url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
-  appcast 'https://github.com/MacDownApp/macdown/releases.atom',
-          checkpoint: '494e6ec6883fd528a9b1905aa3270dfd0361143bfae5bec6b50284b22ef1f966'
+  appcast 'http://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml',
+          checkpoint: 'b5d3dd1f4690778a82675d110ff4699aecbd29a6597214492756d1e8d38310f6'
   name 'MacDown'
   homepage 'https://macdown.uranusjr.com/'
+
+  auto_updates true
 
   app 'MacDown.app'
   binary "#{appdir}/MacDown.app/Contents/SharedSupport/bin/macdown"
 
   zap delete: [
                 '~/Library/Caches/com.uranusjr.macdown',
+                '~/Library/Cookies/com.uranusjr.macdown.binarycookies',
                 '~/Library/Preferences/com.uranusjr.macdown.plist',
                 '~/Library/Preferences/com.uranusjr.macdown.LSSharedFileList.plist',
                 '~/Library/Application Support/MacDown',
+                '~/Library/WebKit/com.uranusjr.macdown',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

-----

I switched the appcast url to the one used by sparkle during auto updates. It is to note that the one in the application is http://macdown.uranusjr.com/sparkle/macdown/appcast.xml but it redirect to http://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml as MacDown now have 2 release branch (`stable` and `testing`).