### PR TITLE
Adding the latest version of deepstream.io to cask

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,0 +1,11 @@
+cask 'deepstream' do
+  version '2.4.0'
+  sha256 '3b4a03a560373493859802b0a802331ddc91fe95bd51bdfa26baa882d2967b8e'
+
+  # s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/ds-server-artifacts/deepstreamIO/deepstream.io/2.4.0/deepstream.io-mac-2.4.0-5bca621.pkg'
+  name 'deepstream.io'
+  homepage 'https://deepstreamhub.com/'
+
+  pkg 'deepstream.io-mac-2.4.0-5bca621.pkg'
+end

--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,6 +1,6 @@
 cask 'deepstream' do
   version '2.4.0'
-  sha256 '3b4a03a560373493859802b0a802331ddc91fe95bd51bdfa26baa882d2967b8e'
+  sha256 '53cde5333b3a32cc626467880bc45748f92a5543613ef3625100e31569c06e69'
 
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"
@@ -10,4 +10,10 @@ cask 'deepstream' do
   homepage 'https://deepstream.io/'
 
   pkg "deepstream.io-mac-#{version}.pkg"
+
+  uninstall pkgutil: 'deepstream.io'
+
+  caveats do
+    files_in_usr_local
+  end
 end

--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -2,10 +2,12 @@ cask 'deepstream' do
   version '2.4.0'
   sha256 '3b4a03a560373493859802b0a802331ddc91fe95bd51bdfa26baa882d2967b8e'
 
-  # s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/ds-server-artifacts/deepstreamIO/deepstream.io/2.4.0/deepstream.io-mac-2.4.0-5bca621.pkg'
-  name 'deepstream.io'
-  homepage 'https://deepstreamhub.com/'
+  # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
+  url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"
+  appcast 'https://github.com/deepstreamIO/deepstream.io/releases.atom',
+          checkpoint: 'e018eef5240d2eaf2158a9c9dad2ba7d5bfe26d33a42762008f15b3bcb66d6aa'
+  name 'deepstream'
+  homepage 'https://deepstream.io/'
 
-  pkg 'deepstream.io-mac-2.4.0-5bca621.pkg'
+  pkg "deepstream.io-mac-#{version}.pkg"
 end


### PR DESCRIPTION
This change allows users to use cask to download the deepstream.io
pkg. A small limitations are the fact that it currently
uses 777 settings for log directories.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
