### PR TITLE
Update navicat-for-mysql to 12.0.9

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.7'
-  sha256 'b1083c4a4727879619cf62fb8259e1810909e6b58235ce5aaba843fa62c7ef69'
+  version '12.0.9'
+  sha256 'ea8aa19ae46e57f7762bcb6cae2f082650675119be2a6620642ff90b148938e1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note#M',
-          checkpoint: '59ee399fc001a0b69cad9f3d54f12c09649e14eedf97f3eded2010c0c9407f17'
+          checkpoint: '9b92707d3cf5f4355e623c6cea606d47176d900a2fdfdcee258fad17b24c3a99'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}