### PR TITLE
Update veusz to 1.26

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,10 +1,10 @@
 cask 'veusz' do
-  version '1.25.1'
-  sha256 '38d4144babf3a07845b018af610cdf4b21a951a9b7c200c904509dbbe1d2b7a7'
+  version '1.26'
+  sha256 'fb45ee123f3d780bf29a3018b732af6733525aa07b8985fcb45aa5e234b172a3'
 
   url "http://download.gna.org/veusz/Binaries-AppleOSX/veusz-#{version}-AppleOSX.dmg"
   appcast 'http://download.gna.org/veusz/Binaries-AppleOSX/',
-          checkpoint: '7dcefe5737e3e8cbd0134289588e301755e351bc8db898e543c762ab8e01c972'
+          checkpoint: 'a4bf7fdb89449897f81e4d3324a66ea87a733b37eae4455d6a463fa07428459e'
   name 'Veusz'
   homepage 'http://home.gna.org/veusz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.