### PR TITLE
Update fork to 1.0.54

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.53.1'
-  sha256 '2a87203e592c5f815f13cab1a84558da9021731206a0a33746faf8fcdc3523b5'
+  version '1.0.54'
+  sha256 '628e82a70b4b19017174da8566fe4d623afcbb4535fa140b5e1589c9c39adabf'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '15550688e0e84df51c22580270f0c6c6fdac6c5516589dc6273a671b44601f63'
+          checkpoint: '32eedd78d300af84720630c15f785708efb7b08f72df13264f9db51440b5a389'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.