### PR TITLE
Update corectl-app to 0.2.9

### DIFF
--- a/Casks/corectl-app.rb
+++ b/Casks/corectl-app.rb
@@ -4,7 +4,7 @@ cask 'corectl-app' do
 
   url "https://github.com/TheNewNormal/corectl.app/releases/download/v#{version}/corectl_v#{version}.dmg"
   appcast 'https://github.com/TheNewNormal/corectl.app/releases.atom',
-          checkpoint: 'a8c59a6b7be6b1dd875acd163e7440dd4d8dbf2d47889efb79a1a93a8a7c161e'
+          checkpoint: 'b00a4524703f6497244e91b895bc71f54f626afeea90c1426c39b988eb807526'
   name 'Corectl'
   homepage 'https://github.com/TheNewNormal/corectl.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}