### PR TITLE
Update inspec to 1.22.0

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.20.0-1'
-  sha256 'b00c795674952a3cc39b746f2e2eecc63739159ad990e84cf3a59e801d0cc07e'
+  version '1.22.0-1'
+  sha256 'b4deb245d2bd0e170899a97f071a1eda6f7c47501ad1d87e5ef6ccfce8b24b4c'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: '452cbaaec7c1befff25f71d458b269b17e9e5c4d9162cef87d7ce9014c556017'
+          checkpoint: 'eb2bf1079cb70b1a9bb788f0606dc2313a645afa272a7950858b1992c6350931'
   name 'InSpec by Chef'
   homepage 'http://inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.