### PR TITLE
Update codekit to 3.3-25900

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,10 +1,10 @@
 cask 'codekit' do
-  version '3.2-25849'
-  sha256 'ef41362ab6a1f22f0d80bf674598614f99d264a6b9f5f7efd481dfd057a18bed'
+  version '3.3-25900'
+  sha256 '2b064f1248530dc1c67fa28757c3ef7c45db8eaab10711472bc4eafcb88d9836'
 
   url "https://codekitapp.com/binaries/codekit-#{version.sub(%r{.*-}, '')}.zip"
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml",
-          checkpoint: '7a4fb00acf71139248a8178bd45c1fea94abd674cc58482e0092fe71a6274387'
+          checkpoint: '27ff20c84b5d9c9f587d9818539ff7c533eea8658434a39f309c310bd93b5633'
   name 'CodeKit'
   homepage 'https://codekitapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.