### PR TITLE
Update hands-off to 3.2.2

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,10 +1,10 @@
 cask 'hands-off' do
-  version '3.2.1'
-  sha256 'cbbcf993d2319d776b7ec1ac35fc4569cc97490fcce6af69e7cbe55464cd351f'
+  version '3.2.2'
+  sha256 '5feba20a5557de862078d053d528d0dc3869cdd4bc8a0dd165628f2a0bc95442'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml",
-          checkpoint: 'ee18f60eb11947b00737cb239eb2bdaf6d011e6b03c8bdcb9335adffb2ac71b1'
+          checkpoint: 'ac2dcf5861f8bed9a7015c3475addedf4384fdc72aa921bb83a6cdb276fd650e'
   name 'Hands Off!'
   homepage 'https://www.oneperiodic.com/products/handsoff/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.