### PR TITLE
Update outset to 2.0.6

### DIFF
--- a/Casks/outset.rb
+++ b/Casks/outset.rb
@@ -1,10 +1,10 @@
 cask 'outset' do
-  version '2.0.5'
-  sha256 'e4ed6a0398295ba44ee1588caebaa6c855aabaed052b3cf930d69c792f219f0d'
+  version '2.0.6'
+  sha256 'bfc3921e91fab1b9ff915c2935162b930ab0035a1336932e085f46bcf95bb752'
 
   url "https://github.com/chilcote/outset/releases/download/v#{version}/outset-#{version}.pkg"
   appcast 'https://github.com/chilcote/outset/releases.atom',
-          checkpoint: 'e95456adc46d0ec04aa6b12c528b56c53cc29a0c8f597e21fbd69cebc55fca63'
+          checkpoint: '5833059196488072b473f5d643bc4b3824fad10396f332a4c04282767a00f113'
   name 'outset'
   homepage 'https://github.com/chilcote/outset'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}