### PR TITLE
Update mono-mdk - uninstall delete

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -11,7 +11,8 @@ cask 'mono-mdk' do
 
   pkg "MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
 
-  uninstall pkgutil: 'com.xamarin.mono-*'
+  uninstall delete:  '/private/etc/paths.d/monocommands',
+            pkgutil: 'com.xamarin.mono-*'
 
   caveats <<-EOS.undent
     Installing #{token} removes mono and mono dependant formula binaries in


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`/private/etc/paths.d/monocommands` is part of the post-install script and isn't removed by `pkgutil`.