### PR TITLE
Update pomodone to 1.5.994

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,6 +1,6 @@
 cask 'pomodone' do
-  version '1.5.989'
-  sha256 '3a11f78fd7fa0bc1412791dcc2ef948f0385375c91e747e7ab40b5d273168649'
+  version '1.5.994'
+  sha256 'e65bfb455b25245422c5fbd4069a0e7770d52fde16d5cee1759c484d66ba95c7'
 
   url "https://app.pomodoneapp.com/installers/PomoDoneApp-#{version}.dmg"
   name 'PomoDone'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.