### PR TITLE
Update wavebox to 3.1.5

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.1.4'
-  sha256 '099a263622f30f840adbec3e586300a37ee0e5428595c3251dc4127850024fd2'
+  version '3.1.5'
+  sha256 '3433e0dd06ed4e0ecc6312f1011e218fccd3f25bfe63b59df74a375b3d173a00'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: 'c674c9861705c949b9b253b91edcc47ad14b7e2a7dd260b7ade20bf427366468'
+          checkpoint: '83fd855b7fa2f7faa871dfa43deaf160021bdacbd542fafc36128be2261b7687'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.