### PR TITLE
Update bisq to 0.5.3

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -5,7 +5,7 @@ cask 'bisq' do
   # github.com/bitsquare/bitsquare was verified as official when first introduced to the cask
   url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
-          checkpoint: '9e0099bc84038f67609e5a3d7327f3adaffedfbac879f98ddc3b1a32706efb2d'
+          checkpoint: 'a4a386edb7bedaffe3f2f282a42042fed68a086538af81dc08ca4689b008221e'
   name 'Bisq'
   homepage 'https://bitsquare.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}