### PR TITLE
Update omnioutliner to 5.0.2

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,6 +1,6 @@
 cask 'omnioutliner' do
-  version '5.0.1'
-  sha256 '6b9e85db62565e804562701b16dfa30e51469d54e6c8faacb7dd1aee6b293c95'
+  version '5.0.2'
+  sha256 'be66619497a8c31f21ea790c24a53e41b9968957740d9f1c66ad774c57d71779'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
   name 'OmniOutliner'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.