### PR TITLE
Update letterfix to 2.5.3,67423

### DIFF
--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -2,9 +2,9 @@ cask 'letterfix' do
   version '2.5.3,67423'
   sha256 'b6125a0f55ef0c52711403613473ba6fc396745f7d2ace88cc46f9d9df57b41d'
 
-  url "http://dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
-  appcast 'https://osdn.jp/projects/letter-fix/releases/rss',
-          checkpoint: '8fa3a0fc1cb40fd5d73719f4e82c8857038afaa14b2d0bf2ef87649fbc46e116'
+  url "http://onet.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
+  appcast 'https://ja.osdn.net/projects/letter-fix/releases/rss',
+          checkpoint: 'bdb6da9001b4a915f5059542ea8152bb4103fec4df47e028afbefce63d4e1b34'
   name 'LetterFix'
   homepage 'https://osdn.jp/projects/letter-fix/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.