### PR TITLE
Update navicat-for-mariadb to 12.0.10

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.9'
-  sha256 'b04a892527819ecdce8ba1ce0d2b0dd32cafe3a972ea9d4140c565d5bb36187b'
+  version '12.0.10'
+  sha256 'bde6a69dad45c80fdd0ca9b8ec6d5308e231d7e0aa8f9d77da2ef48b3f3bf54a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mariadb-release-note#M',
-          checkpoint: 'bf3926dfbd12fb7195438c5901208b484b3c7cc13b19acbb8bacb67c19f4291e'
+          checkpoint: '8a751685c8288fac250fa559e99b8347c3295f80bf97ff1697f9ebbca575b8ba'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}