### PR TITLE
Update soundcloud-downloader to 2.7.2

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
-  version '2.6.8'
-  sha256 'eeb09d781956764e7c7ee949b18cb0de30848b4473deba3083279c5ed4e1ee67'
+  version '2.7.2'
+  sha256 '0272b1ebd6c6d28e4737ec08cb6ef560cc4c9f2b9d626806d4bef58fb37e278b'
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
   appcast 'http://black-burn.ch/applications/scd/updates.php?hwni=1',
-          checkpoint: 'cdc2148baf8a3d61472eaac288b66b3cb297005979800fe990a08e8e36f078b4'
+          checkpoint: '18614c69ab696d1af1aeee1edf18c87ebc29aa81af2c33d1ab283e8f869aafb8'
   name 'SoundCloud Downloader'
   homepage 'http://black-burn.ch/scd/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.