### PR TITLE
Update fuse to 1.1.0.13808

### DIFF
--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -1,6 +1,6 @@
 cask 'fuse' do
-  version '0.36.0.11838'
-  sha256 '0abda27b6020dee30a3e146c3c0cc100e5b3772ccbc9ff1edf5a16e642014a2c'
+  version '1.1.0.13808'
+  sha256 '2ca9a5e60d2d504935a13ac6618b06df045aabc2d33ed50bec8ce5fd7768d598'
 
   # fuse-dl.azureedge.net was verified as official when first introduced to the cask
   url "https://fuse-dl.azureedge.net/releaseartifacts/fuse_osx_#{version.dots_to_underscores}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}