### PR TITLE
Update kollaborate-folder-watcher to 1.2.1.0

### DIFF
--- a/Casks/kollaborate-folder-watcher.rb
+++ b/Casks/kollaborate-folder-watcher.rb
@@ -1,6 +1,6 @@
 cask 'kollaborate-folder-watcher' do
-  version '1.2.0.0'
-  sha256 'e34920ccea7e85dfd88d27a02714837c5d79a3210453cf4a4f7d1d1745123419'
+  version '1.2.1.0'
+  sha256 '0dbc9a1563df0cee0a8fde79145a9840d80906c0c31f0579340cebbde3d33ec4'
 
   # digitalrebellion.com was verified as official when first introduced to the cask
   url "http://www.digitalrebellion.com/download/kollabfolderwatcher?version=#{version.no_dots}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.