### PR TITLE
dropdmg: remove duplicate zap

### DIFF
--- a/Casks/dropdmg.rb
+++ b/Casks/dropdmg.rb
@@ -10,7 +10,6 @@ cask 'dropdmg' do
 
   zap delete: [
                 '~/Library/Application Support/DropDMG',
-                '~/Library/Caches/com.c-command.DropDMG',
                 '~/Library/Automator/DropDMG.action',
                 '~/Library/Automator/Expand Disk Image.action',
                 '~/Library/Caches/com.c-command.DropDMG',


### PR DESCRIPTION
Accidentally introduced in #32175.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.