### PR TITLE
Update nucleo to 2.0.5

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,11 +1,11 @@
 cask 'nucleo' do
-  version '2.0.2'
-  sha256 '89641365b6de691d6761cda630d1ffe034c39cadbcdf99a6a02154a229ed2683'
+  version '2.0.5'
+  sha256 '0a8a26891d938f9406e71126407e7d277a1dcd6429aff9d842cd6a4c390f5d91'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"
   appcast 'https://nucleoapp.com/updates',
-          checkpoint: 'd083d6ad0f542ccabc982f8f5fe19c6bfb86d513eac739302235d6d0bf4f49e2'
+          checkpoint: '5182b46d00306264b2047e1f207c2a22c5226cc20e8d122bde8bd6bb018ade31'
   name 'Nucleo'
   homepage 'https://nucleoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}