### PR TITLE
Update microsoft-teams to 1.0.00.13751

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '1.0.00.13152'
-  sha256 '02a9f6542437431d6f1e902ec0fe713fca2c985c27537e7989a9119e74d49c86'
+  version '1.0.00.13751'
+  sha256 'fe1b99af080630e45413d74dbcbabf19087dae87e808079daf786bf9ff7c85fa'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: '94fa706f6c8ad65d63d865105826dceb14dc4cbc12710003269551ec5c478926'
+          checkpoint: '8511fd80c9976fff63b3d2cba2d1a9dae922189ebccca8f793f52af53bee51ea'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.