### PR TITLE
Update hab to 0.24.1-20170522075711

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.24.0-20170519202549'
-  sha256 '3c1bc6fd18ac12caffedca88dbda4765459ebc83f5b7e543e83a0cacd4c55f45'
+  version '0.24.1-20170522075711'
+  sha256 '8bdab4e58decfe42ad5170ba0b0d8dc9cb482a9306f752790eeeec857184b786'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '39ccfe8ccb72f752e1ca8d6e7ec995c2e347ba80334ef10388414f6c79a1101a'
+          checkpoint: 'cc5d983ced8070064836cac42b9fd37b153f4f57cd1dc28016eca203971c30a1'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.