### PR TITLE
Update tuneinstructor to 3.6

### DIFF
--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,6 +1,6 @@
 cask 'tuneinstructor' do
   version '3.6'
-  sha256 '9f68e5d1d31a7a7502f84e21f1d26cd8fd3a8eba7708f07386aa641551592d14'
+  sha256 '04921ad3d8d458725baefb98d7c9a192d7e41e7ba9db3469b44dc749c292893a'
 
   url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version}.dmg"
   name 'Tune•Instructor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.