### PR TITLE
Update frostwire to 6.5.0

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.4.9'
-  sha256 '99c016a3dad8aa897f6d1fc488b5df4cfd17667395b52df2ae6ce1aeabb1cb7a'
+  version '6.5.0'
+  sha256 'a460e11b4773b0caf2d4f35522225b2b1f10594eb4feec7f61814ca1f518ecad'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '4f9f4c920e0ca56fb3349c0c682be75b4e469c17fd93d3e613039dc65e4d393c'
+          checkpoint: '04b05bfbd8ab9670591859d82ad201261606fa4ea0f377aaf57ad31ca0efa32c'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.