### PR TITLE
Update reactotron to 1.10.0

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,10 +1,10 @@
 cask 'reactotron' do
-  version '1.9.0'
-  sha256 '4ebd0266db38a2595fd2030020e99167cd60d8c8a644c6c63c0184caed41125e'
+  version '1.10.0'
+  sha256 'f82fa933d35c77db7f6b5ef18b968a3ce1369e43a119637ae3349bede55a2cbf'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron.app.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom',
-          checkpoint: '932db7cdfc462df04fcce4e9e998912014e5579a97c30b8bbf2298852374a643'
+          checkpoint: 'aa52002c0ba9e8a020c23db2a4cacc7ffbaace86d590dbeab0293336cacc6b86'
   name 'Reactotron'
   homepage 'https://github.com/infinitered/reactotron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.