### PR TITLE
Update darwindumper.rb for appcast and zap

### DIFF
--- a/Casks/darwindumper.rb
+++ b/Casks/darwindumper.rb
@@ -3,8 +3,17 @@ cask 'darwindumper' do
   sha256 '15eca11d9c03c4af0ceb335efb844db02eb1a5ad1ce85691ec6ea7c6c30c7148'
 
   url "https://bitbucket.org/blackosx/darwindumper/downloads/DarwinDumper_v#{version}.zip"
+  appcast 'https://bitbucket.org/blackosx/darwindumper/wiki/DD_AppCast.xml',
+          checkpoint: 'c3da1e92be8ac71baabd3714c7758479684b59ead90adca0688522720f5bbc89'
   name 'DarwinDumper'
   homepage 'https://bitbucket.org/blackosx/darwindumper'
 
   app 'DarwinDumper.app'
+
+  zap delete: [
+                '~/Library/Caches/com.DarwinDumper',
+                '~/Library/Preferences/com.DarwinDumper.plist',
+                '~/Library/Preferences/org.tom.DarwinDumper.plist',
+                '~/Library/Saved Application State/com.DarwinDumper.savedState',
+              ]
 end


### PR DESCRIPTION
Update darwindumper.rb for appcast and zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
