### PR TITLE
Update tagspaces to 2.9.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,11 +1,11 @@
 cask 'tagspaces' do
-  version '2.8.0'
-  sha256 '840f76b0429390c5a78600802a4974093e8f137ba9c0acc316e62d74ae92d551'
+  version '2.9.0'
+  sha256 '33082fa72bb6334cea6be44c8b7b36f57590e00e04487f556f615f76753fca9b'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-#{version}-osx64.zip"
   appcast 'https://github.com/tagspaces/tagspaces/releases.atom',
-          checkpoint: 'e601645ae85002fad000f8cd4295c4a47fe37863cb43a161afc7e8bd41322a7b'
+          checkpoint: 'a6df7302fd03b659071c81d193f655cea5399e8ee6a41529635a465bb3a64af1'
   name 'TagSpaces'
   homepage 'https://www.tagspaces.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,  
      provide public confirmation ([How?][version-checksum]): {{link}}