### PR TITLE
Update qmapshack to 1.8.1

### DIFF
--- a/Casks/qmapshack.rb
+++ b/Casks/qmapshack.rb
@@ -1,6 +1,6 @@
 cask 'qmapshack' do
-  version '1.8.0'
-  sha256 '9887b20014d64d69c993811d9e10b3ed880250a0d4b4c00b50430067627541b1'
+  version '1.8.1'
+  sha256 '8ecfe0f7ba39e036c5ab7d85ce1d222b526c6915a1a3b6b69ac8b343c26e3a09'
 
   url "https://bitbucket.org/maproom/qmapshack/downloads/QMapShack-MacOSX_#{version}.tar.gz"
   name 'QMapShack'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.