### PR TITLE
Update aria-maestosa to 1.4.13c

### DIFF
--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -1,10 +1,10 @@
 cask 'aria-maestosa' do
-  version '1.4.13'
-  sha256 'a3a04954ff7258141d4762659f49a204e42f24a06fab6ba318f47a749e6398c0'
+  version '1.4.13c'
+  sha256 '59d77eb575ed6dcd4d3caeddac78dfe26f44c272e25e480e55733f15428d0946'
 
   url "https://downloads.sourceforge.net/ariamaestosa/AriaMaestosa-osx-#{version}.zip"
   appcast 'https://sourceforge.net/projects/ariamaestosa/rss',
-          checkpoint: '27ab42b1eaccdf79de35fa54c8dfd33c8e25b079a221e14d11e7d17efb64cac6'
+          checkpoint: '4f4a6df18a56ca2469c1d07d9e97451988ecd9c79a5fdc9978b4510dfc3a827a'
   name 'Aria Maestosa'
   homepage 'http://ariamaestosa.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.