### PR TITLE
Update webcatalog to 6.0.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '5.2.1'
-  sha256 'adf48096578e5467677c9998ab4b5d1d2c3153b258b7abb14910a062fd421d91'
+  version '6.0.0'
+  sha256 '698bad59ab8e978bf7a7a8aaf8e8e62b84c91132db827b6572dac1ee0b3812a0'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '53e7c05bc0d381483de96614d4d2ae18c9028cc9610aee6151f7317cc402cf01'
+          checkpoint: '80fe4496b798a929b6d98a8e15d75a14267dbe6d8a58ffdcbd96663d7d252a02'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/download/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}