### PR TITLE
Update wifispoof to 3.0.4.1

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,11 +1,11 @@
 cask 'wifispoof' do
-  version '3.0.4'
-  sha256 'cdcf7a8908de5c092349cea9fc9f4d608406a638e190792665fed0d0a810c720'
+  version '3.0.4.1'
+  sha256 'ae6ad4e57b1e2f991cd90a25773b6bda83230a5267e6b1eefdb163bcaec60ab9'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"
   appcast 'https://sweetpproductions.com/products/wifispoof3/appcast.xml',
-          checkpoint: '0cf1f17460ff75966efb3e067048a21e18c75d19befc51fc0543a7746fd40b82'
+          checkpoint: 'eff33d438f8aa5b91576f8b6891f44e923a833806a4a32d4ce16f988d2e811ae'
   name 'WiFiSpoof'
   homepage 'https://wifispoof.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.