### PR TITLE
Update numi to 3.15.1,110:1495862794

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,11 +1,11 @@
 cask 'numi' do
-  version '3.15,109:1495727941'
-  sha256 '23582ee171ab9cc3a89fbfc18fafd6ec6e1046a7476a1de3816b5928551afedd'
+  version '3.15.1,110:1495862794'
+  sha256 '7010f8000258ba0d6b079a70fe6ac22b5ce31763bbcf5160d2f466f04b841e36'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"
   appcast 'http://updates.devmate.com/com.dmitrynikolaev.numi.xml',
-          checkpoint: 'f8996449e00cca07caaac815bfa09e0af2e3bf6411f49d2ad369fa9946283b70'
+          checkpoint: '1f1fbe5b0370bda68b0972f12b15d888197acef5a0564c493fe8f224a5857635'
   name 'Numi'
   homepage 'https://numi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.