### PR TITLE
Update quodlibet to 3.9.0

### DIFF
--- a/Casks/quodlibet.rb
+++ b/Casks/quodlibet.rb
@@ -1,11 +1,11 @@
 cask 'quodlibet' do
-  version '3.8.1'
-  sha256 '6bc27b27be763f7c4fe48cfd62b7ccb0070474455a0b668ac36c8d3d844ab0b8'
+  version '3.9.0'
+  sha256 '82b24c2cf41ea18df2b8c7a7823331ea84ce076a2a9c3d0eea8c6b263d2905a7'
 
   # bitbucket.org/lazka/quodlibet was verified as official when first introduced to the cask
   url "https://bitbucket.org/lazka/quodlibet/downloads/QuodLibet-#{version}.dmg"
   appcast 'https://github.com/quodlibet/quodlibet/releases.atom',
-          checkpoint: '2c4aa5c46bf6b4ecb5a4321de3d63f015520f48ade3de3720a86a92a18143170'
+          checkpoint: '1cb6bed33dc0a4c621a01ac5d6148a59ef525c3d9c5449c2a760c22f45ab3a7d'
   name 'Quod Libet'
   homepage 'https://quodlibet.readthedocs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.