### PR TITLE
updated qnapi to 0.2.3 release

### DIFF
--- a/Casks/qnapi.rb
+++ b/Casks/qnapi.rb
@@ -1,11 +1,11 @@
 cask 'qnapi' do
-  version '0.2.2'
-  sha256 'eff53b9c04b23e9c3d1af26a0a384973ca314cd1e1e234a8bdad149d12ddb159'
+  version '0.2.3'
+  sha256 '9bb7f9ba42f6795c7e094ba6555e14955e02b5e2f5277454dc4a96b1569871d1'
 
   # github.com/QNapi/qnapi was verified as official when first introduced to the cask
   url "https://github.com/QNapi/qnapi/releases/download/#{version}/QNapi-#{version}.dmg"
   appcast 'https://github.com/QNapi/qnapi/releases.atom',
-          checkpoint: '04f877f7a0fc67f108c3f8eb137858e8a674ca8bed8353c6a539b35bb68d267c'
+          checkpoint: '0aa41961e853473ceb4559e3c9319dd660a00022e98d0053fa650b75f0b53e5b'
   name 'QNapi'
   homepage 'https://qnapi.github.io/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
