### PR TITLE
Quit istat-menus 5.31 on uninstall

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -9,6 +9,12 @@ cask 'istat-menus' do
 
   app 'iStat Menus.app'
 
+  uninstall quit: [
+                    'com.bjango.iStat-Menus-Notifications',
+                    'com.bjango.iStatMenusAgent',
+                    'com.bjango.istatmenusstatus',
+                  ]
+
   zap delete: [
                 "/Library/Application Support/iStat Menus #{version.major}",
                 '/Library/LaunchAgents/com.bjango.istatmenusagent.plist',


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.