### PR TITLE
Update insync to 1.3.15.36150

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '1.3.14.36131'
-  sha256 'b19d6e43134e3630ec8b710742ee1a729d076ad9f19aa4cd22eaa3ae96965df3'
+  version '1.3.15.36150'
+  sha256 '20525affb45cb8b040b0dfdfc9128a0c6dfe37bdd88f8de2f1c4a802dd01b96a'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   name 'Insync'


### PR DESCRIPTION
After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask\'s name and version.