### PR TITLE
Update robomongo to 1.0.0,89f24ea

### DIFF
--- a/Casks/robomongo.rb
+++ b/Casks/robomongo.rb
@@ -1,6 +1,6 @@
 cask 'robomongo' do
-  version '1.0.0-rc1,496f5c2'
-  sha256 '7b2e0ee1effb36d548945fe668c2e584c1e2dde1e3b7786f2ee134dc419ed1ef'
+  version '1.0.0,89f24ea'
+  sha256 'd664aad1ed2aee2f3b108f545e91df9024fce7827816439c6b8401c2de8c4ed0'
 
   url "https://download.robomongo.org/#{version.before_comma}/osx/robomongo-#{version.before_comma}-darwin-x86_64-#{version.after_comma}.dmg"
   name 'Robomongo'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.