### PR TITLE
Update sqlitebrowser to 3.10.0

### DIFF
--- a/Casks/sqlitebrowser.rb
+++ b/Casks/sqlitebrowser.rb
@@ -1,11 +1,11 @@
 cask 'sqlitebrowser' do
-  version '3.9.1v2'
-  sha256 '52c92282e70e9d7f328329e12682d8ab7e06456071465f63196f769d98d6e6d7'
+  version '3.10.0'
+  sha256 'b7d5bdc92c4d5b4d1b69203033e75cc537daca00b95e39f737ed32eae728c6aa'
 
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom',
-          checkpoint: 'a1d8a2c59bf2b56883c84e5ad66b837959a1001824ca307564beb00597b96082'
+          checkpoint: '513c8130253637a28925d3d5e2ff287a128fed1d001b1947ea11be8ef48b1405'
   name 'SQLite Database Browser'
   homepage 'http://sqlitebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.