### PR TITLE
Update thunder to 3.1.1.3012

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '3.1.0.2968'
-  sha256 'a1f7d9496e5abff021d18a56a0d1984b62e67c8851ad78d840776f652764661f'
+  version '3.1.1.3012'
+  sha256 '39e93dd5eb1e5ce48630713aac457c8667f4871529e72ea963b45e8a3ff9fee0'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_#{version}.dmg"


### PR DESCRIPTION
Update thunder to 3.1.1.3012

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
