### PR TITLE
Update composercat to 0.4.0

### DIFF
--- a/Casks/composercat.rb
+++ b/Casks/composercat.rb
@@ -1,6 +1,6 @@
 cask 'composercat' do
-  version '0.3.1'
-  sha256 '6944ccd5d9e641dc7ffac35107d18a776858a01c9f6518aa54496a796caed944'
+  version '0.4.0'
+  sha256 '32cbc8da97b13050aee645dc84e4fb799e105603920375a3212b83f7c4be9fa6'
 
   url "https://downloads.getcomposercat.com/composercat/Composercat-#{version}.dmg"
   name 'Composercat'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}