### PR TITLE
Update gramps to 4.2.5-1

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -5,7 +5,7 @@ cask 'gramps' do
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"
   appcast 'https://github.com/gramps-project/gramps/releases.atom',
-          checkpoint: '98778e06cbb65bc14cc4f42ad301a9ef0f711f729a2ad5d4ae6492dac7a50ec9'
+          checkpoint: '21afd12a9830d38f741cab4452b405f02e89b69a99105118fb2ff69174a6efc2'
   name 'Gramps'
   homepage 'https://gramps-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.