### PR TITLE
Update framer to 8580,1493217501

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '88'
-  sha256 'e21d9da0358cfba73ab2f1539a27d7b4e65a596d29a6f2d96940d21fb0d20984'
+  version '8580,1493217501'
+  sha256 '1f3e9c6ee3230b8342215c552ab1a578fab86cff2872e6e4288bb1f6772ad103'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
+  url "https://dl.devmate.com/com.motif.framer/#{version.before_comma}/#{version.after_comma}/FramerStudio-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: 'c322309f181fa2756e766e53f1a5a001f0a527b3571b39650c6767723895eff7'
+          checkpoint: 'cb259305a31e47f9a709f0ea9198ad2526491ee1675a1cba691a6dc29734c8bf'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.