### PR TITLE
Update nzbget to 19.0

### DIFF
--- a/Casks/nzbget.rb
+++ b/Casks/nzbget.rb
@@ -1,11 +1,11 @@
 cask 'nzbget' do
-  version '18.1'
-  sha256 '61acf00f3d274127a1e7c687a7215e04f04b76e04319d82b5fbd2556f1bc6c5a'
+  version '19.0'
+  sha256 '02896f52816a0c093515ef8a0ce111ec7ce32c308d007c9b46864067a36d71f4'
 
   # github.com/nzbget/nzbget was verified as official when first introduced to the cask
   url "https://github.com/nzbget/nzbget/releases/download/v#{version}/nzbget-#{version}-bin-macos.zip"
   appcast 'https://github.com/nzbget/nzbget/releases.atom',
-          checkpoint: 'fb133a71209efc75adc7820600ad76d7738a9d4346623b23aae97319d2df4cdb'
+          checkpoint: 'cdf5ef1d82b91e409686b3dcd2affd82d2ccde86246af5682dab547979a539cb'
   name 'NZBGet'
   homepage 'https://nzbget.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}