### PR TITLE
Update spacelauncher to 1.4.6

### DIFF
--- a/Casks/spacelauncher.rb
+++ b/Casks/spacelauncher.rb
@@ -1,10 +1,10 @@
 cask 'spacelauncher' do
-  version '1.3.7'
-  sha256 '86db8cfc72adf4e20997476e6fee05fe4292383acf1340625d0149219d5e32c3'
+  version '1.4.6'
+  sha256 'b6fe6aed9712a61c931bb5fa05fe7c2d2da99d65a48b402781a9fe44cfe8b682'
 
   url 'https://spacelauncherapp.com/download/SpaceLauncher.zip'
   appcast 'https://spacelauncherapp.com/download/appcast.xml',
-          checkpoint: 'a262d584b7e34ce9355a33e3252e8d2ebf17f491cd9a706c6d31c06b563114e4'
+          checkpoint: '7989ee373965a77232e260385ed83a87019008a20c6ca8454f1bd77acb17881e'
   name 'SpaceLauncher'
   homepage 'https://spacelauncherapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.