### PR TITLE
update powerword to 1.0.1

### DIFF
--- a/Casks/powerword.rb
+++ b/Casks/powerword.rb
@@ -1,11 +1,11 @@
 cask 'powerword' do
-  version '1.0.0'
-  sha256 '8bee28fa52bc967f91f6700d9642e00fc5e275cc41e0c15e5bf288fcac537c07'
+  version '1.0.1'
+  sha256 'bacf37532f98879761c098cfa93777ef0250ec9ae8e63392f87c5e34cd74c363'
 
-  url "https://download.iciba.com/pc/powerword_macosx_beta_#{version}.dmg"
-  name 'Powerword'
-  name '词霸'
-  homepage 'https://www.iciba.com/powerword'
+  url "https://download.iciba.com/mac/mac#{version}/PowerWord.dmg"
+  name 'PowerWord'
+  name '金山词霸'
+  homepage 'https://cp.iciba.com/mac/'
 
   app '金山词霸.app'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
---
According to [official release page](https://cp.iciba.com/mac/), the Chinese name is `金山词霸`(not `词霸`). And according to download link, the English name is `PowerWord`.
