### PR TITLE
Add Covered v2.0

### DIFF
--- a/Casks/covered.rb
+++ b/Casks/covered.rb
@@ -2,7 +2,7 @@ cask 'covered' do
   version '2.0'
   sha256 '7120675e783ecf43d35e75808bc60b3726ac9bb33541a2be155594fd1b315646'
 
-  url 'http://robheague.com/s/Covered-20.zip'
+  url "http://robheague.com/s/Covered-#{version.no_dots}.zip"
   name 'Covered'
   homepage 'http://robheague.com/covered'
 

--- a/Casks/covered.rb
+++ b/Casks/covered.rb
@@ -1,0 +1,10 @@
+cask 'covered' do
+  version '2.0'
+  sha256 '7120675e783ecf43d35e75808bc60b3726ac9bb33541a2be155594fd1b315646'
+
+  url 'http://robheague.com/s/Covered-20.zip'
+  name 'Covered'
+  homepage 'http://robheague.com/covered'
+
+  app 'Covered.app'
+end


### PR DESCRIPTION
I appreciate some logic can be applied to the URL but have had a good sniff through the docs and can't find the right way to apply version but removing the dot. Would appreciate feedback! Thanks!

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
