### PR TITLE
Update inspec to 1.31.1-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.30.0-1'
-  sha256 'f08843ba011fcb596bd729af631e8aea3629e125bd552f69fadd4b81b1c60c70'
+  version '1.31.1-1'
+  sha256 '9a3fbc0560cdeaa89df1de261d58dd1d993caac74482c073b550ff3602374dd6'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: '83e82046fe0b9f6c20710bc1f1401ae0da132e60872cf13cc50512bb54815d32'
+          checkpoint: '3727b9ad3e4b0e0db23aa01da65d7a127e30a34106ee9116c87dede7d87502a5'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}