### PR TITLE
Update flash-npapi to 25.0.0.127

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -17,5 +17,6 @@ cask 'flash-npapi' do
   zap       delete: [
                       '~/Library/Caches/Adobe/Flash Player',
                       '~/Library/Logs/FlashPlayerInstallManager.log',
+                      '/Library/Internet Plug-Ins/flashplayer.xpt',
                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.