### PR TITLE
Update devrantron to 1.3.4

### DIFF
--- a/Casks/devrantron.rb
+++ b/Casks/devrantron.rb
@@ -1,11 +1,11 @@
 cask 'devrantron' do
-  version '1.3.3'
-  sha256 'bbec22e9f9961c2e75336c8491c6090f70c00f9b28d36c839bb6ab0764c45dfe'
+  version '1.3.4'
+  sha256 'c58566219f1363123071c63cbd0e8a97b9ff8891d07bba8691b0697dbb0c9227'
 
   # github.com/tahnik/devRantron was verified as official when first introduced to the cask
   url "https://github.com/tahnik/devRantron/releases/download/v#{version}/devrantron-#{version}.dmg"
   appcast 'https://github.com/tahnik/devRantron/releases.atom',
-          checkpoint: 'f6ec743be9f653ee8e906ae95258f176cea4d00badc781a441310752daa81358'
+          checkpoint: '714a6d6d9c8bff9abf46e728ac158556c7cbe5373b846037a45364d25cc22a6f'
   name 'devRantron'
   homepage 'https://devrantron.firebaseapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.