### PR TITLE
Update noiz2sa to 0.51.5

### DIFF
--- a/Casks/noiz2sa.rb
+++ b/Casks/noiz2sa.rb
@@ -4,7 +4,7 @@ cask 'noiz2sa' do
 
   url "https://workram.com/downloads/Noiz2sa-for-OS-X-#{version}.dmg"
   appcast 'https://workram.com/games/noiz2sa/',
-          checkpoint: '7d75d2d0426fbf93afc384cff783faf59f5feecf592abc194146eeb13bd01f15'
+          checkpoint: '3c92353aee8455acd1d51f88410a69d9ebac3d53368501e0ed24a14cba05bbfa'
   name 'Noiz2sa'
   homepage 'https://workram.com/games/noiz2sa/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.