### PR TITLE
wd-my-cloud remove `uninstall delete: .app`

### DIFF
--- a/Casks/wd-my-cloud.rb
+++ b/Casks/wd-my-cloud.rb
@@ -9,5 +9,5 @@ cask 'wd-my-cloud' do
   pkg 'Install WD My Cloud.pkg'
 
   uninstall  pkgutil: 'com.wdc.wdMyCloud.*',
-             rmdir:   '/Applications/WD My Cloud'
+             delete:  '~/Desktop/WD My Cloud.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801

`pkgutil` does not remove the shortcut on the desktop.