### PR TITLE
Update doomsday-engine to 2.0.1

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,11 +1,11 @@
 cask 'doomsday-engine' do
-  version '2.0.0'
-  sha256 '4694061347d8f14880de8e5973816424263552b28773596116a410c7e3c721f1'
+  version '2.0.1'
+  sha256 'c4dfbfdc452bb6d1552a3ab9c5da0ab74352ed044d783ed0e7729668a2a12f83'
 
   # sourceforge.net/deng was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/deng/rss',
-          checkpoint: 'a0f2b88741910a1dec68fb19e6ade3bbb117553af312f09d673bc7081823f8f9'
+          checkpoint: 'eab4789b2598ebf25216bc55882d17156bb87f444441e36ab1359936f479c717'
   name 'Doomsday Engine'
   homepage 'http://dengine.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.