### PR TITLE
Update bandage to 0.8.1

### DIFF
--- a/Casks/bandage.rb
+++ b/Casks/bandage.rb
@@ -5,7 +5,7 @@ cask 'bandage' do
   # github.com/rrwick/Bandage was verified as official when first introduced to the cask
   url "https://github.com/rrwick/Bandage/releases/download/v#{version}/Bandage_Mac_v#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/rrwick/Bandage/releases.atom',
-          checkpoint: '31d89821f7d090aa6a4ed73752942e232ba1309fc2338ced357adf5bcbb5faab'
+          checkpoint: '538b835e813476438dcfb0fca69c044b4c2766c5e65b5bba1980c3c33c1dc81f'
   name 'Bandage'
   homepage 'https://rrwick.github.io/Bandage/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}