### PR TITLE
Update minitube to 2.8

### DIFF
--- a/Casks/minitube.rb
+++ b/Casks/minitube.rb
@@ -1,10 +1,10 @@
 cask 'minitube' do
-  version '2.7'
-  sha256 '54e11efb1498309ee4d9331fca327f987552806b7c2633e7f1a68a9bed2adeae'
+  version '2.8'
+  sha256 '982f89c34ac425b50ffc79c2a586bacb1a6c3b501ec8294ddca6595ea2baa08e'
 
   url 'http://flavio.tordini.org/files/minitube/minitube.dmg'
   appcast 'http://flavio.tordini.org/minitube-ws/appcast.xml',
-          checkpoint: '4f982ecfcbe80a5c1f4c894812dc9a2bbd011d1c70fb961ff2f355825c858c8e'
+          checkpoint: '9135952d27429f3e81c1aaea2546a194df9cb29abfe180ad805ab3f9b18c6b9c'
   name 'Minitube'
   homepage 'http://flavio.tordini.org/minitube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.