### PR TITLE
Update gogs to 0.11.29

### DIFF
--- a/Casks/gogs.rb
+++ b/Casks/gogs.rb
@@ -1,11 +1,11 @@
 cask 'gogs' do
-  version '0.11.19'
-  sha256 'd2f609a7f7abc0ba58968992136dde2c517534343869d6eb2b4101b979c40f8d'
+  version '0.11.29'
+  sha256 '25e12b7e7baf333baa8a5f12fd4d2458e36ed66dd8ac81aa2ad5c0a02a9ded8d'
 
   # github.com/gogits/gogs was verified as official when first introduced to the cask
   url "https://github.com/gogits/gogs/releases/download/v#{version}/darwin_amd64.zip"
   appcast 'https://github.com/gogits/gogs/releases.atom',
-          checkpoint: 'b7e205e24b18e58698a65436d394196ff78c17a749c019568119a34d85f23254'
+          checkpoint: 'eb7f96e10404437352cd32e252b633ff4d106bf5ad808d6c26e74b29e4f8e271'
   name 'Go Git Service'
   homepage 'https://gogs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.