### PR TITLE
Update unity-windows-support-for-editor to 2017.1.0f3,472613c02cf7

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '5.6.2f1,a2913c821e27'
-  sha256 '47c3fd017bf7099e16db043666f88cd6f89f9814b8b1881202a9339240bf20d1'
+  version '2017.1.0f3,472613c02cf7'
+  sha256 'cb403ba4c64b5faf9ef74982b35c8bfa299abbdc24075ddcfc9fbfe3eb13ceb5'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Windows Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}