### PR TITLE
Update ovito to 2.8.2

### DIFF
--- a/Casks/ovito.rb
+++ b/Casks/ovito.rb
@@ -1,6 +1,6 @@
 cask 'ovito' do
-  version '2.8.1'
-  sha256 'ece52b1dc5b0b7e18380c4df105ecc6a6ffb9e3a8fe7cdef100744457b5a8d2a'
+  version '2.8.2'
+  sha256 'b0baaa0709aec816d87f3877a417f26d289981f60d004d7c894174e4f5b890d6'
 
   url "https://ovito.org/download/#{version}/ovito-#{version}-macos.dmg"
   name 'OVITO'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.