### PR TITLE
Update qcad to 3.17.2

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,8 +1,8 @@
 cask 'qcad' do
-  version '3.15.5'
-  sha256 '70a96698259f9f07ca68ed6b2fa6cc5db1e28f9c83bd156d49a544afb34a8c6b'
+  version '3.17.2'
+  sha256 'a49856a3371d4d309696023826244817f89ccce4e7c5a3b77f68c5d641d01546'
 
-  url "https://www.qcad.org/archives/qcad/qcad-#{version}-osx-10.6-10.11.dmg"
+  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.12.dmg"
   name 'QCAD'
   homepage 'https://www.qcad.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update `url`.