### PR TITLE
Process monitor 1.1

### DIFF
--- a/Casks/process-monitor.rb
+++ b/Casks/process-monitor.rb
@@ -1,6 +1,6 @@
 cask 'process-monitor' do
   version '1.1'
-  sha256 :no_check
+  sha256 'ef074c433a75ab347856b26a7fa0568558c2b938d7b531c12cd53ae1ddfebea8'
 
   # s3.amazonaws.com/sqwarq.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip'

--- a/Casks/process-monitor.rb
+++ b/Casks/process-monitor.rb
@@ -2,15 +2,15 @@ cask 'process-monitor' do
   version '1.1'
   sha256 :no_check
 
-  # s3.amazonaws.com/sqwarq.com/AppCasts was verified as official when first introduced to the cask
+  # s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip'
   appcast 'https://s3.amazonaws.com/sqwarq.com/AppCasts/procmon-updates.xml',
           checkpoint: '3961558b7f0ee17bdb52704fa2237bcd161f4812d01690f7579e7612fc84db95'
   name 'Process Monitor'
   homepage 'https://sqwarq.com/process-monitor/'
 
-  depends_on macos: '>= :mountain_lion'
   auto_updates true
+  depends_on macos: '>= :mountain_lion'
 
   app 'Process Monitor.app'
 end

--- a/Casks/process-monitor.rb
+++ b/Casks/process-monitor.rb
@@ -2,7 +2,7 @@ cask 'process-monitor' do
   version '1.1'
   sha256 :no_check
 
-  # s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip was verified as official when first introduced to the cask
+  # s3.amazonaws.com/sqwarq.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip'
   appcast 'https://s3.amazonaws.com/sqwarq.com/AppCasts/procmon-updates.xml',
           checkpoint: '3961558b7f0ee17bdb52704fa2237bcd161f4812d01690f7579e7612fc84db95'

--- a/Casks/process-monitor.rb
+++ b/Casks/process-monitor.rb
@@ -1,0 +1,16 @@
+cask 'process-monitor' do
+  version '1.1'
+  sha256 :no_check
+
+  # s3.amazonaws.com/sqwarq.com/AppCasts was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip'
+  appcast 'https://s3.amazonaws.com/sqwarq.com/AppCasts/procmon-updates.xml',
+          checkpoint: '3961558b7f0ee17bdb52704fa2237bcd161f4812d01690f7579e7612fc84db95'
+  name 'Process Monitor'
+  homepage 'https://sqwarq.com/process-monitor/'
+
+  depends_on macos: '>= :mountain_lion'
+  auto_updates true
+
+  app 'Process Monitor.app'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

This is a new one. The public download URL listed on the website and the one used in the Appcast feed are the same, and not versioned. It seems possible then that future updates will simply use the same URL and the feed would be updated to have only the latest item.

For this reason it seems also reasonable to use `version :latest` instead of `1.1`, but I wasn't sure. Since this is so new there's not an established pattern for how this will get updates.