### PR TITLE
Update total finder app

### DIFF
--- a/Casks/totalfinder.rb
+++ b/Casks/totalfinder.rb
@@ -14,5 +14,6 @@ cask 'totalfinder' do
             script:  {
                        executable: 'TotalFinder Uninstaller.app/Contents/MacOS/TotalFinder Uninstaller',
                        args:       %w[--headless],
+                       sudo:       true,
                      }
 end


### PR DESCRIPTION
- included ```sudo:  true``` since the uninstaller is requiring sudo to run it headles

Ref . #32014

After Updating
```
$ brew cask uninstall totalfinder.rb
==> Running uninstall process for totalfinder; your password may be necessary
==> Running uninstall script TotalFinder Uninstaller.app/Contents/MacOS/TotalFinder Uninstaller
Password:
==>   shutdown TotalFinderCrashWatcher ...
==>     TotalFinderCrashWatcher was not running
==>   shutdown TotalFinder agent ...
==>     TotalFinder agent was not running
==>   shutdown Finder ...
==>   remove TotalFinder.app from login items ...
==>   removing the old TotalFinder files (0.8.2 and earlier) ...
==>   unload TotalFinder.kext ...
==>     TotalFinder.kext not loaded
==>   remove TotalFinder.app ...
==>   remove TotalFinder.kext ...
==>   remove TotalFinder.osax ...
==>   enable Finder animations again ...
==>   hide system files in Finder again ...
==>   relaunch Finder ...
==> TotalFinder uninstallation done.
==> Uninstalling packages:
com.binaryage.pkg.totalfinder.app
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

