### PR TITLE
Update expandrive to 5.5.4

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,10 +1,10 @@
 cask 'expandrive' do
-  version '5.5.0'
-  sha256 '537a2dd653d7e5442e0cd0eb2a07bae24e18bdf84a22df546423595b49a755ba'
+  version '5.5.4'
+  sha256 'cd315e227a1fc4719a77760de6b7a27f6b5dd9036a58319352e72fbbaa60a623'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
   appcast 'https://updates.expandrive.com/appcast/expandrive.xml?version=3',
-          checkpoint: 'ef7b60656f23aecb19ed13fa535bf8f85c8642312a3500ab0d2cdee19c974e6f'
+          checkpoint: '5ef57ba7165a2afc67ab96fd08e68aed3a2a90a273fa717b887c0c34040b2ca7'
   name 'ExpanDrive'
   homepage 'https://www.expandrive.com/apps/expandrive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}