### PR TITLE
Update fredm-fuse to 1.3.4

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,12 +1,12 @@
 cask 'fredm-fuse' do
-  version '1.3.1'
-  sha256 'caeb272533fefcaad6864c8f556deb32294d3c3cc207aae8e21a2036a58c3415'
+  version '1.3.4'
+  sha256 'ed2cd936a220091c55285b2543ce7ec19603018dafdf12f1cc5bff758315a999'
 
-  url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOSX-#{version}.zip"
+  url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '37a3f5feb4738593160361ed1018da1d37a9aa5c855e3c7758e67fd807f7c418'
+          checkpoint: '879ca9987e1fae8ec6ce39f04a90d8e489afdb97c990e7c44ad1a869befc4e25'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 
-  app 'Fuse for Mac OS X/Fuse.app'
+  app 'Fuse for MacOS/Fuse.app'
 end


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.