### PR TITLE
Update coyim to 0.3.8

### DIFF
--- a/Casks/coyim.rb
+++ b/Casks/coyim.rb
@@ -1,6 +1,6 @@
 cask 'coyim' do
   version '0.3.8'
-  sha256 '80ef836252349f867cd48a2532b65505aceac480c25b02472a1416b88d3e9494'
+  sha256 '1238d6d67087c38a003eafa54286b492342e2f62ddcb0d4a0fcacde07591fdf1'
 
   # bintray.com/twstrike/coyim was verified as official when first introduced to the cask
   url "https://dl.bintray.com/twstrike/coyim/v#{version}/mac-bundle/coyim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/35352

Published checksum at 
https://bintray.com/twstrike/coyim/coyim-bin/v0.3.8# --> Files --> checksum
or
https://bintray.com/twstrike/coyim/download_file?file_path=v0.3.8%2Fchecksum (downloads checksum)