### PR TITLE
Update kite to 0.20170526.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170524.1'
-  sha256 '1a4159df5f31106e0accde132bddb9ec05c6312137b765313700f388b1fd5bb2'
+  version '0.20170526.0'
+  sha256 'cbb98923c46bd2c2b16cc03d6df2051ab6b6e8dda777f6884197d6257c0e8ee7'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '537a25a1e6854b347154555befc7eb3a06982f15bd7e0a8895fef1a4a79f2167'
+          checkpoint: 'c2f06763e6c89c4d273930cc9aa8a530617539c861edfb70e6d0f71fad4c100c'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.