### PR TITLE
PULL_REQUEST_TEMPLATE.md: add "How?" to sha256 part

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@ After making all changes to the cask:
 
 Additionally, if **updating a cask**:
 
-- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
-      provide public confirmation by the developer: {{link}}
+- [ ] If the `sha256` changed but the `version` didn’t,  
+      provide public confirmation by the developer ([How?][version-checksum]): {{link}}
 
 Additionally, if **adding a new cask**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ After making all changes to the cask:
 Additionally, if **updating a cask**:
 
 - [ ] If the `sha256` changed but the `version` didn’t,  
-      provide public confirmation by the developer ([How?][version-checksum]): {{link}}
+      provide public confirmation ([How?][version-checksum]): {{link}}
 
 Additionally, if **adding a new cask**:
 


### PR DESCRIPTION
Most contributors either ignore this section or mark it when they shouldn’t. Seems to me like no one clicks through. Perhaps a “How?” will make it more explicit.

To do after merging:

- [x] Update in `cask-repair`
- [x] Run the sync script