### PR TITLE
Update komodo-edit to 10.2.2-17703

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,6 +1,6 @@
 cask 'komodo-edit' do
-  version '10.2.1-17670'
-  sha256 'fa911f9c7b1fe398d8ec69eb5207c37c11a09e1981c3efcb96e1c507de42d4c5'
+  version '10.2.2-17703'
+  sha256 'a4e61666fe1268ce560d6127957bc3a82104052fcdd49463426b8f33afead6cf'
 
   # activestate.com/Komodo was verified as official when first introduced to the cask
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}