### PR TITLE
Update frostwire to 6.5.1

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.5.0'
-  sha256 'a460e11b4773b0caf2d4f35522225b2b1f10594eb4feec7f61814ca1f518ecad'
+  version '6.5.1'
+  sha256 '02c215975a4c7aa2b0693ab02a0fccce9675d072aa955518dae5b171f0dcf5e4'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '04b05bfbd8ab9670591859d82ad201261606fa4ea0f377aaf57ad31ca0efa32c'
+          checkpoint: '0ea2c01c793be51f738d4e6c0d260678816a4402f65bcbf4bd74ad29d10a0d89'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.