### PR TITLE
gog-galaxy update uninstall

### DIFF
--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -10,7 +10,14 @@ cask 'gog-galaxy' do
 
   pkg "galaxy_client_#{version}.pkg"
 
-  uninstall delete: '/Applications/GalaxyClient.app'
-
-  zap delete: '/Users/Shared/GOG.com'
+  uninstall delete: [
+                      '/Applications/GalaxyClient.app',
+                      '/Library/LaunchAgents/com.gog.galaxy.commservice.plist',
+                      '/Library/LaunchDaemons/com.gog.galaxy.ClientService.plist',
+                      '/Library/PrivilegedHelperTools/com.gog.galaxy.ClientService',
+                      '~/Library/Preferences/com.gog.galaxy.cef.renderer.plist',
+                      '~/Library/Preferences/com.gog.galaxy.plist',
+                      '/Users/Shared/GOG.com/Galaxy',
+                    ],
+            rmdir:  '/Users/Shared/GOG.com'
 end

--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -10,14 +10,16 @@ cask 'gog-galaxy' do
 
   pkg "galaxy_client_#{version}.pkg"
 
-  uninstall delete: [
-                      '/Applications/GalaxyClient.app',
-                      '/Library/LaunchAgents/com.gog.galaxy.commservice.plist',
-                      '/Library/LaunchDaemons/com.gog.galaxy.ClientService.plist',
-                      '/Library/PrivilegedHelperTools/com.gog.galaxy.ClientService',
-                      '~/Library/Preferences/com.gog.galaxy.cef.renderer.plist',
-                      '~/Library/Preferences/com.gog.galaxy.plist',
-                      '/Users/Shared/GOG.com/Galaxy',
-                    ],
-            rmdir:  '/Users/Shared/GOG.com'
+  uninstall delete:    '/Applications/GalaxyClient.app',
+            launchctl: [
+                         'com.gog.galaxy.ClientService',
+                         'com.gog.galaxy.commservice',
+                       ]
+
+  zap delete: [
+                '/Library/PrivilegedHelperTools/com.gog.galaxy.ClientService',
+                '/Users/Shared/GOG.com',
+                '~/Library/Preferences/com.gog.galaxy.cef.renderer.plist',
+                '~/Library/Saved Application State/com.gog.galaxy.savedState',
+              ]
 end

--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -10,6 +10,7 @@ cask 'gog-galaxy' do
 
   pkg "galaxy_client_#{version}.pkg"
 
-  uninstall pkgutil: "com.gog.galaxy.galaxy_client_#{version}.pkg",
-            delete:  '/Applications/GalaxyClient.app'
+  uninstall delete: '/Applications/GalaxyClient.app'
+
+  zap delete: '/Users/Shared/GOG.com'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed `pkgutil` uninstall (no `pkg` record to uninstall) and add zap.