### PR TITLE
Update kite to 0.20170519.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170518.0'
-  sha256 '140ee91554c8db696c2256613bcf964df35978bf55e43ae79a30e94e1c6d180d'
+  version '0.20170519.0'
+  sha256 '79c7609075d40362e34322dc472fd733f6c5a8f9fccab73f18830384a11c41f5'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: 'fc23fa6dd8299320c7ca08e412b67a2eb16a5600d6139f4dca96e4dedbeb3618'
+          checkpoint: '780d78c4ae33d46d3b2257842345e40a360d5c13c3ca1a704c4a4b2c3cfb6794'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.