### PR TITLE
Update keystore-explorer to 5.2.2

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,12 +1,13 @@
 cask 'keystore-explorer' do
   version '5.2.2'
-  sha256 'c6ab532a0e9ec41caf0177823b9ced256c9d241e77f3c39a6ad1070cfffe5a0f'
+  sha256 '64123f31c0216608aaf2e51dd6cf7715c067ef8985945c150e390c5104af78ef'
 
-  url "https://downloads.sourceforge.net/keystore-explorer/KSE%20#{version}/kse-#{version.no_dots}.dmg"
-  appcast 'https://sourceforge.net/projects/keystore-explorer/rss',
-          checkpoint: '6e53faf2de2906e436facf8a5798956fcbb525b3d55728d1ad14424684fa6e1a'
+  # github.com/kaikramer/keystore-explorer was verified as official when first introduced to the cask
+  url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version}/kse-#{version.no_dots}.dmg"
+  appcast 'https://github.com/kaikramer/keystore-explorer/releases.atom',
+          checkpoint: '6a4b8e5da148a2c0671e630d954989ddbd3d946e2927563e5611ce71da26e84c'
   name 'KeyStore Explorer'
-  homepage 'http://keystore-explorer.sourceforge.net/'
+  homepage 'http://keystore-explorer.org/'
 
   app "KeyStore Explorer #{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

VirusTotal: https://www.virustotal.com/en-gb/file/64123f31c0216608aaf2e51dd6cf7715c067ef8985945c150e390c5104af78ef/analysis/1482156130/