### PR TITLE
Updated tifig to v0.7.0

### DIFF
--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -1,11 +1,11 @@
 cask 'tifig' do
-  version '0.6.0-201705041302'
-  sha256 'd3f865ca20ac3919be67da639af6fedef7ed87084713f88ff1e6e3e606ee4be4'
+  version '0.7.0-201708110628'
+  sha256 '5e34a2271adc0aa70cab11b46d73c4fd838799b278939f3cb856305932061dec'
 
   # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.tifig.net/download/',
-          checkpoint: 'd1bc27d2d83cdecd4042d01da0ad91ae621dd120f4ba43eff15e1384f3207df0'
+          checkpoint: 'ed1edfbbda20e164397fe91f2f14cf2d14a14a7f5a24620158fb1a54fa84e1ee'
   name 'Tifig'
   homepage 'https://www.tifig.net/'
 


### PR DESCRIPTION
This pull request updates the cask for the Tifig Swift IDE to v0.7.0.
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
