### PR TITLE
Update brave to 0.18.23

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.18.14'
-  sha256 '0a3d15b924a4ad85a51d3c1b62943ea6aa92381a80bea4933284174fd0c13f11'
+  version '0.18.23'
+  sha256 '4fa819c9a08d91dfd644a1c476e8c6c614301f91b98f951bcb3bf7255b8b3e41'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '74f0088db0f580ecc5276ca073d2e8b6d1fe9065cfac0123844584fb39edfbc0'
+          checkpoint: '0cfb69cbf42db5b8550b472297d9e41f0b5eec9e37d77e67ca9966f10297be80'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.