### PR TITLE
Update dbschema to 7.5.2

### DIFF
--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -1,6 +1,6 @@
 cask 'dbschema' do
-  version '7.5.1'
-  sha256 'cf7450e331f80edeb56f1f4365ddcdf577a6694bd3b37e8ff4003815a65359ef'
+  version '7.5.2'
+  sha256 'ce1ca78bad8aa817ab899bf57de1d4e215ed172d72773beea37f6126609c8993'
 
   url "http://www.dbschema.com/download/DbSchema_macos_#{version.dots_to_underscores}.tgz"
   name 'DbSchema'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}