### PR TITLE
Update ableton-live-lite to 9.7.2

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '9.7.1'
-  sha256 '8cc2779b3888a74aa481ef6729564ad7938180b5fd9e1c07c79bad32708d26b1'
+  version '9.7.2'
+  sha256 '2e6454bec98f66b8c7e947e5e794cbb555af6a41e5d5b04fc8d5ecfd70bf85fc'
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   name 'Ableton Live Lite'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.