### PR TITLE
Update gifcapture to 1.0.4

### DIFF
--- a/Casks/gifcapture.rb
+++ b/Casks/gifcapture.rb
@@ -1,10 +1,10 @@
 cask 'gifcapture' do
-  version '1.0.3'
-  sha256 '7bd3fe54c39986828688220680b8b31c848d22a4a0722e52f67b920de5e4c41f'
+  version '1.0.4'
+  sha256 'cb72748fdb58204d72e7531d3fbcb91293d6052d437b51323d1706b554079e69'
 
   url "https://github.com/onmyway133/GifCapture/releases/download/#{version}/GifCapture.zip"
   appcast 'https://github.com/onmyway133/GifCapture/releases.atom',
-          checkpoint: 'c6f1765d3174c178e8b1fa57b6f6c1d8e9879b58d2c567837d4d37051c471038'
+          checkpoint: '709e318e5cc58b657e6aa0fbf94e6c4b6eceeb1caea0a290a2a3b9ca6b320921'
   name 'GifCapture'
   homepage 'https://github.com/onmyway133/GifCapture'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.