### PR TITLE
Update donut to 2.4.0

### DIFF
--- a/Casks/donut.rb
+++ b/Casks/donut.rb
@@ -5,7 +5,7 @@ cask 'donut' do
   # github.com/harshjv/donut was verified as official when first introduced to the cask
   url "https://github.com/harshjv/donut/releases/download/#{version}/donut-#{version}.dmg"
   appcast 'https://github.com/harshjv/donut/releases.atom',
-          checkpoint: '7d57c0616555224cdd707890102c283c3ea6daf3a557167b78fe75eed1bf53c0'
+          checkpoint: '51dbb61af89a2dd2d170623a81a7d121facd4532130ae3ca6743b5d9ded49be4'
   name 'donut'
   homepage 'https://harshjv.github.io/donut/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}