### PR TITLE
Update protant to 1.2.1

### DIFF
--- a/Casks/protant.rb
+++ b/Casks/protant.rb
@@ -1,10 +1,10 @@
 cask 'protant' do
-  version '1.2.0'
-  sha256 'db0a3b6af8034d622009fbfd0b44913c242d6e962a439610af3e0c4b64003272'
+  version '1.2.1'
+  sha256 'ae3d9cb279723ec7ce4580ef16a43fd30745b0b3b196c7ba92e5aff713e086c2'
 
   url "http://www.laurenceanthony.net/software/protant/releases/ProtAnt#{version.no_dots}/ProtAnt.zip"
   appcast 'http://www.laurenceanthony.net/software/protant/releases/',
-          checkpoint: '8e326bcde694d5f24eb20c0d1e0d7066543cf50782616b99afa3da0695daa62c'
+          checkpoint: 'd0b65e2a685fe67264776b409b16234414492ad722e4757f8f40b7b473190b1d'
   name 'ProtAnt'
   homepage 'http://www.laurenceanthony.net/software/protant/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.