### PR TITLE
Update qownnotes to 17.06.0,b3031-165427

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.05.8,b2964-114007'
-  sha256 '317f61d41786aab36cb04982173d32863aaf276a73148d8fe1fa70630d27275e'
+  version '17.06.0,b3031-165427'
+  sha256 '6270a190b3cef6d237fc6d6663b60f34a1bc1b7db42ea820608489d91d8e32a7'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: 'd972189954857d9668198aa9da874db2e2b7c6b74d461479e932c30e2610f56f'
+          checkpoint: '331417beb4880fc7478f1cc6ac49768909874cc03749a50e3e8c47cd3813aea6'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.