### PR TITLE
Update psychopy to 1.85.2

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,10 +1,10 @@
 cask 'psychopy' do
-  version '1.85.1'
-  sha256 '6bf222b08cb6e88271226ccfa5c0c1cb25dd10fb44a4e5d2f9a684a867e4e237'
+  version '1.85.2'
+  sha256 '544caead453b328afa38a5ad535198714ec7e2405bcba668c35a7c93b35e96b9'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom',
-          checkpoint: 'd8606caabf407d77969cbc220b81052989868ea5cb1534d8b0b63d04d428bd32'
+          checkpoint: '5622392b1d4d26628d9e003322bd9ee2a7c33c263a7aa6552d624254b0b09357'
   name 'PsychoPy'
   homepage 'https://github.com/psychopy/psychopy'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}