### PR TITLE
Update react-native-debugger (0.7.1)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.0'
-  sha256 'fa079f63f505ad5269b2a252766b79c29a6a07483a418f12fd72f8d9cffb7056'
+  version '0.7.1'
+  sha256 'aaa8201a76ae728cffb96daaf6b112ab35388608b19a2f9f81aedda42cf9bb94'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '80d5f23cadbce885d32ef01b06889ad9e1ef5febb922491562fdf8aee0ce5f9e'
+          checkpoint: '4a53752138c3c47eaf1ae398d8e83f3dda9e3fba5840ab4e563b6d3601522b2d'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.