### PR TITLE
Update texshop to 3.84

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,10 +1,10 @@
 cask 'texshop' do
-  version '3.83'
-  sha256 'adae60e4bda3fb708ed967c0b79e32ba1208e3673ced732ede100771b82dbe53'
+  version '3.84'
+  sha256 'ae7065a9abe630bfe6b1c78a23fcbbd93981b40c5fbfa976363aed8185aaa791'
 
   url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
-          checkpoint: '7e80acf776e667b141a2543397ce720ed695b6a7c1bc001a47dd9b88c6f5ce55'
+          checkpoint: '10daeb2cc33d1316978c731991e961e9cbc001e382e36680573bee81278a5acd'
   name 'TeXShop'
   homepage 'http://pages.uoregon.edu/koch/texshop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}