### PR TITLE
Update devonthink to 2.9.12

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.11'
-  sha256 '041824169a78b9f8b53b533456f40bd9dacc5845822d9e32ed9f6a1b756b6575'
+  version '2.9.12'
+  sha256 '3aa6866089f91b1d9d14598954443218d731f443627a2ac102649b51acbdf168'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: 'eaefb172efe90c48f1726e416ef0b42400fb07a82f5f614d44e1ec07430ab27c'
+          checkpoint: '17e7dd27abdb4be17e08dced0087fe90161d48fd64edba69e618f611cb6555eb'
   name 'DEVONthink Personal'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.