### PR TITLE
Update wordpresscom to 2.5.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '2.3.0'
-  sha256 '95e6faa4d81c7bb7b70114e3094e0a78dcd3400af3525d425c3d3214c519e11f'
+  version '2.5.0'
+  sha256 '8f6a520d3ffbdc65fa21f76a8f6347c049ca35172003a6d3c301d85e9843864c'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: '7ef15118771d0d3f3a7fa3120c86f3d440b1284afefb5cbcbbe2f87d32fffeb1'
+          checkpoint: 'd4040433b138f7d6fae6e70ff560b01bef5a40118f2309d49c4f313227a8f14e'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.