### PR TITLE
Update mqttfx to 1.4.1

### DIFF
--- a/Casks/mqttfx.rb
+++ b/Casks/mqttfx.rb
@@ -1,6 +1,6 @@
 cask 'mqttfx' do
-  version '1.3.1'
-  sha256 'c9d4d1c862e5aab194338f3508f166d20a9116c9ba2be70e1e4341bad6c96070'
+  version '1.4.1'
+  sha256 'e9b16f46c3b8ae0d9da9c7944cd5abc3b4b47ef29c3885e278c5a4289bd755df'
 
   # jensd.de/apps/mqttfx was verified as official when first introduced to the cask
   url "http://www.jensd.de/apps/mqttfx/#{version}/mqttfx-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.