### PR TITLE
Update trenchbroom to 1.1.6_2759

### DIFF
--- a/Casks/trenchbroom.rb
+++ b/Casks/trenchbroom.rb
@@ -3,8 +3,8 @@ cask 'trenchbroom' do
   sha256 '92eeb77b0a4b3be21421120d78e5996ff6d2e3f8c41afac6cbd8185f5798c67a'
 
   url "http://kristianduske.com/trenchbroom/downloads/macosx/stable/TrenchBroom_Mac_#{version}.zip"
-  appcast 'http://kristianduske.com/trenchbroom/downloads.php?platform=macosx',
-          checkpoint: '07694d7d87fc302601918c5ef21dbf33cf8c6f55cbc61351d220d96533dcf09e'
+  appcast 'https://github.com/kduske/TrenchBroom/releases.atom',
+          checkpoint: '73154a4bd9b4fa17f744edcaffcb556c0c7edc8932c8e7d24d60a0cbf666c7f0'
   name 'TrenchBroom'
   homepage 'http://kristianduske.com/trenchbroom/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
