### PR TITLE
Update doublecommand to 1.7

### DIFF
--- a/Casks/doublecommand.rb
+++ b/Casks/doublecommand.rb
@@ -4,7 +4,7 @@ cask 'doublecommand' do
 
   url "http://doublecommand.sourceforge.net/files/DoubleCommand-#{version}.dmg"
   appcast 'https://github.com/mbaltaks/doublecommand/releases.atom',
-          checkpoint: '094eeb41e5a274d0eb3e01c4d2049efca7da3f5badeb62ef92431515e08203ef'
+          checkpoint: '3b4f7064893eb668a43ffcbd82993b469a116b23404dfeacc29895faf13d7ac8'
   name 'DoubleCommand'
   homepage 'http://doublecommand.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}