### PR TITLE
Update keybase to 1.0.23-20170522181119,8a8aea0

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,10 +1,10 @@
 cask 'keybase' do
-  version '1.0.22-20170515141716,b608f0e'
-  sha256 '0d6d03b6d5b13e0916f18d156dd83a5b46d9f6b25625af8723f211ad39d261cb'
+  version '1.0.23-20170522181119,8a8aea0'
+  sha256 '61d3eb58c637cc9b2dde8d9ba44456bd7fa592afc0b0fe1114610fdab70489fc'
 
   url "https://prerelease.keybase.io/darwin/Keybase-#{version.before_comma}%2B#{version.after_comma}.dmg"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json',
-          checkpoint: '862c9f6e526b007329ec3166f8e6fa841ff9b7c068ebd46600144e8944333dea'
+          checkpoint: '16388f8a9ca5077186277daae34e72d0572620263293744df77c274fa252b500'
   name 'Keybase'
   homepage 'https://keybase.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.