### PR TITLE
Update the-escapers-flux to 7.0.1

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '6.1.13'
-  sha256 '582bd6abcf49f3c1e67547020af7a7fd4026f3c7e8e3ff373e985361e98934f9'
+  version '7.0.1'
+  sha256 'eabe7049aad6a56a80b8ecdb3abc8163100f8a2a9eb5bc1e4c48864dfeb70683'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '9de24e75553e652fad15b333e89bd126668b51d45dcbcacea9092f23e804067c'
+          checkpoint: '4acbad66977c8639e30f8d7b6c1d3a40e05d8b26de251c4a54fd19321dbb3e81'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.