### PR TITLE
Rename cloud to cloudapp

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,4 +1,4 @@
-cask 'cloud' do
+cask 'cloudapp' do
   version '4.2.1'
   sha256 '41e6ceb4d5b861a952cba834b1cc9234bd423519eb0f34e188b9a581b0fe65a7'
 


### PR DESCRIPTION
If there’s one case where the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md) fails to prevent duplicates, it’s this one. We repeatedly get submissions of this app as `cloudapp`.

I was going to rename it and add an exception to the token reference, but then I realised [it’s already there](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md#finding-the-simplified-name-of-the-vendors-distribution) (fourth point):

> Remove from the end: the string “app”, if the vendor styles the name like “Software App.app”. Exception: when “app” is an inseparable part of the name, without which the name would be inherently nonsensical, as in rcdefaultapp.rb.