### PR TITLE
Update brisk to 0.2.1

### DIFF
--- a/Casks/brisk.rb
+++ b/Casks/brisk.rb
@@ -1,10 +1,10 @@
 cask 'brisk' do
-  version '0.2.0'
-  sha256 'fa466a06e20374c091ed299367b6e0b58525fcad74a36419ca06f8685d49da76'
+  version '0.2.1'
+  sha256 'a1c5022d4c8234586cc8d11df181f9584f4d7ad28c1d872e8e25b90a7a6df9f0'
 
   url "https://github.com/br1sk/brisk/releases/download/#{version}/Brisk.app.tar.gz"
   appcast 'https://github.com/br1sk/brisk/releases.atom',
-          checkpoint: 'fbc52e647fb83bf6b4856de0d0c9a60c4cfc12c5ebce6c782c1625a1b03cb72f'
+          checkpoint: 'f5b88f40bcbb907c8de2ef984a86158e869e4a69eb09b418d9a0276e669907f7'
   name 'Brisk'
   homepage 'https://github.com/br1sk/brisk'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}