### PR TITLE
Update couchpotato to 3.0.1

### DIFF
--- a/Casks/couchpotato.rb
+++ b/Casks/couchpotato.rb
@@ -5,7 +5,7 @@ cask 'couchpotato' do
   # github.com/CouchPotato/CouchPotatoServer was verified as official when first introduced to the cask
   url "https://github.com/CouchPotato/CouchPotatoServer/releases/download/build%2F#{version}/CouchPotato-#{version}.macosx-10_6-intel.zip"
   appcast 'https://github.com/CouchPotato/CouchPotatoServer/releases.atom',
-          checkpoint: '5ac2077dbad662df75bb50b160040d6d87862e171e32717bf9ef2b23ddb8089e'
+          checkpoint: 'c86a3db5923c3cdb0d581e39706895abdd0b3a5a24daa7b7be448a5130bad0fd'
   name 'CouchPotato'
   homepage 'https://couchpota.to/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}