### PR TITLE
Update Sigil to 0.9.8.

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,11 +1,11 @@
 cask 'sigil' do
-  version '0.9.7'
-  sha256 '539801d7c35b0f3e7a393f5ce16bded49755bbe5f2fa4c7cfd23d653d8b0e968'
+  version '0.9.8'
+  sha256 'cd54a70314df223bad7a1c6d5322b012ddf3402ead14e11b88372165ca66decf'
 
   # github.com/Sigil-Ebook/Sigil was verified as official when first introduced to the cask
   url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"
   appcast 'https://github.com/Sigil-Ebook/Sigil/releases.atom',
-          checkpoint: '72eec9fe9708e2704e8ea9e1dbf465b6475afbf7192df66fcfbe59b4e6b5b565'
+          checkpoint: '241988e25e2e75340deb541c27f86783a6d4f240a104bd6388e0965afe57388d'
   name 'Sigil'
   homepage 'https://sigil-ebook.com/'
 


### PR DESCRIPTION


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
