### PR TITLE
Update proxpn to 5.0.0.0

### DIFF
--- a/Casks/proxpn.rb
+++ b/Casks/proxpn.rb
@@ -1,10 +1,10 @@
 cask 'proxpn' do
-  version '4.4.2.3'
-  sha256 '66d1abf1c285706da9170139fe5f573b8461bef24690bb2383991f5c2ee9ffa9'
+  version '5.0.0.0'
+  sha256 'dfba1633e886f56c124283b2005fbb63a2704db1c539fa645b316c5b10831dcb'
 
   url "https://www.proxpn.com/updater/proXPN-MacOSX-10.7-#{version}.dmg"
   appcast 'https://www.proxpn.com/updater/appcast.rss',
-          checkpoint: '46d37714ca2eded9491f53aa20c41dcd39c9cd6179b02753f55f6489b3efb0cd'
+          checkpoint: 'a3ae70769f37488f80b4566f8f8eba45097a08725873ad6262a09e2eb8ba0859'
   name 'proXPN'
   homepage 'https://www.proxpn.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.