### PR TITLE
Update openshot-video-editor to 2.3.4

### DIFF
--- a/Casks/openshot-video-editor.rb
+++ b/Casks/openshot-video-editor.rb
@@ -1,11 +1,11 @@
 cask 'openshot-video-editor' do
-  version '2.3.3'
-  sha256 '7ec5b208696abc7227f3b06798ad0e737f315b928e67d5dcf234e5a16e356704'
+  version '2.3.4'
+  sha256 '637d2c4e0a72f2a4ae4e81c255e79e5eda6433ed7b6ac1346760c8fbed149e7e'
 
   # github.com/OpenShot/openshot-qt was verified as official when first introduced to the cask
   url "https://github.com/OpenShot/openshot-qt/releases/download/v#{version}/OpenShot-v#{version}-x86_64.dmg"
   appcast 'https://github.com/OpenShot/openshot-qt/releases.atom',
-          checkpoint: '194faffc09a3fec4c00394c36510459cb675d8582251bee132c38c4e7d12f0cc'
+          checkpoint: '542e05435129515489447249319896c57fb7c779d509577e21407a80699ccb69'
   name 'OpenShot Video Editor'
   homepage 'https://openshot.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.