### PR TITLE
Update fork to 1.0.52.2

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.52.1'
-  sha256 '76db690b6be6391dd26b4cd0c6650747cd6cc15a79ca5fd71389b5e84e1f0ae8'
+  version '1.0.52.2'
+  sha256 'd75267f2564fe7bdde57313460b8feac3e65ccef746974589b2e46462dcb21ea'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '3e16aa6fae38c6d464665ab18032c9669d73ca6a84341821c146f3fd81460576'
+          checkpoint: 'a80dd32c29ca47a81b52aaf709f89321882b70402589e99be875c6284861a73f'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}