### PR TITLE
Update a-better-finder-attributes to 6.05

### DIFF
--- a/Casks/a-better-finder-attributes.rb
+++ b/Casks/a-better-finder-attributes.rb
@@ -1,10 +1,10 @@
 cask 'a-better-finder-attributes' do
-  version '6.04'
-  sha256 '6d1c36842cb33e022cfa254c0f9e59141e28e8fdb2135482f90c4540f57e8f07'
+  version '6.05'
+  sha256 'f1eeaedfed5a9fe1fe6777bca8e5e265e2d3e71aedb398ccf8782d8e5ac165ac'
 
   url 'http://www.publicspace.net/download/ABFAX.dmg'
   appcast "http://www.publicspace.net/app/signed_abfa#{version.major}.xml",
-          checkpoint: '157b591920718041f5144b68312336449b90f961724d6fe841fbc1d5b0223b14'
+          checkpoint: '13f663c360067db8891ceea870526b27e1d35ed7c9363e80bf2c835e5b2d9af3'
   name 'A Better Finder Attributes'
   homepage 'http://www.publicspace.net/ABetterFinderAttributes/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.