### PR TITLE
Update poi to 7.6.0

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,11 +1,11 @@
 cask 'poi' do
-  version '7.5.2'
-  sha256 '0eef145a3b1ceb97a427b324fcdb571b5b9f1fd2e2c6980c4213543297f30f41'
+  version '7.6.0'
+  sha256 '5acc3c86d3d4d056a507fa6072c862f263ac54e80899fec9fe9df911d9e3e226'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}-macos-x64.dmg"
   appcast 'https://github.com/poooi/poi/releases.atom',
-          checkpoint: '84868653fb4d7f7fb3d6652cd58d0709fbd8f36d084cd04547c9de47d82765af'
+          checkpoint: '7b3ce9df1edaf9deec955c73062a88162a964c8b3e68518631175b74fa183e05'
   name 'poi'
   homepage 'https://poi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.