### PR TITLE
Update cloudapp to 4.2.5

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -5,7 +5,7 @@ cask 'cloudapp' do
   # amazonaws.com/downloads.getcloudapp.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://updates.getcloudapp.com/appcast.xml',
-          checkpoint: '13392ccf2006b0acd00b48ef20307c9acb2e39fe269bfb84469b59d3c59a2470'
+          checkpoint: '1c250b628b810cb5c3cdbf38ec793c8c53e4ad47d51c69d7a5ac33082720cda0'
   name 'CloudApp'
   homepage 'https://www.getcloudapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}