### PR TITLE
Update endlesssky to 0.9.6

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -5,7 +5,7 @@ cask 'endlesssky' do
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom',
-          checkpoint: '71c0eb49c10962c2d95084f5cb18d9fce17dbe59765f5246a0d335649e1ccd4d'
+          checkpoint: 'c34ea684bdcc3048f628e337e6a8b959fd0a4144ca202153cf374975d0456698'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}