### PR TITLE
Update eldeveloper-macfusion to 2.1.1-dev.3

### DIFF
--- a/Casks/eldeveloper-macfusion.rb
+++ b/Casks/eldeveloper-macfusion.rb
@@ -4,7 +4,7 @@ cask 'eldeveloper-macfusion' do
 
   url "https://github.com/ElDeveloper/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
   appcast "https://github.com/ElDeveloper/macfusion#{version.major}/releases.atom",
-          checkpoint: '7f4ed144badd1a5762911adbd1430169f1ba9e727d95ddaa9fbbee6027b7317e'
+          checkpoint: '4f19fdf3855e04e508dec355554487deaba49414556e6f93bc947d054703808b'
   name 'Macfusion'
   homepage "https://github.com/ElDeveloper/macfusion#{version.major}/"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}