### PR TITLE
Update beyond-compare to 4.2.2.22384

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,10 +1,10 @@
 cask 'beyond-compare' do
-  version '4.2.1.22354'
-  sha256 '50d87a513e1addacfdd85aa688d062807e214e78284a3ffc5bbfc8821bb69dce'
+  version '4.2.2.22384'
+  sha256 '53d6394b4751a50e14cd5c8dcd1650c09d662b6b46c067f8f3bf879634f26724'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "http://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx",
-          checkpoint: 'f35fb654ee34fd334318c25fadf79a9b34d977c54de6bb37498702526f23d64d'
+          checkpoint: '7367a47a30dbe60cda77a1c461bee54a7300467393a7362fc788de2bfb8743f2'
   name 'Beyond Compare'
   homepage 'https://www.scootersoftware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.