### PR TITLE
Update navicat-for-sql-server to 11.2.18

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -3,6 +3,8 @@ cask 'navicat-for-sql-server' do
   sha256 '192b85d9f7d50ce37afab48ef834cf61de6ab298182f4e70f1a379a47c3a1478'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
+  appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note',
+          checkpoint: '11f0134465eb9c7f0526a03e4fcab01760bfa43352b0678e1d78364361a62625'  
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 

--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '11.2.17'
-  sha256 '84826b23b496dc809794c91ad77bce6deff9978c5ddb780999e9dd76ae776cc3'
+  version '11.2.18'
+  sha256 '192b85d9f7d50ce37afab48ef834cf61de6ab298182f4e70f1a379a47c3a1478'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   name 'Navicat for SQL Server'

--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -4,7 +4,7 @@ cask 'navicat-for-sql-server' do
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note',
-          checkpoint: '11f0134465eb9c7f0526a03e4fcab01760bfa43352b0678e1d78364361a62625'  
+          checkpoint: '11f0134465eb9c7f0526a03e4fcab01760bfa43352b0678e1d78364361a62625'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.