### PR TITLE
Update vimr to 0.15.1-199

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.15.0-191'
-  sha256 '5466a01d9a7f5085b5cb59fcb82db0333a878a5a8635b03af893fbd13fdb5048'
+  version '0.15.1-199'
+  sha256 '7b1b516f24441687df769e827bc833c12346f9e213b535c17511bb69e5123768'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '300e7e1ce4c37bf1dca8f3296303fdf00a19852f2c59a423d2cbf464b92464aa'
+          checkpoint: 'b10e8afdfbd4777500ac0f50e7846dca9a79fac6d53592c2658e85ae746bfae9'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.