### PR TITLE
Update soundflower to 2.0b2

### DIFF
--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -4,7 +4,7 @@ cask 'soundflower' do
 
   url "https://github.com/mattingalls/Soundflower/releases/download/#{version}/Soundflower-#{version}.dmg"
   appcast 'https://github.com/mattingalls/Soundflower/releases.atom',
-          checkpoint: '02b56380ecc6fe4e29bd5a1b1410eee360c2947faf69b114b401e440455353a0'
+          checkpoint: '66b123eab71bad4083491bf309fcc04ec01d35b6841431acd76ae6172edb2b55'
   name 'Soundflower'
   homepage 'https://github.com/mattingalls/Soundflower'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.