### PR TITLE
Make google-cloud-sdk versioned to 165.0.0

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,8 +1,8 @@
 cask 'google-cloud-sdk' do
-  version :latest
-  sha256 :no_check
+  version '165.0.0'
+  sha256 'e4ff9f899ae94efecb601feb5b24ca48918317986a5f29200467736ff4132c7a'
 
-  url 'https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz'
+  url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-#{version}-darwin-x86_64.tar.gz"
   name 'Google Cloud SDK'
   homepage 'https://cloud.google.com/sdk/'
 

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -14,18 +14,11 @@ cask 'google-cloud-sdk' do
   binary 'google-cloud-sdk/bin/gcloud'
   binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', target: 'git-credential-gcloud'
   binary 'google-cloud-sdk/bin/gsutil'
+  artifact 'google-cloud-sdk/completion.bash.inc', target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/google-cloud-sdk-completion.bash"
+  artifact 'google-cloud-sdk/completion.zsh.inc', target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/google-cloud-sdk-completion.zsh"
+  artifact 'google-cloud-sdk/path.bash.inc', target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/google-cloud-sdk-path.bash"
+  artifact 'google-cloud-sdk/path.fish.inc', target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/google-cloud-sdk-path.fish"
+  artifact 'google-cloud-sdk/path.zsh.inc', target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/google-cloud-sdk-path.zsh"
 
   uninstall delete: "#{staged_path}/#{token}" # Not actually necessary, since it would be deleted anyway. It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
-
-  caveats <<-EOS.undent
-    #{token} is installed at #{staged_path}/#{token}. Add your profile:
-
-      for bash users
-        source '#{staged_path}/#{token}/path.bash.inc'
-        source '#{staged_path}/#{token}/completion.bash.inc'
-
-      for zsh users
-        source '#{staged_path}/#{token}/path.zsh.inc'
-        source '#{staged_path}/#{token}/completion.zsh.inc'
-  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}