### PR TITLE
Update little-snitch to 4.0

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -31,9 +31,7 @@ cask 'little-snitch' do
                 '~/Library/Preferences/at.obdev.LittleSnitchSoftwareUpdate.plist',
                 '~/Library/Saved Application State/at.obdev.LittleSnitchInstaller.savedState',
               ],
-      rmdir:  [
-                '/Library/Application Support/Objective Development',
-              ]
+      rmdir:  '/Library/Application Support/Objective Development'
 
   caveats do
     reboot

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -1,24 +1,15 @@
 cask 'little-snitch' do
-  if MacOS.version <= :mountain_lion
-    version '3.3.4'
-    sha256 '19dfcd33594fc14be321c3f54651059029b73f715158e0498ba01ceb69bf6c4a'
-    url "https://www.obdev.at/downloads/littlesnitch/legacy/LittleSnitch-#{version}.dmg"
-  elsif MacOS.version <= :mavericks
-    version '3.6.4'
-    sha256 '143070b3d8fd7370aa9c7881d3239efe33f05f4d4413a46e22988dd64f5b5223'
-    url "https://www.obdev.at/downloads/littlesnitch/legacy/LittleSnitch-#{version}.dmg"
-  else
-    version '3.7.4'
-    sha256 'b0ce3519d72affbc7910c24c264efa94aa91c9ad9b1a905c52baa9769156ea22'
-    url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
-  end
+  version '4.0'
+  sha256 '5d3b823eb55204055ac53c2d03a1783c4c42214079ee8ec085a4aaca0d052a60'
 
+  url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html',
-          checkpoint: '08b0322185fc2c0d636aa19369a076c62e30b50b868e44807e7128843af15b54'
+          checkpoint: 'aa855e2c38d2bf3e001915a2d47e0916f9eaa5d8ce8281d4f2743ed78d1567df'
   name 'Little Snitch'
   homepage 'https://www.obdev.at/products/littlesnitch/index.html'
 
   auto_updates true
+  depends_on macos: '>= :el_capitan'
 
   installer manual: 'Little Snitch Installer.app'
 

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -4,7 +4,7 @@ cask 'little-snitch' do
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html',
-          checkpoint: 'aa855e2c38d2bf3e001915a2d47e0916f9eaa5d8ce8281d4f2743ed78d1567df'
+          checkpoint: 'ffdec57721163f55004abc8201d47b9393ecfbc1b7ae7077e60c24db97c12e6b'
   name 'Little Snitch'
   homepage 'https://www.obdev.at/products/littlesnitch/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`4.0` is a paid upgrade. https://www.obdev.at/products/littlesnitch/order.html

Requires >= 10.11 https://www.obdev.at/products/littlesnitch/download.html

Migrated `little-snitch` `3.*.*` to `little-snitch3` https://github.com/caskroom/homebrew-versions/pull/4110

