### PR TITLE
Update fldigi to 4.0.6

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.5'
-  sha256 '44dd15440087c177def8187a3622f76b7d210cd0f220f665b4feffa29c0ab30f'
+  version '4.0.6'
+  sha256 '5364eac98775094e2a37f140c5ea0261deaa28d459bf7bf42c36b2965f98cfb7'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'b2ed526c7ab311c48ae0e57aae8dab5e458221bdf46dacbd716eebe6b26837a7'
+          checkpoint: '27bbacb30ebbed8e86bd611961027aef90bfaaed00e550e182358d031cf5baa7'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}