### PR TITLE
Update invisor-lite to 3.8.1

### DIFF
--- a/Casks/invisor-lite.rb
+++ b/Casks/invisor-lite.rb
@@ -1,10 +1,10 @@
 cask 'invisor-lite' do
-  version '3.7'
-  sha256 '4b1d1f73c76d278f8bc09ff117ec880b8446273dc026b4007297d1cedbb4abc0'
+  version '3.8.1'
+  sha256 '49b8d3dee4bb0e0018d211fc2245475e193b99bfa2a41fbf07adb1c5c1dc8574'
 
   url "http://www.pozdeev.com/invisor/download/InvisorLite-#{version}.dmg"
   appcast 'http://www.pozdeev.com/invisor/appcast_lite.xml',
-          checkpoint: '09e107fc3df2dcb1aeece9acc2eddcf9bb04632bb94f3d362f981abee7c22595'
+          checkpoint: '716c0cab315874094b6247c06347d02870260652790614719225cdec3cccc31b'
   name 'Invisor Lite'
   homepage 'https://www.pozdeev.com/invisor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.