### PR TITLE
Fix pkg in quik 2.3.0.6256

### DIFF
--- a/Casks/quik.rb
+++ b/Casks/quik.rb
@@ -6,7 +6,7 @@ cask 'quik' do
   name 'GoPro Quik'
   homepage 'https://shop.gopro.com/softwareandapp/quik-%7C-desktop/Quik-Desktop.html'
 
-  pkg 'Quik.pkg'
+  pkg 'GoPro Quik.pkg'
 
   uninstall pkgutil: 'com.GoPro.pkg.GoProApp'
 end


### PR DESCRIPTION
Fixed pkg to reflect correct package name. This fixed the installation error: “Error: pkg source file not found: '/usr/local/Caskroom/quik/2.3.0.6256/Quik.pkg’”

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.