### PR TITLE
Update aquaterm to 1.1.1

### DIFF
--- a/Casks/aquaterm.rb
+++ b/Casks/aquaterm.rb
@@ -4,7 +4,7 @@ cask 'aquaterm' do
 
   url "https://downloads.sourceforge.net/aquaterm/AquaTerm/v#{version}/AquaTerm-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/aquaterm/rss?path=/AquaTerm',
-          checkpoint: '7690e67a0a5101a228b261979ab45b525f57bddcfe0fa10409ad16bc7621afed'
+          checkpoint: '919b1aaf6bdb5814d370b76ea198c20ee2595a738ba0697f3dd88c4b96b46050'
   name 'AquaTerm'
   homepage 'https://sourceforge.net/projects/aquaterm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.