### PR TITLE
Update milkytracker to 1.00.00

### DIFF
--- a/Casks/milkytracker.rb
+++ b/Casks/milkytracker.rb
@@ -1,10 +1,11 @@
 cask 'milkytracker' do
-  version '0.90.86'
-  sha256 '0029fe9a5e62d2b0db11fcbedb3c13997a4199259d1f36c55f966b0417d818b0'
+  version '1.00.00'
+  sha256 '8b8c4ba5e5459b7c83959990d302dce780c01faea7786b47ca0e2b3100b5b364'
 
-  url "http://milkytracker.titandemo.org/files/milkytracker-#{version}-osx_universal.zip"
+  # github.com was verified as official when first introduced to the cask
+  url 'https://github.com/milkytracker/MilkyTracker/releases/download/v1.0.0/milkytracker-1.00.00-osx.dmg'
   name 'MilkyTracker'
   homepage 'http://milkytracker.titandemo.org/'
 
-  app "milkytracker-#{version}-osx_universal/MilkyTracker.app"
+  app 'MilkyTracker.app'
 end

--- a/Casks/milkytracker.rb
+++ b/Casks/milkytracker.rb
@@ -1,9 +1,9 @@
 cask 'milkytracker' do
-  version '1.00.00'
+  version '1.0.0,1.00.00'
   sha256 '8b8c4ba5e5459b7c83959990d302dce780c01faea7786b47ca0e2b3100b5b364'
 
-  # github.com was verified as official when first introduced to the cask
-  url 'https://github.com/milkytracker/MilkyTracker/releases/download/v1.0.0/milkytracker-1.00.00-osx.dmg'
+  # github.com/milkytracker/MilkyTracker was verified as official when first introduced to the cask
+  url "https://github.com/milkytracker/MilkyTracker/releases/download/v#{version.before_comma}/milkytracker-#{version.after_comma}-osx.dmg"
   name 'MilkyTracker'
   homepage 'http://milkytracker.titandemo.org/'
 


### PR DESCRIPTION
Update to 1.00.00 and point to the new release URL.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
