### PR TITLE
Update freesmug-chromium to 58.0.3029.110

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '58.0.3029.96'
-  sha256 'e3a9c917f75a7a27e964d6da004ff740a13fba4a8128a8c2058b0efec05fb45d'
+  version '58.0.3029.110'
+  sha256 '6d6b602aef9892d41bfea727f8cf86d0040a27d0249b4ef45cc983cbac9d3086'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: 'd01f184a87ac7f991e2d363e224397ab48670e75c69ae577b2e1c39ca921b3f8'
+          checkpoint: '32d6fbca1fee4aca5f5dde5b25b8410d22d3f2c64829f3300fd47151a5c6af54'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.