### PR TITLE
Update dbeaver-community to 4.1.3

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.1.2'
-  sha256 '16da10fdec55bf5c45ed0be344e2dc0da75ded9d86ffbc6eae0a4c94f454783c'
+  version '4.1.3'
+  sha256 '38c7fa69791bfa169d06d32222a74274d0776d02e2e8890c02fe0d9d571b391d'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '9c5b919ff4826130c412eb4a8d3f634e9ab4c68ba5b6c2c40771e49d0c9bbd84'
+          checkpoint: 'cb702cead4abdc1d103efcdb5c515e53c37e4e2fef63d618daf33c0d31df6619'
   name 'DBeaver Community Edition'
   homepage 'http://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.