### PR TITLE
Update bitcoin-classic to 1.2.5

### DIFF
--- a/Casks/bitcoin-classic.rb
+++ b/Casks/bitcoin-classic.rb
@@ -5,7 +5,7 @@ cask 'bitcoin-classic' do
   # github.com/bitcoinclassic was verified as official when first introduced to the cask
   url "https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v#{version}/bitcoin-#{version}-osx.dmg"
   appcast 'https://github.com/bitcoinclassic/bitcoinclassic/releases.atom',
-          checkpoint: 'f269c31370e255b28402bf355d5cea800267202f4008266469fe89d1e6e0924b'
+          checkpoint: '732baf9915ea324c4130292ee428b677da117adf3f797d4b09d8f957d12d38f8'
   name 'Bitcoin Classic'
   homepage 'https://bitcoinclassic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}