### PR TITLE
Update MacID to 1.3.6

### DIFF
--- a/Casks/macid.rb
+++ b/Casks/macid.rb
@@ -1,6 +1,6 @@
 cask 'macid' do
-  version '1.3.5'
-  sha256 'fdb37485748ad774e6e78e5d9134ce355aa5227e2926206a0e2314cc660ae452'
+  version '1.3.6'
+  sha256 'b13c7018e073007ec5ad2e2b8573b0d1dae7d7be77fb380ac0055ba269fdf80b'
 
   url "https://macid.co/app/#{version}/MacID%20for%20macOS.zip"
   name 'MacID'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.