### PR TITLE
Update resolume-avenue to 4.6.4

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,6 +1,6 @@
 cask 'resolume-avenue' do
-  version '4.6.2'
-  sha256 '0dfe3f28308c05dd180619071b87256333f00b2f3a19e1a2b9ea1fa649c74451'
+  version '4.6.4'
+  sha256 'e6adfd60d07cfa025bd61c1047b4451c07407e1bf67746fa741952c3efbde7ae'
 
   # d19j6z4lvv1vde.cloudfront.net was verified as official when first introduced to the cask
   url "https://d19j6z4lvv1vde.cloudfront.net/Resolume_Avenue_#{version.dots_to_underscores}_Installer.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.