### PR TITLE
Update minishift to 1.2.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.1.0'
-  sha256 '6c516e11c8b69995df76e39100cda98906259ea5f5ceb860cac51a451bc39d0a'
+  version '1.2.0'
+  sha256 '686f0ceee33118612d6f4a8b42e797ab1ffa8dddd35ea30efe639e3c369e6ab0'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: 'b6068bca3356018f3bddba72eb7b6ee45caa29846c3284956504d13603963111'
+          checkpoint: '8dac7ac65ad19b67bd6f54a087199043f3438855c02f21e260fdfbda54bc6012'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}