### PR TITLE
Update the-escapers-flux to 7.1.5

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.1.4'
-  sha256 '60c02c10ada8474c6dcc0c9d53443cde771839248ee3ef9ab63cf6b009c9e327'
+  version '7.1.5'
+  sha256 'e140827287bdd62e566dff6eaef632572c266ef3bcdae7a51fbb0aaef4784c30'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '2d2da03ed273b921d60fe3c6916668044736ab9349d8b037e22c1cebeb4cffa3'
+          checkpoint: '925fc4a4cdd9b4a0f82ebd0a2ab0e47e59799d3fbe99dd9cff0920a2d4a8767e'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.