### PR TITLE
Update virtualbox - add uninstall preflight

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -10,6 +10,12 @@ cask 'virtualbox' do
 
   pkg 'VirtualBox.pkg'
 
+  uninstall_preflight do
+    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack")
+      system_command 'brew', args: ['cask', 'uninstall', 'virtualbox-extension-pack']
+    end
+  end
+
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',
                        args:       %w[--unattended],


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Checks to see if `virtualbox-extension-pack` exists at `"#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack"` and uninstalls if it is found.

> https://github.com/caskroom/homebrew-cask/issues/29301#issuecomment-295478018 
> `virtualbox` was updated today with a minor version change which happens to be a dependent of `virtualbox-extension-pack`. Reinstall works fine, but then the extension pack is missing because everything had been deleted even though cask shows the package as installed.

I've had this happen a few times with updates or switching between `virtualbox` / `virtualbox-beta`,  also you can't uninstall `virtualbox-extension-pack` without `virtualbox`.

/cc @colindunn 