### PR TITLE
Update electrum to 2.9.3

### DIFF
--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -1,10 +1,10 @@
 cask 'electrum' do
-  version '2.9.0'
-  sha256 '2b3a740703ae3f2eefcb057a17744c31ea8de37ea71965d0345ff2c3a8242cfc'
+  version '2.9.3'
+  sha256 '228fd5d7e4bc151604ba814fbe5b25be994dfb33e51f3b7ecf58246856aef0b4'
 
   url "https://download.electrum.org/#{version}/electrum-#{version}.dmg"
   appcast 'https://github.com/spesmilo/electrum/releases.atom',
-          checkpoint: 'e88c7a60523d673f319302d6d4c1fe88fc677ee0868275bb1c4b84f9b1fb4793'
+          checkpoint: 'cc6fee2cd1357ad49eeed0dafccf340e6133ebf1202ab5508d4de9e567a85144'
   name 'Electrum'
   homepage 'https://electrum.org/'
   gpg "#{url}.asc", key_id: '6694d8de7be8ee5631bed9502bd5824b7f9470e6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
  - The `rubocop` throws me a `/Users/pyppe/.rvm/gems/ruby-2.4.0/gems/json-2.1.0/lib/json/ext/parser.bundle: [BUG] Segmentation fault`... 
- [x] The commit message includes the cask’s name and version.
