### PR TITLE
Update epichrome to 2.1.20

### DIFF
--- a/Casks/epichrome.rb
+++ b/Casks/epichrome.rb
@@ -1,10 +1,10 @@
 cask 'epichrome' do
-  version '2.1.18'
-  sha256 '47ad63649deb9fb0fb389a7b9caccba089e059981c1a8d17d5e24656ff069f65'
+  version '2.1.20'
+  sha256 'c2853e73d9b13ed59ee16a478e3e8ad7e27e1ebb8f18e03984a72e04830f6dfe'
 
   url "https://github.com/dmarmor/epichrome/releases/download/v#{version}/epichrome-#{version}.dmg"
   appcast 'https://github.com/dmarmor/epichrome/releases.atom',
-          checkpoint: 'c510586ccd7d6682a802365024da2d00e2cc262a61fa23a4251b025ca6b15dc5'
+          checkpoint: '806b74de039f75312a2a161298dc39037958e277b173fdbf6f492311c2c7f22a'
   name 'Epichrome'
   homepage 'https://github.com/dmarmor/epichrome'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.