### PR TITLE
Update pyfa to 1.29.1,yc119.5-1.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.28.1,yc119.3-1.0'
-  sha256 '8fbef12da3d055e84c76dd50b828aa9f439d51fbd3496751f37c57f2c7bd58c6'
+  version '1.29.1,yc119.5-1.0'
+  sha256 'ad3e29b890715bf34bcdb7bf0d6d368fe3c829f44fda0df970e9bd8bb098f42d'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: 'd6d6082e15b9942824b9e389e3ed4297996bb1bfe340d2d78d99d98cf29a2273'
+          checkpoint: 'fd8c36da203fc98e89e22034851170611ff3bd36e06af008146572b28c2694ab'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.