### PR TITLE
Update lifesize to 10.3.5-224

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,9 +1,11 @@
 cask 'lifesize' do
-  version '10.3.3-209'
-  sha256 '182b67f1649f5d3be8d844ef78976f8d05225bf8994bd2b2852859d048105be0'
+  version '10.3.5-224'
+  sha256 '9ed0f8f45385dcba95bd61d42a6753a493cd1386150439b38e5109a76fdd99dc'
 
   # cdn.lifesizecloud.com was verified as official when first introduced to the cask
   url "https://cdn.lifesizecloud.com/LifesizeCloud-#{version}-signed.pkg"
+  appcast 'https://cdn.lifesizecloud.com/OSX_Clients/Sparkle_Upgrades/LifesizeAppcast.xml',
+          checkpoint: 'f508b0aa56c8d4b0736018cfd3166878122c3df409a02c3b4ce7dab0149ae4b8'
   name 'lifesize'
   homepage 'https://www.lifesize.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.