### PR TITLE
Update all Eclipse Casks to avoid conflicts

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -8,5 +8,6 @@ cask 'eclipse-cpp' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse CPP.app'
 end

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -8,5 +8,6 @@ cask 'eclipse-java' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse Java.app'
 end

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -8,7 +8,8 @@ cask 'eclipse-jee' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse JEE.app'
 
   caveats do
     depends_on_java

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -8,5 +8,6 @@ cask 'eclipse-modeling' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse Modeling.app'
 end

--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -8,5 +8,6 @@ cask 'eclipse-php' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse PHP.app'
 end

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -8,5 +8,6 @@ cask 'eclipse-platform' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse Platform.app'
 end

--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -8,5 +8,6 @@ cask 'eclipse-ptp' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse PTP.app'
 end

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -8,5 +8,6 @@ cask 'eclipse-rcp' do
 
   depends_on macos: '>= :leopard'
 
-  app 'Eclipse.app'
+  # Renamed to avoid conflict with other Eclipse.
+  app 'Eclipse.app', target: 'Eclipse RCP.app'
 end


### PR DESCRIPTION
- Renaming Eclipse App to avoid conflicts

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

```
$ brew cask install eclipse-cpp
==> Satisfying dependencies
complete
==> Downloading https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/3/eclipse-cpp-neon-3-macosx-cocoa-x86_64.tar.gz&r=1
Already downloaded: /Users/gobinathm/Library/Caches/Homebrew/Cask/eclipse-cpp--4.6.3,neon:3.gz&r=1
==> Verifying checksum for Cask eclipse-cpp
==> Moving App 'Eclipse.app' to '/Applications/Eclipse.app'.
🍺  eclipse-cpp was successfully installed!
```
```
$ brew cask install eclipse-php
==> Satisfying dependencies
complete
==> Downloading https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/3/eclipse-php-neon-3-macosx-cocoa-x86_64.tar.gz&r=1
Already downloaded: /Users/gobinathm/Library/Caches/Homebrew/Cask/eclipse-php--4.6.3,neon:3.gz&r=1
==> Verifying checksum for Cask eclipse-php
Error: It seems there is already an App at '/Applications/Eclipse.app'.
Error: nothing to install
```