### PR TITLE
Update cura to 2.6.1

### DIFF
--- a/Casks/cura.rb
+++ b/Casks/cura.rb
@@ -1,6 +1,6 @@
 cask 'cura' do
-  version '2.6.0'
-  sha256 '853cd9da76e122df4246a52cd538b71a57cef51ecce4f684063a2d1780d888a4'
+  version '2.6.1'
+  sha256 'ef82c18345bdbb1492ff937a2f4e65ea7e858a131091267c5237c4261620ced9'
 
   url "https://software.ultimaker.com/current/Cura-#{version}-Darwin.dmg"
   name 'Cura'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}