### PR TITLE
Update etcher to 1.1.2

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,20 +1,20 @@
 cask 'etcher' do
-  version '1.1.1'
-  sha256 '7e9819cfe9fd8be1c8267d084ff45286d1c4b6cf962603a2722f2c35829692eb'
+  version '1.1.2'
+  sha256 'b562c7ff89e0de86003ee1cc14a1ee08ab5988a543b6e22235fe3773a48074a4'
 
   # github.com/resin-io/etcher/releases/download was verified as official when first introduced to the cask
-  url "https://github.com/resin-io/etcher/releases/download/v#{version}/Etcher-#{version}-darwin-x64.dmg"
+  url "https://github.com/resin-io/etcher/releases/download/v#{version}/Etcher-#{version}.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: '79f30bce292808848cd66af411c60ba2679931f61c1687e83cd7a22486172e04'
+          checkpoint: 'd30055c539e29585db3819fdfcb3a0ebdb5671c45a886e4d455f2d226ecefdd6'
   name 'Etcher'
   homepage 'https://etcher.io/'
 
   app 'Etcher.app'
 
-  zap delete: [
+  zap delete: '~/Library/Saved Application State/io.resin.etcher.savedState',
+      trash:  [
                 '~/Library/Application Support/etcher',
                 '~/Library/Preferences/io.resin.etcher.helper.plist',
                 '~/Library/Preferences/io.resin.etcher.plist',
-                '~/Library/Saved Application State/io.resin.etcher.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.