### PR TITLE
Update beyond-compare to 4.2.0.22302

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,10 +1,10 @@
 cask 'beyond-compare' do
-  version '4.2.0.22108'
-  sha256 '5850db6b7f9415785c9e722943cfb601d074d706e2233c87667f96cdcbed754d'
+  version '4.2.0.22302'
+  sha256 '6f927f5c1044f217ce0a37ea7869770f98ecaeff73222c0af5151055f5bc3729'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "http://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx",
-          checkpoint: 'd5d70e04ae38dbeddeaf77db67081be70a04c98e01e263a5f8352ad042ae6670'
+          checkpoint: '18ae0b43e5d8123d75501e785b7677f5bddd37f81681150afb33baa518560101'
   name 'Beyond Compare'
   homepage 'https://www.scootersoftware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.