### PR TITLE
Update natron to 2.2.8

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.2.7'
-  sha256 '5347361fe84701be6afbd569681af0152af5e7899815458cae9211d399af1d4b'
+  version '2.2.8'
+  sha256 '2db9bd55951edb2142b3f8be6d4ec778c80f3bd242b79c29af901105db65b1bf'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: 'c7218d11a2702e4c6d8089bcfced683cff365a8594655d1cfc7dfa4f0df55074'
+          checkpoint: '75b1133136e5a790bc8cf6519cc7933d95d2a061801eeb291805f510376a4e29'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.