### PR TITLE
Update keeweb to 1.5.4

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,11 +1,11 @@
 cask 'keeweb' do
-  version '1.5.3'
-  sha256 'd22774eaf24b7058fbe85b6af5b9c932931c7a33a25509d03b32677e669aba23'
+  version '1.5.4'
+  sha256 '4ec4e2d9bd7bd9a562f0f419d67d3a0e926eab6b82fce3334cfa3f9e96843e89'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"
   appcast 'https://github.com/keeweb/keeweb/releases.atom',
-          checkpoint: 'bb6b711f74257a4e478788dc87b1964addf6a2985d29dcd372b144eecf750b8f'
+          checkpoint: '4ad0e816ad5a75a9e8f45519abba391be51c0d16b48608109f2d33d0745c9eb7'
   name 'KeeWeb'
   homepage 'https://keeweb.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.