### PR TITLE
Update twist to 1.0.10,2864

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,10 +1,10 @@
 cask 'twist' do
-  version '1.0.10,2844'
-  sha256 '8e7606f2e975cfd60760334ac0d3babe3c05a5727dde89e7e682657c5372bdf5'
+  version '1.0.10,2864'
+  sha256 'a8b69af53e4fad7f52aabc069494cfbc19a11676f5572ca0c6b02c2779431c2e'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml',
-          checkpoint: '0e358713c31b2080fb75120ec2e6f1798e22eadf20bd8c19ff4c2d8ed5b0423d'
+          checkpoint: 'c4295d2b33f520788c4b33cdc8d7678fd25b95def1315a1090f5f8a160af915f'
   name 'Twist'
   homepage 'https://twistapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}