### PR TITLE
Update tiled to 1.0.0

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,11 +1,11 @@
 cask 'tiled' do
-  version '0.18.2'
-  sha256 '138d5492d202e3209481078eb9bf5e346067b42446eb5d9086a7f49bba55df13'
+  version '1.0.0'
+  sha256 '0607713d702b662f430a2aaf7305203db8f5d2c9620a708d3ca73a5c3c742047'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
   appcast 'https://github.com/bjorn/tiled/releases.atom',
-          checkpoint: '8bc7a9709eee6356947b83b0e4eca59857e6700ed13bd810a510580357377e22'
+          checkpoint: 'fbfb63f98888678531f5b6ab4206b666bdcac546a27653af66db778664f8f8a6'
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.