### PR TITLE
Update google-earth-pro to 7.3.0.3832

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask 'google-earth-pro' do
-  version '7.3.0.3830'
-  sha256 'bc9fab7a6d83fa9f0bd218cb56162dd31337cb52c7874b3ace0330cd5d73f9bf'
+  version '7.3.0.3832'
+  sha256 'a55a7f97ea498cb0e5704681b0e4f33af73c97d5813a239bbece57f1f5bb23aa'
 
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg'
   name 'Google Earth Pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.