### PR TITLE
Update vuescan to 9.5.81

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.80'
-  sha256 'd5277b3d3e5331ec35ed9e2598490d525f87b6ae3257add7321a54a21727c6c2'
+  version '9.5.81'
+  sha256 'dae617a7e60fec6c090f4308bc58d569dbfb86d0291c0ecc9bbb6b20b8fac6d7'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: 'f70e45d351f1d53a3c7940d301de27d59a2c52dcc1c393b64504f7acb289a380'
+          checkpoint: '6d28f18e975e33d901556a7f3effcf540c0671f9d30744a34f92f66ec9eb5837'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}