### PR TITLE
Update neofinder to 7.1.2

### DIFF
--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,11 +1,11 @@
 cask 'neofinder' do
-  version '7.1.1'
-  sha256 'ceee1d367fb0c6927fba86c66d33d5e20d93a93748a4cba4e3ce4799d7911387'
+  version '7.1.2'
+  sha256 '88693244a23edd7e07becf323e3f2671822577eb497418502ae53758606b6975'
 
   # wfs-apps.de was verified as official when first introduced to the cask
   url "https://www.wfs-apps.de/updates/neofinder.#{version}.zip"
   appcast 'https://www.wfs-apps.de/updates/neofinder-appcast-64.xml',
-          checkpoint: '673d705249d43830686a44fa7d4adff37c85451c3d13c69216da4cb6e8b04026'
+          checkpoint: 'fc593ae0aa0ccf78e35c7833c32d47dd18404ee2d44e7dc8c43ecc2361ec857e'
   name 'NeoFinder'
   homepage 'https://www.cdfinder.de/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}