### PR TITLE
Update pdfpenpro to 911.1,1503633565

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '910.13,1501038914'
-  sha256 '529ce7afcda234443f510bd046650225135ab4e3a054cd49d071d1dbe9676d99'
+  version '911.1,1503633565'
+  sha256 '1385502192334f9c69c8e5ef38a69185dbd26742615a8184199d81552ff886e6'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '6ab6e52e8c7afcb947a136f86ed6c86537335c57f46f8a380aa72448f3c63079'
+          checkpoint: '5f91f9a37b7a3a4e86b57eb3cd02d4d393b3725deb85879bc151d425947d328d'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.