### PR TITLE
Update copper to latest

### DIFF
--- a/Casks/copper.rb
+++ b/Casks/copper.rb
@@ -8,6 +8,8 @@ cask 'copper' do
           checkpoint: '165e078d5a0f364870d7586995682b8277bbf79c6e7cfb7e69837d95e4dc94e4'
   name 'Copper'
   homepage 'https://www.copper-app.com/'
+  
+  auto_updates true
 
   app 'Copper.app'
 end

--- a/Casks/copper.rb
+++ b/Casks/copper.rb
@@ -1,11 +1,11 @@
 cask 'copper' do
-  version '1.3'
-  sha256 '81a536e5dcf737d0d6f887a3422bc30c90466d96e6a3019fc8ac154607a4ba85'
+  version :latest
+  sha256 :no_check
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.appfruits.copper/Copper.zip'
   appcast 'https://updates.devmate.com/com.appfruits.copper.xml',
-          checkpoint: '740c67fe43ee3794dc82fb08f6b641a3d46b59dde7d444cdcd709adaf41749b0'
+          checkpoint: '165e078d5a0f364870d7586995682b8277bbf79c6e7cfb7e69837d95e4dc94e4'
   name 'Copper'
   homepage 'https://www.copper-app.com/'
 


### PR DESCRIPTION
- App Update was available and the latest version is 1.3.1
- modified version to ```:latest``` and sha256 to ```:no_check``` as the download URL is not versioned. 

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.