### PR TITLE
Update downie to 2.9.4,1496

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -3,7 +3,7 @@ cask 'downie' do
   sha256 '723e0d9d0dfe8dc553f80c870818a0f3a0e6045997c12178217cf7d463e528f2'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
-  appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
+  appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
           checkpoint: '824fcfcc1368b40fc75e67b73f4b669f787fc74f0b82c59b2fed8d555c2489e2'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'

--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.9.1,1486'
-  sha256 '302f7cf0c9da10e21032a09d98da6ad6f6f52fe31632a74894bafabc593e7289'
+  version '2.9.4,1496'
+  sha256 '723e0d9d0dfe8dc553f80c870818a0f3a0e6045997c12178217cf7d463e528f2'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.3.xml',
-          checkpoint: '030d8f3e46d92d0bb9e8b86ab78ea38fd588247c2e00a309e4c1cf7d0b98461a'
+          checkpoint: '824fcfcc1368b40fc75e67b73f4b669f787fc74f0b82c59b2fed8d555c2489e2'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}