### PR TITLE
Update tagger to 1.8.0.7

### DIFF
--- a/Casks/tagger.rb
+++ b/Casks/tagger.rb
@@ -5,7 +5,7 @@ cask 'tagger' do
   # github.com/Bilalh/Tagger was verified as official when first introduced to the cask
   url "https://github.com/Bilalh/Tagger/releases/download/1.8.0/Tagger_#{version}.zip"
   appcast 'https://github.com/Bilalh/Tagger/releases.atom',
-          checkpoint: 'bec52aec35f7c2d84da353a17220a2c9830a1c4e54c00e995b38812004c522f1'
+          checkpoint: '88594d3413f6c50e21bbf6cbe08a7f1df4e674f92b0c0745e4d02e91b9f09960'
   name 'Tagger'
   homepage 'https://bilalh.github.io/projects/tagger/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.