### PR TITLE
Update postage to 3.2.12

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.2.6'
-  sha256 '89e81c9b89d4227fc665d9726c58b5e007cb3d8abe5547f96a85a8d900f3d9fb'
+  version '3.2.12'
+  sha256 'c507f5073655a07d4c71ceff07053f87506a0661385c6354d532701e2069dcd3'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: 'dfe95068750c40183306fc3046f906e78ea83bb0cfa7220415268099afbf7a2b'
+          checkpoint: '7f69cde0a7468ba95d7c24117010d6f15fc3d243868998a8b5228ddab12b2dc7'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.