### PR TITLE
Update hyper to 1.3.2

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.3.1'
-  sha256 '00c622b181a83cb9e458f7d16704b32ce37a92d85a6dfe5fdac9356fb7fdc7d5'
+  version '1.3.2'
+  sha256 '719576676f5c5037c04e77a6a5c4aac82df4fd132a5a3521293f619f67114257'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: 'a47b64cf6d22b8e442b840fa6e7707873dd86139d23ad6d629974ec0644be26b'
+          checkpoint: '65da4620f6941662e33be4c09b49c8ea87a8644d99cbc1d375c6ead0aa02bdd8'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.