### PR TITLE
Update dbeaver-community to 4.1.0

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.0.8'
-  sha256 'a20ac8c269d7f9827a858dec40e097dfef8c18bf6e6e9bd756769784d63edf29'
+  version '4.1.0'
+  sha256 '5e775008555f11204f49761c43de99f66e016de75022621b8c977a96ce63799a'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '819404d93e01f2fd30b525bc64234f6342a5f4dc150073b609d7850f45cfa3cc'
+          checkpoint: '8c27449d66211e0df84e62db3acf3b0981efd11b80d49dffef100f189217e4ad'
   name 'DBeaver Community Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}