### PR TITLE
Update mongodb to 3.4.4-build.1

### DIFF
--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -1,11 +1,11 @@
 cask 'mongodb' do
-  version '3.4.3-build.1'
-  sha256 'a8be6a015386b247b841f4a8a18b93ee8bd307b7b33d8432f56e0dead0742962'
+  version '3.4.4-build.1'
+  sha256 'f302e4329b9dab24b389cb53d603bdc27abf8c5b0701da96a8878c8289a5d54a'
 
   # github.com/gcollazo/mongodbapp was verified as official when first introduced to the cask
   url "https://github.com/gcollazo/mongodbapp/releases/download/#{version}/MongoDB.zip"
   appcast 'https://github.com/gcollazo/mongodbapp/releases.atom',
-          checkpoint: '5a02dee4a4176129f578935a774af3373baf1ed5c25482e55c71a29e216b5d1c'
+          checkpoint: 'd402fc3ceb29eccdefc77ae01c7139ef4885e0000bbd7cbaabdfb5784344af02'
   name 'MongoDB'
   homepage 'https://elweb.co/mongodb-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}