### PR TITLE
steelseries-engine remove `uninstall delete: .app`

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -16,9 +16,5 @@ cask 'steelseries-engine' do
                          'com.steelseries.ssenext.uninstaller',
                        ],
             launchctl: 'com.steelseries.SSENext',
-            quit:      "com.steelseries.SteelSeries-Engine-#{version.major}",
-            delete:    [
-                         "/Applications/SteelSeries Engine #{version.major}",
-                         '/Library/LaunchAgents/com.steelseries.SSENext.plist',
-                       ]
+            quit:      "com.steelseries.SteelSeries-Engine-#{version.major}"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801 

`launchagent` is removed by `launchctl`