### PR TITLE
Update cyberghost to 5.0.15.5

### DIFF
--- a/Casks/cyberghost.rb
+++ b/Casks/cyberghost.rb
@@ -1,10 +1,10 @@
 cask 'cyberghost' do
-  version '5.0.15.3'
-  sha256 '78bd6bf3a5e07bc6a2ec0106dd8d98e7f5e16914be5c98ae9bece80921290c69'
+  version '5.0.15.5'
+  sha256 '197e9501953861f0265c415b58f6a8983d97530860885f3135f6f75aeb9f5985'
 
   url "https://download.cyberghostvpn.com/mac/cg5mac_#{version}.dmg"
   appcast 'https://download.cyberghostvpn.com/mac/updates/cyberghost_mac_update.inf',
-          checkpoint: '68b94750860c5b28bd90bf39553d87d219bd41adca3363e119b3c58d6614ade4'
+          checkpoint: 'a68792b9b3cec2b27a436f2f516f98c892a60ca0f8e972468b0e0c0b6ccbe7f2'
   name 'CyberGhost'
   homepage 'https://www.cyberghostvpn.com/en'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}