### PR TITLE
Update rsyncosx to 4.3.0

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -4,7 +4,7 @@ cask 'rsyncosx' do
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: '153df6d14205becd264b7177d88b4bd8a4afd8522c855696bcb8df8ece845f3f'
+          checkpoint: '7bd1f80ca4ae6bc48c85cef27671d29c5faccec2380f821d7805f5ae55d8a4ee'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.