### PR TITLE
Update kite to 0.20170725.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170713.0'
-  sha256 'e770e310ac049715cb01fb97a16e86f0795e635efccc615c864c0b12a766992e'
+  version '0.20170725.1'
+  sha256 '9e65b50a34a0606d15eb121db20b3aeb4da25809467cf2ea4ab687ed57f64316'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '22d3bc2dcbc481e0919d72756be78d05378eb8db7b0414d4a365aa5bf0a251c9'
+          checkpoint: 'd463940e7333433908d245169a2bc77a364117e83a1a9d08a3d652f6a813ec61'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}