### PR TITLE
Update adobe-bloodhound to 3.1.1

### DIFF
--- a/Casks/adobe-bloodhound.rb
+++ b/Casks/adobe-bloodhound.rb
@@ -5,7 +5,7 @@ cask 'adobe-bloodhound' do
   # github.com/Adobe-Marketing-Cloud/mobile-services was verified as official when first introduced to the cask
   url "https://github.com/Adobe-Marketing-Cloud/mobile-services/releases/download/Bloodhound-v#{version}-OSX/Bloodhound-#{version}-OSX.dmg"
   appcast 'https://github.com/Adobe-Marketing-Cloud/mobile-services/releases.atom',
-          checkpoint: '72bb527592738d6f10e62265fc35a47091ab1aac2673a13293eb3c295a0d7b7f'
+          checkpoint: '3a13afde4f9588d12890710d799dd38bb95f79c3d238cebe34d861b45288e359'
   name 'Adobe Bloodhound'
   homepage 'https://marketing.adobe.com/resources/help/en_US/mobile/bloodhound/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}