### PR TITLE
Update dropshare to 4.6.3,4608

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4.6.2,4604'
-  sha256 'c8c49b5c5850d2302dc38ec296e469076eb7c52b96c6602f19c57aae7a46949b'
+  version '4.6.3,4608'
+  sha256 'cf0beb0c4bff79ec5c18196e57d31c13cae86f94d3786e9543018735e48f8d70'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
-          checkpoint: '29d4f921cc895cf48feabfd2dfa06b56118827952bdb41d062aeb41cfecc5952'
+          checkpoint: '7e9bdabcc538c1f91f67dcd73aa63256eeb0e64396a5ad3187074fb052ec0df8'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.