### PR TITLE
Update etcher to 1.0.0-rc.5

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,11 +1,11 @@
 cask 'etcher' do
-  version '1.0.0-rc.4'
-  sha256 'a8404e1297578f00e726b7ef08a17c3440aa4861bed8e6f295bff7cb8d9997dd'
+  version '1.0.0-rc.5'
+  sha256 '119840577a54057d4893b27e8ea67e700949097ca09ea2b9b9070a7f43d10f50'
 
   # resin-production-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://resin-production-downloads.s3.amazonaws.com/etcher/#{version}/Etcher-#{version}-darwin-x64.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: 'e1caafd5c5f64d21d0009dc9c11e2402f8068ef0f56cb1264638d21a2d427ac4'
+          checkpoint: '8768b21701a9b4540cd06c243bbe06dea6b13b1a7b974f7b59cab632dd9733d6'
   name 'Etcher'
   homepage 'https://etcher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.