### PR TITLE
Update brave to 0.15.2

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.15.1'
-  sha256 '6cef3e45939601f0a9baa3be5cf66d86fcc1e6189bde19f37cb4e952e806f70d'
+  version '0.15.2'
+  sha256 '56ef38654223c910dd8219fce426e27b613eedb900608304c260021f7f774210'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '2b352cc2e21c34a50b8f1470c2091b5c820f13c67b6daa973b3c3206edc8eabd'
+          checkpoint: '28faec1a4f4f33af8ebe244ad22994557e875ae3a9531fadc29e80f6bbd3a110'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.