### PR TITLE
Update dymo-label to 8.6.2

### DIFF
--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -1,6 +1,6 @@
 cask 'dymo-label' do
-  version '8.6'
-  sha256 '9cf5440008967274189a8124461a3a80481d3c4b2ff14d262257a691216add7a'
+  version '8.6.2'
+  sha256 'efda7c1428974261c77b765d94751502eaf58521f179c8bc169362f9fddaee6e'
 
   url "http://download.dymo.com/dymo/Software/Mac/DLS#{version.major}Setup.#{version}.dmg"
   name 'Dymo Label'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}