### PR TITLE
Update macspice to 3.1.15

### DIFF
--- a/Casks/macspice.rb
+++ b/Casks/macspice.rb
@@ -1,10 +1,10 @@
 cask 'macspice' do
-  version '3.1.14'
-  sha256 'a645d1264621f1cf3dbc796545e624ca5210d4aefe8907da3dfd4a91c7f77aab'
+  version '3.1.15'
+  sha256 'c12699e694d415ef7711e45d3f348e84202188014e679d505a2d5f126c84f77c'
 
   url "http://www.macspice.com/mirror/binaries/v#{version}/MacSpice3f5.dmg"
   appcast 'http://www.macspice.com/AppCast-v2.xml',
-          checkpoint: '02531b3fc5be586cfe543c5a4b78b206369945aad9a698ccc6fa44dd64d053ad'
+          checkpoint: '0d57f4a640d1d4991aab10d13a744be9d2afcec1b9ee1621ea5668f4964eb6a9'
   name 'MacSpice'
   homepage 'http://www.macspice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.