### PR TITLE
Update aircall to 1.4.5

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,10 +1,10 @@
 cask 'aircall' do
-  version '1.4.1'
-  sha256 '4843613cb55bfc9af16d04a7e678a6fb3d8c031c52209e3d94f618184636d586'
+  version '1.4.5'
+  sha256 '65a0cea18bc48a88bd33964a05f636a394de075f25c8d3c88e758fc5d23c41f5'
 
   url "https://electron.aircall.io/download/version/#{version}/osx_64?filetype=dmg&channel=stable"
   appcast 'https://electron.aircall.io/update/osx/1.1.0',
-          checkpoint: 'c235df2beef18673343c81193fc66f03068a954967e9dd2b32662102c0b9191e'
+          checkpoint: 'e8c9a599631eac4bd8921d35e6ccd59f25a578c3a98a3a5ccc71755b212dcdda'
   name 'Aircall'
   homepage 'https://aircall.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.