### PR TITLE
Update minerva to 3.5.0

### DIFF
--- a/Casks/minerva.rb
+++ b/Casks/minerva.rb
@@ -2,9 +2,10 @@ cask 'minerva' do
   version '3.5.0'
   sha256 'c2a53ab7bd14924e2a7e3f987eae2586f408c6b24b8b59cad435f9bd7668a130'
 
-  url "http://blog.coursevector.com/downloads/Minerva-#{version.dots_to_hyphens}.air"
+  # videosmnv.s3.amazonaws.com/CV/downloads/Minerva- was verified as official when first introduced to the cask
+  url "https://videosmnv.s3.amazonaws.com/CV/downloads/Minerva-#{version.dots_to_hyphens}.air"
   name '.minerva'
-  homepage 'https://blog.coursevector.com/minerva'
+  homepage 'https://mariani.life/projects/minerva-air/'
 
   depends_on cask: 'adobe-air'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.