### PR TITLE
Update vox to 2.8.26

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '2.8.24'
-  sha256 '3baa7e05db55a1f7c0d4f3d53f4ce3986125f25dee07308f94b42a0f4326d419'
+  version '2.8.26'
+  sha256 '102e87e1f2d271d6b36120e252b6d07a35240ee11177a238ef757cb77394ed7d'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: '639cb0855b29b520d0eb59d337b4f6487d737c62fc8c59f7163c51d12144d42e'
+          checkpoint: 'c5abaf11d0b33d34a8f7f60d1592d05176e29bbbacafdc6212c94df94d26f1f3'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}