### PR TITLE
Update airtame to 2.4.1

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '2.3.4'
-  sha256 'a3e59296542c080e5580815fec9fbf3cab765f56cc55b14c164fdb777f1c0efd'
+  version '2.4.1'
+  sha256 '7e6bd34618b56cfc0f02588560df04f4882be074912d761ebf7e0264db870655'
 
   url "https://downloads-cdn.airtame.com/application/ga/osx_x64/releases/airtame-application-#{version}.dmg"
   name 'Airtame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.