### PR TITLE
Update rowanj-gitx to 0.15.1964

### DIFF
--- a/Casks/rowanj-gitx.rb
+++ b/Casks/rowanj-gitx.rb
@@ -13,7 +13,7 @@ cask 'rowanj-gitx' do
   # github.com/rowanj/gitx was verified as official when first introduced to the cask
   url "https://github.com/rowanj/gitx/releases/download/builds/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
   appcast 'https://github.com/rowanj/gitx/releases.atom',
-          checkpoint: 'b1e11ef3e13e74f84a51bfd6169db61f9c37fe5df851bb8c5f131c1981f8fdc0'
+          checkpoint: '45b0d334c14de07deb1f391d25a71e434bc55edf772c2c5cb852bdf655c1964d'
   name 'GitX-dev'
   homepage 'https://rowanj.github.io/gitx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.