### PR TITLE
Update eintopf to 1.3.2

### DIFF
--- a/Casks/eintopf.rb
+++ b/Casks/eintopf.rb
@@ -5,7 +5,7 @@ cask 'eintopf' do
   # github.com/mazehall/eintopf was verified as official when first introduced to the cask
   url "https://github.com/mazehall/eintopf/releases/download/#{version}/eintopf_#{version}-x64.dmg"
   appcast 'https://github.com/mazehall/eintopf/releases.atom',
-          checkpoint: '00c28a1e17d3252dfbe019e551fb6d610599fb41d3b3c8fdf6a718f6b083859f'
+          checkpoint: 'a8c2ba60ed12b1cdf2a2054c4d06a93c8dd3d3712f3bdb74baab179b4cec2ab0'
   name 'Eintopf'
   homepage 'https://eintopf.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}