### PR TITLE
Update polymail to 1.39

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.38'
-  sha256 'de5f4279c10af0132bacfc56d58ffb1915e4d7ea4013a30aff00a47b69462ba8'
+  version '1.39'
+  sha256 '89bc6f2a0245961ab205a27e52f032d90d0d165824a616ce947a8d4e615f5872'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'c0633242fd02b71f08873078a7cfb6b7000c2c0e44769c2cccce33dd3b85b238'
+          checkpoint: 'c7edbad342f80754f20fdf1b797fd50f301c530189db8f3eba2e26f36f0bc8f5'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}