### PR TITLE
Update lingon-x to 5.0.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.0.1'
-  sha256 '0d6dad8bffcb393702656bf27f1514de061143667e4068972c5f2d8bc0e3d768'
+  version '5.0.2'
+  sha256 'd3ab9a7d33c2aff7153d4b4bd001c38e16216a7722127a8baed2199ad77fc62b'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'afc0efe73dd7a0093a4a76cc315697fb064f80755f0897a553e785f407cef398'
+          checkpoint: '8532e54ccbfc85cecc5055c76089b4e71a175dc7734b574828e7283a7cd51545'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.