### PR TITLE
Update splitshow to 0.9.9-alpha

### DIFF
--- a/Casks/splitshow.rb
+++ b/Casks/splitshow.rb
@@ -1,10 +1,10 @@
 cask 'splitshow' do
-  version '0.9.8-alpha3'
-  sha256 'ca1b9e296f61b3bab58bf4b23b90e84483471b0fe31c8209d3c46e338fceb652'
+  version '0.9.9-alpha'
+  sha256 '751ddad47f75834ebd998e9de6bc5640b741f0a2ee4f892188f2ac0ae3c26d15'
 
-  url "https://github.com/mpflanzer/splitshow/releases/download/#{version}/SplitShow.app.zip"
+  url "https://github.com/mpflanzer/splitshow/releases/download/v#{version}/SplitShow.app.zip"
   appcast 'https://github.com/mpflanzer/splitshow/releases.atom',
-          checkpoint: '14daaed9d6c9596b938cec20cbbd27b7cdced0c096e570938c42b762c803137c'
+          checkpoint: '37df53bd109adabe4c948e5eeeb22ac805617354a54e092c034f458706897981'
   name 'SplitShow'
   homepage 'https://github.com/mpflanzer/splitshow'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.