### PR TITLE
Update ramme to 3.2.1

### DIFF
--- a/Casks/ramme.rb
+++ b/Casks/ramme.rb
@@ -1,10 +1,10 @@
 cask 'ramme' do
-  version '3.2.0'
-  sha256 '1a26355a331f5e9eb27a174f4f4e3d65cec5bf63435a1c6155486070a32a178f'
+  version '3.2.1'
+  sha256 '6e54d64515efcda9c7c28db3e17410e95eb7272848ed77b2bc7f7f7c8d41de81'
 
   url "https://github.com/terkelg/ramme/releases/download/v#{version}/Ramme-#{version}.dmg"
   appcast 'https://github.com/terkelg/ramme/releases.atom',
-          checkpoint: 'd842097f78a5f6f638cfa0e5b4eadcc0fc36955022733f0fb6fde0ac6b7e6314'
+          checkpoint: 'c698b2e8a3c248b7463efa4fe9fa4dee7404c23b3ac697d17c3ed66ebf640b5d'
   name 'Ramme'
   homepage 'https://github.com/terkelg/ramme/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.