### PR TITLE
Update kactus to 0.2.1

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.1.14'
-  sha256 'cf5ba67e11e9a3ac7583dd5b90d1653d77149a4ec799aebaca3bdc1def12309f'
+  version '0.2.1'
+  sha256 '864d981f70dc8ccd03c8e95227905a0407562734ad9790838079c751e4d6a877'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: '23743bc8f8c0791b844e0d19868222628e96584c30fc1ac7a2afe2c4b220c419'
+          checkpoint: 'ce6902d4aade77ed5f22683313d826806107317becc80a48c27ca7aa46c800cc'
   name 'Kactus'
   homepage 'http://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}