### PR TITLE
Update ganttproject to 2.8.5,r2179

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,11 +1,11 @@
 cask 'ganttproject' do
-  version '2.8.4,r2134'
-  sha256 '1e42d88ac4122bdef7631aba589241ec431902859d7af18250891c486e5f242c'
+  version '2.8.5,r2179'
+  sha256 '0f8a752c03e29196d38b1874239c4e8e048b3b8360c82d8da3262ec9e1160ad9'
 
   # github.com/bardsoftware/ganttproject/releases/download was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/bardsoftware/ganttproject/releases.atom',
-          checkpoint: '6cb5f272592593f3fe23cacc2c7bb18d0a5fbfab18a8c87ec98c92db69252711'
+          checkpoint: '3bf25b7d2739eace46496219d2955bfcf420a00c9a315a9ff948267d40b7c9d9'
   name 'GanttProject'
   homepage 'https://www.ganttproject.biz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.