### PR TITLE
Fix latest gif-for-mac cask.

### DIFF
--- a/Casks/gif-for-mac.rb
+++ b/Casks/gif-for-mac.rb
@@ -7,5 +7,5 @@ cask 'gif-for-mac' do
   name 'GIF for Mac'
   homepage 'https://tenor.com/mac'
 
-  app 'GIF for Mac.app'
+  app 'Tenor.app'
 end

--- a/Casks/tenor.rb
+++ b/Casks/tenor.rb
@@ -1,10 +1,10 @@
-cask 'gif-for-mac' do
+cask 'tenor' do
   version :latest
   sha256 :no_check
 
   # media.tenor.co/mac/bin was verified as official when first introduced to the cask
   url 'https://media.tenor.co/mac/bin/GIFforMac.dmg'
-  name 'GIF for Mac'
+  name 'Tenor'
   homepage 'https://tenor.com/mac'
 
   app 'Tenor.app'

--- a/Casks/tenor.rb
+++ b/Casks/tenor.rb
@@ -1,11 +1,16 @@
 cask 'tenor' do
-  version :latest
-  sha256 :no_check
+  version '2.0.2'
+  sha256 'c3faf005a6454d4ddfdaa73796ccf86579a7e2a62580e8be85a43e2dba329c59'
 
   # media.tenor.co/mac/bin was verified as official when first introduced to the cask
   url 'https://media.tenor.co/mac/bin/GIFforMac.dmg'
+  appcast 'https://media.tenor.co/mac/gif_for_mac_appcast.xml',
+          checkpoint: '5730b07c9aa3ddf9964a14ac5f905ba26c74f80496a5d00066f5a8926aa54d0d'
   name 'Tenor'
   homepage 'https://tenor.com/mac'
 
   app 'Tenor.app'
+
+  uninstall login_item: 'Tenor',
+            quit:       'com.riffsy.GIF-for-Mac'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].