### PR TITLE
Update haskell-for-mac to 1.5.0,1335.1499064501

### DIFF
--- a/Casks/haskell-for-mac.rb
+++ b/Casks/haskell-for-mac.rb
@@ -1,11 +1,11 @@
 cask 'haskell-for-mac' do
-  version '1.4.0,1286.1490060445'
-  sha256 'de90e6effa54f0941f135252565a851de17eaefcdf00bdb2a5ca38e1d2135214'
+  version '1.5.0,1335.1499064501'
+  sha256 '9105671f870a12928aafbdcc3533b846946266991c945bcfc649eb589b012185'
 
   # dl.devmate.com/com.haskellformac.Haskell.basic was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.haskellformac.Haskell.basic/#{version.after_comma.dots_to_slashes}/Haskell%E2%80%94FunctionalProgrammingLab-#{version.after_comma.major}.zip"
   appcast 'https://updates.devmate.com/com.haskellformac.Haskell.basic.xml',
-          checkpoint: '51841c041b2cfe2a0950e820c972865ed0a9c97f502d46437581f1b8fc5c7312'
+          checkpoint: '7ef96fe31bcc10a8a71f586edb518a4c15e1a8c1330aab4ecd8fba21c0d6ecc3'
   name 'Haskell for Mac'
   homepage 'http://haskellformac.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}