### PR TITLE
Update vysor to 1.8.2

### DIFF
--- a/Casks/vysor.rb
+++ b/Casks/vysor.rb
@@ -1,11 +1,11 @@
 cask 'vysor' do
-  version '1.7.3'
-  sha256 'bce80d4b5e27d1698e974de42372125419ad0fd06e8b339d039e93e2c0af41a1'
+  version '1.8.2'
+  sha256 '6cfe7409a5f31bf3dd29b35a3d6dcdd37595aee5417ffb64c6dfd13fbb99a3af'
 
   # github.com/koush/vysor.io was verified as official when first introduced to the cask
   url "https://github.com/koush/vysor.io/releases/download/v#{version}/Vysor-mac.zip"
   appcast 'https://github.com/koush/vysor.io/releases.atom',
-          checkpoint: '76c3b4c7924032bcd52ea262756145fd0c2864f0afa8f08d9aa2167e3699234c'
+          checkpoint: '16574e5b6b3dc897079babc6444a4e591660429c108cf3b4cb5e67ac2d653aa0'
   name 'Vysor'
   homepage 'https://www.vysor.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}