### PR TITLE
Update mattermost to 3.7.0

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,10 +1,10 @@
 cask 'mattermost' do
-  version '3.6.0'
-  sha256 '2422c261242106055534d9ee5689131a698351480a3b24d612178994fe44d988'
+  version '3.7.0'
+  sha256 '9d5c7a870b85dc162c5d761dee00532c78817d38cc2b11ba8038d3ca35ac2a83'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: '2b457d45458875bc53e941d74040dec76a298d34be9e2ec33d35115f487672a4'
+          checkpoint: '0e0178d773dc7bc8b499d97251a57a4646f8e8f1491c1791d09db171be0743a0'
   name 'Mattermost'
   homepage 'https://about.mattermost.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.