### PR TITLE
Update swinsian to 1.13.3

### DIFF
--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,10 +1,10 @@
 cask 'swinsian' do
-  version '1.13.2'
-  sha256 '7af1694f399f3e36aef148c6ed7bcb824316b10d7a761f565196a17f839e56b6'
+  version '1.13.3'
+  sha256 'f087555165a4d79ba3d3be31c48772c9e0f269bcfeeb89bc511ad516fce204be'
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml',
-          checkpoint: '120c3fac361ced3d110e6e3e5a01692f0bf9fe57e6661792b62dce39571863bc'
+          checkpoint: 'c0f58171731e99437092a5b3ac787e6980e167f34ce5c842e5c37fdca244843e'
   name 'Swinsian'
   homepage 'https://swinsian.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}