### PR TITLE
Update filezilla.rb for depends_on

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,5 +1,5 @@
 cask 'filezilla' do
-  if MacOS.version <= :mavericks
+  if MacOS.version == :mavericks
     version '3.24.1'
     sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
   else
@@ -14,12 +14,14 @@ cask 'filezilla' do
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 
+  depends_on macos: '>= :mavericks'
+
   app 'FileZilla.app'
 
   zap delete: [
                 '~/.config/filezilla',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/de.filezilla.sfl',
-                '~/Library/Saved Application State/de.filezilla.savedState',
                 '~/Library/Preferences/de.filezilla.plist',
+                '~/Library/Saved Application State/de.filezilla.savedState',
               ]
 end

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,11 +1,6 @@
 cask 'filezilla' do
-  if MacOS.version == :mavericks
-    version '3.24.1'
-    sha256 '79f28c13820ffcb9e6fa4446a1a317a45fd91d6a67fb1a562d30443f1abe186e'
-  else
-    version '3.26.2'
-    sha256 'c5028031ac3eb9ae2ae9cb2a16f0931b74dd2396f04fda1ec67374b692835750'
-  end
+  version '3.26.2'
+  sha256 'c5028031ac3eb9ae2ae9cb2a16f0931b74dd2396f04fda1ec67374b692835750'
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"


### PR DESCRIPTION
`Requires OS X 10.9 or newer` via https://filezilla-project.org/download.php?show_all=1

---

Update filezilla.rb for depends_on

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.