### PR TITLE
Update nanobox to 2.1.1

### DIFF
--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -1,19 +1,22 @@
 cask 'nanobox' do
-  version '0.18.2'
-  sha256 '433efa3076ab217e04707f8707476af48b1bc2727791cfcb5230d12a9003be1b'
+  version '2.1.1'
+  sha256 '2c5e001b55c0741a359fa8f7a93b78608e3c8584adead4a0c09a59a563f05d1c'
 
   # s3.amazonaws.com/tools.nanobox.io was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/tools.nanobox.io/cli/darwin/amd64/nanobox'
+  url "https://s3.amazonaws.com/tools.nanobox.io/installers/v#{version.major}/mac/Nanobox.pkg"
   appcast 'https://github.com/nanobox-io/nanobox/releases.atom',
-          checkpoint: 'ec194abb98dfcd6f3604dcfb307713989febbdc36de96259b1c57563cf414962'
+          checkpoint: '5a76290986958e939845f9d1f9946ee63593709f3733c319eb030c64ab7e8e26'
   name 'nanobox'
   homepage 'https://www.nanobox.io/'
 
-  depends_on cask: 'virtualbox'
-  depends_on cask: 'vagrant'
-  container type: :naked
+  pkg 'Nanobox.pkg'
 
-  binary 'nanobox'
+  uninstall launchctl: 'net.sf.tuntaposx.tap',
+            kext:      'net.sf.tuntaposx.tap',
+            pkgutil:   [
+                         'net.sf.tuntaposx.tap',
+                         'io.nanobox.pkg.nanobox',
+                       ]
 
   zap delete: [
                 '~/.nanobox',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/pull/34176

Changed to `pkg` install.

Removed dependencies. `nanobox` can be used with `docker for mac` or `virtualbox`.