### PR TITLE
Update ransomwhere to 1.2.0

### DIFF
--- a/Casks/ransomwhere.rb
+++ b/Casks/ransomwhere.rb
@@ -4,10 +4,12 @@ cask 'ransomwhere' do
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/RansomWhere_#{version}.zip"
-  appcast 'https://objective-see.com/products.json',
-          checkpoint: '89dae1300c90242339b554780b2592f96a3da1be144c26555b290f499e1abde5'
+  appcast 'https://objective-see.com/products/changelogs/RansomWhere.txt',
+          checkpoint: '1021aba2b54083b9d794406402eb89f2a38dac6fd23b843aad9ed5b42b2edd90'
   name 'RansomWhere'
   homepage 'https://objective-see.com/products/ransomwhere.html'
+
+  depends_on macos: '>= :mountain_lion'
 
   installer script: {
                       executable: "#{staged_path}/RansomWhere_Installer.app/Contents/MacOS/RansomWhere_Installer",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.