### PR TITLE
torguard remove `uninstall delete: .app`

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -11,8 +11,7 @@ cask 'torguard' do
 
   pkg 'Install TorGuard.pkg'
 
-  uninstall pkgutil: 'net.torguard.TorGuardDesktopQt',
-            delete:  '/Applications/TorGuard.app'
+  uninstall pkgutil: 'net.torguard.TorGuardDesktopQt'
 
   zap delete: [
                 '~/Library/Preferences/net.torguard.TorGuard*.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801
