### PR TITLE
Add leonsoft-kras-transmission-remote-gui 5.8.3

### DIFF
--- a/Casks/leonsoft-kras-transmission-remote-gui.rb
+++ b/Casks/leonsoft-kras-transmission-remote-gui.rb
@@ -1,0 +1,12 @@
+cask 'leonsoft-kras-transmission-remote-gui' do
+  version '5.8.3'
+  sha256 '81de0a2d8b9c429094e2399a9ab3c73eec3a8baf756ad371a782782ec71e33f5'
+
+  url "https://github.com/leonsoft-kras/transmisson-remote-gui/releases/download/v#{version}/transgui-#{version}.dmg"
+  appcast 'https://github.com/leonsoft-kras/transmisson-remote-gui/releases.atom',
+          checkpoint: 'e31df4f989aa69da74411612b84981d0056014490236fe6e120498ef51b96125'
+  name 'Transmission Remote GUI'
+  homepage 'https://github.com/leonsoft-kras/transmisson-remote-gui'
+
+  app 'Transmission Remote GUI.app'
+end


### PR DESCRIPTION
Cask currently points to https://sourceforge.net/projects/transgui/
SourceForge project has not had a release in over 2 years and no commits in over 1 year.
Notable bugs include not running on High Sierra.
This commit changes the cask to a fork that is current and actively maintained at https://github.com/leonsoft-kras/transmisson-remote-gui

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask