### PR TITLE
Update markright to 0.1.11

### DIFF
--- a/Casks/markright.rb
+++ b/Casks/markright.rb
@@ -4,7 +4,7 @@ cask 'markright' do
 
   url "https://github.com/dvcrn/markright/releases/download/#{version}/MarkRight_Mac.dmg"
   appcast 'https://github.com/dvcrn/markright/releases.atom',
-          checkpoint: '22f02dc7556d19456dcd5f7aed4c9ed078db8b26d0890ba950b60a81fde542ab'
+          checkpoint: '390d273e0e50e5560cb447d2a3f6efbd4742fd82a18c6a7ee6345075357b5fc9'
   name 'MarkRight'
   homepage 'https://github.com/dvcrn/markright'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}