### PR TITLE
Update context-free to 3.0.11.3

### DIFF
--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -1,10 +1,10 @@
 cask 'context-free' do
-  version '3.0.11'
-  sha256 'ecc71fe3b9f7f589c1bd55fa551a4b0f5caaa9660770eb516fa148ce5d04ef87'
+  version '3.0.11.3'
+  sha256 '5baae1cf7487ea0902f781f0891d3f7dc2c01071ab9546a1e2523676ea45c0da'
 
   url "http://www.contextfreeart.org/download/ContextFree#{version}.dmg"
   appcast 'https://github.com/MtnViewJohn/context-free/releases.atom',
-          checkpoint: '6b36b78fb8b7843415e0c8daff96faf420896c32516cc364269f0263dba19080'
+          checkpoint: 'e870c4c9ad2c4e7dcd36b196f0008000a4f821cf6f86a55237067f37769f809b'
   name 'Context Free'
   homepage 'https://www.contextfreeart.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}