### PR TITLE
Update mountain-duck to 1.9.9.7330

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '1.9.8.7322'
-  sha256 '3cbe041f9a6bc25f3315e3e864dec532498080beadc63791fad5a0bf46f91ada'
+  version '1.9.9.7330'
+  sha256 '5e1cd826b75c6b2a16a9efc704e5201250e50c33ff13bac4f4da6076af8e32d1'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '764cb5b8669c7e64fd53afdaa29c189c4f407062157abe705cf3ad2cbaa77f39'
+          checkpoint: '480673a2acf4ceafbb395edffa2fb07c70532291d1bcc20a79df15655c35ddab'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}