### PR TITLE
Update choosy to 1.2.1

### DIFF
--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -1,10 +1,10 @@
 cask 'choosy' do
-  version '1.2'
-  sha256 '17e36cff2321d7626402b3e9bceb04feb02dbe981c22b2de7b97c161d141ed98'
+  version '1.2.1'
+  sha256 '820009af29bcc9bf1b476962b028c6dd49486ab20b45fbd6d8ee3f1f3abce46a'
 
   url "https://downloads.choosyosx.com/choosy_#{version}.zip"
   appcast 'https://www.choosyosx.com/sparkle/feed',
-          checkpoint: '2537fbe06e3763105b4081854bb7a86c61b27d9fc07fd3065afed61bfcc60f47'
+          checkpoint: '66dd9d3135d0fb6668d120b5cb5011e2add6aae160e12abe0246513a2693f7fd'
   name 'Choosy'
   homepage 'https://www.choosyosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}