### PR TITLE
Update polymail to 1.34

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.33'
-  sha256 '98e0551b1c3bba24cab945b11373f9c09193d5e538506ab740498f4ca5e5fbf5'
+  version '1.34'
+  sha256 '1ee8aa7c33a3e467ab8df961d2e1c77e139a2864569d802e7f0db20e39cc7fdf'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '735db562c3237f645ba7614521701f66288ab26865c16e4111861fad60443341'
+          checkpoint: '8fe8a7e20206b348b4c68c4dd38505cd084a660be4b3d1edbaa2b6ccf6b7e2c9'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.