### PR TITLE
Update m3unify to 1.8.0

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,10 +1,10 @@
 cask 'm3unify' do
-  version '1.7.1'
-  sha256 '29d67b2e0e584bb0472d219e36a77b587b6ff8fd76402eff60737a794e094650'
+  version '1.8.0'
+  sha256 '81ee37aa657f9907e4b96e07f93bf5e591349f8afea27adb0296c3f344da6d3d'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
-          checkpoint: 'bc96f543e21d718b84ab6cfd1d977d5b2d54c6db122648abb2a520ded22af106'
+          checkpoint: '36775d0461ca8a0b0d99aa0b08659bd8917cd7263597e542d3a28cc89e243e51'
   name 'M3Unify'
   homepage 'https://dougscripts.com/apps/m3unifyapp.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.