### PR TITLE
Update ctivo to 2.5.1

### DIFF
--- a/Casks/ctivo.rb
+++ b/Casks/ctivo.rb
@@ -4,7 +4,7 @@ cask 'ctivo' do
 
   url "https://github.com/dscottbuch/cTiVo/releases/download/#{version}/cTiVo.zip"
   appcast 'https://github.com/dscottbuch/cTiVo/releases.atom',
-          checkpoint: '86ba8bd71ce51346185a0c877452b4a508e568258a7f86641fb405bb278d4254'
+          checkpoint: '8ee3a8d13c36610f7256fc859799193fee6a16ae417f04be1a5ec850d657bc2c'
   name 'cTiVo'
   homepage 'https://github.com/dscottbuch/cTiVo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}