### PR TITLE
Update checksum for istat-menus 5.32

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus' do
   version '5.32'
-  sha256 '99e1a262cddc9bf368cb01854610b64b8c5551ace4f5a89aad6d63ca054e5ecf'
+  sha256 '208bc52e8ae6e04e6b001f9f3da7bfd57e919625f10f582ba078ff7032609401'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"


### PR DESCRIPTION
💁  It appears that the checksum for this cask has changed:

      $ brew cask install istat-menus
      ==> Satisfying dependencies
      ==> Downloading https://s3.amazonaws.com/bjango/files/istatmenus5/istatmenus5.32.zip
      ######################################################################## 100.0%
      ==> Verifying checksum for Cask istat-menus
      ==> Note: running "brew update" may fix sha256 checksum errors
      Error: Checksum for Cask 'istat-menus' does not match.

      Expected: 99e1a262cddc9bf368cb01854610b64b8c5551ace4f5a89aad6d63ca054e5ecf
      Actual:   208bc52e8ae6e04e6b001f9f3da7bfd57e919625f10f582ba078ff7032609401

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
