### PR TITLE
Update file-juicer to 4.58

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,8 +1,8 @@
 cask 'file-juicer' do
-  version :latest
-  sha256 :no_check
+  version '4.58'
+  sha256 'd5534d38a0e263b08b6376072ed739171526f2ca160a9bb64e5df60ebd282356'
 
-  url 'http://echoone.com/filejuicer/FileJuicer.dmg'
+  url 'https://echoone.com/filejuicer/FileJuicer-4.58.zip'
   name 'File Juicer'
   homepage 'https://echoone.com/filejuicer/'
 

--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -2,7 +2,7 @@ cask 'file-juicer' do
   version '4.58'
   sha256 'd5534d38a0e263b08b6376072ed739171526f2ca160a9bb64e5df60ebd282356'
 
-  url 'https://echoone.com/filejuicer/FileJuicer-4.58.zip'
+  url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   name 'File Juicer'
   homepage 'https://echoone.com/filejuicer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.