### PR TITLE
Update handy-outliner to 1.1.6.2

### DIFF
--- a/Casks/hackmd.rb
+++ b/Casks/hackmd.rb
@@ -4,7 +4,7 @@ cask 'hackmd' do
 
   url "https://github.com/hackmdio/hackmd-desktop/releases/download/v#{version}/HackMD-#{version}.dmg"
   appcast 'https://github.com/hackmdio/hackmd-desktop/releases.atom',
-          checkpoint: '5267ea53c9028a21d3eea4fc1576230fc0a54b531e0ddf961eefb8a8508edc5b'
+          checkpoint: '1ad1bec0cb8d094e1fe0d011ec3cb726264eedd7ef8287bac1aeb8b909f36eae'
   name 'HackMD'
   homepage 'https://github.com/hackmdio/hackmd-desktop'
 

--- a/Casks/hackmd.rb
+++ b/Casks/hackmd.rb
@@ -4,7 +4,7 @@ cask 'hackmd' do
 
   url "https://github.com/hackmdio/hackmd-desktop/releases/download/v#{version}/HackMD-#{version}.dmg"
   appcast 'https://github.com/hackmdio/hackmd-desktop/releases.atom',
-          checkpoint: '1ad1bec0cb8d094e1fe0d011ec3cb726264eedd7ef8287bac1aeb8b909f36eae'
+          checkpoint: '5267ea53c9028a21d3eea4fc1576230fc0a54b531e0ddf961eefb8a8508edc5b'
   name 'HackMD'
   homepage 'https://github.com/hackmdio/hackmd-desktop'
 

--- a/Casks/handy-outliner.rb
+++ b/Casks/handy-outliner.rb
@@ -4,7 +4,7 @@ cask 'handy-outliner' do
 
   url "https://downloads.sourceforge.net/handyoutlinerfo/handyoutliner_#{version}.zip"
   appcast 'https://sourceforge.net/projects/handyoutlinerfo/rss',
-          checkpoint: '282f0552ceda6abaad84f75cb938aa90454a111dc309be4fb61aa493553ae99d'
+          checkpoint: 'cecb51c6c4341e9527776b119dee4b9774b73e5f710dd8221f2af8d626fa05e2'
   name 'HandyOutliner for DjVu and PDF'
   homepage 'http://handyoutlinerfo.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.