### PR TITLE
Update canary to 0.965

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,9 +1,9 @@
 cask 'canary' do
   version '0.965'
-  sha256 'efd57e00bd616d3e1cf10447e14d7a91ed8075f25a99bccc0263298fb01fed2c'
+  sha256 '6e38dc9cbf416dbca72c7331ec4026de533f9e36408d7161a2363fdfb8b7e04b'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/304?format=zip'
+  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
           checkpoint: '6f149aba00dc0b5ee994e8fc95401aa9ebeefd760ed3a9fc0b51f5b3ddc45f46'
   name 'Canary'

--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -3,7 +3,7 @@ cask 'canary' do
   sha256 '6e38dc9cbf416dbca72c7331ec4026de533f9e36408d7161a2363fdfb8b7e04b'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/?format=zip'
+  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/305?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
           checkpoint: '6f149aba00dc0b5ee994e8fc95401aa9ebeefd760ed3a9fc0b51f5b3ddc45f46'
   name 'Canary'

--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -3,7 +3,7 @@ cask 'canary' do
   sha256 'efd57e00bd616d3e1cf10447e14d7a91ed8075f25a99bccc0263298fb01fed2c'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/236?format=zip'
+  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/304?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
           checkpoint: '6f149aba00dc0b5ee994e8fc95401aa9ebeefd760ed3a9fc0b51f5b3ddc45f46'
   name 'Canary'

--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,15 +1,20 @@
 cask 'canary' do
-  version '0.916'
+  version '0.965'
   sha256 'efd57e00bd616d3e1cf10447e14d7a91ed8075f25a99bccc0263298fb01fed2c'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/236?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: '066146a5d4973df03299e08672af916e90e61954d9bd9dbf5a5201c87e84103d'
+          checkpoint: '6f149aba00dc0b5ee994e8fc95401aa9ebeefd760ed3a9fc0b51f5b3ddc45f46'
   name 'Canary'
   homepage 'https://canarymail.io/'
 
   auto_updates true
 
-  app 'canary.app'
+  app 'Canary.app'
+
+  zap delete: [
+                '~/Library/Application Scripts/Sanghani.Canary',
+                '~/Library/Containers/Sanghani.Canary',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.