### PR TITLE
Update anaconda - add postflight

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -15,6 +15,10 @@ cask 'anaconda' do
                       sudo:       true,
                     }
 
+  postflight do
+    set_ownership "#{HOMEBREW_PREFIX}/anaconda3"
+  end
+
   uninstall delete: "#{HOMEBREW_PREFIX}/anaconda3"
 
   zap delete: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Add `postflight` `set_ownership`

`sudo` is required for install in `/usr/local` https://github.com/caskroom/homebrew-cask/pull/32706

Closes https://github.com/caskroom/homebrew-cask/issues/33904