### PR TITLE
Update multimarkdown-composer-pro to 3.0b51

### DIFF
--- a/Casks/multimarkdown-composer-pro.rb
+++ b/Casks/multimarkdown-composer-pro.rb
@@ -1,6 +1,6 @@
 cask 'multimarkdown-composer-pro' do
-  version '3.0b47'
-  sha256 '0c2d1e0e1ac380501076e54de138278492a83c9750e079c05faac07ca0e81461'
+  version '3.0b51'
+  sha256 '845027aedcaefb1d50955acc2a355422eded7e15a49f4343a5915828f9a903b7'
 
   # files.fletcherpenney.net.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.fletcherpenney.net.s3.amazonaws.com/MultiMarkdown%20Composer%20Pro%20%28Beta%29-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}