### PR TITLE
Update anaconda to use --installation-path option

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -11,10 +11,11 @@ cask 'anaconda' do
 
   installer script: {
                       executable: "Anaconda3-#{version}-MacOSX-x86_64.sh",
-                      args:       ['-b'],
+                      args:       ['-b', '-p/usr/local/anaconda3'],
+                      sudo:       true,
                     }
 
-  uninstall delete: '~/anaconda3'
+  uninstall delete: '/usr/local/anaconda3'
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.continuum.io.sfl',
@@ -22,6 +23,7 @@ cask 'anaconda' do
               ]
 
   caveats do
-    path_environment_variable '~/anaconda3/bin'
+    path_environment_variable '/usr/local/anaconda3/bin'
+    files_in_usr_local
   end
 end

--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -11,7 +11,7 @@ cask 'anaconda' do
 
   installer script: {
                       executable: "Anaconda3-#{version}-MacOSX-x86_64.sh",
-                      args:       ['-b', '-p/usr/local/anaconda3'],
+                      args:       ['-b', '-p', '/usr/local/anaconda3'],
                       sudo:       true,
                     }
 

--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -11,11 +11,11 @@ cask 'anaconda' do
 
   installer script: {
                       executable: "Anaconda3-#{version}-MacOSX-x86_64.sh",
-                      args:       ['-b', '-p', '/usr/local/anaconda3'],
+                      args:       ['-b', '-p', "#{HOMEBREW_PREFIX}/anaconda3"],
                       sudo:       true,
                     }
 
-  uninstall delete: '/usr/local/anaconda3'
+  uninstall delete: "#{HOMEBREW_PREFIX}/anaconda3"
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.continuum.io.sfl',
@@ -23,7 +23,7 @@ cask 'anaconda' do
               ]
 
   caveats do
-    path_environment_variable '/usr/local/anaconda3/bin'
+    path_environment_variable "#{HOMEBREW_PREFIX}/anaconda3/bin"
     files_in_usr_local
   end
 end


### PR DESCRIPTION
- Move the installation to /usr/local instead of home directory

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---
Closes #32699