### PR TITLE
Update yujitach-menumeters to 1.9.5

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -1,8 +1,10 @@
 cask 'yujitach-menumeters' do
-  version '1.9.4'
-  sha256 'eaf8c7e23c68248d6231de94095157758046f0cb574c8651a9c986659fba58d5'
+  version '1.9.5'
+  sha256 '1f1b1c50e2571be5a3e380642019cc8fc46a482e230d04c4a2ff4514b823a6a8'
 
   url "http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
+  appcast 'https://github.com/yujitach/MenuMeters/releases.atom',
+          checkpoint: '01a1f125355897c488c91588ad65c1d57628ef9a8f4afde5c749a8762851ce14'
   name 'MenuMeters for El Capitan (and later)'
   homepage 'http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.