### PR TITLE
Update freedom to 1.4.6

### DIFF
--- a/Casks/cuda.rb
+++ b/Casks/cuda.rb
@@ -14,5 +14,14 @@ cask 'cuda' do
   uninstall script: {
                       executable: "/Developer/NVIDIA/CUDA-#{version.major_minor}/bin/uninstall_cuda_#{version.major_minor}.pl",
                       sudo:       true,
-                    }
+                    },
+            launchctl: [
+                         'com.nvidia.CUDASoftwareUpdate',
+                         'com.nvidia.cuda.launcher',
+                         'com.nvidia.cudad',
+                       ],
+            kext: 'com.nvidia.CUDA',
+            delete: '/Library/PreferencePanes/CUDA Preferences.prefPane'
+
+  zap delete: '/Library/Frameworks/CUDA.framework'
 end

--- a/Casks/cuda.rb
+++ b/Casks/cuda.rb
@@ -11,17 +11,17 @@ cask 'cuda' do
                       args:       ['--accept-eula', '--silent'],
                     }
 
-  uninstall script: {
-                      executable: "/Developer/NVIDIA/CUDA-#{version.major_minor}/bin/uninstall_cuda_#{version.major_minor}.pl",
-                      sudo:       true,
-                    },
+  uninstall script:    {
+                         executable: "/Developer/NVIDIA/CUDA-#{version.major_minor}/bin/uninstall_cuda_#{version.major_minor}.pl",
+                         sudo:       true,
+                       },
             launchctl: [
                          'com.nvidia.CUDASoftwareUpdate',
                          'com.nvidia.cuda.launcher',
                          'com.nvidia.cudad',
                        ],
-            kext: 'com.nvidia.CUDA',
-            delete: '/Library/PreferencePanes/CUDA Preferences.prefPane'
+            kext:      'com.nvidia.CUDA',
+            delete:    '/Library/PreferencePanes/CUDA Preferences.prefPane'
 
   zap delete: '/Library/Frameworks/CUDA.framework'
 end

--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,14 +1,15 @@
 cask 'freedom' do
   version '1.4.6'
-  sha256 'de857dbbcf3f1f65dc8a44380977ed7dc3a7da6bda1e5616f3555767b459384e'
+  sha256 'efb5dd8d8679bc4ccd07b7056ff482ace085e55615063a05c2141c8080b73563'
 
-  url 'https://cdn.freedom.to/installers/FreedomSetup.dmg'
+  url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml',
-          checkpoint: 'd5b94d6d470c8ecc7f77bca718d6641ea5de9188fa4db354bad5fa700e1d7fd5'
+          checkpoint: 'd9bb4ab2f960211a26b7e1b99ac2dd3b2346035d032d944cce12e04a6c688587'
   name 'Freedom'
   homepage 'https://freedom.to/'
 
   auto_updates true
+  depends_on macos: '>= :mavericks'
 
   app 'Freedom.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.