### PR TITLE
Update wesnoth to 1.13.8

### DIFF
--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -1,11 +1,11 @@
 cask 'wesnoth' do
-  version '1.12.6'
-  sha256 'c94fe7880b1ed0f52e31ad570d3f082412ffbeb9d7ddadf0c64d501dfc1f0589'
+  version '1.13.8'
+  sha256 'df98a343ac2d83fb5f4144fb79379afa827c57cb8c68c3eaa29a2afb706352b5'
 
   # sourceforge.net/wesnoth was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/wesnoth/rss',
-          checkpoint: '89627cdd04c99f01f2cd150189e8de27f7efe76b0dfda47219722360a734c108'
+          checkpoint: '23497792e09d8ffeec2329c807e16a429f9694dc496649add9e23c753f369829'
   name 'The Battle for Wesnoth'
   homepage 'https://wesnoth.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.