### PR TITLE
Update navicat-for-mysql to 12.0.2

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '11.2.18'
-  sha256 'bd2e1f93e2e2512f8298498b1f40b632a206f8b8d0fa4fd9566787ba634cea4d'
+  version '12.0.2'
+  sha256 '82b407f81df5cbd468f76fca65384c5827ee505a0dc3fb1058ca58f95f10122e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note',
-          checkpoint: '3b1d2837be33fd080b74cf7a37d6a2213eb5915979af2abc0660c6f858834c45'
+          checkpoint: '34e696692858e4c0ad6a52a60590c2b509ab93d3084c369ad354c537e0b4934d'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.