### PR TITLE
Update qtpass to 1.1.6

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -5,7 +5,7 @@ cask 'qtpass' do
   # github.com/IJHack/qtpass was verified as official when first introduced to the cask
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: '56021f84c929bfa5afc5053d46090c6b92cb94d494c12809255b2072abf373ed'
+          checkpoint: '426e2c46f4e7ec81b5d7cd801778de605237964f002d109084234a0531f2dd29'
   name 'QtPass'
   homepage 'https://qtpass.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.