### PR TITLE
Updated RawTherapee to 5.1

### DIFF
--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,12 +1,13 @@
 cask 'rawtherapee' do
-  version '5.0-r1_gtk3'
-  sha256 '4a8c7d527d06e674e9a3d61dac3a45760c5ff1314db06b81e63f74bc8a3dff16'
+  version '5.1'
+  sha256 '0490769c37dd8b70a6aa35f51b36e2acbdd7b9f4f4b3707a967abf8ad0edcd5f'
 
-  url "http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_#{version}.app.zip"
+  url "http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_64_#{version}.zip"
   name 'RawTherapee'
   homepage 'http://rawtherapee.com/'
 
-  depends_on macos: '>= 10.8'
+  depends_on macos: '>= 10.9'
+  container nested: "RawTherapee_OSX_10.9_64_#{version}.dmg"
 
-  app 'RawTherapee-gtk3.app'
+  app 'RawTherapee.app'
 end

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -7,7 +7,6 @@ cask 'rawtherapee' do
   homepage 'http://rawtherapee.com/'
 
   depends_on macos: '>= 10.9'
-
   container nested: "RawTherapee_OSX_10.9_64_#{version}.dmg"
 
   app 'RawTherapee.app'

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -7,7 +7,7 @@ cask 'rawtherapee' do
   homepage 'http://rawtherapee.com/'
 
   depends_on macos: '>= 10.9'
-  
+
   container nested: "RawTherapee_OSX_10.9_64_#{version}.dmg"
 
   app 'RawTherapee.app'

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -7,6 +7,7 @@ cask 'rawtherapee' do
   homepage 'http://rawtherapee.com/'
 
   depends_on macos: '>= 10.9'
+  
   container nested: "RawTherapee_OSX_10.9_64_#{version}.dmg"
 
   app 'RawTherapee.app'


### PR DESCRIPTION
I updated [RawTherapee](http://www.rawtherapee.com/) formula to 5.1, its latest version (with the help in #35392).

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
