### PR TITLE
Update gotomeeting to 8.6.0.7107,ka338000000CjdPAAS

### DIFF
--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,6 +1,6 @@
 cask 'gotomeeting' do
-  version '8.5.0.6956,ka338000000CjPXAA0'
-  sha256 '5722fb63a00c320a20d071f8cb00d2fe93a1c4f73cbf8b80602021a8f8fb82de'
+  version '8.6.0.7107,ka338000000CjdPAAS'
+  sha256 'a731facb69b4c5b5f5bb59365e0765d24849ed9ee9adc114825083f41b8bee4d'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
   url "https://support.citrixonline.com/servlet/fileField?entityId=#{version.after_comma}&field=Content__Body__s"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}