### PR TITLE
Update nzbget to 19.1

### DIFF
--- a/Casks/nzbget.rb
+++ b/Casks/nzbget.rb
@@ -1,11 +1,11 @@
 cask 'nzbget' do
-  version '19.0'
-  sha256 '02896f52816a0c093515ef8a0ce111ec7ce32c308d007c9b46864067a36d71f4'
+  version '19.1'
+  sha256 '31968feb84de337353d3a8387e3ac3cba2c1cebe2e9a432b7ff4e42407c1dea8'
 
   # github.com/nzbget/nzbget was verified as official when first introduced to the cask
   url "https://github.com/nzbget/nzbget/releases/download/v#{version}/nzbget-#{version}-bin-macos.zip"
   appcast 'https://github.com/nzbget/nzbget/releases.atom',
-          checkpoint: 'cdf5ef1d82b91e409686b3dcd2affd82d2ccde86246af5682dab547979a539cb'
+          checkpoint: '23cbf7664ec459011bc7f3df37a702dcba86e0ba17437e6a8326739ce8c128ac'
   name 'NZBGet'
   homepage 'https://nzbget.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}