### PR TITLE
Update 115browser to 8.4.0.19

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -4,7 +4,7 @@ cask '115browser' do
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
   appcast 'https://pc.115.com/#mac',
-          checkpoint: '3226edb24d62209969e17ad1dbd21953bfc71043dfe5893658501d3c196eec89'
+          checkpoint: 'e2ea2eb6965afff80577b6faf59e14b696a40db8a0e1a1c7caa14c3f689ed982'
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}