### PR TITLE
Update apple-events to 0.8

### DIFF
--- a/Casks/apple-events.rb
+++ b/Casks/apple-events.rb
@@ -1,10 +1,10 @@
 cask 'apple-events' do
-  version '0.7'
-  sha256 '02348341c90ac1810e326ee936854254fe1f29b50fac751266bd6934eba6b206'
+  version '0.8'
+  sha256 'ed120b247a17dc873c8ee8c1c87a1ffa41d0d26e05361a352d55017a24033806'
 
-  url "https://github.com/insidegui/AppleEvents/releases/download/#{version}/AppleEvents_v#{version}_r.zip"
+  url "https://github.com/insidegui/AppleEvents/releases/download/#{version}/AppleEvents_v#{version}.zip"
   appcast 'https://github.com/insidegui/AppleEvents/releases.atom',
-          checkpoint: 'cdf5faa46cdf2b6215c68424a681bba8462d5f4e0d39791929f2411b4bd08b9f'
+          checkpoint: 'f2d92a82be4e0ccaa583de775f63de1f79a8f81e44974ec554a6b8a36a3a055f'
   name 'Apple Events'
   homepage 'https://github.com/insidegui/AppleEvents'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.