### PR TITLE
Update doomsday-engine to 2.0.0

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -4,6 +4,8 @@ cask 'doomsday-engine' do
 
   # sourceforge.net/deng was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
+  appcast 'https://sourceforge.net/projects/deng/rss',
+          checkpoint: 'a0f2b88741910a1dec68fb19e6ade3bbb117553af312f09d673bc7081823f8f9'
   name 'Doomsday Engine'
   homepage 'http://dengine.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.