### PR TITLE
Add cask for Now.app

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -12,7 +12,7 @@ cask 'now' do
   app 'Now.app'
 
   zap delete: [
-                '~/.now.json'
+                '~/.now.json',
                 '~/Library/Application Support/Now',
                 '~/Library/Caches/co.zeit.now',
                 '~/Library/Caches/co.zeit.now.ShipIt',

--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -2,7 +2,7 @@ cask 'now' do
   version '1.2.2'
   sha256 '94fbdafdd33c2add2e29b841d433e28fe7eeff49e412966295ef779cdd100aa0'
 
-  # github.com/zeit/hyper was verified as official when first introduced to the cask
+  # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
           checkpoint: '79a2e0ea9a90908f688661758090480e5a3f1bd4817fa93a61242d26fffef422'
@@ -17,6 +17,6 @@ cask 'now' do
                 '~/Library/Caches/co.zeit.now',
                 '~/Library/Caches/co.zeit.now.ShipIt',
                 '~/Library/Preferences/co.zeit.now.plist',
-                '~/Library/Preferences/co.zeit.now.helper.plist'
+                '~/Library/Preferences/co.zeit.now.helper.plist',
               ]
 end

--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,0 +1,22 @@
+cask 'now' do
+  version '1.2.2'
+  sha256 '94fbdafdd33c2add2e29b841d433e28fe7eeff49e412966295ef779cdd100aa0'
+
+  # github.com/zeit/hyper was verified as official when first introduced to the cask
+  url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
+  appcast 'https://github.com/zeit/now-desktop/releases.atom',
+          checkpoint: '79a2e0ea9a90908f688661758090480e5a3f1bd4817fa93a61242d26fffef422'
+  name 'Now'
+  homepage 'https://zeit.co/now'
+
+  app 'Now.app'
+
+  zap delete: [
+                '~/.now.json'
+                '~/Library/Application Support/Now',
+                '~/Library/Caches/co.zeit.now',
+                '~/Library/Caches/co.zeit.now.ShipIt',
+                '~/Library/Preferences/co.zeit.now.plist',
+                '~/Library/Preferences/co.zeit.now.helper.plist'
+              ]
+end


### PR DESCRIPTION
This PR introduces Now.app as a new cask! 😊 

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
