### PR TITLE
update wiznote to 2.5.3

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.5.0,2017-04-19'
-  sha256 'c7d318b6632d6477ee6342b9a6be1aff9749d0b6dee2196c4fdc7349a90a1ecd'
+  version '2.5.3,2017-04-27'
+  sha256 '946015b4db3c935ac66dfd9fcd59956d9e6ad309b1d1b07a6d23ca74efe92475'
 
   url "http://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   name 'WizNote'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.