### PR TITLE
Update boostnote to 0.8.11

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.10'
-  sha256 '7d6b58b4894629c6d83d40b0496db227e81a2aed7c24c4f57f5baad8b1ef90ab'
+  version '0.8.11'
+  sha256 '2a3d6a934b40a40729109dd5977f6b900f784a33e3ecdada048192fe99fd21a2'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '4b5a1137977c41115cfe7da3bde3b7b39b86b8a9d64b818a6c39c1d1945b1b59'
+          checkpoint: '03445af0e25f85979dfc442881094dbaacaa57fc72ff816db50797ea369254bf'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}