### PR TITLE
Update pyfa to 1.30.0,yc119.7-1.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.29.4,yc119.5-1.0'
-  sha256 '14cfdaaf480b98e08b88cf6015064ac4f7873c276cc96ae6770b5e56c6e05e2a'
+  version '1.30.0,yc119.7-1.0'
+  sha256 '2fecdb7792de43158e5d3662547ae6fbf2d9c9c1f2816a0016b15434657501c0'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '839cab356a4b1c4a0ad7e6f8a33b4f68ba479973494540f22261104f438c8e78'
+          checkpoint: 'a41c2fdb1aec564129fa98d3c0242eb529959411081fbaad05e20e16522fe64c'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}