### PR TITLE
Update qfinder-pro to 2.4.1.0328

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,10 +1,10 @@
 cask 'qfinder-pro' do
-  version '2.4.0.0316'
-  sha256 '379b6e6c6b8611cda3394ba34fb754b0a67a82694f0d935c270b0f746941eef2'
+  version '2.4.1.0328'
+  sha256 '1efdc25912281e71fd4cbfbb0646b7492659741022494e9405a8ae504d962b25'
 
   url "http://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'http://update.qnap.com/SoftwareRelease.xml',
-          checkpoint: '772710ef910a5786ba790ed6d963b7a9ae391d2459e18f65a631a4e0531935fd'
+          checkpoint: '6c9a8e8468c537a19ad9c60d92f702045af614022fde70334c9692da11587362'
   name 'Qnap Qfinder Pro'
   homepage 'https://www.qnap.com/en/utilities#utliity_5'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.