### PR TITLE
Adding Katana version 1.1.1

### DIFF
--- a/Casks/bluegill-katana.rb
+++ b/Casks/bluegill-katana.rb
@@ -1,0 +1,13 @@
+cask 'bluegill-katana' do
+  version '1.1.1'
+  sha256 'bb618628bd335c60dab87bc82c4e5d72df8e80e0baf5510c861962afda915fbc'
+
+  # github.com/bluegill/katana was verified as official when first introduced to the cask
+  url "https://github.com/bluegill/katana/releases/download/v#{version}/katana-#{version}-mac.zip"
+  appcast 'https://github.com/bluegill/katana/releases.atom',
+          checkpoint: '182dca3e37fd246414b9fec5b3034df2c826fd779b0ab8e93c3b08b9a2daa4bf'
+  name 'Katana'
+  homepage 'https://getkatana.com/'
+
+  app 'Katana.app'
+end


### PR DESCRIPTION
- Including New Katana app by bluegill
- This app is different from the on we already have in cask katana. Hence Prepend the vendor name if this is not a duplicate.
- The Provide of this software is https://getkatana.com/
- Earlier Rejected cask due to “too obscure”. Now the repo have 10 Stars

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

---
Ref #30815