### PR TITLE
Update trolcommander to 0.9.9

### DIFF
--- a/Casks/trolcommander.rb
+++ b/Casks/trolcommander.rb
@@ -5,7 +5,7 @@ cask 'trolcommander' do
   # github.com/trol73/mucommander was verified as official when first introduced to the cask
   url "https://github.com/trol73/mucommander/releases/download/v#{version}/trolcommander-#{version.dots_to_underscores}.app.tar.gz?raw=true"
   appcast 'https://github.com/trol73/mucommander/releases.atom',
-          checkpoint: 'ea64230d7f4a982b1da1c84371c4ca801d1031e105f266b64dd5f5d8aca96430'
+          checkpoint: '22b048caa74885952e57ddeb25080a8a566e289b017386e38416d6f7309eb400'
   name 'trolCommander'
   homepage 'https://trolsoft.ru/en/soft/trolcommander'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.