### PR TITLE
Update waterfox to 55.0.1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -11,7 +11,10 @@ cask 'waterfox' do
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.waterfox.sfl',
-                '~/Library/Application Support/Waterfox',
                 '~/Library/Caches/Waterfox',
+              ],
+      trash:  [
+                '~/Library/Application Support/Waterfox',
+                '~/Library/Preferences/org.waterfoxproject.waterfox.plist',
               ]
 end

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '54.0.1'
-  sha256 'd33158ea714652002a6ead9f94d4f049521031e2a32d53c25ec57921c69b3367'
+  version '55.0.1'
+  sha256 '5a487f253a02e012fc6d1dbf2e148996cf66dffff7c943c3f84fca390076334d'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version.before_comma}%20Setup.dmg"

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -8,4 +8,10 @@ cask 'waterfox' do
   homepage 'https://www.waterfoxproject.org/'
 
   app 'Waterfox.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.waterfox.sfl',
+                '~/Library/Application Support/Waterfox',
+                '~/Library/Caches/Waterfox',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.