### PR TITLE
Update wireshark uninstall

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -24,7 +24,7 @@ cask 'wireshark' do
   end
 
   uninstall_preflight do
-    set_permissions '/Library/Application Support/Wireshark', '0755'
+    set_ownership '/Library/Application Support/Wireshark'
 
     system_command '/usr/sbin/dseditgroup',
                    args: [
@@ -37,6 +37,7 @@ cask 'wireshark' do
 
   uninstall pkgutil: 'org.wireshark.*',
             delete:  [
+                       '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist',
                        '/usr/local/bin/capinfos',
                        '/usr/local/bin/dftest',
                        '/usr/local/bin/dumpcap',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#31694 

I tried #32259 again after getting [`uninstall_preflight`](https://github.com/caskroom/homebrew-cask/issues/32300) to run.


```
==> Un-installing artifact of class Hbc::Artifact::PreflightBlock
==> Executing: ["/bin/chmod", "-R", "--", "0755", "/Library/Application Support/Wireshark"]
==> chmod: Unable to change file mode on /Library/Application Support/Wireshark: Operation not permitted
==> chmod: /Library/Application Support/Wireshark: Permission denied
==> chmod: Unable to change file mode on /Library/Application Support/Wireshark: Operation not permitted
Error: Command failed to execute!
```

Changed `set_permissions` to `set_ownership`.

```
==> Un-installing artifact of class Hbc::Artifact::PreflightBlock
==> Executing: ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "commitay:staff", "/Library/Application Support/Wireshark"]
==> Executing: ["/usr/bin/sudo", "-E", "--", "/usr/sbin/dseditgroup", "-o", "delete", "access_bpf"]
```

Added `/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist` to `delete:` as it is not removed by any of the `pkg` uninstalls.