### PR TITLE
Update vuescan to 9.5.77

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.74'
-  sha256 'dccf616b79c0f502eadb345e72e7ef0053c3f18f915e712e430ad46094002784'
+  version '9.5.77'
+  sha256 'fa24e4544100dab9da6634a34787b0cbac680dc04b77eff230dca84705c3cf5e'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '696c1b876893d46e371c6e1b274d782d6e4f7a07600e9b6b7fc4b6ed5b564e69'
+          checkpoint: 'd8bc6eb834aef316a39208adac3cebfcd0e2b1f45c4eb9935f2859a459787506'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.