### PR TITLE
Update go-server to 17.5.0-5095

### DIFF
--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,11 +1,11 @@
 cask 'go-server' do
-  version '17.4.0-4892'
-  sha256 'f3b70cfec9a79ce6966f8e71e9ba6acbbbb5b90a4c2048e001675264bdc6c3bb'
+  version '17.5.0-5095'
+  sha256 '8f2ed15fa4e20918a2540f45678beb0d7f956d8586524ed58ac9f0fedaecf7d6'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: 'abcc8b9914fb3fdb0658581f43d6e5f673af0e359519febad83f61583ef76b70'
+          checkpoint: '4e4f162d063d75ea1ff1642a0c0544cf6c628b1a915329e8c5fbf88da2dd6ce8'
   name 'Go Server'
   homepage 'https://www.gocd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.