### PR TITLE
Update ui-browser to 2.6.3

### DIFF
--- a/Casks/ui-browser.rb
+++ b/Casks/ui-browser.rb
@@ -1,6 +1,6 @@
 cask 'ui-browser' do
-  version '2.6.2'
-  sha256 'bb43a84913d98576197645ec5214eadf2b86a11ece5d4bdb591c38e8d689dafb'
+  version '2.6.3'
+  sha256 '1a78045ab21da512f15f7203fa430cff61592aadb17cbdc0bc4aaf734412dac1'
 
   url "http://pfiddlesoft.com/uibrowser/downloads/UIBrowser#{version.no_dots}.dmg"
   name 'UI Browser'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}