### PR TITLE
Update dockstation to 1.2.1

### DIFF
--- a/Casks/dockstation.rb
+++ b/Casks/dockstation.rb
@@ -1,11 +1,11 @@
 cask 'dockstation' do
-  version '1.2.0'
-  sha256 '7ec7df116f1bb04dc047cde75132583b489cfbd3c96038166fd0903106e6dd25'
+  version '1.2.1'
+  sha256 '95a1c7f7f554ab6ece946e965a48a4afecbf3bade7689bced3c63be33ebc034e'
 
   # github.com/DockStation/dockstation was verified as official when first introduced to the cask
   url "https://github.com/DockStation/dockstation/releases/download/v#{version}/dockstation-#{version}.dmg"
   appcast 'https://github.com/DockStation/dockstation/releases.atom',
-          checkpoint: '5a4d580832647d273819630c6ca8148ba43744f69ade04cb1ab405484d5beaab'
+          checkpoint: '04a77c5ff85c177c98cdcc9fbc1b95931e158c27bb20f0d3a2a17ea8694e9ab9'
   name 'DockStation'
   homepage 'https://dockstation.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}