### PR TITLE
Update colour-contrast-analyser to 2.3

### DIFF
--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -5,7 +5,7 @@ cask 'colour-contrast-analyser' do
   # github.com/ThePacielloGroup/CCA-OSX was verified as official when first introduced to the cask
   url "https://github.com/ThePacielloGroup/CCA-OSX/releases/download/#{version}/Colour.Contrast.Analyser.app.zip"
   appcast 'https://github.com/ThePacielloGroup/CCA-OSX/releases.atom',
-          checkpoint: '4ab9b55e98b8b2dfff03bfbbd3b71bc797c8094c6d3005d6629f3686879e634a'
+          checkpoint: 'b61166779a9aa65f2b42468fb272235940f5ecf2eb75ab113bc9231033a2923c'
   name 'Colour Contrast Analyser'
   homepage 'https://www.paciellogroup.com/resources/contrastanalyser/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}