### PR TITLE
Update caret to 2.0.10

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.9'
-  sha256 'f8d71709326b8668af999e23be7a0084ef81d158cc448643be42999d212a7232'
+  version '2.0.10'
+  sha256 '133f25af85e2051e8bbc29ffe650efcd3a615e45a5e811243836e0b7724a7dc3'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '41762b4c3561b26ae561dfd8482cc36d73e51db8ada719fc205ede3655a49348'
+          checkpoint: 'ee703f7bd12d45bc1b531e069ec2a9507a3ff8726e3a0f7ab74616e921f1861b'
   name 'Caret'
   homepage 'https://caret.io/'
 

--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -5,7 +5,7 @@ cask 'caret' do
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'ee703f7bd12d45bc1b531e069ec2a9507a3ff8726e3a0f7ab74616e921f1861b'
+          checkpoint: '944218f54d6df9cc36e3fdd577d39cccd041cb1fa24954a903d30eede66a65d3'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.