### PR TITLE
Update mactex to 20170524

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,23 +1,23 @@
 cask 'mactex' do
-  version '20161009'
-  sha256 'b44873d445881900401d0e0eddccc78140b9ed51b538364889eb8529350d5bd7'
+  version '20170524'
+  sha256 '0caf76027c9e0534a0b636f2b880ace4a0463105a7ad5774ccacede761be8c2d'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   appcast 'https://www.tug.org/mactex/downloading.html',
-          checkpoint: '822244b8386bf149f1ef93c2e5c1552c3024c8bb991dfbcfcfce9f624e97c2f2'
+          checkpoint: 'dcfb71e2918169fbd0a270994e722db3447fe1727fdff10a016db92c4f9492c1'
   name 'MacTeX'
   homepage 'https://www.tug.org/mactex/'
 
   pkg "mactex-#{version}.pkg"
 
   uninstall pkgutil: [
-                       'org.tug.mactex.ghostscript9.19',
-                       'org.tug.mactex.gui2016',
-                       'org.tug.mactex.texlive2016',
+                       'org.tug.mactex.ghostscript9.21',
+                       'org.tug.mactex.gui2017',
+                       'org.tug.mactex.texlive2017',
                      ],
             delete:  [
-                       '/usr/local/texlive/2016',
+                       '/usr/local/texlive/2017',
                        '/Applications/TeX',
                        '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
                        '/etc/paths.d/TeX',
@@ -40,7 +40,7 @@ cask 'mactex' do
                 '~/Library/Preferences/fr.chachatelier.pierre.LaTeXiT.plist',
                 '~/Library/Preferences/TeXShop.plist',
                 '~/Library/Saved Application State/edu.bucknell.Excalibur.savedState',
-                '~/Library/texlive/2016',
+                '~/Library/texlive/2017',
                 '~/Library/TeXShop',
               ],
       rmdir:  [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated `uninstall` and `zap`.

Closes https://github.com/caskroom/homebrew-cask/pull/35194