### PR TITLE
Update wireshark casks - launchctl

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -53,8 +53,8 @@ cask 'wireshark-chmodbpf' do
                    sudo: true
   end
 
-  uninstall pkgutil: 'org.wireshark.ChmodBPF.pkg',
-            delete:  '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist'
+  uninstall pkgutil:   'org.wireshark.ChmodBPF.pkg',
+            launchctl: 'org.wireshark.ChmodBPF'
 
   caveats do
     <<-EOS.undent

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -35,22 +35,22 @@ cask 'wireshark' do
                    sudo: true
   end
 
-  uninstall pkgutil: 'org.wireshark.*',
-            delete:  [
-                       '/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist',
-                       '/private/etc/manpaths.d/Wireshark',
-                       '/private/etc/paths.d/Wireshark',
-                       '/usr/local/bin/capinfos',
-                       '/usr/local/bin/dftest',
-                       '/usr/local/bin/dumpcap',
-                       '/usr/local/bin/editcap',
-                       '/usr/local/bin/mergecap',
-                       '/usr/local/bin/randpkt',
-                       '/usr/local/bin/rawshark',
-                       '/usr/local/bin/text2pcap',
-                       '/usr/local/bin/tshark',
-                       '/usr/local/bin/wireshark',
-                     ]
+  uninstall pkgutil:   'org.wireshark.*',
+            launchctl: 'org.wireshark.ChmodBPF',
+            delete:    [
+                         '/private/etc/manpaths.d/Wireshark',
+                         '/private/etc/paths.d/Wireshark',
+                         '/usr/local/bin/capinfos',
+                         '/usr/local/bin/dftest',
+                         '/usr/local/bin/dumpcap',
+                         '/usr/local/bin/editcap',
+                         '/usr/local/bin/mergecap',
+                         '/usr/local/bin/randpkt',
+                         '/usr/local/bin/rawshark',
+                         '/usr/local/bin/text2pcap',
+                         '/usr/local/bin/tshark',
+                         '/usr/local/bin/wireshark',
+                       ]
 
   zap delete: '~/Library/Saved Application State/org.wireshark.Wireshark.savedState'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

I added `/Library/LaunchDaemons/org.wireshark.ChmodBPF.plist` to `delete` by mistake, it should have been added to `launchctl`.