### PR TITLE
Update now to 2.0.2

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.0.1'
-  sha256 '1f8131d027fd47da3f859a3f0c11f1035ae8d9436962960137bc0cc95a676ef0'
+  version '2.0.2'
+  sha256 '565280be47de3674fa8f3af9d2d3c4d8c7492f5a1a382d908be201df9b0ce7de'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '16349895c78f2da8cba80e6c06dddeb788c26705748efa91ff6f9d06487dfdba'
+          checkpoint: 'c040b6350861b93276316c1c87739bb84afbb04dad4c5e437f57ab8b420172df'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}