### PR TITLE
Update appdelete to 4.3.3

### DIFF
--- a/Casks/appdelete.rb
+++ b/Casks/appdelete.rb
@@ -1,10 +1,10 @@
 cask 'appdelete' do
-  version '4.3.2'
-  sha256 '8ebdb3579dabd0d50382aca0101d58c9b31f3d70d909c7fa53948ed1ca313c16'
+  version '4.3.3'
+  sha256 'ac7ce8a55ad74eed68d79ccf69284a1174bf74a2a376f73c63e51ca8c4687547'
 
   url 'http://www.reggieashworth.com/downloads/AppDelete.dmg'
   appcast "http://www.reggieashworth.com/AD#{version.major}Appcast.xml",
-          checkpoint: 'b6256893f57e19683482cc32b9e73093b86814d9c74d60747d2b1dd0d6a9e772'
+          checkpoint: '2ee2069f1fb1f4a76adde5c9be3c120742556ed741b1dd43ee4804017db86d61'
   name 'AppDelete'
   homepage 'http://www.reggieashworth.com/appdelete'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.