### PR TITLE
update qctools v0.8fix1

### DIFF
--- a/Casks/qctools.rb
+++ b/Casks/qctools.rb
@@ -1,6 +1,6 @@
 cask 'qctools' do
-  version '0.8'
-  sha256 'd3cfaeeaf74fe2bdc90d37e3ae22d3c429c2fdeb89fb1f0466150f9ad0c23d51'
+  version '0.8fix1'
+  sha256 'a3ab7b29af8a5baff47b337acdd99bc2eb34bc9862807c2c68508d884a519f46'
 
   url "https://github.com/bavc/qctools/releases/download/v#{version.major_minor_patch}/QCTools_#{version}_mac.dmg"
   appcast 'https://github.com/bavc/qctools/releases.atom',

--- a/Casks/qctools.rb
+++ b/Casks/qctools.rb
@@ -4,7 +4,7 @@ cask 'qctools' do
 
   url "https://github.com/bavc/qctools/releases/download/v#{version.major_minor_patch}/QCTools_#{version}_mac.dmg"
   appcast 'https://github.com/bavc/qctools/releases.atom',
-          checkpoint: '85e48dfbc70a96cf01b636dd382f2e7c28cc788d128a5009072c1a5829822e6c'
+          checkpoint: 'b9de9aa7936bba0d6c5a9137d8d85e07f9abcddd4e90332c727693761cbeab9f'
   name 'QCTools'
   homepage 'https://github.com/bavc/qctools'
 


### PR DESCRIPTION
addresses a fix in the mac build of qctools

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
