### PR TITLE
Update mnemosyne to 2.5

### DIFF
--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -1,11 +1,11 @@
 cask 'mnemosyne' do
-  version '2.4.1'
-  sha256 'c302624b8652f397c18fe6cbdaf520c9898dd97a68b8a02f90b96cbe5177df8d'
+  version '2.5'
+  sha256 'bc96a436f59e1f7f02a536679c8a811db844b5a267e88962c2159f90937ac9d4'
 
   # sourceforge.net/mnemosyne-proj was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/mnemosyne-proj/mnemosyne/mnemosyne-#{version}/Mnemosyne-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/mnemosyne-proj/rss?path=/mnemosyne',
-          checkpoint: '0b5bd0a344a750820cb2ebce55dae58341670b395546cac3f8b3440c0e4ba602'
+          checkpoint: '43fb5c0bf4be29f6e67f10a3cef5994da60864520723073c22f8280860546272'
   name 'Mnemosyne'
   homepage 'http://mnemosyne-proj.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}