### PR TITLE
Update switchhosts to 3.3.2.5193

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.1.5128'
-  sha256 '80abbe065b3d3caaf180a20129fa64875306091ec1d6b7daf8ed32c3cadd19ec'
+  version '3.3.2.5193'
+  sha256 '3777f66ff7e19cd99a6894e952aecfc6b0691b67ac4431ebe9920dfe4a803ad2'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: 'e502d92aae68fdf45197547066d19ad58a1fc2dd7ccf03597beca31f2cc46b55'
+          checkpoint: '379a30dee6142e775c70bc79b43674d1ce3d9a02a09baee22610b66e7581f1e4'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.