### PR TITLE
Update komodo-ide to 10.2.2-89895

### DIFF
--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -1,6 +1,6 @@
 cask 'komodo-ide' do
-  version '10.2.1-89853'
-  sha256 'd69251338694b43a02cfc3824a2c4bf6ecf8c3a717472bc129d4f53c8bed8e9b'
+  version '10.2.2-89895'
+  sha256 '21a103a8c30a87bd5e69d1f37af410cd1fe5e27f4d5f7f73a53cf16c2c959fe0'
 
   # activestate.com/Komodo was verified as official when first introduced to the cask
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.