### PR TITLE
Update instead to 3.0.1

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,11 +1,11 @@
 cask 'instead' do
-  version '3.0.0'
-  sha256 '6208f42a252efe875a74371e59f511e602c219674e57a18881e5e40bb940a6ce'
+  version '3.0.1'
+  sha256 'ac4cf3ee747156a541b8050c9b3da0c8d57c1fe741a1c0ee5a3025897027dbbe'
 
   # sourceforge.net/instead was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/instead/instead/#{version}/Instead-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/instead/rss?path=/instead',
-          checkpoint: 'bd545932d3e4426cb0b5bc69fb762694a5c6382a340f32994ebf498940ad84b2'
+          checkpoint: 'd9aefb4fb9fd86981bef23f2974eaf85a18126c03290235ad860356f8095f472'
   name 'INSTEAD'
   homepage 'https://instead.syscall.ru/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.