### PR TITLE
Update Pomotodo to 3.3.0

### DIFF
--- a/Casks/pomotodo.rb
+++ b/Casks/pomotodo.rb
@@ -1,11 +1,11 @@
 cask 'pomotodo' do
-  version '3.2.2,1493264068'
-  sha256 '3c176306627bf20080681cef7d982eb5fcfd535666f79dcef2ddef7fb5fd66cd'
+  version '3.3.0,1499943104'
+  sha256 '429c1235bb4a0279723bf141ad92690acf1a2e0c813affb38e0d510cf107821b'
 
   # cdn.hackplan.com/theair was verified as official when first introduced to the cask
   url "http://cdn.hackplan.com/theair/#{version.after_comma}/Pomotodo_v#{version.before_comma}.dmg"
   appcast "https://air.pomotodo.com/v1/p/com.pomotodo.PomotodoMac#{version.major}/latest.xml",
-          checkpoint: 'd901ecb9af3414888d4acec8f61eebe4cf4640e4ef298934ece09fe67ab0ce99'
+          checkpoint: '21ebb47c0df9fa1e7af72db365b4f76f9bc0db105e16d866d36f6ad2512a7ba3'
   name 'Pomodoro'
   homepage 'https://pomotodo.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}