### PR TITLE
Update panini to 0.71.104

### DIFF
--- a/Casks/panini.rb
+++ b/Casks/panini.rb
@@ -4,7 +4,7 @@ cask 'panini' do
 
   url "https://downloads.sourceforge.net/pvqt/Panini-#{version}B-mac.dmg"
   appcast 'https://sourceforge.net/projects/pvqt/rss',
-          checkpoint: '240ebece43c34eee4cd45ba8638d99c936281337fae4864fbe32083536ee052e'
+          checkpoint: 'ff8c509bfe4ac83c5d4482b500643bb34d877b063fdffa33ee581bc01c854112'
   name 'Panini'
   homepage 'https://sourceforge.net/projects/pvqt/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.