### PR TITLE
Update mountain-duck to 1.9.0.6581

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.8.3.6544'
-  sha256 'e27704f34a24e44827709792fa126971679995ce267ee0f3d211e5bae090a571'
+  version '1.9.0.6581'
+  sha256 'c1f7f0acdd32f7335c74d202689581df8e09b8a6896ae5e8390bfb28cfcb8d32'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'ff9534f358fed0dc0fe7b03ff97736b08c6442dcf326f843204926a49dfa5a46'
+          checkpoint: 'e586f5a29e37a2ea7be25a1ceb2746737e073f2e6a4b23c822a088656f86707d'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.