### PR TITLE
Update prey to 1.6.6

### DIFF
--- a/Casks/prey.rb
+++ b/Casks/prey.rb
@@ -1,11 +1,11 @@
 cask 'prey' do
-  version '1.6.5'
-  sha256 'd343a28e63f58a079c8698d308d230565ab4d5ca04a064aebe7ab4ba25a8ed07'
+  version '1.6.6'
+  sha256 '9320748f34804fa69f9526692151fa0a2c21de175e095f676fc5b41f64a55530'
 
   # prey-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://prey-releases.s3.amazonaws.com/node-client/#{version}/prey-mac-#{version}-x86.pkg"
   appcast 'https://github.com/prey/prey-node-client/releases.atom',
-          checkpoint: '6b1a945fa9ec384f0f3237c9096bd2794276467ef7796467f615cb1f180d2200'
+          checkpoint: '83e37aa898a33accd7860a9a600e5979155b24d150f7476a6938465a3078247c'
   name 'Prey'
   homepage 'https://www.preyproject.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.