### PR TITLE
Update gns3 to 2.0.1

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.0.0'
-  sha256 'a1ca4e436cd2486e740dc6bf32804e20ba2356955975e6907b288e84540ce377'
+  version '2.0.1'
+  sha256 '68197caeb90f849c79eef749ed460073a74d25838cc2d074506acec7a2d79577'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: '588acf941d0d8e20a7b329fa118453ad93ef157d245e9a5bd696a818ef73d941'
+          checkpoint: 'c15cfc06e174a66080507d0092f39591582feb5b177a984bb4e61088237bcc46'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.