### PR TITLE
Update cloudtv to 3.8.6

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,11 +1,11 @@
 cask 'cloudtv' do
-  version '3.8.5'
-  sha256 '2dca199c56a8db1df31efd268f48cfd5e37e8d54d6f29b830e5919b84325471f'
+  version '3.8.6'
+  sha256 'fb96cbfbf4cb5bc45fa03cdb01caec81a1249a95cda86ef4c76e5847e0da3c6a'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.nonoche.CloudTV/CloudTV.dmg?v=#{version}"
   appcast 'https://updates.devmate.com/com.nonoche.CloudTV.xml',
-          checkpoint: '8b98e25e64374be42ab6941fa7023639cf10e18a0f3970460949e8ea6860c6b0'
+          checkpoint: '260e36a28c5947855e9b904094049f573ca0f75aa55b2e6e272c7681a4084d30'
   name 'CloudTV'
   homepage 'https://cloudtvapp.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.