### PR TITLE
sauce-connect 4.4.8

### DIFF
--- a/Casks/sauce-connect.rb
+++ b/Casks/sauce-connect.rb
@@ -1,6 +1,6 @@
 cask 'sauce-connect' do
-  version '4.4.6'
-  sha256 'ebc6a92e4f269a46042c5a82f8da69ef17ffc7784e1d3bbb4d90ad1cf142d946'
+  version '4.4.8'
+  sha256 'efd6aee54d7ab7e677d813876166b26a7d51161dc81a4f4e5b7899864f671339'
 
   url "https://saucelabs.com/downloads/sc-#{version}-osx.zip"
   name 'Sauce Connect'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.