### PR TITLE
Update seamonkey to 2.48

### DIFF
--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -1,37 +1,37 @@
 cask 'seamonkey' do
-  version '2.46'
+  version '2.48'
 
   language 'de' do
-    sha256 '683425c2b85e65a979cd812214ff040e6a043bd15a1d79416ad4d3f03ef7fe37'
+    sha256 'da2708b80251636955d802bb32de8a352a46df661337f23801fa3c0f847f40c5'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '45c5de71e807d8f8f28a96f48c0c309d0fe740a6b3276d89733a5ffa12f5888c'
+    sha256 'db5ed7989a2cac2c560dd8d3b5e231499a2cefbf944626eaf44b44445d1f5d1f'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '167ae1fa1cd84006d1c85991b983dc9c9d00463f45ac480a3d6d41436bcb6f59'
+    sha256 '53431df9cd50cb6b7442fa5496f57b4b5bca0e5e005c058401f8ca958ad96428'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '297e1272f196f9ba3b2d61cabdd295a36575f9d5d6119b59652b2b2191ea6f54'
+    sha256 '2ca2ec22cc28676721813d147355c2c0e3b3f9c97bba9fe00ef31bc642ee254f'
     'fr'
   end
 
   language 'it' do
-    sha256 'a784bb5817626b1a69885ba39ee149ef6de7b9465d8fc29ea08cd239e454a2fd'
+    sha256 '717a3f87c37bb76a712dfa81a6483ae17e179b9e5daf644585838ea03e961ee2'
     'it'
   end
 
   language 'ru' do
-    sha256 '52ef4becc913bddc64c04683d53b3e42a04ab78b3df7ca6263060fb9ddc9c4ca'
+    sha256 '44f30154148f6ae7754ea849e0fd93fe305eb9cf6ffdd9a42b1b57cab4b0048c'
     'ru'
   end
 
-  # mozilla.org was verified as official when first introduced to the cask
+  # mozilla.org/pub/seamonkey/releases was verified as official when first introduced to the cask
   url "https://ftp.mozilla.org/pub/seamonkey/releases/#{version}/mac/#{language}/SeaMonkey%20#{version}.dmg"
   name 'SeaMonkey'
   homepage 'https://www.seamonkey-project.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.