### PR TITLE
Update comictagger to 1.1.16-beta-rc2

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,6 +1,6 @@
 cask 'comictagger' do
-  version '1.1.15-beta'
-  sha256 '6640834d966c1cc760de6aa32729bf139bf06727f8d650a4534cdf780f084960'
+  version '1.1.16-beta-rc2'
+  sha256 '3d2d883371a22074205ef96f98fdd0ccc35399f9439bc235b6f4c1c21e856bc5'
 
   url "https://github.com/davide-romanini/comictagger/releases/download/#{version}/ComicTagger-#{version}.dmg"
   appcast 'https://github.com/davide-romanini/comictagger/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.