### PR TITLE
Update free-download-manager to 5.1.29

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,10 +1,18 @@
 cask 'free-download-manager' do
-  version '5.1.28'
-  sha256 'c92674e88a741cec39a77d1ae03ce6cee017e065b13dc920b9d73549a2462305'
+  version '5.1.29'
+  sha256 '272ba51600440ba5c9c57d2eb8331bb5219821625514bca8c497b84e595c150e'
 
   url "http://files2.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
   name 'Free Download Manager'
   homepage 'http://www.freedownloadmanager.org/landing5.htm'
 
   app 'Free Download Manager.app'
+
+  zap delete: [
+                '~/Library/Application Support/Free Download Manager',
+                "~/Library/Caches/org.freedownloadmanager.fdm#{version.major}",
+                "~/Library/Preferences/org.freedownloadmanager.fdm#{version.major}.plist",
+                "~/Library/Saved Application State/org.freedownloadmanager.fdm#{version.major}.savedState",
+                "~/Library/LaunchAgents/org.freedownloadmanager.fdm#{version.major}.helper.plist",
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}