### PR TITLE
Update hammerspoon to 0.9.55

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -1,11 +1,11 @@
 cask 'hammerspoon' do
-  version '0.9.54'
-  sha256 'c7c9313b0bd7f892c13b4b7dc23e578bdec881af49e1552d9851000794c31baa'
+  version '0.9.55'
+  sha256 'c4b494f3ca6c1254564b04399114016b483424571c763b26c4c775f5b185fe18'
 
   # github.com/Hammerspoon/hammerspoon was verified as official when first introduced to the cask
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip"
   appcast 'https://github.com/Hammerspoon/hammerspoon/releases.atom',
-          checkpoint: '67022a741662cc92b2a2398d8d6ea6a9b3bde5ae020736124abc1636c4fc96c3'
+          checkpoint: '0e19eefbacf22da1012a91c3347c6be9bd51cc639c9edbe235a31a6154964b66'
   name 'Hammerspoon'
   homepage 'http://www.hammerspoon.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}