### PR TITLE
Update imagealpha to 1.5.1

### DIFF
--- a/Casks/imagealpha.rb
+++ b/Casks/imagealpha.rb
@@ -3,10 +3,10 @@ cask 'imagealpha' do
     version '1.2.3'
     sha256 '79388edcaf5cb29234f722a672b069c6d51fb812e89969ba8db8e957b9a32bf3'
   else
-    version '1.5.0'
-    sha256 'f0e06109d7348f41bc0fa9c62caac997b9601777f23f1fd522efdea2188ccf54'
+    version '1.5.1'
+    sha256 'be8a4544a2a855ba424e33819940b4b0ddb1221d1f46ca360181fd4ee2bef24b'
     appcast 'https://pngmini.com/appcast.xml',
-            checkpoint: '09bfb1631ef1024e04c78fccae8fb50bfabbb113304e442d6fc5c156b494b686'
+            checkpoint: '76ca766570428cdd1ce9e69bb3c302c087d41226489c76fd6b9ea0c4e0594363'
   end
 
   url "https://pngmini.com/ImageAlpha#{version}.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}