### PR TITLE
Update rsyncosx to 4.4.6

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '4.4.0'
-  sha256 '7b437a9a4013045e57b49ea05ed871acf5db03c7029b49d77824e741d59d1d65'
+  version '4.4.6'
+  sha256 '104e488c979645b7cca8a976603a39684df0e4c9d69dfaa0edb672f6a3116bd9'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: '8ef30e93f33e44d828fd9aeb7b0b9a2986f2f422cf3ead479bfcbf989ff325bf'
+          checkpoint: '1e219dda6cee2f2953d067c49c008809e3c9979cadc2a7b9ce2f2138b174725a'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}