### PR TITLE
Update fork to 1.0.54.1

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.54'
-  sha256 '628e82a70b4b19017174da8566fe4d623afcbb4535fa140b5e1589c9c39adabf'
+  version '1.0.54.1'
+  sha256 '415b34993615537fd0772713d0c613a5ce6e93bdb751783a3bc9b82de16b54cf'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '32eedd78d300af84720630c15f785708efb7b08f72df13264f9db51440b5a389'
+          checkpoint: 'd1e53dee117680cc5a90e85137e8b4b7c5c228b27770651b8ff8f04f92f0b630'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
