### PR TITLE
Download unetbootin 627 over HTTPS

### DIFF
--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -3,7 +3,7 @@ cask 'unetbootin' do
   sha256 '6f0abd2ab696501dbddde135d4709259d6d4ca2de33a54bfb10f51b4d5ffd22a'
 
   # launchpad.net/unetbootin was verified as official when first introduced to the cask
-  url "http://launchpad.net/unetbootin/trunk/#{version}/+download/unetbootin-mac-#{version}.dmg"
+  url "https://launchpad.net/unetbootin/trunk/#{version}/+download/unetbootin-mac-#{version}.dmg"
   appcast 'https://github.com/unetbootin/unetbootin/releases.atom',
           checkpoint: 'fd308855106d78c0ad2e793b760b6ee07abeef5456d0cbcc2f87236a314bc06f'
   name 'UNetbootin'


### PR DESCRIPTION
Switches unetbootin to download over HTTPS rather than HTTP.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

