### PR TITLE
Update nylas-mail to 2.0.14-8c3dc81

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '2.0.13-b7cdb41'
-  sha256 '665323485ce1d79d316c52471bb430e5bc8feb0aa40dcb5b10c3fae373dae2e2'
+  version '2.0.14-8c3dc81'
+  sha256 '352144bbef94b531713521caa016ffecd484181e17bd2a5b20760842aa103f32'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
-  url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.zip"
+  url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.dmg"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '45b2b789b5f306b0af3f14573f235d18e7b178d1e5930d5d60b94d1eb1a3d969'
+          checkpoint: '2ab2ec2c3a568f7d1f5ab3569a2638cbaa5fea816ee5a41dcd05b496343cfa07'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.