### PR TITLE
Update standard-notes to 0.3.4

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.3.3'
-  sha256 'b321e1792b015702d9c8b3c4ebba1bdc0fa5902cc618c83470d676eedf14a239'
+  version '0.3.4'
+  sha256 'e2d9e3d1e9fc9f508b6dffe61218350ef2916cb4ff7a9fa8636b6739a3739656'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '28550074e3d62cf01ce1655c03016dfc69d43d64a1716f691bd66f7d8efd8b1f'
+          checkpoint: 'c5a7d3a4cea9667e8cdd9c0b8eb9564950ea58daa1281cdfd090f102ccc66064'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.