### PR TITLE
Update cloudtv to 3.8.4

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,11 +1,11 @@
 cask 'cloudtv' do
-  version '3.8.3'
-  sha256 '111f18b7459f8f6d3c1189353b0eb160e45a48bd92972594e897384cadd102d1'
+  version '3.8.4'
+  sha256 'a7ec2e55ddff9dfb22abd2990e6e82c0dc8ea2b804e0df5f48cdcc9f99233131'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.nonoche.CloudTV/CloudTV.dmg?v=#{version}"
   appcast 'https://updates.devmate.com/com.nonoche.CloudTV.xml',
-          checkpoint: 'd0888b4b32c0ea6adab6b6a6619a3ee7e510e4066b9b4310bf2647578fe9681f'
+          checkpoint: 'c15e92ae96a894d8bba5b68c6e01461be44f9dd7590653498bf4fb655b94ad3d'
   name 'CloudTV'
   homepage 'https://cloudtvapp.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.