### PR TITLE
Update beacon-scanner to 1.1.13

### DIFF
--- a/Casks/beacon-scanner.rb
+++ b/Casks/beacon-scanner.rb
@@ -4,7 +4,7 @@ cask 'beacon-scanner' do
 
   url "https://github.com/mlwelles/BeaconScanner/releases/download/#{version}/Beacon.Scanner.zip"
   appcast 'https://github.com/mlwelles/BeaconScanner/releases.atom',
-          checkpoint: '0d519e3cfa636ace2d9c385d70cea818ec9f5c325a2f4521278fb6c44f09de5e'
+          checkpoint: 'bd753dc63baf03d9a954bdf044848959520b948219e578fc3a98599df138bb71'
   name 'BeaconScanner'
   homepage 'https://github.com/mlwelles/BeaconScanner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}