### PR TITLE
Update downie to 2.8.5,1467

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.8.4,1465'
-  sha256 '80bd572edf62f7b21f03058f5a6465e56934b20060d9a2ca40ae68354adcd842'
+  version '2.8.5,1467'
+  sha256 'edcbddf62335840ed14bd6714fbd4508e8de41453986903e5c7773647383dbb6'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'c7305024c02128466f8349fa22d66d643a6e2e105ed7939da955d9296757d2d8'
+          checkpoint: 'f830eae7dbd8e3b52c7afdc3472d571a0e22c347ee1688a7b907d00cba91c646'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.