### PR TITLE
Update standard-notes to 1.0.1

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '1.0.0'
-  sha256 '323a3f7b542f01a7a11abd27a1dc6be6358a54e5472412cc5b7b401f8e13350c'
+  version '1.0.1'
+  sha256 'ed8c051b5c97057b3aa29bcf9a768e142cc68617cecb0f43e546bfb59ce6cf67'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '4df4aae5a8688eef1225879017d83ba391f43743f6bfca245373b9315b464d35'
+          checkpoint: 'db186136e9ba6f1b372a0245433f5265b216672984dc93ae7d52ace165ab26fe'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.