### PR TITLE
Update kotori to 0.24

### DIFF
--- a/Casks/kotori.rb
+++ b/Casks/kotori.rb
@@ -1,10 +1,10 @@
 cask 'kotori' do
-  version '0.23'
-  sha256 '5580ff12ef4233dcbea8dc797ab5008ca53b97236831e5d4861f755dab533300'
+  version '0.24'
+  sha256 '02b2cf71d5ff4138a768781c920232ab905d852e20b3db0e178c3d611f640636'
 
   url "https://github.com/Watson1978/kotori/releases/download/v#{version}/kotori_#{version}.dmg"
   appcast 'https://github.com/Watson1978/kotori/releases.atom',
-          checkpoint: 'a5cb9f6f791624e6f4c2ab5f5e30760b6f0cafb0fdd3a23f632a9f049196439b'
+          checkpoint: 'cede69926c796533f8b4d0c24887d9bf028ef7a3824d29450b3963e4ac52ed07'
   name 'kotori'
   name '小鳥'
   homepage 'https://github.com/Watson1978/kotori'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}