### PR TITLE
Update soundcloud-downloader to 2.7.9

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
-  version '2.7.7'
-  sha256 'fa43678ebedfd71edf3ee6972f824aa5f39b55f640e011b408a6e9b69878703b'
+  version '2.7.9'
+  sha256 '2215a7ec8783d68cc93bdd866156692bf68bdd9be1dcfd1f3f591b83e2a3b869'
 
-  url "http://black-burn.ch/scd/downloads/#{version.no_dots}/in/b"
+  url "https://black-burn.ch/app/SCD2/download/#{version}"
   appcast 'https://black-burn.ch/apps/SCD2/updates/gold.xml?hwni=1',
-          checkpoint: '26e98b02b515fa664bd395dfe5ecaac54a8dba3507953bf245a3524f7099ea46'
+          checkpoint: '4670f08a8ea2ab622ef3698cced08d56c630e324337cb2407f64ef479809c4a6'
   name 'SoundCloud Downloader'
   homepage 'https://black-burn.ch/app/SCD2'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.