### PR TITLE
Update spillo to 158_2.0

### DIFF
--- a/Casks/spillo.rb
+++ b/Casks/spillo.rb
@@ -1,11 +1,11 @@
 cask 'spillo' do
-  version '157_1.10.1'
-  sha256 '37aaebfc396d31475c4733648678f965f2190b323b3d92cad8165f6ec503cee8'
+  version '158_2.0'
+  sha256 '0228766974d6a65de9aca459a21e8ff06af813f9c3643ba5a8c98486e3bc8d0c'
 
   # s3.amazonaws.com/bananafish-builds/spillo was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bananafish-builds/spillo/spillo_#{version}.zip"
   appcast 'https://bananafishsoftware.com/feeds/spillo.xml',
-          checkpoint: 'db784836ef38a7dc1d547bec7a1289166ed41a3c0818b538120f50efdeb69631'
+          checkpoint: 'da4a586369b44cc5e04e7a3858de7e89ddf0b5c2fe94f04aa68da111ee99c8a4'
   name 'Spillo'
   homepage 'https://bananafishsoftware.com/products/spillo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.