### PR TITLE
Update brisk to 1.1.0

### DIFF
--- a/Casks/brisk.rb
+++ b/Casks/brisk.rb
@@ -1,10 +1,10 @@
 cask 'brisk' do
-  version '1.0.1'
-  sha256 '75efe333c1f5e20c58e010f443dae505a679b651f5fecf6f6a49e5d5763475ac'
+  version '1.1.0'
+  sha256 '6a407ca571d558efcc465777583b7bc24ffc62828aa0f510357da69296a48b1d'
 
   url "https://github.com/br1sk/brisk/releases/download/#{version}/Brisk.app.tar.gz"
   appcast 'https://github.com/br1sk/brisk/releases.atom',
-          checkpoint: 'c12db840df66de26359e114c345c65297edb88857e893573e037edf197be9218'
+          checkpoint: '23ca138fa5319b1798a5d0551c84c75f04e647fd7f795c9c0e0b70fc9979b0e6'
   name 'Brisk'
   homepage 'https://github.com/br1sk/brisk'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
