### PR TITLE
Update qownnotes to 17.06.2,b3039-094931

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.06.1,b3034-151538'
-  sha256 '0355e9986be0b31a480255a9bc762b9c5a4113af551f3f8caa5a79cbf8d6decb'
+  version '17.06.2,b3039-094931'
+  sha256 '75fba5fb7254483bc5dd112e665fff0ae9196b70e3240ce18d1ab3e4295a652e'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '322b61637084f1c1185bcdb28b10f80f6d62ef9cb5e9c40d640759122d6cfdc5'
+          checkpoint: '2a5723eb27ec292017442db4b7b65f9ae09a473035c8d629e8330aaf83e0660a'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.