### PR TITLE
Update libreoffice-language-pack to v5.3.3

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,553 +1,553 @@
 cask 'libreoffice-language-pack' do
-  version '5.3.2'
+  version '5.3.3'
 
   language 'af' do
-    sha256 '5782e7f5ba984cdc0392ce69262a4c035a45e08f8782f98368a18e5f6554a369'
+    sha256 '6c3e8a233bdbbe71e4ee1aa5cd7bdcb5569ba40ec2f3e3978581903efc090b45'
     'af'
   end
 
   language 'am' do
-    sha256 '05a903ed95a328188f320e9f0a476172abf721eeac7f3f689f94fa7ad9fc7ce8'
+    sha256 '08d26cf075b5b453d0d5e227794bbde8f72ef80313c870d6f3fc947bdda9e39f'
     'am'
   end
 
   language 'ar' do
-    sha256 '678075889eea99f77b4629d9e2f7e8beb877be76dfe38d41ed966c3028e40f57'
+    sha256 '2adb3e01300ff17fffdb55e8218c547e83c9aae6cce2a57921b5faae46cae953'
     'ar'
   end
 
   language 'as' do
-    sha256 'aa81b6399b3ca931c66a6432d0cf181b48f23eae2aa76fdbd7a1f2d114fb5f94'
+    sha256 '056a5090ba555bce3878ae768e820f60480a1b12238c542ad19188a68a92a11b'
     'as'
   end
 
   language 'ast' do
-    sha256 '1bcb39a21186939d76b7f6c600444e82102a8b89da7958fa62b8248d7319893e'
+    sha256 '6b511c7246b3129ab9f3686ab34e11d0cf95660a6cf7a44b6ebaa1ca23645b63'
     'ast'
   end
 
   language 'be' do
-    sha256 'ff9bf89505d89a5112a9e6efd1ea90acd59c378ace03deca5f176cef55bbf2a9'
+    sha256 '448e43754378fe3e32ac458e5222a355e4e29756d7940030b9016e1333f6b1d1'
     'be'
   end
 
   language 'bg' do
-    sha256 '42a15562aa2ad58687b33487e186fc23502f49bfda334c30e71b8674e95ebdf1'
+    sha256 'cab4bed2f3958a72656c1179d3873f5a237979a721eebb2fb169d8052dc5c2a4'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '495399ff91a59defd9d0c10ee5febdfc456ccd81f24faa66af2c35b09724e1a4'
+    sha256 '632c00b36333850c5a0e59092582d70f2b629755ea8507dea3511b394fa2d218'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 'baeca91305bb96ab04f3d474e452fefc0319194c4d2244672d927849f2be5fe4'
+    sha256 '042f35a29a14c5d5e8d633711c4b197fe96c1b6869ebad7f634bd3fba4cd9516'
     'bn'
   end
 
   language 'bo' do
-    sha256 '3274a668af8668a1954c8bef5f162178be1346624f76565090694e3ee82bfc6e'
+    sha256 'a4ad14acdb67891e86777f1332dbe93f3c3f04920a1aad0d8b267c0acb60c583'
     'bo'
   end
 
   language 'br' do
-    sha256 'c432dfa9dd914f23ba7231aceca03d373ec8e040ada0c8efbcb4ae94c5fa6fda'
+    sha256 'a8d2fac380c7c89dea05a07f05bbee370c151c3e988b15505b5b1b7f00e43c3d'
     'br'
   end
 
   language 'brx' do
-    sha256 '18e81f1f8980199b16bfc91eb460a01713b6b9783820d4f560a64bd2ba4e0ad9'
+    sha256 '7419397da0c89a904b2ad056002b50d26497788fdf65defe5a1cb45bbdc8d323'
     'brx'
   end
 
   language 'bs' do
-    sha256 '9bd837982957472e5b1daededb29c7065f98411d05d9362ab6ae14bc00450ff4'
+    sha256 'e63d485bbf545d82326d62b5c30505a97458c011d158afb65e430bde77481f85'
     'bs'
   end
 
   language 'ca' do
-    sha256 '281cb860594b4e03dd898613a6c1aba7c23ec2976579f19e0b08701c5406904d'
+    sha256 '2b0541365bba616ede5c46fb9a21b6de2f8f5baecf6a95454d3a6436a1dc42dc'
     'ca'
   end
 
   language 'cs' do
-    sha256 '836e83b3e7d26a5b275ec08ade747dc26eff7d949d07486560652d2fc4609629'
+    sha256 '077ec4fe28a310de91a4a51af4729f0927874e9e22297c608920c8114252bc1e'
     'cs'
   end
 
   language 'cy' do
-    sha256 '8728ec544453771f2ecd58309102ada75d9c1584cd6f2e0186c5ae0ca819f355'
+    sha256 '83618db853d6b28fbb715e7290c203f45028b9aa62db777cb41ea75d607ad16e'
     'cy'
   end
 
   language 'da' do
-    sha256 '0abb493b39e31d9559647df3effb6f2a82891e872eb70ec395767b1eeca7978b'
+    sha256 '08d07e1eba1900c6bad97a8da696845ace1e207be189f82b629c84c4f9d0be47'
     'da'
   end
 
   language 'de' do
-    sha256 '388f826cd2e3306450e8b93945da4decfb6998da07238aa91401ef96e0db99c6'
+    sha256 '5c8f978a49a71d37d5e6e0305c1934207a94fb6f8cc82c9fb47b43ca6ca6056e'
     'de'
   end
 
   language 'dgo' do
-    sha256 '57c888b3bf0f04a447623fef0d45d4acc89502d99105c678272217392f4a048b'
+    sha256 'd1a497e8c816af70cf3395b98609512f6e2a3edc0093cc686edfceaeb3e89745'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '67a3ebaaf68211e4e2c3c0c8005c1ca59ddfa36bbfb47e13a574a9aed0f3b6c9'
+    sha256 '8e89d00be9e1f9209be3e0a0316ad6f0a0eb2c7c30e57fe9e2cd142339578bd9'
     'dz'
   end
 
   language 'el' do
-    sha256 'eff6804bf4b7221f21b9868229a58ae33cda78b4c1b7d9998197b933eb3742f7'
+    sha256 'f48e25c238ae165f49071822bcb692c6052772508dd0eec93ce7b04d2ec96041'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '5aaabebf58c62f10dc4d15eae26c62d26b0d9021457cb40d3b24719ed80755c4'
+    sha256 '3eb09c6ae21dcadea80485d7c3391feebe15ec6ad2dbd4f13ba9565032924464'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '2b305322f32c22e88b40137286c7aca115a798c6a93d9031e85047101db32968'
+    sha256 '8e39e2db0172e9a8d44ca85fa7c04a7a15884cdff95b7c1da22f76492acc43bb'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 'a7abf440798dee3e9783e8ea01109fff448054778985fef4f6c13a83a6d83dd7'
+    sha256 '32f322d5f3c88c5832b0229f7b3877f0bd0795db87cbb17a1d8301399417d1de'
     'eo'
   end
 
   language 'es' do
-    sha256 'd0af0e2ccb625df199b280995891daa554e2e2409f72e3d2e1f8b3cac44cb02d'
+    sha256 '839e47b4bb11c46b78b0077f4a4290faac738858e303a057ac3ee414fd2686de'
     'es'
   end
 
   language 'et' do
-    sha256 'ec30eef49bcb3e8ef0e14e5829a1982807b4a6a25c11f550c7866d41b5a4dacf'
+    sha256 '7d2abf101139cfd85ddc3c9c189d226cbda0cb6aa07bb4ffc6d95dbe9775017c'
     'et'
   end
 
   language 'eu' do
-    sha256 'b5c3fcf4dd69b5b26c9f4d15e29dca51d0563335443a1dfe9bc3e5c05311e426'
+    sha256 'b6b8abd4b7911530fb1928873f59e67d401f3c3170537d261cc87cefb92affee'
     'eu'
   end
 
   language 'fa' do
-    sha256 '26e066f089274e812b712fdfe85d09f778bc8813af200c2e2b922d185741e1f2'
+    sha256 '148457a518aaa13bd540a1ccb7054d85db44d9bc25e37b83bf7dfe030f547f7b'
     'fa'
   end
 
   language 'fi' do
-    sha256 '32709c4ee7c55d1ac7f33ffb7bdda05b91c88fca433309b2034c670faa606658'
+    sha256 '6c71edfd9034c0ecf53067b3f144d364bb451ef192a552a18302eb06b9a8b899'
     'fi'
   end
 
   language 'fr' do
-    sha256 'bf45df28de72991b7deb0617a3eed6045d995c1343ed976ae27a39ba9485f165'
+    sha256 'd558a4a529f640f68293d9e76b4725db1a8546ff59f2948109da84c8a959c83e'
     'fr'
   end
 
   language 'ga' do
-    sha256 '6663fbb2a090c5c9f9a2259dc241db3b32f270b81253ee6ea70fec4a4e54c60f'
+    sha256 '70da5453511ff0f4a8158c4b88b423da5767f7001ae9eeb51adffe2bad1dbda5'
     'ga'
   end
 
   language 'gd' do
-    sha256 'da40e2ebf2a21240c68d3c6663e0c5c24975a73630570f34633191a2d93356e7'
+    sha256 '16afbab0a88f1822ab02c0571829f9dab58b8077ad86ad4e8279dd623d36f8e7'
     'gd'
   end
 
   language 'gl' do
-    sha256 'a1c08125265fe6b8bde7e1e89a365c502749cd567d4813d5b541145c3d1b0add'
+    sha256 'ad782c32b99e1a12bee6f582a0f61c0dd64cb3798aa0a801d78908e6b2074239'
     'gl'
   end
 
   language 'gu' do
-    sha256 '7f7b92a989ee0a3cbf8d9a00f7cdc578b2f60a5575a606a00a51ae1e98acde80'
+    sha256 '0392034571c2583e21482b6bd744ebcf653a7815e61fb184fa7b163c6454445f'
     'gu'
   end
 
   language 'gug' do
-    sha256 'd41dfde5bfa895e69f4974af1c6e706b3ed33a9cf103ccc6d6a91f5ac028cdee'
+    sha256 '1c27b4629e65e8041e21921e2b253fc768114412b4a978281eb9c97724ae64df'
     'gug'
   end
 
   language 'he' do
-    sha256 '1c09a33c02ce69682849f6fd8597553b073d0b82f896a719f45b4786d16b4901'
+    sha256 '3dec9ed2514514d363b1bc322516283cea0bb657dab878d6c88dec2fe59d113a'
     'he'
   end
 
   language 'hi' do
-    sha256 '88f61ec68cbafce1352252a3ff1263dfc1cda1309aae147bb1dbe9beab65afda'
+    sha256 '80a8bdd3ed0752f2d303d4319497547ab6e530014054954313f6edede9636cb6'
     'hi'
   end
 
   language 'hr' do
-    sha256 '61b5258e1898269b44ea2565c7ab624a72e5180a98fa1cf0623631d8e7f15df5'
+    sha256 'b828b640e1a47601aef300f50b6765becff0004c33780de05557a64f1165b033'
     'hr'
   end
 
   language 'hu' do
-    sha256 '4d6e67e80cb93aea1ef205594ccf67eefa9fdf9ff1abba7c99e54e7868579129'
+    sha256 '1c55410e86e7b4faea9f7b040d29382c09d77abb25114a17642558000d064385'
     'hu'
   end
 
   language 'id' do
-    sha256 '227b5280e86bfd00512dc18bd21ce399b9587caf1937d44bd2cf05ad1d8e872a'
+    sha256 'a56735366a5516613711717a9805c41ade2b7a8e1faad4a38cf04784961976e1'
     'id'
   end
 
   language 'is' do
-    sha256 '4b6b6c059f87a1e117d050ba50c89b27b644c162fcb9466139aff1729875ef06'
+    sha256 '5e7d3671969bb1712e7c5e3ada1760ef6b0e8cdb6e7ff94c8b2b8a1f142eb7d6'
     'is'
   end
 
   language 'it' do
-    sha256 '34b3dbc35d718087933e825bb8cac30df560adc10f73c55d5683dc4f13abbf7f'
+    sha256 '5acc7820451a8ddad18091f265ea38976916f5e636180219413e184ff647f365'
     'it'
   end
 
   language 'ja' do
-    sha256 'c98846974828eb30ed2c0456ed3a507c44e7c25203e63bcf2853ec23280faf53'
+    sha256 'deed26caac9ec2b4e28e6eac5a11e3efe9d213c0b04c739e709001fc637d3d2e'
     'ja'
   end
 
   language 'ka' do
-    sha256 '6749679f679a4e5f3a6359aa83d4e76d685456b7e8e5faf4d81836aee6d96234'
+    sha256 '4513638617c9863802daca3b7e14a2d33ac7b5fc3b782f706991987fa6478fdd'
     'ka'
   end
 
   language 'kk' do
-    sha256 'fd5514f9a8e61a2a70b00f2c30d559cc99828e3a1ed2e59ebc9658761a857c0f'
+    sha256 '3631a1ecb2ae337bc36020370714af1c73e180718ab72282ca7ddd7a0071f3e3'
     'kk'
   end
 
   language 'km' do
-    sha256 '13908116219a4582424036c3f73201bb6305710b6ec7ad46da77664ed4bcb7c6'
+    sha256 '218fdebb01f0bf82ac49a04acccc99a302bc78f481dd3eb8f31760c01a64ff14'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '39141b8e5e9d6ae5cd7b0e6b6c7effe3c05e14d701873a0646d295037fee1a5e'
+    sha256 '31a1f38554f91e889994db527f56778afb53693a23245e2168182487c041842e'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'fb57837e684d49c2c6490987d8ae559177a312b8ae348516f21207851b909c8b'
+    sha256 '90352a43e316b1d996aba9c430503890e90e08f989d79673b9240f44ba45874e'
     'kn'
   end
 
   language 'ko' do
-    sha256 '8ca9e90349eccbd5bf124e5ed308015d36efacb7c92d9a06587558f115f7bfc8'
+    sha256 '167469a7db24ca025110d5aa38ffc35b6140c0957517a1baad9a25f02a869314'
     'ko'
   end
 
   language 'kok' do
-    sha256 'e6fa85752b7616d3401e28dca2f19879bf9749a94a7ef658b6a68e27e11641fb'
+    sha256 '7b5aebd2f16a6a47895de703d8a9134eb887fc9c6435229adb48a451a97434a4'
     'kok'
   end
 
   language 'ks' do
-    sha256 '0e56734e5ee8d61d6c53007c579fd860560e6967846b9fb2ac370a2ec1c20626'
+    sha256 '70f49610c0ea5392e3a852640e6f6a438bfee167469470a119dd91ece457b5d6'
     'ks'
   end
 
   language 'lb' do
-    sha256 '9b9d90abd9c373f6ecffc4073696de4c889eaf6037944560355d0b64d876ee15'
+    sha256 '7525209d0a6e2d4924e16632710b01cd9cdbff760f4058bd2bb5ec3cdda68b59'
     'lb'
   end
 
   language 'lo' do
-    sha256 '3a7efe70f8c0f58d70ef1f29053f8c2099f2fa3ee682b3cac0d56fb20525b1da'
+    sha256 '5f3d347ddb74edff255beb2abe468936b6781d139814d388ac862b7bfc8b1bc5'
     'lo'
   end
 
   language 'lt' do
-    sha256 'a9ed8736524f3a4108278471853298056b2c81f98a55e49e6f7ecfc4fc56972a'
+    sha256 '5685c1d9ea895dd2b21404668228bfc72c4107cab1772e4603278b099b394444'
     'lt'
   end
 
   language 'lv' do
-    sha256 '9a6990f38fa91f6a4b992d835f4f4504fccd8d559265ced8a22d7657c7d5d895'
+    sha256 'e7fe4fa03b0b6439d73453453368edfea40d2a17b69d55bc0d475d2f5096c1af'
     'lv'
   end
 
   language 'mai' do
-    sha256 '24601395181a8dd284a9a3ae38c6654f8850373bbbb10fbbd225e29316b27d92'
+    sha256 '4964a14e5eba38bfdf5fa8e0cedc34756a7ebc958ff3ca685f77da58df3bbe16'
     'mai'
   end
 
   language 'mk' do
-    sha256 '772739a129e5189b253b13f0fb3e544bcf069d3ab5c9757c04137fe363c161fd'
+    sha256 '926cc9e7ef287fd4ebe46de73dc287b027cbaaabdcfb9b33fddc46489d644bfe'
     'mk'
   end
 
   language 'ml' do
-    sha256 '4b2d37dc3cded4e6e481f3f5b3827636328e32c251cecb6e23c28e123eedcc57'
+    sha256 '5305f9752c46ee29fe0536953f47d1015eba339155bb0ffc98bfa9c87914cafa'
     'ml'
   end
 
   language 'mn' do
-    sha256 '5b25f7ec7693a8b3adae7abb783af799e151ce283f56257d7b5dc46af92c4543'
+    sha256 '4b61243ab8a7e56603a1039e327db43627a301ba19719c8664e38b5927ef3937'
     'mn'
   end
 
   language 'mni' do
-    sha256 'cdb6fcf41106fe96daf6917e420450d4ed4215ad6689fc82812191b1b4d799a1'
+    sha256 '2f208737a4e2f4c0ba2a053d8bc782591cec4247e1a0a86b2410524bdf0dc18e'
     'mni'
   end
 
   language 'mr' do
-    sha256 '2eb8a13bf9183ff4020b0eb8b7333da952247400617a91fca9a70ae11ee88876'
+    sha256 'ea6debb4faaf16f7b31090fe4110558c6410b84717b76ac0ea435235f2d9128b'
     'mr'
   end
 
   language 'my' do
-    sha256 'f7c521cca936c22b36e86ef80884632df148ac3a058aa4f98b22591b46f565ea'
+    sha256 '5f8726f89e4d11ee1da710430f60788dde2b81d696935c8b3fbcae14a7c14571'
     'my'
   end
 
   language 'nb' do
-    sha256 '7f0901945457bdeeb973ff1dbd786cb9ae57060b68c213621e48a7e1a4c5ee1a'
+    sha256 'ca4695ded8094b67c67ac1907c657ab76e5c9fcf0b28604e4ef9ee1077ec7573'
     'nb'
   end
 
   language 'ne' do
-    sha256 '5212d2e6246ee14f16c05cd38f78c1584313263689d9faffab0f835092ca63a6'
+    sha256 '5d2201f0c37e30308a5c4c1ba5cd0b093e4df335f3999b4595ac0170cf9d34cb'
     'ne'
   end
 
   language 'nl' do
-    sha256 '6a20dac570e635a148cd27c9160facaf721035bc6b8e3d769fc2bb00adab1b71'
+    sha256 '9e535d4fef7b95a291025f3a6e06be79d2b702c0e6ccd90267580a544554af07'
     'nl'
   end
 
   language 'nn' do
-    sha256 '907ead67af885e5eb94e16f9227941575fbe4455372f4829783105087352884c'
+    sha256 'c019e08535a6bebd2f1cb83febbbaa55006b6d0d147ed78a88ff204729b6d5a1'
     'nn'
   end
 
   language 'nr' do
-    sha256 '15fe565e637a4facfbfbba7bb0fba68588af3f3ad2d04084c9de165f92f4b8ca'
+    sha256 '593ceab0a89f5c2a956f4bd349bece4877e2c0be9dfe43b34a5b4f0c49352096'
     'nr'
   end
 
   language 'nso' do
-    sha256 '1b7817a4808d1c26cdc940736d169be8eedf338469acac752daf88445c804906'
+    sha256 '02488376f965ebf80b87e0a2175e58a8243da480d05ecac8103f19b592868855'
     'nso'
   end
 
   language 'oc' do
-    sha256 '9352b8fa25d10c88995828d54f4c7a789769479c629a34356bf346c524b69b0a'
+    sha256 '47400cc3f6859007fc5824a4e1c8c101eae1294433b8dba9dfb82ab3df2b86f4'
     'oc'
   end
 
   language 'om' do
-    sha256 '30b6980b03dd60ba4bd4b09d6650404425aba3ce1e4024264315365ac999f861'
+    sha256 '6b54ff8d0260c20381a1251faf0bf7758391461871f07e3a3ed3602d68641097'
     'om'
   end
 
   language 'or' do
-    sha256 '0846266c363ce89fa0b757ee1209985313f5fc12ab92d380152f57b8ca17a019'
+    sha256 'b1a77ddf9dea2ae50ec393a2f2989260d3b8f8e3c61571bc96d8135b3e1ba776'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '07de55ec7bd45e2700f6481dc8bd4508fd51323e36603678a54c68f70ee51862'
+    sha256 'bbbfc9eab6d2cdb106364c69c6927728094fa79dd114c6af26d465475a3124a6'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 'a2dc09479b7bc5aaf24b6b27fefca4f721830fbd849d5388149c2d3929301a46'
+    sha256 'c0d0667c629f96a4bdd416fba0f12d88cf321f05d7d017f110df949350785677'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'da777ac768a073d3c604073b16348a33f91e81257a2860279ca1c552891f0d52'
+    sha256 '906bc233c38232896b5a6f00b7628218b78f5e60d77a4f2f912106b3531e3700'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'a211ed4cf0b64e5f7453d5f29801b9095c8d29164e24dbfa7be2e8c94425e552'
+    sha256 '483558a8fb0d6c41b2e7658eede4a0c3fd4269325d0439c65022d4f104fd5752'
     'pt'
   end
 
   language 'ro' do
-    sha256 '1f9e5f06e936f7f654eb2cf6da41e64be19a89b3c8855c36919e8bd039f066db'
+    sha256 'c69d308700e860e88101d6d512c7b9762877c487546e96d6cfdb598700a63f13'
     'ro'
   end
 
   language 'ru' do
-    sha256 '8b973578d27a1a1698036e51d60111c9a73ab7e68d3c7afd0d85667e76d76f85'
+    sha256 'be23bd677c23a0a1fe003e6804ac5b27a357541689a2ef523b4932791cce6ba6'
     'ru'
   end
 
   language 'rw' do
-    sha256 '2fa94ff46cdfbc78f76089c2b096edd1f7e2dc820be1d919689dcd1bffb66aa2'
+    sha256 '742c082099c6906be8c5c94ee809157cc28237028f98dc98a57f6f6edce0a4bb'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '5269417f2a11cc81f39b54d9324721597b4be78e3abfca284f2ade687a21a066'
+    sha256 '44151c7a066b47bde0f23eab7e48671e0c9b99e0b6fc0bde581d04891db7d69e'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '90588fc4a825f1b5783acc7fd89dc4c4fd98fd7593b1ca3b84a90f38b4d18265'
+    sha256 'eea4dcc23f52325a33591323340107deed92da56de7c132bedbdb8d3aab09781'
     'sat'
   end
 
   language 'sd' do
-    sha256 '9bf103a87fb6cc4d018301c3fc03a5ef04cb99b7e0dea072349f0df1e0e7ab0e'
+    sha256 'ce2f0d9b348045cd0c4fbfe86cabe99aabc2def9ae036a1ae1fd12f0c6855fb6'
     'sd'
   end
 
   language 'si' do
-    sha256 'a8479ddd5ad40e172b95ea4c73d090d50a0c7b65b3bb2f64b9cd5860f5b0c9bd'
+    sha256 'e571fc8db76965c7dcaa0453fd09632a5b43dd1984d69c64f3f8466086fc2fc2'
     'si'
   end
 
   language 'sid' do
-    sha256 'fe43d91f9d8b5997b351c260a67e4818abfbe99d4a115a2722eb1de987544fbd'
+    sha256 '7031458f492688d450eb35c334d530f1f78d6f13311791f14d4d7f47c07826f9'
     'sid'
   end
 
   language 'sk' do
-    sha256 'f5818b18311be1d79ab55094722e1fc3a357e1afca259eed5fa93df62f1815f4'
+    sha256 '1b1c3b5563bc52c5575bccaecfc5a09dfa4a10cbdd274de35edda1bf134ba2f2'
     'sk'
   end
 
   language 'sl' do
-    sha256 '370a695bc4aac0a85d5a495632510efdc4dab9e2c7733dfc38fb0a7040da9402'
+    sha256 'dd7b5b1c83321c1b04819f348c8aea4b423401cebf9473745d941862623e04fe'
     'sl'
   end
 
   language 'sq' do
-    sha256 'a8a7348f08701d510e3e64eefef02596889b39a514ef9fd17d00d5ad2872e721'
+    sha256 '9259211877b372bf5375cd06d130582b8ac90615ba7ee9f838dc002dcbbd511a'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '44ec3293076c2d884c2710185b4a0971a418287a79edca2b850db8c1886257c9'
+    sha256 '7da7a635b276422822bcf1194e9d74186b8baf4d69f5414ed2ecf5d8ba3ae37f'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'eb935118489ce91b3e4e129f003645c587a330c31bed576b66eb33ad33a8fcb6'
+    sha256 '8d5ada9002436c32cf37296a39a8a07a0889721d2dd1e65477f1b20374c18ca9'
     'sr'
   end
 
   language 'ss' do
-    sha256 '330ef402302524ce7fb95c60956102ec25134be8e7c348eb74cf606eeac7871f'
+    sha256 'd46be0768f5da0caa27610ac7e997bd26443da6b698ba6d060815415aed2f8a1'
     'ss'
   end
 
   language 'st' do
-    sha256 '052534f62e0a8ef22f8c0afd7063172cf2c6886ee476c5ea0bb1f11ba0ba1178'
+    sha256 'ce8058c21af7d741e86ea455bfea86c53297d4952c6f816de1904b951df26edf'
     'st'
   end
 
   language 'sv' do
-    sha256 '71cfb4e610258c0c94acf7a220f7d5b6603789e51c2ceb42ea01b57cb4bef92d'
+    sha256 'ff46bd80648283f5e592f2f48ec10a27144a4ff1fc49c17aaa36966dde1ebebc'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 '770c052a2fb6daab8736a6651d0123a92ebb710a98e12b0174ddad96cff37e74'
+    sha256 '18b18e6e9babd3f3384d035e98c336409fb886551fa51c2d17bf770ddd32e24b'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '03123c5ca6d8d381f346ab53320db86d689f39e418eeac18a43a037d47f71eae'
+    sha256 'b0ee2d1fc17d86d2866929102823f136d8ac4500b3599ab2a3b72761fe543bfb'
     'ta'
   end
 
   language 'te' do
-    sha256 '0e6c9d0fa35f74fb3344850a1d19690a15898c11f36e6efa215c9c3f77c83611'
+    sha256 'a5ef603a6b741e02d660ff50f4787d61468ecb6a3910e0488d87ea0867a14730'
     'te'
   end
 
   language 'tg' do
-    sha256 '63002ef3a7b8892ecbf3cf382365827002d0e642e781cc6ede01f7fca491e3f0'
+    sha256 'c3b282d24848079c11b42dec65b404a22daa4d8ff8c3c67226932b8cdd8a44f6'
     'tg'
   end
 
   language 'th' do
-    sha256 'b30abbeb312f926db73790cbda4a7a75abb406d041087ff01dc49b7927d0d858'
+    sha256 '42927c74760d37c06a2104cb63964c6b03abacef86959c816849296d71f24835'
     'th'
   end
 
   language 'tn' do
-    sha256 'f3ded419f3172b8aaf762fcb819d8dedcdb921293df975037bd3ae4f5af32109'
+    sha256 'f3f109612c39c562c1f10ffa3d0cd61a635ad91b918272303e3595ec4479c320'
     'tn'
   end
 
   language 'tr' do
-    sha256 'bafc1360bca5456314407b7563ee358429fefd73d03a833b7e3d97252517bee6'
+    sha256 'fb7142da98340ca9b2a3f82d8484455db14fb09d3ae50cab704724df697ff49b'
     'tr'
   end
 
   language 'ts' do
-    sha256 '5f112e53affdfe044f7b527749014f1af8fadbb7399bb9157b2f97c0d85c88a8'
+    sha256 'ae9c9dc5f4bf3f4015ed72241da2ae221d529b16a461335d2923e53206ef3936'
     'ts'
   end
 
   language 'tt' do
-    sha256 'b173c92b63e0047d2b6fbcc18cb6d947af793a0e1dd1451b2c875e6a4894b9b4'
+    sha256 'a5ce08222f67b08218533bd782b98dfd258230e25870d0d52d31362fdeaae5d5'
     'tt'
   end
 
   language 'ug' do
-    sha256 '00f7eb32ae0e766245d70c6fdd84b470eaebe3b9a688ecff952b358ee52f64ca'
+    sha256 '3f77876dfff892a3b78406a4968c1d7c9a8e9ee61a503fc35bd83095e2da512c'
     'ug'
   end
 
   language 'uk' do
-    sha256 'fb53ce0d2922af3756af376143882ee613440e79381c4a4c6e06cdebbe4c2ad6'
+    sha256 'b2170ebc8e33a8012ed108eed19c518ab68f34d86d2376779194c24da38adc65'
     'uk'
   end
 
   language 'uz' do
-    sha256 '1e3a5b2c12e4acfc3106024925b1d10d1423a354bb7d0c98b7ee08e3a563145b'
+    sha256 'ef8f083e61e7cc8f7224a293b511fcbab4000e95066495b28fdba305df2de12a'
     'uz'
   end
 
   language 've' do
-    sha256 'a52f508768bf544ea6434639c43e8ac92c496729d8bf7d6fbe3caa1e06a57d13'
+    sha256 'aca9499e4989a89e39ef51886ecf9a55f85af3c0d63cbb9e801c30b9926f5a33'
     've'
   end
 
   language 'vec' do
-    sha256 '77b8a5871716a220c678f9b780a19e7063b02a67d33e6c6a55aa9bed84ddc927'
+    sha256 'cfb0c9e4af67f195d808c9b91e89cf2667f2ed67a83a1624aeeaf9f9ceaf8dcf'
     'vec'
   end
 
   language 'vi' do
-    sha256 'e48bcff5ebf9b6116dcf69954e244cc66b5e8cbb20824a44e509364b71b3f240'
+    sha256 '459575e0a8e57c9db6d4e43c7fed472f77bbf9ee65bcd5bf30d57b8177339575'
     'vi'
   end
 
   language 'xh' do
-    sha256 '99e30010e9a817b2f52c8b0b788da22806747584d64b64230ba605f6b20130ea'
+    sha256 '54ee25ff6419d6924288c9f1e13082c0c54812596f1bc475725a6fefc23b4a9f'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'dc2f51fe9d5ca9669c1c1989f3d134cea882f30d78bd8c91ee92f83ec5e47ce8'
+    sha256 'e0c4b43976f6d9cac963e3f56f9dab11a30c41dc7d50033bcb5204475dcf24f1'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '71fc1c9d84123a13896a4d6cc4ff5a975420349ef6eeedbc7399d5ea4f2e8b61'
+    sha256 '1901280ff645473c43de1b1cc88f99011e3e5aa51507cdcc10d645f9731abdf1'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '9fb892187d09897b10a5aa9fcdb029594afcb74eb371edf3d25d7781fe4756a5'
+    sha256 '6eabbcac9ab3ec9b33427557b9a07589ec0319f8d256a9505de66f6ec1c480ee'
     'zu'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.