### PR TITLE
Update canary to 0.965,239

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,15 +1,16 @@
 cask 'canary' do
-  version '0.965'
+  version '0.965,239'
   sha256 '6e38dc9cbf416dbca72c7331ec4026de533f9e36408d7161a2363fdfb8b7e04b'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/305?format=zip'
+  url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
           checkpoint: '6f149aba00dc0b5ee994e8fc95401aa9ebeefd760ed3a9fc0b51f5b3ddc45f46'
   name 'Canary'
   homepage 'https://canarymail.io/'
 
   auto_updates true
+  depends_on macos: '>= :yosemite'
 
   app 'Canary.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.