### PR TITLE
Update psi to 0.15

### DIFF
--- a/Casks/psi.rb
+++ b/Casks/psi.rb
@@ -5,7 +5,7 @@ cask 'psi' do
   # sourceforge.net/psi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psi/Psi-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/psi/rss',
-          checkpoint: '6b691e4a98bad7d78a2950991802450741fdca717ccd881bf324f73b07834220'
+          checkpoint: '6deea178cf2eb60cad4c796b71826028cb13945b952430c9e4bdb9adb6319753'
   name 'Psi'
   homepage 'http://psi-im.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}