### PR TITLE
Update polymail to 1.38

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.37'
-  sha256 'f1c3955222f1430174cfecfa4d59ec48212a1aa87c5da069c9f626f35734ead3'
+  version '1.38'
+  sha256 'de5f4279c10af0132bacfc56d58ffb1915e4d7ea4013a30aff00a47b69462ba8'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '51b845a01b7f351b0c2b21e47cc39a187ef26c4198fbfd247043dfed2b52595b'
+          checkpoint: 'c0633242fd02b71f08873078a7cfb6b7000c2c0e44769c2cccce33dd3b85b238'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256],
      provide public confirmation by the developer: {{link}}