### PR TITLE
Update unison - postflight defaults write

### DIFF
--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -30,6 +30,6 @@ cask 'unison' do
   binary "#{appdir}/Unison.app/Contents/MacOS/cltool", target: 'unison'
 
   postflight do
-    system_command '/usr/bin/defaults', args: ['write', 'edu.upenn.cis.Unison CheckCltool', '-bool', 'false']
+    system_command '/usr/bin/defaults', args: ['write', 'edu.upenn.cis.Unison', 'CheckCltool', '-bool', 'false']
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Add `,`