### PR TITLE
Update vagrant to 1.9.6

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,11 +1,11 @@
 cask 'vagrant' do
-  version '1.9.5'
-  sha256 'ac16217b114d8816264700e41114b62acd0c071d2699ae13954086ae3fcb151c'
+  version '1.9.6'
+  sha256 'bf3ed196cc12f9906d1d1dbe38c297d42e1de318f1ac0f7eb720894af9519141'
 
   # hashicorp.com/vagrant was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"
   appcast 'https://github.com/mitchellh/vagrant/releases.atom',
-          checkpoint: '0e748c3d3565674755733283f882e3e1899ea4134292877aa2a8275fca66d08f'
+          checkpoint: 'c459223d93951b2bdbdd1ff9b8ed09e098dc6377e60f90d241e138b0b8ffd0c1'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}