### PR TITLE
Update angry-ip-scanner to 3.5.1

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -2,10 +2,10 @@ cask 'angry-ip-scanner' do
   version '3.5.1'
   sha256 '3283db621b621cbd7761709125c8097dc52ef0b9329bd25c9eb79a162b86eb12'
 
-  # github.com/angryziber/ipscan was verified as official when first introduced to the cask
-  url "https://github.com/angryziber/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"
-  appcast 'https://github.com/angryziber/ipscan/releases.atom',
-          checkpoint: 'd3e193b2867c3e37d0516b1d12363026c8dd80b7069b2d69b082f5edea7b6493'
+  # github.com/angryip/ipscan was verified as official when first introduced to the cask
+  url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"
+  appcast 'https://github.com/angryip/ipscan/releases.atom',
+          checkpoint: '6d6ec55fce2ab10346564d7990c4645dbb1b63c71d6f4fc73922c49051f53e21'
   name 'Angry IP Scanner'
   homepage 'http://angryip.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.