### PR TITLE
Update coconutbattery to 3.6.1

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -4,11 +4,11 @@ cask 'coconutbattery' do
     sha256 '0edf6bdaf28fb3cc9c242fd916c348fbbae30a5356ddc1d6e5158d50f96d740d'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.dots_to_underscores}.zip"
   else
-    version '3.6'
-    sha256 '0a36363af6dfb5fd8f1c7c43933b148040eec95dae8ea3589ff71d1f053c6444'
+    version '3.6.1'
+    sha256 '9707b852365221e714e59952e1cb237fea66fed512b1e32f9f14fb485aba66e1'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml',
-            checkpoint: '97ae1f9d69b836bac944132bad2faa3dfa587c901c7ce0a7499e5815e223f443'
+            checkpoint: '4a995713587c36dd8b92bed98875073bd498c5ac7feb5c84b5b7da4f0b269f31'
   end
 
   name 'coconutBattery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.