### PR TITLE
Update deegain to 1.1.0

### DIFF
--- a/Casks/deegain.rb
+++ b/Casks/deegain.rb
@@ -1,8 +1,8 @@
 cask 'deegain' do
   version '1.1.0'
-  sha256 '3ad7fd274120a694cf7ab99f266c7a29e9e2476c9d46e433067c3079169d9dc5'
+  sha256 '7440f83665b04be13e0cb1f3f948a4261011f68db7ca0fd4b1ef7d3ec7795aba'
 
-  url "https://dotec-audio.com/release/DeeGain/DeeGainMac_#{version}.zip"
+  url "https://dotec-audio.com/release/DeeGain/DeeGainMacA_#{version}.zip"
   name 'DOTEC-AUDIO DeeGain'
   homepage 'https://dotec-audio.com/deegain.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [X] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer:

https://dotec-audio.com/deegain.html states in the release notes
Jun/7/2017 Version 1.1.0 :  New!
Released AAX Version.
Changed the support MacOSX version "10.9 or later" to "10.7 or later"

They have changed both the download location and added a feature without version bump