### PR TITLE
Update compositor to 0.9.7

### DIFF
--- a/Casks/compositor.rb
+++ b/Casks/compositor.rb
@@ -1,10 +1,10 @@
 cask 'compositor' do
-  version '0.9.6'
-  sha256 'ce3a597efaa23450f684af996e5566ebdf414cc8a0564e76e900ecf137dc6e2a'
+  version '0.9.7'
+  sha256 '6ba5a2ae4648e3b67ecdb6ed4828c90277036c980ddaca23ea62e29555fc9b91'
 
   url 'http://compositorapp.com/downloads/Compositor.dmg'
   appcast 'http://compositorapp.com/updates/appcast.xml',
-          checkpoint: 'fca97ef0ec6c707a7fae46a76081e9715ddf9bdc64541d36db073981b9aaea31'
+          checkpoint: 'dedfcaec78ef68b6fe792ae2895acd1218586cdbe1c4d2936bf61b7150e64063'
   name 'Compositor'
   homepage 'http://compositorapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.