### PR TITLE
Update textsoap to 8.3.4

### DIFF
--- a/Casks/textsoap.rb
+++ b/Casks/textsoap.rb
@@ -1,11 +1,11 @@
 cask 'textsoap' do
-  version '8.3.3'
-  sha256 '2b03bde3fc8391a4a1adc8f705f08f7d0f5383f7a46afb0588d1d0c6f3cf3e47'
+  version '8.3.4'
+  sha256 '6578d77c28affcc8791bddacc34eadc505b9679ecb8dcaf03589a062313d2e6a'
 
   # unmarked.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://unmarked.s3.amazonaws.com/textsoap#{version.major}.zip"
   appcast "https://unmarked.s3.amazonaws.com/appcast/textsoap#{version.major}.xml",
-          checkpoint: 'a4a2218e787c24a36617ad8cabfd0a170cfdeb12e00aca07874d4fc252776b16'
+          checkpoint: '8fcfec9b49a1840bf0119925a6a5bb0d13850593901a340b07e5fe5f059f8b72'
   name 'TextSoap'
   homepage 'https://www.unmarked.com/textsoap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.