### PR TITLE
Update Free Download Manager to use Latest Link

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -10,11 +10,21 @@ cask 'free-download-manager' do
 
   app 'Free Download Manager.app'
 
+  uninstall launchctl: [
+                         "org.freedownloadmanager.fdm#{version.major}",
+                         "org.freedownloadmanager.fdm#{version.major}.helper",
+                       ],
+            quit:      [
+                         "org.freedownloadmanager.fdm#{version.major}",
+                         "org.freedownloadmanager.fdm#{version.major}.launcher",
+                       ]
+
   zap delete: [
-                '~/Library/Application Support/Free Download Manager',
                 "~/Library/Caches/org.freedownloadmanager.fdm#{version.major}",
-                "~/Library/Preferences/org.freedownloadmanager.fdm#{version.major}.plist",
                 "~/Library/Saved Application State/org.freedownloadmanager.fdm#{version.major}.savedState",
-                "~/Library/LaunchAgents/org.freedownloadmanager.fdm#{version.major}.helper.plist",
+              ],
+      trash:  [
+                '~/Library/Application Support/Free Download Manager',
+                "~/Library/Preferences/org.freedownloadmanager.fdm#{version.major}.plist",
               ]
 end

--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,10 +1,10 @@
 cask 'free-download-manager' do
-  version '5.1.31'
-  sha256 '845964e7172ac10e297b6734270bfbee1c7263bd8c0a6f9688bb63c1c9e000bb'
+  version :latest
+  sha256 :no_check
 
-  url "http://files2.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
+  url 'http://dn3.freedownloadmanager.org/5/5.1-latest/fdm.dmg'
   name 'Free Download Manager'
-  homepage "http://www.freedownloadmanager.org/landing#{version.major}.htm"
+  homepage 'http://www.freedownloadmanager.org/landing#{version.major}.htm'
 
   depends_on macos: '>= 10.9'
 
@@ -12,9 +12,9 @@ cask 'free-download-manager' do
 
   zap delete: [
                 '~/Library/Application Support/Free Download Manager',
-                "~/Library/Caches/org.freedownloadmanager.fdm#{version.major}",
-                "~/Library/Preferences/org.freedownloadmanager.fdm#{version.major}.plist",
-                "~/Library/Saved Application State/org.freedownloadmanager.fdm#{version.major}.savedState",
-                "~/Library/LaunchAgents/org.freedownloadmanager.fdm#{version.major}.helper.plist",
+                '~/Library/Caches/org.freedownloadmanager.fdm*',
+                '~/Library/Preferences/org.freedownloadmanager.fdm5.plist',
+                '~/Library/Saved Application State/org.freedownloadmanager.fdm5.savedState',
+                '~/Library/LaunchAgents/org.freedownloadmanager.fdm5.helper.plist',
               ]
 end

--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -4,7 +4,7 @@ cask 'free-download-manager' do
 
   url 'http://dn3.freedownloadmanager.org/5/5.1-latest/fdm.dmg'
   name 'Free Download Manager'
-  homepage 'http://www.freedownloadmanager.org/landing#{version.major}.htm'
+  homepage 'http://www.freedownloadmanager.org/'
 
   depends_on macos: '>= 10.9'
 

--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,8 +1,8 @@
 cask 'free-download-manager' do
-  version :latest
-  sha256 :no_check
+  version '5.1'
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url 'http://dn3.freedownloadmanager.org/5/5.1-latest/fdm.dmg'
+  url "http://dn3.freedownloadmanager.org/#{version.major}/#{version}-latest/fdm.dmg"
   name 'Free Download Manager'
   homepage 'http://www.freedownloadmanager.org/'
 
@@ -12,9 +12,9 @@ cask 'free-download-manager' do
 
   zap delete: [
                 '~/Library/Application Support/Free Download Manager',
-                '~/Library/Caches/org.freedownloadmanager.fdm*',
-                '~/Library/Preferences/org.freedownloadmanager.fdm5.plist',
-                '~/Library/Saved Application State/org.freedownloadmanager.fdm5.savedState',
-                '~/Library/LaunchAgents/org.freedownloadmanager.fdm5.helper.plist',
+                "~/Library/Caches/org.freedownloadmanager.fdm#{version.major}",
+                "~/Library/Preferences/org.freedownloadmanager.fdm#{version.major}.plist",
+                "~/Library/Saved Application State/org.freedownloadmanager.fdm#{version.major}.savedState",
+                "~/Library/LaunchAgents/org.freedownloadmanager.fdm#{version.major}.helper.plist",
               ]
 end


### PR DESCRIPTION
Update Free Download Manager to use Latest Link, not a specific version.  Also fixes `sha256` mismatch errors.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
