### PR TITLE
Update dbeaver-community to 4.1.2

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.1.1'
-  sha256 '2b352d3423ed1ce4e4fb22f362f8951d2bf8184c5ef8fe287cca29daebc2d639'
+  version '4.1.2'
+  sha256 '16da10fdec55bf5c45ed0be344e2dc0da75ded9d86ffbc6eae0a4c94f454783c'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '5dad4cf7af76ac761e8a9ef2dba8a28477debfed3c97a5c69f48abaef51cdead'
+          checkpoint: '9c5b919ff4826130c412eb4a8d3f634e9ab4c68ba5b6c2c40771e49d0c9bbd84'
   name 'DBeaver Community Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}