### PR TITLE
Update filezilla to 3.25.2

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -3,14 +3,14 @@ cask 'filezilla' do
     version '3.24.1'
     sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
   else
-    version '3.25.1'
-    sha256 '76c1b583d2ddd1526bb5fa55f8c109b3172e5334cf5d848f04db039da35e5bc0'
+    version '3.25.2'
+    sha256 'bf5e491445fe92d0546c4baf00398be42bf6af5384a3c5b7e6c6b773640166cb'
   end
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '0f23e3c46d6ac5c13761ffc1fa255ba0bcd163537f245efbd3907081078fc56c'
+          checkpoint: '6fabbc12cfe1f1d1cb6aa260fff01a0e1cb577da427ba517cab2ecca74e0ed7b'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.