### PR TITLE
bump iMazing to 2.3.1

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,15 +1,15 @@
 cask 'imazing' do
-  version '2.3.0'
-  sha256 '79f0a8f50aadf5695bd6b89e6ceca0668eb0f043b3bdfeb6df25fcb6b18bed2e'
+  version '2.3.1'
+  sha256 '65820880df939380db9730117669a5f2c4c4a334660762900aeda9e54539a25e'
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing#{version.major}Mac/iMazing#{version.major}forMac.dmg"
-  name 'iMazing'
+  name 'iMazing Mini'
   homepage 'https://imazing.com/'
 
   depends_on macos: '>= :lion'
 
-  app 'iMazing.app'
+  app 'iMazing Mini.app'
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.digidna.imazingmac.sfl',

--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
   version '2.3.1'
-  sha256 '65820880df939380db9730117669a5f2c4c4a334660762900aeda9e54539a25e'
+  sha256 'cda074ee3c13d2a0a9fb7da96a347db068c87fd5d583f1fa24352ae7b2f33ac1'
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing#{version.major}Mac/iMazing#{version.major}forMac.dmg"

--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -4,12 +4,12 @@ cask 'imazing' do
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing#{version.major}Mac/iMazing#{version.major}forMac.dmg"
-  name 'iMazing Mini'
+  name 'iMazing'
   homepage 'https://imazing.com/'
 
   depends_on macos: '>= :lion'
 
-  app 'iMazing Mini.app'
+  app 'iMazing.app'
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.digidna.imazingmac.sfl',


### PR DESCRIPTION
Might want to rename to to `iMazing Mini` due to `.app` bundle name change. Same application though, new binary bundle name.

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.