### PR TITLE
Add TouchDesigner v099

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -3,7 +3,7 @@ cask 'touchdesigner' do
   sha256 'a2d0d1b50f431ba7587eeb99ebc0aa8c55b5d5d2c9b66f3c905551c62df53028'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
-  appcast 'https://www.derivative.ca/099/Downloads/Default.asp',
+  appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp",
           checkpoint: '90aacc97f46bf0ab6d0bf0cd9c28a423e3adaf7fdf27d6464648f2bd040c5c71'
   name 'Derivative TouchDesigner'
   homepage 'https://www.derivative.ca/'

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,0 +1,12 @@
+cask 'touchdesigner' do
+  version '099.2017.7180'
+  sha256 'a2d0d1b50f431ba7587eeb99ebc0aa8c55b5d5d2c9b66f3c905551c62df53028'
+
+  url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
+  appcast 'https://www.derivative.ca/099/Downloads/Default.asp',
+          checkpoint: '90aacc97f46bf0ab6d0bf0cd9c28a423e3adaf7fdf27d6464648f2bd040c5c71'
+  name 'Derivative TouchDesigner'
+  homepage 'https://www.derivative.ca/'
+
+  app "TouchDesigner#{version.split('.').first}.app"
+end

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -8,5 +8,5 @@ cask 'touchdesigner' do
   name 'Derivative TouchDesigner'
   homepage 'https://www.derivative.ca/'
 
-  app "TouchDesigner#{version.split('.').first}.app"
+  app "TouchDesigner#{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

While TouchDesigner 099 is officially referred to as "experimental", it's currently the only build of TouchDesigner that exists for MacOS.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
