### PR TITLE
Update navicat-for-mysql to 12.0.11

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.10'
-  sha256 '2ed01b5e3dbd79db3121084b6f6c3995f4f7002b85ac5dc614ce04219da77703'
+  version '12.0.11'
+  sha256 'f7b22c3da51bdcea56b8f7d67cef2e7f665ad4f5a7ef90aa346fad22af784cb0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note#M',
-          checkpoint: '7a6bc0cd7a00f52b354592effe043f2265365bf59b3deb44498c5383e788f303'
+          checkpoint: 'c0c9fc6ddb0ee67671fe78804ea204c823d50e360751d53b75c76402159d52f6'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}