### PR TITLE
Update pdfpenpro to 910.13,1501038914

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '902.1,1495072320'
-  sha256 'deba16a6fbfe426b3329cde6b587b04c8e6f906651d098de02ffe69f5feeb764'
+  version '910.13,1501038914'
+  sha256 '529ce7afcda234443f510bd046650225135ab4e3a054cd49d071d1dbe9676d99'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '1e4f169c7a9b4853d2e6594ac48bd6b03060e56b0eb7f61199087a27849a6b1a'
+          checkpoint: '6ab6e52e8c7afcb947a136f86ed6c86537335c57f46f8a380aa72448f3c63079'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}