### PR TITLE
Update armitage - add shimscript

### DIFF
--- a/Casks/armitage.rb
+++ b/Casks/armitage.rb
@@ -7,4 +7,14 @@ cask 'armitage' do
   homepage 'http://www.fastandeasyhacking.com/'
 
   app 'Armitage.app'
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/armitage.wrapper.sh"
+  binary shimscript, target: 'armitage'
+
+  preflight do
+    IO.write shimscript, <<-EOS.undent
+      #!/bin/sh
+      java "$@" -jar '#{appdir}/Armitage.app/Contents/Java/armitage.jar'
+    EOS
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/34322

Adds a `shimscript` with `preflight`.

This does not apply the patch requested in https://github.com/caskroom/homebrew-cask/issues/34322 but provides a binary that allows the user to run `armitage` from the command line and pass options to `java`. `armitage` itself does not accept options.
```
commitay$ armitage -XX:ParallelGCThreads=8
```
There are also cases where it would be useful/necessary (depending on how the user has installed `metasploit`/`postgresql`) to be able to `sudo -E armitage` 

> http://www.fastandeasyhacking.com/start

> To connect to Metasploit's database, Armitage must be able to read the database.yml file created by Metasploit. This file is installed so that only root may read it. Start Armitage with root privileges.

> You may want to try sudo -E to launch Armitage. This form of sudo will have Armitage inherit the root user's environment--including the MSF_DATABASE_CONFIG variable.

I'm not an `armitage` user so to quote @vitorgalvao “[I have no strong feelings one way or the other](https://youtu.be/CxK_nA2iVXw)” as to if this is merged or not.
