### PR TITLE
Update onyx to 3.2.5

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -4,12 +4,12 @@ cask 'onyx' do
     sha256 '7f8df2c9e97eb465aba88b000fa2f58958421efeba1239303ff0071e9b7b0536'
   else
     version '3.2.5'
-    sha256 '068b9d4df199727ecf750879b943efc9b5813aab318cca05f937be7f9a075d81'
+    sha256 '60783b270825013b7130f0f9457f9a3fea6e628d9756d79af46e35d55ad25de7'
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/OnyX.dmg"
   appcast 'http://www.titanium-software.fr/en/release_onyx.html',
-          checkpoint: '8c5bb3c8c171a69ac4f185b504b0ec16c8c774b40dfac8856a8c60edfbe499b8'
+          checkpoint: '6185c1ab05614da66cb728171d2c2c5554fc94ea9ca6b2f8483acb00b013af0b'
   name 'OnyX'
   homepage 'https://www.titanium-software.fr/en/onyx.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}