### PR TITLE
Update tortoisehg to 4.1.1

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.1.0'
-  sha256 'd1a62adf235370205756d29dd1b965e70be26ded6ac606ac94f729e59b244bdc'
+  version '4.1.1'
+  sha256 'e6f65041f1c20d98d18cd14f4394351f5c3c73f649175581941e0e737c492db5'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.