### PR TITLE
Update react-native-debugger (0.6.6)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.6.5'
-  sha256 '6ff60327e55fe77ca9018b0a7b6e32cc693e8073f59ef263e227e98ad341df7d'
+  version '0.6.6'
+  sha256 'c50e9f15fb4610ae7fcbff0cabb221af3b767656f54e29e0b40f0956c53759de'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '78ca7ed23b171f4a57c69a654c60195c6df0b73172b1d71b7f68bf913e782b4d'
+          checkpoint: '2a5f43f42089475203f240a1f3272a7a671a60d6ebc72fdc14ec4048874fee0e'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
