### PR TITLE
Update tla-plus-toolbox to 1.5.3

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,9 +1,11 @@
 cask 'tla-plus-toolbox' do
-  version '1.5.2'
-  sha256 '4c35713d1c5cdb8c4b3883fcd002098dcc1d2e64f9251455857fcb71a44d00e6'
+  version '1.5.3'
+  sha256 'a6cb45ec112930a208d63fe31f0f42f45e07c4bbdf977ffc9ef656269e9eb1d5'
 
-  # tla.msr-inria.inria.fr/tlatoolbox was verified as official when first introduced to the cask
-  url "https://tla.msr-inria.inria.fr/tlatoolbox/products/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"
+  # github.com/tlaplus/tlaplus/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"
+  appcast 'https://github.com/tlaplus/tlaplus/releases.atom',
+          checkpoint: '63d6d8ff6410ea03083cd1ca9bc12668613fb43ae9935d6a2c89ba086e35f1c4'
   name 'TLA+ Toolbox'
   homepage 'https://lamport.azurewebsites.net/tla/toolbox.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.