### PR TITLE
Update vimr to 0.16.0-205

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.15.2-201'
-  sha256 '6c410b2d42f7efa418f4d2ec43f72990b746432c4d13c03d31840ede18ca4be3'
+  version '0.16.0-205'
+  sha256 'd9717861767666cd9c2503408a10f4e92219030283568a8dd4a346308eaf92cc'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'bbeb4136d39b0d09e51ea84bcce85ad10ce83582f68ce5c95c2b15641d618601'
+          checkpoint: '53c00a0b368982be2edd2382abf87a77f71b459eb4b6dabc4d8dda30bf218e67'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}