### PR TITLE
Update sqlectron to 1.21.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.20.2'
-  sha256 '90303d151090c22d45d33277adbebbda801fa0fd50bee3f0a1b2040a1a40e978'
+  version '1.21.0'
+  sha256 'e8e7f7c9e3dd75c55ace6326dbab9e9c885394bccffd4252ac621d74fc1ba9e2'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: '0cf8fbbc1100a25d3b8077310322b75e0da67a917277c7cb94ad8657856897ca'
+          checkpoint: 'b84e0ceb5f55bd4548f039e9af3fbdb4458b1e94597b718ab1bb8d7a68fe6a2d'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.