### PR TITLE
Update flash-player to 26.0.0.126

### DIFF
--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,11 +1,11 @@
 cask 'flash-player' do
-  version '25.0.0.171'
-  sha256 'fdf6971ccb1b2662ad07e41b870b55b139a50e6350c639ef1568d2b42e14328f'
+  version '26.0.0.126'
+  sha256 'f5b2151a1af02471f2d380e77bb17727a586dea68162b82e565cdfaf1a9ff9ca'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: 'bc60c681da9e15721efefa90e1ed00d341c6774a91d8fe182c81348c826c5dee'
+          checkpoint: '788a4e4eaa4bda842e2890baafd3e6d176ebc53eaf42255ec18808d5fb601594'
   name 'Adobe Flash Player projector'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}