### PR TITLE
Update aqua-data-studio to 18.0.8

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,10 +1,10 @@
 cask 'aqua-data-studio' do
-  version '17.0.11'
-  sha256 '0c252f39f662542066793f9d57712740fae39e29ef45469521e21c9de53e0885'
+  version '18.0.8'
+  sha256 '4ec2bbb8b8ff86e35d449e94589c723e4c367a523d949bd6833991b7dc6b7376'
 
   url "http://www.aquafold.com/download/v#{version.major}.0.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'http://www.aquafold.com/download/',
-          checkpoint: '03f771b8d51c558dbbd33b15b590f0820f8e05f66a7afdad346d8efb2c30a75e'
+          checkpoint: 'fd0ba390df27eff956c67848e12b7d24a9560f964e95d78cd6a038401a2fdd6a'
   name 'Aquafold Aqua Data Studio'
   homepage 'http://www.aquafold.com/aquadatastudio.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.