### PR TITLE
Update enpass to 5.5.4

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -1,6 +1,6 @@
 cask 'enpass' do
-  version '5.5.3'
-  sha256 '9ed5f8b573ea64306723f14f0792ce0c78bd3c38007ea0cef618e8fc22748f97'
+  version '5.5.4'
+  sha256 '43f774acbd23f8e079abf8da9dcf6639b559fc59c84e7915fca9e0a7a86edaa9'
 
   # sinew.in was verified as official when first introduced to the cask
   url "https://dl.sinew.in/mac/setup/Enpass-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.