### PR TITLE
Update discord to 0.0.248

### DIFF
--- a/Casks/discord.rb
+++ b/Casks/discord.rb
@@ -1,6 +1,6 @@
 cask 'discord' do
-  version '0.0.247'
-  sha256 '381ff1e790ee788da348fb6cd1cc8f5be99589eac39cbd619ddbe45adbbfebea'
+  version '0.0.248'
+  sha256 'd4bab00d8f804474648c2109e56cf572ebbd342ffee32c03043e78399618717b'
 
   url "https://cdn.discordapp.com/apps/osx/#{version}/Discord.dmg"
   name 'Discord'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.