### PR TITLE
Update now to 2.2.0

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.1.0'
-  sha256 'fc696b9cdf3d323784099e6602e0478cf5bb9a52735f8c954802d8fd7e9b6cbe'
+  version '2.2.0'
+  sha256 'de360d3e0fa96170771e9751461c354f0a45972b4a17a80450672bca92117a33'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'd6c7ce14b96a2b05d1051299bdd9b40f6492276dd4a4dc7e1a6de5b6948943e8'
+          checkpoint: 'd2d71bec1abce4aac1bf76b0d0d45f67e8f64ee71404e8e90e4760ccbb377dea'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}