### PR TITLE
Update cathode to 2.4.1

### DIFF
--- a/Casks/cathode.rb
+++ b/Casks/cathode.rb
@@ -1,11 +1,11 @@
 cask 'cathode' do
-  version '2.3.0'
-  sha256 'dd176890c8e8d6d37334440b13402d04b5344d009804f8624985cef3c081ac8b'
+  version '2.4.1'
+  sha256 'd2cfbbf480cf9e921f7f76bf7972d60dad4b734abbe7b424b84890b22c589c25'
 
   # amazonaws.com/cjcaufield was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/cjcaufield/products/cathode/cathode_#{version.no_dots}.zip"
   appcast 'http://store.secretgeometry.com/appcast.php?id=7',
-          checkpoint: '9c9d24dd500bc58e625114c7e9c045ba41d86887e044c8f7441811b5bc237a94'
+          checkpoint: 'd5a68264c7b23c600344384e8982f0e41562a1848587ef0e5944fc04c554d72a'
   name 'Cathode'
   homepage 'http://www.secretgeometry.com/apps/cathode/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.