### PR TITLE
Update telegram to 2.96-94323

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
   version '2.96-94323'
-  sha256 'e44612746753ec14c4616e5a71c50768a0d544611ba14f449cd5dc9ab7feb29a'
+  sha256 'afc6196f064368e6b6084d2b844d83f15295bc51101e0d5addc3839ddb510a70'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '9b95cfd73f79a97cfd393ba6f8f689f07049afb9b2d802f0ce762af1f0720a9b'
+          checkpoint: 'bfce3755e325aa52c76a07035d4fe44bb89067a94ae1d8a25dae4c0bd1bbc698'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.