### PR TITLE
Update cloudy to 1.2

### DIFF
--- a/Casks/cloudy.rb
+++ b/Casks/cloudy.rb
@@ -4,7 +4,7 @@ cask 'cloudy' do
 
   url 'https://github.com/calebd/cloudy/releases/download/v5/Cloudy.zip'
   appcast 'https://github.com/calebd/cloudy/releases.atom',
-          checkpoint: 'e4dabdd103758cca09814f6d68675e887c6775390e18d334e221fceb0a362818'
+          checkpoint: '613e2382baff34c0207ce1d52c0c37646de3173512c9fe6e42d9e7c1fbeb23fd'
   name 'Cloudy'
   homepage 'https://github.com/calebd/cloudy'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}