### PR TITLE
Update duplicati to 2.0.2.1,2017-08-01

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -1,10 +1,10 @@
 cask 'duplicati' do
-  version '2.0.1.73,2017-07-15'
-  sha256 '9f4550958722d08125df303b062e0d22a7981c697f758d45e7b4e1ebb62b1206'
+  version '2.0.2.1,2017-08-01'
+  sha256 '2f1f8ada0a8e09db6d967adcb76ce976d41d53318fdbba3bbdd279ca849e8e27'
 
-  url "https://updates.duplicati.com/experimental/duplicati-#{version.before_comma}_experimental_#{version.after_comma}.dmg"
+  url "https://updates.duplicati.com/beta/duplicati-#{version.before_comma}_beta_#{version.after_comma}.dmg"
   appcast 'https://github.com/duplicati/duplicati/releases.atom',
-          checkpoint: '7b18b4c85186739f3060ae6cd25308992e5d503b3e36e434084089f27ed4eab1'
+          checkpoint: 'a62964fa18b2896ce5de9ac6c7a2012457c1bfb4b36d9cf2ae4f336aca5e65fd'
   name 'Duplicati'
   homepage 'https://www.duplicati.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}