### PR TITLE
Update vivaldi to 1.8.770.56

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi' do
-  version '1.8.770.54'
-  sha256 '5e22c7062475b5e9580dc02d4980fc52e6a9222cc14a2e86a9d9b6e8a022351e'
+  version '1.8.770.56'
+  sha256 '69774addb959bcad66e2a97deb9d70285ac9ac52703ffadec36b8db41964e5e1'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '286ade0553fc0b51f1fcc20de98c90e757803a7d856e29cf4045340054320c76'
+          checkpoint: 'c80c0682afc0636241d400fa3dae4139383a8c3daaf4b7c5aea449f1e5adfafc'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.