### PR TITLE
Update fork to 1.0.52

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.51'
-  sha256 'beabba4ea1f407f1f02bcf966b77f7a2e5baecfe154a6e0af14115d0186c1057'
+  version '1.0.52'
+  sha256 'f1584b9b7016d4618abe15a44b13278ecf164875b5012e6f9b5d3f60d05ad532'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '642961c5f84bbe638bed24d67bd8f831f332bb83ec7c6b16e29ad2ca78626655'
+          checkpoint: '23b1312f08d0e03f2b0e94cbd5dd9ab12116aaf0e37ee36a6a3d8434772c16c5'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}