### PR TITLE
Update softu2f - postflight set_ownership

### DIFF
--- a/Casks/softu2f.rb
+++ b/Casks/softu2f.rb
@@ -19,7 +19,7 @@ cask 'softu2f' do
                    args: ['unload', launchd_plist],
                    sudo: true
 
-    set_ownership launchd_plist
+    set_ownership '~/Library/LaunchAgents'
 
     system_command '/bin/launchctl',
                    args: ['load', launchd_plist]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

The postinstall script for `softu2f` creates `~/Library/LaunchAgents` (owned by root)  if it does not exist.

Edit: Closing, can't assume that the user owns everything in `~/Library/LaunchAgents`