### PR TITLE
Update cleartext to 2.45

### DIFF
--- a/Casks/cleartext.rb
+++ b/Casks/cleartext.rb
@@ -4,7 +4,7 @@ cask 'cleartext' do
 
   url "https://github.com/mortenjust/cleartext-mac/releases/download/#{version}/Cleartext.zip"
   appcast 'https://github.com/mortenjust/cleartext-mac/releases.atom',
-          checkpoint: 'bfaebff6f178edaefb157c457a0c577c3d63ed0003cd426b2c4837ab4cd8e6cb'
+          checkpoint: 'c4327bb05e50b5e7b13c63c7a5ab58095809c269b12fc295bfec2493a7fef7bc'
   name 'Cleartext'
   homepage 'https://github.com/mortenjust/cleartext-mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}