### PR TITLE
Update aria2gui to 1.3.7

### DIFF
--- a/Casks/aria2gui.rb
+++ b/Casks/aria2gui.rb
@@ -1,10 +1,10 @@
 cask 'aria2gui' do
-  version '1.3.6'
-  sha256 '789c28ccb8f9f09e0618c437485b63e390b7d0b289ce37d6d71b253daf571d12'
+  version '1.3.7'
+  sha256 '96779f1cc15120f7d2cd716e55ffb52848937084b916d19c147cada0ff485396'
 
   url "https://github.com/yangshun1029/aria2gui/releases/download/#{version}/Aria2GUI-v#{version}.zip"
   appcast 'https://github.com/yangshun1029/aria2gui/releases.atom',
-          checkpoint: '857f8649c18697d34035a317dffada3b132b308630edb00e75b1d7eab5fb7442'
+          checkpoint: '9bcb6e2b5713da199f1e9912b392c0b18192a7f1beae50b49898637edf24cf26'
   name 'Aria2GUI'
   homepage 'https://github.com/yangshun1029/aria2gui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.