### PR TITLE
Update wavebox to 3.1.3

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.1.2'
-  sha256 '6d148a1b664e3f68ef33f21a7b9c70923cc7e0dddc3968f5652334b87e9a4498'
+  version '3.1.3'
+  sha256 'c09fa53cc3d9c37aa4c70e008365110528ebbbf520ab1d5b0f998f0bb5a339e7'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: '083acaf74bf7f452d7fa540ca7da3c2b9bc786afd560e4b8a6477fe1d9925b54'
+          checkpoint: '9a00410586c5119602537dbc8a6651b6f8e551637b84c7e341f83e95809bd7a8'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.