### PR TITLE
Maltego casks - add java caveat and zap

### DIFF
--- a/Casks/maltego-casefile.rb
+++ b/Casks/maltego-casefile.rb
@@ -7,4 +7,11 @@ cask 'maltego-casefile' do
   homepage 'https://www.paterva.com/web7/buy/maltego-clients/casefile.php'
 
   app "Maltego CaseFile v#{version.major_minor_patch}.app"
+
+  zap delete: "~/Library/Application Support/maltego/v#{version.major_minor_patch}CaseFile",
+      rmdir:  '~/Library/Application Support/maltego'
+
+  caveats do
+    depends_on_java('7+')
+  end
 end

--- a/Casks/maltego-ce.rb
+++ b/Casks/maltego-ce.rb
@@ -7,4 +7,11 @@ cask 'maltego-ce' do
   homepage 'https://www.paterva.com/web7/buy/maltego-clients/maltego-ce.php'
 
   app "Maltego CE v#{version.major_minor_patch}.app"
+
+  zap delete: "~/Library/Application Support/maltego/v#{version.major_minor_patch}CE",
+      rmdir:  '~/Library/Application Support/maltego'
+
+  caveats do
+    depends_on_java('7+')
+  end
 end

--- a/Casks/maltego-classic.rb
+++ b/Casks/maltego-classic.rb
@@ -7,4 +7,11 @@ cask 'maltego-classic' do
   homepage 'https://www.paterva.com/web7/buy/maltego-clients/maltego.php'
 
   app "Maltego Classic v#{version.major_minor_patch}.app"
+
+  zap delete: "~/Library/Application Support/maltego/v#{version.major_minor_patch}",
+      rmdir:  '~/Library/Application Support/maltego'
+
+  caveats do
+    depends_on_java('7+')
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Add `zap` and java `caveats` to 3 maltego casks