### PR TITLE
Update standard-notes to 0.3.3

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.2.6'
-  sha256 'a40f0fec1dd4e86ae57e16e8d3c308a419660220debfcc71100e30055048fa8c'
+  version '0.3.3'
+  sha256 'b321e1792b015702d9c8b3c4ebba1bdc0fa5902cc618c83470d676eedf14a239'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '7421d16a0413fcea9df2df4f6089b66c4f6e3b0d429af77ab767600b804b1678'
+          checkpoint: '28550074e3d62cf01ce1655c03016dfc69d43d64a1716f691bd66f7d8efd8b1f'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.