### PR TITLE
PULL_REQUEST_TEMPLATE.md: clarify sha change with "I"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@ After making all changes to the cask:
 
 Additionally, if **updating a cask**:
 
-- [ ] If the `sha256` changed but the `version` didn’t,  
-      provide public confirmation ([How?][version-checksum]): {{link}}
+- [ ] `sha256` changed but the `version` didn’t ([what is this?][version-checksum]).  
+      I’m providing public confirmation below.
 
 Additionally, if **adding a new cask**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ After making all changes to the cask:
 
 Additionally, if **updating a cask**:
 
-- [ ] `sha256` changed but the `version` didn’t ([what is this?][version-checksum]).  
+- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
       I’m providing public confirmation below.
 
 Additionally, if **adding a new cask**:


### PR DESCRIPTION
Trying to make the message even clearer:

+ Removed `{{link}}`:
  + Few people actually use it.
  + It’s inconsistent with the rest of the template where `{{}}` means something you change *locally*, not in the template itself.
  + Confirmation is frequently accompanied by more than just a link.
+ Made the message about providing confirmation more personal.
+ “What is this” instead of “how”. More “in your face” regarding “we know this might be confusing, so see a longer explanation here”.

To do after merging:

- [ ] Update in `cask-repair`
- [ ] Run the sync script