### PR TITLE
Update cog to r2068

### DIFF
--- a/Casks/cog.rb
+++ b/Casks/cog.rb
@@ -1,14 +1,14 @@
 cask 'cog' do
-  version 'r2051'
-  sha256 '1cc55f718a15810cccc5141312c01079e1da230a2412e4bc66c172de7aee36fe'
+  version 'r2068'
+  sha256 '9c9ad68bf9fa29da31f69bb19e45fce694e5122a6360d275eeaf2b0e4b58f33f'
 
   # the stable package on sourceforge is a bzip-inside-bzip that we can't handle
 
-  url "https://cogx.org/nightly_builds/cog-#{version}.tbz"
-  appcast 'https://mamburu.net/cog/stable.xml',
+  url "http://cogx.org/nightly_builds/cog-#{version}.tbz"
+  appcast 'http://mamburu.net/cog/stable.xml',
           checkpoint: 'f5770d73ad0c4a19af24cf25195c01d1cc05b937a79416fe82ead0949beee62e'
   name 'Cog'
-  homepage 'https://cogx.org/'
+  homepage 'http://cogx.org/'
 
   app 'Cog.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.