### PR TITLE
Update appzapper to 2.0.1

### DIFF
--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -4,7 +4,7 @@ cask 'appzapper' do
 
   url "https://www.appzapper.com/downloads/AppZapper#{version}.zip"
   appcast "https://www.appzapper.com/az#{version.major}appcast.xml",
-          checkpoint: 'b91ae47cbd23159ada1e03357647dc3140cd35ef509dfa44ed13e369aad07e88'
+          checkpoint: '726661c71d2e4be4a6905d6ca410674a146c1e7f3333155c415a958da4a8ef39'
   name 'AppZapper'
   homepage 'https://www.appzapper.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.