### PR TITLE
Update writefull to 3.0.0-beta14

### DIFF
--- a/Casks/writefull.rb
+++ b/Casks/writefull.rb
@@ -1,9 +1,9 @@
 cask 'writefull' do
-  version :latest
-  sha256 :no_check
+  version '3.0.0-beta14'
+  sha256 '3e73acde34d9100d823c16ae3c2c1224715d05210368505835fb8e790fbcbbb8'
 
   # d3aw1w08kaciwn.cloudfront.net was verified as official when first introduced to the cask
-  url 'https://d3aw1w08kaciwn.cloudfront.net/Writefull.dmg'
+  url "https://d3aw1w08kaciwn.cloudfront.net/#{version}-gem2/Writefull.dmg"
   name 'Writefull'
   homepage 'https://writefullapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.