### PR TITLE
Update utox to 0.9.8

### DIFF
--- a/Casks/utox.rb
+++ b/Casks/utox.rb
@@ -5,7 +5,7 @@ cask 'utox' do
   # github.com/uTox/uTox was verified as official when first introduced to the cask
   url "https://github.com/uTox/uTox/releases/download/v#{version}/uTox-#{version}.dmg"
   appcast 'https://github.com/uTox/uTox/releases.atom',
-          checkpoint: 'eee22a515c835b9a12c6dfc727a144227c27ec56d1b613a46362c8927b333a4a'
+          checkpoint: '3ac9e7a194c722a871e25415c165dbe8b6fe9e3930a94bee38b66846e1beaea6'
   name 'uTox'
   homepage 'https://www.tox.chat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.