### PR TITLE
Update veracrypt to 1.21

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,11 +1,11 @@
 cask 'veracrypt' do
-  version '1.20'
-  sha256 '63b186cd9d117a13bf249445b9d0551391babf12512a974978baf44a65bcfd37'
+  version '1.21'
+  sha256 'cbd3f80eca753edce40be134ccbd288805c93643b21d8cf21fd72c0fd544f377'
 
   # launchpad.net/veracrypt/trunk/ was verified as official when first introduced to the cask
   url "https://launchpad.net/veracrypt/trunk/#{version}/+download/VeraCrypt_#{version}.dmg"
   appcast 'https://github.com/veracrypt/VeraCrypt/releases.atom',
-          checkpoint: '9b200f08d719ba486a9bc732c35b45ef945291e788cf98ea8a0e664fd1d35ad6'
+          checkpoint: 'fffe46cc3d4758cb1066693e84a4349a2b9c618700571541c446959adc7a95da'
   name 'VeraCrypt'
   homepage 'https://www.veracrypt.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}