### PR TITLE
Update nomachine to 5.3.9_7

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '5.2.21_1'
-  sha256 '76106afead704af9cae68afb2eb1bd2f77ecb1616063b958fd88c84dbb9106b4'
+  version '5.3.9_7'
+  sha256 'cc9bffba27d511dc74da7421500eb0362a5b5f1d9fe88dba8871c666ffe18ef8'
 
   url "http://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.