### PR TITLE
Update fredm-fuse to 1.3.5

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,10 +1,10 @@
 cask 'fredm-fuse' do
-  version '1.3.4'
-  sha256 'ed2cd936a220091c55285b2543ce7ec19603018dafdf12f1cc5bff758315a999'
+  version '1.3.5'
+  sha256 'c8ceb38cd4439151ef45e49ec82e0ad90a9553ba1422d11b7964d1bf0cb62e09'
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '879ca9987e1fae8ec6ce39f04a90d8e489afdb97c990e7c44ad1a869befc4e25'
+          checkpoint: '5c6518610d364eeef84beb2fea002d073abc80556581a1c85a0642bc08f79e83'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.