### PR TITLE
Update pharo-launcher to 0.2.13 - url / homepage

### DIFF
--- a/Casks/pharo-launcher.rb
+++ b/Casks/pharo-launcher.rb
@@ -1,11 +1,11 @@
 cask 'pharo-launcher' do
-  version :latest
-  sha256 :no_check
+  version '0.2.13'
+  sha256 '96959ac605a23ec9566a7ddf4c7f5f303cb46f2dd002b1013f90942cb29054f7'
 
-  # ci.inria.fr/pharo/view/Launcher/job/Launcher-Mac was verified as official when first introduced to the cask
-  url 'https://ci.inria.fr/pharo/view/Launcher/job/Launcher-Mac/lastSuccessfulBuild/artifact/latest.dmg'
+  # ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac was verified as official when first introduced to the cask
+  url "https://ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac/lastSuccessfulBuild/artifact/Pharo_#{version}.dmg"
   name 'Pharo Launcher'
-  homepage 'http://smalltalkhub.com/#!/~Pharo/PharoLauncher/'
+  homepage 'https://github.com/pharo-project/pharo-launcher'
 
   # Renamed to avoid conflict with pharo.
   app 'Pharo.app', target: 'Pharo Launcher.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/36928

Travis has failed several times while downloading.