### PR TITLE
Update now - zap

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -12,11 +12,14 @@ cask 'now' do
   app 'Now.app'
 
   zap delete: [
-                '~/.now.json',
                 '~/Library/Application Support/Now',
                 '~/Library/Caches/co.zeit.now',
                 '~/Library/Caches/co.zeit.now.ShipIt',
+              ],
+      trash:  [
+                '~/.now.json',
                 '~/Library/Preferences/co.zeit.now.plist',
                 '~/Library/Preferences/co.zeit.now.helper.plist',
+                '/usr/local/bin/now',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update `zap` - delete and trash

`'/usr/local/bin/now'` is installed by `Now.app`  and can still be used after the cask is uninstalled.

`'/usr/local/bin/now'`  is also installed by `now-cli` https://github.com/caskroom/homebrew-cask/pull/35853