### PR TITLE
Update navicat-for-sqlite to 12.0.9

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.7'
-  sha256 'eec796045334b2e9ad4d487b43a5b70335bf8c5f0c83bda0f2d11e3765b8f220'
+  version '12.0.9'
+  sha256 '71eb73e5f6ab1dfc4a94f1c4d12e7275348a9e682546eea445621475e87e632d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note#M',
-          checkpoint: '64cac2b68826fd3eee6581712bc2763812fa382d2b12c63f9d1e0001fc4ff06c'
+          checkpoint: 'd2218389e4dff13e75cc049cc37f6b9a17bf8bead07a5a0c85a6c56b6933e9d0'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}