### PR TITLE
Update switchhosts to 3.3.1.5128

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.2.3.4264'
-  sha256 'bd54356ffa87273f1a76240968931c89c03cba69c22ed4c6a4970551631ffe36'
+  version '3.3.1.5128'
+  sha256 '80abbe065b3d3caaf180a20129fa64875306091ec1d6b7daf8ed32c3cadd19ec'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: '18bafbfc31172dba074161927649424dd8c19555e13b149febca108c844a8ba9'
+          checkpoint: 'e502d92aae68fdf45197547066d19ad58a1fc2dd7ccf03597beca31f2cc46b55'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.