### PR TITLE
Update mediainfo to 0.7.97

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,10 +1,10 @@
 cask 'mediainfo' do
-  version '0.7.96'
-  sha256 '48f80b6c8bf17049d24d74b47a0ed2f8d0feb8ded13d61ab57e51be48939cb34'
+  version '0.7.97'
+  sha256 'd55cb482fc89d31a457e9da11f57617b18bf546aa8c43120a42f5ac0ed52b9b7'
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   appcast 'https://mediaarea.net/rss/mediainfo_updates.xml',
-          checkpoint: '3cb2fe783dc79b65374c461f6d21ee6d29a970ed0ec2a520512550e5a0ca5990'
+          checkpoint: '0f95d5796562506e3748fd235dd6633495fc5f0cfe0e5c9060070d7312cdd222'
   name 'MediaInfo'
   homepage 'https://mediaarea.net/en/MediaInfo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}