### PR TITLE
Update istopmotion to 3.8.2-16057

### DIFF
--- a/Casks/istopmotion.rb
+++ b/Casks/istopmotion.rb
@@ -4,7 +4,7 @@ cask 'istopmotion' do
 
   url "https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_#{version}.app.zip"
   appcast 'https://www.boinx.com/d/connect/histories/istopmotion',
-          checkpoint: '9234c3abcb9738d7bbfcc6098c5e6ae22f3cf0c742e6bbd395c3da94859e5ea3'
+          checkpoint: '27df05aa9511e2bdfa3b70434664de287efabcc6e80d316eb5b8acf63093c456'
   name 'iStopMotion'
   homepage 'https://www.boinx.com/istopmotion/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.