### PR TITLE
Update gitkraken to 2.6.0

### DIFF
--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -1,6 +1,6 @@
 cask 'gitkraken' do
-  version '2.5.0'
-  sha256 '1ce872bd7fba5ffa20ddec4d57c6e4bb820f0e62f97bc7161a06464d3deafca4'
+  version '2.6.0'
+  sha256 '83375b055240a3284d1fa9493e8972694c7790cea272e210b8a1f599987fbdd6'
 
   url "https://release.gitkraken.com/darwin/v#{version}.zip"
   appcast 'https://release.gitkraken.com/darwin/RELEASES',

--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -4,7 +4,7 @@ cask 'gitkraken' do
 
   url "https://release.gitkraken.com/darwin/v#{version}.zip"
   appcast 'https://release.gitkraken.com/darwin/RELEASES',
-          checkpoint: '121f306630a8ba306125f02f7eedb44a8752c6110600a322184dab38e12a7490'
+          checkpoint: '9f50a52c11208da590f3c8a2a848064232229f93ddd1c09b31cddefe8d7be66c'
   name 'GitKraken'
   homepage 'https://www.gitkraken.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

~~`appcast` hasn't been updated but `2.6.0` is listed in release notes.~~ 

Edit: `appcast` updated.