### PR TITLE
Update shotcut to 17.08.01

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '17.06.01'
-  sha256 'fb5cace2417203553154d6a711e4c15ec91ccfce25ea0081c30099832e07c341'
+  version '17.08.01'
+  sha256 '5bf3b5c642a01791864d9187ea1094af5b4a2672c285cfb2167347d2df4c4dc7'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '44e1bb07086f28d93ed45d2729ef756eb3c5575bcf09dc4d7ccfcb712119e579'
+          checkpoint: '6e6baee0986b94f81f862cbf0d057c43799241d2ea1010c6bda6ce9f5a7803bd'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.