### PR TITLE
Update tagaini-jisho to 1.0.3

### DIFF
--- a/Casks/tagaini-jisho.rb
+++ b/Casks/tagaini-jisho.rb
@@ -5,7 +5,7 @@ cask 'tagaini-jisho' do
   # github.com/Gnurou/tagainijisho was verified as official when first introduced to the cask
   url "https://github.com/Gnurou/tagainijisho/releases/download/#{version}/Tagaini.Jisho-#{version}.dmg"
   appcast 'https://github.com/Gnurou/tagainijisho/releases.atom',
-          checkpoint: '155c918aab4ba9bdbe952eb766e1b94e0bfdd206824adc27a1576e186052affa'
+          checkpoint: 'a5cbf611c97beabda85e0ddaf6b189ecc407aeb447b05f8aa2bc8a03f6a0010c'
   name 'Tagaini Jisho'
   homepage 'https://www.tagaini.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.