### PR TITLE
Update raven-lite to 2.0.0.0036

### DIFF
--- a/Casks/raven-lite.rb
+++ b/Casks/raven-lite.rb
@@ -1,8 +1,8 @@
 cask 'raven-lite' do
-  version '2.0.0.0022'
-  sha256 '84c8d97df6119605ff645c93d896d472a814246fb87128611225168459423532'
+  version '2.0.0.0036'
+  sha256 'ddc3100ed48449e76b8c022e6da4661fea94b1fb372546030d64ff847a7924ea'
 
-  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller/InstData/MacOSX/RavenLite-#{version}_macosx.dmg"
+  url "http://www.birds.cornell.edu/brp/RavenLite/RavenLiteFullInstaller_64Bit/InstData/MacOSX/RavenLite-#{version}_macosx.dmg"
   name 'Raven Lite'
   homepage 'http://www.birds.cornell.edu/brp/raven/RavenOverview.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.