### PR TITLE
Update cisdem-pdfmanagerultimate to 2.5.0

### DIFF
--- a/Casks/cisdem-pdfmanagerultimate.rb
+++ b/Casks/cisdem-pdfmanagerultimate.rb
@@ -1,8 +1,8 @@
 cask 'cisdem-pdfmanagerultimate' do
-  version :latest
-  sha256 :no_check
+  version '2.5.0'
+  sha256 '572ed99e8ea18474a0dfe7fd42e0fe704e40607f12a979ada704054fc81d05de'
 
-  url 'https://www.cisdem.com/download/cisdem-pdfmanagerultimate.dmg'
+  url 'https://www.cisdem.com/downloads/cisdem-pdfmanagerultimate-15.dmg'
   name 'Cisdem PDFManagerUltimate'
   homepage 'https://www.cisdem.com/pdf-manager-ultimate-mac.html'
 

--- a/Casks/cisdem-pdfmanagerultimate.rb
+++ b/Casks/cisdem-pdfmanagerultimate.rb
@@ -3,6 +3,8 @@ cask 'cisdem-pdfmanagerultimate' do
   sha256 '572ed99e8ea18474a0dfe7fd42e0fe704e40607f12a979ada704054fc81d05de'
 
   url 'https://www.cisdem.com/downloads/cisdem-pdfmanagerultimate-15.dmg'
+  appcast 'https://www.cisdem.com/pdf-manager-ultimate-mac/release-notes.html',
+           checkpoint: 'a35891d9723f5f33675c20e926f3190c31140ad40bf861a2c0bf8e8db5805fed'  
   name 'Cisdem PDFManagerUltimate'
   homepage 'https://www.cisdem.com/pdf-manager-ultimate-mac.html'
 

--- a/Casks/cisdem-pdfmanagerultimate.rb
+++ b/Casks/cisdem-pdfmanagerultimate.rb
@@ -4,7 +4,7 @@ cask 'cisdem-pdfmanagerultimate' do
 
   url 'https://www.cisdem.com/downloads/cisdem-pdfmanagerultimate-15.dmg'
   appcast 'https://www.cisdem.com/pdf-manager-ultimate-mac/release-notes.html',
-           checkpoint: 'a35891d9723f5f33675c20e926f3190c31140ad40bf861a2c0bf8e8db5805fed'  
+          checkpoint: 'a35891d9723f5f33675c20e926f3190c31140ad40bf861a2c0bf8e8db5805fed'
   name 'Cisdem PDFManagerUltimate'
   homepage 'https://www.cisdem.com/pdf-manager-ultimate-mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.