### PR TITLE
Update keybase uninstall / zap

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -17,11 +17,32 @@ cask 'keybase' do
                    args: ["--app-path=#{appdir}/Keybase.app", '--run-mode=prod', '--timeout=10']
   end
 
-  uninstall_preflight do
-    if system_command('launchctl', args: ['list']).stdout =~ %r{/^\d+.*keybase.Electron/}
-      system_command 'killall', args: ['-kill', 'Keybase']
-    end
-    system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
-                   args: ['uninstall']
-  end
+  uninstall launchctl:  'keybase.Helper',
+            login_item: 'Keybase',
+            signal:     [
+                          ['TERM', 'keybase.Electron'],
+                          ['TERM', 'keybase.ElectronHelper'],
+                          ['KILL', 'keybase.Electron'],
+                          ['KILL', 'keybase.ElectronHelper'],
+                        ],
+            script:     {
+                          executable: "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
+                          args:       ['uninstall'],
+                        }
+
+  zap delete: [
+                '~/Library/Application Support/Keybase',
+                '~/Library/Caches/Keybase',
+                '~/Library/Group Containers/keybase',
+                '~/Library/Logs/Keybase.app.log',
+                '~/Library/Logs/keybase.kbfs.log',
+                '~/Library/Logs/keybase.service.log',
+                '~/Library/Logs/keybase.start.log',
+                '~/Library/Logs/keybase.updater.log',
+                '~/Library/Preferences/keybase.Electron.plist',
+                '~/Library/Preferences/keybase.ElectronHelper.plist',
+                '/Library/Logs/keybase.system.log',
+                '/Library/PrivilegedHelperTools/keybase.Helper',
+              ],
+      rmdir:  '/keybase'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Changed from `uninstall_preflight` to `uninstall` with `zap`.

`uninstall quit:` does not quit the app and causes an error during uninstall.

Refs: https://github.com/caskroom/homebrew-cask/pull/30151#issuecomment-280450778, https://github.com/caskroom/homebrew-cask/issues/30145, https://github.com/caskroom/homebrew-cask/pull/29956

Note: 
- This cask now requries `uninstall` artifact sort discussed in https://github.com/caskroom/homebrew-cask/issues/32300, see [comment](https://github.com/caskroom/homebrew-cask/issues/32300#issuecomment-299666142)

- `uninstall` will fail when run with `--force` if the script does not exist. https://github.com/caskroom/homebrew-cask/pull/30151#issuecomment-280451939