### PR TITLE
Update standard-notes to 1.0.0

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '0.4.0'
-  sha256 '718621b0883caa4768161f95ca05e902d154bf96a30610ce0a8c355dcd786715'
+  version '1.0.0'
+  sha256 '323a3f7b542f01a7a11abd27a1dc6be6358a54e5472412cc5b7b401f8e13350c'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'ecf0295f1718917894ab5124e345f09d8ce997aa250c9d42de49523d76a8e153'
+          checkpoint: '4df4aae5a8688eef1225879017d83ba391f43743f6bfca245373b9315b464d35'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.