### PR TITLE
Update hyne to 1.9.2c

### DIFF
--- a/Casks/hyne.rb
+++ b/Casks/hyne.rb
@@ -4,7 +4,7 @@ cask 'hyne' do
 
   url "https://github.com/myst6re/hyne/releases/download/#{version}/Hyne-#{version}-osx64.tar.gz"
   appcast 'https://github.com/myst6re/hyne/releases.atom',
-          checkpoint: 'da938c2c2d76c46d384b6db7eb993d44b46a32cffd0eb99dfb09b958bf2fe5d1'
+          checkpoint: 'ce3d4525e66fc4b0454233846491c36ec4141653a70c002e9e83c9f5bd1d49a7'
   name 'Hyne'
   homepage 'https://github.com/myst6re/hyne'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.