### PR TITLE
Update libreoffice.rb for zap

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -34,7 +34,10 @@ cask 'libreoffice' do
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl',
-                '~/Library/Application Support/LibreOffice',
                 '~/Library/Saved Application State/org.libreoffice.script.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/LibreOffice',
+                '~/Library/Preferences/org.libreoffice.script.plist',
               ]
 end


### PR DESCRIPTION
Update libreoffice.rb for zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
