### PR TITLE
Update texpad to 1.7.43,210,723a277

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -5,12 +5,12 @@ cask 'texpad' do
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.dots_to_underscores}.zip"
   else
-    version '1.7.42,193,622c26c'
-    sha256 'a2b095f213b282bb456454a14dfd970c2f98043de4b32758a47dce96b35f3fd3'
+    version '1.7.43,210,723a277'
+    sha256 'f26843b05b8e325ac7606745375470ee34d3aa9e5f074cdd854366e0a9dce859'
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"
     appcast 'https://www.texpadapp.com/static-collected/upgrades/texpadappcast.xml',
-            checkpoint: '2d146fde5f39654c07e189240547beeeeb9375bce6b1c9345088134d83199177'
+            checkpoint: 'a7e90c042274d6a1c061fa16b956172e4ce2503dba18861eef2e8fa2fb77d013'
   end
 
   name 'Texpad'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}