### PR TITLE
Update aqua-data-studio to 18.0.12

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,10 +1,10 @@
 cask 'aqua-data-studio' do
-  version '18.0.10'
-  sha256 'fefb3acab875b675a4f5af1e701fd542fd51aa2e64a0607718f4ed95f63f91fa'
+  version '18.0.12'
+  sha256 '1f7490c75e72baf1a37bae3dff97f3db60d7ac4c116f7270b9413ce1ecbf4bca'
 
   url "http://www.aquafold.com/download/v#{version.major}.0.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'http://www.aquafold.com/download/',
-          checkpoint: '4ea4c5ab005a8b364c88375d5de968b32bb0d4f0e032bffaedf87e5112bad5cc'
+          checkpoint: 'c6d6214937a9956254f981bc650e2dd0aa6fc9c49d9f36214074d36748b19d56'
   name 'Aquafold Aqua Data Studio'
   homepage 'http://www.aquafold.com/aquadatastudio.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.