### PR TITLE
Update newmoon to 27.2.1

### DIFF
--- a/Casks/newmoon.rb
+++ b/Casks/newmoon.rb
@@ -1,10 +1,14 @@
 cask 'newmoon' do
-  version '26.5.0-131'
-  sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
+  version '27.2.1'
+  sha256 'bfc9ed4a2f2f18d5738d924b37dd96b1d1be4be9f4f94a528d8689667a0c2b46'
 
-  url "https://mac.palemoon.org/dist/palemoon-#{version}-gstreamer.en-US.mac64.dmg"
+  url "http://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
   name 'Pale Moon'
   homepage 'https://www.palemoon.org/'
 
   app 'NewMoon.app'
+
+  zap delete: [
+                '~/Library/Preferences/org.mozilla.palemoon.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.