### PR TITLE
Update photoninja to 1.3.5c

### DIFF
--- a/Casks/photoninja.rb
+++ b/Casks/photoninja.rb
@@ -1,6 +1,6 @@
 cask 'photoninja' do
-  version '1.2.7'
-  sha256 'cf159ad6075fded4c4ab14c0f427bd9b54554a0eb60c3c1a6c77309933331010'
+  version '1.3.5c'
+  sha256 '1d557da4734a84abe2f45e7f5c562dc9ebdb5a8430865a8a97bcb54361ab30d4'
 
   # picturecode.cachefly.net was verified as official when first introduced to the cask
   url "https://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.