### PR TITLE
Update context-free to 3.0.11

### DIFF
--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -1,10 +1,10 @@
 cask 'context-free' do
-  version '3.0.10'
-  sha256 '43fc99a9558393a726a04846eedca662d8c1cede68eddcb8aa91f7ee31bfa042'
+  version '3.0.11'
+  sha256 'ecc71fe3b9f7f589c1bd55fa551a4b0f5caaa9660770eb516fa148ce5d04ef87'
 
   url "http://www.contextfreeart.org/download/ContextFree#{version}.dmg"
   appcast 'https://github.com/MtnViewJohn/context-free/releases.atom',
-          checkpoint: '20779f86861972f42628dbecd36b5b6f7444f10994c23ca723958a7adb03f573'
+          checkpoint: '6b36b78fb8b7843415e0c8daff96faf420896c32516cc364269f0263dba19080'
   name 'Context Free'
   homepage 'https://www.contextfreeart.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.