### PR TITLE
Update xld to 2017.07.29

### DIFF
--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -1,11 +1,11 @@
 cask 'xld' do
-  version '2017.07.10-3'
-  sha256 '58dff4c83a70d83fa5425a78988d13b2d39d7270dc02af0c4eb3d2891789fe01'
+  version '2017.07.29'
+  sha256 '0ef55204816e7b52fe276dccd29253947be7b14da29e4ae1a505496174eb194a'
 
   # sourceforge.net/xld was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/xld/xld-#{version.no_dots}.dmg"
   appcast 'https://svn.code.sf.net/p/xld/code/appcast/xld-appcast_e.xml',
-          checkpoint: 'a4ee16852253d2510498c9ba658fa18e3eba379eb1ee359ea33f25d16d65a0c8'
+          checkpoint: 'f5e4d70aac60e258968ab12605ba0834e370e77aa88b1147aa4cdcafd9c07666'
   name 'X Lossless Decoder'
   name 'XLD'
   homepage 'http://tmkk.undo.jp/xld/index_e.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}