### PR TITLE
Update kactus to 0.2.6

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.2.1'
-  sha256 '864d981f70dc8ccd03c8e95227905a0407562734ad9790838079c751e4d6a877'
+  version '0.2.6'
+  sha256 'e689e10903196cab231b372a0f5b811fe7881bef30d8eaa7a973c0bccc0937b1'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: 'ce6902d4aade77ed5f22683313d826806107317becc80a48c27ca7aa46c800cc'
+          checkpoint: 'bcfb454afb3d4069a76e153e0e7068502c18844ab8166133ae1e74eb05b179c9'
   name 'Kactus'
   homepage 'https://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.