### PR TITLE
Update diumoo to 1.6.0beta

### DIFF
--- a/Casks/diumoo.rb
+++ b/Casks/diumoo.rb
@@ -5,7 +5,7 @@ cask 'diumoo' do
   # github.com/shanzi/diumoo was verified as official when first introduced to the cask
   url "https://github.com/shanzi/diumoo/releases/download/#{version}/diumoo.zip"
   appcast 'https://github.com/shanzi/diumoo/releases.atom',
-          checkpoint: '5e4e7dc23c4461c9f091a583139d7abc5fd7a78a826c4bab526eb7d21374684d'
+          checkpoint: 'ea8df697446f43212c3a242b7718f94595276e6de73cfb6a15b8a0b16f27d1f0'
   name 'diumoo'
   homepage 'http://diumoo.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}