### PR TITLE
Update lighttable to 0.8.1

### DIFF
--- a/Casks/lighttable.rb
+++ b/Casks/lighttable.rb
@@ -5,7 +5,7 @@ cask 'lighttable' do
   # github.com/LightTable/LightTable was verified as official when first introduced to the cask
   url "https://github.com/LightTable/LightTable/releases/download/#{version}/lighttable-#{version}-mac.tar.gz"
   appcast 'https://github.com/LightTable/LightTable/releases.atom',
-          checkpoint: '6195e1333c6a146c67861a8c7269e8c8405f04d628a0aa4742e159d3bfe98600'
+          checkpoint: '82351dbb67ea8a9051843b9690917ca22ead040fd0cad9b6cd3a81743da08366'
   name 'Light Table'
   homepage 'http://lighttable.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.