### PR TITLE
Update avidemux to 2.6.20

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.6.19'
-  sha256 '606e239b7833fdb4e86422979189c31942ced034f8d8fd2cde0ee4cff7de13eb'
+  version '2.6.20'
+  sha256 '16e23d01a71b431c2a80d7c0c7d10c6e4cbe5eb188e86805428fe0c2a4c1962a'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: '48d5f951633deea796cee416eec784b6f338923abba559a74bed937cca40e5dd'
+          checkpoint: '91c1e993f3113b394bb56191613269558116a53bf762cc2d449af7f9b281cb54'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.