### PR TITLE
Update copyq to 3.0.2

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -1,11 +1,11 @@
 cask 'copyq' do
-  version '3.0.1'
-  sha256 '82bbba7a0a9166a6b56b53e7fcf3f9ce3f4353acc8a8ab4bb046c1284e08d74c'
+  version '3.0.2'
+  sha256 'e7769a6eb9f5c078810f2874a2fa6033ad0108baa5c43a2d81ce0eec62e9dfa7'
 
   # github.com/hluk/CopyQ was verified as official when first introduced to the cask
   url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ.dmg"
   appcast 'https://github.com/hluk/CopyQ/releases.atom',
-          checkpoint: 'a7c386b6d52ec0103a28614a057d03b09297cbcf2ee4363de6d0912c15a548fd'
+          checkpoint: 'cdc9f601cb27de56005da03e55e4b6df2c582be6e766b303fd7f0c47904ec698'
   name 'CopyQ'
   homepage 'https://hluk.github.io/CopyQ/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.