### PR TITLE
Update parallels access to 3.1.6-31326

### DIFF
--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -1,8 +1,8 @@
 cask 'parallels-access' do
-  version '3.0.2-30719'
-  sha256 'afafadd6f3e384c0e421b10eb827f83fa65b60206c938431c9c20083d6a0f252'
+  version '3.1.6-31326'
+  sha256 '1713e25c009785bb53f8eb1d193155a4c401ebba4361ce577e3e5c16f3ce787e'
 
-  url "https://download.parallels.com/pmobile/v#{version.major}/#{version.major_minor_patch}/ParallelsAccess-#{version}-mac.dmg"
+  url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name 'Parallels Access'
   homepage 'https://www.parallels.com/products/access/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Didn't actually update the version with #32145. Sorry @miccal .