### PR TITLE
Update chitchat to 1.5

### DIFF
--- a/Casks/chitchat.rb
+++ b/Casks/chitchat.rb
@@ -4,7 +4,7 @@ cask 'chitchat' do
 
   url "https://github.com/stonesam92/ChitChat/releases/download/v#{version}/ChitChat.zip"
   appcast 'https://github.com/stonesam92/ChitChat/releases.atom',
-          checkpoint: '69a46ab6fcee6ee92bee663a47fbfd141845ef87de39a97ee90dee5b98dfc9b2'
+          checkpoint: 'dbf95f4eac9084b8b95eb773f93bd8906de08451c32891ddcfdc23edfd3f283c'
   name 'ChitChat'
   homepage 'https://github.com/stonesam92/ChitChat'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}