### PR TITLE
Update caprine to 2.1.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.0.0'
-  sha256 '7153bf40ec2b4202b9c93e300f666821df3b3b5b42f1a78f2c79efeb925745b3'
+  version '2.1.0'
+  sha256 '084b66565fb9aa9f5503cf0170122549e1cea0d76c0faafef91881ee3185d1b0'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: '6f37dffea18bf7589886abcdc36b8463393a981f12a4e0c23727fe4e9f8195f6'
+          checkpoint: 'd966ff7ecf9f5277084b52d744048c2dcc4cbae2c464bbd3cd6c528e7fe44a21'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.