### PR TITLE
Update brave to 0.17.16

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.17.13'
-  sha256 'd32bcbbd015af192aae33c3dc69d722d1c774cd7d705ad93396cc22a835ba323'
+  version '0.17.16'
+  sha256 'a6d47e1dd02c90d2daf8d0e2d7a160ec63205f2cfeaaee329edfc370a556d6fc'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '7aed2b5c599512210351090c0c30e0b6d0d934f1704b9176d4611dde2079883d'
+          checkpoint: 'dfcf4d0f135a37404d12c33617ca81e320669e1bf1608b8d712484befaa3b59d'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}