### PR TITLE
Update browser-chooserx to 1.3.6

### DIFF
--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -1,10 +1,10 @@
 cask 'browser-chooserx' do
-  version '1.3.5'
-  sha256 '681f04c397abeab090bf2d00f626a8fca1c88ba70b5896e72b7a0cbf4dfbb621'
+  version '1.3.6'
+  sha256 '0cecf4e72e345bd6cc8de96807897a28290624a4c904399be1a5e530fded2487'
 
   url 'https://www.bdevapps.com/files/downloads/Browser%20ChooserX.zip'
   appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
-          checkpoint: '87c94dff51987453b566647b19cb38f57e855e5842dd8b86848eba9f55ef1cf1'
+          checkpoint: '01a52d65b6e9c758ad6c1964cba23c4462d93ca7008c38fc20d3940dc7e2ac2c'
   name 'Browser ChooserX'
   homepage 'https://bdevapps.com/'
 
@@ -13,6 +13,11 @@ cask 'browser-chooserx' do
   app 'Browser ChooserX.app'
 
   zap delete: [
+                '~/Library/Application Scripts/com.bdevapps.Browser-ChooserX.Open-with-Browser-ChooserX',
+                '~/Library/Caches/com.bdevapps.Browser-ChooserX',
+                '~/Library/Containers/com.bdevapps.Browser-ChooserX.Open-with-Browser-ChooserX',
+                '~/Library/Cookies/com.bdevapps.Browser-ChooserX.binarycookies',
+                '~/Library/Group Containers/group.com.bdevapps.BrowserChooserX',
                 '~/Library/Preferences/com.bdevapps.Browser-ChooserX.plist',
                 '~/Library/Saved Application State/com.bdevapps.Browser-ChooserX.savedState',
               ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.