### PR TITLE
Update telegram to 2.96-94514

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '2.96-94323'
-  sha256 'afc6196f064368e6b6084d2b844d83f15295bc51101e0d5addc3839ddb510a70'
+  version '2.96-94514'
+  sha256 '8188e3dab733d33f8ffea4e9d87f66fd4c473cd250ac13d50ba8696bf8210a77'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'bfce3755e325aa52c76a07035d4fe44bb89067a94ae1d8a25dae4c0bd1bbc698'
+          checkpoint: '4daa0e964e32e7b7f513acc61fed3341373fda5a33dbeaf85c3c0b6fbe009bdf'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.