### PR TITLE
Update media-center to v23

### DIFF
--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -8,6 +8,8 @@ cask 'media-center' do
 
   app "Media Center #{version.major}.app"
 
-  zap delete: '~/Library/Application Support/J River/',
-      trash:  '~/Documents/JRiver/'
+  zap trash: [
+               '~/Library/Application Support/J River/',
+               '~/Documents/JRiver/',
+             ]
 end

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -1,6 +1,6 @@
 cask 'media-center' do
-  version '22.00.88'
-  sha256 '6f6776197f7034f73d131ebe73c95b0fadfc889a067f8933cd9e543cfd9051f0'
+  version '23.00.20'
+  sha256 '70042295e59a0114900ca475cb2ab46d8c8793c58dbb429542ce4129614e5f25'
 
   url "http://files.jriver.com/mediacenter/channels/v#{version.major}/stable/MediaCenter#{version.no_dots}.dmg"
   name 'JRiver Media Center'
@@ -9,4 +9,5 @@ cask 'media-center' do
   app "Media Center #{version.major}.app"
 
   zap delete: '~/Library/Application Support/J River/'
+  zap devete: '~/Documents/JRiver/'
 end

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -8,6 +8,6 @@ cask 'media-center' do
 
   app "Media Center #{version.major}.app"
 
-  zap delete: '~/Library/Application Support/J River/'
-  zap devete: '~/Documents/JRiver/'
+  zap delete: '~/Library/Application Support/J River/',
+      trash:  '~/Documents/JRiver/'
 end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
