### PR TITLE
Update dwarf-fortress - remove depends_on / postflight

### DIFF
--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -6,9 +6,6 @@ cask 'dwarf-fortress' do
   name 'Dwarf Fortress'
   homepage 'http://www.bay12games.com/dwarves/'
 
-  depends_on cask: 'sdl-framework'
-  depends_on cask: 'sdl-ttf-framework'
-
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/df_osx/df.wrapper.sh"
   binary shimscript, target: 'dwarf-fortress'
@@ -18,19 +15,6 @@ cask 'dwarf-fortress' do
       #!/bin/sh
       exec '#{staged_path}/df_osx/df' "$@"
     EOS
-  end
-
-  postflight do
-    Dir.chdir("#{staged_path}/df_osx/libs") do
-      {
-        'SDL'     => 'sdl-framework',
-        'SDL_ttf' => 'sdl-ttf-framework',
-      }.each do |key, value|
-        name = "#{key}.framework"
-        File.rename(name, "#{name}.orig")
-        File.symlink(Hbc::CaskLoader.load(value).staged_path.join(name), name)
-      end
-    end
   end
 
   uninstall_preflight do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/36032

`dwarf-fortress` doesn't seem to require dependancies. https://github.com/caskroom/homebrew-cask/pull/36050