### PR TITLE
Update electron-api-demos to 1.3.0

### DIFF
--- a/Casks/electron-api-demos.rb
+++ b/Casks/electron-api-demos.rb
@@ -4,7 +4,7 @@ cask 'electron-api-demos' do
 
   url "https://github.com/electron/electron-api-demos/releases/download/v#{version}/electron-api-demos-mac.zip"
   appcast 'https://github.com/electron/electron-api-demos/releases.atom',
-          checkpoint: '3183363297478ddd29e40ce54b36bd6af491431bc6daf84d6281dd76c74619eb'
+          checkpoint: '677193eb3022a2627a43ffeae39a2373f3aacc0da0a920424f66e91303383292'
   name 'Electron API Demos'
   homepage 'https://github.com/electron/electron-api-demos'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}