### PR TITLE
Update navicat-for-mysql to 12.0.5

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.2'
-  sha256 '82b407f81df5cbd468f76fca65384c5827ee505a0dc3fb1058ca58f95f10122e'
+  version '12.0.5'
+  sha256 'a05751caa4469ac1e82586af1254964ebde1ceaedafe7f5e766ad45a022a7ab8'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note',
-          checkpoint: '34e696692858e4c0ad6a52a60590c2b509ab93d3084c369ad354c537e0b4934d'
+          checkpoint: '7ca5fe14f57dab0ae1e497c6a7f6b0b63a346c8e5aad929460796fc8709a81b9'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}