### PR TITLE
Update carbon-copy-cloner to 4.1.7.4577

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.16.4569'
-  sha256 'c7d309ef9372546106443baf9de5e08dc4c9aaac90a1e61cd54a43ace39939ac'
+  version '4.1.17.4577'
+  sha256 'fc26ed71558ae20e298c1bb203714fd9214c63495614cb6457b57e968291e0c9'
 
   url "https://bombich.com/software/download_ccc.php?v=#{version}"
   name 'Carbon Copy Cloner'


### PR DESCRIPTION
- [x] `brew cask audit --download Casks/carbon-copy-cloner.rb` is error-free.
- [x] `brew cask style --fix Casks/carbon-copy-cloner.rb ` reports no offenses.
- [x] The commit message includes the cask’s name and version.