### PR TITLE
Update keystore-explorer to 5.3.0

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -3,7 +3,7 @@ cask 'keystore-explorer' do
   sha256 '8ccf57e1282d2a4538d9a2b551bc0825cc3144c18068b0fd492251340497a5a7'
 
   # github.com/kaikramer/keystore-explorer was verified as official when first introduced to the cask
-  url "https://github.com/kaikramer/keystore-explorer/releases/download/v5.3/kse-#{version.no_dots}.dmg"
+  url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version.major_minor}/kse-#{version.no_dots}.dmg"
   appcast 'https://github.com/kaikramer/keystore-explorer/releases.atom',
           checkpoint: '5712e8f8baedb730cd02b27274daf3a052116caba13ce6e12d97f3a2ac93513d'
   name 'KeyStore Explorer'

--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,11 +1,11 @@
 cask 'keystore-explorer' do
-  version '5.2.2'
-  sha256 '64123f31c0216608aaf2e51dd6cf7715c067ef8985945c150e390c5104af78ef'
+  version '5.3.0'
+  sha256 '8ccf57e1282d2a4538d9a2b551bc0825cc3144c18068b0fd492251340497a5a7'
 
   # github.com/kaikramer/keystore-explorer was verified as official when first introduced to the cask
-  url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version}/kse-#{version.no_dots}.dmg"
+  url "https://github.com/kaikramer/keystore-explorer/releases/download/v5.3/kse-#{version.no_dots}.dmg"
   appcast 'https://github.com/kaikramer/keystore-explorer/releases.atom',
-          checkpoint: '6a4b8e5da148a2c0671e630d954989ddbd3d946e2927563e5611ce71da26e84c'
+          checkpoint: '5712e8f8baedb730cd02b27274daf3a052116caba13ce6e12d97f3a2ac93513d'
   name 'KeyStore Explorer'
   homepage 'http://keystore-explorer.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}