### PR TITLE
Update dockstation to 1.2.4

### DIFF
--- a/Casks/dockstation.rb
+++ b/Casks/dockstation.rb
@@ -5,7 +5,7 @@ cask 'dockstation' do
   # github.com/DockStation/dockstation was verified as official when first introduced to the cask
   url "https://github.com/DockStation/dockstation/releases/download/v#{version}/dockstation-#{version}.dmg"
   appcast 'https://github.com/DockStation/dockstation/releases.atom',
-          checkpoint: '1e36b6544959b5c78cb89ee996a601d72992f4beab91640552fa155163fba6cd'
+          checkpoint: '5e48f61d0e862dab3df692d9fb9023d8707e36018b52a6713fa9a7a1450e3b50'
   name 'DockStation'
   homepage 'https://dockstation.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}