### PR TITLE
Update downie to 2.8,1458

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.8,1455'
-  sha256 'c6a7a247f804ebe7ead0fb77d5412596d928b61126563a3d5fbe65367975a36e'
+  version '2.8,1458'
+  sha256 'afaa29461264618999ddebc8a6c1da05ba30a33ffd043ba3b9aac3aa9dc4ff26'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '39d946b861ff1a1d929908c6c26c81558002a0f10a50d36b71d87a46ec804b78'
+          checkpoint: 'ecb6d89e50a9dd53c385f7d755ce41f008e75ee31fe08d60fe15d3ab92c939a8'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.