### PR TITLE
Update peakhour to 4.0.1

### DIFF
--- a/Casks/peakhour.rb
+++ b/Casks/peakhour.rb
@@ -1,12 +1,28 @@
 cask 'peakhour' do
-  version '3.1.8'
-  sha256 'c43fad5d78f915705bb29e7379090c0eee1b5190b1be412be20afdb1ab7659b0'
+  version '4.0.1'
+  sha256 '582d9d7205ffe29cea59ba6d4a36bb64b72ca7bb6761a951bab69cb384c84903'
 
   url "https://updates.peakhourapp.com/releases/PeakHour%20#{version}.zip"
-  appcast 'https://updates.peakhourapp.com/PeakHourAppcast.xml',
-          checkpoint: '9448a1d6045cec40d42aa6a271ecdaa7f318f90a6f0d110ccdef5461d9db2eac'
+  appcast "https://updates.peakhourapp.com/PeakHour#{version.major}Appcast.xml",
+          checkpoint: '5971c9c3e40a29c33cf9bf8eb53ecc67dbd03077f5e3bede697682a86fd70b5a'
   name 'PeakHour'
   homepage 'https://www.peakhourapp.com/'
 
   app "PeakHour #{version.major}.app"
+
+  uninstall launchctl: "com.digitician.peakhour#{version.major}.launchAtLoginHelper",
+            quit:      "com.digitician.peakhour#{version.major}"
+
+  zap delete: [
+                "~/Library/Application Scripts/com.digitician.peakhour#{version.major}.launchAtLoginHelper",
+                "~/Library/Caches/com.digitician.peakhour#{version.major}",
+                "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.digitician.peakhour#{version.major}",
+                "~/Library/Containers/com.digitician.peakhour#{version.major}.launchAtLoginHelper",
+                "~/Library/Cookies/com.digitician.peakhour#{version.major}.binarycookies",
+              ],
+      trash:  [
+                "~/Library/Application Support/com.digitician.peakhour#{version.major}",
+                '~/Library/Application Support/PeakHour*',
+                "~/Library/Preferences/com.digitician.peakhour#{version.major}.plist",
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update `appcast` and add `uninstall` / `zap`