### PR TITLE
appcleaner - remove outdated `version`

### DIFF
--- a/Casks/appcleaner.rb
+++ b/Casks/appcleaner.rb
@@ -1,21 +1,15 @@
 cask 'appcleaner' do
-  if MacOS.version <= :leopard
-    version '1.2.2'
-    sha256 '58972cb1b8256d6de1a11ed225c94b240c2923f1c814975ccbcb94806fc439dc'
-    url "https://freemacsoft.net/downloads/AppCleaner#{version}.dmg"
+  if MacOS.version <= :mavericks
+    version '2.3'
+    sha256 '69da212e2972e23e361c93049e4b4505d7f226aff8652192125f078be7eecf7f'
   else
-    if MacOS.version <= :mavericks
-      version '2.3'
-      sha256 '69da212e2972e23e361c93049e4b4505d7f226aff8652192125f078be7eecf7f'
-    else
-      version '3.4'
-      sha256 '0c60d929478c1c91e0bad76d3c04795665c07a05e45e33321db845429c9aefa8'
-      appcast 'https://freemacsoft.net/appcleaner/Updates.xml',
-              checkpoint: '2743c995613fd53c24e271384e2de79eb781dd4d21fd32627e3ac244704e1b04'
-    end
-    url "https://www.freemacsoft.net/downloads/AppCleaner_#{version}.zip"
+    version '3.4'
+    sha256 '0c60d929478c1c91e0bad76d3c04795665c07a05e45e33321db845429c9aefa8'
+    appcast 'https://freemacsoft.net/appcleaner/Updates.xml',
+            checkpoint: '2743c995613fd53c24e271384e2de79eb781dd4d21fd32627e3ac244704e1b04'
   end
 
+  url "https://www.freemacsoft.net/downloads/AppCleaner_#{version}.zip"
   name 'AppCleaner'
   homepage 'https://freemacsoft.net/appcleaner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Remove `leopard` version