### PR TITLE
Update electorrent to 2.1.2

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.1'
-  sha256 'cbca6493f3b817429e990a273ff86e25801cf68dfcfeb7904c8aa0e780e0a8fa'
+  version '2.1.2'
+  sha256 'd512358894f0a37a98f22e1c37513a661af48d8232a09fd6bd9d7d123936cc9e'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: 'f3be26d66a45c1957385f08d1574e7c4271a2044138ffbfc2d673a169e9451f8'
+          checkpoint: '016da9cb8be6d066c271ba0f9cce6883a4c86d124b1ee92c549b533711f6917c'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}