### PR TITLE
Update simpholders to 2.2

### DIFF
--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -3,8 +3,8 @@ cask 'simpholders' do
   sha256 '0f12b0076f2bef08cd3129916a6fbe6f92bd7601a96bc787bfc0c5feda4b4d4a'
 
   url "https://simpholders.com/site/assets/files/1968/simpholders_#{version.dots_to_underscores}.dmg"
-  appcast 'https://simpholders.com/updates/releases.xml',
-          checkpoint: '5bf1c98cf80e24efdcb1fed5726780a58b9867d7b09e9f5c08fedcdd2f7897d8'
+  appcast 'https://simpholders.com/releases/',
+          checkpoint: 'ea4bde230320d53d2180dc75110878f45e47b434e2a6a7c77e1e16c057f4b9bd'
   name 'SimPholders'
   homepage 'https://simpholders.com/'
 


### PR DESCRIPTION
- App Cast URL has changed

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.