### PR TITLE
Update devonthink-pro to 2.9.13

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.12'
-  sha256 '558c7b513ad9586e7847ba1fb977620eb9a363a08993348c5bebf2411ba97678'
+  version '2.9.13'
+  sha256 '1705c28fef0ef199e7b4a81b28feb35df79e3f2cd34096db435c8375ec998235'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '445b4ee1c063e9877b64fbe5646d278ea3ce8b878afe7ab900feae51e3db604c'
+          checkpoint: '22d13ee1bb93e91602ee0428c6f03dc6095da90a236cedf3f66a54e961315fdb'
   name 'DEVONthink Pro'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}