### PR TITLE
Update dragthing to 5.9.17

### DIFF
--- a/Casks/dragthing.rb
+++ b/Casks/dragthing.rb
@@ -5,7 +5,7 @@ cask 'dragthing' do
   # amazonaws.com/tlasystems was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tlasystems/DragThing-#{version}.dmg"
   appcast 'http://www.dragthing.com/english/download.html',
-          checkpoint: '193085839afd838f3b81674f261e32fd6d2790e938834c245d4ca1a365501446'
+          checkpoint: '2f4f10b7778cbc2ce8198bafdc1e63cd0edb626054926cf25eb20325ea206c6d'
   name 'DragThing'
   homepage 'http://www.dragthing.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.