### PR TITLE
Update flycut to 1.8.2

### DIFF
--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -4,7 +4,7 @@ cask 'flycut' do
 
   url "https://github.com/TermiT/Flycut/releases/download/#{version}/Flycut.app.#{version}.zip"
   appcast 'https://github.com/TermiT/Flycut/releases.atom',
-          checkpoint: '1cb31799329d090ccf363ba982998f099eefe915826eae38e62aa5951da6d974'
+          checkpoint: 'c978b2178af3240b1d123542b6aece9228dd4ef0c6a8e96a652fae7fc78edb45'
   name 'Flycut'
   homepage 'https://github.com/TermiT/Flycut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.