### PR TITLE
Update paye-tools to 17.2.17125.433

### DIFF
--- a/Casks/paye-tools.rb
+++ b/Casks/paye-tools.rb
@@ -1,6 +1,6 @@
 cask 'paye-tools' do
-  version '17.0.17068.356'
-  sha256 'dd568956b671e41c656835fb50e188de2932558cea79363c02407d9faf37cdc0'
+  version '17.2.17125.433'
+  sha256 'e8d2f9d27d873c120cd11343753fc23a917b27d8ddfbf32f65590409019f20b8'
 
   url "https://www.gov.uk/government/uploads/uploaded/hmrc/payetools-rti-#{version}-osx.zip"
   name 'Basic PAYE Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.