### PR TITLE
Update microsoft-teams to 1.0.00.19452

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '1.0.00.16451'
-  sha256 'aea55301c8b16abc7a004f6cf1b94471f0b28de198cae9c9f7894e546944ef10'
+  version '1.0.00.19452'
+  sha256 '4b13e4ac981e88fb8be520b357f29eb5ad1ef569c7a4d5381c6fe9b32ab91851'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: '5e08eeb6a34c82633fd25ea457054aca34fe18c09e6cbc6d0909f46439f06b69'
+          checkpoint: 'f7a0012359bba498872b4caa27701ad1612c3b81d2beb67930bded38984e8b4d'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}