### PR TITLE
Update inspec to 1.32.1-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.31.1-1'
-  sha256 '9a3fbc0560cdeaa89df1de261d58dd1d993caac74482c073b550ff3602374dd6'
+  version '1.32.1-1'
+  sha256 'c2fcce3f239f749c0ea3356da26da9cb4d48dac3ae7fe0bf61f79fd5d3da7270'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: '3727b9ad3e4b0e0db23aa01da65d7a127e30a34106ee9116c87dede7d87502a5'
+          checkpoint: '78f296772661942094895dc2ee832f4e9ad7c7210cd7144d92629a6a454bc01e'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}