### PR TITLE
owasp-zap - add zap and caveat

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -18,7 +18,15 @@ cask 'owasp-zap' do
                       executable: "/Applications/ZAP #{version}.app/OWASP Zed Attack Proxy Uninstaller.app/Contents/MacOS/JavaApplicationStub",
                       args:       %w[-q -c],
                       sudo:       true,
-
                     },
             delete: "/Applications/ZAP #{version}.app"
+
+  zap delete: [
+                '~/Library/Preferences/org.zaproxy.zap.plist',
+                '~/Library/Application Support/ZAP',
+              ]
+
+  caveats do
+    depends_on_java
+  end
 end

--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -27,6 +27,6 @@ cask 'owasp-zap' do
               ]
 
   caveats do
-    depends_on_java
+    depends_on_java('7+')
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed empty line.

Added `caveats` and `zap`.

Java does not seem to be bundled with `owasp-zap`


![](https://cloud.githubusercontent.com/assets/26216252/24784234/7e2eb0c8-1b94-11e7-91ad-a7af47903b50.png)
