### PR TITLE
Update teamviewer casks (2) - change to sha256 no_check

### DIFF
--- a/Casks/teamviewer-host.rb
+++ b/Casks/teamviewer-host.rb
@@ -2,7 +2,7 @@ cask 'teamviewer-host' do
   version '12'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://download.teamviewer.com/download/version_#{version.major}x/TeamViewerHost.dmg"
+  url "https://download.teamviewer.com/download/version_#{version}x/TeamViewerHost.dmg"
   name 'TeamViewer Host'
   homepage 'https://www.teamviewer.com/'
 
@@ -13,7 +13,7 @@ cask 'teamviewer-host' do
   uninstall pkgutil: 'com.teamviewer.teamviewerhost.*',
             delete:  [
                        '/Applications/TeamViewerHost.app',
-                       "/Library/Fonts/TeamViewer#{version.major}Host.otf",
+                       "/Library/Fonts/TeamViewer#{version}Host.otf",
                        '~/Library/Application Support/TeamViewer Host',
                        '~/Library/Caches/com.teamviewer.TeamViewerHost',
                        '~/Library/Preferences/com.teamviewer.TeamViewerHost.plist',

--- a/Casks/teamviewer-host.rb
+++ b/Casks/teamviewer-host.rb
@@ -1,6 +1,6 @@
 cask 'teamviewer-host' do
-  version '12.0.80984'
-  sha256 '93fbde09b14cfac13f4f3fd3e7c02bdd3712b6a5c598c00c7a40b8c981938024'
+  version '12'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://download.teamviewer.com/download/version_#{version.major}x/TeamViewerHost.dmg"
   name 'TeamViewer Host'

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -2,7 +2,7 @@ cask 'teamviewer' do
   version '12'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://download.teamviewer.com/download/version_#{version.major}x/TeamViewer.dmg"
+  url "https://download.teamviewer.com/download/version_#{version}x/TeamViewer.dmg"
   name 'TeamViewer'
   homepage 'https://www.teamviewer.com/'
 
@@ -10,10 +10,10 @@ cask 'teamviewer' do
 
   pkg 'Install TeamViewer.pkg'
 
-  uninstall pkgutil: "com.teamviewer.teamviewer#{version.major}(?!AuthPlugin|PriviledgedHelper).*",
+  uninstall pkgutil: "com.teamviewer.teamviewer#{version}(?!AuthPlugin|PriviledgedHelper).*",
             delete:  [
                        '/Applications/TeamViewer.app',
-                       "/Library/Fonts/TeamViewer#{version.major}.otf",
+                       "/Library/Fonts/TeamViewer#{version}.otf",
                      ]
 
   zap       delete: [

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,6 +1,6 @@
 cask 'teamviewer' do
-  version '12.0.81279'
-  sha256 'e15da207c2b4831e893b5c6092f9565f8c35c1ae8379532d1d5ca41573b37fa6'
+  version '12'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://download.teamviewer.com/download/version_#{version.major}x/TeamViewer.dmg"
   name 'TeamViewer'


### PR DESCRIPTION
The changelog for these casks is unstable and cannot be used as an appcast. 

The version is shown here https://www.teamviewer.com/en/download/mac/ but the downloads seem to be updated in place without a version bump.