### PR TITLE
Update caveats for google-cloud-sdk

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -15,8 +15,8 @@ cask 'google-cloud-sdk' do
 
   uninstall delete: "#{staged_path}/#{token}" # Not actually necessary, since it would be deleted anyway. It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
 
-  caveats do
-    "#{token} is installed at #{staged_path}/#{token}. Add your profile:
+  caveats <<-EOS.undent
+    #{token} is installed at #{staged_path}/#{token}. Add your profile:
 
       for bash users
         source '#{staged_path}/#{token}/path.bash.inc'
@@ -25,11 +25,5 @@ cask 'google-cloud-sdk' do
       for zsh users
         source '#{staged_path}/#{token}/path.zsh.inc'
         source '#{staged_path}/#{token}/completion.zsh.inc'
-
-      for fish users
-        set fish_user_paths #{staged_path}/#{token}/bin
-        set -x MANPATH #{staged_path}/#{token}/help/man /usr/local/share/man /usr/share/man /opt/x11/share/man
-
-        Run fish_update_completions to generate completions for fish based on the man pages"
-  end
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed fish completion instructions from `caveats`. Closes #30847.

Fish completions have been removed from the unversioned `url` download. 

While they are included in a versioned alternative I don't see how to make this a versioned cask without users having to update their profiles with each new version or using `postflight` to create symlinks somewhere so as to have a static path to the completions.


<pre>
source '/usr/local/Caskroom/google-cloud-sdk/<b>latest</b>/google-cloud-sdk/completion.bash.inc'
</pre>
