### PR TITLE
Update kite to 0.20170608.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170601.0'
-  sha256 '66f8c4d217af9ec5839ed23e4e2b72c699ec9fbb95fdcccbc20aa78d14e8242b'
+  version '0.20170608.0'
+  sha256 '8f2e11ba726dbfa26719cb2053e4b62110c4d66e23e5ca7ebb055db1251c9891'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '0249db2c900276925fb608b24329c60a114ea7648a231bd2b18ab32b31ab3c9b'
+          checkpoint: '75ed70bdc770adb3d099db11d52af02d766cba66bc52dce4811c6db10c579d81'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.