### PR TITLE
Update etcher to 1.0.0-rc.2

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,13 +1,20 @@
 cask 'etcher' do
-  version '1.0.0-beta.19'
-  sha256 'c8f01a62c0d5927b85e2f6ad9a69d6c712e857446ecede87d3297041ac66627b'
+  version '1.0.0-rc.2'
+  sha256 'c5e40463a728df61cfc0f351a179f22e5468af829321fa8c55a8ec071db0ce91'
 
   # resin-production-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://resin-production-downloads.s3.amazonaws.com/etcher/#{version}/Etcher-#{version}-darwin-x64.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: '814b7e053ba2b60f94d0a5918489ca36b9b215b32c619ffe301ee865c33d139a'
+          checkpoint: '99a96bc2569337690652c28b7cd055f14f2f0ce7158f6f4e464412e190da7a15'
   name 'Etcher'
   homepage 'https://etcher.io/'
 
   app 'Etcher.app'
+
+  zap delete: [
+                '~/Library/Application Support/etcher',
+                '~/Library/Preferences/io.resin.etcher.helper.plist',
+                '~/Library/Preferences/io.resin.etcher.plist',
+                '~/Library/Saved Application State/io.resin.etcher.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.