### PR TITLE
Update zerotier-one to 1.2.4

### DIFF
--- a/Casks/zazu.rb
+++ b/Casks/zazu.rb
@@ -5,7 +5,7 @@ cask 'zazu' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/tinytacoteam/zazu/releases/download/v#{version}/zazu-#{version}.dmg"
   appcast 'https://github.com/tinytacoteam/zazu/releases.atom',
-          checkpoint: '4e9961944aab036beb9cebf4d8c20cd70e3b365a7e2f029e1dceda2ba0578d78'
+          checkpoint: '1b8094222b8cc1d81d7eec245ca9b0c8a4fa40020d72d8dcb410ffea4da8d188'
   name 'Zazu'
   homepage 'http://zazuapp.org/'
 

--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -4,7 +4,7 @@ cask 'zerotier-one' do
 
   url 'https://download.zerotier.com/dist/ZeroTier%20One.pkg'
   appcast 'https://github.com/zerotier/ZeroTierOne/releases.atom',
-          checkpoint: 'f6fff965c1d1377ab6c104a6282ca43aca3d893866d69aa2eb085e90b54aa1df'
+          checkpoint: '71ba09b3edd757ba67d9283c1203b1282d3a5d48ed9d6de6f147e152de6d075c'
   name 'ZeroTier One'
   homepage 'https://www.zerotier.com/download.shtml'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}