### PR TITLE
Update championify to 2.0.6

### DIFF
--- a/Casks/championify.rb
+++ b/Casks/championify.rb
@@ -1,10 +1,10 @@
 cask 'championify' do
-  version '2.0.5'
-  sha256 '535a166078e499789db6ed714d552620e9558e8152e3caf2a9a43a036fae8070'
+  version '2.0.6'
+  sha256 'a04a0c71f9e3ede49037db19efe6b9a203fee7930dbb6d76c2193706839771de'
 
   url "https://github.com/dustinblackman/Championify/releases/download/#{version}/Championify-OSX-#{version}.dmg"
   appcast 'https://github.com/dustinblackman/Championify/releases.atom',
-          checkpoint: 'e7d723dec6246c502e37fc8e4257c5d96b191601392afa8c47f2982ce6a697e8'
+          checkpoint: 'badfb4d023789324753d29c8fd0d1b1940a9df13cdfe174011c6a3cc1560cef5'
   name 'Championify'
   homepage 'https://github.com/dustinblackman/Championify/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}