### PR TITLE
Update telegram to 3.1.1-101770

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.1-101250'
-  sha256 '85b5b5914cdcf91bc032969e2102f4358783812c14db11fac4fa22ad4926cd24'
+  version '3.1.1-101770'
+  sha256 'e9362eab45998b28d6d4946741ecc7652474d7ab002ead9552094f1d49a093af'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'f9b4add04471a56b3bd37430b304e9abb9c00416596c43ed1605346b19623f35'
+          checkpoint: '7faa9ab246ce31cfbf8357e8dd80e733a33763658c4fdb523ddacbf9b9f34dfc'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
