### PR TITLE
Update webcatalog to 5.1.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '5.0.0'
-  sha256 '0e2f6c535fc0beaaed8b79b3bc5b72ce90804412b686e1c33bcc4892e7c616ca'
+  version '5.1.0'
+  sha256 '59f652c9da402372c6a00a96e68d20316461ef54a369ce6a285631d365a6599a'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '8366161fa961bd1c52f2ee1a95f3648df66a81a0f30dd1d7bfab17964e687a87'
+          checkpoint: 'a65f887267d1734e802c486489ee01f26b1401f7c0be750616fc0ecf97348614'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/downloads/mac'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.