### PR TITLE
Update ngrok to latest

### DIFF
--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -1,9 +1,9 @@
 cask 'ngrok' do
-  version '2.2.6,4VmDzA7iaHb'
-  sha256 '54dd3706f628213931ae3566b63ef740ce97ef68351e51fcf55f08a8c9ae33d2'
+  version :latest
+  sha256 :no_check
 
   # bin.equinox.io was verified as official when first introduced to the cask
-  url "https://bin.equinox.io/c/#{version.after_comma}/ngrok-stable-darwin-amd64.zip"
+  url 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip'
   name 'ngrok'
   homepage 'https://ngrok.com/'
 


### PR DESCRIPTION
This URL actually points to the latest version of ngrok and has for
every release after 2.0.19 from around March 2016.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}