### PR TITLE
Update fotomagico to 5.4.2-22652

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,10 +1,10 @@
 cask 'fotomagico' do
-  version '5.3-22548'
-  sha256 'f99311b87873a93e62a83e36f3426d327d3daa5b120534747bef75c4e78b10eb'
+  version '5.4.2-22652'
+  sha256 'eb5cc2032db34ac6460313c18895842be9ca45bcb654dab71d2178babb81df75'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://www.boinx.com/d/connect//histories/fotomagico',
-          checkpoint: 'd861d636b0640a5c583302ddd2d819aa2166c380ae9a29876d7eb72e7e02a796'
+          checkpoint: '4d6df3a75a8c83c8504db84a99d5b94da07b0934bbffec43c6601500a00c0bcb'
   name 'FotoMagico'
   homepage 'https://www.boinx.com/fotomagico/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.