### PR TITLE
Update scrutiny to 7.5.5

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,10 +1,10 @@
 cask 'scrutiny' do
-  version '7.5.3'
+  version '7.5.5'
   sha256 '3692ca7be75487999766f2fd7a5aca5debea206a90b6468ebb8c5df18eece06a'
 
   url 'http://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
-  appcast "http://peacockmedia.software/mac/scrutiny/updates/v#{version.major}currentversion.plist",
-          checkpoint: '9611e910e878931d72d0d42fe0858304cfa0429a2b48b5a851ce57bc3e868f07'
+  appcast 'http://peacockmedia.software/mac/scrutiny/version_history.html',
+          checkpoint: '50b6c966f3e646f152b388d775c7bb7ff5912731086f08c5619151317d7ef583'
   name 'Scrutiny'
   homepage 'http://peacockmedia.software/mac/scrutiny/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Use changelog instead of plist for appcast.