### PR TITLE
Add nomad :latest

### DIFF
--- a/Casks/nomad.rb
+++ b/Casks/nomad.rb
@@ -3,7 +3,7 @@ cask 'nomad' do
   sha256 :no_check
 
   url 'https://www.nomad.menu/download/NoMAD.pkg'
-  name 'NoMad'
+  name 'NoMAD'
   homepage 'https://www.nomad.menu/'
 
   depends_on macos: '>= :yosemite'

--- a/Casks/nomad.rb
+++ b/Casks/nomad.rb
@@ -1,0 +1,20 @@
+cask 'nomad' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://www.nomad.menu/download/NoMAD.pkg'
+  name 'NoMad'
+  homepage 'https://www.nomad.menu/'
+
+  depends_on macos: '>= :yosemite'
+
+  pkg 'NoMAD.pkg'
+
+  uninstall pkgutil: 'com.trusourcelabs.NoMAD'
+
+  zap delete: [
+                '~/Library/Application Support/CrashReporter/NoMAD*',
+                '~/Library/Logs/DiagnosticReports/NoMAD*',
+                '~/Library/Preferences/com.trusourcelabs.NoMAD.plist',
+              ]
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

I realise that there has been a `nomad` cask in the past which was moved to Homebrew core (#23636). I also noticed that an entry has been made in the `tap_migrations.json` file, showing that `nomad` has moved to Homebrew core. 

I'm not sure what to do about this, so rather than editing `tap_migrations.json` myself, I'll leave that part to a maintainer (that is, if it even needs editing).

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
