### PR TITLE
Update wavebox to 3.1.6

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.1.5'
-  sha256 '3433e0dd06ed4e0ecc6312f1011e218fccd3f25bfe63b59df74a375b3d173a00'
+  version '3.1.6'
+  sha256 'a67163e34bb81cf8366246f8f76ac80d63f0a107c397681486d3faacede9c650'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: '83fd855b7fa2f7faa871dfa43deaf160021bdacbd542fafc36128be2261b7687'
+          checkpoint: '6b653c07bf348487e2deccaf2c35012ea7f0fbf22c7572a217252d9609d105de'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.