### PR TITLE
Update servetome to 4.0.0144

### DIFF
--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -4,7 +4,7 @@ cask 'servetome' do
 
   url "http://downloads.zqueue.com/ServeToMe-v#{version}.dmg"
   appcast 'https://www.zqueue.com/servetome/changehistory.html',
-          checkpoint: 'e94a01c4410b8d1bfe8fce5feb9dc465e9fbbf1dc5510ac80fb0bdce886156ab'
+          checkpoint: 'feed3e29ad59f08e1add12b87f065fc7f6daa2977790dd0fc744e2caf4a4f566'
   name 'ServeToMe'
   homepage 'https://www.zqueue.com/servetome/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.