### PR TITLE
Update astroimager to 2.7

### DIFF
--- a/Casks/astroimager.rb
+++ b/Casks/astroimager.rb
@@ -1,6 +1,6 @@
 cask 'astroimager' do
-  version '2.6'
-  sha256 'c2e5198ead29a41c5a5be649ba41b6578f80f2fed1c4625b8fdab7f2452fd320'
+  version '2.7'
+  sha256 'a4f08f24119e1f59d01d18b49c0f0d2a43c4f4190580c9c6827b87fba9353257'
 
   url "http://download.cloudmakers.eu/AstroImager_#{version}.dmg"
   name 'AstroImager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.