### PR TITLE
Update webcatalog to 5.2.1

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '5.2.0'
-  sha256 '05a66ed27f84054e664cbe6417e036d436bea6a2aa85b13f1bc5547ab02452c5'
+  version '5.2.1'
+  sha256 'adf48096578e5467677c9998ab4b5d1d2c3153b258b7abb14910a062fd421d91'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '0926f1ecfa79d1152af17835ebfe3dbf4d038c068fa5ae1070508ad0afd26a99'
+          checkpoint: '53e7c05bc0d381483de96614d4d2ae18c9028cc9610aee6151f7317cc402cf01'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/downloads/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.