### PR TITLE
Update gpxsee to 4.12

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,11 +1,11 @@
 cask 'gpxsee' do
-  version '4.11'
-  sha256 '75c08b0356ad8d930e9be5ba9487f6396956144ac4d90e8dad96208df699c21a'
+  version '4.12'
+  sha256 'd33b455c8c35f041e2376605313ba73c90b4094dd265b1b5febd936b51588f39'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/gpxsee/rss?path=/Mac%20OS%20X',
-          checkpoint: '6dd35ef7b0d64f4d31a5a8739e1e207c5ad10f080edd0e93f76128d5ce4fec7f'
+          checkpoint: '2811012f6096f1c00dbba1eb28dd7d4291866d0a7e45f6c422e97bd52241c11e'
   name 'GPXSee'
   homepage 'http://www.gpxsee.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.