### PR TITLE
Update installer.md

### DIFF
--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -18,7 +18,7 @@ installer manual: 'Little Snitch Installer.app'
 
 | key             | value
 | ----------------|------------------------------
-| `script:`       | path to an install script to be run via `sudo`. (Required first key.)
+| `executable:`   | path to an install script to be run via `sudo`. (Required first key.)
 | `args:`         | array of arguments to the install script
 | `input:`        | array of lines of input to be sent to `stdin` of the script
 | `must_succeed:` | set to `false` if the script is allowed to fail

--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -24,10 +24,12 @@ installer manual: 'Little Snitch Installer.app'
 | `must_succeed:` | set to `false` if the script is allowed to fail
 | `sudo:`         | set to `true` if the script needs `sudo`
 
-The path may be absolute, or relative to the Cask. Example (from [adobe-air.rb](https://github.com/caskroom/homebrew-cask/blob/312ae841f1f1b2ec07f4d88b7dfdd7fbdf8d4f94/Casks/adobe-air.rb#L10-#L12)):
+The path may be absolute, or relative to the Cask. Example (from [ransomwhere.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/ransomwhere.rb#L12-L16)):
 
 ```ruby
-installer script: 'Adobe AIR Installer.app/Contents/MacOS/Adobe AIR Installer',
-          args:   %w[-silent],
-          sudo:   true
+  installer script: {
+                      executable: "#{staged_path}/RansomWhere.app/Contents/MacOS/RansomWhere",
+                      args:       ['-install'],
+                      sudo:       true,
+                    }
 ```

--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -24,7 +24,7 @@ installer manual: 'Little Snitch Installer.app'
 | `must_succeed:` | set to `false` if the script is allowed to fail
 | `sudo:`         | set to `true` if the script needs `sudo`
 
-The path may be absolute, or relative to the Cask. Example (from [ransomwhere.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/ransomwhere.rb#L12-L16)):
+The path may be absolute, or relative to the Cask. Example (from [ransomwhere.rb](https://github.com/caskroom/homebrew-cask/blob/2a7499561420bd375e45e96082c273ca75b600d1/Casks/ransomwhere.rb#L12-L16)):
 
 ```ruby
   installer script: {

--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -33,3 +33,9 @@ The path may be absolute, or relative to the Cask. Example (from [ransomwhere.rb
                       sudo:       true,
                     }
 ```
+
+If the `installer script:` does not require any of the key-values it can point directly to the path of the install script. Example (from [amazon-drive.rb](https://github.com/caskroom/homebrew-cask/blob/427c52acdc3ce0ab1e97950e6cee9896480d7353/Casks/amazon-drive.rb#L10)):
+
+```ruby
+installer script: 'Amazon Drive Installer.app/Contents/MacOS/Amazon Drive Installer'
+```

--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -18,7 +18,7 @@ installer manual: 'Little Snitch Installer.app'
 
 | key             | value
 | ----------------|------------------------------
-| `executable:`   | path to an install script to be run. (Required first key.)
+| `executable:`   | path to an install script to be run
 | `args:`         | array of arguments to the install script
 | `input:`        | array of lines of input to be sent to `stdin` of the script
 | `must_succeed:` | set to `false` if the script is allowed to fail

--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -18,7 +18,7 @@ installer manual: 'Little Snitch Installer.app'
 
 | key             | value
 | ----------------|------------------------------
-| `executable:`   | path to an install script to be run via `sudo`. (Required first key.)
+| `executable:`   | path to an install script to be run. (Required first key.)
 | `args:`         | array of arguments to the install script
 | `input:`        | array of lines of input to be sent to `stdin` of the script
 | `must_succeed:` | set to `false` if the script is allowed to fail


### PR DESCRIPTION
This was going to be a issue but I thought opening a PR to ask / propose a change might be better.

Which style for install scripts with args/sudo is preferred?

The docs for [installer.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/installer.md#installer-script) show one style, but some casks have a style that matches the example for [uninstall.md](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/uninstall.md#uninstall-key-script).

- [burp-suite](https://github.com/caskroom/homebrew-cask/blob/master/Casks/burp-suite.rb#L9-L13)
- [mqttfx](https://github.com/caskroom/homebrew-cask/blob/master/Casks/mqttfx.rb#L10-L14)
- [ransomwhere](https://github.com/caskroom/homebrew-cask/blob/master/Casks/ransomwhere.rb#L12-L16)

I'm not sure if there is any function difference but for readability, I personally prefer the uninstall style `{ }` scripts.

I've updated `installer.md` to use `ransomwhere` as an example if it is preferable. 