### PR TITLE
Update fork to 1.0.46.1

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.46'
-  sha256 '32f9f519203108e8c7157c1ce9c6fff34faa05e6b01f0aff5a4e12691ce12bd5'
+  version '1.0.46.1'
+  sha256 '82db8c3263dc33d521a963b7da146e6c7c9d29deabeaf4d159a27a8106818c06'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: 'aa92b57b4957464aa42e12ace9546e2f54958cc5e867352b88a91cb49e3749ac'
+          checkpoint: '7796a4029209e035b9bfe2404ae8ae4d83adb114fdf7e2885b3d13901e61d0d5'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.