### PR TITLE
Update expandrive to 6.0.7

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,6 +1,6 @@
 cask 'expandrive' do
-  version '6.0.5'
-  sha256 '3b4033bfd0b203e202cd4642414b0cafe88729307aa5ad59fd853aaf31788833'
+  version '6.0.7'
+  sha256 '9e922072b328ecd4e398d2d287dc208c2cef74f073a3b5d44bc7d9e0c08946d7'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
   appcast 'https://updates.expandrive.com/appcast/expandrive.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}

`appcast` hasn't been updated, still on `5.5.4`.