### PR TITLE
Update endlesssky to 0.9.7

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -1,11 +1,11 @@
 cask 'endlesssky' do
-  version '0.9.6'
-  sha256 '2044f1458564458ec85663e8f8eba682b0357b309d1877a8022a5fb1faa204ee'
+  version '0.9.7'
+  sha256 '0fa95019d66eb9c1aed307717e127f2a13ddfe72ef1b38b42a5ea52443963ae2'
 
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom',
-          checkpoint: 'c34ea684bdcc3048f628e337e6a8b959fd0a4144ca202153cf374975d0456698'
+          checkpoint: 'a084240d827f236e29aefc2a38d29ee2d5171bc60e522356a8cb33d96d34e038'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}