### PR TITLE
DBeaver casks - add java 8+ caveat

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -10,4 +10,8 @@ cask 'dbeaver-community' do
   homepage 'http://dbeaver.jkiss.org/'
 
   app 'DBeaver.app'
+
+  caveats do
+    depends_on_java('8+')
+  end
 end

--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -9,4 +9,8 @@ cask 'dbeaver-enterprise' do
   homepage 'http://dbeaver.jkiss.org/'
 
   app 'Dbeaver.app'
+
+  caveats do
+    depends_on_java('8+')
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

![dbeaver](https://cloud.githubusercontent.com/assets/26216252/25545407/16202e66-2ca2-11e7-9aa9-4c3c9928786d.png)


http://dbeaver.jkiss.org/download/
> If you are on Mac OS X then you will need JDK 1.8+.