### PR TITLE
Update polymail to 1.32

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.31'
-  sha256 'b6537c22b53a0c42c6c4ef41b06090c9ee2482a5b74ad5fd9077e99551a5f2e2'
+  version '1.32'
+  sha256 '34b17d9cd711c4cbb60115ac47938f0331ca5b04ad166d027b85d74098064d94'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '799155d3e15e7d6883f05770743e0a350cbff5e175eb27e0ab0c068a9037daa6'
+          checkpoint: '37d243d8f94346080a0137bf9aa5966606d4ea8e06f9dc7af556a3a63b902aa3'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.