### PR TITLE
Update bitpay to 3.7.1

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.7.0'
-  sha256 '07ec05d757c1c48607001e562418428df7a6bb6f91a8eb56cd1cb367dc2b2802'
+  version '3.7.1'
+  sha256 '9851b5ea2bea9a84de3d4b327ab8acb78a7bcd8738a8ad38497e91362cc58917'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: '259374855bcdf7d300050a55074578dac00685e1fdc7ccd9f825f499511951a0'
+          checkpoint: 'de673f5a2182368cbb1d0edf10d9d68c99cbecc3391b06d4e834467abe21696c'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}