### PR TITLE
Update writefull to 3.0.0-beta17

### DIFF
--- a/Casks/writefull.rb
+++ b/Casks/writefull.rb
@@ -1,9 +1,11 @@
 cask 'writefull' do
-  version '3.0.0-beta14'
-  sha256 '3e73acde34d9100d823c16ae3c2c1224715d05210368505835fb8e790fbcbbb8'
+  version '3.0.0-beta17'
+  sha256 'da1a9e1d39512c275d57de7de1f01b08ff9132258b02e514d1bd86c388a0fd8c'
 
   # d3aw1w08kaciwn.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d3aw1w08kaciwn.cloudfront.net/#{version}-gem2/Writefull.dmg"
+  url "https://d3aw1w08kaciwn.cloudfront.net/#{version}/Writefull.dmg"
+  appcast 'https://writefullapp.com/js/download-urls.js',
+          checkpoint: 'c264817170cd61498505d1f26cb84a86688751fb3fccc1b47e044aba5f29e0fd'
   name 'Writefull'
   homepage 'https://writefullapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.