### PR TITLE
Update rsyncosx to 4.3.0

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,6 +1,6 @@
 cask 'rsyncosx' do
   version '4.3.0'
-  sha256 '4730280c48329157383577288ef8b3b8c820af66304a63541f4545d61dd6cf6c'
+  sha256 '52337b1e918c6cedabe2c098b77c768b7b706d49c006c28e5f3d0c571ed90433'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] `sha256` was updated, but `version` remained the same.
      Verification Link : https://github.com/rsyncOSX/RsyncOSX/issues/139