### PR TITLE
Fix El Capitan support for SageMath 7.6

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,10 +1,5 @@
 cask 'sage' do
-  if MacOS.version <= :lion
-    version '7.2'
-    sha256 'f88e0686ae8fe31f2684163a57bea938d93f732842cab7c263ee6e4cdeb271cc'
-    # mit.edu/sage was verified as official when first introduced to the cask
-    url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-OSX_10.7.5-x86_64.app.dmg"
-  elsif MacOS.version <= :mavericks
+  if MacOS.version <= :mavericks
     version '7.2'
     sha256 'a4cd5c6f3207cd9c429642bb58a6310ba05e6da9fddbf36dc1aa5e47c5904c96'
     # mit.edu/sage was verified as official when first introduced to the cask

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -9,6 +9,11 @@ cask 'sage' do
     sha256 'a4cd5c6f3207cd9c429642bb58a6310ba05e6da9fddbf36dc1aa5e47c5904c96'
     # mit.edu/sage was verified as official when first introduced to the cask
     url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-OSX_10.9.5-x86_64.app.dmg"
+  elsif MacOS.version <= :el_capitan
+    version '7.6'
+    sha256 'ba9ffba5dea394dc808c31a7b71af4d0db9759d9440b4dc2e35c921bd03e916f'
+    # mit.edu/sage was verified as official when first introduced to the cask
+    url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version}-OSX_10.11.6-x86_64.app.dmg"
   else
     version '7.6'
     sha256 'dbd5e79825ad505dbf852c8c794cd604a3bd560151fb3ec08a9df7f9c5626ab2'


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
I'm on a tethered connection at home, the sage package is 1GB, I don't want to burn through my data limits this early in the month. I did have to download the package at least once (to generate the sha256 and to verify that the `SageMath-7.6.app` file existed in the `.dmg` file) and I did test that the link started to download with `brew cask install sage` with the new `sage.rb` file.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
I accidentally used the project name of the application and not the cask name, I was unaware this would be problematic. The [documentation](https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#commit-messages) spoke of the Application name, which I assume would have been SageMath in this case, but this condition makes it seem like it's the cask name (referred to as token in the documentation, it's sage in this case).