### PR TITLE
Update lrtimelapse to 4.7.6

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,6 +1,6 @@
 cask 'lrtimelapse' do
-  version '4.7.5'
-  sha256 'dde02d27b0bbc9e75868c878e6511a9af676624261c93728ebdff8bc62928313'
+  version '4.7.6'
+  sha256 '6555e671a6276132ceecc6ef8ba63c41ea62c1acc010549f9ae77b4a9fbe60f0'
 
   url "https://lrtimelapse.com/files/lrtimelapse-#{version.dots_to_hyphens}-mac/"
   name 'LRTimelapse'
@@ -8,5 +8,10 @@ cask 'lrtimelapse' do
 
   pkg "LRTimelapse #{version} Installer.pkg"
 
-  uninstall script: 'Uninstall LRTimelapse.command'
+  uninstall script:  'Uninstall LRTimelapse.command',
+            pkgutil: [
+                       'com.lrtimelapse.LRAddons',
+                       'com.lrtimelapse.LRTimelapse4',
+                       'com.lrttimelapse.LRTTools',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.