### PR TITLE
Update fldigi to 4.0.3

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.2'
-  sha256 '79a6102d5d69e814b58d66cb8bc8ceac7f506005b3481fbf71261a9a28296aea'
+  version '4.0.3'
+  sha256 '10ede0d058dc1c1887a6cfc9f8ffa6845dd02be52b76cc622937f0e5be2b6bc0'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'bed8ba38f33a34e1d0c83dd196babcb31cc68126fe5a14a082664a8601d1303e'
+          checkpoint: '48e0dbed30c72fd68197d712b0771560ece6e2cbb259ec80e9d7782528b0da43'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.