### PR TITLE
Update onyx to 3.2.8

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -3,13 +3,13 @@ cask 'onyx' do
     version '3.1.9'
     sha256 '7f8df2c9e97eb465aba88b000fa2f58958421efeba1239303ff0071e9b7b0536'
   else
-    version '3.2.7'
-    sha256 'c19d003bca93adbd5ff661b6ed77293d5590c91c23c0153b9eda10a444048fe4'
+    version '3.2.8'
+    sha256 '01866ed21939e353618ff4427e2396e0fcceeb543f0ae42731644bf4ec410a30'
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/OnyX.dmg"
   appcast 'http://www.titanium-software.fr/en/release_onyx.html',
-          checkpoint: 'db8a115727578fd4823e72bc7fc1e2acecc9e0c559b5d7ebb6095c549f524fdc'
+          checkpoint: 'fd304027ac7c134b6b757a8b7942c03a11bb3e2ff8cd6e0b04b71c7d7734c659'
   name 'OnyX'
   homepage 'https://www.titanium-software.fr/en/onyx.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}