### PR TITLE
Update switchhosts to 3.3.4.5228

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.3.5215'
-  sha256 'cde448ea76857876257fcf165a0f17dd591792e2796ff539210e51848f2a404c'
+  version '3.3.4.5228'
+  sha256 'c90255794774c412c8eb31f3c60453dcea800decbe9bf672a36ea9d6c857c5b8'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: '2d5ec4b21a73ca0d31fc3c7d0c4fb9fe2192f2a1623a2633785f4d42d0e9c549'
+          checkpoint: '7d3a8912b0a7f8a7fac7e6eccdaa2c6a358686e8df09f78dce87932c82dd6c8f'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.