### PR TITLE
Update transmit to 4.4.13

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,10 +1,10 @@
 cask 'transmit' do
-  version '4.4.12'
-  sha256 'b4fdc538d8727bbeb34f2c42b794895b9a8bd4666a9e798ddd05381e94694669'
+  version '4.4.13'
+  sha256 '0d7095351378aa3c581de064f99fedecbfac683377048a4c0457976f5ce79f3b'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
-  appcast 'https://panic.com/transmit/releasenotes.html',
-          checkpoint: '6f0d5a3d469d4a444f181e477c39f0cd47aa79a8f1f4074ac1bc5a4cf294cf1e'
+  appcast "https://library.panic.com/releasenotes/transmit#{version.major}",
+          checkpoint: '10018f05299078b9e4ae952a17a0476151afd29d5612c4fdb51cad84c2a01b79'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update `appcast`