### PR TITLE
Add zap stanza to codekit 3.1-25813

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -11,4 +11,12 @@ cask 'codekit' do
   auto_updates true
 
   app 'CodeKit.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.incident57.CodeKit3',
+                '~/Library/Caches/com.incident57.CodeKit3',
+                '~/Library/Cookies/com.incident57.CodeKit3.binarycookies',
+                '~/Library/Preferences/com.incident57.CodeKit3.plist',
+                '~/Library/Saved Application State/com.incident57.CodeKit3.savedState',
+              ]
 end

--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -13,10 +13,10 @@ cask 'codekit' do
   app 'CodeKit.app'
 
   zap delete: [
-                '~/Library/Application Support/com.incident57.CodeKit3',
-                '~/Library/Caches/com.incident57.CodeKit3',
-                '~/Library/Cookies/com.incident57.CodeKit3.binarycookies',
-                '~/Library/Preferences/com.incident57.CodeKit3.plist',
-                '~/Library/Saved Application State/com.incident57.CodeKit3.savedState',
+                "~/Library/Application Support/com.incident57.CodeKit#{version.major}",
+                "~/Library/Caches/com.incident57.CodeKit#{version.major}",
+                "~/Library/Cookies/com.incident57.CodeKit#{version.major}.binarycookies",
+                "~/Library/Preferences/com.incident57.CodeKit#{version.major}.plist",
+                "~/Library/Saved Application State/com.incident57.CodeKit#{version.major}.savedState",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download codekit` is error-free.
- [x] `brew cask style --fix codekit` reports no offenses.
- [x] The commit message includes the cask’s name and version.