### PR TITLE
Update nylas-mail to 2.0.10-cbc7d0c

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '1.0.48-5a0ce1c'
-  sha256 '4ab09bf095cab41c789536a99b30073ec154e02b51bf08a5ec911a66bc358f1c'
+  version '2.0.10-cbc7d0c'
+  sha256 '5da11f0b890914cab6f115c9d3eb7fffd89f9db792e17d7ae27c74d9baca3f68'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '119668734f2ea41c68dd97ad4372f1c54aea6fee0ebd614ccf9a042580d2ff1f'
+          checkpoint: '7e7241c55a8c06aafdf32f44f2a80e904c1be7f3681eb63b54fe682b4a59411a'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.