### PR TITLE
Update linkliar to 2.1.0

### DIFF
--- a/Casks/linkliar.rb
+++ b/Casks/linkliar.rb
@@ -3,13 +3,13 @@ cask 'linkliar' do
     version '1.1.3'
     sha256 '34c9baeaf1d6732c8ce9add689b281f9b71fddadd8f56cca614cba4f8c167962'
   else
-    version '2.0.0'
-    sha256 '0810a84a99ebd33d39d2b4b990d50df8caab796b36fe3c81a8b6fe159be276f8'
+    version '2.1.0'
+    sha256 'ccb5d99a51a549367dde621102dd313f8da8cc46fed6a65d8e7bfdf4fb39c07a'
   end
 
   url "https://github.com/halo/LinkLiar/releases/download/#{version}/LinkLiar.app.zip"
   appcast 'https://github.com/halo/LinkLiar/releases.atom',
-          checkpoint: '8a426993b3044f7d701dce456a90062ba2725db93299450559996ab3e8e074c9'
+          checkpoint: '02149724f71d7ba213a3bec2fd8cd744b86ae3524bb12fd24208d21e8577f941'
   name 'LinkLiar'
   homepage 'https://github.com/halo/LinkLiar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}