### PR TITLE
Update Firealpaca 1.8.2 (need help)

### DIFF
--- a/Casks/firealpaca.rb
+++ b/Casks/firealpaca.rb
@@ -1,8 +1,9 @@
 cask 'firealpaca' do
-  version '1.8.2'
-  sha256 'ad0897f5b35cd54f411fcf19ef590b119f56801690d383e1fab5a199e9fa5fea'
+  version :latest
+  sha256 :no_check
 
-  url 'http://firealpaca.com/download/mac'
+  url 'http://firealpaca.com/download/mac',
+      referer: 'http://firealpaca.com/'
   name 'Fire Alpaca'
   homepage 'https://firealpaca.com/'
 

--- a/Casks/firealpaca.rb
+++ b/Casks/firealpaca.rb
@@ -1,8 +1,8 @@
 cask 'firealpaca' do
-  version :latest
-  sha256 :no_check
+  version '1.8.2'
+  sha256 'ad0897f5b35cd54f411fcf19ef590b119f56801690d383e1fab5a199e9fa5fea'
 
-  url 'http://firealpaca.com/download.php?os=mac&key=17813449013210197561d4f66c5aca8c'
+  url 'http://firealpaca.com/download/mac'
   name 'Fire Alpaca'
   homepage 'https://firealpaca.com/'
 


### PR DESCRIPTION
### NOTE: Download link fails

This is the link when I am downloading from the website to my machine http://115.146.50.91/firealpaca/bin/FireAlpaca.zip . The actual link from the website is http://firealpaca.com/download/mac . Neither link works. 

The original link http://firealpaca.com/download.php?os=mac&key=17813449013210197561d4f66c5aca8c is broken anyway. 


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.
