### PR TITLE
Update GitHub Desktop to [beta] v0.5.5

### DIFF
--- a/Casks/github-desktop.rb
+++ b/Casks/github-desktop.rb
@@ -1,39 +1,33 @@
 cask 'github-desktop' do
-  version '222'
-  sha256 'b7d001b36a88f75f9c6102de8fbf683ab940caa2b654fd7a1a0f367be689fc02'
+  version '0.5.5-47a3bf36'
+  sha256 'b4ae10437c64d2d0fa51eb91b2ba558413fb5aa9f1709a1a596bbf8cefabe59e'
 
-  url "https://mac-installer.github.com/mac/GitHub%20Desktop%20#{version}.zip"
-  appcast 'https://central.github.com/mac/appcast.xml',
-          checkpoint: 'b6482e6fe6594a1a9aad10b645fc551c9e16d0cd8deb4cedbfca6adaae43f1c2'
+  # githubusercontent.com was verified as official when first introduced to the cask
+  url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
+  appcast 'https://github.com/desktop/desktop/releases.atom',
+          checkpoint: 'ff14e8b0b38c303c01fe78a334f1345f582555c14c610cc527bacbd1e2712751'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 
   auto_updates true
 
   app 'GitHub Desktop.app'
-  binary "#{appdir}/GitHub Desktop.app/Contents/MacOS/github_cli", target: 'github'
 
   postflight do
     suppress_move_to_applications
   end
 
-  uninstall launchctl: [
-                         'com.github.GitHub.Conduit',
-                         'com.github.GitHub.GHInstallCLI',
-                       ]
-
   zap delete: [
-                '~/Library/Application Support/GitHub for Mac',
+                '~/Library/Application Support/GitHub Desktop',
                 '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/ShipIt_stdout.log',
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.github.sfl',
-                '~/Library/Application Support/com.github.GitHub',
-                '~/Library/Application Support/com.github.GitHub.ShipIt',
-                '~/Library/Caches/GitHub for Mac',
-                '~/Library/Caches/com.github.GitHub',
-                '~/Library/Containers/com.github.GitHub.Conduit',
-                '~/Library/Preferences/com.github.GitHub.LSSharedFileList.plist',
-                '~/Library/Preferences/com.github.GitHub.plist',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.GitHubClient.sfl',
+                '~/Library/Application Support/com.github.GitHubClient',
+                '~/Library/Application Support/com.github.GitHubClient.ShipIt',
+                '~/Library/Caches/com.github.GitHubClient',
+                '~/Library/Caches/com.github.GitHubClient.ShipIt',
+                '~/Library/Preferences/com.github.GitHubClient.helper.plist',
+                '~/Library/Preferences/com.github.GitHubClient.plist',
               ],
       rmdir:  '~/.config/git'
 end


### PR DESCRIPTION
See https://github.com/caskroom/homebrew-versions/pull/3869.