### PR TITLE
Adding ‘lincastor’ cask version 1.4

### DIFF
--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -1,6 +1,6 @@
 cask 'lincastor' do
   version '1.4'
-  sha256 'ded9377b56278c6714cfa4ceeefdec37ef43423da910debea1839c89d3d821bf'
+  sha256 '2102986e6a7600ca18c0510ad395f027c4bb4d10beec229b3d73d806b6dfd378'
 
   # dropbox.com/s/43fuhic0mhvhb6f was verified as official when first introduced to the cask
   url 'https://www.dropbox.com/s/43fuhic0mhvhb6f/LinCastor.zip'

--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -1,9 +1,9 @@
 cask 'lincastor' do
   version '1.4'
-  sha256 '2102986e6a7600ca18c0510ad395f027c4bb4d10beec229b3d73d806b6dfd378'
+  sha256 'fbe3af69e932cebdd0ddb76460018a4cc9194d60bb9476c2a42c2ccf59bdbba2'
 
   # dropbox.com/s/43fuhic0mhvhb6f was verified as official when first introduced to the cask
-  url 'https://www.dropbox.com/s/43fuhic0mhvhb6f/LinCastor.zip'
+  url 'https://www.dropbox.com/s/43fuhic0mhvhb6f/LinCastor.zip?dl=1'
   appcast 'https://onflapp.appspot.com/lincastor',
           checkpoint: 'dc2c8150acb3ef4d786d65bf538edd9bdef45c0a4b2ec39fa8c1dd99ffaf3f42'
   name 'LinCastor'

--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -1,0 +1,13 @@
+cask 'lincastor' do
+  version '1.4'
+  sha256 '0856515383b4187179002eb59eb51dfc811d294b4fff355897727ec9b1b656c1'
+
+  # dropbox.com/s/43fuhic0mhvhb6f was verified as official when first introduced to the cask
+  url 'https://www.dropbox.com/s/43fuhic0mhvhb6f/LinCastor.zip'
+  appcast 'https://onflapp.appspot.com/lincastor',
+          checkpoint: 'dc2c8150acb3ef4d786d65bf538edd9bdef45c0a4b2ec39fa8c1dd99ffaf3f42'
+  name 'LinCastor'
+  homepage 'https://onflapp.wordpress.com/lincastor/'
+
+  app 'LinCastor.app'
+end

--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -1,6 +1,6 @@
 cask 'lincastor' do
   version '1.4'
-  sha256 '0856515383b4187179002eb59eb51dfc811d294b4fff355897727ec9b1b656c1'
+  sha256 'ded9377b56278c6714cfa4ceeefdec37ef43423da910debea1839c89d3d821bf'
 
   # dropbox.com/s/43fuhic0mhvhb6f was verified as official when first introduced to the cask
   url 'https://www.dropbox.com/s/43fuhic0mhvhb6f/LinCastor.zip'


### PR DESCRIPTION
- Including Cask lincastor
- This got removed earlier as the app download was issue 404

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

---
Ref #31281