### PR TITLE
Update imazing-mini to 2.3.2

### DIFF
--- a/Casks/imazing-mini.rb
+++ b/Casks/imazing-mini.rb
@@ -1,6 +1,6 @@
 cask 'imazing-mini' do
   version '2.3.2'
-  sha256 'b6e76c0487de9a897fdcee4d207c549108946fcfa02d4fe4b48e733ed562bb1f'
+  sha256 '4b1e2e87b1de185fa6abbb96ccb5cbbbac8f78128ae84e79eb2c62f1972d0330'
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing#{version.major}Mac.Mini/iMazingMini#{version.major}forMac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer:

Codesigning verified locally as VirusTotal doesn't seem to work with this Cask