### PR TITLE
Update electron to 1.3.15

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.6.5'
-  sha256 'ad2d76b03ecb92cea828968e63c5c93042becd1adfcfebc39db594a7893817d5'
+  version '1.3.15'
+  sha256 '660d01eeaef9c13dd47bd756b593a91eb6083163bb63c0a9eba7405dd7ebb341'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'ad29075cbdadb809c3bea834da3e953e9f058c9536c7beb851a44665daf3835a'
+          checkpoint: '20ea3d80c0e90e9981fa0f8b15ffaac3d8a7b6328c8475139242435d9cc5098d'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.