### PR TITLE
Update fly to 3.3.1

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.3.0'
-  sha256 'e41693bec8df5f0a5fb65b99878a74fceb226d51b047625e234b0820488d9f44'
+  version '3.3.1'
+  sha256 'c33c381bb675fc2e777ecbe1f7dff08f30e3ffec639727ef57916983b3f9f702'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: 'f3d29b5a89a5ebd78a238bb09e82dd63675d0da4a0afd9941dddc5cfd3aaa1e5'
+          checkpoint: '36f927788e8f81fdbf54d8d6efde0e41c4e69bdfdf8daba0e680acffe5c2fed6'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}