### PR TITLE
Update zipeg to 2.9.4.1316

### DIFF
--- a/Casks/zipeg.rb
+++ b/Casks/zipeg.rb
@@ -1,6 +1,6 @@
 cask 'zipeg' do
-  version :latest
-  sha256 :no_check
+  version '2.9.4.1316'
+  sha256 '2d619ed6b7b82035bd31fa1ffbcae3d11f0e6e90878f826bf0ba50d158f38c14'
 
   url 'http://www.zipeg.com/downloads/zipeg_mac.dmg'
   name 'Zipeg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.