### PR TITLE
Update rar - sha256 no_check

### DIFF
--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -1,6 +1,6 @@
 cask 'rar' do
   version '5.5.b5'
-  sha256 'a0ae92f5cf0c16cccbc2067292396135e16477594ce026eae9120ad82769470e'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "http://www.rarlab.com/rar/rarosx-#{version}.tar.gz"
   name 'RAR Archiver'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/36399

This was updated to a beta for a security fix. https://github.com/caskroom/homebrew-cask/pull/35866

Updated in-place a few days ago. https://github.com/caskroom/homebrew-cask/pull/36295

Changing to `no_check` until a stable `5.50` release.