### PR TITLE
Update scrutiny to 7.4.3

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,17 +1,21 @@
 cask 'scrutiny' do
-  version '7'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '7.4.3'
+  sha256 'cadb2c325a44c1e580f9289f1edd7c2dedce966971b5bdc4c21a22a35f6324e9'
 
   url 'http://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
+  appcast "http://peacockmedia.software/mac/scrutiny/updates/v#{version.major}currentversion.plist",
+          checkpoint: 'fffded6738d456779ce0e908a52dda4e2fe600515a1bb6b97fca07d838f6dee4'
   name 'Scrutiny'
   homepage 'http://peacockmedia.software/mac/scrutiny/'
 
-  app "Scrutiny #{version}.app"
+  app "Scrutiny #{version.major}.app"
 
   zap delete: [
-                "~/Library/Application Support/Scrutiny#{version}",
-                "~/Library/Caches/com.peacockmedia.Scrutiny#{version}",
-                "~/Library/Preferences/com.peacockmedia.Scrutiny#{version}.plist",
-                "~/Library/Cookies/com.peacockmedia.Scrutiny#{version}.binarycookies",
+                "~/Library/Caches/com.peacockmedia.Scrutiny-#{version.major}",
+                "~/Library/Cookies/com.peacockmedia.Scrutiny-#{version.major}.binarycookies",
+              ],
+      trash:  [
+                "~/Library/Application Support/Scrutiny #{version.major}",
+                "~/Library/Preferences/com.peacockmedia.Scrutiny-#{version.major}.plist",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Changed cask to versioned, add `appcast` and update `zap`