### PR TITLE
Update ddnet to 10.6.2

### DIFF
--- a/Casks/ddnet.rb
+++ b/Casks/ddnet.rb
@@ -1,6 +1,6 @@
 cask 'ddnet' do
-  version '10.6'
-  sha256 'b9abb465cbc81b2fbe8d384a24d73d83136a9bd8527fd48766a43fe6ef934eff'
+  version '10.6.2'
+  sha256 '18ac26b35e740639b9c609a34b9d3c8bcecf39736e1001c8c6f3c4c952b59e8e'
 
   url "https://ddnet.tw/downloads/DDNet-#{version}-osx.dmg"
   name 'DDNet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.