### PR TITLE
Update splashtop-streamer to 3.1.4.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,15 +1,21 @@
 cask 'splashtop-streamer' do
-  version '3.1.2.0'
-  sha256 'e1ee59c52dbb7c478e324d0b0d883bd5dcadadc396a2d8103b0c00543c273fdb'
+  version '3.1.4.0'
+  sha256 '6f01125fbcdf864ab2a37e8d00c90d94e0634e124df970ee320bbee1932185ff'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_v#{version}.dmg"
   appcast 'https://www.splashtop.com/wp-content/themes/responsive/downloadx.php?platform=mac',
-          checkpoint: '4ba18465508615ae26412e19d4515c8cd3b19c7dd7e2790c168632d5f7a3fb40'
+          checkpoint: '62e7e0a8da06f90e0241264417fef6b3e49dc7f4ebccb3adbba46a55b673980c'
   name 'Splashtop Streamer'
   homepage 'https://www.splashtop.com/downloads'
 
   pkg 'Splashtop Streamer.pkg'
 
-  uninstall pkgutil: 'com.splashtop.splashtopStreamer.*'
+  uninstall quit:      'com.splashtop.Splashtop-Streamer',
+            launchctl: [
+                         'com.splashtop.streamer-daemon',
+                         'com.splashtop.streamer-for-user',
+                         'com.splashtop.streamer-srioframebuffer',
+                       ],
+            pkgutil:   'com.splashtop.splashtopStreamer.*'
 end


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.