### PR TITLE
Update Mullvad to v63

### DIFF
--- a/Casks/mullvad.rb
+++ b/Casks/mullvad.rb
@@ -1,6 +1,6 @@
 cask 'mullvad' do
-  version '62'
-  sha256 '980a638842f43a8466c7a856152b65efb7a9aa88721c218194a4ac6653ff3448'
+  version '63'
+  sha256 '6ba5fcf3d29462273b15de586a5f269a0f28e578adf4231b12ac13ac02f4c41b'
 
   url "https://www.mullvad.net/media/client/Mullvad-#{version}.dmg"
   name 'Mullvad'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.