### PR TITLE
fixed dogecoin 1.10.0 app move

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -10,4 +10,10 @@ cask 'dogecoin' do
   homepage 'http://dogecoin.com/'
 
   app 'Dogecoin-Qt.app'
+
+  preflight do
+    set_permissions "#{staged_path}/Dogecoin-Qt.app", '0755'
+  end
+
+  zap delete: '~/Library/com.dogecoin.Dogecoin-Qt.plist'
 end


### PR DESCRIPTION
Failed to install correctly due to permissions on .app move.  
See identical litecoin issue: https://github.com/caskroom/homebrew-cask/pull/22462 
Same fix also in bitcoin-core formula: https://github.com/caskroom/homebrew-cask/blob/master/Casks/bitcoin-core.rb

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
