### PR TITLE
Update hab to 0.24.0-20170519202549

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.23.0-20170511211820'
-  sha256 '07e55b7c22aca00ecf42a401da3d61877b21f0de62a717167443c1183f968272'
+  version '0.24.0-20170519202549'
+  sha256 '3c1bc6fd18ac12caffedca88dbda4765459ebc83f5b7e543e83a0cacd4c55f45'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '70b06a0591bcd5408870ba3a72f88ac43f56fb9d8b1a7afe3cca9486be9b4762'
+          checkpoint: '39ccfe8ccb72f752e1ca8d6e7ec995c2e347ba80334ef10388414f6c79a1101a'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.