### PR TITLE
Update astrotelescope to 1.13

### DIFF
--- a/Casks/astrotelescope.rb
+++ b/Casks/astrotelescope.rb
@@ -1,6 +1,6 @@
 cask 'astrotelescope' do
-  version '1.12'
-  sha256 'a417461c834b1d9a31fd3656e3ee1da2470cc9069df3a205949ef4cb46355e50'
+  version '1.13'
+  sha256 'd6dac278f7b25d5b5d703c643f8bc3eac300a07cdef721585f9f4b9d7b9cd0b8'
 
   url "http://download.cloudmakers.eu/AstroTelescope_#{version}.dmg"
   name 'AstroTelescope'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.