### PR TITLE
Update fork to 1.0.47.1

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.47'
-  sha256 'f874389adfb54302c87bd59817f0791ccd85c815c6af0f415c976c4ff32b502a'
+  version '1.0.47.1'
+  sha256 '8d3d7dd9bd20d00c3e777993a9ed501eb6016acadfba8943fef47e4cc169b7de'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '975d193698a70575f9479efa108b78464b28df67c4c7e04184428ce1b2bbb982'
+          checkpoint: '2fed1e0f792b7cc858ea0c5a7e199b7eb44f49b6bf611e2d01378f0823021f75'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.