### PR TITLE
Update istat-menus to 5.32

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus' do
-  version '5.31'
-  sha256 '4a6056353a2252606a78147473d5b2e7ce35b7dbcd5a8ad6bd5b22c6d07e2b80'
+  version '5.32'
+  sha256 '0dca05fb06315820c537b4c76b3148c79a4c55ace345b2f82167a29c9c98b7c9'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}