### PR TITLE
Update postage to 3.2.6

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.2.4'
-  sha256 '18e5cb40fbf965a70ffb208ac5eb53a103d84a6ed45d5e48b1951485bbfa1634'
+  version '3.2.6'
+  sha256 '89e81c9b89d4227fc665d9726c58b5e007cb3d8abe5547f96a85a8d900f3d9fb'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: '7044df090cc2a1845326ae5c3df077d8cfdcab2d77fea4bb4be68886b984053b'
+          checkpoint: 'dfe95068750c40183306fc3046f906e78ea83bb0cfa7220415268099afbf7a2b'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.