### PR TITLE
Update imazing-mini to 2.3.3

### DIFF
--- a/Casks/imazing-mini.rb
+++ b/Casks/imazing-mini.rb
@@ -1,6 +1,6 @@
 cask 'imazing-mini' do
-  version '2.3.2'
-  sha256 '4b1e2e87b1de185fa6abbb96ccb5cbbbac8f78128ae84e79eb2c62f1972d0330'
+  version '2.3.3'
+  sha256 '93f840ff18ca19247b5851c669c925d0353901cb4f1d7a781c8393dc95a820cd'
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing#{version.major}Mac.Mini/iMazingMini#{version.major}forMac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}