### PR TITLE
Update ndm to 1.2.0

### DIFF
--- a/Casks/ndm.rb
+++ b/Casks/ndm.rb
@@ -1,11 +1,11 @@
 cask 'ndm' do
-  version '1.1.1'
-  sha256 '561d370450f39713e29e42c3971e02c44f071de21402ff8533706afdda38302b'
+  version '1.2.0'
+  sha256 '7feea9270a35f5c3675abec49c6c38e83796f2a9c81040a190932d069e68a921'
 
   # github.com/720kb/ndm was verified as official when first introduced to the cask
   url "https://github.com/720kb/ndm/releases/download/v#{version}/ndm-#{version}.dmg"
   appcast 'https://github.com/720kb/ndm/releases.atom',
-          checkpoint: '8c1048c46c654a57cac40d4d076070577f15f3a263690909c07dafe236858c78'
+          checkpoint: 'deffc1ffb8ea98e4a32a511c4721cc971e874a1310211bdfbec784f544f9403f'
   name 'ndm'
   homepage 'https://720kb.github.io/ndm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.