### PR TITLE
Update soapui 5.3.0 - add postflight / zap

### DIFF
--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -46,5 +46,19 @@ cask 'soapui' do
                                   ],
                     }
 
+  postflight do
+    soapui_sh = "/Applications/SoapUI-#{version}.app/Contents/java/app/bin/soapui.sh"
+    IO.write(soapui_sh, IO.read(soapui_sh).gsub('#   JAVA_OPTS="$JAVA_OPTS -Dsoapui.browser.disabled=true"', '   JAVA_OPTS="$JAVA_OPTS -Dsoapui.browser.disabled=true"'))
+
+    vmoptions_txt = "/Applications/SoapUI-#{version}.app/Contents/vmoptions.txt"
+    IO.write(vmoptions_txt, '-Dsoapui.browser.disabled=true')
+  end
+
   uninstall delete: "/Applications/SoapUI-#{version}.app"
+
+  zap trash: [
+               '~/.soapuios',
+               '~/default-soapui-workspace.xml',
+               '~/soapui-settings.xml',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
___
- [x] `brew cask install {{cask_file}}` worked successfully.

Supersedes https://github.com/caskroom/homebrew-cask/pull/37310