### PR TITLE
Update instead to 3.1.2

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,11 +1,11 @@
 cask 'instead' do
-  version '3.0.1'
-  sha256 'ac4cf3ee747156a541b8050c9b3da0c8d57c1fe741a1c0ee5a3025897027dbbe'
+  version '3.1.2'
+  sha256 '880d2e8f77a99cab8bac110cfb8473acf951c87b2bc26f8ac81870537e4174ae'
 
   # sourceforge.net/instead was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/instead/instead/#{version}/Instead-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/instead/rss?path=/instead',
-          checkpoint: 'd9aefb4fb9fd86981bef23f2974eaf85a18126c03290235ad860356f8095f472'
+          checkpoint: 'b0bb1b1c52f94f3661376bee867fea09f538a2ef0c5674b3f9acacc7364cdd0a'
   name 'INSTEAD'
   homepage 'https://instead.syscall.ru/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.