### PR TITLE
Update kite to 0.20170407.2

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170331.0'
-  sha256 'ec6d1c3b42c687f3efeb8eb2e10ca4b07f402c379d733eb5b7d64a0a7a5cdc84'
+  version '0.20170407.2'
+  sha256 '50dd6cdec183551a4a671cdd3323a0401b7a111a58c1f4ffcb174d29b42f7bbb'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '7611b119c633ab1402d8348f29d1aaa9743b2dadf815a3d984fcb6942e807686'
+          checkpoint: 'd638f4bf0a37d9b6765d8b71068087645850a127a7c4d79c2745358ffe55d867'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.