### PR TITLE
Update freefilesync to 9.3

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '9.3'
-  sha256 '295c219901c698e88e22220d6fa46da1e416c89b3133287894508a96bc763a14'
+  sha256 '987e3f1d1d142ac43896c0c7c9d96498771590e6958c1b44e06938ec61cfb79c'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

https://www.virustotal.com/#/file/987e3f1d1d142ac43896c0c7c9d96498771590e6958c1b44e06938ec61cfb79c/details