### PR TITLE
Update homepage for insomniax

### DIFF
--- a/Casks/insomniax.rb
+++ b/Casks/insomniax.rb
@@ -6,7 +6,7 @@ cask 'insomniax' do
   appcast 'http://insomniax.semaja2.net/profile/profileInfo.php',
           checkpoint: 'ffe4389e2a4f837fbe48aef4017ed326d203fd23068d30dde3b6ae8c5fa80842'
   name 'InsomniaX'
-  homepage 'https://semaja2.net/projects/insomniaxinfo/'
+  homepage 'http://semaja2.net/projects/insomniaxinfo/'
 
   app 'InsomniaX.app'
 end


### PR DESCRIPTION
* Homepage SSL cert expired a long time ago

`The certificate expired on 20 September 2016 at 10:21 pm`

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
