### PR TITLE
Add blu-ray-player-pro latest

### DIFF
--- a/Casks/blu-ray-player-pro.rb
+++ b/Casks/blu-ray-player-pro.rb
@@ -1,8 +1,10 @@
 cask 'blu-ray-player-pro' do
-  version :latest
-  sha256 :no_check
+  version '3.2.3'
+  sha256 'f5dbfe928bd9d6fd52c3e59a0923a64325b9ca8d6310071e49bc468f35f81d1f'
 
   url 'https://www.macblurayplayer.com/user/download/Macgo_Mac_Bluray_Player_Pro.dmg'
+  appcast 'https://macblurayplayer.com/products/mac-bluray-player-pro/Appcast.xml',
+          checkpoint: '3a1e27ceea3acd8d2d0a25ad8f1e0a87fb2380ab09dbc9ae2d2eaf1ae6d53538'
   name 'Macgo Mac Blu-ray Player Pro'
   homepage 'https://www.macblurayplayer.com/'
 

--- a/Casks/blu-ray-player-pro.rb
+++ b/Casks/blu-ray-player-pro.rb
@@ -1,0 +1,10 @@
+cask 'blu-ray-player-pro' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://www.macblurayplayer.com/user/download/Macgo_Mac_Bluray_Player_Pro.dmg'
+  name 'Macgo Mac Blu-ray Player Pro'
+  homepage 'https://www.macblurayplayer.com/'
+
+  app 'Blu-ray Player Pro.app'
+end


### PR DESCRIPTION
This pull request adds a new cask for the Macgo Blu-ray Player (the free Pro version).
I've copied the file from the non-pro version and just adjusted the download url.

======

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,  
      provide public confirmation ([How?][version-checksum]): {{link}}

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
