### PR TITLE
Update tex-live-utility to 1.28

### DIFF
--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -1,10 +1,10 @@
 cask 'tex-live-utility' do
-  version '1.26'
-  sha256 '2af336179817ede13108a4b883223072b0b999b0dff53b9edbc0ef6a704f1f52'
+  version '1.28'
+  sha256 '5e5c115871f897e7c247babfd8049002ab16e0d3c89a1c84cccd72791ac0f941'
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
   appcast 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml',
-          checkpoint: '1057b8465bf967a864151e016ea8ca565a929d23827e520a409de4ce4b909ad4'
+          checkpoint: '1c93aab71ce0a3ca7b9b6507b51fcdb84c08338e2cc11b93e0a3fce5e5019924'
   name 'TeX Live Utility'
   homepage 'https://github.com/amaxwell/tlutility'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.