### PR TITLE
Update aware to 1.0.3

### DIFF
--- a/Casks/aware.rb
+++ b/Casks/aware.rb
@@ -5,7 +5,7 @@ cask 'aware' do
   # github.com/josh/Aware was verified as official when first introduced to the cask
   url "https://github.com/josh/Aware/releases/download/v#{version}/Aware.zip"
   appcast 'https://github.com/josh/Aware/releases.atom',
-          checkpoint: '69d1a1fc0074d3e30dd3cb919be7a930907e690fdf733eb22d4c5bb4b9555986'
+          checkpoint: 'a1a9d088cbf5438c498d9fce094a89ad98ba3e1e7e0f80440fdf6f088b6f21aa'
   name 'Aware'
   homepage 'http://awaremac.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}