### PR TITLE
Update kite to 0.20170518.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170512.0'
-  sha256 '0f4ab7c2fb0501552fd024c796dd1783df6cdd2fd595adb60a78619ab36de6fa'
+  version '0.20170518.0'
+  sha256 '140ee91554c8db696c2256613bcf964df35978bf55e43ae79a30e94e1c6d180d'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '921ed93bdc26a60ebf4c27101b9b78ee526c86634b0f9a5b11c2006c5f0b5a07'
+          checkpoint: 'fc23fa6dd8299320c7ca08e412b67a2eb16a5600d6139f4dca96e4dedbeb3618'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.