### PR TITLE
Update flash-npapi to 26.0.0.131

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-npapi' do
-  version '26.0.0.126'
-  sha256 'f16b3d59a8c45742f48d1a7eb9d9abbc97538e1047dab264abcfc80041f4b471'
+  version '26.0.0.131'
+  sha256 '4edabd847421480096ba13239aceefbdead8db84fc7e701a8caa5b986ec54737'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '788a4e4eaa4bda842e2890baafd3e6d176ebc53eaf42255ec18808d5fb601594'
+          checkpoint: 'cf9933c08cd57d3606059c3fc326e83616aa7bd9b4f5a6a0c01c6f2067ba56dc'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox)'
   homepage 'https://get.adobe.com/flashplayer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}