### PR TITLE
mpv.rb: add binary

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -10,4 +10,5 @@ cask 'mpv' do
   homepage 'https://mpv.io/'
 
   app 'mpv.app'
+  binary "#{appdir}/mpv.app/Contents/MacOS/mpv"
 end


### PR DESCRIPTION
The binary is a full-featured CLI app. The `app` bundle around it is just a simple wrapper and [they encourage direct usage of the binary](https://github.com/mpv-player/mpv/issues/4354#issuecomment-296448420).