### PR TITLE
Update unity-webgl-support-for-editor to 5.6.0f3,497a0f351392

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '5.5.2f1,3829d7f588f3'
-  sha256 '8b4dbca202a16270e614e2425d62d3fbe2b36c1fc46604dfdb25f3078a3f7590'
+  version '5.6.0f3,497a0f351392'
+  sha256 '77f16eaaec847b5afc7795924b2561a8ce16aca132ebe973790b584f7d0aa96e'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity WebGL Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.