### PR TITLE
Update evernote to 6.11_454874

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -19,4 +19,12 @@ cask 'evernote' do
   auto_updates true
 
   app 'Evernote.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.evernote.Evernote',
+                '~/Library/Application Support/com.evernote.EvernoteHelper',
+                '~/Library/Caches/com.evernote.Evernote',
+                '~/Library/Preferences/com.evernote.Evernote.plist',
+                '~/Library/Preferences/com.evernote.EvernoteHelper.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.