### PR TITLE
airmount remove `uninstall delete: .app`

### DIFF
--- a/Casks/airmount.rb
+++ b/Casks/airmount.rb
@@ -11,6 +11,5 @@ cask 'airmount' do
   pkg 'AirMount.pkg'
 
   uninstall quit:    'com.tinkerstuff.AirMount',
-            pkgutil: 'com.tinkerstuff.AirMount',
-            delete:  '/Applications/AirMount.app'
+            pkgutil: 'com.tinkerstuff.AirMount'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801
