### PR TITLE
Update fork to 1.0.45.1

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version :latest
-  sha256 :no_check
+  version '1.0.45.1'
+  sha256 '724af68aa6daffd04ba29b7f9f0a96d7a08a5df22a6cfdbed09d0ddc00e3cdfd'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: 'f4209e679946a2ad3952aa5cea97c51b377b3f6c9ab78856d5a0c9c436306a42'
+          checkpoint: '2a9aa119e228243955ea8aea42a04e7a146fab69c3b3985a6e0e3f6572aebd53'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.