### PR TITLE
Update bbedit to 11.6.6

### DIFF
--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -1,10 +1,11 @@
 cask 'bbedit' do
-  version '11.6.5'
-  sha256 '2b32db1592802aa1b3cddbe7649b005a892eb2a9d5f760d8708f4eaae80fd914'
+  version '11.6.6'
+  sha256 '3ab848da98c59b708601fd78e3fa2f350104e1a6b8cfbcb8f161689e8d521f12'
 
-  url "http://pine.barebones.com/files/BBEdit_#{version}.dmg"
+  # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
+  url "http://s3.amazonaws.com/BBSW-download/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml',
-          checkpoint: 'adcd1cda2c27210d9d75b1a83706c5b388a50347cdaf2677582572a5c0d151cf'
+          checkpoint: 'fe15345679b9c17343ab57f77508f1584dbf2a962c125b61dfeb643fd1bcca8c'
   name 'BBEdit'
   homepage 'https://www.barebones.com/products/bbedit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Download `url` has changed. https://www.barebones.com/products/bbedit/