### PR TITLE
Update protege to 5.2.0

### DIFF
--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -1,11 +1,11 @@
 cask 'protege' do
-  version '5.1.0'
-  sha256 '7d7f836236aca50b475111685ad868b86bb6628104af32b7cee1a085faf421f0'
+  version '5.2.0'
+  sha256 'a6f1c06f8740489c51245683e50493d62b7b019ffc409c137eb511a8d1d140be'
 
   # github.com/protegeproject/protege-distribution was verified as official when first introduced to the cask
   url "https://github.com/protegeproject/protege-distribution/releases/download/v#{version}/Protege-#{version}-os-x.zip"
   appcast 'https://github.com/protegeproject/protege-distribution/releases.atom',
-          checkpoint: '015b97cd269ea62c263f6e647b8a0b435af388ca3bc3fe84dd9b231c795247c7'
+          checkpoint: 'd303ee2d1e3f95ade575ac8b135155cb1beef2d7d241ca09a7bd419f61f2cd2e'
   name 'Protégé'
   homepage 'https://protege.stanford.edu/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.