### PR TITLE
Update sqlectron to 1.24.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.23.0'
-  sha256 '59f3f625fa1e77932fe956e94449c4cf3511d3e4996760751c30c58133b3d7b0'
+  version '1.24.0'
+  sha256 '196b301333a0b23845c5f034af2a189ee96f6c2d8ad28f368970a7ff6115bee9'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: 'c6dc289154bb784d87668cad232ec079a806ef52885337619b27714edcf72958'
+          checkpoint: 'a12e74043c449cd66768ed02b08881304223a138a47bf9cee1732d8dae6151ab'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.