### PR TITLE
Update hex-fiend to 2.8.0

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -1,11 +1,11 @@
 cask 'hex-fiend' do
-  version '2.7.0'
-  sha256 '3b59bbe4b898ae727c07c47f9705fc128c314b57dc76f0ff326127b57a52722a'
+  version '2.8.0'
+  sha256 '42dab86945759333669bbe2dc01c20294ee5ec5f87530e654454cdb2853736cb'
 
   # github.com/ridiculousfish/HexFiend was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"
   appcast 'https://github.com/ridiculousfish/HexFiend/releases.atom',
-          checkpoint: '2c035b9356b4db785f19427c3ad06591cf4b1a3e86ef660e1197e6752702ed7f'
+          checkpoint: '356d40d0edce7acc0a69f8113ed7a39a0eba16846d384f4b5907ae9498500755'
   name 'Hex Fiend'
   homepage 'http://ridiculousfish.com/hexfiend/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}