### PR TITLE
Update sqlectron to 1.22.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.21.0'
-  sha256 'e8e7f7c9e3dd75c55ace6326dbab9e9c885394bccffd4252ac621d74fc1ba9e2'
+  version '1.22.0'
+  sha256 '8a3194129f98d47dec53930795a234718a93a71c9cacbca2d31f26fcb5c8fd1e'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: 'b84e0ceb5f55bd4548f039e9af3fbdb4458b1e94597b718ab1bb8d7a68fe6a2d'
+          checkpoint: '31676b3e34e3cb8790210f9652dae2e6c94772030846d43988378f9c443e0f8d'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}