### PR TITLE
Update studio-3t to 5.3.4

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.3.2'
-  sha256 '19f43b4dd04e077d600c53508cce75d6217a2d57fd742c22a3f0cecd514e5ebb'
+  version '5.3.4'
+  sha256 'a81b31ccf43dcda4374f04f6475a4aefd6e671742155e560224f8eb91a26f374'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '19104d0f3d9e42de6c08f51f8a045ed3934d7026f6944a238d922002db62f7e5'
+          checkpoint: '3320890a84c3fe972e75fe1bb77de8cf5acd50b9218fa8239b6b3a9ce2e52754'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}