### PR TITLE
Update lyn to 1.8.8

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,10 +1,10 @@
 cask 'lyn' do
-  version '1.8.7'
-  sha256 '9cecb54dad68d53432fa15134577662b9c2e7498c93ff52bc406c83f647facd6'
+  version '1.8.8'
+  sha256 'fe1226677960099714c62bdcd1468f1f03d28f296c5a071e903c6364a235f174'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: '1334e552bbbce6ebb899cbe62cabef7d5fd798cbe18a71bb50d1bde3899b88f9'
+          checkpoint: '3fe222bdf415ea4831bf036886bc2c64c9e7f1d29350d88ed7285bd14284d282'
   name 'Lyn'
   homepage 'https://www.lynapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.