### PR TITLE
Update streamlink-twitch-gui to 1.3.0

### DIFF
--- a/Casks/streamlink-twitch-gui.rb
+++ b/Casks/streamlink-twitch-gui.rb
@@ -1,14 +1,14 @@
 cask 'streamlink-twitch-gui' do
-  version '1.2.1'
-  sha256 '9bd8344700888f345bff4c40481c30d20a83e39c4b6b0b2c89698b728ce3a189'
+  version '1.3.0'
+  sha256 '45bc8f6571a8ef76dabc3d173a05959316c9a5a81792f8871e14a1c04f921fd8'
 
   url "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v#{version}/streamlink-twitch-gui-v#{version}-macOS.tar.gz"
   appcast 'https://github.com/streamlink/streamlink-twitch-gui/releases.atom',
-          checkpoint: '69b65c81f5d69953af59bfb629393ebb992922b959249c2fd47cd4ad63cc1307'
+          checkpoint: '61beda7a5bbae69e6844dd81e505060fb6562a43cb2d32d83a0bd56380c56a06'
   name 'Streamlink Twitch GUI'
   homepage 'https://github.com/streamlink/streamlink-twitch-gui/'
 
-  depends_on cask: 'vlc'
+  depends_on formula: 'streamlink'
 
   app 'Streamlink Twitch GUI.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additional notes:

- Remove vlc cask dependency
- Add streamlink formula dependency