### PR TITLE
Update spriteilluminator to 1.4.0

### DIFF
--- a/Casks/spriteilluminator.rb
+++ b/Casks/spriteilluminator.rb
@@ -1,10 +1,10 @@
 cask 'spriteilluminator' do
-  version '1.3.1'
-  sha256 'e51941fbca6c4e9b9f0a347315e69e365b5f63902e1dd4271d4110e748a7f1eb'
+  version '1.4.0'
+  sha256 '111d8df09a4fe622be8f0478ed2cb1f45dc2b31cf3d2c99510cfcfe6a2e1123c'
 
   url "https://www.codeandweb.com/download/spriteilluminator/#{version}/SpriteIlluminator-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/SpriteIlluminator/appcast-mac-release.xml',
-          checkpoint: '997e662cfbe6d4b7e5e3ef5c7eee2bd17c32d91c3ee009949135197fbc8ed67b'
+          checkpoint: '7a3684dfc6d725649c818593de6e825476f1a1091518a47d59622a87ee2aac2d'
   name 'SpriteIlluminator'
   homepage 'https://www.codeandweb.com/spriteilluminator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.