### PR TITLE
Update now to 2.4.2

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.4.0'
-  sha256 '6aeb8765369d051e5831715b9b5471b0b370cd9e747db0852f933ec0fc421dda'
+  version '2.4.2'
+  sha256 'b5974ee8a8522961af2392c021466d0aa74b5b3615dbec3529b64610b41bfa78'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '3f4af0bd3fdc3adbfa693787b9016cd3227399e7c78323040a57e2be82e64652'
+          checkpoint: 'e4f5e47b5f2306bef3edbfe4409bf5e4e817368cdb3e73eacddc6ad41499ff42'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.