### PR TITLE
Update chessx to 1.4.6

### DIFF
--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -1,10 +1,10 @@
 cask 'chessx' do
-  version '1.4.4'
-  sha256 '1304632fa6f6cb6922882de477aab002f2793c18b99718dde86eb08d94432ca2'
+  version '1.4.6'
+  sha256 '86bdd57667bf73d460fa39b45e1cdcf70fb122aeaed255d18ace79389271864b'
 
   url "https://downloads.sourceforge.net/chessx/chessx/#{version}/chessx-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/chessx/rss?path=/chessx',
-          checkpoint: 'a48aa2be2eb2885edaa179620b9cdfc6d8b33224d1db078d3ccea79b7615f798'
+          checkpoint: '425101908c832dc839a05a925807b3abf7bb9430f829ee5a547b20be6469c141'
   name 'ChessX'
   homepage 'http://chessx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.