### PR TITLE
Update midi-monitor to 1.3.2

### DIFF
--- a/Casks/midi-monitor.rb
+++ b/Casks/midi-monitor.rb
@@ -4,7 +4,7 @@ cask 'midi-monitor' do
 
   url "https://www.snoize.com/MIDIMonitor/MIDIMonitor_#{version.dots_to_underscores}.zip"
   appcast 'https://www.snoize.com/MIDIMonitor/MIDIMonitor.xml',
-          checkpoint: 'eb0ebc4edfa5274c5a051c7753c3bcf924cc75392ec9a69d33176184732a29a5'
+          checkpoint: 'de0c37ffdf1e4e8125532139efd591a57a69cb1f53401202848864aef5f2d19f'
   name 'MIDI Monitor'
   homepage 'https://www.snoize.com/MIDIMonitor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.