### PR TITLE
Update cd-to to 2.6.0

### DIFF
--- a/Casks/cd-to.rb
+++ b/Casks/cd-to.rb
@@ -4,7 +4,7 @@ cask 'cd-to' do
 
   url "https://github.com/jbtule/cdto/releases/download/#{version.dots_to_underscores}/cdto_#{version.dots_to_underscores.gsub(%r{_\d$}, '')}.zip"
   appcast 'https://github.com/jbtule/cdto/releases.atom',
-          checkpoint: 'b47d89df99576be853c6b6a1c3be4167cc57675a95464bd5753153de481d9199'
+          checkpoint: 'c21a7e85cf5e33461672d1cc6c88b36124df7846b4569f8619806745c5d76903'
   name 'cd to'
   homepage 'https://github.com/jbtule/cdto'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}