### PR TITLE
Update diskmaker-x to 6rc5

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,10 +1,10 @@
 cask 'diskmaker-x' do
-  version '6rc3'
-  sha256 '762681fff8576a345f2138df17bcb071565171e49de1c5b59e0abc0c8ccbc7d5'
+  version '6rc5'
+  sha256 'bfbaf4db47d2553cbe94773f20eff97b95bdf246bd7145d4fbdafe2117b4744d'
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version}.dmg"
   appcast 'https://diskmakerx.com/feed/',
-          checkpoint: '1645fb12eef9e3976615d9fefdb6c382bf3bc419db00826d23687f545a4ee0ac'
+          checkpoint: '50afcb3b4d239b33c21d8442a91ab257b4c5ce8eddd1bce7561cd2e81e024aa4'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}