### PR TITLE
Update exist-db to 3.4.1

### DIFF
--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -1,6 +1,6 @@
 cask 'exist-db' do
-  version '3.4.0'
-  sha256 '40275a5e997f2e35166eec7c31faec06641ce9a8a1db487e0ef7883ed16902d5'
+  version '3.4.1'
+  sha256 'c4e00257a8de538f68615f211d8fca1c7e835779d5b70dcc37db563acd4e4647'
 
   # bintray.com/artifact/download/existdb was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/existdb/releases/eXist-db-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.