### PR TITLE
Update cinder to 0.9.1

### DIFF
--- a/Casks/cinder.rb
+++ b/Casks/cinder.rb
@@ -1,10 +1,10 @@
 cask 'cinder' do
-  version '0.9.0'
-  sha256 '29506d4fe2e0f64de740d5569117d51e0dcd6f195cb05abf66e42e74f4eee02c'
+  version '0.9.1'
+  sha256 '41e85a595b17181ef46309d44fb5790de93ddf4a7abb5c7261b5a3ba87563337'
 
   url "https://libcinder.org/static/releases/cinder_#{version}_mac.zip"
   appcast 'https://github.com/cinder/cinder/releases.atom',
-          checkpoint: '34a56a382e2a9712275ca7949028059987eb270356566e4e3599aebc856256a9'
+          checkpoint: 'e0db8a004ea98e9cd20247a819305bc1e74486f059e1374fe522dbf09c44c2a0'
   name 'Cinder'
   homepage 'https://libcinder.org/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.