### PR TITLE
Update capture-one to add major version to app name

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -6,5 +6,5 @@ cask 'capture-one' do
   name 'Capture One'
   homepage 'https://www.phaseone.com/en/Products/Software/Capture-One-Pro/Whats-new.aspx'
 
-  app 'Capture One.app'
+  app "Capture One #{version.major}.app"
 end


### PR DESCRIPTION
When installing this the installer choked because it couldn't find the app file, I presume because this was removed so looks like the major version needs to be re-added to the app name.