### PR TITLE
Update vimr to 0.17.0-213

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.16.2-210'
-  sha256 '03f7037be3cc3a268fe1a271c74010f914adc0a9402937744562765edeaeca86'
+  version '0.17.0-213'
+  sha256 'efa3cbae69ac1d66a4b3646b960007a799e53504072cef7264bcfc841e9d94ef'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '8cddda50615fd5c268b3838b219b95c5d89db496361f1bb0a75d3efbb8d876b9'
+          checkpoint: '2ddc72fed692f4dcf73915eb034ce68205c433bcc50cb3289386fbc21a4cefcb'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}