### PR TITLE
Update chromium - remove binary

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -8,16 +8,6 @@ cask 'chromium' do
   homepage 'https://www.chromium.org/Home'
 
   app 'chrome-mac/Chromium.app'
-  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/chromium.wrapper.sh"
-  binary shimscript, target: 'chromium'
-
-  preflight do
-    IO.write shimscript, <<-EOS.undent
-      #!/bin/bash
-      '#{appdir}/Chromium.app/Contents/MacOS/Chromium "$@"
-    EOS
-  end
 
   zap delete: [
                 '~/Library/Preferences/org.chromium.Chromium.plist',

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -8,7 +8,16 @@ cask 'chromium' do
   homepage 'https://www.chromium.org/Home'
 
   app 'chrome-mac/Chromium.app'
-  binary "#{appdir}/Chromium.app/Contents/MacOS/Chromium", target: 'chromium'
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/chromium.wrapper.sh"
+  binary shimscript, target: 'chromium'
+
+  preflight do
+    IO.write shimscript, <<-EOS.undent
+      #!/bin/bash
+      '#{appdir}/Chromium.app/Contents/MacOS/Chromium "$@"
+    EOS
+  end
 
   zap delete: [
                 '~/Library/Preferences/org.chromium.Chromium.plist',


### PR DESCRIPTION
The current `binary` doesn't seem to work.

```
chromium --headless --disable-gpu --screenshot https://www.google.com
dlopen /usr/local/bin/../Versions/61.0.3146.0/Chromium Framework.framework/Chromium Framework: dlopen(/usr/local/bin/../Versions/61.0.3146.0/Chromium Framework.framework/Chromium Framework, 261): image not found
Abort trap: 6
```

![chromium](https://user-images.githubusercontent.com/26216252/27731018-c4bc0e2e-5dce-11e7-959e-d2f1a1194721.png)
___
I'm wondering if we should add shim scripts to the casks that support [headless](https://developers.google.com/web/updates/2017/04/headless-chrome).

This includes (tested)

`cask`
- [google-chrome](https://github.com/caskroom/homebrew-cask/blob/master/Casks/google-chrome.rb)
- [freesmug-chromium](https://github.com/caskroom/homebrew-cask/blob/master/Casks/freesmug-chromium.rb)
- [vivaldi](https://github.com/caskroom/homebrew-cask/blob/master/Casks/vivaldi.rb)

`versions`
- [google-chrome-canary](https://github.com/caskroom/homebrew-versions/blob/master/Casks/google-chrome-canary.rb)
- [google-chrome-beta](https://github.com/caskroom/homebrew-versions/blob/master/Casks/google-chrome-beta.rb)
- [google-chrome-dev](https://github.com/caskroom/homebrew-versions/blob/master/Casks/google-chrome-dev.rb)
- [vivaldi-snapshot](https://github.com/caskroom/homebrew-versions/blob/master/Casks/vivaldi-snapshot.rb)

Supported but doesn't seem to work
- opera 
  - opera-beta
  - opera-developer

Not currently supported
- brave 
- eloston-chromium
- yandex