### PR TITLE
Update endnote to latest

### DIFF
--- a/Casks/endnote.rb
+++ b/Casks/endnote.rb
@@ -2,9 +2,11 @@ cask 'endnote' do
   version :latest
   sha256 :no_check
 
-  url 'http://endnote.com/x7/EndNoteX7Installer.dmg'
+  url 'http://download.endnote.com/downloads/X8/EndNoteX8Installer.dmg'
   name 'EndNote'
   homepage 'http://endnote.com/'
 
-  app 'EndNote X7/EndNote X7.app'
+  container nested: 'Install EndNote X8.app/Contents/Resources/EndNote.zip'
+
+  suite 'EndNote X8'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/pull/33434

https://derflounder.wordpress.com/2016/11/15/preparing-endnote-x8-for-deployment-using-autopkg/