### PR TITLE
Update minikube to 0.19.1

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,11 +1,11 @@
 cask 'minikube' do
-  version '0.19.0'
-  sha256 'efe27dd4f791403b90eefab8c1f6ea3c7f3115a7609f41e3189517f088e20f0e'
+  version '0.19.1'
+  sha256 '1689ff1686c07da8b72a4dd2d472ec4d6cf3347eb33804024bb368f455fb4214'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: 'e0fa248f6eea519d2bfb2b6eaedf5f809ea4fc669f721eb1c8574db10027a8cc'
+          checkpoint: 'acf23bcf8c82a0010c2bd9821ac9d3a9a10e03bd3158da0f3a69127286093f46'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.