### PR TITLE
Update join-together to 7.8.0

### DIFF
--- a/Casks/join-together.rb
+++ b/Casks/join-together.rb
@@ -1,10 +1,10 @@
 cask 'join-together' do
-  version '7.7.3'
-  sha256 '8b8771a048096ba27d01fe334673b990483cb957d7836895ca18f295dd222e30'
+  version '7.8.0'
+  sha256 '707624eba0ef871de19bcad9bc2f4db256f3b82b90fce5b2eb6e6b4bfd78032f'
 
   url "https://dougscripts.com/itunes/scrx/jointogether#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/jointogether_appcast.xml',
-          checkpoint: '2b85a0d3b4ca1b61d84c4c397d738f81864682781eba8adb1f5b8d0f86b5af7d'
+          checkpoint: 'c2b895353bbe21a867ab1c5dc7b80a670019e8eeb5724b70d3da2dc762e90d54'
   name 'Join Together'
   homepage 'https://dougscripts.com/apps/jointogetherapp.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.