### PR TITLE
adobe-dng-converter remove `uninstall delete: .app`

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -16,7 +16,6 @@ cask 'adobe-dng-converter' do
 
   pkg "DNGConverter_#{version.dots_to_underscores}.pkg"
 
-  uninstall delete:  '/Applications/Adobe DNG Converter.app',
-            pkgutil: 'com.adobe.adobeDngConverter*',
+  uninstall pkgutil: 'com.adobe.DNGConverter',
             quit:    'com.adobe.DNGConverter'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801