### PR TITLE
Update freefilesync to 9.1

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '9.0'
-  sha256 '10335b2cbcd17cd4cd4cfbe9c00896ee362a3ca7a542715dfadb9b01defb6189'
+  version '9.1'
+  sha256 '6ece52d396563f468f9213a6314169ff2cf6cec6ccb95b9f13fe898778e25d74'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.