### PR TITLE
Update linkliar to 1.1.3

### DIFF
--- a/Casks/linkliar.rb
+++ b/Casks/linkliar.rb
@@ -4,7 +4,7 @@ cask 'linkliar' do
 
   url "https://github.com/halo/LinkLiar/releases/download/#{version}/LinkLiar.app.zip"
   appcast 'https://github.com/halo/LinkLiar/releases.atom',
-          checkpoint: '27742cdc16226bcd05fef563df4b55f7cf49fe0c169fab9c96ed3ad0ba189d90'
+          checkpoint: '4d7b2d9b6cb988ba6824f1bf0a41ec466c6f737808a03ef5611feb872cc1be17'
   name 'LinkLiar'
   homepage 'https://github.com/halo/LinkLiar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}