### PR TITLE
Update seashore to 0.5.1

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -4,7 +4,7 @@ cask 'seashore' do
 
   url "https://downloads.sourceforge.net/seashore/seashore%20binaries/Seashore%20#{version}/Seashore.zip"
   appcast 'https://sourceforge.net/projects/seashore/rss?path=/seashore%20binaries',
-          checkpoint: '13808d72b3771b130ff83388dbd5ebe591ef3dc6a678ac9d0f78265087542877'
+          checkpoint: '0166c87c323a21d17c1f5c80a979a930546dc7cece1c1a3e4064ce188639a73d'
   name 'Seashore'
   homepage 'http://seashore.sourceforge.net/'
 

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -2,9 +2,9 @@ cask 'seashore' do
   version '0.5.1'
   sha256 '96463a3642f162a20b160d8df273e9b27a5fdbf9708bee6ebf6a6c8528047765'
 
-  url 'https://downloads.sourceforge.net/seashore/Seashore.zip'
+  url "https://downloads.sourceforge.net/seashore/seashore%20binaries/Seashore%20#{version}/Seashore.zip"
   appcast 'https://sourceforge.net/projects/seashore/rss?path=/seashore%20binaries',
-          checkpoint: 'bcf60985cd8080b2d7d2df038b78e4eff30b60ce2e2d562cf91f2939cf4bb451'
+          checkpoint: '13808d72b3771b130ff83388dbd5ebe591ef3dc6a678ac9d0f78265087542877'
   name 'Seashore'
   homepage 'http://seashore.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.