### PR TITLE
Update endlesssky to 0.9.8

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -1,11 +1,11 @@
 cask 'endlesssky' do
-  version '0.9.7'
-  sha256 '0fa95019d66eb9c1aed307717e127f2a13ddfe72ef1b38b42a5ea52443963ae2'
+  version '0.9.8'
+  sha256 'b233c7b7aa3c87346abc325ea2958c7d36a17d276760b926184af7a23b454ec2'
 
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom',
-          checkpoint: 'a084240d827f236e29aefc2a38d29ee2d5171bc60e522356a8cb33d96d34e038'
+          checkpoint: 'd89c3a725f46815f56dde4ca2f90b1c0f6047f4ac1a7666cb694ed39fd50720e'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.