### PR TITLE
mikogo remove `uninstall delete: .app`

### DIFF
--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -9,6 +9,8 @@ cask 'mikogo' do
 
   pkg 'Mikogo-installer.signed.pkg'
 
-  uninstall pkgutil: 'com.mikogo.pkg.open-beta',
-            delete:  '/Applications/Mikogo-host.app'
+  uninstall pkgutil: [
+                       'com.mikogo.open-beta',
+                       'com.mikogo.open-beta.video',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

#30801

Corrected uninstall.