### PR TITLE
Update metasploit to 4.14.18+20170515092249

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,17 +1,17 @@
 cask 'metasploit' do
-  version '4.14.18,20170513092251'
-  sha256 '823293db0245cf564656c6b1bc5301de503ec2f3ff10d22fc024b44c2a0dc991'
+  version '4.14.18+20170515092249'
+  sha256 'b6e1aa0621764f33acabb57f95086d076c88364d89be38b44c23c59385afd231'
 
-  url "https://osx.metasploit.com/metasploit-framework-#{version.major_minor_patch}+#{version.after_comma}-1rapid7-1.pkg"
+  url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: 'ff659a5cff296c665a841a0948b86ec4a090eaf3c9df48ca5865d1a4ad55a40a'
+          checkpoint: '7f58565fee03cb71659b5412de58090d48fb98c1b2988d1204da8f492bc48abb'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'
 
   depends_on formula: 'nmap'
 
-  pkg "metasploit-framework-#{version.major_minor_patch}+#{version.after_comma}-1rapid7-1.pkg"
+  pkg "metasploit-framework-#{version}-1rapid7-1.pkg"
   binary '/opt/metasploit-framework/bin/metasploit-aggregator'
   binary '/opt/metasploit-framework/bin/msfbinscan'
   binary '/opt/metasploit-framework/bin/msfconsole'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Simplify `version` , `url` , `pkg`