### PR TITLE
Update fontbase to 2.0.1

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.0.0'
-  sha256 '5a9169db4e5609539a3a8de0dc091ddd49a4698d47b4845c74650c8e3e328a9d'
+  version '2.0.1'
+  sha256 '012f88b19dba05bb700f0bd9e29409c1d2da30aa6355d84324eb439b9832f742'
 
   url "http://releases.fontba.se/mac/#{version}/FontBase-#{version}.dmg"
   name 'FontBase'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.