### PR TITLE
Update the-escapers-flux to 7.1.3

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.1.2'
-  sha256 '36dc2830072bdd59bce6326899404ee52664b6d448ebaa97c6f25cca507a6cb3'
+  version '7.1.3'
+  sha256 'bb2e75e82b491e70893fb1cee172905afb968bee84d5795ac344b1098e11f9b7'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: 'b48fdd17ba6406585ec934ca63493844329233c1aa6a0b8c2398f9a6fc7c24dd'
+          checkpoint: 'e8f26e3afdb06b7ffb3a3bbc18e1da5800a590a2914692b6a309cb606618ad3f'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.