### PR TITLE
Update opensesame to 3.1.6

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -9,7 +9,7 @@ cask 'opensesame' do
     # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
     url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
     appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: '7024bbce26aa87d4a4f889ed99f08463d120491b085fdba1163f69da98b415a6'
+            checkpoint: '8a82d4c98339aca6ffcb5286805340a54e1e11a87a98fd416c3f2975fc6381ee'
   end
 
   name 'OpenSesame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.