### PR TITLE
Update cyberduck to 6.2.0.25806

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '6.1.0.25371'
-  sha256 'dfde80a2544e778569ee7a474eaaab80d669906c0175be2ad86fdf49ca299fef'
+  version '6.2.0.25806'
+  sha256 'bcbf1d385f2cd54e33a364f3999011e70c42fa06d176beb0cbd9424cafd8313e'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: '808cf385cf4db3311501f6817a1c94cbf1f7981f6007b950b9b857d4f1072bf2'
+          checkpoint: '2518244c8f93892b43c4e43e861c3f919382b719c3fc1c3ba7b29c7b9b89ad3d'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}