### PR TITLE
Update qt-creator to 4.2.2

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.2.1'
-  sha256 '0abe38936d0e6d5cadb3ba877053ad9177f380518ba6fc9571b51160e1ae0e25'
+  version '4.2.2'
+  sha256 '3dcdf070bc0cf3e99a587340119b6bc31d7b123dbf7ad2f904812fc78a0e6fb1'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.