### PR TITLE
Update scala-ide to 4.6.0,2.12:20170516

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,6 +1,6 @@
 cask 'scala-ide' do
-  version '4.5.0,2.11:20161213'
-  sha256 'acfd393b0c4d88049b470e5187acc75c3c95c586834ed58c74fc9e379eae927e'
+  version '4.6.0,2.12:20170516'
+  sha256 '50440c68ab2b3c9ad608676732bef126a36c2c95f6a18a8c76a9d766703c3c78'
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
   url "https://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-neon-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.