### PR TITLE
Update tranzport to 1.0-beta2

### DIFF
--- a/Casks/tranzport.rb
+++ b/Casks/tranzport.rb
@@ -5,7 +5,7 @@ cask 'tranzport' do
   # github.com/steverab/tranzport-mac was verified as official when first introduced to the cask
   url "https://github.com/steverab/tranzport-mac/releases/download/#{version}/Tranzport.app.zip"
   appcast 'https://github.com/steverab/tranzport-mac/releases.atom',
-          checkpoint: 'c4f7bbc0951c936cc1894471e0e6eaae1319f4fbb1c49ae751a02a6246ca97f7'
+          checkpoint: '8be44dc01c149fe13d3d9f05f8b5f48b47b55966e3dccdc894593015dd9e058c'
   name 'Tranzport'
   homepage 'http://steverab.com/tranzport-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.