### PR TITLE
Update downie to 2.8.8,1476

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.8.7,1473'
-  sha256 '85be9b160cf4c87c8ff5fccc0384b2a7a2918aa01be62aed131293d50a231a1b'
+  version '2.8.8,1476'
+  sha256 'b4d3fa995177ec7c3ce5eadb1b8647ae74898a718d7f6ee094d38716ae4113dd'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: 'd3e2d092a60a774d4ccc4fea12e6468cf5d826d18f6fda28603e5289e797d400'
+          checkpoint: '6cce2e1207e8977d9b3a7c3469672c50909e503c66b609c7681e7d8863cf2d2f'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.