### PR TITLE
Update Insomnia to 5.3.6 and fix URL

### DIFF
--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -1,12 +1,14 @@
 cask 'insomnia' do
-  version '5.3.3'
-  sha256 'a266082405fa42e42e3ad7be9a83de69dd042460bbbde5d13012799772723318'
+  version '5.3.6'
+  sha256 '072fd1f7b234cd4e69c8e9b622c3e436e0f860f64696bde3d43ab95dacfc2028'
 
-  url 'https://builds.insomnia.rest/downloads/mac/latest'
+  url "https://builds.insomnia.rest/downloads/mac/#{version}"
   appcast 'https://insomnia.rest/changelog/index.xml',
-          checkpoint: '04e8beea33c6395bf40b02fa8f1aa05632d9a3e1c0edd8de6b8bc43b4930c371'
+          checkpoint: 'c4d09787cd2cf8113c7bce7c0c794625b49cc67835862644e734f968c7b68d52'
   name 'Insomnia'
   homepage 'https://insomnia.rest/'
+
+  auto_updates true
 
   app 'Insomnia.app'
 


### PR DESCRIPTION
This PR updates Insomnia to the latest version, enables auto updates, and fixes the URL to include the version number (was causing things to break before). 

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.