### PR TITLE
Update downie to 2.9.9,1521

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.9.8,1517'
-  sha256 'e354ffb5d7f8cbb14f77d2d3a204e0cce50ef44d98a6a15fae89faa23017bbc9'
+  version '2.9.9,1521'
+  sha256 '270e22205e893c41257fd808d6a42a49316dce79c38cb98ee87fd9f6e6feb06e'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
-          checkpoint: 'da89aa2c34d5bef33e4cfefe7027dd91cc0e215304346da1924b8e656782502f'
+          checkpoint: '2f38958d516214dbd62137332f4176d03af174824cf3e7ed04a1a90e419375c5'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.