### PR TITLE
Update soundcloud-downloader to 2.7.7

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,5 +1,5 @@
 cask 'soundcloud-downloader' do
-  version '2.7.2'
+  version '2.7.7'
   sha256 'fa43678ebedfd71edf3ee6972f824aa5f39b55f640e011b408a6e9b69878703b'
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"

--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
   version '2.7.2'
-  sha256 '0272b1ebd6c6d28e4737ec08cb6ef560cc4c9f2b9d626806d4bef58fb37e278b'
+  sha256 'fa43678ebedfd71edf3ee6972f824aa5f39b55f640e011b408a6e9b69878703b'
 
   url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
-  appcast 'http://black-burn.ch/applications/scd/updates.php?hwni=1',
-          checkpoint: '18614c69ab696d1af1aeee1edf18c87ebc29aa81af2c33d1ab283e8f869aafb8'
+  appcast 'https://black-burn.ch/apps/SCD2/updates/gold.xml?hwni=1',
+          checkpoint: '26e98b02b515fa664bd395dfe5ecaac54a8dba3507953bf245a3524f7099ea46'
   name 'SoundCloud Downloader'
   homepage 'https://black-burn.ch/scd/'
 


### PR DESCRIPTION
- App Cast changed
- Old appcast return 'HTTP response code was returned (302).'

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.