### PR TITLE
{Pending} Update navicat-for-sqlite to 11.2.17

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,5 +1,5 @@
 cask 'navicat-for-sqlite' do
-  version '11.2.18'
+  version '11.2.17'
   sha256 '6c184e3aac0bba7d143278ff8163eed38dc4a9c58100096e437a4001d2f053e1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] `sha256` was updated, but `version` remained the same.
      [Post a link to a public confirmation by the developer.][version-checksum]: 

Verification Requested from the developer: https://twitter.com/gobinathm/status/864565567734370304