### PR TITLE
Update audirvana-plus to 3.1.1

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,10 +1,10 @@
 cask 'audirvana-plus' do
-  version '3.0.7'
-  sha256 '382f15e31d35fc6afc9ce975ed9233c88eb3f49f7e5dc0b2f2bed8580697e5cb'
+  version '3.1.1'
+  sha256 '23656b75c257276ceaa8c1aa2d7899fdf04e878d35fa6b278b3732084201476b'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml",
-          checkpoint: '30f626a1c93bf9daff71d7336bdb87186a1ed2167604c92d671ba2af1797e162'
+          checkpoint: '8c3789c04cf9340a888c8f8c1a8939110e0441b65cf8321bd2982592c852d913'
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.