### PR TITLE
Update caret to 3.3.0

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,6 +1,6 @@
 cask 'caret' do
-  version '3.2.2'
-  sha256 '208eb97c5649d7b9a3722ffc4979f8e9cdf89f48923ba142c1745b28df541738'
+  version '3.3.0'
+  sha256 '43cf2cd024ac09b8d09b46529e3bbe7132876809e88930199858644c09d47f7d'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}