### PR TITLE
Update sejda-pdf-desktop to 2.5.9

### DIFF
--- a/Casks/sejda-pdf-desktop.rb
+++ b/Casks/sejda-pdf-desktop.rb
@@ -1,6 +1,6 @@
 cask 'sejda-pdf-desktop' do
-  version '2.5.2'
-  sha256 '8794c77b77ed3b170b2c5d8b960d786fe4f38d5fa85310802099935619522480'
+  version '2.5.9'
+  sha256 '3abb670a1013df9292ef70cf11ec0ab3016e609143a458b0f478c673757e6867'
 
   # bitbucket.org/sejdapdf/sejda-desktop-public was verified as official when first introduced to the cask
   url "https://bitbucket.org/sejdapdf/sejda-desktop-public/downloads/sejda-desktop_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.