### PR TITLE
Update etcher to 1.1.1

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,11 +1,11 @@
 cask 'etcher' do
-  version '1.0.0'
-  sha256 '11259ae4a3b36a60092bdf365fd3f54eba854e9f0a88e661d5a7969d26d51fae'
+  version '1.1.1'
+  sha256 '7e9819cfe9fd8be1c8267d084ff45286d1c4b6cf962603a2722f2c35829692eb'
 
   # github.com/resin-io/etcher/releases/download was verified as official when first introduced to the cask
   url "https://github.com/resin-io/etcher/releases/download/v#{version}/Etcher-#{version}-darwin-x64.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: '224fc003a5ce5ef1fa4b7473d692a0eecf6c4b68790494875d42ecf13252c883'
+          checkpoint: '79f30bce292808848cd66af411c60ba2679931f61c1687e83cd7a22486172e04'
   name 'Etcher'
   homepage 'https://etcher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}