### PR TITLE
Update qladdict to 1.2.4

### DIFF
--- a/Casks/qladdict.rb
+++ b/Casks/qladdict.rb
@@ -1,10 +1,10 @@
 cask 'qladdict' do
-  version '1.2.3'
-  sha256 'bee39f46772ab709aae84bfbaa95f68294cc7de13969c8fa58afb3c94661d483'
+  version '1.2.4'
+  sha256 '2af44d8392f75616c7852f37e627b674d561306328351331cb592ac93ea244cd'
 
   url "https://github.com/tattali/QLAddict/releases/download/#{version}/QLAddict.qlgenerator.#{version}.zip"
   appcast 'https://github.com/tattali/QLAddict/releases.atom',
-          checkpoint: 'af4bd13681cb0a00e4fc3277257d01ffe8bbffc03292fcfa059687e0a7790c7d'
+          checkpoint: '6a7c4a7082cbcd9b69eccc2587ca853c4c840e79b33f3ad698962df108cf75bb'
   name 'QLAddict'
   homepage 'https://github.com/tattali/QLAddict/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}