### PR TITLE
Update macdown to 0.7

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -1,11 +1,11 @@
 cask 'macdown' do
-  version '0.6.4'
-  sha256 'fcc7950c69eca4428a2eb4c2705e032a747eacb2b657bc48195c3aee60d35f25'
+  version '0.7'
+  sha256 '48860effc92c39ffbaa41f182d55c2997d4f4fb47b19ec522d3ead07884ee6b3'
 
   # github.com/MacDownApp/macdown was verified as official when first introduced to the cask
   url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
   appcast 'http://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml',
-          checkpoint: 'b5d3dd1f4690778a82675d110ff4699aecbd29a6597214492756d1e8d38310f6'
+          checkpoint: '916680a21f1811ce86ddf065c9623f313901358e223fe9d756325d911a1a69b8'
   name 'MacDown'
   homepage 'https://macdown.uranusjr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.