### PR TITLE
Update ccleaner to 1.14.451

### DIFF
--- a/Casks/ccleaner.rb
+++ b/Casks/ccleaner.rb
@@ -13,5 +13,7 @@ cask 'ccleaner' do
                 '~/Library/Caches/com.piriform.ccleaner',
                 '~/Library/Preferences/com.piriform.ccleaner.plist',
                 '~/Library/Saved Application State/com.piriform.ccleaner.savedState',
+                '~/Library/Cookies/com.piriform.ccleaner.binarycookies',
+                '/Users/Shared/CCleaner',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.