### PR TITLE
Update ticktick to 1.7.60,36

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '1.7.00,31'
-  sha256 '15f40901064e3fc17eb155535940784e0dc6db45d5e61eeed4e79276cec426e5'
+  version '1.7.60,36'
+  sha256 '5d2639624fdca42f2665d87ca08c618b6eb5e7a580d832b4e3f8d4776bce8061'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.