### PR TITLE
Update flightgear to 2017.2.1

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2017.1.3'
-  sha256 '78ed634c5db8a3a28f7babf656d7190c0d5fea0013a3c0ff8e1ba45c0d3933af'
+  version '2017.2.1'
+  sha256 '117fb9d18681e52007895c876ab9864aaf99f5b7a7899928bc7e365de4f1b6d7'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: 'cdd2c3e5595760f450f4c442b4be6ec1aca0870cf4fa356e1b9294af287021e8'
+          checkpoint: '2816d3c494591d56409e1e06e20e844ce4343f8b654e20e7a98d8e4454d1f680'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.