### PR TITLE
Update navicat-for-sqlite to 12.0.10

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.9'
-  sha256 '71eb73e5f6ab1dfc4a94f1c4d12e7275348a9e682546eea445621475e87e632d'
+  version '12.0.10'
+  sha256 'f2f90c46c0147fdc927486963a595d71e6f97b89b25a661efba638392554e393'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note#M',
-          checkpoint: 'd2218389e4dff13e75cc049cc37f6b9a17bf8bead07a5a0c85a6c56b6933e9d0'
+          checkpoint: '8cd2bf791f63a2d271a9d551297d26ad6c452ab5c52f91566412e31aae1823c5'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}