### PR TITLE
Update eintopf to 1.3.2

### DIFF
--- a/Casks/eintopf.rb
+++ b/Casks/eintopf.rb
@@ -5,7 +5,7 @@ cask 'eintopf' do
   # github.com/mazehall/eintopf was verified as official when first introduced to the cask
   url "https://github.com/mazehall/eintopf/releases/download/#{version}/eintopf_#{version}-x64.dmg"
   appcast 'https://github.com/mazehall/eintopf/releases.atom',
-          checkpoint: '2f683218039482487cb26a62f378cef879b5504f694736b58c14663bcd6bd978'
+          checkpoint: '00c28a1e17d3252dfbe019e551fb6d610599fb41d3b3c8fdf6a718f6b083859f'
   name 'Eintopf'
   homepage 'https://eintopf.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.