### PR TITLE
Update cocoarestclient to 1.4.1

### DIFF
--- a/Casks/cocoarestclient.rb
+++ b/Casks/cocoarestclient.rb
@@ -1,11 +1,11 @@
 cask 'cocoarestclient' do
-  version '1.3.15'
-  sha256 '1a49512f86d95193704a11bb1e6abd8647d5d8a665688d10fd75b4addb48620c'
+  version '1.3.16'
+  sha256 '330d075ef8e7937aff4f583fc47c4f5dd094b07360946602f0790cfde958dfd9'
 
   # github.com/mmattozzi/cocoa-rest-client was verified as official when first introduced to the cask
   url "https://github.com/mmattozzi/cocoa-rest-client/releases/download/#{version}/CocoaRestClient-#{version}.dmg"
   appcast 'https://github.com/mmattozzi/cocoa-rest-client/releases.atom',
-          checkpoint: 'a49066cfd87b96657f1a0abbe866f8f6040e44d8e37c702efb93495c47fd81f9'
+          checkpoint: 'e227c188c94e718eab556b3d1a97ea037ae78e43b2f62e00009e5d99a1145a59'
   name 'CocoaRestClient'
   homepage 'https://mmattozzi.github.io/cocoa-rest-client/'
 

--- a/Casks/cocoarestclient.rb
+++ b/Casks/cocoarestclient.rb
@@ -1,11 +1,11 @@
 cask 'cocoarestclient' do
-  version '1.3.16'
-  sha256 '330d075ef8e7937aff4f583fc47c4f5dd094b07360946602f0790cfde958dfd9'
+  version '1.4.1'
+  sha256 '6dd1268e1c23efc6938d5615a691255c356d317918e89346e86caefec8d599bf'
 
   # github.com/mmattozzi/cocoa-rest-client was verified as official when first introduced to the cask
   url "https://github.com/mmattozzi/cocoa-rest-client/releases/download/#{version}/CocoaRestClient-#{version}.dmg"
   appcast 'https://github.com/mmattozzi/cocoa-rest-client/releases.atom',
-          checkpoint: 'e227c188c94e718eab556b3d1a97ea037ae78e43b2f62e00009e5d99a1145a59'
+          checkpoint: '10c6f9905497ea558e43425388e947af9c1a8ade867a311b503b1e69a69f2511'
   name 'CocoaRestClient'
   homepage 'https://mmattozzi.github.io/cocoa-rest-client/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}