### PR TITLE
Update macs-fan-control to 1.4.8.1

### DIFF
--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -1,18 +1,19 @@
 cask 'macs-fan-control' do
-  if MacOS.version <= :snow_leopard
-    version '1.2.1.0'
-    sha256 '6e47db508e2fbb54c626a9ba37baeeda0d6acc920a9f07b6d7c3526fc11d898e'
-    url 'https://www.crystalidea.com/downloads/legacy/macsfancontrol_10.6.zip'
-  else
-    version :latest
-    sha256 :no_check
-    url 'https://www.crystalidea.com/downloads/macsfancontrol.zip'
-  end
+  version '1.4.8.1'
+  sha256 'd5e84f099c5e1cb6e56ab376784be5e9e7e3552ce773af41494a1a22df20e8e6'
 
+  url 'https://www.crystalidea.com/downloads/macsfancontrol.zip'
+  appcast 'https://www.crystalidea.com/macs-fan-control/release-notes',
+          checkpoint: 'fc88cb022f266ad06bbeb3f9fbb23847d2f1e0e7ccdac072738327aa4571a621'
   name 'Macs Fan Control'
   homepage 'https://www.crystalidea.com/macs-fan-control'
 
+  auto_updates true
+
   app 'Macs Fan Control.app'
 
-  zap delete: '~/Libary/Preferences/com.crystalidea.MacsFanControl.plist'
+  uninstall login_item: 'Macs Fan Control',
+            signal:     ['TERM', 'com.crystalidea.MacsFanControl']
+
+  zap trash: '~/Library/Preferences/com.crystalidea.macsfancontrol.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed `snow_leopard` version, changed cask to versioned.

Add `appcast`, `uninstall` and update `zap`