### PR TITLE
Update glyphs to 2.4.2-1043

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.4.2-1029'
-  sha256 'dce89ce890ff3a0dd8fe3eb3322e4d979db44a4f8689658f8e9b6e0a7ea0b893'
+  version '2.4.2-1043'
+  sha256 'fbde454ade6b88afbfb5af0df617576d27bbcd6c046370f3b7358d6d02e50062'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: 'ff5df21d32fab1fb5171cca67d4c3ba0a2b18cd5d3c63806cb49047089f25cbf'
+          checkpoint: '6e53ed25e0b8f96f0fd708a88fc087d6c7da349940cf6f3fe8f91d7cb9c079b5'
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}