### PR TITLE
Update powerphotos to 1.2.3

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -1,11 +1,11 @@
 cask 'powerphotos' do
-  version '1.2.2'
-  sha256 '5d88d7bb8164c700b64ba22ab93ada0309a548ecc1a80f2ad2ca1d797fe07b76'
+  version '1.2.3'
+  sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
 
   # s3.amazonaws.com/fatcatsoftware/powerphotos was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/fatcatsoftware/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: '5f7b2f3a82cd8910441231320f6d3c631215c97245a6a5fd6a24da3abcb4854c'
+          checkpoint: 'de0223b548bbf05509395979a516b4ac8e6dc168332fc1a81eb454eb90241ebe'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.