### PR TITLE
Update seil with OS Dependency of :el_capitan & below

### DIFF
--- a/Casks/seil.rb
+++ b/Casks/seil.rb
@@ -34,4 +34,8 @@ cask 'seil' do
                       '~/Library/Preferences/org.pqrs.PCKeyboardHack.plist',
                       '~/Library/Preferences/org.pqrs.Seil.plist',
                     ]
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/seil.rb
+++ b/Casks/seil.rb
@@ -16,7 +16,7 @@ cask 'seil' do
   name 'Seil'
   homepage 'https://pqrs.org/osx/karabiner/seil.html'
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '<= :el_capitan'
 
   if MacOS.version <= :mountain_lion
     pkg 'Seil.pkg'


### PR DESCRIPTION
- As per official website there is no support for sierra in this product.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

![screen shot 2017-04-19 at 5 29 56 pm](https://cloud.githubusercontent.com/assets/450222/25203067/d9a3863c-2525-11e7-9c79-68b37b4f6734.png)
