### PR TITLE
Update vimr to 0.15.0-191

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.14.3-185'
-  sha256 '3bae52d8bd27943f64b41645466fa5c4482b50df4bd8bd151281c7509047517f'
+  version '0.15.0-191'
+  sha256 '5466a01d9a7f5085b5cb59fcb82db0333a878a5a8635b03af893fbd13fdb5048'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '4130f45b6b31c103ea009b80c09529b29bb75de7de566bed168363d9dbce25ba'
+          checkpoint: '5451bfd1d007032ab989a0078ad8c8856210ad9f5803210c983f95ec8facda64'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.