### PR TITLE
Update subler to 1.3.5

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.3.4'
-  sha256 'd2e3c615d8f8a6fa5a49b7917524bf6b4489b0af5a133de8f6fe9c66a799d4f1'
+  version '1.3.5'
+  sha256 '28963c8d344ac4817d040cf20495c74fb1bca1111ae3213dc859f5770551064a'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: 'c12b341c814209f7bf0e6b00fe1ef25c0c9a14c23289687592172b3dbb2a44b6'
+          checkpoint: '87cb85473d19e13f8d0fa7c3a0c901dd3ad34b1b4002013cbb451ac70afe15f8'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.