### PR TITLE
Update bootxchanger to 2.0

### DIFF
--- a/Casks/bootxchanger.rb
+++ b/Casks/bootxchanger.rb
@@ -5,7 +5,7 @@ cask 'bootxchanger' do
   # github.com/zydeco/bootxchanger was verified as official when first introduced to the cask
   url "https://github.com/zydeco/bootxchanger/releases/download/v#{version}/bootxchanger_#{version}.dmg"
   appcast 'https://github.com/zydeco/bootxchanger/releases.atom',
-          checkpoint: 'd158358503b6b107f45d87f29b87d859447eb57f8c59a3fbbdded976ae7caba5'
+          checkpoint: '0b9450d1da78c34dc9808527a70a4aa36f7a2e6faa412dd6981b5f30b506b773'
   name 'BootXChanger'
   homepage 'https://namedfork.net/bootxchanger/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}