### PR TITLE
Update libreoffice-language-pack to 5.3.2

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,553 +1,553 @@
 cask 'libreoffice-language-pack' do
-  version '5.3.1'
+  version '5.3.2'
 
   language 'af' do
-    sha256 'c1ed3a465da633697877aaa9e29b795d403d7f551829f24c1a64c1badfdd9255'
+    sha256 '5782e7f5ba984cdc0392ce69262a4c035a45e08f8782f98368a18e5f6554a369'
     'af'
   end
 
   language 'am' do
-    sha256 '33dfaf695bdc3858aee7e51ed1303c2ca544a63c8dffd8b4d219e387a4f61170'
+    sha256 '05a903ed95a328188f320e9f0a476172abf721eeac7f3f689f94fa7ad9fc7ce8'
     'am'
   end
 
   language 'ar' do
-    sha256 'c13512b194562cf05fbf2436b780186cdda30143ca62bba6a1072b64129677b0'
+    sha256 '678075889eea99f77b4629d9e2f7e8beb877be76dfe38d41ed966c3028e40f57'
     'ar'
   end
 
   language 'as' do
-    sha256 '8cfe2da3ec6455a9c8237b36f2fa3dea70d80217bcfcbf79ec23f7d73ca7516c'
+    sha256 'aa81b6399b3ca931c66a6432d0cf181b48f23eae2aa76fdbd7a1f2d114fb5f94'
     'as'
   end
 
   language 'ast' do
-    sha256 '0abe4d440f5209d7633461dc9b9a78123a178b99f3dd94e18abaaa76df61b988'
+    sha256 '1bcb39a21186939d76b7f6c600444e82102a8b89da7958fa62b8248d7319893e'
     'ast'
   end
 
   language 'be' do
-    sha256 '3e572cdcdf915bbecd51d5908826537f8d90b5c4e4be339a1a07c9b2cfe924d8'
+    sha256 'ff9bf89505d89a5112a9e6efd1ea90acd59c378ace03deca5f176cef55bbf2a9'
     'be'
   end
 
   language 'bg' do
-    sha256 'ffd7ebd704303589415f9f9c74ea0cc128bfd13309846391dc2c4f23a155b600'
+    sha256 '42a15562aa2ad58687b33487e186fc23502f49bfda334c30e71b8674e95ebdf1'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 'fd55f9f0220a004344d5924a9398f8af5bf164e9524f7f9ee5d7580f72980a56'
+    sha256 '495399ff91a59defd9d0c10ee5febdfc456ccd81f24faa66af2c35b09724e1a4'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 'db2539aaf0fd295bb51a7be8c59ecf41ac2cd61751e4951d118c1c47892ba414'
+    sha256 'baeca91305bb96ab04f3d474e452fefc0319194c4d2244672d927849f2be5fe4'
     'bn'
   end
 
   language 'bo' do
-    sha256 '38cb0c49733b998a79b0a319af424d71c0ddf0e87503fda027665e28d155e1a1'
+    sha256 '3274a668af8668a1954c8bef5f162178be1346624f76565090694e3ee82bfc6e'
     'bo'
   end
 
   language 'br' do
-    sha256 '0cffd51c637c14866e53caae888fc428bdc7ef5e88d6fa812b5eafe2dc34ab60'
+    sha256 'c432dfa9dd914f23ba7231aceca03d373ec8e040ada0c8efbcb4ae94c5fa6fda'
     'br'
   end
 
   language 'brx' do
-    sha256 '666ec426803a33d8acb7c41a8c69399b396b89af79c3e4b2aa7e7467db44252a'
+    sha256 '18e81f1f8980199b16bfc91eb460a01713b6b9783820d4f560a64bd2ba4e0ad9'
     'brx'
   end
 
   language 'bs' do
-    sha256 '028b454904ea63d5346e8984112d1a1d8cbb3943c251dfce2a65af2dba216d18'
+    sha256 '9bd837982957472e5b1daededb29c7065f98411d05d9362ab6ae14bc00450ff4'
     'bs'
   end
 
   language 'ca' do
-    sha256 'ff1b53c86db02ec695cbd8351736a9a7826e88ef74234cb9335397fa1cedd077'
+    sha256 '281cb860594b4e03dd898613a6c1aba7c23ec2976579f19e0b08701c5406904d'
     'ca'
   end
 
   language 'cs' do
-    sha256 '312240cbe89978f6acf377dcbc32bdf9500edd3299c397dec53287be0e3738ae'
+    sha256 '836e83b3e7d26a5b275ec08ade747dc26eff7d949d07486560652d2fc4609629'
     'cs'
   end
 
   language 'cy' do
-    sha256 '3685a5b3d9b8fe3aaa30a78fe5ca4ccbb68923b012d17e584804b1edb1015eb6'
+    sha256 '8728ec544453771f2ecd58309102ada75d9c1584cd6f2e0186c5ae0ca819f355'
     'cy'
   end
 
   language 'da' do
-    sha256 '18129239ff00e2aef5401a0b8d0dcca122c994860298355131dc2e251ca41c9f'
+    sha256 '0abb493b39e31d9559647df3effb6f2a82891e872eb70ec395767b1eeca7978b'
     'da'
   end
 
   language 'de' do
-    sha256 '6c99e49f2bf4c6af7cec2f175a48eb3696085601ccfe08848fb902b6d6ce5658'
+    sha256 '388f826cd2e3306450e8b93945da4decfb6998da07238aa91401ef96e0db99c6'
     'de'
   end
 
   language 'dgo' do
-    sha256 '6bb1a1be16eef4e8c94a5ecbc50a109b523981c913ce0310357ee8d0a02c4636'
+    sha256 '57c888b3bf0f04a447623fef0d45d4acc89502d99105c678272217392f4a048b'
     'dgo'
   end
 
   language 'dz' do
-    sha256 'dbc9a099a4b46d89546b37e9e1e2893767feeb5a72c72a521481f8f3a64e528a'
+    sha256 '67a3ebaaf68211e4e2c3c0c8005c1ca59ddfa36bbfb47e13a574a9aed0f3b6c9'
     'dz'
   end
 
   language 'el' do
-    sha256 'f0414108f5e51c7715fc79d755592f3f9993ae13f82150b858b0fd143f227c97'
+    sha256 'eff6804bf4b7221f21b9868229a58ae33cda78b4c1b7d9998197b933eb3742f7'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '1d3c114cb7b170fe4b0d741848204062eb106939ff8aa816bb3240089e5d5b4d'
+    sha256 '5aaabebf58c62f10dc4d15eae26c62d26b0d9021457cb40d3b24719ed80755c4'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '97d42c78a6447b17fd37e02455da37a1fd4a0014e18dc22e8de9918b79bf1805'
+    sha256 '2b305322f32c22e88b40137286c7aca115a798c6a93d9031e85047101db32968'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '953b0d83d1e95403075418b59f6da10261f32f049eb35767bb42d2301ec6d697'
+    sha256 'a7abf440798dee3e9783e8ea01109fff448054778985fef4f6c13a83a6d83dd7'
     'eo'
   end
 
   language 'es' do
-    sha256 '5b123651972c92bffec2377610ffc24b505ff9ba689d8578cf700f0a859f8ec1'
+    sha256 'd0af0e2ccb625df199b280995891daa554e2e2409f72e3d2e1f8b3cac44cb02d'
     'es'
   end
 
   language 'et' do
-    sha256 '240590e5a32f50227094884d934d9b84f7480469520afa178b4cb482a0a72ae3'
+    sha256 'ec30eef49bcb3e8ef0e14e5829a1982807b4a6a25c11f550c7866d41b5a4dacf'
     'et'
   end
 
   language 'eu' do
-    sha256 '8f3f1c83c4aacb15b5b000973bb39194709e046f4e7d56598eb4958fc0e99fca'
+    sha256 'b5c3fcf4dd69b5b26c9f4d15e29dca51d0563335443a1dfe9bc3e5c05311e426'
     'eu'
   end
 
   language 'fa' do
-    sha256 '776592e22ce9c60a5c824583fb09883ac886a39c53d9a82c5ed5d25ef4b802c3'
+    sha256 '26e066f089274e812b712fdfe85d09f778bc8813af200c2e2b922d185741e1f2'
     'fa'
   end
 
   language 'fi' do
-    sha256 '77e982134016769854b2ccb9d2d55d36c87311889ddae5dd23818236deeaa9df'
+    sha256 '32709c4ee7c55d1ac7f33ffb7bdda05b91c88fca433309b2034c670faa606658'
     'fi'
   end
 
   language 'fr' do
-    sha256 'e4b3591127ccb37ce518b0c2415a3d68825fc21212bba2fdec5fc5b8fe10e66b'
+    sha256 'bf45df28de72991b7deb0617a3eed6045d995c1343ed976ae27a39ba9485f165'
     'fr'
   end
 
   language 'ga' do
-    sha256 'a2871f5f136e36fb3d2e9d04fa75604cdd1253a9a3f362b9efe1c590bd39b74d'
+    sha256 '6663fbb2a090c5c9f9a2259dc241db3b32f270b81253ee6ea70fec4a4e54c60f'
     'ga'
   end
 
   language 'gd' do
-    sha256 '4748b1d7174fa02029ba529fbeb41bb9475978c002a1f7522b5e863412ac3070'
+    sha256 'da40e2ebf2a21240c68d3c6663e0c5c24975a73630570f34633191a2d93356e7'
     'gd'
   end
 
   language 'gl' do
-    sha256 'd99a70418043f3a96021b948a639d261ce0086439b7f22abcf780fe612f440f7'
+    sha256 'a1c08125265fe6b8bde7e1e89a365c502749cd567d4813d5b541145c3d1b0add'
     'gl'
   end
 
   language 'gu' do
-    sha256 '196fd3f037c7bd0d161762ce7a2a83940fc91ae1050f297a8c32ea867de998f6'
+    sha256 '7f7b92a989ee0a3cbf8d9a00f7cdc578b2f60a5575a606a00a51ae1e98acde80'
     'gu'
   end
 
   language 'gug' do
-    sha256 'd9b932e8f9b21ce1390beb549475c9a262338c430357878f6d42ec3f4b5bb9cd'
+    sha256 'd41dfde5bfa895e69f4974af1c6e706b3ed33a9cf103ccc6d6a91f5ac028cdee'
     'gug'
   end
 
   language 'he' do
-    sha256 'ec9b4ecff444bc8a5b012eda5fce487fce429afaff3a58c440690a419c583d06'
+    sha256 '1c09a33c02ce69682849f6fd8597553b073d0b82f896a719f45b4786d16b4901'
     'he'
   end
 
   language 'hi' do
-    sha256 '7f8c26b732f0b2d65dfa2c89a17c107ba79bddef43fb1b0331da3ff45d9e14f9'
+    sha256 '88f61ec68cbafce1352252a3ff1263dfc1cda1309aae147bb1dbe9beab65afda'
     'hi'
   end
 
   language 'hr' do
-    sha256 'd7ac88b0f95006f3dc16ef0a995696d7d02ce205a7b757fc4e3a6e751aa03d87'
+    sha256 '61b5258e1898269b44ea2565c7ab624a72e5180a98fa1cf0623631d8e7f15df5'
     'hr'
   end
 
   language 'hu' do
-    sha256 '504344562d731bb18fbb623a793c440cd6ef6f8984b7f722bbfb0f9aedf4c536'
+    sha256 '4d6e67e80cb93aea1ef205594ccf67eefa9fdf9ff1abba7c99e54e7868579129'
     'hu'
   end
 
   language 'id' do
-    sha256 '12044ede8fed4203010e4fcd2d8c9fd8887bb7a99a6692b0f7623d4a1434398b'
+    sha256 '227b5280e86bfd00512dc18bd21ce399b9587caf1937d44bd2cf05ad1d8e872a'
     'id'
   end
 
   language 'is' do
-    sha256 'b6298cc9af44b69cb66d999e54bf3264e217a2db4b0077db383e1c80723dad63'
+    sha256 '4b6b6c059f87a1e117d050ba50c89b27b644c162fcb9466139aff1729875ef06'
     'is'
   end
 
   language 'it' do
-    sha256 '36e7b78f7db1a4cf488eaded6e0f188f65d5d406c51d84db6f07d76e5c9f49e7'
+    sha256 '34b3dbc35d718087933e825bb8cac30df560adc10f73c55d5683dc4f13abbf7f'
     'it'
   end
 
   language 'ja' do
-    sha256 'fd7ea0da2b47e3ba3b5910f4b5bd0b3b5ecfc5e0be582459788c7bedeabbb876'
+    sha256 'c98846974828eb30ed2c0456ed3a507c44e7c25203e63bcf2853ec23280faf53'
     'ja'
   end
 
   language 'ka' do
-    sha256 '2c4aebe0fa3434e1c199eb64887b4b1ffe28eb6a98611d7128a3d9d5883b457e'
+    sha256 '6749679f679a4e5f3a6359aa83d4e76d685456b7e8e5faf4d81836aee6d96234'
     'ka'
   end
 
   language 'kk' do
-    sha256 'bfa66bb79e208de6c0fb0515f245284de9274faaac85622dad949f2b92e016c9'
+    sha256 'fd5514f9a8e61a2a70b00f2c30d559cc99828e3a1ed2e59ebc9658761a857c0f'
     'kk'
   end
 
   language 'km' do
-    sha256 '15c790c69a8878697befb21a4e7dd70493b244915d9bc3c60a35d536334d1999'
+    sha256 '13908116219a4582424036c3f73201bb6305710b6ec7ad46da77664ed4bcb7c6'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '4e65dc2b0b14d5bbfe11c4a92fb704235096c4d6ddecb4958ee68a40948f4f35'
+    sha256 '39141b8e5e9d6ae5cd7b0e6b6c7effe3c05e14d701873a0646d295037fee1a5e'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'b9c10203c23e69eb37086e96084f59906c377fc0c9a9bc6f1071f98f5588ff82'
+    sha256 'fb57837e684d49c2c6490987d8ae559177a312b8ae348516f21207851b909c8b'
     'kn'
   end
 
   language 'ko' do
-    sha256 '3ffcf1652d849b229505d5d3c054573ac0f49e141a99b0935f94d7466235d4aa'
+    sha256 '8ca9e90349eccbd5bf124e5ed308015d36efacb7c92d9a06587558f115f7bfc8'
     'ko'
   end
 
   language 'kok' do
-    sha256 '03e9f581dd02adb1dafcc2cd6f9f23ffcf7a36ddfa263daa080fec8d1d7058bc'
+    sha256 'e6fa85752b7616d3401e28dca2f19879bf9749a94a7ef658b6a68e27e11641fb'
     'kok'
   end
 
   language 'ks' do
-    sha256 'b3c78a31dd2d8e413b327ca6a761ad19613b407a488a43773e0b4df36281c70e'
+    sha256 '0e56734e5ee8d61d6c53007c579fd860560e6967846b9fb2ac370a2ec1c20626'
     'ks'
   end
 
   language 'lb' do
-    sha256 'b1df60f6144b3bb30c0a8b04189c126cde5d386c5bff8e2ff2e13165f4e442db'
+    sha256 '9b9d90abd9c373f6ecffc4073696de4c889eaf6037944560355d0b64d876ee15'
     'lb'
   end
 
   language 'lo' do
-    sha256 '1a45c9507d823ab48a9a288dbbf1d2aafa9df65f5af2ac5b15e87b296ea3eecc'
+    sha256 '3a7efe70f8c0f58d70ef1f29053f8c2099f2fa3ee682b3cac0d56fb20525b1da'
     'lo'
   end
 
   language 'lt' do
-    sha256 '93e8362fc7a9e80db17f053626751d530ad694a8070d01e43a8cd82232aeb19b'
+    sha256 'a9ed8736524f3a4108278471853298056b2c81f98a55e49e6f7ecfc4fc56972a'
     'lt'
   end
 
   language 'lv' do
-    sha256 '0e09cacabe2a0b500300752c5e7de3d4e6c234daf75fab5b3fb58d982b08f16f'
+    sha256 '9a6990f38fa91f6a4b992d835f4f4504fccd8d559265ced8a22d7657c7d5d895'
     'lv'
   end
 
   language 'mai' do
-    sha256 '1f42f6b2d51b4ceea6c8d878b4615c1fb06543f5a447554ce16aa416a9c8ba6c'
+    sha256 '24601395181a8dd284a9a3ae38c6654f8850373bbbb10fbbd225e29316b27d92'
     'mai'
   end
 
   language 'mk' do
-    sha256 'b2eabeaa04468f700ce154502dde3657342b18204d0d1f1f7eb9e28a6e855f90'
+    sha256 '772739a129e5189b253b13f0fb3e544bcf069d3ab5c9757c04137fe363c161fd'
     'mk'
   end
 
   language 'ml' do
-    sha256 'e4086f1f271255038b7095595071792f400866fcbb916aaf51d49c50e6397990'
+    sha256 '4b2d37dc3cded4e6e481f3f5b3827636328e32c251cecb6e23c28e123eedcc57'
     'ml'
   end
 
   language 'mn' do
-    sha256 '836e581f60a3b45ce1597db2cc480e305bd29b642cf9904a4e64334d051298fd'
+    sha256 '5b25f7ec7693a8b3adae7abb783af799e151ce283f56257d7b5dc46af92c4543'
     'mn'
   end
 
   language 'mni' do
-    sha256 '506f80d45643a19febe36ddc0a896b50ca5bb3b2aef5772575e0e847f4b69293'
+    sha256 'cdb6fcf41106fe96daf6917e420450d4ed4215ad6689fc82812191b1b4d799a1'
     'mni'
   end
 
   language 'mr' do
-    sha256 '48780bfb6e1f2504a30a274f1df2fe0c0d64ff23afc385b2bd2001ae8dcb8946'
+    sha256 '2eb8a13bf9183ff4020b0eb8b7333da952247400617a91fca9a70ae11ee88876'
     'mr'
   end
 
   language 'my' do
-    sha256 '36989371f58d95e5942244c8da198f154dd5323d3d7f547a1c979d2d45067d46'
+    sha256 'f7c521cca936c22b36e86ef80884632df148ac3a058aa4f98b22591b46f565ea'
     'my'
   end
 
   language 'nb' do
-    sha256 '878d08c65ae4ec5615f704408aa9f9e773ce19877dc52a06d6b736e2b3125e88'
+    sha256 '7f0901945457bdeeb973ff1dbd786cb9ae57060b68c213621e48a7e1a4c5ee1a'
     'nb'
   end
 
   language 'ne' do
-    sha256 '35eb9bc2f80daf69c0489367ca82093b23877b4d0e71da9dbc65cfe39ec598bb'
+    sha256 '5212d2e6246ee14f16c05cd38f78c1584313263689d9faffab0f835092ca63a6'
     'ne'
   end
 
   language 'nl' do
-    sha256 'a73bfdfd4eb2657ac5e02a6b97b595c2b2411f387836bcccd877a4954e2801eb'
+    sha256 '6a20dac570e635a148cd27c9160facaf721035bc6b8e3d769fc2bb00adab1b71'
     'nl'
   end
 
   language 'nn' do
-    sha256 '11e4b921dc991e8b9fa730194cba31f9cce37e6406fe92dfab716ba5141d4330'
+    sha256 '907ead67af885e5eb94e16f9227941575fbe4455372f4829783105087352884c'
     'nn'
   end
 
   language 'nr' do
-    sha256 'a97f4243732ce71113f88b457ee61ec8d4b749ceaaf5f9b14fe03cd5850775a4'
+    sha256 '15fe565e637a4facfbfbba7bb0fba68588af3f3ad2d04084c9de165f92f4b8ca'
     'nr'
   end
 
   language 'nso' do
-    sha256 'cf80704285efc1bdf91461d56e18b00a5d003443ac4b978c0cdfae439b54c523'
+    sha256 '1b7817a4808d1c26cdc940736d169be8eedf338469acac752daf88445c804906'
     'nso'
   end
 
   language 'oc' do
-    sha256 'c10338956b4f0b644784f0145b46d8b2c9d36fdee5818489ea26ecd8ebab95d4'
+    sha256 '9352b8fa25d10c88995828d54f4c7a789769479c629a34356bf346c524b69b0a'
     'oc'
   end
 
   language 'om' do
-    sha256 '4bae65d4fe2cea0113dfa144f79cea0ea1e9e9a122b76eacbc12927fb7d8e8ec'
+    sha256 '30b6980b03dd60ba4bd4b09d6650404425aba3ce1e4024264315365ac999f861'
     'om'
   end
 
   language 'or' do
-    sha256 '5c19474b4947c709625099fcb2c03b4698ced2cd019ca1ed4df679d4f8e3c4bc'
+    sha256 '0846266c363ce89fa0b757ee1209985313f5fc12ab92d380152f57b8ca17a019'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 'a9e08105a34494d78601afee9f9fc796b31aebc094f05d388a16f7c3438c6059'
+    sha256 '07de55ec7bd45e2700f6481dc8bd4508fd51323e36603678a54c68f70ee51862'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '35474d9ca2e9b22e3b183e8540c73b5de2ab5f1618c5fc035ad93cb00536afab'
+    sha256 'a2dc09479b7bc5aaf24b6b27fefca4f721830fbd849d5388149c2d3929301a46'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '09e72a3e9656ebd829555a28aea7d0e05e9b5babab6b6c0d66da300a9a89942c'
+    sha256 'da777ac768a073d3c604073b16348a33f91e81257a2860279ca1c552891f0d52'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '3c50173707c2c1c61632a3505f28f0f6a554c116d23be68fc982fd777ece24af'
+    sha256 'a211ed4cf0b64e5f7453d5f29801b9095c8d29164e24dbfa7be2e8c94425e552'
     'pt'
   end
 
   language 'ro' do
-    sha256 '7b13969c293b96a584457ffa2982f84f4393fa52587c0db4605c134cbb27aa73'
+    sha256 '1f9e5f06e936f7f654eb2cf6da41e64be19a89b3c8855c36919e8bd039f066db'
     'ro'
   end
 
   language 'ru' do
-    sha256 'bcc7e788dd96664b0981c9dd79fb421758c30e3d4e1e155d557143ae07adf368'
+    sha256 '8b973578d27a1a1698036e51d60111c9a73ab7e68d3c7afd0d85667e76d76f85'
     'ru'
   end
 
   language 'rw' do
-    sha256 'f7a7c098b2692066178043791484f2c76dd82bddd95922ea7dc09e26312b091c'
+    sha256 '2fa94ff46cdfbc78f76089c2b096edd1f7e2dc820be1d919689dcd1bffb66aa2'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '6ab010f52a9c67d8d0c1605f754cb730fcf90d34a453edf1ef9af8ed5bae6aa8'
+    sha256 '5269417f2a11cc81f39b54d9324721597b4be78e3abfca284f2ade687a21a066'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '8e57b8192a45776cc61797fbcbc882b603cb799d2a42e5ba0096b07ad3ce92d2'
+    sha256 '90588fc4a825f1b5783acc7fd89dc4c4fd98fd7593b1ca3b84a90f38b4d18265'
     'sat'
   end
 
   language 'sd' do
-    sha256 'c4840e71245b0dc283670a8cc020b9d0d61e8b04065dbef12c135a8003cf7d6a'
+    sha256 '9bf103a87fb6cc4d018301c3fc03a5ef04cb99b7e0dea072349f0df1e0e7ab0e'
     'sd'
   end
 
   language 'si' do
-    sha256 'b8e1c6546de052703809ec8dcc5cda279bacd40001fd1ee78dd6cb2b6bc8baad'
+    sha256 'a8479ddd5ad40e172b95ea4c73d090d50a0c7b65b3bb2f64b9cd5860f5b0c9bd'
     'si'
   end
 
   language 'sid' do
-    sha256 '8275929b86e11c086b85db7ddd0ca433d0205fc9bf51b5433c9dc1a4224020fc'
+    sha256 'fe43d91f9d8b5997b351c260a67e4818abfbe99d4a115a2722eb1de987544fbd'
     'sid'
   end
 
   language 'sk' do
-    sha256 '219db1cb600d52e73fff8c5df20fd09450e342375e74c7858ba8a3d59c50c9f2'
+    sha256 'f5818b18311be1d79ab55094722e1fc3a357e1afca259eed5fa93df62f1815f4'
     'sk'
   end
 
   language 'sl' do
-    sha256 'ad50bbc40a23846f66c7c5162a6d55bbdb5e09a736fdbc57114a5fd9b6ce9681'
+    sha256 '370a695bc4aac0a85d5a495632510efdc4dab9e2c7733dfc38fb0a7040da9402'
     'sl'
   end
 
   language 'sq' do
-    sha256 '896347210083f105018dda26d210d634251d515558a0866a49c8ebdb7fbca502'
+    sha256 'a8a7348f08701d510e3e64eefef02596889b39a514ef9fd17d00d5ad2872e721'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 'd2d6efb8acc1cdcd6bbcac92bdd873fbadf112538ee068dd86cb23dfe3b42bef'
+    sha256 '44ec3293076c2d884c2710185b4a0971a418287a79edca2b850db8c1886257c9'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'e9c6ca9cfb1629f262428b6fa42f4fcce91af90a156875ae916f014d603c5b44'
+    sha256 'eb935118489ce91b3e4e129f003645c587a330c31bed576b66eb33ad33a8fcb6'
     'sr'
   end
 
   language 'ss' do
-    sha256 '038830f477cf2db399ad9e255a4d88bea8cabb871038c14b41ebf78e69268710'
+    sha256 '330ef402302524ce7fb95c60956102ec25134be8e7c348eb74cf606eeac7871f'
     'ss'
   end
 
   language 'st' do
-    sha256 '99ee720f6fbdd87b032e8ae90a0118b1cd46e6bf884fb582f8fb52bd20fba86a'
+    sha256 '052534f62e0a8ef22f8c0afd7063172cf2c6886ee476c5ea0bb1f11ba0ba1178'
     'st'
   end
 
   language 'sv' do
-    sha256 '9c17d9d106b19b1eb208af1b9d830c8ccac06ae28534ff8540a71c162729673a'
+    sha256 '71cfb4e610258c0c94acf7a220f7d5b6603789e51c2ceb42ea01b57cb4bef92d'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 '3e564b2bedadaa17d220ff1eb9dfc1fd15c56f10dca3781687f2548001d5a90d'
+    sha256 '770c052a2fb6daab8736a6651d0123a92ebb710a98e12b0174ddad96cff37e74'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 'ddb7cf2c8236022f19304f90494444e10cf9c03fe536b164299e74e8e5ed08e7'
+    sha256 '03123c5ca6d8d381f346ab53320db86d689f39e418eeac18a43a037d47f71eae'
     'ta'
   end
 
   language 'te' do
-    sha256 'cb250253fbb53900429f03f7f1ea1c86fb7b34ae5488392e22fd38ecf708c9fa'
+    sha256 '0e6c9d0fa35f74fb3344850a1d19690a15898c11f36e6efa215c9c3f77c83611'
     'te'
   end
 
   language 'tg' do
-    sha256 'e693581cb1e1b1fa3d02454e0dd2ca9d5d3d2f579c7506575cd099d6be65403e'
+    sha256 '63002ef3a7b8892ecbf3cf382365827002d0e642e781cc6ede01f7fca491e3f0'
     'tg'
   end
 
   language 'th' do
-    sha256 'fb32a792d4a9374eb3efbc44a918c7a93fb7add1c938fc9da60466cda34a0210'
+    sha256 'b30abbeb312f926db73790cbda4a7a75abb406d041087ff01dc49b7927d0d858'
     'th'
   end
 
   language 'tn' do
-    sha256 'f4abe032d241f5e19da21a871d728998931bae184d82199cab4f5af1c35c10ca'
+    sha256 'f3ded419f3172b8aaf762fcb819d8dedcdb921293df975037bd3ae4f5af32109'
     'tn'
   end
 
   language 'tr' do
-    sha256 '311f7efcfe4b0b27de2b3b1eba2ecd5d46963512d7b47cab76275afa643bbb8a'
+    sha256 'bafc1360bca5456314407b7563ee358429fefd73d03a833b7e3d97252517bee6'
     'tr'
   end
 
   language 'ts' do
-    sha256 'ee5415938ba721acef5a99824fa3919a27af8e89fa8d2cc9c2db4c622f01f0b8'
+    sha256 '5f112e53affdfe044f7b527749014f1af8fadbb7399bb9157b2f97c0d85c88a8'
     'ts'
   end
 
   language 'tt' do
-    sha256 '96caa1e74118003b026e35ecaeb883f03a224f9af201f7c425ad43d6365ed33f'
+    sha256 'b173c92b63e0047d2b6fbcc18cb6d947af793a0e1dd1451b2c875e6a4894b9b4'
     'tt'
   end
 
   language 'ug' do
-    sha256 '9ef599e4b0c91120f98cb20c8eef4b25f1a37326f989c49b5b69fe917f5651c0'
+    sha256 '00f7eb32ae0e766245d70c6fdd84b470eaebe3b9a688ecff952b358ee52f64ca'
     'ug'
   end
 
   language 'uk' do
-    sha256 '8e609431260b2298ba91e70b23d456ed104fb6ccd208146d69d8862d141ef928'
+    sha256 'fb53ce0d2922af3756af376143882ee613440e79381c4a4c6e06cdebbe4c2ad6'
     'uk'
   end
 
   language 'uz' do
-    sha256 '5dc4105d4483ae37a0f6c5e9dfc46a03211f2cf8edfba90028f5da4fc4263219'
+    sha256 '1e3a5b2c12e4acfc3106024925b1d10d1423a354bb7d0c98b7ee08e3a563145b'
     'uz'
   end
 
   language 've' do
-    sha256 '766bee2128edb61fa11365db69d5db81d89d8fcbeab0188067b686da4f9f5893'
+    sha256 'a52f508768bf544ea6434639c43e8ac92c496729d8bf7d6fbe3caa1e06a57d13'
     've'
   end
 
   language 'vec' do
-    sha256 'dcee0858456f89b035f9a7a70415597a885109870a41d176db1d2c5e1a6c8972'
+    sha256 '77b8a5871716a220c678f9b780a19e7063b02a67d33e6c6a55aa9bed84ddc927'
     'vec'
   end
 
   language 'vi' do
-    sha256 '05a439e3a1ed42bd394d0a81a9714caf0ba5548c89fc30749fa970a7922b23c4'
+    sha256 'e48bcff5ebf9b6116dcf69954e244cc66b5e8cbb20824a44e509364b71b3f240'
     'vi'
   end
 
   language 'xh' do
-    sha256 '96764615a7530eefec49004769d5e642a7773b0d1bd82d8f4210fd9ea26f1d9f'
+    sha256 '99e30010e9a817b2f52c8b0b788da22806747584d64b64230ba605f6b20130ea'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 '84dbb0edcdd75abefe6648a6cf08c7698853462fd1a5994f0678bc8a78e2bb20'
+    sha256 'dc2f51fe9d5ca9669c1c1989f3d134cea882f30d78bd8c91ee92f83ec5e47ce8'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 'e42d476083c325f62dfa18e4f85ffbf74624d2ba24d31cb67022884cc492d908'
+    sha256 '71fc1c9d84123a13896a4d6cc4ff5a975420349ef6eeedbc7399d5ea4f2e8b61'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 'aa72c67f8923fdbaf4ad5823839e731fbc5ce7ad30d8bc55cb6c65b08707dcc9'
+    sha256 '9fb892187d09897b10a5aa9fcdb029594afcb74eb371edf3d25d7781fe4756a5'
     'zu'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.