### PR TITLE
Update coda to 2.6.2

### DIFF
--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -1,10 +1,10 @@
 cask 'coda' do
-  version '2.6.1'
-  sha256 '7403457c8a03b51579f7532e855849ce213a454cdf7b49b4ae935ea9064f770e'
+  version '2.6.2'
+  sha256 'ac7c948dad9d003925bcd1425018bf684c93feac67e2d48241c631ee310cf897'
 
   url "https://download.panic.com/coda/Coda%20#{version}.zip"
   appcast "https://www.panic.com/updates/update.php?appName=Coda%20#{version.major}",
-          checkpoint: '57518b1b52efc789af936a62d71d4133323427dcdaa8e9eb09dd634823c0735a'
+          checkpoint: '0e1810845ca1aeac2468eea47b5551119d6aadf6c3b46aa1c8150e9bd5d0ccc4'
   name 'Panic Coda'
   homepage 'https://panic.com/coda/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.