### PR TITLE
Updating Expandrive to v6.0.5

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,9 +1,9 @@
 cask 'expandrive' do
-  version '5.5.4'
-  sha256 'cd315e227a1fc4719a77760de6b7a27f6b5dd9036a58319352e72fbbaa60a623'
+  version '6.0.5'
+  sha256 '3b4033bfd0b203e202cd4642414b0cafe88729307aa5ad59fd853aaf31788833'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
-  appcast 'https://updates.expandrive.com/appcast/expandrive.xml?version=3',
+  appcast 'https://updates.expandrive.com/appcast/expandrive.xml',
           checkpoint: '5ef57ba7165a2afc67ab96fd08e68aed3a2a90a273fa717b887c0c34040b2ca7'
   name 'ExpanDrive'
   homepage 'https://www.expandrive.com/apps/expandrive/'
@@ -12,7 +12,10 @@ cask 'expandrive' do
 
   zap trash: [
                '~/Library/Application Support/ExpanDrive',
+               '~/Library/Preferences/com.expandrive.exfs.plist',
+               '~/Library/Preferences/com.expandrive.ExpanDrive.plist',
                '~/Library/Preferences/com.expandrive.ExpanDrive2.plist',
                '~/Library/Preferences/com.expandrive.ExpanDrive3.plist',
+               '~/Library/Preferences/com.expandrive.ExpanDrive.helper.plist',
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
