### PR TITLE
Update cocktail to 10.4

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -21,8 +21,8 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml',
             checkpoint: 'ffe079c9b71d0f356c8a4d45ecf4f5a50e1d284c972b0a1e5cf92234d7a1010e'
   elsif MacOS.version == :el_capitan
-    version '9.6'
-    sha256 'c399be6b837482cb5ae80bb1f40a6e5cd39ff62179698c277a67122062c8ee50'
+    version '9.6.2'
+    sha256 '9534da88b075da6df3655da1781b7c849646b3eb4da1b97760e75f3e499cc43f'
 
     url "https://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -28,12 +28,12 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
             checkpoint: 'caf773ffc53978e4d0469056f0822c5acb9d85fc0ae1f43c51732c7e1dccfcca'
   else
-    version '10.3.5'
-    sha256 'b5e32572112d354f07b502e8bc2df99b780dbf006bc1c0a04a38dbeeec737fd8'
+    version '10.4'
+    sha256 'f7f258d3edb24afe11a810dbb88cf61a4318b565dca8f1c3f9bd1b1a1c6c05d3'
 
     url "https://www.maintain.se/downloads/sparkle/sierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml',
-            checkpoint: '7b8899bbf5095b8ea98b3521312e1f8530f6dbcb7f542431eb17a70221c59f2f'
+            checkpoint: 'd0aa31925f316daceec6d29d5bb818b3eeb721535526bfd6ae5915a844274666'
   end
 
   name 'Cocktail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}