### PR TITLE
Updated tifig to v0.6.0

### DIFF
--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -1,11 +1,11 @@
 cask 'tifig' do
-  version '0.5.0-201703231706'
-  sha256 'a31c3ed704a2b03b50e6c9acaf05baac84ef3568bb8e22ecb715d22d6113b3d8'
+  version '0.6.0-201705041302'
+  sha256 'd3f865ca20ac3919be67da639af6fedef7ed87084713f88ff1e6e3e606ee4be4'
 
   # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.tifig.net/download/',
-          checkpoint: 'efc2bf8825f0dba8ddce55d6d5a6d6521f8696f7e0c4a4eef43b1c13087f0e1c'
+          checkpoint: 'd1bc27d2d83cdecd4042d01da0ad91ae621dd120f4ba43eff15e1384f3207df0'
   name 'Tifig'
   homepage 'https://www.tifig.net/'
 


### PR DESCRIPTION
This pull request updates the cask for the Tifig Swift IDE to v0.6.0.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
