### PR TITLE
Update now to 2.2.1

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.2.0'
-  sha256 'de360d3e0fa96170771e9751461c354f0a45972b4a17a80450672bca92117a33'
+  version '2.2.1'
+  sha256 'b3e4979da58db651591adb17753a934a1ed2a660b9bc7d9db5533105c98fb8e3'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'd2d71bec1abce4aac1bf76b0d0d45f67e8f64ee71404e8e90e4760ccbb377dea'
+          checkpoint: 'ce157e2545771cbdbff3d157fae0d1587101a34910964d4878282c4817e96af1'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}