### PR TITLE
Update twist to 1.0.14,3053

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,10 +1,10 @@
 cask 'twist' do
-  version '1.0.10,2864'
-  sha256 'a8b69af53e4fad7f52aabc069494cfbc19a11676f5572ca0c6b02c2779431c2e'
+  version '1.0.14,3053'
+  sha256 '0ab4a357d2492d1b29e3bedf1147a0eac09440a05d99693823d3642ab77a118f'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml',
-          checkpoint: 'c4295d2b33f520788c4b33cdc8d7678fd25b95def1315a1090f5f8a160af915f'
+          checkpoint: 'ef6e6a0ab4aa1d5671c8e7fb6358a9fab4ad0beb6d76a54efde56fd5ee2ade15'
   name 'Twist'
   homepage 'https://twistapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.