### PR TITLE
Update cloudytabs to 1.6

### DIFF
--- a/Casks/cloudytabs.rb
+++ b/Casks/cloudytabs.rb
@@ -4,7 +4,7 @@ cask 'cloudytabs' do
 
   url "https://github.com/josh-/CloudyTabs/releases/download/v#{version}/CloudyTabs.zip"
   appcast 'https://github.com/josh-/CloudyTabs/releases.atom',
-          checkpoint: '8934ab65f5388b68ff231beb004bd956da07a8f79cd95060d67502296819d037'
+          checkpoint: '5f2c823f1891600d3a521bf7c90f05da9038af80aeba06f2567f59f4bb77fac1'
   name 'CloudyTabs'
   homepage 'https://github.com/josh-/CloudyTabs/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}