### PR TITLE
Update airtable to 1.1.12

### DIFF
--- a/Casks/airtable.rb
+++ b/Casks/airtable.rb
@@ -2,7 +2,7 @@ cask 'airtable' do
   version '1.1.12'
   sha256 '3d54d45b7f65119dc2b94cc0a6d086b65cd1d188ddd2b4b1b7d22dc5e1def14c'
 
-  url 'https://static.airtable.com/download/macos/Airtable-1.1.12.dmg'
+  url "https://static.airtable.com/download/macos/Airtable-#{version}.dmg"
   name 'Airtable'
   homepage 'https://airtable.com/'
 

--- a/Casks/airtable.rb
+++ b/Casks/airtable.rb
@@ -1,8 +1,8 @@
 cask 'airtable' do
-  version :latest
-  sha256 :no_check
+  version '1.1.12'
+  sha256 '3d54d45b7f65119dc2b94cc0a6d086b65cd1d188ddd2b4b1b7d22dc5e1def14c'
 
-  url 'https://static.airtable.com/download/AirtableInstaller.dmg'
+  url 'https://static.airtable.com/download/macos/Airtable-1.1.12.dmg'
   name 'Airtable'
   homepage 'https://airtable.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}