### PR TITLE
Update vlc to 2.2.5.1

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,6 +1,6 @@
 cask 'vlc' do
-  version '2.2.4'
-  sha256 'fd071b9817c9efccac5a144d69893a4a5323cbde4a74d5691c3cf3ab979d4160'
+  version '2.2.5.1'
+  sha256 '7e31cf16b944ef84d7cbf40b23cafa6f7dc53c2163b2e46bda5e518c46880bdf'
 
   url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
   appcast 'http://update.videolan.org/vlc/sparkle/vlc-intel64.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This has been available for a day now from https://www.videolan.org/vlc/ but the `appcast`  still hasn't been updated.