### PR TITLE
Update pdfpen to 834.1,1491271097

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,10 +1,10 @@
 cask 'pdfpen' do
-  version '833.3,1489545388'
-  sha256 '787774f1f8f44eccce65c525426dc5b79e1c7bcdc198f844a84f3ff8fc1c3bcd'
+  version '834.1,1491271097'
+  sha256 '1a7c2b7ceedcf30dedf8bca6326842f17fa66edf2552030138f82d98ed2b443d'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
-          checkpoint: '7a1c84860de5ad3f72fedd1b5ad623deb458c3b91a6c2d1a9d09133d980e7894'
+          checkpoint: 'b11aad2c6c88f13c85b47081770173da679040e2d02ad9cfbcee44a348f18256'
   name 'PDFpen'
   homepage 'https://smilesoftware.com/PDFpen'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.