### PR TITLE
Update owasp-zap to use `installer`

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -10,5 +10,15 @@ cask 'owasp-zap' do
   name 'ZAP'
   homepage 'https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project'
 
-  app 'OWASP ZAP.app'
+  installer script: 'OWASP Zed Attack Proxy Installer.app/Contents/MacOS/JavaApplicationStub',
+            args:   ['-q'],
+            sudo:   true
+
+  uninstall script: {
+                      executable: "/Applications/ZAP #{version}.app/OWASP Zed Attack Proxy Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+                      args:       %w[-q -c],
+                      sudo:       true,
+
+                    },
+            delete: "/Applications/ZAP #{version}.app"
 end

--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -5,7 +5,7 @@ cask 'owasp-zap' do
   # github.com/zaproxy/zaproxy was verified as official when first introduced to the cask
   url "https://github.com/zaproxy/zaproxy/releases/download/#{version}/ZAP_#{version.dots_to_underscores}_macos.dmg"
   appcast 'https://github.com/zaproxy/zaproxy/releases.atom',
-          checkpoint: '7b84ad46090667a859271d665f06266f2397582390c78a92ce3b974c0229e7f4'
+          checkpoint: '205f9bd6402fa384e38f5536187cda3380802698aa2e18ffdafa889a260545e3'
   name 'OWASP Zed Attack Proxy'
   name 'ZAP'
   homepage 'https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project'


### PR DESCRIPTION
- OWASP-ZAP changed to `installer`
- Install / Uninstall is now using JavaApplicationStub

Ref #31981

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.