### PR TITLE
Update tankix to 677

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '676'
-  sha256 '1d6efde3d133889e8d8a3c804be1959d56a7df2901146e2feaa860c0039930d8'
+  version '677'
+  sha256 '460764ea193bfc4f82637558a6f5d6ea0fc9002dfe3fe0599fe4cecfffd1eecb'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/prod_#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}