### PR TITLE
Update shiftit to 1.6.3

### DIFF
--- a/Casks/shiftit.rb
+++ b/Casks/shiftit.rb
@@ -4,7 +4,7 @@ cask 'shiftit' do
 
   url "https://github.com/fikovnik/ShiftIt/releases/download/version-#{version}/ShiftIt-#{version}.zip"
   appcast 'https://github.com/fikovnik/ShiftIt/releases.atom',
-          checkpoint: '27768f3e0be91ae446110e3e478d895b543745f2c01f914cfb2b932f1070fba8'
+          checkpoint: 'ce84bfdc0d373f8fc0eb8a97f23934ca2cf7e7d075bc5b4ff07bc2d68d7ad947'
   name 'ShiftIt'
   homepage 'https://github.com/fikovnik/ShiftIt/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.