### PR TITLE
Update caret to 2.0.9

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.8'
-  sha256 '7d24156368ba7ae7f2fbd89583fe53783af44c6fa2add4d79640439e45fd2312'
+  version '2.0.9'
+  sha256 'f8d71709326b8668af999e23be7a0084ef81d158cc448643be42999d212a7232'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'bafbb6a15b2107268ecc61fd66969b1d1eaba391fa7f798d332557f60803f745'
+          checkpoint: '41762b4c3561b26ae561dfd8482cc36d73e51db8ada719fc205ede3655a49348'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.