### PR TITLE
Update adium to 1.5.10.4

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -4,7 +4,7 @@ cask 'adium' do
 
   url "http://download.adium.im/Adium_#{version}.dmg"
   appcast 'https://www.adium.im/sparkle/appcast-release.xml',
-          checkpoint: 'c0e7148f802efc6a1d255c420ec386c7de1fd1f4cd096970986a8bf891c5f342'
+          checkpoint: 'bd77f84e4dba32a3337f79e6a7bb3e5678750f79248c048d3cf7661634c94028'
   name 'Adium'
   homepage 'https://www.adium.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.