### PR TITLE
Update angry-ip-scanner to 3.5.1

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -5,7 +5,7 @@ cask 'angry-ip-scanner' do
   # github.com/angryip/ipscan was verified as official when first introduced to the cask
   url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"
   appcast 'https://github.com/angryip/ipscan/releases.atom',
-          checkpoint: '6d6ec55fce2ab10346564d7990c4645dbb1b63c71d6f4fc73922c49051f53e21'
+          checkpoint: '361e1b18d29be11a526cc85ff7fd2e56c2ea1daff7cd261e9fc58f99e84a0cf5'
   name 'Angry IP Scanner'
   homepage 'http://angryip.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}