### PR TITLE
Update brisk to 1.0.1

### DIFF
--- a/Casks/brisk.rb
+++ b/Casks/brisk.rb
@@ -4,7 +4,7 @@ cask 'brisk' do
 
   url "https://github.com/br1sk/brisk/releases/download/#{version}/Brisk.app.tar.gz"
   appcast 'https://github.com/br1sk/brisk/releases.atom',
-          checkpoint: '5e8c5b48f8af9de1dab910ab3e1cc4960e0c9b577745b22db677febdfe66ec82'
+          checkpoint: 'c12db840df66de26359e114c345c65297edb88857e893573e037edf197be9218'
   name 'Brisk'
   homepage 'https://github.com/br1sk/brisk'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}