### PR TITLE
Tweak wording of readme for clearer definition of correct repo.

### DIFF
--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -202,7 +202,7 @@ Stable versions live in the main repository at [caskroom/homebrew-cask](https://
 
 ### But There Is No Stable Version!
 
-When an App is only available as beta, development, or unstable versions, or in cases where such a version is the general standard, then said version can go into the main repo.
+When an App is only available as beta, development, or unstable versions, or in cases where such a version is the general standard, then said version should go into the main repo, and not into [caskroom/homebrew-versions](https://github.com/caskroom/homebrew-versions).
 
 ### Beta, Unstable, Development, Nightly, or Legacy
 


### PR DESCRIPTION
I submitted a cask for an EAP version this morning to homebrew-versions in caskroom/homebrew-versions#3897, but that was incorrect and I moved to caskroom/homebrew-cask#34865

I was confused by the wording that said in the situation where the app is only available in beta, it _can_ go in the main repo.

I took this to mean it _can_ but it doesn't have to, so submitted there anyway.

This PR tries to make the wording to make it clear in this case it _should_ go to the main repo, and _not_ in the versions repo.

I hope that helps, it could just be user error on my part!