### PR TITLE
Update aria2gui to 1.3.8

### DIFF
--- a/Casks/aria2gui.rb
+++ b/Casks/aria2gui.rb
@@ -4,7 +4,7 @@ cask 'aria2gui' do
 
   url "https://github.com/yangshun1029/aria2gui/releases/download/#{version}/Aria2GUI-v#{version}.zip"
   appcast 'https://github.com/yangshun1029/aria2gui/releases.atom',
-          checkpoint: '495a38eb7f2ab8baf97150d2f74ce6cf9b423c9c8cc0643b2a8558436f469fc4'
+          checkpoint: '7b0c901e232a7cbf8ff6c426a81aa1258b0c400c5e237d2eb33e48fa47c48c6e'
   name 'Aria2GUI'
   homepage 'https://github.com/yangshun1029/aria2gui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}