### PR TITLE
Update blocs to 2.3.2

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,11 +1,11 @@
 cask 'blocs' do
   version '2.3.2'
-  sha256 'c766c135dbe42a2900b66dc2f6e07e855f392fe35baf89b3af46d0000a6779f0'
+  sha256 '76efb708686274c89beb13e96592449504cc0788b00142003e28b6d94d6e088c'
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
   appcast "https://uistore.io/blocs/#{version.major}.0/info.xml",
-          checkpoint: '5a471db8fc9e3eef22c4e23ba2daccb3a027677f71141224889c9259d68ca9f7'
+          checkpoint: 'e71c5c4e997865268eced3ee239229ebdd1588808e98fff183cbf43010d207c6'
   name 'Blocs'
   homepage 'https://blocsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: https://www.virustotal.com/en-gb/file/76efb708686274c89beb13e96592449504cc0788b00142003e28b6d94d6e088c/analysis/

<img width="1067" alt="screen shot 2017-06-13 at 20 54 34" src="https://user-images.githubusercontent.com/25732197/27101676-9f0a2a5a-507a-11e7-92bc-0337dd182b84.png">
