### PR TITLE
Add cask for QLAddict 1.1.9

### DIFF
--- a/Casks/qladdict.rb
+++ b/Casks/qladdict.rb
@@ -1,0 +1,10 @@
+cask 'qladdict' do
+  version '1.1.9'
+  sha256 '477fad7db9e993127ae3666eda2725d62d999300b0529e654f686eebc8315278'
+
+  url "https://github.com/tattali/QLAddict/releases/download/#{version}/QuickLookAddict.qlgenerator.#{version}.zip"
+  name 'QuickLookAddict'
+  homepage 'https://github.com/tattali/QLAddict/'
+
+  qlplugin 'QuickLookAddict.qlgenerator'
+end

--- a/Casks/qladdict.rb
+++ b/Casks/qladdict.rb
@@ -1,8 +1,10 @@
-cask 'quicklookaddict' do
+cask 'qladdict' do
   version '1.1.9'
   sha256 '477fad7db9e993127ae3666eda2725d62d999300b0529e654f686eebc8315278'
 
   url "https://github.com/tattali/QLAddict/releases/download/#{version}/QuickLookAddict.qlgenerator.#{version}.zip"
+  appcast 'https://github.com/tattali/QLAddict/releases.atom',
+          checkpoint: 'fb11e07a57ef9507ce915e55e7a35419852767a4b39157dabda9e8914444d3b5'
   name 'QuickLookAddict'
   homepage 'https://github.com/tattali/QLAddict/'
 

--- a/Casks/quicklookaddict.rb
+++ b/Casks/quicklookaddict.rb
@@ -1,4 +1,4 @@
-cask 'qladdict' do
+cask 'quicklookaddict' do
   version '1.1.9'
   sha256 '477fad7db9e993127ae3666eda2725d62d999300b0529e654f686eebc8315278'
 


### PR DESCRIPTION
refused in #31629 because of the rule
> GitHub repository that is not notable enough (< 10 stars)

But it was crossed today [QLAddict](https://github.com/tattali/QLAddict)

After making all changes to the cask:

- [x] `brew cask audit --download qladdict` is error-free.
- [x] `brew cask style --fix Casks/qladdict.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install qladdict` worked successfully.
- [x] `brew cask uninstall qladdict` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
