### PR TITLE
Update airflow to 2.0.0-beta1

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,6 +1,6 @@
 cask 'airflow' do
-  version '1.0.0-beta7'
-  sha256 '2231ab369188a8de83ddf7cda95b89e5198f0d43655b58d0e9f1aa9a0c6169bd'
+  version '2.0.0-beta1'
+  sha256 'e3e603d4f7bab4b21b1e32dbb900f09d2089d52bf4bc26f0522e666941727a3f'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.