### PR TITLE
Update kode54-cog to 0.08,67332f49

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,0217d5de'
-  sha256 'b1272c067f23a6d9f5481ca79d91aa3869d67066fc24b47ec88b0b22f7d87eef'
+  version '0.08,67332f49'
+  sha256 'dd1a360d46893092d11981145b08971aec82b6df804ce14b000e6d30c02864a5'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.