### PR TITLE
Update graphicconverter to 10.4.1,2758

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,13 +1,16 @@
 cask 'graphicconverter' do
-  version '10.2743'
-  sha256 'afb9db2618b6d89f954604ceb52091cb9cc03b8b219ad8979bcf06100044aeaf'
+  version '10.4.1,2758'
+  sha256 '92c0ad87c3d70f231ad2be28d6613651872d53be10a5a1debb31d1ddbf83c3d2'
 
   # lemkesoft.info was verified as official when first introduced to the cask
-  url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.minor}.zip"
-  appcast "http://www.lemkesoft.org/files/graphicconverter/graphicconverter#{version.major}.xml",
-          checkpoint: '621f0918d123dd684b30e03995c383469a893408dc180aba7a760e87c0d1cf6f'
+  url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
+  appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml",
+          checkpoint: 'c030fb7c2b96c05f50b1afb09419d4ab58da157ff5c58cd7c8a30141bd9bedc3'
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
+
+  auto_updates true
+  depends_on macos: '>= :mavericks'
 
   app "GraphicConverter #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.