### PR TITLE
Update munki to 3.0.0.3333

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,11 +1,11 @@
 cask 'munki' do
-  version '2.8.2.2855'
-  sha256 '1a2221a5032921f7380f4d3517889ab52cc3a9f47a7cdeac16fbdb4a0e2279dd'
+  version '3.0.0.3333'
+  sha256 'ad18edc7014c6fe9070a0be278d9595d882406f85cb02789eb1d21fa3cf893fb'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.sub(%r{^(\d+\.\d+.\d+).*}, '\1')}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: 'ee95f6982a48663fa66993f999343d7d6f1cb5853ddc977d56ed8b23c34120cb'
+          checkpoint: '1a0d98eb051e609fe94e8624b88d23bb3e79944c1810bc8316531c8736e20804'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.