### PR TITLE
Updates for r formula migration

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -16,7 +16,7 @@ cask 'rstudio' do
     There are different ways to satisfy that dependency and we don’t want to impose one, so it is up to you to satisfy it.
     We suggest you do so by running one of:
 
-      brew install homebrew/science/r
+      brew install r
       brew cask install r-app
   EOS
 end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -81,7 +81,7 @@
   "purescript": "homebrew/core",
   "python": "homebrew/core",
   "python3": "homebrew/core",
-  "r": "homebrew/science",
+  "r": "homebrew/core",
   "razer-synapse": "caskroom/drivers",
   "redis": "homebrew/core",
   "ricoh-driver-aficio-sp-c240dn": "caskroom/drivers",


### PR DESCRIPTION
On hold until https://github.com/Homebrew/homebrew-core/pull/14416 is merged.

`r` is migrating from `homebrew/science` to `homebrew/core`

- Updated `rstudio` caveat - `brew install r`
- Updated `tap_migrations.json` - `homebrew/core`