### PR TITLE
Update caprine to 2.3.1

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.2.0'
-  sha256 '175b29b7d78e21117dfdc0dc60d66f542f5ccbd4a091650a8cdb12e3f2db79d1'
+  version '2.3.1'
+  sha256 'bd3c5d39b17bb9e03be17673c6cb014fa52fca37931324c100ed27f226fbbb09'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: '9bbe02c49e919e2c30042a262c392b75e3f8a994374ff050306f9caf60e93aef'
+          checkpoint: '62c7d84c12bff83cd8dd0712ecb00f7bb34402aba5a2796eb3c32509c39d08cb'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.