### PR TITLE
Update opera to 46.0.2597.32

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '46.0.2597.26'
-  sha256 'bfa6c0961f77847934cde994fc5a29d4a78b13e394ebe81e7d7496b7aba8200b'
+  version '46.0.2597.32'
+  sha256 '3b12a16b99c3dcc05d3ea2b601a28d1ff4d2d9c210008ef57b82f4219dca34aa'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}