### PR TITLE
Update 14 Jetbrains Casks - uninstall / zap

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -13,13 +13,15 @@ cask 'appcode' do
   app 'AppCode.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'appcode') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'appcode') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/AppCode#{version.major_minor}",
-                "~/Library/Application Support/AppCode#{version.major_minor}",
                 "~/Library/Caches/AppCode#{version.major_minor}",
                 "~/Library/Logs/AppCode#{version.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Preferences/AppCode#{version.major_minor}",
+                "~/Library/Application Support/AppCode#{version.major_minor}",
               ]
 end

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -13,13 +13,15 @@ cask 'clion' do
   app 'CLion.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/CLion#{version.major_minor}",
-                "~/Library/Application Support/CLion#{version.major_minor}",
                 "~/Library/Caches/CLion#{version.major_minor}",
                 "~/Library/Logs/CLion#{version.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Preferences/CLion#{version.major_minor}",
+                "~/Library/Application Support/CLion#{version.major_minor}",
               ]
 end

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -13,13 +13,15 @@ cask 'datagrip' do
   app 'DataGrip.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'datagrip') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'datagrip') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/DataGrip#{version.major_minor}",
-                "~/Library/Application Support/DataGrip#{version.major_minor}",
                 "~/Library/Caches/DataGrip#{version.major_minor}",
                 "~/Library/Logs/DataGrip#{version.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Preferences/DataGrip#{version.major_minor}",
+                "~/Library/Application Support/DataGrip#{version.major_minor}",
               ]
 end

--- a/Casks/gogland.rb
+++ b/Casks/gogland.rb
@@ -15,13 +15,15 @@ cask 'gogland' do
   app "Gogland #{version.before_comma}.app"
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'Gogland') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'Gogland') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/Gogland#{version.major_minor}",
-                "~/Library/Application Support/Gogland#{version.major_minor}",
                 "~/Library/Caches/Gogland#{version.major_minor}",
                 "~/Library/Logs/Gogland#{version.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Preferences/Gogland#{version.major_minor}",
+                "~/Library/Application Support/Gogland#{version.major_minor}",
               ]
 end

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -14,15 +14,17 @@ cask 'intellij-idea-ce' do
   app 'IntelliJ IDEA CE.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Application Support/IdeaIC#{version.major_minor}",
-                "~/Library/Preferences/IdeaIC#{version.major_minor}",
                 "~/Library/Caches/IdeaIC#{version.major_minor}",
                 "~/Library/Logs/IdeaIC#{version.major_minor}",
-                '~/Library/Preferences/com.jetbrains.intellij.ce.plist',
                 '~/Library/Saved Application State/com.jetbrains.intellij.ce.savedState',
+              ],
+      trash:  [
+                "~/Library/Application Support/IdeaIC#{version.major_minor}",
+                "~/Library/Preferences/IdeaIC#{version.major_minor}",
+                '~/Library/Preferences/com.jetbrains.intellij.ce.plist',
               ]
 end

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -13,15 +13,17 @@ cask 'intellij-idea' do
   app 'IntelliJ IDEA.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",
+                '~/Library/Saved Application State/com.jetbrains.intellij.savedState',
+              ],
+      trash:  [
                 "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
                 "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
                 '~/Library/Preferences/com.jetbrains.intellij.plist',
-                '~/Library/Saved Application State/com.jetbrains.intellij.savedState',
               ]
 end

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -12,11 +12,17 @@ cask 'mps' do
 
   app "MPS #{version.major_minor}.app"
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mps') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
+  end
+
   zap delete: [
                 "~/MPSSamples.#{version.before_comma.major_minor}",
-                "~/Library/Application Support/MPS#{version.before_comma.major_minor}",
-                "~/Library/Preferences/MPS#{version.before_comma.major_minor}",
                 "~/Library/Caches/MPS#{version.before_comma.major_minor}",
                 "~/Library/Logs/MPS#{version.before_comma.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Application Support/MPS#{version.before_comma.major_minor}",
+                "~/Library/Preferences/MPS#{version.before_comma.major_minor}",
               ]
 end

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -13,14 +13,16 @@ cask 'phpstorm' do
   app 'PhpStorm.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'pstorm') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'pstorm') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/PhpStorm#{version.major_minor}",
                 "~/Library/Caches/PhpStorm#{version.major_minor}",
                 "~/Library/Logs/PhpStorm#{version.major_minor}",
+              ],
+      trash:  [
                 "~/Library/Application Support/PhpStorm#{version.major_minor}",
+                "~/Library/Preferences/PhpStorm#{version.major_minor}",
                 '~/Library/Preferences/jetbrains.phpstorm.*.plist',
               ]
 end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -14,17 +14,19 @@ cask 'pycharm-ce' do
   app 'PyCharm CE.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Application Support/PyCharm#{version.major_minor}",
                 "~/Library/Caches/PyCharmCE#{version.major_minor}",
                 "~/Library/Caches/PyCharm#{version.major_minor}",
                 "~/Library/Logs/PyCharm#{version.major_minor}",
                 "~/Library/Logs/PyCharmCE#{version.major_minor}",
+                '~/Library/Saved Application State/com.jetbrains.pycharm.savedState',
+              ],
+      trash:  [
+                "~/Library/Application Support/PyCharm#{version.major_minor}",
                 "~/Library/Preferences/PyCharm#{version.major_minor}",
                 "~/Library/Preferences/PyCharmCE#{version.major_minor}",
-                '~/Library/Saved Application State/com.jetbrains.pycharm.savedState',
               ]
 end

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -14,13 +14,15 @@ cask 'pycharm-edu' do
   app 'PyCharm Edu.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/PyCharmEdu#{version.major_minor.no_dots}",
-                "~/Library/Application Support/PyCharmEdu#{version.major_minor.no_dots}",
                 "~/Library/Caches/PyCharmEdu#{version.major_minor.no_dots}",
                 "~/Library/Logs/PyCharmEdu#{version.major_minor.no_dots}",
+              ],
+      trash:  [
+                "~/Library/Application Support/PyCharmEdu#{version.major_minor.no_dots}",
+                "~/Library/Preferences/PyCharmEdu#{version.major_minor.no_dots}",
               ]
 end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -13,13 +13,15 @@ cask 'pycharm' do
   app 'PyCharm.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Preferences/PyCharm#{version.major_minor}",
-                "~/Library/Application Support/PyCharm#{version.major_minor}",
                 "~/Library/Caches/PyCharm#{version.major_minor}",
                 "~/Library/Logs/PyCharm#{version.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Application Support/PyCharm#{version.major_minor}",
+                "~/Library/Preferences/PyCharm#{version.major_minor}",
               ]
 end

--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -12,14 +12,18 @@ cask 'rider' do
 
   app "Rider #{version.major_minor}.app"
 
-  uninstall delete: ENV['PATH'].split(File::PATH_SEPARATOR).map { |p| "#{p}/rider" }.select { |f| File.exist?(f) }
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'rider') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
+  end
 
   zap delete: [
                 "~/Library/Caches/Rider#{version.major_minor}",
                 "~/Library/Logs/Rider#{version.major_minor}",
+                '~/Library/Saved Application State/com.jetbrains.rider.savedState',
+              ],
+      trash:  [
                 "~/Library/Application Support/Rider#{version.major_minor}",
                 "~/Library/Preferences/Rider#{version.major_minor}",
                 '~/Library/Preferences/jetbrains.rider.71e559ef.plist',
-                '~/Library/Saved Application State/com.jetbrains.rider.savedState',
               ]
 end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -13,13 +13,15 @@ cask 'rubymine' do
   app 'RubyMine.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mine') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mine') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Application Support/RubyMine#{version.major_minor}",
-                "~/Library/Preferences/RubyMine#{version.major_minor}",
                 "~/Library/Caches/RubyMine#{version.major_minor}",
                 "~/Library/Logs/RubyMine#{version.major_minor}",
+              ],
+      trash:  [
+                "~/Library/Application Support/RubyMine#{version.major_minor}",
+                "~/Library/Preferences/RubyMine#{version.major_minor}",
               ]
 end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -13,15 +13,17 @@ cask 'webstorm' do
   app 'WebStorm.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'wstorm') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'wstorm') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
-                "~/Library/Application Support/WebStorm#{version.major_minor}",
                 "~/Library/Caches/WebStorm#{version.major_minor}",
                 "~/Library/Logs/WebStorm#{version.major_minor}",
+                '~/Library/Saved Application State/com.jetbrains.WebStorm.savedState',
+              ],
+      trash:  [
+                "~/Library/Application Support/WebStorm#{version.major_minor}",
                 "~/Library/Preferences/WebStorm#{version.major_minor}",
                 '~/Library/Preferences/jetbrains.webstorm.aaac0500.plist',
-                '~/Library/Saved Application State/com.jetbrains.WebStorm.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/37371

Updated Jetbrains Casks `uninstall_postflight`

Changed `zap delete` to `zap trash` for `preferences` and `application support`

____

- `mps` did not have an `uninstall_postflight`

- `rider` used `uninstall delete:` instead of `uninstall_postflight`, also used a slightly different style.