### PR TITLE
Update whatpulse to 2.8.1

### DIFF
--- a/Casks/whatpulse.rb
+++ b/Casks/whatpulse.rb
@@ -1,6 +1,6 @@
 cask 'whatpulse' do
-  version '2.7.1'
-  sha256 '1fba8223d08056cc0ba6d7a3b647cbd581cd8808bf4e2d91ac666a6ee39f9747'
+  version '2.8.1'
+  sha256 'e9b0435874830fb9de0ee32411e918e12a8651c0e676daf9eccf84946d8ffd6d'
 
   url "http://amcdn.whatpulse.org/files/whatpulse-mac-#{version}.dmg"
   name 'WhatPulse'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}