### PR TITLE
Update navicat-for-postgresql to 12.0.2

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '11.2.18'
-  sha256 'c6098bf586280e7d9115a26f6dc1b665845855b5bf7d42d900fd063d21e4e24e'
+  version '12.0.2'
+  sha256 '7ea2b4ebdc589b7bd88aed2eda202a0e7bfb72bd03ca90e5995bad1c56acc658'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
-          checkpoint: 'b32845d48dcb1be5d2783cfdd1b39ec6ccfdd79dbb8522cfd0510ad7dc8effe7'
+          checkpoint: '687ad5be37d8913e37adbfcb4d2fefbc1d3d1a5dca349ba08311545398c696de'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.