### PR TITLE
Update eagle to 8.2.2

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,6 +1,6 @@
 cask 'eagle' do
-  version '8.2.1'
-  sha256 'eaf0b8fe0c090de5799516a0ba42344cbdfbafbbc4a6c33d999ecbe9e13be3f4'
+  version '8.2.2'
+  sha256 '39836bea001b2709cbc16951753674a2042355bc9a9039965c7217af44cc4e3a'
 
   url "http://trial2.autodesk.com/NET17SWDLD/2017/EGLPRM/ESD/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   name 'CadSoft EAGLE'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}