### PR TITLE
Update opera to 47.0.2631.71

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '47.0.2631.55'
-  sha256 'a8db6cb368af538e516bce1fa3a3e1f0f0e0b1669ff5db2f9f1fd39e14e691a6'
+  version '47.0.2631.71'
+  sha256 '918876b5c784d8823cea362cc808ad16dd873bc8fe07b92396ba246afbd54532'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.