### PR TITLE
soundflower remove `uninstall delete: .app`

### DIFF
--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -23,6 +23,5 @@ cask 'soundflower' do
                             must_succeed: false,
                           },
             pkgutil:      'com.cycling74.soundflower.*',
-            delete:       '/Applications/Soundflower',
             kext:         'com.Cycling74.driver.Soundflower'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801

`soundflower` does not install an `.app`