### PR TITLE
Update frescobaldi to 2.20.0

### DIFF
--- a/Casks/frescobaldi.rb
+++ b/Casks/frescobaldi.rb
@@ -3,9 +3,9 @@ cask 'frescobaldi' do
   sha256 '575910ceaeb6016355dcfac77ab5dcfceca42a7ff84db5f3316030231cb86bfc'
 
   # github.com/wbsoft/frescobaldi was verified as official when first introduced to the cask
-  url 'https://github.com/wbsoft/frescobaldi/releases/download/v2.20.0/Frescobaldi-2.20.0-x86_64.dmg'
+  url "https://github.com/wbsoft/frescobaldi/releases/download/v#{version}/Frescobaldi-#{version}-x86_64.dmg"
   appcast 'https://github.com/wbsoft/frescobaldi/releases.atom',
-          checkpoint: '1edb6cbd5767024e224f7aecda697d206b49a180066180dd3201359cf4f6a598'
+          checkpoint: 'dfe4bd17509d8217cb2833bc85f834ad2c30fd1e3eebcf235b7b777d6c25bcd6'
   name 'Frescobaldi'
   homepage 'http://frescobaldi.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.