### PR TITLE
Update pritunl to 1.0.1364.29

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1363.37'
-  sha256 '3f70267fa1f8c48e23f3c9ef29d8293a76c78f0e36cbfb364e1f39636693414c'
+  version '1.0.1364.29'
+  sha256 'becddef266b34eaf082d0824e1194e141094aa53eb6850b5e69fe5ecfd5c5e2a'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'da5e340f57e6f00e3817db2d4864094d891e270e58a5c03af3d6c28b51a7b58b'
+          checkpoint: '9fdabdf6411f99bc79a9e91031d8a8863ba2287411113c327002a1508e014bb8'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.