### PR TITLE
Update byteball to 1.10.0

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,11 +1,11 @@
 cask 'byteball' do
-  version '1.9.3'
-  sha256 '34da236b12e015918ad5b3f70c439ca4a11c019407079ba68cd2efc8e4c51e03'
+  version '1.10.0'
+  sha256 '7180e99ae30db400955e29cc8b87c138c0f7d6d5640636f7c7bc0c44feea3348'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"
   appcast 'https://github.com/byteball/byteball/releases.atom',
-          checkpoint: '713b6dc6665cd1131b7813e2d57898c671a4dab731cd6f3e4924b0e0972a0a9e'
+          checkpoint: '566d628ad47525ad75c4ca0692845a0d63d7167f7fc0618c4f0e3677432915b3'
   name 'Byteball'
   homepage 'https://byteball.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}