### PR TITLE
Update crypter to 3.0.0

### DIFF
--- a/Casks/crypter.rb
+++ b/Casks/crypter.rb
@@ -4,7 +4,7 @@ cask 'crypter' do
 
   url "https://github.com/HR/Crypter/releases/download/v#{version}/Crypter-#{version}.dmg"
   appcast 'https://github.com/HR/Crypter/releases.atom',
-          checkpoint: 'c27754561a4ceaee39898c4eb5d52062c8d4b4237f32d55132a602fdfd884450'
+          checkpoint: 'e0858d3f61c773b3c4d6bc567036ca3258875dd804657b36c41e04b4c64b0553'
   name 'Crypter'
   homepage 'https://github.com/HR/Crypter'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}