### PR TITLE
Update iphoto-library-manager to 4.2.6

### DIFF
--- a/Casks/iphoto-library-manager.rb
+++ b/Casks/iphoto-library-manager.rb
@@ -1,10 +1,10 @@
 cask 'iphoto-library-manager' do
-  version '4.2.5'
-  sha256 '797e14d8714c82d35e0a81e1dddb04117b9188e668aa453256f63f7faa816274'
+  version '4.2.6'
+  sha256 '00bf533f8e086ee5a5eb74e48af10dc828400610407e1213f1b83a7d6f881fbc'
 
   url 'https://www.fatcatsoftware.com/iplm/iPhotoLibraryManager.zip'
   appcast "https://www.fatcatsoftware.com/iplm/iplm#{version.major}_appcast.xml",
-          checkpoint: 'd050807aec6efe87d4fa378e18000bc5292171c4488398702ffa181fadb99c1e'
+          checkpoint: 'f54b77cc4cef9ee266aa32a91059473b3f13e8a6d558ce8e3e1719f52437f2cd'
   name 'iPhoto Library Manager'
   homepage 'https://www.fatcatsoftware.com/iplm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.