### PR TITLE
Update macspice to 3.1.16

### DIFF
--- a/Casks/macspice.rb
+++ b/Casks/macspice.rb
@@ -1,10 +1,10 @@
 cask 'macspice' do
-  version '3.1.15'
-  sha256 'c12699e694d415ef7711e45d3f348e84202188014e679d505a2d5f126c84f77c'
+  version '3.1.16'
+  sha256 '5ef9430b956b8a3795a7e605fb0d5ce235d55dbcd886f06fc4959ff61427cd39'
 
   url "http://www.macspice.com/mirror/binaries/v#{version}/MacSpice3f5.dmg"
   appcast 'http://www.macspice.com/AppCast-v2.xml',
-          checkpoint: '0d57f4a640d1d4991aab10d13a744be9d2afcec1b9ee1621ea5668f4964eb6a9'
+          checkpoint: '52a03cddd8a97bbec18832c2bbebccb8e8edfefc67b80c03f30b48662a007f6c'
   name 'MacSpice'
   homepage 'https://www.macspice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}