### PR TITLE
Update openzfs - uninstall

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -20,11 +20,13 @@ cask 'openzfs' do
     pkg "OpenZFS on OS X #{version.before_comma} Sierra.pkg"
   end
 
-  uninstall_preflight do
-    system_command '/usr/bin/sed',
-                   args: ['-i', '.bak', 's|/usr/sbin/zpool|/usr/local/bin/zpool|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
-    system_command '/usr/bin/sed',
-                   args: ['-i', '.bak', 's|/usr/sbin/zfs|/usr/local/bin/zfs|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
+  if MacOS.version >= :el_capitan
+    uninstall_preflight do
+      system_command '/usr/bin/sed',
+                     args: ['-i', '.bak', 's|/usr/sbin/zpool|/usr/local/bin/zpool|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
+      system_command '/usr/bin/sed',
+                     args: ['-i', '.bak', 's|/usr/sbin/zfs|/usr/local/bin/zfs|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
+    end
   end
 
   uninstall script: {

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -20,5 +20,15 @@ cask 'openzfs' do
     pkg "OpenZFS on OS X #{version.before_comma} Sierra.pkg"
   end
 
-  uninstall pkgutil: 'net.lundman.openzfs.*'
+  uninstall_preflight do
+    system_command '/usr/bin/sed',
+                   args: ['-i', '.bak', 's|/usr/sbin/zpool|/usr/local/bin/zpool|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
+    system_command '/usr/bin/sed',
+                   args: ['-i', '.bak', 's|/usr/sbin/zfs|/usr/local/bin/zfs|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
+  end
+
+  uninstall script: {
+                      executable: "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh",
+                      sudo:       true,
+                    }
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fixes https://github.com/caskroom/homebrew-cask/issues/32769, script checks for imported pools before uninstall/reinstall.

Updated cask to use `uninstall script:`
- https://openzfsonosx.org/wiki/Uninstall
- https://github.com/ilovezfs/openzfsonosx-installer/blob/master/scripts/dmg-scripts/uninstall-openzfsonosx.sh

Script checks for imported pools, unloads kexts / launchctl, removes files and forgets the `pkg`s.

Currently the script looks for `zpool` and `zfs` in `/usr/sbin` instead of `/usr/local/bin` so `uninstall_preflight` changes it to look in the correct directory.
____
Edit: Just realised the script will work without modification if the MacOS version is older than 10.11, updated `uninstall_preflight` to use `if MacOS.version >= :el_capitan`.