### PR TITLE
bump carbon-copy-cloner to v4.1.14.4543

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -3,8 +3,8 @@ cask 'carbon-copy-cloner' do
   sha256 '158908f6cf6ef76485aa708482440652745968d5866ce542762b6efe5758f6ca'
 
   url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
-  appcast "https://bombich.com/software/updates/ccc.php?os_minor=11&os_bugfix=#{version.major}&ccc=#{version.after_comma}&beta=0&locale=en",
-          checkpoint: '1b64d38745f95986b8b0e0bf1b72341cc4a46616bd17226dec102a32b81c3b5a'
+  appcast 'https://bombich.com/software/updates/ccc.php',
+          checkpoint: 'eec027f0d0aa576e292b4fe57441f1821409c6295330787dd82533b0d483cb26'
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
 

--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.13.4496'
-  sha256 'bdebeb3f168eb8ca793e2cd635609a9054af6c68c6952e0813b398a3100482c9'
+  version '4.1.14.4543'
+  sha256 '158908f6cf6ef76485aa708482440652745968d5866ce542762b6efe5758f6ca'
 
   url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
   appcast "https://bombich.com/software/updates/ccc.php?os_minor=11&os_bugfix=#{version.major}&ccc=#{version.after_comma}&beta=0&locale=en",


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

---

| cask | carbon-copy-cloner |
| ----- | ---- |
| version | 4.1.14.4543 |
| sha256 | 158908f6cf6ef76485aa708482440652745968d5866ce542762b6efe5758f6ca |