### PR TITLE
Update postbox to 5.0.17,1_3ea43ad54c853e46222d5129a9b00191f61654f8

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '5.0.16,1_207311d175a64da24ff197bea1c2ea651498c034'
-  sha256 '3c6a03608df99290cded2adca789bb032ec07bcaaf341db1d165356296ea01fd'
+  version '5.0.17,1_3ea43ad54c853e46222d5129a9b00191f61654f8'
+  sha256 'daad0981a28e56915ff20c6cf425540070d5d37c60e557602d7b374d71c59b5f'
 
   # amazonaws.com/download.getpostbox.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/download.getpostbox.com/installers/#{version.before_comma}/#{version.after_comma}/postbox-#{version.before_comma}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.