### PR TITLE
Update qtox to 1.10.1

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.10.0'
-  sha256 'f9adc318ea4b89c089ad11ef6a74dec7fa83499a232c1ebe9fdebdcf4fc58265'
+  version '1.10.1'
+  sha256 '611b4ce4792e5b99dac4095cc8ec9dde7641f3985acaf74151721c2e6523616b'
 
   # github.com/tux3/qTox was verified as official when first introduced to the cask
   url "https://github.com/tux3/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/tux3/qtox/releases.atom',
-          checkpoint: 'd74c248f0c50c446be1676b1fc490a027c0e997d42d0320b4e652a00ee0b967b'
+          checkpoint: '3d680b77edfd26458214ee7774bbb733bad55f6ef9ab5c10e1e2289b2e897d58'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.