### PR TITLE
dmmbookviewer remove `uninstall delete: .app`

### DIFF
--- a/Casks/dmmbookviewer.rb
+++ b/Casks/dmmbookviewer.rb
@@ -9,6 +9,12 @@ cask 'dmmbookviewer' do
 
   pkg "DMMViewerSetup_Mac_#{version}.pkg"
 
-  uninstall pkgutil: 'com.dmm.DMMbookviewer',
-            delete:  '/Applications/DMMbookviewer.app'
+  uninstall pkgutil: [
+                       'com.dmm.DMMbookviewer',
+                       'jp.co.cyphertec.installer.acwd.plist',
+                       'jp.co.cyphertec.installer.framework.CypherGuardAC',
+                       'jp.co.cyphertec.installer.info.CypherGuardAC',
+                       'jp.co.cyphertec.installer.kext.nosigned',
+                       'jp.co.cyphertec.installer.kext.signed',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801
 
Updated uninstall.

The `plist` is a `pkg`.