### PR TITLE
Update react-native-debugger (0.7.0)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.6.6'
-  sha256 'c50e9f15fb4610ae7fcbff0cabb221af3b767656f54e29e0b40f0956c53759de'
+  version '0.7.0'
+  sha256 'fa079f63f505ad5269b2a252766b79c29a6a07483a418f12fd72f8d9cffb7056'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '2a5f43f42089475203f240a1f3272a7a671a60d6ebc72fdc14ec4048874fee0e'
+          checkpoint: '80d5f23cadbce885d32ef01b06889ad9e1ef5febb922491562fdf8aee0ce5f9e'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.