### PR TITLE
Remove dependency from metasploit

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -9,10 +9,7 @@ cask 'metasploit' do
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'
 
-  depends_on formula: %w[
-                        nmap
-                        postgresql
-                      ]
+  depends_on formula: 'nmap'
 
   pkg "metasploit-framework-#{version.major_minor_patch}+#{version.after_comma}-1rapid7-1.pkg"
   binary '/opt/metasploit-framework/bin/metasploit-aggregator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed `postgresql` from dependancies. `postgresql` is bundled in the package installer.

My fault for not checking this before submitting #31311.