### PR TITLE
Update virtualc64 to 1.5.1

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,11 +1,11 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.4.2'
-  sha256 '8a000f9f4e16e6583901f9e19e9c6a5173d8cc13e7ed015b18eaf480cb05c616'
+  version '1.5.1'
+  sha256 '7029b58d62887a81c9c6d984a2ae8d54335276c2fe6ff818b5bcfefa047fe62d'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml',
-          checkpoint: '81d3f0fbe4227e74b6712d99b265d6da4d57cf732ed1d7cef7028816748f3633'
+          checkpoint: '8665d923f94636c8b9a2ae31afe31ede39099425e26bf5c94509eb5b3be0f0a5'
   name 'Virtual C64'
   homepage 'http://www.dirkwhoffmann.de/virtualc64/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}