### PR TITLE
Update cloudapp to 4.2.4

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,11 +1,11 @@
 cask 'cloudapp' do
-  version '4.2.3'
-  sha256 '2a470ed2777a5ddb150bc8f3045480eafc22c60ff95dd757701ed0f26e4a36c2'
+  version '4.2.4'
+  sha256 '7b1a7d836ae23c60fbfef3e187f584015178a25684a615df9b8741a83fe4d408'
 
   # amazonaws.com/downloads.getcloudapp.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://updates.getcloudapp.com/appcast.xml',
-          checkpoint: '057f9d73f842f88c8572680cd87f18159914e83103e4bd94fda9f9b9542390a1'
+          checkpoint: '770e1b76aec53bd5b3d90f0d745e03e27de0de52ffa002bf552e762e0f50703d'
   name 'CloudApp'
   homepage 'https://www.getcloudapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.