### PR TITLE
Update scribus to 1.4.6

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -5,7 +5,7 @@ cask 'scribus' do
   # sourceforge.net/scribus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/scribus/rss?path=/scribus',
-          checkpoint: '1a6d38a6de2e0d1432e7ddcce97aeee5725eeaa873dbca16052741df52c3f9be'
+          checkpoint: '977e2163a7477ca20e74f118a54acbb2df4e47567c1656cd08680bac65e9be7c'
   name 'Scribus'
   homepage 'https://www.scribus.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.