### PR TITLE
Update brushviewql to 1.1

### DIFF
--- a/Casks/brushviewql.rb
+++ b/Casks/brushviewql.rb
@@ -3,8 +3,8 @@ cask 'brushviewql' do
   sha256 '5211b8b62a8d03a9859c96ebba94fa3262e633a3f7420a1972eaa1ab37b1347f'
 
   url 'http://brushviewer.sourceforge.net/brushviewql.zip'
-  appcast 'http://brushviewer.sourceforge.net/brushviewql.zip',
-          checkpoint: '486964fda08be301457c6bf2bb4b72d6d06f73c53e18ab1d467beb9b6ae7dff7'
+  appcast 'https://sourceforge.net/projects/brushviewer/rss',
+          checkpoint: 'c3c9f0da3d3ebd5aaa4610590d5d76067b2e6542feb3d5e277f7fa90dfc9e21f'
   name 'BrushViewQL'
   homepage 'http://brushviewer.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.