### PR TITLE
Update gns3 to 2.0.3

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.0.2'
-  sha256 '1c7a615cc81c1e7084d7c5f3d588bbfb22b73d9309be4326a01d4da29b9a9758'
+  version '2.0.3'
+  sha256 'f10f1ad5b0622f09f4c9e0c84c5bdd9ce7b29c14ad26d2dec0f7b884822d9dea'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: 'b4c6212f3079363b3c2b6369ff56518545fd7bb969c61ed9cb5cbc238edd9d96'
+          checkpoint: '7f9723fb47b9666f132c1d1fc0fbd3bf5dbed340cf7fd46450d38e97908aefec'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}