### PR TITLE
Update pritunl to 1.0.1380.37

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1364.29'
-  sha256 'becddef266b34eaf082d0824e1194e141094aa53eb6850b5e69fe5ecfd5c5e2a'
+  version '1.0.1380.37'
+  sha256 'd0c38088036293cfb1556e74e2a787cad017aaa3f12ec7017f23dc213d917f96'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: '9fdabdf6411f99bc79a9e91031d8a8863ba2287411113c327002a1508e014bb8'
+          checkpoint: '3bfaa622bd031f96d50d817a9076ed11152dbbffb129b0c0a4eddd0238c73c9b'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}