### PR TITLE
Update mudlet to 3.0.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,10 +1,12 @@
 cask 'mudlet' do
-  version '2.1'
-  sha256 'c7c33cb0dba8223c094bed4caade243b0ae2fb70e71f0e18d2aa8434cc583bae'
+  version '3.0.0'
+  sha256 'ff255617dc3b566529f3147d1c4b6a4a200344bbe2925788a26cd115b5f0cfff'
 
-  url "http://www.mudlet.org/download/Mudlet-#{version}.zip"
+  url "http://www.mudlet.org/download/Mudlet-#{version}.dmg"
+  appcast 'https://github.com/Mudlet/Mudlet/releases.atom',
+          checkpoint: 'ce9dad74f3aa718606dab97081a2abb691a4a497b1be63b4da6a46db1ef3138a'
   name 'Mudlet'
   homepage 'http://www.mudlet.org/'
 
-  app "Mudlet-#{version}.app"
+  app 'Mudlet.app'
 end


### PR DESCRIPTION
* There is no github based download URL but the github feed is a good source for the appcast

---

After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.