### PR TITLE
Update comma-chameleon to 0.5.2

### DIFF
--- a/Casks/comma-chameleon.rb
+++ b/Casks/comma-chameleon.rb
@@ -5,7 +5,7 @@ cask 'comma-chameleon' do
   # github.com/theodi/comma-chameleon was verified as official when first introduced to the cask
   url "https://github.com/theodi/comma-chameleon/releases/download/#{version}/Comma.Chameleon-darwin-x64.zip"
   appcast 'https://github.com/theodi/comma-chameleon/releases.atom',
-          checkpoint: '69d6c44cff9461e20c4152b819e978ad88abf1e029c2f1f0be2b35b320da8d43'
+          checkpoint: '673f3eb04098a27cb5232c6042d43002302d47609062010b43fc164b0b6e7de6'
   name 'Comma Chameleon'
   homepage 'https://comma-chameleon.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}