### PR TITLE
Update scilab to 6.0.0

### DIFF
--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -1,8 +1,8 @@
 cask 'scilab' do
-  version '5.5.2'
-  sha256 '6e855c4aae6f75d37ced77bea64ac5cf33f65f3925107c65547b2a5fede3bd91'
+  version '6.0.0'
+  sha256 '87ec97f04f64e1fe8133e639a784fc02ca0802adf6c7c2c98c6d8febf59cc40e'
 
-  url "https://www.scilab.org/download/#{version}/scilab-#{version}-x86_64_yosemite.dmg"
+  url "https://www.scilab.org/download/#{version}/scilab-#{version}-x86_64.dmg"
   name 'Scilab'
   homepage 'https://www.scilab.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.