### PR TITLE
Update mist to 0.9.0

### DIFF
--- a/Casks/mist.rb
+++ b/Casks/mist.rb
@@ -1,10 +1,10 @@
 cask 'mist' do
-  version '0.8.10'
-  sha256 '3f85562aabf4b6fff060ca67f61e3ff4223c9f3c1fdbb9969cba62f817876d8d'
+  version '0.9.0'
+  sha256 'daf781fb64312400c3c85a1899f989a42a568d1b527c318b78d83084d31c4664'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: 'db29dbab760464a21b06e97487eb4fc6266d26318c2af95b12c3737335a67e40'
+          checkpoint: '2d21d2003f91bff6b6eb3ecc232b6f675faca97e224bb318cc3a8595916f2ba2'
   name 'Mist'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}