### PR TITLE
Update antconc to 3.5.0

### DIFF
--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -3,13 +3,13 @@ cask 'antconc' do
     version '3.4.1'
     sha256 '03c353c059b8c0762b01d9be83f435321f5396cbf203bd8b36c6a56682b6a240'
   else
-    version '3.4.4'
-    sha256 '2c346728c70dce3279647005f8dd704e48368c91aada684aaee4ce01017c1327'
+    version '3.5.0'
+    sha256 'd79cdc444f7284c34dc51b8aebf4bdf356ef82ea6a9ad17858db083277ef5369'
   end
 
   url "http://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   appcast 'http://www.laurenceanthony.net/software/antconc/releases/',
-          checkpoint: '3b6352481b07ab6b297efd9cd958049804507fff9edab63995b341534618cf1c'
+          checkpoint: '14a5a7f4bbde6c7e9c2856083571414a30454e7bf2f2d907935842e0490f9cf4'
   name 'AntConc'
   homepage 'http://www.laurenceanthony.net/software/antconc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.