### PR TITLE
Update nextcloud to 2.3.2.1

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -1,10 +1,10 @@
 cask 'nextcloud' do
-  version '2.2.4.1'
-  sha256 'b466cd8ec6c7d105e51019f49c31a1009068ae7fade787d7e7cab0ee469ae6ed'
+  version '2.3.2.1'
+  sha256 '2b2afb95d015726f35533d98dc4b7682736ea10f6272b3c280ee1801013dbf55'
 
   url "https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-#{version}.pkg"
   appcast 'https://github.com/nextcloud/client_theming/releases.atom',
-          checkpoint: 'd6cd43112beceba98ec788b300c58c663aaa7b60d68cd507482ac06aa44e324f'
+          checkpoint: '2a12315ea22a0100ebcb20ab75e33c9f925b5d76849187086031e4fcfc6f5c5b'
   name 'Nextcloud'
   homepage 'https://nextcloud.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.