### PR TITLE
Update wechatwebdevtools to 0.17.170900

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '0.17.170800'
-  sha256 'abd3c1d113138e98026b40dbf6e654548e1f687087553340b5efd0cf9976cacf'
+  version '0.17.170900'
+  sha256 '6aae58fd615f909d70eef1d13cb729e78af7f32429e60c5fd758cfee2230f567'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.no_dots}/wechat_web_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.