### PR TITLE
Update hstracker to 1.0.2

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.0.1'
-  sha256 'b4b00999888159541b38971315277e2b09079300dd51804274fbd30e35693ffd'
+  version '1.0.2'
+  sha256 '96754067f819a580407096d54557ddbab1a82542a4c20f601d6b2c95cb9e108b'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: '5cea139c7ba0cf899ee177e4516d340af733cd321b20709689e342279c360b66'
+          checkpoint: '7a26f0bb02dc4c51cc9090d2979c1d539b1af9d3ddc7a861c57f4ee54dcb12c4'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.