### PR TITLE
Update nylas-mail to 2.0.31-e675deb

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -1,11 +1,11 @@
 cask 'nylas-mail' do
-  version '2.0.28-37242ab'
-  sha256 'e6908f6f8388298152248b5aa2f78c49126ad139bb3b9eaa96775d8cc8682fda'
+  version '2.0.31-e675deb'
+  sha256 'f0dba07e2585f401bc190c4b5618124c7457c31df46ad3be117b42a0b48f0758'
 
   # edgehill.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://edgehill.s3-us-west-2.amazonaws.com/#{version}/darwin/x64/NylasMail.dmg"
   appcast 'https://edgehill.nylas.com/update-check?platform=darwin&arch=64',
-          checkpoint: '165a6c8f6b769756c90f216ee0374ea9537910ece6f84f5d4d88d0db482acdbd'
+          checkpoint: 'f3dc638fbcac0ee7a0dbd8a13a33b578d2ff917c39bccac712a1e42cebd30c4e'
   name 'Nylas Mail'
   homepage 'https://www.nylas.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.