### PR TITLE
Update xamarin-mac to 3.6.0.17

### DIFF
--- a/Casks/xamarin-mac.rb
+++ b/Casks/xamarin-mac.rb
@@ -1,10 +1,10 @@
 cask 'xamarin-mac' do
-  version '3.4.0.36'
-  sha256 'e26a80365b60ef38b5815bdfbea3fc60cba98ae11e6e0822f3c37707d63978ce'
+  version '3.6.0.17'
+  sha256 '4b87b8cce87ede88ceaacc2aef14718b23acf2f613b491d0db440d7a1ea3d67d'
 
   url "https://dl.xamarin.com/XamarinforMac/Mac/xamarin.mac-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: 'd1c454ead2e12eb823776ab1e0f18c35cb9372379ac93aacff7107c0c76b8c0b'
+          checkpoint: '21f7412cc871cceda8f7caf320f994a15cf1ee2f57865518ff9ed027bb76d604'
   name 'Xamarin Mac'
   homepage 'https://www.xamarin.com/platform'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.