### PR TITLE
Update contexts to 3.0.1

### DIFF
--- a/Casks/contexts.rb
+++ b/Casks/contexts.rb
@@ -1,10 +1,10 @@
 cask 'contexts' do
-  version '2.9'
-  sha256 '816a2d51ebe1168fec9a5aa8d8c447ca72b66f29f6fae4f103cf00de51daaf29'
+  version '3.0.1'
+  sha256 'ce0c36f282d4d87267f5218d298e32f3dfc4827dd790a789fb6f505b32e4e6d7'
 
-  url "https://contexts.co/releases/Contexts-#{version}.zip"
+  url "https://contexts.co/releases/Contexts-#{version}.dmg"
   appcast 'https://contexts.co/appcasts/stable.xml',
-          checkpoint: 'b805ef491b8c9f80b25f52599d99251f2e7f36cb3b117ac7c8eb156daf0d366f'
+          checkpoint: '16223ae7b370f760ded25abfa5d66e23de3776ebad193ce5760c9435271e7fb0'
   name 'Contexts'
   homepage 'https://contexts.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.