### PR TITLE
Update nndd to 2.4.3,62201

### DIFF
--- a/Casks/nndd.rb
+++ b/Casks/nndd.rb
@@ -3,8 +3,8 @@ cask 'nndd' do
   sha256 '6a73dcad2e73d877ad1503ed1162cae1a1c84f21d1abaa6aaf9b31bb2fbca531'
 
   url "http://dl.osdn.jp/nndd/#{version.after_comma}/NNDD_v#{version.before_comma.dots_to_underscores}.dmg"
-  appcast 'https://osdn.jp/projects/nndd/releases/rss',
-          checkpoint: '688d962d47c3a84d474ddbb25c37fbe44240bba4f792bcfdb8cb6f1134fef678'
+  appcast 'https://ja.osdn.net/projects/nndd/releases/rss',
+          checkpoint: '63fae7ea9a0a42bd34091f032cdce3fe8a26c3c9a9866f1e29a45555ada52fc3'
   name 'NNDD'
   homepage 'https://osdn.jp/projects/nndd/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.