### PR TITLE
Update track-o-bot to 0.8.6

### DIFF
--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -5,7 +5,7 @@ cask 'track-o-bot' do
   # github.com/stevschmid/track-o-bot was verified as official when first introduced to the cask
   url "https://github.com/stevschmid/track-o-bot/releases/download/#{version}/Track-o-Bot_#{version}.dmg"
   appcast 'https://github.com/stevschmid/track-o-bot/releases.atom',
-          checkpoint: '1962fe0965f3939f91f2418a2c26967c99a2bd109dd9441454da612eedc176e6'
+          checkpoint: '2d0e7b3d56f1ddf9ca07cea3a3ff473bc7a3cebf769c024dc7ad8df6ee79ed42'
   name 'Track-o-Bot'
   homepage 'https://trackobot.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.