### PR TITLE
Update colour-contrast-analyser to 2.3

### DIFF
--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -5,7 +5,7 @@ cask 'colour-contrast-analyser' do
   # github.com/ThePacielloGroup/CCA-OSX was verified as official when first introduced to the cask
   url "https://github.com/ThePacielloGroup/CCA-OSX/releases/download/#{version}/Colour.Contrast.Analyser.app.zip"
   appcast 'https://github.com/ThePacielloGroup/CCA-OSX/releases.atom',
-          checkpoint: '0ecc055439e78cedf4195b8c810b30bf8a9e59db0fe36e3292d532b0ffeb9c15'
+          checkpoint: '4ab9b55e98b8b2dfff03bfbbd3b71bc797c8094c6d3005d6629f3686879e634a'
   name 'Colour Contrast Analyser'
   homepage 'https://www.paciellogroup.com/resources/contrastanalyser/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.