### PR TITLE
Update qlvideo to 1.88

### DIFF
--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -1,10 +1,10 @@
 cask 'qlvideo' do
-  version '1.87'
-  sha256 '0f21d994715fa409a858b5f04a76708975b4109dd9ac4e820dbccb7caaf61ded'
+  version '1.88'
+  sha256 '7c59d0ae79a64bbe0ffe233df474d765a7682614ee8339c19bae49e1f6856316'
 
   url "https://github.com/Marginal/QLVideo/releases/download/rel-#{version.no_dots}/QLVideo_#{version.no_dots}.pkg"
   appcast 'https://github.com/Marginal/QLVideo/releases.atom',
-          checkpoint: '2dbbdfc46712b462753a2d0a0c54c74c98a746eaf63896c0db4d1b09463d8266'
+          checkpoint: 'a9013818ec62665be6f6a1a6d398d7e931492f0f6ac06a3f0ff8d3d872e3c8b0'
   name 'QuickLook Video'
   homepage 'https://github.com/Marginal/QLVideo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}