### PR TITLE
fix download link for Hedgewars v0.9.22

### DIFF
--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -2,7 +2,6 @@ cask 'hedgewars' do
   version '0.9.22'
   sha256 'adc0b6dd3b47de115e85db1cb72841836444c0ebc77caee8139bfd6561e28fe8'
 
-  # download.gna.org/hedgewars was verified as official when first introduced to the cask
   url "http://www.hedgewars.org/download/releases/Hedgewars-#{version}.dmg"
   appcast 'https://www.hedgewars.org/download/appcast.xml',
           checkpoint: 'b568efa383a1243786b557c0d85dc0b3612afebcd310c77d91b5ec3c288a3264'

--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -3,7 +3,7 @@ cask 'hedgewars' do
   sha256 'adc0b6dd3b47de115e85db1cb72841836444c0ebc77caee8139bfd6561e28fe8'
 
   # download.gna.org/hedgewars was verified as official when first introduced to the cask
-  url "http://download.gna.org/hedgewars/Hedgewars-#{version}.dmg"
+  url "http://www.hedgewars.org/download/releases/Hedgewars-#{version}.dmg"
   appcast 'https://www.hedgewars.org/download/appcast.xml',
           checkpoint: 'b568efa383a1243786b557c0d85dc0b3612afebcd310c77d91b5ec3c288a3264'
   name 'Hedgewars'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
