### PR TITLE
Update java - add uninstall_preflight

### DIFF
--- a/Casks/java-jdk-javadoc.rb
+++ b/Casks/java-jdk-javadoc.rb
@@ -31,5 +31,7 @@ cask 'java-jdk-javadoc' do
     License Agreement for Java SE at
 
       https://www.oracle.com/technetwork/java/javase/terms/license/index.html
+
+     #{token} will be uninstalled when the Java Cask is uninstalled or reinstalled
   EOS
 end

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -45,6 +45,16 @@ cask 'java' do
     end
   end
 
+  uninstall_preflight do
+    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/java-jdk-javadoc")
+      system_command 'brew', args: ['cask', 'uninstall', 'java-jdk-javadoc']
+    end
+
+    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/jce-unlimited-strength-policy")
+      system_command 'brew', args: ['cask', 'uninstall', 'jce-unlimited-strength-policy']
+    end
+  end
+
   uninstall pkgutil:   [
                          "com.oracle.jdk#{version.minor}u#{java_update}",
                          'com.oracle.jre',

--- a/Casks/jce-unlimited-strength-policy.rb
+++ b/Casks/jce-unlimited-strength-policy.rb
@@ -62,5 +62,7 @@ cask 'jce-unlimited-strength-policy' do
   caveats <<-EOS.undent
     Installing this Cask means you have AGREED to the Oracle Binary Code License Agreement for Java SE at
       https://www.oracle.com/technetwork/java/javase/terms/license/index.html
+
+    #{token} will be uninstalled when the Java Cask is uninstalled or reinstalled
   EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[`java-jdk-javadoc`](https://github.com/caskroom/homebrew-cask/blob/master/Casks/java-jdk-javadoc.rb) and [`jce-unlimited-strength-policy`](https://github.com/caskroom/homebrew-cask/blob/master/Casks/jce-unlimited-strength-policy.rb) are casks installed using `system_command` into `java_home`.

Trying to uninstall/reinstall either of these casks after `java` is uninstalled/reinstalled fails.

This adds an `uninstall_preflight` that checks `#{HOMEBREW_PREFIX}/Caskroom/` for both of these casks and uninstalls them if found.