### PR TITLE
Update rodeo to 2.5.2

### DIFF
--- a/Casks/rodeo.rb
+++ b/Casks/rodeo.rb
@@ -5,7 +5,7 @@ cask 'rodeo' do
   # github.com/yhat/rodeo was verified as official when first introduced to the cask
   url "https://github.com/yhat/rodeo/releases/download/v#{version}/Rodeo-#{version}.dmg"
   appcast 'https://github.com/yhat/rodeo/releases.atom',
-          checkpoint: '11314607f359d744a2a1f03a11aef9528e71290df56645f146d9a9a94974c893'
+          checkpoint: 'a6d00bc7800b4934d4850b4aac2698a56b8939e22fab4fc155a31833441da61b'
   name 'Rodeo'
   homepage 'http://rodeo.yhat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.