### PR TITLE
Update keka to 1.0.10

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,11 +1,11 @@
 cask 'keka' do
-  version '1.0.9'
-  sha256 'abdaf40c6ea1de14a052ce721fa7ebc786a35bbcd98fc4adfcda33325df8dbb5'
+  version '1.0.10'
+  sha256 '38b29ef0f44610cc8145bf41538b23cc2207f5d4248de40ec4236b81e8e6f0fb'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: 'f77559d899ecfad0992417891104b856b2c1ad7c21041646b56c62c838ec3052'
+          checkpoint: 'e9fb90f00dec38642c198fdf8c965c2b6dd39e3c87788f47afdec145335c3857'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}