### PR TITLE
Update brl-cad-mged to 7.24.0

### DIFF
--- a/Casks/brl-cad-mged.rb
+++ b/Casks/brl-cad-mged.rb
@@ -5,7 +5,7 @@ cask 'brl-cad-mged' do
   # downloads.sourceforge.net/brlcad was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/#{version}/BRL-CAD%20#{version}.dmg"
   appcast 'https://sourceforge.net/projects/brlcad/rss?path=/BRL-CAD%20for%20Mac%20OS%20X',
-          checkpoint: 'b10ff43a62b9f9f66ed5ea4aa691603aedc8f65ea3370d08daeb641a807a0db5'
+          checkpoint: '2eab38bc2e4ea3ece9faaf3d5d887130716427a3eaa92716f4d0aeb17e94f3a7'
   name 'BRL-CAD'
   homepage 'https://brlcad.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.