### PR TITLE
Update polymail to 1.31

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.30'
-  sha256 'e9e1e8494e653ebc160af4af58eba1aafb6d73d4b016dceaa1b5a90caa8f0791'
+  version '1.31'
+  sha256 'b6537c22b53a0c42c6c4ef41b06090c9ee2482a5b74ad5fd9077e99551a5f2e2'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'be7aa3378687ce8a34382f666cfdbd288658860736038a46f3491da3bf447e06'
+          checkpoint: '799155d3e15e7d6883f05770743e0a350cbff5e175eb27e0ab0c068a9037daa6'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.