### PR TITLE
Update dollydrive to 3.96,39625

### DIFF
--- a/Casks/dollydrive.rb
+++ b/Casks/dollydrive.rb
@@ -1,10 +1,10 @@
 cask 'dollydrive' do
-  version '3.94.12'
-  sha256 '654c2b0d5a6eab71e6bf60769ace36f5c24b287d00ce8f5b6fcb47ac904825ee'
+  version '3.96,39625'
+  sha256 '87d3925035f8af2a410c035f426d1e47115d119fb08f4a5e14e4972399263a71'
 
-  url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.major_minor}_#{version.no_dots}_CERTIFIED.zip"
+  url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.before_comma}_#{version.after_comma}_CERTIFIED.zip"
   appcast "http://www.dollydrive.com/dolly#{version.major}.xml",
-          checkpoint: '3ff4fe0e5a38053b5179774599043aa76b718d6af4286d28ace8a8bce93524d1'
+          checkpoint: '4e4d8683c5b445f35a83f963c82963d70b68bc16b8235d0db37788eda253de88'
   name 'DollyDrive'
   homepage 'http://www.dollydrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}