### PR TITLE
Update losslesscut to 1.7.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,10 +1,10 @@
 cask 'losslesscut' do
-  version '1.6.0'
-  sha256 '8624ff9bc07aa534ded12445a21d066500a64738ccfcfba83ce9f34bdef36200'
+  version '1.7.0'
+  sha256 '4bec87f6e63c003b889a714a2c2e01598a3614dd7779ff2544e5466d52cd8244'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-darwin-x64.zip"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom',
-          checkpoint: 'e41c4175f58c355299c08313177137b3b14ce347f7db962d6f3e75760562b495'
+          checkpoint: 'c7a899db1ecbdc4e133c2f69253b6eeebbb632c1c5822b50aad27d7af6749210'
   name 'Loslesscut'
   homepage 'https://github.com/mifi/lossless-cut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.