### PR TITLE
Update luminance-hdr to 2.5.1_1

### DIFF
--- a/Casks/luminance-hdr.rb
+++ b/Casks/luminance-hdr.rb
@@ -4,7 +4,7 @@ cask 'luminance-hdr' do
 
   url "https://downloads.sourceforge.net/qtpfsgui/Luminance_HDR_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/qtpfsgui/rss',
-          checkpoint: 'ba334f17992a87cd3126b40338693e564c4d16bf568ba78ec77d1fac517130bc'
+          checkpoint: '3ecae87283d3f01c31c1905d25cf0320518d9947577af0d2f3edc3ac8d89ded2'
   name 'Luminance HDR'
   homepage 'http://qtpfsgui.sourceforge.net/'
 

--- a/Casks/luminance-hdr.rb
+++ b/Casks/luminance-hdr.rb
@@ -1,10 +1,10 @@
 cask 'luminance-hdr' do
-  version '2.5.1'
-  sha256 '6edefd0e7342ae59eb02bd809eef379f2f25af355ef9ed63394c7a1fa7424b45'
+  version '2.5.1_1'
+  sha256 'be4ae6c1110bbac4fd57358e1a0489871ba143f4f295a6d07f95be9aaecb4d18'
 
   url "https://downloads.sourceforge.net/qtpfsgui/Luminance_HDR_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/qtpfsgui/rss',
-          checkpoint: '6296e73a0733f04360dc725ece14c3de282b192ae40787485f18810d867019f1'
+          checkpoint: 'ba334f17992a87cd3126b40338693e564c4d16bf568ba78ec77d1fac517130bc'
   name 'Luminance HDR'
   homepage 'http://qtpfsgui.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}