### PR TITLE
Update saoimage-ds9 to 7.5

### DIFF
--- a/Casks/saoimage-ds9.rb
+++ b/Casks/saoimage-ds9.rb
@@ -1,10 +1,10 @@
 cask 'saoimage-ds9' do
   version '7.5'
 
-  if MacOS.version.eql? :yosemite
+  if MacOS.version == :yosemite
     sha256 '2b8df99204f6d739da4e4dc784056350ee7670ac896baa16be8f2fb0847a9755'
     url "http://ds9.si.edu/download/macosxyosemite/SAOImage%20DS9%20#{version}.dmg"
-  elsif MacOS.version.eql? :el_capitan
+  elsif MacOS.version == :el_capitan
     sha256 'bfb80ed0311034ac060fc7ef455fae4056870c93f06f90606da4fd49eb551b4b'
     url "http://ds9.si.edu/download/macosxelcapitan/SAOImage%20DS9%20#{version}.dmg"
   else
@@ -15,7 +15,7 @@ cask 'saoimage-ds9' do
   name 'SAOImage DS9'
   homepage 'http://ds9.si.edu/site/Home.html'
 
-  depends_on macos: '> :yosemite'
+  depends_on macos: '=> :yosemite'
 
   app 'SAOImage DS9.app'
 end

--- a/Casks/saoimage-ds9.rb
+++ b/Casks/saoimage-ds9.rb
@@ -1,22 +1,21 @@
 cask 'saoimage-ds9' do
-  version '7.4.1'
+  version '7.5'
 
-  if MacOS.version <= :mountain_lion
-    sha256 '91bf399b974a5e5d12d09e7f9f4a8acf826813eb1b05d865c0ac070fab58aca3'
-    url "http://ds9.si.edu/download/macosxmountainlion/SAOImage%20DS9%20#{version}.dmg"
-  elsif MacOS.version <= :mavericks
-    sha256 '35767c2e6116e49b9569180847ceb90fb1bf0d6379254b8834709b67e8e65e8d'
-    url "http://ds9.si.edu/download/macosxmavericks/SAOImage%20DS9%20#{version}.dmg"
-  elsif MacOS.version <= :yosemite
-    sha256 '6ff7b79f2b0e3b07b990b467fcecfdc35ba0cc6aa7575d97102b21791e9f3bf0'
+  if MacOS.version.eql? :yosemite
+    sha256 '2b8df99204f6d739da4e4dc784056350ee7670ac896baa16be8f2fb0847a9755'
     url "http://ds9.si.edu/download/macosxyosemite/SAOImage%20DS9%20#{version}.dmg"
-  else
-    sha256 'b935e9f90d667dc6f53d325d55bf2fc535fb1dd03ac65bcb63bf925dde25d804'
+  elsif MacOS.version.eql? :el_capitan
+    sha256 'bfb80ed0311034ac060fc7ef455fae4056870c93f06f90606da4fd49eb551b4b'
     url "http://ds9.si.edu/download/macosxelcapitan/SAOImage%20DS9%20#{version}.dmg"
+  else
+    sha256 '4fde92df2c2b216de34eff8b962c24f0a49b93c641575f5ea4f68009b97b45e9'
+    url "http://ds9.si.edu/download/macosxsierra/SAOImage%20DS9%20#{version}.dmg"
   end
 
   name 'SAOImage DS9'
   homepage 'http://ds9.si.edu/site/Home.html'
+
+  depends_on macos: '> :yosemite'
 
   app 'SAOImage DS9.app'
 end

--- a/Casks/saoimage-ds9.rb
+++ b/Casks/saoimage-ds9.rb
@@ -15,7 +15,7 @@ cask 'saoimage-ds9' do
   name 'SAOImage DS9'
   homepage 'http://ds9.si.edu/site/Home.html'
 
-  depends_on macos: '=> :yosemite'
+  depends_on macos: '>= :yosemite'
 
   app 'SAOImage DS9.app'
 end


### PR DESCRIPTION
* Updating this to support only the last 3 os versions

---

After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.