### PR TITLE
Update prince to 11.3

### DIFF
--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -1,6 +1,6 @@
 cask 'prince' do
-  version '11.1'
-  sha256 '5bd703ce9510b29985cfec52036528add2fba0f5c0e158ff2f523116e4231f75'
+  version '11.3'
+  sha256 'eb45c067620d7978eee6bc615fe19524039a06ef2ee1a25349e49c72ad2e84da'
 
   url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
   name 'Prince'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.