### PR TITLE
Update zest to 0.1.1

### DIFF
--- a/Casks/zazu.rb
+++ b/Casks/zazu.rb
@@ -5,7 +5,7 @@ cask 'zazu' do
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/tinytacoteam/zazu/releases/download/v#{version}/zazu-#{version}.dmg"
   appcast 'https://github.com/tinytacoteam/zazu/releases.atom',
-          checkpoint: '4e9961944aab036beb9cebf4d8c20cd70e3b365a7e2f029e1dceda2ba0578d78'
+          checkpoint: '1b8094222b8cc1d81d7eec245ca9b0c8a4fa40020d72d8dcb410ffea4da8d188'
   name 'Zazu'
   homepage 'http://zazuapp.org/'
 

--- a/Casks/zest.rb
+++ b/Casks/zest.rb
@@ -5,7 +5,7 @@ cask 'zest' do
   # github.com/zestdocs/zest was verified as official when first introduced to the cask
   url "https://github.com/zestdocs/zest/releases/download/v#{version}/zest-v#{version}.dmg"
   appcast 'https://github.com/zestdocs/zest/releases.atom',
-          checkpoint: '4e96ba4628f1ff8b6adec3c4b674af5bcb7b971cdb44d3a73367231550a7b221'
+          checkpoint: 'ce12604361b9320b61c35f325e639a45b2fba445d38f6de64b54686cc2d865c5'
   name 'Zest'
   homepage 'https://zestdocs.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}