### PR TITLE
Update devdogs to 0.2.1

### DIFF
--- a/Casks/devdogs.rb
+++ b/Casks/devdogs.rb
@@ -4,7 +4,7 @@ cask 'devdogs' do
 
   url "https://github.com/ragingwind/devdogs/releases/download/v#{version}/Devdogs-#{version}.zip"
   appcast 'https://github.com/ragingwind/devdogs/releases.atom',
-          checkpoint: 'a7376c6ffe714969b60b94a478fb74e8eb0a34fed5a4e372d566257bfc35dd52'
+          checkpoint: '6e2731d0405cd98e1e9242ba097893ddab3efa8dea80200da8c4c3f00cacc2d4'
   name 'Devdogs'
   homepage 'https://github.com/ragingwind/devdogs'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}