### PR TITLE
Update corelocationcli to 3.0.1

### DIFF
--- a/Casks/corelocationcli.rb
+++ b/Casks/corelocationcli.rb
@@ -4,7 +4,7 @@ cask 'corelocationcli' do
 
   url "https://github.com/fulldecent/corelocationcli/releases/download/#{version}/CoreLocationCLI.zip"
   appcast 'https://github.com/fulldecent/corelocationcli/releases.atom',
-          checkpoint: '65e6d799fcdc80d57b426855653aaaa5bbc03efdad5f578a550c5a98ca876eee'
+          checkpoint: '50fc2119711333b356b2d30e3d3683b1f64a3d52a780a1f5f51a0366145d4328'
   name 'Core Location CLI'
   homepage 'https://github.com/fulldecent/corelocationcli'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}