### PR TITLE
Update camunda-modeler to 1.8.2

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.8.1'
-  sha256 'b3a13bb3ce4783c68cad274a10a154766bdc4de27d87e28ff5d203be538d5743'
+  version '1.8.2'
+  sha256 'e5cf41e4007994e3997d6f6561d437e4965a6ff20e7046b97fa2e5fabcff621b'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.