### PR TITLE
Update propresenter to 6.2.1_b16020

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.2_b16019'
-  sha256 'd53e10333be04bacde94b6c50d0bfd20376fa173ac2ea006499b10bcae0adea3'
+  version '6.2.1_b16020'
+  sha256 '2be4c6a776ff9b12e626374ccaeabde139709c130cbfa19de4ec67bd942f1a2d'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: 'f5c03888077a21b8b6c938d6d8c2eba181e90c6b56490e92685bbc6709519123'
+          checkpoint: 'cf0ea3d657a0eaa3a688eede5b8caf0a2e151bf731c6ff724bf9d453445e9ad0'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.