### PR TITLE
Add Phew 1.0 - FLIF image previewer

### DIFF
--- a/Casks/phew.rb
+++ b/Casks/phew.rb
@@ -2,7 +2,7 @@ cask 'phew' do
   version '1.0'
   sha256 'f4d6c78f98926b5e84bdbba68e06f5646545af15623807df26a7715e3397203d'
 
-  url 'url "https://sveinbjorn.org/files/software/phew/Phew-#{version}.zip"'
+  url "https://sveinbjorn.org/files/software/phew/Phew-#{version}.zip"
   appcast 'https://sveinbjorn.org/files/appcasts/PhewAppcast.xml',
           checkpoint: 'c413dc2541ade9496867e6e16a8915de2692e22b07773e02e27e3a1d85680c26'
   name 'Phew'

--- a/Casks/phew.rb
+++ b/Casks/phew.rb
@@ -2,15 +2,14 @@ cask 'phew' do
   version '1.0'
   sha256 'f4d6c78f98926b5e84bdbba68e06f5646545af15623807df26a7715e3397203d'
 
-  url 'https://sveinbjorn.org/files/software/phew/Phew-1.0.zip'
+  url 'url "https://sveinbjorn.org/files/software/phew/Phew-#{version}.zip"'
   appcast 'https://sveinbjorn.org/files/appcasts/PhewAppcast.xml',
           checkpoint: 'c413dc2541ade9496867e6e16a8915de2692e22b07773e02e27e3a1d85680c26'
-  name 'Phew - FLIF Image Viewer and QuickLook plugin'
+  name 'Phew'
   homepage 'https://sveinbjorn.org/phew'
 
   auto_updates true
 
   app 'Phew.app'
-
-  caveats 'To install the QuickLook plugin, look in the File menu.'
+  qlplugin "#{appdir}/Phew.app/Contents/Resources/FLIFImages.qlgenerator"
 end

--- a/Casks/phew.rb
+++ b/Casks/phew.rb
@@ -1,0 +1,16 @@
+cask 'phew' do
+  version '1.0'
+  sha256 'f4d6c78f98926b5e84bdbba68e06f5646545af15623807df26a7715e3397203d'
+
+  url 'https://sveinbjorn.org/files/software/phew/Phew-1.0.zip'
+  appcast 'https://sveinbjorn.org/files/appcasts/PhewAppcast.xml',
+          checkpoint: 'c413dc2541ade9496867e6e16a8915de2692e22b07773e02e27e3a1d85680c26'
+  name 'Phew - FLIF Image Viewer and QuickLook plugin'
+  homepage 'https://sveinbjorn.org/phew'
+
+  auto_updates true
+
+  app 'Phew.app'
+
+  caveats 'To install the QuickLook plugin, look in the File menu.'
+end


### PR DESCRIPTION
Phew is a FLIF image format previewer with an accompanying QuickLook plugin.

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
