### PR TITLE
Update waterfox to 53.0.1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '52.0.1'
-  sha256 '895572090b15427ad974fa17238923265700fc30890c5950a27afc85e494f8f8'
+  version '53.0.1'
+  sha256 'c01f3b3a7ff5febf86c0151982e5a18d7a11ba9704509095d3a34ea5ff524028'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version.before_comma}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.