### PR TITLE
Update 1clipboard to 0.1.8

### DIFF
--- a/Casks/1clipboard.rb
+++ b/Casks/1clipboard.rb
@@ -4,11 +4,26 @@ cask '1clipboard' do
 
   url "http://1clipboard.io/download/darwin/#{version}/1Clipboard.zip"
   appcast 'http://1clipboard.io/download/darwin/',
-          checkpoint: '7dc172ad10ca0239253aff64fae7a09d4b082f6c11cbcfae95be1e2bacb60f9d'
+          checkpoint: '391698b82a53cc527c9616be048d56b6547b7df947b1588e24692e934280fdf7'
   name '1Clipboard'
   homepage 'http://1clipboard.io/'
 
   depends_on macos: '>= :mountain_lion'
 
   app '1Clipboard.app'
+
+  uninstall login_item: '1Clipboard',
+            quit:       [
+                          'com.ngwin.1clipboard',
+                          'com.ngwin.1clipboardhelper',
+                        ]
+
+  zap delete: [
+                '~/Library/Application Support/1Clipboard',
+                '~/Library/Application Support/com.ngwin.1clipboard.ShipIt',
+                '~/Library/Caches/1Clipboard',
+                '~/Library/Caches/com.ngwin.1clipboard',
+                '~/Library/Preferences/com.ngwin.1clipboard.plist',
+                '~/Library/Saved Application State/com.ngwin.1clipboard.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.