### PR TITLE
Update qnapi to 0.2.2

### DIFF
--- a/Casks/qnapi.rb
+++ b/Casks/qnapi.rb
@@ -5,7 +5,7 @@ cask 'qnapi' do
   # github.com/QNapi/qnapi was verified as official when first introduced to the cask
   url "https://github.com/QNapi/qnapi/releases/download/#{version}/QNapi-#{version}.dmg"
   appcast 'https://github.com/QNapi/qnapi/releases.atom',
-          checkpoint: '7f86d17cfff871b1a1bb1b1071b25bc49ecdfb05e7534068614f2d49911b2448'
+          checkpoint: '04f877f7a0fc67f108c3f8eb137858e8a674ca8bed8353c6a539b35bb68d267c'
   name 'QNapi'
   homepage 'https://qnapi.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.