### PR TITLE
Update electorrent to 2.1.1

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.0'
-  sha256 '0a72c239b7af55b9795d338ce8ac0802c0172295fd6545d1eb3cc9eb2d3ce266'
+  version '2.1.1'
+  sha256 'cbca6493f3b817429e990a273ff86e25801cf68dfcfeb7904c8aa0e780e0a8fa'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '560f46eb463e3ffda063f93b900d67fee399b9a5065c65f5d805086f50a87234'
+          checkpoint: 'f3be26d66a45c1957385f08d1574e7c4271a2044138ffbfc2d673a169e9451f8'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}