### PR TITLE
Update caprine to 2.2.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.1.0'
-  sha256 '084b66565fb9aa9f5503cf0170122549e1cea0d76c0faafef91881ee3185d1b0'
+  version '2.2.0'
+  sha256 '175b29b7d78e21117dfdc0dc60d66f542f5ccbd4a091650a8cdb12e3f2db79d1'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: 'd966ff7ecf9f5277084b52d744048c2dcc4cbae2c464bbd3cd6c528e7fe44a21'
+          checkpoint: '9bbe02c49e919e2c30042a262c392b75e3f8a994374ff050306f9caf60e93aef'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.