### PR TITLE
Update vagrant - uninstall script

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -14,6 +14,7 @@ cask 'vagrant' do
   uninstall script:  {
                        executable: 'uninstall.tool',
                        input:      %w[Yes],
+                       sudo:       true,
                      },
             pkgutil: 'com.vagrant.vagrant'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`vagrant` uninstall script requires sudo.

![vagrant](https://user-images.githubusercontent.com/26216252/27775880-6c04d000-5fe9-11e7-8926-84c1f0ae9523.png)
