### PR TITLE
Update react-native-debugger (0.7.2)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.1'
-  sha256 'aaa8201a76ae728cffb96daaf6b112ab35388608b19a2f9f81aedda42cf9bb94'
+  version '0.7.2'
+  sha256 '01c41ab5e558eeb5cf4bd56455b16608d121389a9e5182b06fa8774cb9cd4506'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '4a53752138c3c47eaf1ae398d8e83f3dda9e3fba5840ab4e563b6d3601522b2d'
+          checkpoint: '79ee8eb03c6a05cf89e3daf36121c7209bca76f29b1860949d31b49528056e73'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.