### PR TITLE
Update cloudapp to 4.2.5

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,6 +1,6 @@
 cask 'cloudapp' do
   version '4.2.5'
-  sha256 'fd52e042cdb7abda070dba5f569354a41fedbf46c9970b600dd7f19a885162b9'
+  sha256 '6288cc1773b406457d0d4be4142594d68e7c1867a5f5128462b6196c6340e5fc'
 
   # amazonaws.com/downloads.getcloudapp.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: https://www.virustotal.com/en/file/6288cc1773b406457d0d4be4142594d68e7c1867a5f5128462b6196c6340e5fc/analysis/1500021989/