### PR TITLE
Update sourcetree to 2.6.1a

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.6b'
-    sha256 'aa32d50139c35b37e43d7ffe96ae1587c50f43d60e3935f82fb0f9b863e90380'
+    version '2.6.1a'
+    sha256 '1dec4c36c4d8ff5f11d2fe4c8ec9b7db4ea61cfe3508aac327d76b0e2c8a1635'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}