### PR TITLE
Update fontbase to 2.1.2

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.0.2'
-  sha256 'bbbf9d6d9919c4816e312fa975696b3fba07819b5813a6c39ac914b5a8fdf59d'
+  version '2.1.2'
+  sha256 '850157757b70196860862303e84944056bfab0719567c21c80a5868323e1b019'
 
   url "http://releases.fontba.se/mac/#{version}/FontBase-#{version}.dmg"
   name 'FontBase'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.