### PR TITLE
Update itsycal to 0.11.4

### DIFF
--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -13,12 +13,12 @@ cask 'itsycal' do
     url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
   else
     version '0.11.4'
-    sha256 '6edab3ee4ed721729b9d8a9069060af36ab2fcef0bbfaeda6e9aed7eea688398'
+    sha256 '145913bacd6089980485b9d33787fb91847127ee9fed0e2bfe16a7e6691f9ea0'
 
     # s3.amazonaws.com/itsycal was verified as official when first introduced to the cask
     url "https://s3.amazonaws.com/itsycal/Itsycal-#{version}.zip"
     appcast 'https://s3.amazonaws.com/itsycal/itsycal.xml',
-            checkpoint: '62f9fef9bbdd8e08bfabcea6c90d15e03b9dd6cc9415ead875f5debf670b370d'
+            checkpoint: '91a8899f47d78263a9b8ee51d816346ac2298d2310b820dd7918483598c0f642'
   end
 
   name 'Itsycal'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: https://www.virustotal.com/en/file/145913bacd6089980485b9d33787fb91847127ee9fed0e2bfe16a7e6691f9ea0/analysis/