### PR TITLE
Update owasp-zap to 2.6.0

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -5,7 +5,7 @@ cask 'owasp-zap' do
   # github.com/zaproxy/zaproxy was verified as official when first introduced to the cask
   url "https://github.com/zaproxy/zaproxy/releases/download/#{version}/ZAP_#{version.dots_to_underscores}_macos.dmg"
   appcast 'https://github.com/zaproxy/zaproxy/releases.atom',
-          checkpoint: 'ea8d9d2157f2b03f69b7a17a86e2bcd078af3981167bba5eaa95fdfe8c7ca769'
+          checkpoint: 'bf151984173f9ecb8a77e02058401895da7332ede605f486bb4957dab0774882'
   name 'OWASP Zed Attack Proxy'
   name 'ZAP'
   homepage 'https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.