### PR TITLE
Update 115browser to 8.3.0.10

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,8 +1,10 @@
 cask '115browser' do
-  version '8.2.0.25'
-  sha256 'b4c04ca9073d7166c384f4ad47ec3d2edd5751c29b27f7a878193c06866875a5'
+  version '8.3.0.10'
+  sha256 'e996139197874685dcfd366b12c5e5efe2ddd152f87e294ee65efd4835d459eb'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
+  appcast 'https://pc.115.com/#mac',
+          checkpoint: '6f8a8353a6a9c7f9c4207c3a67a801e557eec3291d10f1bd8ed5a16821621f13'
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.