### PR TITLE
Update deegain-vst to 1.0.5

### DIFF
--- a/Casks/deegain-vst.rb
+++ b/Casks/deegain-vst.rb
@@ -1,8 +1,8 @@
 cask 'deegain-vst' do
-  version :latest
-  sha256 :no_check
+  version '1.0.5'
+  sha256 '57e60cb7f0baf3e52622edfd8a61997aac7256a63b7d16f65700649206b2c437'
 
-  url 'http://dotec-audio.com/release/DeeGain/latest/mac/DeeGainMac.zip'
+  url "https://dotec-audio.com/release/DeeGain/DeeGainMac_#{version}.zip"
   name 'DOTEC-AUDIO DeeGain (VST)'
   homepage 'https://dotec-audio.com/deegain.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.