### PR TITLE
Update makeiphoneringtone to 1.3.5

### DIFF
--- a/Casks/makeiphoneringtone.rb
+++ b/Casks/makeiphoneringtone.rb
@@ -2,9 +2,9 @@ cask 'makeiphoneringtone' do
   version '1.3.5'
   sha256 'a7d06d2d1ee496c534e77da69362c91d6acef5f1ff9edf7713a572dbd60eaf8a'
 
-  url 'https://rogueamoeba.com/freebies/download/MakeiPhoneRingtone.zip'
+  url "https://rogueamoeba.com/legacy/downloads/MakeiPhoneRingtone-#{version.no_dots}.zip"
   appcast 'https://rogueamoeba.com/freebies/version-mir.rss',
-          checkpoint: '537cf0c3d30d57c1fa5912271b9b00f335d87caffd13ebd2fe762caaa7ea9f13'
+          checkpoint: '3fbc49574d199b91687894fa3cc64d219838dcb5f52fde13e793704de5833e6e'
   name 'MakeiPhoneRingtone'
   homepage 'https://rogueamoeba.com/freebies/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.