### PR TITLE
Update blackvue-viewer to 1.09,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.07,74331'
-  sha256 '64cb8d56e6b56cebd7f38f7e8704d87b5a230a25afe90a94a2887947e1b5594e'
+  version '1.09,74331'
+  sha256 'a36ee16aa51185229b5dd81a2931d0dad6ef8ba37ce9aeeb2d31fa30f2de07ad'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   name 'BlackVue Viewer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.