### PR TITLE
Update fldigi to 4.0.2

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -4,7 +4,7 @@ cask 'fldigi' do
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: '893060e24002b65d1e34da33fba64724cb6648e29f83d7e25f7cb1465265fd7c'
+          checkpoint: 'bed8ba38f33a34e1d0c83dd196babcb31cc68126fe5a14a082664a8601d1303e'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.1'
-  sha256 '025c953be210e180abbb9c2e04451db34286eff016150d7eb770c137f9461594'
+  version '4.0.2'
+  sha256 '79a6102d5d69e814b58d66cb8bc8ceac7f506005b3481fbf71261a9a28296aea'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'fe8a66f3cd9a0d49afbbe3d1b492848fa765fab8f334e943bb0ca156f8bf1775'
+          checkpoint: '893060e24002b65d1e34da33fba64724cb6648e29f83d7e25f7cb1465265fd7c'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.