### PR TITLE
Update opera to 45.0.2552.898

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '45.0.2552.888'
-  sha256 'd0248a14f784324a2a7d04992232953dc22256ecdb9cf5f91ab4fff65745b11e'
+  version '45.0.2552.898'
+  sha256 '3b0cab4c8a9635b563d5539647da1e0e761c6f2491519a3c647546ac69c4143a'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}