### PR TITLE
Update goodsync to 10.4.6

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask 'goodsync' do
-  version '10.4.5'
-  sha256 '71f6e32d3ca57e02af1e7d728ff724576373fbd6d4e63833b52a17745a9dfc9b'
+  version '10.4.6'
+  sha256 '22d13a613fb836034aa6271674288868d221e7d49ce70681570c5c05c1b73f0c'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   name 'GoodSync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

@miccal

> Version 10.4.6 May 05, 2017 

https://www.goodsync.com/news-mac

Closes https://github.com/caskroom/homebrew-cask/pull/33762