### PR TITLE
Update exodus to 1.31.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.30.2'
-  sha256 '2c77fa32563c26d72bfed82f7de8b83c058bd4e5f13378e41b3c0e6748b98240'
+  version '1.31.0'
+  sha256 '44ae651871426dd66daebaa3bdee0f010c419e779982ba6f761025835b703711'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/Exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '3b9befa6053e6a93490a7236d9b22075bd827422b35088eae4a74e739a9c1d1e'
+          checkpoint: '27381c2d2a322cbd0226b4d170da45fa83b97805046b82dfad1448ce63f23b0d'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}