### PR TITLE
Update colortester to latest

### DIFF
--- a/Casks/colortester.rb
+++ b/Casks/colortester.rb
@@ -3,7 +3,7 @@ cask 'colortester' do
   sha256 :no_check
 
   # alfasado.co.jp was verified as official when first introduced to the cask
-  url 'https://www.alfasado.co.jp/download/ColorTester_Mac.zip'
+  url 'http://www.alfasado.co.jp/download/ColorTester_Mac.zip'
   name 'ColorTester'
   homepage 'https://alfasado.net/apps/colortester.html'
 


### PR DESCRIPTION
- SSL Certificate is expired for almost a month now.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

<img width="811" alt="screen shot 2017-04-06 at 11 41 09 am" src="https://cloud.githubusercontent.com/assets/450222/24763047/3053980e-1abe-11e7-8b82-2ffc25856695.png">
