### PR TITLE
Update navicat-for-mariadb to 11.2.18

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -4,7 +4,7 @@ cask 'navicat-for-mariadb' do
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mariadb-release-note',
-          checkpoint: '08104c4aa3b8513eb9f6eabaa6889bd4815e64b03a3a92c0efb568eb83aa5457'  
+          checkpoint: '08104c4aa3b8513eb9f6eabaa6889bd4815e64b03a3a92c0efb568eb83aa5457'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 

--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -3,6 +3,8 @@ cask 'navicat-for-mariadb' do
   sha256 '46f76645544a625a8fd6aeb46ff9677aa23e635a21996a459f5581ed9e1861ec'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
+  appcast 'https://www.navicat.com/products/navicat-for-mariadb-release-note',
+          checkpoint: '08104c4aa3b8513eb9f6eabaa6889bd4815e64b03a3a92c0efb568eb83aa5457'  
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 

--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '11.2.17'
-  sha256 'e0510d95a12ddaf15d705bdf452ede866227f056b54cd1af0f4d9c085ce7a872'
+  version '11.2.18'
+  sha256 '46f76645544a625a8fd6aeb46ff9677aa23e635a21996a459f5581ed9e1861ec'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   name 'Navicat for MariaDB'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.