### PR TITLE
Update istat-menus to 5.32

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus' do
   version '5.32'
-  sha256 '0dca05fb06315820c537b4c76b3148c79a4c55ace345b2f82167a29c9c98b7c9'
+  sha256 'd3a2e7121e8fedba6310c1c66b09a8dfd3d0f42b3daa66de3854246a6ec7dfdd'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): https://www.virustotal.com/en/file/d3a2e7121e8fedba6310c1c66b09a8dfd3d0f42b3daa66de3854246a6ec7dfdd/analysis/1502171454/