### PR TITLE
Update wechatwebdevtools to 0.17.172600

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
   version '0.17.172600'
-  sha256 '81dae5e1c9604915faa80e51f35f711f7991ceac027433bfe831d4edda79ca42'
+  sha256 'cbe73da09f9503ebc4d5ae449bcfafbcd61bbc88626e328b9aef653c4ea0961a'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.no_dots}/wechat_web_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the codesign: https://www.virustotal.com/en/file/cbe73da09f9503ebc4d5ae449bcfafbcd61bbc88626e328b9aef653c4ea0961a/analysis/

[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256