### PR TITLE
Update wordpresscom to 2.3.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '2.2.0'
-  sha256 '17e0c52cd2d157e56586d1f51f20c6ac073bf452e6cc49e55e2cf80078d2330a'
+  version '2.3.0'
+  sha256 '95e6faa4d81c7bb7b70114e3094e0a78dcd3400af3525d425c3d3214c519e11f'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: 'e38a213a734691af97f6e35d5326b87260fbfa7c3bf4fa43b720ab857d372659'
+          checkpoint: 'a3105289fe7f1aec303176ae98d6213774ee21cd83ed732a7002301d29839b50'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.