### PR TITLE
Update mono-mdk to 5.0.0.100

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk' do
-  version '4.8.1.0'
-  sha256 '5f1ee8314e3b61e2c81fc95cae4c6610a467adc2bb1299ab44c9b4a568bc0efd'
+  version '5.0.0.100'
+  sha256 '66398a86a7d7daf1a79ff940a5562c8386f48d7f40693e7936cbb356cf855e1f'
 
   # mono-project.azureedge.net/archive was verified as official when first introduced to the cask
   url "https://mono-project.azureedge.net/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.