### PR TITLE
Update aqua-data-studio to 18.0.13

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,10 +1,10 @@
 cask 'aqua-data-studio' do
-  version '18.0.12'
-  sha256 '1f7490c75e72baf1a37bae3dff97f3db60d7ac4c116f7270b9413ce1ecbf4bca'
+  version '18.0.13'
+  sha256 '879181aeb6237118ed040a9095c1558ca182fb958a671783da9ae4f67e845084'
 
   url "http://www.aquafold.com/download/v#{version.major}.0.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'http://www.aquafold.com/download/',
-          checkpoint: 'c6d6214937a9956254f981bc650e2dd0aa6fc9c49d9f36214074d36748b19d56'
+          checkpoint: 'ef91e22d2d66c511d7063eeaedf35b5cd7f0b3429b2c3724801b36e004923ef0'
   name 'Aquafold Aqua Data Studio'
   homepage 'http://www.aquafold.com/aquadatastudio.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.