### PR TITLE
Update exfalso to 3.9.0

### DIFF
--- a/Casks/exfalso.rb
+++ b/Casks/exfalso.rb
@@ -1,11 +1,11 @@
 cask 'exfalso' do
-  version '3.8.1'
-  sha256 '8184024910a6d2914cb30bf662f31a69a1bad077f6c0c909269f9dd4e11462e3'
+  version '3.9.0'
+  sha256 '4da83c06cc6fa9961cb00c711220c17627107a6e27bc8b57459c3805a1f2c651'
 
   # bitbucket.org/lazka/quodlibet was verified as official when first introduced to the cask
   url "https://bitbucket.org/lazka/quodlibet/downloads/ExFalso-#{version}.dmg"
   appcast 'https://github.com/quodlibet/quodlibet/releases.atom',
-          checkpoint: '2c4aa5c46bf6b4ecb5a4321de3d63f015520f48ade3de3720a86a92a18143170'
+          checkpoint: '1cb6bed33dc0a4c621a01ac5d6148a59ef525c3d9c5449c2a760c22f45ab3a7d'
   name 'Ex Falso'
   homepage 'https://quodlibet.readthedocs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.