### PR TITLE
Update navicat-for-mysql to 11.2.18

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '11.2.17'
-  sha256 '8e328346efddb8b0b2f8a3a8df5ab595c5ded8c7b774aa764812bdfaa1888229'
+  version '11.2.18'
+  sha256 'bd2e1f93e2e2512f8298498b1f40b632a206f8b8d0fa4fd9566787ba634cea4d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   name 'Navicat for MySQL'

--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -4,7 +4,7 @@ cask 'navicat-for-mysql' do
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note',
-          checkpoint: '3b1d2837be33fd080b74cf7a37d6a2213eb5915979af2abc0660c6f858834c45'  
+          checkpoint: '3b1d2837be33fd080b74cf7a37d6a2213eb5915979af2abc0660c6f858834c45'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 

--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -3,6 +3,8 @@ cask 'navicat-for-mysql' do
   sha256 'bd2e1f93e2e2512f8298498b1f40b632a206f8b8d0fa4fd9566787ba634cea4d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
+  appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note',
+          checkpoint: '3b1d2837be33fd080b74cf7a37d6a2213eb5915979af2abc0660c6f858834c45'  
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.