### PR TITLE
Update modmove to 1.0.1

### DIFF
--- a/Casks/modmove.rb
+++ b/Casks/modmove.rb
@@ -1,10 +1,10 @@
 cask 'modmove' do
-  version '1.0.0'
-  sha256 '1d0cc13c38a4f76ae4f3a5d24c31553d4607c2d180ec1cdc93b43ee8787fe679'
+  version '1.0.1'
+  sha256 'e26b49608d57659e4a7a22b3e48a10d6636d79022240ea555357ef9ff323f0c9'
 
   url "https://github.com/keith/modmove/releases/download/#{version}/ModMove.app.zip"
   appcast 'https://github.com/keith/modmove/releases.atom',
-          checkpoint: '827b0314616db7d97a0c5f9cfc2252097a815781673ccf4bcc87aec34a691667'
+          checkpoint: '88f04c4c40d50c0174706559bcfd55de28ee2ee4d0cfd737e9033d879bedec53'
   name 'ModMove'
   homepage 'https://github.com/keith/modmove'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.