### PR TITLE
Update nomachine to 5.2.21_1

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '5.2.11_1'
-  sha256 '8bceb4a87c1cd448d8a39fcb5b09b94508a74c72d4f34e17a00d21c87c98ebf2'
+  version '5.2.21_1'
+  sha256 '76106afead704af9cae68afb2eb1bd2f77ecb1616063b958fd88c84dbb9106b4'
 
   url "http://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.