### PR TITLE
Update patchwork to 3.6.6

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,10 +1,10 @@
 cask 'patchwork' do
-  version '3.6.5'
-  sha256 'bb95d84ae6f33d3d32eb53fb58ed2acd62dbb6c533d5f166a32ee27bb6b6188e'
+  version '3.6.6'
+  sha256 'da627845e0b7978f9dd86f990d411f7be3586cc267ea0273e274b19cbdd30702'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom',
-          checkpoint: '548805d36a44614dd7d98344a0061b6ca068cc3f81447382380256ae3c782a3f'
+          checkpoint: '8cdc768452e1fcfc21628ffd6a7a3992084316e5a351f665716564f58db13c6b'
   name 'Patchwork'
   homepage 'https://github.com/ssbc/patchwork'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}