### PR TITLE
Update pritunl to 1.0.1311.6

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1294.83'
-  sha256 '9d3b8fa6d7a6eeb7a052e0fc673fa590595a9e4cd44a39e42ae95fb5f01a7a39'
+  version '1.0.1311.6'
+  sha256 '869e430730bb883b62813a646045b67b6c6a76a15c56fb0d2ccc1a188c290f42'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'aa68002ff055a59b277b27d459a64891a0d8f59069f445185cdc804b82c2200a'
+          checkpoint: 'd8cba37545c72767f9be9ed7a0d4636ac8c9466abc17aeb770e8641bd0c1e4e6'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.