### PR TITLE
Update electron to 1.6.2

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.4.16'
-  sha256 '0881abc3d51fd80b2e0e02e449e7b2719d48a89ac41b549b235aff5bbd4fa223'
+  version '1.6.2'
+  sha256 '6e2e9d3fa3197c00e243f3eba7e24e9c1ff318377422106d51ede6b63b814e86'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'e364dcf83a8b0c77bdc5e793ac66410b29cf9694e5b9cbb94e3c6f61049c9fef'
+          checkpoint: 'd0f3af25be0d6fa480d1d7f0801f7f7eaca632521f24c5339c767180b133b7a3'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.