### PR TITLE
Update hab to 0.25.1-20170708003355

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,6 +1,6 @@
 cask 'hab' do
-  version '0.25.1-20170708003355'
-  sha256 'c015ff55d00a9de0a20e3b24b121925656ae7a724b4afc44633df988e6875ffc'
+  version '0.26.1-20170715032253'
+  sha256 '5835891dbb8f7d5a14c153d182cbfa17cff0c835c0ac90cb7019f893ff694b16'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"

--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -5,7 +5,7 @@ cask 'hab' do
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '1923540425b658e1480c30ce8932e8f579b456e61ed92380fcbb460d36662c74'
+          checkpoint: '591b43b67c430f83edff841178b812c86c1baf9fc6267ae6c05398cf89db1fc2'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}