### PR TITLE
Update mirrordisplays to 1.1

### DIFF
--- a/Casks/mirrordisplays.rb
+++ b/Casks/mirrordisplays.rb
@@ -5,7 +5,7 @@ cask 'mirrordisplays' do
   # github.com/fcanas/mirror-displays was verified as official when first introduced to the cask
   url "https://github.com/fcanas/mirror-displays/releases/download/v#{version}/MirrorDisplays.zip"
   appcast 'https://github.com/fcanas/mirror-displays/releases.atom',
-          checkpoint: 'e2b3b062a7439dd4b91f437b146ea32ee3c3038492af356d966b97673ac1c04a'
+          checkpoint: '95b3f775e677d90f09f0c2b2a7b192ffddc73cf05cd45f79ae2c41807ee2cdd0'
   name 'Mirror Displays'
   homepage 'https://fabiancanas.com/open-source/mirror-displays'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.