### PR TITLE
Update munki to 3.0.2.3348

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,11 +1,11 @@
 cask 'munki' do
-  version '3.0.0.3333'
-  sha256 'ad18edc7014c6fe9070a0be278d9595d882406f85cb02789eb1d21fa3cf893fb'
+  version '3.0.2.3348'
+  sha256 'ded633688981b600aacfc07db99c29b888cb4c33f64fdc830eb85847831221c1'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.sub(%r{^(\d+\.\d+.\d+).*}, '\1')}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: '1a0d98eb051e609fe94e8624b88d23bb3e79944c1810bc8316531c8736e20804'
+          checkpoint: 'c8d4df84e5acb4f360c15331045752bad77c9ae71a2a5e5ae71fa7a8eb8e28f3'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}