### PR TITLE
Update tad to 0.8.4

### DIFF
--- a/Casks/tad.rb
+++ b/Casks/tad.rb
@@ -1,11 +1,11 @@
 cask 'tad' do
-  version '0.8.3'
-  sha256 '1ab122288b3a28247c14b7757a0c498fa318d47b6e6bf3c33051ebe8a5ea795b'
+  version '0.8.4'
+  sha256 'b33e31d9f3ca4c45ecf382cfdc28cb37d1f0d5d38ed0afc2f99226b0eca23bf2'
 
   # github.com/antonycourtney/tad was verified as official when first introduced to the cask
   url "https://github.com/antonycourtney/tad/releases/download/v#{version}/tad-#{version}.dmg"
   appcast 'https://github.com/antonycourtney/tad/releases.atom',
-          checkpoint: 'e9fa5bde4aef870bed82205196e5ee0990b155873c11597c3d5e84f54ece71ac'
+          checkpoint: 'f4225bce372de45c0369167b06084ef971a3344597b9a67ab7d74c6a7604b1b2'
   name 'Tad'
   homepage 'http://tadviewer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.