### PR TITLE
Update caprine to 2.5.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.4.0'
-  sha256 'ec0dc7d6e5eff8e8569e501b34bd2c590525d1b02918ae7b18ece4881f356c98'
+  version '2.5.0'
+  sha256 'fef69ef1f09623ba429bf90b940aaea59f93e23225e0cb53f23702b7d3c14062'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: '6790d11ddca8d12233616beef6353dac6374b3901539faadfdceec24009c9a83'
+          checkpoint: 'eeadbb7e6220e50e1140bac345bdbad0f31832d5e143af1839eb113d23f29541'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}