### PR TITLE
Update sqlpro-for-mysql to 1.0.36

### DIFF
--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-mysql' do
-  version '1.0.33'
-  sha256 'd00c4cfbebd94b8847d69e1ad8e2f5d3ea23a2fd16e3c338ab989f99f4e049b7'
+  version '1.0.36'
+  sha256 '79c28cdd091a7ff1562faaec01fac8f7300df38cf1d5d3c2a097ab198effff77'
 
   # d3fwkemdw8spx3.cloudfront.net/mysql was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.