### PR TITLE
parallels access dmg fix

### DIFF
--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -6,11 +6,17 @@ cask 'parallels-access' do
   name 'Parallels Access'
   homepage 'https://www.parallels.com/products/access/'
 
-  installer script: {
-                      executable: 'Parallels Access.app/Contents/MacOS/pm_ctl',
-                      args:       %w[instance_install],
-                      sudo:       true,
-                    }
+  container type: :naked
+
+  preflight do
+    system_command '/usr/bin/hdiutil',
+                   args: ['attach', '-nobrowse', "#{staged_path}/ParallelsAccess-#{version}-mac.dmg"]
+    system_command '/Volumes/Parallels Access/Parallels Access.app/Contents/MacOS/pm_ctl',
+                   args: ['instance_install'],
+                   sudo: true
+    system_command '/usr/bin/hdiutil',
+                   args: ['detach', '/Volumes/Parallels Access']
+  end
 
   uninstall launchctl: [
                          'com.parallels.mobile.startgui.launchagent',

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -6,7 +6,7 @@ cask 'parallels-access' do
   name 'Parallels Access'
   homepage 'https://www.parallels.com/products/access/'
 
-  # Contents of DMG cannot be extracted by Cask
+  # This .dmg cannot be extracted normally
   # Original discussion: https://github.com/caskroom/homebrew-cask/issues/26872
   container type: :naked
 

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -6,6 +6,8 @@ cask 'parallels-access' do
   name 'Parallels Access'
   homepage 'https://www.parallels.com/products/access/'
 
+  # Contents of DMG cannot be extracted by Cask
+  # Original discussion: https://github.com/caskroom/homebrew-cask/issues/26872
   container type: :naked
 
   preflight do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #26872.

Cask fails when extracting from the `dmg` to the staged path.

This uses `container type: :naked` to move the `dmg` to the staged path then mount and run the installer using `preflight`.

I don't know if this is an acceptable fix or not. 