### PR TITLE
Update mac2imgur to b223

### DIFF
--- a/Casks/mac2imgur.rb
+++ b/Casks/mac2imgur.rb
@@ -1,10 +1,10 @@
 cask 'mac2imgur' do
-  version 'b221'
-  sha256 '72e75d3878eac82914b88d1cf1e4dd164fdebb864daa748bc665686f5dbbb93e'
+  version 'b223'
+  sha256 'b2e4dce409b2855a351beedd0151da08c7f90567cba8dd1f4f21ce02beb4f345'
 
   url "https://github.com/mileswd/mac2imgur/releases/download/#{version}/mac2imgur.zip"
   appcast 'https://mileswd.com/mac2imgur/update',
-          checkpoint: '65b7e39d312b95fc9cf8e0990903f87c7b07665326c2197a96a7f607fe6ac864'
+          checkpoint: '57c7f3e153fb500c6db3534651d4fb93c291b399c4c7578cc427b4278715963c'
   name 'mac2imgur'
   homepage 'https://github.com/mileswd/mac2imgur'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.