### PR TITLE
Update weka to 3.8.1

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,11 +1,11 @@
 cask 'weka' do
-  version '3.9.1'
-  sha256 'eecbe8dd3ea1b2a10195077f19c0667c465cd37a8ae135c9e7f2748c0966060c'
+  version '3.8.1'
+  sha256 '7714dd0cddee3412d5092a3b439c9a06844134885c39f30f5ad63e89d852bd9b'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-oracle-jvm.dmg"
   appcast 'https://sourceforge.net/projects/weka/rss',
-          checkpoint: '7c6d73f13bb91b88f7c9e5a329409012390835b85397bc97ff6ed6223c37690b'
+          checkpoint: '39aecb6a42219cfc46e42fb5c6518c4a3defdf1c3c285e2c9672589ca2f16e34'
   name 'Weka'
   homepage 'http://www.cs.waikato.ac.nz/ml/weka/'
 


### PR DESCRIPTION
- Official Home claims 3.8.1 as stable version. So 3.9.1 should ideally be in homebrew-version not here.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

![weka-3](https://cloud.githubusercontent.com/assets/450222/25821767/5497dbda-3404-11e7-9873-b0bff565f1dd.png)
![weka-2](https://cloud.githubusercontent.com/assets/450222/25821768/549a63aa-3404-11e7-8a64-288c4979d908.png)
![weka-1](https://cloud.githubusercontent.com/assets/450222/25821769/54a53bf4-3404-11e7-9c59-22af8c6d2d2f.png)
