### PR TITLE
Update idefrag to 5.1.8

### DIFF
--- a/Casks/idefrag.rb
+++ b/Casks/idefrag.rb
@@ -3,8 +3,8 @@ cask 'idefrag' do
     version '5.1.3'
     sha256 '4b695c04f491b8f9f60a1fb43836164960f7d95f82aaa38d1e3b7dd4eacd7d5c'
   else
-    version '5.1.5'
-    sha256 'fef5403743b383cabacdb0636eb61f7d61f752a0a16592853a95bd100c1bf2ff'
+    version '5.1.8'
+    sha256 '2e072ee9a7e3469bbb93b749ae01cc562a0b404dc46daa349edeeaeaede03ecc'
   end
 
   url "https://coriolis-systems.com/downloads/iDefrag-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.