### PR TITLE
Update nylas-mail to 2.0.13-b7cdb41

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '2.0.10-cbc7d0c'
-  sha256 '5da11f0b890914cab6f115c9d3eb7fffd89f9db792e17d7ae27c74d9baca3f68'
+  version '2.0.13-b7cdb41'
+  sha256 '665323485ce1d79d316c52471bb430e5bc8feb0aa40dcb5b10c3fae373dae2e2'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '7e7241c55a8c06aafdf32f44f2a80e904c1be7f3681eb63b54fe682b4a59411a'
+          checkpoint: '45b2b789b5f306b0af3f14573f235d18e7b178d1e5930d5d60b94d1eb1a3d969'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.