### PR TITLE
Update psychopy to 1.85.1

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,10 +1,10 @@
 cask 'psychopy' do
-  version '1.85.0'
-  sha256 'f14253facd263245dc36c51fb0318d7b8061d4bd145a802a0d7ead94400b4dac'
+  version '1.85.1'
+  sha256 '6bf222b08cb6e88271226ccfa5c0c1cb25dd10fb44a4e5d2f9a684a867e4e237'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom',
-          checkpoint: 'da63260b70b661fee5a17d94721ab01f6e6610a9334de39d073a97fcb56ab20c'
+          checkpoint: 'd8606caabf407d77969cbc220b81052989868ea5cb1534d8b0b63d04d428bd32'
   name 'PsychoPy'
   homepage 'https://github.com/psychopy/psychopy'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.