### PR TITLE
Update fips to 3.1.1

### DIFF
--- a/Casks/fips.rb
+++ b/Casks/fips.rb
@@ -1,11 +1,11 @@
 cask 'fips' do
-  version '3.1.0'
-  sha256 '2c53554e93b5ff8264cf98d707cf8cb80b539346f868066d8de8dc411556de01'
+  version '3.1.1'
+  sha256 'bc7e2d401dd577f2edf1c0e02b7b309e002df4b5069dd995e241a2c64337e69f'
 
   # github.com/matwey/fips3/releases was verified as official when first introduced to the cask
   url "https://github.com/matwey/fips3/releases/download/#{version}/Fips-#{version}-Darwin.dmg"
   appcast 'https://github.com/matwey/fips3/releases.atom',
-          checkpoint: 'd0416bc12df4f5d435f4b3e98949dd1019c14af03650ad20a1ed041942b6e72d'
+          checkpoint: '86ab8bd37a91e7e2d93de73ede1255507c1b6704e6d3146c2e2b981d70810850'
   name 'Fips'
   homepage 'http://fips.space/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.