### PR TITLE
Update caret to 3.3.1

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '3.3.0'
-  sha256 '43cf2cd024ac09b8d09b46529e3bbe7132876809e88930199858644c09d47f7d'
+  version '3.3.1'
+  sha256 '5cf27bbe41505bf7f5e7cd8bcb195d320ad7ee6a19ca5e439eecaa5abfe14051'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'f033817978cca18c8fe537e31796323313f42a974d6ebd0d510a2f988acd808b'
+          checkpoint: '89b735f5542d0a670b915dbd75438d83411c7815812294f605a24a90a7fb606a'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}