### PR TITLE
Update qownnotes to 17.07.9,b3124-102541

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.07.6,b3105-073004'
-  sha256 'ba13ef08af0615f8d6a47d0b8df811e46fee7700e9d822dd852fd720be2cea93'
+  version '17.07.9,b3124-102541'
+  sha256 '529a039151fd99a22dfedc9f42cd1500de693555e9915ce1b5683ae0a265102e'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '9a0695bf2a548874245f72af0460e5d1c5421e2b9e875bb44450c3ac1d02cd39'
+          checkpoint: '1fd46c8e2420d29d8ceace6780009a381f44b62b1cf7424802d6630024067d27'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}