### PR TITLE
Update mono-mdk to 5.0.1.1

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,11 +1,11 @@
 cask 'mono-mdk' do
-  version '5.0.0.100'
-  sha256 '66398a86a7d7daf1a79ff940a5562c8386f48d7f40693e7936cbb356cf855e1f'
+  version '5.0.1.1'
+  sha256 '60eef93597fd4fc0fa617e0bd1df14da506611087e4117ac366b332ecf70a5a0'
 
   # mono-project.azureedge.net/archive was verified as official when first introduced to the cask
   url "https://mono-project.azureedge.net/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'http://www.mono-project.com/docs/about-mono/releases/index.html',
-          checkpoint: 'e4491dc51d494c0af9739a68d2da0582718146aaff098ff94578189ca7bbb22f'
+          checkpoint: '36e268757b172e76ecb96591bfd804d477bfa6aa890d0a1bc67bbe86f70e0b7a'
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.