### PR TITLE
Update hex-fiend - binary / zap

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -10,9 +10,11 @@ cask 'hex-fiend' do
   homepage 'http://ridiculousfish.com/hexfiend/'
 
   app 'Hex Fiend.app'
+  binary "#{appdir}/Hex Fiend.app/Contents/Resources/hexf"
 
   zap delete: [
-                '~/Library/Preferences/com.ridiculousfish.HexFiend.LSSharedFileList.plist',
-                '~/Library/Preferences/com.ridiculousfish.HexFiend.plist',
-              ]
+                '~/Library/Caches/com.ridiculousfish.HexFiend',
+                '~/Library/Saved Application State/com.ridiculousfish.HexFiend.savedState',
+              ],
+      trash:  '~/Library/Preferences/com.ridiculousfish.HexFiend.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Add `binary`

> https://github.com/ridiculousfish/HexFiend/blob/master/docs/ReleaseNotes.html#L36