### PR TITLE
Update flux to 39.981

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,6 +1,6 @@
 cask 'flux' do
-  version '39.98'
-  sha256 '4b041705c40a593dbf745b83f49254c5a4f46b7e3bedcf150194e3f0840dd525'
+  version '39.981'
+  sha256 'b614541f49399aa2c92e667aca4b601c2f17ec1be2de43e4e8d7eb3716646ce4'
 
   url "https://justgetflux.com/mac/Flux#{version}.zip"
   appcast 'https://justgetflux.com/mac/macflux.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

No `appcast` `(39.94)` or changelog `(39.96)` update but `39.981` is the version you get downloading from https://justgetflux.com/ 

The version bump is unusual `**.**1` so confirmed with virustotal for codesigning. 
> https://www.virustotal.com/en/file/b614541f49399aa2c92e667aca4b601c2f17ec1be2de43e4e8d7eb3716646ce4/analysis/1496660301/
