### PR TITLE
Update now to 2.2.4

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.2.3'
-  sha256 '7ae68d7ab6f9f47f5c461dc7666feffcb568d2f312691d8e622b5adabd3448ae'
+  version '2.2.4'
+  sha256 'a165ec9db4b37a8f2ee167c6afe046ccad54a57caff9731c917735c1bae5ce70'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'a9627d521b73532acdd4e3057eafacf0398477b56bb1f4f3b7f74c9302748b20'
+          checkpoint: 'f5520cb8d84de51dee7a7b5653641a656f3d13d90d8f306fba3a8040fe53800d'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}