### PR TITLE
Update sabnzbd to 2.1.0

### DIFF
--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -1,11 +1,11 @@
 cask 'sabnzbd' do
-  version '2.0.1'
-  sha256 '98c47f916caad5fe265735222b298374655a06be38e5f488a5cfb45977abc2f9'
+  version '2.1.0'
+  sha256 'f86f532f1bca5cd34fca5f3c44a00b95101e2c0f018198c0e9c8f8a23ebfdfa4'
 
   # github.com/sabnzbd/sabnzbd was verified as official when first introduced to the cask
   url "https://github.com/sabnzbd/sabnzbd/releases/download/#{version}/SABnzbd-#{version}-osx.dmg"
   appcast 'https://github.com/sabnzbd/sabnzbd/releases.atom',
-          checkpoint: '93497fe19902aeb39e16524adbdbae0ea9ecef4144cc320a2c470bd1a187a25a'
+          checkpoint: '8a52017d7f82de2147265f899b65e96dea9fda7b0d179197288b3e9fe9075c70'
   name 'SABnzbd'
   homepage 'https://sabnzbd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.