### PR TITLE
Front - Updating Front dmg file to the latest location

### DIFF
--- a/Casks/front.rb
+++ b/Casks/front.rb
@@ -2,7 +2,7 @@ cask 'front' do
   version :latest
   sha256 :no_check
 
-  url 'https://dl.frontapp.com/osx/front.dmg'
+  url 'https://dl.frontapp.com/macos/Front.dmg'
   name 'Front'
   homepage 'https://frontapp.com/'
 


### PR DESCRIPTION
Following our migration to Electron a few months back, we updated our download path to a different one, so that the osx link is pointing at an older link.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.



[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
