### PR TITLE
Update navicat-premium-essentials to 12.0.10

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '12.0.9'
-  sha256 '7a5fcabaabc0097113a4a446d9d75983455b1608df1df0cb69cdfa070e8eba9f'
+  version '12.0.10'
+  sha256 '2afcd68020c16e88f72793bb9e0c669908a2340daef3e74e0145411cb84c0154'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium Essentials'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}