### PR TITLE
Update electrum to 2.8.3

### DIFF
--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -1,10 +1,10 @@
 cask 'electrum' do
-  version '2.8.2'
-  sha256 '1ebe0772fcfa1d04761d23174d1793009cf16b75b90034d8e384f9cc3fd29077'
+  version '2.8.3'
+  sha256 '9090baab30f1d1b1ecde62b8eb976a1e025b85c8c2849ea0467a34de0c255a68'
 
   url "https://download.electrum.org/#{version}/electrum-#{version}.dmg"
   appcast 'https://github.com/spesmilo/electrum/releases.atom',
-          checkpoint: '3f13cfabbecbd6b6804f125c966e40a8c2dc733a9e9e8e7530fc13cbedbdcbae'
+          checkpoint: '6d8cc7c042551a1f0c037dad1eaf0666def3a81184078b2db109c1a0773b5958'
   name 'Electrum'
   homepage 'https://electrum.org/'
   gpg "#{url}.asc", key_id: '6694d8de7be8ee5631bed9502bd5824b7f9470e6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.
- [x] The commit message includes the cask’s name and version.