### PR TITLE
Update aria2gui to 1.3.8

### DIFF
--- a/Casks/aria2gui.rb
+++ b/Casks/aria2gui.rb
@@ -1,10 +1,10 @@
 cask 'aria2gui' do
-  version '1.3.7'
-  sha256 '96779f1cc15120f7d2cd716e55ffb52848937084b916d19c147cada0ff485396'
+  version '1.3.8'
+  sha256 '34cf93dd67ac61dda5ab2cba76c60caa7e004c88244b30c2a77cbe3c2e96809c'
 
   url "https://github.com/yangshun1029/aria2gui/releases/download/#{version}/Aria2GUI-v#{version}.zip"
   appcast 'https://github.com/yangshun1029/aria2gui/releases.atom',
-          checkpoint: '9bcb6e2b5713da199f1e9912b392c0b18192a7f1beae50b49898637edf24cf26'
+          checkpoint: '495a38eb7f2ab8baf97150d2f74ce6cf9b423c9c8cc0643b2a8558436f469fc4'
   name 'Aria2GUI'
   homepage 'https://github.com/yangshun1029/aria2gui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.