### PR TITLE
Update qlimagesize - postflight / uninstall

### DIFF
--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -21,4 +21,8 @@ cask 'qlimagesize' do
                        '~/Library/Spotlight/mdImageSize.mdimporter',
                      ],
             pkgutil: 'fr.whine.qlimagesize.pkg'
+
+  caveats do
+    reboot
+  end
 end

--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -9,5 +9,10 @@ cask 'qlimagesize' do
 
   pkg 'qlImageSize.pkg'
 
-  uninstall pkgutil: 'io.whine.qlimagesize.pkg'
+  postflight do
+    set_ownership '~/Library/QuickLook/qlImageSize.qlgenerator'
+  end
+
+  uninstall delete:  '~/Library/QuickLook/qlImageSize.qlgenerator',
+            pkgutil: 'fr.whine.qlimagesize.pkg'
 end

--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -10,9 +10,15 @@ cask 'qlimagesize' do
   pkg 'qlImageSize.pkg'
 
   postflight do
-    set_ownership '~/Library/QuickLook/qlImageSize.qlgenerator'
+    set_ownership [
+                    '~/Library/QuickLook/qlImageSize.qlgenerator',
+                    '~/Library/Spotlight/mdImageSize.mdimporter',
+                  ]
   end
 
-  uninstall delete:  '~/Library/QuickLook/qlImageSize.qlgenerator',
+  uninstall delete:  [
+                       '~/Library/QuickLook/qlImageSize.qlgenerator',
+                       '~/Library/Spotlight/mdImageSize.mdimporter',
+                     ],
             pkgutil: 'fr.whine.qlimagesize.pkg'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/35839

Add `postflight` `set_ownership` and `uninstall delete:`

Update `pkgutil`

Also added reboot `caveat` rather than running `qlmanage` and `mdimport` in `postflight`