### PR TITLE
Update switchhosts to 3.3.3.5215

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.2.5193'
-  sha256 '3777f66ff7e19cd99a6894e952aecfc6b0691b67ac4431ebe9920dfe4a803ad2'
+  version '3.3.3.5215'
+  sha256 'cde448ea76857876257fcf165a0f17dd591792e2796ff539210e51848f2a404c'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: '379a30dee6142e775c70bc79b43674d1ce3d9a02a09baee22610b66e7581f1e4'
+          checkpoint: 'a439e65ebd787caeb787d858f9c604bd2039e1a876e2ee403b6f352310976515'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.