### PR TITLE
Add ExpressScribe.app (free version)

### DIFF
--- a/Casks/expressscribe.rb
+++ b/Casks/expressscribe.rb
@@ -1,0 +1,21 @@
+cask 'expressscribe' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.nch.com.au/scribe/scribemaci.zip'
+  name 'NCH Software Express Scribe Transcription Software Free'
+  homepage 'http://www.nch.com.au/scribe/index.html'
+
+  auto_updates true
+  depends_on macos: '>= 10.5'
+
+  app 'ExpressScribe.app'
+
+  uninstall quit:       'com.nchsoftware.expressscribe-free',
+            login_item: 'ExpressScribe'
+
+  zap delete: [
+                '~/Library/Preferences/com.nchsoftware.expressscribe-free.plist',
+                '~/Library/Saved Application State/com.nchsoftware.expressscribe-free.savedState',
+              ]
+end

--- a/Casks/expressscribe.rb
+++ b/Casks/expressscribe.rb
@@ -7,7 +7,6 @@ cask 'expressscribe' do
   homepage 'http://www.nch.com.au/scribe/index.html'
 
   auto_updates true
-  depends_on macos: '>= 10.5'
 
   app 'ExpressScribe.app'
 

--- a/Casks/expressscribe.rb
+++ b/Casks/expressscribe.rb
@@ -3,7 +3,7 @@ cask 'expressscribe' do
   sha256 :no_check
 
   url 'http://www.nch.com.au/scribe/scribemaci.zip'
-  name 'NCH Software Express Scribe Transcription Software Free'
+  name 'Express Scribe Transcription Software'
   homepage 'http://www.nch.com.au/scribe/index.html'
 
   auto_updates true


### PR DESCRIPTION
This adds a cask for ExpressScribe (stylized "Express Scribe" at times),
the audio transcription software. Installs the free version of the
freemium app, which can be registered/upgraded from within the software.

Couldn't find a versioned download URL, and the developer's website
does not run in https :(

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

> **The vendor doesn't provide the version in the download URL.**

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
