### PR TITLE
Update freeplane to 1.5.21

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,10 +1,10 @@
 cask 'freeplane' do
-  version '1.5.20'
-  sha256 '441fd9ec1bc825483bbd89ec27718f67961a6339b1f13ea1069ad4e1b87217cf'
+  version '1.5.21'
+  sha256 'c5962df33a6d8d7ae60dc68d17f9903f0fb90fb6dbf5dc45d52c4442a7e6377b'
 
-  url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app-#{version}.dmg"
+  url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app_jre-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable',
-          checkpoint: '15df09a5aa35c9653383bc995a5cbe94ff62a8377e2da76b30b8d01698d47759'
+          checkpoint: '2c56cb6782167d26122ebffbfb42dc58c40c665052178439f5f32e48bb0364cc'
   name 'Freeplane'
   homepage 'http://freeplane.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.