### PR TITLE
Update lepton to 1.2.2

### DIFF
--- a/Casks/lepton.rb
+++ b/Casks/lepton.rb
@@ -1,11 +1,11 @@
 cask 'lepton' do
-  version '1.2.1'
-  sha256 '8b8487425b8a2e4649e860fa223500c7ea7894ae7f2774680eef99cc74c8899f'
+  version '1.2.2'
+  sha256 'f829674b3c4bc37b429c50cb4a1ebd3a44e2aa4a198c10fb68344a24c496a263'
 
   # github.com/hackjutsu/Lepton was verified as official when first introduced to the cask
   url "https://github.com/hackjutsu/Lepton/releases/download/v#{version}/Lepton-#{version}-mac.zip"
   appcast 'https://github.com/hackjutsu/Lepton/releases.atom',
-          checkpoint: '10612fabc575066085e1da2609be43562e70b1e18db8c1842bc6e80ac18fc817'
+          checkpoint: '77ddd48b815605224488b1015e11da14d82a3481cf4c14018f9b008aa0c2324a'
   name 'Lepton'
   homepage 'http://hackjutsu.com/Lepton/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.