### PR TITLE
Update vimr to 0.14.0-181

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.13.1-167'
-  sha256 '570ab8df069fa6a7bdd042144125ad56258f82f5aec46630cd880f044b60d9a6'
+  version '0.14.0-181'
+  sha256 '5dfcccc20efb00f9e8c3a5a572c199379fa6ad7af5bd7b42763b0e1c9d1a1ef3'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '7619a0d2d13f1f7474780807a5870d1ef879360314542b49e406dc35d22f24fd'
+          checkpoint: '46f2c429b566f5a3b58952898346bfc1468950c3ed5dd164338b177329f0eecd'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.