### PR TITLE
Update brisk to 1.0.1

### DIFF
--- a/Casks/brisk.rb
+++ b/Casks/brisk.rb
@@ -1,10 +1,10 @@
 cask 'brisk' do
-  version '0.2.2'
-  sha256 'ec17a4ad7e150ab036c62f692703948cea8dca5ee6f2476c00c194bf28513726'
+  version '1.0.1'
+  sha256 '75efe333c1f5e20c58e010f443dae505a679b651f5fecf6f6a49e5d5763475ac'
 
   url "https://github.com/br1sk/brisk/releases/download/#{version}/Brisk.app.tar.gz"
   appcast 'https://github.com/br1sk/brisk/releases.atom',
-          checkpoint: '66a6e11873950b1e6eea0d455de432e74837b4c4b5a118699272a83a90405da6'
+          checkpoint: '5e8c5b48f8af9de1dab910ab3e1cc4960e0c9b577745b22db677febdfe66ec82'
   name 'Brisk'
   homepage 'https://github.com/br1sk/brisk'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Note that the appcast has been updated since Brisk now supports Sparkle