### PR TITLE
Update julia to 0.5.2

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask 'julia' do
-  version '0.5.1'
-  sha256 '201a7bfa19cb832beec10579c02dbbc069a8966b87a4c7d1f80b4937a7f5dc1b'
+  version '0.5.2'
+  sha256 'cad1e1c5fff6d386c21964ffd332e13ee3c75f364b2c0212ce035c803c1fffb6'
 
   # s3.amazonaws.com/julialang was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/julialang/bin/osx/x64/#{version.major_minor}/julia-#{version}-osx10.7+.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.