### PR TITLE
Update framer to 9520

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '9475'
-  sha256 '89271d51287506d18c03d308a5eaf33c80fbd27dbf18694bc852789b474a37b9'
+  version '9520'
+  sha256 '2ff5bcbf98e71c2b77bd4bd28fd3fa0d30826c48449e3a257508c935fd8694b3'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: 'cfa0c4116ced02b627e998cbfba1daf3a73939d9ad115c7854cbd0e3e89fe4ac'
+          checkpoint: '934532390e02d0b5a5f9a2909a27356442f8775c0cb25ebbada19da11c6ee614'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}