### PR TITLE
Update hab to 0.28.0-20170729010833

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.26.1-20170715032253'
-  sha256 '5835891dbb8f7d5a14c153d182cbfa17cff0c835c0ac90cb7019f893ff694b16'
+  version '0.28.0-20170729010833'
+  sha256 '536f531be330e5011b08648f88c2f7afaeaa3cdfa98f169e0e0ac881f30cd02a'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '591b43b67c430f83edff841178b812c86c1baf9fc6267ae6c05398cf89db1fc2'
+          checkpoint: '32276538b3f7d50035d5430caa521b19ea6a8d955644da8f9b2dc8852a2d806f'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}