### PR TITLE
Update frostwire to 6.4.9

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.4.7'
-  sha256 'e1223dc702203a953f35afab525f45f4971ac57ea89da10525105b717d6dca13'
+  version '6.4.9'
+  sha256 '99c016a3dad8aa897f6d1fc488b5df4cfd17667395b52df2ae6ce1aeabb1cb7a'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '3c4212b7442ba5b19b2d292efc5be41eb71628112aa499294f0971702f79a331'
+          checkpoint: '4f9f4c920e0ca56fb3349c0c682be75b4e469c17fd93d3e613039dc65e4d393c'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.