### PR TITLE
Update private-internet-access to v70

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -2,7 +2,7 @@ cask 'private-internet-access' do
   version 'v70'
   sha256 '0aa85a36735985b3d83c715f317f9adf16081d1c9bd7fb6c55afe118913470f1'
 
-  url 'https://installers.privateinternetaccess.com/download/pia-v70-installer-mac.dmg'
+  url "https://installers.privateinternetaccess.com/download/pia-#{version}-installer-mac.dmg"
   name 'Private Internet Access'
   homepage 'https://www.privateinternetaccess.com/'
 

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,8 +1,8 @@
 cask 'private-internet-access' do
-  version :latest
-  sha256 :no_check
+  version 'v70'
+  sha256 '0aa85a36735985b3d83c715f317f9adf16081d1c9bd7fb6c55afe118913470f1'
 
-  url 'https://www.privateinternetaccess.com/installer/installer_osx.dmg'
+  url 'https://installers.privateinternetaccess.com/download/pia-v70-installer-mac.dmg'
   name 'Private Internet Access'
   homepage 'https://www.privateinternetaccess.com/'
 


### PR DESCRIPTION
Update the cask because the website offers versioned installers and the formula was versionless.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.