### PR TITLE
Update airflow to 2.0.0-beta7

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,6 +1,6 @@
 cask 'airflow' do
-  version '2.0.0-beta6'
-  sha256 '13ea1d24e43be6b49cfeccf3075743ed55cbaf2656d4891067797cc569573e80'
+  version '2.0.0-beta7'
+  sha256 'e681a1ab47bcb0ff5800e8d5d6ae59b9e93ccb764a6d56d024c30c48db04cd23'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.