### PR TITLE
Update trickster to 2.6

### DIFF
--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -4,12 +4,12 @@ cask 'trickster' do
     sha256 'cddc4a27c3c2a016f86d1688ef9708d3e8c605cfe06302470471309ccdc241db'
   else
     version '2.6'
-    sha256 'e3e3e93da2f9e1743cf597633c5443cb59f75ac8938db4dcc14b2554126cb986'
+    sha256 '73ddedc3e3622284f5111f9f85f0b8068355eeafe1f47c61990de1a3c0d86d91'
   end
 
   url "https://dl.apparentsoft.com/Trickster_#{version}.zip"
   appcast 'https://dl.apparentsoft.com/trickster.rss',
-          checkpoint: '83ad3c8336c908829948296e96ad2095d0655965080a72aafdf110129e2dfd98'
+          checkpoint: 'fd7806111308b4b506d92fbdbad2fb90661b0933a3e3c40896927eb7f1a693cf'
   name 'Trickster'
   homepage 'https://www.apparentsoft.com/trickster/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---
Ref: https://twitter.com/gobinathm/status/861799497445380098

#### Confirmation in Progress via Tweet
<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/tricksterapp">@tricksterapp</a>  sha256 seems 2 be updated 4 Trickster app. Have u updated the app without bumping version?<br><br>cc/ <a href="https://twitter.com/homebrewcask">@homebrewcask</a></p>&mdash; gobinathm (@gobinathm) <a href="https://twitter.com/gobinathm/status/861799497445380098">May 9, 2017</a></blockquote>
