### PR TITLE
Update bilibili to 2.52

### DIFF
--- a/Casks/bilibili.rb
+++ b/Casks/bilibili.rb
@@ -1,10 +1,10 @@
 cask 'bilibili' do
-  version '2.51'
-  sha256 '7baf5fcfc4a467f03dbcd1165faae9fa339ece6972a4a38f37dd18f773c08268'
+  version '2.52'
+  sha256 'ba1d37b249201bdf3b839d11c3a0def86df42ca71dfc28631ecee269ee1284c7'
 
   url "https://github.com/typcn/bilibili-mac-client/releases/download/#{version}/Bilibili.dmg"
   appcast 'https://github.com/typcn/bilibili-mac-client/releases.atom',
-          checkpoint: 'c0cbd681945ac2760929b24e6549f041df7fcd24960653c1bc602dfc04146fcd'
+          checkpoint: '51ac10a613683a37d4d6de604e58904a7b750d3ba1b6b341c112256680bf29d3'
   name 'Bilibili'
   homepage 'https://github.com/typcn/bilibili-mac-client/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.