### PR TITLE
Update ricochet to 1.1.4.1

### DIFF
--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -4,7 +4,7 @@ cask 'ricochet' do
 
   url "https://ricochet.im/releases/#{version.major_minor_patch}/ricochet-#{version}-macos.dmg"
   appcast 'https://github.com/ricochet-im/ricochet/releases.atom',
-          checkpoint: 'e108bebf36774267a8598891ee6fef1315022a04cc3efb94ff13fbb80e201d55'
+          checkpoint: 'a4e6947602fdb6f03be93ab1f0cd18426a21e6486c61a28a1d1b12696713fbb4'
   name 'Ricochet'
   homepage 'https://ricochet.im/'
   gpg "#{url}.asc", key_id: '9032cae4cbfa933a5a2145d5ff97c53f183c045d'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.