### PR TITLE
Update hex-fiend to 2.6.0

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -1,11 +1,11 @@
 cask 'hex-fiend' do
-  version '2.5.0'
-  sha256 '54090c9c4861f2a681b6f27558a2772767f321b57df3e49e8dd432121142ab81'
+  version '2.6.0'
+  sha256 '20480ad7fe030c81285a15cb359e596ddc5a143d3af3a910f6c71177d3570c21'
 
   # github.com/ridiculousfish/HexFiend was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"
   appcast 'https://github.com/ridiculousfish/HexFiend/releases.atom',
-          checkpoint: 'e3f2f50763b4be2983633d6500fa3a2f22c03f4ca6f26dcdecf9d0f3cbd2effb'
+          checkpoint: '182b01dd2fc85a502336258e6b024b8f9a72dd2a2a5e657aa24c09e73011f357'
   name 'Hex Fiend'
   homepage 'http://ridiculousfish.com/hexfiend/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.