### PR TITLE
Update hab to 0.22.1-20170509231134

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.22.0-20170506033930'
-  sha256 '3dd7524ab546e1f6fcb68f289d780c7085dd146c3f5901d336f767e78272d19d'
+  version '0.22.1-20170509231134'
+  sha256 'f77cf1d070e1033d2a4360601789a984748b44bdc401cf3849ade36191351e30'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'e5813ce6a0e5195f9c663aaac314c68734427a71edaf953c17d4d93db68185db'
+          checkpoint: '3f845727f29dc09954bf12df1c0b6be55a56981aeb62d465937480a4e59f9d2e'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.