### PR TITLE
Update vmware-fusion to 8.5.8-5824040

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,10 +1,10 @@
 cask 'vmware-fusion' do
-  version '8.5.7-5528452'
-  sha256 '6ef593263303f13702d3a3c7934785b7936f053fca2d728e574e5a5c77cccc20'
+  version '8.5.8-5824040'
+  sha256 'fe74972b36960b43a092619105d5053d391d39c55f04991ea3fdce2e9680c035'
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   appcast 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml',
-          checkpoint: '2f3c86aceddfd0081e47e0d10b78217fb665c74157d6933ce4036dbf37d1659d'
+          checkpoint: 'ad9fd8c30e14e34d54f0878a3926773ca8e6ba5ff21eb25f124ca79f82a087e3'
   name 'VMware Fusion'
   homepage 'https://www.vmware.com/products/fusion.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}