### PR TITLE
cask panopoly-v4.8.1 correct sha256 

### DIFF
--- a/Casks/panoply.rb
+++ b/Casks/panoply.rb
@@ -1,6 +1,6 @@
 cask 'panoply' do
   version '4.8.1'
-  sha256 'e6142a1c1d83313381ab33b9faa2fe85aa455fc816d55fb5d02231b484eaf520'
+  sha256 'cd8c729cfa71f3bac7ab12eb4932de16486389990d850ef95377c0232129505d'
 
   url "https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-#{version}.dmg"
   name 'Panoply netCDF, HDF and GRIB Data Viewer'


### PR DESCRIPTION
Tried installing via `brew cask install panoply` and got a sha256 mismatch.  I am not sure where sha256 in the file from but I did a couple tests downloads and consistently getting `cd8c729cfa71f3bac7ab12eb4932de16486389990d850ef95377c0232129505d` for the **v4.8.1** OSX DMG.

Project page:
https://www.giss.nasa.gov/tools/panoply/

Download page:
https://www.giss.nasa.gov/tools/panoply/download/

The 4.8.1 download with 
https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-4.8.1.dmg

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: https://www.virustotal.com/en/file/cd8c729cfa71f3bac7ab12eb4932de16486389990d850ef95377c0232129505d/analysis/1501707284/

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256