### PR TITLE
Update ring to 0.67

### DIFF
--- a/Casks/ring.rb
+++ b/Casks/ring.rb
@@ -1,11 +1,11 @@
 cask 'ring' do
-  version '0.55'
-  sha256 'ea0a97d692866e9dbc09f228b6b098b3e3ecc1cc0d8ed04c0d649204035b7acd'
+  version '0.67'
+  sha256 '6207ca367e0979e944d2b9caa2f56c185d2ec7231ca74a6e96b78285c577df90'
 
   # ring-mac-app-assets.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ring-mac-app-assets.s3.amazonaws.com/production/Ring_#{version}.zip"
   appcast 'https://ring-mac-app-assets.s3.amazonaws.com/production/ring-appcast.xml',
-          checkpoint: 'cc3682c38fe59e30111fee2ef9bfab02661c0f188082c29f82df04f047e5d11f'
+          checkpoint: 'e12f99e8f9c17d6afd11cd185b955cd08421c9c8d910471e12d38f51412a39e7'
   name 'Ring'
   homepage 'https://ring.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.