### PR TITLE
Update ogdesign-eagle to 1.1.5

### DIFF
--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -1,9 +1,9 @@
 cask 'ogdesign-eagle' do
-  version '1.1.3'
-  sha256 'bc79a7bef63a5c32a8f12131a346b5d692e99f2ca07a69cfd57ad6ae63170168'
+  version '1.1.5'
+  sha256 '64809a425f05483d8fe5ba291ac8622338a53d8fbe09be879c83e7071c0dea23'
 
   # eagle-1253434826.file.myqcloud.com was verified as official when first introduced to the cask
-  url "http://eagle-1253434826.file.myqcloud.com/releases/darwin/#{version}/Eagle.zip"
+  url "http://eagle-1253434826.file.myqcloud.com/releases/darwin/#{version}/Eagle-#{version}.zip"
   name 'Eagle'
   homepage 'https://eagle.cool/macOS'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.