### PR TITLE
chefdk/1.3.40

### DIFF
--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -9,7 +9,7 @@ cask 'chefdk' do
 
   url "https://packages.chef.io/stable/mac_os_x/#{MacOS.version}/chefdk-#{version}.dmg"
   appcast "https://www.chef.io/chef/metadata-chefdk?p=mac_os_x&pv=#{MacOS.version}&m=x86_64&v=latest&prerelease=false",
-          checkpoint: 'd6ccec9ff6bc78bdc2be118667aecf01e0f1b91d030a0bfdb8e167cdd621427d'
+          checkpoint: 'c6fb09107f5368d9042a3adb85c54ba592717e721e590b84c184bc39afe0e04d'
   name 'Chef Development Kit'
   name 'ChefDK'
   homepage 'https://downloads.chef.io/chefdk/'

--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -3,8 +3,8 @@ cask 'chefdk' do
     version '0.11.2-1'
     sha256 '56899eab322cacac7f445a24d3159af34fccb5910642f4535eff4ee47321fe56'
   else
-    version '1.2.22-1'
-    sha256 '5c435de289e90da45938a0f1a1f7e472e73a84f9b6bbe93e50342e11cc935458'
+    version '1.3.40-1'
+    sha256 '294503947bcb4076f63bd8805b5049f2789df2a3e4f40be973e12687586ad961'
   end
 
   url "https://packages.chef.io/stable/mac_os_x/#{MacOS.version}/chefdk-#{version}.dmg"


### PR DESCRIPTION
* announced via https://discourse.chef.io/t/chefdk-1-3-40-released/10726
* final Chef 12-based Chef Development Kit

$ chef -v
Chef Development Kit Version: 1.3.40
chef-client version: 12.19.36
delivery version: master (69bfa4a76959a8d093511a90fddd7a1f7e43e354)
berks version: 5.6.4
kitchen version: 1.16.0

- [x] The commit message includes the cask’s name and version.
