### PR TITLE
Update expressions to 1.3.1

### DIFF
--- a/Casks/expressions.rb
+++ b/Casks/expressions.rb
@@ -1,6 +1,6 @@
 cask 'expressions' do
-  version '1.2.2'
-  sha256 '459b6b8e39cb167c3c36c435fcb5006bff5b4cf18646cf48e68d03e08eb73640'
+  version '1.3.1'
+  sha256 '1d8daf05089da36d9d95e107e2b20c69e65e3160b73ba1da848220aa1114de08'
 
   url "http://www.apptorium.com/products/expressions/releases/Expressions-#{version}.zip"
   name 'Expressions'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}