### PR TITLE
Update geany to 1.31

### DIFF
--- a/Casks/geany.rb
+++ b/Casks/geany.rb
@@ -1,10 +1,10 @@
 cask 'geany' do
-  version '1.30.1'
-  sha256 '499fb2200dff408b2b94e7564086509386ff912a47f1090eef1e83c025f972e3'
+  version '1.31'
+  sha256 'ccc4eb540c2f1ea0d8af62efcd91a63f37c523b428ec9185e5e0edf5a7b836c5'
 
   url "https://download.geany.org/geany-#{version}_osx.dmg"
   appcast 'https://github.com/geany/geany/releases.atom',
-          checkpoint: '1e0c199a9ce1279101ad962cc31de94cdfb91a60206f24e15dcc557f7fa6a35d'
+          checkpoint: '715c1e046317b3353e7c62f889193387b1a4b754d26e7dc51b158c83c575eff3'
   name 'Geany'
   homepage 'https://www.geany.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.