### PR TITLE
Update poi to 7.9.1

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,11 +1,11 @@
 cask 'poi' do
-  version '7.9.0'
-  sha256 'e5cef1c67f7a27424bb483dc8ad89f09f3f97b922cecbe18360448eff8ee65f9'
+  version '7.9.1'
+  sha256 '5f1156e3f656be6d7dd180da24b3d1443c2d45313be6c0eef3267abd8525702f'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}.dmg"
   appcast 'https://github.com/poooi/poi/releases.atom',
-          checkpoint: '991485a28130a1ead77efea2da6e1ca581b1c39f8808c7c91fb9ad8302ae929b'
+          checkpoint: 'ee2467e717010b9382dc5949d65b5ef64e3b44fc26ca602f8e4905dfdda5292d'
   name 'poi'
   homepage 'https://poi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
