### PR TITLE
Update 4k-stogram to 2.3.2.1276

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -2,9 +2,9 @@ cask '4k-stogram' do
   version '2.3.2.1276'
   sha256 'ab7937cd1c47ee966fcafa1cb8a16917482157e3deae1380dd7be516998e6619'
 
-  url "https://downloads.4kdownload.com/app/4kstogram_#{version.major_minor}.dmg"
+  url "https://downloads2.4kdownload.com/app/4kstogram_#{version.major_minor}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '50a40a2c1f278c002cbc84514c32402410eb7ed9e2ac528d2cf2705a50cbcbb8'
+          checkpoint: '1c02cd4a525457c3267dbdaa1a313ee0e547e4d31e4352f564a57b06fa4e9bd1'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.