### PR TITLE
Update wiretap-studio to 1.2.2

### DIFF
--- a/Casks/wiretap-studio.rb
+++ b/Casks/wiretap-studio.rb
@@ -3,10 +3,10 @@ cask 'wiretap-studio' do
   sha256 'cfb0eb8b10828153f900d93a920b650cbba8a21d1f7e28bedc0414ccb2c3f8d8'
 
   url 'http://downloads3.ambrosiasw.com/wiretapstudio/essentials/WireTapStudio.dmg'
-  appcast 'https://www.ambrosiasw.com/updates/profile.php/wiretap_studio/release',
+  appcast 'http://www.ambrosiasw.com/updates/profile.php/wiretap_studio/release',
           checkpoint: '88e49bedea4c9426997c344bda3f61959f3b7f0b05f432de0d9c26cf40a44fa4'
   name 'WireTap Studio'
-  homepage 'https://www.ambrosiasw.com/utilities/wiretap/'
+  homepage 'http://www.ambrosiasw.com/utilities/wiretap/'
 
   app 'WireTap Studio.app'
 end


### PR DESCRIPTION
- Certificate Expired since Nov 2016

![wiretap studio](https://cloud.githubusercontent.com/assets/450222/25826314/566e1c66-3414-11e7-9969-a2fc670a09d4.png)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.