### PR TITLE
Update disablemonitor to 1.92

### DIFF
--- a/Casks/disablemonitor.rb
+++ b/Casks/disablemonitor.rb
@@ -4,7 +4,7 @@ cask 'disablemonitor' do
 
   url "https://github.com/Eun/DisableMonitor/releases/download/G#{version}/DisableMonitor-G#{version}.zip"
   appcast 'https://github.com/Eun/DisableMonitor/releases.atom',
-          checkpoint: 'fe771d9958403ea039c1ffa4e8edbc69dee465e1cff42456c18780d1dcbd91af'
+          checkpoint: 'fd9162d7883f57f079de4f05fb86865503cf66c35633486e0d0bbf7a3c934cb8'
   name 'DisableMonitor'
   homepage 'https://github.com/Eun/DisableMonitor'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.