### PR TITLE
Update xamarin-android to 7.3.0-13

### DIFF
--- a/Casks/xamarin-android.rb
+++ b/Casks/xamarin-android.rb
@@ -3,7 +3,7 @@ cask 'xamarin-android' do
   sha256 'eb4024e7d6710794a55fe812a8239df0fd5ed97f95ae6513d22543c4974253cc'
 
   url "https://dl.xamarin.com/MonoforAndroid/Mac/xamarin.android-#{version}.pkg"
-  appcast 'https://static.xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+  appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           checkpoint: '477c85901ee0146c2f34467c8cfc1f3a94bcb96c5467bb8b5cfc1ed765b3676e'
   name 'Xamarin.Android'
   homepage 'https://www.xamarin.com/platform'


### PR DESCRIPTION
- AppCast URL has changed

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.