### PR TITLE
Update `appcast` for 3 casks

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -4,8 +4,8 @@ cask 'mono-mdk' do
 
   # mono-project.azureedge.net/archive was verified as official when first introduced to the cask
   url "https://mono-project.azureedge.net/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
-  appcast 'http://www.mono-project.com/docs/about-mono/releases/index.html',
-          checkpoint: '36e268757b172e76ecb96591bfd804d477bfa6aa890d0a1bc67bbe86f70e0b7a'
+  appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+          checkpoint: 'd1c454ead2e12eb823776ab1e0f18c35cb9372379ac93aacff7107c0c76b8c0b'
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 

--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -4,8 +4,8 @@ cask 'visual-studio' do
 
   # dl.xamarin.com was verified as official when first introduced to the cask
   url "https://dl.xamarin.com/VsMac/VisualStudioForMac-#{version}.dmg"
-  appcast 'http://xamarin.com/installer_assets/v3/vsmac/Mac/Universal/InstallationManifest.xml',
-          checkpoint: '2adcc7a40fa47b7ac33576ffcf44ff529fbd853f49c2e5806f7c34c5cb07b338'
+  appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+          checkpoint: 'd1c454ead2e12eb823776ab1e0f18c35cb9372379ac93aacff7107c0c76b8c0b'
   name 'Visual Studio for Mac'
   homepage 'https://www.visualstudio.com/vs/visual-studio-mac/'
 

--- a/Casks/xamarin-mac.rb
+++ b/Casks/xamarin-mac.rb
@@ -3,8 +3,8 @@ cask 'xamarin-mac' do
   sha256 'e26a80365b60ef38b5815bdfbea3fc60cba98ae11e6e0822f3c37707d63978ce'
 
   url "https://dl.xamarin.com/XamarinforMac/Mac/xamarin.mac-#{version}.pkg"
-  appcast "http://xamarin.com/installer_assets/v#{version.major}/vsmac/Mac/Universal/InstallationManifest.xml",
-          checkpoint: '2adcc7a40fa47b7ac33576ffcf44ff529fbd853f49c2e5806f7c34c5cb07b338'
+  appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
+          checkpoint: 'd1c454ead2e12eb823776ab1e0f18c35cb9372379ac93aacff7107c0c76b8c0b'
   name 'Xamarin Mac'
   homepage 'https://www.xamarin.com/platform'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Updated `appcast` for `mono-mdk`, `visual-studio` and `xamarin-mac` to match the rest of the xamarin casks.

Current `appcast`s sometimes revert to previous versions.

The `appcast` for `xamarin-mac` should be `v3` as it is not part of the cask `version`.