### PR TITLE
Update vox to 2.8.24

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '2.8.22'
-  sha256 '57ed213a6215556f733c581bf4403a8c47b33994f62799536b28361234b00d02'
+  version '2.8.24'
+  sha256 '3baa7e05db55a1f7c0d4f3d53f4ce3986125f25dee07308f94b42a0f4326d419'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: '157f10f4867c7b73b0c592b55bda3285096c8bb7c09465a1d51218fa2e99205b'
+          checkpoint: '639cb0855b29b520d0eb59d337b4f6487d737c62fc8c59f7163c51d12144d42e'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.