### PR TITLE
Update wireshark-chmodbpf to 2.2.8

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,10 +1,10 @@
 cask 'wireshark-chmodbpf' do
-  version '2.2.7'
-  sha256 '6d46e7270fc6b661ece24c0fcaf56c7e4ce4f65501ef055ea46c6cfdf95c6dcb'
+  version '2.2.8'
+  sha256 'efc681a6ef2bb52e76e15853c5d1b143078c548951d256283a53cc61c894d77f'
 
   url "https://www.wireshark.org/download/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.wireshark.org/download/osx/',
-          checkpoint: '6ee31ea196b816cef77baae0b19fb88c6bdef3af8543049d5a293ab3fba60838'
+          checkpoint: '4fa50cf63466dc33edae4b07387721c83d71aad5c3a636e11475d8edd0abfd8d'
   name 'Wireshark-ChmodBPF'
   homepage 'https://www.wireshark.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}