### PR TITLE
Update hands-off to 3.2.1

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,10 +1,10 @@
 cask 'hands-off' do
-  version '3.1.5'
-  sha256 '2975e091aa94e71ae75dbf9490db566ee5938630bc793d8a99a8281ab9f48847'
+  version '3.2.1'
+  sha256 'cbbcf993d2319d776b7ec1ac35fc4569cc97490fcce6af69e7cbe55464cd351f'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml",
-          checkpoint: '8ab51e82722f6cffbfaad89a554111762c3c14bc9163a6a6afdf4a477c53368c'
+          checkpoint: 'ee18f60eb11947b00737cb239eb2bdaf6d011e6b03c8bdcb9335adffb2ac71b1'
   name 'Hands Off!'
   homepage 'https://www.oneperiodic.com/products/handsoff/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}