### PR TITLE
Update parallels-access to 3.2.0-31423

### DIFF
--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -1,6 +1,6 @@
 cask 'parallels-access' do
-  version '3.1.6-31326'
-  sha256 '1713e25c009785bb53f8eb1d193155a4c401ebba4361ce577e3e5c16f3ce787e'
+  version '3.2.0-31423'
+  sha256 'e5fd360aa76f3ba5a681b065fbdeaa5b43a4fc8a6bae0b182a27bcdde55d183a'
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name 'Parallels Access'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}