### PR TITLE
iholdem-indicator remove `uninstall delete: .app`

### DIFF
--- a/Casks/iholdem-indicator.rb
+++ b/Casks/iholdem-indicator.rb
@@ -13,8 +13,7 @@ cask 'iholdem-indicator' do
                          'com.ckmn.iHoldemIndicator',
                          'com.ckmn.IndicatorHelper',
                        ],
-            pkgutil:   'iHoldemIndicatorInstaller',
-            delete:    '/Applications/iHoldemIndicator.app'
+            pkgutil:   'com.ckmn.iholdemIndicator.iHoldemIndicator.pkg'
 
   zap delete: '~/Library/Application Support/iHoldemIndicator'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801

Updated `uninstall`
