### PR TITLE
Update mjml to 2.0.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,11 +1,11 @@
 cask 'mjml' do
-  version '1.7.0'
-  sha256 '2011466db5b37cc2e06aec3412bf0a1e560fc59636a39e3b224bddb507818e80'
+  version '2.0.0'
+  sha256 '90523caaea7b3a391cafd9c423a8db8f4b5a3f4f49a1a9e7654d4de911588bed'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-osx_#{version}.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom',
-          checkpoint: '4debad94aeeb57ed7f2597d8f31e62990c7b6567fb1472af3f78f8dbf44d0d94'
+          checkpoint: 'af7a682eb55ee1a3b5334795ea8a4cab00e517b69da3d29f32b39fa61e239043'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.