### PR TITLE
Update minishift to 1.4.1

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.3.1'
-  sha256 '52cf602df1f5bec59b78f54625513eae3ed90150096e2cf29237e1cc3cdbd96d'
+  version '1.4.1'
+  sha256 '9386b713847e454ad43c007c53ce23e609b730b081f75e42264b7485160a96cf'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: 'a89c6e022f360d6b0b4715aab07e78dfed5173230c27944d98caf6f41a06921a'
+          checkpoint: '5455eb097ac76d06263e3097f498e6a6b6b66c721b490767f1f65773daa633bb'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}