### PR TITLE
Update aptible to 0.11.1

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,6 +1,6 @@
 cask 'aptible' do
-  version '0.11.0+20170530075306,143'
-  sha256 '41b1fdd464c049105e0fadfc18b6041aa88ba17ab903c84280e584c74e9ecea1'
+  version '0.11.1+20170706115813,147'
+  sha256 'd7a54df30ac4423e35c7c9769a699c9d1eac04bd5438b163691014e20ffe3e08'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.before_comma.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.