### PR TITLE
soapui fix - program hangs on first launch

### DIFF
--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -66,8 +66,9 @@ cask 'soapui' do
 
   uninstall delete: "/Applications/SoapUI-#{version}.app"
 
-  zap delete: [
-                '~/default-soapui-workspace.xml',
-                '~/soapui-settings.xml',
-              ]
+  zap trash: [
+               '~/.soapuios',
+               '~/default-soapui-workspace.xml',
+               '~/soapui-settings.xml',
+             ]
 end

--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -46,5 +46,23 @@ cask 'soapui' do
                                   ],
                     }
 
+  postflight do
+    "/Applications/SoapUI-#{version}.app/Contents/vmoptions.txt".tap do |file|
+      break unless File.exist? file
+      # Does it already exist in the file?
+      break if File.read(file) =~ %r{^\s*-Dsoapui\.browser\.disabled=true(?:\s+.*)?$}i
+
+      File.open(file, 'a') { |f| f.puts '-Dsoapui.browser.disabled=true' }
+    end
+
+    "/Applications/SoapUI-#{version}.app/Contents/java/app/bin/soapui.sh".tap do |file|
+      break unless File.exist? file
+      # Does it already exist in the file?
+      break if File.read(file) =~ %r{^(?<!#)JAVA_OPTS=".+-Dsoapui\.browser\.disabled=true(?:\s.*)?"(?:\s+.*)?$}i
+
+      system %Q{sed -i'' -e 's/#.*\\(JAVA_OPTS=".*-Dsoapui\\.browser\\.disabled=true".*\\)$/\\1/g' "#{file}" 1>/dev/null}
+    end
+  end
+
   uninstall delete: "/Applications/SoapUI-#{version}.app"
 end

--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -65,4 +65,9 @@ cask 'soapui' do
   end
 
   uninstall delete: "/Applications/SoapUI-#{version}.app"
+
+  zap delete: [
+                '~/default-soapui-workspace.xml',
+                '~/soapui-settings.xml',
+              ]
 end


### PR DESCRIPTION
Due diligence:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] If `sha256` changed but the version didn't, included public confirmation by developer.

---

See [StackOverflow answer](https://stackoverflow.com/a/44325050/1236035) about problem with running SOAP UI after installing. This automates that fix, with slightly future-proof checks in case it is fixed upstream.

Also includes some configuration file additions to zap, since there was a missing zap stanza.