### PR TITLE
Update paparazzi 1.0b5 checkpoint & add zap stanza

### DIFF
--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -9,4 +9,12 @@ cask 'paparazzi' do
   homepage 'https://derailer.org/paparazzi/'
 
   app 'Paparazzi!.app'
+
+  zap delete: [
+                '~/Library/Application Support/Paparazzi!',
+                '~/Library/Caches/org.derailer.Paparazzi',
+                '~/Library/Cookies/org.derailer.Paparazzi.binarycookies',
+                '~/Library/Preferences/org.derailer.Paparazzi.plist',
+                '~/Library/Saved Application State/org.derailer.Paparazzi.savedState',
+              ]
 end

--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -4,7 +4,7 @@ cask 'paparazzi' do
 
   url "https://derailer.org/paparazzi/Paparazzi!%20#{version}.dmg"
   appcast 'https://derailer.org/paparazzi/appcast/',
-          checkpoint: 'dadd0160957d37476f8b45b79442213ac8e8621918467c0ca4c02c328840bc5a'
+          checkpoint: '1673362065a3a18036832bdc850b40b24b44bfb1188739b134f9dcabf48c6fa1'
   name 'Paparazzi!'
   homepage 'https://derailer.org/paparazzi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] `sha256` was updated, but `version` remained the same.