### PR TITLE
Update mucommander to 0.9.2

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,11 +1,11 @@
 cask 'mucommander' do
-  version '0.9.1'
-  sha256 'e623a1ecdf198fae40d8f42a8898667f5fc38efbc158bfc01df6c0b746d22934'
+  version '0.9.2'
+  sha256 '54486fba723d3d54084414e31337b010c2f28fc4820cefc01cad65e4a5a84744'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"
   appcast 'https://github.com/mucommander/mucommander/releases.atom',
-          checkpoint: 'dc6b3cc95d6a209036e2b564854f85dd3778abdee72b0f53f9671ae4134e6500'
+          checkpoint: '85dd3667b8c8e365c48aa185a0e2711a7d26f3829a756c06c405c7ae9e9aea8b'
   name 'muCommander'
   homepage 'http://www.mucommander.com/'
 


### PR DESCRIPTION
It's my first update of a cask guys, so sorry of something is not ideally done. Tried using `cask-repair` and got to a point of seeing this diff: 

```diff
-  version '0.9.1'
-  sha256 'e623a1ecdf198fae40d8f42a8898667f5fc38efbc158bfc01df6c0b746d22934'
+  version '0.9.2'
+  sha256 '54486fba723d3d54084414e31337b010c2f28fc4820cefc01cad65e4a5a84744'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"
   appcast 'https://github.com/mucommander/mucommander/releases.atom',
-          checkpoint: 'dc6b3cc95d6a209036e2b564854f85dd3778abdee72b0f53f9671ae4134e6500'
+          checkpoint: '85dd3667b8c8e365c48aa185a0e2711a7d26f3829a756c06c405c7ae9e9aea8b'
   name 'muCommander'
   homepage 'http://www.mucommander.com/'

```

but then got stuck at:
```
Submitting…
Error creating pull request: Unprocessable Entity (HTTP 422)
Invalid value for "head"
Error creating pull request: Unprocessable Entity (HTTP 422)
Invalid value for "head"
```

So the PR is created manually via Github website.

Thanks to @giannitm who suggested to try `cask-repair` in https://github.com/caskroom/homebrew-cask/pull/34097!