### PR TITLE
Update vitamin-r to 2.48

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -15,11 +15,11 @@ cask 'vitamin-r' do
     url "http://www.publicspace.net/download/Vitamin_#{version.dots_to_underscores}.dmg"
     app "Vitamin-R #{version.major}.app"
   else
-    version '2.47'
-    sha256 'c23503e957f7419696f6020b8dd47dacabe246e880ba36212f25a1039403ffad'
+    version '2.48'
+    sha256 '9e01139578b3d02deb849d1dafe806690e4a54afe89c45eb473fec2d256d99c6'
     url "http://www.publicspace.net/download/signedVitamin#{version.major}.zip"
     appcast "http://www.publicspace.net/app/vitamin#{version.major}.xml",
-            checkpoint: 'b40ae7bfc99783e7dcbf20c3d8da849d8a4a62edfb3934f6fd53adeb9c09d03b'
+            checkpoint: '97be23f3c019e9df51cd272ac2fc63ba8f3c7a4cedf5ed77dbcaa506ea6eb809'
     app "Vitamin-R #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}