### PR TITLE
Update react-native-debugger (0.6.4)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.6.3'
-  sha256 'a4d740f17451c5a8b0c201c9e0f704c5fbab27e118ade0954acfd765b9b00d22'
+  version '0.6.4'
+  sha256 'bfa93efdcb8af5d17886aa3276d29bdc3e4dcf4e62af64d3d9f60a0a87460687'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: 'cf25e5bbe4e11ba4bc11f31cd8a02b4ea47e6b68d5288d2fc3b2329b53e9e915'
+          checkpoint: '46ea6b82282db961d60cbe3dde5d809ac02e4bf2cc84802d360482b6308c0126'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.