### PR TITLE
Update navicat-for-oracle to 12.0.10

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.9'
-  sha256 '22d6f49b7b7c8c267ac83e082c4ac8424eec3c51d5850eddf153b4ba1a86a89c'
+  version '12.0.10'
+  sha256 'e596eebf36ecf4cdd20784dfd0b31255c67aba81fb33b4a7f7fc8f755dfcb518'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note#M',
-          checkpoint: '29d5d6507f2a2ace6777d16f8f5204c7c6fd42145767770ab04d8f389992d553'
+          checkpoint: 'ebf364b59c523ff561a7a31b7e99b18e32ec6c54f466fffb9b2b165ad65d044d'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}