### PR TITLE
Update devdocs to 0.6.1

### DIFF
--- a/Casks/devdocs.rb
+++ b/Casks/devdocs.rb
@@ -1,6 +1,6 @@
 cask 'devdocs' do
-  version '0.6.0'
-  sha256 'daea1cb863a38294b881fe68539cae8aa2e8f44ef660464626c1baf21d3b92eb'
+  version '0.6.1'
+  sha256 'b2a011097388f34be59d6dd8644175934df048477b6d22b5cee889b8c666f054'
 
   url "https://github.com/egoist/devdocs-app/releases/download/v#{version}/DevDocs-#{version}.dmg"
   appcast 'https://github.com/egoist/devdocs-app/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}