### PR TITLE
Update pgweb to 0.9.7

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,10 +1,10 @@
 cask 'pgweb' do
-  version '0.9.6'
-  sha256 '7ae19e6fd93ef53cadd31ca623d2193f93b175be5cba0f0dfe80a84f1eeb09f4'
+  version '0.9.7'
+  sha256 '26c615c03f5341412f1c22c23844438e91cf191a6e8c2c6112a96e05976679a1'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   appcast 'https://github.com/sosedoff/pgweb/releases.atom',
-          checkpoint: '85469b28b0473229d9c5383706716d0631e8a9bbd911b21895a9205b0ed542bb'
+          checkpoint: '1814398fb6974f711ca00a386821a3f0b7225b0107175af21eadc8ec175e6cb4'
   name 'pgweb'
   homepage 'https://github.com/sosedoff/pgweb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.