### PR TITLE
Update impactor to 0.9.42

### DIFF
--- a/Casks/impactor.rb
+++ b/Casks/impactor.rb
@@ -1,11 +1,11 @@
 cask 'impactor' do
-  version '0.9.41'
-  sha256 '6c7fd51067320bdfd26b23977b04ec4de8e71bf125a928aef06f95173c0d1cbb'
+  version '0.9.42'
+  sha256 '367ee0dde296ee44c4d4474aeedd03000537c425429ac52eaf58aa35fc4c56eb'
 
   # cache.saurik.com/impactor was verified as official when first introduced to the cask
   url "https://cache.saurik.com/impactor/mac/Impactor_#{version}.dmg"
   appcast 'https://cydia.saurik.com/api/appcast/1',
-          checkpoint: 'ecdff740f3eaa97ca4f168302ebfb559f6d1a9cc58472cab4259ec765c06c004'
+          checkpoint: '50b4d0401be38b412868f9cca690365c11f6e1497359b08cf773e336c7b4fa93'
   name 'Impactor'
   homepage 'http://www.cydiaimpactor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.