### PR TITLE
Update unrarx to 2.2

### DIFF
--- a/Casks/unrarx.rb
+++ b/Casks/unrarx.rb
@@ -2,11 +2,11 @@ cask 'unrarx' do
   version '2.2'
   sha256 '616c5c536efb29a35fe45c8171874592cc28b269e5d7ed6947c19c8cbb686955'
 
-  url "https://www.unrarx.com/files/UnRarX_#{version}.zip"
-  appcast 'https://www.unrarx.com/update.xml',
+  url "http://www.unrarx.com/files/UnRarX_#{version}.zip"
+  appcast 'http://www.unrarx.com/update.xml',
           checkpoint: 'c42c5affe2dd688136eb43599d6bc91e2a6816a7be9cf063e58d81004b359ba6'
   name 'UnRarX'
-  homepage 'https://www.unrarx.com/'
+  homepage 'http://www.unrarx.com/'
 
   app 'UnRarX.app'
 end


### PR DESCRIPTION
- SSL Expired almost 2 months back & not updated. Hence removing HTTPS

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.


<img width="468" alt="ssl_expired_unrarx" src="https://cloud.githubusercontent.com/assets/450222/25098449/9ea30586-2376-11e7-8e0d-3d66dfb9153b.png">
