### PR TITLE
Update ckb to 0.2.6

### DIFF
--- a/Casks/ckb.rb
+++ b/Casks/ckb.rb
@@ -4,7 +4,7 @@ cask 'ckb' do
 
   url "https://github.com/ccMSC/ckb/releases/download/v#{version}/ckb.pkg"
   appcast 'https://github.com/ccMSC/ckb/releases.atom',
-          checkpoint: 'a986b9f3e5d5d9103c7711f5032cfbf4140eafac008342bc9e9907798f5e2421'
+          checkpoint: '7c4d9d7c8e23e91beb865efdf41512c8ed77b820fe28d11630dc67ab5fc710b9'
   name 'ckb'
   homepage 'https://github.com/ccMSC/ckb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}