### PR TITLE
Update lektor to 3.0.1

### DIFF
--- a/Casks/lektor.rb
+++ b/Casks/lektor.rb
@@ -1,11 +1,11 @@
 cask 'lektor' do
-  version '2.3'
-  sha256 '42b78c60a13fe2c58b238878b020677661cb410f753136a0a6b7f9165de49b31'
+  version '3.0.1'
+  sha256 '112e42681bb86840261ee456f632f5e2807b5d24e41a2e84046f1586379e3572'
 
   # github.com/lektor/lektor was verified as official when first introduced to the cask
   url "https://github.com/lektor/lektor/releases/download/#{version}/Lektor-#{version}.dmg"
   appcast 'https://github.com/lektor/lektor/releases.atom',
-          checkpoint: '5c3be26bd3bdd6849048dacfcf92fc6976e9e901325fbb6066c144e933e63648'
+          checkpoint: 'd96a45877cbbf6b254a0204ad7da6a9b52a4b568a76fabb52db1ad3a726c87ea'
   name 'Lektor'
   homepage 'https://www.getlektor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}