### PR TITLE
Update toggldesktop to 7.4.53

### DIFF
--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop' do
-  version '7.4.47'
-  sha256 '1dd41946486763c767aa25ecf425e3cbf529c7bd95060a88776655581df627f7'
+  version '7.4.53'
+  sha256 'be99aec956a5c0c462abb0aeac86433c0d6f7b9fd6cf52de3b30d58453c04c40'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml',
-          checkpoint: '981b83d74b75daa47e4f07aedd1bf08fadef51542bec3a512b8ad31761ec3db0'
+          checkpoint: '9454d90a2bdf976c0ad4cf88495e6324e1c36c4a4c564335d2d4df2580b0c8a1'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}