### PR TITLE
Update geotag to 4.0.2

### DIFF
--- a/Casks/geotag.rb
+++ b/Casks/geotag.rb
@@ -1,15 +1,10 @@
 cask 'geotag' do
-  if MacOS.version <= :mountain_lion
-    version '2.2'
-    sha256 'c5553af3b37903b7e4f402d8c9fbeced63492295c6bdd25987dd70ab367c32e9'
-  else
-    version '3.5.8'
-    sha256 '02dcf8c87b69ab517f0c7919104da97ca09028c41f1b8c408026331b29a36685'
-  end
+  version '4.0.2'
+  sha256 '513b422ea25c21630cb9946dd597d44dbc46199c25c66ace1736037dc296c97f'
 
   url "https://www.snafu.org/GeoTag/GeoTag-#{version}.dmg"
   appcast 'https://www.snafu.org/GeoTag/',
-          checkpoint: '30f80a387e9aad3cf530878242d2d8bc4489ddb1cdbd1b0b3f2127cc4058d837'
+          checkpoint: 'e34194cba9d767551e615c05bd5e5547a9e688587c3e4e6eedf7e2b976954719'
   name 'GeoTag'
   homepage 'https://www.snafu.org/GeoTag/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}