### PR TITLE
Update inpad to 0.1.0

### DIFF
--- a/Casks/inpad.rb
+++ b/Casks/inpad.rb
@@ -2,12 +2,12 @@ cask 'inpad' do
   version '0.1.0'
   sha256 'a66a0be66bc98d31f36232ab9b5ea5a47fdb644e4234673d8ccc26bd637841f1'
 
-  # github.com/Sarah-Seo/Inpad was verified as official when first introduced to the cask
-  url "https://github.com/Sarah-Seo/Inpad/releases/download/v#{version}/Inpad-#{version}.dmg"
-  appcast 'https://github.com/Sarah-Seo/Inpad/releases.atom',
-          checkpoint: '3a738e6fe75a048c190c52e31a4d6151af05928da27625e3b1e864f268175a05'
+  # github.com/CarbonStack/Inpad was verified as official when first introduced to the cask
+  url "https://github.com/CarbonStack/Inpad/releases/download/v#{version}/Inpad-#{version}.dmg"
+  appcast 'https://github.com/CarbonStack/Inpad/releases.atom',
+          checkpoint: '11613d811f66156c887ef949f34618423fb986af906143ef700dbd848e0172f7'
   name 'Inpad'
-  homepage 'https://sarah-seo.github.io/Inpad/'
+  homepage 'https://carbonstack.github.io/Inpad/'
 
   app 'Inpad.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.