### PR TITLE
Update feeds to 2.1.2

### DIFF
--- a/Casks/feeds.rb
+++ b/Casks/feeds.rb
@@ -5,7 +5,7 @@ cask 'feeds' do
   # storage.googleapis.com/feeds-releases was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/feeds-releases/Feeds-#{version}.zip"
   appcast 'https://storage.googleapis.com/feeds-releases/appcast.xml',
-          checkpoint: '4450c36d30006bb4b85fa047d9062a3ce22d3d170824eea73db3db01acb0a880'
+          checkpoint: 'c0b0eaa83743909eae1e42bb7bc1d5d3e8c0375b23364e1007ce09eaf0f64739'
   name 'Feeds'
   homepage 'http://www.feedsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.