### PR TITLE
Update cryptomator to 1.3.0

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,11 +1,11 @@
 cask 'cryptomator' do
-  version '1.2.4'
-  sha256 'f3753716ee69240d2904740c38a0c280bfca1e3b89fa5111b98db484a896d090'
+  version '1.3.0'
+  sha256 '6fa678f0bdc15af485664d18cb6a3381733d97d5222581fb01087ed712a9fbce'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
   appcast 'https://github.com/cryptomator/cryptomator/releases.atom',
-          checkpoint: 'a46bed0d8c85da9b93bd70b17091b30098a68186751ec92fe65bd54e5407432f'
+          checkpoint: 'a5785478203f4bd2e500ee0d62b0077fb27437aa138fb78f805304022315ce48'
   name 'Cryptomator'
   homepage 'https://cryptomator.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}