### PR TITLE
Update linein to 2.3.0

### DIFF
--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -9,4 +9,8 @@ cask 'linein' do
   homepage 'https://www.rogueamoeba.com/freebies/'
 
   app 'LineIn.app'
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -2,9 +2,9 @@ cask 'linein' do
   version '2.3.0'
   sha256 '583ce553838779116d5b25f20a3855260a1e8580f9b55a134a58a24bfdf31c96'
 
-  url 'https://www.rogueamoeba.com/freebies/download/LineIn.zip'
+  url "https://rogueamoeba.com/legacy/downloads/LineIn-#{version.no_dots}.zip"
   appcast 'https://rogueamoeba.com/freebies/version-linein.rss',
-          checkpoint: '212705064a7c63980fa1eb4ec1f1334212bf8e23a639b507c31b0d09b65d7db8'
+          checkpoint: '6a8876f58d14769a263366de29dbc292638e35c5834cc04985ef41a794555722'
   name 'LineIn'
   homepage 'https://www.rogueamoeba.com/freebies/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.