### PR TITLE
Update beyond-compare to 4.2.1.22354

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,10 +1,10 @@
 cask 'beyond-compare' do
-  version '4.2.0.22302'
-  sha256 '6f927f5c1044f217ce0a37ea7869770f98ecaeff73222c0af5151055f5bc3729'
+  version '4.2.1.22354'
+  sha256 '50d87a513e1addacfdd85aa688d062807e214e78284a3ffc5bbfc8821bb69dce'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "http://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx",
-          checkpoint: '18ae0b43e5d8123d75501e785b7677f5bddd37f81681150afb33baa518560101'
+          checkpoint: 'f35fb654ee34fd334318c25fadf79a9b34d977c54de6bb37498702526f23d64d'
   name 'Beyond Compare'
   homepage 'https://www.scootersoftware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.