### PR TITLE
Update blocs to 2.3.2

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,11 +1,11 @@
 cask 'blocs' do
-  version '2.3.1'
-  sha256 '1cd1d8175d944400b2180b9100543307b2e85f49066b477e24921a231ebadfa7'
+  version '2.3.2'
+  sha256 'c766c135dbe42a2900b66dc2f6e07e855f392fe35baf89b3af46d0000a6779f0'
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
   appcast "https://uistore.io/blocs/#{version.major}.0/info.xml",
-          checkpoint: '061ab429695d3970897cf2102e7b48008c3eb3d35463a9a64a22685710adc47f'
+          checkpoint: '5a471db8fc9e3eef22c4e23ba2daccb3a027677f71141224889c9259d68ca9f7'
   name 'Blocs'
   homepage 'https://blocsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.