### PR TITLE
Update navicat-for-sql-server to 12.0.11

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.10'
-  sha256 '59828dd38eeedbd1489a84526f17a5ca908ed3b3850bc03ffe2b7f90dd34de2a'
+  version '12.0.11'
+  sha256 'fe436b0ae16b04ca19fb434cc1fccddef45317201aac1ff4ce1893e907f27ef8'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note#M',
-          checkpoint: '789127e485e0ae3dcd54eb327711cf9b1516e7c292b2982096e0dabb0b5fe08b'
+          checkpoint: '39bbf588df7ca4739b78e95580b50e4218c8eaa2e6e71db9d8e53b5fc5e00acd'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}