### PR TITLE
Update audioslicer to 1.1.1

### DIFF
--- a/Casks/audioslicer.rb
+++ b/Casks/audioslicer.rb
@@ -4,7 +4,7 @@ cask 'audioslicer' do
 
   url "https://downloads.sourceforge.net/audioslicer/AudioSlicer/#{version}/AudioSlicer-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/audioslicer/rss?path=/AudioSlicer',
-          checkpoint: '6d9e32d6082008a24ad9d89b196e90ccda2a085eb5a0224e41ad11c63606a963'
+          checkpoint: 'ab26db9b0c9258922696373309828bb0353b53d11c873e9b6fec6eaa3c451a86'
   name 'AudioSlicer'
   homepage 'http://audioslicer.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.