### PR TITLE
Update inspec to 1.30.0-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.28.1-1'
-  sha256 'b869468f68925d783f1ac99514b28e79c37befbc33a2391affa11d057a400261'
+  version '1.30.0-1'
+  sha256 'f08843ba011fcb596bd729af631e8aea3629e125bd552f69fadd4b81b1c60c70'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'c33d2ec8a6abc1d5872bf1aa4d52dccc0dcbd554571463f8363b801eba87923f'
+          checkpoint: '83e82046fe0b9f6c20710bc1f1401ae0da132e60872cf13cc50512bb54815d32'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}