### PR TITLE
Update react-native-debugger (0.6.5)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.6.4'
-  sha256 'bfa93efdcb8af5d17886aa3276d29bdc3e4dcf4e62af64d3d9f60a0a87460687'
+  version '0.6.5'
+  sha256 '6ff60327e55fe77ca9018b0a7b6e32cc693e8073f59ef263e227e98ad341df7d'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '46ea6b82282db961d60cbe3dde5d809ac02e4bf2cc84802d360482b6308c0126'
+          checkpoint: '7e5b7fac1d1f4f0f7b521323ff705d7fe9700a33b598a1e0834dfa6887ffb2f7'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] `sha256` was updated, but `version` remained the same.