### PR TITLE
boxcryptor 2.10.820

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,6 +1,6 @@
 cask 'boxcryptor' do
-  version '2.8.800'
-  sha256 '1c2b1ec2899e2ef6390cbce8322d3623b3f08dc3c1f8ea86e4d167527a5e9a9d'
+  version '2.10.820'
+  sha256 '4e4d2ad6c5d00011edcee1cbed149eedd5546dd273d3f3f03ce6ab4ebb70a914'
 
   # d3k3ih5otj72mn.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3k3ih5otj72mn.cloudfront.net/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"

--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -2,8 +2,7 @@ cask 'boxcryptor' do
   version '2.10.820'
   sha256 '4e4d2ad6c5d00011edcee1cbed149eedd5546dd273d3f3f03ce6ab4ebb70a914'
 
-  # d3k3ih5otj72mn.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d3k3ih5otj72mn.cloudfront.net/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
+  url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://rink.hockeyapp.net/api/2/apps/7fd6db3e51a977132e3b120c613eaea8',
           checkpoint: '96de80d6dc8c7dfbe069a33e4dda791feaf7158fa2b681c3fc42e83459367720'
   name 'Boxcryptor'


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

