### PR TITLE
Update acronis-true-image to 2017.11.04,6115

### DIFF
--- a/Casks/acronis-true-image.rb
+++ b/Casks/acronis-true-image.rb
@@ -4,7 +4,7 @@ cask 'acronis-true-image' do
 
   url "https://dl.acronis.com/s/AcronisTrueImage#{version.major}.dmg"
   appcast 'https://www.acronis.com/en-us/support/updates/changes.html?p=39955',
-          checkpoint: '64a5df85dc47fd0fe89569d55f4d4fdc1d4f9e8da9ef72a79b2ad5205296b402'
+          checkpoint: '8c25836b3c2cf2bc0a083c1d6742138eae724fcd06bb0c79b9179edb25a1fdd0'
   name 'Acronis True Image'
   homepage 'https://www.acronis.com/de-de/personal/computer-backup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}