### PR TITLE
Update metasploit to 4.16.3+20170826101329

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.2+20170824101201'
-  sha256 '0ad3c8fff7fe85b6088444231efca96007a37a876d9590c77e629d8a80adf9d8'
+  version '4.16.3+20170826101329'
+  sha256 'd13de77d672cbb41ea366f37930a818b78d195698b45dcf10c7ba505c8fc1029'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: 'a1baab36cc8622fc48f2c8812e05f19c59314b3cf738a7a2d30915058ef4cd0d'
+          checkpoint: 'a4bf6fdbbe98d6b9cfa34f6ec78639a1ce1112c77a13eb36c3ad394859f7a072'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.