### PR TITLE
Update minizincide to 2.1.5

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -5,7 +5,7 @@ cask 'minizincide' do
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"
   appcast 'https://github.com/MiniZinc/MiniZincIDE/releases.atom',
-          checkpoint: 'c76cd4c6464934c9445128ba2a04b5c07624fe6113e2823401bfb5fcfc542d83'
+          checkpoint: '209b6573001b7200fbf592591124c31a8d77baa0076410a1af445b63e8b504c3'
   name 'MiniZincIDE'
   homepage 'http://www.minizinc.org/ide/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}