### PR TITLE
Update lima to 1.4.3

### DIFF
--- a/Casks/lima.rb
+++ b/Casks/lima.rb
@@ -1,6 +1,6 @@
 cask 'lima' do
-  version '1.4.1'
-  sha256 'f8d94837746deb73aaf1bf33102955f3bbf0ef3f0402b0a7cd1bd33b69f63c3a'
+  version '1.4.3'
+  sha256 '64a9950e77a735b43010ac451eb4dd96284c7e142de2492526baca2408c8b822'
 
   url "https://update.api.meetlima.com/downloads/osx/dist/Lima_#{version}.dmg"
   name 'Lima'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.