### PR TITLE
Update mist to 0.8.10

### DIFF
--- a/Casks/mist.rb
+++ b/Casks/mist.rb
@@ -4,7 +4,7 @@ cask 'mist' do
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: 'f746379a4327fc4c202784bb6ce39e90b8e16bf955ad436d1b6b583051d5fc91'
+          checkpoint: '41be9ca825d4ef2c63f83035f42b9e4da799a91fa58226b26ba1ef3bd2822ec0'
   name 'Mist'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.