### PR TITLE
Update poi to 7.5.2

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,11 +1,11 @@
 cask 'poi' do
-  version '7.5.1'
-  sha256 '38cfdcf542ae063f25774a65f118ac27b2af375dc564e5659e654804e6e2c4a3'
+  version '7.5.2'
+  sha256 '0eef145a3b1ceb97a427b324fcdb571b5b9f1fd2e2c6980c4213543297f30f41'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}-macos-x64.dmg"
   appcast 'https://github.com/poooi/poi/releases.atom',
-          checkpoint: 'f5244514ffd9d5f72b6a15aec75a264f1fdb304fb621153c32f0733a74aad64c'
+          checkpoint: '84868653fb4d7f7fb3d6652cd58d0709fbd8f36d084cd04547c9de47d82765af'
   name 'poi'
   homepage 'https://poi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


