### PR TITLE
Update parse to 3.0.5

### DIFF
--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -2,8 +2,8 @@ cask 'parse' do
   version '3.0.5'
   sha256 '30c305a76beb8913392b74977a6801e817c3477bd3de72ecd1887a8ca57ea888'
 
-  # github.com/ParsePlatform was verified as official when first introduced to the cask
-  url "https://github.com/ParsePlatform/parse-cli/releases/download/release_#{version}/parse"
+  # github.com/parse-community was verified as official when first introduced to the cask
+  url "https://github.com/parse-community/parse-cli/releases/download/release_#{version}/parse"
   appcast 'https://github.com/parse-community/parse-cli/releases.atom',
           checkpoint: '028a2ba1e6a24b6cc7735aec49a3f60c076613a2160d9272c1fe3230cc952be2'
   name 'Parse'

--- a/Casks/parse.rb
+++ b/Casks/parse.rb
@@ -4,8 +4,8 @@ cask 'parse' do
 
   # github.com/ParsePlatform was verified as official when first introduced to the cask
   url "https://github.com/ParsePlatform/parse-cli/releases/download/release_#{version}/parse"
-  appcast 'https://github.com/ParsePlatform/parse-cli/releases.atom',
-          checkpoint: '07e39670b7193e99e97346f3b3e2c10d79b56285f53544f55d1b86f758d70e63'
+  appcast 'https://github.com/parse-community/parse-cli/releases.atom',
+          checkpoint: '028a2ba1e6a24b6cc7735aec49a3f60c076613a2160d9272c1fe3230cc952be2'
   name 'Parse'
   homepage 'http://parseplatform.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.