### PR TITLE
Update paparazzi to 1.0b5

### DIFF
--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -1,10 +1,10 @@
 cask 'paparazzi' do
-  version '1.0b4'
-  sha256 'f1eaa066035b5b168e253d5ec1c0de02281c6ac8039d4fbccc81ebcde323c5de'
+  version '1.0b5'
+  sha256 'f65571f660e100ac9531fab9edef6413e1f23a5a952e6f2553380cecc3fc0b7b'
 
   url "https://derailer.org/paparazzi/Paparazzi!%20#{version}.dmg"
   appcast 'https://derailer.org/paparazzi/appcast/',
-          checkpoint: 'a5cc985565c2c343f26232b64853850a45c22ae7875b2d618e70fa2fecc78fe5'
+          checkpoint: 'dadd0160957d37476f8b45b79442213ac8e8621918467c0ca4c02c328840bc5a'
   name 'Paparazzi!'
   homepage 'https://derailer.org/paparazzi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.