### PR TITLE
Update Virtualbox to 5.1.20-114629 - remove outdated `versions`

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,14 +1,6 @@
 cask 'virtualbox' do
-  if MacOS.version <= :lion
-    version '4.3.40-110317'
-    sha256 'eb70fc0f36844ced6dc7deeb30397866fbaffb4a8dfb6071b047e943cae6a312'
-  elsif MacOS.version == :mountain_lion
-    version '5.0.32-112930'
-    sha256 'c693083f1df96a95d5faf794b22737df103973de3e0d89f04734d401962f81cf'
-  else
-    version '5.1.20-114628'
-    sha256 '4980b883721e3b4b2455a66db3edaa9a5cfec8c8d9d872edc90b781259488819'
-  end
+  version '5.1.20-114628'
+  sha256 '4980b883721e3b4b2455a66db3edaa9a5cfec8c8d9d872edc90b781259488819'
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/VirtualBox-#{version}-OSX.dmg"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox' do
   version '5.1.20-114629'
-  sha256 '774f79d770d2176fad2c1cdba52f424dc28154c02339c22c7d1fd17a227dc64'
+  sha256 '774f79d770d2176fad2c1cdba52f424dc28154c02339c22c7d1fd17a227dc642'
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/VirtualBox-#{version}-OSX.dmg"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox' do
-  version '5.1.20-114628'
-  sha256 '4980b883721e3b4b2455a66db3edaa9a5cfec8c8d9d872edc90b781259488819'
+  version '5.1.20-114629'
+  sha256 '774f79d770d2176fad2c1cdba52f424dc28154c02339c22c7d1fd17a227dc64'
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/VirtualBox-#{version}-OSX.dmg"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated to 5.1.20-114629

Remove `lion` and `mountain lion` support.

#32560