### PR TITLE
Update bitkeeper to 7.3.1ce

### DIFF
--- a/Casks/bitkeeper.rb
+++ b/Casks/bitkeeper.rb
@@ -4,7 +4,7 @@ cask 'bitkeeper' do
 
   url "http://www.bitkeeper.org/downloads/#{version}/bk-#{version}-x86_64-macosx.pkg"
   appcast 'http://www.bitkeeper.org/download.html',
-          checkpoint: '3ec320168eb53f3f1317b7ef2f9fefdf3633b40d18022c554b228eb1db50d8a8'
+          checkpoint: '012486fc8f110b56139f497338253996bf6629c2f47c80d8b2a88ede9fc404ee'
   name 'BitKeeper'
   homepage 'http://www.bitkeeper.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}