### PR TITLE
fix(brave): set auto_updates dependencies

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -9,6 +9,9 @@ cask 'brave' do
   name 'Brave'
   homepage 'https://brave.com/'
 
+  auto_updates true
+  depends_on macos: '>= :mavericks'
+
   app 'Brave.app'
 
   zap delete: [


### PR DESCRIPTION
 - fix annoying `brew cask outdated`message version mismatch
 - add minimal install dependencies on osx

