### PR TITLE
Update navicat-premium to 12.0.5

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '12.0.2'
-  sha256 'cb3bb9314b2580712967179acc12ed2823181db79ae33f483781d23f47bc821a'
+  version '12.0.5'
+  sha256 '042ccaa80291eb6b2cc3889a0241a7c90260352696d0f249b94f9a33d9e8dcd4'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}