### PR TITLE
Update texshop to 3.8.5

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,10 +1,10 @@
 cask 'texshop' do
-  version '3.84'
-  sha256 'ae7065a9abe630bfe6b1c78a23fcbbd93981b40c5fbfa976363aed8185aaa791'
+  version '3.8.5'
+  sha256 'ac68bd5851892477a0530a04fe9494183ff68406b89e6a3e0887311910e7fe13'
 
   url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
-          checkpoint: '10daeb2cc33d1316978c731991e961e9cbc001e382e36680573bee81278a5acd'
+          checkpoint: '556e2e54e5e651a4d39e3385bfb9c4908d80779c8ecdb6266bf57c10709c4cce'
   name 'TeXShop'
   homepage 'http://pages.uoregon.edu/koch/texshop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}