### PR TITLE
Update airtool to 1.5.2

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,11 +1,11 @@
 cask 'airtool' do
-  version '1.5'
-  sha256 'eeb72720d1288278430441f005204d3d622059ad29776b642076d63541f12b5d'
+  version '1.5.2'
+  sha256 '44916ef0a988287f7e8f0b3e5a256fa82069a12a8f080f26f49d1bafd293d7b2'
 
-  # amazonaws.com/adriangranados was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/adriangranados/airtool_#{version}.pkg"
+  # amazonaws.com/apps.adriangranados.com was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/apps.adriangranados.com/airtool_#{version}.pkg"
   appcast 'https://www.adriangranados.com/appcasts/airtoolcast.xml',
-          checkpoint: '3e1c379598102166045827ca23e8c4b948803f21bbb9bc3de05c051facf095db'
+          checkpoint: '86821c7eed263fafce0ba3dde932791420a5d0ce121f861b0292a00329d8749c'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.