### PR TITLE
Update twine to 2.1.3

### DIFF
--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -1,11 +1,11 @@
 cask 'twine' do
-  version '2.1.1'
-  sha256 '4aad95da8b4fc2d6bb961ea48baeb78fdf81dd5ef9f0e5e085c31fdb66bc79f3'
+  version '2.1.3'
+  sha256 'f99eafcf3d70f6851016e350705aca563520b204cec13f86c353569f6ab362a4'
 
   # bitbucket.org/klembot/twinejs was verified as official when first introduced to the cask
   url "https://bitbucket.org/klembot/twinejs/downloads/twine_#{version}_osx.zip"
   name 'Twine'
   homepage 'https://twinery.org/'
 
-  app 'nw/Twine/osx64/Twine.app'
+  app 'Twine.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.