### PR TITLE
Fix Soda Player cask

### DIFF
--- a/Casks/soda-player.rb
+++ b/Casks/soda-player.rb
@@ -1,8 +1,8 @@
 cask 'soda-player' do
-  version '1.1.3'
-  sha256 '759793eb97409fde0063bf954792598063457b5ea73d1ce17b477b480d2d3913'
+  version :latest
+  sha256 :no_check
 
-  url "https://releases.sodaplayer.com/mac/Soda%20Player.dmg?version=#{version}"
+  url 'https://releases.sodaplayer.com/mac/Soda%20Player.dmg'
   name 'Soda Player'
   homepage 'https://www.sodaplayer.com/'
 


### PR DESCRIPTION
It seems that the version provided in the download URL is ignored,
I tried to download 1.1.3 and 1.1.4 and they both result in files
sharing the SAME hashsum.

I changed the cask to use `version: :latest` and `sha256 :no_check`,
like stated here: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#examples

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
