### PR TITLE
Update flux to 39.96

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,6 +1,6 @@
 cask 'flux' do
-  version '39.94'
-  sha256 '45e69b3f02c02e6f442c1e2ce49b70e14f69d5cb7453cad031e61055ffbdb318'
+  version '39.96'
+  sha256 '8514ba63c69e74d9c1973a757e901e4622cfefb2e46b66d726bfcf4bd1322d7f'
 
   url "https://justgetflux.com/mac/Flux#{version}.zip"
   appcast 'https://justgetflux.com/mac/macflux.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`appcast` hasn't been updated yet but the [changelog](https://justgetflux.com/news/pages/mac/#changelog) lists `39.96`