### PR TITLE
Update mnemosyne to 2.4.1

### DIFF
--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -1,11 +1,11 @@
 cask 'mnemosyne' do
   version '2.4.1'
-  sha256 'c302624b8652f397c18fe6cbdaf520c9898dd97a68b8a02f90b96cbe5177df8d'
+  sha256 '8c641a1e7862e28db0469e031e6255ef6da6b5b8de0b6bb366b40500406e8baa'
 
   # sourceforge.net/mnemosyne-proj was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/mnemosyne-proj/mnemosyne/mnemosyne-#{version}/Mnemosyne-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/mnemosyne-proj/rss?path=/mnemosyne',
-          checkpoint: '0b5bd0a344a750820cb2ebce55dae58341670b395546cac3f8b3440c0e4ba602'
+          checkpoint: 'f85fdd39069b9dda98e8b13376e30a07672ca11424ca8c17d3da3132d03553a4'
   name 'Mnemosyne'
   homepage 'http://mnemosyne-proj.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

VirusTotal: https://www.virustotal.com/en-gb/file/71cbd92d9621834701c2420b53f9e05290b6c39c061157ccd8b076eca6a6d43d/analysis/1494752816/