### PR TITLE
Update tortoisehg to 4.2.0

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.1.2'
-  sha256 'd631dc1ea4406d48f8a44549768b940d12cb668df92ced109a6db82de3c0b4f5'
+  version '4.2.0'
+  sha256 'faba58c9b0a7ddf20abb0811a4fc3ab63ed7c1573495c27e164b3a776308c778'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.