### PR TITLE
Update pyfa to 1.29.3,yc119.5-1.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.29.2,yc119.5-1.0'
-  sha256 'c14dab644980de80ddb93c4b1e3d7c5426680022e854cd24ce0c036b0c088193'
+  version '1.29.3,yc119.5-1.0'
+  sha256 '1c9de1119d9e7cfc1b004e5196747c1d59c767a88f8e1d3fd9e6ecaa388cc1a9'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '553ae62cc168d9dff299c2fce097a3114dcc8fdbd26c4c27eb67b399fc672d33'
+          checkpoint: '2940e61ab40bee484b4a1f0d27286492140b35bd65ce2c58e662cd3748e875bc'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.