### PR TITLE
Update opera to 45.0.2552.888

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '45.0.2552.881'
-  sha256 'f9afb6145299283fd9dfbb9b8c04d6327e00a213a41f34cec621ebd1e7565406'
+  version '45.0.2552.888'
+  sha256 'd0248a14f784324a2a7d04992232953dc22256ecdb9cf5f91ab4fff65745b11e'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.