### PR TITLE
panoply v4.8.2

### DIFF
--- a/Casks/panoply.rb
+++ b/Casks/panoply.rb
@@ -1,5 +1,4 @@
 cask 'panoply' do
-  # https://www.giss.nasa.gov/tools/panoply/download/
   version '4.8.2'
   sha256 'f08f3593961c49133bd9562bb240b6bfa89d4ebd0d16f86df612974be38fbdb4'
 

--- a/Casks/panoply.rb
+++ b/Casks/panoply.rb
@@ -1,6 +1,7 @@
 cask 'panoply' do
-  version '4.8.1'
-  sha256 'cd8c729cfa71f3bac7ab12eb4932de16486389990d850ef95377c0232129505d'
+  # https://www.giss.nasa.gov/tools/panoply/download/
+  version '4.8.2'
+  sha256 'f08f3593961c49133bd9562bb240b6bfa89d4ebd0d16f86df612974be38fbdb4'
 
   url "https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-#{version}.dmg"
   name 'Panoply netCDF, HDF and GRIB Data Viewer'


### PR DESCRIPTION
Shortly after fixing the v4.8.1 sha256 v4.8.2 rolls out.

I've added a short comment to the webpage where NASA distributes these packages and links to their checksum files.

NASA uses sha1sum.  I verified the download matches their sha1sum published on https://www.giss.nasa.gov/tools/panoply/download/Panoply-4.8.2.sha1.txt

`curl https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-4.8.2.dmg | shasum`

We will need somebody else to verify the sha256sum I provide in this PR is correct.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.