### PR TITLE
Update picat checksums

### DIFF
--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,10 +1,10 @@
 cask 'picat' do
   version '2.1'
-  sha256 '683d869c45eae37ef9d2827744b413700ad5b2a423d1bb089d8b80845855c339'
+  sha256 '2a51c892388ffc48a7a55b336dfcf7c7dbb0c347bbcaf4038d2f1ea10f9b0097'
 
   url "http://picat-lang.org/download/picat#{version.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt',
-          checkpoint: 'a07a65a27557fe066abfe5a989415401600630d3dca16914aa0e9c49f9beec2a'
+          checkpoint: 'c2e35787d2c61d8e73ef38369fa0c139e153a24169d43bb8f43a33ba58ae0a39'
   name 'Picat'
   homepage 'http://www.picat-lang.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: [appcast notes updated version (Version 2.1#3 (May 26, 2017))](http://picat-lang.org/updates.txt)
