### PR TITLE
Update folding-at-home to 7.4.4

### DIFF
--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -4,7 +4,7 @@ cask 'folding-at-home' do
 
   url "https://fah.stanford.edu/file-releases/public/release/fah-installer/osx-10.6.4-64bit/v#{version.sub(%r{\.\d+$}, '')}/fah-installer_#{version}_x86_64.mpkg.zip"
   appcast "https://folding.stanford.edu/download/releases.py?series=#{version.major_minor}&release=public&platform=MacIntel",
-          checkpoint: '9d2d2b557b3f554559018dd369a04fbaa32a6572ac654ba1f544941252b4f39b'
+          checkpoint: '3d1ba1efbfeeb186c5d289116b8864d1f7619ed971b517e4026d0073a5a2f335'
   name 'Folding@home'
   homepage 'https://folding.stanford.edu/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.