### PR TITLE
Update burp-suite to 1.7.26

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,10 +1,10 @@
 cask 'burp-suite' do
-  version '1.7.24'
-  sha256 '4edfbf71499ffbaa5baaac04db6eed995537ca39da98928e649e6922abff1f20'
+  version '1.7.26'
+  sha256 '859b1625e411c58b6b6d64f8e7516bc74449849ceddc082622f8cfa4ddffe36d'
 
   url "https://portswigger.net/burp/releases/download?product=free&version=#{version}&type=macosx"
   appcast 'https://portswigger.net/burp/freereleasesarchive',
-          checkpoint: '11a60e0ad23663faae4f0626e99c9bec1bc13c148339c131563987df48c631d1'
+          checkpoint: '6dbcb76fdab04c8abbf115d2416993b0a274a6d1a0195701c9673a36341706e7'
   name 'Burp Suite'
   homepage 'https://portswigger.net/burp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}