### PR TITLE
Bump Skype for Business to 16.8.0.196

### DIFF
--- a/Casks/skype-for-business.rb
+++ b/Casks/skype-for-business.rb
@@ -1,6 +1,6 @@
 cask 'skype-for-business' do
-  version '16.6.0.333'
-  sha256 'cf2fddc7e45010d5a0b968c900bf130762ac22305e61c94351c25f0e18e0f662'
+  version '16.8.0.196'
+  sha256 'a9b713ba254e035a0535d5ad2857d2ab8e890d02721c84dc39057f128ed0dfd1'
 
   url "https://download.microsoft.com/download/D/0/5/D055DA17-C7B8-4257-89A1-78E7BBE3833F/SkypeForBusinessInstaller-#{version}.pkg"
   name 'Skype for Business'


### PR DESCRIPTION
Hello,

Here is an update for the Skype-for-Business cask.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
