### PR TITLE
Update unity-android-support-for-editor to 5.6.0f3,497a0f351392

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '5.5.2f1,3829d7f588f3'
-  sha256 'c49c63cad3748a2ea48cdc6f27fd70c5a56ef4125a66efe882385d7cbc1c66e9'
+  version '5.6.0f3,497a0f351392'
+  sha256 '8b59a00f4bd6d17ef5a64185fc9d53d9c6746d58e7431ae9c88ecf01157d8acc'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Android Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.