### PR TITLE
Update flash-ppapi to 26.0.0.151

### DIFF
--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,10 +1,10 @@
 cask 'flash-ppapi' do
-  version '26.0.0.137'
-  sha256 'c3b30698b08ed8a62014f4c9f46efc2ac1dafe128436a3eb36ac21f438060437'
+  version '26.0.0.151'
+  sha256 'a848828c6f852374412de2a59af8834817751ca184eff107f4d65da0c48f44e4'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',
-          checkpoint: 'c17c3d3ba056fdf8caaab6e886d7a7dc7b5d57069df585d9fa2a009552ee61da'
+          checkpoint: '918f08ed443fe8c1da41ed988a4c80208063c10994a52b6b01322c410a86e6c9'
   name 'Adobe Flash Player PPAPI (plugin for Opera and Chromium)'
   homepage 'https://get.adobe.com/flashplayer/otherversions/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}