### PR TITLE
Update softu2f to 0.0.14

### DIFF
--- a/Casks/softu2f.rb
+++ b/Casks/softu2f.rb
@@ -1,10 +1,10 @@
 cask 'softu2f' do
-  version '0.0.13'
-  sha256 '94b226aa26439e2fc418d51529cffd510e7a3ee768b50948bdbfc9b70e7bda48'
+  version '0.0.14'
+  sha256 '6cc54f89438a4dacf5a009e4eba6d5ab8df81ec54b86d88cc5276cc144a73f76'
 
   url "https://github.com/github/SoftU2F/releases/download/#{version}/SoftU2F.pkg"
   appcast 'https://github.com/github/SoftU2F/releases.atom',
-          checkpoint: '2b02c008438e95878370d136846a4c1642b5a33a3e40bf843c18c986d846add9'
+          checkpoint: '7e3daaca9a5282c0316a39572dcef62b40303d3859c8bad99879122dc2be02ca'
   name 'Soft U2F'
   homepage 'https://github.com/github/SoftU2F'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.