### PR TITLE
Update texmaker to 5.0.2

### DIFF
--- a/Casks/texmaker.rb
+++ b/Casks/texmaker.rb
@@ -1,10 +1,10 @@
 cask 'texmaker' do
-  version '5.0.1'
-  sha256 '6ad92da13d2c895621ee6a82f5d6afb0dd4a12d65add2934d85a602175638535'
+  version '5.0.2'
+  sha256 'c23a912f7fc47d2dd28590d3a704f8e3df55a68f2ab21267a16b294d59fe9657'
 
   url "http://www.xm1math.net/texmaker/assets/files/texmaker-#{version}.dmg"
   appcast 'http://www.xm1math.net/texmaker/log.html',
-          checkpoint: '1ae50704060807cbf2460153b2f750c88b2ce70eb79fd17a46b4048d0e4ba2bc'
+          checkpoint: '6d16b088787f6cf801902fd6d9c3a7c6b7a4fadc785c9b6da7a1944b4bfa5fd6'
   name 'Texmaker'
   homepage 'http://www.xm1math.net/texmaker/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.