### PR TITLE
Update beyond-compare to 4.2.2.22384

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -4,7 +4,7 @@ cask 'beyond-compare' do
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "http://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx",
-          checkpoint: '7367a47a30dbe60cda77a1c461bee54a7300467393a7362fc788de2bfb8743f2'
+          checkpoint: 'd124591e52265bd641981b99d9ab0307cbd01f4641e3b8b744aded4552d5e53f'
   name 'Beyond Compare'
   homepage 'https://www.scootersoftware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}