### PR TITLE
Update macdown.rb for sha256, depends_on and zap

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -1,25 +1,27 @@
 cask 'macdown' do
   version '0.7.1'
-  sha256 '9856d701739fab66b75aa52c98ba54d93eb10de765f63ffe149e666e6e035578'
+  sha256 '4b26fb70b399cd998f226a78f81cd74348da19a8953aca80169fd7d00667496c'
 
   # github.com/MacDownApp/macdown was verified as official when first introduced to the cask
   url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
-  appcast 'http://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml',
-          checkpoint: '258b52ee033ead7b2264e772b077e747bfedd4cc081d5b4bb16217f94451e35e'
+  appcast 'https://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml',
+          checkpoint: '0f66f2a2ec60b25ce7b15cf153db4245badf0c1252196e2bfda8a9d401767789'
   name 'MacDown'
   homepage 'https://macdown.uranusjr.com/'
 
   auto_updates true
+  depends_on macos: '>= :mountain_lion'
 
   app 'MacDown.app'
   binary "#{appdir}/MacDown.app/Contents/SharedSupport/bin/macdown"
 
   zap delete: [
+                '~/Library/Application Support/MacDown',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uranusjr.macdown.sfl',
                 '~/Library/Caches/com.uranusjr.macdown',
                 '~/Library/Cookies/com.uranusjr.macdown.binarycookies',
                 '~/Library/Preferences/com.uranusjr.macdown.plist',
-                '~/Library/Preferences/com.uranusjr.macdown.LSSharedFileList.plist',
-                '~/Library/Application Support/MacDown',
+                '~/Library/Saved Application State/com.uranusjr.macdown.savedState',
                 '~/Library/WebKit/com.uranusjr.macdown',
               ]
 end


### PR DESCRIPTION
Update macdown.rb for sha256, depends_on and zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256