### PR TITLE
Update keypad-layout to 1.6

### DIFF
--- a/Casks/keypad-layout.rb
+++ b/Casks/keypad-layout.rb
@@ -1,10 +1,10 @@
 cask 'keypad-layout' do
-  version '1.5'
-  sha256 '04cf2fb5c17d03d96cd3275127c7031f2a7d90e1327162deb9093075b76c8616'
+  version '1.6'
+  sha256 '12a980ca6cda993a064331c07e3939bde2749fcc99e3a31ab31ded8edd01596c'
 
   url "https://github.com/janten/keypad-layout/releases/download/#{version}/Keypad-Layout.zip"
   appcast 'https://github.com/janten/keypad-layout/releases.atom',
-          checkpoint: '972af51872da1819ca43d67f6ed1a7435cb09099a848ed6a4a3be72cccf62127'
+          checkpoint: '8b5b40b44a66972a6a614122705294eff4086de2dc59d43874c8b9e6d688ffd9'
   name 'Keypad Layout'
   homepage 'https://github.com/janten/keypad-layout'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.