### PR TITLE
Added chatmate-for-whatsapp with latest

### DIFF
--- a/Casks/chatmate-for-whatsapp.rb
+++ b/Casks/chatmate-for-whatsapp.rb
@@ -1,0 +1,20 @@
+cask 'chatmate-for-whatsapp' do
+  version :latest
+  sha256 :no_check
+
+  # dl.devmate.com/net.coldx.mac.WhatsApp was verified as official when first introduced to the cask
+  url 'https://dl.devmate.com/net.coldx.mac.WhatsApp/ChatMateforWhatsApp.dmg'
+  name 'ChatMate for WhatsApp'
+  homepage 'https://chatmate.io/'
+
+  app 'ChatMate for WhatsApp.app'
+
+  zap delete: [
+                '~/Library/Application Support/ChatMate for WhatsApp',
+                '~/Library/Application Support/ColdX/net.coldx.mac.WhatsApp',
+                '~/Library/Caches/net.coldx.mac.WhatsApp',
+                '~/Library/Cookies/net.coldx.mac.WhatsApp.binarycookies',
+                '~/Library/Preferences/net.coldx.mac.WhatsApp.plist',
+                '~/Library/WebKit/net.coldx.mac.WhatsApp',
+              ]
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download chatmate-for-whatsapp` is error-free.
- [X] `brew cask style --fix chatmate-for-whatsapp` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install chatmate-for-whatsapp` worked successfully.
- [X] `brew cask uninstall chatmate-for-whatsapp` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
