### PR TITLE
Update istat-menus - uninstall / zap

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -9,22 +9,30 @@ cask 'istat-menus' do
 
   app 'iStat Menus.app'
 
-  uninstall quit: [
-                    'com.bjango.iStat-Menus-Notifications',
-                    'com.bjango.iStatMenusAgent',
-                    'com.bjango.istatmenusstatus',
-                  ]
+  uninstall delete:    "/Library/Application Support/iStat Menus #{version.major}",
+            launchctl: [
+                         'com.bjango.istatmenusagent',
+                         'com.bjango.istatmenusdaemon',
+                         'com.bjango.istatmenusnotifications',
+                         'com.bjango.istatmenusstatus',
+                       ],
+            signal:    [
+                         ['TERM', 'com.bjango.iStat-Menus-Notifications'],
+                         ['TERM', 'com.bjango.iStatMenusAgent'],
+                         ['TERM', 'com.bjango.istatmenusstatus'],
+                         ['TERM', 'com.bjango.istatmenus'],
+                         ['HUP', 'com.bjango.istatmenus'],
+                       ]
 
-  zap delete: [
-                "/Library/Application Support/iStat Menus #{version.major}",
-                '/Library/LaunchAgents/com.bjango.istatmenusagent.plist',
-                '/Library/LaunchAgents/com.bjango.istatmenusnotifications.plist',
-                '/Library/LaunchAgents/com.bjango.istatmenusstatus.plist',
-                '/Library/LaunchDaemons/com.bjango.istatmenusdaemon.plist',
-                '~/Library/Caches/com.bjango.istatmenus',
-                '~/Library/Caches/com.bjango.istatmenusstatus',
-                '~/Library/Logs/iStat Menus',
-                "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
-                '~/Library/Preferences/com.bjango.istatmenusstatus.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/iStat Menus',
+               '~/Library/Caches/com.bjango.istatmenus',
+               '~/Library/Caches/com.bjango.istatmenusstatus',
+               '~/Library/Caches/com.bjango.iStat-Menus-Updater',
+               '~/Library/Caches/com.bjango.iStatMenusAgent',
+               '~/Library/Logs/iStat Menus',
+               '~/Library/Preferences/com.bjango.istatmenus.plist',
+               "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
+               '~/Library/Preferences/com.bjango.istatmenusstatus.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.