### PR TITLE
Update dbeaver-enterprise to 4.1.1

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,10 +1,12 @@
 cask 'dbeaver-enterprise' do
-  version '4.0.5'
-  sha256 'c58b03056e0a845f2d7fff7ca37dcdf8b4dc2ded74e1932bc2654f8676510bf0'
+  version '4.1.1'
+  sha256 '345fa36b74a08512d868e0232a3f5e043c132d1fa1e90ad57040d4d48c85fa6c'
 
-  url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
+  url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
+  appcast 'https://dbeaver.com/files/',
+          checkpoint: 'e96df7f78b09351188ce5e9eb0d0952fe14c0322e4b41b1d1ce6760d9cbab16a'
   name 'DBeaver Enterprise Edition'
-  homepage 'http://dbeaver.jkiss.org/'
+  homepage 'https://dbeaver.com/'
 
   app 'Dbeaver.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`dbeaver-enterprise` is now hosted at https://dbeaver.com