### PR TITLE
Update mongodb to 3.4.3-build.1

### DIFF
--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -1,11 +1,11 @@
 cask 'mongodb' do
-  version '3.2.10-build.1'
-  sha256 '29b36cafb62e7ba6ac728fb98e8a264fd7a6494db4350975bdab4c38d332f87b'
+  version '3.4.3-build.1'
+  sha256 'a8be6a015386b247b841f4a8a18b93ee8bd307b7b33d8432f56e0dead0742962'
 
   # github.com/gcollazo/mongodbapp was verified as official when first introduced to the cask
   url "https://github.com/gcollazo/mongodbapp/releases/download/#{version}/MongoDB.zip"
   appcast 'https://github.com/gcollazo/mongodbapp/releases.atom',
-          checkpoint: '93e15dcc180c256dd01d3b4ba1d2d06ce5220bd5424ff9277e3c17f858e94330'
+          checkpoint: '5a02dee4a4176129f578935a774af3373baf1ed5c25482e55c71a29e216b5d1c'
   name 'MongoDB'
   homepage 'https://elweb.co/mongodb-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.