### PR TITLE
Update anyipsum to 0.1.4

### DIFF
--- a/Casks/anyipsum.rb
+++ b/Casks/anyipsum.rb
@@ -1,10 +1,10 @@
 cask 'anyipsum' do
-  version '0.1.2'
-  sha256 'cdc592a9d97d16cd3e48bc58fcac8471adf0c35d5470857e5b1cb97d65c6a844'
+  version '0.1.4'
+  sha256 'cfb13bbcc2a7ae9e55d26810fb6fb747c9740e0fb18d09d849e7ad6e8af9f139'
 
   url "https://github.com/jlowgren/AnyIpsum/releases/download/v#{version}/AnyIpsum.dmg"
   appcast 'https://github.com/jlowgren/AnyIpsum/releases.atom',
-          checkpoint: '1ab7b72988f8466cd743095dfd62cf4f4232fc9d9a0cea33b960583989b5098a'
+          checkpoint: 'adb3b644a915e880a8b3adeb4e393ec8ba696018bcb04994651751051b595780'
   name 'AnyIpsum'
   homepage 'https://github.com/jlowgren/AnyIpsum'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.