### PR TITLE
Update stretchlink to 1.0.3-105

### DIFF
--- a/Casks/stretchlink.rb
+++ b/Casks/stretchlink.rb
@@ -2,9 +2,10 @@ cask 'stretchlink' do
   version '1.0.3-105'
   sha256 'a12b8199207009a4906d5bc54992bdccc91ff9c877c4d2b8730a2153d04c8180'
 
-  url 'http://stretchlinkapp.com/download/StretchLink.zip'
+  # abyss.designheresy.com/stretchlink was verified as official when first introduced to the cask
+  url "http://abyss.designheresy.com/stretchlink/stretchlink#{version.no_dots}.zip"
   appcast 'http://abyss.designheresy.com/stretchlink/stretchlink.xml',
-          checkpoint: '50db6bf7a27a9a4fe0b3c7f802913be1dfd54cbb85c9f42c7513184c9014f0c9'
+          checkpoint: '24ee72f9dc64631fda556cda283c474f9acc0e976d6650e5f95e5270daff1496'
   name 'StretchLink'
   homepage 'http://stretchlinkapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.