### PR TITLE
Update feeder to 3.4.6

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.4.5'
-  sha256 '767ce870dbdebd86f6e7a3d429631ff01a76f38ad30bbee22ec37f6330378829'
+  version '3.4.6'
+  sha256 '7992036e6ab5a5df7ee077aeba926d745a02a89a83b37ff5d1d62fd669c48978'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: '302aedf8f58105111e08073037dc9a6fdc055097845de7a6fe7e358bad0395a4'
+          checkpoint: 'eb54f81d111e9b6afa48b9d41c56edae9341e3b0a39464ed5510458e8ed9ab87'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}