### PR TITLE
Update iphone-backup-extractor to 1.2.4

### DIFF
--- a/Casks/iphone-backup-extractor.rb
+++ b/Casks/iphone-backup-extractor.rb
@@ -4,7 +4,7 @@ cask 'iphone-backup-extractor' do
 
   url 'http://supercrazyawesome.com/downloads/iPhone%20Backup%20Extractor.app.zip'
   appcast 'http://supercrazyawesome.com/sparkle.xml',
-          checkpoint: 'dbed6231a752fb8fbdbab3956ffd48552ff2332333c01d682f1482fd982620cb'
+          checkpoint: '7ce7eba0039adda89d370eeece1d47ab05eb2bff78fea85383cb7f167b737369'
   name 'iPhone Backup Extractor'
   homepage 'http://supercrazyawesome.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.