### PR TITLE
Update exodus to 1.27.2

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.27.1'
-  sha256 '28eeac975f978ab1c38e5395046d5f1b019baf09da1fbdbcaa352b48e992a2f9'
+  version '1.27.2'
+  sha256 '31a3b18be13678d5f4df80420da031f51a09441c808214dd0eb1499b2b084c27'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/Exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '5cac7bfce196de841826eec8c3c987df557efdbf5730d31298e4234dbbcfb50f'
+          checkpoint: '87b87fbc30ec3859525d6178abf7f2d04f1621b5f581c70164870d4b68625e84'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.