### PR TITLE
Update flowdock to 1.2.9

### DIFF
--- a/Casks/flowdock.rb
+++ b/Casks/flowdock.rb
@@ -1,11 +1,11 @@
 cask 'flowdock' do
-  version '1.2.7'
-  sha256 '80cce5d7062ca5e24189d268bb6b0c08ce732c5039156bbe393c0bdecec5eadd'
+  version '1.2.9'
+  sha256 '803c42d393f91f2b8f08ad890f7603c9607d9adcac5acaf495e9ba66441657e7'
 
   # amazonaws.com/flowdock-resources was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/flowdock-resources/mac/#{version}/Flowdock.zip"
   appcast 'https://s3.amazonaws.com/flowdock-resources/mac/appcast.xml',
-          checkpoint: '05c0917ea74ed402ec6f41dac60a62549f062e7a2f983f410a860d324cdcf976'
+          checkpoint: 'e032b539857ff609e45db3de3e095c2d9334781bb6a29e6cf0192a63bd41a134'
   name 'Flowdock'
   homepage 'https://www.flowdock.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum], provide public confirmation by the developer: (both changed)

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
