### PR TITLE
Update electron to 1.6.10

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.6.8'
-  sha256 '40fb4f098321f1a1988d379e4a617df59513ad8e6faa9a3c741a6934f8366ee4'
+  version '1.6.10'
+  sha256 '1e3118f2421cfb3af07000ca255009e6c32bda026bda016d63aa3086014789a4'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'c041c996a5aa2f0504817aee7b6f5b61c4f528113e7715e904502cc82806f65b'
+          checkpoint: '72fe4eef9cf453d5cd2d6d65fdab88c03e6644967ffbb4598e27d41ea5a8ad28'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.