### PR TITLE
Update upterm to 0.2.161

### DIFF
--- a/Casks/upterm.rb
+++ b/Casks/upterm.rb
@@ -1,10 +1,10 @@
 cask 'upterm' do
-  version '0.2.160'
-  sha256 'ed08cf9b3b82f7440c1a8b974ae2960b296d9efdec17e57cab583e97b602764b'
+  version '0.2.161'
+  sha256 '2f6299d8b9c08ab4d665ab3e8bbbed891f9ed6d6754238ea0fff45cb7770f6f4'
 
-  url "https://github.com/railsware/upterm/releases/download/v#{version}/upterm-#{version}-mac.zip"
+  url "https://github.com/railsware/upterm/releases/download/v#{version}/upterm-#{version}-osx.dmg"
   appcast 'https://github.com/railsware/upterm/releases.atom',
-          checkpoint: '4c2274b768b2beac856c9afbfbdf55aa59040726d2c9d67532e1023390702ca2'
+          checkpoint: '2fed35ecf1f63e2fffe396b6f4051109ca1b6f5b08c145313cccaea0a9bd3842'
   name 'Upterm'
   homepage 'https://github.com/railsware/upterm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}
