### PR TITLE
Update archi to 4.0.2

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -4,7 +4,7 @@ cask 'archi' do
 
   url "http://www.archimatetool.com/downloads/release/v#{version.major}/Archi-mac-#{version}.zip"
   appcast 'https://github.com/archimatetool/archi/releases.atom',
-          checkpoint: 'c2fad564fc2be522c1b2860280041c48c772b57b6065ce81ef97b5980ca77a3c'
+          checkpoint: '53c09c7b5f52da00c23cd94c9b0870b1a655292eb4377d7660eb832f5032374a'
   name 'Archi'
   homepage 'https://www.archimatetool.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}