### PR TITLE
Update openshot-video-editor to 2.3.2

### DIFF
--- a/Casks/openshot-video-editor.rb
+++ b/Casks/openshot-video-editor.rb
@@ -1,11 +1,11 @@
 cask 'openshot-video-editor' do
-  version '2.3.1'
-  sha256 '735b1e511f97bceca0306f8afb0c81509f88b75f2334d2d0bbd1c289d393293d'
+  version '2.3.2'
+  sha256 'e65ff6fdcdfeb11880b0fac95fad86b06b334927ef58b4c9f5e985a166eba57c'
 
   # github.com/OpenShot/openshot-qt was verified as official when first introduced to the cask
   url "https://github.com/OpenShot/openshot-qt/releases/download/v#{version}/OpenShot-v#{version}-x86_64.dmg"
   appcast 'https://github.com/OpenShot/openshot-qt/releases.atom',
-          checkpoint: '150d0dc218d3d53e4f30e45accc245d8b12c9951e55dd68f48f0bc445be0eee8'
+          checkpoint: 'b9d68ef0727965693320bced947420b4cff9ecc8386e43fdc46fe98ce4405662'
   name 'OpenShot Video Editor'
   homepage 'https://openshot.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.