### PR TITLE
Update microsoft-teams to 1.0.00.14454

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '1.0.00.13751'
-  sha256 'fe1b99af080630e45413d74dbcbabf19087dae87e808079daf786bf9ff7c85fa'
+  version '1.0.00.14454'
+  sha256 'f4cd9a151746aa1c85aa5a41c112c7ab3ca9094888971c893484a68b0d386bc2'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: '8511fd80c9976fff63b3d2cba2d1a9dae922189ebccca8f793f52af53bee51ea'
+          checkpoint: 'df65b75e8bf1a602351a7ab980e12b41edba7d9740f39807ae648d73962621dd'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.