### PR TITLE
Update cisdem-pdfmanagerultimate to 2.5.0

### DIFF
--- a/Casks/cisdem-pdfmanagerultimate.rb
+++ b/Casks/cisdem-pdfmanagerultimate.rb
@@ -2,7 +2,7 @@ cask 'cisdem-pdfmanagerultimate' do
   version '2.5.0'
   sha256 '572ed99e8ea18474a0dfe7fd42e0fe704e40607f12a979ada704054fc81d05de'
 
-  url 'https://www.cisdem.com/downloads/cisdem-pdfmanagerultimate-15.dmg'
+  url 'https://www.cisdem.com/download/cisdem-pdfmanagerultimate.dmg'
   appcast 'https://www.cisdem.com/pdf-manager-ultimate-mac/release-notes.html',
           checkpoint: '1a02e2ff75effa10451a124a858681542b20527d40d7ea3142450943335212e7'
   name 'Cisdem PDFManagerUltimate'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.