### PR TITLE
Update imagej to 1.50

### DIFF
--- a/Casks/imagej.rb
+++ b/Casks/imagej.rb
@@ -1,8 +1,9 @@
 cask 'imagej' do
-  version '1.49'
-  sha256 '539c816c10849cb9820663d46c28b9ae1d36f43a29cc50fe7b5d819e9e60dd44'
+  version '1.50'
+  sha256 '681bb1af1cc1797e2fe5eddd5828a38128d3fc5cf9ea05a268650466e2eb6b93'
 
-  url "https://imagej.nih.gov/ij/download/osx/ImageJ#{version.no_dots}.zip"
+  # wsr.imagej.net was verified as official when first introduced to the cask
+  url "https://wsr.imagej.net/distros/osx/ImageJ#{version.no_dots}.zip"
   name 'ImageJ'
   homepage 'https://imagej.nih.gov/ij/index.html'
 

--- a/Casks/imagej.rb
+++ b/Casks/imagej.rb
@@ -2,7 +2,7 @@ cask 'imagej' do
   version '1.50'
   sha256 '681bb1af1cc1797e2fe5eddd5828a38128d3fc5cf9ea05a268650466e2eb6b93'
 
-  # wsr.imagej.net was verified as official when first introduced to the cask
+  # wsr.imagej.net/distros/osx was verified as official when first introduced to the cask
   url "https://wsr.imagej.net/distros/osx/ImageJ#{version.no_dots}.zip"
   name 'ImageJ'
   homepage 'https://imagej.nih.gov/ij/index.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}