### PR TITLE
Update bisq to 0.5.3

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.5.2'
-  sha256 'd2edab14c1ec8cf6f748c53c64fe7e8f0096cdbb3af4157da7b47da6c79496c8'
+  version '0.5.3'
+  sha256 'fa3b44ea298f66be697556b967d53e78964abc8b9da52bc8bad5e0500fd4b65b'
 
   # github.com/bitsquare/bitsquare was verified as official when first introduced to the cask
   url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
-          checkpoint: 'cfcd4a185ded5d1e6dd0ab8534439f97176362b99c80f8d83ff044b764a79034'
+          checkpoint: '9e0099bc84038f67609e5a3d7327f3adaffedfbac879f98ddc3b1a32706efb2d'
   name 'Bisq'
   homepage 'https://bitsquare.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}