### PR TITLE
Update putio-adder to 3.0.3

### DIFF
--- a/Casks/putio-adder.rb
+++ b/Casks/putio-adder.rb
@@ -1,10 +1,10 @@
 cask 'putio-adder' do
-  version '3.0.2'
-  sha256 '592449ab9fb38b9800b4f36afb0b3622b536ab75b6efadf7a40be4a15f08426a'
+  version '3.0.3'
+  sha256 'c42b4c57d63e6fbd615c40723edf5cb9dee47a566f1f6dfedfb7d213797d0b40'
 
   url "https://github.com/nicoSWD/put.io-adder/releases/download/v#{version}/put.io-adder-v#{version}.zip"
   appcast 'https://github.com/nicoSWD/put.io-adder/releases.atom',
-          checkpoint: 'dcf34cf9fcbe706e3a04e7b8a5ecd13656943d8d0cffa0927d3cdf58d55dfe66'
+          checkpoint: '1af60519628aee23f998cb8ddfa51db300f29ddff73e8064e2a95ece9249585f'
   name 'Put.IO Adder'
   homepage 'https://github.com/nicoSWD/put.io-adder'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.