### PR TITLE
Update dropshare to 4.6.4,4626

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4.6.3,4608'
-  sha256 'cf0beb0c4bff79ec5c18196e57d31c13cae86f94d3786e9543018735e48f8d70'
+  version '4.6.4,4626'
+  sha256 '07b7d289bb65b7d810a83258eb524188f04250f351a7860ea082b06be52c7b19'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
-          checkpoint: '7e9bdabcc538c1f91f67dcd73aa63256eeb0e64396a5ad3187074fb052ec0df8'
+          checkpoint: 'c41a0d0b597b59839084537e33509df834521c79a91f1cb494d85e022019fb69'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}