### PR TITLE
Update boostnote to 0.8.8

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.7'
-  sha256 'c04a17c97426ccb4c780c45469f5f4e9f2a4d5af7afcbea099a89a1d1ef36f8b'
+  version '0.8.8'
+  sha256 '320e7cce5711fab8e541f2124549790178a56953cafb7310c01bce3520b574fe'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: 'a92d744121e88bb9f117fde6c4ab8dabf99ef1050283d4122d96493cd1014b12'
+          checkpoint: 'abcad29ba9d5e6f2b182cc7b2d1361dd80ad7c6e45d9bc015c404167fe9633a0'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

