### PR TITLE
Update cctalk to 0.8.4-275,2017-07-20.19.21

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,11 +1,11 @@
 cask 'cctalk' do
-  version '0.8.3-260,2017-06-30.13.25'
-  sha256 '37b79b64f66b6dc7fc07db46bef1ca4dd4a20cf43fdcc82504312fedfda43e78'
+  version '0.8.4-275,2017-07-20.19.21'
+  sha256 '1c935522e0e9b89cc49cb98f6b0dcd20b5b65e9a90806534aa6295465a114da5'
 
   # f1.ct.hjfile.cn was verified as official when first introduced to the cask
   url "http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/archive/#{version.before_comma.hyphens_to_dots}/CCtalk-#{version.before_comma}-xianghu-#{version.after_comma}.dmg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml',
-          checkpoint: '2515a739cd17b23c7a86e7c0d1b9953600d0a4dc062855cbfdb745a1258bd6eb'
+          checkpoint: '2968b4d9ed3442e34a53426e2bbb3f73ea061c8a6eaf7ded3161e68d50eedf71'
   name 'CCTalk'
   homepage 'https://www.cctalk.com/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}