### PR TITLE
Update downie to 2.8.3,1462

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.8,1458'
-  sha256 'afaa29461264618999ddebc8a6c1da05ba30a33ffd043ba3b9aac3aa9dc4ff26'
+  version '2.8.3,1462'
+  sha256 '14f162e1da2432889685db50de05f1be88289ec668d89a82650552f7cbdd825b'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'ecb6d89e50a9dd53c385f7d755ce41f008e75ee31fe08d60fe15d3ab92c939a8'
+          checkpoint: '3a2f070fa765275bac5ca74b4657e2a03c66e080b49269e03c1b872c9eef8c6f'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.