### PR TITLE
Update Nozbe (3.5.0)

### DIFF
--- a/Casks/nozbe.rb
+++ b/Casks/nozbe.rb
@@ -1,6 +1,6 @@
 cask 'nozbe' do
-  version '3.4.2'
-  sha256 'c0bc0c848c686510bab619c8330725ef1105cdf1e264b513720633aa447a50e8'
+  version '3.5.0'
+  sha256 'b1ac7699dc9a8c2b89c84bcd5cbe0a1646859e9f56c8c4e0c103a91ae0c293b5'
 
   url "https://files.nozbe.com/#{version.no_dots}/Nozbe.app.zip"
   name 'Nozbe'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.