### PR TITLE
Update qgroundcontrol to 3.2.1

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.2.0'
-  sha256 '210265941ccd2efc990ca4ee11d943d4aafb8e98ee09d180daf8502c04c2e873'
+  version '3.2.1'
+  sha256 '9131b3175b7a3fb380f453bdcf9c4b4311996924c80bbcb06090b22d6acc14f2'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: '5ab64372c8266e0c59085d23a18b632eac6750b6dad42bb4cc3265f8bfe91689'
+          checkpoint: 'c0d30ed2eb0172cb4e2cbaa12551c5042f15cf95ae591e01af441c684724bc1d'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}