### PR TITLE
Update paste to 2.2.1

### DIFF
--- a/Casks/paste.rb
+++ b/Casks/paste.rb
@@ -2,7 +2,7 @@ cask 'paste' do
   version '2.2.1'
   sha256 '131e1a2c06e88c1532570e4342073b043023fd049508b31be9d90a93f6defab1'
 
-  # rink.hockeyapp.net/api/2/apps/ee24d1a939cd4ff8b2861eb8c788a995was verified as official when first introduced to the cask
+  # rink.hockeyapp.net/api/2/apps/ee24d1a939cd4ff8b2861eb8c788a995 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/ee24d1a939cd4ff8b2861eb8c788a995/app_versions/6?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/ee24d1a939cd4ff8b2861eb8c788a995',
           checkpoint: 'c1c8499b83a3f44b49f8985d7c508cea576cca12c8619720491c33f58458d06f'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.