### PR TITLE
Added Rebol programming language, core and view v2.7.8 and v3(v2.101.0.2.40,gbf237fc)

### DIFF
--- a/Casks/rebol-core.rb
+++ b/Casks/rebol-core.rb
@@ -1,0 +1,12 @@
+cask 'rebol-core' do
+  version '2.7.8'
+  sha256 'edfa75f1be9d0d4f92a217185a3810e05b0dee41f8d24096f7568515b7b4aa06'
+
+  url "http://www.rebol.com/downloads/v#{version.no_dots}/rebol-core-#{version.no_dots}-2-5.tar.gz"
+  name 'Rebol, Relative Expression Based Object Language'
+  homepage 'http://www.rebol.com/'
+
+  conflicts_with cask: 'rebol-view'
+
+  binary 'releases/rebol-core/rebol', target: 'rebol'
+end

--- a/Casks/rebol-view.rb
+++ b/Casks/rebol-view.rb
@@ -1,0 +1,12 @@
+cask 'rebol-view' do
+  version '2.7.8'
+  sha256 '9aff51eb1d388ec93ce6385eb77a285064a101b5f2f716851170d2e6b9f6e031'
+
+  url "http://www.rebol.com/downloads/v#{version.no_dots}/rebol-view-#{version.no_dots}-2-5.tar.gz"
+  name 'Rebol distribution with additional graphics support'
+  homepage 'http://www.rebol.com/'
+
+  conflicts_with cask: 'rebol-core'
+
+  binary 'releases/rebol-view/rebol', target: 'rebol'
+end

--- a/Casks/rebol3.rb
+++ b/Casks/rebol3.rb
@@ -1,0 +1,13 @@
+cask 'rebol3' do
+  version '2.101.0.2.40,gbf237fc'
+  sha256 'a4e65efb42c97e91f4d780d52ab5d146644152c4fa590b3931df58fda09c7eb1'
+
+  # rebolsource.net was verified as official when first introduced to the cask
+  url "http://rebolsource.net/downloads/experimental/r3-osx-x64-#{version.after_comma}"
+  name 'Rebol Programming Language, v3'
+  homepage 'http://www.rebol.com/'
+
+  container type: :naked
+
+  binary "r3-osx-x64-#{version.after_comma}", target: 'r3'
+end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

**Rebol3 has no official builds yet, the but the [code](https://github.com/rebol/rebol) has no updates for over 3 years, the link provided in the cask is listed on the [official website](http://www.rebol.com/downloads.html). So we can assume it is an `official recommended` version**

Rebol 2 casks were deleted in [homebrew-binary](https://github.com/Homebrew/homebrew-binary/pull/358/files) before

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

