### PR TITLE
Update electorrent to 2.1.6

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.5'
-  sha256 '2e54d9522624200e7d15a00662f9d440383b4d3d018378464689b7a37865cd04'
+  version '2.1.6'
+  sha256 '2d2a2e95ae663583eef0e1e3950a31ebc6357a54dda43caccc798c63ee504b6a'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '97a48528bbbbf226deccbafb52d9dab3ec370ee0a71e5678c827c8a49cb4eb67'
+          checkpoint: '33f8a0b15fb675f44ec859effecda703570f46beae21f9db2813d693592d23f5'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}