### PR TITLE
Update tankix to 633

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '630'
-  sha256 '8bcd1a90b8d1ee1566823a412a48875ed7bd4356d582f26ab7c758da4e16d2c8'
+  version '633'
+  sha256 'caf639baddf44d615ef18d46d63e4ac39c9d31f533585f5ee0098e6cae21355d'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.