### PR TITLE
Update bee to 2.4.11

### DIFF
--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -1,13 +1,21 @@
 cask 'bee' do
-  version '2.4.10'
-  sha256 '65a9ba7cc0eb48249cf57ef31f0e56338a0c72dd39bdc0668f0c4284b82cfbfd'
+  version '2.4.11'
+  sha256 'e274ef79065a077427774727f2896b340a98b0a0703ab8a491302cdf32463070'
 
   # bee-app.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://bee-app.s3.amazonaws.com/public/Bee-#{version}.zip"
   appcast 'https://s3.amazonaws.com/www.neat.io/appcasts/bee-appcast.xml',
-          checkpoint: '577df18dd9fd5db5a9d7f02cc3e985be21b70c2de51becc9b2d0f553ba4da707'
+          checkpoint: '05094dc3e9f421d0dc0c0656ade2da908f389873672b94f63e03e79b10d2f5c8'
   name 'Bee'
   homepage 'http://www.neat.io/bee/'
 
   app 'Bee.app'
+
+  zap delete: [
+                '~/Library/Application Scripts/io.neat.Bee',
+                '~/Library/Application Scripts/io.neat.Bee-Mutator',
+                '~/Library/Application Scripts/io.neat.Bee-Updater',
+                '~/Library/Containers/io.neat.Bee',
+                '~/Library/Containers/io.neat.Bee-Mutator',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.