### PR TITLE
dropbox: remove appcast

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,9 +1,8 @@
 cask 'dropbox' do
-  version '23.4.17'
-  sha256 '1c92b57810a677243caa194b5c0edd383ba88f58f62852c08c1e4c8aec7fbc0f'
+  version :latest
+  sha256 :no_check
 
-  # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
-  url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"
+  url 'https://www.dropbox.com/download?plat=mac&full=1'
   name 'Dropbox'
   homepage 'https://www.dropbox.com/'
 

--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -4,8 +4,6 @@ cask 'dropbox' do
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"
-  appcast 'https://www.dropbox.com/release_notes/rss.xml',
-          checkpoint: '2794637a8b028d903f0d27432291dce968886923a86325994156cf1206edec80'
   name 'Dropbox'
   homepage 'https://www.dropbox.com/'
 


### PR DESCRIPTION
What hasn't been updated for months is now finally gone.

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.