### PR TITLE
Update cryptomator to 1.2.4

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -5,7 +5,7 @@ cask 'cryptomator' do
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
   appcast 'https://github.com/cryptomator/cryptomator/releases.atom',
-          checkpoint: 'd39d0da435a1b07582924063c0074457bb7f6524b6b153964345e6afa28a65e3'
+          checkpoint: 'aa4063276e835ad31b9455607ffca5aba1742e4789dbe022b5ca21dab4581b72'
   name 'Cryptomator'
   homepage 'https://cryptomator.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.