### PR TITLE
Update audio-hijack to 3.3.4

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -1,10 +1,10 @@
 cask 'audio-hijack' do
-  version '3.3.3'
-  sha256 '2f7a71ec69a58220520639f623a14caab19405c498de8e2e016039edda99eaf2'
+  version '3.3.4'
+  sha256 'f09d429133554616a56cf5f154d559117aaa4642c32db38fe3c5bacd1dc0838d'
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   appcast "https://www.rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.audiohijack#{version.major}",
-          checkpoint: 'df40cf3050072b517ae78d04abee1d561bbf62c4bcffd29356562cb1afa119ca'
+          checkpoint: 'e70c82ddc6154bc0665ca08535d2505ca4214be1d6b1c2f2ef8c2c7dad659524'
   name 'Audio Hijack'
   homepage 'https://www.rogueamoeba.com/audiohijack/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.