### PR TITLE
Update nanobox to 2.2.0

### DIFF
--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -1,6 +1,6 @@
 cask 'nanobox' do
   version '2.2.0'
-  sha256 '998432ff26f10a70cccdd65c9e7cfde7c7b7169bd70152f606ae5daabe4fb9be'
+  sha256 'a601fbef6ae9403d0139a188d380ed852b31cc8adbb7836d41573a452bb27034'
 
   # s3.amazonaws.com/tools.nanobox.io was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tools.nanobox.io/installers/v#{version.major}/mac/Nanobox.pkg"

--- a/Casks/nanobox.rb
+++ b/Casks/nanobox.rb
@@ -1,11 +1,11 @@
 cask 'nanobox' do
-  version '2.1.2'
-  sha256 '06fcf6071244cd5f7b74b8ea0b1df5a15ff26790f987698f2ad812fbd7732e54'
+  version '2.2.0'
+  sha256 '998432ff26f10a70cccdd65c9e7cfde7c7b7169bd70152f606ae5daabe4fb9be'
 
   # s3.amazonaws.com/tools.nanobox.io was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tools.nanobox.io/installers/v#{version.major}/mac/Nanobox.pkg"
   appcast 'https://github.com/nanobox-io/nanobox/releases.atom',
-          checkpoint: 'ea5b2c616c63b0bf023ffdb11ec901e2b047a1f2c993e8c5d4c1a6843651f20d'
+          checkpoint: 'c8bab1b2a3f6216c4bae24b692a8e4c6327c3fbc8dd87928d58bbd6710269e8a'
   name 'nanobox'
   homepage 'https://www.nanobox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.