### PR TITLE
Update veracrypt to 1.20

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,13 +1,13 @@
 cask 'veracrypt' do
-  version '1.19'
-  sha256 'da098bba200d2cebb193bd699eef6dec7834c8eeb579ed40bcd21d45487e6ce7'
+  version '1.20'
+  sha256 '63b186cd9d117a13bf249445b9d0551391babf12512a974978baf44a65bcfd37'
 
   # launchpad.net/veracrypt/trunk/ was verified as official when first introduced to the cask
   url "https://launchpad.net/veracrypt/trunk/#{version}/+download/VeraCrypt_#{version}.dmg"
   appcast 'https://github.com/veracrypt/VeraCrypt/releases.atom',
-          checkpoint: '7c26121dc95c7344b9413ad24b204adaa10c338d91eac4b77122e7ac0adf64e8'
+          checkpoint: '9b200f08d719ba486a9bc732c35b45ef945291e788cf98ea8a0e664fd1d35ad6'
   name 'VeraCrypt'
-  homepage 'https://veracrypt.codeplex.com/'
+  homepage 'https://www.veracrypt.fr/'
 
   depends_on cask: 'osxfuse'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated `homepage`