### PR TITLE
Update glyphs to 2.4.1-983

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -4,7 +4,7 @@ cask 'glyphs' do
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: 'e90536931075a32aed280b693ac4fb89a9361be1c19530d9657890af2c9f2050'
+          checkpoint: 'bb9b963606e84a994a62a9ac66d0ea04220176f3074fb2362da886d309e727a6'
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.