### PR TITLE
Add Background Music v0.1.1

### DIFF
--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -2,7 +2,7 @@ cask 'background-music' do
   version '0.1.1'
   sha256 '7ce875bb00fdeb2b5b363aa92367b3fa096d18cb02a02c461d5df66307ab1088'
 
-  url "https://github.com/kyleneideck/BackgroundMusic/releases/download/v0.1.1/BackgroundMusic-#{version}.pkg"
+  url "https://github.com/kyleneideck/BackgroundMusic/releases/download/v#{version}/BackgroundMusic-#{version}.pkg"
   appcast 'https://github.com/kyleneideck/BackgroundMusic/releases.atom',
           checkpoint: 'ba1cfbe4e14dfa185f3de08e2bf4bab608ca015fb96f6369c4d556567a5b9b39'
   name 'Background Music'

--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -8,12 +8,12 @@ cask 'background-music' do
   name 'Background Music'
   homepage 'https://github.com/kyleneideck/BackgroundMusic'
 
+  depends_on macos: '>= 10.10'
+
   pkg "BackgroundMusic-#{version}.pkg"
 
-  uninstall quit:    'com.bearisdriving.BGM.App',
-
-            pkgutil: [
-                       'com.bearisdriving.BGM',
-                       'com.bearisdriving.BGM.XPCHelper',
-                     ]
+  uninstall launchctl: 'com.bearisdriving.BGM.XPCHelper',
+            pkgutil:   'com.bearisdriving.BGM',
+            quit:      'com.bearisdriving.BGM.App',
+            script:    '/Applications/Background Music.app/Contents/Resources/_uninstall-non-interactive.sh'
 end

--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -1,0 +1,19 @@
+cask 'background-music' do
+  version '0.1.1'
+  sha256 '7ce875bb00fdeb2b5b363aa92367b3fa096d18cb02a02c461d5df66307ab1088'
+
+  url "https://github.com/kyleneideck/BackgroundMusic/releases/download/v0.1.1/BackgroundMusic-#{version}.pkg"
+  appcast 'https://github.com/kyleneideck/BackgroundMusic/releases.atom',
+          checkpoint: 'ba1cfbe4e14dfa185f3de08e2bf4bab608ca015fb96f6369c4d556567a5b9b39'
+  name 'Background Music'
+  homepage 'https://github.com/kyleneideck/BackgroundMusic'
+
+  pkg "BackgroundMusic-#{version}.pkg"
+
+  uninstall quit:    'com.bearisdriving.BGM.App',
+
+            pkgutil: [
+                       'com.bearisdriving.BGM',
+                       'com.bearisdriving.BGM.XPCHelper',
+                     ]
+end


### PR DESCRIPTION
Adds Background Music, an app to pause/un-pause music in the background
such as Spotify and iTunes.

After making all changes to the cask:

- [x] `brew cask audit --download background-music.rb` is error-free.
- [x] `brew cask style --fix background-music.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install background-music` worked successfully.
- [x] `brew cask uninstall background-music` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
