### PR TITLE
Update colorsnapper to 1.3.2

### DIFF
--- a/Casks/colorsnapper.rb
+++ b/Casks/colorsnapper.rb
@@ -1,6 +1,6 @@
 cask 'colorsnapper' do
-  version '1.1.3'
-  sha256 'b31c2926a702f350e826fa26ab8617da3418809114fb3691439a061595b0873a'
+  version '1.3.2'
+  sha256 'd866cf1040cfab7f4036050d1b50f9d9e05a65316607a0c55c3d96eb7443eaef'
 
   # amazonaws.com/cs2-binaries was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/cs2-binaries/ColorSnapper2-#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.