### PR TITLE
before_script.sh - alternative gpg key

### DIFF
--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -11,7 +11,7 @@
 header 'Running before_script.sh...'
 
 # Required workarounds
-run gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 # Required by RVM: https://rvm.io/rvm/security
+curl -sSL https://rvm.io/mpapis.asc | gpg --import - # Required by RVM: https://rvm.io/rvm/security
 run rvm get stable # Required due to Travis bug: https://github.com/travis-ci/travis-ci/issues/6307#issuecomment-233315824
 
 # see https://github.com/travis-ci/travis-ci/issues/2666


### PR DESCRIPTION
This seems to be the suggested solution for the `gpg --keyserver` errors.

> https://rvm.io/rvm/security
> In rare cases the gpg --keyserver is failing, use this instead:
> curl -sSL https://rvm.io/mpapis.asc | gpg --import -