### PR TITLE
Update 115browser to 8.4.0.19

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,10 +1,10 @@
 cask '115browser' do
-  version '8.3.0.10'
-  sha256 'e996139197874685dcfd366b12c5e5efe2ddd152f87e294ee65efd4835d459eb'
+  version '8.4.0.19'
+  sha256 '0097f09f4cbf0db887d9ccf47ec35bcebaedb0252cf56938785857015a20c207'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
   appcast 'https://pc.115.com/#mac',
-          checkpoint: '6f8a8353a6a9c7f9c4207c3a67a801e557eec3291d10f1bd8ed5a16821621f13'
+          checkpoint: '3226edb24d62209969e17ad1dbd21953bfc71043dfe5893658501d3c196eec89'
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.