### PR TITLE
syncthing-bar remove `uninstall delete: .app`

### DIFF
--- a/Casks/syncthing-bar.rb
+++ b/Casks/syncthing-bar.rb
@@ -12,8 +12,7 @@ cask 'syncthing-bar' do
 
   uninstall quit:      'koeln.mop.syncthing-bar',
             pkgutil:   'koeln.mop.syncthing-bar',
-            launchctl: 'koeln.mop.syncthing-bar.agent',
-            delete:    '/Applications/syncthing-bar.app'
+            launchctl: 'koeln.mop.syncthing-bar.agent'
 
   zap delete: [
                 '~/Library/Application Support/Syncthing',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801