### PR TITLE
Update zerotier-one to 1.2.4

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -1,10 +1,10 @@
 cask 'zerotier-one' do
-  version '1.2.2'
-  sha256 'e57245b90c8620a0448ac2aba4cc24c57a3b1010f448879c7a953779d3f4435e'
+  version '1.2.4'
+  sha256 '127216c5287d748a8e63bea0487775ea18a51b84fbcdd9461caa85da07c3991a'
 
   url 'https://download.zerotier.com/dist/ZeroTier%20One.pkg'
   appcast 'https://github.com/zerotier/ZeroTierOne/releases.atom',
-          checkpoint: '032cf7579d5fbb1eeb5d8c49bc74e4a1c6dec93c04cf5086a4d6210cea800eca'
+          checkpoint: '2889963712a378cb1a035823a36dc918af88797185876b9a000ce7d4715dddc9'
   name 'ZeroTier One'
   homepage 'https://www.zerotier.com/download.shtml'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.