### PR TITLE
Add QLCommonMark.qlgenerator v1.1

### DIFF
--- a/Casks/qlcommonmark.rb
+++ b/Casks/qlcommonmark.rb
@@ -1,0 +1,12 @@
+cask 'qlcommonmark' do
+  version '1.1'
+  sha256 '7778fae360f844fc17b17a4d5f8d3a01db811b0f78e174b70bea4410de2b12c7'
+
+  url "https://github.com/digitalmoksha/QLCommonMark/releases/download/v#{version}/QLCommonMark.qlgenerator.zip"
+  appcast 'https://github.com/digitalmoksha/QLCommonMark/releases.atom',
+          checkpoint: '3584231f55aedf0d7f0fffed34f9fdf2c3136bb5f32eec37f566e42a883d4b07'
+  name 'QLCommonMark'
+  homepage 'https://github.com/digitalmoksha/QLCommonMark'
+
+  qlplugin 'QLCommonMark.qlgenerator'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
    Was unable to complete this because I got the error: 
`Installing or updating 'rubocop-cask' gem`  
`Error: no implicit conversion of nil into String`
But I believe I followed the styles correctly
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
