### PR TITLE
Add auto_updates to adobe-photoshop-lightroom, crashplan, yourkit-java-profiler

### DIFF
--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -6,6 +6,7 @@ cask 'adobe-photoshop-lightroom' do
   name 'Adobe Photoshop Lightroom'
   homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
 
+  auto_updates true
   depends_on cask: 'caskroom/versions/adobe-photoshop-lightroom600'
 
   # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight

--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -6,6 +6,8 @@ cask 'crashplan' do
   name 'CrashPlan'
   homepage 'https://www.crashplan.com/'
 
+  auto_updates true
+
   pkg 'Install CrashPlan.pkg'
 
   uninstall launchctl: 'com.backup42.desktop',

--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -6,5 +6,7 @@ cask 'yourkit-java-profiler' do
   name 'YourKit Java Profiler'
   homepage 'https://www.yourkit.com/features/'
 
+  auto_updates true
+
   app "YourKit-Java-Profiler-#{version.major_minor}.app"
 end


### PR DESCRIPTION
These casks that were reported as outdated despite being automatically kept up-to-date with built-in updaters.

---
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
