### PR TITLE
Update appserver to 1.1.4-212

### DIFF
--- a/Casks/appserver.rb
+++ b/Casks/appserver.rb
@@ -1,11 +1,11 @@
 cask 'appserver' do
-  version '1.1.3-200'
-  sha256 'dc7a94a1812356250b2cca7eb337c7fc7ad38c71745fc243492ec3113fac6c31'
+  version '1.1.4-212'
+  sha256 '81f40c5335774b469ddfe4045462510a576a0f9ad5bbfc2363ea7b3de582bb46'
 
   # github.com/appserver-io/appserver was verified as official when first introduced to the cask
   url "https://github.com/appserver-io/appserver/releases/download/#{version.sub(%r{-.*}, '')}/appserver-dist_#{version}_x86_64.pkg"
   appcast 'https://github.com/appserver-io/appserver/releases.atom',
-          checkpoint: '7ff61bdab52711e2f289f89835204463370d5bc6769aa1fb17584a074a38aaea'
+          checkpoint: '1d421bed542b5ce4df18f0388ae00f2cc38b661ba9f0d5deedffced970095e4a'
   name 'appserver.io'
   homepage 'http://appserver.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.