### PR TITLE
Update the-unarchiver to 3.11.1

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,10 +1,8 @@
 cask 'the-unarchiver' do
-  version '3.11.1'
-  sha256 '12d1af6475149647f996f1b0510e067f057444852f1aa08a8dad75d6debe6ddf'
+  version :latest
+  sha256 :no_check
 
   url 'https://theunarchiver.com/downloads/TheUnarchiver.zip'
-  appcast 'http://blog.macpaw.com/rss',
-          checkpoint: 'cd9dbb45bb6fd7c13de7493a2e9549221c5751a2ecb7f2e248bf69bf1faa5b7d'
   name 'The Unarchiver'
   homepage 'https://theunarchiver.com/'
 
@@ -16,6 +14,6 @@ cask 'the-unarchiver' do
   zap delete: [
                 '~/Library/Caches/cx.c3.theunarchiver',
                 '~/Library/Cookies/cx.c3.theunarchiver.binarycookies',
-                '~/Library/Preferences/cx.c3.theunarchiver.plist',
-              ]
+              ],
+      trash:  '~/Library/Preferences/cx.c3.theunarchiver.plist'
 end

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,12 +1,12 @@
 cask 'the-unarchiver' do
   version '3.11.1'
-  sha256 '2b9e1c0f6bcad958c19bfa0b5b1c59ad0681574100918004c0bcad2e43dc0761'
+  sha256 '12d1af6475149647f996f1b0510e067f057444852f1aa08a8dad75d6debe6ddf'
 
-  url "https://unarchiver.c3.cx/downloads/TheUnarchiver#{version}.zip"
-  appcast 'https://unarchiver.c3.cx/updates.rss',
-          checkpoint: '12b3e96559528c84b7353ce25f66d685b3813a4f86b3802835988f9b90084228'
+  url 'https://theunarchiver.com/downloads/TheUnarchiver.zip'
+  appcast 'http://blog.macpaw.com/rss',
+          checkpoint: 'cd9dbb45bb6fd7c13de7493a2e9549221c5751a2ecb7f2e248bf69bf1faa5b7d'
   name 'The Unarchiver'
-  homepage 'https://unarchiver.c3.cx/unarchiver'
+  homepage 'https://theunarchiver.com/'
 
   auto_updates true
   depends_on macos: '>= :lion'

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,6 +1,6 @@
 cask 'the-unarchiver' do
-  version :latest
-  sha256 :no_check
+  version '3.11.1'
+  sha256 '12d1af6475149647f996f1b0510e067f057444852f1aa08a8dad75d6debe6ddf'
 
   url 'https://theunarchiver.com/downloads/TheUnarchiver.zip'
   name 'The Unarchiver'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}