### PR TITLE
Update opera to 44.0.2510.1449

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '44.0.2510.1218'
-  sha256 '1cff95623e5a4cbb4e6e9594b3ea83eac22d880a63252dc7683d349a617f34d7'
+  version '44.0.2510.1449'
+  sha256 '5699184a138d9ec6932b4106b3ed905ea37b5aab5d7f82ef900fe39a73013395'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.