### PR TITLE
Update asciidocfx to 1.5.5

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -5,7 +5,7 @@ cask 'asciidocfx' do
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"
   appcast 'https://github.com/asciidocfx/AsciidocFX/releases.atom',
-          checkpoint: '71e3d7c0e829ecf95331d9c9a5576bea320ea45c520516fa5ac8b9e9d738a7fe'
+          checkpoint: '9e3703d63f0923fd1d2d3abf5326da6558400635fbfeec18aaecc252cc6a1dab'
   name 'AsciidocFX'
   homepage 'http://www.asciidocfx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}