### PR TITLE
Update trezor-bridge to 1.2.1

### DIFF
--- a/Casks/trezor-bridge.rb
+++ b/Casks/trezor-bridge.rb
@@ -1,11 +1,11 @@
 cask 'trezor-bridge' do
-  version '1.2.0'
-  sha256 'be5b39d77e142ba87dab75fd7c0c8840fb69ad47acad4ace1acc8f66ff777ec5'
+  version '1.2.1'
+  sha256 'd87255da91d4815ab289e79d2e1609888589c42a0a22b6861f26816a4ad920da'
 
   # wallet.mytrezor.com/data/bridge was verified as official when first introduced to the cask
   url "https://wallet.mytrezor.com/data/bridge/#{version}/trezor-bridge-#{version}.pkg"
   appcast 'https://wallet.mytrezor.com/data/bridge/latest.txt',
-          checkpoint: '1e5b51cde515396a9fa762909cf8ca6584ccc564b325d2eebeea76175fe95c4d'
+          checkpoint: '6cf4e084b47f33c9b02ef79279d157833868f8f70514169a768be353ee328fea'
   name 'TREZOR Bridge'
   homepage 'https://wallet.trezor.io/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.