### PR TITLE
Update axoloti-runtime to 1.0.12-1

### DIFF
--- a/Casks/axoloti-runtime.rb
+++ b/Casks/axoloti-runtime.rb
@@ -5,7 +5,7 @@ cask 'axoloti-runtime' do
   # github.com/axoloti/axoloti was verified as official when first introduced to the cask
   url "https://github.com/axoloti/axoloti/releases/download/#{version}/axo_runtime_mac_#{version}.dmg"
   appcast 'https://github.com/axoloti/axoloti/releases.atom',
-          checkpoint: 'b5ac28c3d438cb88140ef924d860a46cd73ca19f474ddcfb403c41c26030d538'
+          checkpoint: 'af66fae3e4388e6f6654ca48a693147c94fa537aa78bac545af9c8bb7b919d2d'
   name 'Axoloti Runtime'
   homepage 'http://www.axoloti.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.