### PR TITLE
Update kube-cluster to 0.5.3

### DIFF
--- a/Casks/kube-cluster.rb
+++ b/Casks/kube-cluster.rb
@@ -4,7 +4,7 @@ cask 'kube-cluster' do
 
   url "https://github.com/TheNewNormal/kube-cluster-osx/releases/download/v#{version}/Kube-Cluster_v#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/kube-cluster-osx/releases.atom',
-          checkpoint: '12142417fce52c3258b14094dd17f96d259c33e2f7250f207196e2db241c2f4c'
+          checkpoint: 'ef4bf984c711141c7db3b433e716aa9f0bd41069463cbe174ffbe22f4fecf227'
   name 'Kube-Cluster'
   homepage 'https://github.com/TheNewNormal/kube-cluster-osx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}