### PR TITLE
Update exodus to 1.32.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.31.1'
-  sha256 '3cb576f088d73c153105ec8a50c1cb46ae4a572cec33d2392c13c0cd0174c02f'
+  version '1.32.0'
+  sha256 '70c907046fceadcca17038427cbb5cf5262e8014f8cf9d07612648a062d931bb'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/Exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '6b3805591eaf4e9fbdf2b97ab5a2c89b8198584454717c71aa30811c547fbc48'
+          checkpoint: '74c0d3d79c6f10996dd610c96aa32fb01829b48dd8518076363e3be63b0ab588'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.