### PR TITLE
Update beaker-electron to 1.7.1-0-g6dac09a

### DIFF
--- a/Casks/beaker-electron.rb
+++ b/Casks/beaker-electron.rb
@@ -5,7 +5,7 @@ cask 'beaker-electron' do
   # d299yghl10frh5.cloudfront.net was verified as official when first introduced to the cask
   url "https://d299yghl10frh5.cloudfront.net/beaker-notebook-#{version}-electron-mac.dmg"
   appcast 'https://github.com/twosigma/beakerx/releases.atom',
-          checkpoint: '4fec60a4331b6add7fb39b4819cdd8989a4898ece8c16debe3b1b584a17d1399'
+          checkpoint: 'a66b88ef479e3a664e0591c30517386bc4d5e4e14a4b0294be303f6595189072'
   name 'Beaker Electron'
   homepage 'http://beakernotebook.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.