### PR TITLE
Update the-escapers-flux to 7.0.3

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.0.1'
-  sha256 'eabe7049aad6a56a80b8ecdb3abc8163100f8a2a9eb5bc1e4c48864dfeb70683'
+  version '7.0.3'
+  sha256 '1f6f9f41da1b37661be42167c97a61936ec789d4cc2731e9d303fda103392a8a'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '4acbad66977c8639e30f8d7b6c1d3a40e05d8b26de251c4a54fd19321dbb3e81'
+          checkpoint: '1e8d171e9e6e964de17ed9fb967afc5f205085d9d184f7ec5c82484024b50c42'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.