### PR TITLE
Update downie to 2.9.5,1505

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.9.4,1496'
-  sha256 '723e0d9d0dfe8dc553f80c870818a0f3a0e6045997c12178217cf7d463e528f2'
+  version '2.9.5,1505'
+  sha256 '41025d496ab9eafcd1f1edb9e5c9aa0fcbad32e444030333339d75df905b986e'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
-          checkpoint: '824fcfcc1368b40fc75e67b73f4b669f787fc74f0b82c59b2fed8d555c2489e2'
+          checkpoint: '8e63f501445ba7b6dedc74f1724d1a23c091bc45111002edc7bfc660fc311b6e'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}