### PR TITLE
Updated cevelop to v1.7.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,8 +1,10 @@
 cask 'cevelop' do
-  version '1.6.0-201701201507'
-  sha256 'd6b9ad4657a3753290927ec451867ca4e43d441af9440c4653fa4424a66e8d23'
+  version '1.7.0-201704121451'
+  sha256 '80cf1c8b2a922e62fbdd23f7bc231feebc869b237ffc39764b1f74c04c622876'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
+  appcast 'https://www.cevelop.com/download/',
+          checkpoint: '8906632c2c715dce25d629c7b82321201e66614ba5631f3fbd7b1f5ac3e61686'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.7.0.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.