### PR TITLE
Update exodus to 1.30.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.29.1'
-  sha256 '23dce14070b510f29c7cdfe9d126225b1c6998b7423e22e8ab7244c9969decb1'
+  version '1.30.0'
+  sha256 '8b9d55875ff5742fddfd37d8e1a662f94c5800c808dacffbc992b78008fedf0c'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/Exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '23852ab775a6084ac6c9a2656dbf2ada60435af69d8958caa18d49c2e9ce3ba1'
+          checkpoint: '5940ee17b192356966a6cafc44d5e6ed0f412b2c141d00d374e035c419f15c09'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}