### PR TITLE
Update electorrent to 2.1.7

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.6'
-  sha256 '2d2a2e95ae663583eef0e1e3950a31ebc6357a54dda43caccc798c63ee504b6a'
+  version '2.1.7'
+  sha256 '9caf9257667ea448f4c439cad553a618476c3a16971bf39ee11a69d2910ef88e'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '33f8a0b15fb675f44ec859effecda703570f46beae21f9db2813d693592d23f5'
+          checkpoint: '0d0ba7cec9f443c34fedc12db75f14a7a64ddf4ccc71001ae3583fb327eec2ab'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}