### PR TITLE
Update lightning to 1.8.6

### DIFF
--- a/Casks/lightning.rb
+++ b/Casks/lightning.rb
@@ -1,6 +1,6 @@
 cask 'lightning' do
-  version '1.8.4'
-  sha256 '98eca9d7ea7e8f35c213d646830f773f923b28abf13df81eb6560ba488d5d80f'
+  version '1.8.6'
+  sha256 'c551fee0e7dc9949683a555406f94f2d5300af3459f9c85c032a938d0f67d4a6'
 
   url "https://fwdl.filewave.com/lightning/FileWave_Lightning-#{version}.dmg"
   name 'FileWave Lightning'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.