### PR TITLE
Update standard-notes to 0.4.0

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.3.4'
-  sha256 'e2d9e3d1e9fc9f508b6dffe61218350ef2916cb4ff7a9fa8636b6739a3739656'
+  version '0.4.0'
+  sha256 '718621b0883caa4768161f95ca05e902d154bf96a30610ce0a8c355dcd786715'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'c5a7d3a4cea9667e8cdd9c0b8eb9564950ea58daa1281cdfd090f102ccc66064'
+          checkpoint: 'ecf0295f1718917894ab5124e345f09d8ce997aa250c9d42de49523d76a8e153'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.