### PR TITLE
Update fontprep to 3.1.1

### DIFF
--- a/Casks/fontprep.rb
+++ b/Casks/fontprep.rb
@@ -4,7 +4,7 @@ cask 'fontprep' do
 
   url "https://github.com/briangonzalez/fontprep/releases/download/v3.1.1/FontPrep_#{version}.zip"
   appcast 'https://github.com/briangonzalez/fontprep/releases.atom',
-          checkpoint: '2d96c015ce34e1a5a5891838fff8c575779d2dac56bd39d135162b79f64083ed'
+          checkpoint: '0203f810a63e0b1cebe83abb424bfc04919ae861e592c13e476ae0e1e51fb343'
   name 'FontPrep'
   homepage 'https://github.com/briangonzalez/fontprep'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.