### PR TITLE
Update consul-web-ui - discontinued

### DIFF
--- a/Casks/consul-web-ui.rb
+++ b/Casks/consul-web-ui.rb
@@ -4,8 +4,6 @@ cask 'consul-web-ui' do
 
   # hashicorp.com was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/consul/#{version}/consul_#{version}_web_ui.zip"
-  appcast 'https://github.com/hashicorp/consul/releases.atom',
-          checkpoint: '63c6dc0162381b6e93453e2140df07e88e98c1da12c5052a6c6cf98865f557f8'
   name 'Consul Web UI'
   homepage 'https://www.consul.io/intro/getting-started/ui.html'
 
@@ -14,6 +12,6 @@ cask 'consul-web-ui' do
   stage_only true
 
   caveats do
-    "Invoke consul with '-ui-dir #{staged_path}'"
+    discontinued
   end
 end


### PR DESCRIPTION
`consul-web-ui` has been discontinued at `0.8.5` 

https://github.com/hashicorp/consul/blob/v0.9.0/CHANGELOG.md

We can delete this cask in a couple of months but because of problems with `0.9.0` probably don't want to remove it right now.