### PR TITLE
Update qtox to 1.10.2

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.10.1'
-  sha256 '611b4ce4792e5b99dac4095cc8ec9dde7641f3985acaf74151721c2e6523616b'
+  version '1.10.2'
+  sha256 'dd82521fc2e8f5f7a521c88e22be22f94965c79ea863dca7c55ccdff8d9a6ba6'
 
   # github.com/tux3/qTox was verified as official when first introduced to the cask
   url "https://github.com/tux3/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/tux3/qtox/releases.atom',
-          checkpoint: '3d680b77edfd26458214ee7774bbb733bad55f6ef9ab5c10e1e2289b2e897d58'
+          checkpoint: '96844650df8a0add7996e9a0538cb3de3279943321631910df4b44fdc65f5ff8'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.