### PR TITLE
Update stretchly to 0.8.1

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.8.0'
-  sha256 'c8a4a0a5108a98f981fdbf86535454282500ae4b0b3b9e4d6b25b784b9dedf6e'
+  version '0.8.1'
+  sha256 '91ea23edc565123365ca51b236b466e0ecd590c12d9296ce61b590f522660759'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '81a5c7150ce4b74bfa0d72d1774cd6e23d28e9bc9f7177d2d88cc483b8e76e1c'
+          checkpoint: '5f2804a12585ecec78e7ffe7fc8eb5f0990adc1c5e3016a34b97ca3e3efdd1b7'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.