### PR TITLE
Add TablePlus.app v1.0

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,0 +1,21 @@
+cask 'tableplus' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://tableplus.io/release/osx/tableplus_latest.zip'
+  appcast 'https://tableplus.io/osx/version.xml',
+          checkpoint: 'ce45c6d4a38e7b1a4af6e1f0960117ccf8191a41b41dc5db5ad1a898f3748b3c'
+  name 'TablePlus'
+  homepage 'https://tableplus.io/'
+
+  auto_updates true
+
+  app 'TablePlus.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.tinyapp.TablePlus',
+                '~/Library/Caches/com.tinyapp.TablePlus',
+                '~/Library/Cookies/com.tinyapp.TablePlus.binarycookies',
+                '~/Library/Preferences/com.tinyapp.TablePlus.plist',
+              ]
+end

--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version :latest
-  sha256 :no_check
+  version '1.0'
+  sha256 'ca5655445c2f4674eda66fd1833a9f8dedb80937073b0b4a204100e7f2b21fe5'
 
   url 'https://tableplus.io/release/osx/tableplus_latest.zip'
   appcast 'https://tableplus.io/osx/version.xml',


### PR DESCRIPTION
Add version 1.0 of [TablePlus](https://tableplus.io/).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].
