### PR TITLE
Update xld to 2017.07.10-3

### DIFF
--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -1,6 +1,6 @@
 cask 'xld' do
-  version '2017.07.10'
-  sha256 '4703f2326a1937625991214e9fde56239322cfe02e151f9e054c52b4438680c0'
+  version '2017.07.10-3'
+  sha256 '58dff4c83a70d83fa5425a78988d13b2d39d7270dc02af0c4eb3d2891789fe01'
 
   # sourceforge.net/xld was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/xld/xld-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}