### PR TITLE
Update rar to 5.5.b4

### DIFF
--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -1,6 +1,6 @@
 cask 'rar' do
-  version '5.4.0'
-  sha256 '09a14f40718c68fc1c24b30acb55d0f2f90f3e13b372c48b6ef1e789d748b754'
+  version '5.5.b4'
+  sha256 '98a41a4b833a59d5d4ad89d5854343e15cc410b23e8008e9dc82839939899e88'
 
   url "http://www.rarlab.com/rar/rarosx-#{version}.tar.gz"
   name 'RAR Archiver'


### PR DESCRIPTION
Update rar to 5.5.b4 to fix a security vulnerability found in rar 5.4.0
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
