### PR TITLE
Update trash-it - remove appcast

### DIFF
--- a/Casks/trash-it.rb
+++ b/Casks/trash-it.rb
@@ -10,8 +10,6 @@ cask 'trash-it' do
     url 'http://nonamescriptware.com/wp-content/uploads/Trashit.zip'
     app "Trash It! #{version}/Drag content to Desktop/Trash It!.app"
   end
-  appcast 'http://nonamescriptware.com/downloads/',
-          checkpoint: '7a27f7d208c8fdb0e95a83e5981061714feb271e1ce611c4e765285471f75ada'
   name 'Trash It!'
   homepage 'http://nonamescriptware.com/'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`version` is `:latest`