### PR TITLE
Update freeplane to 1.6.3

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,10 +1,10 @@
 cask 'freeplane' do
-  version '1.5.21'
-  sha256 '666375b683378e535c86b464545f52c0dcffb75b3d82a0863350eafdb9f5e350'
+  version '1.6.3'
+  sha256 '0bfb46c67ba83ab330e4b61f4bc0092669ff023b9d091baf42ed27deaeda4f37'
 
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app_jre-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable',
-          checkpoint: '98f2b4ff1a0f17110621a5ab1d7a34da8057df4918f48e2f88a98bcec4635a49'
+          checkpoint: 'e4e395faaf9ab2d5019e1233b77ed3aff7653e2dca35d67e4bce0c499740107d'
   name 'Freeplane'
   homepage 'http://freeplane.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}