### PR TITLE
Update cuppa to 1.7.9

### DIFF
--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -4,7 +4,7 @@ cask 'cuppa' do
 
   url "https://www.nathanatos.com/software/downloads/Cuppa-#{version}.zip"
   appcast 'https://www.nathanatos.com/software/cuppa.xml',
-          checkpoint: 'f01c77b88898d21e63f1fb75b9f00e182664d674a9b2b9f4d4daba61e14440e0'
+          checkpoint: '0a5d7da8744a77eb818aa12dcc6a033d70c5fa18c5cb7b81787e21670621974f'
   name 'Cuppa'
   homepage 'https://www.nathanatos.com/software/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.