### PR TITLE
Fixed Turbo Boost Switcher 2.5.0 Update

### DIFF
--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -7,7 +7,8 @@ cask 'turbo-boost-switcher' do
   name 'Turbo Boost Switcher'
   homepage 'http://www.rugarciap.com/turbo-boost-switcher-for-os-x/'
 
-  app 'Turbo Boost Switcher (English).app'
+  # App renamed to remove "(English)" suffix
+  app 'Turbo Boost Switcher.app'
 
   uninstall quit:       'rugarciap.com.Turbo-Boost-Switcher',
             kext:       'com.rugarciap.DisableTurboBoost',

--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -1,6 +1,6 @@
 cask 'turbo-boost-switcher' do
-  version '2.4.0'
-  sha256 'ae7cab0ecbf750becf438d45104e20b7332788d9479cc1bf7b1d1dc6a91a10d7'
+  version '2.5.0'
+  sha256 '7d52727d1b99dc12fa6c151ccd75bd7630e3a88b8927652a34d1d013dd5f3d52'
 
   # s3.amazonaws.com/turbo-boost-switcher was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/turbo-boost-switcher/Turbo+Boost+Switcher_#{version}.zip"


### PR DESCRIPTION
This fixes my previous PR (https://github.com/caskroom/homebrew-cask/pull/32129) which did not account for the reverted app name *inside* the downloaded archive.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
