### PR TITLE
Add Chrome and Gecko WebDrivers

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,0 +1,13 @@
+cask 'chromedriver' do
+  version '2.29'
+  sha256 '6c30bba7693ec2d9af7cd9a54729e10aeae85c0953c816d9c4a40a1a72fd8be0'
+
+  url 'https://chromedriver.storage.googleapis.com/2.29/chromedriver_mac64.zip'
+  appcast 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE',
+          checkpoint: 'ec82d4ced9fa1fb7a81d67e6559af505df8c885efe8ecac580602e41933ac835'
+  name 'ChromeDriver'
+  name 'Chrome WebDriver'
+  homepage 'https://sites.google.com/a/chromium.org/chromedriver/'
+
+  binary 'chromedriver'
+end

--- a/Casks/geckodriver.rb
+++ b/Casks/geckodriver.rb
@@ -1,0 +1,13 @@
+cask 'geckodriver' do
+  version '0.16.1'
+  sha256 'eb5a2971e5eb4a2fe74a3b8089f0f2cc96eed548c28526b8351f0f459c080836'
+
+  url "https://github.com/mozilla/geckodriver/releases/download/v#{version}/geckodriver-v#{version}-macos.tar.gz"
+  appcast 'https://github.com/mozilla/geckodriver/releases.atom',
+          checkpoint: '822086125ca1c1c76dffc0bba3127bd0e984559a3ae32dd7f4408768950ac3da'
+  name 'GeckoDriver'
+  name 'Gecko WebDriver'
+  homepage 'https://github.com/mozilla/geckodriver'
+
+  binary 'geckodriver'
+end


### PR DESCRIPTION
These are tools to automate browsers, and not actually drivers in the typical sense, so I think these should still go into the main repo.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
