### PR TITLE
Update gimp to 2.8.22

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,8 +1,8 @@
 cask 'gimp' do
-  version '2.8.20-x86_64'
-  sha256 'c15f9b86a74af150f257aa3909a166bf643caa17dde48d9e6ebaeff7b58115a2'
+  version '2.8.22'
+  sha256 '3414960c54b262b5793947f55a6d1ab53045a507978a21ff758a54bf6be4bd16'
 
-  url "https://download.gimp.org/pub/gimp/v2.8/osx/gimp-#{version}.dmg"
+  url "https://download.gimp.org/pub/gimp/v#{version.major_minor}/osx/gimp-#{version}-x86_64.dmg"
   name 'GIMP'
   homepage 'https://www.gimp.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated `version` and `url`