### PR TITLE
Update catch to 1.9.4

### DIFF
--- a/Casks/catch.rb
+++ b/Casks/catch.rb
@@ -5,7 +5,7 @@ cask 'catch' do
   # github.com/mipstian/catch was verified as official when first introduced to the cask
   url "https://github.com/mipstian/catch/releases/download/#{version}/Catch-#{version}.zip"
   appcast 'https://github.com/mipstian/catch/releases.atom',
-          checkpoint: '5d1a90f8341e2467530d4254620dbd2c1760eae5ce296ef3e31764c3ff74d2d3'
+          checkpoint: '0312c93e1d9dc541ce8dbcfde2fa667350ee31034513d16a14aeb6370837b378'
   name 'Catch'
   homepage 'https://www.giorgiocalderolla.com/index.html#catch'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}