### PR TITLE
Update glyphs to 2.4.2-1029

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.4.2-1026'
-  sha256 '3a01bd9c852f176b2a35be6642d5515395b670a2dc6311da5abb1b31f813a1a8'
+  version '2.4.2-1029'
+  sha256 'dce89ce890ff3a0dd8fe3eb3322e4d979db44a4f8689658f8e9b6e0a7ea0b893'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: '27a593d068a6bb6e5ee0e737b0a0bf97b34bd1948c9359f580857315be65f1c7'
+          checkpoint: 'ff5df21d32fab1fb5171cca67d4c3ba0a2b18cd5d3c63806cb49047089f25cbf'
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.