### PR TITLE
Update numi to 3.17,131:1500983122

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,11 +1,11 @@
 cask 'numi' do
-  version '3.16,129:1499870033'
-  sha256 'cafcf48855d7ee0fcfdb88d45e213480dc6bdddd6c5f2de3e3b96cf5c403cdd2'
+  version '3.17,131:1500983122'
+  sha256 'cd65462aa9a6441849dd93692fc7c28ccd646805969830acc301f001ad9235b2'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"
   appcast 'http://updates.devmate.com/com.dmitrynikolaev.numi.xml',
-          checkpoint: 'feb8849c1202797c06d76a39c96f5bea4eeb4b79533f79bab0965464665ac6cf'
+          checkpoint: '5e2dbe0540908141c5fb4b4334fc454d5e954639c266e3cad0418e48aca17ca6'
   name 'Numi'
   homepage 'https://numi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}