### PR TITLE
Update coconutbattery to 3.6.3

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -4,11 +4,11 @@ cask 'coconutbattery' do
     sha256 '0edf6bdaf28fb3cc9c242fd916c348fbbae30a5356ddc1d6e5158d50f96d740d'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.dots_to_underscores}.zip"
   else
-    version '3.6.2'
-    sha256 '56d9207b1edd9179692cdfba77dca0c1735759b20177dd0502bad75f44ef1dc8'
+    version '3.6.3'
+    sha256 '4ba6e7cb99d08444aa92d00f898eae4e1d22aa67e8aab953fc034c08ac3254c3'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml',
-            checkpoint: '4bd74dc4adfa63c4df95fb0c7e7c29875514f7a0be952ab9c845d11705d8896a'
+            checkpoint: 'e324ffa6292bd276745cdc8e6f27aff23873fea790726a01eaf614e7364535f5'
   end
 
   name 'coconutBattery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.