### PR TITLE
Update cloudtv to 3.8.5

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,11 +1,11 @@
 cask 'cloudtv' do
-  version '3.8.4'
-  sha256 'a7ec2e55ddff9dfb22abd2990e6e82c0dc8ea2b804e0df5f48cdcc9f99233131'
+  version '3.8.5'
+  sha256 '2dca199c56a8db1df31efd268f48cfd5e37e8d54d6f29b830e5919b84325471f'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.nonoche.CloudTV/CloudTV.dmg?v=#{version}"
   appcast 'https://updates.devmate.com/com.nonoche.CloudTV.xml',
-          checkpoint: 'c15e92ae96a894d8bba5b68c6e01461be44f9dd7590653498bf4fb655b94ad3d'
+          checkpoint: '8b98e25e64374be42ab6941fa7023639cf10e18a0f3970460949e8ea6860c6b0'
   name 'CloudTV'
   homepage 'https://cloudtvapp.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}