### PR TITLE
Update eloston-chromium to 58.0.3029.110-1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,11 +1,11 @@
 cask 'eloston-chromium' do
-  version '57.0.2987.133-1'
-  sha256 '48846204762fecf5dfa9f381df067b2ba1279f94b1f6af73332e9863af4d1ddd'
+  version '58.0.3029.110-1'
+  sha256 'a39466fa9dca06fede63043486618e776ff0404ba8c47a4e85c3132e070c4f28'
 
-  # github.com/9Morello/ungoogled-chromium-binaries was verified as official when first introduced to the cask
-  url "https://github.com/9Morello/ungoogled-chromium-binaries/releases/download/#{version.split('-')[0]}/ungoogled-chromium_#{version}_macos.dmg"
-  appcast 'https://github.com/ungoogled-software/ungoogled-chromium-binaries/releases.atom',
-          checkpoint: 'dbb87319a87c7ccf876d7df29abf5dbbf95c97935855238aafe9daabd093fd9a'
+  # github.com/nixballs/ungoogled-chromium was verified as official when first introduced to the cask
+  url "https://github.com/nixballs/ungoogled-chromium/releases/download/#{version}/ungoogled-chromium_#{version}_macos.dmg"
+  appcast 'https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/macos/',
+          checkpoint: 'c6ad5cd11b7d64f9042ba410e5fbe241d59eb7891e94136b9c8175ffeb324d9a'
   name 'Ungoogled Chromium'
   homepage 'https://ungoogled-software.github.io/ungoogled-chromium-binaries/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update `url` - binaries have changed repos
Update `appcast` - The previous github releases appcast was outdated

https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/macos/58.0.3029.110-1