### PR TITLE
Update themeengine to 1.0.0(111)

### DIFF
--- a/Casks/themeengine.rb
+++ b/Casks/themeengine.rb
@@ -10,7 +10,7 @@ cask 'themeengine' do
 
     url "https://github.com/alexzielenski/ThemeEngine/releases/download/#{version}/ThemeEngine_111.zip"
     appcast 'https://github.com/alexzielenski/ThemeEngine/releases.atom',
-            checkpoint: 'd821fde4587a4f20706dbdfe8913d7e9c8b757144680cdf31ce648674ab38e72'
+            checkpoint: '2a7e7a1de19bee26223d2c6d486064866309203aef57d77a77b247f9c9904a39'
   end
 
   name 'ThemeEngine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.