### PR TITLE
Update pokerstars cask to remove unavailable languages

### DIFF
--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -10,28 +10,8 @@ cask 'pokerstars' do
     %w[.eu EU]
   end
 
-  language 'BE' do
-    %w[.be BE]
-  end
-
-  language 'BG' do
-    %w[.bg BG]
-  end
-
   language 'DK' do
     %w[.dk DK]
-  end
-
-  language 'EE' do
-    %w[.ee EE]
-  end
-
-  language 'ES' do
-    %w[.es ES]
-  end
-
-  language 'FR' do
-    %w[.fr FR]
   end
 
   language 'GR' do


### PR DESCRIPTION
- Following languages are removed as they are not available to download any more	
  - BE
  - BG
  - EE
  - ES
  - FR

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.