### PR TITLE
Update botframework-emulator to 3.5.27

### DIFF
--- a/Casks/botframework-emulator.rb
+++ b/Casks/botframework-emulator.rb
@@ -1,10 +1,10 @@
 cask 'botframework-emulator' do
-  version '3.5.25'
-  sha256 '78fb6ea5289a6e8fb0d2d54d921bb582af03f733de71efbb1598c5110b8e4fda'
+  version '3.5.27'
+  sha256 '906216cb5cb4491918cb21bb222bb53ae3d4439510f897a0f75a8bdcc85ba579'
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom',
-          checkpoint: '77b6108493d7f104e623f266e462f615530fec6480f1e0b07adac2148ec01bc9'
+          checkpoint: '5f0a1e4ce3f689504abf504fc47b85ce40debd931d948128a485e99d0c4d0489'
   name 'Microsoft Bot Framework Emulator'
   homepage 'https://github.com/Microsoft/BotFramework-Emulator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.