### PR TITLE
Update hackety-hack to 1.0.1

### DIFF
--- a/Casks/hackety-hack.rb
+++ b/Casks/hackety-hack.rb
@@ -5,7 +5,7 @@ cask 'hackety-hack' do
   # github.com/downloads/hacketyhack/hacketyhack was verified as official when first introduced to the cask
   url "https://github.com/downloads/hacketyhack/hacketyhack/hacketyhack-#{version}.dmg"
   appcast 'https://github.com/hacketyhack/hacketyhack/releases.atom',
-          checkpoint: 'cfda5003270eacc46238ea3aa8982ef2c2db8e56ef3b2131adcddfdac437d91e'
+          checkpoint: 'de303742e55c3a64bf9425621a9ae430ea6c40ee5b0c51d0e16b970e9ba2c11c'
   name 'Hackety Hack'
   homepage 'http://www.hackety.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}