### PR TITLE
Update aseprite to 1.2-beta12

### DIFF
--- a/Casks/aseprite.rb
+++ b/Casks/aseprite.rb
@@ -1,10 +1,10 @@
 cask 'aseprite' do
-  version '1.1.13'
-  sha256 'a7dd98d99a343a04a833522b64d185d6ff7bca44ddaf0376784ffb724816eb64'
+  version '1.2-beta12'
+  sha256 '90939bc06f5694a512d233018ae12ce7ce3bed409e7164d4160dbfe16afc4609'
 
   url "https://www.aseprite.org/downloads/Aseprite-v#{version}-trial-MacOSX.dmg"
   appcast 'https://github.com/aseprite/aseprite/releases.atom',
-          checkpoint: 'cf6fde61cc8d0eba7f306b303192503dd9f04083c202cef4736c6cdb88283b1a'
+          checkpoint: '69daacf9be253265a763583cb67dc3c9e92078d6c056c1c736ec2d457444b594'
   name 'Aseprite'
   homepage 'https://www.aseprite.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}