### PR TITLE
Fix Small Typos in hacking.md:External Commands

### DIFF
--- a/doc/development/hacking.md
+++ b/doc/development/hacking.md
@@ -79,7 +79,7 @@ The first line of a commit message (the summary line) is like the subject line o
 
 ## External Commands
 
-Advanced users may create their own external commands for Homebrew-Cask by following conventions similar to external commands for git or Homebrew. An external command may be any executable on your `$PATH` which follows the form `brewcask-<command>`. (So long as `<command>` does not conflict with an existing command verb.) The command will be invoked by `exec` and passed any unprocessed arguments from the original command-line. An external command may also be implemented as an executable Ruby file, on your `$PATH`, which follows the form `brewcask-<command>.rb`. The Ruby file will be `required` and will have full access to the Ruby environments of both Homebrew-Cask and Homebrew.
+Advanced users may create their own external commands for Homebrew-Cask by following conventions similar to external commands for git or Homebrew. An external command may be any executable on your `$PATH` which follows the form `brew cask <command>`. (So long as `<command>` does not conflict with an existing command verb.) The command will be invoked by `exec` and passed any unprocessed arguments from the original command-line. An external command may also be implemented as an executable Ruby file, on your `$PATH`, which follows the form `brew cask <command>.rb`. The Ruby file will be `required` and will have full access to the Ruby environments of both Homebrew-Cask and Homebrew.
 
 ### The External Command `_stanza`
 


### PR DESCRIPTION
Fixes a few small typos in the documentation, namely doc/development/hacking.md: External Commands.