### PR TITLE
Update numi to 3.17.1,134:1501511032

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,11 +1,11 @@
 cask 'numi' do
   version '3.17.1,134:1501511032'
-  sha256 'cbb8fb2e424b593e1b448ecd4eb707f459d1aad71e1fc0c0da0778108c5a296d'
+  sha256 '1a01370a5dd7ca9b7f1a7cc3253d39c0b57aed65127b1ee2741336326a72cb37'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"
+  url 'http://dl.devmate.com/com.dmitrynikolaev.numi/Numi.zip'
   appcast 'http://updates.devmate.com/com.dmitrynikolaev.numi.xml',
-          checkpoint: '0628e73a0ef4fbfc4564fa6408358eadca3a724266ee26e5969d36488aebe953'
+          checkpoint: 'e36b71a82c8eb8d35cbfeb660f237e88a10e46551b678a8e0338906b28962729'
   name 'Numi'
   homepage 'https://numi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.