### PR TITLE
Update omnioutliner to 5.1.1

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,10 +1,10 @@
 cask 'omnioutliner' do
-  version '5.0.4'
-  sha256 '1cc528b984b98eb2a17d2c10d943d0941b6834008d304002c0ecf9c3c1e36de3'
+  version '5.1.1'
+  sha256 '8df460567efca3e071257e4c45d13b9773d3451f036ae78ca9b8d7d15f796474'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}",
-          checkpoint: 'a2b591b031821d53be2d40ca50b1dd23fcb3076cd3a2efd1dad8928969593498'
+          checkpoint: '5c8fe90134382f8d91e67f54f2e50c44d8e7261718dcecfbdd65f20a6febcd7b'
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}