### PR TITLE
Update dollydrive to 3.97,39700

### DIFF
--- a/Casks/dollydrive.rb
+++ b/Casks/dollydrive.rb
@@ -1,10 +1,10 @@
 cask 'dollydrive' do
-  version '3.96,39625'
-  sha256 '87d3925035f8af2a410c035f426d1e47115d119fb08f4a5e14e4972399263a71'
+  version '3.97,39700'
+  sha256 '7b9ff26dd871ea7b899875707539c99d61060818669bbbe4906fa77a7e49c3ac'
 
   url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.before_comma}_#{version.after_comma}_CERTIFIED.zip"
   appcast "http://www.dollydrive.com/dolly#{version.major}.xml",
-          checkpoint: '4e4d8683c5b445f35a83f963c82963d70b68bc16b8235d0db37788eda253de88'
+          checkpoint: '1ced9e101f9709ba80ab6303e71b8fba4a1c4f95374838b1c1c3803b0f870d10'
   name 'DollyDrive'
   homepage 'http://www.dollydrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}