### PR TITLE
Update minikube to 0.20.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,11 +1,11 @@
 cask 'minikube' do
-  version '0.19.1'
-  sha256 '1689ff1686c07da8b72a4dd2d472ec4d6cf3347eb33804024bb368f455fb4214'
+  version '0.20.0'
+  sha256 'c09b3ff9045a9b4c2bc9dab85b981f7846b77417bcfeb3248fc50cd985a5c5fe'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: 'b72d7dd99f9e92b115c459ce532db88b70490a5eae48b189947c4881281ac5e0'
+          checkpoint: 'c6be88cbd2d7e87f50c33d6be3ecd34a32eb07415659d27a8e745349357fedb4'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}