### PR TITLE
Update dropzone to 3.6.3

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,10 +1,10 @@
 cask 'dropzone' do
-  version '3.6.2'
-  sha256 'c9f2df6979b4cdfd8c2040a47e1cfbd08634508e73321eaf797d1aef4221000a'
+  version '3.6.3'
+  sha256 '97c217771313ab85f1bfe9035d62f1572c7e0dbfab3463b027f790ded543d13e'
 
   url "https://aptonic.com/dropzone3/sparkle/Dropzone-#{version}.zip"
   appcast 'https://aptonic.com/sparkle/updates.xml',
-          checkpoint: '157cdc4b0ac7d8a9e5f1a19b2d20333fe3f780e3e8982636e51247bf83c73f47'
+          checkpoint: '2359652041c439eed3e4da25d262b24250984cf6789b1e998427701dace700d5'
   name 'Dropzone'
   homepage 'https://aptonic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.