### PR TITLE
Update pritunl to 1.0.1363.37

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -5,7 +5,7 @@ cask 'pritunl' do
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'bebd7c03ccc0d6d0aeae908faf891d062ef34a0962821b6e6ec3b9c7b8c32c25'
+          checkpoint: 'da5e340f57e6f00e3817db2d4864094d891e270e58a5c03af3d6c28b51a7b58b'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 

--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1356.36'
-  sha256 'a400becb21b44a3c47553a66c401f77a56d92f2c4fdc6b9be1e4ae8cce1ac9bf'
+  version '1.0.1363.37'
+  sha256 '3f70267fa1f8c48e23f3c9ef29d8293a76c78f0e36cbfb364e1f39636693414c'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'bd9114e9f12dad6b341c9410096fc229743950bc36af4c61a1e612659ee792d8'
+          checkpoint: 'bebd7c03ccc0d6d0aeae908faf891d062ef34a0962821b6e6ec3b9c7b8c32c25'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.