### PR TITLE
Updated cevelop to v1.7.1

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,10 +1,10 @@
 cask 'cevelop' do
-  version '1.7.0-201704121451'
-  sha256 '80cf1c8b2a922e62fbdd23f7bc231feebc869b237ffc39764b1f74c04c622876'
+  version '1.7.1-201704211123'
+  sha256 '5561659187360aa635ce04220544eb841e2e245f1a757c9b90f5f7a8ecef228f'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/',
-          checkpoint: '8906632c2c715dce25d629c7b82321201e66614ba5631f3fbd7b1f5ac3e61686'
+          checkpoint: '913de30886b050e25b8e0996cb593a18412d2dec9d5664fac00b668cbd7e0ef9'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 

--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -3,8 +3,6 @@ cask 'cevelop' do
   sha256 '5561659187360aa635ce04220544eb841e2e245f1a757c9b90f5f7a8ecef228f'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
-  appcast 'https://www.cevelop.com/download/',
-          checkpoint: '913de30886b050e25b8e0996cb593a18412d2dec9d5664fac00b668cbd7e0ef9'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 

--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -3,6 +3,8 @@ cask 'cevelop' do
   sha256 '5561659187360aa635ce04220544eb841e2e245f1a757c9b90f5f7a8ecef228f'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
+  appcast 'https://www.cevelop.com/download/',
+          checkpoint: '913de30886b050e25b8e0996cb593a18412d2dec9d5664fac00b668cbd7e0ef9'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.7.1.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.