### PR TITLE
Update cmucl to 21b

### DIFF
--- a/Casks/cmucl.rb
+++ b/Casks/cmucl.rb
@@ -5,7 +5,7 @@ cask 'cmucl' do
   # common-lisp.net/project/cmucl was verified as official when first introduced to the cask
   url "https://common-lisp.net/project/cmucl/downloads/release/#{version}/cmucl-#{version}-x86-darwin.tar.bz2"
   appcast 'https://common-lisp.net/project/cmucl/downloads/release/',
-          checkpoint: '532de0c79a895ca878da189f81b785852cb583ac892d02208abffafaa65ace17'
+          checkpoint: '3fba3d06219fd1dee10e62801d0a957775443059d58d2026c5d637649795a4da'
   name 'Cmucl'
   homepage 'https://www.cons.org/cmucl/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}