### PR TITLE
Update devonthink-pro to 2.9.15

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.13'
-  sha256 '1705c28fef0ef199e7b4a81b28feb35df79e3f2cd34096db435c8375ec998235'
+  version '2.9.15'
+  sha256 '599e5e256684c52bb3812e2e978f6c0e961701460470e4dfe2e05bad73d13e1c'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '2425fd0aa471911fff4b6ff4622078031abe1bf647f72197fc9779ed43b489e4'
+          checkpoint: 'e5bbfe68292e234acdf6a14e8c95d8fc007d25da23edb641abb6cafcb79f34cc'
   name 'DEVONthink Pro'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.