### PR TITLE
Update iina to 0.0.12-build37

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -1,11 +1,11 @@
 cask 'iina' do
-  version '0.0.12'
-  sha256 'e563e45666a97a2c618dfcebfdfeae8ac22f6d68af0071a7b26f34458187152c'
+  version '0.0.12-build37'
+  sha256 '5b4bd7cc48cf153c3488539fa6a9f60a5850c60e616110553cc833358d66bcbe'
 
   # dl-portal.iina.io was verified as official when first introduced to the cask
   url "https://dl-portal.iina.io/IINA.v#{version}.dmg"
-  appcast 'https://github.com/lhc70000/iina/releases.atom',
-          checkpoint: 'f465cc540b2fdbe4582b02c2b5eec9a227cc78e0caef939f5e0dc852487e96c7'
+  appcast 'https://www.iina.io/appcast.xml',
+          checkpoint: '1a82d5afaeb09f22737d3c06195ac12afcedb9935c50d86fe4f770ecfe97d112'
   name 'IINA'
   homepage 'https://lhc70000.github.io/iina/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Ref: https://github.com/caskroom/homebrew-cask/pull/36631

The `iina` github releases page doesn't seem to reflect the current version available.
- https://github.com/lhc70000/iina/releases
- https://lhc70000.github.io/iina/
- https://www.iina.io/appcast.xml

![iina](https://user-images.githubusercontent.com/26216252/28322139-b1d47fe6-6c18-11e7-94f6-2a668325a831.png)
