### PR TITLE
Update vuescan to 9.5.78

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.77'
-  sha256 'fa24e4544100dab9da6634a34787b0cbac680dc04b77eff230dca84705c3cf5e'
+  version '9.5.78'
+  sha256 '436fdf63e057f8f2e6feecebd45f34c11b2083cd8eff52e12c3a4664dbdb064b'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: 'd8bc6eb834aef316a39208adac3cebfcd0e2b1f45c4eb9935f2859a459787506'
+          checkpoint: 'a1d48b72f23eb8141ae2544a1b868de1a15f0071410ce7a8ff67734cd5ab31d6'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.