### PR TITLE
Update onlyoffice to 4.3

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,10 +1,10 @@
 cask 'onlyoffice' do
-  version '4.2.2'
-  sha256 '2eb9cc0633417ad13c961f66d0efe37dd8610244551b41a879f3969f6420f424'
+  version '4.3'
+  sha256 'cc71c3e66059e209910b8e273f9c9493e098a392e60735f981c135ab6a9bc2ce'
 
   url "http://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'http://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml',
-          checkpoint: '3cbd648735c37e206767fa08c19e49a02545bf489ff882e05cb349a1ee339a1c'
+          checkpoint: 'c46e9714ef779a757717ee2ef2c2663b1ef714ac0b974cd8c8dcd3fcf4ec6e13'
   name 'ONLYOFFICE'
   homepage 'https://www.onlyoffice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.