### PR TITLE
Update diskmaker-x to 6rc5

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -4,7 +4,7 @@ cask 'diskmaker-x' do
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version}.dmg"
   appcast 'https://diskmakerx.com/feed/',
-          checkpoint: '50afcb3b4d239b33c21d8442a91ab257b4c5ce8eddd1bce7561cd2e81e024aa4'
+          checkpoint: 'fbe8f4d4b56239101361e209d451be39637f77a5f2a97ebf5b17c76255caf77a'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}