### PR TITLE
Update zoc to 7.15.3

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,10 +1,10 @@
 cask 'zoc' do
-  version '7.15.2'
-  sha256 'cf310792778f652c2d515e56d13ffef3dfbc2eafee45db501e9f5d95174f9f65'
+  version '7.15.3'
+  sha256 '67d51014ce461260330198a5f0ecc3edf2c7c595e836db0bee1112152434ef42'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast "http://www.emtec.com/downloads/zoc/zoc#{version.no_dots}_changes.txt",
-          checkpoint: 'e4323e87104849a700c8aa5c866d499bd2de2e43ea14975e4ad3da06cc956422'
+          checkpoint: '80eed1e255a1bbf6abacb189cbb08ed725f5a31a98ba2bed07acd36fdeebffe9'
   name 'ZOC'
   homepage 'https://www.emtec.com/zoc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}