### PR TITLE
Update alcatraz to 1.2.1

### DIFF
--- a/Casks/alcatraz.rb
+++ b/Casks/alcatraz.rb
@@ -5,7 +5,7 @@ cask 'alcatraz' do
   # github.com/alcatraz/Alcatraz was verified as official when first introduced to the cask
   url "https://github.com/alcatraz/Alcatraz/releases/download/#{version}/Alcatraz.tar.gz"
   appcast 'https://github.com/alcatraz/Alcatraz/releases.atom',
-          checkpoint: '053f4ce6f085330611cfad0aacab07d2e3973233ff0b86881b22d0efee331914'
+          checkpoint: '81d85c5ef11fd873f22145b9045e372a7c8bf2f50687b29b950162116439830c'
   name 'alcatraz'
   homepage 'http://alcatraz.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}