### PR TITLE
Update socket-io-tester to 1.1.1

### DIFF
--- a/Casks/socket-io-tester.rb
+++ b/Casks/socket-io-tester.rb
@@ -1,11 +1,11 @@
 cask 'socket-io-tester' do
-  version '1.1.0'
-  sha256 'fde5d254f993efe901c6292b85fce646eefdb4108c7e5007333ae310f053ad76'
+  version '1.1.1'
+  sha256 'd0d24270be25fdfc5f5ec703fbf57c5a88595540f0d4ee38d79bd49cee258ba1'
 
   # github.com/AppSaloon/socket.io-tester was verified as official when first introduced to the cask
   url "https://github.com/AppSaloon/socket.io-tester/releases/download/v#{version}/socket-io-tester-darwin-x64.zip"
   appcast 'https://github.com/AppSaloon/socket.io-tester/releases.atom',
-          checkpoint: '7e8912e2318f5619a1f16c3b61547123752a1cb0d358f4e639f9fd9ef4b03918'
+          checkpoint: 'bd60343db134474587b697365fe1e0863454048e17a42da22a30180505f62a90'
   name 'socket-io-tester.app'
   homepage 'https://appsaloon.github.io/socket.io-tester/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.