### PR TITLE
Update wraparound to 2.0b3-2020

### DIFF
--- a/Casks/wraparound.rb
+++ b/Casks/wraparound.rb
@@ -1,8 +1,8 @@
 cask 'wraparound' do
-  version '2.0b2'
-  sha256 'f156dfa65dad43d38cb3b0f8febd8de9711f4794bb166a293ced93860ebf7879'
+  version '2.0b3-2020'
+  sha256 '6b7626af484bc6070cb822197dbe22014b3a1433ac072caf57d5272ada2437f2'
 
-  url "http://www.digicowsoftware.com/downloads/Wraparound#{version}-2010.zip"
+  url "http://www.digicowsoftware.com/downloads/Wraparound#{version}.zip"
   name 'Wraparound'
   homepage 'http://www.digicowsoftware.com/detail?_app=Wraparound'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.