### PR TITLE
Update vimr to 0.14.1-182

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.14.0-181'
-  sha256 '5dfcccc20efb00f9e8c3a5a572c199379fa6ad7af5bd7b42763b0e1c9d1a1ef3'
+  version '0.14.1-182'
+  sha256 'c1728b3163a3e2dffdc064cb57776fdadb2f6855dfb590ba8c31f31f663d975d'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '46f2c429b566f5a3b58952898346bfc1468950c3ed5dd164338b177329f0eecd'
+          checkpoint: '16a9d448bbbfd40f624295e48b9abfdc00690bec95cc0c4bcb5e2ec869858914'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.