### PR TITLE
Update polymail to 1.35

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.34'
-  sha256 '1ee8aa7c33a3e467ab8df961d2e1c77e139a2864569d802e7f0db20e39cc7fdf'
+  version '1.35'
+  sha256 '7da5c110d109bb1ef56e9b9ff946bbbe45b574eac8ad568078158393f5a89df4'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '8fe8a7e20206b348b4c68c4dd38505cd084a660be4b3d1edbaa2b6ccf6b7e2c9'
+          checkpoint: 'd648f2446d54a64a9a4abe552b0087afb9dd1c3e07a550f5ba35dff9ce42d281'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.