### PR TITLE
Update gephi to 0.9.1

### DIFF
--- a/Casks/gephi.rb
+++ b/Casks/gephi.rb
@@ -5,7 +5,7 @@ cask 'gephi' do
   # github.com/gephi/gephi was verified as official when first introduced to the cask
   url "https://github.com/gephi/gephi/releases/download/v#{version}/gephi-#{version}-macos.dmg"
   appcast 'https://github.com/gephi/gephi/releases.atom',
-          checkpoint: '1f99988a585f7c98e3a95d775887ad8ccd827865c47047740bb9a5ccfac0da67'
+          checkpoint: '69dacb6508d264fcd35789495674f909c6166cdae43625b208fed0c854082418'
   name 'Gephi'
   homepage 'https://gephi.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}