### PR TITLE
Update mp3gain-express to 2.0.1

### DIFF
--- a/Casks/mp3gain-express.rb
+++ b/Casks/mp3gain-express.rb
@@ -1,10 +1,10 @@
 cask 'mp3gain-express' do
-  version '1.2'
-  sha256 '4bf1f7f900e11830ccb0acf248d1873d14db8b6b0e87386770adf85b6b6eda35'
+  version '2.0.1'
+  sha256 'bc949b6e1dcf804782fc95b4e6991a98e041a36fcec54b6a297fea9d4c41651c'
 
   url "http://projects.sappharad.com/mp3gain/mp3gain_mac#{version.no_dots}.zip"
   appcast 'http://projects.sappharad.com/mp3gain/updates.xml',
-          checkpoint: '6065d4e0b882f7b4d703bad0f6d64ad15f8afc11125f0d033857db773d9a3a7d'
+          checkpoint: '96fdeecd2fc58bdc4b2428c4f193e2f6edebf4a7b888c793e105cd08ef946ddd'
   name 'MP3Gain Express'
   homepage 'http://projects.sappharad.com/mp3gain/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}