### PR TITLE
Update pharo-launcher to latest

### DIFF
--- a/Casks/pharo-launcher.rb
+++ b/Casks/pharo-launcher.rb
@@ -1,9 +1,9 @@
 cask 'pharo-launcher' do
-  version '0.2.13'
-  sha256 '96959ac605a23ec9566a7ddf4c7f5f303cb46f2dd002b1013f90942cb29054f7'
+  version :latest
+  sha256 :no_check
 
   # ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac was verified as official when first introduced to the cask
-  url "https://ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac/lastSuccessfulBuild/artifact/Pharo_#{version}.dmg"
+  url 'https://ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac/lastSuccessfulBuild/artifact/latest.dmg'
   name 'Pharo Launcher'
   homepage 'https://github.com/pharo-project/pharo-launcher'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/36973

Changed back to `latest` after changing to versioned https://github.com/caskroom/homebrew-cask/pull/36932, downloads are hosted on a CI system and even versioned files seem to be updated in place.