### PR TITLE
Update freesmug-chromium to 60.0.3112.78

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '59.0.3071.115'
-  sha256 'bc1e6fa694a58939b3bd94d8b2ee5686443c8f8cd7eab27002a352c6d2ac10ba'
+  version '60.0.3112.78'
+  sha256 'd9cf52c43e2d541d7c24b73db6903d9c7183eedfe9b957f45e19565f09067f96'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '33f57360db998ab207078bddc41bf74d41d39ec39546d6925ec381d7563bc364'
+          checkpoint: 'ca25958a6d249df9ccbee4056b8cba6cb8bdcca11caea041cf39c586a12dd36e'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}