### PR TITLE
Update mosh to 1.3.2

### DIFF
--- a/Casks/mosh.rb
+++ b/Casks/mosh.rb
@@ -1,6 +1,6 @@
 cask 'mosh' do
-  version '1.3.0'
-  sha256 'a423fcb5aab7079e20b03cfa5e8623bb89391087dd5492d68947c89a39eee80c'
+  version '1.3.2'
+  sha256 '7b00838e04e954e19d6bd5a63ff9729084bd55e21d894994916b73e996a9c42f'
 
   url "https://mosh.org/mosh-#{version}.pkg"
   name 'Mosh'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}