### PR TITLE
Update fiddler to latest

### DIFF
--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -2,11 +2,12 @@ cask 'fiddler' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.telerik.com/docs/default-source/fiddler/fiddler-mac.zip'
+  # telerik-fiddler.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://telerik-fiddler.s3.amazonaws.com/fiddler/fiddler-mac.zip'
   name 'Telerik Fiddler Proxy'
   homepage 'http://www.telerik.com/fiddler'
 
   depends_on cask: 'mono-mdk'
 
-  app 'Fiddler.app'
+  app 'mono Fiddler.exe', target: 'Fiddler.app'
 end

--- a/Casks/fiddler.rb
+++ b/Casks/fiddler.rb
@@ -2,12 +2,22 @@ cask 'fiddler' do
   version :latest
   sha256 :no_check
 
-  # telerik-fiddler.s3.amazonaws.com was verified as official when first introduced to the cask
+  # telerik-fiddler.s3.amazonaws.com/fiddler was verified as official when first introduced to the cask
   url 'https://telerik-fiddler.s3.amazonaws.com/fiddler/fiddler-mac.zip'
   name 'Telerik Fiddler Proxy'
   homepage 'http://www.telerik.com/fiddler'
 
   depends_on cask: 'mono-mdk'
 
-  app 'mono Fiddler.exe', target: 'Fiddler.app'
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/fiddler.wrapper.sh"
+  binary shimscript, target: 'fiddler'
+
+  preflight do
+    IO.write shimscript, <<-EOS.undent
+      #!/bin/bash
+      cd "$(dirname "$(readlink -n "${0}")")" && \
+        mono Fiddler.exe "${@}"
+    EOS
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.