### PR TITLE
Update freesmug-chromium to 58.0.3029.96

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '58.0.3029.81'
-  sha256 '3dc87ce8fd91d589bb7f3ab3d6e2458fd92806f2086f609fa214411d0217a68b'
+  version '58.0.3029.96'
+  sha256 'e3a9c917f75a7a27e964d6da004ff740a13fba4a8128a8c2058b0efec05fb45d'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '553a66d99cfce3b6dc0010ff231c4fdba91b188cb99a5ed609e8bc039134b84e'
+          checkpoint: 'd01f184a87ac7f991e2d363e224397ab48670e75c69ae577b2e1c39ca921b3f8'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.