### PR TITLE
Update prefs-editor to 1.2.3

### DIFF
--- a/Casks/prefs-editor.rb
+++ b/Casks/prefs-editor.rb
@@ -1,8 +1,10 @@
 cask 'prefs-editor' do
-  version :latest
-  sha256 :no_check
+  version '1.2.3'
+  sha256 '7d1ba23c60ffa085e581a3d7c326df6f833b2778755f60b31fa3812cfc53a4ca'
 
-  url 'http://files.tempel.org/Various/OSX_Prefs_Editor/PrefsEditor.zip'
+  url "http://files.tempel.org/Various/OSX_Prefs_Editor/PrefsEditor-#{version}.zip"
+  appcast 'http://apps.tempel.org/PrefsEditor/appcast.xml',
+          checkpoint: '318a32c8958d155691c6a1bb81f2209cb33754a67252b2f6e18d6fabf9310dbb'
   name 'Prefs Editor'
   homepage 'http://apps.tempel.org/PrefsEditor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update `url`. Add `appcast`, `version` and `sha256`