### PR TITLE
Virtualbox-extension-pack - remove outdated `versions` - add license

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -37,5 +37,5 @@ cask 'virtualbox-extension-pack' do
     VirtualBox Personal Use and Evaluation License at
 
     https://www.virtualbox.org/wiki/VirtualBox_PUEL
-    EOS
+  EOS
 end

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,14 +1,6 @@
 cask 'virtualbox-extension-pack' do
-  if MacOS.version <= :lion
-    version '4.3.40-110317a'
-    sha256 '829812f9a94204cd206968a8b8c3ca14f719f9cc8e3e1c6825b68c2c3da13033'
-  elsif MacOS.version == :mountain_lion
-    version '5.0.32-112930'
-    sha256 '3a0c45eb2471566787def7d73f8c01b03a806e5b2042c21911c2142dafdf9a44'
-  else
-    version '5.1.20-114628'
-    sha256 '51e85e3792a5a435d88368a52a363321acdd913f4fb3c55cd623911d447ad148'
-  end
+  version '5.1.20-114628'
+  sha256 '51e85e3792a5a435d88368a52a363321acdd913f4fb3c55cd623911d447ad148'
 
   url "http://download.virtualbox.org/virtualbox/#{version.sub(%r{-.*}, '')}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST.TXT',
@@ -25,7 +17,8 @@ cask 'virtualbox-extension-pack' do
     system_command '/usr/local/bin/VBoxManage',
                    args: [
                            'extpack', 'install',
-                           '--replace', "#{staged_path}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
+                           '--replace', "#{staged_path}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack",
+                           '--accept-license=715c7246dc0f779ceab39446812362b2f9bf64a55ed5d3a905f053cfab36da9e'
                          ],
                    sudo: true
   end
@@ -38,4 +31,11 @@ cask 'virtualbox-extension-pack' do
                          ],
                    sudo: true
   end
+
+  caveats <<-EOS.undent
+    Installing this Cask means you have AGREED to the
+    VirtualBox Personal Use and Evaluation License at
+
+    https://www.virtualbox.org/wiki/VirtualBox_PUEL
+    EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Remove `lion` and `mountain lion` support.

#32560

Add license to `postflight`

Add license caveat.