### PR TITLE
Rename formula: studio -> bricklink-studio latest

### DIFF
--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -1,4 +1,4 @@
-cask 'studio' do
+cask 'bricklink-studio' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
The cask name "studio" for [Bricklink Studio](https://studio.bricklink.com/v2/build/studio.page) is a bit misleading, since it's such a generic name that so many different products use. Nothing about the name "studio" implies "this is a LEGO program'. It is referred to as "Stud.io" on the Bricklink site, but that's because in that setting it is so clearly underneath the "Bricklink" umbrella. This setting is lost in the current name, and it's hard to find.

I propose renaming it to `bricklink-studio`.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.