### PR TITLE
Add zap paths to a-better-finder-attributes

### DIFF
--- a/Casks/a-better-finder-attributes.rb
+++ b/Casks/a-better-finder-attributes.rb
@@ -9,4 +9,11 @@ cask 'a-better-finder-attributes' do
   homepage 'http://www.publicspace.net/ABetterFinderAttributes/'
 
   app "A Better Finder Attributes #{version.major}.app"
+
+  zap delete: [
+                "~/Library/Caches/net.publicspace.abfa#{version.major}",
+                "~/Library/Cookies/net.publicspace.abfa#{version.major}.binarycookies",
+                "~/Library/Preferences/net.publicspace.abfa#{version.major}.plist",
+                "~/Library/Saved Application State/net.publicspace.abfa#{version.major}.savedState",
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

I don't know the correct PR format for these kind of edits. Hope this is ok.