### PR TITLE
Update ndk casks - preflight symlink

### DIFF
--- a/Casks/android-ndk.rb
+++ b/Casks/android-ndk.rb
@@ -12,7 +12,7 @@ cask 'android-ndk' do
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/ndk_exec.sh"
   preflight do
-    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/android-ndk")
+    FileUtils.ln_sf("#{staged_path}/android-ndk-r#{version}", "#{HOMEBREW_PREFIX}/share/android-ndk")
 
     IO.write shimscript, <<-EOS.undent
       #!/bin/bash

--- a/Casks/crystax-ndk.rb
+++ b/Casks/crystax-ndk.rb
@@ -11,7 +11,7 @@ cask 'crystax-ndk' do
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/ndk_exec.sh"
   preflight do
-    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/crystax-ndk")
+    FileUtils.ln_sf("#{staged_path}/crystax-ndk-r#{version}", "#{HOMEBREW_PREFIX}/share/crystax-ndk")
 
     IO.write shimscript, <<-EOS.undent
       #!/bin/bash


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/35726

Changed `preflight` symlink to `#{staged_path}/*-ndk-r#{version}` 