### PR TITLE
Update devonthink-pro-office to 2.9.15

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro-office' do
-  version '2.9.14'
-  sha256 'fd425a5beb6e179bac7f61ad1b0564de358991a7d571d64a989e26e7b52b06e1'
+  version '2.9.15'
+  sha256 'aec9b2402ed6983007f7e73e1c397ea377c9d7daa52a8f6e5b7f553f0830fefc'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300125739&format=xml',
-          checkpoint: '7f6d6c712da496696fbac9e0fc2dcc210e0b45134b1bd69c3ce107ae2b1ab786'
+          checkpoint: '57d540196fb5844572cb1b2839d6877e77a7f2ae753e08346d5f566d7a8977df'
   name 'DEVONthink Pro Office'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-pro-office.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.