### PR TITLE
Update blink1control to 1.98

### DIFF
--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -5,7 +5,7 @@ cask 'blink1control' do
   # github.com/todbot/blink1 was verified as official when first introduced to the cask
   url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
   appcast 'https://github.com/todbot/blink1/releases.atom',
-          checkpoint: 'f8419b73ae281066a793d7d79211b45be165de976186784fb1271d2a8afa00c7'
+          checkpoint: 'a2c1b1807df8f633e5e9aaa9b29242929fdb4dec7e84cc011a15ec03ef305cf1'
   name 'Blink1Control'
   homepage 'https://blink1.thingm.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.