### PR TITLE
Update gotomeeting to 8.5.0.6956

### DIFF
--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,9 +1,9 @@
 cask 'gotomeeting' do
-  version :latest
-  sha256 :no_check
+  version '8.5.0.6956'
+  sha256 '5722fb63a00c320a20d071f8cb00d2fe93a1c4f73cbf8b80602021a8f8fb82de'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
-  url 'https://support.citrixonline.com/servlet/fileField?entityId=ka3380000000FRYAA2&field=Content__Body__s'
+  url 'https://support.citrixonline.com/servlet/fileField?retURL=%2Fapex%2FCPDownloadStarter%3FarticleLinkId%3DG2MD00250%26l%3Den_US%26product%3DMeeting&entityId=ka338000000CjPXAA0&field=Content__Body__s'
   name 'GoToMeeting'
   homepage 'https://www.gotomeeting.com/'
 

--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,9 +1,9 @@
 cask 'gotomeeting' do
-  version '8.5.0.6956'
+  version '8.5.0.6956,ka338000000CjPXAA0'
   sha256 '5722fb63a00c320a20d071f8cb00d2fe93a1c4f73cbf8b80602021a8f8fb82de'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
-  url 'https://support.citrixonline.com/servlet/fileField?retURL=%2Fapex%2FCPDownloadStarter%3FarticleLinkId%3DG2MD00250%26l%3Den_US%26product%3DMeeting&entityId=ka338000000CjPXAA0&field=Content__Body__s'
+  url "https://support.citrixonline.com/servlet/fileField?entityId=#{version.after_comma}&field=Content__Body__s"
   name 'GoToMeeting'
   homepage 'https://www.gotomeeting.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.