### PR TITLE
digital-power-station remove `uninstall delete: .app`

### DIFF
--- a/Casks/digital-power-station.rb
+++ b/Casks/digital-power-station.rb
@@ -9,6 +9,5 @@ cask 'digital-power-station' do
   pkg 'Bongiovi DPS.pkg'
 
   uninstall pkgutil: 'com.bongiovi.pkg.BongioviDPS.*',
-            kext:    'com.bongiovi.DPSReflector',
-            delete:  '/Applications/Bongiovi DPS'
+            kext:    'com.bongiovi.DPSReflector'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801
