### PR TITLE
Update android-studio to 2.3.2.0,162.3934792

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '2.3.1.0,162.3871768'
-  sha256 '7af9bb72c8ede549b3a4d0d8fc6dbc597bb4b726e15d2fba73edf12dd2ebc6d8'
+  version '2.3.2.0,162.3934792'
+  sha256 '484a698f9a4a6bdb860186d4b89be16bb37fc1f23842faacd416d5aca2fb1c3f'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.