### PR TITLE
Update soqlxplorer to 2.70

### DIFF
--- a/Casks/soqlxplorer.rb
+++ b/Casks/soqlxplorer.rb
@@ -1,10 +1,10 @@
 cask 'soqlxplorer' do
-  version '2.60'
-  sha256 '29a7b9b9ae13d25038dd25d53a7b15ae4f80640b83dad5ef96dc5d9ecfcd2f29'
+  version '2.70'
+  sha256 '742487d026df3984ee0851d3a2a77b6f003262ebd6845c069aba67c8d03f4088'
 
   url "http://www.pocketsoap.com/osx/soqlx/soqlXplorer_v#{version}.zip"
   appcast 'http://www.pocketsoap.com/osx/soqlx/appcast.xml',
-          checkpoint: '70205d0d804a6f29f27f8b52cc9f965456cbf8c41b2f46da0461dd5c6d840f11'
+          checkpoint: '15219bccd9809cb334dd164846a7b43421a079918c50c7091773778712e976c9'
   name 'SoqlXplorer'
   homepage 'http://www.pocketsoap.com/osx/soqlx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.