### PR TITLE
Update vox to 2.8.28

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '2.8.26'
-  sha256 '102e87e1f2d271d6b36120e252b6d07a35240ee11177a238ef757cb77394ed7d'
+  version '2.8.28'
+  sha256 'fecd524c097e89343f74bef0032e19b2756d5237a42312180d20db1a576960c1'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: 'c5abaf11d0b33d34a8f7f60d1592d05176e29bbbacafdc6212c94df94d26f1f3'
+          checkpoint: 'e5cc5670e95e28a8e064c87a20eb6ba33682f9f8baf8641c1f3bcddf8b7b6861'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}