### PR TITLE
Update adobe-air-sdk to v25

### DIFF
--- a/Casks/adobe-air-sdk.rb
+++ b/Casks/adobe-air-sdk.rb
@@ -1,8 +1,8 @@
 cask 'adobe-air-sdk' do
-  version '22.0'
-  sha256 'c6a851909dfaab7ee33cc03c98499363a7e59a6d9e4596f86d93b2bb7a895bc1'
+  version '25.0'
+  sha256 '36cb9c62ad245c8f84efce0f218e8465cfec40d657e35533ba21a48107a8c6ba'
 
-  url "https://airdownload.adobe.com/air/mac/download/#{version}/AIRSDK_Compiler.tbz2"
+  url "https://airdownload.adobe.com/air/mac/download/#{version}/AIRSDK_Compiler.dmg"
   name 'Adobe AIR SDK'
   homepage 'https://www.adobe.com/devnet/air/air-sdk-download.html'
 
@@ -43,4 +43,20 @@ cask 'adobe-air-sdk' do
       EOS
     end
   end
+
+  postflight do
+    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/adobe-air-sdk")
+  end
+
+  uninstall_postflight do
+    FileUtils.rm("#{HOMEBREW_PREFIX}/share/adobe-air-sdk")
+  end
+
+  caveats <<-EOS.undent
+    You may want to add to your profile:
+      'export ADOBE_AIR_HOME=#{HOMEBREW_PREFIX}/share/adobe-air-sdk'
+
+    This operation may take up to 10 minutes depending on your internet connection.
+    Please, be patient.
+  EOS
 end


### PR DESCRIPTION
#{HOMEBREW_PREFIX}/share/adobe-air-sdk added for ease of use (similar to android-sdk)

For some reason rubocop was segfaulting, so the style check couldn't be completed. The changes were very minor though.