### PR TITLE
Update hab to 0.22.0-20170506033930

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.21.0-20170421000356'
-  sha256 '2eaef5b747411e96148f03a9fde8d3689ebb15b7298370cd88e7b4a2fc049502'
+  version '0.22.0-20170506033930'
+  sha256 '3dd7524ab546e1f6fcb68f289d780c7085dd146c3f5901d336f767e78272d19d'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '2f2e308774833bd6100b626bb92cb588dadac73a97f91aa3da0f11294329dc1c'
+          checkpoint: 'e5813ce6a0e5195f9c663aaac314c68734427a71edaf953c17d4d93db68185db'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.