### PR TITLE
Update craftstudio: Change mono-mre dependency to mono-mdk

### DIFF
--- a/Casks/craftstudio.rb
+++ b/Casks/craftstudio.rb
@@ -7,7 +7,7 @@ cask 'craftstudio' do
   name 'CraftStudio'
   homepage 'https://sparklinlabs.itch.io/craftstudio'
 
-  depends_on cask: 'mono-mre'
+  depends_on cask: 'mono-mdk'
 
   pkg 'CraftStudio.pkg'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

cask `mono-mre` does not exist anymore as of https://github.com/caskroom/homebrew-cask/pull/10575