### PR TITLE
Update freeplane to 1.5.20

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,10 +1,10 @@
 cask 'freeplane' do
-  version '1.5.18'
-  sha256 '8227c396ab9d580126d0d08da84ba6b859eb54116b7902b20b7d7dfd812bbbb0'
+  version '1.5.20'
+  sha256 '441fd9ec1bc825483bbd89ec27718f67961a6339b1f13ea1069ad4e1b87217cf'
 
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable',
-          checkpoint: '18ffd999954ce5c856a46e3474487804445a3da40a0f4f209f54dfbffee34456'
+          checkpoint: '15df09a5aa35c9653383bc995a5cbe94ff62a8377e2da76b30b8d01698d47759'
   name 'Freeplane'
   homepage 'http://freeplane.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.