### PR TITLE
android-sdk 25.2.3: Update env variable name

### DIFF
--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -53,7 +53,7 @@ cask 'android-sdk' do
     We will install android-sdk-tools, platform-tools, and build-tools for you.
     You can control android sdk packages via the sdkmanager command.
     You may want to add to your profile:
-      'export ANDROID_HOME=#{HOMEBREW_PREFIX}/share/android-sdk'
+      'export ANDROID_SDK_ROOT=#{HOMEBREW_PREFIX}/share/android-sdk'
 
     This operation may take up to 10 minutes depending on your internet connection.
     Please, be patient.


### PR DESCRIPTION
As described on https://developer.android.com/studio/command-line/variables.html the environment variable to set is now `ANDROID_SDK_ROOT`. It is outdated to set `ANDROID_HOME`.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

