### PR TITLE
Use `zap trash:`.

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -14,10 +14,12 @@ cask '115browser' do
   app '115Browser.app'
 
   zap delete: [
-                '~/Library/Application Support/115Browser',
                 '~/Library/Caches/115Browser',
                 '~/Library/Caches/org.115Browser.115Browser',
-                '~/Library/Preferences/org.115Browser.115Browser.plist',
                 '~/Library/Saved Application State/org.115Browser.115Browser.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/115Browser',
+                '~/Library/Preferences/org.115Browser.115Browser.plist',
               ]
 end

--- a/Casks/1clipboard.rb
+++ b/Casks/1clipboard.rb
@@ -19,11 +19,14 @@ cask '1clipboard' do
                         ]
 
   zap delete: [
-                '~/Library/Application Support/1Clipboard',
-                '~/Library/Application Support/com.ngwin.1clipboard.ShipIt',
                 '~/Library/Caches/1Clipboard',
                 '~/Library/Caches/com.ngwin.1clipboard',
-                '~/Library/Preferences/com.ngwin.1clipboard.plist',
                 '~/Library/Saved Application State/com.ngwin.1clipboard.savedState',
+
+              ],
+      trash:  [
+                '~/Library/Application Support/1Clipboard',
+                '~/Library/Application Support/com.ngwin.1clipboard.ShipIt',
+                '~/Library/Preferences/com.ngwin.1clipboard.plist',
               ]
 end

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -32,10 +32,10 @@ cask '1password' do
 
   auto_updates true
 
-  zap delete: [
-                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',
-                '~/Library/Containers/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',
-                '~/Library/Containers/com.agilebits.onepassword-osx',
-                '~/Library/Group Containers/2BUA8C4S2C.com.agilebits',
-              ]
+  zap trash: [
+               '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',
+               '~/Library/Containers/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',
+               '~/Library/Containers/com.agilebits.onepassword-osx',
+               '~/Library/Group Containers/2BUA8C4S2C.com.agilebits',
+             ]
 end

--- a/Casks/4k-slideshow-maker.rb
+++ b/Casks/4k-slideshow-maker.rb
@@ -11,8 +11,10 @@ cask '4k-slideshow-maker' do
   app '4K Slideshow Maker.app'
 
   zap delete: [
+                '~/Library/Saved Application State/com.openmedia.4kslideshowmaker.savedState',
+              ],
+      trash:  [
                 '~/Library/Preferences/com.4kdownload.4K Slideshow Maker.plist',
                 '~/Library/Application Support/4kdownload.com',
-                '~/Library/Saved Application State/com.openmedia.4kslideshowmaker.savedState',
               ]
 end

--- a/Casks/4k-video-to-mp3.rb
+++ b/Casks/4k-video-to-mp3.rb
@@ -10,8 +10,8 @@ cask '4k-video-to-mp3' do
 
   app '4K Video to MP3.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.4kdownload.4K Video to MP3.plist',
-                '~/Library/Application Support/4kdownload.com',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.4kdownload.4K Video to MP3.plist',
+               '~/Library/Application Support/4kdownload.com',
+             ]
 end

--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -31,10 +31,10 @@ cask 'adobe-photoshop-lightroom' do
     system_command 'brew', args: ['cask', 'uninstall', 'adobe-photoshop-lightroom600']
   end
 
-  zap delete: [
-                '~/Library/Application Support/Adobe/Lightroom',
-                "~/Library/Preferences/com.adobe.Lightroom#{version.major}.plist",
-              ]
+  zap trash: [
+               '~/Library/Application Support/Adobe/Lightroom',
+               "~/Library/Preferences/com.adobe.Lightroom#{version.major}.plist",
+             ]
 
   caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identify the conflicting processes.'
 end

--- a/Casks/controlplane.rb
+++ b/Casks/controlplane.rb
@@ -16,5 +16,5 @@ cask 'controlplane' do
 
   app 'ControlPlane.app'
 
-  zap delete: '~/Library/Preferences/com.dustinrue.ControlPlane.plist'
+  zap trash: '~/Library/Preferences/com.dustinrue.ControlPlane.plist'
 end

--- a/Casks/cord.rb
+++ b/Casks/cord.rb
@@ -10,5 +10,5 @@ cask 'cord' do
 
   app 'CoRD.app'
 
-  zap delete: '~/Library/Application Support/CoRD'
+  zap trash: '~/Library/Application Support/CoRD'
 end

--- a/Casks/coreos.rb
+++ b/Casks/coreos.rb
@@ -12,5 +12,5 @@ cask 'coreos' do
 
   app 'CoreOS.app'
 
-  zap delete: '~/coreos-osx'
+  zap trash: '~/coreos-osx'
 end

--- a/Casks/couchpotato.rb
+++ b/Casks/couchpotato.rb
@@ -11,5 +11,5 @@ cask 'couchpotato' do
 
   app 'CouchPotato.app'
 
-  zap delete: '~/Library/Application Support/CouchPotato'
+  zap trash: '~/Library/Application Support/CouchPotato'
 end

--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -14,7 +14,7 @@ cask 'dbvisualizer' do
 
   uninstall signal: [['TERM', 'com.dbvis.DbVisualizer']]
 
-  zap delete: '~/.dbvis'
+  zap trash: '~/.dbvis'
 
   caveats do
     depends_on_java('8')

--- a/Casks/dcommander.rb
+++ b/Casks/dcommander.rb
@@ -8,5 +8,5 @@ cask 'dcommander' do
 
   app 'DCommander.app'
 
-  zap delete: '~/Library/Containers/com.devstorm.dc3'
+  zap trash: '~/Library/Containers/com.devstorm.dc3'
 end

--- a/Casks/deckard.rb
+++ b/Casks/deckard.rb
@@ -12,10 +12,10 @@ cask 'deckard' do
 
   app 'Deckard.app'
 
-  zap delete: [
-                '~/.deckard',
-                '~/Library/Preferences/ai.deckard.ui.plist',
-                '~/Library/Preferences/ai.deckard.ui.helper.plist',
-                '~/Library/Application Support/deckard',
-              ]
+  zap trash: [
+               '~/.deckard',
+               '~/Library/Preferences/ai.deckard.ui.plist',
+               '~/Library/Preferences/ai.deckard.ui.helper.plist',
+               '~/Library/Application Support/deckard',
+             ]
 end

--- a/Casks/deco.rb
+++ b/Casks/deco.rb
@@ -11,8 +11,8 @@ cask 'deco' do
 
   app 'Deco.app'
 
-  zap delete: [
-                '~/.Deco',
-                '~/Library/Application Support/com.decosoftware.Deco',
-              ]
+  zap trash: [
+               '~/.Deco',
+               '~/Library/Application Support/com.decosoftware.Deco',
+             ]
 end

--- a/Casks/deepvacuum.rb
+++ b/Casks/deepvacuum.rb
@@ -8,5 +8,5 @@ cask 'deepvacuum' do
 
   app 'DeepVacuum.app'
 
-  zap delete: '~/Library/Preferences/com.hexcat.deepvacuum.plist'
+  zap trash: '~/Library/Preferences/com.hexcat.deepvacuum.plist'
 end

--- a/Casks/dhs.rb
+++ b/Casks/dhs.rb
@@ -11,5 +11,5 @@ cask 'dhs' do
 
   app 'DHS.app'
 
-  zap delete: '~/Library/Preferences/com.objective-see.DHS.plist'
+  zap trash: '~/Library/Preferences/com.objective-see.DHS.plist'
 end

--- a/Casks/diddumsdeux.rb
+++ b/Casks/diddumsdeux.rb
@@ -8,5 +8,5 @@ cask 'diddumsdeux' do
 
   app 'DiddumsDeux.app'
 
-  zap delete: '~/Preferences/com.alasdairmonk.diddums.plist'
+  zap trash: '~/Preferences/com.alasdairmonk.diddums.plist'
 end

--- a/Casks/discovercare.rb
+++ b/Casks/discovercare.rb
@@ -10,5 +10,5 @@ cask 'discovercare' do
 
   app 'DiscoverCare.app'
 
-  zap delete: '~/DiscoverCare'
+  zap trash: '~/DiscoverCare'
 end

--- a/Casks/disk-arbitrator.rb
+++ b/Casks/disk-arbitrator.rb
@@ -14,5 +14,5 @@ cask 'disk-arbitrator' do
   uninstall launchctl: 'us.burghardt.Disk-Arbitrator',
             quit:      'us.burghardt.Disk-Arbitrator'
 
-  zap delete: '~/Library/Preferences/us.burghardt.Disk-Arbitrator.plist'
+  zap trash: '~/Library/Preferences/us.burghardt.Disk-Arbitrator.plist'
 end

--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -32,5 +32,5 @@ cask 'dotnet-sdk' do
   uninstall pkgutil: 'com.microsoft.dotnet.*',
             delete:  '/etc/paths.d/dotnet'
 
-  zap delete: '~/.nuget'
+  zap trash: '~/.nuget'
 end

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -32,5 +32,5 @@ cask 'dotnet' do
   uninstall pkgutil: 'com.microsoft.dotnet.*',
             delete:  '/etc/paths.d/dotnet'
 
-  zap delete: '~/.nuget'
+  zap trash: '~/.nuget'
 end

--- a/Casks/earthdeskprefpane.rb
+++ b/Casks/earthdeskprefpane.rb
@@ -18,10 +18,10 @@ cask 'earthdeskprefpane' do
                       '/Library/PreferencePanes/EarthDesk.prefpane',
                     ]
 
-  zap delete: [
-                '~/Library/Preferences/com.apple.desktop.plist',
-                '~/Library/Preferences/com.xericdesign.earthdesk.core.plist',
-                '~/Library/Preferences/com.xericdesign.earthdesk.engine.plist',
-                '~/Library/Preferences/com.xericdesign.earthdesk.prefPane.plist',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.apple.desktop.plist',
+               '~/Library/Preferences/com.xericdesign.earthdesk.core.plist',
+               '~/Library/Preferences/com.xericdesign.earthdesk.engine.plist',
+               '~/Library/Preferences/com.xericdesign.earthdesk.prefPane.plist',
+             ]
 end

--- a/Casks/easysimbl.rb
+++ b/Casks/easysimbl.rb
@@ -10,8 +10,8 @@ cask 'easysimbl' do
 
   app 'EasySIMBL.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.github.norio-nomura.EasySIMBL.plist',
-                '~/Library/Preferences/com.github.norio-nomura.SIMBL-Agent.plist',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.github.norio-nomura.EasySIMBL.plist',
+               '~/Library/Preferences/com.github.norio-nomura.SIMBL-Agent.plist',
+             ]
 end

--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -8,8 +8,8 @@ cask 'editready' do
 
   app 'EditReady.app'
 
-  zap delete: [
-                '~/Library/Application Support/EditReady',
-                '~/Library/Preferences/com.divergentmedia.EditReady.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/EditReady',
+               '~/Library/Preferences/com.divergentmedia.EditReady.plist',
+             ]
 end

--- a/Casks/enjoyable.rb
+++ b/Casks/enjoyable.rb
@@ -10,5 +10,5 @@ cask 'enjoyable' do
 
   app 'Enjoyable.app'
 
-  zap delete: '~/Library/Preferences/com.yukkurigames.Enjoyable.plist'
+  zap trash: '~/Library/Preferences/com.yukkurigames.Enjoyable.plist'
 end

--- a/Casks/eve-launcher.rb
+++ b/Casks/eve-launcher.rb
@@ -10,9 +10,9 @@ cask 'eve-launcher' do
 
   app 'EVE Launcher.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.ccpgames.EVE.plist',
-                '~/Library/Application Support/EVE Online',
-                '~/Library/Application Support/CCP/EVE',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.ccpgames.EVE.plist',
+               '~/Library/Application Support/EVE Online',
+               '~/Library/Application Support/CCP/EVE',
+             ]
 end

--- a/Casks/exfalso.rb
+++ b/Casks/exfalso.rb
@@ -11,5 +11,5 @@ cask 'exfalso' do
 
   app 'ExFalso.app'
 
-  zap delete: '~/.quodlibet'
+  zap trash: '~/.quodlibet'
 end

--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -10,5 +10,5 @@ cask 'exifrenamer' do
 
   app 'ExifRenamer.app'
 
-  zap delete: '~/Library/Preferences/de.qdev.ExifRenamer.plist'
+  zap trash: '~/Library/Preferences/de.qdev.ExifRenamer.plist'
 end

--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -10,9 +10,9 @@ cask 'expandrive' do
 
   app 'ExpanDrive.app'
 
-  zap delete: [
-                '~/Library/Application Support/ExpanDrive',
-                '~/Library/Preferences/com.expandrive.ExpanDrive2.plist',
-                '~/Library/Preferences/com.expandrive.ExpanDrive3.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/ExpanDrive',
+               '~/Library/Preferences/com.expandrive.ExpanDrive2.plist',
+               '~/Library/Preferences/com.expandrive.ExpanDrive3.plist',
+             ]
 end

--- a/Casks/expressions.rb
+++ b/Casks/expressions.rb
@@ -8,8 +8,8 @@ cask 'expressions' do
 
   app 'Expressions.app'
 
-  zap delete: [
-                '~/Library/Application Scripts/com.apptorium.Expressions-dm',
-                '~/Library/Containers/com.apptorium.Expressions-dm',
-              ]
+  zap trash: [
+               '~/Library/Application Scripts/com.apptorium.Expressions-dm',
+               '~/Library/Containers/com.apptorium.Expressions-dm',
+             ]
 end

--- a/Casks/fantastical.rb
+++ b/Casks/fantastical.rb
@@ -10,5 +10,5 @@ cask 'fantastical' do
 
   app "Fantastical #{version.major}.app"
 
-  zap delete: '~/Library/Preferences/com.flexibits.fantastical.plist'
+  zap trash: '~/Library/Preferences/com.flexibits.fantastical.plist'
 end

--- a/Casks/faw-circle.rb
+++ b/Casks/faw-circle.rb
@@ -10,5 +10,5 @@ cask 'faw-circle' do
 
   uninstall pkgutil: 'com.futureaudioworkshop.pkg.*'
 
-  zap delete: '~/Library/Preferences/Circle2.settings'
+  zap trash: '~/Library/Preferences/Circle2.settings'
 end

--- a/Casks/fbreader.rb
+++ b/Casks/fbreader.rb
@@ -8,7 +8,7 @@ cask 'fbreader' do
 
   app 'FBReader.app'
 
-  zap delete: [
-                '~/.FBReader',
-              ]
+  zap trash: [
+               '~/.FBReader',
+             ]
 end

--- a/Casks/fcs-remover.rb
+++ b/Casks/fcs-remover.rb
@@ -8,5 +8,5 @@ cask 'fcs-remover' do
 
   app 'FCS Remover.app'
 
-  zap delete: '~/Library/Preferences/com.digitalrebellion.FCSRemover.plist'
+  zap trash: '~/Library/Preferences/com.digitalrebellion.FCSRemover.plist'
 end

--- a/Casks/feed-the-beast.rb
+++ b/Casks/feed-the-beast.rb
@@ -11,7 +11,7 @@ cask 'feed-the-beast' do
 
   app 'Feed The Beast.app'
 
-  zap delete: '~/Library/Application Support/ftblauncher'
+  zap trash: '~/Library/Application Support/ftblauncher'
 
   caveats do
     depends_on_java

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -12,7 +12,7 @@ cask 'filebot' do
   # The darwin package only includes the CLI tools. Launching the app bundle merely redirects to the Mac App Store.
   binary 'FileBot.app/Contents/MacOS/filebot.sh', target: 'filebot'
 
-  zap delete: '~/Library/Preferences/net.filebot.ui.plist'
+  zap trash: '~/Library/Preferences/net.filebot.ui.plist'
 
   caveats do
     depends_on_java('8')

--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -11,5 +11,5 @@ cask 'find-any-file' do
 
   app 'Find Any File.app'
 
-  zap delete: '~/Library/Application Support/Find Any File'
+  zap trash: '~/Library/Application Support/Find Any File'
 end

--- a/Casks/finderminder.rb
+++ b/Casks/finderminder.rb
@@ -12,5 +12,5 @@ cask 'finderminder' do
 
   app 'FinderMinder.app'
 
-  zap delete: '~/Library/Preferences/com.irradiatedsoftware.FinderMinder.plist'
+  zap trash: '~/Library/Preferences/com.irradiatedsoftware.FinderMinder.plist'
 end

--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -10,5 +10,5 @@ cask 'flinto' do
 
   uninstall pkgutil: 'com.flinto.*'
 
-  zap delete: '~/Library/Application Scripts/com.flinto.Flinto'
+  zap trash: '~/Library/Application Scripts/com.flinto.Flinto'
 end

--- a/Casks/fluid.rb
+++ b/Casks/fluid.rb
@@ -10,8 +10,8 @@ cask 'fluid' do
 
   app 'Fluid.app'
 
-  zap delete: [
-                '~/Library/Application Support/Fluid',
-                '~/Library/Preferences/com.fluidapp.Fluid.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Fluid',
+               '~/Library/Preferences/com.fluidapp.Fluid.plist',
+             ]
 end

--- a/Casks/flume.rb
+++ b/Casks/flume.rb
@@ -12,5 +12,5 @@ cask 'flume' do
 
   app 'Flume.app'
 
-  zap delete: '~/Library/Application Support/Flume'
+  zap trash: '~/Library/Application Support/Flume'
 end

--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -10,5 +10,5 @@ cask 'flycut' do
 
   app 'Flycut.app'
 
-  zap delete: '~/Library/Preferences/com.generalarcade.flycut.plist'
+  zap trash: '~/Library/Preferences/com.generalarcade.flycut.plist'
 end

--- a/Casks/folio.rb
+++ b/Casks/folio.rb
@@ -9,5 +9,5 @@ cask 'folio' do
 
   app 'Folio.app'
 
-  zap delete: '~/Library/Application Support/co.ysberg.Folio'
+  zap trash: '~/Library/Application Support/co.ysberg.Folio'
 end

--- a/Casks/freeze.rb
+++ b/Casks/freeze.rb
@@ -10,8 +10,8 @@ cask 'freeze' do
 
   app 'Freeze.app'
 
-  zap delete: [
-                '~/Library/Application Scripts/seb.GlacierMac',
-                '~/Library/Containers/seb.GlacierMac',
-              ]
+  zap trash: [
+               '~/Library/Application Scripts/seb.GlacierMac',
+               '~/Library/Containers/seb.GlacierMac',
+             ]
 end

--- a/Casks/frescobaldi.rb
+++ b/Casks/frescobaldi.rb
@@ -11,5 +11,5 @@ cask 'frescobaldi' do
 
   app 'Frescobaldi.app'
 
-  zap delete: '~/Library/Preferences/org.frescobaldi.frescobaldi.plist'
+  zap trash: '~/Library/Preferences/org.frescobaldi.frescobaldi.plist'
 end

--- a/Casks/geomap.rb
+++ b/Casks/geomap.rb
@@ -8,5 +8,5 @@ cask 'geomap' do
 
   app 'GeoMapApp.app'
 
-  zap delete: '~/.GMA'
+  zap trash: '~/.GMA'
 end

--- a/Casks/gitbox.rb
+++ b/Casks/gitbox.rb
@@ -11,5 +11,5 @@ cask 'gitbox' do
 
   app 'Gitbox.app'
 
-  zap delete: '~/Library/Preferences/com.oleganza.gitbox.plist'
+  zap trash: '~/Library/Preferences/com.oleganza.gitbox.plist'
 end

--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -11,5 +11,5 @@ cask 'mplayer-osx-extended' do
 
   app 'MPlayer OSX Extended.app'
 
-  zap delete: '~/.mplayer'
+  zap trash: '~/.mplayer'
 end

--- a/Casks/mqttfx.rb
+++ b/Casks/mqttfx.rb
@@ -15,8 +15,8 @@ cask 'mqttfx' do
 
   uninstall delete: '/Applications/MQTT.fx.app'
 
-  zap delete: [
-                '~/Library/Application Support/MQTT-FX',
-                '~/Library/Application Support/MQTT.fx',
-              ]
+  zap trash: [
+               '~/Library/Application Support/MQTT-FX',
+               '~/Library/Application Support/MQTT.fx',
+             ]
 end

--- a/Casks/myo-connect.rb
+++ b/Casks/myo-connect.rb
@@ -9,5 +9,5 @@ cask 'myo-connect' do
 
   app 'Myo Connect.app'
 
-  zap delete: '~/Library/Preferences/com.thalmic.Myo Connect.plist'
+  zap trash: '~/Library/Preferences/com.thalmic.Myo Connect.plist'
 end

--- a/Casks/mysql-shell.rb
+++ b/Casks/mysql-shell.rb
@@ -10,5 +10,5 @@ cask 'mysql-shell' do
 
   uninstall pkgutil: 'com.mysql.shell'
 
-  zap delete: '~/.mysqlsh'
+  zap trash: '~/.mysqlsh'
 end

--- a/Casks/nagstamon.rb
+++ b/Casks/nagstamon.rb
@@ -11,5 +11,5 @@ cask 'nagstamon' do
 
   app "Nagstamon-#{version}.app"
 
-  zap delete: '~/.nagstamon'
+  zap trash: '~/.nagstamon'
 end

--- a/Casks/namecoin.rb
+++ b/Casks/namecoin.rb
@@ -11,8 +11,8 @@ cask 'namecoin' do
 
   app 'Namecoin-Qt.app'
 
-  zap delete: [
-                '~/Library/Application Support/Namecoin',
-                '~/Library/Preferences/Namecoin-Qt.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Namecoin',
+               '~/Library/Preferences/Namecoin-Qt.plist',
+             ]
 end

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -9,5 +9,5 @@ cask 'ngrok' do
 
   binary 'ngrok'
 
-  zap delete: '~/.ngrok2'
+  zap trash: '~/.ngrok2'
 end

--- a/Casks/nix.rb
+++ b/Casks/nix.rb
@@ -29,9 +29,9 @@ cask 'nix' do
 
   uninstall delete: '/nix'
 
-  zap delete: [
-                '~/.nix-channels',
-                '~/.nix-defexpr',
-                '~/.nix-profile',
-              ]
+  zap trash: [
+               '~/.nix-channels',
+               '~/.nix-defexpr',
+               '~/.nix-profile',
+             ]
 end

--- a/Casks/not-tetris.rb
+++ b/Casks/not-tetris.rb
@@ -10,5 +10,5 @@ cask 'not-tetris' do
 
   app "Not Tetris #{version}.app"
 
-  zap delete: '~/Library/Application Support/LOVE/not_tetris_2'
+  zap trash: '~/Library/Application Support/LOVE/not_tetris_2'
 end

--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -8,9 +8,9 @@ cask 'notion' do
 
   app 'Notion.app'
 
-  zap delete: [
-                '~/Library/Application Support/Notion',
-                '~/Library/Preferences/notion.id.helper.plist',
-                '~/Library/Preferences/notion.id.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Notion',
+               '~/Library/Preferences/notion.id.helper.plist',
+               '~/Library/Preferences/notion.id.plist',
+             ]
 end

--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -9,8 +9,8 @@ cask 'nvalt' do
 
   app 'nvALT.app'
 
-  zap delete: [
-                '~/Library/Preferences/net.elasticthreads.nv.plist',
-                '~/Library/Application Support/Notational Velocity',
-              ]
+  zap trash: [
+               '~/Library/Preferences/net.elasticthreads.nv.plist',
+               '~/Library/Application Support/Notational Velocity',
+             ]
 end

--- a/Casks/nzbget.rb
+++ b/Casks/nzbget.rb
@@ -11,8 +11,8 @@ cask 'nzbget' do
 
   app 'NZBGet.app'
 
-  zap delete: [
-                '~/Library/Application Support/NZBGet',
-                '~/Library/Preferences/net.sourceforge.nzbget.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/NZBGet',
+               '~/Library/Preferences/net.sourceforge.nzbget.plist',
+             ]
 end

--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -22,5 +22,5 @@ cask 'omnigraffle' do
 
   app 'OmniGraffle.app'
 
-  zap delete: '~/Library/Application Support/The Omni Group/OmniGraffle'
+  zap trash: '~/Library/Application Support/The Omni Group/OmniGraffle'
 end

--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -35,5 +35,5 @@ cask 'openoffice' do
 
   app 'OpenOffice.app'
 
-  zap delete: '~/Library/Application Support/OpenOffice'
+  zap trash: '~/Library/Application Support/OpenOffice'
 end

--- a/Casks/orfo.rb
+++ b/Casks/orfo.rb
@@ -19,7 +19,7 @@ cask 'orfo' do
             delete:     '/Library/PreferencePanes/ORFOSetup.prefPane',
             login_item: 'OrfoUpdate'
 
-  zap delete: '/Library/Application Support/ORFO 2016'
+  zap trash: '/Library/Application Support/ORFO 2016'
 
   caveats do
     reboot

--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -23,10 +23,10 @@ cask 'owasp-zap' do
                     },
             delete: "/Applications/ZAP #{version}.app"
 
-  zap delete: [
-                '~/Library/Preferences/org.zaproxy.zap.plist',
-                '~/Library/Application Support/ZAP',
-              ]
+  zap trash: [
+               '~/Library/Preferences/org.zaproxy.zap.plist',
+               '~/Library/Application Support/ZAP',
+             ]
 
   caveats do
     depends_on_java('7+')

--- a/Casks/particle-dev.rb
+++ b/Casks/particle-dev.rb
@@ -9,8 +9,8 @@ cask 'particle-dev' do
 
   app 'Particle Dev.app'
 
-  zap delete: [
-                '~/.particle',
-                '~/.particledev',
-              ]
+  zap trash: [
+               '~/.particle',
+               '~/.particledev',
+             ]
 end

--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -8,8 +8,8 @@ cask 'path-finder' do
 
   app 'Path Finder.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.cocoatech.PathFinder.plist',
-                '~/Library/Application Support/Path Finder',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.cocoatech.PathFinder.plist',
+               '~/Library/Application Support/Path Finder',
+             ]
 end

--- a/Casks/pcp.rb
+++ b/Casks/pcp.rb
@@ -87,7 +87,7 @@ cask 'pcp' do
                        ],
             launchctl: 'io.pcp'
 
-  zap delete: '~/.pcp'
+  zap trash: '~/.pcp'
 
   caveats <<-EOS.undent
     During installation 2 windows will pop up asking your permission for access for network ports for `pmlogger` and `pmcd`.  This is expected.

--- a/Casks/phoenix.rb
+++ b/Casks/phoenix.rb
@@ -13,8 +13,8 @@ cask 'phoenix' do
 
   app 'Phoenix.app'
 
-  zap delete: [
-                '~/.phoenix.js',
-                '~/Library/Application Support/Phoenix/storage.json',
-              ]
+  zap trash: [
+               '~/.phoenix.js',
+               '~/Library/Application Support/Phoenix/storage.json',
+             ]
 end

--- a/Casks/pins.rb
+++ b/Casks/pins.rb
@@ -8,5 +8,5 @@ cask 'pins' do
 
   app 'Pins.app'
 
-  zap delete: '~/Library/Containers/com.pinsapp.pins'
+  zap trash: '~/Library/Containers/com.pinsapp.pins'
 end

--- a/Casks/pixelconduit.rb
+++ b/Casks/pixelconduit.rb
@@ -10,8 +10,8 @@ cask 'pixelconduit' do
 
   app 'PixelConduit.app'
 
-  zap delete: [
-                '~/Library/Application Support/Conduit',
-                '~/Library/Preferences/fi.lacquer.PixelConduit.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Conduit',
+               '~/Library/Preferences/fi.lacquer.PixelConduit.plist',
+             ]
 end

--- a/Casks/plistedit-pro.rb
+++ b/Casks/plistedit-pro.rb
@@ -9,8 +9,8 @@ cask 'plistedit-pro' do
   app 'PlistEdit Pro.app'
   binary "#{appdir}/PlistEdit Pro.app/Contents/MacOS/pledit"
 
-  zap delete: [
-                '~/Library/Preferences/com.fatcatsoftware.pledpro.plist',
-                '~/Library/Application Support/PlistEdit Pro',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.fatcatsoftware.pledpro.plist',
+               '~/Library/Application Support/PlistEdit Pro',
+             ]
 end

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -13,5 +13,5 @@ cask 'plover' do
 
   app 'Plover.app'
 
-  zap delete: '~/Library/Application Support/plover/'
+  zap trash: '~/Library/Application Support/plover/'
 end

--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -11,5 +11,5 @@ cask 'poi' do
 
   app 'poi.app'
 
-  zap delete: '~/Library/Application Support/poi/'
+  zap trash: '~/Library/Application Support/poi/'
 end

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -10,5 +10,5 @@ cask 'processing' do
 
   app 'Processing.app'
 
-  zap delete: '~/Library/Processing/preferences.txt'
+  zap trash: '~/Library/Processing/preferences.txt'
 end

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -23,5 +23,5 @@ cask 'puppet-agent' do
   uninstall launchctl: %w[puppet pxp-agent mcollective],
             pkgutil:   'com.puppetlabs.puppet-agent'
 
-  zap delete: '~/.puppetlabs'
+  zap trash: '~/.puppetlabs'
 end

--- a/Casks/pyzo.rb
+++ b/Casks/pyzo.rb
@@ -11,5 +11,5 @@ cask 'pyzo' do
 
   app 'pyzo.app'
 
-  zap delete: '~/Library/Application Support/pyzo'
+  zap trash: '~/Library/Application Support/pyzo'
 end

--- a/Casks/qsyncthingtray.rb
+++ b/Casks/qsyncthingtray.rb
@@ -10,5 +10,5 @@ cask 'qsyncthingtray' do
 
   app 'QSyncthingTray.app'
 
-  zap delete: '~/Library/Preferences/com.sieren.QSyncthingTray.plist'
+  zap trash: '~/Library/Preferences/com.sieren.QSyncthingTray.plist'
 end

--- a/Casks/quadrosync.rb
+++ b/Casks/quadrosync.rb
@@ -20,5 +20,5 @@ cask 'quadrosync' do
             launchctl:  'com.quadro.QuadroInstaller.HelperTool',
             login_item: 'QuadroSync'
 
-  zap delete: '/Library/Application Support/Quadro'
+  zap trash: '/Library/Application Support/Quadro'
 end

--- a/Casks/quodlibet.rb
+++ b/Casks/quodlibet.rb
@@ -11,5 +11,5 @@ cask 'quodlibet' do
 
   app 'QuodLibet.app'
 
-  zap delete: '~/.quodlibet'
+  zap trash: '~/.quodlibet'
 end

--- a/Casks/radio-silence.rb
+++ b/Casks/radio-silence.rb
@@ -27,5 +27,5 @@ cask 'radio-silence' do
                             'com.radiosilenceapp.nke',
                           ]
 
-  zap delete: '~/Library/Application Support/Radio Silence'
+  zap trash: '~/Library/Application Support/Radio Silence'
 end

--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -8,5 +8,5 @@ cask 'razorsql' do
 
   app 'RazorSQL.app'
 
-  zap delete: '~/.razorsql'
+  zap trash: '~/.razorsql'
 end

--- a/Casks/rclone-browser.rb
+++ b/Casks/rclone-browser.rb
@@ -13,8 +13,8 @@ cask 'rclone-browser' do
 
   app "rclone-browser-#{version.before_comma}-#{version.after_comma}-macOS/Rclone Browser.app"
 
-  zap delete: [
-                '~/Library/Preferences/Rclone Browser.plist',
-                '~/Library/Preferences/com.rclone-browser.rclone-browser.plist',
-              ]
+  zap trash: [
+               '~/Library/Preferences/Rclone Browser.plist',
+               '~/Library/Preferences/com.rclone-browser.rclone-browser.plist',
+             ]
 end

--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -10,7 +10,7 @@ cask 'reactotron' do
 
   app 'Reactotron.app'
 
-  zap delete: [
-                '~/Library/Application Support/Reactotron',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Reactotron',
+             ]
 end

--- a/Casks/readcube.rb
+++ b/Casks/readcube.rb
@@ -10,5 +10,5 @@ cask 'readcube' do
 
   uninstall trash: '/Applications/ReadCube.app'
 
-  zap delete: '~/Library/Preferences/com.readcube.Desktop/'
+  zap trash: '~/Library/Preferences/com.readcube.Desktop/'
 end

--- a/Casks/rest.rb
+++ b/Casks/rest.rb
@@ -11,5 +11,5 @@ cask 'rest' do
   uninstall quit:      'dangelov.Rest-Lite',
             launchctl: 'dangelov.RestHelper'
 
-  zap delete: '~/Library/Preferences/dangelov.Rest-Lite.plist'
+  zap trash: '~/Library/Preferences/dangelov.Rest-Lite.plist'
 end

--- a/Casks/resxtreme.rb
+++ b/Casks/resxtreme.rb
@@ -8,5 +8,5 @@ cask 'resxtreme' do
 
   app 'ResXtreme.app'
 
-  zap delete: '~/Library/Preferences/info.chrismiles.ResXtreme.plist'
+  zap trash: '~/Library/Preferences/info.chrismiles.ResXtreme.plist'
 end

--- a/Casks/ship.rb
+++ b/Casks/ship.rb
@@ -10,8 +10,8 @@ cask 'ship' do
 
   app 'Ship.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.realartists.Ship.plist',
-                '~/Library/Application Support/Ship',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.realartists.Ship.plist',
+               '~/Library/Application Support/Ship',
+             ]
 end

--- a/Casks/shuttle.rb
+++ b/Casks/shuttle.rb
@@ -11,5 +11,5 @@ cask 'shuttle' do
 
   app 'Shuttle.app'
 
-  zap delete: '~/.shuttle.json'
+  zap trash: '~/.shuttle.json'
 end

--- a/Casks/simple-hub.rb
+++ b/Casks/simple-hub.rb
@@ -10,8 +10,8 @@ cask 'simple-hub' do
 
   app 'Simple Hub.app'
 
-  zap delete: [
-                '~/Library/Application Support/Roomie Agent',
-                '~/Library/Preferences/com.roomie.agent.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Roomie Agent',
+               '~/Library/Preferences/com.roomie.agent.plist',
+             ]
 end

--- a/Casks/simplemoviex.rb
+++ b/Casks/simplemoviex.rb
@@ -8,5 +8,5 @@ cask 'simplemoviex' do
 
   app 'SimpleMovieX.app'
 
-  zap delete: '~/Library/Preferences/com.BJ.SimpleMovieX.plist'
+  zap trash: '~/Library/Preferences/com.BJ.SimpleMovieX.plist'
 end

--- a/Casks/sizeup.rb
+++ b/Casks/sizeup.rb
@@ -13,8 +13,8 @@ cask 'sizeup' do
 
   app 'SizeUp.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.irradiatedsoftware.SizeUp.plist',
-                '~/Library/Application Support/SizeUp',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.irradiatedsoftware.SizeUp.plist',
+               '~/Library/Application Support/SizeUp',
+             ]
 end

--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -13,5 +13,5 @@ cask 'skim' do
   binary "#{appdir}/Skim.app/Contents/SharedSupport/skimnotes"
   binary "#{appdir}/Skim.app/Contents/SharedSupport/skimpdf"
 
-  zap delete: '~/Library/Preferences/net.sourceforge.skim-app.skim.plist'
+  zap trash: '~/Library/Preferences/net.sourceforge.skim-app.skim.plist'
 end

--- a/Casks/slate.rb
+++ b/Casks/slate.rb
@@ -13,9 +13,9 @@ cask 'slate' do
 
   app 'Slate.app'
 
-  zap delete: [
-                '~/.slate',
-                '~/.slate.js',
-                '~/Library/Application Support/com.slate.Slate',
-              ]
+  zap trash: [
+               '~/.slate',
+               '~/.slate.js',
+               '~/Library/Application Support/com.slate.Slate',
+             ]
 end

--- a/Casks/spark.rb
+++ b/Casks/spark.rb
@@ -8,5 +8,5 @@ cask 'spark' do
 
   app 'Spark.app'
 
-  zap delete: '~/Library/Application Support/Spark'
+  zap trash: '~/Library/Application Support/Spark'
 end

--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -15,5 +15,5 @@ cask 'speedify' do
                        ],
             script:    "#{appdir}/Speedify.app/Contents/Resources/uninstall-speedify-service.sh"
 
-  zap delete: '~/Library/Speedify'
+  zap trash: '~/Library/Speedify'
 end

--- a/Casks/sql-tabs.rb
+++ b/Casks/sql-tabs.rb
@@ -8,5 +8,5 @@ cask 'sql-tabs' do
 
   app 'SQL Tabs.app'
 
-  zap delete: '~/.sqltabs'
+  zap trash: '~/.sqltabs'
 end

--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -13,8 +13,8 @@ cask 'sqlectron' do
 
   app 'Sqlectron.app'
 
-  zap delete: [
-                '~/.sqlectron.json',
-                '~/Library/Application Support/Sqlectron',
-              ]
+  zap trash: [
+               '~/.sqlectron.json',
+               '~/Library/Application Support/Sqlectron',
+             ]
 end

--- a/Casks/squidman.rb
+++ b/Casks/squidman.rb
@@ -8,7 +8,7 @@ cask 'squidman' do
 
   app 'SquidMan.app'
 
-  zap delete: '/usr/local/squid'
+  zap trash: '/usr/local/squid'
 
   caveats do
     files_in_usr_local

--- a/Casks/squirrelsql.rb
+++ b/Casks/squirrelsql.rb
@@ -79,7 +79,7 @@ cask 'squirrelsql' do
     system_command 'java', args: ['-jar', "#{appdir}/SQuirreLSQL.app/Uninstaller/uninstaller.jar", '-f', '-c']
   end
 
-  zap delete: '~/.squirrel-sql'
+  zap trash: '~/.squirrel-sql'
 
   caveats do
     depends_on_java('6+')

--- a/Casks/ssh-tunnel-manager.rb
+++ b/Casks/ssh-tunnel-manager.rb
@@ -9,5 +9,5 @@ cask 'ssh-tunnel-manager' do
 
   app 'SSH Tunnel Manager.app'
 
-  zap delete: '~/Library/Preferences/org.tynsoe.sshtunnelmanager.plist'
+  zap trash: '~/Library/Preferences/org.tynsoe.sshtunnelmanager.plist'
 end

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -11,5 +11,5 @@ cask 'stellarium' do
 
   app 'Stellarium.app'
 
-  zap delete: '~/Library/Preferences/Stellarium'
+  zap trash: '~/Library/Preferences/Stellarium'
 end

--- a/Casks/stemcreator.rb
+++ b/Casks/stemcreator.rb
@@ -9,5 +9,5 @@ cask 'stemcreator' do
   app 'StemCreator.app'
   artifact 'Documentation', target: Pathname.new(File.expand_path('~')).join('Library/Application Support/Native Instruments/Stem Creator/Documentation')
 
-  zap delete: '~/Library/Application Support/Native Instruments/Stem Creator'
+  zap trash: '~/Library/Application Support/Native Instruments/Stem Creator'
 end

--- a/Casks/studiolinkcomponent.rb
+++ b/Casks/studiolinkcomponent.rb
@@ -11,5 +11,5 @@ cask 'studiolinkcomponent' do
 
   audio_unit_plugin 'StudioLink.component'
 
-  zap delete: '~/.studio-link-plugin'
+  zap trash: '~/.studio-link-plugin'
 end

--- a/Casks/studiolinkstandalone.rb
+++ b/Casks/studiolinkstandalone.rb
@@ -11,5 +11,5 @@ cask 'studiolinkstandalone' do
 
   app 'StudioLinkStandalone.app'
 
-  zap delete: '~/.studio-link'
+  zap trash: '~/.studio-link'
 end

--- a/Casks/subtitles.rb
+++ b/Casks/subtitles.rb
@@ -10,5 +10,5 @@ cask 'subtitles' do
 
   app 'Subtitles.app'
 
-  zap delete: '~/Library/Application Support/Subtitles'
+  zap trash: '~/Library/Application Support/Subtitles'
 end

--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -9,5 +9,5 @@ cask 'superduper' do
 
   app 'SuperDuper!.app'
 
-  zap delete: '~/Library/Application Support/SuperDuper!'
+  zap trash: '~/Library/Application Support/SuperDuper!'
 end

--- a/Casks/syncany.rb
+++ b/Casks/syncany.rb
@@ -8,5 +8,5 @@ cask 'syncany' do
 
   app 'Syncany.app'
 
-  zap delete: '~/.config/syncany'
+  zap trash: '~/.config/syncany'
 end

--- a/Casks/teseve.rb
+++ b/Casks/teseve.rb
@@ -13,8 +13,8 @@ cask 'teseve' do
 
   app 'Teseve.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.flatland.app.teseve.plist',
-                '~/Library/Application Support/teseve',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.flatland.app.teseve.plist',
+               '~/Library/Application Support/teseve',
+             ]
 end

--- a/Casks/texmacs.rb
+++ b/Casks/texmacs.rb
@@ -10,5 +10,5 @@ cask 'texmacs' do
 
   app "TeXmacs-#{version}.app"
 
-  zap delete: '~/.TeXmacs'
+  zap trash: '~/.TeXmacs'
 end

--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -28,5 +28,5 @@ cask 'textexpander' do
 
   uninstall login_item: 'TextExpander'
 
-  zap delete: '~/Library/Application Support/TextExpander/'
+  zap trash: '~/Library/Application Support/TextExpander/'
 end

--- a/Casks/textual.rb
+++ b/Casks/textual.rb
@@ -8,8 +8,8 @@ cask 'textual' do
 
   app 'Textual.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.codeux.apps.textual.plist',
-                '~/Library/Application Support/Textual',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.codeux.apps.textual.plist',
+               '~/Library/Application Support/Textual',
+             ]
 end

--- a/Casks/timer.rb
+++ b/Casks/timer.rb
@@ -8,8 +8,8 @@ cask 'timer' do
 
   app 'Timer.app'
 
-  zap delete: [
-                '~/Library/Preferences/Apimac',
-                '~/Library/Application Support/Apimac',
-              ]
+  zap trash: [
+               '~/Library/Preferences/Apimac',
+               '~/Library/Application Support/Apimac',
+             ]
 end

--- a/Casks/touche.rb
+++ b/Casks/touche.rb
@@ -11,8 +11,8 @@ cask 'touche' do
 
   app 'Touché.app'
 
-  zap delete: [
-                '~/Library/Containers/com.red-sweater.touche',
-                '~/Library/Preferences/com.red-sweater.touche.plist',
-              ]
+  zap trash: [
+               '~/Library/Containers/com.red-sweater.touche',
+               '~/Library/Preferences/com.red-sweater.touche.plist',
+             ]
 end

--- a/Casks/transmit-disk.rb
+++ b/Casks/transmit-disk.rb
@@ -24,8 +24,8 @@ cask 'transmit-disk' do
                      ],
             delete:  "#{appdir}/Transmit Disk.app"
 
-  zap delete: [
-                '~/Library/Preferences/com.panic.Transmit.TransmitDisk.plist',
-                '/Library/Filesystems/transmitdisk.fs/',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.panic.Transmit.TransmitDisk.plist',
+               '/Library/Filesystems/transmitdisk.fs/',
+             ]
 end

--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -10,8 +10,8 @@ cask 'transmit' do
 
   app 'Transmit.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.panic.Transmit.plist',
-                '~/Library/Application Support/Transmit',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.panic.Transmit.plist',
+               '~/Library/Application Support/Transmit',
+             ]
 end

--- a/Casks/tripmode.rb
+++ b/Casks/tripmode.rb
@@ -12,5 +12,5 @@ cask 'tripmode' do
 
   app 'TripMode.app'
 
-  zap delete: '~/Library/Preferences/ch.tripmode.TripMode.plist'
+  zap trash: '~/Library/Preferences/ch.tripmode.TripMode.plist'
 end

--- a/Casks/trusteer-rapport.rb
+++ b/Casks/trusteer-rapport.rb
@@ -14,8 +14,8 @@ cask 'trusteer-rapport' do
                      },
             pkgutil: 'com.trusteer.ibmSecurityTrusteerEndpointProtection.*'
 
-  zap delete: [
-                '~/Library/Application Support/Rapport',
-                '~/Library/Preferences/com.trusteer.rapportd.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Rapport',
+               '~/Library/Preferences/com.trusteer.rapportd.plist',
+             ]
 end

--- a/Casks/tuck.rb
+++ b/Casks/tuck.rb
@@ -10,7 +10,7 @@ cask 'tuck' do
 
   app 'Tuck.app'
 
-  zap delete: [
-                '~/Library/Preferences/com.irradiatedsoftware.Tuck.plist',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.irradiatedsoftware.Tuck.plist',
+             ]
 end

--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -14,5 +14,5 @@ cask 'turbo-boost-switcher' do
             kext:       'com.rugarciap.DisableTurboBoost',
             login_item: 'Turbo Boost Switcher'
 
-  zap delete: '~/Library/Preferences/rugarciap.com.Turbo-Boost-Switcher.plist'
+  zap trash: '~/Library/Preferences/rugarciap.com.Turbo-Boost-Switcher.plist'
 end

--- a/Casks/tvshows.rb
+++ b/Casks/tvshows.rb
@@ -10,5 +10,5 @@ cask 'tvshows' do
 
   prefpane 'TVShows.prefPane'
 
-  zap delete: '~/Library/Application Support/TVShows 2'
+  zap trash: '~/Library/Application Support/TVShows 2'
 end

--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -11,5 +11,5 @@ cask 'universal-media-server' do
 
   app 'Universal Media Server.app'
 
-  zap delete: '~/Library/Application Support/UMS/'
+  zap trash: '~/Library/Application Support/UMS/'
 end

--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -11,5 +11,5 @@ cask 'vagrant-manager' do
 
   app 'Vagrant Manager.app'
 
-  zap delete: '~/Library/Preferences/lanayo.Vagrant-Manager.plist'
+  zap trash: '~/Library/Preferences/lanayo.Vagrant-Manager.plist'
 end

--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -17,5 +17,5 @@ cask 'vagrant' do
                      },
             pkgutil: 'com.vagrant.vagrant'
 
-  zap delete: '~/.vagrant.d'
+  zap trash: '~/.vagrant.d'
 end

--- a/Casks/vfuse.rb
+++ b/Casks/vfuse.rb
@@ -13,7 +13,7 @@ cask 'vfuse' do
 
   uninstall pkgutil: 'com.chilcote.vfuse'
 
-  zap delete: '~/Library/Preferences/com.chilcote.vfused.plist'
+  zap trash: '~/Library/Preferences/com.chilcote.vfused.plist'
 
   caveats do
     files_in_usr_local

--- a/Casks/vin047-abgx360.rb
+++ b/Casks/vin047-abgx360.rb
@@ -10,5 +10,5 @@ cask 'vin047-abgx360' do
 
   app 'abgx360 GUI.app'
 
-  zap delete: '~/.abgx360'
+  zap trash: '~/.abgx360'
 end

--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -11,8 +11,8 @@ cask 'vox' do
 
   app 'VOX.app'
 
-  zap delete: [
-                '~/Library/Containers/com.coppertino.Vox',
-                '~/Library/Preferences/com.coppertino.Vox.plist',
-              ]
+  zap trash: [
+               '~/Library/Containers/com.coppertino.Vox',
+               '~/Library/Preferences/com.coppertino.Vox.plist',
+             ]
 end

--- a/Casks/vpaint.rb
+++ b/Casks/vpaint.rb
@@ -11,5 +11,5 @@ cask 'vpaint' do
 
   app 'vpaint.app'
 
-  zap delete: '~/.config/vpaint'
+  zap trash: '~/.config/vpaint'
 end

--- a/Casks/vuze.rb
+++ b/Casks/vuze.rb
@@ -14,7 +14,7 @@ cask 'vuze' do
 
   uninstall delete: '/Applications/Vuze.app'
 
-  zap delete: '~/Library/Application Support/Vuze'
+  zap trash: '~/Library/Application Support/Vuze'
 
   caveats do
     depends_on_java

--- a/Casks/winfo.rb
+++ b/Casks/winfo.rb
@@ -12,5 +12,5 @@ cask 'winfo' do
 
   app 'Winfo.app'
 
-  zap delete: '~/Library/Preferences/com.irradiatedsoftware.Winfo.plist'
+  zap trash: '~/Library/Preferences/com.irradiatedsoftware.Winfo.plist'
 end

--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -19,5 +19,5 @@ cask 'witch' do
 
   prefpane 'Witch.prefPane'
 
-  zap delete: '~/Library/Preferences/com.manytricks.Witch.plist'
+  zap trash: '~/Library/Preferences/com.manytricks.Witch.plist'
 end

--- a/Casks/wxcrafter.rb
+++ b/Casks/wxcrafter.rb
@@ -10,8 +10,8 @@ cask 'wxcrafter' do
 
   app 'wxCrafter.app'
 
-  zap delete: [
-                '~/Library/Application Support/wxcrafter',
-                '~/Library/Preferences/wxcrafter.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/wxcrafter',
+               '~/Library/Preferences/wxcrafter.plist',
+             ]
 end

--- a/Casks/xoctave.rb
+++ b/Casks/xoctave.rb
@@ -13,5 +13,5 @@ cask 'xoctave' do
 
   uninstall quit: 'org.magnifier.magnifier'
 
-  zap delete: '~/xoctave'
+  zap trash: '~/xoctave'
 end

--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -10,5 +10,5 @@ cask 'xpra' do
 
   uninstall pkgutil:  'org.xpra.pkg'
 
-  zap delete: '/Library/Application Support/Xpra'
+  zap trash: '/Library/Application Support/Xpra'
 end

--- a/Casks/youdao.rb
+++ b/Casks/youdao.rb
@@ -16,5 +16,5 @@ cask 'youdao' do
 
   app '有道词典.app'
 
-  zap delete: '~/Library/com.youdao.YoudaoDict'
+  zap trash: '~/Library/com.youdao.YoudaoDict'
 end

--- a/Casks/youku.rb
+++ b/Casks/youku.rb
@@ -16,8 +16,8 @@ cask 'youku' do
 
   app '优酷.app'
 
-  zap delete: [
-                '~/Library/Application Scripts/com.youku.mac',
-                '~/Library/Containers/com.youku.mac',
-              ]
+  zap trash: [
+               '~/Library/Application Scripts/com.youku.mac',
+               '~/Library/Containers/com.youku.mac',
+             ]
 end

--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -12,5 +12,5 @@ cask 'yujitach-menumeters' do
 
   prefpane 'MenuMeters.prefPane'
 
-  zap delete: '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'
+  zap trash: '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'
 end

--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -10,9 +10,9 @@ cask 'zeplin' do
 
   app 'Zeplin.app'
 
-  zap delete: [
-                '~/Library/Logs/Zeplin',
-                '~/Library/Caches/io.zeplin.osx',
-                '~/Library/Preferences/io.zeplin.osx.plist',
-              ]
+  zap trash: [
+               '~/Library/Logs/Zeplin',
+               '~/Library/Caches/io.zeplin.osx',
+               '~/Library/Preferences/io.zeplin.osx.plist',
+             ]
 end

--- a/Casks/zoolz.rb
+++ b/Casks/zoolz.rb
@@ -13,5 +13,5 @@ cask 'zoolz' do
             pkgutil:    'ZoolzInstaller',
             delete:     '/Applications/ZoolzRestore.app'
 
-  zap delete: '~/.config/Genie9/Zoolz'
+  zap trash: '~/.config/Genie9/Zoolz'
 end

--- a/Casks/zxpinstaller.rb
+++ b/Casks/zxpinstaller.rb
@@ -11,5 +11,5 @@ cask 'zxpinstaller' do
 
   app 'ZXPInstaller.app'
 
-  zap delete: '~/Library/Preferences/com.electron.zxpinstaller.plist'
+  zap trash: '~/Library/Preferences/com.electron.zxpinstaller.plist'
 end

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -22,7 +22,7 @@ cask 'shuttle' do
 
   app 'Shuttle.app'
 
-  zap delete: '~/.shuttle.json'
+  zap trash: '~/.shuttle.json'
 end
 ```
 


### PR DESCRIPTION
These are by far not all Casks that should use this. We will need to gradually separate `delete` from `trash`.

I think these kind of files should still always be deleted, not trashed:

- `/Library/Logs/*`
- `/Library/Caches/*`
- `~/Library/Caches/*`
- `~/Library/Cookies/*`
- `~/Library/Preferences/*.LSSharedFileList.plist`
- `~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/*.sfl`
- `~/Library/Saved Application State/*`
