### PR TITLE
Update utox to 0.16.1

### DIFF
--- a/Casks/utox.rb
+++ b/Casks/utox.rb
@@ -1,11 +1,11 @@
 cask 'utox' do
-  version '0.9.8'
-  sha256 'a004c4bb1b01963fa910482bf6631a1f3a5c60ebf575259c168f5d95f38356eb'
+  version '0.16.1'
+  sha256 '722ef3e8d1145b7746db6544ccb50a85558da93e0d39a588223a4489479fd85d'
 
   # github.com/uTox/uTox was verified as official when first introduced to the cask
   url "https://github.com/uTox/uTox/releases/download/v#{version}/uTox-#{version}.dmg"
   appcast 'https://github.com/uTox/uTox/releases.atom',
-          checkpoint: '3ac9e7a194c722a871e25415c165dbe8b6fe9e3930a94bee38b66846e1beaea6'
+          checkpoint: '762ca9b3d6015647546bcee5ca8859ff3b4f4f281373149511229b860413d651'
   name 'uTox'
   homepage 'https://www.tox.chat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.