### PR TITLE
Update onlyoffice to 4.4

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,10 +1,10 @@
 cask 'onlyoffice' do
-  version '4.3'
-  sha256 'cc71c3e66059e209910b8e273f9c9493e098a392e60735f981c135ab6a9bc2ce'
+  version '4.4'
+  sha256 'ef98728c2b644e025d75c4abb722da71627e9d56169e4cd8ff95487e9ae27ce6'
 
   url "http://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'http://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml',
-          checkpoint: 'c46e9714ef779a757717ee2ef2c2663b1ef714ac0b974cd8c8dcd3fcf4ec6e13'
+          checkpoint: '3ba11ef937106e8a2cbc29434efb68419b8f3c49abc288f5dbb295a005c5a019'
   name 'ONLYOFFICE'
   homepage 'https://www.onlyoffice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}