### PR TITLE
Update cheatsheet to 1.2.8

### DIFF
--- a/Casks/cheatsheet.rb
+++ b/Casks/cheatsheet.rb
@@ -1,11 +1,11 @@
 cask 'cheatsheet' do
-  version '1.2.7'
-  sha256 'cfe0c699e04ea116965d13be02eee8358d5acd89c32144c388d0e28ee693fbd3'
+  version '1.2.8'
+  sha256 'fa33612d16a36f3817f2388c65539254c6e77f7f3e546f05ff97eeae534166f2'
 
   # mediaatelier.com/CheatSheet was verified as official when first introduced to the cask
   url "https://mediaatelier.com/CheatSheet/CheatSheet_#{version}.zip"
   appcast 'https://mediaatelier.com/CheatSheet/feed.php',
-          checkpoint: '9d6994ef2b83ba8bd7ef7ab4ff4aff486ca226c28fac40569f448e27790d7ab2'
+          checkpoint: 'e37ea0a75cb998a0369066ba60004bc2b079c1f3898db523c73c0fbf78835241'
   name 'CheatSheet'
   homepage 'https://www.cheatsheetapp.com/CheatSheet/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}