### PR TITLE
Update aptible to 0.8.5

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,13 +1,13 @@
 cask 'aptible' do
-  version '0.8.5+20170417215450'
+  version '0.8.5+20170417215450,134'
   sha256 'dc8d5f356ab3aaa9e532e63704021aadab2f2c82212aab57c13dfa922e3c3bd6'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/134/pkg/aptible-toolbelt-#{version.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"
+  url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"
   name 'Aptible Toolbelt'
   homepage 'https://www.aptible.com/support/toolbelt/'
 
-  pkg "aptible-toolbelt-#{version}-mac-os-x.10.11.6-1.pkg"
+  pkg "aptible-toolbelt-#{version.before_comma}-mac-os-x.10.11.6-1.pkg"
 
   uninstall pkgutil: 'com.aptible.toolbelt'
 end

--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -3,7 +3,7 @@ cask 'aptible' do
   sha256 'dc8d5f356ab3aaa9e532e63704021aadab2f2c82212aab57c13dfa922e3c3bd6'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"
+  url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.before_comma.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"
   name 'Aptible Toolbelt'
   homepage 'https://www.aptible.com/support/toolbelt/'
 

--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,9 +1,9 @@
 cask 'aptible' do
-  version '0.8.4+20170125122046'
-  sha256 '6cb9763d0ac9369241a3fc390762916cd46434572182dd268c70dc7b4c082719'
+  version '0.8.5+20170417215450'
+  sha256 'dc8d5f356ab3aaa9e532e63704021aadab2f2c82212aab57c13dfa922e3c3bd6'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/132/pkg/aptible-toolbelt-#{version.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"
+  url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/134/pkg/aptible-toolbelt-#{version.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"
   name 'Aptible Toolbelt'
   homepage 'https://www.aptible.com/support/toolbelt/'
 


### PR DESCRIPTION
We updated this today: https://github.com/aptible/www.aptible.com/pull/459

Let me know if this is missing anything :)

Thanks!

----

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.