### PR TITLE
Update imazing to 2.3.2

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
   version '2.3.2'
-  sha256 '69d3d1656ad7c434ada1f744bdd2d43a4e559d8d69101635f31efa8a7bf5f530'
+  sha256 '603bb52c2ce07ece36229384248bccc4e9e9dc06f30b83e2ae9bd15b3dabd11b'
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing#{version.major}Mac/iMazing#{version.major}forMac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [X] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer:

Codesigning verified locally as VirusTotal doesn't seem to work with this Cask



https://github.com/caskroom/homebrew-cask/issues/36977