### PR TITLE
Add mruby-cli v0.0.4

### DIFF
--- a/Casks/mruby-cli.rb
+++ b/Casks/mruby-cli.rb
@@ -1,0 +1,12 @@
+cask 'mruby-cli' do
+  version 'v0.0.4'
+  sha256 'e78be1c039085d0024fd8337ec40328cb1d64b7251357ec5ae8c680d9b27de8d'
+
+  url 'https://github.com/hone/mruby-cli/releases/download/v0.0.4/mruby-cli-0.0.4-x86_64-apple-darwin14.tgz'
+  appcast 'https://github.com/hone/mruby-cli/releases.atom',
+          checkpoint: '576fb78542078a5060ad42f8c9db9278a0aadb9c7ce3d9757707b95ebca0c0fa'
+  name 'mruby-cli'
+  homepage 'https://github.com/hone/mruby-cli/'
+
+  binary 'mruby-cli'
+end

--- a/Casks/mruby-cli.rb
+++ b/Casks/mruby-cli.rb
@@ -2,7 +2,7 @@ cask 'mruby-cli' do
   version 'v0.0.4'
   sha256 'e78be1c039085d0024fd8337ec40328cb1d64b7251357ec5ae8c680d9b27de8d'
 
-  url 'https://github.com/hone/mruby-cli/releases/download/v0.0.4/mruby-cli-0.0.4-x86_64-apple-darwin14.tgz'
+  url "https://github.com/hone/mruby-cli/releases/download/#{version}/mruby-cli-#{version.delete('v')}-x86_64-apple-darwin14.tgz"
   appcast 'https://github.com/hone/mruby-cli/releases.atom',
           checkpoint: '576fb78542078a5060ad42f8c9db9278a0aadb9c7ce3d9757707b95ebca0c0fa'
   name 'mruby-cli'

--- a/Casks/mruby-cli.rb
+++ b/Casks/mruby-cli.rb
@@ -1,8 +1,8 @@
 cask 'mruby-cli' do
-  version 'v0.0.4'
+  version '0.0.4'
   sha256 'e78be1c039085d0024fd8337ec40328cb1d64b7251357ec5ae8c680d9b27de8d'
 
-  url "https://github.com/hone/mruby-cli/releases/download/#{version}/mruby-cli-#{version.delete('v')}-x86_64-apple-darwin14.tgz"
+  url "https://github.com/hone/mruby-cli/releases/download/v#{version}/mruby-cli-#{version}-x86_64-apple-darwin14.tgz"
   appcast 'https://github.com/hone/mruby-cli/releases.atom',
           checkpoint: '576fb78542078a5060ad42f8c9db9278a0aadb9c7ce3d9757707b95ebca0c0fa'
   name 'mruby-cli'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Was previously rejected by homebrew because the formula submitted used a binary:
https://github.com/Homebrew/legacy-homebrew/pull/46085

The official instructions for building the CLI binary involve using a docker image which installs a cross compilation toolchain.  It will be easier to get this tool on user's machines by deploying a prebuilt MacOS binary.

