### PR TITLE
Update grabbox to 2.0.0

### DIFF
--- a/Casks/grabbox.rb
+++ b/Casks/grabbox.rb
@@ -1,12 +1,12 @@
 cask 'grabbox' do
-  version '0.4.2'
-  sha256 'e6f92efce8585b58d1b5d9afc4a2187e07bf76c14961aff1b83a8422fb342f2f'
+  version '2.0.0'
+  sha256 '7d8d01aff457666380c38c1a8799c64851c90dc1d5c84f5697f55cfae6b27036'
 
-  url "http://grabbox.devsoft.no/updates/GrabBox%20Beta%20v#{version}.zip"
-  appcast 'http://grabbox.devsoft.no/appcastBeta.xml',
-          checkpoint: '984e696e4034f787eae08c3977eb9a85fd5f8a02756f3b92fde13975f17dc334'
+  url "https://grabbox.bitspatter.com/updates/GrabBox-#{version}.zip"
+  appcast 'https://grabbox.bitspatter.com/updates/appcast.xml',
+          checkpoint: '3a10ed571d39005e4b3af39c3d56b6ce5c181bfcf3615c0478df6f126fab5548'
   name 'GrabBox'
-  homepage 'http://grabbox.devsoft.no/'
+  homepage 'https://grabbox.bitspatter.com/'
 
   app 'GrabBox.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}