### PR TITLE
Update geogebra to 6.0.348.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,15 +1,16 @@
 cask 'geogebra' do
-  version '6.0.295.0'
-  sha256 '597bd732b3096defd129501b4dcd0282cb257cb82c495a4006cef3c8cdc30a72'
+  version '6.0.348.0'
+  sha256 'f63bf6f5f75f571b07832e9b88632259d8491adce8b61dcac8c53d0e4bb95a00'
 
-  url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-MacOS-Portable-#{version.dots_to_hyphens}.zip"
+  url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-MacOS-Portable-#{version.dots_to_hyphens}.pkg"
   name 'GeoGebra'
   homepage 'https://www.geogebra.org/'
 
-  app 'GeoGebra.app'
+  pkg "GeoGebra-MacOS-Portable-#{version.dots_to_hyphens}.pkg"
 
   uninstall quit:       'org.geogebra.mathapps',
-            login_item: 'GeoGebra'
+            login_item: 'GeoGebra',
+            pkgutil:    'org.geogebra6.mac'
 
   zap delete: [
                 '~/Library/GeoGebra',


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.