### PR TITLE
Update bitpay to 3.4.0

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.2.0'
-  sha256 '6427948d520262d0b18fa85dcef7797b5f9393d72a62fbb01cc2282ba02c223b'
+  version '3.4.0'
+  sha256 '32a7f0339b54669b45604646d73bd93fc512834d1e078997c2c139dec3bda568'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'd4f00bf868b39cd25caa5e4fe7aac91b039079772c7785f2f4cd9b3bcf6185f7'
+          checkpoint: 'fb1285278a060ae1a67ac5e8058146a28037fd47cd26257673d858d33b2f00ed'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.