### PR TITLE
Update sha256 sums for puppet-agent 1.10.1-1 for yosemite and el_capitan

### DIFF
--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -2,9 +2,9 @@ cask 'puppet-agent' do
   version '1.10.1-1'
 
   if MacOS.version == :yosemite
-    sha256 '18e6eb90656e90f98ee4197a442a0d40bfb2a2e72ea0582e514429322dd75eb0'
+    sha256 '03c9a5c43cd5e865967381d5ff51a4fa84d0241814148b323d479e0593d95ebe'
   elsif MacOS.version == :el_capitan
-    sha256 '8bb89eaf4b4b36e8e2937bfe888a2464fbadd9797142c8c534d4c3a6152c1c53'
+    sha256 '80973fed3afb8527568d2d07f7b3ed8db15dbe814320e36922f95532b76381a4'
   else
     sha256 '64c72aeeab9fa3e06b5317ea3d32145ee34be88df4f8b5d667b5fead2a863679'
   end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

I do not believe this applies because the last version change did not fully update the versions for all macOS available.  It is just finishing the update started for this version.  The version bump from c011f5d56d0f2baff2eb3e15bcb1408e7aeabf44 clearly does not update what I am updating and this commit (93f9b5a424b545cb0fe21e4c264c81ca597a027a) clearly does not update what they updated.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
