### PR TITLE
Update caret to 3.2.1

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '3.2.0'
-  sha256 '69d36574574aab004bfab950694072aa43abea14612304f15e5d34b4225c0abd'
+  version '3.2.1'
+  sha256 '6b78ee73f50cd637624cccc780eb5cf9b4a81c6d8fb3f18d4bc5d11d44e04651'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '313a6a7f125770fe01111e3230b4da673588beb2ead52200d05b18dff252564f'
+          checkpoint: '4cc82530a6efb155fad7a6142d0437584a67a73fe0d84006ecf15ee7ec1147a1'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}