### PR TITLE
Update automute to 1.1

### DIFF
--- a/Casks/automute.rb
+++ b/Casks/automute.rb
@@ -4,7 +4,7 @@ cask 'automute' do
 
   url "https://github.com/Lorenzo45/AutoMute/releases/download/v#{version}/AutoMute.zip"
   appcast 'https://github.com/Lorenzo45/AutoMute/releases.atom',
-          checkpoint: 'f469d4109bc963a303a2672bbb13588f515496625144ec12d8190781db6021c3'
+          checkpoint: '34edd5b7f90bc080de072f0dc3c8fb3a089ee2f62b2650827bfec0ba5cf4c236'
   name 'AutoMute'
   homepage 'https://github.com/Lorenzo45/AutoMute'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}