### PR TITLE
Update jce-unlimited-strength-policy 

### DIFF
--- a/Casks/jce-unlimited-strength-policy.rb
+++ b/Casks/jce-unlimited-strength-policy.rb
@@ -25,6 +25,21 @@ cask 'jce-unlimited-strength-policy' do
                      args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.minor}/local_policy.jar", "#{path}/jre/lib/security/local_policy.jar"],
                      sudo: true
     end
+    system_command '/bin/cp',
+                   args: ['-an', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/US_export_policy.jar', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/US_export_policy.jar.bak'],
+                   sudo: true
+
+    system_command '/bin/cp',
+                   args: ['-an', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/local_policy.jar', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/local_policy.jar.bak'],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.minor}/US_export_policy.jar", '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/US_export_policy.jar'],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: ['-nsf', "#{staged_path}/UnlimitedJCEPolicyJDK#{version.minor}/local_policy.jar", '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/local_policy.jar'],
+                   sudo: true
   end
 
   uninstall_postflight do
@@ -36,6 +51,12 @@ cask 'jce-unlimited-strength-policy' do
                      args: ['-f', "#{path}/jre/lib/security/local_policy.jar.bak", "#{path}/jre/lib/security/local_policy.jar"],
                      sudo: true
     end
+    system_command '/bin/mv',
+                   args: ['-f', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/US_export_policy.jar.bak', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/US_export_policy.jar'],
+                   sudo: true
+    system_command '/bin/mv',
+                   args: ['-f', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/local_policy.jar.bak', '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security/local_policy.jar'],
+                   sudo: true
   end
 
   caveats <<-EOS.undent


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/32720

Update `postflight` and `uninstall_postflight` to backup, symlink and restore policy files in `/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/security`