### PR TITLE
Update horos to 2.2.0

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -6,8 +6,8 @@ cask 'horos' do
     version '2.0.2'
     sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
   else
-    version '2.1.1'
-    sha256 '060162d17aa06762b907665dbd809d096b53a56b1c69e779951a3581b8f70743'
+    version '2.2.0'
+    sha256 'ea585fc74311db9e934ffb3b02829f25ea41f38cbc135e8e6507950240225c41'
   end
 
   url "https://www.horosproject.org/wp-content/uploads/downloads/Horos#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.