### PR TITLE
Update webcatalog to 6.1.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '6.0.0'
-  sha256 '698bad59ab8e978bf7a7a8aaf8e8e62b84c91132db827b6572dac1ee0b3812a0'
+  version '6.1.0'
+  sha256 'cfb58095ba2bf7cfc2804dc816ec69bb3a80bbd1d4c657a06610707d7d0fd953'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '80fe4496b798a929b6d98a8e15d75a14267dbe6d8a58ffdcbd96663d7d252a02'
+          checkpoint: '6d0d9a0d86a3b3d0b014c47a1e187d00bbb438bf21199947bf7c8946ec977387'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/download/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.