### PR TITLE
Update bluemix-cli to 0.5.4

### DIFF
--- a/Casks/bluemix-cli.rb
+++ b/Casks/bluemix-cli.rb
@@ -1,11 +1,11 @@
 cask 'bluemix-cli' do
-  version '0.5.1'
-  sha256 '013fca457b4577d715c8b7c4bffe8aa7fa94a3cf1bf32947091ec6a483837cfe'
+  version '0.5.4'
+  sha256 '9d9df4be6faaef93395de4737f45a153c689c2b3425bd157b4dd18dac1b24549'
 
   # public.dhe.ibm.com was verified as official when first introduced to the cask
   url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_#{version}.pkg"
   appcast 'https://clis.ng.bluemix.net/ui/all_versions.html',
-          checkpoint: '83ca45ba084621c0e8a37f7f0b39adf4887cd26cbb4d9b6c5c713a6531704a23'
+          checkpoint: 'cd618fc6668b264a6e5ab31305b9868b5df9298baba8870b1bf0dd47b0b5e8b6'
   name 'Bluemix-CLI'
   homepage 'https://clis.ng.bluemix.net/ui/home.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.