### PR TITLE
Update fly to 3.1.1

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.0.1'
-  sha256 '41677d20bc6fd9e6720c67536aa32a3acbf9f729361349340e6d027464fbf57f'
+  version '3.1.1'
+  sha256 'd6f4b49d4413297b3820db87e57dde8de7eb5750096cbaa5d3c3096e2cadbfec'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: '5bebac739c1c6bd929715b76dfbee23f7727fa9a57f17e5a4d3d183ff501c8b7'
+          checkpoint: 'd67cb757161067df1ff201edeb95a922899e4b2cfb77b1def2cfeeab61786bd2'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.