### PR TITLE
Update twine to 2.1.1

### DIFF
--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -1,6 +1,6 @@
 cask 'twine' do
-  version '2.1.0b5'
-  sha256 '355b2ef4ecf82ff5e696f3b7337e9d8939d0625b5e35c0a9a2889f98d25cd435'
+  version '2.1.1'
+  sha256 '4aad95da8b4fc2d6bb961ea48baeb78fdf81dd5ef9f0e5e085c31fdb66bc79f3'
 
   # bitbucket.org/klembot/twinejs was verified as official when first introduced to the cask
   url "https://bitbucket.org/klembot/twinejs/downloads/twine_#{version}_osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.