### PR TITLE
Update vuescan to 9.5.74

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.73'
-  sha256 '0aa8f38a0c70a3fd7d226f584d65083fd82abc09644ce4938aa5a0832fe36165'
+  version '9.5.74'
+  sha256 '9d42b7075e839266041020094368abe622a50e1a6d87f2728fa30fa4edff5d62'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: 'e8d0f5888e2dc916718208c528746602c57e31ad2d743c8324fea7dc11744edf'
+          checkpoint: '696c1b876893d46e371c6e1b274d782d6e4f7a07600e9b6b7fc4b6ed5b564e69'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.