### PR TITLE
{WIP} Update nanobox to 2.1.1

### DIFF
--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -1,11 +1,11 @@
 cask 'nanobox' do
-  version '0.18.2'
+  version '2.1.1'
   sha256 '433efa3076ab217e04707f8707476af48b1bc2727791cfcb5230d12a9003be1b'
 
   # s3.amazonaws.com/tools.nanobox.io was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/tools.nanobox.io/cli/darwin/amd64/nanobox'
   appcast 'https://github.com/nanobox-io/nanobox/releases.atom',
-          checkpoint: 'ec194abb98dfcd6f3604dcfb307713989febbdc36de96259b1c57563cf414962'
+          checkpoint: '5a76290986958e939845f9d1f9946ee63593709f3733c319eb030c64ab7e8e26'
   name 'nanobox'
   homepage 'https://www.nanobox.io/'
 


### PR DESCRIPTION
There is PKG download now. Checking the cask to support it.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.