### PR TITLE
Bump Digikam to 5.6.0-01

### DIFF
--- a/Casks/digikam.rb
+++ b/Casks/digikam.rb
@@ -1,11 +1,11 @@
 cask 'digikam' do
-  version '5.5.0-01'
-  sha256 '3592d0a6ef3882676af3b028c62805894bff7b59dae6a9e4464d557787622ddc'
+  version '5.6.0-01'
+  sha256 '69b79d983534d0111c0c9cba5a211d594fa449706bada2c60826f319238f5fe3'
 
   # kde.org/stable/digikam was verified as official when first introduced to the cask
   url "https://download.kde.org/stable/digikam/digiKam-#{version}-MacOS-x86-64.pkg"
   appcast 'https://download.kde.org/stable/digikam/',
-          checkpoint: '43d3da19a65b3595a6dd05bcacd4938eb1bef69fd8709127b496d7e3b0277231'
+          checkpoint: '20038497c4e4a4455925ef921328cc30c06f740759ab7ab7b6852b06fbd86fd8'
   name 'digiKam'
   homepage 'https://www.digikam.org/'
 


### PR DESCRIPTION
| parameter | value |
| ---- | ---- |
| version | 5.6.0-01 |
| sha256 | 69b79d983534d0111c0c9cba5a211d594fa449706bada2c60826f319238f5fe3 |
| appcast | 20038497c4e4a4455925ef921328cc30c06f740759ab7ab7b6852b06fbd86fd8 |

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

---
```
tyr:~/Code/git/Mine/homebrew-cask/Casks (master) benc$ brew cask install ./digikam.rb
==> Downloading https://download.kde.org/stable/digikam/digiKam-5.6.0-01-MacOS-x
Already downloaded: /Users/benc/Library/Caches/Homebrew/Cask/digikam--5.6.0-01.pkg
==> Verifying checksum for Cask digikam
==> Installing Cask digikam
==> Running installer for digikam; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are i
Password:
==> installer: Package name is digikam-5.6.0-01-MacOS-x86-64
==> installer: Installing at base path /
==> installer: The install was successful.
🍺  digikam was successfully installed!
```