### PR TITLE
Update navicat-for-sql-server to 12.0.9

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.7'
-  sha256 '424f794eb4581449b08218f797d53150eaa5373770bfa946bf4217a5b8e10359'
+  version '12.0.9'
+  sha256 'f1ed72d07a79600c95a969632365ed8f8223e20f6dc2818737ce095656d307a1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note#M',
-          checkpoint: '05a0ed62125794426753c5a9eecbc9713e016b7e805ae71beacc382aa74180cd'
+          checkpoint: '7141a0cea3e1e67444f620a8fbfa87eeaa47e51ab59bd3a03ff2a6764c580a18'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}