### PR TITLE
Update mediainfo to 0.7.98

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,10 +1,10 @@
 cask 'mediainfo' do
-  version '0.7.97'
-  sha256 'd55cb482fc89d31a457e9da11f57617b18bf546aa8c43120a42f5ac0ed52b9b7'
+  version '0.7.98'
+  sha256 '96f952e71e1a302a52bdb9a226c4246496af892e769d4b396191227436264017'
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   appcast 'https://mediaarea.net/rss/mediainfo_updates.xml',
-          checkpoint: '0f95d5796562506e3748fd235dd6633495fc5f0cfe0e5c9060070d7312cdd222'
+          checkpoint: '0650eb4cc0a43924c65afe9490c46614cf59f1f8cd7c611fdb2466da6faa3545'
   name 'MediaInfo'
   homepage 'https://mediaarea.net/en/MediaInfo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.