### PR TITLE
Update studio-3t to 5.1.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '5.1.0'
-  sha256 'dadebaf4b47832c6ac11977ad15accee5c1e5105e8254186d19e5a75a99fad52'
+  version '5.1.1'
+  sha256 '730a7fb8d8da605f44696bbc5dd34e3b1fcc2d3e74e8eaa308d806f9081ef96f'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.