### PR TITLE
Update subler to 1.3

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.2.9'
-  sha256 'fc8979fdb4db0db571f73d4234ffa5c3ded6d9daf7df89798888235cc2f0fcb8'
+  version '1.3'
+  sha256 '130a133e40d283a62ece72ee9bfe1d6222975a1056dcd8db17a7b9159d56c7c6'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: 'da29fbc8041ea889513cf55c7a5a3f29a7d2786df21e294657ec7adf8967bf89'
+          checkpoint: '2d14d580292a0948b37d7f20f95de0727c466fc0946c86ae04808f2a69cf4f76'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.