### PR TITLE
Update ticktick to 1.6.70,28

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '1.6.61,27'
-  sha256 '7752268c42645ed09c299b97768aebdbe1c50f399071962c2a95667e3863af24'
+  version '1.6.70,28'
+  sha256 '6196c9652c7aa57ea88a0dd6a0f577c449bf8512f997c563aca81864f664c31c'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.