### PR TITLE
Update bdash to 1.2.0

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -4,7 +4,7 @@ cask 'bdash' do
 
   url "https://github.com/bdash-app/bdash/releases/download/#{version}/Bdash-#{version}-macOS.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom',
-          checkpoint: '3c4c5ff7503686c516a3f1bc16616857bba73ef602aa59cc52c3bea5fcefd8d9'
+          checkpoint: '7ad7fa99e2324187649091259bb13ffd43c203a0ad900115eecc2e4ca2b15779'
   name 'Bdash'
   homepage 'https://github.com/bdash-app/bdash'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}