### PR TITLE
Update natron to 2.3.0

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.2.8'
-  sha256 '2db9bd55951edb2142b3f8be6d4ec778c80f3bd242b79c29af901105db65b1bf'
+  version '2.3.0'
+  sha256 '882e7869e65f29fbe0b2c97adb0065a86bfe47f9f01622dbddd64deeba89a32a'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: '75b1133136e5a790bc8cf6519cc7933d95d2a061801eeb291805f510376a4e29'
+          checkpoint: '4d89bf0b2b8449a032f002135c79c38bba5110d46a8262f7c8a8fbd44254cfcb'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}