### PR TITLE
jce-unlimited-strength-policy: simplify version matching

### DIFF
--- a/Casks/jce-unlimited-strength-policy.rb
+++ b/Casks/jce-unlimited-strength-policy.rb
@@ -2,10 +2,10 @@ cask 'jce-unlimited-strength-policy' do
   version '1.8'
   sha256 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
 
-  url "http://download.oracle.com/otn-pub/java/jce/#{version.split('.')[1]}/jce_policy-#{version.split('.')[1]}.zip",
+  url "http://download.oracle.com/otn-pub/java/jce/#{version.minor}/jce_policy-#{version.minor}.zip",
       cookies: { 'oraclelicense' => 'accept-securebackup-cookie' }
   name 'Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files'
-  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jce#{version.split('.')[1]}-download-2133166.html"
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jce#{version.minor}-download-2133166.html"
 
   postflight do
     `/usr/libexec/java_home -v #{version} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
@@ -18,11 +18,11 @@ cask 'jce-unlimited-strength-policy' do
                      sudo: true
 
       system_command '/bin/ln',
-                     args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.split('.')[1]}/US_export_policy.jar", "#{path}/jre/lib/security/US_export_policy.jar"],
+                     args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.minor}/US_export_policy.jar", "#{path}/jre/lib/security/US_export_policy.jar"],
                      sudo: true
 
       system_command '/bin/ln',
-                     args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.split('.')[1]}/local_policy.jar", "#{path}/jre/lib/security/local_policy.jar"],
+                     args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.minor}/local_policy.jar", "#{path}/jre/lib/security/local_policy.jar"],
                      sudo: true
     end
   end


### PR DESCRIPTION
No need for `version.split('.')[1]`, when handy `version.minor` is around.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
