### PR TITLE
Update tankix to 598

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '597'
-  sha256 '0f1d21818bb4e28b2cae2a9c9ccdf2f9513c539faa41878a538b33ae5359f1e8'
+  version '598'
+  sha256 'a2be5f6e9543bffe9e3b0bf3a40748a82d95aa1315a0eac921f1f832a30d4ab6'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.