### PR TITLE
Update kite to 0.20170713.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170629.0'
-  sha256 'd87aaa6c5fef1d9396b265ddf056dd4cb3b4310a28a3d04840bebc7b2557030c'
+  version '0.20170713.0'
+  sha256 'e770e310ac049715cb01fb97a16e86f0795e635efccc615c864c0b12a766992e'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '2e94f5ecca2fdf362389418175ef683ae0cb6bef73799a91574061b6329b0c83'
+          checkpoint: '22d3bc2dcbc481e0919d72756be78d05378eb8db7b0414d4a365aa5bf0a251c9'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}