### PR TITLE
Update aria2gui to 1.3.6

### DIFF
--- a/Casks/aria2gui.rb
+++ b/Casks/aria2gui.rb
@@ -1,10 +1,10 @@
 cask 'aria2gui' do
-  version '1.3.5'
-  sha256 'b5a7f0dd34b779cc6cbda6f612ecda6bc57022f30fd371c8433d47eab26cb944'
+  version '1.3.6'
+  sha256 '789c28ccb8f9f09e0618c437485b63e390b7d0b289ce37d6d71b253daf571d12'
 
   url "https://github.com/yangshun1029/aria2gui/releases/download/#{version}/Aria2GUI-v#{version}.zip"
   appcast 'https://github.com/yangshun1029/aria2gui/releases.atom',
-          checkpoint: 'cf4c11c299e639d7979e80c46d43979f11c26fe1b2f3098523598aab16e29910'
+          checkpoint: '857f8649c18697d34035a317dffada3b132b308630edb00e75b1d7eab5fb7442'
   name 'Aria2GUI'
   homepage 'https://github.com/yangshun1029/aria2gui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.