### PR TITLE
Update scythebill to 13.6.0

### DIFF
--- a/Casks/scythebill.rb
+++ b/Casks/scythebill.rb
@@ -1,11 +1,11 @@
 cask 'scythebill' do
-  version '13.5.0'
-  sha256 'bd30b4e8ffba2f5a538f5128ddcef797a9bcbe766d39485de064d3e9fe2f16f6'
+  version '13.6.0'
+  sha256 'c331db9215c1f67f325ca8bf701a4ed26160c1272c84069f28c32aacc2633871'
 
   # amazonaws.com/downloads.scythebill.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.scythebill.com/Scythebill-#{version}.dmg"
   appcast 'http://www.scythebill.com/download.html',
-          checkpoint: '1f5bdc71b76823ce6f6503c101b3e9a519ac21695b1b4436c2ec4dbc860943dc'
+          checkpoint: 'bd019e0885d4e16340f8bb00be73b0ad01a26ff69e9fbf126f8d2102b345c4e8'
   name 'Scythebill'
   homepage 'http://www.scythebill.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.