### PR TITLE
Update fldigi to 4.0.8

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.7'
-  sha256 '66466560f28e5e18edeef6673d941e45346bf1a84423766d4ee9a9439032bece'
+  version '4.0.8'
+  sha256 '9d45400b1b3942b5a79d01042bd284c99cf9575157542be152160717f17c6f5e'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'ee2330d042d6df30eb9647b195eafb613323636c3ca68c459d9da056e9ff41ae'
+          checkpoint: 'f27999aae707e424c0d55062a925f2af154563bb4479dbfd87cead956b975d1c'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}