### PR TITLE
Update mysql-utilities to 1.6.5

### DIFF
--- a/Casks/mysql-utilities.rb
+++ b/Casks/mysql-utilities.rb
@@ -6,8 +6,6 @@ cask 'mysql-utilities' do
   name 'MySQL Utilities'
   homepage 'https://dev.mysql.com/downloads/utilities/'
 
-  license :gpl
-
   depends_on macos: '>= :sierra'
 
   pkg "mysql-utilities-#{version}.pkg"


### PR DESCRIPTION
- Removed license stanza

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.