### PR TITLE
Update downie to 2.9.7,1517

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,5 +1,5 @@
 cask 'downie' do
-  version '2.9.7,1517'
+  version '2.9.8,1517'
   sha256 'e354ffb5d7f8cbb14f77d2d3a204e0cce50ef44d98a6a15fae89faa23017bbc9'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"

--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.9.7,1515'
-  sha256 '3f0d9a8651a49d4a026d6c0c0493625bca3bbfe1ab41e30a946723a5d7224b74'
+  version '2.9.7,1517'
+  sha256 'e354ffb5d7f8cbb14f77d2d3a204e0cce50ef44d98a6a15fae89faa23017bbc9'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
-          checkpoint: 'b162072402fcd0ca248aca55d0d49faa1b3b20a0a0d3f0e3b69017b1bd6880c0'
+          checkpoint: 'da89aa2c34d5bef33e4cfefe7027dd91cc0e215304346da1924b8e656782502f'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.