### PR TITLE
Update buttercup to 0.11.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.9.0'
-  sha256 '0a4278e8a60303e2bdbf97c4b8398841825572406c1cab5be4689be526374925'
+  version '0.11.1'
+  sha256 '8cc59c37b518028ecc9658160486c1f21b336ea57484ddb0e6333e2bf71d0722'
 
   # github.com/buttercup-pw/buttercup was verified as official when first introduced to the cask
   url "https://github.com/buttercup-pw/buttercup/releases/download/v#{version}-alpha/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup-pw/buttercup/releases.atom',
-          checkpoint: '69d0de7af6b2fb88d7407130ff58107d21c211fde295492892d3766c05da3b7f'
+          checkpoint: '8bba0fe2ffb90f0bd29ea83e483ad9a33b7cd96b196b6f6b741a456d43a471a4'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.