### PR TITLE
Update goofy to 3.2.1

### DIFF
--- a/Casks/goofy.rb
+++ b/Casks/goofy.rb
@@ -1,11 +1,11 @@
 cask 'goofy' do
-  version '3.2.0'
-  sha256 'd208a9e901be0fbeb96e344e5b3c8ad17aef21f9948e84f40c836dce7301289e'
+  version '3.2.1'
+  sha256 'a85b5055b0e33d60ae54694118cb46e37bb0a5ac282b7f1de8993a481bd37f78'
 
   # github.com/danielbuechele/goofy was verified as official when first introduced to the cask
   url "https://github.com/danielbuechele/goofy/releases/download/v#{version}/goofy-core-#{version}-mac.zip"
   appcast 'https://github.com/danielbuechele/goofy/releases.atom',
-          checkpoint: '0419f2ee9aa22a06774f76ffcd2ba99f4950f3de2c774fd0c40e56467e34a25b'
+          checkpoint: '707ac5b64712a1598c826614d0608536915a75f62382f0108a56180d5dab6cbf'
   name 'Goofy'
   homepage 'http://www.goofyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.