### PR TITLE
Update frostwire to 6.4.7

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,6 +1,6 @@
 cask 'frostwire' do
   version '6.4.7'
-  sha256 'f15d73d145009a41319aad7384731e9fffffe3c5ae930a9db92a844f99406170'
+  sha256 'e1223dc702203a953f35afab525f45f4971ac57ea89da10525105b717d6dca13'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"

--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.4.6'
-  sha256 'edc23f818cf0a036003b3ca67bebd942c4f6af3098c35ce7e1f9b9cfcbed8e6e'
+  version '6.4.7'
+  sha256 'f15d73d145009a41319aad7384731e9fffffe3c5ae930a9db92a844f99406170'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '7bc2380d6e95de62112c532e5de887e47813766ac26739dfaab5109496519db9'
+          checkpoint: '3c4212b7442ba5b19b2d292efc5be41eb71628112aa499294f0971702f79a331'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.