### PR TITLE
Update transmit to 5.0.1

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,10 +1,10 @@
 cask 'transmit' do
-  version '5.0'
-  sha256 '3858e700f3fb48f00182936119193c4b09af7f86e4090187414cd6d8306fbdc3'
+  version '5.0.1'
+  sha256 '0ca64381d9b2e6970a7e43340ad53d90fc1ec8eb0f6e354d27e307d3dd9b957f'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}",
-          checkpoint: '939ceb813a55471ec5a94183d50d9fbed9f2081cbfbda965b1399e9e7188e315'
+          checkpoint: '2e117f0d3f16d822f081af54d85db24ac224c6ed4f9951d135f4e5a44b13a88d'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}