### PR TITLE
Update qtox to 1.10.0

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.9.0'
-  sha256 '5f4144c3659e7e56b6c9e6414acfc8e053d42e90d42e2ad4e62e9103ab8dd847'
+  version '1.10.0'
+  sha256 'f9adc318ea4b89c089ad11ef6a74dec7fa83499a232c1ebe9fdebdcf4fc58265'
 
   # github.com/tux3/qTox was verified as official when first introduced to the cask
   url "https://github.com/tux3/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/tux3/qtox/releases.atom',
-          checkpoint: '25c0bfb96726ee382d587e787945ae543b3237246ed1e21063c1a8aa7752662c'
+          checkpoint: 'd74c248f0c50c446be1676b1fc490a027c0e997d42d0320b4e652a00ee0b967b'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.