### PR TITLE
Update icons8 to 5.6.2

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -1,7 +1,7 @@
 cask 'icons8' do
   # note: "8" is not a version number, but an intrinsic part of the product name
-  version '5.6'
-  sha256 'aec06e37c9a028e73a959f843e71bde611a26a8b1db601a3ae98ab72786eaa2d'
+  version '5.6.2'
+  sha256 '3bf80f88d0ffa08a96f4747453f534f4ad058a6a76e2348bad7c85d07a25c6c1'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
   appcast 'https://maxcdn.icons8.com/download/icons8_cast.xml',

--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -4,8 +4,8 @@ cask 'icons8' do
   sha256 '3bf80f88d0ffa08a96f4747453f534f4ad058a6a76e2348bad7c85d07a25c6c1'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
-  appcast 'https://maxcdn.icons8.com/download/icons8_cast.xml',
-          checkpoint: 'ac1d98b11528f0f3417ed8e84ce258c06c726874e6b35ae2ca882a60969c5f7d'
+  appcast 'https://desktop.icons8.com/updates/mac/icons8_cast.xml',
+          checkpoint: '9688fb2b390f16363062bc105b7bdbf88840a771d3d4070d000c673f74d22c13'
   name 'Icons8 App'
   homepage 'https://icons8.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}