### PR TITLE
Bump tormessenger to 0.4.0b3

### DIFF
--- a/Casks/tormessenger.rb
+++ b/Casks/tormessenger.rb
@@ -1,6 +1,6 @@
 cask 'tormessenger' do
-  version '0.4.0b2'
-  sha256 '7b374ca8fa687b7a59858bf5f17923cbdfaae0d1688856c2b8f75c4b67473514'
+  version '0.4.0b3'
+  sha256 'fdd787a8f1a3e8097e5d88eb6a3aa9d39006f3617e22aa47ab4374b9791c3475'
 
   url "https://dist.torproject.org/tormessenger/#{version}/TorMessenger-#{version}-osx64_en-US.dmg"
   name 'Tor Messenger'


### PR DESCRIPTION
Tor Messenger has been updated: https://blog.torproject.org/blog/tor-messenger-040b3-released
This reflects the new version and sha256.

Verified working in my tap

---

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.