### PR TITLE
Update postage to 3.2.16

### DIFF
--- a/Casks/postage.rb
+++ b/Casks/postage.rb
@@ -1,11 +1,11 @@
 cask 'postage' do
-  version '3.2.15'
-  sha256 'acc41d713a645db0b38d1b0b5fbe59b575f965cb9faa18ea144bac9d64d19674'
+  version '3.2.16'
+  sha256 '982d65c43ea3ad8484bbc513335bc0fe655813d8627df0af524be227385641c6'
 
   # github.com/workflowproducts/postage was verified as official when first introduced to the cask
   url "https://github.com/workflowproducts/postage/releases/download/eV#{version}/Postage-#{version}.dmg"
   appcast 'https://github.com/workflowproducts/postage/releases.atom',
-          checkpoint: 'de36ba3d4eb97dac51d0ca8181ced8d022111f640f409ab5b0b84847653b5352'
+          checkpoint: '97f98c7a4b42bc1d143bf40dfc8baa28872b599a2e8db732ec0606ed6c8732b5'
   name 'Postage'
   homepage 'https://www.workflowproducts.com/postage.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}