### PR TITLE
Update lingon-x to 5.0

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,14 +1,19 @@
 cask 'lingon-x' do
-  version '4.3.7'
-  sha256 '2a108b6da46f1b4f30b9ef95412c6b806c7e92f2b4a28bff7bf67558a7ec9e7b'
+  version '5.0'
+  sha256 'b0aa33d90994d3724c60357ad50248f4db25ac8058c5596db390758ec5d3fd17'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '30913d1fd664606610ddb39899a1a3038340282d5a6aa86351bd795429ebdab1'
+          checkpoint: 'a2c4b4fce8357186a6ea23b30db9bd75550a00845571808cfb87ed1421857288'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :sierra'
 
   app 'Lingon X.app'
+
+  zap delete: [
+                '~/Library/Application Scripts/com.peterborgapps.LingonX5',
+                '~/Library/Containers/com.peterborgapps.LingonX5',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.