### PR TITLE
Update dropshare to 4.6.2,4604

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4.6,4575'
-  sha256 '7113e9d3d1ce1653f849ffbce4aecd268a616489fb2b975f60549c50ad7b9096'
+  version '4.6.2,4604'
+  sha256 'c8c49b5c5850d2302dc38ec296e469076eb7c52b96c6602f19c57aae7a46949b'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
-          checkpoint: '25d657a10239410e626c20992bf849c7d7e1ea123a8cad032e67ceef52632492'
+          checkpoint: '29d4f921cc895cf48feabfd2dfa06b56118827952bdb41d062aeb41cfecc5952'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.