### PR TITLE
Update brave to 0.18.14

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -5,7 +5,7 @@ cask 'brave' do
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'f0d17e4e0c39695638d0fa3bb20b27020d4f94584fc3e8c9d02b3e97411a8c60'
+          checkpoint: '74f0088db0f580ecc5276ca073d2e8b6d1fe9065cfac0123844584fb39edfbc0'
   name 'Brave'
   homepage 'https://brave.com/'
 

--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.17.19'
-  sha256 '67f40e780dcd352134d9f743ce4aacdbd27555ca7706d6ef60918a68cf2f6e54'
+  version '0.18.14'
+  sha256 '0a3d15b924a4ad85a51d3c1b62943ea6aa92381a80bea4933284174fd0c13f11'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '49c6ea4d3a43429a52906ed9b49d36176981d037074b595370e0906fec748a9a'
+          checkpoint: 'f0d17e4e0c39695638d0fa3bb20b27020d4f94584fc3e8c9d02b3e97411a8c60'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}