### PR TITLE
Update cubicsdr to 0.2.2

### DIFF
--- a/Casks/cubicsdr.rb
+++ b/Casks/cubicsdr.rb
@@ -1,11 +1,11 @@
 cask 'cubicsdr' do
-  version '0.2.0'
-  sha256 '0ca38efcc5355585a1fdcb8f617bcc6bc4031513aa33d7117fe3c426892321bb'
+  version '0.2.2'
+  sha256 'e0099a2c8fefc1a997057b95f72c74769c3e0f91b8821f1cd7f494f609c477cb'
 
   # github.com/cjcliffe/CubicSDR was verified as official when first introduced to the cask
   url "https://github.com/cjcliffe/CubicSDR/releases/download/#{version}/CubicSDR-#{version}-Darwin.dmg"
   appcast 'https://github.com/cjcliffe/CubicSDR/releases.atom',
-          checkpoint: '99f6b7502f66e40a6a940da7fd5c57b5b2daa39ee7162afdf45b4c53300d5733'
+          checkpoint: '5683e9da113bc2e07f43b57837d80d02ac3853df256b34a9bbd8eb76e633d842'
   name 'CubicSDR'
   homepage 'http://cubicsdr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.