### PR TITLE
Update jasper to 0.3.1

### DIFF
--- a/Casks/jasper.rb
+++ b/Casks/jasper.rb
@@ -1,11 +1,11 @@
 cask 'jasper' do
-  version '0.3.0'
-  sha256 '3cbce35847c2cfdf29d2b76bafc0a2e71c14ec7be5a9c59eccc59311244345e6'
+  version '0.3.1'
+  sha256 '6de55bce4ac61bddc891ffd7c83658f4f7b2aba63da7ca6f37d70d12ce321de2'
 
   # github.com/jasperapp/jasper was verified as official when first introduced to the cask
   url "https://github.com/jasperapp/jasper/releases/download/v#{version}/jasper_v#{version}_mac.zip"
   appcast 'https://jasperapp.io/-/versions-mac.json',
-          checkpoint: '4b6a99cac755f6f6c3f7a0c7d832f94bf7cdd7b66e8c7b58e591722e6e5d24b1'
+          checkpoint: '4e7433ae8552e9956b99a0168cd9dd154a03749c9ae81ebb4e43f35584872193'
   name 'Jasper'
   homepage 'https://jasperapp.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.