### PR TITLE
Update barxtemp to 1.3.2

### DIFF
--- a/Casks/barxtemp.rb
+++ b/Casks/barxtemp.rb
@@ -5,7 +5,7 @@ cask 'barxtemp' do
   # github.com/Gabriele91/barXtemp was verified as official when first introduced to the cask
   url "https://github.com/Gabriele91/barXtemp/releases/download/#{version}/barXtemp.app.zip"
   appcast 'https://github.com/Gabriele91/barXtemp/releases.atom',
-          checkpoint: '9b9241fbc6f23d60d033f2567a8d21f4aa077055c46fb87541ff6ef5cb2cdbae'
+          checkpoint: 'e4a37ae70ef4022ff29169770d6dd9c2be30ffc4f381ba55fdb5bdf1e437ee07'
   name 'barXtemp'
   homepage 'https://gabriele91.github.io/barXtemp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}