### PR TITLE
Update dotnet-sdk to 1.0.4

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,32 +1,35 @@
 cask 'dotnet-sdk' do
-  version '1.1.1'
-  sha256 '5b432bc4cf63ea63e8c28a089747feb8a10364e91dae734ca69942ea14188c81'
+  version '1.0.4'
+  sha256 'ec1e1eafad419c86933a5c2c07841a9f4bd65f1145883cad2f95d5028bf70460'
 
-  url "https://download.microsoft.com/download/8/F/9/8F9659B9-E628-4D1A-B6BF-C3004C8C954B/dotnet-#{version}-sdk-osx-x64.pkg"
-  name '.Net Core SDK'
+  url "https://download.microsoft.com/download/B/9/F/B9F1AF57-C14A-4670-9973-CDF47209B5BF/dotnet-dev-osx-x64.#{version}.pkg"
+  name '.Net Core SDK 1.0.4 with .NET Core 1.0.5(LTS) and .NET Core 1.1.2(Current)'
   homepage 'https://www.microsoft.com/net/core#macos'
 
   depends_on formula: 'openssl'
 
-  pkg "dotnet-#{version}-sdk-osx-x64.pkg"
+  pkg "dotnet-dev-osx-x64.#{version}.pkg"
 
   # Patch .NET Core to use the latest version of OpenSSL installed via Homebrew.
   # https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl
   postflight do
-    dotnet_core = "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/#{version}"
-    system_command '/usr/bin/install_name_tool',
-                   args: [
-                           "#{dotnet_core}/System.Security.Cryptography.Native.OpenSsl.dylib",
-                           '-add_rpath', "#{HOMEBREW_PREFIX}/opt/openssl/lib"
-                         ],
-                   sudo: true
-    system_command '/usr/bin/install_name_tool',
-                   args: [
-                           "#{dotnet_core}/System.Net.Http.Native.dylib",
-                           '-change', '/usr/lib/libcurl.4.dylib',
-                           "#{HOMEBREW_PREFIX}/opt/curl/lib/libcurl.4.dylib"
-                         ],
-                   sudo: true
+    run_times = ['1.0.5', '1.1.2']
+    run_times.each do |version|
+      dotnet_core = "/usr/local/share/dotnet/shared/Microsoft.NETCore.App/#{version}"
+      system_command '/usr/bin/install_name_tool',
+                     args: [
+                             "#{dotnet_core}/System.Security.Cryptography.Native.OpenSsl.dylib",
+                             '-add_rpath', "#{HOMEBREW_PREFIX}/opt/openssl/lib"
+                           ],
+                     sudo: true
+      system_command '/usr/bin/install_name_tool',
+                     args: [
+                             "#{dotnet_core}/System.Net.Http.Native.dylib",
+                             '-change', '/usr/lib/libcurl.4.dylib',
+                             "#{HOMEBREW_PREFIX}/opt/curl/lib/libcurl.4.dylib"
+                           ],
+                     sudo: true
+    end
   end
 
   uninstall pkgutil: 'com.microsoft.dotnet.*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}