### PR TITLE
Update tad.rb

### DIFF
--- a/Casks/tad.rb
+++ b/Casks/tad.rb
@@ -1,13 +1,14 @@
 cask 'tad' do
-  version '0.8.4'
-  sha256 'b33e31d9f3ca4c45ecf382cfdc28cb37d1f0d5d38ed0afc2f99226b0eca23bf2'
+  version '0.8.5'
+  sha256 'd18ee34912d9730dfd8608a0063aaadac83ed56ae168e2659650f7133142eacb'
 
   # github.com/antonycourtney/tad was verified as official when first introduced to the cask
   url "https://github.com/antonycourtney/tad/releases/download/v#{version}/tad-#{version}.dmg"
   appcast 'https://github.com/antonycourtney/tad/releases.atom',
-          checkpoint: 'f4225bce372de45c0369167b06084ef971a3344597b9a67ab7d74c6a7604b1b2'
+          checkpoint: '047fd74d0603b63f2f51f2fecb8bae52128787cb664df1d5b3bcc0a1d2a3a5a1'
   name 'Tad'
   homepage 'http://tadviewer.com/'
 
   app 'Tad.app'
+  binary "#{appdir}/Tad.app/Contents/MacOS/Tad", target: 'tad'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Closes https://github.com/caskroom/homebrew-cask/issues/36538.