### PR TITLE
Update marp to 0.0.11

### DIFF
--- a/Casks/marp.rb
+++ b/Casks/marp.rb
@@ -1,11 +1,11 @@
 cask 'marp' do
-  version '0.0.10'
-  sha256 'e099aac307ebb0b5e749353a8cc07673af2160314f35b9b829fe9086e3d218c8'
+  version '0.0.11'
+  sha256 '07d0663e71adb90d2d9b8a992a62dc5fe0cdf0f4d47b1c2433718582cc0ef722'
 
   # github.com/yhatt/marp was verified as official when first introduced to the cask
   url "https://github.com/yhatt/marp/releases/download/v#{version}/#{version}-Marp-darwin-x64.dmg"
   appcast 'https://github.com/yhatt/marp/releases.atom',
-          checkpoint: 'e1958593081010d4663d670cb4a72111d948de6156e10ec6c1aebc4852e251c8'
+          checkpoint: '6969d13883018b8647cbd947b1d93890482af371576413f79deeaf9c310c1035'
   name 'Marp'
   homepage 'https://yhatt.github.io/marp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}