### PR TITLE
Update mimolive to 2.9-23073

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,10 +1,10 @@
 cask 'mimolive' do
-  version '2.8.2-23030'
-  sha256 '4d01e27e13f08ba8e2b66f7e6cb40ce18f5dece9eb74f8aecb3a3c9fe4dc7d08'
+  version '2.9-23073'
+  sha256 '182b017d87f164378a20560fd929869e98434ae369a9cddab42400afbf3011e0'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect//histories/mimolive',
-          checkpoint: 'd4931f0307d990a4a33a0f8620ef1b81b9aafb0cf80ecadfb939581eafb3a35c'
+          checkpoint: '3370379dc4e03822a6cb9cb8767abb191e127a737941e3f0748d437a9658970d'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.