### PR TITLE
Update overture to 2.4.8

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.4.6'
-  sha256 'd766aea619b3185f318f22cefeba53e7f07db2bee551fc551bbff6b99fc5785a'
+  version '2.4.8'
+  sha256 'b2d93c06529bef563b7ee0bbd1e4488c02c22ccf8dd977c5be6e1ff1e912d871'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: '78269cfc592aff4bfdf33770d5bb12c598475c6526d0cf3904afe650704d0ec0'
+          checkpoint: '33c6493d0bf533dd560165333c18b05884c22cb3baa97d58b771214d318ebf42'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.