### PR TITLE
Update mudlet to 3.4.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -2,7 +2,7 @@ cask 'mudlet' do
   version '3.4.0'
   sha256 '5db3b751bdca324d8cc37db1f38d3f93600fbf0c722b4691f0f6d25274b02183'
 
-  url "http://www.mudlet.org/download/Mudlet-#{version}.dmg"
+  url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom',
           checkpoint: '4e76377fea71f981fe492ab7cb5357de55fb06ba96a39fbb81d57f5a0cf0fd01'
   name 'Mudlet'

--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,10 +1,10 @@
 cask 'mudlet' do
-  version '3.1.0'
-  sha256 'b29fbb950c2292231d253b40f58739093c39dea388362dfc9fe0a9f344e98cbd'
+  version '3.4.0'
+  sha256 '5db3b751bdca324d8cc37db1f38d3f93600fbf0c722b4691f0f6d25274b02183'
 
-  url "http://www.mudlet.org/download/Mudlet-#{version}.dmg"
+  url 'https://www.mudlet.org/download/Mudlet-3.4.0.dmg'
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom',
-          checkpoint: '533a8fd5aa78ba4c215e7414f3fce9e94ddbf67415c278c3d197bd4093c31ab9'
+          checkpoint: '4e76377fea71f981fe492ab7cb5357de55fb06ba96a39fbb81d57f5a0cf0fd01'
   name 'Mudlet'
   homepage 'https://www.mudlet.org/'
 

--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -2,7 +2,7 @@ cask 'mudlet' do
   version '3.4.0'
   sha256 '5db3b751bdca324d8cc37db1f38d3f93600fbf0c722b4691f0f6d25274b02183'
 
-  url 'https://www.mudlet.org/download/Mudlet-3.4.0.dmg'
+  url "http://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom',
           checkpoint: '4e76377fea71f981fe492ab7cb5357de55fb06ba96a39fbb81d57f5a0cf0fd01'
   name 'Mudlet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.