### PR TITLE
Update fredm-fuse to 1.3.7

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,10 +1,10 @@
 cask 'fredm-fuse' do
-  version '1.3.6'
-  sha256 'd4cb5ef2446e67d075f53426c33ec3b674f91f2a2a25cf9b312675a85314feb9'
+  version '1.3.7'
+  sha256 'c86c2820ca65af064bb9971cfb7cdff81f2f974c3492ea10d7cc7d0c82493a08'
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '2c76f89cc4facdf0d95628b02804a78e0e7d6c2f048a7ce562fc6ca94fb47159'
+          checkpoint: '9b4362ea3a1b8e0eae268315258065061af8bd4f0a58f4e3cb7684e51c9de025'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}