### PR TITLE
Update dnscrypt to 1.0.14

### DIFF
--- a/Casks/dnscrypt.rb
+++ b/Casks/dnscrypt.rb
@@ -4,7 +4,7 @@ cask 'dnscrypt' do
 
   url "https://github.com/alterstep/dnscrypt-osxclient/releases/download/#{version}/dnscrypt-osxclient-#{version}.dmg"
   appcast 'https://github.com/alterstep/dnscrypt-osxclient/releases.atom',
-          checkpoint: '5c70d1cacc0474db72080234398d44dfc9b85839261ddebbf72d060ab158cdb8'
+          checkpoint: '6b13fdad0f4aea1215133d485319946f98a1ef63a263de7c3776bbc06a209b7e'
   name 'DNSCrypt'
   homepage 'https://github.com/alterstep/dnscrypt-osxclient'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}