### PR TITLE
Update tiled to 0.18.2

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,11 +1,11 @@
 cask 'tiled' do
-  version '0.18.1'
-  sha256 '9e10a68320cc46137f9f8efbab161d63d9d20b998230ea25d20e48d21387494b'
+  version '0.18.2'
+  sha256 '138d5492d202e3209481078eb9bf5e346067b42446eb5d9086a7f49bba55df13'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
   appcast 'https://github.com/bjorn/tiled/releases.atom',
-          checkpoint: 'ee27a4e25a860f377a6823bfdce3b72fad3d25103513eecb445a709aa8d24e93'
+          checkpoint: '8bc7a9709eee6356947b83b0e4eca59857e6700ed13bd810a510580357377e22'
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.