### PR TITLE
Update aquamacs to 3.3

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -5,7 +5,7 @@ cask 'aquamacs' do
   # github.com/davidswelt/aquamacs-emacs was verified as official when first introduced to the cask
   url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}/Aquamacs-Emacs-#{version}.dmg"
   appcast 'https://github.com/davidswelt/aquamacs-emacs/releases.atom',
-          checkpoint: '255752184faa29423a6b8828a4b99118de74850b10ef5ed6d56816d632e53131'
+          checkpoint: 'a40804fd3ecb2089f76cc5bac7fc6bbe5e4d49e023dd2099b4e9b4565e26f651'
   name 'Aquamacs'
   homepage 'http://aquamacs.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}