### PR TITLE
Update sourcetree to 2.5.1a

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.5c'
-    sha256 '1a240b1e055911e07266d15f361ed12ae7dabdabb8ac5db708f95e89cbf18a1c'
+    version '2.5.1a'
+    sha256 'cc84b44be7442d427c4e2347d969fde5b48f00509dc12d8bf0648dc9ea789ae0'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
- [X] `brew cask audit --download sourcetree` is error-free.
- [X] `brew cask style --fix sourcetree` reports no offenses.
- [X] The commit message includes the cask’s name and version.