### PR TITLE
Update rssowl to 2.2.1

### DIFF
--- a/Casks/rssowl.rb
+++ b/Casks/rssowl.rb
@@ -5,7 +5,7 @@ cask 'rssowl' do
   # github.com/rssowl/RSSOwl was verified as official when first introduced to the cask
   url "https://github.com/rssowl/RSSOwl/releases/download/#{version}/RSSOwl.#{version}.dmg"
   appcast 'https://github.com/rssowl/RSSOwl/releases.atom',
-          checkpoint: 'aca4721ee09aa7ade00abf0a203ec7c37c22c114a85f6d830524f46269aad71f'
+          checkpoint: 'c5c344994e6ee5c772afcd0b71437c319f88a8471dbb9f535c6552eb6498e0cd'
   name 'RSSOwl'
   homepage 'http://www.rssowl.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.