### PR TITLE
Update doomsday-engine to 2.0.0

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,15 +1,12 @@
 cask 'doomsday-engine' do
-  version '1.15.8'
-  sha256 '6882d3ff2aa855096e003ec19b1ccca4e9b2b4576d2c667abf8e48310f08f098'
+  version '2.0.0'
+  sha256 '4694061347d8f14880de8e5973816424263552b28773596116a410c7e3c721f1'
 
   # sourceforge.net/deng was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/deng/doomsday_#{version}.dmg"
-  appcast 'https://sourceforge.net/projects/deng/rss',
-          checkpoint: '889f9570d9b2cdc64198a4766473d44f8c923affd73ff6879fed3f5feec6f87c'
+  url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
   name 'Doomsday Engine'
   homepage 'http://dengine.net/'
 
-  pkg 'Doomsday.pkg'
-
-  uninstall pkgutil: 'net.dengine.doomsday.*'
+  app 'Doomsday.app'
+  app 'Doomsday Shell.app'
 end


### PR DESCRIPTION
* Removed appcast as it is full of nightly builds and not really any use for stable version tracking

---
 
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.