### PR TITLE
Update tormessenger to 0.4.0b2

### DIFF
--- a/Casks/tormessenger.rb
+++ b/Casks/tormessenger.rb
@@ -1,6 +1,6 @@
 cask 'tormessenger' do
-  version '0.3.0b2'
-  sha256 '14b9d7afab95963b419d1191304ef1ce6abf5af0f2b1d0eab105e05e0b31f3c1'
+  version '0.4.0b2'
+  sha256 '7b374ca8fa687b7a59858bf5f17923cbdfaae0d1688856c2b8f75c4b67473514'
 
   url "https://dist.torproject.org/tormessenger/#{version}/TorMessenger-#{version}-osx64_en-US.dmg"
   name 'Tor Messenger'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.