### PR TITLE
Update tg-pro to 2.25

### DIFF
--- a/Casks/tg-pro.rb
+++ b/Casks/tg-pro.rb
@@ -1,10 +1,10 @@
 cask 'tg-pro' do
-  version '2.23'
-  sha256 'f216465db1b63bb0cce52781603dd7c217aeb3fd634efbcc6af154b6033982aa'
+  version '2.25'
+  sha256 'ff4ee152575211be085c79b407ed05e8a1aa5cfa84274045cf2caff82a6ad6c9'
 
   url "https://www.tunabellysoftware.com/resources/TGPro_#{version.dots_to_underscores}.zip"
   appcast 'https://www.tunabellysoftware.com/resources/sparkle/tgpro/profileInfo.php',
-          checkpoint: 'd16c89cc6681bf34c6008a373ed4c1e19ad5e70d3363e77b40e2bed6b5871ca3'
+          checkpoint: '3bad8d81b1e08fd1d79ef1abb49df711e25f512b79974477584959f1b67ecf05'
   name 'TG Pro'
   homepage 'https://www.tunabellysoftware.com/tgpro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.