### PR TITLE
Update qt-creator to 4.3.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.2.2'
-  sha256 '3dcdf070bc0cf3e99a587340119b6bc31d7b123dbf7ad2f904812fc78a0e6fb1'
+  version '4.3.0'
+  sha256 '37118c49b724d5986fdd052b1098e3d648224837fdc4a8ba4d8fd842dfd561e6'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.