### PR TITLE
Update yujitach-menumeters to 1.9.6

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -1,10 +1,10 @@
 cask 'yujitach-menumeters' do
-  version '1.9.5'
-  sha256 '1f1b1c50e2571be5a3e380642019cc8fc46a482e230d04c4a2ff4514b823a6a8'
+  version '1.9.6'
+  sha256 'c2fe26a31743b9d4a0216a4415b8253dd0c2a1fd4d6d1fc7d2d4b9e33d9cc588'
 
   url "http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
   appcast 'https://github.com/yujitach/MenuMeters/releases.atom',
-          checkpoint: '01a1f125355897c488c91588ad65c1d57628ef9a8f4afde5c749a8762851ce14'
+          checkpoint: '3fc1845ad638f6b32312a4dd61c640d60d5ef4cf2684f7470c98c2b3eaeb54d9'
   name 'MenuMeters for El Capitan (and later)'
   homepage 'http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.