### PR TITLE
Actual folders for uninstalling, enable auto-updates for Avocode 2.14.4

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -6,14 +6,17 @@ cask 'avocode' do
   name 'Avocode'
   homepage 'https://avocode.com/'
 
+  auto_updates true
+
   app 'Avocode.app'
 
   zap delete: [
-                '~/Library/Preferences/com.madebysource.avocode.plist',
-                '~/Library/Preferences/com.madebysource.avocode.helper.plist',
-                '~/Library/Application Support/Avocode',
-                '~/Library/Saved Application State/com.madebysource.avocode.savedState',
-                '~/Library/Caches/com.madebysource.avocode',
                 '~/.avocode',
+                '~/Library/Application Support/Avocode',
+                '~/Library/Caches/com.madebysource.avocode',
+                '~/Library/Caches/com.madebysource.avocode.ShipIt',
+                '~/Library/Preferences/com.madebysource.avocode.helper.plist',
+                '~/Library/Preferences/com.madebysource.avocode.plist',
+                '~/Library/Saved Application State/com.madebysource.avocode.savedState',
               ]
 end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.