### PR TITLE
Update cinder to 0.9.1

### DIFF
--- a/Casks/cinder.rb
+++ b/Casks/cinder.rb
@@ -4,7 +4,7 @@ cask 'cinder' do
 
   url "https://libcinder.org/static/releases/cinder_#{version}_mac.zip"
   appcast 'https://github.com/cinder/cinder/releases.atom',
-          checkpoint: 'e0db8a004ea98e9cd20247a819305bc1e74486f059e1374fe522dbf09c44c2a0'
+          checkpoint: '7976c5140bdbaaab1907056c7646a0f4a0a8dfd9691d2aeb4a3c50781a30c12d'
   name 'Cinder'
   homepage 'https://libcinder.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}