### PR TITLE
Fixing xscreensaver 5.37 entry

### DIFF
--- a/Casks/xscreensaver.rb
+++ b/Casks/xscreensaver.rb
@@ -218,6 +218,7 @@ cask 'xscreensaver' do
   screen_saver 'Screen Savers/Unicrud.saver'
   screen_saver 'Screen Savers/UnknownPleasures.saver'
   screen_saver 'Screen Savers/Vermiculate.saver'
+  screen_saver 'Screen Savers/Vigilance.saver'
   screen_saver 'Screen Savers/Voronoi.saver'
   screen_saver 'Screen Savers/Wander.saver'
   screen_saver 'Screen Savers/WebCollage.saver'


### PR DESCRIPTION
After update to version 5.37, the cask recipe is missing the definition for the new screensaver "vigilance"

Script generated commit: 4fa3814ab4d056fd3ffc7b7b94da74189e48d857
Changelog: https://www.jwz.org/xscreensaver/changelog.html

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
