### PR TITLE
Update telegram to 3.0-100026

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
   version '3.0-100026'
-  sha256 'a3f6c6f82555cd17ac6f9454954f0b27172e0ebf4b0f211dbb1e5e02df6d7d72'
+  sha256 'edc275b350f9a6634af22bb6cce694c7fe3219851c71caf037dadc5c699d2299'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'b2af446d207df282c0fc0e7f035881cf56594d5ff7d17470a3340131226e559e'
+          checkpoint: '1b389b86702e5666ee303fd78d4bc94edc4d9c58b523c21149d6dd2a170fb72a'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: https://www.virustotal.com/en/file/edc275b350f9a6634af22bb6cce694c7fe3219851c71caf037dadc5c699d2299/analysis/1499136409/