### PR TITLE
Update prott to 1.0.3

### DIFF
--- a/Casks/prott.rb
+++ b/Casks/prott.rb
@@ -1,10 +1,10 @@
 cask 'prott' do
-  version '1.0.1'
-  sha256 'bd03b75cff0ae35cd636853838d932870f27600783b7e41f0f8110f8246c80d9'
+  version '1.0.3'
+  sha256 '874cef4081941e0bfa52ddeb5c199b432e838fe017d22b891d38ec5a5196933b'
 
   url 'https://dl.prottapp.com/apps/prott.dmg'
   appcast 'https://dl.prottapp.com/apps/appcast.xml',
-          checkpoint: 'e348ca40d19d94c2376bda86a421feaa7e56e50fc211e3c4a600295d183e1529'
+          checkpoint: '48798baddf5d9dc4179cc24c6a32678fff443141155791b66ce91c6e6076d08c'
   name 'Prott'
   homepage 'https://prottapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.