### PR TITLE
Update argoumi - java caveat

### DIFF
--- a/Casks/argouml.rb
+++ b/Casks/argouml.rb
@@ -9,6 +9,6 @@ cask 'argouml' do
   app 'ArgoUML.app'
 
   caveats do
-    depends_on_java('6')
+    depends_on_java('6+')
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Changed java to `(6+)`, requires JVM 1.5 or higher.

http://argouml-stats.tigris.org/documentation/quickguide-0.34/ch02.html#d0e155