### PR TITLE
Update vuescan to 9.5.73

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.72'
-  sha256 '83bc294956d7220b3f7737a6131c118f40dfd7d66715f5cd854faff645c02302'
+  version '9.5.73'
+  sha256 '0aa8f38a0c70a3fd7d226f584d65083fd82abc09644ce4938aa5a0832fe36165'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '33c0355f8b17951c95777e1230f738c5173616b3fbb9687c43baf3a4e0c68c30'
+          checkpoint: 'e8d0f5888e2dc916718208c528746602c57e31ad2d743c8324fea7dc11744edf'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.