### PR TITLE
Update gemini to 2.3.8

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,11 +1,11 @@
 cask 'gemini' do
-  version '2.3.7'
-  sha256 '6c5eac00d57a19ccf86621c182d51d591260c3616373a80be523a2ced407c510'
+  version '2.3.8'
+  sha256 '44ab91c03c71b10ba00d5e3e6c0ea2b63a16e1529fa1b34ea141f95a1f44f40c'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/Gemini#{version.major}.dmg"
   appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml",
-          checkpoint: 'bff28f0b81578e21fd0e33d18d5f599fdcf81c05f516dfa168e2f783a2b246b4'
+          checkpoint: 'b9d735bb41a35d6536d0ccaf64e73fd57a49cfb3991e58a15651c186f90dd8a4'
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.