### PR TITLE
Update nscope to 0.7

### DIFF
--- a/Casks/nscope.rb
+++ b/Casks/nscope.rb
@@ -1,10 +1,8 @@
 cask 'nscope' do
-  version '0.6'
-  sha256 'bbee7f4acb848617cadf84d164a3f8c58d426528c56e96a4018d16aeac49409d'
+  version '0.7'
+  sha256 '34d8c3cc3858a1f007f82687482a3421685b809452b8c84af8e75ea65d680c11'
 
-  url "http://www.nscope.org/prerelease2015/v#{version.no_dots}/mac/nScope.dmg"
-  appcast 'https://github.com/nLabs-nScope/nScope/releases.atom',
-          checkpoint: '12f3b54ce7a1fea1f5f2987f3959eba11bf04ad1afbb0338897ae9b77d7c84df'
+  url "http://www.nscope.org/v#{version.no_dots}/mac/nScope.dmg"
   name 'nScope'
   homepage 'http://www.nscope.org/'
 


### PR DESCRIPTION
* Unfortunately they are not updating the releases properly on the github feed. Removed

---

After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.