### PR TITLE
Update keka to 1.0.11

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,11 +1,11 @@
 cask 'keka' do
-  version '1.0.10'
-  sha256 '38b29ef0f44610cc8145bf41538b23cc2207f5d4248de40ec4236b81e8e6f0fb'
+  version '1.0.11'
+  sha256 '3b4d136df8c8bf9a30ec2a5d15f6223eb0f55f1ffc1ef358ea49c8aa09a92329'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: 'e9fb90f00dec38642c198fdf8c965c2b6dd39e3c87788f47afdec145335c3857'
+          checkpoint: '41cd85c996c54ca0d730ba17ae82c4eea4d40c0db45c0adb71675e662b04f123'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}