### PR TITLE
Update create-recovery-partition-installer to 1.1

### DIFF
--- a/Casks/create-recovery-partition-installer.rb
+++ b/Casks/create-recovery-partition-installer.rb
@@ -4,7 +4,7 @@ cask 'create-recovery-partition-installer' do
 
   url "https://github.com/MagerValp/Create-Recovery-Partition-Installer/releases/download/v#{version}/Create.Recovery.Partition.Installer-#{version}.dmg"
   appcast 'https://github.com/MagerValp/Create-Recovery-Partition-Installer/releases.atom',
-          checkpoint: '08c16597d72d24da4a1155e5b68fe7e9bc52e94570cdea8238189dfa265f0160'
+          checkpoint: '3283f1ad38653f2f9f72a5f1b3db2ba3d800fd4ed585c9b93f7cc6fe98cce0f6'
   name 'Create Recovery Partition Installer'
   homepage 'https://github.com/MagerValp/Create-Recovery-Partition-Installer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}