### PR TITLE
Update nimble to 1.3.3

### DIFF
--- a/Casks/nimble.rb
+++ b/Casks/nimble.rb
@@ -5,7 +5,7 @@ cask 'nimble' do
   # github.com/Maybulb/Nimble was verified as official when first introduced to the cask
   url "https://github.com/Maybulb/Nimble/releases/download/#{version}/Nimble-#{version}.dmg"
   appcast 'https://github.com/Maybulb/Nimble/releases.atom',
-          checkpoint: '1fbfbe392a526e27648c7a354ccde21e759d7da604afb196c90453974df23e69'
+          checkpoint: '59612688040237acec569456b374bcd12da6bbb39c0eaebd2f9753caa98d3a14'
   name 'Nimble'
   homepage 'http://maybulb.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.