### PR TITLE
Updated cevelop to v1.8.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,10 +1,10 @@
 cask 'cevelop' do
-  version '1.7.1-201704211123'
-  sha256 '5561659187360aa635ce04220544eb841e2e245f1a757c9b90f5f7a8ecef228f'
+  version '1.8.0-201707131430'
+  sha256 '5317b246223334c3c46a82ca35df852b518b7ecdc6ff715c3ff77124c2642a89'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/',
-          checkpoint: '913de30886b050e25b8e0996cb593a18412d2dec9d5664fac00b668cbd7e0ef9'
+          checkpoint: 'c5873f22b5b702dfd01b0541ba18dbf354d42d71f1ab45e69e6f41ae5e3c7fe0'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.8.0.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.