### PR TITLE
lilypond - Use shimscripts for app binaries

### DIFF
--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -30,7 +30,6 @@ cask 'lilypond' do
           #!/bin/sh
           exec '#{appdir}/LilyPond.app/Contents/Resources/bin/#{shimscript}' "$@"
         EOS
-      set_permissions shimscript, '+x'
     end
   end
 

--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -11,6 +11,29 @@ cask 'lilypond' do
 
   app 'LilyPond.app'
 
+  binaries = %w[
+               abc2ly
+               convert-ly
+               lilypond
+               lilypond-book
+               musicxml2ly
+             ]
+
+  binaries.each do |shimscript|
+    binary "#{staged_path}/#{shimscript}.wrapper.sh", target: shimscript
+  end
+
+  preflight do
+    binaries.each do |shimscript|
+      # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+      IO.write "#{staged_path}/#{shimscript}.wrapper.sh", <<-EOS.undent
+          #!/bin/sh
+          exec '#{appdir}/LilyPond.app/Contents/Resources/bin/#{shimscript}' "$@"
+        EOS
+      set_permissions shimscript, '+x'
+    end
+  end
+
   zap delete: [
                 '~/Library/Preferences/org.lilypond.lilypond.plist',
                 '~/Library/Preferences/org.lilypond.lilypond.LSSharedFileList.plist',


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Added shimscripts for some binaries inside the app bundle. Version not updated. 