### PR TITLE
Update electron to 1.6.11

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.6.10'
-  sha256 '1e3118f2421cfb3af07000ca255009e6c32bda026bda016d63aa3086014789a4'
+  version '1.6.11'
+  sha256 'f932b3afc059ccaf77ff5239d7e0eb61c472e6e1bd4785164afc06f35ec2545b'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '72fe4eef9cf453d5cd2d6d65fdab88c03e6644967ffbb4598e27d41ea5a8ad28'
+          checkpoint: 'f064337f1fcdc461719c4cc47625b4406811bc8415d255475aedf88b78c7cf75'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}