### PR TITLE
Update camerabag-photo to 3.0.1c

### DIFF
--- a/Casks/camerabag-photo.rb
+++ b/Casks/camerabag-photo.rb
@@ -1,6 +1,6 @@
 cask 'camerabag-photo' do
-  version '3.0.1'
-  sha256 '5fd4bad30ae1d84d179c0b10a38ea9df3f89d7c450e1c8f912da2f8f37949c9d'
+  version '3.0.1c'
+  sha256 '5ea0312ecc6246b95f28e9848548432d328808c892cff9fd4f09aba2798fd8ea'
 
   # downloads.nevercenter.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://downloads.nevercenter.com.s3.amazonaws.com/CameraBag_Photo_Mac_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.