### PR TITLE
Update screens to 3.8.7

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,10 +1,8 @@
 cask 'screens' do
-  version '3.8.4'
-  sha256 '340fbcfee35b7eacd170e58cbcd2d9f3ca6078ef54371f245115d74c55e46ce3'
+  version '3.8.7'
+  sha256 'b59924846a4e0d6bda05626657c06a17d43ae564a2c9307de349bcf885f45e6a'
 
   url "https://download.edovia.com/screens/Screens_#{version}.zip"
-  appcast 'https://edovia.com/screens/',
-          checkpoint: 'afbc9761b0f6069adf295371727c6505eadc088aba11bec329c4af4fd25ed3f1'
   name 'Screens'
   homepage 'https://edovia.com/screens/#mac'
 


### PR DESCRIPTION
* Appcast removed as the web page has changed and no longer indicates version

---
 
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.