### PR TITLE
Update openttd to 1.7.1

### DIFF
--- a/Casks/openttd.rb
+++ b/Casks/openttd.rb
@@ -1,6 +1,6 @@
 cask 'openttd' do
-  version '1.7.0'
-  sha256 '208e2f876450fdac4caf4e5f5b16714cef3e9ac3047f465cdddbf8d03567dcb2'
+  version '1.7.1'
+  sha256 '6f2b4ff490b32e2e3d1519c0477cc90620f261f623dc52944b8a43a109cb8c23'
 
   url "http://binaries.openttd.org/releases/#{version}/openttd-#{version}-macosx-universal.zip"
   name 'OpenTTD'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.