### PR TITLE
Update goofy to 3.2.0

### DIFF
--- a/Casks/goofy.rb
+++ b/Casks/goofy.rb
@@ -1,11 +1,11 @@
 cask 'goofy' do
-  version '3.1.0'
-  sha256 'fe514568ded928f75a38f86fccea42c5f75f3ed2c69b4525a5eca47fe73070fd'
+  version '3.2.0'
+  sha256 'd208a9e901be0fbeb96e344e5b3c8ad17aef21f9948e84f40c836dce7301289e'
 
   # github.com/danielbuechele/goofy was verified as official when first introduced to the cask
   url "https://github.com/danielbuechele/goofy/releases/download/v#{version}/goofy-core-#{version}-mac.zip"
   appcast 'https://github.com/danielbuechele/goofy/releases.atom',
-          checkpoint: '1325e34e791ecb6a741dad59b295b988375e1a02f5f66c797ea6cd6a599a9951'
+          checkpoint: '0419f2ee9aa22a06774f76ffcd2ba99f4950f3de2c774fd0c40e56467e34a25b'
   name 'Goofy'
   homepage 'http://www.goofyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.