### PR TITLE
Update zoc to 7.15.1

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,10 +1,10 @@
 cask 'zoc' do
-  version '7.15.0'
-  sha256 '361d2bbad2b6cbaa1c1288bd4331696942762aca9dd09e290d1ede335f5a816a'
+  version '7.15.1'
+  sha256 '6c3d659cc0faed97ab39f794a4514cc31bb834b728f481e001a812550304e6dd'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast "http://www.emtec.com/downloads/zoc/zoc#{version.no_dots}_changes.txt",
-          checkpoint: '565dfc143f2c4f8ec418762d7684fb693b10009591c26800d6cf27cb37d397a5'
+          checkpoint: 'c33a198c8b5828e99d797abe6683ca752c7ca7cd3b151b4324afa6ffa23f6e23'
   name 'ZOC'
   homepage 'https://www.emtec.com/zoc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}