### PR TITLE
Update vimediamanager to 0,7a15:c

### DIFF
--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -1,10 +1,10 @@
 cask 'vimediamanager' do
-  version '0,7a14:c'
-  sha256 '2fb3dc8b5d2c5ab40a34e18c0860da98d1b92bac673f8a134bfca82cf013714a'
+  version '0,7a15:c'
+  sha256 '020ad0384093cc7846234f38e6e4016743368e1f83a462b0771e9471c2cae7ab'
 
   url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version.after_comma.before_colon}/vimediamanager_v#{version.before_comma}.#{version.after_comma.before_colon}#{version.after_colon}.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom',
-          checkpoint: '691bcae2d5e238bf242193f5e6191a759b810766a832de3e93eebaa59a6898c4'
+          checkpoint: '238a92a1893bda5b37298493fc872f0055ffcfaf7815619b8d547ff838ab1510'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.