### PR TITLE
Update asset-catalog-tinkerer to 2.5

### DIFF
--- a/Casks/asset-catalog-tinkerer.rb
+++ b/Casks/asset-catalog-tinkerer.rb
@@ -4,7 +4,7 @@ cask 'asset-catalog-tinkerer' do
 
   url "https://github.com/insidegui/AssetCatalogTinkerer/releases/download/#{version}/AssetCatalogTinkerer_v#{version}.zip"
   appcast 'https://github.com/insidegui/AssetCatalogTinkerer/releases.atom',
-          checkpoint: 'e4eddf825266995ad02b1bb1eaef219aa00d44153ad01a4011b0fca71b2860b1'
+          checkpoint: 'a1a11ef5ebe65978f31dd93039911862022963f4e8600c7c131986a6980dbb67'
   name 'Asset Catalog Tinkerer'
   homepage 'https://github.com/insidegui/AssetCatalogTinkerer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}