### PR TITLE
Update telegram to 2.92-91713

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.92-91700'
-  sha256 'e4039991e0bc7aa29276d70a01423649439b30fd9a338a2fa9fe4f96d3450cea'
+  version '2.92-91713'
+  sha256 '19bb025863120007403817fd0c98ff8451b07e2c56d6e0081076c30d5e8a3b0b'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '84720ca5be5778990d90e1667d1df17ac2ff3a83b6a8a109d34228722636cb1b'
+          checkpoint: '41ce5767e24230d8da49c046816c67f5553b050543c3430ba369e7fac37afdf3'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
