### PR TITLE
Update caret to 3.2.0

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '3.1.0'
-  sha256 'fe4604692dfec100b1f69af2563f51d39a9dd85c62a896ac435d01280ae0a1ec'
+  version '3.2.0'
+  sha256 '69d36574574aab004bfab950694072aa43abea14612304f15e5d34b4225c0abd'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '58e0e821d6d9f57cd3f1eea8867f75164a67ec859ac8c2afcc64806f86d0bf71'
+          checkpoint: '313a6a7f125770fe01111e3230b4da673588beb2ead52200d05b18dff252564f'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}