### PR TITLE
Update eaglefiler to 1.7.6

### DIFF
--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,6 +1,6 @@
 cask 'eaglefiler' do
-  version '1.7.5'
-  sha256 '0105c3cd7027d9d0f6f158814143358fe3d80414ad44fe923a6f74828f10cb8a'
+  version '1.7.6'
+  sha256 'a22cefbe1a8782bf2ade632928cf70cada5731fb231bb8b9acf5c0fc30e1285c'
 
   url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   name 'EagleFiler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.