### PR TITLE
Update creepy to 1.4.1

### DIFF
--- a/Casks/creepy.rb
+++ b/Casks/creepy.rb
@@ -5,7 +5,7 @@ cask 'creepy' do
   # github.com/jkakavas/creepy was verified as official when first introduced to the cask
   url "https://github.com/jkakavas/creepy/releases/download/v#{version}/cree.py_#{version}.dmg.zip"
   appcast 'https://github.com/jkakavas/creepy/releases.atom',
-          checkpoint: 'f6b7733a0ba803c626be8f77deea458e1d31fdbfd85d5037c38ac1ddf09f454d'
+          checkpoint: 'd640eb6c043a90d66418b5420beaf11f24dac67f70bd231173219dbe0d34ba2b'
   name 'Creepy'
   homepage 'http://www.geocreepy.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}