### PR TITLE
Update tankix to 618

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '617'
-  sha256 '625f24d03a02061844dc20507b20431f969318159d1a81e0cd8d345ce059bc69'
+  version '618'
+  sha256 'b36b80ee17c486bfc8352d18dacb17a2c4dbb958502e933cd6fd836a59c29049'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.