### PR TITLE
Update wwdc to 5.0.4

### DIFF
--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -1,11 +1,11 @@
 cask 'wwdc' do
-  version '5.0.3'
-  sha256 '75121262fe2a50cc6e4046160f85b7f508d9c5486d6d125cfe780db868d55fe7'
+  version '5.0.4'
+  sha256 '7d724e63fdc84c7eed67ea618ee1cf513aa0154581672353012457fc34c4d50d'
 
   # github.com/insidegui/WWDC was verified as official when first introduced to the cask
   url "https://github.com/insidegui/WWDC/releases/download/#{version}/WWDC_v#{version}.zip"
   appcast 'https://github.com/insidegui/WWDC/releases.atom',
-          checkpoint: '50d8b2567a563c1e9c5e2e19730731f19445f61777988ff626aa7b91a01709e0'
+          checkpoint: '10ae8c5b6bc7fc1bd09cac9ddc70528fad3fac49cc24288a96c6952d3733ddc8'
   name 'WWDC'
   homepage 'https://wwdc.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.