### PR TITLE
Update brisk to 1.1.1

### DIFF
--- a/Casks/brisk.rb
+++ b/Casks/brisk.rb
@@ -1,10 +1,10 @@
 cask 'brisk' do
-  version '1.1.0'
-  sha256 '6a407ca571d558efcc465777583b7bc24ffc62828aa0f510357da69296a48b1d'
+  version '1.1.1'
+  sha256 '0a4ba3fe9a48ad95ebd313b09dab57e11b1940238019bbb9e77ce72dc2c3864b'
 
   url "https://github.com/br1sk/brisk/releases/download/#{version}/Brisk.app.tar.gz"
   appcast 'https://github.com/br1sk/brisk/releases.atom',
-          checkpoint: '23ca138fa5319b1798a5d0551c84c75f04e647fd7f795c9c0e0b70fc9979b0e6'
+          checkpoint: 'caf4d4d20cb70c806f92e01d30b8e8dc213da21c54a1449a37b18f5d7ea50cca'
   name 'Brisk'
   homepage 'https://github.com/br1sk/brisk'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.