### PR TITLE
Update metasploit to 4.14.16,20170505092251

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.14.16,20170502210246'
-  sha256 'd7f6bcb873fa9c109f0272a28004223601c14bc552c6febdf783263b9028828a'
+  version '4.14.16,20170505092251'
+  sha256 '0ff9d7a97970ca3101f85004703c59f73def02fb0c0b46c5e8024a80f6182fc4'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version.major_minor_patch}+#{version.after_comma}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '38fedb94483ef1685c9435d32e7597a55fd41db6c17c0dcb25340daeb7e18867'
+          checkpoint: '42866156feced9c582a635ffa4893653e0f886b41de2f947dc6860053c14f2b2'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.