### PR TITLE
coconutbattery - fix sha mismatch - remove outdated `versions`

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -1,22 +1,14 @@
 cask 'coconutbattery' do
-  if MacOS.version <= :tiger
-    version '2.6.6'
-    sha256 '8d235b237e42754ceda26af2babc160fd23f890d0fe6d7780b86a8e9c6effe42'
-    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
-  elsif MacOS.version <= :snow_leopard
-    version '2.8'
-    sha256 'fcfc81214ff26afff9f5c6c7cdc455b23ac898b6918f864b641a9e31526692d4'
-    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
-  elsif MacOS.version <= :mavericks
+  if MacOS.version <= :mavericks
     version '3.3.4'
     sha256 '0edf6bdaf28fb3cc9c242fd916c348fbbae30a5356ddc1d6e5158d50f96d740d'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.dots_to_underscores}.zip"
   else
     version '3.6'
-    sha256 '5a44bd35ad37c42ae8354f4ffec978772f700e3ebfeb37bf398cd87a1e91a174'
+    sha256 '0a36363af6dfb5fd8f1c7c43933b148040eec95dae8ea3589ff71d1f053c6444'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml',
-            checkpoint: '42708a4f00ab9826dfbd84b4d8e1410c9ac9714637cdb7ac4e586ea296accfa0'
+            checkpoint: '97ae1f9d69b836bac944132bad2faa3dfa587c901c7ce0a7499e5815e223f443'
   end
 
   name 'coconutBattery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fix `sha` mismatch. https://github.com/caskroom/homebrew-cask/pull/32782

Remove `tiger` and `snow_leopard` versions.