### PR TITLE
Update prismatik to 5.11.2

### DIFF
--- a/Casks/prismatik.rb
+++ b/Casks/prismatik.rb
@@ -5,7 +5,7 @@ cask 'prismatik' do
   # github.com/woodenshark/Lightpack was verified as official when first introduced to the cask
   url "https://github.com/woodenshark/Lightpack/releases/download/#{version}/Prismatik.#{version}.dmg"
   appcast 'https://github.com/woodenshark/Lightpack/releases.atom',
-          checkpoint: 'ed21f0f168d0db0f3764fdb42fa027c394f3df5781cd504526393422fe522351'
+          checkpoint: '9643c17cba55157325ba00abd2244d07b369d848f49b32565ee11e01103bf6a5'
   name 'Prismatik'
   homepage 'https://lightpack.tv/promo/lightpack1.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.