### PR TITLE
Fix macfusion sshfs dependency

### DIFF
--- a/Casks/macfusion.rb
+++ b/Casks/macfusion.rb
@@ -4,11 +4,11 @@ cask 'macfusion' do
 
   url "http://macfusionapp.org/releases/Macfusion_#{version}.zip"
   appcast 'http://macfusionapp.org/appcast.xml',
-          checkpoint: '6035a7a17249b0f1106400fff4e81df9815f99eca3ef1e5b4a98d54fa97bfad3'
+          checkpoint: 'a729fa91bda8853699381f87427e24c155d7bbef62a9b2e58720ce6415871d20'
   name 'Macfusion'
   homepage 'http://macfusionapp.org/'
 
-  depends_on formula: 'homebrew/fuse/sshfs'
+  depends_on formula: 'homebrew/core/sshfs'
 
   app 'Macfusion.app'
 


### PR DESCRIPTION
* sshfs has moved to homebrew core


- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

No change to version. App cast checkpoint updated by `brew cask audit`.