### PR TITLE
Update bootxchanger to 2.0

### DIFF
--- a/Casks/bootxchanger.rb
+++ b/Casks/bootxchanger.rb
@@ -2,9 +2,10 @@ cask 'bootxchanger' do
   version '2.0'
   sha256 'cfb05680ab6a7d0b1793a33135dd15562a7b5fd59bb1ebf3ad6067c2c9fad6c1'
 
-  url "http://namedfork.net/_media/bootxchanger_#{version}.dmg"
-  appcast 'http://swupdate.namedfork.net/bootxchanger.xml',
-          checkpoint: '1c3c0913f51c0d8dd6b8320460e3be60f9541f62dab75f56e5befb690a7566dc'
+  # github.com/zydeco/bootxchanger was verified as official when first introduced to the cask
+  url "https://github.com/zydeco/bootxchanger/releases/download/v#{version}/bootxchanger_#{version}.dmg"
+  appcast 'https://github.com/zydeco/bootxchanger/releases.atom',
+          checkpoint: 'b257f8f3f178a084c67277024c1d91c8a72bbeb11872176a007378150a7c15c9'
   name 'BootXChanger'
   homepage 'https://namedfork.net/bootxchanger/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.