### PR TITLE
Update horos - add versions for 10.10 / 10.11

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -1,6 +1,14 @@
 cask 'horos' do
-  version '2.1.1'
-  sha256 '060162d17aa06762b907665dbd809d096b53a56b1c69e779951a3581b8f70743'
+  if MacOS.version >= 10.12
+    version '2.1.1'
+    sha256 '060162d17aa06762b907665dbd809d096b53a56b1c69e779951a3581b8f70743'
+  elsif MacOS.version == 10.11
+    version '2.0.2'
+    sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
+  else
+    version '1.1.7'
+    sha256 'd15e02d7678e0f41ad12910176307aeb6312e62d7386051bfe5a261a7feb004a'
+  end
 
   url "https://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"
   name 'Horos – Free, open medical image viewer'

--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -1,13 +1,13 @@
 cask 'horos' do
-  if MacOS.version >= 10.12
-    version '2.1.1'
-    sha256 '060162d17aa06762b907665dbd809d096b53a56b1c69e779951a3581b8f70743'
-  elsif MacOS.version == 10.11
+  if MacOS.version <= :yosemite
+    version '1.1.7'
+    sha256 'd15e02d7678e0f41ad12910176307aeb6312e62d7386051bfe5a261a7feb004a'
+  elsif MacOS.version <= :el_capitan
     version '2.0.2'
     sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
   else
-    version '1.1.7'
-    sha256 'd15e02d7678e0f41ad12910176307aeb6312e62d7386051bfe5a261a7feb004a'
+    version '2.1.1'
+    sha256 '060162d17aa06762b907665dbd809d096b53a56b1c69e779951a3581b8f70743'
   end
 
   url "https://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"


### PR DESCRIPTION
Add MacOS release dependency versioning to the Horos package, as well as bump `2.0.0` to `2.0.2` which is -current for `10.11`.

---

![horos-2 1 1-error](https://user-images.githubusercontent.com/8225968/28444433-3b08d8fc-6d8b-11e7-9184-ab20c5ddb089.png)

---

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and versions.