### PR TITLE
Update amethyst to 0.11.3

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -6,13 +6,13 @@ cask 'amethyst' do
     version '0.10.1'
     sha256 '9fd1ac2cfb8159b2945a4482046ee6d365353df617f4edbabc4e8cadc448c1e7'
   else
-    version '0.11.2'
-    sha256 '03ffc1fcb65f6e229d18cf8da4ccd38fd35a532a05a9ec4f7847a002e98b6693'
+    version '0.11.3'
+    sha256 '8574e41178714fd52a8e5c8e8e2b580eb3e604b3c4d4579cbf84ff49472c55e8'
   end
 
   url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   appcast 'https://ianyh.com/amethyst/appcast.xml',
-          checkpoint: 'e8aba6a90fc074ca0a3d0085a9d4d63dc1b70c06be80dd6e035ffc166c58f832'
+          checkpoint: '260eea33504e9dcc4d535110e727180abc42b0bf28f41ebe0d59613284902de1'
   name 'Amethyst'
   homepage 'https://ianyh.com/amethyst/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}