### PR TITLE
Update vitamin-r to 2.47

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -20,11 +20,11 @@ cask 'vitamin-r' do
     url "http://www.publicspace.net/download/Vitamin_#{version.dots_to_underscores}.dmg"
     app "Vitamin-R #{version.major}.app"
   else
-    version '2.45'
-    sha256 'b5059380472d47cc9771691125d53a249924a711dc88993364246f978c7f6e67'
+    version '2.47'
+    sha256 'c23503e957f7419696f6020b8dd47dacabe246e880ba36212f25a1039403ffad'
     url "http://www.publicspace.net/download/signedVitamin#{version.major}.zip"
     appcast "http://www.publicspace.net/app/vitamin#{version.major}.xml",
-            checkpoint: '9ee7f7129fa7184a5d8238f82adbc4122e5cb9ebfffab380e827cf7957206566'
+            checkpoint: 'b40ae7bfc99783e7dcbf20c3d8da849d8a4a62edfb3934f6fd53adeb9c09d03b'
     app "Vitamin-R #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.