### PR TITLE
Update google-earth to 7.3.0.3827

### DIFF
--- a/Casks/google-earth.rb
+++ b/Casks/google-earth.rb
@@ -1,6 +1,6 @@
 cask 'google-earth' do
-  version '7.1.8.3036'
-  sha256 'a6cdb98e2caf0162c425b1acc0dab6196a220bf59eef378624b8b7c60a22bf18'
+  version '7.3.0.3827'
+  sha256 '85e49d4a377b148a4529f53624114647d6da9714074cc8b2c147ed152f2d25a0'
 
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthMac-Intel.dmg'
   name 'Google Earth'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}