### PR TITLE
Update ramme to 3.2.0

### DIFF
--- a/Casks/ramme.rb
+++ b/Casks/ramme.rb
@@ -1,10 +1,10 @@
 cask 'ramme' do
-  version '3.1.0'
-  sha256 'e8eaef921eab170f99396c127495b558d6b2cbaf1df914bcccd5ab37d592e1da'
+  version '3.2.0'
+  sha256 '1a26355a331f5e9eb27a174f4f4e3d65cec5bf63435a1c6155486070a32a178f'
 
   url "https://github.com/terkelg/ramme/releases/download/v#{version}/Ramme-#{version}.dmg"
   appcast 'https://github.com/terkelg/ramme/releases.atom',
-          checkpoint: '3c25b04a09e8545b9d472753fbc540c339a5ce4c3ea4655aeff0796c164fcf27'
+          checkpoint: 'd842097f78a5f6f638cfa0e5b4eadcc0fc36955022733f0fb6fde0ac6b7e6314'
   name 'Ramme'
   homepage 'https://github.com/terkelg/ramme/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.