### PR TITLE
Update vuescan to 9.5.82

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.81'
-  sha256 'dae617a7e60fec6c090f4308bc58d569dbfb86d0291c0ecc9bbb6b20b8fac6d7'
+  version '9.5.82'
+  sha256 '6dc65687bc41a721ad6ff05d2f98bfffabd983064f240ae311901722bc8fec2b'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '6d28f18e975e33d901556a7f3effcf540c0671f9d30744a34f92f66ec9eb5837'
+          checkpoint: 'cb79c782f7d4c997550dd4f35fbe96925034166966c7fce846d36ce72547b164'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.