### PR TITLE
Update natron to 2.2.6

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.2.5'
-  sha256 'a6d5e7898fdc2a1ebd4ef427df3ec7402db51684eb5b12a64ef97024c7878d7d'
+  version '2.2.6'
+  sha256 '90f154cde045e4a72727f8073e6bb12550a464d9b345b6d9370682d0f95165db'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: '8623d800936db165a0494334b9d655d40edb82a665480b2624f351a298458951'
+          checkpoint: 'b275a3eb14ba19e50c55bbf49cc6a54e03aaba19675bf5c7e2f889c304017159'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
