### PR TITLE
Update openzfs - uninstall_preflight

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -22,10 +22,9 @@ cask 'openzfs' do
 
   if MacOS.version >= :el_capitan
     uninstall_preflight do
-      system_command '/usr/bin/sed',
-                     args: ['-i', '.bak', 's|/usr/sbin/zpool|/usr/local/bin/zpool|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
-      system_command '/usr/bin/sed',
-                     args: ['-i', '.bak', 's|/usr/sbin/zfs|/usr/local/bin/zfs|', "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"]
+      uninstall_zfs = "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"
+      IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub('/usr/sbin/zpool', '/usr/local/bin/zpool'))
+      IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub('/usr/sbin/zfs', '/usr/local/bin/zfs'))
     end
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
___

- [x] `brew cask uninstall {{cask_file}}` worked successfully.

Uses ruby instead of `sed` to edit the `uninstall script`