### PR TITLE
Update bisq to 0.5.1

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.5.0'
-  sha256 'c8d7b040f6f1e506741054b19677671e99ae3265eb879aa5d2c902667b81c63b'
+  version '0.5.1'
+  sha256 '68c7fdbead8b723c9a887576a4d9be497a1c525db029ccec8af62001a7a42d6a'
 
   # github.com/bitsquare/bitsquare was verified as official when first introduced to the cask
   url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
-          checkpoint: 'e17cb7c3259e7e08aeeeb391d2d7ad4b5d0c8c535b32891f238379551f955c56'
+          checkpoint: '09835a205339c4157693f75fcbe7e0ca6725a3b82008f8180bc25d6e5a6c21d5'
   name 'Bisq'
   homepage 'https://bitsquare.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}