### PR TITLE
Update aircall to 1.4.10

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,10 +1,10 @@
 cask 'aircall' do
-  version '1.4.6'
-  sha256 'af236681d59eaad9178d98ce8ff277bf7feb1cb10ec61de2f37205e0363cbc93'
+  version '1.4.10'
+  sha256 'c70ae1bd8913ca9c3b1dd5037d600f4c9e901bc38a17829fb11b7f1d4579a5eb'
 
   url "https://electron.aircall.io/download/version/#{version}/osx_64?filetype=dmg&channel=stable"
   appcast 'https://electron.aircall.io/update/osx/1.1.0',
-          checkpoint: '49896c1d229b67bd8f347dc82acdca6407198205204efc6952de1d1664ca33bb'
+          checkpoint: '891aa7db25ac73b5d2c654381b8bae5c9c981629b0c51abd2096e6c9946214c1'
   name 'Aircall'
   homepage 'https://aircall.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}