### PR TITLE
Update rsyncosx to 4.4.0

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -4,7 +4,7 @@ cask 'rsyncosx' do
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: 'c0db3454b0447da55cf1f4c8497b65a32d87d5d20445f9b1882cb6807569f06f'
+          checkpoint: '8ef30e93f33e44d828fd9aeb7b0b9a2986f2f422cf3ead479bfcbf989ff325bf'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}