### PR TITLE
Update flux to 39.98

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,6 +1,6 @@
 cask 'flux' do
-  version '39.97'
-  sha256 'de1add26c8d20925e728b5f9e0266855bc89a8128277131273aa66850f79869e'
+  version '39.98'
+  sha256 '4b041705c40a593dbf745b83f49254c5a4f46b7e3bedcf150194e3f0840dd525'
 
   url "https://justgetflux.com/mac/Flux#{version}.zip"
   appcast 'https://justgetflux.com/mac/macflux.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`39.98` is available from https://justgetflux.com/ but the changelog is at `39.96` and the appcast is at `39.94`.