### PR TITLE
Update kite to 0.20170419.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170407.2'
-  sha256 '50dd6cdec183551a4a671cdd3323a0401b7a111a58c1f4ffcb174d29b42f7bbb'
+  version '0.20170419.0'
+  sha256 '6794196ba6365433fece6e2c8004b0ba32b28973c24c2f85a0553a850039f262'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: 'd638f4bf0a37d9b6765d8b71068087645850a127a7c4d79c2745358ffe55d867'
+          checkpoint: 'a0d6674f48647c35dd58a06fc3db29cebe7ad29e33537ab05e356fdc5ac807b2'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.