### PR TITLE
Add wire 2.15.2750

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,0 +1,21 @@
+cask 'wire' do
+  version '2.15.2750'
+  sha256 '4c0ccf4c2993fab9fda12b40697f219dd78376eb7612d67a75e0dcccf93a4f38'
+
+  # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
+  url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"
+  appcast 'https://github.com/wireapp/wire-desktop/releases.atom',
+          checkpoint: 'f1b7d2c79908b9113e5129a5fdff8cc203505069c6288fbd0bba79d5cfbcdda1'
+  name 'Wire'
+  homepage 'https://wire.com/'
+
+  pkg 'Wire.pkg'
+
+  uninstall pkgutil: 'com.wearezeta.zclient.mac',
+            signal:  [
+                       ['TERM', 'com.wearezeta.zclient.mac.helper'],
+                       ['TERM', 'com.wearezeta.zclient.mac'],
+                     ]
+
+  zap delete: '~/Library/Containers/com.wearezeta.zclient.mac'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].
____
https://github.com/caskroom/homebrew-cask/issues/23884

https://github.com/wireapp/wire-desktop/releases/tag/macos%2F2.15.2750

Cask version matches MAS version.

https://itunes.apple.com/app/wire/id931134707?mt=12


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
