### PR TITLE
Update renamer - sha256 no_check

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
-  version '5.0.3'
-  sha256 '59e9d52740d5ff04003f195ef5ffe582d7f9db5c1a7ad53c5264185e27497c6f'
+  version '5'
+  sha256 :no_check # required as upstream package is updated in-place
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`appcast` was removed in https://github.com/caskroom/homebrew-cask/pull/22185, doesn't seem to have an `appcast` or a changelog we can use currently.

Curent version is `5.1.0` https://twitter.com/renamerapp/status/884770852847456256