### PR TITLE
Update pagico to 8.7.2171

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '8.7.2161'
-  sha256 '0d0ebf19632dbb2a8279e04868fba42eed74ace7be1cdf9de47659b9a92d42bd'
+  version '8.7.2171'
+  sha256 '443bf9eb12e5f8a148edf65f0384719ad03ccc4cef113eef4862cdea804de160'
 
   url "https://www.pagico.com/downloads/Pagico_Desktop_r#{version.patch}.dmg"
   name 'Pagico'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.