### PR TITLE
Update hachidori to 2.0b12

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,11 +1,11 @@
 cask 'hachidori' do
-  version '2.0b8'
-  sha256 '74da8cb0a48b894dca503cf8fd498da652d9a1bc14a37482e186d4b8641098e4'
+  version '2.0b12'
+  sha256 'e22551430945ffce90232485fc4fe89964207b900bcaa09c88243dfc12d05f15'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/Hachidori-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/hachidori/releases.atom',
-          checkpoint: 'f07684030a1b5aa4eb7293758fa7338a5fa89da0577571b195a3b60d9cd3e61d'
+          checkpoint: 'a37270b79c8f43a3a62e286e55562b3b7e1432fb5a394fc0eec918f29ef9e169'
   name 'Hachidori'
   homepage 'https://hachidori.ateliershiori.moe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}