### PR TITLE
Update hab to 0.21.0-20170421000356

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.20.0-20170407015129'
-  sha256 '38925f5a870ac91661738b0223fa152269ede86abcfa3d9999bf9bcdac3081c7'
+  version '0.21.0-20170421000356'
+  sha256 '2eaef5b747411e96148f03a9fde8d3689ebb15b7298370cd88e7b4a2fc049502'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '131c5340e019175e9ada6375f178ed0735ff037b0eaca873e64814efa7b14ea4'
+          checkpoint: '2f2e308774833bd6100b626bb92cb588dadac73a97f91aa3da0f11294329dc1c'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.