### PR TITLE
Update powershell - add depends_on macos

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -10,6 +10,7 @@ cask 'powershell' do
   homepage 'https://msdn.microsoft.com/powershell'
 
   depends_on formula: 'openssl'
+  depends_on macos: '>= :sierra'
 
   pkg "powershell-#{version}-osx.10.12-x64.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[Requires Sierra](https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#macos-1012)