### PR TITLE
Update hopper-disassembler to 4.1.3

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.1.1'
-  sha256 'f5b4d78f244e91a6cd0178eeecabdc55ce6b00485cfdf0f64c54ffc6093d93f7'
+  version '4.1.3'
+  sha256 '6dc6a638c3151fe62679d81cd6863dadc6a76da9f8fe18060e7a263189d7505a'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '522ab7399c2be7373fea926b1d984e9adf50d0b056278cad8b421df0c76b1cb4'
+          checkpoint: '8c3395ae493d7b667a834d6be21df91006a1270b567063efa08de4bc7ba8be51'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.