### PR TITLE
Update ridibooks to 2.2.3

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,6 +1,6 @@
 cask 'ridibooks' do
-  version '2.2.2'
-  sha256 'e41e6c8fd79e88fa8ffb0198bc7f91c427ee5e44b2a97b2c99972d47898a0dae'
+  version '2.2.3'
+  sha256 '4ea7a3447a9a28cabd19082727037582ed65b0722e99783a62a3f8d086d3bbed'
 
   # ridicorp.com was verified as official when first introduced to the cask
   url "https://cdn.ridicorp.com/app/mac/ridibooks-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.