### PR TITLE
Update webcatalog to 6.2.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '6.1.0'
-  sha256 'cfb58095ba2bf7cfc2804dc816ec69bb3a80bbd1d4c657a06610707d7d0fd953'
+  version '6.2.0'
+  sha256 '1acad43afb616dbab03fee24f3e28902ec902fea3907c59243a7f0c65002917f'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '6d0d9a0d86a3b3d0b014c47a1e187d00bbb438bf21199947bf7c8946ec977387'
+          checkpoint: 'f7d29f47ffe516e84f7d49f5923d298f6f13ca8b869acec16bae792cd03d0b9c'
   name 'WebCatalog'
   homepage 'https://getwebcatalog.com/download/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}