### PR TITLE
Update dupin to 2.11.2

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,11 +3,11 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.11.1'
-    sha256 '1cb909a9e49ece636bfcd1a56827fb5ed89bd9089200bd8a56937787677da7d1'
+    version '2.11.2'
+    sha256 'c5f8ab3dc16eebf2fb7205e88a000e68bb6256aa86f96539083b6c6b344768e4'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml',
-            checkpoint: '25f4adcc0846dcaf3d05488681bf7e70e7f338212e2097bf4f469ede80330ded'
+            checkpoint: 'fa1d7890a2e25dc093172271be546ae3e40dc473814859c7f403c61047c6d124'
   end
 
   url "https://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.