### PR TITLE
Update texstudio to 2.12.6

### DIFF
--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -1,10 +1,10 @@
 cask 'texstudio' do
-  version '2.12.4'
-  sha256 'b594f4c72454a5d56732c8e4c74690a77f72d99440db5bbbead6cf9640c37666'
+  version '2.12.6'
+  sha256 '01f659d2ec82714b9fca5b5055df274c9229f8d793e7a511520a409a81958619'
 
   url "https://downloads.sourceforge.net/texstudio/texstudio-#{version}-osx-qt5.7.1.zip"
   appcast 'https://sourceforge.net/projects/texstudio/rss',
-          checkpoint: 'c3f6d18e93f6500312031cc65b613d80c5fb5189859067eedb00494320b634be'
+          checkpoint: 'ba62f75afe0418bc7ebb9b2121d07f4f0c90f93aa9ed5002eb0dcecc173b065b'
   name 'TeXstudio'
   homepage 'http://texstudio.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}