### PR TITLE
Update navicat-for-postgresql to 12.0.12

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.11'
-  sha256 'f1ca1da0668727d24ca464f2914ad55cad25336ef0777376043e5520bd4b28fb'
+  version '12.0.12'
+  sha256 '2c52774d8fee30ab81fcc71cb3dd40236f0f221c0f7bfb6447ff78c7653a55e1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
-          checkpoint: 'ff02dfdf055cbd32031b54d04f1d65c7d1cfa5491479935f5c574f808ab881d4'
+          checkpoint: '22a5952473f5114cfce991d98ef8351edcc45e5bd92b84d3a6ba1ded18feb2c6'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.