### PR TITLE
Update parallels-access install script

### DIFF
--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -6,9 +6,11 @@ cask 'parallels-access' do
   name 'Parallels Access'
   homepage 'https://www.parallels.com/products/access/'
 
-  installer script: 'Parallels Access.app/Contents/MacOS/pm_ctl',
-            args:   %w[instance_install],
-            sudo:   true
+  installer script: {
+                      executable: 'Parallels Access.app/Contents/MacOS/pm_ctl',
+                      args:       %w[instance_install],
+                      sudo:       true,
+                    }
 
   uninstall launchctl: [
                          'com.parallels.mobile.startgui.launchagent',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated install script.

Note: still does not work.