### PR TITLE
Update tankix to 636

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '635'
-  sha256 '901981079260f2c6755e5ca8ff60e14bb71e8aec2a5a3406dbbe1ee4e24062d5'
+  version '636'
+  sha256 'b69144882d5ad0230f610ce375cdccf565d46298acea655c6487421a504a6811'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.