### PR TITLE
Update processing to 3.3.3

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,10 +1,10 @@
 cask 'processing' do
-  version '3.3.2'
-  sha256 '4797b00bd0b8ef19bff355059abe81b7b10fffdc60c5fd90bb643b707fcab033'
+  version '3.3.3'
+  sha256 '4ae4d7bc7f8a0db711d6908e4f9d80b97132d08ceac6b7cd6ab43e2d8546a840'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: 'b848a8e099ac8d3eff94ba98fd0609dbaa57f6892a48f477b59c09bfe1ecc20d'
+          checkpoint: 'fe4db0a7b4e5551f953f4731733bce3563bcc4f5e047a7effbee4db81821c0f9'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.