### PR TITLE
Update cloudapp to 4.2.5

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,11 +1,11 @@
 cask 'cloudapp' do
-  version '4.2.4'
-  sha256 '7b1a7d836ae23c60fbfef3e187f584015178a25684a615df9b8741a83fe4d408'
+  version '4.2.5'
+  sha256 'fd52e042cdb7abda070dba5f569354a41fedbf46c9970b600dd7f19a885162b9'
 
   # amazonaws.com/downloads.getcloudapp.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://updates.getcloudapp.com/appcast.xml',
-          checkpoint: '770e1b76aec53bd5b3d90f0d745e03e27de0de52ffa002bf552e762e0f50703d'
+          checkpoint: '13392ccf2006b0acd00b48ef20307c9acb2e39fe269bfb84469b59d3c59a2470'
   name 'CloudApp'
   homepage 'https://www.getcloudapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}