### PR TITLE
Update thunder to 3.1.2.3078

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '3.1.1.3012'
-  sha256 '39e93dd5eb1e5ce48630713aac457c8667f4871529e72ea963b45e8a3ff9fee0'
+  version '3.1.2.3078'
+  sha256 '60ddd58c725194817d3b7ebc61c077610ffab5c5c33679a110b8add4dbb5f0e0'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_#{version}.dmg"
@@ -13,14 +13,17 @@ cask 'thunder' do
   app 'Thunder.app'
 
   zap delete: [
-                '~/Library/Application Support/Thunder',
                 '~/Library/Caches/com.xunlei.Thunder',
                 '~/Library/Caches/com.xunlei.XLPlayer',
                 '~/Library/Cookies/com.xunlei.Thunder.binarycookies',
+                '~/Library/Saved Application State/com.xunlei.Thunder.savedState',
+                '~/Library/Saved Application State/com.xunlei.XLPlayer.savedState',
+                '~/Library/WebKit/com.xunlei.Thunder',
+              ],
+      trash:  [
+                '~/Library/Application Support/Thunder',
                 '~/Library/Preferences/com.xunlei.Thunder.loginSDK.plist',
                 '~/Library/Preferences/com.xunlei.Thunder.plist',
                 '~/Library/Preferences/com.xunlei.XLPlayer.plist',
-                '~/Library/Saved Application State/com.xunlei.Thunder.savedState',
-                '~/Library/Saved Application State/com.xunlei.XLPlayer.savedState',
               ]
 end


### PR DESCRIPTION
Update thunder to 3.1.2.3078

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
