### PR TITLE
Update apple-events to 0.8

### DIFF
--- a/Casks/apple-events.rb
+++ b/Casks/apple-events.rb
@@ -4,7 +4,7 @@ cask 'apple-events' do
 
   url "https://github.com/insidegui/AppleEvents/releases/download/#{version}/AppleEvents_v#{version}.zip"
   appcast 'https://github.com/insidegui/AppleEvents/releases.atom',
-          checkpoint: 'f2d92a82be4e0ccaa583de775f63de1f79a8f81e44974ec554a6b8a36a3a055f'
+          checkpoint: '0d8764624f518ee3eb39bc461706450727f5dad71cfd0f3a3305fb71b6ddabb5'
   name 'Apple Events'
   homepage 'https://github.com/insidegui/AppleEvents'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}