### PR TITLE
Update shotcut to 17.06.01

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '17.05.03'
-  sha256 'afee561c5a1165b66bfaeb4f01794f4f134b68c5b878c8c0247a4f9ecc48d46e'
+  version '17.06.01'
+  sha256 'fb5cace2417203553154d6a711e4c15ec91ccfce25ea0081c30099832e07c341'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: 'e7d908f37dae5fb618909fdc7ec648acbcce54a9a5af91f8bc4e2ef9580f1b15'
+          checkpoint: '44e1bb07086f28d93ed45d2729ef756eb3c5575bcf09dc4d7ccfcb712119e579'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.