### PR TITLE
Update devdocs to 0.6.5

### DIFF
--- a/Casks/devdocs.rb
+++ b/Casks/devdocs.rb
@@ -1,10 +1,10 @@
 cask 'devdocs' do
-  version '0.6.4'
-  sha256 '01583744b531848f0af0dd708b64537c657e7261f61a3fccfdc1de7adff5d6b8'
+  version '0.6.5'
+  sha256 '9fefb1192a919d49b86bfc7d4c985167f1da935045cdb6f6515116e6cf487677'
 
   url "https://github.com/egoist/devdocs-desktop/releases/download/v#{version}/DevDocs-#{version}.dmg"
   appcast 'https://github.com/egoist/devdocs-desktop/releases.atom',
-          checkpoint: '6d224b56ffab0d6ab371d0d3fababbdb042e56c009e60d2d6bfb83dff3aee226'
+          checkpoint: '09e231f559e035bcd9061cf131517ed86705b050395d15b75e92478fba39f385'
   name 'DevDocs App'
   homepage 'https://github.com/egoist/devdocs-desktop'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.