### PR TITLE
fix LibreOffice 5.4.0 checksum

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
   version '5.4.0'
-  sha256 '42341a418b8aba70750aa4a8da4f66467cbc889fa14370dbb285ce4c61124c79'
+  sha256 '1dfbf1f5dff032dd60343c5e9eaa44496553c3929447f0496c15e7fd54f1b9b8'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
as per
http://download.documentfoundation.org/libreoffice/stable/5.4.0/mac/x86_64/LibreOffice_5.4.0_MacOS_x86-64.dmg.mirrorlist
and by verifying manually as well.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: http://download.documentfoundation.org/libreoffice/stable/5.4.0/mac/x86_64/LibreOffice_5.4.0_MacOS_x86-64.dmg.mirrorlist

Additionally, if **adding a new cask**:

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
