### PR TITLE
Update androidtool to 1.66

### DIFF
--- a/Casks/androidtool.rb
+++ b/Casks/androidtool.rb
@@ -4,7 +4,7 @@ cask 'androidtool' do
 
   url "https://github.com/mortenjust/androidtool-mac/releases/download/#{version}/AndroidTool.zip"
   appcast 'https://github.com/mortenjust/androidtool-mac/releases.atom',
-          checkpoint: '805d52304d73fffab4c20e35c6705294b9914512c9359c07b2b6b20c967c5cb1'
+          checkpoint: '7d1026a00e430e46f941f76a7199b56628e939b80977bbc6b6d8e63ea3935809'
   name 'AndroidTool'
   homepage 'https://github.com/mortenjust/androidtool-mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}