### PR TITLE
Update metabase-app to 0.25.0.1

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,10 +1,10 @@
 cask 'metabase-app' do
-  version '0.24.2.0'
-  sha256 '7bae276d6ae9060a4675f54cdaf9feb3c1f915a72412b33b976860918d3ce3a6'
+  version '0.25.0.1'
+  sha256 '3638b269ea10e8947b12bacbdd0ce1a9eec1846d8b8262c18626caf4bd6dec34'
 
   url "http://downloads.metabase.com/v#{version.major_minor_patch}/Metabase.dmg"
   appcast 'http://downloads.metabase.com/appcast.xml',
-          checkpoint: 'f78f47fdab94af73e9fcb8c27d0e32de26e4e718e4f550b8df1b70f73233b9ad'
+          checkpoint: 'ab55257f203ca49af7fa17b9264b70e7bb830a6c11e02dce31673bbc353fcda7'
   name 'Metabase'
   homepage 'http://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}