### PR TITLE
Update mjml to 2.2.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,11 +1,11 @@
 cask 'mjml' do
-  version '2.1.0'
-  sha256 '079d8ce7e62ac1f780530d375361e85410d60c319e6f8ac7392398c7a042bb47'
+  version '2.2.0'
+  sha256 'ab847bc3205a5251cd972f86b6d4e11923417eb65acbc807cd3d346b8c982c2b'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-osx_#{version}.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom',
-          checkpoint: '8c2244aa5349f7955680dc71c5ea402567fc28abfd1cb4fea916e490844a15f6'
+          checkpoint: '9a7ccd724d1f3488c4edaac58d20dda75b143da637eab5031b70a7405e7cbfe9'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.