### PR TITLE
Update inkdrop to 3.7.1

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,11 +1,11 @@
 cask 'inkdrop' do
-  version '3.6.1'
-  sha256 '245ff3e0f89d163fb39df99d3ecf8588e6a2ca69cafddfdd965976eed5b00f0c'
+  version '3.7.1'
+  sha256 'bb2d841f769e02a7b8ce911a2a6cf85939dd6a4b4a5bc45f8de21bbbe7f2375e'
 
   # github.com/inkdropapp was verified as official when first introduced to the cask
   url "https://github.com/inkdropapp/releases/releases/download/v#{version}/Inkdrop-#{version}-Mac.zip"
   appcast 'https://github.com/inkdropapp/releases/releases.atom',
-          checkpoint: '349c8d8ab37f69d278717628e85c613ab6819b4d1045c68f0b6170e460535f8c'
+          checkpoint: '7b19281f2a3a7fd9f30882850bd60b4436eea3fd51ef9bbae36fb28f4c5516a2'
   name 'Inkdrop'
   homepage 'https://www.inkdrop.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}