### PR TITLE
Update together to 3.8.8

### DIFF
--- a/Casks/together.rb
+++ b/Casks/together.rb
@@ -1,10 +1,10 @@
 cask 'together' do
-  version '3.8.6'
-  sha256 'd0d90cf8bf2f4dd2ab8a3db9a084d9f4aa672ecb3c6c53e97f93a23fe6b537f3'
+  version '3.8.8'
+  sha256 '689992d5d84f1137cbbd23e9b9114dd56545fbe8df40310ea19b715c447fbae2'
 
   url "https://reinventedsoftware.com/together/downloads/Together_#{version}.dmg"
   appcast "https://reinventedsoftware.com/together/downloads/Together#{version.major}.xml",
-          checkpoint: '1b9fbab834de660897b21c643e2eeddc70c92e9286cdac0e6adabbaae9acecc5'
+          checkpoint: 'c48a8d1604cae34b5682560af9f43446a76a6482abc3b57654ddcfdedb0af2a0'
   name 'Together'
   homepage 'https://reinventedsoftware.com/together/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.