### PR TITLE
Update choosy to 1.2.2

### DIFF
--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -9,7 +9,7 @@ cask 'choosy' do
 
   url "https://downloads.choosyosx.com/choosy_#{version}.zip"
   appcast 'https://www.choosyosx.com/sparkle/feed',
-          checkpoint: '93b9ecf77d1bb96cd4db63ced49152e9053bf380c2c616b736da2941937b40fa'
+          checkpoint: '26d78f4ed03425e2c1bb0bc7055a678c0df548a6f5aebf4f6d9b428811c92195'
   name 'Choosy'
   homepage 'https://www.choosyosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}