### PR TITLE
Update navicat-for-postgresql to 12.0.5

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.2'
-  sha256 '7ea2b4ebdc589b7bd88aed2eda202a0e7bfb72bd03ca90e5995bad1c56acc658'
+  version '12.0.5'
+  sha256 '3b176125455105d758814aa2ca2c8b66cb572acdeb5b99d62871f990ce6b6a6a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
-          checkpoint: '687ad5be37d8913e37adbfcb4d2fefbc1d3d1a5dca349ba08311545398c696de'
+          checkpoint: '5027b8d4261d8b3912c98280e2b0abe784daa621a055d0dbf9e2d08e20be90d4'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}