### PR TITLE
Update endnote 8 - zap

### DIFF
--- a/Casks/endnote.rb
+++ b/Casks/endnote.rb
@@ -14,7 +14,7 @@ cask 'endnote' do
                 '/Library/Application Support/ResearchSoft/EndNote',
                 '~/Library/Application Support/EndNote',
                 '~/Library/Caches/com.ThomsonResearchSoft.EndNote',
-                '~/Library/Services/ENService.app/Contents/Resources/EndNote.icns',
+                '~/Library/Services/ENService.app',
                 '~/Library/Spotlight/EndNote.mdimporter',
               ],
       trash:  '~/Library/Preferences/com.ThomsonResearchSoft.EndNote.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This fixes a incorrect `zap` in https://github.com/caskroom/homebrew-cask/pull/36013