### PR TITLE
Update fldigi to 4.0.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.6'
-  sha256 '5364eac98775094e2a37f140c5ea0261deaa28d459bf7bf42c36b2965f98cfb7'
+  version '4.0.7'
+  sha256 '66466560f28e5e18edeef6673d941e45346bf1a84423766d4ee9a9439032bece'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: '27bbacb30ebbed8e86bd611961027aef90bfaaed00e550e182358d031cf5baa7'
+          checkpoint: 'e6fff3321535dfd0859c3042833132886967212b1ea19465187c8514f0414962'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -4,7 +4,7 @@ cask 'fldigi' do
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'e6fff3321535dfd0859c3042833132886967212b1ea19465187c8514f0414962'
+          checkpoint: 'ee2330d042d6df30eb9647b195eafb613323636c3ca68c459d9da056e9ff41ae'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}