### PR TITLE
Update sketch to 46.1-44463

### DIFF
--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -1,10 +1,10 @@
 cask 'sketch' do
-  version '46-44423'
-  sha256 'a67a166f66dae9784f182b4ea61e3113322cbff66fcd622a12138da87caa849c'
+  version '46.1-44463'
+  sha256 '47ab4d4da61e616396063643e1ff0f18ee283b4fcedf2fcbcf8fadf9c309f3e9'
 
   url "https://download.sketchapp.com/sketch-#{version}.zip"
   appcast 'https://download.sketchapp.com/sketch-versions.xml',
-          checkpoint: '1b487dc0c9c57cd2ad260f1030b3ef62115533207d39b51232bdce5ddafd3aee'
+          checkpoint: '095f0eb4e89a46173d8fc1e3e2379035773c175096f6d770d4a03e72cfbf7ff5'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}