### PR TITLE
Update magicavoxel to 0.98.2

### DIFF
--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,11 +1,11 @@
 cask 'magicavoxel' do
-  version '0.98'
-  sha256 '8fb7dc065ede34fa64203faf6da8bd9c54d65950177e0601225880d94010f83d'
+  version '0.98.2'
+  sha256 'be65de92473a586e4a8392feac28e43506fa700ba25c660a0036ba7f8c25addd'
 
   # 23.98.147.40 was verified as official when first introduced to the cask
-  url "http://23.98.147.40/uploads/MagicaVoxel-#{version}-win-mac.zip"
+  url "http://23.98.147.40/uploads/MagicaVoxel-#{version}-mac.zip"
   name 'MagicaVoxel'
   homepage 'https://ephtracy.github.io/'
 
-  suite "MagicaVoxel-#{version}"
+  suite "MagicaVoxel-#{version}-mac"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.