### PR TITLE
Update witgui to 2.2.6

### DIFF
--- a/Casks/witgui.rb
+++ b/Casks/witgui.rb
@@ -1,10 +1,10 @@
 cask 'witgui' do
-  version '2.2.5'
-  sha256 'b62ab17de12fc12fbf4dcbacfae5e4c86c7ea3073b3c43a26447914f13c57b39'
+  version '2.2.6'
+  sha256 'd147cf2d06623641a0e2b49bb5780e7f20a8da5d71e68aa067fad837dc678e8b'
 
   url "http://desairem.altervista.org/witgui/download.php?version=#{version}"
   appcast 'http://desairem.altervista.org/witgui/appcast.xml',
-          checkpoint: 'b5ca8f503372e8bd082eb4845b69e05d877f15543f21b8957e7bce97264f0e57'
+          checkpoint: '385d3a172a15b155e9ed72e5f41c14ed4c3d6cd696a978814e92c3d297eeb884'
   name 'Witgui'
   homepage 'http://desairem.altervista.org/wordpress/witgui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.