### PR TITLE
Update hachidori to 2.0b8

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,11 +1,11 @@
 cask 'hachidori' do
-  version '1.1.9.1'
-  sha256 'd4f1d11d3f3278dea79bc43f47576aaea36e2acdac3672164b95cbdddd91391d'
+  version '2.0b8'
+  sha256 '74da8cb0a48b894dca503cf8fd498da652d9a1bc14a37482e186d4b8641098e4'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/Hachidori-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/hachidori/releases.atom',
-          checkpoint: 'b888480cde439d3cfcc5499b2ab2bcebbe3aed0a4906f28f3a3a35fb293924af'
+          checkpoint: 'f07684030a1b5aa4eb7293758fa7338a5fa89da0577571b195a3b60d9cd3e61d'
   name 'Hachidori'
   homepage 'https://hachidori.ateliershiori.moe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.