### PR TITLE
Update numi to 3.15,109:1495727941

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,11 +1,11 @@
 cask 'numi' do
-  version '3.0b14,90:1478584117'
-  sha256 'a9452e903169d3a735db1af2eb684521ff0828a2f39f1d34acda2c8602762627'
+  version '3.15,109:1495727941'
+  sha256 '23582ee171ab9cc3a89fbfc18fafd6ec6e1046a7476a1de3816b5928551afedd'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"
   appcast 'http://updates.devmate.com/com.dmitrynikolaev.numi.xml',
-          checkpoint: 'd05068f1767ef5c8bd6ea5435737c347755799881b15ef43a49a2429635fb6ad'
+          checkpoint: 'f8996449e00cca07caaac815bfa09e0af2e3bf6411f49d2ad369fa9946283b70'
   name 'Numi'
   homepage 'https://numi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.