### PR TITLE
Update 9 `jetbrains` casks - remove EAP `conflicts_with`

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -9,7 +9,6 @@ cask 'appcode' do
   homepage 'https://www.jetbrains.com/objc/'
 
   auto_updates true
-  conflicts_with cask: 'appcode-eap'
 
   app 'AppCode.app'
 

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -9,7 +9,6 @@ cask 'clion' do
   homepage 'https://www.jetbrains.com/clion/'
 
   auto_updates true
-  conflicts_with cask: 'clion-eap'
 
   app 'CLion.app'
 

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -9,7 +9,6 @@ cask 'datagrip' do
   homepage 'https://www.jetbrains.com/datagrip/'
 
   auto_updates true
-  conflicts_with cask: 'datagrip-eap'
 
   app 'DataGrip.app'
 

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -8,6 +8,8 @@ cask 'mps' do
   name 'JetBrains MPS'
   homepage 'https://www.jetbrains.com/mps/'
 
+  auto_updates true
+
   app "MPS #{version.major_minor}.app"
 
   zap delete: [

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -8,8 +8,6 @@ cask 'mps' do
   name 'JetBrains MPS'
   homepage 'https://www.jetbrains.com/mps/'
 
-  conflicts_with cask: 'mps-eap'
-
   app "MPS #{version.major_minor}.app"
 
   zap delete: [

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -9,7 +9,6 @@ cask 'phpstorm' do
   homepage 'https://www.jetbrains.com/phpstorm/'
 
   auto_updates true
-  conflicts_with cask: 'phpstorm-eap'
 
   app 'PhpStorm.app'
 

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -10,7 +10,6 @@ cask 'pycharm-ce' do
   homepage 'https://www.jetbrains.com/pycharm/'
 
   auto_updates true
-  conflicts_with cask: 'pycharm-ce-eap'
 
   app 'PyCharm CE.app'
 

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -9,7 +9,6 @@ cask 'pycharm' do
   homepage 'https://www.jetbrains.com/pycharm/'
 
   auto_updates true
-  conflicts_with cask: 'pycharm-eap'
 
   app 'PyCharm.app'
 

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -9,7 +9,6 @@ cask 'rubymine' do
   homepage 'https://www.jetbrains.com/ruby/'
 
   auto_updates true
-  conflicts_with cask: 'rubymine-eap'
 
   app 'RubyMine.app'
 

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -9,7 +9,6 @@ cask 'webstorm' do
   homepage 'https://www.jetbrains.com/webstorm/'
 
   auto_updates true
-  conflicts_with cask: 'webstorm-eap'
 
   app 'WebStorm.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Removed `conflicts_with` EAP `versions`

Add `auto_updates` to `mps`