### PR TITLE
Update switchhosts to 3.3.6.5287

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.5.5268'
-  sha256 '6bc37cacc7b9447dad4f8a433828ef838e70e7d165fe9cd8e39dd97f3460262d'
+  version '3.3.6.5287'
+  sha256 'deda73aeff1945fee6db09039b6f5a8d36e32b4e29530510b4717adfc8ff4536'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: '25ea9da31c91de09b7ea4bfbacd0728a432248263c5ca8af399fd00e8afd71f5'
+          checkpoint: '152d4cfe878cf7c89e48ea39f3bb2baa098d4b41946ec981c10f870c3d20a933'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}