### PR TITLE
Update ubersicht to 1.2.48

### DIFF
--- a/Casks/ubersicht.rb
+++ b/Casks/ubersicht.rb
@@ -1,10 +1,10 @@
 cask 'ubersicht' do
-  version '1.2.46'
-  sha256 '4629eb4863673e69599d51f986d469c4a3f13b6b843cb0d065c08f767e3b2eea'
+  version '1.2.48'
+  sha256 'c16f40978f89ed593e27bfc8c5b6912ffea1ef02bc08a79a4ccb234c00080512'
 
   url "http://tracesof.net/uebersicht/releases/Uebersicht-#{version}.app.zip"
   appcast 'http://tracesof.net/uebersicht/updates.xml.rss',
-          checkpoint: '7aefd5941e00dafaaee47492bf2a2cc0f2fdd2871fd73e94d14f4bb7c7fb4ba8'
+          checkpoint: '63d38503521d1c1fe1a7dd8505e7e64383293d161cbf624da41b7adecd8266e0'
   name 'Übersicht'
   homepage 'http://tracesof.net/uebersicht/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.