### PR TITLE
Update brave to 0.16.9

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.16.6'
-  sha256 '89172182380df394f1179457aef789d23fbe72050a75088644f055e0c3678b72'
+  version '0.16.9'
+  sha256 '00332b9f639e72cbbca7c7480b6b108155de2bdf90fd3e8c3c3d620168dd9898'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'cdd61e485943bf99d9dc908cb23b9abfa612e1ca623fcfbabf35393c828a1077'
+          checkpoint: '02e2bb69de5bf1dc1fe59863b936a095afb67044e659898cfdf0a458ae2cb308'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.