### PR TITLE
Update navicat-for-oracle to 12.0.12

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.11'
-  sha256 'd5ef957445619e06852c48a89afb77a04c801b2a89c30aa5afbe92db3158c722'
+  version '12.0.12'
+  sha256 'a40c2310fe3b97a8d871a1ecf8e158caa155c3cb72308a2841bafc5b623cc1cb'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note#M',
-          checkpoint: '1f85766e639ebf7f0a8ae1dd5c98ce1084126af08332eb3bb55a1b86e2e0d563'
+          checkpoint: 'eca4933d1021c0a51c96126eb80023c153c09d738f17c9ce11e1ef00ed57eb8d'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.