### PR TITLE
Update brave to 0.15.1

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.15.0'
-  sha256 '1d0fc1b43ec5dbbf2f73b27b4c5a15ce1ce804da16d7a6b6c4819b054cbf2afd'
+  version '0.15.1'
+  sha256 '6cef3e45939601f0a9baa3be5cf66d86fcc1e6189bde19f37cb4e952e806f70d'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'b4d0072ff21d7d5b3e899df1076c61101c1eae3fec0116978ea9c762331a307a'
+          checkpoint: '2f18feb61f5f08bf3e8bbb84d82f2003a3865806062025f8168a5ebafcc5e5d3'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.