### PR TITLE
Update firefox to 53.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,104 +1,104 @@
 cask 'firefox' do
-  version '53.0'
+  version '53.0.2'
 
   language 'de' do
-    sha256 '9598b9cd660619147d8593c64dd0bc0dcd0473adc780b93acf8fac8056b6b086'
+    sha256 '96329cad2acebc2ae17e995fade5240554640d9dc5a91532e29a138282948ac2'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '8f29a4fb7a39d46da512674e8f26699bde69e5c52130c8634c8398c039d3064d'
+    sha256 '77566765663ad491c55c8470e4e1234bb30f3388c2a6546ed18c90992e01de94'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '6010f574b54e79060ebce8cce50cb19bfe82066b36ea84dff6f323299dcf47bc'
+    sha256 '180ae12e65fb2c8025ffad501d998dc01dbe19408b528c78a05a163f0fa0b5be'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 '9f235ad092c9cb562291e7f4d4d6b67c691d7b79dffc5e033f7a1ad683dba0e1'
+    sha256 'a02002d0c46591b9bda866b4825bafd7e902bb1863b257fd0725a8c92cb53f31'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '3f53175ad89d109837fe6ecbdf3f14a99e6c05414bcf2d34e61a06aeb3e4fa6b'
+    sha256 '83e16ed13d50509a85b2cb0020bd7bb2f1dfb58a54fcea254ee63e91a7f7f7bb'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'e10fd368619ad63952dd9b7c87cfca893ee92b65b1d8d956ba039671598e718a'
+    sha256 'd2632f01b5e78a314e45437ff4ff532fb79f7867e73baabbb7f66a38b3404143'
     'es-ES'
   end
 
   language 'fr' do
-    sha256 '89af9c2f0ebb82f9b8bc0a9fadd58fc470ffce36005fafd041774ea00a07539c'
+    sha256 '4fbf4c892fc846ba0d3b830d64f20b3c87d5d5152b04202c35012ca25ab7c06a'
     'fr'
   end
 
   language 'gl' do
-    sha256 '1164f95b60ba14d35220dbd4e9f938e77a9a1ddab76d3f5c19ab6b15f0f79128'
+    sha256 'cc843bde7af770e3ec0f848122b90343b088279c8736764df6f7db426408c35d'
     'gl'
   end
 
   language 'in' do
-    sha256 '162161f3975a3ad1e6faefac957f38270d23f56326f29eb1a620c741cd19dd82'
+    sha256 '04e3a3eccb234b7527ea7246883480ba6cc386e98fb8caaff6a4d0ff9a0a37d6'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 'baee090e5785dd4d051ee6464ca8db6612a06e034ef232a32d8f65189e2e8d77'
+    sha256 '34126aea59b21a291561962ad134e26abb0d3e2149648e743fbdd17c3d9ad040'
     'it'
   end
 
   language 'ja' do
-    sha256 '993cb253f626460bb2be007dba62475452c9da442dd2ecd1675e7dd2d61fab44'
+    sha256 'b81d55a3c28307df6402815d3d5a0b8e69df964025b8aae360176dea831310f6'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'fe9d16b9be4d1719e19a0ef4ee32ca7453ee23dc4c0479ea772f5b01e55f848d'
+    sha256 '1b9150319b17abd1bf9f6f0be694ae6f85de45f7a05abf378b1efce22e281bbf'
     'nl'
   end
 
   language 'pl' do
-    sha256 'aea3ccfcbaacec53aee07a0d9414df772731c8644ccbdc0474a5cafd5ab783c3'
+    sha256 '69a096e8448fa8518fda150581dba868253c7e973a5948433083c6bd4f9a7fd9'
     'pl'
   end
 
   language 'pt' do
-    sha256 'ac81c93422921fecc68a024b30ff15cde36c5868a6b2126d9dff3054612bcc2a'
+    sha256 '19b50f76a3ed54a783db53d152f9dbc6f0718a22ad9e9fcfc760bea9918dbe77'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '03ee36e26c341927f96244d9cf7bf4db78ca602b6693ed185c705091d8ed68e0'
+    sha256 '35d3bd38d9bf82529906388f21df7d53faa58275d77b7cfbb90d705d487c1352'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 'b9865dbc25493a944c3ac57d8ca14304f55e9f0629ab472a5d93350765ebdac7'
+    sha256 'c0bda939d321b5bf22d4946c1e674cd8ad9f9aeaf75c6cc714007d0165b65e46'
     'ru'
   end
 
   language 'uk' do
-    sha256 '329df3d472228cad7ab431af62c35237ff5afafd87c506bac30ae08df1cd7e58'
+    sha256 '6be6646d1be1e25ea03c78925a121a7a6211cfdf206b0d7eda05955d16415a97'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '3182b2370377597e9e6e899e41dea8afd5b8f482d2cbf3d05a1661772985df53'
+    sha256 '9ad5be1df9ce7ea6b5a7812a1261b990006dfb515d40194933d6455ac8706c49'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '6c10b1f3d65be02aec264e17736cdab4c2ad45a987a1ad4f08eb1c937fb3d22e'
+    sha256 'af5d9b89103b63b7f36c9edf8f61b5d641c26104c0f743b65faa1c163a217dd5'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '9caabb97d8e03057db992fc8ac27546c2c76161ba26e75502b1a446cd4443d8c'
+          checkpoint: 'ca5771d3afe74b835adfd425531641f59af117ba6ed9a4ce6dc4803d465af15a'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
