### PR TITLE
Update mysql-shell to 1.0.10

### DIFF
--- a/Casks/mysql-shell.rb
+++ b/Casks/mysql-shell.rb
@@ -1,6 +1,6 @@
 cask 'mysql-shell' do
-  version '1.0.9'
-  sha256 'c47ebefa2bb8f0a949843e5eb198857d4e96a4e296c4bde5f1afec03c295844a'
+  version '1.0.10'
+  sha256 'e9089ee384b4f9de1c2566043b232db2e4fdb8e9a722e24ef1b6dbf2e3e76344'
 
   url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version}-macos10.12-x86-64bit.dmg"
   name 'MySQL Shell'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}