### PR TITLE
Update metasploit to 4.14.13,20170419092313.git.3.750fe8c

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.14.12,20170417092313'
-  sha256 'aebcc0836f6099b041df3dac0a092eb90183a478f2d8829cb362d2eba6ae7c57'
+  version '4.14.13,20170419092313.git.3.750fe8c'
+  sha256 '9284e2112209c3758f48941f3054f698ad0a9c84dafef4f38af8e712965c3ab3'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version.major_minor_patch}+#{version.after_comma}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '6dd1cb6fee8930d657585f37883b4d1346801fc13c56c514284e5d21763262a7'
+          checkpoint: '34c8b32ac501eb92fc94e020d5dc3af4b89868b2b3e8cb9fd9e61201e6143ba1'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.