### PR TITLE
Update choosy to 1.2

### DIFF
--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -1,10 +1,10 @@
 cask 'choosy' do
-  version '1.1'
-  sha256 'c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c'
+  version '1.2'
+  sha256 '17e36cff2321d7626402b3e9bceb04feb02dbe981c22b2de7b97c161d141ed98'
 
   url "https://downloads.choosyosx.com/choosy_#{version}.zip"
   appcast 'https://www.choosyosx.com/sparkle/feed',
-          checkpoint: '588d73c48a23dc024ddd2b16029e989a731c7c53012bc87e46fb66fb8b807d95'
+          checkpoint: '2537fbe06e3763105b4081854bb7a86c61b27d9fc07fd3065afed61bfcc60f47'
   name 'Choosy'
   homepage 'https://www.choosyosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}