### PR TITLE
Update squeak to 5.1-16549

### DIFF
--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -1,12 +1,12 @@
 cask 'squeak' do
-  version '5.1-16548'
-  sha256 'c78258c6cc0cb9e3a433230518b065fcf10b5710da7821ef335cf7d8b2fe2f8a'
+  version '5.1-16549'
+  sha256 '42cfa72371a86e95c18dda29c2cbd41d48c71285e01a8e2e7e88e2d09e2962a2'
 
   url "http://files.squeak.org/#{version.major_minor}/Squeak#{version}-32bit/Squeak#{version}-32bit-All-in-One.zip"
   name 'Squeak'
   homepage 'http://squeak.org/'
 
-  app "Squeak#{version}-32bit-All-in-One/Squeak#{version}-32bit-All-in-One.app"
+  app "Squeak#{version}-32bit-All-in-One.app"
 
   zap delete: '~/Library/Saved Application State/org.squeak.Squeak#{version.major_minor}.32.All-in-One.savedState'
 end


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.