### PR TITLE
Update flash-player-debugger to 26.0.0.151

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger' do
-  version '26.0.0.137'
-  sha256 '66a42beb863b635cc09fb90a59e9f067bad955de4e1f86e4d17ae8370652eff2'
+  version '26.0.0.151'
+  sha256 '88e4a78743d70023cefe22adaf893fa6fed2f30f3656e5230e2ecdeb3a4ef8a7'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',
-          checkpoint: 'c17c3d3ba056fdf8caaab6e886d7a7dc7b5d57069df585d9fa2a009552ee61da'
+          checkpoint: '918f08ed443fe8c1da41ed988a4c80208063c10994a52b6b01322c410a86e6c9'
   name 'Adobe Flash Player projector content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}