### PR TITLE
Update deepstream to 2.4.0

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -5,7 +5,7 @@ cask 'deepstream' do
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"
   appcast 'https://github.com/deepstreamIO/deepstream.io/releases.atom',
-          checkpoint: 'e018eef5240d2eaf2158a9c9dad2ba7d5bfe26d33a42762008f15b3bcb66d6aa'
+          checkpoint: '0bfc169e99e6f7f20c060de54122436f71f672c811fe7f4a319c6bc4781e3f61'
   name 'deepstream'
   homepage 'https://deepstream.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}