### PR TITLE
Update catlight to 2.8.5

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,8 +1,8 @@
 cask 'catlight' do
-  version :latest
-  sha256 :no_check
+  version '2.8.5'
+  sha256 'f1387c0876e78361213ac2ca291cdf750916ad93a67fa9acc00accae92ae5b6d'
 
-  url 'https://catlight.io/downloads/mac/beta'
+  url "https://www.catlight.io/dl/mac/beta/setup-#{version}.zip"
   name 'catlight'
   homepage 'https://catlight.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.