### PR TITLE
remove auto-updates from java

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -10,8 +10,6 @@ cask 'java' do
   name 'Java Standard Edition Development Kit'
   homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.minor}-downloads-2133151.html"
 
-  auto_updates true
-
   pkg "JDK #{version.minor} Update #{java_update}.pkg"
 
   postflight do


### PR DESCRIPTION
#26856 added `auto_updates` to Java cask, which removes it from non-greedy `brew cask outdated`. I believe this is not entirely correct: while JDK does come with an auto-update tool, it only updates `/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home` JRE used by the browser plugin, and not `/Library/Java/JavaVirtualMachines/` JDK itself. The tools behaviour is rather misleading and leads to Java Control Panel reporting that I have the latest Java (update 131), but `java -version` and Java apps (eg. YourKit Java Profiler) reporting an older version (update 121).

Since browser plugin is no longer supported by Chrome and Firefox and is barely used (in fact is [scheduled for removal](https://blogs.oracle.com/java-platform-group/moving-to-a-plugin-free-web) in Java 9), and `/usr/libexec/java_home` points to `/Library/Java/JavaVirtualMachines/`, I would argue that the JDK version is more important than the one of the browser plugin, and since it is not automatically updated the cask should not have the flag.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
