### PR TITLE
fix/update carbon-copy-cloner cask to 4.1.15.4549

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,10 +1,8 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.15.4548'
-  sha256 'e11584ea9b61b2c4d2fb8839158f7c087b3c78a7b49bc4d5814a85c192e6aa33'
+  version '4.1.15.4549'
+  sha256 'f38819717b85fffea19536b6029d77f2dedf566b86bb8fabaf977b5dbc567459'
 
-  url "https://bombich.com/software/download_ccc_update.php?v=#{version}"
-  appcast 'https://bombich.com/software/updates/ccc.php',
-          checkpoint: 'eec027f0d0aa576e292b4fe57441f1821409c6295330787dd82533b0d483cb26'
+  url "https://bombich.com/software/download_ccc.php?v=#{version}"
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
 


### PR DESCRIPTION
Changes:
- remove appcast/checkpoint since its out of date (last updated 2012 with major version 3, now on major version 4)
- update program from 4.1.15.4548 to 4.1.15.4549 including sha256
- change download url from download_ccc_update.php to the newer download_ccc.php

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
