### PR TITLE
Update macpass to 0.6.2-alpha

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -5,7 +5,7 @@ cask 'macpass' do
   # github.com/mstarke/MacPass was verified as official when first introduced to the cask
   url "https://github.com/mstarke/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
   appcast 'https://github.com/mstarke/MacPass/releases.atom',
-          checkpoint: 'e0cb1a3c927f46c82094b92ff519cf38dfb89d00e79f665428517773ba130bff'
+          checkpoint: 'a104302161f8b56ca01d8bcb141fd7fbb639fe6cf973a0a32cb3a26a876d5752'
   name 'MacPass'
   homepage 'https://mstarke.github.io/MacPass/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.