### PR TITLE
Update the-escapers-flux to 7.1.2

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.1.0'
-  sha256 '08f24df342d7abc50ceaa01cbaddd66619c57df498f747eff29281e752e6ceee'
+  version '7.1.2'
+  sha256 '36dc2830072bdd59bce6326899404ee52664b6d448ebaa97c6f25cca507a6cb3'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '6bf528da2a326f87abb64653d237684a367137171a35c8934a65a795c5d5ac19'
+          checkpoint: 'b48fdd17ba6406585ec934ca63493844329233c1aa6a0b8c2398f9a6fc7c24dd'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}