### PR TITLE
Update iphoto-library-manager to 4.2.7

### DIFF
--- a/Casks/iphoto-library-manager.rb
+++ b/Casks/iphoto-library-manager.rb
@@ -1,10 +1,10 @@
 cask 'iphoto-library-manager' do
-  version '4.2.6'
-  sha256 '00bf533f8e086ee5a5eb74e48af10dc828400610407e1213f1b83a7d6f881fbc'
+  version '4.2.7'
+  sha256 '19befc6553638687f27883e822d7ecb780f31ad358bd3057c2079de4f12edea9'
 
   url 'https://www.fatcatsoftware.com/iplm/iPhotoLibraryManager.zip'
   appcast "https://www.fatcatsoftware.com/iplm/iplm#{version.major}_appcast.xml",
-          checkpoint: 'f54b77cc4cef9ee266aa32a91059473b3f13e8a6d558ce8e3e1719f52437f2cd'
+          checkpoint: '4235fdb961dc7a4fafff3681b3caa985431e6689c9642e59e53cd11180f22641'
   name 'iPhoto Library Manager'
   homepage 'https://www.fatcatsoftware.com/iplm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.