### PR TITLE
Update launchcontrol to 1.32.4 - uninstall / zap

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -1,19 +1,18 @@
 cask 'launchcontrol' do
-  version '1.32.3'
-  sha256 '1dc5dfbf6237b5486caa5b4aa0544f1d5acd722bf7d3f70fa5cd6bdd84b05fa8'
+  version '1.32.4'
+  sha256 '7390e09fb745f8dcbab6f4fb01ceff2822f85171129668ec9b42d4fd91061910'
 
   url "http://www.soma-zone.com/download/files/LaunchControl_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/LaunchControl/a/appcast.xml',
-          checkpoint: '2f07f86c2d24763859dcdd142ab0326dadc43d4cfa336a73f6ac74429f3568c1'
+          checkpoint: 'e7bfa5b7ee9691c7fe8a3926412265956eed2e32ffbd85aa6342a41e3a156944'
   name 'LaunchControl'
   homepage 'http://www.soma-zone.com/LaunchControl/'
 
   app 'LaunchControl.app'
 
-  zap delete: [
-                '/Library/LaunchDaemons/com.soma-zone.LaunchControl.Helper.plist',
-                '/Library/PrivilegedHelperTools/com.soma-zone.LaunchControl.Helper',
-                '~/Library/Caches/com.apple.helpd/Generated/com.soma-zone.LaunchControl.help',
-                '~/Library/Preferences/com.soma-zone.LaunchControl.plist',
-              ]
+  uninstall delete:    '/Library/PrivilegedHelperTools/com.soma-zone.LaunchControl.Helper',
+            launchctl: 'com.soma-zone.LaunchControl.Helper'
+
+  zap delete: '~/Library/Caches/com.apple.helpd/Generated/com.soma-zone.LaunchControl.help',
+      trash:  '~/Library/Preferences/com.soma-zone.LaunchControl.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.