### PR TITLE
Update musescore to 2.1

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,6 +1,6 @@
 cask 'musescore' do
-  version '2.0.3.1'
-  sha256 'a166a21bf6259331a42b3a5ed73cfb69f653095a27a676fbf94a747d98153b29'
+  version '2.1'
+  sha256 '251dea5f14b48b87e5cd3aba57bcc9cf0e430e363c0e6b6e741be6356957b3a7'
 
   # ftp.osuosl.org/pub/musescore was verified as official when first introduced to the cask
   url "https://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.