### PR TITLE
Update tap migrations - tomtom-mysports-connect

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -101,7 +101,6 @@
   "synology-photo-station-uploader": "caskroom/drivers",
   "synologyeiauthenticator": "caskroom/drivers",
   "terraform": "homebrew/core",
-  "tomtom-mysports-connect": "caskroom/drivers",
   "unifi-controller": "caskroom/drivers",
   "vault": "homebrew/core",
   "volatility": "homebrew/core",


### PR DESCRIPTION
This was renamed with https://github.com/caskroom/homebrew-drivers/pull/36. Not sure if the entry in `tap_migrations.json` needs to be removed or renamed.