### PR TITLE
Update nylas-mail zap

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -22,5 +22,6 @@ cask 'nylas-mail' do
                 '~/Library/Caches/Nylas Mail',
                 '~/Library/Preferences/com.nylas.nylas-mail.plist',
                 '~/Library/Saved Application State/com.nylas.nylas-mail.savedState',
+                '~/.nylas-mail',
               ]
 end


### PR DESCRIPTION
The `zap` stanza in `nylas-mail.rb` does not include `~/.nylas-mail`, one of the largest of its cache directories.

###### Reference:

* [Uninstalling Nylas Mail](https://support.nylas.com/hc/en-us/articles/216837327-Uninstalling-Nylas-Mail), note the `.nylas` directory referred to in this help document has been [renamed](nylas/nylas-mail@63a0f4946b42d8589a2779b79a0f131b7b1af8c8) to `.nylas-mail`.

