### PR TITLE
Update dropdmg to 3.4.6

### DIFF
--- a/Casks/dropdmg.rb
+++ b/Casks/dropdmg.rb
@@ -1,6 +1,6 @@
 cask 'dropdmg' do
-  version '3.4.5'
-  sha256 '7bfe7042a454debefbfc17d52d57c407a416b10c78b1944f8c3b11152bfd1c22'
+  version '3.4.6'
+  sha256 '90d130084b39bd1b42f0cc140e8dbc972e0f6dc9583a42322b44631a2d6086fe'
 
   url "https://c-command.com/downloads/DropDMG-#{version}.dmg"
   name 'DropDMG'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.