### PR TITLE
Update powershell to 6.0.0-beta.3

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -1,11 +1,11 @@
 cask 'powershell' do
-  version '6.0.0-beta.2'
-  sha256 '9a55a6d82bd7dacde9e0d160d6f105dfe84993a7504e67d2ccdc5478ab2fca9f'
+  version '6.0.0-beta.3'
+  sha256 '512690287eb0445f6211c3d535021b68772b98687063b593b1b9d4f58d3ed85c'
 
   # github.com/PowerShell/PowerShell was verified as official when first introduced to the cask
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx.10.12-x64.pkg"
   appcast 'https://github.com/PowerShell/PowerShell/releases.atom',
-          checkpoint: 'cae17c2b2ddb28fb7bc1dc5d6a7e6e4d813e25abfc6dbbf7619c8b46033a71bf'
+          checkpoint: 'b95dbb56fd042f69f318924e68780b88772d8f42132e3a4b9ec0c362de0f3422'
   name 'PowerShell'
   homepage 'https://msdn.microsoft.com/powershell'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}