### PR TITLE
Update navicat-for-mariadb to 12.0.5

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.2'
-  sha256 'bae188ec3bbe8171800cd9b873198aea5c0498e64697f71bdb1bdb63295254d2'
+  version '12.0.5'
+  sha256 '7b865937b3eb5971f9c06afd1b0515c68bb2aa56a7c9d8780e392f12e971ccb6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mariadb-release-note',
-          checkpoint: 'f1b71ca2b54f36aaf347234e551bd2b1c2c54ceb782ad3cc240cbd5ea1247c1d'
+          checkpoint: '36fa0e353e43b4bbadb5f7c056d779b51b9ba100cfcf82e89d95e7aca4edc0c4'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}