### PR TITLE
Update armory to 0.95.1

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -5,7 +5,7 @@ cask 'armory' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: 'bf767eddf6993b33b66fd8803023597f83b280e3b25e870869b55a580d084ead'
+          checkpoint: '789e1706eb0ccced9e766ea9967d485b5875d63f25e4ce5940932793720717e2'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.