### PR TITLE
Update brackets to 1.10

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -5,7 +5,7 @@ cask 'brackets' do
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
   appcast 'https://github.com/adobe/brackets/releases.atom',
-          checkpoint: '3559e75e79f9cbb64679435add8870e45f2c7c15daca08ef9e890a46920e38ee'
+          checkpoint: '593cb947ceb3b2b02102c979debfc0c6dc777de6db3b82efef64ed21ba753760'
   name 'Brackets'
   homepage 'http://brackets.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}