### PR TITLE
Update minishift to 1.5.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.4.1'
-  sha256 '9386b713847e454ad43c007c53ce23e609b730b081f75e42264b7485160a96cf'
+  version '1.5.0'
+  sha256 '7edd01f8231d135bb8ef54074e38abcebc998c957f9e14b9a2b305f25e7a2e36'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: '5455eb097ac76d06263e3097f498e6a6b6b66c721b490767f1f65773daa633bb'
+          checkpoint: 'b98d0b863523d4ebe12c39886a5bab76c92f5336b3b7a9d46cfd58cc465b1098'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

My testing:
```
# Edit cask file
$ vim minishift.rb

# Install new cask
$ brew cask install minishift.rb
==> Satisfying dependencies
==> Downloading https://github.com/minishift/minishift/releases/download/v1.5.0/minishift-1.5.0-darwin-amd64.tgz
######################################################################## 100.0%
==> Verifying checksum for Cask minishift
==> Installing Cask minishift
==> Linking Binary 'minishift' to '/usr/local/bin/minishift'.
🍺  minishift was successfully installed!

# Check version
$ /usr/local/bin/minishift version
minishift v1.5.0+ae62cf2

# Audit Check
$ brew cask audit minishift.rb --download
==> Downloading https://github.com/minishift/minishift/releases/download/v1.5.0/minishift-1.5.0-darwin-amd64.tgz
Already downloaded: /Users/devtools/Library/Caches/Homebrew/Cask/minishift--1.5.0.tgz
==> Verifying checksum for Cask minishift
audit for minishift: passed

# Style Check
$ brew cask style minishift.rb

1 file inspected, no offenses detected
```
