### PR TITLE
Update wiznote to 2.5.0,2017-04-19

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.4.4,2017-03-14'
-  sha256 '35090576e94ad67f84c213571818fe44cf45ebc0ad1a977a8a53b2a0d1f95ea6'
+  version '2.5.0,2017-04-19'
+  sha256 'c7d318b6632d6477ee6342b9a6be1aff9749d0b6dee2196c4fdc7349a90a1ecd'
 
   url "http://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   name 'WizNote'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.