### PR TITLE
Update hstracker to 1.1.0

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.0.3'
-  sha256 '048e3dc4080adf51858cf430b136598daa22fb43743e3ba06d519086f1bbf192'
+  version '1.1.0'
+  sha256 '3e4cc33e2ca25e873ad9d7170cdd905274dc3761ed30acbbbcc010a84bb0e6e4'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: 'cc21c4c1bd2e7d03df1b2b6727e0731d7faf9a77e5766eb45bc0e09b7e111390'
+          checkpoint: '91b6829e6db43a691771dad82a1e456803fcd89c4b90cc517e4879345c6ab4cf'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.