### PR TITLE
Update cleanmymac to 3.8.3,1495210751

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -37,13 +37,13 @@ cask 'cleanmymac' do
                   "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.plist",
                 ]
   else
-    version '3.8.2,1495123534'
-    sha256 'a97b74892940d1fc079440d943fd649f12e14320fe8f10c660cb3e38b108b256'
+    version '3.8.3,1495210751'
+    sha256 '485c1b57ad83da9979d83a632a5d4ba55e12ff1d51b83e3233ba167a41bc4055'
 
     # devmate.com/com.macpaw.CleanMyMac3 was verified as official when first introduced to the cask
     url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.major}/#{version.major_minor_patch}/#{version.after_comma}/CleanMyMac3-#{version.major_minor_patch}.zip"
     appcast "https://updates.devmate.com/com.macpaw.CleanMyMac#{version.major}.xml",
-            checkpoint: 'b12f2e6c71cc6641a8792d662d71d280213e5d264a528438c2c4f15638b0f184'
+            checkpoint: '9e5ecd85c8ee39d0061d91b35690016ac59b592a37d3e62c2eab15df72e9120a'
     app "CleanMyMac #{version.major}.app"
 
     postflight do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.