### PR TITLE
Update tiled to 1.0.1

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,11 +1,11 @@
 cask 'tiled' do
-  version '1.0.0'
-  sha256 '0607713d702b662f430a2aaf7305203db8f5d2c9620a708d3ca73a5c3c742047'
+  version '1.0.1'
+  sha256 'db21bb075ba19bcf92234ab70313edff688bf03a0a18a2adad1532c975ae3a21'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
   appcast 'https://github.com/bjorn/tiled/releases.atom',
-          checkpoint: 'fbfb63f98888678531f5b6ab4206b666bdcac546a27653af66db778664f8f8a6'
+          checkpoint: '963dc752b96cd16496b68bf2ea68e3b6ed65e71f587f9b3a100b7a97b5cdd0e8'
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}