### PR TITLE
Update dbeaver-community to 4.1.1

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.1.0'
-  sha256 '5e775008555f11204f49761c43de99f66e016de75022621b8c977a96ce63799a'
+  version '4.1.1'
+  sha256 '2b352d3423ed1ce4e4fb22f362f8951d2bf8184c5ef8fe287cca29daebc2d639'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '8c27449d66211e0df84e62db3acf3b0981efd11b80d49dffef100f189217e4ad'
+          checkpoint: '5dad4cf7af76ac761e8a9ef2dba8a28477debfed3c97a5c69f48abaef51cdead'
   name 'DBeaver Community Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}