### PR TITLE
Update balsamiq-mockups to 3.5.13

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -1,10 +1,10 @@
 cask 'balsamiq-mockups' do
-  version '3.5.9'
-  sha256 '13abbe8f62973ec455bf3706e7deb1e833b4073d71f4cf58b8f0574447b2056b'
+  version '3.5.13'
+  sha256 'f2a6afc250a0d933f9f9aa73f5f65ad2c1f34161fb12dcbc84154c8cfb4b59ae'
 
   url "https://builds.balsamiq.com/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"
   appcast 'https://builds.balsamiq.com/mockups-desktop/version.jsonp',
-          checkpoint: 'ca9cca286e7d59af89cf5dd70cd4431e45ecfd24fa6347dba14f2263c20871d3'
+          checkpoint: '28b33f160de8915347e3baea1680179c72c4ac31cd86d2f67f138a6f8194580d'
   name 'Balsamiq Mockups'
   homepage 'https://balsamiq.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}