### PR TITLE
Update mongoclient to 2.1.0

### DIFF
--- a/Casks/mongoclient.rb
+++ b/Casks/mongoclient.rb
@@ -1,11 +1,11 @@
 cask 'mongoclient' do
-  version '2.0.0'
-  sha256 'b9652b457ab66c6797cc8a83623c248ae56fe0ee8d1b0c4c9b95ff71104e2bea'
+  version '2.1.0'
+  sha256 '4ae7a761f82d315c43f238f98ff5dabc0a78b8445fe392a1bf521b7a30c977d3'
 
   # github.com/mongoclient/mongoclient was verified as official when first introduced to the cask
   url "https://github.com/mongoclient/mongoclient/releases/download/#{version}/osx-portable.zip"
   appcast 'https://github.com/mongoclient/mongoclient/releases.atom',
-          checkpoint: '7a8466a1cd519ee10758c002fe61da5c817b90d6f6215dbf70f99e7ca50733a0'
+          checkpoint: '5979ef2c12d00e088649c32b45e6ceae2b721bf81d19b1b8186a39942236623f'
   name 'Mongoclient'
   homepage 'https://www.mongoclient.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.