### PR TITLE
Update armory to 0.95.1

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -5,7 +5,7 @@ cask 'armory' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: 'd07ce0e7298475fc9a26b19ec5f525d987f6d245a9fc3e7050f1facf504f1d74'
+          checkpoint: '584efce1d00aab244bbd9d23bfb0e5150b7600c293160aca4ba0e57f144b3cd4'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.