### PR TITLE
Update icons8 to 5.6.3

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -1,11 +1,11 @@
 cask 'icons8' do
   # note: "8" is not a version number, but an intrinsic part of the product name
-  version '5.6.2'
-  sha256 '3bf80f88d0ffa08a96f4747453f534f4ad058a6a76e2348bad7c85d07a25c6c1'
+  version '5.6.3'
+  sha256 '820b3eb24c6868d272f995d44220aa121c1483be30c676a19ce465229712982c'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
   appcast 'https://desktop.icons8.com/updates/mac/icons8_cast.xml',
-          checkpoint: '9688fb2b390f16363062bc105b7bdbf88840a771d3d4070d000c673f74d22c13'
+          checkpoint: '622623074f09dcca53259515f60d9d0302c5b675e45fb0ec3963dcb1dce9e460'
   name 'Icons8 App'
   homepage 'https://icons8.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}