### PR TITLE
Update bluefish to 2.2.10

### DIFF
--- a/Casks/bluefish.rb
+++ b/Casks/bluefish.rb
@@ -1,11 +1,11 @@
 cask 'bluefish' do
-  version '2.2.8'
-  sha256 '46e6202adc39d4759380ab603174f3549a9620e735c816c61392ac2900350f4e'
+  version '2.2.10'
+  sha256 'e6edd693b174c186be5eb2d2a8a89ae2608e8661f6441edbcaf27d2457d616fa'
 
   # bennewitz.com was verified as official when first introduced to the cask
   url "https://www.bennewitz.com/bluefish/stable/binaries/macosx/Bluefish-#{version}.dmg"
   appcast 'http://www.bennewitz.com/bluefish/stable/binaries/macosx/',
-          checkpoint: '72278d0e8f14cc4b157f1f672d76fe1c4e5c34ac9444e8f83959a8bf298dca20'
+          checkpoint: '8caecd64ed7ba8bfe38f7bec653ebbba19372c885ccde58d12f6a67cd10cadec'
   name 'Bluefish'
   homepage 'http://bluefish.openoffice.nl/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.