### PR TITLE
Update texshop to 3.81

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,10 +1,10 @@
 cask 'texshop' do
-  version '3.80'
-  sha256 'afac0057f7e0ac2fc20679d26f2729735a570de9f644f4f2d67d361bd55cb209'
+  version '3.81'
+  sha256 '3c9720165a3171377afa6aa2c249297a22688956efd06a001929f4d636559694'
 
   url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
-          checkpoint: '93f1e79a4fda1b4cb76fabf5de03daf0fb1091682785e02a9b7009ce732178b7'
+          checkpoint: 'ad764d21b8ce2d4e2aa7aef12b28ec16f90480de551f3faded46060c5df6aa13'
   name 'TeXShop'
   homepage 'http://pages.uoregon.edu/koch/texshop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}