### PR TITLE
Update praat to 6.0.29

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,11 +1,11 @@
 cask 'praat' do
-  version '6.0.28'
-  sha256 '698932902082910592944ad01641ce1be8708982ac3f7fcf18c575bec182c8ed'
+  version '6.0.29'
+  sha256 'b9dd8f7740fb76529b2c9ea77b77fd1dd75e72dc981d2274bfa21e38aff63661'
 
   # github.com/praat/praat/releases was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom',
-          checkpoint: '251289d3ed912f18a332ec7c8c719a0074e25726a98f5baf80674b754e293de8'
+          checkpoint: 'fbbaffeae204e976fe348e78bedcf41f49dc93c2be7f3f43b7d129d99e43f85b'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.