### PR TITLE
Update browser-chooserx to 1.3.8

### DIFF
--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -1,10 +1,10 @@
 cask 'browser-chooserx' do
-  version '1.3.7'
-  sha256 '439b8d137bed44de3a052c6dfce4fa38818f05108f6370d3ebc76b1492cb24dc'
+  version '1.3.8'
+  sha256 'a4fba428fea4071c8ae2461e99e95dbf7ec6ed4cb815cfc712adc532d73caf5b'
 
   url 'https://www.bdevapps.com/files/downloads/Browser%20ChooserX.zip'
   appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
-          checkpoint: '555b74bd4f0f4b014f9063250f12f598ca26eb71c38b039092b6d93914a8ee1f'
+          checkpoint: 'f7343e7855c687933dd4da8cb0236bafaa634dc24f89c05910ea2c1a8987dc80'
   name 'Browser ChooserX'
   homepage 'https://bdevapps.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.