### PR TITLE
Update downie to 2.8.7,1473

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.8.5,1467'
-  sha256 'edcbddf62335840ed14bd6714fbd4508e8de41453986903e5c7773647383dbb6'
+  version '2.8.7,1473'
+  sha256 '85be9b160cf4c87c8ff5fccc0384b2a7a2918aa01be62aed131293d50a231a1b'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'f830eae7dbd8e3b52c7afdc3472d571a0e22c347ee1688a7b907d00cba91c646'
+          checkpoint: 'd3e2d092a60a774d4ccc4fea12e6468cf5d826d18f6fda28603e5289e797d400'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.