### PR TITLE
Update inspec to 1.23.0-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.22.0-1'
-  sha256 'b4deb245d2bd0e170899a97f071a1eda6f7c47501ad1d87e5ef6ccfce8b24b4c'
+  version '1.23.0-1'
+  sha256 '4146a25ad605b806b3f74cd1b339a0ee7c44e4bf678f6deb0d7075e5c85b168f'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'eb2bf1079cb70b1a9bb788f0606dc2313a645afa272a7950858b1992c6350931'
+          checkpoint: '2e604c16470c7389eaebf194cba848bb57684e03c3dccf717c9844aed5846b21'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.