### PR TITLE
Update subler to 1.3.3

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.3.2'
-  sha256 '6bfa953b6247d35c0a4132cc562ff3e46006bd2586413b3614a606f43cd00125'
+  version '1.3.3'
+  sha256 '0d40b42798dcc2a3a43192aadc3a9a526259de482fb698fde2f956e4e0504a39'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: '3ad70676f826fc7e2c0d733d5afec7a63c3994f86be2ccbe3954ec02ebf4b7ee'
+          checkpoint: '45930d82bd59c678d88ffc9a9e6bd058e7eb888b3da75615c294bbe8ffa7befc'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}