### PR TITLE
Update microsoft-teams to 1.0.00.10951

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '1.0.00.8201'
-  sha256 '01e8d6d19a1d50e7fe06dbfb1c4cd78df1657b361cec3751fa83a885bfef6909'
+  version '1.0.00.10951'
+  sha256 'ed19b0efcb0e68ae3d8b6966e60e2090b20da09137462c94a15981ab022874f5'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: 'd93cfc3109bab479ca409d6a1d9623acd4e33e7d116db6f693d19134b77c1d95'
+          checkpoint: 'd249664a8f614c9f7ee3f7fb4743dc11eb451c64963b5e7ac0a48a8bd496e07b'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.