### PR TITLE
Update now to 2.2.5

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.2.4'
-  sha256 'a165ec9db4b37a8f2ee167c6afe046ccad54a57caff9731c917735c1bae5ce70'
+  version '2.2.5'
+  sha256 'b87ba686a5a8b2b5eb433e65fcde27f3de9d2fd70e7083ddf02df4cb0b21bd1d'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'f5520cb8d84de51dee7a7b5653641a656f3d13d90d8f306fba3a8040fe53800d'
+          checkpoint: 'e502d30e32ee5bc6946919f75545555ce41d79f0d6fa1cac225fbc3fb2b03b77'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}