### PR TITLE
Update sha256 of renamer 5.0.3

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
   version '5.0.3'
-  sha256 '59e9d52740d5ff04003f195ef5ffe582d7f9db5c1a7ad53c5264185e27497c6f'
+  sha256 '9928730fb00bfbaa606ad903440fcbb108147f93f2284543d20f44286eaf074d'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer.zip"


### PR DESCRIPTION
It looks like the proper sha256 checksum should be`9928730fb00bfbaa606ad903440fcbb108147f93f2284543d20f44286eaf074d`

https://github.com/caskroom/homebrew-cask/commit/c6b8d6a732c0d040a98a07fe556e36ab8e5dbdb7#commitcomment-23254452

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: https://www.virustotal.com/en/url/9429156a8bc3d06856dd4bd3b18ad1810f413eb34aceafd57923b4020135d4f3/analysis/1500861913/
<img width="953" alt="screen shot 2017-07-23 at 7 07 37 pm" src="https://user-images.githubusercontent.com/3271834/28505590-396f1dfc-6fda-11e7-9d3d-c771f5fda0ca.png">
