### PR TITLE
Update bdash to 1.2.0

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,10 +1,10 @@
 cask 'bdash' do
-  version '1.1.0'
-  sha256 '3ac716d55d7d615554256d443b9bef84b13fc3d1c99be3fe9fc0fe1e6946cea4'
+  version '1.2.0'
+  sha256 '204fa27decbda2cc356617726f5fae6356540b904b32ad47a26a3b7b1b6bc4b9'
 
   url "https://github.com/bdash-app/bdash/releases/download/#{version}/Bdash-#{version}-macOS.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom',
-          checkpoint: '95e075bce9e77985a21130a3f9c9891ec1c755d972ae7b3dc750661c80f8868a'
+          checkpoint: '3c4c5ff7503686c516a3f1bc16616857bba73ef602aa59cc52c3bea5fcefd8d9'
   name 'Bdash'
   homepage 'https://github.com/bdash-app/bdash'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.