### PR TITLE
Update comictagger to 1.1.16-beta-rc2

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -4,7 +4,7 @@ cask 'comictagger' do
 
   url "https://github.com/davide-romanini/comictagger/releases/download/#{version}/ComicTagger-#{version}.dmg"
   appcast 'https://github.com/davide-romanini/comictagger/releases.atom',
-          checkpoint: 'f7b51d43427127ee247bb47425d9419c8cd59df043063fa29345bdb12928900d'
+          checkpoint: '6f8c330b4be724d22619da7536028e38c4a86d126fd636ce8e1bd64b3451beb0'
   name 'ComicTagger'
   homepage 'https://github.com/davide-romanini/comictagger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}