### PR TITLE
Update duplicati to 2.0.1.53,2017-03-13

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -1,10 +1,10 @@
 cask 'duplicati' do
-  version '1.3.4'
-  sha256 'd97065d012fb929fa4e37b5efab2d246b6aef667f892a95301a1271f704963f2'
+  version '2.0.1.53,2017-03-13'
+  sha256 '6e147cb47326c8376049ffb381d2e438cea48bde9e2717c167018709e3931185'
 
-  url "http://updates.duplicati.com/#{version.major_minor}.x/Duplicati%20#{version}.dmg"
+  url "https://updates.duplicati.com/experimental/duplicati-#{version.before_comma}_experimental_#{version.after_comma}.dmg"
   appcast 'https://github.com/duplicati/duplicati/releases.atom',
-          checkpoint: '5b228522bece130f042464271a9a9d49febd1e6935f9642653c12666d870af07'
+          checkpoint: 'fb7210a75a4678a6fbdf376fd2bcc1e4536234e5f5790c9f0c739ce22a43551c'
   name 'Duplicati'
   homepage 'https://www.duplicati.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.