### PR TITLE
Update psi to 0.15

### DIFF
--- a/Casks/psi.rb
+++ b/Casks/psi.rb
@@ -5,7 +5,7 @@ cask 'psi' do
   # sourceforge.net/psi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psi/Psi-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/psi/rss',
-          checkpoint: 'bbf17a9c5d9c3112b96276bc0d7756b9ef4e24a2e2621fdf2f23a06c36494a28'
+          checkpoint: '3fa22a0a94dc9ee85a98016bc7e06da56ed2b08d43e75cd7fc01487fd2ccfbf3'
   name 'Psi'
   homepage 'http://psi-im.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.