### PR TITLE
Update zazu to 0.5.2

### DIFF
--- a/Casks/zazu.rb
+++ b/Casks/zazu.rb
@@ -5,7 +5,7 @@ cask 'zazu' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/tinytacoteam/zazu/releases/download/v#{version}/zazu-#{version}.dmg"
   appcast 'https://github.com/tinytacoteam/zazu/releases.atom',
-          checkpoint: '1b8094222b8cc1d81d7eec245ca9b0c8a4fa40020d72d8dcb410ffea4da8d188'
+          checkpoint: '4467936c2454df94c8e6b680d2343ce8afabe2734ee001e4292b3703cc6f0098'
   name 'Zazu'
   homepage 'http://zazuapp.org/'
 

--- a/Casks/zazu.rb
+++ b/Casks/zazu.rb
@@ -5,7 +5,7 @@ cask 'zazu' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/tinytacoteam/zazu/releases/download/v#{version}/zazu-#{version}.dmg"
   appcast 'https://github.com/tinytacoteam/zazu/releases.atom',
-          checkpoint: '4e9961944aab036beb9cebf4d8c20cd70e3b365a7e2f029e1dceda2ba0578d78'
+          checkpoint: '1b8094222b8cc1d81d7eec245ca9b0c8a4fa40020d72d8dcb410ffea4da8d188'
   name 'Zazu'
   homepage 'http://zazuapp.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}