### PR TITLE
Update keepassxc to 2.1.4

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,11 +1,11 @@
 cask 'keepassxc' do
-  version '2.1.3'
-  sha256 '1a31ed5236f1c69698b65c2360b7499ef9bc3c77a37a6b465672753625552b63'
+  version '2.1.4'
+  sha256 '186538b397a1302728e43bd596f96e228fd9f39ca4c94e657c48ab45a91c1738'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
   appcast 'https://github.com/keepassxreboot/keepassxc/releases.atom',
-          checkpoint: '13e80f21f311288d042402f0f3e7d5e8bfacefaaf649c2834014f9c56a856fe8'
+          checkpoint: '760a591c31edbf5a3b04893b3baa871dc015394fc0bee66f9f1c6a39cee685e5'
   name 'KeePassXC'
   homepage 'https://keepassxc.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.