### PR TITLE
Update chrome-devtools to 1.1.0

### DIFF
--- a/Casks/chrome-devtools.rb
+++ b/Casks/chrome-devtools.rb
@@ -4,7 +4,7 @@ cask 'chrome-devtools' do
 
   url "https://github.com/auchenberg/chrome-devtools-app/releases/download/v#{version}/chrome-devtools-app_#{version}.dmg"
   appcast 'https://github.com/auchenberg/chrome-devtools-app/releases.atom',
-          checkpoint: 'cdbba9426341e0ad1d5b7a01c5f007091cc1d41bce9b50923166837d85f6d943'
+          checkpoint: '67fbcc2f435ff12e0666763b98130ede4f9ac0b748b7a153e5ccabc31a5ecc13'
   name 'Chrome DevTools'
   homepage 'https://github.com/auchenberg/chrome-devtools-app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}