### PR TITLE
Update mame to 0.135

### DIFF
--- a/Casks/mame.rb
+++ b/Casks/mame.rb
@@ -4,7 +4,7 @@ cask 'mame' do
 
   url "https://downloads.sourceforge.net/mameosx/MAMEOSX-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/mameosx/rss',
-          checkpoint: '05d87458543be825903620c590fc797a842cdcd8f91cab8b88623ecc701992b7'
+          checkpoint: 'a3295c669aae45dd0ae512c6db410298b0b59bad9c537200b2b1b7df8207279f'
   name 'MAME'
   homepage 'http://mameosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.