### PR TITLE
Update quickhash to 2.8.1,379

### DIFF
--- a/Casks/quickhash.rb
+++ b/Casks/quickhash.rb
@@ -1,10 +1,10 @@
 cask 'quickhash' do
-  version '2.8.0,313'
-  sha256 '29892d6dd758c5dbaf9fe3619d693bb4c5a359bc35e8a9d6a8a88954b02b5460'
+  version '2.8.1,379'
+  sha256 '64afa9be2625ff0d0544cf944faa467f412777457c102fe0dd789b4566afb0e3'
 
   url "http://quickhash-gui.org/download/quickhash-v#{version.before_comma.dots_to_hyphens}-for-apple-mac-osx/?wpdmdl=#{version.after_comma}"
   name 'Quickhash'
   homepage 'http://quickhash-gui.org/'
 
-  app 'QuickHash.app'
+  app 'OSX/QuickHash.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.