### PR TITLE
Update buttercup to 0.14.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.14.0'
-  sha256 '4a9233c266dda6bd2643db23da1c76be45faa3c214b92f0554ec55043ebc37b3'
+  version '0.14.2'
+  sha256 '6c8d1d5da41d30c48c06438e5a7f6ac2fce4c0bc65735302a8c55df985a48c63'
 
   # github.com/buttercup/buttercup was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup/releases/download/v#{version}/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup/releases.atom',
-          checkpoint: '7703beb0ee8b9c7bfb54cd529e0996542d71e21baa192c2faee60cc94a08b43f'
+          checkpoint: 'a7cfe2c582aff349d1fb84c522a88adc4d452a15b44cb8607391e76a4a9fd170'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.