### PR TITLE
Update typinator to 7.2

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,11 +1,11 @@
 cask 'typinator' do
-  version '7.1'
-  sha256 '8cf28e133d3e555b6f14ddde0b4b1177c7df20cccc7769a5318fdbb9ff5422d5'
+  version '7.2'
+  sha256 '153ae0ac3441744c369d08ff376e6856bbb49a9a379351f1d3cd7a31f7889de9'
 
   url "http://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake
   appcast 'http://www.ergonis.com/products/typinator/history.html',
-          checkpoint: 'aad99f2f3863403c556b5124780f2d03d69d25296a5223486ae797428a228e17'
+          checkpoint: 'bf00eb396aec76a1a501756d237e20a91f959793e9343a7cc19bbf6f0e54c005'
   name 'Typinator'
   homepage 'http://www.ergonis.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.