### PR TITLE
Update bzflag to 2.4.10

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -4,7 +4,7 @@ cask 'bzflag' do
 
   url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom',
-          checkpoint: 'bf375854bf8e5da22b1c39a064f92c6f1cae3143f240342505c383e3ce18caf2'
+          checkpoint: '3977e768b79641b31bccaddf102b29a8c8e53ed1f5f238bd70a2bb28d9ec5196'
   name 'BZFlag'
   homepage 'https://www.bzflag.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}