### PR TITLE
Update luyten to 0.5.3

### DIFF
--- a/Casks/luyten.rb
+++ b/Casks/luyten.rb
@@ -1,11 +1,11 @@
 cask 'luyten' do
-  version '0.5.2'
-  sha256 '45327b427747c96e280e2f1b045e462212fbe0c935a8318836af77c79e0f7dd2'
+  version '0.5.3'
+  sha256 '7caa0bf2debcdb61bf53c528c48dd97b533152fe6f86b0f57bf1f416dc5b7bc0'
 
   # github.com/deathmarine/Luyten was verified as official when first introduced to the cask
   url "https://github.com/deathmarine/Luyten/releases/download/v#{version}/luyten-OSX-#{version}.zip"
   appcast 'https://github.com/deathmarine/Luyten/releases.atom',
-          checkpoint: '81f177352f2a973779f22eecf0b7a10781b286e260e3e25b54ecd4a05e73d039'
+          checkpoint: '80f6b0c24cdedec4e4396b30ef54e608847809c62a89d573d006b0c034665a14'
   name 'Luyten'
   homepage 'https://deathmarine.github.io/Luyten/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.