### PR TITLE
Update birdfont to 2.18.5

### DIFF
--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -1,10 +1,10 @@
 cask 'birdfont' do
-  version '2.18.3'
-  sha256 'a3c20e3d53feda829e2a573b2a463488d601812e9119ce91828a6197efb3bf5f'
+  version '2.18.5'
+  sha256 'f023d17ebd5786a68dba306c2d32d6c5d463769fda8fbd0542e78c2d5258547f'
 
   url "https://birdfont.org/download/birdfont-#{version}-free.dmg"
   appcast 'https://github.com/johanmattssonm/birdfont/releases.atom',
-          checkpoint: '470a4c4caa05c16e8432edb5b5d46d160326d22aa959a47dfd4cacd547187233'
+          checkpoint: '141eddd0351e489949f929223cbfa4fd4ee90852875ce0c714727cb72013a65c'
   name 'BirdFont'
   homepage 'https://birdfont.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}