### PR TITLE
Update prepros to 6.0.15

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.0.13'
-  sha256 'abae52c93005edca3eb5d3f1bbd6fc9d4d7138b4b1b4f14c1685ca9d49ead429'
+  version '6.0.15'
+  sha256 '4363647a73677849977b7070736dba373e33d5bbb018d3c9883ec69fb4622335'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: '448a374bb1ed28af9cb06387b5c87e5d3a8c50eb11742daf68b74bcc473a7b54'
+          checkpoint: 'b518bf8720292d7d8c494440201dade320a6f520ccf2bc0476ffe86f5ce0f666'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.