### PR TITLE
Fix freefilesync sha256 hash to match current file from upstream file

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '9.3'
-  sha256 '987e3f1d1d142ac43896c0c7c9d96498771590e6958c1b44e06938ec61cfb79c'
+  sha256 '03bf3a00ceae583e87c9e2afae255e75ece6ff218a2021b5fd9ccfdcdda6c33d'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.<br/>***NOTE:*** Cask version has not changed, only the upstream hosted file's sha256!  Apparently they appear to have swapped out the original file with something else?  Not sure what the difference is, because I had not downloaded the fresh release of this version prior to the file swap.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Confirmation:

```
$ brew cask reinstall freefilesync
==> Satisfying dependencies
==> Downloading http://www.freefilesync.org/download/FreeFileSync_9.3_macOS.zip
######################################################################## 100.0%
==> Verifying checksum for Cask freefilesync
==> Note: running "brew update" may fix sha256 checksum errors
Error: Checksum for Cask 'freefilesync' does not match.

Expected: 987e3f1d1d142ac43896c0c7c9d96498771590e6958c1b44e06938ec61cfb79c
Actual:   03bf3a00ceae583e87c9e2afae255e75ece6ff218a2021b5fd9ccfdcdda6c33d
File:     /Users/jcuzella/Library/Caches/Homebrew/Cask/freefilesync--9.3.zip

To retry an incomplete download, remove the file above.
Error: Install incomplete.

$ curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8"  -Lso -  https://www.freefilesync.org/download/FreeFileSync_9.3_macOS.zip | shasum -a 256 -
03bf3a00ceae583e87c9e2afae255e75ece6ff218a2021b5fd9ccfdcdda6c33d  -
```

I'm not really sure why this changed, but [VirusTotal says it's not detecting anything][virustotal-by-sha] as of 08-26-2017.  So this looks like a re-release assuming the virus definitions are good enough to detect anything that would be in this.  It's also saying that it has a valid signature by the developer:

```
Signature Info:

Signature Verification:       Signed file, valid signature

File Version Information:

Identifier                    Zenju.FreeFileSync
Authority                     Apple Root CA
Date Signed                   Aug 20, 2017, 11:19:34 AM
Team Identifier               Y8U4RUM443

Signers:

Florian Bauer
Apple Inc.
Apple Inc.
```

[virustotal-by-sha]: https://www.virustotal.com/#/file/03bf3a00ceae583e87c9e2afae255e75ece6ff218a2021b5fd9ccfdcdda6c33d/detection

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
