### PR TITLE
Update bitsquare to 0.4.9.9.3

### DIFF
--- a/Casks/bitsquare.rb
+++ b/Casks/bitsquare.rb
@@ -1,11 +1,11 @@
 cask 'bitsquare' do
-  version '0.4.9.9.1'
-  sha256 '33e03ba7fe43a6d1db29aaf7c94ea66078f853c2b4e851abd2688f43152c3cd7'
+  version '0.4.9.9.3'
+  sha256 '4e44b70dd12cc2ef2d3cc641c84a6bc8c38518fba5af327acf0de8985cccdcd1'
 
   # github.com/bitsquare/bitsquare was verified as official when first introduced to the cask
   url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bitsquare-#{version}.dmg"
   appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
-          checkpoint: '972e9ef712ad7c0350af858b89d717cf70eda2ed7baa0290e9f25ff1a7067ba1'
+          checkpoint: 'f1ce7f5db8512545a60123e5fa567ad8737f3ffb8672d17b298002f5faba156f'
   name 'Bitsquare'
   homepage 'https://bitsquare.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.