### PR TITLE
Update todometer to 1.0.4

### DIFF
--- a/Casks/todometer.rb
+++ b/Casks/todometer.rb
@@ -1,8 +1,9 @@
 cask 'todometer' do
-  version :latest
-  sha256 :no_check
+  version '1.0.4'
+  sha256 '49a744d996cfa925b50064f1853f8bf1372a3073f449a482f7896ccc5ca15d48'
 
-  url 'https://cassidoo.github.io/todometer/release-builds/install-todometer.dmg'
+  # github.com/cassidoo/todometer was verified as official when first introduced to the cask
+  url 'https://github.com/cassidoo/todometer/releases/download/v1.0.4/install-todometer.dmg'
   name 'todometer'
   homepage 'https://cassidoo.github.io/todometer/'
 

--- a/Casks/todometer.rb
+++ b/Casks/todometer.rb
@@ -3,7 +3,9 @@ cask 'todometer' do
   sha256 '49a744d996cfa925b50064f1853f8bf1372a3073f449a482f7896ccc5ca15d48'
 
   # github.com/cassidoo/todometer was verified as official when first introduced to the cask
-  url 'https://github.com/cassidoo/todometer/releases/download/v1.0.4/install-todometer.dmg'
+  url "https://github.com/cassidoo/todometer/releases/download/v#{version}/install-todometer.dmg"
+  appcast 'https://github.com/cassidoo/todometer/releases.atom',
+          checkpoint: 'd15eedbb844a21e27f9ac743cce59b6ae34f3e9ca1e184dcf3bfd1b48fed8726'
   name 'todometer'
   homepage 'https://cassidoo.github.io/todometer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}