### PR TITLE
Update bisq to 0.5.0

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,4 +1,4 @@
-cask 'bitsquare' do
+cask 'bisq' do
   version '0.5.0'
   sha256 'c8d7b040f6f1e506741054b19677671e99ae3265eb879aa5d2c902667b81c63b'
 
@@ -6,9 +6,9 @@ cask 'bitsquare' do
   url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
           checkpoint: 'e17cb7c3259e7e08aeeeb391d2d7ad4b5d0c8c535b32891f238379551f955c56'
-  name 'Bitsquare'
+  name 'Bisq'
   homepage 'https://bitsquare.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'
 
-  app 'Bitsquare.app'
+  app 'Bisq.app'
 end

--- a/Casks/bitsquare.rb
+++ b/Casks/bitsquare.rb
@@ -1,11 +1,11 @@
 cask 'bitsquare' do
-  version '0.4.9.9.3'
-  sha256 '4e44b70dd12cc2ef2d3cc641c84a6bc8c38518fba5af327acf0de8985cccdcd1'
+  version '0.5.0'
+  sha256 'c8d7b040f6f1e506741054b19677671e99ae3265eb879aa5d2c902667b81c63b'
 
   # github.com/bitsquare/bitsquare was verified as official when first introduced to the cask
-  url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bitsquare-#{version}.dmg"
+  url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
-          checkpoint: 'f1ce7f5db8512545a60123e5fa567ad8737f3ffb8672d17b298002f5faba156f'
+          checkpoint: 'e17cb7c3259e7e08aeeeb391d2d7ad4b5d0c8c535b32891f238379551f955c56'
   name 'Bitsquare'
   homepage 'https://bitsquare.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}