### PR TITLE
Update ubar to 3.2.6

### DIFF
--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -1,10 +1,10 @@
 cask 'ubar' do
-  version '3.2.5'
-  sha256 '25d42b6770e2ae2debb4d570c33b5e661b71b4c7f24bda61016968cd66fe3638'
+  version '3.2.6'
+  sha256 '76f87ebb3a74b40d6299354cd4f34c63480cd5951c2276a3a4d95c65882dd1a0'
 
   url "http://www.brawersoftware.com/downloads/ubar/ubar#{version.no_dots}.zip"
   appcast "https://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
-          checkpoint: 'd09faa07d4adfc30ac31934981bf90162fc1c007cfc5affbf53b5118ccd79ca2'
+          checkpoint: 'bd56dabff2625be4c5843c8cd67eeac340dc7f38f0e05487336bb3907202b7c0'
   name 'uBar'
   homepage 'https://brawersoftware.com/products/ubar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.