### PR TITLE
Update polymail to 1.40

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.39'
-  sha256 '89bc6f2a0245961ab205a27e52f032d90d0d165824a616ce947a8d4e615f5872'
+  version '1.40'
+  sha256 '0d65877b693ce57d766f4e583f5ac977ec40a04123f82d52cfbd6d9a4af517d2'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'c7edbad342f80754f20fdf1b797fd50f301c530189db8f3eba2e26f36f0bc8f5'
+          checkpoint: '9d99f7c42935c08a94bf37627c88f8e007bcf8711c8c3443bfe0808e6e326632'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.