### PR TITLE
Update mountain-duck to 1.9.7.7313

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.9.6.7308'
-  sha256 '0ee5b9e0e3326626b527462574892e315bcf7857b203d45d88a54b27aad00c9c'
+  version '1.9.7.7313'
+  sha256 '7ea53e67bba8fa17e8a27266a22b6d7031a49a42c4a446ee8f9f0b29c8dbeb4a'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '76519ffe9ebed19b3aa3744c30bfbf44e366c7cac71e45e7e9e097904774d3c1'
+          checkpoint: '2bfdd1eb702fdbea8ba6d2524c9a2ee5663912b5a8e5bd9a535a9c0d2ebbc5d7'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}