### PR TITLE
Update wifi-explorer to 2.3.2

### DIFF
--- a/Casks/wifi-explorer.rb
+++ b/Casks/wifi-explorer.rb
@@ -1,11 +1,11 @@
 cask 'wifi-explorer' do
-  version '2.3.1'
-  sha256 '7c89a610b88e396ecbfea3c837463fa9493f1a1ec753d4d0644ad9909742edfb'
+  version '2.3.2'
+  sha256 '96cf78ae761e68ecf4141b919d1fa8a578e665ed678066cfcb75380dff54b990'
 
   # s3.amazonaws.com/apps.adriangranados.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/apps.adriangranados.com/wifiexplorer.zip'
   appcast 'https://www.adriangranados.com/appcasts/wifiexplorercast.xml',
-          checkpoint: 'ffbc98d5db6d4eb7d5bbdd71b9bafe11ff718070a12624ab0798fd32cd48974b'
+          checkpoint: 'ab789ce78c00e1ba7490aa4741205244d0bb00e956e1c1d0e413a6e8449538f4'
   name 'WiFi Explorer'
   homepage 'https://www.adriangranados.com/apps/wifi-explorer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}