### PR TITLE
Update hugin to 2016.2.0

### DIFF
--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -4,7 +4,7 @@ cask 'hugin' do
 
   url "https://downloads.sourceforge.net/hugin/Hugin-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/hugin/rss',
-          checkpoint: 'b5547e1ec75e4c68666a44ba0b96a8d7c24b4be47b950668df81159e7a49f829'
+          checkpoint: '7c098890c5f1723f0fa0160a96c2cec13fbdf24706ad5a2a54394a0d971ac47d'
   name 'Hugin'
   homepage 'http://hugin.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.