### PR TITLE
Update navicat-for-postgresql to 11.2.18

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -4,7 +4,7 @@ cask 'navicat-for-postgresql' do
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
-          checkpoint: 'b32845d48dcb1be5d2783cfdd1b39ec6ccfdd79dbb8522cfd0510ad7dc8effe7'  
+          checkpoint: 'b32845d48dcb1be5d2783cfdd1b39ec6ccfdd79dbb8522cfd0510ad7dc8effe7'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 

--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '11.2.17'
-  sha256 '426fcc44ffc1ae21a855a3d7a56c31dd47ab8ca517df1f782b81a2b45e31abdb'
+  version '11.2.18'
+  sha256 'c6098bf586280e7d9115a26f6dc1b665845855b5bf7d42d900fd063d21e4e24e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   name 'Navicat for PostgreSQL'

--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -3,6 +3,8 @@ cask 'navicat-for-postgresql' do
   sha256 'c6098bf586280e7d9115a26f6dc1b665845855b5bf7d42d900fd063d21e4e24e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
+  appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
+          checkpoint: 'b32845d48dcb1be5d2783cfdd1b39ec6ccfdd79dbb8522cfd0510ad7dc8effe7'  
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.