### PR TITLE
Update minizincide to 2.1.4

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,13 +1,13 @@
 cask 'minizincide' do
-  version '2.1.3'
-  sha256 'a4ec64bee9a04702f02bd82cdd182843f373d9f2986d11c580f3dc6e1dfd3d81'
+  version '2.1.4'
+  sha256 '7ea43eb8aa51deeb259610f15da46cab36c80781b99eb102cc946b24fd550624'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"
   appcast 'https://github.com/MiniZinc/MiniZincIDE/releases.atom',
-          checkpoint: '9593f8dba4def26ae00a1ddb5e6eb11bca329a88b6b6ad199322a682187b6548'
+          checkpoint: '63c3d0c1bf56af919bc5ca96ba0c2a04a6a7abcd2e5e758366f9f684415e7e57'
   name 'MiniZincIDE'
-  homepage 'https://www.minizinc.org/ide/index.html'
+  homepage 'http://www.minizinc.org/ide/index.html'
 
   app 'MiniZincIDE.app'
 end


### PR DESCRIPTION
* Homepage https was broken, so adjusted it to http

---

After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.