### PR TITLE
Update radio-silence to 2.2

### DIFF
--- a/Casks/radio-silence.rb
+++ b/Casks/radio-silence.rb
@@ -1,10 +1,10 @@
 cask 'radio-silence' do
-  version '2.1'
-  sha256 '64500a1f683ca17b1e7fe2b05f870a871765352472c2f51b158607aa393b26d0'
+  version '2.2'
+  sha256 '657a80c8b2ac76e63ed09f0f332f8bbf42b1fb4cd416dcb37c1797306e19bfe6'
 
   url "https://radiosilenceapp.com/downloads/Radio_Silence_#{version}.pkg"
   appcast 'https://radiosilenceapp.com/update',
-          checkpoint: 'fc370e4a6397e4b72f6a81c3b840ae1c45376e23d55b258f2f52b01fae037949'
+          checkpoint: '5d359c3bfd4bd081b10e8c71b6947f6448ab108be39080d44bf38b947e6d4475'
   name 'Radio Silence'
   homepage 'https://radiosilenceapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}