### PR TITLE
Update cisdem-pdfmanagerultimate to 2.5.0

### DIFF
--- a/Casks/cisdem-pdfmanagerultimate.rb
+++ b/Casks/cisdem-pdfmanagerultimate.rb
@@ -4,7 +4,7 @@ cask 'cisdem-pdfmanagerultimate' do
 
   url 'https://www.cisdem.com/download/cisdem-pdfmanagerultimate.dmg'
   appcast 'https://www.cisdem.com/pdf-manager-ultimate-mac/release-notes.html',
-          checkpoint: '1a02e2ff75effa10451a124a858681542b20527d40d7ea3142450943335212e7'
+          checkpoint: '12e51c88946084cc1cb074d43d68857993a6c83e46cfbd63a4695f47aa841fb1'
   name 'Cisdem PDFManagerUltimate'
   homepage 'https://www.cisdem.com/pdf-manager-ultimate-mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}