### PR TITLE
Update paparazzi to 1.0b6

### DIFF
--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -1,10 +1,10 @@
 cask 'paparazzi' do
-  version '1.0b5'
-  sha256 'f65571f660e100ac9531fab9edef6413e1f23a5a952e6f2553380cecc3fc0b7b'
+  version '1.0b6'
+  sha256 'f5362e23ba840247a03dea426e3d3f4fdf9b3f832cf3cf4e27498564da7af0c9'
 
   url "https://derailer.org/paparazzi/Paparazzi!%20#{version}.dmg"
   appcast 'https://derailer.org/paparazzi/appcast/',
-          checkpoint: '1673362065a3a18036832bdc850b40b24b44bfb1188739b134f9dcabf48c6fa1'
+          checkpoint: 'ca001383f08caeaa53ecf37407f5ec589aecd2dc1a2cfd705bffbaf9416a3628'
   name 'Paparazzi!'
   homepage 'https://derailer.org/paparazzi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}