### PR TITLE
Update namechanger to 3.3.0

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -4,7 +4,7 @@ cask 'namechanger' do
 
   url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.dots_to_underscores}.zip"
   appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
-          checkpoint: '00cc536c81895136ea548eed2cf5cc5236089e1026f0dd99244db6ef7a4d9737'
+          checkpoint: 'bc5602d20c7b88ad517282a8d1ae96327dd2c074fafd9ba36b76679c52b56e07'
   name 'NameChanger'
   homepage 'https://mrrsoftware.com/namechanger/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.