### PR TITLE
Update the-escapers-flux to 6.1.13

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,13 +1,13 @@
 cask 'the-escapers-flux' do
-  version '6.0.16'
-  sha256 '9e2a0a1ae4483a2842b6d7ca5df3dbb89a07c5e192a7c35b35c2d380b60f019e'
+  version '6.1.13'
+  sha256 '582bd6abcf49f3c1e67547020af7a7fd4026f3c7e8e3ff373e985361e98934f9'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
-  appcast 'http://www.theescapers.com/flux/flux.xml',
-          checkpoint: '5186709410d51bcd39f1fc569ecee474c97846173e483871eb8d1fd7ddf06099'
+  appcast 'http://s3.amazonaws.com/Flux/flux.xml',
+          checkpoint: '9de24e75553e652fad15b333e89bd126668b51d45dcbcacea9092f23e804067c'
   name 'Flux'
-  homepage 'http://www.theescapers.com/flux/'
+  homepage 'http://www.theescapers.com/product.php?product=flux'
 
   app 'Flux.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.