### PR TITLE
Update cmd-eikana to 2.2.3

### DIFF
--- a/Casks/cmd-eikana.rb
+++ b/Casks/cmd-eikana.rb
@@ -4,7 +4,7 @@ cask 'cmd-eikana' do
 
   url "https://github.com/iMasanari/cmd-eikana/releases/download/v#{version}/eikana-#{version}.app.zip"
   appcast 'https://github.com/iMasanari/cmd-eikana/releases.atom',
-          checkpoint: 'e40616ed8d7a7b08955274084c954db289fe30e7abfe12989c01e3abf08bf2aa'
+          checkpoint: '3c6423032f1850dfd5358f8fac7e22d4aded4d3039c2b81b412d688aadcf773e'
   name 'cmd-eikana'
   name '⌘英かな'
   homepage 'https://github.com/iMasanari/cmd-eikana'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}