### PR TITLE
Update navicat-for-sqlite to 12.0.12

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.11'
-  sha256 '44d560e88608d2b33315f13da251a29b55c339366b8fcbf4fadebb02438d28d1'
+  version '12.0.12'
+  sha256 '948b61773963a0a2d3a2c10ef02bd6c628d6df0691822e325444102cbf0b7485'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note#M',
-          checkpoint: '223133c10332340cf1f24482f7a301f9b4d7927523b999702e0f81618a8c411e'
+          checkpoint: 'f7e4827d553f7dd3a8199f296a578b3f049b6a974cce7d887d17ea18a107efb0'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.