### PR TITLE
Update sparkle to 1.18.1

### DIFF
--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -1,11 +1,11 @@
 cask 'sparkle' do
-  version '1.18.0'
-  sha256 '7256b93d78fb7eb69b26852379a5e7709e5e67b33d7726fc461097b6a7180616'
+  version '1.18.1'
+  sha256 '7a7a486d2c5adb75bdd78775946da2b37b82b93cb3eea96049f7b1d8569f11cc'
 
   # github.com/sparkle-project/Sparkle was verified as official when first introduced to the cask
   url "https://github.com/sparkle-project/Sparkle/releases/download/#{version}/Sparkle-#{version}.tar.bz2"
   appcast 'https://github.com/sparkle-project/Sparkle/releases.atom',
-          checkpoint: '84a74248bab7cec6b2df5941f756f850bf75a71285b898c44b0603a5fb26ce37'
+          checkpoint: '64a09869d80b7e7355696e243a05692ea77414a97e12f71ff4e6535acd224a47'
   name 'Sparkle'
   homepage 'https://sparkle-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.