### PR TITLE
Update buttercup to 0.12.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.11.1'
-  sha256 '8cc59c37b518028ecc9658160486c1f21b336ea57484ddb0e6333e2bf71d0722'
+  version '0.12.2'
+  sha256 'a4182de9f197328cdca3988b4d58d2051cdc118e53855de525b59e38fa4a2feb'
 
   # github.com/buttercup-pw/buttercup was verified as official when first introduced to the cask
   url "https://github.com/buttercup-pw/buttercup/releases/download/v#{version}-alpha/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup-pw/buttercup/releases.atom',
-          checkpoint: '8bba0fe2ffb90f0bd29ea83e483ad9a33b7cd96b196b6f6b741a456d43a471a4'
+          checkpoint: 'f2ecf71a7abfd434bd34d70d72c6ecb843eda8dc404a34fe0b706ad741e93d61'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] The commit message includes the cask’s name and version.