### PR TITLE
Update flightgear to 2017.1.3

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2017.1.2'
-  sha256 'bd6270404515914c882f8a9c3be9073339d1dd998b7f88220ed15b9fe7d77dea'
+  version '2017.1.3'
+  sha256 '78ed634c5db8a3a28f7babf656d7190c0d5fea0013a3c0ff8e1ba45c0d3933af'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: '4a83731f1a473aa983bc3c40b820cc212c5d2429eb39be63e391d57909790daf'
+          checkpoint: '5d03dd66d39c6b9ff96d3d273dc5f5a7fb4e60707596e7ba858f593e0f75e236'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.