### PR TITLE
Update fredm-fuse to 1.3.6

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,10 +1,10 @@
 cask 'fredm-fuse' do
-  version '1.3.5'
-  sha256 'c8ceb38cd4439151ef45e49ec82e0ad90a9553ba1422d11b7964d1bf0cb62e09'
+  version '1.3.6'
+  sha256 'd4cb5ef2446e67d075f53426c33ec3b674f91f2a2a25cf9b312675a85314feb9'
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '5c6518610d364eeef84beb2fea002d073abc80556581a1c85a0642bc08f79e83'
+          checkpoint: '2c76f89cc4facdf0d95628b02804a78e0e7d6c2f048a7ce562fc6ca94fb47159'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.