### PR TITLE
Update opera to 44.0.2510.1159

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '44.0.2510.857'
-  sha256 'd341700f1b86d4359effde4354217c8a0c46f3dfc8bb50c2eceb0b42a9653613'
+  version '44.0.2510.1159'
+  sha256 '22b3082bf1d8f5e01368b7d39029ad5a89ff30e41c549c8b27ad6ab73b5dcd62'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #.