### PR TITLE
Update sonic-pi to 3.0.0

### DIFF
--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -1,10 +1,10 @@
 cask 'sonic-pi' do
-  version '2.11.1'
-  sha256 'fbe9d5939d296b9ffae69432dffb6a6b1b4e06d5d89754d3c110a5cfdd5cd954'
+  version '3.0.0'
+  sha256 '824e822c797547067952a7579b2c881fc2b90b1435f9ab1c824bfc3564869310'
 
-  url "http://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-v#{version}.dmg"
+  url "http://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-v#{version.major}.dmg"
   appcast 'https://github.com/samaaron/sonic-pi/releases.atom',
-          checkpoint: 'eb4ec1bd1e5fabf1dca795111628996bb3eef2696fd2ca52d866ca4f0337ded9'
+          checkpoint: '79311a5aa2256aec0bfa80f12338eace4daca987844fa9853c6a6e7de95c6a5d'
   name 'Sonic Pi'
   homepage 'http://sonic-pi.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}