### PR TITLE
Update zoc to 7.14.5

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,10 +1,10 @@
 cask 'zoc' do
-  version '7.14.4'
-  sha256 'd2ba59b89c2f9bfaafde872f6133bc78e5e88caf37c704bf7b3ce24cf1992d4d'
+  version '7.14.5'
+  sha256 'd5d1f396e0addd6685c1be37ca47a1b35cf79cf6d215df8f6cafce770daace31'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast "http://www.emtec.com/downloads/zoc/zoc#{version.no_dots}_changes.txt",
-          checkpoint: 'f205e684983eac36dddfe25f78606264ef5520fc0c9e6716008e2b7861000965'
+          checkpoint: '0d96259c490c220663f82b799a4c2770b573cabbcd62d4cd70ae9076f398ed43'
   name 'ZOC'
   homepage 'https://www.emtec.com/zoc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}