### PR TITLE
Update cmd-eikana to 2.2.3

### DIFF
--- a/Casks/cmd-eikana.rb
+++ b/Casks/cmd-eikana.rb
@@ -1,10 +1,10 @@
 cask 'cmd-eikana' do
-  version '2.2.1'
-  sha256 '483d0e80f723cad860adaf8fcd28f8161360cf7b0ab4e1cdca73be3b04337c26'
+  version '2.2.3'
+  sha256 '8e4157304ae21566339e956423632d34aacd12c96e87f35ffc83bf2304ff9be4'
 
   url "https://github.com/iMasanari/cmd-eikana/releases/download/v#{version}/eikana-#{version}.app.zip"
   appcast 'https://github.com/iMasanari/cmd-eikana/releases.atom',
-          checkpoint: 'bbf8ce2d63895d64f6309c5ea4f808d3a2c11d3dc2c513394dcaae37e6426685'
+          checkpoint: 'e40616ed8d7a7b08955274084c954db289fe30e7abfe12989c01e3abf08bf2aa'
   name 'cmd-eikana'
   name '⌘英かな'
   homepage 'https://github.com/iMasanari/cmd-eikana'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}