### PR TITLE
Update bluestacks - add uninstall_preflight

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -8,6 +8,10 @@ cask 'bluestacks' do
 
   app 'BlueStacks.app'
 
+  uninstall_preflight do
+    set_ownership "#{appdir}/BlueStacks.app"
+  end
+
   uninstall launchctl: [
                          'com.BlueStacks.AppPlayer.bstservice_helper',
                          'com.BlueStacks.AppPlayer.Service',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/34297

Add `uninstall_preflight` `set_ownership` 

`bluestacks` changes ownership of the `app` on first launch.

Note: `uninstall_preflight` is not currently working, not sure if this should be merged before it is fixed. https://github.com/caskroom/homebrew-cask/issues/32300