### PR TITLE
Update mudlet to 3.1.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,10 +1,10 @@
 cask 'mudlet' do
-  version '3.0.1'
-  sha256 '56ae0589db2f3bc2b9e54ad2d030f09a8edbbbc73bbe17b91f19e13c9aeee5a0'
+  version '3.1.0'
+  sha256 'b29fbb950c2292231d253b40f58739093c39dea388362dfc9fe0a9f344e98cbd'
 
   url "http://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom',
-          checkpoint: 'ac9ebb084ffbca5e331634e5413261c463078f76db82d20581ea5ff108b59292'
+          checkpoint: '533a8fd5aa78ba4c215e7414f3fce9e94ddbf67415c278c3d197bd4093c31ab9'
   name 'Mudlet'
   homepage 'http://www.mudlet.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.