### PR TITLE
Add Undercover 6.5

### DIFF
--- a/Casks/undercover.rb
+++ b/Casks/undercover.rb
@@ -1,0 +1,13 @@
+cask 'undercover' do
+  version '6.5'
+  sha256 '3eeacdf5dc74cd3f75c40ba975d728551da001571ba8eafc270646e29c22b9fb'
+
+  # undercoverhq.com was verified as official when first introduced to the cask
+  url "http://assets.undercoverhq.com/client/#{version}/undercover_mac.pkg"
+  name 'Undercover'
+  homepage 'http://orbicule.com/undercover/'
+
+  pkg 'undercover_mac.pkg'
+
+  uninstall pkgutil: 'com.orbicule.pkg.Undercover'
+end


### PR DESCRIPTION
This has previously existed but was removed due to being walled. This is no longer the case so re-adding. See https://github.com/caskroom/homebrew-cask/pull/9084#issuecomment-302947995 

Note, on install a GUI pops up to complete setup. Not sure if that's a problem?

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
