### PR TITLE
Update processing to 3.3.1

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,10 +1,10 @@
 cask 'processing' do
-  version '3.3'
-  sha256 'a3cb41eb4a4d69484c5e5359d9a03e526a4d4e97bbdb177bda2ee24d51b99a75'
+  version '3.3.1'
+  sha256 'dffac411d9ea98be868e888d4b282f3ed6454da137f6779f0101a6ab391fd987'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: '63af13fc24f0f94d590fe12aad94394b5139a8a3a85df968db7e6ecf556cd24d'
+          checkpoint: '57cf02861e7246ca2a052527d5d08bf236611e2a8362862605a3be377eed800c'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.