### PR TITLE
Update wechatwebdevtools to 0.17.172600

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '0.17.171900'
-  sha256 '9d9987aa662e7a203ac8f0891b19803b77e355c490c4b1ae1620ede32f7db482'
+  version '0.17.172600'
+  sha256 '81dae5e1c9604915faa80e51f35f711f7991ceac027433bfe831d4edda79ca42'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.no_dots}/wechat_web_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.