### PR TITLE
Update betterzip.rb for depends_on and zap

### DIFF
--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -9,8 +9,22 @@ cask 'betterzip' do
   homepage 'https://macitbetter.com/'
 
   auto_updates true
+  depends_on macos: '>= :yosemite'
 
   app 'BetterZip.app'
 
-  zap delete: '~/Library/Preferences/com.macitbetter.betterzip.plist'
+  zap delete: [
+                '~/Library/Application Scripts/com.macitbetter.betterzip.findersyncextension',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macitbetter.betterzip.sfl',
+                '~/Library/Caches/com.apple.helpd/Generated/com.macitbetter.betterzip.help',
+                '~/Library/Caches/com.macitbetter.betterzip',
+                '~/Library/Containers/com.macitbetter.betterzip.findersyncextension',
+                '~/Library/Group Containers/79RR9LPM2N.group.com.macitbetter.betterzip',
+                '~/Library/Group Containers/79RR9LPM2N.group.com.macitbetter.betterzip-setapp',
+                '~/Library/Saved Application State/com.macitbetter.betterzip.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/com.macitbetter.betterzip',
+                '~/Library/Preferences/com.macitbetter.betterzip.plist',
+              ]
 end


### PR DESCRIPTION
- `**.workflow (example: '使用 BetterZip 解压')` in `~/Library/Services` is with local language name.
- `com.macitbetter.betterzip.help` in `~/Library/Caches/com.apple.helpd/SDMHelpData/Other/**/HelpSDMIndexFile (example: 'zh_CN')` is with local language.

I don't know how to write rules of zap.

---

Update betterzip.rb for depends_on and zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
