### PR TITLE
Update dbeaver-enterprise to 4.0.5

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,5 +1,5 @@
 cask 'canary' do
-  version '0.972,241'
+  version '0.972.304,241'
   sha256 '4fd067a2115da6b02b332d7afec15e967c7e32e84f5eaf188c3ba18750df1ef4'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask

--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,5 +1,5 @@
 cask 'canary' do
-  version '0.972.307,241'
+  version '0.972,241'
   sha256 '4fd067a2115da6b02b332d7afec15e967c7e32e84f5eaf188c3ba18750df1ef4'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask

--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,5 +1,5 @@
 cask 'canary' do
-  version '0.972.304,241'
+  version '0.972.307,241'
   sha256 '4fd067a2115da6b02b332d7afec15e967c7e32e84f5eaf188c3ba18750df1ef4'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask

--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -4,7 +4,7 @@ cask 'dbeaver-enterprise' do
 
   url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
   appcast 'http://dbeaver.jkiss.org/files/',
-          checkpoint: '1eb06a10ea66e414bfcca9a160d742491a7aa5c6a933f2d8ba1d6276b6f1e566'
+          checkpoint: 'f600c36bda2d4ce9c33e3a8aa006a61a74fb8f825f373a3ea82e41fe2ca6d49e'
   name 'DBeaver Enterprise Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.