### PR TITLE
Update darktable to 2.2.4,3

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,11 +1,11 @@
 cask 'darktable' do
-  version '2.2.3'
-  sha256 '1ebe9a9905b895556ce15d556e49e3504957106fe28f652ce5efcb274dadd41c'
+  version '2.2.4,3'
+  sha256 'b44345a02cab9b5d8cf0ac5aa050389479763cc2c2d5b4f7f71f927a72d2e056'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
-  url "https://github.com/darktable-org/darktable/releases/download/release-#{version}/darktable-#{version}.dmg"
+  url "https://github.com/darktable-org/darktable/releases/download/release-#{version.before_comma}/darktable-#{version.before_comma}.#{version.after_comma}.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: 'f225149b844fe6a48ee77247f1542271354c0496bd91ed447e57543b6f180e31'
+          checkpoint: '94669d14c09987ea6f6e9d7cd95267a4c1c7357e073b9725931068de2e02d9de'
   name 'darktable'
   homepage 'https://www.darktable.org/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.