### PR TITLE
Update jasp to 0.8.1.2

### DIFF
--- a/Casks/jasp.rb
+++ b/Casks/jasp.rb
@@ -1,6 +1,6 @@
 cask 'jasp' do
-  version '0.8.1.1'
-  sha256 '9afe2beaa766b322a414bb68377893bcce0b9a582abc0b226f5d20fe84da7b3c'
+  version '0.8.1.2'
+  sha256 '64803cce71189738eb658040d2d66920b06d10dff015374d7618f707b21c8356'
 
   url "https://static.jasp-stats.org/JASP-#{version}.dmg"
   name 'JASP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}