### PR TITLE
Update freac to 20170729

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,11 +1,11 @@
 cask 'freac' do
-  version '20170317'
-  sha256 '5651c5ed5fbd96a7c44b3f116e7e8ceceda9772daf592b30b720d0c5d91b95af'
+  version '20170729'
+  sha256 '5bef885fb4d714a8d3e768daffd30457711dbbdf0172f4ad83c97bf213ca53d0'
 
   # sourceforge.net/bonkenc was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/bonkenc/rss',
-          checkpoint: 'ab72691a5e1ddc009262196cd28963e420b01caab9fe45f62056df50fb4c5425'
+          checkpoint: '0672e279e9a47574d7dba80dd21e007e3cdabd30a296d957da8cbdbfe3db6660'
   name 'fre:ac'
   homepage 'https://www.freac.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}