### PR TITLE
Update vectr to 0.1.15

### DIFF
--- a/Casks/vectr.rb
+++ b/Casks/vectr.rb
@@ -1,6 +1,6 @@
 cask 'vectr' do
-  version '0.1.14'
-  sha256 '67c440898f34ff34d8d61d07c3a5e3de8068f0182a080998cec5090bd7b90d97'
+  version '0.1.15'
+  sha256 '3b5ebbfb7656ff722f0e0fdaf97500a9c9d6eeaeb9d7885aa00bcd6af8853862'
 
   url "http://download.vectr.com/desktop/#{version}/mac/Vectr-mac.dmg"
   name 'Vectr'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.