### PR TITLE
Update the-escapers-flux to 7.0.8

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,5 +1,5 @@
 cask 'the-escapers-flux' do
-  version '7.0.6'
+  version '7.0.8'
   sha256 '2114522e95f43d5bfb15515ea7889fb6f09188c03ad16fba0f75d64337f6e7cf'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask


### PR DESCRIPTION
- Correct Version of this App is 7.0.8
- Correct SHA256 Got updated in #34783

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---
Ref Screenshot below: This app was downloaded from http://www.theescapers.com/product.php?product=flux, not beta's
![screen shot 2017-05-23 at 9 24 35 am](https://cloud.githubusercontent.com/assets/450222/26356414/fb0964e8-3f99-11e7-940b-960c052a61a8.png)
