### PR TITLE
Update 4k-stogram to 2.3.2.1276

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,8 +1,8 @@
 cask '4k-stogram' do
-  version '2.3'
-  sha256 'f7c36efaab29f018966f811ec5419c332c0f295071917593bf9709c10911a607'
+  version '2.3.2.1276'
+  sha256 'ab7937cd1c47ee966fcafa1cb8a16917482157e3deae1380dd7be516998e6619'
 
-  url "https://downloads.4kdownload.com/app/4kstogram_#{version}.dmg"
+  url "https://downloads.4kdownload.com/app/4kstogram_#{version.major_minor}.dmg"
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.