### PR TITLE
Update play to 2.0.8

### DIFF
--- a/Casks/play.rb
+++ b/Casks/play.rb
@@ -1,11 +1,11 @@
 cask 'play' do
-  version '2.0.7'
-  sha256 '38be5271a5bfe79168c3b57164f75a908dcec88f2a53607bef0b6516d90183b2'
+  version '2.0.8'
+  sha256 'b7c69c9149ddc46ed04020cbf87e4036d3d862584ad0da5f01044e0c1bdfa8c5'
 
   # github.com/pmsaue0/play was verified as official when first introduced to the cask
   url "https://github.com/pmsaue0/play/releases/download/v#{version}/play_#{version}.dmg.zip"
   appcast 'https://github.com/pmsaue0/play/releases.atom',
-          checkpoint: '5d4d468b6c0a2e4a17e8257400da857f92e1a2e338ae7d17a3a56a534361b3d4'
+          checkpoint: '918770f4ae2268efbf810b53e80ade1eb3795eebd2e5038ef7387f4991ca2f92'
   name 'Play'
   homepage 'https://pmsaue0.github.io/play/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.