### PR TITLE
Add zenmap 7.50

### DIFF
--- a/Casks/zenmap.rb
+++ b/Casks/zenmap.rb
@@ -1,0 +1,48 @@
+cask 'zenmap' do
+  version '7.50'
+  sha256 '03d03fbbf2b3648d611a788781773efe13447abf512dd76f0c791e9ce7c6991c'
+
+  url "https://nmap.org/dist/nmap-#{version}.dmg"
+  name 'Zenmap'
+  homepage 'https://nmap.org/zenmap/'
+
+  depends_on formula: 'nmap'
+
+  pkg "nmap-#{version}.mpkg",
+      choices: [
+                 {
+                   'choiceIdentifier' => 'org.insecure.nmap',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'org.insecure.nmap.ncat',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'org.insecure.nmap.ndiff',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'org.insecure.nmap.nping',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'org.insecure.nmap.nmap-update',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'org.insecure.nmap.zenmap',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+               ]
+
+  uninstall pkgutil: 'org.insecure.nmap.zenmap'
+
+  zap delete: '~/Library/Saved Application State/org.insecure.Zenmap.savedState'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

____

This re-adds the former [`nmap`](https://github.com/caskroom/homebrew-cask/pull/23734) cask as `zenmap` with the `pkg` install choices configured to only install the `Zenmap.app` GUI while depending on the `nmap` formula to provide the CLI tools.

The [`nmap`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/nmap.rb#L14-L17) formula does provide an option to install Zenmap but it requires building from source.
```
brew deps nmap
openssl
```
```
brew deps nmap --with-pygtk
atk
cairo
fontconfig
freetype
gdbm
gdk-pixbuf
gettext
glib
gobject-introspection
graphite2
gtk+
harfbuzz
hicolor-icon-theme
icu4c
jpeg
libffi
libpng
libtiff
openssl
pango
pcre
pixman
pkg-config
py2cairo
pygobject
pygtk
python
readline
shared-mime-info
sqlite
```