### PR TITLE
Update pencil to 3.0.4

### DIFF
--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -1,10 +1,10 @@
 cask 'pencil' do
-  version '3.0.3'
-  sha256 '4b1e13354b76a5fd3d662edcc26aeab156a38b46f4e2e8f84582f369c725fbf2'
+  version '3.0.4'
+  sha256 '3ca99c293be804067c95db77a7248531ede321d0c9a436bac0a34c57a192088f'
 
   url "http://pencil.evolus.vn/dl/V#{version}/Pencil-#{version}.dmg"
   appcast 'https://github.com/evolus/pencil/releases.atom',
-          checkpoint: 'e65e3ee4c1e89054083e0f3a8fb7078baea1ad126e2953e8d39a015214af8828'
+          checkpoint: '56eb8c89548bf892d419eed8a4ff34f1a727be0feab2ae6c58b108eda9cb4989'
   name 'Pencil'
   homepage 'https://pencil.evolus.vn/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}