### PR TITLE
Update vuescan to 9.5.80

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
   version '9.5.80'
-  sha256 '84d2a5481012ca453d6d278f457783bca16cdbe6ec1ec565195242139bf88e0e'
+  sha256 'd5277b3d3e5331ec35ed9e2598490d525f87b6ae3257add7321a54a21727c6c2'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Only SHA changed. I contacted the developer via Twitter to confirm that's expected (not sure if I'll hear back). I also ran the DMG through [virustotal.com](https://www.virustotal.com/en/file/d5277b3d3e5331ec35ed9e2598490d525f87b6ae3257add7321a54a21727c6c2/analysis/1498657693/) to confirm no issues exist.