### PR TITLE
Update postage to 3.2.14

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.2.12'
-  sha256 'c507f5073655a07d4c71ceff07053f87506a0661385c6354d532701e2069dcd3'
+  version '3.2.14'
+  sha256 '4d644afc5181498cf4a0859f763fda0d0d89ad95e3a3ed21856d30580fc56c26'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: '7f69cde0a7468ba95d7c24117010d6f15fc3d243868998a8b5228ddab12b2dc7'
+          checkpoint: '136a805a46e7098a7ff6dcdae3b7d2e02464e5206693d15c450fc19531310915'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.