### PR TITLE
Update electorrent to 2.1.5

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.4'
-  sha256 'a33c7ee0652dec678659e4712745024c8016a827c6d22e53745335165074be2b'
+  version '2.1.5'
+  sha256 '2e54d9522624200e7d15a00662f9d440383b4d3d018378464689b7a37865cd04'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: 'f365bad3325db723c51c5b3ff1d3879d6ca0a83acb866e75a95630ee320e0783'
+          checkpoint: '97a48528bbbbf226deccbafb52d9dab3ec370ee0a71e5678c827c8a49cb4eb67'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}