### PR TITLE
Update archi to 4.0.2

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,10 +1,10 @@
 cask 'archi' do
-  version '4.0.1'
-  sha256 'e9878c66975937f23f3ebd3a281785790ae3b32cb9f19a49a8b24787af126a6d'
+  version '4.0.2'
+  sha256 'ad5c59e14ff09a1bd8cecb6bb739a5e8ff60bd9644fb8a0772224469d652686f'
 
   url "http://www.archimatetool.com/downloads/release/v#{version.major}/Archi-mac-#{version}.zip"
   appcast 'https://github.com/archimatetool/archi/releases.atom',
-          checkpoint: '3c389b77dfe3bc869572814461b948ae00e067f629f0769776219166ba6864a4'
+          checkpoint: 'c2fad564fc2be522c1b2860280041c48c772b57b6065ce81ef97b5980ca77a3c'
   name 'Archi'
   homepage 'https://www.archimatetool.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}