### PR TITLE
update Choosy with system requirements

### DIFF
--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -2,15 +2,14 @@ cask 'choosy' do
   if MacOS.version <= :el_capitan
     version '1.1'
     sha256 'c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c'
-    url "https://downloads.choosyosx.com/choosy_#{version}.zip"
   else
     version '1.2.2'
     sha256 'a6d2ee7c3e9e0ab9b6170305877e17bd070a3d3eb589643bee7e361d9dd68f23'
-    url "https://downloads.choosyosx.com/choosy_#{version}.zip"
-    appcast 'https://www.choosyosx.com/sparkle/feed',
-            checkpoint: '93b9ecf77d1bb96cd4db63ced49152e9053bf380c2c616b736da2941937b40fa'
   end
 
+  url "https://downloads.choosyosx.com/choosy_#{version}.zip"
+  appcast 'https://www.choosyosx.com/sparkle/feed',
+          checkpoint: '93b9ecf77d1bb96cd4db63ced49152e9053bf380c2c616b736da2941937b40fa'
   name 'Choosy'
   homepage 'https://www.choosyosx.com/'
 

--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -1,12 +1,20 @@
 cask 'choosy' do
-  version '1.2.2'
-  sha256 'a6d2ee7c3e9e0ab9b6170305877e17bd070a3d3eb589643bee7e361d9dd68f23'
+  if MacOS.version <= :el_capitan
+    version '1.1'
+    sha256 'c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c'
+    url "https://downloads.choosyosx.com/choosy_#{version}.zip"
+  else
+    version '1.2.2'
+    sha256 'a6d2ee7c3e9e0ab9b6170305877e17bd070a3d3eb589643bee7e361d9dd68f23'
+    url "https://downloads.choosyosx.com/choosy_#{version}.zip"
+    appcast 'https://www.choosyosx.com/sparkle/feed',
+            checkpoint: '93b9ecf77d1bb96cd4db63ced49152e9053bf380c2c616b736da2941937b40fa'
+  end
 
-  url "https://downloads.choosyosx.com/choosy_#{version}.zip"
-  appcast 'https://www.choosyosx.com/sparkle/feed',
-          checkpoint: '93b9ecf77d1bb96cd4db63ced49152e9053bf380c2c616b736da2941937b40fa'
   name 'Choosy'
   homepage 'https://www.choosyosx.com/'
+
+  depends_on macos: '>= :yosemite'
 
   prefpane 'Choosy.prefPane'
 end


### PR DESCRIPTION
This updates the Choosy cask with version requirements, as seen on [the 1.2 release notes page](https://www.choosyosx.com/releases/1.2). Choosy 1.2 and above require 10.12, and Choosy 1.1 works with 10.10 and 10.11.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.