### PR TITLE
Update 4k-slideshow-maker to 1.6.1.938

### DIFF
--- a/Casks/4k-slideshow-maker.rb
+++ b/Casks/4k-slideshow-maker.rb
@@ -2,9 +2,9 @@ cask '4k-slideshow-maker' do
   version '1.6.1.938'
   sha256 '86f893e8b2e5e120e8c01fff359c73c3d58f8cc576d3bdefb016301c0c4812ca'
 
-  url "https://downloads.4kdownload.com/app/4kslideshowmaker_#{version.major_minor}.dmg"
+  url "https://downloads2.4kdownload.com/app/4kslideshowmaker_#{version.major_minor}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '50a40a2c1f278c002cbc84514c32402410eb7ed9e2ac528d2cf2705a50cbcbb8'
+          checkpoint: '1c02cd4a525457c3267dbdaa1a313ee0e547e4d31e4352f564a57b06fa4e9bd1'
   name '4K Slideshow Maker'
   homepage 'https://www.4kdownload.com/products/product-slideshowmaker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.