### PR TITLE
Update gogs to 0.11.4

### DIFF
--- a/Casks/gogs.rb
+++ b/Casks/gogs.rb
@@ -1,11 +1,11 @@
 cask 'gogs' do
-  version '0.10.18'
-  sha256 '2cff63d4ee55866325f4c581721825a9f5204b8dcae712179a87cd2fe1c9355d'
+  version '0.11.4'
+  sha256 'edcfa64ceec253f1782c52ef0afb2cd60dfa6fd3bbf7716e66ff875d1bd4a44f'
 
   # github.com/gogits/gogs was verified as official when first introduced to the cask
   url "https://github.com/gogits/gogs/releases/download/v#{version}/darwin_amd64.zip"
   appcast 'https://github.com/gogits/gogs/releases.atom',
-          checkpoint: '008541d957ba25e33febe14263d4ae20ee32b25c541b360d7639328c2c6b8dba'
+          checkpoint: '7a50e42ab166717df1960825119a6a75087514ceecfc7671ec87c30106868f91'
   name 'Go Git Service'
   homepage 'https://gogs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.