### PR TITLE
Update black-ink to 1.6.8

### DIFF
--- a/Casks/black-ink.rb
+++ b/Casks/black-ink.rb
@@ -1,10 +1,10 @@
 cask 'black-ink' do
-  version '1.6.7'
-  sha256 '795c74fca4681fd51e0910484ba19e0c2aeea48b36d4d5236104e9117bc3bb4e'
+  version '1.6.8'
+  sha256 '7d9c2f2db5bc1967355ebc346047d6df9f99c747a46f69fa7cd6627b67221584'
 
   url "https://red-sweater.com/blackink/BlackInk#{version}.zip"
   appcast 'https://red-sweater.com/blackink/appcast1.php',
-          checkpoint: '788f8eca5bd2ee64c87dbb0f7df707c184450bc35b2449e661aaf6cd3345d816'
+          checkpoint: '69246c15127250855cf291db0613053da3583dcff4532f1bff0b8fc39b583b44'
   name 'Black Ink'
   homepage 'https://red-sweater.com/blackink/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.