### PR TITLE
Update texworks to 0.6.2,201704300713:7ecce17

### DIFF
--- a/Casks/texworks.rb
+++ b/Casks/texworks.rb
@@ -1,11 +1,11 @@
 cask 'texworks' do
-  version '0.6.1,201605010904:3614278'
-  sha256 'd447ba603da349cb893fead53efcdc3bf9a5165c0ca22f5ad5611865deabc596'
+  version '0.6.2,201704300713:7ecce17'
+  sha256 '6ca09e0cd1007139d5ef0bb711812745ce20a3206ba97e812297bd301bac9820'
 
   # github.com/TeXworks/texworks was verified as official when first introduced to the cask
   url "https://github.com/TeXworks/texworks/releases/download/release-#{version.before_comma}/TeXworks-osx-#{version.before_comma}-#{version.after_comma.before_colon}-git_#{version.after_colon}.dmg"
   appcast 'https://github.com/TeXworks/texworks/releases.atom',
-          checkpoint: '89401a7527b606e156e2bd8eb4ee4306dfcf599ef261be39c04ac530de727f9d'
+          checkpoint: '65bd655851715490fc8743798328d01d00518b5bb2b483a525c5fd8dfba9e4ea'
   name 'TeXworks'
   homepage 'https://www.tug.org/texworks/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.