### PR TITLE
Update laullon-gitx to 0.8.4

### DIFF
--- a/Casks/laullon-gitx.rb
+++ b/Casks/laullon-gitx.rb
@@ -5,7 +5,7 @@ cask 'laullon-gitx' do
   # github.com/downloads/laullon was verified as official when first introduced to the cask
   url "https://github.com/downloads/laullon/gitx/GitX-L_v#{version}.zip"
   appcast 'http://gitx.laullon.com/appcast.xml',
-          checkpoint: '8514821f4dd35269cfe030744f84a5c586e30215db82c54abbadb43f68a2a26b'
+          checkpoint: 'e4fce47175b38b461d1065919a82a2072652afe233adfe43fb22cb438907e9db'
   name 'GitX (L)'
   homepage 'http://gitx.laullon.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.