### PR TITLE
Update cyberduck to 5.4.4.23962

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '5.4.3.23925'
-  sha256 'e64faf13c551d5bd4d1b651d2541596e7640cc3575f53066525f429eb8157488'
+  version '5.4.4.23962'
+  sha256 'bac70133ce58f432a5da4264525cdb941707d587a614dc5b9cb2bfc6e127d85f'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: '0dfa2f54272ccabdd6b0ea205f4f96a262241d3bc378043d617ed15507473d50'
+          checkpoint: 'b50b9fc667e3717cd9ccbebda9e86eda50f7f38d72146f19e8d9bec15bacdb47'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.