### PR TITLE
pydiosync remove `uninstall delete: .app`

### DIFF
--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -8,8 +8,7 @@ cask 'pydiosync' do
 
   pkg 'PydioSync-Setup.pkg'
 
-  uninstall pkgutil: 'io.pyd.sync.installer.PydioSync',
-            delete:  '/Applications/PydioSync.app'
+  uninstall pkgutil: 'io.pyd.sync.installer.PydioSync'
 
   zap delete: '~/Pydio'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801
