### PR TITLE
Update kitematic to 0.17.0

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -5,7 +5,7 @@ cask 'kitematic' do
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
-          checkpoint: '207a6a91905e76654f500007f89bf788f26084e56b9f80725626dc14919d6c1a'
+          checkpoint: '9187da9aa977402aef3f5bd90a2327c12ba709f574e174269cdf24a629cc457c'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.