### PR TITLE
Update tableplus to 1.0

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,10 +1,10 @@
 cask 'tableplus' do
   version '1.0'
-  sha256 'ca5655445c2f4674eda66fd1833a9f8dedb80937073b0b4a204100e7f2b21fe5'
+  sha256 'db93faa8a2d4634b64de9c8aaa3584d25fc94e2d36483109a747af2a7fafb3fe'
 
   url 'https://tableplus.io/release/osx/tableplus_latest.zip'
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: 'ce45c6d4a38e7b1a4af6e1f0960117ccf8191a41b41dc5db5ad1a898f3748b3c'
+          checkpoint: '51cb29aa41a145dff4a5a7d515fa0807b8624da215a5b9c5ffd1621dfd75795b'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 

--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,5 +1,5 @@
 cask 'tableplus' do
-  version '1.0'
+  version '1.0,59'
   sha256 'db93faa8a2d4634b64de9c8aaa3584d25fc94e2d36483109a747af2a7fafb3fe'
 
   url 'https://tableplus.io/release/osx/tableplus_latest.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.