### PR TITLE
Update buttercup to 0.14.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.13.0'
-  sha256 '3785bd76b70029211525ad97039fc1f46d7c55b265602691c975f10a16aeb8b4'
+  version '0.14.0'
+  sha256 '4a9233c266dda6bd2643db23da1c76be45faa3c214b92f0554ec55043ebc37b3'
 
   # github.com/buttercup/buttercup was verified as official when first introduced to the cask
-  url "https://github.com/buttercup/buttercup/releases/download/v#{version}-alpha/Buttercup-#{version}-mac.zip"
+  url "https://github.com/buttercup/buttercup/releases/download/v#{version}/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup/releases.atom',
-          checkpoint: '20dad1973c4adac03a57456b21cbaaeeb4e1f8493d4529a132ff04b69e5ce3b7'
+          checkpoint: '7703beb0ee8b9c7bfb54cd529e0996542d71e21baa192c2faee60cc94a08b43f'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.