### PR TITLE
Update bitrix24 to 5.0.26.38

### DIFF
--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -1,11 +1,11 @@
 cask 'bitrix24' do
   # note: "24" is not a version number, but an intrinsic part of the product name
-  version '4.1.110.37'
-  sha256 '2603689737b99e06601467a4f1754200e8c19a6dc2d488b0fb9fb64502c34768'
+  version '5.0.26.38'
+  sha256 '07124b45085322208e97c98a5a6f5d46d1f2da775ac0fba4c073b54e3d904d07'
 
   url 'http://dl.bitrix24.com/b24/bitrix24_desktop.dmg'
   appcast 'https://www.bitrix24.com/osx_version.php',
-          checkpoint: '71865756e2c4ddfd42c7713a4337154729b614b55cbe38347e65e7c6be181144'
+          checkpoint: '3c6f7bb642b97bd5d70c70e2f5e4f38187a842dc0b45dfa2b179d3d0959eddda'
   name 'Bitrix24'
   homepage 'https://www.bitrix24.com/apps/mobile-and-desktop-apps.php#desktop_app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.