### PR TITLE
Fix Sylo version

### DIFF
--- a/Casks/sylo.rb
+++ b/Casks/sylo.rb
@@ -1,11 +1,9 @@
 cask 'sylo' do
-  version '3.9'
-  sha256 'd676d6e204dd15a10eed22efde791e46819344be6cbf31dfdefb8508bdd76854'
+  version :latest
+  sha256 :no_check
 
   # s3-us-west-2.amazonaws.com/unision was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/unision/Sylo.dmg'
-  appcast 'http://admin.unisionmusic.com/sylo/update.xml',
-          checkpoint: '80bb4b95f922dc23c9218daca0f1629b7dd3845e00f4cb5a623d2b847d3ecc28'
   name 'Sylo'
   homepage 'http://www.sylomusic.com/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This PR fixes the version check of Sylo because it's always the latest version at this URL.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256