### PR TITLE
Update freesmug-chromium to 59.0.3071.109

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '59.0.3071.104'
-  sha256 'ce944e3a14c776feee8ada77708973dbd0593717a22a8f6f1a064ed457c31df2'
+  version '59.0.3071.109'
+  sha256 '2df1379b5f4deba470061fb2b6be9ec08f2dc2948be2cb8860881ae8c610eaf6'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '749115b377f138af594fc25d246543d210ac5597d9877e89dd29d161f17c6ca0'
+          checkpoint: 'fa3c48071a407928858bcdbce1eb09d277c333e2f80b5cbbb456fb0fd2984d13'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}