### PR TITLE
Update basictex to 20170523

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -1,6 +1,6 @@
 cask 'basictex' do
-  version '2016.1009'
-  sha256 '17f27a9c05f108b889b39d8ea2ff6236c1265f244e8e0376e9d14af4acf680bd'
+  version '20170523'
+  sha256 '024fc0e2bff8d28074a25ee8adc12c2ab37202cfea7229678d92a7b5d1debba2'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.