### PR TITLE
Update exodus to 1.30.2

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.30.0'
-  sha256 '8b9d55875ff5742fddfd37d8e1a662f94c5800c808dacffbc992b78008fedf0c'
+  version '1.30.2'
+  sha256 '2c77fa32563c26d72bfed82f7de8b83c058bd4e5f13378e41b3c0e6748b98240'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/Exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '5940ee17b192356966a6cafc44d5e6ed0f412b2c141d00d374e035c419f15c09'
+          checkpoint: '3b9befa6053e6a93490a7236d9b22075bd827422b35088eae4a74e739a9c1d1e'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}