### PR TITLE
Update processing to 3.3.4

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,10 +1,10 @@
 cask 'processing' do
-  version '3.3.3'
-  sha256 '4ae4d7bc7f8a0db711d6908e4f9d80b97132d08ceac6b7cd6ab43e2d8546a840'
+  version '3.3.4'
+  sha256 '65aaa629b04b37976b456e8834de1c5c7f19fb92cb94b6496b0a8222f627e6b2'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: 'fe4db0a7b4e5551f953f4731733bce3563bcc4f5e047a7effbee4db81821c0f9'
+          checkpoint: '60699238aa599f5c023d6f8d485a2f72f6c85e468b95183d069eb79a9361a7c9'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.