### PR TITLE
Update free-download-manager to 5.1.28

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,6 +1,6 @@
 cask 'free-download-manager' do
-  version '5.1.27'
-  sha256 '05c969ff67df393afec1b456005a5d8b52e7d14942bc0b1640ccc59a2ea4a759'
+  version '5.1.28'
+  sha256 'c92674e88a741cec39a77d1ae03ce6cee017e065b13dc920b9d73549a2462305'
 
   url "http://files2.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
   name 'Free Download Manager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.