### PR TITLE
Update crystax-ndk - install / uninstall

### DIFF
--- a/Casks/crystax-ndk.rb
+++ b/Casks/crystax-ndk.rb
@@ -11,7 +11,7 @@ cask 'crystax-ndk' do
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/ndk_exec.sh"
   preflight do
-    FileUtils.ln(staged_path.to_s, "#{HOMEBREW_PREFIX}/opt/crystax-ndk", force: true)
+    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/crystax-ndk")
 
     IO.write shimscript, <<-EOS.undent
       #!/bin/bash
@@ -28,8 +28,12 @@ cask 'crystax-ndk' do
     ndk-which
   ].each { |link_name| binary shimscript, target: link_name }
 
+  uninstall_postflight do
+    FileUtils.rm("#{HOMEBREW_PREFIX}/share/crystax-ndk")
+  end
+
   caveats <<-EOS.undent
    You may want to add to your profile:
-      'export ANDROID_NDK_HOME="#{HOMEBREW_PREFIX}/opt/crystax-ndk"'
+      'export ANDROID_NDK_HOME="#{HOMEBREW_PREFIX}/share/crystax-ndk"'
   EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

As this is identical to the `android-ndk` install, updating to match https://github.com/caskroom/homebrew-cask/pull/35609

Changed `preflight` symlink to `"#{HOMEBREW_PREFIX}/share/crystax-ndk"`

Added `uninstall_postflight` 

