### PR TITLE
Update free-download-manager to 5.1.31

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,10 +1,12 @@
 cask 'free-download-manager' do
   version '5.1.31'
-  sha256 '449dcaba5cbea8eb716f9cfa1895aae4247336e0552ad49df510745635d1500c'
+  sha256 '845964e7172ac10e297b6734270bfbee1c7263bd8c0a6f9688bb63c1c9e000bb'
 
   url "http://files2.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
   name 'Free Download Manager'
-  homepage 'http://www.freedownloadmanager.org/landing5.htm'
+  homepage "http://www.freedownloadmanager.org/landing#{version.major}.htm"
+
+  depends_on macos: '>= 10.9'
 
   app 'Free Download Manager.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}