### PR TITLE
Update poi to 7.8.0

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,11 +1,11 @@
 cask 'poi' do
-  version '7.7.0'
-  sha256 'e0ba73f8dc86af22b5311d349f65b26348321d7eb2c64036f31f6a4b2e9c9d1d'
+  version '7.8.0'
+  sha256 '840fc068b106b07de19098f06c98b6590dc6626e43587d3a65bf5c519a5dc3ba'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
-  url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}-macos-x64.dmg"
+  url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}.dmg"
   appcast 'https://github.com/poooi/poi/releases.atom',
-          checkpoint: '5f5d84d8bbb2a815e2c7a171105e1ea8ae29da16b6cc079c8802d5848bb89023'
+          checkpoint: '6e500d26ec04e58eb2cab4ef67b706ea027024f20543020ef19133e1a963d65f'
   name 'poi'
   homepage 'https://poi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.