### PR TITLE
Update go-agent to 17.4.0-4892

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,6 +1,6 @@
 cask 'go-agent' do
-  version '17.3.0-4704'
-  sha256 'a3f4fc0bf61e6a75c86fe7a7651d4125fca337d4ace25bde289c7fa959d9c789'
+  version '17.4.0-4892'
+  sha256 '61c0ee4c74328d16cc543963217b9f79470b795870427834b67c30162e957b1b'
 
   url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.