### PR TITLE
Update selfcontrol to 2.2.1

### DIFF
--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -3,13 +3,13 @@ cask 'selfcontrol' do
     version '1.5.1'
     sha256 'd3823a1e9ba0b47dc2cb39c93cd51837c2dafc7d5a5a564825f4a440fd2ab9ad'
   else
-    version '2.1.1'
-    sha256 'ac492ce596f7189088db56c1e8a2663504d1036264745a66a7202fe5b4dca6e8'
+    version '2.2.1'
+    sha256 'aee5d3f5d48c8e073aee1d5ad15feb966018c8b5f9a3ca217c30e87c934d8d74'
   end
 
   url "http://downloads.selfcontrolapp.com/SelfControl-#{version}.zip"
   appcast 'https://selfcontrolapp.com/SelfControlAppcast.xml',
-          checkpoint: '731efae243c693b57617da396c134fc23263b944b3af7d5e3e77ebf6ed2ab6fe'
+          checkpoint: 'b61ac0ef34e3b92390b5c178293c2a72cc59d46040d43c99cc8ea084dcd99abd'
   name 'SelfControl'
   homepage 'https://selfcontrolapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}