### PR TITLE
Updates cdn download link.

### DIFF
--- a/Casks/cakebrew.rb
+++ b/Casks/cakebrew.rb
@@ -4,7 +4,7 @@ cask 'cakebrew' do
 
   url "https://cakebrew-377a.kxcdn.com/cakebrew-#{version}.dmg"
   appcast 'https://www.cakebrew.com/appcast/profileInfo.php',
-          checkpoint: 'febdbeca94df821a28298c2454f8d0c0a7272379bbe743174e2764865aac5bcb'
+          checkpoint: 'a1aaa9cb869aa3740faf459cf4fdbed932d5bd00375854ad6ca58a1b562624b4'
   name 'Cakebrew'
   homepage 'https://www.cakebrew.com/'
 

--- a/Casks/cakebrew.rb
+++ b/Casks/cakebrew.rb
@@ -2,7 +2,7 @@ cask 'cakebrew' do
   version '1.2.3'
   sha256 '12b35753178ebb73cb71631c363ab8bdee1e06597015780c259e4483c1fa522a'
 
-  url "https://cdn.cakebrew.com/cakebrew-#{version}.dmg"
+  url "https://cakebrew-377a.kxcdn.com/cakebrew-#{version}.dmg"
   appcast 'https://www.cakebrew.com/appcast/profileInfo.php',
           checkpoint: 'febdbeca94df821a28298c2454f8d0c0a7272379bbe743174e2764865aac5bcb'
   name 'Cakebrew'

--- a/Casks/cakebrew.rb
+++ b/Casks/cakebrew.rb
@@ -2,6 +2,7 @@ cask 'cakebrew' do
   version '1.2.3'
   sha256 '12b35753178ebb73cb71631c363ab8bdee1e06597015780c259e4483c1fa522a'
 
+  # cakebrew-377a.kxcdn.com was verified as official when first introduced to the cask
   url "https://cakebrew-377a.kxcdn.com/cakebrew-#{version}.dmg"
   appcast 'https://www.cakebrew.com/appcast/profileInfo.php',
           checkpoint: 'a1aaa9cb869aa3740faf459cf4fdbed932d5bd00375854ad6ca58a1b562624b4'


### PR DESCRIPTION
Developer no longer has certificate for cdn.cakebrew.com. The following
URL should be used instead: https://cakebrew-377a.kxcdn.com/cakebrew-1.2.3.dmg

More [detailed discussion](https://github.com/brunophilipe/Cakebrew/issues/187).