### PR TITLE
Update postico to 1.2.2

### DIFF
--- a/Casks/postico.rb
+++ b/Casks/postico.rb
@@ -1,6 +1,6 @@
 cask 'postico' do
-  version '1.2'
-  sha256 'f2dbeeb6245bfc144af85929a698a1abed755955dd9a2bb899efe7c1b1eb43fa'
+  version '1.2.2'
+  sha256 '6bae5e169ddf91af762be0ace4e8a9695c0b52ca5285c1cb330e287d29234404'
 
   # amazonaws.com/eggerapps-downloads was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/eggerapps-downloads/postico-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}