### PR TITLE
Update caret to 3.4.3

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -1,11 +1,11 @@
 cask 'caret' do
-  version '3.3.1'
-  sha256 '5cf27bbe41505bf7f5e7cd8bcb195d320ad7ee6a19ca5e439eecaa5abfe14051'
+  version '3.4.3'
+  sha256 '2a435248be7907144352dc94a3170af1acf800edbc76353c818195f40b0e0917'
 
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: '89b735f5542d0a670b915dbd75438d83411c7815812294f605a24a90a7fb606a'
+          checkpoint: 'e288c7b0b3622dd6981f7ef3a7489640e05badf23c30917059bc4ef2d55a1fe0'
   name 'Caret'
   homepage 'https://caret.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.