### PR TITLE
Update intel power gadget - version / url

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,8 +1,8 @@
 cask 'intel-power-gadget' do
-  version '3.0.7,553992'
+  version '3.0.7'
   sha256 '4474360bf027a76b69a5803a681ff9cded1e0a92c9e03c57bfc127d29eea0319'
 
-  url "https://software.intel.com/file/#{version.after_comma}/download"
+  url 'https://software.intel.com/sites/default/files/managed/10/45/Intel%C2%AE%20Power%20Gadget.dmg'
   name 'Intel Power Gadget'
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fixes https://github.com/caskroom/homebrew-cask/issues/36156

Tried adding an `appcast` to this but it is only intermittently stable.

The updated `url` looks like it changes with each `version`.