### PR TITLE
Update iridium to 58.0.0

### DIFF
--- a/Casks/iridium.rb
+++ b/Casks/iridium.rb
@@ -1,10 +1,10 @@
 cask 'iridium' do
-  version '57.0.0'
-  sha256 '3fec33a6426d1ee1a52371a721b4760fa8d0bd355cf5e0060f84201859210b66'
+  version '58.0.0'
+  sha256 'f4d4e634f879a0df1ca70fccd827975f33789265930d06cb4213830bd432e88e'
 
   url "https://downloads.iridiumbrowser.de/macosx/#{version}/iridium_browser_#{version}_osx_x64.dmg"
   appcast 'https://downloads.iridiumbrowser.de/macosx/',
-          checkpoint: '8eecacd9cc8db0fca9979234468787faedff9a7a902f0740a23aa70a5cceca95'
+          checkpoint: '512bf95c7d4448ab7dca6af5c544b349f2c59649d0507d05abf67cecd59997f8'
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.