### PR TITLE
Update tagspaces to 2.8.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,11 +1,11 @@
 cask 'tagspaces' do
-  version '2.7.0'
-  sha256 'c1214f39732de3531bd4ccf9558ddb40d56b1dad3acef92a02c49cae1bfe4194'
+  version '2.8.0'
+  sha256 '840f76b0429390c5a78600802a4974093e8f137ba9c0acc316e62d74ae92d551'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-#{version}-osx64.zip"
   appcast 'https://github.com/tagspaces/tagspaces/releases.atom',
-          checkpoint: 'fd5b21e6f3efe7295ab25b09e1eaa3cfc53f28798822839fc2df895df152b9cf'
+          checkpoint: 'e601645ae85002fad000f8cd4295c4a47fe37863cb43a161afc7e8bd41322a7b'
   name 'TagSpaces'
   homepage 'https://www.tagspaces.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.