### PR TITLE
Update mudlet to 3.0.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,10 +1,10 @@
 cask 'mudlet' do
-  version '3.0.0'
-  sha256 'ff255617dc3b566529f3147d1c4b6a4a200344bbe2925788a26cd115b5f0cfff'
+  version '3.0.1'
+  sha256 '56ae0589db2f3bc2b9e54ad2d030f09a8edbbbc73bbe17b91f19e13c9aeee5a0'
 
   url "http://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom',
-          checkpoint: 'ce9dad74f3aa718606dab97081a2abb691a4a497b1be63b4da6a46db1ef3138a'
+          checkpoint: 'ac9ebb084ffbca5e331634e5413261c463078f76db82d20581ea5ff108b59292'
   name 'Mudlet'
   homepage 'http://www.mudlet.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.