### PR TITLE
Update boostnote to 0.8.9

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.8'
-  sha256 '320e7cce5711fab8e541f2124549790178a56953cafb7310c01bce3520b574fe'
+  version '0.8.9'
+  sha256 '5eb25597dc37b6726ee52e64bac1ef95d9473165eed4481369322ee880dcdee2'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: 'abcad29ba9d5e6f2b182cc7b2d1361dd80ad7c6e45d9bc015c404167fe9633a0'
+          checkpoint: '901a7e7e0da3985c427a6947be0a40bdc772f407bc9d9be0ead2cf7c1df4c17e'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.