### PR TITLE
Update navicat-for-sqlite to 12.0.2

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '11.2.18'
-  sha256 '6c184e3aac0bba7d143278ff8163eed38dc4a9c58100096e437a4001d2f053e1'
+  version '12.0.2'
+  sha256 'bd887056fe1dc4ed3c0fbd6d72032df8697dbb1ba8cd31c13bbaa154622347b6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note',
-          checkpoint: '6c0ec4a5a8156be12a5111c94bf8f2ebceda8b1ad9064e95c42646078afd36a6'
+          checkpoint: 'fe421cb6f83a201df044dc1349fe8bae0de41469302342a16af326463f10ba37'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.