### PR TITLE
Bump watchguard-mobile-vpn-with-ssl version to 11.12.2

### DIFF
--- a/Casks/watchguard-mobile-vpn-with-ssl.rb
+++ b/Casks/watchguard-mobile-vpn-with-ssl.rb
@@ -1,12 +1,12 @@
 cask 'watchguard-mobile-vpn-with-ssl' do
-  version '11.12.2'
+  version '11.12.2,523558'
   sha256 '2cf8435e9dd1ba77efc44e40b52f102306a0f1a3ba6f3830677ba55cf84b4232'
 
-  url "http://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.dots_to_underscores}/WG-MVPN-SSL_#{version.dots_to_underscores}.dmg"
+  url "http://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.before_comma.dots_to_underscores}/WG-MVPN-SSL_#{version.before_comma.dots_to_underscores}.dmg"
   name 'WatchGuard Mobile VPN with SSL'
   homepage 'https://www.watchguard.com/'
 
-  pkg 'WatchGuard Mobile VPN with SSL Installer V523558.mpkg'
+  pkg "WatchGuard Mobile VPN with SSL Installer V#{version.after_comma}.mpkg"
 
   uninstall pkgutil: 'com.watchguard.*'
 end

--- a/Casks/watchguard-mobile-vpn-with-ssl.rb
+++ b/Casks/watchguard-mobile-vpn-with-ssl.rb
@@ -1,12 +1,12 @@
 cask 'watchguard-mobile-vpn-with-ssl' do
-  version '11.11.0'
-  sha256 '9908e4ef7f758c0be8d9ef5ac167e6bfa2a5b44ffbc07aa5db36ba7bdb6f5089'
+  version '11.12.2'
+  sha256 '2cf8435e9dd1ba77efc44e40b52f102306a0f1a3ba6f3830677ba55cf84b4232'
 
-  url "http://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.major_minor.dots_to_underscores}/WG-MVPN-SSL_#{version.major_minor.dots_to_underscores}.dmg"
+  url "http://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.dots_to_underscores}/WG-MVPN-SSL_#{version.dots_to_underscores}.dmg"
   name 'WatchGuard Mobile VPN with SSL'
   homepage 'https://www.watchguard.com/'
 
-  pkg 'WatchGuard Mobile VPN with SSL Installer V495947.mpkg'
+  pkg 'WatchGuard Mobile VPN with SSL Installer V523558.mpkg'
 
   uninstall pkgutil: 'com.watchguard.*'
 end


### PR DESCRIPTION
Version bump from 11.11.0 to 11.12.2. 

The download URL format also changed slightly, from only being major/minor to using all parts of the version.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
