### PR TITLE
Update handshaker to 2.1.1

### DIFF
--- a/Casks/handshaker.rb
+++ b/Casks/handshaker.rb
@@ -1,11 +1,11 @@
 cask 'handshaker' do
-  version '2.1.0'
-  sha256 'f337d070c79da0542e1728dab7a27c2eeccddf4aa4fa6475d8e77887ac3dfd36'
+  version '2.1.1'
+  sha256 '35f77d7991b30f8bbd062ea23644c1a45e61058722ee43f2885c2eaa2cae7022'
 
   # dl2.smartisan.cn was verified as official when first introduced to the cask
   url "http://dl2.smartisan.cn/app/HandShaker.v#{version}.dmg"
   appcast 'https://sf.smartisan.com/update.plist',
-          checkpoint: '175bafc5f53c7d3c356088708285d308aceb73932b4a0a8fb72080b2c17dd1bd'
+          checkpoint: '6acfae4d43e92c8314b76a685d37452ea7477230de6405f54c331eec15274c00'
   name 'HandShaker'
   homepage 'http://www.smartisan.com/apps/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}