### PR TITLE
Update porting-kit to 2.6.150

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,10 +1,10 @@
 cask 'porting-kit' do
-  version '2.6.148'
-  sha256 '922f1a2132301b31a955ead36f782f30ef7821b07cf65ddd17fe87689c407a5a'
+  version '2.6.150'
+  sha256 '0aed7817a416f6021d60b6190c603b2224d2671a677a68726ab2eb8e59d4abce'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '1dabd3935feb14d0afa603da136c4b33985b0bc0df936bab5d1d5cfab07f4fad'
+          checkpoint: '64cfcf1b72c707b48811aed9cc01cd5353c4c54ba2bd9aa01e8aa7c8fa92f654'
   name 'Porting Kit'
   homepage 'http://portingkit.com/en/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}