### PR TITLE
Update natron to 2.2.7

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.2.6'
-  sha256 '90f154cde045e4a72727f8073e6bb12550a464d9b345b6d9370682d0f95165db'
+  version '2.2.7'
+  sha256 '5347361fe84701be6afbd569681af0152af5e7899815458cae9211d399af1d4b'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: 'b275a3eb14ba19e50c55bbf49cc6a54e03aaba19675bf5c7e2f889c304017159'
+          checkpoint: 'c7218d11a2702e4c6d8089bcfced683cff365a8594655d1cfc7dfa4f0df55074'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.