### PR TITLE
Update gifcapture to 1.1.0

### DIFF
--- a/Casks/gifcapture.rb
+++ b/Casks/gifcapture.rb
@@ -1,10 +1,10 @@
 cask 'gifcapture' do
-  version '1.0.4'
-  sha256 'cb72748fdb58204d72e7531d3fbcb91293d6052d437b51323d1706b554079e69'
+  version '1.1.0'
+  sha256 '29a6d998b3028fb0f2f232b8b99dd388d338a713aab4aac71699ceb7330af5ba'
 
   url "https://github.com/onmyway133/GifCapture/releases/download/#{version}/GifCapture.zip"
   appcast 'https://github.com/onmyway133/GifCapture/releases.atom',
-          checkpoint: '709e318e5cc58b657e6aa0fbf94e6c4b6eceeb1caea0a290a2a3b9ca6b320921'
+          checkpoint: 'dffcce8923fc1eb86fe6fee1aee24710ffa01cc8ef82fde3ef85618b9c039313'
   name 'GifCapture'
   homepage 'https://github.com/onmyway133/GifCapture'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}