### PR TITLE
Update chronocube to 0.5.1

### DIFF
--- a/Casks/chronocube.rb
+++ b/Casks/chronocube.rb
@@ -5,7 +5,7 @@ cask 'chronocube' do
   # github.com/pablopunk/chronocube was verified as official when first introduced to the cask
   url "https://github.com/pablopunk/chronocube/releases/download/v#{version}/Chronocube-Mac.dmg"
   appcast 'https://github.com/pablopunk/chronocube/releases.atom',
-          checkpoint: '3d862c1dad31e0d8570a254d82d787313db3b8e46995c213aefd8f7aa725d949'
+          checkpoint: '759d59106cc594bc439d71086e5762fabdd283b95fa156b46620ce1f8d4a15ee'
   name 'Chronocube'
   homepage 'http://chronocube.live/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}