### PR TITLE
Update metabase-app to 0.25.2.0

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,10 +1,10 @@
 cask 'metabase-app' do
-  version '0.25.1.5'
-  sha256 '750c08de9ae2dbf13a914cf8b582619b35f0e653754600571926d4f1d107500c'
+  version '0.25.2.0'
+  sha256 'fbc31267d3e06ff441f442ae7e6059f6d8c23a624c8784ec3c46c429de105148'
 
   url "http://downloads.metabase.com/v#{version.major_minor_patch}/Metabase.dmg"
   appcast 'http://downloads.metabase.com/appcast.xml',
-          checkpoint: '7be00243c1167f95f21d68db259936c8812aad521699b75bf2da525c3652c916'
+          checkpoint: '997b7868639e988e4d94fe3be1e0068f6f3b461b9327824389ce44e97535b1bb'
   name 'Metabase'
   homepage 'http://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}