### PR TITLE
Update macdive to 2.8.3

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,11 +1,11 @@
 cask 'macdive' do
-  version '2.8.2'
-  sha256 '777a5531a2b1f6c63fb41faa41eb5c001c4ba275d97b1257e1623e2c4d3ca154'
+  version '2.8.3'
+  sha256 '4c39a54b585137fbaabac85d639400fc2c16991440e620fa7c5d102a6d4815a0'
 
   url "http://mac-dive.com/shimmer/?download&appName=MacDive&appVariant=&appVersion=#{version}"
   appcast 'https://mac-dive.com/shimmer/?appcast&appName=MacDive',
-          checkpoint: 'bff5205ec140f3054efc5547272890dfd8ee098f19097e0ab448b9cfa0e8c409'
-  name '715b20c9633a9459f1e7154e99094b0f306033c46468bc36cee65252628c9d17'
+          checkpoint: '4920ce219477bc4f30f4f90e8e0bb01e17e40b57c71095d446be2e7542760957'
+  name 'MacDive'
   homepage 'https://www.mac-dive.com/'
 
   app 'MacDive.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}

I additionally fixed the `name` entry in the file.