### PR TITLE
Upgrade Sandman from 1.9.1 to 1.9.2

### DIFF
--- a/Casks/sandman.rb
+++ b/Casks/sandman.rb
@@ -1,11 +1,11 @@
 cask 'sandman' do
-  version '1.9.1'
-  sha256 '231bdc3194678c32aa8f16c1604cb1e1b84ac488f962a87a8d81170b01e5d221'
+  version '1.9.2'
+  sha256 '0a85754b845f09b114c051be50980aa3098f87cfe09bc2f0ed7a091f87266233'
 
   # github.com/alexanderepstein/Sandman was verified as official when first introduced to the cask
   url "https://github.com/alexanderepstein/Sandman/releases/download/v#{version}/Sandman-#{version}.dmg"
   appcast 'https://github.com/alexanderepstein/Sandman/releases.atom',
-          checkpoint: '135446e926f3d617eda7b18b46dd589ad818173d7f976f62dad1c4bc0729e7fd'
+          checkpoint: 'b6bc71dd796dc5d37028616ccd320bb9654a6c8ed740c73761af8ef512d4a890'
   name 'Sandman'
   homepage 'https://alexanderepstein.github.io/Sandman/'
 


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

