### PR TITLE
Update minikube to 0.21.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,11 +1,11 @@
 cask 'minikube' do
-  version '0.20.0'
-  sha256 '591737b728745dbf01f634bf714353c416c2e56c39e2e0431910fa51783b7a19'
+  version '0.21.0'
+  sha256 '2a6960cfa2b5aed9fec8d8cbe357fa8f5776761ee5efa3dd26abccc894f4b453'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: 'e2e87909431bf9cb14f674040e819abe54f5184531dfeca9775b3a380a66755f'
+          checkpoint: '71b9148f998fdf663ebf04524a153e467557727e89ab0e62ad6617d42cf6aaa2'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.