### PR TITLE
Update opensesame to 3.1.6

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -9,7 +9,7 @@ cask 'opensesame' do
     # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
     url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
     appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: '27ce86920dfb1d7815fdae809f67a4c28b21448abcaa7a4a1878682f9a6331a2'
+            checkpoint: '7024bbce26aa87d4a4f889ed99f08463d120491b085fdba1163f69da98b415a6'
   end
 
   name 'OpenSesame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.