### PR TITLE
Update imageoptim to 1.7.1

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,10 +1,10 @@
 cask 'imageoptim' do
-  version '1.7.0.1'
-  sha256 'ebcf28a510bca4ecee44150e0c65c30f27c1db6cc25c213328c93ceb59643a8b'
+  version '1.7.1'
+  sha256 '7d5dfb69568559d6932cbe5a512e0d0b4af56fbc364e67302affe2bef07b8a7f'
 
   url "https://imageoptim.com/ImageOptim#{version}.tar.bz2"
   appcast 'https://imageoptim.com/appcast.xml',
-          checkpoint: '304f6afe472866f93bc16c090226d46108cfecc20b5907243f4f163bfb8df52f'
+          checkpoint: '931c407d8ceddf9d2a1c4c5de280c6ed0602118a9f35b6466d296f74a109b53f'
   name 'ImageOptim'
   homepage 'https://imageoptim.com/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}