### PR TITLE
Update cantata to 2.1.0

### DIFF
--- a/Casks/cantata.rb
+++ b/Casks/cantata.rb
@@ -1,10 +1,10 @@
 cask 'cantata' do
-  version '2.0.1'
-  sha256 '534fc39e4b540a2aafbcb06f175af2a772fd503a9f7434a9be2bb82a39a78277'
+  version '2.1.0'
+  sha256 '3b7c790e3fce64c91a898324e1204c785a516be80def4b2e189ec794f03ba25a'
 
   url "https://github.com/CDrummond/cantata/releases/download/v#{version}/Cantata-#{version}.dmg"
   appcast 'https://github.com/CDrummond/cantata/releases.atom',
-          checkpoint: '3b9ed09aca605ae43105f789fdd9c5f39a5f391d5132e5e9390056a8b7f2f5de'
+          checkpoint: '9b8bedfff18435b3fa30fe7813adfcaa5460daaaa1e42dbb756bd798fdd6644d'
   name 'Cantata'
   homepage 'https://github.com/cdrummond/cantata'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.