### PR TITLE
Update boostnote to 0.8.11

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -5,7 +5,7 @@ cask 'boostnote' do
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '03445af0e25f85979dfc442881094dbaacaa57fc72ff816db50797ea369254bf'
+          checkpoint: '4702612a0187e73b5ff1662866cf94708322c76fa749a2b82943d22a974a7e7e'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}