### PR TITLE
Update the-escapers-flux to 7.0.4

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.0.3'
-  sha256 '1f6f9f41da1b37661be42167c97a61936ec789d4cc2731e9d303fda103392a8a'
+  version '7.0.4'
+  sha256 '39ac23c213731caf5474f623b620a2cb9a1c8c61403ac3bcfa44c00ffc121342'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '1e8d171e9e6e964de17ed9fb967afc5f205085d9d184f7ec5c82484024b50c42'
+          checkpoint: '26104dcb813671c024c6e70d4ab881d566840d178acd9065bd56b5b2c74f2d0c'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.