### PR TITLE
Update aseprite to 1.1.13

### DIFF
--- a/Casks/aseprite.rb
+++ b/Casks/aseprite.rb
@@ -1,10 +1,10 @@
 cask 'aseprite' do
   version '1.1.13'
-  sha256 '2a0903a9d09c6d90147566ab3e87678f54025f537d260119d26bc5f855fbc87e'
+  sha256 'a7dd98d99a343a04a833522b64d185d6ff7bca44ddaf0376784ffb724816eb64'
 
   url "https://www.aseprite.org/downloads/Aseprite-v#{version}-trial-MacOSX.dmg"
   appcast 'https://github.com/aseprite/aseprite/releases.atom',
-          checkpoint: 'b2296a003cd21e360a0035d7097bd25d8585b449ce2fe4e52bd4b089e1249d5b'
+          checkpoint: 'cf6fde61cc8d0eba7f306b303192503dd9f04083c202cef4736c6cdb88283b1a'
   name 'Aseprite'
   homepage 'https://www.aseprite.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.