### PR TITLE
Update brackets to 1.10

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,11 +1,11 @@
 cask 'brackets' do
-  version '1.9'
-  sha256 '489846205d13eb5abe156e0ffd171f0dfaf2183d216e6165f26a84caae1002d5'
+  version '1.10'
+  sha256 'a4faac726671439590e462af46d228e97ed70ede2e101bbd195b1f03143b00db'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
   appcast 'https://github.com/adobe/brackets/releases.atom',
-          checkpoint: 'cf3c947a5903174f207a1251c0536d66f304d1af0a2e173f7e235496d866fc40'
+          checkpoint: '3559e75e79f9cbb64679435add8870e45f2c7c15daca08ef9e890a46920e38ee'
   name 'Brackets'
   homepage 'http://brackets.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}