### PR TITLE
Update navicat-for-sqlite to 12.0.11

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.10'
-  sha256 'f2f90c46c0147fdc927486963a595d71e6f97b89b25a661efba638392554e393'
+  version '12.0.11'
+  sha256 '44d560e88608d2b33315f13da251a29b55c339366b8fcbf4fadebb02438d28d1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note#M',
-          checkpoint: '8cd2bf791f63a2d271a9d551297d26ad6c452ab5c52f91566412e31aae1823c5'
+          checkpoint: '223133c10332340cf1f24482f7a301f9b4d7927523b999702e0f81618a8c411e'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}