### PR TITLE
Update losslesscut to 1.6.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,10 +1,10 @@
 cask 'losslesscut' do
-  version '1.5.0'
-  sha256 '98f972bd24c78142d847e5beb2529bcd0496c8c79ee919696329bf5bb2fbcb73'
+  version '1.6.0'
+  sha256 '8624ff9bc07aa534ded12445a21d066500a64738ccfcfba83ce9f34bdef36200'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-darwin-x64.zip"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom',
-          checkpoint: '4ef5a96c89e9f8f77a1c7902b4c3602bb3d96c06c32e4e66c093f1251ef46726'
+          checkpoint: 'e41c4175f58c355299c08313177137b3b14ce347f7db962d6f3e75760562b495'
   name 'Loslesscut'
   homepage 'https://github.com/mifi/lossless-cut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.