### PR TITLE
Update studio-3t to 5.3.5

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.3.4'
-  sha256 'a81b31ccf43dcda4374f04f6475a4aefd6e671742155e560224f8eb91a26f374'
+  version '5.3.5'
+  sha256 '8c06bf4c9d6a7190c6665133a892e2a5b9f1201fe3a65ce19d736d6964987a7a'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '3320890a84c3fe972e75fe1bb77de8cf5acd50b9218fa8239b6b3a9ce2e52754'
+          checkpoint: 'b7c9ead7645dd3b6d9b0db600905ffc8a606843d8f80be9d2d9abbc463820dd7'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}