### PR TITLE
Update navicat-for-mariadb to 12.0.2

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '11.2.18'
-  sha256 '46f76645544a625a8fd6aeb46ff9677aa23e635a21996a459f5581ed9e1861ec'
+  version '12.0.2'
+  sha256 'bae188ec3bbe8171800cd9b873198aea5c0498e64697f71bdb1bdb63295254d2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mariadb-release-note',
-          checkpoint: '08104c4aa3b8513eb9f6eabaa6889bd4815e64b03a3a92c0efb568eb83aa5457'
+          checkpoint: 'f1b71ca2b54f36aaf347234e551bd2b1c2c54ceb782ad3cc240cbd5ea1247c1d'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.