### PR TITLE
Update chronocube to 0.5.1

### DIFF
--- a/Casks/chronocube.rb
+++ b/Casks/chronocube.rb
@@ -5,7 +5,7 @@ cask 'chronocube' do
   # github.com/pablopunk/chronocube was verified as official when first introduced to the cask
   url "https://github.com/pablopunk/chronocube/releases/download/v#{version}/Chronocube-Mac.dmg"
   appcast 'https://github.com/pablopunk/chronocube/releases.atom',
-          checkpoint: '0a834802763635f2efdd91bce9443d92abb1046e59cd241b611656c10e5fafea'
+          checkpoint: '62e9382b48906ab7df517d11e00cd4b61054b5fd05a8ee413335e6c98fa008c6'
   name 'Chronocube'
   homepage 'http://chronocube.live/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.