### PR TITLE
Update navicat-for-sql-server to 12.0.5

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.2'
-  sha256 'a989eaca6becc7f5a243922de7b8fa6c78dc3f4046f2c0e6632e270061d7a0a9'
+  version '12.0.5'
+  sha256 '26816ff695560ffc956b8d52a86aede849faf2908943f87a219faa00451988b6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note',
-          checkpoint: 'fecfcb9ca68e5b374c1d1dad8a8facac205104df9e2e94e2ba43a18574e7a528'
+          checkpoint: '4da3d123de6cd8095bf554722e23020c9b8c6ea8742df8fe661cf49dea9dbc98'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}