### PR TITLE
Update santa to 0.9.19

### DIFF
--- a/Casks/santa.rb
+++ b/Casks/santa.rb
@@ -1,10 +1,10 @@
 cask 'santa' do
-  version '0.9.18'
-  sha256 'abd30ad8b275f7b961cd8133e0fb2702aa5f21c06d7a5e0e64be2507c80dafe3'
+  version '0.9.19'
+  sha256 '6ad41b41be22e23674cfec284dc5c115262dd1bee9acb7e12f4c2213514a4a2a'
 
   url "https://github.com/google/santa/releases/download/#{version}/santa-#{version}.dmg"
   appcast 'https://github.com/google/santa/releases.atom',
-          checkpoint: 'f09d5b02abb675e7c89d358b451cc60cb0a536c17a83c0effabe61c87b46b61e'
+          checkpoint: '5b2f3dd9b5f4dd06d72d78e81e41798443edda93b69d9d4b185d436a863e14dc'
   name 'Santa'
   homepage 'https://github.com/google/santa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}