### PR TITLE
Update telegram-desktop to 1.1.9

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -1,11 +1,11 @@
 cask 'telegram-desktop' do
-  version '1.1.7'
-  sha256 '52c80d990bfce7a58caebca57c7d5f23e8de8df98aad7ec3406ae56bd0165b85'
+  version '1.1.9'
+  sha256 '89bbb2408ff93990bb0ddba281ba441d2f412ee53321264b5ddc46ee2b0c9f05'
 
   # github.com/telegramdesktop/tdesktop/releases/download was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"
   appcast 'https://github.com/telegramdesktop/tdesktop/releases.atom',
-          checkpoint: '5f69b7f4e3ddea61d988e6c316b97560a830f0f08e81c99df92ff89c88b438dc'
+          checkpoint: '5c345c053ef33e7a285796be8ab0f16340ad440034e4b044a7c144bac4faca82'
   name 'Telegram Desktop'
   homepage 'https://desktop.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}