### PR TITLE
Update inspec to 1.19.1-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.7.1-1'
-  sha256 'f6864c80146c1867d47e14014a1ba8e8733819890789106b3e8f57cae963d47e'
+  version '1.19.1-1'
+  sha256 '99b6b428570fb0e428df12ee2f2f1805c9e79a8b87fc08bcb7aa466e9ed32b81'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: '435f1d336ebd4def62c9c7e110a76bd94a140974c80347d401c306e332166cb4'
+          checkpoint: '45f3d1ca5d9001841b04289c1b6eeb56333d1478a54ec31f19d632fba8fcaa75'
   name 'InSpec by Chef'
   homepage 'http://inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.