### PR TITLE
Update mono-mdk - add caveat

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -18,7 +18,7 @@ cask 'mono-mdk' do
     /usr/local/bin and adds #{token} to /private/etc/paths.d/
     You may want to:
 
-    brew unlink {formula} && brew link {formula}
+      brew unlink {formula} && brew link {formula}
 
     and/or remove /private/etc/paths.d/monocommands
   EOS

--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -12,4 +12,14 @@ cask 'mono-mdk' do
   pkg "MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
 
   uninstall pkgutil: 'com.xamarin.mono-*'
+
+  caveats <<-EOS.undent
+    Installing #{token} removes mono and mono dependant formula binaries in
+    /usr/local/bin and adds #{token} to /private/etc/paths.d/
+    You may want to:
+
+    brew unlink {formula} && brew link {formula}
+
+    and/or remove /private/etc/paths.d/monocommands
+  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`mono-mdk` runs a post-install script which checks for `mono` and mono related (`nuget`, etc) binaries in `/usr/local/bin` and removes them if found.
It also adds `/Library/Frameworks/Mono.framework/Versions/Current/Commands` to `/private/etc/paths.d/monocommands`.