### PR TITLE
Update telegram to 2.96-94323

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.95-94203'
-  sha256 '18b908e48d104c5146c53df63198d291e9306e5d3a0c4060df45abe8a6c6c74f'
+  version '2.96-94323'
+  sha256 'e44612746753ec14c4616e5a71c50768a0d544611ba14f449cd5dc9ab7feb29a'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'da3d85bc5eb7e460b5c08955d2ce4d2cc21ca1abcd6699444301cf771f9d6ed2'
+          checkpoint: '9b95cfd73f79a97cfd393ba6f8f689f07049afb9b2d802f0ce762af1f0720a9b'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.