### PR TITLE
Add qlcommonmark 1.1

### DIFF
--- a/Casks/qlcommonmark.rb
+++ b/Casks/qlcommonmark.rb
@@ -1,0 +1,12 @@
+cask 'qlcommonmark' do
+  version '1.1'
+  sha256 '7778fae360f844fc17b17a4d5f8d3a01db811b0f78e174b70bea4410de2b12c7'
+
+  url "https://github.com/digitalmoksha/QLCommonMark/releases/download/v#{version}/QLCommonMark.qlgenerator.zip"
+  appcast 'https://github.com/digitalmoksha/QLCommonMark/releases.atom',
+          checkpoint: '3584231f55aedf0d7f0fffed34f9fdf2c3136bb5f32eec37f566e42a883d4b07'
+  name 'QLCommonMark'
+  homepage 'github.com/digitalmoksha/QLCommonMark/'
+
+  qlplugin 'QLCommonMark.qlgenerator'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

https://github.com/caskroom/homebrew-cask/issues/36890

This has ~~8~~ 9 stars and it's a cask request from a different user, not self-submitted so I'm not sure if it's too obscure or not.

[QLCommonMark](https://github.com/digitalmoksha/QLCommonMark)