### PR TITLE
Update now to 2.0.1

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '1.3.3'
-  sha256 '2d394531662b9a6bc7e6fb1a8001090788f1f5da932235bb500129f769858774'
+  version '2.0.1'
+  sha256 '1f8131d027fd47da3f859a3f0c11f1035ae8d9436962960137bc0cc95a676ef0'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '900d9116c5463270836ac8be335b76a687919bff7b94f70ad41ffdf714820be7'
+          checkpoint: '16349895c78f2da8cba80e6c06dddeb788c26705748efa91ff6f9d06487dfdba'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}