### PR TITLE
Update navicat-for-mariadb to 12.0.11

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.10'
+  version '12.0.11'
   sha256 'bde6a69dad45c80fdd0ca9b8ec6d5308e231d7e0aa8f9d77da2ef48b3f3bf54a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mariadb-release-note#M',
-          checkpoint: '8a751685c8288fac250fa559e99b8347c3295f80bf97ff1697f9ebbca575b8ba'
+          checkpoint: '7c8f6b813af3d7732be2138fd73482ac64136701401dfce8710157c868f68a49'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}