### PR TITLE
Update diumoo to 1.6.0beta

### DIFF
--- a/Casks/diumoo.rb
+++ b/Casks/diumoo.rb
@@ -1,11 +1,11 @@
 cask 'diumoo' do
-  version '1.5.0'
-  sha256 'f6a6628dab6c64752f6827e453368c18dcd06962ee0823d51d51c439cf7e04b6'
+  version '1.6.0beta'
+  sha256 '6747c250af4a3ad6ea022725b0183e968f4be3f0333130de55f5795095c3759a'
 
   # github.com/shanzi/diumoo was verified as official when first introduced to the cask
-  url "https://github.com/shanzi/diumoo/releases/download/v#{version}/diumoo.zip"
+  url "https://github.com/shanzi/diumoo/releases/download/#{version}/diumoo.zip"
   appcast 'https://github.com/shanzi/diumoo/releases.atom',
-          checkpoint: 'a821ab089dadfb4dbaa63b68c5c7725588f40a1e144488519f80fa67b05e5eb9'
+          checkpoint: '5e4e7dc23c4461c9f091a583139d7abc5fd7a78a826c4bab526eb7d21374684d'
   name 'diumoo'
   homepage 'http://diumoo.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}