### PR TITLE
Update retroshare to 0.6.0,20160209-4033f35f

### DIFF
--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -5,7 +5,7 @@ cask 'retroshare' do
   # github.com/RetroShare/RetroShare was verified as official when first introduced to the cask
   url "https://github.com/RetroShare/RetroShare/releases/download/v#{version.before_comma}/Retroshare-#{version.before_comma}-OSX-#{version.after_comma}.dmg"
   appcast 'https://github.com/RetroShare/RetroShare/releases.atom',
-          checkpoint: '42336e0b3033221bde5f0dd6caf5eb6e08fbe72fe3f8efb67e232946a9f86cd8'
+          checkpoint: 'd2927acaf91cc42399574ff1805c75bec21b249670e47a7c0e1ef31ee140a875'
   name 'RetroShare'
   homepage 'http://retroshare.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.