### PR TITLE
Add/remove binaries in the emacs cask

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -9,6 +9,7 @@ cask 'emacs' do
   homepage 'https://emacsformacosx.com/'
 
   app 'Emacs.app'
+  binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -8,8 +8,10 @@ cask 'emacs' do
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 
-  conflicts_with formula: 'emacs'
-  conflicts_with formula: 'ctags'
+  conflicts_with formula: %w[
+                            emacs
+                            ctags
+                          ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -10,7 +10,6 @@ cask 'emacs' do
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ctags"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
 end

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -8,11 +8,12 @@ cask 'emacs' do
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 
-  conflicts_with formula: 'emacs'
+  conflicts_with formula: 'emacs', 'ctags'
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ctags"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
 end

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -8,6 +8,8 @@ cask 'emacs' do
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 
+  conflicts_with formula: 'emacs'
+
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -8,7 +8,8 @@ cask 'emacs' do
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 
-  conflicts_with formula: 'emacs', 'ctags'
+  conflicts_with formula: 'emacs'
+  conflicts_with formula: 'ctags'
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'


### PR DESCRIPTION
- Remove `ctags` binary, since it conflicts with the [ctags formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ctags.rb) in homebrew-core.
- Add `emacs` binary.
- Add `conflicts_with formula: 'emacs'`

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
