### PR TITLE
Update framer to 9475

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '9386'
-  sha256 '485fbe07bfaf8f7675b2c50075f5b51ff9293f6125246db69735ad58feb30487'
+  version '9475'
+  sha256 '89271d51287506d18c03d308a5eaf33c80fbd27dbf18694bc852789b474a37b9'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '2daebfdeb9371eb119eff4ce446ef8d931bd5db5b1fca2ffaf20a04a1077e78b'
+          checkpoint: 'cfa0c4116ced02b627e998cbfba1daf3a73939d9ad115c7854cbd0e3e89fe4ac'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}