### PR TITLE
Update colorschemer-studio to 2.0.1

### DIFF
--- a/Casks/colorschemer-studio.rb
+++ b/Casks/colorschemer-studio.rb
@@ -1,10 +1,10 @@
 cask 'colorschemer-studio' do
-  version '2.0'
+  version '2.0.1'
   sha256 '6c2fb0ac5fa628ab5cca6e9b34579e800824a50bc46d47b6c95da53403911163'
 
   url 'http://www.colorschemer.com/colorschemerstudio.dmg'
   appcast "http://www.colorschemer.com/appcast/studio#{version.major}_mac.xml",
-          checkpoint: '8faf423e6e94caef34de09fc83c720ef2473d1a37bf4777a95717a814f73a722'
+          checkpoint: '5984524da1e43fbf7f16f4d7e4f2807b910157c08af4d29d8ca7b1c6fab66d5a'
   name 'ColorSchemer Studio'
   homepage 'https://www.colorschemer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.