### PR TITLE
Added cask to install Rider EAP from Jetbrains, at version EAP Build 22

### DIFF
--- a/Casks/rider-eap.rb
+++ b/Casks/rider-eap.rb
@@ -10,7 +10,7 @@ cask 'rider-eap' do
 
   app 'Rider EAP.app'
 
-  uninstall delete: ENV['PATH'].split(File::PATH_SEPARATOR).map { |p| "{p}/rider" }.each { |path| File.delete(path) if File.exist?(path) }
+  uninstall delete: ENV['PATH'].split(File::PATH_SEPARATOR).map { |p| "#{p}/rider" }.select { |f| File.exist?(f) }
 
   zap delete: [
                 '~/Library/Caches/Rider10',

--- a/Casks/rider-eap.rb
+++ b/Casks/rider-eap.rb
@@ -1,0 +1,23 @@
+cask 'rider-eap' do
+  version 'EAP build 22'
+  sha256 'dc995c3d9483c1b033a2de38fa81982e125ebafe478559f23f058989d90092dd'
+
+  url 'https://download.jetbrains.com/resharper/riderRS-171.4456.199.dmg'
+  name 'Jetbrains Rider'
+  homepage 'https://www.jetbrains.com/rider/'
+
+  auto_updates true
+
+  app 'Rider EAP.app'
+
+  uninstall delete: ENV['PATH'].split(File::PATH_SEPARATOR).map { |p| "{p}/rider" }.each { |path| File.delete(path) if File.exist?(path) }
+
+  zap delete: [
+                '~/Library/Caches/Rider10',
+                '~/Library/Logs/Rider10',
+                '~/Library/Application Support/Rider10',
+                '~/Library/Preferences/Rider10',
+                '~/Library/Preferences/com.jetbrains.rider-EAP.plist',
+                '~/Library/Saved Application State/com.jetbrains.rider-EAP.savedState',
+              ]
+end


### PR DESCRIPTION
Moved existing PR here from homebrew-versions caskroom/homebrew-versions#3897

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
