### PR TITLE
Update fish to 2.6.0

### DIFF
--- a/Casks/fish.rb
+++ b/Casks/fish.rb
@@ -1,10 +1,10 @@
 cask 'fish' do
-  version '2.5.0'
-  sha256 'cef62c9643e3303777db3c80e63caf505f43694bbff120506159684645755d51'
+  version '2.6.0'
+  sha256 '9cd25bc469dbd0415dda125acedfc1a9512c28847b4bec52ce3fd127b78f6ecd'
 
   url "https://fishshell.com/files/#{version}/fish-#{version}.app.zip"
   appcast 'https://fishshell.com/release_notes.html',
-          checkpoint: 'ac58c33821f3ac78e1d1b7cdb2de9a8a5a71fc02b0e147bb0e6c4786d9313f03'
+          checkpoint: '6bb8e589c1e26f8c6285c96e1771e11969c36ccce3fd6d5e15a39a1e57c1865d'
   name 'Fish App'
   homepage 'https://fishshell.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}