### PR TITLE
Update m3unify to 1.8.2

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,10 +1,10 @@
 cask 'm3unify' do
-  version '1.8.1'
-  sha256 '2792731dab19e90571ef08ba8dd3b6e65a778cfcb1f0ef221ea033d670ddf338'
+  version '1.8.2'
+  sha256 'ffaaba934c061488e0d6f9941b287f555e7ed4ee561c79f15ccf10b7864669bf'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml',
-          checkpoint: 'fabd6382ec57e9f980a2ece0d19b097382c962b0376dc9def8c5ad4e1e59fde6'
+          checkpoint: 'c535c7926508af1fab1d79ccbee51f77d92a50f40ba5f2d3f1185207ed238a43'
   name 'M3Unify'
   homepage 'https://dougscripts.com/apps/m3unifyapp.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}