### PR TITLE
Add zaps to cleanmymac 3.8.1,1493201482

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -80,7 +80,6 @@ cask 'cleanmymac' do
                   '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macpaw.cleanmymac3.scheduler.sfl',
                   '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macpaw.cleanmymac3.sfl',
                 ]
-
   end
 
   name 'CleanMyMac'

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -77,7 +77,10 @@ cask 'cleanmymac' do
                   "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.Scheduler.plist",
                   "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.plist",
                   "~/Pictures/Photos Library.photoslibrary/private/com.macpaw.CleanMyMac#{version.major}",
+                  '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macpaw.cleanmymac3.scheduler.sfl',
+                  '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macpaw.cleanmymac3.sfl',
                 ]
+
   end
 
   name 'CleanMyMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download cleanmymac` is error-free.
- [x] `brew cask style --fix cleanmymac` reports no offenses.
- [x] The commit message includes the cask’s name and version.
