### PR TITLE
Update poi to 7.7.0

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,11 +1,11 @@
 cask 'poi' do
-  version '7.6.0'
-  sha256 '5acc3c86d3d4d056a507fa6072c862f263ac54e80899fec9fe9df911d9e3e226'
+  version '7.7.0'
+  sha256 'e0ba73f8dc86af22b5311d349f65b26348321d7eb2c64036f31f6a4b2e9c9d1d'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}-macos-x64.dmg"
   appcast 'https://github.com/poooi/poi/releases.atom',
-          checkpoint: '7b3ce9df1edaf9deec955c73062a88162a964c8b3e68518631175b74fa183e05'
+          checkpoint: '5f5d84d8bbb2a815e2c7a171105e1ea8ae29da16b6cc079c8802d5848bb89023'
   name 'poi'
   homepage 'https://poi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


