### PR TITLE
Update goofy to 3.2.2

### DIFF
--- a/Casks/goofy.rb
+++ b/Casks/goofy.rb
@@ -1,11 +1,11 @@
 cask 'goofy' do
-  version '3.2.1'
-  sha256 'a85b5055b0e33d60ae54694118cb46e37bb0a5ac282b7f1de8993a481bd37f78'
+  version '3.2.2'
+  sha256 '6c85abf245abf5acbd0d76d9ca5af895756f3362c52dd0e460ada3b8c1652db6'
 
   # github.com/danielbuechele/goofy was verified as official when first introduced to the cask
   url "https://github.com/danielbuechele/goofy/releases/download/v#{version}/goofy-core-#{version}-mac.zip"
   appcast 'https://github.com/danielbuechele/goofy/releases.atom',
-          checkpoint: '707ac5b64712a1598c826614d0608536915a75f62382f0108a56180d5dab6cbf'
+          checkpoint: '327de9ef1549aaa5db1b5ee5f93dc714bc3786b949a05c1fda4287720c8f540f'
   name 'Goofy'
   homepage 'http://www.goofyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}