### PR TITLE
fender-fuse remove `uninstall delete: .app`

### DIFF
--- a/Casks/fender-fuse.rb
+++ b/Casks/fender-fuse.rb
@@ -9,6 +9,5 @@ cask 'fender-fuse' do
 
   pkg 'Fender FUSE Installer.app/Contents/Resources/Fender FUSE.pkg'
 
-  uninstall pkgutil: 'com.Fender.pkg.FenderFUSE',
-            delete:  '/Applications/Fender FUSE.app'
+  uninstall pkgutil: 'com.Fender.pkg.FenderFUSE'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801