### PR TITLE
Add anka-run 1.0_34

### DIFF
--- a/Casks/anka-run.rb
+++ b/Casks/anka-run.rb
@@ -16,7 +16,11 @@ cask 'anka-run' do
                     }
 
   zap delete: [
+                '~/.anka.log',
+                '~/.anka.mac_counter.txt',
+                '~/.anka.mac_prefix.txt',
                 '~/Library/Application Support/Veertu/Anka',
+                '~/Library/Logs/com.veertu.anka',
                 '/Library/Application Support/Veertu/Anka',
               ],
       rmdir:  [

--- a/Casks/anka-run.rb
+++ b/Casks/anka-run.rb
@@ -1,0 +1,26 @@
+cask 'anka-run' do
+  version '1.0_34'
+  sha256 'b1d5edd68a20964298c3ff41c48b5b0fe7ce0974e57f666a1de087919167ed2d'
+
+  # d1efqjhnhbvc57.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d1efqjhnhbvc57.cloudfront.net/AnkaRun-#{version}.pkg"
+  name 'Veertu Anka Run'
+  homepage 'https://veertu.com/'
+
+  pkg "AnkaRun-#{version}.pkg"
+
+  uninstall script: {
+                      executable: '/Library/Application Support/Veertu/Anka/tools/uninstall.sh',
+                      args:       ['-f'],
+                      sudo:       true,
+                    }
+
+  zap delete: [
+                '~/Library/Application Support/Veertu/Anka',
+                '/Library/Application Support/Veertu/Anka',
+              ],
+      rmdir:  [
+                '~/Library/Application Support/Veertu',
+                '/Library/Application Support/Veertu',
+              ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Currently in beta, download link is publicly available: https://veertu.com/download-anka-run/

`uninstall pkgutil:` is not needed as the `uninstall script:` removes and forgets the packages.

/cc @vitorgalvao 