### PR TITLE
Update ctivo to 2.5.1

### DIFF
--- a/Casks/ctivo.rb
+++ b/Casks/ctivo.rb
@@ -4,7 +4,7 @@ cask 'ctivo' do
 
   url "https://github.com/dscottbuch/cTiVo/releases/download/#{version}/cTiVo.zip"
   appcast 'https://github.com/dscottbuch/cTiVo/releases.atom',
-          checkpoint: 'e0c8386ad0bfde5c29b0a953fcc1cdd16cc8e6787a44337006d9a535a0f8903b'
+          checkpoint: '86ba8bd71ce51346185a0c877452b4a508e568258a7f86641fb405bb278d4254'
   name 'cTiVo'
   homepage 'https://github.com/dscottbuch/cTiVo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.