### PR TITLE
Update soundcleod to 1.3.0

### DIFF
--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -1,11 +1,11 @@
 cask 'soundcleod' do
-  version '1.1.8'
-  sha256 '7f156643b65afa0a5cc42af1e20f1a01756536c13341430d6c2e1d84264c4c1b'
+  version '1.3.0'
+  sha256 '15215156a85848b23034857d64768a94a1f7a866e5eca4dd0efc9ddaf2bb2ae6'
 
   # github.com/salomvary/soundcleod was verified as official when first introduced to the cask
   url "https://github.com/salomvary/soundcleod/releases/download/v#{version}/SoundCleod-#{version}.dmg"
   appcast 'https://github.com/salomvary/soundcleod/releases.atom',
-          checkpoint: 'ffd100db4ee4740cb9f025d3f99d1e5b139ad47fc9f212bd63005cb77dacb47b'
+          checkpoint: '776c533e7f56d078cd42c08cfe0d569c5ad4c7a9679c4afa4257879e51ec3430'
   name 'SoundCleod'
   homepage 'https://soundcleod.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.