### PR TITLE
Update bloodhound to 1.2.1

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -5,7 +5,7 @@ cask 'armory' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: '584efce1d00aab244bbd9d23bfb0e5150b7600c293160aca4ba0e57f144b3cd4'
+          checkpoint: 'bf767eddf6993b33b66fd8803023597f83b280e3b25e870869b55a580d084ead'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 

--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -5,7 +5,7 @@ cask 'armory' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: 'bf767eddf6993b33b66fd8803023597f83b280e3b25e870869b55a580d084ead'
+          checkpoint: '584efce1d00aab244bbd9d23bfb0e5150b7600c293160aca4ba0e57f144b3cd4'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 

--- a/Casks/bloodhound.rb
+++ b/Casks/bloodhound.rb
@@ -4,7 +4,7 @@ cask 'bloodhound' do
 
   url "https://github.com/BloodHoundAD/BloodHound/releases/download/#{version}/BloodHound-darwin-x64.zip"
   appcast 'https://github.com/BloodHoundAD/BloodHound/releases.atom',
-          checkpoint: 'f5395c0c5cf8e8826339aa4c5b9d77f085674390173ace64152c511b8c5b9189'
+          checkpoint: 'e97ce200da16ade01d53aefca9252e16bc0370a3a554291d3d47780919c78ada'
   name 'bloodhound'
   homepage 'https://github.com/BloodHoundAD/BloodHound'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.