### PR TITLE
Update porting-kit to 2.6.220

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,23 +1,27 @@
 cask 'porting-kit' do
-  version '2.6.160'
-  sha256 '17ebd1c6812369f5f5d9e3571151a077add79b42e0a23b6ad886c5f7f02e400f'
+  version '2.6.220'
+  sha256 'ec239a881d476b861497dab2a49777d669a5e750d8bade60cdba78967913b084'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml',
-          checkpoint: '950bc899f7b9e0c4c33e463b9d85811d5ce79c31367af6f2aa31a4ac7696906e'
+          checkpoint: '63adac1b64b4506b2de1f12cafdaa62154c2c7a5655eccb8d4128951000715b6'
   name 'Porting Kit'
   homepage 'http://portingkit.com/en/'
 
   auto_updates true
   conflicts_with cask: 'caskroom/versions/porting-kit-legacy'
+  depends_on macos: '>= :mountain_lion'
 
   app 'Porting Kit.app'
 
   zap delete: [
-                '~/Library/Preferences/edu.ufrj.vitormm.Porting-Kit.plist',
-                '~/Library/Application Support/Porting-Kit',
-                '~/Library/Saved Application State/edu.ufrj.vitormm.Porting-Kit.savedState',
-                '~/Library/Caches/edu.ufrj.vitormm.Porting-Kit',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/edu.ufrj.vitormm.porting-kit.sfl',
+                '~/Library/Caches/edu.ufrj.vitormm.Porting-Kit',
+                '~/Library/Cookies/edu.ufrj.vitormm.Porting-Kit.binarycookies',
+                '~/Library/Saved Application State/edu.ufrj.vitormm.Porting-Kit.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/Porting-Kit',
+                '~/Library/Preferences/edu.ufrj.vitormm.Porting-Kit.plist',
               ]
 end


### PR DESCRIPTION
Update porting-kit to 2.6.220

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
