### PR TITLE
Update pyfa to 1.29.2,yc119.5-1.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.29.1,yc119.5-1.0'
-  sha256 'ad3e29b890715bf34bcdb7bf0d6d368fe3c829f44fda0df970e9bd8bb098f42d'
+  version '1.29.2,yc119.5-1.0'
+  sha256 'c14dab644980de80ddb93c4b1e3d7c5426680022e854cd24ce0c036b0c088193'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: 'fd8c36da203fc98e89e22034851170611ff3bd36e06af008146572b28c2694ab'
+          checkpoint: '553ae62cc168d9dff299c2fce097a3114dcc8fdbd26c4c27eb67b399fc672d33'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.