### PR TITLE
Update instead to 3.0.0

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,11 +1,11 @@
 cask 'instead' do
-  version '2.4.1'
-  sha256 'c9e7af048230da3f1390118a55ab13fa02a6915c0d15c1290cbb2d34a4ea176f'
+  version '3.0.0'
+  sha256 '6208f42a252efe875a74371e59f511e602c219674e57a18881e5e40bb940a6ce'
 
   # sourceforge.net/instead was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/instead/instead/#{version}/Instead-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/instead/rss?path=/instead',
-          checkpoint: '6941875157d2644ec6dac6163e6c4a60b130a585f6b38e1e79de46d8d0307d0a'
+          checkpoint: 'bd545932d3e4426cb0b5bc69fb762694a5c6382a340f32994ebf498940ad84b2'
   name 'INSTEAD'
   homepage 'https://instead.syscall.ru/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.