### PR TITLE
Update electorrent to 2.1.3

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.2'
-  sha256 'd512358894f0a37a98f22e1c37513a661af48d8232a09fd6bd9d7d123936cc9e'
+  version '2.1.3'
+  sha256 'd6703208c45ecb8d8342d2c620d19ab980f5fedc33f7a8cd2d7b159168dd6959'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '016da9cb8be6d066c271ba0f9cce6883a4c86d124b1ee92c549b533711f6917c'
+          checkpoint: '309d619751e7196268fc6c4a8d6fa2f0cfa9248e1c6b84e4dfe84fcc2a8830fa'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}