### PR TITLE
Update lingon-x to 5.0.3

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.0.2'
-  sha256 'd3ab9a7d33c2aff7153d4b4bd001c38e16216a7722127a8baed2199ad77fc62b'
+  version '5.0.3'
+  sha256 'a7ca279baa962f2aa56484c08956d4cda94f5207a1731be1c6b8753e97b70d51'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '8532e54ccbfc85cecc5055c76089b4e71a175dc7734b574828e7283a7cd51545'
+          checkpoint: '45238c0ee4b02eb599909f93ed61b51855ebb49576dc77ad71b2debcad128610'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.