### PR TITLE
Update electron to 1.6.8

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.6.6'
-  sha256 'c464773064ff706f02039aafda251f28678943c99bdc5f5a82d553317c14e4c2'
+  version '1.6.8'
+  sha256 '40fb4f098321f1a1988d379e4a617df59513ad8e6faa9a3c741a6934f8366ee4'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '6e4158cccd5bed9d4d5734713f194467bd2798560e9046b5369b68a19421d4ca'
+          checkpoint: 'c041c996a5aa2f0504817aee7b6f5b61c4f528113e7715e904502cc82806f65b'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.