### PR TITLE
Update unetbootin to 647

### DIFF
--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -1,11 +1,11 @@
 cask 'unetbootin' do
-  version '638'
-  sha256 '044bfc61889e899c0e2130ef6882c4743eb0f3dfcc7bd42ff6d606df85b1a6f1'
+  version '647'
+  sha256 '6f0abd2ab696501dbddde135d4709259d6d4ca2de33a54bfb10f51b4d5ffd22a'
 
   # launchpad.net/unetbootin was verified as official when first introduced to the cask
   url "http://launchpad.net/unetbootin/trunk/#{version}/+download/unetbootin-mac-#{version}.dmg"
   appcast 'https://github.com/unetbootin/unetbootin/releases.atom',
-          checkpoint: '40834386a2952a46adb82252c0d7b06994e49134a678aace34f32d442527959a'
+          checkpoint: 'fd308855106d78c0ad2e793b760b6ee07abeef5456d0cbcc2f87236a314bc06f'
   name 'UNetbootin'
   homepage 'https://unetbootin.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.