### PR TITLE
Update qbittorrent to 3.3.15

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,11 +1,11 @@
 cask 'qbittorrent' do
-  version '3.3.14'
-  sha256 '6164d99fb61820f34c5d19132ee663107b0cc767a858da63794cf6a018212204'
+  version '3.3.15'
+  sha256 '10b9f6afc250de301ef95f65107539296d8ebb93df776245bec2f57b5598f85e'
 
   # sourceforge.net/qbittorrent was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/qbittorrent/rss?path=/qbittorrent-mac',
-          checkpoint: '3ed2b9372910bf8f27d20bf30ac07457b61c87fdcd4335bfff14fa7ef05c887b'
+          checkpoint: 'd188cd20ca406a4f1085eb79e2a4b148204764d9043894bea841f1089104457f'
   name 'qBittorrent'
   homepage 'https://www.qbittorrent.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}