### PR TITLE
Update 2 teamviewer casks - uninstall / zap

### DIFF
--- a/Casks/teamviewer-host.rb
+++ b/Casks/teamviewer-host.rb
@@ -7,29 +7,34 @@ cask 'teamviewer-host' do
   homepage 'https://www.teamviewer.com/'
 
   auto_updates true
+  conflicts_with cask: 'teamviewer'
 
   pkg 'Install TeamViewerHost.pkg'
 
-  uninstall pkgutil: 'com.teamviewer.teamviewerhost.*',
-            delete:  [
-                       '/Applications/TeamViewerHost.app',
-                       "/Library/Fonts/TeamViewer#{version}Host.otf",
-                       '~/Library/Application Support/TeamViewer Host',
-                       '~/Library/Caches/com.teamviewer.TeamViewerHost',
-                       '~/Library/Preferences/com.teamviewer.TeamViewerHost.plist',
-                     ]
+  uninstall pkgutil:   'com.teamviewer.*',
+            delete:    [
+                         '/Applications/TeamViewerHost.app',
+                         "/Library/Fonts/TeamViewer#{version}Host.otf",
+                         '/Library/PrivilegedHelperTools/com.teamviewer.Helper',
+                         '/Library/Security/SecurityAgentPlugins/TeamViewerAuthPlugin.bundle',
+                       ],
+            launchctl: [
+                         'com.teamviewer.Helper',
+                         'com.teamviewer.desktop',
+                         'com.teamviewer.service',
+                         'com.teamviewer.teamviewer',
+                         'com.teamviewer.teamviewer_service',
+                       ],
+            quit:      'com.teamviewer.TeamViewerHost'
 
   zap       delete: [
-                      '/Library/LaunchAgents/com.teamviewer.teamviewer_desktop.plist',
-                      '/Library/LaunchAgents/com.teamviewer.teamviewer.plist',
-                      '/Library/LaunchDaemons/com.teamviewer.Helper.plist',
-                      '/Library/LaunchDaemons/com.teamviewer.teamviewer_service.plist',
-                      '/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
-                      '/Library/PrivilegedHelperTools/com.teamviewer.Helper',
-                      '/Library/Security/SecurityAgentPlugins/TeamViewerAuthPlugin.bundle',
+                      '~/Library/Caches/com.teamviewer.TeamViewerHost',
                       '~/Library/Logs/TeamViewer',
+                    ],
+            trash:  [
+                      '/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
+                      '~/Library/Application Support/TeamViewer Host',
                       '~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
+                      '~/Library/Preferences/com.teamviewer.TeamViewerHost.plist',
                     ]
-
-  caveats   'Performing a zap on this cask removes files pertaining to both teamviewer and teamviewer-host, so it should not be done if you only want to uninstall one of them.'
 end

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -7,31 +7,37 @@ cask 'teamviewer' do
   homepage 'https://www.teamviewer.com/'
 
   auto_updates true
+  conflicts_with cask: 'teamviewer-host'
 
   pkg 'Install TeamViewer.pkg'
 
-  uninstall pkgutil: "com.teamviewer.teamviewer#{version}(?!AuthPlugin|PriviledgedHelper).*",
-            delete:  [
-                       '/Applications/TeamViewer.app',
-                       "/Library/Fonts/TeamViewer#{version}.otf",
-                     ]
+  uninstall pkgutil:   'com.teamviewer.*',
+            delete:    [
+                         '/Applications/TeamViewer.app',
+                         "/Library/Fonts/TeamViewer#{version}.otf",
+                         '/Library/PrivilegedHelperTools/com.teamviewer.Helper',
+                         '/Library/Security/SecurityAgentPlugins/TeamViewerAuthPlugin.bundle',
+                       ],
+            launchctl: [
+                         'com.teamviewer.Helper',
+                         'com.teamviewer.desktop',
+                         'com.teamviewer.service',
+                         'com.teamviewer.teamviewer',
+                         'com.teamviewer.teamviewer_service',
+                       ],
+            quit:      'com.teamviewer.TeamViewer'
 
   zap       delete: [
-                      '/Library/LaunchAgents/com.teamviewer.teamviewer_desktop.plist',
-                      '/Library/LaunchAgents/com.teamviewer.teamviewer.plist',
-                      '/Library/LaunchDaemons/com.teamviewer.Helper.plist',
-                      '/Library/LaunchDaemons/com.teamviewer.teamviewer_service.plist',
-                      '/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
-                      '/Library/PrivilegedHelperTools/com.teamviewer.Helper',
-                      '/Library/Security/SecurityAgentPlugins/TeamViewerAuthPlugin.bundle',
-                      '~/Library/Application Support/TeamViewer',
                       '~/Library/Caches/com.teamviewer.TeamViewer',
                       '~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies',
                       '~/Library/Logs/TeamViewer',
-                      '~/Library/Preferences/com.teamviewer.TeamViewer.plist',
-                      '~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
                       '~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState',
+                    ],
+            trash:  [
+                      '/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
+                      '~/Library/Application Support/TeamViewer',
+                      '~/Library/Preferences/com.teamviewer.TeamViewer.plist',
+                      '~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist',
+                      '~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist',
                     ]
-
-  caveats   'Performing a zap on this cask removes files pertaining to both teamviewer and teamviewer-host, so it should not be done if you only want to uninstall one of them.'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Add `conflicts_with` to allow complete uninstalls for each cask. 

`teamviewer` provides the same "host" features as `teamviewer-host` so it seems unlikely anyone would want to have both installed.