### PR TITLE
Update enpass to 5.5.8

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -1,6 +1,6 @@
 cask 'enpass' do
-  version '5.5.7'
-  sha256 'c93381bfa56d1f430f85ea70b760ab39fdf845e43e7921e4c0271003eebc2eda'
+  version '5.5.8'
+  sha256 'f7a75036f95f4ba535ccff9c9f1be93250222c5c880e9d0d2aa19bfe749f4588'
 
   # sinew.in was verified as official when first introduced to the cask
   url "https://dl.sinew.in/mac/setup/Enpass-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}