### PR TITLE
Revert "Update newmoon to 27.2.1 (#31973)"

### DIFF
--- a/Casks/newmoon.rb
+++ b/Casks/newmoon.rb
@@ -1,6 +1,6 @@
 cask 'newmoon' do
   version '26.5.0-131'
-  sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
+  sha256 'cfb774a32ec323829a5a03fefd6a07fd9242d32856aee5c22bbfdf0d44abe8dd'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}-gstreamer.en-US.mac64.dmg"
   name 'Pale Moon'

--- a/Casks/newmoon.rb
+++ b/Casks/newmoon.rb
@@ -1,14 +1,10 @@
 cask 'newmoon' do
-  version '27.2.1'
-  sha256 'bfc9ed4a2f2f18d5738d924b37dd96b1d1be4be9f4f94a528d8689667a0c2b46'
+  version '26.5.0-131'
+  sha256 '617581f55863b2ab0f55538791d2c82a06378febffebce14b8d1c1d625f465cb'
 
-  url "http://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
+  url "https://mac.palemoon.org/dist/palemoon-#{version}-gstreamer.en-US.mac64.dmg"
   name 'Pale Moon'
   homepage 'https://www.palemoon.org/'
 
   app 'NewMoon.app'
-
-  zap delete: [
-                '~/Library/Preferences/org.mozilla.palemoon.plist',
-              ]
 end


### PR DESCRIPTION
This reverts commit 628f93560d82da9c9dec88459caadb42895e07c5.
Reason for reversion detailed in https://github.com/caskroom/homebrew-cask/pull/31973

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
