### PR TITLE
flowsync remove `uninstall delete: .app`

### DIFF
--- a/Casks/flowsync.rb
+++ b/Casks/flowsync.rb
@@ -9,7 +9,6 @@ cask 'flowsync' do
 
   pkg "FlowSync_#{version}.pkg"
 
-  uninstall pkgutil: "FlowSync_#{version}.pkg",
-            quit:    'fi.polar.FlowSync',
-            delete:  '/Applications/FlowSync.app'
+  uninstall pkgutil: 'com.polarelectro.pkg.flowsync',
+            quit:    'fi.polar.FlowSync'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801 

Updated `pkg` uninstall.