### PR TITLE
Update astroguider to 1.8

### DIFF
--- a/Casks/astroguider.rb
+++ b/Casks/astroguider.rb
@@ -1,6 +1,6 @@
 cask 'astroguider' do
-  version '1.7'
-  sha256 'b5ae7e42ea5073657a00697b860fd495f74a75b27658ccc55156c5cad5a45e3e'
+  version '1.8'
+  sha256 '23a564dad7cfe21ad89f2d34cad80b3771c070fc5048015a44df91765a740b96'
 
   url "http://download.cloudmakers.eu/AstroGuider_#{version}.dmg"
   name 'AstroGuider'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.