### PR TITLE
Update mcbopomofo to 0.9.8

### DIFF
--- a/Casks/mcbopomofo.rb
+++ b/Casks/mcbopomofo.rb
@@ -1,11 +1,11 @@
 cask 'mcbopomofo' do
-  version '0.9.7'
-  sha256 '67781854868a4186e47eb431d0290eff7161f41cdfb7a200d1deb30c379bdcd2'
+  version '0.9.8'
+  sha256 '2d29b07a90d76a24558442bde9df0b922a307106d5ae5a5fde77698f134d2d6d'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/openvanilla/McBopomofo/releases/download/#{version}/McBopomofo-Installer-#{version}.zip"
   appcast 'https://github.com/openvanilla/McBopomofo/releases.atom',
-          checkpoint: 'd664ecb07c906c48fd9f09a28b29e76413768ddb20f897e5272b73cee27aeccb'
+          checkpoint: '3589b9e4636ba8607d1717f7b0d6f1e24270ae9d3176f1c0b6d5b1ea15102d56'
   name 'McBopomofo'
   homepage 'https://mcbopomofo.openvanilla.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.