### PR TITLE
Update lilypond to 2.19.61-1

### DIFF
--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -1,11 +1,11 @@
 cask 'lilypond' do
-  version '2.19.60-1'
-  sha256 'f96d9a51fb38b0acd60f037d13fd12347ea315a9e09318fb34ee664e8edd0ddb'
+  version '2.19.61-1'
+  sha256 'db415bd8332fbb02853dcd4f66be6b8f5326e5b0144a6e44743bd4aeefb59f0d'
 
   # linuxaudio.org/lilypond was verified as official when first introduced to the cask
   url "http://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   appcast 'http://download.linuxaudio.org/lilypond/binaries/darwin-x86/',
-          checkpoint: 'a0c5e6bc2f2555b5e3ffaf117a969c8d59714aee760ed7cdda98e17163079d79'
+          checkpoint: 'c4bed67fabce3ea6b4929db72714173c5b98cac0b881108a9a35eee3764c6cd4'
   name 'LilyPond'
   homepage 'http://lilypond.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.