### PR TITLE
Update keeweb to 1.5.1

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,11 +1,11 @@
 cask 'keeweb' do
-  version '1.5.0'
-  sha256 '4b8476149c4da15e1b973ceb151bab08533f01431235572dfd8d9e2fc907b263'
+  version '1.5.1'
+  sha256 '732ff8a7b8098beed69c459ca5334ae818b6946a89d0508d827b546663465930'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"
   appcast 'https://github.com/keeweb/keeweb/releases.atom',
-          checkpoint: '8e1d8bfc9ca84496fb5d12e234a599dc2d965cb04743dfa9e554a8590045960f'
+          checkpoint: 'fa88335e6baefeff0651dbf4c49911a218c2bb280f9c22edc33a9c0176587cd5'
   name 'KeeWeb'
   homepage 'https://keeweb.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.