### PR TITLE
Update appserver to 1.1.4-212

### DIFF
--- a/Casks/appserver.rb
+++ b/Casks/appserver.rb
@@ -5,7 +5,7 @@ cask 'appserver' do
   # github.com/appserver-io/appserver was verified as official when first introduced to the cask
   url "https://github.com/appserver-io/appserver/releases/download/#{version.sub(%r{-.*}, '')}/appserver-dist_#{version}_x86_64.pkg"
   appcast 'https://github.com/appserver-io/appserver/releases.atom',
-          checkpoint: '1d421bed542b5ce4df18f0388ae00f2cc38b661ba9f0d5deedffced970095e4a'
+          checkpoint: '6b6938251698ee9bf9c3f14095cdc1a750ae77c5af45eccbf7aa8cd0d6f4f623'
   name 'appserver.io'
   homepage 'http://appserver.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}