### PR TITLE
Update buttercup to 0.12.4

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.12.2'
-  sha256 'a4182de9f197328cdca3988b4d58d2051cdc118e53855de525b59e38fa4a2feb'
+  version '0.12.4'
+  sha256 'eb736d455a948471990acb62afaf91da870c9a0487f5d5019f08b8e42480295c'
 
   # github.com/buttercup-pw/buttercup was verified as official when first introduced to the cask
   url "https://github.com/buttercup-pw/buttercup/releases/download/v#{version}-alpha/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup-pw/buttercup/releases.atom',
-          checkpoint: 'f2ecf71a7abfd434bd34d70d72c6ecb843eda8dc404a34fe0b706ad741e93d61'
+          checkpoint: '846ff5fe9b28aa03281214e30cb579f548eee1d23b96ea6231c70d396a0e6de1'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.