### PR TITLE
tsprint remove `uninstall delete: .app`

### DIFF
--- a/Casks/tsprint.rb
+++ b/Casks/tsprint.rb
@@ -9,6 +9,5 @@ cask 'tsprint' do
   pkg 'TSPrintClient.pkg'
 
   uninstall quit:    'com.terminalworks.TSPrintClient',
-            trash:   '/Applications/TSPrintClient.app',
-            pkgutil: 'com.terminalworks.TSPrintClient'
+            pkgutil: 'com.terminalworks.tsprintclient.TSPrintClient.pkg'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Corrected `pkgutil uninstall`

#30801