### PR TITLE
Update cctalk to 0.8.1-231,2017-06-02.16.13

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,11 +1,11 @@
 cask 'cctalk' do
-  version '0.8.1-223,2017-05-17.21.49'
-  sha256 'cb57ea0dd82ced44c006eceaee8979784c532650248a91ff3cd14ba2730eb579'
+  version '0.8.1-231,2017-06-02.16.13'
+  sha256 'c7b6b77b49a86d342797907980777b6301f3f1157dc80ec9adcaaf1171e81a1e'
 
   # f1.ct.hjfile.cn was verified as official when first introduced to the cask
   url "http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/archive/#{version.before_comma.hyphens_to_dots}/CCtalk-#{version.before_comma}-hujiang-#{version.after_comma}.dmg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml',
-          checkpoint: '5af68358c49fcb4be9db0f185dc174d8c09beac13ca710d8141cafaf6162de70'
+          checkpoint: 'c08047aa69dc3ba5b8bc9c24ebf3bbc473e91090435a6107898543a4afa543ca'
   name 'CCTalk'
   homepage 'https://www.cctalk.com/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.