### PR TITLE
Update fotomagico to 5.4.3-22666

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,10 +1,10 @@
 cask 'fotomagico' do
-  version '5.4.2-22652'
-  sha256 'eb5cc2032db34ac6460313c18895842be9ca45bcb654dab71d2178babb81df75'
+  version '5.4.3-22666'
+  sha256 '27666b42b4cc1a4fd2ce01381610a94a35e304f6c400b43f764ecc6c5355e00e'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://www.boinx.com/d/connect//histories/fotomagico',
-          checkpoint: '6163e011fc17f4335203652980ff318a7c616f74d78a516317cadbaa67ad7a0d'
+          checkpoint: '9727c0a09a7f2ce884677cdd74963cb201899f2f552b1d85ea6a5ec25e2faea7'
   name 'FotoMagico'
   homepage 'https://www.boinx.com/fotomagico/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}