### PR TITLE
Update grisbi to 1.0.0

### DIFF
--- a/Casks/grisbi.rb
+++ b/Casks/grisbi.rb
@@ -5,7 +5,7 @@ cask 'grisbi' do
   # sourceforge.net/grisbi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/grisbi/grisbi%20stable/#{version.major_minor}.x/Grisbi-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/grisbi/rss?path=/grisbi%20stable',
-          checkpoint: '8bc783ac775193a3212e54c1429eb18f9d285986c0d77fb507628402e8f0d68e'
+          checkpoint: '790edde71963156092aa6f4d118a4d1e13986f86d1d4f80fe6b874484a45b7a7'
   name 'Grisbi'
   homepage 'http://www.grisbi.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}