### PR TITLE
Update ticktick to 1.6.52,25

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -4,18 +4,22 @@ cask 'macdown' do
 
   # github.com/MacDownApp/macdown was verified as official when first introduced to the cask
   url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
-  appcast 'https://github.com/MacDownApp/macdown/releases.atom',
-          checkpoint: '494e6ec6883fd528a9b1905aa3270dfd0361143bfae5bec6b50284b22ef1f966'
+  appcast 'http://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml',
+          checkpoint: 'b5d3dd1f4690778a82675d110ff4699aecbd29a6597214492756d1e8d38310f6'
   name 'MacDown'
   homepage 'https://macdown.uranusjr.com/'
+
+  auto_updates true
 
   app 'MacDown.app'
   binary "#{appdir}/MacDown.app/Contents/SharedSupport/bin/macdown"
 
   zap delete: [
                 '~/Library/Caches/com.uranusjr.macdown',
+                '~/Library/Cookies/com.uranusjr.macdown.binarycookies',
                 '~/Library/Preferences/com.uranusjr.macdown.plist',
                 '~/Library/Preferences/com.uranusjr.macdown.LSSharedFileList.plist',
                 '~/Library/Application Support/MacDown',
+                '~/Library/WebKit/com.uranusjr.macdown',
               ]
 end

--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -7,7 +7,7 @@ cask 'macdown' do
   appcast 'http://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml',
           checkpoint: 'b5d3dd1f4690778a82675d110ff4699aecbd29a6597214492756d1e8d38310f6'
   name 'MacDown'
-  homepage 'https://macdown.uranusjr.com/'
+  homepage 'http://macdown.uranusjr.com/'
 
   auto_updates true
 

--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,9 +1,9 @@
 cask 'ticktick' do
-  version '1.6.31'
-  sha256 'b5fb9aa43ddd2a2ff6636cbf6feb274e2b10bce2330b23635624f06b9d37d770'
+  version '1.6.52,25'
+  sha256 '6b8fe96976883f99fee0180d227a2e3a6839bf26f365e5bf07f03ce227aac29c'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version}.dmg"
+  url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"
   name 'TickTick'
   homepage 'https://www.ticktick.com/home'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.