### PR TITLE
Update propresenter to 6.1.7_b16016

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.1.6_b16010'
-  sha256 'e152be6197344962ce92242064d3f98e81a8d964e8dae5f9938131fafb824398'
+  version '6.1.7_b16016'
+  sha256 'b011a63932ab7a6d50f239b2b65a9e57c395f95b01d1d69057831358689b1d05'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: 'dcf7f904b59b81c63d5de618e34d4ab6125702a9088df9800f330b5770d3b090'
+          checkpoint: '815df72d9d454f8dfcf581b84112a1971845537e7e1bf56dd3ee648c02cfdb42'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.