### PR TITLE
Update apptrap to 1.2.3

### DIFF
--- a/Casks/apptrap.rb
+++ b/Casks/apptrap.rb
@@ -4,7 +4,7 @@ cask 'apptrap' do
 
   url "http://onnati.net/apptrap/download/AppTrap#{version.dots_to_hyphens}.zip"
   appcast 'http://onnati.net/apptrap/ReleaseNotes.xml',
-          checkpoint: '561cc83e41aea261c0472d73369c19b7c738b95b764eb346508a654643d651d5'
+          checkpoint: '5808b1d59e4a2d49af25be84bc388e586ece3d22840a4c07368ee6044357ebf0'
   name 'AppTrap'
   homepage 'http://onnati.net/apptrap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.