### PR TITLE
Update inkdrop to 3.8.0

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,11 +1,11 @@
 cask 'inkdrop' do
-  version '3.7.2'
-  sha256 '1ae58bff03ebc65647be302e820dbe43168fcdca39261d5a7b0a07cadde55993'
+  version '3.8.0'
+  sha256 'a4ad37c9e2e442962a80022e5ac1b8d717d32cb87144b3bb1967e02f9b1ee8d3'
 
   # github.com/inkdropapp was verified as official when first introduced to the cask
   url "https://github.com/inkdropapp/releases/releases/download/v#{version}/Inkdrop-#{version}-Mac.zip"
   appcast 'https://github.com/inkdropapp/releases/releases.atom',
-          checkpoint: '5d00994f45fbfe76babbf1533e806d672fed01ca369551f10ac26feabc804b7c'
+          checkpoint: '10fa5717a0e6d31de0cb7039c830d81d52edd1f60c367a50a9e18080ee7a6668'
   name 'Inkdrop'
   homepage 'https://www.inkdrop.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.