### PR TITLE
Update auristor-client to 0.150

### DIFF
--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -1,5 +1,5 @@
 cask 'auristor-client' do
-  version '0.149'
+  version '0.150'
 
   if MacOS.version == :mavericks
     sha256 'e79579c9ac2cd609bedd2e01104c113a3417e082e6b5a9f8d333d74e8a6d5030'
@@ -11,10 +11,12 @@ cask 'auristor-client' do
     sha256 'b0a7eee25398e265304a7adfe672f8daa942b916ed7e069d45c3b871d023086f'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.11/AuriStor-client-#{version}-ElCapitan.dmg"
   else
-    sha256 'a5b0cb5e14654e7e0558b779f3c5c32e03a691be10f3f88ea7857cebea2f66f1'
+    sha256 '2e7ca7a7d0759d4f25db904035c0b00c59abdb2667f9dcd2e4a75892c5a60968'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.12/AuriStor-client-#{version}-Sierra.dmg"
   end
 
+  appcast 'https://www.auristor.com/filesystem/client-installer/',
+          checkpoint: 'f1372d3bc0b5d5184ea71c189282a5f5cd5a7134a79ba25b8b2946b503e0a604'
   name 'AuriStor File System Client'
   homepage 'https://www.auristor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.