### PR TITLE
move gogland cask (1.0,171.3780.106) from versions

### DIFF
--- a/Casks/gogland.rb
+++ b/Casks/gogland.rb
@@ -1,0 +1,27 @@
+cask 'gogland' do
+  # Gogland is EAP only for now
+  version '1.0,171.3780.106'
+  sha256 '6b700b1437304e1e58ea3d1f866b2b3545cc83642bcc9a727887f9e0c998a097'
+
+  url "https://download.jetbrains.com/go/gogland-#{version.after_comma}.dmg"
+  appcast 'https://data.services.jetbrains.com/products/releases?code=GO&latest=true&type=eap',
+          checkpoint: 'ab45225047d94c87872bf592b51a028157c187dd71cd96b828c4d01917ba321e'
+  name 'Gogland'
+  name 'Gogland EAP'
+  homepage 'https://www.jetbrains.com/go/'
+
+  auto_updates true
+
+  app "Gogland #{version.before_comma} EAP.app"
+
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'Gogland') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
+  zap delete: [
+                "~/Library/Preferences/Gogland#{version.major_minor}",
+                "~/Library/Application Support/Gogland#{version.major_minor}",
+                "~/Library/Caches/Gogland#{version.major_minor}",
+                "~/Library/Logs/Gogland#{version.major_minor}",
+              ]
+end


### PR DESCRIPTION
I also:
- adjusted name from gogland-eap to gogland
- added appcast
- removed unneeded cask conflict
- added `auto_updates true` (locally verified)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

References:
- [Removal from homebrew-versions](https://github.com/caskroom/homebrew-versions/pull/3683)
- Discussions: https://github.com/caskroom/homebrew-cask/issues/32521 and https://github.com/caskroom/homebrew-versions/issues/3630

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
