### PR TITLE
Upgrade hstracker to 0.20.1.

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '0.19.1462'
-  sha256 'bf5fe3ed2b95ec4edb83cdb48fe09d720fa29b9bdaf39a2193f66874233c91d7'
+  version '0.20.1'
+  sha256 '7f4dd8330c1b6cd95dcc5f8a7911778aad02cca7198929a2db7ef8524fcd0620'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: 'b4b7e236a34ede43524224d3771d333ad4a3b65fe0a536806016fd061ff1e3bd'
+          checkpoint: 'a7d91467a1b02b0e1f7eb489a3de2559db6737fe3707681280a07baf9958769d'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
