### PR TITLE
Update keeweb to 1.5.3

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,11 +1,11 @@
 cask 'keeweb' do
-  version '1.5.2'
-  sha256 'b61a6fc649203c4c1b815cf2722a357005b7cafeda650788443dfe6090cc585d'
+  version '1.5.3'
+  sha256 'd22774eaf24b7058fbe85b6af5b9c932931c7a33a25509d03b32677e669aba23'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"
   appcast 'https://github.com/keeweb/keeweb/releases.atom',
-          checkpoint: 'e63815d4197f194eef78478a4b15091e424489ffca4767ed9f242319f1f5dc1e'
+          checkpoint: 'bb6b711f74257a4e478788dc87b1964addf6a2985d29dcd372b144eecf750b8f'
   name 'KeeWeb'
   homepage 'https://keeweb.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.