### PR TITLE
Update fly to 2.7.7

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '2.7.4'
-  sha256 '624e5af6ff44c01e838d8a517a71f61c5aff350038817396c9c387bd17fa65f7'
+  version '2.7.7'
+  sha256 '8c0e90030753405ceafe93ff5e3c6d14c16a5672b6f34a24e39ce25a163c7463'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: 'f3e9d5f7ef7ff923f0635fba79facb8ca690c6637fedcbabe8b0cac60c842e7b'
+          checkpoint: 'd9b2cc55c187727c53977d2bd456bf8f95bddbdc50f1c590e55d4dc15c037fc9'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.