### PR TITLE
Update iordning to 6.0.65

### DIFF
--- a/Casks/iordning.rb
+++ b/Casks/iordning.rb
@@ -1,10 +1,10 @@
 cask 'iordning' do
-  version '6.0.63'
-  sha256 '68bc19dcbbb5485ab2505a5c9c38114be06bd1a8e0a00f71cb6fe6cc96ee2944'
+  version '6.0.65'
+  sha256 'd0c2252eea5e9025b22abd54f66d8c9dd9791e1aa93453e7e7aa13e7a55d396b'
 
   url "https://www.aderstedtsoftware.com/downloads/iOrdning#{version.major}.zip"
   appcast "https://www.aderstedtsoftware.com/economacs/v#{version.major}_appcast.xml",
-          checkpoint: '60d2225ba97b22fd1b99f3409cd8c4f4130b55f0ea1f2524ea1e648987dae7e9'
+          checkpoint: '03e9ac2ab55ae8b0d9fb4bbf915c58c0c36159253bae31710de307354f586cdc'
   name 'iOrdning'
   name 'Economacs'
   homepage 'https://www.aderstedtsoftware.com/iordning/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.