### PR TITLE
Update game-capture-hd to 2.6_1214

### DIFF
--- a/Casks/game-capture-hd.rb
+++ b/Casks/game-capture-hd.rb
@@ -5,14 +5,14 @@ cask 'game-capture-hd' do
 
     url "http://files.elgato.com/gamecapture/gchdm_#{version.no_dots}.dmg"
   else
-    version '2.5.1_1123'
-    sha256 'e4c8b6cce606d9254a67bbd4784354bb837674ada28d326753edcac340edb2f9'
+    version '2.6_1214'
+    sha256 'eb5236e5435f45123edd28510a1c0c97248bebd6c3c870bfef55aa30694664e6'
 
     url "https://edge.elgato.com/egc/macos/egcm/#{version.major_minor_patch}/final/gchdm_#{version.no_dots}.dmg"
   end
 
   appcast 'http://updates.elgato.com/autoupdate/gameCapture20.rss?lang=English',
-          checkpoint: 'd35e51bebe6a775722c02bd53f3804d2530f4df98c833c0057ff76c62d0d0a19'
+          checkpoint: 'af4fe0ec28b8c1593175660072a1929fc7db163ea9a4bb83c1e3bea2144d34b2'
   name 'Game Capture HD'
   homepage 'https://www.elgato.com/en/gaming/gamecapture-hd'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.