### PR TITLE
Update shuttle to 1.2.9

### DIFF
--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -5,7 +5,7 @@ cask 'shuttle' do
   # github.com/fitztrev/shuttle was verified as official when first introduced to the cask
   url "https://github.com/fitztrev/shuttle/releases/download/v#{version}/Shuttle.zip"
   appcast 'https://github.com/fitztrev/shuttle/releases.atom',
-          checkpoint: '450d58e7a2032148d809afe3bc6dd4cb7b0fd0bb807855fa17f452c57ace3a3b'
+          checkpoint: 'a3106eb50a233be242a85cb52fd14956c5629c4367f86de0fa2ab4d6f63e9208'
   name 'Shuttle'
   homepage 'https://fitztrev.github.io/shuttle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.