### PR TITLE
Update kite to 0.20170421.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170419.0'
-  sha256 '6794196ba6365433fece6e2c8004b0ba32b28973c24c2f85a0553a850039f262'
+  version '0.20170421.0'
+  sha256 '398d809b9b3529a75c26e95e6bb6c924bc822eff5966c17518c7072a0f0fe254'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: 'a0d6674f48647c35dd58a06fc3db29cebe7ad29e33537ab05e356fdc5ac807b2'
+          checkpoint: 'd6b17c1d294c7cf4e239380b3b5bd2529f300d2279c583805d8e83335dde0f60'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.