### PR TITLE
Update omnifocus to 2.10

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -12,13 +12,13 @@ cask 'omnifocus' do
     sha256 'a273e55c15f82540fe305344f9e49ad7d0d9c326ba2c37c312076ffd73780f80'
     url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
   else
-    version '2.9.1'
-    sha256 '4866356bbc3bd5f3d31bd64d528fe1ddc1c0db3a5400be05ca2c443508d996ea'
+    version '2.10'
+    sha256 'e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8'
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
   end
 
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniFocus#{version.major}",
-          checkpoint: '269ee59938e4785ce50bcaefb9c84c7f5407dc03ca9703fb259620e4870fc99e'
+          checkpoint: 'de61d32697bb5a1b8b927df2adb90ebcc505979d73424f1b6631a8eccd9f3347'
   name 'OmniFocus'
   homepage 'https://www.omnigroup.com/omnifocus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}