### PR TITLE
Update bitcoin-classic to 1.2.5

### DIFF
--- a/Casks/bitcoin-classic.rb
+++ b/Casks/bitcoin-classic.rb
@@ -1,11 +1,11 @@
 cask 'bitcoin-classic' do
-  version '1.2.3'
-  sha256 'f691d218b5c1f24c458a3a5b144518a99dbc64fa0fcc4329735e35f39f498fa0'
+  version '1.2.5'
+  sha256 '43376113b68a115ab3d04135527bd3d660b3183cd6a31d27471d93886de3051f'
 
   # github.com/bitcoinclassic was verified as official when first introduced to the cask
   url "https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v#{version}/bitcoin-#{version}-osx.dmg"
   appcast 'https://github.com/bitcoinclassic/bitcoinclassic/releases.atom',
-          checkpoint: '64a310cb19e13569c87f8b054e84de08a894e4e456d78f49346018930b751975'
+          checkpoint: 'f269c31370e255b28402bf355d5cea800267202f4008266469fe89d1e6e0924b'
   name 'Bitcoin Classic'
   homepage 'https://bitcoinclassic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.