### PR TITLE
Fix insomniax

### DIFF
--- a/Casks/insomniax.rb
+++ b/Casks/insomniax.rb
@@ -6,7 +6,7 @@ cask 'insomniax' do
   appcast 'http://insomniax.semaja2.net/profile/profileInfo.php',
           checkpoint: 'ffe4389e2a4f837fbe48aef4017ed326d203fd23068d30dde3b6ae8c5fa80842'
   name 'InsomniaX'
-  homepage 'https://semaja2.net/projects/insomniaxinfo/'
+  homepage 'http://semaja2.net/projects/insomniaxinfo/'
 
   app 'InsomniaX.app'
 end

--- a/Casks/objectivesharpie.rb
+++ b/Casks/objectivesharpie.rb
@@ -3,8 +3,6 @@ cask 'objectivesharpie' do
   sha256 'a3f0b65895e55fa7628e3727772bed99fa7713cc059b716d3f30266b9b18ce0f'
 
   url "https://download.xamarin.com/objective-sharpie/ObjectiveSharpie-#{version}.pkg"
-  appcast 'https://developer.xamarin.com/guides/cross-platform/macios/binding/objective-sharpie/releases/',
-          checkpoint: '7a7dee3899648ea6ed857bde3d9e06e2b17114b52a83d66d36c47f1264a7eaa9'
   name 'Objective Sharpie'
   homepage 'https://developer.xamarin.com/guides/cross-platform/macios/binding/objective-sharpie/'
 


### PR DESCRIPTION
* Homepage SSL cert expired a long time ago

`The certificate expired on 20 September 2016 at 10:21 pm`

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.