### PR TITLE
Update omegat to 3.6.0_05

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,11 +1,11 @@
 cask 'omegat' do
-  version '3.6.0_04'
-  sha256 '4f08f22619d2b4fa4afca0eecac0f137ddc11a69da4bd79f7e6f6877e99ffba3'
+  version '3.6.0_05'
+  sha256 '7140f71701523a13cc79791aafca105bfa6ed5b401a1cad25954a3007d1b68a2'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}%20update%204/OmegaT_#{version}_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard',
-          checkpoint: '3e8ab4a55aa7d1dd368b7b67072bb8791e388273f8d0437ba2605f5b5123c620'
+          checkpoint: '2155252f798843886b330aa944c9c41f8b53790d3c9fbd36a1a1f332d5248390'
   name 'OmegaT'
   homepage 'http://www.omegat.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.