### PR TITLE
Update firefox to 55.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,114 +1,114 @@
 cask 'firefox' do
-  version '55.0.1'
+  version '55.0.2'
 
   language 'cs' do
-    sha256 '37c72356eef711c7fe86fb841cf6980d6362046624930d7d58aca03b8f693c76'
+    sha256 'a42208298cd9f44aad5a130a581ddc04faa95caf5647f76a91abfee919392d53'
     'cs'
   end
 
   language 'de' do
-    sha256 '7c3a8df2309bb1b2ed6dfe53ec7c266343d102305551642831a28887041171b0'
+    sha256 'f368d41c61a2af75ad45fa41f5954c53b4d89c59592bdd959d4630299ca9f49d'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'a8c3aeda4847af689214b974a75abf033f4ee378ce0c249faa8c8158b1054fb6'
+    sha256 '3a1925b35c5a6ab751cd25413112c4ec114cf0ac551c14536fd52c8e54524fcf'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '3e7e9f43cfdbb48d635607dd0f4c8a04f667d6885be68a15be5a0d4fbb0f9764'
+    sha256 '3e9ee0836ff975caba2f2cefb8681d7d0a8fe832896421fd152dc314e5fabf55'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 '0e97c8ecfc04f5ea9a8c6029087e2e3c9fc645a0e40920c605071ef052f4b6b7'
+    sha256 '8be98ec0dfc6f799cfd831392ea6907eed41e7f9b151188804c049fa7da467dc'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '498d94acc2b256773890e96f5ee07fbd4ab099953b89fe25618da06802a2ad10'
+    sha256 '3ce8275f38d6219e6892f3cf03094497d63bebaff9495670f9753af36ebf1bef'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '7214e6c646a0caa53ddd911963f9c0157fc0f9cf0e115519ee4b60c11a23f064'
+    sha256 'cd31031f064ed41e6dedd9da4becdf7d077cb003d86533ef0fa488941555a6de'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 'd5ed4df87f05f4c69fdfe3e8d1c463e8168173dc41b4fb324d4b36ebc37301ec'
+    sha256 'ff602aaa45faab7d50d7b460115dfc48d9f8b87c2ae3b407768062e859a6e5ee'
     'fi'
   end
 
   language 'fr' do
-    sha256 'd699b0fd1d3a245b64d9a7c93295c21523a030a13a324c904dc2068b5ad42947'
+    sha256 'fc6437eac348e6a297fa9b47be94732d0f72acef289ba44056d0ecc5e1522a7e'
     'fr'
   end
 
   language 'gl' do
-    sha256 'f87b21c75f84527a267eab79df8bae85eb35a4157bcaa146f6e522a99e80d192'
+    sha256 'f1056b32cf2633feb193bf3fec3f254bd990c065ac82e0dfd326fcb5729f324d'
     'gl'
   end
 
   language 'in' do
-    sha256 '3e140af1e91dd6003981fae6fa69f7847c9fef839ce8e9f3a72af634f792627c'
+    sha256 '7e8d955fbfd9255132a0f395429dfe1647a9c824c057bd864a26ede248d32fd0'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 'ecf50beb87fd5d3664015f40f946df439d88e8c6e444c5fc54f613a39cfa5a09'
+    sha256 '224952b13017000dfd055d8f8a2e1364b5a7f3b8589a10ddd9e31caa317c7b8e'
     'it'
   end
 
   language 'ja' do
-    sha256 'ec4987cb957fe6d9bb916f74e9a095543f74fc354cb9c3c5e38e53a2bcd10e8f'
+    sha256 '75ef5a2bb0761065e8d84979f1beafbd75c5fd3b888df3db2915731cd8fdb240'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '49a7f400eff40d134066fac7250b8232f550f5dc2c07ab4d135fcd070ebfc1fa'
+    sha256 'd41b91befa06a7a65d400db074369bab47d36be21f9ea882ee1dd7c5887bea95'
     'nl'
   end
 
   language 'pl' do
-    sha256 '974b7fd93a56e04a9512e2f9bd86642f5e7aaa803175ca448b937dfe44043ab5'
+    sha256 'ffff693d956e03e11e77c500362e0d12b5e64a29c1de7de76c5af0b6715df524'
     'pl'
   end
 
   language 'pt' do
-    sha256 'deee4fab2d9ff57a25592bad09d2239da5bac025557a284f5f01ea2d10ef6134'
+    sha256 'ae1dd56ce99d6c0edd6ca14a5f310d82ee8ec351f880aa628a944f04997480a0'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '3506bd3c219d872fcc0c6f19e55d1dcb6f468a0b4208882a4ddfc9a6dc71992d'
+    sha256 '9e5d417782e77244f9acc781f4c9d97275581102bb3a44d9a1163393c9240d10'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 'a6d6b0d3672a8f090159adb16f5783a436214bd16ba2d8c744772b2397493a6a'
+    sha256 '4a1e8b664895f1361054d5fbfa071b18e19f960d997ae0e2b95598c701d45a11'
     'ru'
   end
 
   language 'uk' do
-    sha256 '7801603209d848ef61ad35bca225772a6cfe1b2c79b4a075787ae14bee9669f1'
+    sha256 'd4051d64acd1734c85bd6b91abc9461f083bf895d57b6a3044898e126d70fc79'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'def54eab0638885e5b6004bdecbad7779c65ae87a58ac48774f35b1ca4849d62'
+    sha256 '10bcf15cb4abbebedab8abad359b5000b03791176aca68b9b9620d5c7c844bf4'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'ae51f3aea0e494db1af3edc3f065260fd7fab40b0b022359995b0914cf1ebd43'
+    sha256 'a6c03e2ee6a3170bc5b85703804a0844c01a745edaefa19179b1cee50a539820'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '43ae1d42c868786225b5cb4365ccb577fcc8e1e0cfae1da4d75499935802cf98'
+          checkpoint: '40c0e5a526829e0993d35f103f437b17eaf44bf3a71c2c4ad783d03429d87e6f'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.