### PR TITLE
bandage 0.8.1: Add binary

### DIFF
--- a/Casks/bandage.rb
+++ b/Casks/bandage.rb
@@ -11,10 +11,11 @@ cask 'bandage' do
 
   app 'Bandage.app'
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  binary staged_path / 'Bandage'
+  shimscript = "#{staged_path}/bandage.wrapper.sh"
+  binary shimscript, target: 'bandage'
 
   preflight do
-    IO.write staged_path / 'Bandage', <<-EOS.undent
+    IO.write shimscript, <<-EOS.undent
       #!/bin/sh
       exec '#{appdir}/Bandage.app/Contents/MacOS/Bandage' "$@"
     EOS

--- a/Casks/bandage.rb
+++ b/Casks/bandage.rb
@@ -10,4 +10,13 @@ cask 'bandage' do
   homepage 'https://rrwick.github.io/Bandage/'
 
   app 'Bandage.app'
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  binary staged_path / 'Bandage'
+
+  preflight do
+    IO.write staged_path / 'Bandage', <<-EOS.undent
+      #!/bin/sh
+      exec '#{appdir}/Bandage.app/Contents/MacOS/Bandage' "$@"
+    EOS
+  end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

-----

A shell shim script is needed. A symlink gives the error:
This application failed to start because it could not find
or load the Qt platform plugin "minimal" in "". Reinstalling
the application may fix this problem.

This issue has been reported upstream:
https://github.com/rrwick/Bandage/issues/22