### PR TITLE
Update bettertouchtool to 2.292

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -14,11 +14,11 @@ cask 'bettertouchtool' do
     sha256 '41013cfeffee286a038363651db3dd315ff3a1e0cf07774d9ce852111be50a5a'
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.291'
-    sha256 'ff6b23d340def3fb5dd0b774c2c478e910e5e37ac4a88c90d246ee7c605df7cc'
+    version '2.292'
+    sha256 'fe0c4b7712e340fcb1d03aa20580fb7407b891a8eab1056bf366e780e0df66c2'
     url "https://bettertouchtool.net/releases/btt#{version}.zip"
     appcast 'https://updates.bettertouchtool.net/appcast.xml',
-            checkpoint: '6a0e90a1934477bdce99c01e32f64494c0d1a45d7472eb1889fca2d463e548f9'
+            checkpoint: '2a3f44055e377f6e2d3e00054f5104dd4a2c3fc6b483198b1a887dfea8499280'
   end
 
   name 'BetterTouchTool'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.