### PR TITLE
Update electronic-wechat to 2.0

### DIFF
--- a/Casks/electronic-wechat.rb
+++ b/Casks/electronic-wechat.rb
@@ -4,7 +4,7 @@ cask 'electronic-wechat' do
 
   url "https://github.com/geeeeeeeeek/electronic-wechat/releases/download/V#{version}/mac-osx.tar.gz"
   appcast 'https://github.com/geeeeeeeeek/electronic-wechat/releases.atom',
-          checkpoint: '83930ec4e35c1c775a6fe5512d661718781cb456ce973808629929e0cff9415d'
+          checkpoint: 'c1ecc5779be1473be10667310df8d1a00790382af0ec0746cde056b737b5072f'
   name 'Electronic WeChat'
   homepage 'https://github.com/geeeeeeeeek/electronic-wechat'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}