### PR TITLE
Update latexdraw to 3.3.6

### DIFF
--- a/Casks/latexdraw.rb
+++ b/Casks/latexdraw.rb
@@ -1,10 +1,10 @@
 cask 'latexdraw' do
-  version '3.3.5'
-  sha256 '905da2d258baf777dff9cb14468207dff04094049f9bc82f050d8a8541967965'
+  version '3.3.6'
+  sha256 '01a29a4886cf71ad914724d38eb5d470fae707eac40f5f1e70d45673780e4b07'
 
-  url "https://downloads.sourceforge.net/latexdraw/LaTeXDraw-#{version}.app.zip"
+  url "https://downloads.sourceforge.net/latexdraw/LaTeXDraw-#{version}.app"
   appcast 'https://sourceforge.net/projects/latexdraw/rss?path=/latexdraw',
-          checkpoint: 'e032f06eb8bb7ed367670947673f763ff1d9b4a1cc662a969c28c29dcbcabe56'
+          checkpoint: '88d1f7154a75ba13476ee3ce6498452c54c23bb4d0a4aa5561c93c3bcda239ec'
   name 'LaTexDraw'
   homepage 'http://latexdraw.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}