### PR TITLE
Update receitanet - java caveat

### DIFF
--- a/Casks/receitanet.rb
+++ b/Casks/receitanet.rb
@@ -20,6 +20,6 @@ cask 'receitanet' do
                     }
 
   caveats do
-    depends_on_java('7')
+    depends_on_java('7+')
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Changed java to `(7+)`, requires JVM 1.7 or higher.

http://idg.receita.fazenda.gov.br/interface/cidadao/irpf/2016/download/instrucoes-de-instalacao