### PR TITLE
Update google-earth-pro to 7.3.0.3827

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask 'google-earth-pro' do
-  version '7.1.8.3036'
-  sha256 '6eff03463b4ae435d7e27a5501352e85ed7b92eadafbe341c3b88784f6d4fd4e'
+  version '7.3.0.3827'
+  sha256 '85e49d4a377b148a4529f53624114647d6da9714074cc8b2c147ed152f2d25a0'
 
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg'
   name 'Google Earth Pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}