### PR TITLE
Update boom to 1.6.1,1500546110

### DIFF
--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -1,11 +1,11 @@
 cask 'boom' do
-  version '1.6,1490693621'
-  sha256 '24b32b7c13988bd5c71d6ff3a91bef2a686e2cff101d2cee739af5737f9644f0'
+  version '1.6.1,1500546110'
+  sha256 '33993c1c921014b33e3c3e5a7c1e7e530b68393e17eb6090d1a7d45192a63fac'
 
   # devmate.com/com.globaldelight.Boom2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Boom2/#{version.before_comma}/#{version.after_comma}/Boom2-#{version.before_comma}.dmg"
   appcast 'https://updates.devmate.com/com.globaldelight.Boom2.xml',
-          checkpoint: '4f468fa05290cc89e015a6e3310c47f42d56df4ca8cd916045288354568b18bd'
+          checkpoint: 'a48ebf2304d51f57504d44f0550ccfc64dd35dca87199241648f575cd24ff286'
   name 'Boom'
   homepage 'http://www.globaldelight.com/boom'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}