### PR TITLE
Update piezo to 1.5.4

### DIFF
--- a/Casks/piezo.rb
+++ b/Casks/piezo.rb
@@ -1,10 +1,10 @@
 cask 'piezo' do
-  version '1.5.2'
-  sha256 'fdd387448fef83bc27cee79c01d4d2e99605bee8df1cf0b3a18fec12c4115554'
+  version '1.5.4'
+  sha256 'e06d4c9e4234ecb8623076b176e8c48c32d26138dc62b6c99eced2045311f50f'
 
   url 'https://rogueamoeba.com/piezo/download/Piezo.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Piezo&system=10114',
-          checkpoint: 'f40dd24bc2ab3e76c10a88b777d24f807805071f2f823c9af48f40f1a5d5a075'
+          checkpoint: '58f6ae1b8daaacbc537e89486351f886706e2868da3f2fc1a0309a00d1dbf72e'
   name 'Piezo'
   homepage 'https://rogueamoeba.com/piezo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.