### PR TITLE
Update fotomagico to 5.4.2-22652

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -4,7 +4,7 @@ cask 'fotomagico' do
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://www.boinx.com/d/connect//histories/fotomagico',
-          checkpoint: '4d6df3a75a8c83c8504db84a99d5b94da07b0934bbffec43c6601500a00c0bcb'
+          checkpoint: '6163e011fc17f4335203652980ff318a7c616f74d78a516317cadbaa67ad7a0d'
   name 'FotoMagico'
   homepage 'https://www.boinx.com/fotomagico/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.