### PR TITLE
Update traktable to 0.6-alpha1,a

### DIFF
--- a/Casks/traktable.rb
+++ b/Casks/traktable.rb
@@ -1,11 +1,11 @@
 cask 'traktable' do
-  version '0.5.2'
-  sha256 '77d3800f02f2b5a2aef8a56e7986b731831738673e35c633d743df87bc556225'
+  version '0.6-alpha1,a'
+  sha256 '6bf5b2e30e8378d46e5c69494bc23617a3f410856ee4682899683607cb0dee79'
 
   # github.com/yo-han/Traktable was verified as official when first introduced to the cask
-  url "https://github.com/yo-han/Traktable/releases/download/#{version}/Traktable.zip"
+  url "https://github.com/yo-han/Traktable/releases/download/#{version.before_comma}/Traktable-#{version.before_comma}#{version.after_comma}.zip"
   appcast 'https://github.com/yo-han/Traktable/releases.atom',
-          checkpoint: 'ed5ed4c4b7c56e4a348823f162e8d23fb9f4395a0d456ca2ea8fe36b9e7e8d6e'
+          checkpoint: '85c3a5b3b36bb8e5d220c9ecb4f3f8f3a00df75f00c266edd1b0256d81c46270'
   name 'Traktable'
   homepage 'https://yo-han.github.io/Traktable/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.