### PR TITLE
Update openra to 20170421

### DIFF
--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -1,11 +1,11 @@
 cask 'openra' do
-  version '20161019'
-  sha256 '216ed0d307a57b7c7c5d8e304ba227e11548aabfa696247446ada5e9f88e5e00'
+  version '20170421'
+  sha256 '4b90257e4a0687a8ae3cf5c1ea257df8df9aad382d94e9cf28d6b5d39d0c89e2'
 
   # github.com/OpenRA/OpenRA was verified as official when first introduced to the cask
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.zip"
   appcast 'https://github.com/OpenRA/OpenRA/releases.atom',
-          checkpoint: 'da02f72b8d7631c584ba88626c1dc82bec737f2ea0de0d1edb41e6a3ca6b800f'
+          checkpoint: '5523815bd7c5e8ddc7c256ef3452d0ff6922996ebb4d8520b91f8d5f2582a576'
   name 'OpenRA'
   homepage 'http://www.openra.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.