### PR TITLE
Update sync_templates_and_ci

### DIFF
--- a/developer/bin/sync_templates_and_ci
+++ b/developer/bin/sync_templates_and_ci
@@ -31,7 +31,7 @@ function copy_templates_and_ci {
   local repo_name
 
   repo_name="${1}"
-  rsync --archive --delete "${main_repo_dir}"/{.github,.travis.yml,ci} '.'
+  rsync --archive --delete "${main_repo_dir}"/{.editorconfig,.gitattributes,.github,.gitignore,.travis.yml,ci} '.'
   /usr/bin/sed -i '' -E "s:homebrew-cask/(pulls|issues):${repo_name}/\1:" '.github/PULL_REQUEST_TEMPLATE.md' # PULL_REQUEST_TEMPLATE has repo-specific links
 }
 


### PR DESCRIPTION
Updated `sync_templates_and_ci` to include:
- `.editorconfig`
- `.gitattributes`
- `.gitignore`

I was going to do PRs to add `.gitignore` to the repos but thought it might be better to keep them in sync.