### PR TITLE
Update softu2f to 0.0.11

### DIFF
--- a/Casks/softu2f.rb
+++ b/Casks/softu2f.rb
@@ -1,10 +1,10 @@
 cask 'softu2f' do
-  version '0.0.10'
-  sha256 '73b3006f667f3c67e4208ce5a2b826698991116f6be273c7e5962f2293c911c3'
+  version '0.0.11'
+  sha256 'bc47d9283fb997ebce2dee6b4e5b1f21d38db37f34bbbf7a962da99d3f62439e'
 
   url "https://github.com/github/SoftU2F/releases/download/#{version}/SoftU2F.pkg"
   appcast 'https://github.com/github/SoftU2F/releases.atom',
-          checkpoint: 'ccddc49f472d2fb421d15002510265e24475309b98b28ca770388075c6412b3b'
+          checkpoint: 'f303ba212e38f75d5fcfe0eb998407c793c000253cbb05f89fe6ee1c2c983fb0'
   name 'Soft U2F'
   homepage 'https://github.com/github/SoftU2F'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}