### PR TITLE
Update remember-the-milk to 1.1.8

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.1.3'
-  sha256 '8817c88f395ca9d1d5ad74dbd69b01196ea27a46e4e691789fb0762a78886596'
+  version '1.1.8'
+  sha256 '2b918c5687e6c0780ec6422dcabbfed3e9462ce342be2f93c28528d03562c1cf'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   name 'Remember The Milk'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.