### PR TITLE
Update jad to 1.5.8g

### DIFF
--- a/Casks/jad.rb
+++ b/Casks/jad.rb
@@ -4,7 +4,7 @@ cask 'jad' do
 
   url "https://www.varaneckas.com/jad/jad#{version.no_dots}.mac.intel.zip"
   appcast 'https://varaneckas.com/jad/',
-          checkpoint: '3e17e5ad6e2154b16d1a69d8f6acd5e983ae450a5107e128963c4e33b4eb3609'
+          checkpoint: 'bb55710550b36e3add01abe3d3746f0c12e6d9b1dbecc7c8898f997742b325d2'
   name 'Jad - the fast Java Decompiler'
   homepage 'https://varaneckas.com/jad/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}