### PR TITLE
Update google-play-music-desktop-player to 4.3.0

### DIFF
--- a/Casks/google-play-music-desktop-player.rb
+++ b/Casks/google-play-music-desktop-player.rb
@@ -5,7 +5,7 @@ cask 'google-play-music-desktop-player' do
   # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
   url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"
   appcast 'https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases.atom',
-          checkpoint: '27cf7147e022a5f64ca7fb4dea73597499e6e584cbfdee2ea269b9e0c30899cd'
+          checkpoint: '9e44e95944481b7485480a0288aa3e94f84975c921b21e1708f0f7a96725d0ec'
   name 'Google Play Music Desktop Player'
   homepage 'https://www.googleplaymusicdesktopplayer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}