### PR TITLE
Update vimr to 0.14.3-185

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.14.2-184'
-  sha256 '978fa81a5f946b9122a328aa26809620e3b4e1302229590363d3b33b8162fd52'
+  version '0.14.3-185'
+  sha256 '3bae52d8bd27943f64b41645466fa5c4482b50df4bd8bd151281c7509047517f'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '0184afa2f70bb203637180ecd7d76398556c7e6dea283892130bb593b339e33e'
+          checkpoint: '4130f45b6b31c103ea009b80c09529b29bb75de7de566bed168363d9dbce25ba'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.