### PR TITLE
Update espresso to 5.0.1

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,11 +1,11 @@
 cask 'espresso' do
-  version '5.0'
+  version '5.0.1'
   sha256 '462a57b2364764f15b62da95cab24633cb59b3dca1c4f05ac6ad85701372dda4'
 
   # static.macrabbit.com was verified as official when first introduced to the cask
   url "https://static.macrabbit.com/downloads/Espresso%20v#{version.major}.zip"
   appcast "https://update.macrabbit.com/espresso/#{version}.xml",
-          checkpoint: 'ac70487ffbb4c6bd7c32ddde622b66bc622a8538850b20ccc22bc2c279e84c8f'
+          checkpoint: '15bb98f284a0b4171c89b16254c77d2f4d9df7989ed0725cc0911153c155f615'
   name 'Espresso'
   homepage 'https://espressoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}