### PR TITLE
Update stamp to 4.7.1

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.6.3'
-  sha256 '02c26def4301964cc1a884d520842e1e67445328e2923c1e2ca3995a1e7b92ee'
+  version '4.7.1'
+  sha256 '2c8a4b9470e1bc70942cd857e42f33b422268419916304d2c25f5c62bd01b0e3'
 
   url "https://freeyourmusic.com/media/STAMP#{version.no_dots}.dmg"
   name 'Stamp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.