### PR TITLE
Update santa - uninstall

### DIFF
--- a/Casks/santa.rb
+++ b/Casks/santa.rb
@@ -10,7 +10,8 @@ cask 'santa' do
 
   pkg "santa-#{version}.pkg"
 
-  uninstall kext:      'com.google.santa-driver',
+  uninstall delete:    '/usr/local/bin/santactl',
+            kext:      'com.google.santa-driver',
             launchctl: ['com.google.santad', 'com.google.santagui'],
             pkgutil:   'com.google.santa'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`/usr/local/bin/santactl` is a symlink that is created by the `pkg` postinstall script and is not removed by `uninstall pkgutil`