### PR TITLE
Update dungeon-crawl-stone-soup-tiles to 0.20.1

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -4,7 +4,7 @@ cask 'dungeon-crawl-stone-soup-tiles' do
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom',
-          checkpoint: '3c14c15c6218ff47d09578610b247ebcf514d3071a3a1b913fe0d1a2bd99cb73'
+          checkpoint: '957a105056d323391f7fb641d3b2443f87b02ec3fcc92eb15e3382bfac2a042c'
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}