### PR TITLE
Update licecap to 1.25

### DIFF
--- a/Casks/licecap.rb
+++ b/Casks/licecap.rb
@@ -2,9 +2,9 @@ cask 'licecap' do
   version '1.25'
   sha256 '0ed33667b3e19ee47fc09b3619499816e229bc678884fd5c27e24e785472f6ba'
 
-  url "http://www.cockos.com/licecap/licecap#{version.no_dots}.dmg"
-  appcast 'http://www.cockos.com/licecap/',
-          checkpoint: '507aa808788cad8ecfa938a3a839c67164a25d37d166cb7972c7cf7016a37a13'
+  url "https://www.cockos.com/licecap/licecap#{version.no_dots}.dmg"
+  appcast 'https://www.cockos.com/licecap/',
+          checkpoint: '3213076943b13521614da283c34456831dc9cf09f74bbf204bb08921dc8aa581'
   name 'LICEcap'
   homepage 'https://www.cockos.com/licecap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}