### PR TITLE
Update toggldesktop to 7.4.45

### DIFF
--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -1,6 +1,6 @@
 cask 'toggldesktop' do
-  version '7.4.42'
-  sha256 '14430977b771a368f281138fc45b8deec4dfb9780f33ce9c7cf72e2e8f6238c0'
+  version '7.4.45'
+  sha256 '2ef6cbc8c949a1c537290f38f907d81361b7f482524a67b697f166f08b2cdbdf'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.