### PR TITLE
Update postage to 3.2.4

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.1.3'
-  sha256 'ad6713f5246ecc0612da2f0062821e8eee175f42381264ab4c84126c4e7517a7'
+  version '3.2.4'
+  sha256 '18e5cb40fbf965a70ffb208ac5eb53a103d84a6ed45d5e48b1951485bbfa1634'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: 'c56474558f912d5a3eabfd68e2c72186f34efb746bd960e65b620ee3544be457'
+          checkpoint: '7044df090cc2a1845326ae5c3df077d8cfdcab2d77fea4bb4be68886b984053b'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.