### PR TITLE
wireshark-chmodbpf.rb: refactor uninstall

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -41,14 +41,17 @@ cask 'wireshark-chmodbpf' do
                    sudo: true
   end
 
-  uninstall script:  {
-                       executable: '/usr/sbin/dseditgroup',
-                       args:       ['-o', 'delete', 'access_bpf'],
-                     },
-            pkgutil: 'org.wireshark.ChmodBPF.pkg',
-            delete:  [
-                       '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist',
-                     ],
+  uninstall_preflight do
+    system_command '/usr/sbin/dseditgroup',
+                   args: [
+                           '-o',
+                           'delete',
+                           'access_bpf',
+                         ]
+  end
+
+  uninstall pkgutil: 'org.wireshark.ChmodBPF.pkg',
+            delete:  '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist'
             rmdir:   [
                        '/Library/Application Support/Wireshark/ChmodBPF',
                        '/Library/Application Support/Wireshark',

--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -52,7 +52,7 @@ cask 'wireshark-chmodbpf' do
   end
 
   uninstall pkgutil: 'org.wireshark.ChmodBPF.pkg',
-            delete:  '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist'
+            delete:  '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist',
             rmdir:   [
                        '/Library/Application Support/Wireshark/ChmodBPF',
                        '/Library/Application Support/Wireshark',

--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -47,7 +47,8 @@ cask 'wireshark-chmodbpf' do
                            '-o',
                            'delete',
                            'access_bpf',
-                         ]
+                         ],
+                   sudo: true
   end
 
   uninstall pkgutil: 'org.wireshark.ChmodBPF.pkg',


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

`uninstall script:` was being wrongly used.