### PR TITLE
Update beaker to 1.7.1-0-g6dac09a

### DIFF
--- a/Casks/beaker.rb
+++ b/Casks/beaker.rb
@@ -5,7 +5,7 @@ cask 'beaker' do
   # d299yghl10frh5.cloudfront.net was verified as official when first introduced to the cask
   url "https://d299yghl10frh5.cloudfront.net/beaker-notebook-#{version}-mac.dmg"
   appcast 'https://github.com/twosigma/beakerx/releases.atom',
-          checkpoint: 'ae403b460dcf94e72fff17103953b47a338279bf9c7e4de43cc670004d4935b3'
+          checkpoint: '9a4fae4b7b68e6d0eab78ac00e4c2be7687337bdc525ac539f73fb954ab814e7'
   name 'Beaker'
   homepage 'http://beakernotebook.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}