### PR TITLE
Update metasploit to 4.15.4+20170723215451

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.15.1+20170717101235'
-  sha256 'b964564d019aaec22986d04b8cde73342766a10a063722961794a188d7626cdb'
+  version '4.15.4+20170723215451'
+  sha256 '6646145662381d96552875986495469dabe65b50145b2b6bf28f32f550ea1d87'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: 'cfc65a290f7e7b130e0a4b0d3452143fba6a9e4942fccd0ba58bfc8e6d4c19d0'
+          checkpoint: '63609831dd02109d56918db4a59a1e4386cdb0876085cc55e666cf2fe35cec62'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}