### PR TITLE
Update avocode to 2.14.4

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -10,9 +10,10 @@ cask 'avocode' do
 
   zap delete: [
                 '~/Library/Preferences/com.madebysource.avocode.plist',
+                '~/Library/Preferences/com.madebysource.avocode.helper.plist',
                 '~/Library/Application Support/Avocode',
                 '~/Library/Saved Application State/com.madebysource.avocode.savedState',
-                '~/Library/Caches/Avocode',
-                '~/.avcd',
+                '~/Library/Caches/com.madebysource.avocode',
+                '~/.avocode',
               ]
 end

--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '2.14.2'
-  sha256 'fe5fe595443eb540bd3c13635366fee9c139fb821b11e6e08ba588a2dbfa443d'
+  version '2.14.4'
+  sha256 '13a9b25339048cb3228d399239ec4e1f30a816be0278a62edcdb28d7f75f6824'
 
   url "http://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   name 'Avocode'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}