### PR TITLE
Update parallels-access to 3.2.0-31423

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.49'
-  sha256 '3a0fb8575557020457f1863b7afcacaa11c8a4c2db9406e560be23a8ecc8a62f'
+  version '1.0.50'
+  sha256 '2fdcc85463e07d493cab12099ba8c05e248ce724b673e3531006051514a9bbed'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '54ae268bbfe5c0ef5bdc5c06632ee623fa02919163490973d6330145ac3a5d00'
+          checkpoint: '224c28c892578d51a4b9041632b85957f9072ccb9d6c2b362a28b87bfa921ea8'
   name 'Fork'
   homepage 'https://git-fork.com/'
 

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -1,6 +1,6 @@
 cask 'parallels-access' do
-  version '3.1.6-31326'
-  sha256 '1713e25c009785bb53f8eb1d193155a4c401ebba4361ce577e3e5c16f3ce787e'
+  version '3.2.0-31423'
+  sha256 'e5fd360aa76f3ba5a681b065fbdeaa5b43a4fc8a6bae0b182a27bcdde55d183a'
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name 'Parallels Access'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}