### PR TITLE
Add versioning to ZeroNet ('0.5.7') current

### DIFF
--- a/Casks/zeronet.rb
+++ b/Casks/zeronet.rb
@@ -1,6 +1,6 @@
 cask 'zeronet' do
-  version :latest
-  sha256 :no_check
+  version '0.5.7'
+  sha256 'beac83a1299415a90d58b680c0f466337d527337d9214b96e188fcc8ce733d8f'
 
   # github.com/HelloZeroNet/ZeroNet-mac was verified as official when first introduced to the cask
   url 'https://github.com/HelloZeroNet/ZeroNet-mac/archive/dist/ZeroNet-mac.zip'


### PR DESCRIPTION
The `sha256` and `version` will change but the `URL` currently won't.

Unfortunately, I don't see a way to automate versioning as their own versioning is out of date: https://github.com/HelloZeroNet/ZeroNet/tags versus the target URLs on https://zeronet.io/

Though this slightly increases maintainer overhead considering it is a security/privacy app, I think a functioning `sha` is good.

---

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**: