### PR TITLE
Update the freesmug-chromium to 58.0.3029.81

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '57.0.2987.133'
-  sha256 '60ef3b7f5d604b58be2e4e17d58fbc94353ea4573918cce1f134ae81551a135e'
+  version '58.0.3029.81'
+  sha256 '3dc87ce8fd91d589bb7f3ab3d6e2458fd92806f2086f609fa214411d0217a68b'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '82ca911ebc6653dce108e8dc1d52112902ba5c2394b0489b31cf310557b60b91'
+          checkpoint: '553a66d99cfce3b6dc0010ff231c4fdba91b188cb99a5ed609e8bc039134b84e'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
