### PR TITLE
Update devdocs to 0.6.0

### DIFF
--- a/Casks/devdocs.rb
+++ b/Casks/devdocs.rb
@@ -1,10 +1,10 @@
 cask 'devdocs' do
-  version '0.5.1'
-  sha256 '328b5e53819f484033e82d7d056bb290cb78193625193ad53f00496884dd82e5'
+  version '0.6.0'
+  sha256 'daea1cb863a38294b881fe68539cae8aa2e8f44ef660464626c1baf21d3b92eb'
 
   url "https://github.com/egoist/devdocs-app/releases/download/v#{version}/DevDocs-#{version}.dmg"
   appcast 'https://github.com/egoist/devdocs-app/releases.atom',
-          checkpoint: 'd8788cdd26808681562f88e23915437cca964062d68eab7be0e3caedd65a6990'
+          checkpoint: '14a976be78f508ce80c9db7bb5de9c793428306e77462b39077bc2d772600e70'
   name 'DevDocs App'
   homepage 'https://github.com/egoist/devdocs-app'
 

--- a/Casks/devdocs.rb
+++ b/Casks/devdocs.rb
@@ -4,7 +4,7 @@ cask 'devdocs' do
 
   url "https://github.com/egoist/devdocs-app/releases/download/v#{version}/DevDocs-#{version}.dmg"
   appcast 'https://github.com/egoist/devdocs-app/releases.atom',
-          checkpoint: '14a976be78f508ce80c9db7bb5de9c793428306e77462b39077bc2d772600e70'
+          checkpoint: '53cdfb1e0e99c951739deaf30a66dbb25de493340c9bb6a19ef3562c78e81c69'
   name 'DevDocs App'
   homepage 'https://github.com/egoist/devdocs-app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}