### PR TITLE
Update mono-mdk to 5.2.0.215

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,11 +1,11 @@
 cask 'mono-mdk' do
-  version '5.0.1.1'
-  sha256 '60eef93597fd4fc0fa617e0bd1df14da506611087e4117ac366b332ecf70a5a0'
+  version '5.2.0.215'
+  sha256 'bf7e7c0439783015168662833754bd83f1a9ffe5970919213a762f313cc53909'
 
   # mono-project.azureedge.net/archive was verified as official when first introduced to the cask
   url "https://mono-project.azureedge.net/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: '08fef545d50bd40a08d194b082bba6752cb27453d3381fd4c0504bdf18dd6ab2'
+          checkpoint: '3440e32fa546571a45474a6bc9bbe8047cb1f8035af1679c502e49f1ac9de4d7'
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.