### PR TITLE
Update patchwork to 3.5.1

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,10 +1,10 @@
 cask 'patchwork' do
-  version '3.4.0'
-  sha256 '9be5a32dbabcdd3ca046afb0032c3de47b3d56bfea269d53d0655445c6ffc2db'
+  version '3.5.1'
+  sha256 'bd8b91f6ce9a3291140060229f10f0807ca37fb0b98c14f6c3e03d62a43d408b'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom',
-          checkpoint: '4a97057f15b9aff08e08356369003363d3c965ded15a763aa80058c4ce79bb1d'
+          checkpoint: 'ef5de6d58580dceda0a990c0c979aefec1bff3217d3b0b08f20ed4495c0ff9ad'
   name 'Patchwork'
   homepage 'https://github.com/ssbc/patchwork'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}