### PR TITLE
Update stattransfer to 13

### DIFF
--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -1,6 +1,6 @@
 cask 'stattransfer' do
   version '13'
-  sha256 '66c223a0f194e4ff566d73cea1210dd378b52e696f75dd72fd6b3a18ccc8b20a'
+  sha256 'a4a4372982fba0ebb4896b30d6bd51abf740ceda0bcf17f3603cc8843b2222dc'
 
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'
   name 'Stat/Transfer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.