### PR TITLE
Update airflow to 2.0.0-beta4

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,6 +1,6 @@
 cask 'airflow' do
-  version '2.0.0-beta3'
-  sha256 '8440e6fa315f416342e68b34ea076bfcf071d9ea33f19f19c7434446cf393cfe'
+  version '2.0.0-beta4'
+  sha256 'c0e0fb3aa79e8aafba6b5371a7968115e36e828c048e43ec56ea795a20bce85d'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}