### PR TITLE
Update endnote - version / zap

### DIFF
--- a/Casks/endnote.rb
+++ b/Casks/endnote.rb
@@ -1,12 +1,21 @@
 cask 'endnote' do
-  version :latest
-  sha256 :no_check
+  version '8'
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url 'http://download.endnote.com/downloads/X8/EndNoteX8Installer.dmg'
+  url "http://download.endnote.com/downloads/X#{version}/EndNoteX#{version}Installer.dmg"
   name 'EndNote'
   homepage 'http://endnote.com/'
 
-  container nested: 'Install EndNote X8.app/Contents/Resources/EndNote.zip'
+  container nested: "Install EndNote X#{version}.app/Contents/Resources/EndNote.zip"
 
-  suite 'EndNote X8'
+  suite "EndNote X#{version}"
+
+  zap delete: [
+                '/Library/Application Support/ResearchSoft/EndNote',
+                '~/Library/Application Support/EndNote',
+                '~/Library/Caches/com.ThomsonResearchSoft.EndNote',
+                '~/Library/Services/ENService.app/Contents/Resources/EndNote.icns',
+                '~/Library/Spotlight/EndNote.mdimporter',
+              ],
+      trash:  '~/Library/Preferences/com.ThomsonResearchSoft.EndNote.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update cask to use `#{version}` and add `zap`