### PR TITLE
Update fedora-media-writer to 4.1.0

### DIFF
--- a/Casks/fedora-media-writer.rb
+++ b/Casks/fedora-media-writer.rb
@@ -1,11 +1,11 @@
 cask 'fedora-media-writer' do
-  version '4.0.8'
-  sha256 'd457232f0cac86514a8d32ae9673fcde1386f3349b98c47f84b9d6f318f00753'
+  version '4.1.0'
+  sha256 '747e7862563cabaea9d8a9151d6be728df33e400be62a07f12f3bbc3c4f51f65'
 
   # github.com/MartinBriza/MediaWriter was verified as official when first introduced to the cask
   url "https://github.com/MartinBriza/MediaWriter/releases/download/#{version}/FedoraMediaWriter-osx-#{version}.dmg"
   appcast 'https://github.com/MartinBriza/MediaWriter/releases.atom',
-          checkpoint: 'a7569ce2fa71ba8b6c7391629b4b73f0fa0dfb012effc6d5e863ec4f5a13095a'
+          checkpoint: 'c4b473faa782ec2a58121900e3f48c236370f049f5580b20db119f5cb6cb988a'
   name 'Fedora Media Writer'
   homepage 'https://fedoraproject.org/wiki/How_to_create_and_use_Live_USB'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.