### PR TITLE
Update qownnotes to 17.06.1,b3034-151538

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.06.0,b3031-165427'
-  sha256 '6270a190b3cef6d237fc6d6663b60f34a1bc1b7db42ea820608489d91d8e32a7'
+  version '17.06.1,b3034-151538'
+  sha256 '0355e9986be0b31a480255a9bc762b9c5a4113af551f3f8caa5a79cbf8d6decb'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '331417beb4880fc7478f1cc6ac49768909874cc03749a50e3e8c47cd3813aea6'
+          checkpoint: '322b61637084f1c1185bcdb28b10f80f6d62ef9cb5e9c40d640759122d6cfdc5'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.