### PR TITLE
spatial: latest - After installation, set the command structure to v2 which is current.

### DIFF
--- a/Casks/spatial.rb
+++ b/Casks/spatial.rb
@@ -10,4 +10,9 @@ cask 'spatial' do
   container type: :naked
 
   binary 'mac', target: 'spatial'
+
+  postflight do
+    puts 'Setting cli-structure to v2 (current).'
+    `spatial config set cli-structure v2`
+  end
 end


### PR DESCRIPTION
This eliminates a manual step on our setup guide for new users: https://spatialos.improbable.io/docs/reference/10.3/setup-spatialos/mac#2-set-up-the-spatialos-cli

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer:

  _I'm making the contribution from my company's fork._


Additionally, if **adding a new cask**:

n/a
