### PR TITLE
Remove appcast from objectivesharpie

### DIFF
--- a/Casks/objectivesharpie.rb
+++ b/Casks/objectivesharpie.rb
@@ -3,8 +3,6 @@ cask 'objectivesharpie' do
   sha256 'a3f0b65895e55fa7628e3727772bed99fa7713cc059b716d3f30266b9b18ce0f'
 
   url "https://download.xamarin.com/objective-sharpie/ObjectiveSharpie-#{version}.pkg"
-  appcast 'https://developer.xamarin.com/guides/cross-platform/macios/binding/objective-sharpie/releases/',
-          checkpoint: '7a7dee3899648ea6ed857bde3d9e06e2b17114b52a83d66d36c47f1264a7eaa9'
   name 'Objective Sharpie'
   homepage 'https://developer.xamarin.com/guides/cross-platform/macios/binding/objective-sharpie/'
 


### PR DESCRIPTION
* Appcast has changed 3 times over the last week. Removing as it is ineffective.

---

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
