### PR TITLE
Update google-play-music-desktop-player 4.4.0 - uninstall / zap

### DIFF
--- a/Casks/google-play-music-desktop-player.rb
+++ b/Casks/google-play-music-desktop-player.rb
@@ -11,14 +11,24 @@ cask 'google-play-music-desktop-player' do
 
   app 'Google Play Music Desktop Player.app'
 
+  uninstall login_item: 'Google Play Music Desktop Player',
+            signal:     [
+                          ['TERM', 'google-play-music-desktop-player'],
+                          ['TERM', 'google-play-music-desktop-player.helper'],
+                        ]
+
   zap delete: [
-                '~/Library/Application\ Support/Google\ Play\ Music\ Desktop\ Player',
-                '~/Library/Application\ Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/google-play-music-desktop-player.sfl',
-                '~/Library/Application\ Support/google-play-music-desktop-player.ShipIt',
-                '~/Library/Caches/Google\ Play\ Music\ Desktop\ Player',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/google-play-music-desktop-player.sfl',
+                '~/Library/Caches/Google Play Music Desktop Player',
+                '~/Library/Caches/google-play-music-desktop-player.ShipIt',
                 '~/Library/Caches/google-play-music-desktop-player',
                 '~/Library/Cookies/google-play-music-desktop-player.binarycookies',
+                '~/Library/Saved Application State/google-play-music-desktop-player.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/Google Play Music Desktop Player',
+                '~/Library/Application Support/google-play-music-desktop-player.ShipIt',
+                '~/Library/Preferences/google-play-music-desktop-player.helper.plist',
                 '~/Library/Preferences/google-play-music-desktop-player.plist',
-                '~/Library/Saved\ Application\ State/google-play-music-desktop-player.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.