### PR TITLE
Update gotomeeting to 8.4.6871

### DIFF
--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,6 +1,6 @@
 cask 'gotomeeting' do
-  version :latest
-  sha256 :no_check
+  version '8.4.6871'
+  sha256 'd8de55400362f9913017dc4a82373c1148adf4ff24c4b4f82b5d40dadbb4f8dc'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
   url 'https://support.citrixonline.com/servlet/fileField?entityId=ka3380000000FRYAA2&field=Content__Body__s'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.