### PR TITLE
Update porting-kit to 2.6.2

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,10 +1,10 @@
 cask 'porting-kit' do
-  version '2.6.1'
-  sha256 'f6abdbdbd209bc68b5f8779e84e71c1dcc804ff3837f259d6150283a2f2ea8d1'
+  version '2.6.2'
+  sha256 '2af934470e1bf65d380eece4874dc06845b1fe52ea1ff64c010fda5f29e213c9'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '3e2061d80821149aab024fc9c7ea211f4e96cb959ab0e4b3800c0130128af2cd'
+          checkpoint: 'e455506405f4028de661339cacaf638650c37ffcaaf555e0845007ce1831a1b7'
   name 'Porting Kit'
   homepage 'http://portingkit.com/en/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.