### PR TITLE
Update flash-player-debugger-npapi to 26.0.0.126

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger-npapi' do
-  version '25.0.0.171'
-  sha256 '16a14d8180d153b00390081da214f76b1bc8fa66b35b9abd72a46094e2f72cb8'
+  version '26.0.0.126'
+  sha256 '6ea0b2fcf2c5e0375c6d3c0ca04a01418b8ce039374af3d267903015fa9bf635'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: 'bc60c681da9e15721efefa90e1ed00d341c6774a91d8fe182c81348c826c5dee'
+          checkpoint: '788a4e4eaa4bda842e2890baafd3e6d176ebc53eaf42255ec18808d5fb601594'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}