### PR TITLE
Update firefox to 53.0.3

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,104 +1,104 @@
 cask 'firefox' do
-  version '53.0.2'
+  version '53.0.3'
 
   language 'de' do
-    sha256 '96329cad2acebc2ae17e995fade5240554640d9dc5a91532e29a138282948ac2'
+    sha256 '35524e21ff7ddf4b73a00e8307930db6eef306777e515d8b497249a1dfc6e2b9'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '77566765663ad491c55c8470e4e1234bb30f3388c2a6546ed18c90992e01de94'
+    sha256 'a1a877a9e170630ea2e9530bd1b103f5e47ba707c19810793d73ac56ddcad092'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '180ae12e65fb2c8025ffad501d998dc01dbe19408b528c78a05a163f0fa0b5be'
+    sha256 '809887b3bdf826c4f2f7c47f714e6bb609a345d30a318f45d3d3f90bb79466d7'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 'a02002d0c46591b9bda866b4825bafd7e902bb1863b257fd0725a8c92cb53f31'
+    sha256 '6c1d50959bdaf50fc6a42ec6cc51a875d7716aa2009214768557fa648ed898a2'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '83e16ed13d50509a85b2cb0020bd7bb2f1dfb58a54fcea254ee63e91a7f7f7bb'
+    sha256 '3c99fa87e636daad6bb7e5790330c5b4e4ef915680a382292b9305444ab93bdd'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'd2632f01b5e78a314e45437ff4ff532fb79f7867e73baabbb7f66a38b3404143'
+    sha256 'dc5df02e388dd78f460029f4ac9b97825ca47486eadb5a2cde13e3544e9898ba'
     'es-ES'
   end
 
   language 'fr' do
-    sha256 '4fbf4c892fc846ba0d3b830d64f20b3c87d5d5152b04202c35012ca25ab7c06a'
+    sha256 '6d22f1b4e60d2885db693890a0f83c1fe7d1b95200dfade43d210ee081382bfd'
     'fr'
   end
 
   language 'gl' do
-    sha256 'cc843bde7af770e3ec0f848122b90343b088279c8736764df6f7db426408c35d'
+    sha256 '42b270766a233c26874b9d00d29947745766c08b0647931812dec5b6014fad4f'
     'gl'
   end
 
   language 'in' do
-    sha256 '04e3a3eccb234b7527ea7246883480ba6cc386e98fb8caaff6a4d0ff9a0a37d6'
+    sha256 '38c98904ca9e177964ae74e11df3e89be318aaa24f8b00b2e22116b30679cc7d'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '34126aea59b21a291561962ad134e26abb0d3e2149648e743fbdd17c3d9ad040'
+    sha256 'c99b910b7bc819d7963c314b7369e2ca56f850ecfb5ccd26e74de7cc06e2bec4'
     'it'
   end
 
   language 'ja' do
-    sha256 'b81d55a3c28307df6402815d3d5a0b8e69df964025b8aae360176dea831310f6'
+    sha256 '0ec6a011aa60ec3f2a7186dd8eac62b1e425b4dc9f4d9b5746607e2c2fa326ac'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '1b9150319b17abd1bf9f6f0be694ae6f85de45f7a05abf378b1efce22e281bbf'
+    sha256 '879f55c9796db3a0b314f2ad6ce618c17787ca6206a0e0c57397e5d4b72a2ccf'
     'nl'
   end
 
   language 'pl' do
-    sha256 '69a096e8448fa8518fda150581dba868253c7e973a5948433083c6bd4f9a7fd9'
+    sha256 '4828a7f2500475bd433f18dc6c281bb3653f8e51977d685cde09b5db0587c4a8'
     'pl'
   end
 
   language 'pt' do
-    sha256 '19b50f76a3ed54a783db53d152f9dbc6f0718a22ad9e9fcfc760bea9918dbe77'
+    sha256 'f9891129ae30538c7707a0433f2c5fd46ec1513559b95168585e1be28eec77ef'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '35d3bd38d9bf82529906388f21df7d53faa58275d77b7cfbb90d705d487c1352'
+    sha256 '4097e0554410e93a4eb26c53375b737d9efa6cd4794480985c2c59214797aa64'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 'c0bda939d321b5bf22d4946c1e674cd8ad9f9aeaf75c6cc714007d0165b65e46'
+    sha256 '33cc03282c2dfd4bd7da3c040a6790468ef79faa4acc76fe9e39b7cb87a19b42'
     'ru'
   end
 
   language 'uk' do
-    sha256 '6be6646d1be1e25ea03c78925a121a7a6211cfdf206b0d7eda05955d16415a97'
+    sha256 '3100fe02bcca2875a04e54a6d3745e2879dd2a65b24c3d02e9d4d77ae09cc031'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '9ad5be1df9ce7ea6b5a7812a1261b990006dfb515d40194933d6455ac8706c49'
+    sha256 'ae04ca911fdb0fe6750cc9337334becb13f7213bc77c41ea335e2be12c4fdfe1'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'af5d9b89103b63b7f36c9edf8f61b5d641c26104c0f743b65faa1c163a217dd5'
+    sha256 'e8b94aa3c0f25f8cb4339afdb1c7f2130263a72d8b0601e3f4b89f49fcafa154'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: 'ca5771d3afe74b835adfd425531641f59af117ba6ed9a4ce6dc4803d465af15a'
+          checkpoint: '33144ae798d85f7f1791a9593a4d6db762720621cfb74bea00e2e0d442fa03a1'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}
