### PR TITLE
Update kaku to 1.9.0

### DIFF
--- a/Casks/kaku.rb
+++ b/Casks/kaku.rb
@@ -1,11 +1,11 @@
 cask 'kaku' do
-  version '1.8.5'
-  sha256 '7610ba4a10126127b919bb917fb5d1854286a9ae76e22df8660284857cdf781f'
+  version '1.9.0'
+  sha256 '3c5edd62a85a244140e73d728879dec93c0073b104fe59726579ebbb97e82546'
 
   # github.com/EragonJ/Kaku was verified as official when first introduced to the cask
   url "https://github.com/EragonJ/Kaku/releases/download/#{version}/Kaku-#{version}.dmg"
   appcast 'https://github.com/EragonJ/Kaku/releases.atom',
-          checkpoint: '9d430dc3a9e05ecd244fed81aeb766e68d710fb97d59bdaf2070f7b7e12a769c'
+          checkpoint: '1618f1ba499e2ac9d16b866a68d58f97dc7cc94b8bcfec3a31dd63879634f289'
   name 'Kaku'
   homepage 'http://kaku.rocks/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.