### PR TITLE
Update stretchly to 0.8.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.7.0'
-  sha256 'b6958ccbb3e33afcd8b9484bdd25f3d15cfb204faa780b55783c6726c14e928e'
+  version '0.8.0'
+  sha256 'c8a4a0a5108a98f981fdbf86535454282500ae4b0b3b9e4d6b25b784b9dedf6e'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: 'dd45ca7702c61033305c5a750ca2afd55244c268598332279c8502ab9b45153d'
+          checkpoint: '81a5c7150ce4b74bfa0d72d1774cd6e23d28e9bc9f7177d2d88cc483b8e76e1c'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

