### PR TITLE
Update downie to 2.8.9,1479

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.8.8,1476'
-  sha256 'b4d3fa995177ec7c3ce5eadb1b8647ae74898a718d7f6ee094d38716ae4113dd'
+  version '2.8.9,1479'
+  sha256 '0666d2791634dcb90e1b8b07eb76f5af6e79da59e0fe32be6e8bd55f101710e1'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '6cce2e1207e8977d9b3a7c3469672c50909e503c66b609c7681e7d8863cf2d2f'
+          checkpoint: '74281b09b6cf49099fe90b70bad3536cb7042723e082b0178e55ef0a667e76cd'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.