### PR TITLE
Update dropdmg to 3.5

### DIFF
--- a/Casks/dropdmg.rb
+++ b/Casks/dropdmg.rb
@@ -1,6 +1,6 @@
 cask 'dropdmg' do
-  version '3.4.6'
-  sha256 '90d130084b39bd1b42f0cc140e8dbc972e0f6dc9583a42322b44631a2d6086fe'
+  version '3.5'
+  sha256 '6efa9fff298cdf3ec3e5d234220cafab6c0d5981d2fbbd0aa7b72005b4e4052e'
 
   url "https://c-command.com/downloads/DropDMG-#{version}.dmg"
   name 'DropDMG'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}