### PR TITLE
Remove `tiger` and `leopard` version from 5 Casks

### DIFF
--- a/Casks/mailfollowup.rb
+++ b/Casks/mailfollowup.rb
@@ -1,11 +1,5 @@
 cask 'mailfollowup' do
-  if MacOS.version <= :tiger
-    version '1.1'
-    sha256 '1f345ae0c814cbdc7adad9d5b20003fbad2cdf4da0a9f9de4936fc2d2c65067d'
-  elsif MacOS.version <= :leopard
-    version '1.3.1'
-    sha256 'ac90c2ee400ea3b8f727d46d0347893e538e17eedd97a16c94300b1cf194f1b1'
-  elsif MacOS.version <= :snow_leopard
+  if MacOS.version <= :snow_leopard
     version '1.4.5'
     sha256 '5a0f4eaac8aec89d49c8cc54ff479d7c5d94436e9b26a57fe940974cb8120ef0'
   elsif MacOS.version <= :lion

--- a/Casks/moneywell.rb
+++ b/Casks/moneywell.rb
@@ -1,10 +1,5 @@
 cask 'moneywell' do
-  if MacOS.version <= :tiger
-    version '1.4.13'
-    sha256 'b2eb23a4d5d9e555d00529f83d4cae43abc184c9174a4b729693b55787dfd64d'
-
-    url "http://downloads.nothirst.com/MoneyWell_#{version.major_minor}.zip"
-  elsif MacOS.version <= :snow_leopard
+  if MacOS.version <= :snow_leopard
     version '1.7.3'
     sha256 '6f34a57999fcc09147035f62caff7efede3a385c0f2e7b6f3f90e9a64e826410'
 

--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -1,8 +1,5 @@
 cask 'monolingual' do
-  if MacOS.version <= :tiger
-    version '1.3.9'
-    sha256 '7bf1ec8642ec8674443945dec12cf9c991306912e1e27c305c6db4776e037b16'
-  elsif MacOS.version <= :snow_leopard
+  if MacOS.version <= :snow_leopard
     version '1.4.5'
     sha256 '7684b6b6d41b784d06e636f5e7993ca3730680ccbfa83e90e74b43be58ad3e21'
   elsif MacOS.version <= :mavericks

--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -1,21 +1,8 @@
 cask 'spamsieve' do
-  if MacOS.version <= :tiger
-    version '2.9.6'
-    sha256 'f060af29ab260450f0c0a906ada3e60408c9b6cd871e1df272dde2521bafeed3'
+  version '2.9.28'
+  sha256 '4a33813d05de530b686374815622c0d3629f2ae28c68e05f7adeb0378945ce96'
 
-    url "https://c-command.com/downloads/SpamSieve-#{version}-tiger.dmg"
-  elsif MacOS.version == :leopard
-    version '2.9.14'
-    sha256 '9acd154e5c379b21ca752ff70bd59766cc2f91532a10ea12dce87f71101d2f11'
-
-    url "https://c-command.com/downloads/SpamSieve-#{version}-leopard.dmg"
-  else
-    version '2.9.28'
-    sha256 '4a33813d05de530b686374815622c0d3629f2ae28c68e05f7adeb0378945ce96'
-
-    url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
-  end
-
+  url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
   name 'SpamSieve'
   homepage 'https://c-command.com/spamsieve/'
 

--- a/Casks/tnefs-enough.rb
+++ b/Casks/tnefs-enough.rb
@@ -1,10 +1,5 @@
 cask 'tnefs-enough' do
-  if MacOS.version <= :tiger
-    version '2.0'
-    sha256 '555ba1f181023f0a48014e1b2fe0168fbb6e58731042c57509506ddf37512c5c'
-
-    url "http://www.joshjacob.com/mac-development/TNEF#{version}.dmg"
-  elsif MacOS.version <= :snow_leopard
+  if MacOS.version <= :snow_leopard
     version '2.2'
     sha256 '0cccaf239829961b835f0661d3a0f96fc53f3fd29533ab52172eeb357f974fb5'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Forgot to do single commits, sorry.