### PR TITLE
Update 4k-stogram to 2.4.2.1306

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,10 +1,10 @@
 cask '4k-stogram' do
-  version '2.4.1.1296'
-  sha256 'ec2b4dad2fc0ec7f46ff2d6eada87ad9fa84426e79298725b15172f84051d379'
+  version '2.4.2.1306'
+  sha256 '5e6b21b06587a98a048640f1fe6e653a40e4f2d4489701995c64e1520580e3cf'
 
   url "https://downloads2.4kdownload.com/app/4kstogram_#{version.major_minor}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '29846a3e3c2576f8500fe70c2df014c24e61d3b809f69e9dee980614916f56d3'
+          checkpoint: '49ff507a887439ff101f36b84c58788834a7a4a7638127609c8a49fa6278b627'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}