### PR TITLE
Update buttercup to 0.17.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.16.0'
-  sha256 '3d98eecc9792131146221896989e8b77264a216b37a29162b42160e1aa31f1a1'
+  version '0.17.0'
+  sha256 'afbbe3eb80d4e8872f808b91eb9785ec8b685a1bdc17419f537db053683f5a9b'
 
   # github.com/buttercup/buttercup was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup/releases/download/v#{version}/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup/releases.atom',
-          checkpoint: 'e933253ed823eae796a453fd953c38f34160e3af1f8e7071ca06bb2b2fad083c'
+          checkpoint: 'f826642604cef94caf9be98fc0c491c890b1f5227195a9c4dfbc8d5942d16012'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.