### PR TITLE
Update screenflow to 6.2.2

### DIFF
--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -1,10 +1,10 @@
 cask 'screenflow' do
-  version '6.2.1'
-  sha256 '06859b806ee441afc47dbf9e073464430c84ec0ff1615765cf8345ec50edeee3'
+  version '6.2.2'
+  sha256 '93d82f6e52db68b41c899e3221e08620df8c2bee8b82ffd07f384a8c1deaea96'
 
   url "https://www.telestream.net/download-files/screenflow/#{version.major_minor.dots_to_hyphens}/ScreenFlow-#{version}.dmg"
   appcast 'https://www.telestream.net/updater/screenflow/appcast.xml',
-          checkpoint: 'c445b8b0128c522ed6f8b20e86e4c2fe9d308cb8e1e7422bbb839ba754f50c58'
+          checkpoint: 'd4f5505fab9e422c897ee659aff793d023130c7de5e004d2ca9746668f6c0e8c'
   name 'ScreenFlow'
   homepage 'https://www.telestream.net/screenflow/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.