### PR TITLE
Update rhinoceros to 5.3.2

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceros' do
-  version '5.3.1'
-  sha256 '0973e54e9da5d3bb5218288ecdef4ad4d032644447c7568c205cb7115a1b8063'
+  version '5.3.2'
+  sha256 '0b3ad681897954cf26fcbe6904516ae8526a050eaed61be8e4c2e09dd5725b05'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/#{version.major}.0/Mac/Rhinoceros_#{version}.dmg"
   appcast "https://files.mcneel.com/rhino/#{version.major}.0/mac/#{version.major}CcommercialUpdates.xml",
-          checkpoint: 'b4e600b807a804d5979bf02927d48eb6374781fc779f24a5ba2b85c574225710'
+          checkpoint: 'cdd83fed27818db57ff1c252c38254aa77137f7cfbb6bdec0225c010ed69452a'
   name 'Rhinoceros'
   homepage 'https://www.rhino3d.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.