### PR TITLE
Update gtkwave to 3.3.82

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.81'
-  sha256 '184c810d01dd5ae425f132060259bd387300e0e114689e54c20f0e8fb175fe53'
+  version '3.3.82'
+  sha256 'c656e5eb6348302a439c148a16888f7dfea97a38145f9f09fbaf859f09676515'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: '0fc1886f475feb6031c5d9fd29b22c6c73ec9f8a4dc04175c9968ce7a462a08f'
+          checkpoint: '2c63fa8ff01133af5132f9b07d7bde65a7a5265e32491794ea437f3e882e6786'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}