### PR TITLE
Update adobe-air-sdk to 26.0

### DIFF
--- a/Casks/adobe-air-sdk.rb
+++ b/Casks/adobe-air-sdk.rb
@@ -1,6 +1,6 @@
 cask 'adobe-air-sdk' do
-  version '25.0'
-  sha256 '36cb9c62ad245c8f84efce0f218e8465cfec40d657e35533ba21a48107a8c6ba'
+  version '26.0'
+  sha256 'dececd6dc01f6fdd53f410a6c7dc70037f34af07de49ca8ccd54c945c4284af1'
 
   url "https://airdownload.adobe.com/air/mac/download/#{version}/AIRSDK_Compiler.dmg"
   name 'Adobe AIR SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
