### PR TITLE
Update xiami to 3.0.4

### DIFF
--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -1,9 +1,9 @@
 cask 'xiami' do
-  version '3.0.2'
-  sha256 '6fe366c25bf53597dfc955a2581f22992ba0fef766461c23964c72ade9b6a9fb'
+  version '3.0.4'
+  sha256 '997757060358f32a33f8636fdfc369b9eacae8342c3cb74397287619c2149e91'
 
   # gxiami.alicdn.com/xiami-desktop was verified as official when first introduced to the cask
-  url "http://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"
+  url "http://gxiami.alicdn.com/xiami-desktop%2fupdate%2f%e8%99%be%e7%b1%b3%e9%9f%b3%e4%b9%90-#{version}.dmg"
   name 'Xiami'
   name '虾米音乐'
   homepage 'http://www.xiami.com/'


### PR DESCRIPTION
I am running OSX 10.10.5, and I have this problem with starting Xiami 3.0.4:

![xiami_3 0 4_error](https://cloud.githubusercontent.com/assets/760008/25466721/dcc6e7b0-2b3c-11e7-92a0-dd6dccfd9af1.png)

```
Uncaught Exception:
Error: Cannot find module '/Applications/虾米音乐.app/Contents/Resources/app.asar/app/node_modules/sqlite3/lib/binding/electron-v1.6-darwin-x64/node_sqlite3.node'
    at Module._resolveFilename (module.js:470:15)
    at Function.Module._resolveFilename (/Applications/虾米音乐.app/Contents/Resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Applications/虾米音乐.app/Contents/Resources/app.asar/app/node_modules/sqlite3/lib/sqlite3.js:4:15)
    at Object.<anonymous> (/Applications/虾米音乐.app/Contents/Resources/app.asar/app/node_modules/sqlite3/lib/sqlite3.js:190:3)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
```

Please advise how I should proceed. 
