### PR TITLE
Update carbon-copy-cloner to 4.1.18.4592

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '4.1.17.4577'
-  sha256 'fc26ed71558ae20e298c1bb203714fd9214c63495614cb6457b57e968291e0c9'
+  version '4.1.18.4592'
+  sha256 'f2beabeb9d6c0a3c7bbc842abb21d7d999f1a6ef587a7e74a962dca64d4bfef4'
 
   url "https://bombich.com/software/download_ccc.php?v=#{version}"
   name 'Carbon Copy Cloner'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.