### PR TITLE
Update electorrent to 2.1.4

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.3'
-  sha256 'd6703208c45ecb8d8342d2c620d19ab980f5fedc33f7a8cd2d7b159168dd6959'
+  version '2.1.4'
+  sha256 'a33c7ee0652dec678659e4712745024c8016a827c6d22e53745335165074be2b'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '309d619751e7196268fc6c4a8d6fa2f0cfa9248e1c6b84e4dfe84fcc2a8830fa'
+          checkpoint: 'f365bad3325db723c51c5b3ff1d3879d6ca0a83acb866e75a95630ee320e0783'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}