### PR TITLE
Update mimolive to 2.9.2-23125

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,10 +1,10 @@
 cask 'mimolive' do
-  version '2.9-23073'
-  sha256 '182b017d87f164378a20560fd929869e98434ae369a9cddab42400afbf3011e0'
+  version '2.9.2-23125'
+  sha256 '590fad1c33bf30a105ca78557a6c7defc376735acafb373970a2772cf72c8fb4'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect//histories/mimolive',
-          checkpoint: '3370379dc4e03822a6cb9cb8767abb191e127a737941e3f0748d437a9658970d'
+          checkpoint: '5b569a3ae5aaf8986b02d1e0188de9bf6f6c2ecc7b58991feea3298b2fe9b8a0'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'
 

--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -3,7 +3,7 @@ cask 'mimolive' do
   sha256 '590fad1c33bf30a105ca78557a6c7defc376735acafb373970a2772cf72c8fb4'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
-  appcast 'https://boinx.com/d/connect//histories/mimolive',
+  appcast 'https://boinx.com/d/connect/histories/mimolive',
           checkpoint: '5b569a3ae5aaf8986b02d1e0188de9bf6f6c2ecc7b58991feea3298b2fe9b8a0'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}