### PR TITLE
Update visit to 2.12.2

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,11 +1,11 @@
 cask 'visit' do
-  version '2.12.1'
-  sha256 '95c4dc58a9a6994c69e810dc264d7992addf1b19b6fbd6b4286302586462bff1'
+  version '2.12.2'
+  sha256 '087316bf69f1409def639832bc345021c87394c78015ac436d77d1e91abd7d0a'
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
   url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables',
-          checkpoint: 'd1652e31f41d271e7290841db291be88f269eb1d3f143bec7871bbbbc3b723e9'
+          checkpoint: '6df36aa856eabb5ef8cde95339e46febfe71f6fc06e4e5b48ec7685d4bbc5ab4'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.