### PR TITLE
Update aptible to 0.11.0

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,6 +1,6 @@
 cask 'aptible' do
-  version '0.10.0+20170516175454,141'
-  sha256 'd349560c9d42c64e0e5630f6f532a2d34b77d31db7bac78d8a9aed9cfa79d081'
+  version '0.11.0+20170530075306,143'
+  sha256 '41b1fdd464c049105e0fadfc18b6041aa88ba17ab903c84280e584c74e9ecea1'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.before_comma.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.