### PR TITLE
fix libreoffice-language-pack 5.4.0

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -2,557 +2,557 @@ cask 'libreoffice-language-pack' do
   version '5.4.0'
 
   language 'af' do
-    sha256 '66c3631b2607b9a36b6d330acdc14850b9daede656ed0d4b34240a50b5cf13c7'
+    sha256 'acd600c2fed8b0f435e77b370524f317d721ec2a28f507acd95fdcd0f9da8a34'
     'af'
   end
 
   language 'am' do
-    sha256 '7cf29cdf18c5aa8bfd07b229f718ae8256d6429c4a4b5292d34a04069b084b32'
+    sha256 'd7ab26c6c50eb5ad4119f409c53448e6c7e7b727fbaa6555a746a67023c4af0e'
     'am'
   end
 
   language 'ar' do
-    sha256 '018672ffe5061e55ead7d9b37ad323aa6692fbb06b3ce81e37f2001b3536b2d3'
+    sha256 'c8fd9f555d09f32d8b57f80a6e533987dbab0c6b9ea10a92ed042b98116c8d5d'
     'ar'
   end
 
   language 'as' do
-    sha256 'c9b175bac3e8ef8023beb21071d16bb37d36c85522fd810597f5216583c90f62'
+    sha256 'a409838eaa85bff1c7260aa1c25012abe6fc6a36dafeaa0579a773b4387e0e16'
     'as'
   end
 
   language 'ast' do
-    sha256 '499a4e8a58ca84d6fc29ede392e9196e9a4453cb85bbe5e4519e7eca9004445b'
+    sha256 '1d6848a1720cc973be34187f0f128696cc7a739e7d16e34561ad9048302bac0a'
     'ast'
   end
 
   language 'be' do
-    sha256 '37573fed018ed221a7dc5cffa17a0cf9614efc806fb21597cb6d208f5f8f1896'
+    sha256 'd9fe35dcd7b86cfd0578838380a5e273e4e5f28c10b401af18bf3321c8ffc964'
     'be'
   end
 
   language 'bg' do
-    sha256 '08b28f58f3a34c44fcb156ad5549f103325ae9b009feeec56a55e245c5f9b4e3'
+    sha256 'd23cce4a822f39f45d75057e8712785d6dd5453818842dee9806cc2e4538b4d5'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '0c48aa41a5c13f5186e01db26c1f9678e85b39e6a824788bc7a368f2f1442512'
+    sha256 'd6aedd039c95cbfea95a9fcc0aed0ff5c3cc4e11028e7355e43204f214304ebb'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '6ba2fccf18ca3b5378589029b32186d05ee23d565cac8b98efe6062be5d1b464'
+    sha256 '1d49470bbfdbf55a045d0018485e50897bd806a052764b81f0ab75ff0b86ebc9'
     'bn'
   end
 
   language 'bo' do
-    sha256 'de48377a36ef80223e19aa3c4e2a5521058471321ea55c7d28e303769359206d'
+    sha256 'df0edf6cb05fa4c2153709262fbf2fc9a5e0f97f8266ad0c28aa0de34316c071'
     'bo'
   end
 
   language 'br' do
-    sha256 '43ee8237f08b2dc2b35078d1157c20cc508bc57eccb148bb3ffc052362b0825a'
+    sha256 '4b7db7c7db2f2db7f0a02c727aad0d47d265c7fa561fe5b95dd8136129fd3769'
     'br'
   end
 
   language 'brx' do
-    sha256 'f6307f8433ae3380726d4e837d7839538137f184ae6f768c2d6670cf75f85fb6'
+    sha256 '60907464e6e0a60fa84125f8105e689d5c5872eac3a3c3ad1979e631e929de01'
     'brx'
   end
 
   language 'bs' do
-    sha256 'a63eaa2e041c2415d4ccf5168826d581635d298549661063a5a4c45c61688117'
+    sha256 'f3c994bd49097edf8bbd7e890914e300df1fd413a9fc00db174679f4e09d04a5'
     'bs'
   end
 
   language 'ca' do
-    sha256 'cb4ae0c16b83319f40e9669a3165661e89481b9c829d53f74ff10d27ca912ef4'
+    sha256 'eae330f31beff4361d153fe3e8900476b48f1bfb9a060df79901321fb5998427'
     'ca'
   end
 
   language 'cs' do
-    sha256 '9809d57ae1be621b5d892ea9483f284edd0e3ccebd8bfec4ebb1c4f05c1ec3f2'
+    sha256 '5df50b2ced33848bd95a744e2dbdefcac8b5e345da8cc7829b32a87af588ef04'
     'cs'
   end
 
   language 'cy' do
-    sha256 '0301b9801e7ded73f6aa8df96dac18eb51d9a717e1357b5004299b369c21b371'
+    sha256 '77013af380b5251b108378ac8cfcea0e741231f5e3b69aecb46848ff1756ee99'
     'cy'
   end
 
   language 'da' do
-    sha256 '321b1c39d043600bc5f6fea070af8f978d5c2f6f3feeebd5957a3fae06e5831a'
+    sha256 '8f75e56a1b800ae7738a1f6491995b72a57a7717596606bbe23490a53b18a7cd'
     'da'
   end
 
   language 'de' do
-    sha256 '44e0ce9665800915bb2eef517da46f8d32dc036f6838edf61ea66f6155e0e2dd'
+    sha256 '6ead3b92d58bad7b78a36b5b57b8986d7ee85c3067620be272c4f5216e68daad'
     'de'
   end
 
   language 'dgo' do
-    sha256 'b234d2873dd6285db42e9cbe896aec6413145e1e3c41e3059074f5e9bb73de6c'
+    sha256 '65fc39f9249af75273b8bf6f134012c13cd524e4d5fb9c2d01a15e00fe5b8958'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '5e794e61b9547e193b2be930c273884f46ce90818ac009b782f9c8cbb59ad49f'
+    sha256 '3bdc020bf1fb5af493c15edfce65c5511122bc5c3420f46df181c6fa596467c5'
     'dz'
   end
 
   language 'el' do
-    sha256 '2f828a139970ad05eb2479fc94bd2e09993f2946ca97b8eb74824e6c9f025eb9'
+    sha256 'b1bdf3cc4da423da6a3671fae59b02dcebc04f14ac4871a957df2934fa225d68'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '2110995de1642222a17b823accc67f44ba72cfd7729cde5229a603e0e4752a14'
+    sha256 'f2837f7e5c956b98ee20072a27bf8251cc3aa154ee4db504193081aac27553f8'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 'e61cda560a75a998b7d14b5c407243c117949951461c06906815550c858f43f7'
+    sha256 '18f1d79413bfda18ca50cad4270a16825345c9b697fcf98df738d22a42481b3b'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '499a0a1bcdbffab5cc5402915eb728e0f2b224b4803e3261c3ab5f0a145ef8c2'
+    sha256 '4883e614cddba9a3a5ab9bbfdb4ba444bd0f8176b153dfd0fc6ced84ee8d5abb'
     'eo'
   end
 
   language 'es' do
-    sha256 '4cb7077cc68ed5a2cca0aa7c68f8ec5ceaf5405ddc4e1df85dfa57918a6ca91c'
+    sha256 '88c61ab6bfd46095d90176b1c36f04c339d518d7cd0f88b35b4b02fda18a2521'
     'es'
   end
 
   language 'et' do
-    sha256 'de41e4f591c23f90e4559ed7f6b976004aa7acca7b2b70c5baa5ebf50155d925'
+    sha256 'f6a0e78b0eb66a6b7457aae5e17593562ea50d587c942b4934bda6e569535a6b'
     'et'
   end
 
   language 'eu' do
-    sha256 '9503e74c57f806edf80bb21b93ef5f8aa76f6f21218c064b52e0d3552e8d9cac'
+    sha256 '03f41c2bde4d3f250ae702f33ff5d3b72ace4887db9f893e3717606724d2dd1d'
     'eu'
   end
 
   language 'fa' do
-    sha256 'bbd96744a553fc6a66487df97dc3c1cba133e1e2b473f4a8c3573fce59314548'
+    sha256 '48b44aa7f9df8035236002594c88e0a1df5ccf39452e969a16c434119e499eee'
     'fa'
   end
 
   language 'fi' do
-    sha256 '457d32b67d5e396924f4b534cfe0e600dcbc5003a321ae983017b166f676a988'
+    sha256 '16af414146096a77af84ac4159961020d74b8b2ce4a9fc7191a3e328ad691e16'
     'fi'
   end
 
   language 'fr' do
-    sha256 '75e85432e39b1d6f6c8b83a7f1696e47c2fd59fd4ec41a39b6e27ef61d1eb158'
+    sha256 '7739d29b85bbb82b43cd41d286cdcfc9460a75ce3e6b3a5a77780af8b001f88d'
     'fr'
   end
 
   language 'ga' do
-    sha256 '166822022a4b83c06886b859c0b071b16c09d0045343f29f2aa855b2a5b17fae'
+    sha256 '79746d9de06c7c9167da25a82c053068dd379b135b79eb5beeb10e2db3566b5c'
     'ga'
   end
 
   language 'gd' do
-    sha256 'cedc0eb634078278ea3c65748a4249ebe71849f4123552ffc7fd48a8033c564b'
+    sha256 '1550ff3c8f5cfa099130d42fe7176a03ff8a9d7c7fd44b7c63368b44dc8709ef'
     'gd'
   end
 
   language 'gl' do
-    sha256 '47e82aa65d1e29b7032c2525ed502c9bbfee113d2f71af044f2978af05edef14'
+    sha256 '0ab9a99f2eaa2dbbfa687b36ba60d85f64aa511c589a3db06d4424902daaf24c'
     'gl'
   end
 
   language 'gu' do
-    sha256 'dce280b83621a78570900e2f813f07b0a8475e5543de6629a13c4be7121ec790'
+    sha256 '346cc29bf3135257305f7efe29f0ff82e4d40cf76b4dec410d54c0afc3a886b4'
     'gu'
   end
 
   language 'gug' do
-    sha256 'e95a928e7f4ab8bd9af5cb5ae077af9f87aa64a0ce7403f397595195666fe90c'
+    sha256 '5e21aaa3434bd6bff168488e84b521d78ea31e6598c50e864bbf03fe6edd6b88'
     'gug'
   end
 
   language 'he' do
-    sha256 '6a5caea977ab1eb8f12a80188498dd41c6b1b32851e7b4df43683aea566f49e5'
+    sha256 '918e025f38c939360f9ccfb81c3483263ed1bcd828fdeda8c1adb5b36ed20c2c'
     'he'
   end
 
   language 'hi' do
-    sha256 '352bb96f7e14b8756310afcb8443824279a5f61fa42d0dcde3369ce34e038797'
+    sha256 'b61351326a9d08ab83cca8507b89542620fcda8a7cf0efaa40bb3fcfe49d92c7'
     'hi'
   end
 
   language 'hr' do
-    sha256 '5d09b635a1a2f7c9037d9c049a6e276fe6e0ad8d733c95cc6e1b5157572e9cf4'
+    sha256 '48d8cfdb82dc6521e94b56d5a349d3cd5532135d9d68bca4c6d5342a7ed01e7d'
     'hr'
   end
 
   language 'hsb' do
-    sha256 'de06565e33149da730755f9a6268d32f594ebc725e334e11e1973b0439e0fcae'
+    sha256 'e578a02695b2877ed641b19d57717a2c252eb8efc293223ee10e405102233386'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '7faaf0fa3549a595b844f0f3364002935c5c86b6ab3ee52f68ceea76604e5fe1'
+    sha256 '398d086e1a84e76dc4a53489524d36e8986dc2958b4afdfececc32088edf6246'
     'hu'
   end
 
   language 'id' do
-    sha256 '9d34cb82625e8b3eaeb692be32c43ebf841eff117751a713ca4d3f26faef5a1c'
+    sha256 '88078e422ea01c5fc9ea557a0051614b04e7efc119e329817faf2c37dfa2941c'
     'id'
   end
 
   language 'is' do
-    sha256 '998db9d340a81804812aa474bbc3af421775af7a8f46adc3f7e03a45da8d8337'
+    sha256 '484217bf35c3cd9152b8d70e1a9e4bebbe869f9acdc59a060fbc979c04691e20'
     'is'
   end
 
   language 'it' do
-    sha256 '5e5e9d559fc1e166b4605d97ddf621090b16a04988af80d11071ae136933687b'
+    sha256 '09d5544bef34d5c91f0e79cc90580dbb7cbe45e34ae4bec9ea712e2c72089cee'
     'it'
   end
 
   language 'ja' do
-    sha256 'bdcedc3c739b9ea8e242837c7664129718b859b4a719904d93bdc960c314affc'
+    sha256 'ac544bcf8d14c3ecfe38b2aac20c3886f3c8af60d5bebf80465a127f515dd259'
     'ja'
   end
 
   language 'ka' do
-    sha256 '3810c6e3f0f097e5d5be389fe08ea32c7bde4decc6ea587d528b16ce03583912'
+    sha256 'aa4f7e9d4414591ed90cd3a1077e5f9cea9f528791d553b73e5b417b6b6e5573'
     'ka'
   end
 
   language 'kk' do
-    sha256 '29b607d7f7370541cdc4bdb58d5d813b572a2fb3d862aa71d99827aca4298955'
+    sha256 'a2d74c1a875ef12757c31f7c41d46c9e24539c9b8d13ca9c7665c2b1ce044d03'
     'kk'
   end
 
   language 'km' do
-    sha256 '6eefadccb05daad5e618381cdee29509089a4499c3121d4cbb3025860accc397'
+    sha256 '5fa549b73a39327c77af7509a7eb652fcd306d2d3baef877d1a2edfdfcee9db0'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 'f2dcecce380fcb673e554d4c21da52a2ea579d48a3526bf0de38bb784ce27c2e'
+    sha256 '291fdc97c6f2c26ae16fd4cdf78a6027ad0a7de0999e94843cce19bce80c6867'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 '3def276cd6b4f01f52c66ce3d852f4d7956216275b5ccf159cc8483b5ef87f49'
+    sha256 '3ce7381cae380cb0a06b93d7c5a5d3b7b321138747ea3213895d792fe88b0e0b'
     'kn'
   end
 
   language 'ko' do
-    sha256 '139d74d1cfbccf032326dff3d307543ce5edbfcffdcca7a7fab3bf8d7187ca78'
+    sha256 '4aad4562cfa88889ccb0d45f3b80758e71793ffc1bffd3b85e235b04a66ddadb'
     'ko'
   end
 
   language 'kok' do
-    sha256 '5e2fec0254816b3b6f1b58d503ea84c08ef30f8a7c98f6927338a63e56a8a340'
+    sha256 '292a1273ca69a98e3086b1511fe7ae13110d19f674225428b4ee31aa68d4d561'
     'kok'
   end
 
   language 'ks' do
-    sha256 'e5ce1e737efe06a4d5a1df6ebfea0dcd64340b416f669cd925cb2e91f4b70c76'
+    sha256 '8e078f8a03b8e90bd5cdba11ef818d9ae9f73d44a8eef825538d15149cddee47'
     'ks'
   end
 
   language 'lb' do
-    sha256 '8671d9574345a9d296f02c304c2c998cd279973599dd58f5358c2c10488f6f47'
+    sha256 'e953937825304e750f38bc8c0eb139d76ffbb90e6e3d23507a325c730e6d164e'
     'lb'
   end
 
   language 'lo' do
-    sha256 '113dedd2319c400eed487c9fa519de01ef9870b3ae1a6163ac7696e0caf1ba8c'
+    sha256 '0bcc5e874606385ae3f5e31832cff20106851d754d06b8f425492a5e21bcf0ad'
     'lo'
   end
 
   language 'lt' do
-    sha256 '2d56c7e2edf1ea7db6fbe3739d559a3fff3d2bc8574c7205a15be614a209596e'
+    sha256 '5875211f38ef4bf84c22e60196451ccad470d233c141047a27569929cce0b9cf'
     'lt'
   end
 
   language 'lv' do
-    sha256 'e3d44e1fb205816d5d2afe8b10414a7b5a39a8bc9294aa3774baae5688eb0036'
+    sha256 '85a04009191702fc0341550e1b97e94d7ed4b053638d2c9f5a1f101f4f9a1e71'
     'lv'
   end
 
   language 'mai' do
-    sha256 '9b5952148c56d67a420750e71edb28ca5a74ac13372bf1f9bc96b9e8576db9db'
+    sha256 'fba4e6162b7ce2d2dc213f089b6b39c743c4f4925a5533dc8ecabf4c7ddab0d0'
     'mai'
   end
 
   language 'mk' do
-    sha256 '9c6316ac37bb193231b8db54dafaeec9bf1114e687aced0b0c52c8dc7e74311f'
+    sha256 '675a82bdc24653086c9789242f633382c8b2a58a2dba1e9fb5c4cb026a8fd8b7'
     'mk'
   end
 
   language 'ml' do
-    sha256 'e4986a8213e000b1983ed6b4d25e9c0792f33279c1319d148ff18412516f0049'
+    sha256 'f21a0fd224385cf444aa07e8725d5b16194d26c44fc1f1b57ca928d7bc1bb40c'
     'ml'
   end
 
   language 'mn' do
-    sha256 'c38912cbbdde430d354fbf3d8d20c96e76b7a7a42a5b73f9c662b1200037a54d'
+    sha256 'd78b8bc36e22144aed510f7be355bdd6205b98d14506fc7a669979b68446fa1e'
     'mn'
   end
 
   language 'mni' do
-    sha256 '2b1ede6a88bf59d880526817baab5372acfac6e9b34671f06e6840237b7a3591'
+    sha256 'ffd9c089ef441c6dd389b390ed1be6f42cec220cb652cef535b83541ea611b65'
     'mni'
   end
 
   language 'mr' do
-    sha256 '1a6fc2638bee4d9de50e3a81ffbb459362247127bf4fea6852e70069dc4516b9'
+    sha256 '5908bf46daacfbe395479c7da16dbdc373fac3b56bd01fd2ec720244676d6446'
     'mr'
   end
 
   language 'my' do
-    sha256 '4cc3f17b55b963b9425c8c6564b643c994867716b9ba24e0ef7ec0a314f965a5'
+    sha256 'eecabe6bea37e2dc399a23fa62bfeb72762a8f6f0a968acc0f1c3b9d6e7a1e3f'
     'my'
   end
 
   language 'nb' do
-    sha256 'ae22597d7cec521c16a02a77a4160febc655a65bb1bc6b66df4ac8b54a969740'
+    sha256 'b6f9aac0371044503e2f9116adbaff5fdff3257f490fdfbb0bfafd6c5d045691'
     'nb'
   end
 
   language 'ne' do
-    sha256 'c63ade7b85b14aaaaed0072d81c4dd562b39a8d89e7ae8c1b520c1c00c81d3e7'
+    sha256 '73370a05aec454d98a16044cc9bfa651e56c9d832277c3edeedb915bc881e8f7'
     'ne'
   end
 
   language 'nl' do
-    sha256 '1ace0650fec87f9910e528e08e0bf865faff7bd051a7f0b79cf718744e8b915e'
+    sha256 '985e40ac221a1d0b340bfd7b2700d27f20a5c3c773f8bc58d49616e31c19c33c'
     'nl'
   end
 
   language 'nn' do
-    sha256 'df932836d05f2b65dadc68e2cc5848c20742c5cf6dfe64b66f34cefd4136dbdf'
+    sha256 '8d07dc73f55025e8f4c917735f18363751da8ead69d0196c4bc6b573acbe8952'
     'nn'
   end
 
   language 'nr' do
-    sha256 'fe6de937e90c0d4cc0ab7e8aaadbb7191b0469179d84d15e6cbf09b7b0349dd7'
+    sha256 'a8288dcb38288855174382d1e4b59965c5fab86e90dcb87eb2597d6749fc8b87'
     'nr'
   end
 
   language 'nso' do
-    sha256 '7f3c83a6f720e3612a496df8aff7c87fe8cc9b32895f8855607c10caf4a4baca'
+    sha256 '6162b462933da59f0df14311e582727ef03a2d557e171b1b90d1d88dd32cdf94'
     'nso'
   end
 
   language 'oc' do
-    sha256 'c311346c7502e71fa168358f2da10fb780bceb2277bbfdfda7d1035699553a11'
+    sha256 '447bd3e7ba77f9cc7ec798a44ad0d07761e09c8ffbc4fb2c56eebbc762f83f8b'
     'oc'
   end
 
   language 'om' do
-    sha256 '0c71dae4f7f75fcc01a1e9e6d733e41046b6da932e3de1a5e72e9326e7a80fe6'
+    sha256 '3d35266c3c27cbf4de3739bcdfb22ee0e321963c4e402e83ed1cb942705a3276'
     'om'
   end
 
   language 'or' do
-    sha256 'e6bad1c4175255cd6e215151853183654353342b192c1cdf4c85ee8373564ca2'
+    sha256 '5639078fd55395834014a769be7e37c40b5cb9163c4d2833ba5d3d832f29a07e'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 'b8ac13cf752c8d59d606d77bed469455d99a48e8115823e9f084b8fe71728cb1'
+    sha256 'b8d8a300262f25c9c925373d02b68831380e93280c84ba6492042bc0e033cd89'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '1c17006f1a1ddc46f664206a5402dc0695ba2657f88b98d8199e19a33f52336e'
+    sha256 'e17b86ed2d7c7b85bec4fe2835126faae934f643f1a241a27e8b07c39fa77cc4'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '861e71d91e3e2989e45ca8ae1bd248dd130b5a7360e690756e87a4357fe4c593'
+    sha256 '0cdfe32d7f78fb11f428dfb21b6b5ce49376241d7313bcf86673bf4bc39e8696'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'eed41bce7c94aaa1bb9568a5bbd9351453581b6c5a807347113e66efd231396d'
+    sha256 '8b1a00c3065ed88c4c06b51e0547bc8f5a6777712e92ebcfe1695bde68c9ff0d'
     'pt'
   end
 
   language 'ro' do
-    sha256 'abdee636a317c4b4cc30302ac395816622e13afc0711eab5b1027866ebbe8f6b'
+    sha256 '6e515049d136a8de1d88367300a7b6f9b374c33cef5b51bc533f93a214219b46'
     'ro'
   end
 
   language 'ru' do
-    sha256 'fbef4b95b2ea7be5adc2f6296e5cc9569f3b194de131181bd1d604cb4435437a'
+    sha256 '9906998ec19e6582a1758d801bf098c8b6bd4ef312a1127f8b758869484def64'
     'ru'
   end
 
   language 'rw' do
-    sha256 'dcc5909a5a12eb18ee91578537a30bf38a6931049e9e9abdbbf094f69957ce03'
+    sha256 '9405b3f1d9cea6a01a932b96594ad77890b5a286a5794d949328ecf3be1d09ce'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 'f9be91b04471f063500916168999848cd22e881997ea9d58a595afa8ae6017c0'
+    sha256 '8f507bb27f4eb64b1e4b6b2be55a65a958f486186cc573f44db4aa1218df7ac0'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '6abd3cdfbddea3c8320179901075324fcc49d2cd2744b66b0e24003a000ac420'
+    sha256 '307874b115721c54212d81450449bc3ec1d223a2419c9265df66b7b7a55baba4'
     'sat'
   end
 
   language 'sd' do
-    sha256 '15ab1200103127fb2ba3aebdb39aaf4ce22bcbe6424a0a1ab28caded53c96050'
+    sha256 '04d9beca1ee1c5184813ec5099b0832fcaa2ee7448d9cf305160b144bc3067b9'
     'sd'
   end
 
   language 'si' do
-    sha256 'c04f78a93cf317d6fa39508d7e643ad2089cc779599716e00ec1414118a57149'
+    sha256 '15d4dc5f377db0e198418de19fb669d094b771c0f7d529cafbb01fc13b132f97'
     'si'
   end
 
   language 'sid' do
-    sha256 '4d670d6fae8f0207da70d65977ecbdf5565a343f515b04b692bf3ece9ae2b115'
+    sha256 'ea9b3247089e5d04df2ec44014d2e223b29598747601b7c8c3abbe2428e6dd75'
     'sid'
   end
 
   language 'sk' do
-    sha256 '02e27d5881fd25d0f3bc16905f7a0b5b9b90ba2d58f4076790c5db9d58f36619'
+    sha256 'cb02d0bc934ad58b4a3ef95f219b331ad1771cb869310a7ff81db945964ed279'
     'sk'
   end
 
   language 'sl' do
-    sha256 '2b1e66e93644781fd7404d1e850122982a200b92739107345e0949f429455b39'
+    sha256 '17d515aa104d8a8ca770f683294038ced79ae31fc6798a8d9aaf9f0ce5b962a4'
     'sl'
   end
 
   language 'sq' do
-    sha256 '5697b31a7db4ea9e5bb064232230c6c5fd570063126fe17e1631b5810970e1cb'
+    sha256 'a0cde231d6b766eaceeee972726ba0e0b06821942eee7fd009b109a9806ab88a'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '47b9b16d54a61e94797166c55326fde8f20e31419d99d5833fda57d2947caf63'
+    sha256 'bfe1921804838219dce41531a2ab71021986885faf62966a450e1bf5a7a3d9e6'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'f6797d78575e57571e4811fe886bea79f1acda1f6d1006e6e610006415399bbe'
+    sha256 'bae855464c3802b29362c1ea2ba586d265b2af116a492ac571e7a03fcf377ec7'
     'sr'
   end
 
   language 'ss' do
-    sha256 '5568e0626618384edde0e19f91c098d8778d02a50a3c81ab68cd199f8f431fb4'
+    sha256 'fcbe011763ddf3d72ca8c1363fec26b782088180b8322f3fba28db81c12b1e14'
     'ss'
   end
 
   language 'st' do
-    sha256 '30b8d1454a763926cfe3452d3b04883f20a067989283bf08434ec8f1cb8b0722'
+    sha256 '4c12e46e3cd2a36c461c5be6a1203bfd1a002ddf510baa52333b5db3a9ea93d3'
     'st'
   end
 
   language 'sv' do
-    sha256 'f8f7b34b106018ed59527c5cb6437c6dc890b6a88e8b666324d8081fa28bf91b'
+    sha256 'f3343f11d7dd126e552f2421ff483a94adcc18745a9434fb2f880e6cf3605d7c'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'e0d94b36d9d69c0241d8a1809febf7faadc2192d1e828241f7538dbb13b7dc07'
+    sha256 'c8daf529e0f319dd84287da01dcff69f01c28819cc095db7da2338dd3b36de86'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 'ae802f871823ead297693a1d9e27901da5b2881827c883f6c747198dc6ef4da1'
+    sha256 'daa27070e488cbb30e3509ffd5f8765464a14fa10d958e69f67dbf913dd41a76'
     'ta'
   end
 
   language 'te' do
-    sha256 '22b96e9e580bd9818a026df02a24969f2278e5de8f24fcbde411c3884b7d378f'
+    sha256 'bc66cc7cbed8fa70757c7d518bb815b4d2a40739e996b422c07a7a4bf444612f'
     'te'
   end
 
   language 'tg' do
-    sha256 '8ab610a28f6a3973f050f5a49e4998cc9c748278b3e3ee350f448b8bef4123eb'
+    sha256 '7c5529d4c309429288a59b3c3d865f7a6932b3a4583218afd0791d534c50d5df'
     'tg'
   end
 
   language 'th' do
-    sha256 'fba5e516e49fc54f66163891a25e8ef0e6009b404df5448d6d7b275f0cc36d91'
+    sha256 '88b0edb372f03bd6aaa5999faf06194f0020be8054a5555e6f0543b4cea13800'
     'th'
   end
 
   language 'tn' do
-    sha256 '6db663d6d104566cccbf4a3a133b162b4586e3f26fa3f37fce04ecb5d40e89c3'
+    sha256 'c014f3f86c8ec3778cace71698ee4972dc5eca678b28a400c9f6f7ec2108100b'
     'tn'
   end
 
   language 'tr' do
-    sha256 'a8279795527ac175f02b9a199fbe53c55335b867b88f30cf7134c84875a6538f'
+    sha256 'be65d8b474e2d4a3098ec6a7469f86ce199931c435531cf8ae06cab16757143b'
     'tr'
   end
 
   language 'ts' do
-    sha256 '7149d09d65e803eb8edbda08c78af7e88952f3d1fa389357afe1e32c8add23b0'
+    sha256 '2d91a6814c498449b8c74b75d0b9d69be1b46f4214ae270cc6db82b946a02f01'
     'ts'
   end
 
   language 'tt' do
-    sha256 'd35552b4f975a2fcc70ed58a3c2563573f9ad3a8c7e6930f7f0de637c5224ab4'
+    sha256 '3c6415ce6a8b68ba60f322c54a9254e1711c7b4b1b1d6fcd5aaff5c5e04c10b4'
     'tt'
   end
 
   language 'ug' do
-    sha256 '0376bba9cf90bda46c9d46b01200a45e3dd44d001d79b5092134582094277fc3'
+    sha256 '7f3aa7604c50b7ec439ee4a020c410223cf86b11314a0f9e4293956976781e46'
     'ug'
   end
 
   language 'uk' do
-    sha256 'e644e9ecee940f28f4c54b3fadec5fb515ffaaf171f921d636f3c6cdf6ee409b'
+    sha256 '2ef660f8de6c12d2a9357762cf8aef50b7155fcf2ab3c89320140d8eec91385d'
     'uk'
   end
 
   language 'uz' do
-    sha256 'f4cfa8029af4b5a85b452036766666f859c11ee97607a862f59d4c4ee9dbbb96'
+    sha256 '3cd603cd166e92c45a4d9e60014a852b883514aedef63746e5049a08db743082'
     'uz'
   end
 
   language 've' do
-    sha256 'ff7ea485dbcdb5a0cb29add1139bbcacf14786bffcf0b7fe9a8519389521e031'
+    sha256 'f2a6701d1f99d32f744633c58401913b85be955bd333f088011d653fa84fd2f1'
     've'
   end
 
   language 'vec' do
-    sha256 'f7c77b1dcb3c00ce344db9e4af0656d2fb50e8c5deaf8814b6ceff9d63fb3582'
+    sha256 '5c6df5fa7d74956bc3491d3ef3def2850e3bc7608bfac3cadb6307b30e8ce828'
     'vec'
   end
 
   language 'vi' do
-    sha256 'e5af816f0a6391318b5bb8e9c55a8e98ecb1b1a9f3091b3892fc1b72ca26fff3'
+    sha256 '436eefbe1781051413234ca7a612410bc75c67a37c490cfd1bdc56a6cf9ea4b4'
     'vi'
   end
 
   language 'xh' do
-    sha256 'fb9e628947c9e7b5dd1c75d13237ad73be42341ded0f5ed918df9074b8ed853f'
+    sha256 'bd480267a597a39465b2133fd221f1db05f9b1274b492afb1ac094cc01a6819a'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 '65b37b04b198059e76a731f89932e50077b4fed9cafdaa6af984ca84a9426bd6'
+    sha256 '91196eb6e63cea6d87cac304350154a0ebdaeeee5056e5168020ff6407b3a2e6'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 'c94624c79fcd957bb4e21de9d3d59b8a233fd9194683f631372892e3252701bc'
+    sha256 '476d86a4a69aeebfc6e9d8f4203dd406064302a65acc487e5b84826cacafd67d'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '8bd418fc8859f1ebebe15be6a3461928c6aba935ed7e14992b748c2188f79b8a'
+    sha256 '3258c66eb9a10929e3b2373ba4d69a696966404d43e4cf5eed837e5aa3470aa3'
     'zu'
   end
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: @miccal

sha256sum did not matched for final LibreOffice 5.4.0. One example link for German 5.4.0 language file sha256sum:
https://download.documentfoundation.org/libreoffice/stable/5.4.0/mac/x86_64/LibreOffice_5.4.0_MacOS_x86-64_langpack_de.dmg.mirrorlist