### PR TITLE
Update xtrafinder to 0.25.9

### DIFF
--- a/Casks/xtrafinder.rb
+++ b/Casks/xtrafinder.rb
@@ -2,7 +2,7 @@ cask 'xtrafinder' do
   version '0.25.9'
   sha256 'c01096536843359ace55345c6636f6608668a213f03b76d183cd4182ce027e0a'
 
-  url 'https://www.trankynam.com/xtrafinder/downloads/XtraFinder.dmg'
+  url 'http://www.trankynam.com/xtrafinder/downloads/XtraFinder.dmg'
   appcast 'https://www.trankynam.com/xtrafinder/XtraFinder-Appcast.xml',
           checkpoint: '7645737d49a4e697f4e1361d89d12d513bf2c0f6edefc91131ae3330b910ea3e'
   name 'XtraFinder'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.