### PR TITLE
Update minishift to 1.3.1

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.3.0'
-  sha256 '58adc54b3fbc285ad6fd7037266bc8f134e2521c30836f4ecfe23bcc6110e72c'
+  version '1.3.1'
+  sha256 '52cf602df1f5bec59b78f54625513eae3ed90150096e2cf29237e1cc3cdbd96d'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: 'aa87dfc9508df65e954c52233092a9812152840720d15523302334a87d18cec8'
+          checkpoint: 'a89c6e022f360d6b0b4715aab07e78dfed5173230c27944d98caf6f41a06921a'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}