### PR TITLE
Add authy-desktop 1.0.10

### DIFF
--- a/Casks/authy-desktop.rb
+++ b/Casks/authy-desktop.rb
@@ -1,0 +1,20 @@
+cask 'authy-desktop' do
+  version '1.0.10'
+  sha256 '64c76377fe993eca459bc0f470cd0eaef26e16f7b4ced75adfd46eaf2e37ae89'
+
+  # s3.amazonaws.com/authy-electron-repository-production was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/authy-electron-repository-production/stable/#{version}/darwin/x64/installer.dmg"
+  name 'Authy Desktop'
+  homepage 'https://authy.com/'
+
+  app 'Authy Desktop.app'
+
+  zap delete: [
+                '~/Library/Application Support/Authy Desktop',
+                '~/Library/Caches/com.authy.authy-mac',
+                '~/Library/Caches/com.authy.authy-mac.ShipIt',
+                '~/Library/Cookies/com.authy.authy-mac.binarycookies',
+                '~/Library/Preferences/com.authy.authy-mac.helper.plist',
+                '~/Library/Preferences/com.authy.authy-mac.plist',
+              ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

Closes https://github.com/caskroom/homebrew-cask/issues/34919

`authy-bluetooth` was previously in HBC. https://github.com/caskroom/homebrew-cask/pull/9189

https://authy.com/download/ refers to this as a beta.

Haven't found an `appcast` for this yet.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
