### PR TITLE
Update istumbler to 102.1

### DIFF
--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -8,13 +8,13 @@ cask 'istumbler' do
     sha256 '71f6a6b0e255a853664ed4900835a42f2d23dcb05de35acfb3ac2ec1c5fb2edc'
     url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   else
-    version '101'
-    sha256 'c59192f9a48ba0166f4c21e9d770214d051d67b4a4130fc4195154dea4943985'
+    version '102.1'
+    sha256 '925b1e68a3f47b9bd3581f39ca0744fc20515f3ba69e08991dce48c334c91bd6'
     url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   end
 
   appcast 'https://istumbler.net/feeds/appcast.rss',
-          checkpoint: '34a8b8cf15c866c8e7e3484b5eb894f178a68fb1dde20b47b6ce6d841f976403'
+          checkpoint: '17ef1c38cf3e36fc4d4da1e59f3e769d03462cb853449c9290ed7c2c30d13e42'
   name 'iStumbler'
   homepage 'https://istumbler.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.