### PR TITLE
Upgrade epic to 53.0.2785.143

### DIFF
--- a/Casks/epic.rb
+++ b/Casks/epic.rb
@@ -1,6 +1,6 @@
 cask 'epic' do
-  version '49.0.2575.1'
-  sha256 'a4151a95705685257c7b38a1c6d6496a9a82743c49bdc3ed9c12957cf714e67b'
+  version '53.0.2785.143'
+  sha256 'd5182231a9cbecbe39ff3b562e876b3f03092c71c8ccfb7c71880c88bd271297'
 
   # s3.amazonaws.com/epicprivacybrowser was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/epicprivacybrowser/mac/Epic_OSX_#{version}.zip"

--- a/Casks/epic.rb
+++ b/Casks/epic.rb
@@ -2,8 +2,8 @@ cask 'epic' do
   version '53.0.2785.143'
   sha256 'd5182231a9cbecbe39ff3b562e876b3f03092c71c8ccfb7c71880c88bd271297'
 
-  # s3.amazonaws.com/epicprivacybrowser was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/epicprivacybrowser/mac/Epic_OSX_#{version}.zip"
+  # macepic-cbe.kxcdn.com was verified as official when first introduced to the cask
+  url "https://macepic-cbe.kxcdn.com/Epic_#{version}.dmg"
   appcast 'https://updates.epicbrowser.com/mac_updates/appcast.xml',
           checkpoint: 'baa4248683b2bde4cb5124bada0f5f7330ed865ef266ef7a7014729269debdf3'
   name 'Epic Privacy Browser'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.