### PR TITLE
Update dnscrypt - uninstall / zap

### DIFF
--- a/Casks/dnscrypt.rb
+++ b/Casks/dnscrypt.rb
@@ -17,5 +17,8 @@ cask 'dnscrypt' do
                          'com.github.dnscrypt-osxclient.DNSCryptConsoleChange',
                          'com.github.dnscrypt-osxclient.DNSCryptControlChange',
                          'com.github.dnscrypt-osxclient.DNSCryptNetworkChange',
-                       ]
+                       ],
+            delete:    '/Library/PreferencePanes/DNSCrypt.prefPane'
+
+  zap delete: '/Library/Application Support/DNSCrypt'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Add `uninstall delete: '/Library/PreferencePanes/DNSCrypt.prefPane'`

Occasionally `DNSCrypt.prefPane` is not removed cleanly.

Add `zap`