### PR TITLE
Update file-juicer to 4.59

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,6 +1,6 @@
 cask 'file-juicer' do
-  version '4.58'
-  sha256 'd5534d38a0e263b08b6376072ed739171526f2ca160a9bb64e5df60ebd282356'
+  version '4.59'
+  sha256 '8186265cc569e06f3cee363bec4836da742d9f0825d7f579c2a58ef254d21ad2'
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   name 'File Juicer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.