### PR TITLE
Update BasicTex

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -1,6 +1,6 @@
 cask 'basictex' do
-  version '20170523'
-  sha256 '024fc0e2bff8d28074a25ee8adc12c2ab37202cfea7229678d92a7b5d1debba2'
+  version '20170607'
+  sha256 'da83f12d6bbd9ee427a2142dff9ff3c8f4c4c187285a516c17aa539f09baf563'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg"


### PR DESCRIPTION
Update Basic Tex.

Sadly the mirror in this cask file does only provide the latest version, so the actual cask does not work.

```bash
$ brew cask reinstall basictex
==> Downloading http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-20170523.pkg
######################################################################## 100.0%
curl: (19) Given file does not exist
Error: Download failed on Cask 'basictex' with message: Download failed: http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-20170523.pkg
```
See: http://www.bothelp.net/mirrors/ctan/systems/mac/mactex/