### PR TITLE
Update amazon-chime to 4.4.5770

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,10 +1,10 @@
 cask 'amazon-chime' do
-  version '4.3.5721'
-  sha256 '07132830b91a570c16c2ee78447a0b4c8281f9f63a45afd1ca6098a1b5972413'
+  version '4.4.5770'
+  sha256 '7362d2c196bab810a4848379ac393b0de09015071096652538d68f0fdb2f0fa5'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast',
-          checkpoint: '4b70068c134b8c503c2481ab7e73f65deb88bf8dcb15c13b07cb7258c90ec781'
+          checkpoint: 'e544a838d6c19d646a1d1e2750aa31274bf7716cfefa4d6e90cdff39ad84ea94'
   name 'Amazon Chime'
   homepage 'https://chime.aws/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}