### PR TITLE
Update brave to 0.17.19

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.17.16'
-  sha256 'a6d47e1dd02c90d2daf8d0e2d7a160ec63205f2cfeaaee329edfc370a556d6fc'
+  version '0.17.19'
+  sha256 '67f40e780dcd352134d9f743ce4aacdbd27555ca7706d6ef60918a68cf2f6e54'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'dfcf4d0f135a37404d12c33617ca81e320669e1bf1608b8d712484befaa3b59d'
+          checkpoint: 'd01353583f1f1ab46feba9de8c552c8d386aa20d0d81d01e17f40d0cd1d1724a'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}