### PR TITLE
Update brave to 0.15.314

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.15.310'
-  sha256 '295c7a1a7226f04bc05151c21aefdae15bbf34f7d18578890c0aaa9c4dd91bda'
+  version '0.15.314'
+  sha256 'abb8ceaa780a4dd67a9ff74c5a0603e4a2c4d36809221ddfa66d53fa86ea6e4c'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'f84eca4d6a8277535a558bdf8167d483ecf5ef1a247fd49ccee78a315856dcba'
+          checkpoint: 'c5f0f86daade006949c4a78fb9b3430aa4336d87722192daf979e99dedd52f26'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.