### PR TITLE
Update minizincide to 2.1.5

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,11 +1,11 @@
 cask 'minizincide' do
-  version '2.1.4'
-  sha256 '7ea43eb8aa51deeb259610f15da46cab36c80781b99eb102cc946b24fd550624'
+  version '2.1.5'
+  sha256 'fd427fda74ba0972a9706a09c52fe8bbd19947e54c7c7e52e4c809122acb76b8'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"
   appcast 'https://github.com/MiniZinc/MiniZincIDE/releases.atom',
-          checkpoint: '63c3d0c1bf56af919bc5ca96ba0c2a04a6a7abcd2e5e758366f9f684415e7e57'
+          checkpoint: 'c76cd4c6464934c9445128ba2a04b5c07624fe6113e2823401bfb5fcfc542d83'
   name 'MiniZincIDE'
   homepage 'http://www.minizinc.org/ide/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.