### PR TITLE
Update jclasslib-bytecode-viewer to 5.2

### DIFF
--- a/Casks/jclasslib-bytecode-viewer.rb
+++ b/Casks/jclasslib-bytecode-viewer.rb
@@ -1,10 +1,10 @@
 cask 'jclasslib-bytecode-viewer' do
-  version '5.1'
-  sha256 '02231f57c3672851ea3ce8d9a304641a3c278e4e71abb73067f9db0c6e5f5d64'
+  version '5.2'
+  sha256 '50771508ee35f57f138f46a0def4f31927f00d3f1275c25259247faf223fa7b4'
 
   url "https://github.com/ingokegel/jclasslib/releases/download/#{version}/jclasslib_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/ingokegel/jclasslib/releases.atom',
-          checkpoint: 'e2942d241e41f411bde1977a2ba61570497f1a3f1d7bed9d95f1956b44db231f'
+          checkpoint: '983038f2613ba53c0186c85a30e2d80bd848c0ef8b33163d3f8c24b2336f7290'
   name 'jclasslib bytecode viewer'
   homepage 'https://github.com/ingokegel/jclasslib'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}