### PR TITLE
Update iconjar to 1.3.2,21596:1492364207

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,11 +1,11 @@
 cask 'iconjar' do
-  version :latest
-  sha256 :no_check
+  version '1.3.2,21596:1492364207'
+  sha256 'd9bd76148f7ff6d8be0fc73b054c7945fbef49bd41ed0f777854203f17981417'
 
   # dl.devmate.com/com.iconjar.iconjar was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.iconjar.iconjar/Iconjar.dmg'
+  url "https://dl.devmate.com/com.iconjar.iconjar/#{version.after_comma.before_colon}/#{version.after_colon}/Iconjar-#{version.after_comma.before_colon}.zip"
   appcast 'https://updates.devmate.com/com.iconjar.iconjar.xml',
-          checkpoint: 'ac2cdc02fcba9c9f5e38b379c93a17a86b5fd618d52ef9c1a7b0527dd1531997'
+          checkpoint: '20d5f6c13de357f051c9ffa1fee05387a471aa298cd68f4acee9b4208da91647'
   name 'IconJar'
   homepage 'https://geticonjar.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.