### PR TITLE
Update camunda-modeler to 1.8.1

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.8.0'
-  sha256 '325f33cb325e2ae1ab1bca204804fe6429589d8cc1ffbe45bcf9f8f74f1e5fab'
+  version '1.8.1'
+  sha256 'b3a13bb3ce4783c68cad274a10a154766bdc4de27d87e28ff5d203be538d5743'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.