### PR TITLE
Update virtualbox - uninstall script

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -19,6 +19,7 @@ cask 'virtualbox' do
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',
                        args:       %w[--unattended],
+                       sudo:       true,
                      },
             pkgutil: 'org.virtualbox.pkg.*'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`virtualbox` uninstall script requires sudo, this asks for the password up front rather being prompted by the script itself.

Without:
```
brew cask uninstall virtualbox
==> Uninstalling Cask virtualbox
==> Running uninstall process for virtualbox; your password may be necessary
==> Running uninstall script VirtualBox_Uninstall.tool
==> 
==> Welcome to the VirtualBox uninstaller script.
==> 
==> The following files and directories (bundles) will be removed:
==>     /usr/local/bin/VirtualBox
==>     /usr/local/bin/VBoxManage
==>     /usr/local/bin/VBoxVRDP
==>     /usr/local/bin/VBoxHeadless
Please enter commitay's password:==>     /usr/local/bin/vboxwebsrv
==>     /usr/local/bin/VBoxBugReport
==>     /usr/local/bin/VBoxBalloonCtrl
==>     /usr/local/bin/VBoxAutostart
==>     /usr/local/bin/VBoxDTrace
==>     /usr/local/bin/vbox-img
==>     /Library/LaunchDaemons/org.virtualbox.startup.plist
==>     /Library/Python/2.6/site-packages/vboxapi/VirtualBox_constants.py
==>     /Library/Python/2.6/site-packages/vboxapi/VirtualBox_constants.pyc
==>     /Library/Python/2.6/site-packages/vboxapi/__init__.py
==>     /Library/Python/2.6/site-packages/vboxapi/__init__.pyc
==>     /Library/Python/2.6/site-packages/vboxapi-1.0-py2.6.egg-info
==>     /Library/Python/2.7/site-packages/vboxapi/VirtualBox_constants.py
==>     /Library/Python/2.7/site-packages/vboxapi/VirtualBox_constants.pyc
==>     /Library/Python/2.7/site-packages/vboxapi/__init__.py
==>     /Library/Python/2.7/site-packages/vboxapi/__init__.pyc
==>     /Library/Python/2.7/site-packages/vboxapi-1.0-py2.7.egg-info
==>     /Library/Application Support/VirtualBox/LaunchDaemons/
==>     /Library/Application Support/VirtualBox/VBoxDrv.kext/
==>     /Library/Application Support/VirtualBox/VBoxUSB.kext/
==>     /Library/Application Support/VirtualBox/VBoxNetFlt.kext/
==>     /Library/Application Support/VirtualBox/VBoxNetAdp.kext/
==>     /Applications/VirtualBox.app/
==>     /Library/Python/2.6/site-packages/vboxapi/
==>     /Library/Python/2.7/site-packages/vboxapi/
==> 
==> And the following KEXTs will be unloaded:
==>     org.virtualbox.kext.VBoxUSB
==>     org.virtualbox.kext.VBoxNetFlt
==>     org.virtualbox.kext.VBoxNetAdp
==>     org.virtualbox.kext.VBoxDrv
==> 
==> And the traces of following packages will be removed:
==>     org.virtualbox.pkg.vboxkexts
==>     org.virtualbox.pkg.virtualbox
==>     org.virtualbox.pkg.virtualboxcli
==> 
==> The uninstallation processes requires administrative privileges
==> because some of the installed files cannot be removed by a normal
==> user. You may be prompted for your password now...
==> 


```
With:
```
brew cask uninstall virtualbox
==> Uninstalling Cask virtualbox
==> Running uninstall process for virtualbox; your password may be necessary
==> Running uninstall script VirtualBox_Uninstall.tool
Password:
```