### PR TITLE
Update doomsday-engine to 2.0.2

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -5,7 +5,7 @@ cask 'doomsday-engine' do
   # sourceforge.net/deng was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/deng/rss',
-          checkpoint: 'cc90b05250432b8e38a3637fe15917cd4cc66662916e04fea7ad7f0c21db76db'
+          checkpoint: 'fe367d8acb08fbcc5357afd28de2536c94d8fb5b2127355c2e2ee60d5c463a8b'
   name 'Doomsday Engine'
   homepage 'https://dengine.net/'
 

--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,11 +1,11 @@
 cask 'doomsday-engine' do
-  version '2.0.1'
-  sha256 'c4dfbfdc452bb6d1552a3ab9c5da0ab74352ed044d783ed0e7729668a2a12f83'
+  version '2.0.2'
+  sha256 'dfd6e8a0399bc5a1a828b43254160c5523edbe74077fd0668b9f3bc6637be45a'
 
   # sourceforge.net/deng was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/deng/rss',
-          checkpoint: '4df660f7418c2dfd1be9d923695708b44d2a0353e240c4d25f2930f88cb01e73'
+          checkpoint: 'cc90b05250432b8e38a3637fe15917cd4cc66662916e04fea7ad7f0c21db76db'
   name 'Doomsday Engine'
   homepage 'https://dengine.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}