### PR TITLE
Reflect sshfs's migration from homebrew-fuse to homebrew-core

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -97,7 +97,7 @@
   "sonos": "caskroom/drivers",
   "sony-ericsson-bridge": "caskroom/drivers",
   "srclib": "homebrew/core",
-  "sshfs": "homebrew/fuse",
+  "sshfs": "homebrew/core",
   "sslmate": "homebrew/core",
   "steelseries-engine": "caskroom/drivers",
   "steelseries-exactmouse-tool": "caskroom/drivers",


### PR DESCRIPTION
```
$ brew search sshfs
sshfs

If you meant "sshfs" specifically:
It was migrated from caskroom/cask to homebrew/fuse.
You can access it again by running:
  brew tap homebrew/fuse
```

But Homebrew/fuse is no more; see also Homebrew/homebrew-core@45acb8c25e31f1c1cc99a60fe414437ad08886c5.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*  [**None are applicable.**  — JM]

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
