### PR TITLE
Update thunderbird to 52.3.0

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,84 +1,84 @@
 cask 'thunderbird' do
-  version '52.2.1'
+  version '52.3.0'
 
   language 'cs' do
-    sha256 'ac5c2c799668542e67b841cce89a87338a3b93025ecb2eec8d3e29b581f23845'
+    sha256 'c21f5c7db73c8429509a81afe02df287809ac681b7a20f2dff135c9f4b0ba473'
     'cs'
   end
 
   language 'de' do
-    sha256 'fb98ec6aa92641345134e2bb7a7d7882ff47d5194c970f63f69013f5d3295d8b'
+    sha256 '2df66fb203a1297a9db99e039c9301b91bd50df470f1cf55b05208a046157610'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '7eb8d690dcf6cf215c9481740a663c50382872aab3c3dad4384799a06a86ccc9'
+    sha256 '0be404b39a1902f237609a11aa9b46b3f2a724c004882cef1ae03dca5b3a827e'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'd28e27d5c81ca979c0ca7e02499ac639ed7ff7085f7783ba7ec7c8ca436f2173'
+    sha256 '907c436eeb31e8fb1b58d256bee904705384b66d65dcdedbb00a8102663812bc'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '64af6337773cfaa999f1fedc4f2ce16a1dc7c73a531638421dbbca226e6f314e'
+    sha256 'eacf2d6ea769c657d1e6e72401cc71f883547f97434006123c3713a58a2e5694'
     'fr'
   end
 
   language 'gl' do
-    sha256 '190712b89e77a6c6b5e9112a3efbf7860602d8b013a0e8833851235a4fed8f08'
+    sha256 'a0f0e5fdd5219e5cf1fb9ae7ed9cbf24c09011ca26320e6e3d019f0c011eb8e1'
     'gl'
   end
 
   language 'it' do
-    sha256 '31c2000213e3ae7d1ecca74a69e352fbe80f797e01833ff5e77d52be0c21e0bf'
+    sha256 'ae928191dce629f8cda87021fd66e5cf96bafa52fb3bd075b8f492859dddd32b'
     'it'
   end
 
   language 'ja' do
-    sha256 'db8df93008262775d3bb0e48534556bff9d132149bfa7be402b4db7f4f27deb3'
+    sha256 'b858919fd0c81417bc45986096a4329fe918ff57053616c7dbdca17d3e6720f2'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '42ab0883bc464326e37de8ff9a54b1204ee6c6c4e59489f8823258bfb75bb523'
+    sha256 'f7a80f45cbdbca7d0cae7ad1964d2b9ef001f3bbfae93e76cb24be11296f64a1'
     'nl'
   end
 
   language 'pl' do
-    sha256 'db20825c9f5d96540a2e3976e31d44ccb5e8955ca3b08062182b088e5ff34db0'
+    sha256 '980f387173e3456bec230856fda3d4105754df21881d6cf9a51199b2136aff91'
     'pl'
   end
 
   language 'pt' do
-    sha256 '43c302e9e15fe99ef2d941caa140a874370acd9b785f3d6c6276459e17d0eeb9'
+    sha256 'ffe12c53c71d29cc9093f33ddfafd6b00e140cfad966cf65eda969a75ebdbcc2'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '95761d0a22f7117be5ca188c7c527ef9c2824a1789be0e82341bc5b0cef8cf50'
+    sha256 '9b6855eaa6e84e57c6e8f60089268ef885323956feb81f542d9ae73d83ebec4d'
     'ru'
   end
 
   language 'uk' do
-    sha256 '678b91b7950ad67e4d7f3ab4ab99524d287d925fbdeb0b638c2ecf486171afa5'
+    sha256 'a25b1265b37da886480cf952565d60631c86f52c96ebc03395fb123e438ac257'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '1ab7b0d18c26ebaaa0f5811285dacb8794ae614c20cbd7894a72a48ec86f6c9d'
+    sha256 '88e908c7042cc6675ad5348f4b9758c97baf0a5d308fc073ae5d64128de149c8'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '707d36afbd5bb0017496b07ca37f0bea7c962597857274b9d0e8c202be0f81d7'
+    sha256 'd3fd45faf368a2349cfd336bd609257c40d820175985dc4e0585da021a25b9a9'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/thunderbird/releases/#{version}/mac/#{language}/Thunderbird%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Thunderbird/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '3eb2b1216da873f4eb6fde06e9c2b98e6b468774a6ae820f84709381ea3ccb28'
+          checkpoint: '39905a34f99198fc391db427831a3e786d40387ff811a4c7c5e8b88af89ef3d3'
   name 'Mozilla Thunderbird'
   homepage 'https://www.mozilla.org/thunderbird/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
