### PR TITLE
Update framer to 9282

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '90'
-  sha256 'd4960d0794bea0b52bb7b78834b2555781ad12897c1455c9e2b2ce43f6a633bb'
+  version '9282'
+  sha256 '2408052d95d4f2ec141464631b2bda920b1c6db05ef9a79890c6a419041f28cd'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '30959fb0c4e1b140195ae1acfbc65ed9557d4d852357548059fb33b4916e1f8b'
+          checkpoint: 'c1ec093fd1d47fe48322ccb30b1dd0def242b2cb1782a5dd427d61c0d6599b2f'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.