### PR TITLE
Update hopper-disassembler to 4.2.10

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.2.9'
-  sha256 '239aa35f5c68f894c2d919439da84f07fc3b67db19d99e0628e7781bd715a595'
+  version '4.2.10'
+  sha256 '4efa4ab9a926c8ea55a1772f55d8bc943c380e0aeb958814d58474c4230e33cd'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '8a6b2ffaab33cb54d948e44b98e57ebabe1b969a823647f9f21f68778c2d40ac'
+          checkpoint: 'b56595ce00dc68d3fbad5378e6b5887c4458eba6264e1c83a70ec990c276de95'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}