### PR TITLE
Update docker to 17.03.1-ce-mac12,17661

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,5 +1,5 @@
 cask 'docker' do
-  version '17.03.1-ce,17661'
+  version '17.03.1-ce-mac12,17661'
   sha256 'b65882665a678c5833037637a3dd43997283e6a096a431d83f130642447a855e'
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Changed to full `version`. https://download.docker.com/mac/stable/appcast.xml

Also to match [docker-edge](https://github.com/caskroom/homebrew-versions/blob/409c18c22c837d8f0e7d5f6435e5a1d4954f7ddd/Casks/docker-edge.rb#L2).

![docker](https://cloud.githubusercontent.com/assets/26216252/26473254/c8e01d4e-41ed-11e7-971e-f2578cef1a4c.png)
