### PR TITLE
Update pomodone to 1.5.1008

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,6 +1,6 @@
 cask 'pomodone' do
-  version '1.5.998'
-  sha256 '3c3c0cb9e4b15ed2a8a35a500633d2e2cf15da0c64fc03273a0379b442ae577d'
+  version '1.5.1008'
+  sha256 '46f0d9b1054e1370c6626ecb1bacf3b2fffda92a4eda0319e62c7f597565732c'
 
   url "https://app.pomodoneapp.com/installers/PomoDoneApp-#{version}.dmg"
   name 'PomoDone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.