### PR TITLE
airvpn install fix

### DIFF
--- a/Casks/airvpn.rb
+++ b/Casks/airvpn.rb
@@ -1,15 +1,14 @@
 cask 'airvpn' do
   version '2.12.4'
-  sha256 'ab52cafc027378c8e37c4807b00377a903d82009d5c5afc53a09da5afff20311'
+  sha256 '898abec0155bfe90f5b04c5c22dc20339cc21a59fc5083284550c430acd4b761'
 
   # eddie.website was verified as official when first introduced to the cask
-  url "https://eddie.website/download/?platform=macos&arch=x64&ui=ui&format=installer.pkg&version=#{version}"
+  url "https://eddie.website/download/?platform=macos&arch=x64&ui=ui&format=disk.dmg&version=#{version}"
   name 'Air VPN'
+  name 'Eddie'
   homepage 'https://airvpn.org/macosx/'
 
-  pkg 'airvpn_osx_x64_installer.pkg'
-  binary '/Applications/AirVPN.app/Contents/MacOS/AirVPN'
+  app 'Eddie.app'
 
-  uninstall quit:    'com.airvpn.client',
-            pkgutil: 'com.airvpn.client'
+  uninstall quit: 'com.eddie.client'
 end

--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -1,4 +1,4 @@
-cask 'airvpn' do
+cask 'eddie' do
   version '2.12.4'
   sha256 '898abec0155bfe90f5b04c5c22dc20339cc21a59fc5083284550c430acd4b761'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fixes #28348.

The original fix for #28348 was https://github.com/Homebrew/brew/pull/1748 but it has been closed.

`pkg` downloads but fails to install.

Changed to `dmg` which does install.

Removed `binary` that didn't work.

Not sure if this cask should be renamed to `eddie`