### PR TITLE
Update before_script.sh - remove required workarounds

### DIFF
--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -10,10 +10,6 @@
 
 header 'Running before_script.sh...'
 
-# Required workarounds
-run curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - # Required by RVM: https://rvm.io/rvm/security
-run rvm get stable # Required due to Travis bug: https://github.com/travis-ci/travis-ci/issues/6307#issuecomment-233315824
-
 # see https://github.com/travis-ci/travis-ci/issues/2666
 run export BRANCH_COMMIT="${TRAVIS_COMMIT_RANGE##*.}"
 run export TARGET_COMMIT="${TRAVIS_COMMIT_RANGE%%.*}"


### PR DESCRIPTION
Seems to be an problem with `rvm get stable`
```
>>> rvm get stable
Downloading https://get.rvm.io
Could not download rvm-installer, get some help at #rvm IRC channel at freenode servers.
```

- https://travis-ci.org/caskroom/homebrew-cask/builds/246525411
- https://travis-ci.org/caskroom/homebrew-cask/builds/246532792

The workarounds don't seem to be required.

- https://github.com/caskroom/homebrew-cask/pull/35833
- https://travis-ci.org/caskroom/homebrew-cask/builds/246530284
- https://travis-ci.org/caskroom/homebrew-cask/builds/246531898
____

Edit: I think the `rvm get stable` requirement may have been fixed with the travis `xcode8.3` image.
