### PR TITLE
Update polymail to 1.36

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.35'
-  sha256 '7da5c110d109bb1ef56e9b9ff946bbbe45b574eac8ad568078158393f5a89df4'
+  version '1.36'
+  sha256 '439b0053ce3fbc9862ca80fe9e2b39ee79acfc89e84f0f0b0d47ed22ec8d9852'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'd648f2446d54a64a9a4abe552b0087afb9dd1c3e07a550f5ba35dff9ce42d281'
+          checkpoint: 'c6c55d0b5e71f67e44c562e7a91efbaffd353d2af7d806ca1ca67d6c72ba8226'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.