### PR TITLE
Update nanobox to 2.1.2

### DIFF
--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -1,11 +1,11 @@
 cask 'nanobox' do
-  version '2.1.1'
-  sha256 '2c5e001b55c0741a359fa8f7a93b78608e3c8584adead4a0c09a59a563f05d1c'
+  version '2.1.2'
+  sha256 '03051ff7a197f8641172f8fb8c12e3d34fb5a6d12405e88e2ff0a707b1f8a811'
 
   # s3.amazonaws.com/tools.nanobox.io was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tools.nanobox.io/installers/v#{version.major}/mac/Nanobox.pkg"
   appcast 'https://github.com/nanobox-io/nanobox/releases.atom',
-          checkpoint: '5a76290986958e939845f9d1f9946ee63593709f3733c319eb030c64ab7e8e26'
+          checkpoint: 'ea5b2c616c63b0bf023ffdb11ec901e2b047a1f2c993e8c5d4c1a6843651f20d'
   name 'nanobox'
   homepage 'https://www.nanobox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.