### PR TITLE
Update scrutiny to 7

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,17 +1,17 @@
 cask 'scrutiny' do
-  version :latest
-  sha256 :no_check
+  version '7'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url 'http://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   name 'Scrutiny'
   homepage 'http://peacockmedia.software/mac/scrutiny/'
 
-  app 'Scrutiny.app'
+  app "Scrutiny #{version}.app"
 
   zap delete: [
-                '~/Library/Application Support/Scrutiny5',
-                '~/Library/Caches/com.peacockmedia.Scrutiny5',
-                '~/Library/Preferences/com.peacockmedia.Scrutiny5.plist',
-                '~/Library/Cookies/com.peacockmedia.Scrutiny5.binarycookies',
+                "~/Library/Application Support/Scrutiny#{version}",
+                "~/Library/Caches/com.peacockmedia.Scrutiny#{version}",
+                "~/Library/Preferences/com.peacockmedia.Scrutiny#{version}.plist",
+                "~/Library/Cookies/com.peacockmedia.Scrutiny#{version}.binarycookies",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.