### PR TITLE
Update qiyimedia 4.15.10

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,8 +1,8 @@
 cask 'qiyimedia' do
-  version '005'
-  sha256 '5c4be4a6c91358b40a96747194b90e2360c721648a009354f8fc29a33590b531'
+  version '4.15.10'
+  sha256 'fad57bd51aca4ccd797ea26e165e70a5824a4e62189c0369271ee6f516e94039'
 
-  url "https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_#{version}.dmg"
+  url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_003.dmg'
   name '爱奇艺视频'
   homepage 'https://www.iqiyi.com/'
 

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -2,7 +2,7 @@ cask 'qiyimedia' do
   version :latest
   sha256 :no_check
 
-  url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_003.dmg'
+  url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_005.dmg'
   name '爱奇艺视频'
   homepage 'https://www.iqiyi.com/'
 

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '4.15.10'
-  sha256 'fad57bd51aca4ccd797ea26e165e70a5824a4e62189c0369271ee6f516e94039'
+  version :latest
+  sha256 :no_check
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_003.dmg'
   name '爱奇艺视频'


### PR DESCRIPTION
The `005` in `url` isn't the version.

Update qiyimedia 4.15.10

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
