### PR TITLE
Readd google-earth 7.1.8.3036

### DIFF
--- a/Casks/google-earth.rb
+++ b/Casks/google-earth.rb
@@ -1,0 +1,23 @@
+cask 'google-earth' do
+  version '7.1.8.3036'
+  sha256 'a6cdb98e2caf0162c425b1acc0dab6196a220bf59eef378624b8b7c60a22bf18'
+
+  url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthMac-Intel.dmg'
+  name 'Google Earth'
+  homepage 'https://www.google.com/earth/'
+
+  pkg "Install Google Earth Free #{version}.pkg"
+
+  uninstall pkgutil: [
+                       'com.Google.GoogleEarthPlus',
+                       'com.Google.GoogleEarthPlugin.plugin',
+                     ]
+
+  zap delete: [
+                '~/Library/Application Support/Google Earth',
+                '~/Library/Caches/com.Google.GoogleEarthPlus',
+                '~/Library/Caches/Google Earth',
+                '~/Library/Preferences/com.Google.GoogleEarthPlus.plist',
+              ],
+      rmdir:  '~/Library/Caches/Google Earth'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This reverts https://github.com/caskroom/homebrew-cask/pull/36523 and reverts the changes made to `google-earth` in https://github.com/caskroom/homebrew-cask/pull/36409 and https://github.com/caskroom/homebrew-cask/pull/36500.

Google seems to have downgraded to `7.1.8.3036` and made "Google Earth Free" available for download.