### PR TITLE
Update smartsynchronize to 3.4.10

### DIFF
--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -1,6 +1,6 @@
 cask 'smartsynchronize' do
-  version '3.4.9'
-  sha256 '1594199d9fdc408eea5ae0c74aff48902e8b0b83fb4d9e57148f040c0c128e23'
+  version '3.4.10'
+  sha256 '8526000d1d93f806e9306d3a50b707f00df3ede7c248925552607a397ad2d3cc'
 
   url "https://www.syntevo.com/static/smart/download/smartsynchronize/smartsynchronize-macosx-#{version.dots_to_underscores}.dmg"
   name 'SmartSynchronize'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.