### PR TITLE
Upgrade MMEX.app to v1.3.3

### DIFF
--- a/Casks/mmex.rb
+++ b/Casks/mmex.rb
@@ -1,11 +1,11 @@
 cask 'mmex' do
-  version '1.3.1'
-  sha256 'c84f70258122b2c1037a745a6701fb8bc7a44a2bf9210f8e41152945333cd544'
+  version '1.3.3'
+  sha256 '36380329f017c9edef4b7c00aa076605298830031f9ee2ccd0aba6f7911e0ea1'
 
   # github.com/moneymanagerex/moneymanagerex was verified as official when first introduced to the cask
-  url "https://github.com/moneymanagerex/moneymanagerex/releases/download/v#{version}/mmex-v#{version}-macOS10.9.dmg"
+  url "https://github.com/moneymanagerex/moneymanagerex/releases/download/v#{version}/mmex_#{version}_macos10.9.dmg"
   appcast 'https://github.com/moneymanagerex/moneymanagerex/releases.atom',
-          checkpoint: 'd64a84e883064903f617f33b3c01c2925d239b9f630314e24a32795109802d87'
+          checkpoint: 'b7710b29a059b3f20a943e6d06dbcb95883f135eec8adc63ce625c93c98c0618'
   name 'Money Manager Ex'
   homepage 'http://www.moneymanagerex.org/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
_audit for mmex: passed_
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
**I was able to get it to pass initially, rubocop seems to be crashing now.**
- [x] The commit message includes the cask’s name and version.
_Upgrade MMEX.app to v1.3.3_

Additionally, if **updating a cask**:

- [x] If the `sha256` changed but the `version` didn’t,  
      provide public confirmation by the developer
_version changed, sha256 changed_