### PR TITLE
Update adium to 1.5.10.4

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -1,6 +1,6 @@
 cask 'adium' do
-  version '1.5.10.3'
-  sha256 'da5613e42a16d071704f949b7ad9c3eea6ee7e95b7dd73e9669d595450924d31'
+  version '1.5.10.4'
+  sha256 '31fa3fd32b86dd3381b60e0d5aafbc2a9452036f0fb4963bffbc2a6c64a9458b'
 
   url "http://download.adium.im/Adium_#{version}.dmg"
   appcast 'https://www.adium.im/sparkle/appcast-release.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.