### PR TITLE
Update numi to 3.16,129:1499701563

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,11 +1,11 @@
 cask 'numi' do
-  version '3.15.2,122:1496059169'
-  sha256 '16d6c2c0b8879d44217f0154f7cf5152b286c4c4a1049f9dbee76946719407b2'
+  version '3.16,129:1499701563'
+  sha256 'febb7078173d01199a587c29722aea4ba8515581afd9aff525eb7803d9867133'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"
   appcast 'http://updates.devmate.com/com.dmitrynikolaev.numi.xml',
-          checkpoint: 'c36849ccf43d30f885d718ad155168bc999023253585672d1be1b5795e48236c'
+          checkpoint: '3d3c0c1dd63997eddca5f550ec5190ae969d1d51533cd906ae0e2172675e3e5b'
   name 'Numi'
   homepage 'https://numi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}