### PR TITLE
Update tunnelblick to 3.7.1,4811

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,11 +1,11 @@
 cask 'tunnelblick' do
-  version '3.7.1beta02,4810'
-  sha256 '67fba12a44e57e7330feefa84d0a5c80f70093be7205735817d85ae68ed58707'
+  version '3.7.1,4811'
+  sha256 '7b27baba1d25639560667c29d946e5e9602d874e89a73b7a454e81620feada8d'
 
   # github.com/Tunnelblick/Tunnelblick/releases/download was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://github.com/Tunnelblick/Tunnelblick/releases.atom',
-          checkpoint: 'b0e677e5c750198fe071b45cb221e3db24317bd1daf1c0d4d0311738946118e6'
+          checkpoint: '254699319c1abab58a3f4e8e62f3e2710840ec36c2a9fd8b29b8ba1003218bda'
   name 'Tunnelblick'
   homepage 'https://www.tunnelblick.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.