### PR TITLE
Update conductor to 1.4.1

### DIFF
--- a/Casks/conductor.rb
+++ b/Casks/conductor.rb
@@ -4,7 +4,7 @@ cask 'conductor' do
 
   url "https://github.com/keith/conductor/releases/download/#{version}/Conductor.app.zip"
   appcast 'https://github.com/keith/conductor/releases.atom',
-          checkpoint: 'fb271592f0a88f92c680d2645a036b12da17d13d391b0bb6ce3641c4003723eb'
+          checkpoint: 'a0cb2e172d6824138153f58f0b16cdf642128525861b2f11f979cef6ffad510c'
   name 'Conductor'
   homepage 'https://github.com/keith/conductor'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}