### PR TITLE
serviio: add zap stanza

### DIFF
--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -14,4 +14,14 @@ cask 'serviio' do
                        'org.serviio.pkg.ServiioConsole',
                        'org.serviio.pkg.Serviio',
                      ]
+
+  zap delete: [
+                '/Library/Application Support/Serviio',
+                '/private/var/log/serviio',
+                '~/Library/Application Support/CrashReporter/Serviio-Console Helper_*.plist',
+                '~/Library/Application Support/Serviio-Console-Wrapper',
+                '~/Library/Caches/Serviio-Console-Wrapper',
+                '~/Library/Preferences/org.serviio.serviio-web-console.plist',
+                '~/Library/Saved Application State/org.serviio.serviio-web-console.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Yes, the first one is really `/Library`, not `~/Library`.