### PR TITLE
Update cantata to 2.0.1

### DIFF
--- a/Casks/cantata.rb
+++ b/Casks/cantata.rb
@@ -4,7 +4,7 @@ cask 'cantata' do
 
   url "https://github.com/CDrummond/cantata/releases/download/v#{version}/Cantata-#{version}.dmg"
   appcast 'https://github.com/CDrummond/cantata/releases.atom',
-          checkpoint: '4421d33d3c8b121da3d7740b2ce6bc356d8f04c6a762581f6787ee2e7cdf1c0d'
+          checkpoint: '3b9ed09aca605ae43105f789fdd9c5f39a5f391d5132e5e9390056a8b7f2f5de'
   name 'Cantata'
   homepage 'https://github.com/cdrummond/cantata'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}