### PR TITLE
Update enpass to 5.5.6

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -1,6 +1,6 @@
 cask 'enpass' do
-  version '5.5.5'
-  sha256 'ad5fe4ce337130d0eabb00bcbc47f86d127397622919c6fcb86655e5b67e4b98'
+  version '5.5.6'
+  sha256 '3764ee6ef78c302d144c82ee31b0792776f323c67dd91ee345c6b83846326c7c'
 
   # sinew.in was verified as official when first introduced to the cask
   url "https://dl.sinew.in/mac/setup/Enpass-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}