### PR TITLE
Update tankix to 626

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '625'
-  sha256 '424f90268f59cd65571888d5003c2cb40ef3e78e85ea3753898cfebdb2a8d6cb'
+  version '626'
+  sha256 'd9c4d7b2fd852ca84f63f8d800950d4462f8b56059596265131b448b4eeebff3'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.