### PR TITLE
Update lighting to 1.1.7

### DIFF
--- a/Casks/lighting.rb
+++ b/Casks/lighting.rb
@@ -1,10 +1,10 @@
 cask 'lighting' do
-  version '1.1.6'
-  sha256 'd526872a51249479795ce6cc8684c123d7c288f6bfdf4910d05a3b5703a43386'
+  version '1.1.7'
+  sha256 '8cab328133decacb8a608b034dae899e1105c20d97ec791ff089ddbbb0510d4f'
 
   url "https://github.com/tatey/Lighting/releases/download/#{version}/Lighting-#{version}.zip"
   appcast 'https://github.com/tatey/Lighting/releases.atom',
-          checkpoint: '721c6a4a4a9f2f0819dd63ee5e08625e3841042448d9c37e455755abee1e846e'
+          checkpoint: '8d2bc2228d99b89bad367d7a1abbbf545c5b270708f93087f15026d10c8ea7fb'
   name 'Lighting'
   homepage 'https://github.com/tatey/Lighting'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}