### PR TITLE
Update context-free to 3.0.11.3

### DIFF
--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -4,7 +4,7 @@ cask 'context-free' do
 
   url "http://www.contextfreeart.org/download/ContextFree#{version}.dmg"
   appcast 'https://github.com/MtnViewJohn/context-free/releases.atom',
-          checkpoint: 'e870c4c9ad2c4e7dcd36b196f0008000a4f821cf6f86a55237067f37769f809b'
+          checkpoint: '54b9e3003e60d4ae9ad25ba74a4fa0b78f6837d4a28adb55cfe078c103c81e3f'
   name 'Context Free'
   homepage 'https://www.contextfreeart.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}