### PR TITLE
Update detectx to 2.75

### DIFF
--- a/Casks/detectx.rb
+++ b/Casks/detectx.rb
@@ -1,11 +1,11 @@
 cask 'detectx' do
-  version '2.74'
-  sha256 'b67b09c79a5305c3ef6cf9f4ea1054c8ff9c5726b0c7096b5529299eb7bbd096'
+  version '2.75'
+  sha256 '3d621815eeafefc829ebe125b73e980d2917a7138ad4e203cbe894fea8d3a7cb'
 
   # amazonaws.com/sqwarq.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/sqwarq.com/PublicZips/DetectX.app.zip'
   appcast 'https://s3.amazonaws.com/sqwarq.com/AppCasts/detectx.xml',
-          checkpoint: '91170fce8733f0dc8a1755e930f30a3f00d60872878a8c331704d26fbc5350e9'
+          checkpoint: 'b5606d76b7e5cc6e6a37b21d5d3396ae09bfd6893d1056c94c78086e07e202fd'
   name 'DetectX'
   homepage 'https://sqwarq.com/detectx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}