### PR TITLE
Update reeddit to 1.9.6

### DIFF
--- a/Casks/reeddit.rb
+++ b/Casks/reeddit.rb
@@ -5,7 +5,7 @@ cask 'reeddit' do
   # github.com/berbaquero/Reeddit-app was verified as official when first introduced to the cask
   url "https://github.com/berbaquero/Reeddit-app/releases/download/v#{version}/Reeddit.app.zip"
   appcast 'https://github.com/berbaquero/Reeddit-app/releases.atom',
-          checkpoint: '6c029ef230f82c430494d258b46ce49cd74a73ebb21214ed856b1e007b3fbd7d'
+          checkpoint: '8275a99ccc6c1f97a5f3b93361af5da6dde01f288895aab3e11df2fe326dfb77'
   name 'Reeddit'
   homepage 'http://mac.reedditapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.