### PR TITLE
Update lingon-x to 5.0.1

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.0'
-  sha256 'b0aa33d90994d3724c60357ad50248f4db25ac8058c5596db390758ec5d3fd17'
+  version '5.0.1'
+  sha256 '0d6dad8bffcb393702656bf27f1514de061143667e4068972c5f2d8bc0e3d768'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'a2c4b4fce8357186a6ea23b30db9bd75550a00845571808cfb87ed1421857288'
+          checkpoint: 'afc0efe73dd7a0093a4a76cc315697fb064f80755f0897a553e785f407cef398'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.