### PR TITLE
Update integrity to 6.11.3

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,11 +1,11 @@
 cask 'integrity' do
-  version '6.11.2'
-  sha256 'c0a36b7febd035a881c4e9f2bbf60f6d9aaca795e2399c4dd3cbf0ead0561526'
+  version '6.11.3'
+  sha256 '7c5fb11b8926c22d5f7abdef3c958773accefd30f32a429a90dc26b7eeab54cb'
 
   # peacockmedia.co.uk/integrity was verified as official when first introduced to the cask
   url 'http://peacockmedia.co.uk/integrity/integrity.dmg'
   appcast 'http://peacockmedia.software/mac/integrity/version_history.html',
-          checkpoint: '9af958b2724edad449f8d3b9023768f720f43a6b1e28ffba3b3b44cc500fe44a'
+          checkpoint: '00c843e5a57c8b31ba4471b68eace5877469916bcb813a6c2cbf648d5dafc683'
   name 'Integrity'
   homepage 'http://peacockmedia.software/mac/integrity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.