### PR TITLE
Update pyfa to 1.28.1,yc119.3-1.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.26.0,yc118.10-1.2'
-  sha256 'd5df452ab38ba29ffe1a1bbe1a7316d64f5ce8b8d52c3cac345d870ce4a92b01'
+  version '1.28.1,yc119.3-1.0'
+  sha256 '8fbef12da3d055e84c76dd50b828aa9f439d51fbd3496751f37c57f2c7bd58c6'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '04ce83834d317aeb2747275feb2470d72dd7e6664fd76e08383059b131eb153e'
+          checkpoint: 'd6d6082e15b9942824b9e389e3ed4297996bb1bfe340d2d78d99d98cf29a2273'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.