### PR TITLE
Update pencil to 3.0.3

### DIFF
--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -1,10 +1,10 @@
 cask 'pencil' do
-  version '3.0.2'
-  sha256 '7cfaacb55509b54a134403cb3026724bb55d19f48d5f76690ba4e62c7f31dd0d'
+  version '3.0.3'
+  sha256 '4b1e13354b76a5fd3d662edcc26aeab156a38b46f4e2e8f84582f369c725fbf2'
 
   url "http://pencil.evolus.vn/dl/V#{version}/Pencil-#{version}.dmg"
   appcast 'https://github.com/evolus/pencil/releases.atom',
-          checkpoint: 'f5fb797cc84fd5b99a4d4cd9e7fa5f5fc085d0303a649c38b78c3696b77b47bf'
+          checkpoint: 'e65e3ee4c1e89054083e0f3a8fb7078baea1ad126e2953e8d39a015214af8828'
   name 'Pencil'
   homepage 'https://pencil.evolus.vn/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.