### PR TITLE
Update pdfsam-basic to 3.3.2

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,11 +1,11 @@
 cask 'pdfsam-basic' do
-  version '3.3.0'
-  sha256 'c89c73d6e47ae609f55aa65d8d8c45f53d326750600966218a62cb8f468361c7'
+  version '3.3.2'
+  sha256 '06b48c3da25d674f319131dc9f93ad68471f403fd33b2b2e6a6b940eda8686d8'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}/PDFsam-#{version}.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom',
-          checkpoint: '344c53a87c014250f9388e0c9ea18989b3551774be977b31c2d11c4fd83d186c'
+          checkpoint: 'd5596d303eef7216985f2e5b6e87609bbe693eeaefc3ee52eb307f123269b997'
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.