### PR TITLE
Update exodus to 1.26.1

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.25.3'
-  sha256 'e67802ed151844f1ff61a75dcf618a180cb97e58a07c4693ad5a216a02f4a646'
+  version '1.26.1'
+  sha256 'f1f0eb409d817425ee8e15e456b87043c5aee47e4e9d341181d5d5bbe3bfae0d'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/Exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '42caee46c5b5effee559543dcab13fe553e3f308427ad44d729820e928fd1046'
+          checkpoint: '4445d270597d1823bc6a330715fa83bf394bcf472db7f413f3ad18906d38b458'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.