### PR TITLE
Update spillo to 157_1.10.1

### DIFF
--- a/Casks/spillo.rb
+++ b/Casks/spillo.rb
@@ -1,11 +1,11 @@
 cask 'spillo' do
-  version '149_1.9.11'
-  sha256 'd9292967da8470abc895a24abcedc3e0def01c780aed1d0f1bd788886d419727'
+  version '157_1.10.1'
+  sha256 '37aaebfc396d31475c4733648678f965f2190b323b3d92cad8165f6ec503cee8'
 
   # s3.amazonaws.com/bananafish-builds/spillo was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bananafish-builds/spillo/spillo_#{version}.zip"
   appcast 'https://bananafishsoftware.com/feeds/spillo.xml',
-          checkpoint: '21829106f7be0be62588391ba35eb4f4eac120ce75d2b68cbf9f63aa63d1731f'
+          checkpoint: 'db784836ef38a7dc1d547bec7a1289166ed41a3c0818b538120f50efdeb69631'
   name 'Spillo'
   homepage 'https://bananafishsoftware.com/products/spillo/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.