### PR TITLE
Update carbon-copy-cloner to 4.1.15.4548

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.14.4543'
-  sha256 '158908f6cf6ef76485aa708482440652745968d5866ce542762b6efe5758f6ca'
+  version '4.1.15.4548'
+  sha256 'e11584ea9b61b2c4d2fb8839158f7c087b3c78a7b49bc4d5814a85c192e6aa33'
 
   url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
   appcast 'https://bombich.com/software/updates/ccc.php',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.