### PR TITLE
Update devonthink-pro-office to 2.9.12

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro-office' do
-  version '2.9.11'
-  sha256 '96094e173e43c28c3a8a23289d1264c9ab2bbcc0900e81e8c96c446463dda328'
+  version '2.9.12'
+  sha256 'a576f0762e462e93c903dcf04d3659341959e7419805c662187dd7787a893166'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: '02865f09d74ea8f21513141b36d0cdf2badec5fabd5dd6aa12d21486ae0164fc'
+          checkpoint: '6e3718e4b66cd4c0522364176ae600aa4a5046eb2bc8d776b318cb86fb5c7561'
   name 'DEVONthink Pro Office'
   homepage 'http://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.