### PR TITLE
Update minikube to 0.19.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,11 +1,11 @@
 cask 'minikube' do
-  version '0.18.0'
-  sha256 '301dc5f47cccface80769bd3a03d58ba80893f6ede75f2a7ec22f1bc56666deb'
+  version '0.19.0'
+  sha256 'efe27dd4f791403b90eefab8c1f6ea3c7f3115a7609f41e3189517f088e20f0e'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: '422d4d38d28c8150864e785ae3dd0c6ff3b38ebfcf74f7522a8d561c70fe7a25'
+          checkpoint: 'e0fa248f6eea519d2bfb2b6eaedf5f809ea4fc669f721eb1c8574db10027a8cc'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.