### PR TITLE
Update pocketsmith to 0.1.1

### DIFF
--- a/Casks/pocketsmith.rb
+++ b/Casks/pocketsmith.rb
@@ -1,6 +1,6 @@
 cask 'pocketsmith' do
-  version '0.1.0'
-  sha256 '6b1f0b167ad37b888a677cbade2c2a4445174d06cce20d934f77d80d4a4c8511'
+  version '0.1.1'
+  sha256 '371caff85ccae05b78d42b7d5c973735ab626f5f7284da772599b4360294f295'
 
   # d17qi61ltj6gb6.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17qi61ltj6gb6.cloudfront.net/#{version}/PocketSmith.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.