### PR TITLE
Update paragon-extfs - sha no_check

### DIFF
--- a/Casks/paragon-extfs.rb
+++ b/Casks/paragon-extfs.rb
@@ -1,6 +1,6 @@
 cask 'paragon-extfs' do
   version '11'
-  sha256 '3e000e689433e95087b054e1d3ad8ddb79171c2db2d4e000ac3b05b6b056d9f5'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "http://dl.paragon-software.com/demo/trial_extfs#{version}.dmg"
   name 'Paragon ExtFS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Change to `sha256` `no_check` as upstream will be updated in-place.