### PR TITLE
Update invisionsync to 1.8.5,686

### DIFF
--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -3,8 +3,6 @@ cask 'invisionsync' do
   sha256 '14d79e7ba4d8e91e2dddad38354110f53e42195dddb93a435d3d545ccffa1173'
 
   url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.after_comma}.zip"
-  appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml',
-          checkpoint: '138343407c23eaa7c7dd96f6b50fc914c9d94dc9f0afe4a58db68b67ca478d7b'
   name 'InVision Sync'
   homepage 'https://www.invisionapp.com/'
 

--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -4,7 +4,7 @@ cask 'invisionsync' do
 
   url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.after_comma}.zip"
   appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml',
-          checkpoint: '2be291f642b6bc9d21eb222a48cceaac1ef1e7f82e64541578c8f43b2bfd1755'
+          checkpoint: '138343407c23eaa7c7dd96f6b50fc914c9d94dc9f0afe4a58db68b67ca478d7b'
   name 'InVision Sync'
   homepage 'https://www.invisionapp.com/'
 

--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -1,10 +1,10 @@
 cask 'invisionsync' do
-  version '1.8.3-684'
-  sha256 '17646577e2bf6be6ec96eeffe2bdb12853425673bc22c19946bf5b31a6f1a2fa'
+  version '1.8.5,686'
+  sha256 '14d79e7ba4d8e91e2dddad38354110f53e42195dddb93a435d3d545ccffa1173'
 
-  url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.sub(%r{^.*?-}, '')}.zip"
+  url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.after_comma}.zip"
   appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml',
-          checkpoint: 'bfd3c6b2e7746c0fbe2c89cdefc245e4d8daefc3592d263de299bb05969017fb'
+          checkpoint: '2be291f642b6bc9d21eb222a48cceaac1ef1e7f82e64541578c8f43b2bfd1755'
   name 'InVision Sync'
   homepage 'https://www.invisionapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.