### PR TITLE
Update botframework-emulator to 3.5.29

### DIFF
--- a/Casks/botframework-emulator.rb
+++ b/Casks/botframework-emulator.rb
@@ -4,7 +4,7 @@ cask 'botframework-emulator' do
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom',
-          checkpoint: 'b8557f2447a1cd0fd0a85665f6c27266bc8a7496e5581530be76c36b34f4587f'
+          checkpoint: '55a8b628f1cd6aa5f2cc867021c534df44c5e918d492fac98b132fe4b49039de'
   name 'Microsoft Bot Framework Emulator'
   homepage 'https://github.com/Microsoft/BotFramework-Emulator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}