### PR TITLE
flinto remove `uninstall delete: .app`

### DIFF
--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -8,8 +8,7 @@ cask 'flinto' do
 
   app 'Flinto.app'
 
-  uninstall pkgutil: 'com.flinto.*',
-            delete:  '/Applications/FLinto.app'
+  uninstall pkgutil: 'com.flinto.*'
 
   zap delete: '~/Library/Application Scripts/com.flinto.Flinto'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801