### PR TITLE
Update cctalk to 0.8.1-204,2017-04-17.19.56

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,11 +1,11 @@
 cask 'cctalk' do
-  version '0.8.1-190,2017-03-16.15.35'
-  sha256 'a9375653b644f2c4ea46e726939c15c4810c1dae3b290e80878b20fc89f8696e'
+  version '0.8.1-204,2017-04-17.19.56'
+  sha256 '7b3d9e44b675709cf731183d28cd0385f712d263e1403a03d041d30882388fa2'
 
   # f1.ct.hjfile.cn was verified as official when first introduced to the cask
   url "http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/archive/#{version.before_comma.hyphens_to_dots}/CCtalk-#{version.before_comma}-hujiang-#{version.after_comma}.dmg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml',
-          checkpoint: '50da191b8d58b72dcd008d992b63671ca89c831a3ef2acff0eb8c40dfe3f2133'
+          checkpoint: '8fd173a6b2ec2f22ea0144dd21c74a8bc0faf4ba010ded0f8d16c4865c1261c1'
   name 'CCTalk'
   homepage 'https://www.cctalk.com/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.