### PR TITLE
Update opera to 45.0.2552.881

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '45.0.2552.812'
-  sha256 'c4130a0c6d53528b84d1dc677d4c1b5cff9c07e586e7240b9c8156e510798b7b'
+  version '45.0.2552.881'
+  sha256 'f9afb6145299283fd9dfbb9b8c04d6327e00a213a41f34cec621ebd1e7565406'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.