### PR TITLE
Update clover-configurator to 4.45.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,10 +1,10 @@
 cask 'clover-configurator' do
-  version '4.44.0'
-  sha256 '5c389cc4fcd45c259c64e576178edb554ec9a7ed52291256be547447dbbc2dac'
+  version '4.45.0'
+  sha256 'cbc80f8dbaf8bdbd26763d4e32a2265c36ef53e5df3cae1f2918c0b927c73068'
 
   url 'http://mackie100projects.altervista.org/download-mac.php?version=vibrant'
   appcast 'http://mackie100projects.altervista.org/apps/cloverconf/10.10/update.xml',
-          checkpoint: '543a1d547d7a0f9d0b21d5d3e5fde234de6dc7501fb8332e0a7caa6f7749f0e8'
+          checkpoint: '37404842f371ff0b189c55dba35efa869d2ff1e6bc8e39030370f354e9bee5fa'
   name 'Clover Configurator'
   homepage 'http://mackie100projects.altervista.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}