### PR TITLE
Update amazon-chime to 4.3.5721

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,10 +1,10 @@
 cask 'amazon-chime' do
-  version '4.3.5702'
-  sha256 'f4fc52bca5f93b7d7001073f8be2f592face2c7d5f64db4340e8d50d38a4362b'
+  version '4.3.5721'
+  sha256 '07132830b91a570c16c2ee78447a0b4c8281f9f63a45afd1ca6098a1b5972413'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast',
-          checkpoint: 'b5bf8bdec277f204331fb8734bfdcce4601f4bc43a160df6a7ce28fb352f4262'
+          checkpoint: '4b70068c134b8c503c2481ab7e73f65deb88bf8dcb15c13b07cb7258c90ec781'
   name 'Amazon Chime'
   homepage 'https://chime.aws/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.