### PR TITLE
Update zenmap to 7.60

### DIFF
--- a/Casks/zenmap.rb
+++ b/Casks/zenmap.rb
@@ -1,6 +1,6 @@
 cask 'zenmap' do
-  version '7.50'
-  sha256 '03d03fbbf2b3648d611a788781773efe13447abf512dd76f0c791e9ce7c6991c'
+  version '7.60'
+  sha256 'aadd159f6e1c8c763f0cd0be3923ade38529394c63537b8cea6f5ea48afb213e'
 
   url "https://nmap.org/dist/nmap-#{version}.dmg"
   name 'Zenmap'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}