### PR TITLE
Update stretchly to 0.10.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.9.0'
-  sha256 'd0190422159b2d8f0a60b330b25e3255e931c29d712c2f5e0d1ab3632828297b'
+  version '0.10.0'
+  sha256 'a055d94ceb3b54ba2ea6bcf89ca7f9d5703866caaa50ca6f811d9eefdc350e81'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '83bbd263023d70c1105390158a4a891fee5080d46613699c723a0290a9ea3ce6'
+          checkpoint: '26ac344151004fed93bdeac8e177836e03fe206ff946781de792c664ed40c3de'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.