### PR TITLE
Update mendeley-desktop to 1.17.10

### DIFF
--- a/Casks/mendeley-desktop.rb
+++ b/Casks/mendeley-desktop.rb
@@ -1,6 +1,6 @@
 cask 'mendeley-desktop' do
-  version '1.17.9'
-  sha256 '5575650254bb69052bd0940610fbcd38be4803f86e890b5a3f2fba71acf84283'
+  version '1.17.10'
+  sha256 'bd3dc8748ec29fb7e76aa171e36df1e68b0c792e58d252d3491236e4d953f53d'
 
   url "http://desktop-download.mendeley.com/download/Mendeley-Desktop-#{version}-OSX-Universal.dmg"
   name 'Mendeley'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}