### PR TITLE
Update the-escapers-flux to 7.0.5

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.0.4'
-  sha256 '39ac23c213731caf5474f623b620a2cb9a1c8c61403ac3bcfa44c00ffc121342'
+  version '7.0.5'
+  sha256 '773ca79588ef41bb7b2e5b43fca37a8c25cacc723b4e7efe46223808709284c7'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '26104dcb813671c024c6e70d4ab881d566840d178acd9065bd56b5b2c74f2d0c'
+          checkpoint: '911687c0fafd3a486e20c40e7311b5dc0b410fb7aa2adf41bd4af4d472424b7b'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.