### PR TITLE
Update qownnotes to 17.05.5,b2937-190117

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.04.4,b2877-102903'
-  sha256 'd0e285f13041f32bca42c3eb633df21f71684b604208319d3f9a252a9e5ce511'
+  version '17.05.5,b2937-190117'
+  sha256 '15f2782078792c5ae9af4b9552c5efcfd804f7529648e774b4d59447696ec516'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: 'f1707ba418b8dfccb94e084218c6a07c5088fe0404f4af9a5929de610721e102'
+          checkpoint: '5040dfec5f8f18ee055225e7758ec679bdf1361c1aab97605738d278f552be1c'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.