### PR TITLE
Update telegram to 3.1-101111

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.00.1-100200'
-  sha256 '322e30a4787cc7bd10d0584bd9826329ef5d981f6ca0ab6c8429c7b3faaeed39'
+  version '3.1-101111'
+  sha256 '8995d9cb9b66331f3a857b6eee3166efa3fcde4e586f3405b701e048260c7ee9'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '71d65d276c3136edcf7d76636ce921a320e0ab6deb118ebad4bbad7f42b92fe4'
+          checkpoint: '589413cf4d93a1d9fa3852e38b78fa74cffbe0029924b4fa987a293bc01b90b1'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}