### PR TITLE
Fixed the sha256 checksum for the Nanobox v2.1.2 Cask

### DIFF
--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -1,6 +1,6 @@
 cask 'nanobox' do
   version '2.1.2'
-  sha256 '03051ff7a197f8641172f8fb8c12e3d34fb5a6d12405e88e2ff0a707b1f8a811'
+  sha256 '06fcf6071244cd5f7b74b8ea0b1df5a15ff26790f987698f2ad812fbd7732e54'
 
   # s3.amazonaws.com/tools.nanobox.io was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tools.nanobox.io/installers/v#{version.major}/mac/Nanobox.pkg"


### PR DESCRIPTION
Changed from the expected: 03051ff7a197f8641172f8fb8c12e3d34fb5a6d12405e88e2ff0a707b1f8a811
to the actual:
06fcf6071244cd5f7b74b8ea0b1df5a15ff26790f987698f2ad812fbd7732e54

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}