### PR TITLE
Update celestia to 1.6.1

### DIFF
--- a/Casks/celestia.rb
+++ b/Casks/celestia.rb
@@ -4,7 +4,7 @@ cask 'celestia' do
 
   url "https://downloads.sourceforge.net/celestia/celestia-osx-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/celestia/rss',
-          checkpoint: '56994e2d3dcf5068e11639e2a32f6d76225cc54c077fc7811fad81cc2816a856'
+          checkpoint: 'f42adfe85c82138c4a0d34cb8212c552658765780d93faacd431ccce8ee2a553'
   name 'Celestia'
   homepage 'https://sourceforge.net/projects/celestia/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.