### PR TITLE
Update borgbackup to 1.0.11

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.0.10'
-  sha256 '6c441f77e43909248b7494d768e34e442984ac8aaaa32405aa53fc750d9e1245'
+  version '1.0.11'
+  sha256 'e197a7b830760ddec8b33bdc241312b50e6c27701384e2aafed01c22805395e3'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '5d4f3de5d1e113eb2663fcd107fcafa262a2b74ae2cbd36a61d73beb4ab87aa5'
+          checkpoint: '79f4f919971110b412e3008d8f51645b6ca068d7bcbc0ea0ae99e84220b36038'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.io/en/stable/'
   gpg "#{url}.asc", key_id: '51F78E01'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}