### PR TITLE
Add transmit-disk 4.4.12

### DIFF
--- a/Casks/transmit-disk.rb
+++ b/Casks/transmit-disk.rb
@@ -6,40 +6,11 @@ cask 'transmit-disk' do
   name 'transmit-disk'
   homepage 'https://panic.com/transmit/'
 
-  depends_on cask: 'transmit'
-
-  pkg "Transmit Disk #{version}.pkg",
-      choices: [
-                 {
-                   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
-                   'choiceAttribute'  => 'visible',
-                   'attributeSetting' => false,
-                 },
-                 {
-                   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
-                   'choiceAttribute'  => 'enabled',
-                   'attributeSetting' => true,
-                 },
-                 {
-                   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
-                   'choiceAttribute'  => 'selected',
-                   'attributeSetting' => 1,
-                 },
-                 # FIXME: Puts .app in correct place but fails package validation
-                 # {
-                 #   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
-                 #   'choiceAttribute'  => 'customLocation',
-                 #   'attributeSetting' => '/Applications',
-                 # },
-               ]
+  pkg "Transmit Disk #{version}.pkg"
 
   postflight do
-    system_command 'mv',
-                   args: [
-                           '/tmp/Transmit/Transmit Disk.app',
-                           '/Applications/',
-                         ],
-                   sudo: true
+    set_ownership ['/tmp/Transmit']
+    FileUtils.move('/tmp/Transmit/Transmit Disk.app', "#{appdir}/Transmit Disk.app")
   end
 
   uninstall quit:    [
@@ -51,11 +22,10 @@ cask 'transmit-disk' do
                        'com.panic.TransmitDisk.pkg',
                        'com.panic.TransmitDisk.filesystem.tdfuse.pkg',
                      ],
-            trash:   '/Applications/Transmit Disk.app'
+            delete:  "#{appdir}/Transmit Disk.app"
 
   zap delete: [
                 '~/Library/Preferences/com.panic.Transmit.TransmitDisk.plist',
                 '/Library/Filesystems/transmitdisk.fs/',
-                '/Applications/Transmit Disk.app',
               ]
 end

--- a/Casks/transmit-disk.rb
+++ b/Casks/transmit-disk.rb
@@ -1,0 +1,61 @@
+cask 'transmit-disk' do
+  version '4.4.12'
+  sha256 '3a4e3515450e597fc7f0d75f0d53df215bea3b6d9615c0a960f471b1185602ef'
+
+  url "https://download.panic.com/transmit/Transmit%20Disk%20#{version}.pkg.zip"
+  name 'transmit-disk'
+  homepage 'https://panic.com/transmit/'
+
+  depends_on cask: 'transmit'
+
+  pkg "Transmit Disk #{version}.pkg",
+      choices: [
+                 {
+                   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
+                   'choiceAttribute'  => 'visible',
+                   'attributeSetting' => false,
+                 },
+                 {
+                   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
+                   'choiceAttribute'  => 'enabled',
+                   'attributeSetting' => true,
+                 },
+                 {
+                   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 # FIXME: Puts .app in correct place but fails package validation
+                 # {
+                 #   'choiceIdentifier' => 'com.panic.TransmitDisk.pkg',
+                 #   'choiceAttribute'  => 'customLocation',
+                 #   'attributeSetting' => '/Applications',
+                 # },
+               ]
+
+  postflight do
+    system_command 'mv',
+                   args: [
+                           '/tmp/Transmit/Transmit Disk.app',
+                           '/Applications/',
+                         ],
+                   sudo: true
+  end
+
+  uninstall quit:    [
+                       'com.panic.Transmit',
+                       'com.panic.Transmit.TransmitDisk',
+                       'com.panic.Transmit.TransmitMenu',
+                     ],
+            pkgutil: [
+                       'com.panic.TransmitDisk.pkg',
+                       'com.panic.TransmitDisk.filesystem.tdfuse.pkg',
+                     ],
+            trash:   '/Applications/Transmit Disk.app'
+
+  zap delete: [
+                '~/Library/Preferences/com.panic.Transmit.TransmitDisk.plist',
+                '/Library/Filesystems/transmitdisk.fs/',
+                '/Applications/Transmit Disk.app',
+              ]
+end

--- a/Casks/transmit-disk.rb
+++ b/Casks/transmit-disk.rb
@@ -9,8 +9,8 @@ cask 'transmit-disk' do
   pkg "Transmit Disk #{version}.pkg"
 
   postflight do
-    set_ownership ['/tmp/Transmit']
-    FileUtils.move('/tmp/Transmit/Transmit Disk.app', "#{appdir}/Transmit Disk.app")
+    set_ownership '/tmp/Transmit'
+    FileUtils.mv '/tmp/Transmit/Transmit Disk.app', appdir
   end
 
   uninstall quit:    [


### PR DESCRIPTION
Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

## Notes 

Transmit Disk is a helper app for Transmit which is separate due to Mac App Store sandboxing restrictions. The helper app is necessary to mount a remote server as a disk in the Finder. I believe it uses [FUSE](https://osxfuse.github.io) to do this as it installs a 2nd bundle to `/Library/Filesystems/transmitdisk.fs`.

The `com.panic.TransmitDisk.pkg` package installs `Transmit Disk.app` into `/tmp/` which doesn't seem like a good permanent home.

I tried setting `customLocation` in choices, which worked to put the .app in `/Applications`, but the installer validation failed. So, instead this uses a `postflight` move the .app into `/Applications`, paired with an `uninstall`/`trash` of the .app.