### PR TITLE
Update scala-ide to 4.6.1,2.12:20170609

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,6 +1,6 @@
 cask 'scala-ide' do
-  version '4.6.0,2.12:20170516'
-  sha256 '50440c68ab2b3c9ad608676732bef126a36c2c95f6a18a8c76a9d766703c3c78'
+  version '4.6.1,2.12:20170609'
+  sha256 'fb0868c0ce8559964d5b316d71f15681feccb13ab6b230928c789c562afa7b5c'
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
   url "https://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-neon-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.