### PR TITLE
Update pdfpen to 902.1,1495072427

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,10 +1,10 @@
 cask 'pdfpen' do
-  version '901.0,1492146603'
-  sha256 'ec9fa1f2340e4f4390cc5e3c5ddda7ab768309e6c21d582224e5848f4d7ff24d'
+  version '902.1,1495072427'
+  sha256 '8acb8ed471d1788777d5cb4f9f8f30c4b017de6b3b6bd577b6d9286ff13f02ab'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
-          checkpoint: 'd7e7b325cffc35f07d297ef97f7c0bbe794919718cf42fd76f49f4252805185e'
+          checkpoint: '63a003b38a869e2657902628136836476157aa6c4c8d9d6ed24fb6895bef4c63'
   name 'PDFpen'
   homepage 'https://smilesoftware.com/PDFpen'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.