### PR TITLE
Update unity-android-support-for-editor to 5.6.2f1,a2913c821e27

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '5.6.1f1,2860b30f0b54'
-  sha256 'a1103e439db46065eed8fcbcc3543646ca7bafad18b87c51ad023978b99ae278'
+  version '5.6.2f1,a2913c821e27'
+  sha256 '44570221ac3383d0308d66f8ec4b1c8f91bceb5870db22cb62c53e35c81725d7'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Android Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}