### PR TITLE
iueditor remove `uninstall delete: .app`

### DIFF
--- a/Casks/iueditor.rb
+++ b/Casks/iueditor.rb
@@ -8,8 +8,7 @@ cask 'iueditor' do
 
   pkg "IUEditorV#{version}.pkg"
 
-  uninstall delete:  '/Applications/IUEditor.app',
-            pkgutil: 'org.jdlab.IUEditor'
+  uninstall pkgutil: 'org.jdlab.IUEditor'
 
   zap delete: [
                 '~/Library/Preferences/org.jdlab.IUEditor.LSSharedFileList.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801