### PR TITLE
Update caret to 2.1.1

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.1.0'
-  sha256 'a988d40b40b79d6a1d95076d1851496e05fe47c728617e04436df14b26f7f946'
+  version '2.1.1'
+  sha256 '6db503ac07a5806828914fa1f7ebdfc3ab1a3e9981c10e4caa8298acb00e79a0'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'aadbc41ecae07e89fd1a02fa1b29606386a9b290758a16298c75e0f39aed4b90'
+          checkpoint: '1c9dde8f17a1c0648b0d2d135aa9b287093ab11f1f70540ceb9e69b10427e507'
   name 'Caret'
   homepage 'https://caret.io/'
 

--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '2.0.11'
-  sha256 'a1c768f92a093ef212d953ce4546f6030cd2c0572aa069edf66d8bd14fbdc95e'
+  version '2.1.0'
+  sha256 'a988d40b40b79d6a1d95076d1851496e05fe47c728617e04436df14b26f7f946'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'c091f668e9ca8798039edd24d0cdf5605b3c483b79c2eec1458abe0a5ba50c47'
+          checkpoint: 'aadbc41ecae07e89fd1a02fa1b29606386a9b290758a16298c75e0f39aed4b90'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.