### PR TITLE
Update iueditor to 2.0.5.30

### DIFF
--- a/Casks/iueditor.rb
+++ b/Casks/iueditor.rb
@@ -1,6 +1,6 @@
 cask 'iueditor' do
-  version '2.0.5.28'
-  sha256 '310fae4a3c3b187de789a69224551506c21a1ffcdc34baa2e3ef3a984d0a5c61'
+  version '2.0.5.30'
+  sha256 '04edb407d7056a307754e94b92d3ed144c8a15a11e550d1a97314a33bfa8a86b'
 
   url "https://cdn.iueditor.org/release/IUEditorV#{version}.pkg"
   name 'JDLab IUEditor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.