### PR TITLE
New formula: ICC for Mac v1.0.r7564

### DIFF
--- a/Casks/icc-for-mac.rb
+++ b/Casks/icc-for-mac.rb
@@ -1,0 +1,12 @@
+cask 'icc-for-mac' do
+  version '1.0.r7564'
+  sha256 '28b8fbd96efc571bc00f8088c41dd836a118451cbe39d69e83ba0c5d52c00491'
+
+  url "http://download.chessclub.com/desktop/mac/ICCforMac.#{%r{\d+\.\d+\.(.*)}.match(version)[1]}.pkg"
+  name 'ICC for Mac'
+  homepage 'https://www.chessclub.com/download-software/icc-for-mac'
+
+  pkg "ICCforMac.#{%r{\d+\.\d+\.(.*)}.match(version)[1]}.pkg"
+
+  uninstall pkgutil: 'com.chessclub.*'
+end

--- a/Casks/icc.rb
+++ b/Casks/icc.rb
@@ -10,9 +10,11 @@ cask 'icc' do
 
   uninstall pkgutil: 'com.chessclub.*'
 
-  zap delete: '~/Library/Saved Application State/com.chessclub.desktop-icc.savedState',
-      trash:  [
+  zap delete: [
+                '~/Library/Saved Application State/com.chessclub.desktop-icc.savedState',
                 '~/.cache/internet_chess_club',
+              ],
+      trash:  [
                 '~/.internet_chess_club',
                 '~/Library/Preferences/com.chessclub.desktop-icc',
               ]

--- a/Casks/icc.rb
+++ b/Casks/icc.rb
@@ -1,4 +1,4 @@
-cask 'icc-for-mac' do
+cask 'icc' do
   version '1.0.r7564'
   sha256 '28b8fbd96efc571bc00f8088c41dd836a118451cbe39d69e83ba0c5d52c00491'
 

--- a/Casks/icc.rb
+++ b/Casks/icc.rb
@@ -2,11 +2,11 @@ cask 'icc' do
   version '1.0.r7564'
   sha256 '28b8fbd96efc571bc00f8088c41dd836a118451cbe39d69e83ba0c5d52c00491'
 
-  url "http://download.chessclub.com/desktop/mac/ICCforMac.#{%r{\d+\.\d+\.(.*)}.match(version)[1]}.pkg"
+  url "http://download.chessclub.com/desktop/mac/ICCforMac.#{version.patch}.pkg"
   name 'ICC for Mac'
   homepage 'https://www.chessclub.com/download-software/icc-for-mac'
 
-  pkg "ICCforMac.#{%r{\d+\.\d+\.(.*)}.match(version)[1]}.pkg"
+  pkg "ICCforMac.#{version.patch}.pkg"
 
   uninstall pkgutil: 'com.chessclub.*'
 end

--- a/Casks/icc.rb
+++ b/Casks/icc.rb
@@ -9,4 +9,11 @@ cask 'icc' do
   pkg "ICCforMac.#{version.after_comma}.pkg"
 
   uninstall pkgutil: 'com.chessclub.*'
+
+  zap delete: '~/Library/Saved Application State/com.chessclub.desktop-icc.savedState',
+      trash:  [
+                '~/.cache/internet_chess_club',
+                '~/.internet_chess_club',
+                '~/Library/Preferences/com.chessclub.desktop-icc',
+              ]
 end

--- a/Casks/icc.rb
+++ b/Casks/icc.rb
@@ -1,12 +1,12 @@
 cask 'icc' do
-  version '1.0.r7564'
+  version '1.0,r7564'
   sha256 '28b8fbd96efc571bc00f8088c41dd836a118451cbe39d69e83ba0c5d52c00491'
 
-  url "http://download.chessclub.com/desktop/mac/ICCforMac.#{version.patch}.pkg"
+  url "http://download.chessclub.com/desktop/mac/ICCforMac.#{version.after_comma}.pkg"
   name 'ICC for Mac'
   homepage 'https://www.chessclub.com/download-software/icc-for-mac'
 
-  pkg "ICCforMac.#{version.patch}.pkg"
+  pkg "ICCforMac.#{version.after_comma}.pkg"
 
   uninstall pkgutil: 'com.chessclub.*'
 end


### PR DESCRIPTION
ICC is the most popular chess server worldwide. This is their official Mac client.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
