### PR TITLE
Update ransomwhere to 1.2.0

### DIFF
--- a/Casks/ransomwhere.rb
+++ b/Casks/ransomwhere.rb
@@ -1,11 +1,11 @@
 cask 'ransomwhere' do
-  version '1.1.0'
-  sha256 '7b18e17abd8fb40d7c25f29f65d64a1f65c758d61c9f67c11d9722d1d7486ea9'
+  version '1.2.0'
+  sha256 'b36433e335f4c25de885cfa9af79f07395cf5d2e929900442a00b85983544a52'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/RansomWhere_#{version}.zip"
   appcast 'https://objective-see.com/products.json',
-          checkpoint: 'b2004932186e0eb176a9ac01fe499de292d502d7a17559e900822f9cdbfa74d6'
+          checkpoint: '89dae1300c90242339b554780b2592f96a3da1be144c26555b290f499e1abde5'
   name 'RansomWhere'
   homepage 'https://objective-see.com/products/ransomwhere.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

```
RANSOMWHERE? CHANGELOG

VERSION 1.2.0 (4/20/2017)
 added process monitoring to:
   a) reduce time to detect untrusted processes
   b) track children that are creating encrypted files
   c) identify trusted processes creating encrypted files on behalf of an untrusted ancestor
 added processes signing info to alert window
 added ability to persistently approve unsigned binaries (via hash)
 white listed (via code-signing auth) more AV prodcuts, and other false-positives
 bug fixes, code optimizations, etc.
```