### PR TITLE
Update navicat-for-oracle to 11.2.18

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '11.2.17'
-  sha256 '8a22eb43edba11055f38144be9ed96c858354aeb5c77ac682aaf979b490b625f'
+  version '11.2.18'
+  sha256 'cd957470c76ebdd9ac2ba625746298650d9356640acbda5141f8515b8f1dc321'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   name 'Navicat for Oracle'

--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -3,6 +3,8 @@ cask 'navicat-for-oracle' do
   sha256 'cd957470c76ebdd9ac2ba625746298650d9356640acbda5141f8515b8f1dc321'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
+  appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note',
+          checkpoint: '976ee6551c762789ddd6b656ddad35a11809e83a66cd3e7327fa7e1d2c384105'  
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 

--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -4,7 +4,7 @@ cask 'navicat-for-oracle' do
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note',
-          checkpoint: '976ee6551c762789ddd6b656ddad35a11809e83a66cd3e7327fa7e1d2c384105'  
+          checkpoint: '976ee6551c762789ddd6b656ddad35a11809e83a66cd3e7327fa7e1d2c384105'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.