### PR TITLE
Update hab to 0.20.0-20170407015129

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.19.0-20170311030920'
-  sha256 '81f86f83fc523fb4d666cd38ee1bd105874e10d078d219bd9042da58472e1758'
+  version '0.20.0-20170407015129'
+  sha256 '38925f5a870ac91661738b0223fa152269ede86abcfa3d9999bf9bcdac3081c7'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '1cb1fb007e841e1696028373a1748f17e47e43f9f52bc2cc611bccca563e7fa4'
+          checkpoint: '131c5340e019175e9ada6375f178ed0735ff037b0eaca873e64814efa7b14ea4'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.