### PR TITLE
Update paraview to 5.3.0

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -10,14 +10,15 @@ cask 'paraview' do
     url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=osx&downloadFile=ParaView-#{version}-Qt4-OpenGL2-MPI-OSX10.7-64bit.dmg"
     app 'paraview.app'
   else
-    version '5.4.0'
-    sha256 '079903bff72d5213b9928787db1e0546f9169d2f7ed6e6fa3f5835ef2ccc1065'
-    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=osx&downloadFile=ParaView-#{version}-Qt5-OpenGL2-MPI-OSX10.8-64bit.dmg"
+    version '5.3.0'
+    sha256 '75b385dcf244f3942cb74eeed8e593d6744a330f1f97ae1301c6584da8d607c0'
+    url "http://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=osx&downloadFile=ParaView-#{version}-Qt5-OpenGL2-MPI-OSX10.8-64bit.dmg",
+        user_agent: :fake
     app "Paraview-#{version}.app"
   end
 
   appcast 'http://www.paraview.org/files/paraview-download.js',
-          checkpoint: '971c7202a3757ada059550673c3c7fe0be7193592ef6c933507e83993f099cfa'
+          checkpoint: 'a8988baf9122d1327ebec216cc9334fddc824614ef4c667943900fd818083f9b'
   name 'ParaView'
   homepage 'http://www.paraview.org/'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/34728

Revert to `5.3.0`, current stable release.

Add `user_agent: :fake` for current version, not required for older versions.
