### PR TITLE
Update textadept to 9.4

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,10 +1,10 @@
 cask 'textadept' do
-  version '9.3'
-  sha256 '4bfbf9beb721c2b2381f2f2cf02b3b7140298f0a6c92f84a84cc74bc506ede06'
+  version '9.4'
+  sha256 '187c4de715b355934bf4ac25a8076f428f6c13039ff93bc0c3651adcaf584e22'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
   appcast 'https://foicica.com/textadept/feed',
-          checkpoint: '0314f0b3c5008bb63900076d3bab8f0e555b8b73f15c3911bc7dfe5c96064aa6'
+          checkpoint: 'feade9c945b551c4b5a2aa992c280c5e872d5e7e33f7e315953ec561c09d3205'
   name 'Textadept'
   homepage 'https://foicica.com/textadept/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.