### PR TITLE
Update cyberduck to 6.2.2.26027

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '6.2.0.25806'
-  sha256 'bcbf1d385f2cd54e33a364f3999011e70c42fa06d176beb0cbd9424cafd8313e'
+  version '6.2.2.26027'
+  sha256 '5a5216df134517b49cc1f40e5732fb3d361b97384620d093ff8c074c0737a058'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: '2518244c8f93892b43c4e43e861c3f919382b719c3fc1c3ba7b29c7b9b89ad3d'
+          checkpoint: '7507ff458eeaf235b325997174187a2f73c2031e31f9efbbd5de123bb81a1fe5'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}