### PR TITLE
Update Private Internet Access cask to v72

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,6 +1,6 @@
 cask 'private-internet-access' do
-  version 'v71'
-  sha256 '662317117024ef1e88cf142081f864dc386dfca76b75e3d5535f22720cebabd3'
+  version 'v72'
+  sha256 '08c3e965d40351a81be0d36a1cb6570b39ada54ddad80e5833ca1fc0fd9a87b1'
 
   url "https://installers.privateinternetaccess.com/download/pia-#{version}-installer-mac.dmg"
   name 'Private Internet Access'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download private-internet-access` is error-free.
- [x] `brew cask style --fix private-internet-access` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t][version-checksum]

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
