### PR TITLE
Update datagrip to 2017.1.3,171.4424.16

### DIFF
--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -1,10 +1,10 @@
 cask 'datagrip' do
-  version '2017.1.2,171.4249.43'
-  sha256 '64b60b9370ff8fcd654f0f985e2ff019644aa3abf527015b867754a98a549346'
+  version '2017.1.3,171.4424.16'
+  sha256 'c48aa6c6bc991e598298148cb8e05554e88f2aba153e9a6f31be6fe2fa0e7cb5'
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release',
-          checkpoint: '0e67d03cc3b2560bbae6df734d62cf84e989cbe9dadd632482e7df9c28320731'
+          checkpoint: '705366acab66bbf5ec73fd1da6e6c30fe49428f6a76ae235ba363613beeacf86'
   name 'DataGrip'
   homepage 'https://www.jetbrains.com/datagrip/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.