### PR TITLE
Update Capture One to 10.1.2

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '10.1.1'
-  sha256 'c5c37621481c4f49ff2a91cc3648cadd814d8f6fe95d5633e9d2b506acd936d5'
+  version '10.1.2'
+  sha256 'fc4760f9e5e0470d9e851995cb36180ffc956607735fff36e0b73c737a536d90'
 
   url "http://downloads.phaseone.com/9c7cb7b7-1525-4cfc-86a8-7d8f5a51f38e/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
