### PR TITLE
Update dbeaver-community to 4.0.6

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.0.5'
-  sha256 '08b45c877881e007650618e22c410cf2f7b91b23bd1e25ba4af2933d2919bd3e'
+  version '4.0.6'
+  sha256 'e70e88425ef0eaf1b4893d79c551a77dfd17ab6a74df8c35e860d904cd56e237'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '8e8ef6237cabd59551ad2c6f4d6766fa3442eb7b3015c1da623f127842fd4991'
+          checkpoint: '6325cc362d5d60203aa911da0cd82b298280d8d95f44af92108a6ba9397171c6'
   name 'DBeaver Community Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`dbeaver-enterprise` doesn't have a `4.0.6` release yet. 