### PR TITLE
Update vagrant to 1.9.5

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,11 +1,11 @@
 cask 'vagrant' do
-  version '1.9.4'
-  sha256 '2ae186e762498c8e018efbf3452a3d368627cb7d518b26f3f445f0a3686e5a07'
+  version '1.9.5'
+  sha256 'ac16217b114d8816264700e41114b62acd0c071d2699ae13954086ae3fcb151c'
 
   # hashicorp.com/vagrant was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"
   appcast 'https://github.com/mitchellh/vagrant/releases.atom',
-          checkpoint: 'd9d8ab9e8e0f7f4c520200b2097744b7c46b66908da21432bfc463789602acf7'
+          checkpoint: '0e748c3d3565674755733283f882e3e1899ea4134292877aa2a8275fca66d08f'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.