### PR TITLE
Update metasploit to 4.14.28+20170617092236 - binary / uninstall

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.14.27+20170616092238'
-  sha256 '863433f668b109459916bde9c0a26cf2a397f07ec19c75806cdcce30b698af8d'
+  version '4.14.28+20170617092236'
+  sha256 '8a76196f8b57373a7a6a11ef37b5e98fd28dd1ea5d327cb252e3cb7b4fa4a316'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '9157836d08ef48a551281bdb568c87dc086c6cbb8a8f3767bfaa293ad9bc1df1'
+          checkpoint: 'f218cb29c407e42fb5acc3e0010ad217ad7969ee87fdee3bac056a1376f9e5ba'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'

--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -20,13 +20,17 @@ cask 'metasploit' do
   binary '/opt/metasploit-framework/bin/msfelfscan'
   binary '/opt/metasploit-framework/bin/msfmachscan'
   binary '/opt/metasploit-framework/bin/msfpescan'
-  binary '/opt/metasploit-framework/bin/msfremove'
   binary '/opt/metasploit-framework/bin/msfrop'
   binary '/opt/metasploit-framework/bin/msfrpc'
   binary '/opt/metasploit-framework/bin/msfrpcd'
   binary '/opt/metasploit-framework/bin/msfupdate'
   binary '/opt/metasploit-framework/bin/msfvenom'
 
-  uninstall pkgutil: '.*metasploit.*',
-            delete:  '/opt/metasploit-framework'
+  uninstall_preflight do
+    system_command '/bin/rm',
+                   args: ['-rf', '/opt/metasploit-framework'],
+                   sudo: true
+  end
+
+  uninstall pkgutil: '.*metasploit.*'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}

_____

Removed `binary` - `msfremove`. This is not needed as HBC provides uninstall.

Added `uninstall_preflight` to remove `/opt/metasploit-framework`. 

`metasploit` installs approx 37000 files in this directory which takes a while to uninstall with `pkgutil`, the `uninstall_preflight` makes uninstall/reinstall considerably quicker.
