### PR TITLE
Update operadriver to 2.29

### DIFF
--- a/Casks/operadriver.rb
+++ b/Casks/operadriver.rb
@@ -1,10 +1,10 @@
 cask 'operadriver' do
-  version '2.27'
-  sha256 '2e30a9ab0c05329db8181d8dbc17b89491f7b2504a49a32d4ae2caa907b51be4'
+  version '2.29'
+  sha256 'bcb51661fcddf95d6414ef2a758ae663f91ca64731dd83131de69988212dabca'
 
   url "https://github.com/operasoftware/operachromiumdriver/releases/download/v.#{version}/operadriver_mac64.zip"
   appcast 'https://github.com/operasoftware/operachromiumdriver/releases.atom',
-          checkpoint: '4ea8096bf0d539fcbadd869cd5acdaf8efdccee94553218863a903c439f1099e'
+          checkpoint: '788a89281894453e05aaf927a6535725cbd28fb67fa59165958df589a67b10f4'
   name 'operachromiumdriver'
   homepage 'https://github.com/operasoftware/operachromiumdriver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}