### PR TITLE
Update lyricsx to 1.2.0

### DIFF
--- a/Casks/lyricsx.rb
+++ b/Casks/lyricsx.rb
@@ -1,10 +1,10 @@
 cask 'lyricsx' do
-  version '1.1.4'
-  sha256 '40e96ae29916c791d783c4ebabcfc715c60dc0e5bf0e6bae6e87a149974050a5'
+  version '1.2.0'
+  sha256 'b83a0ed50512192f3f068359528637977674bd00f744e64a8d2a053da5c79d8e'
 
   url "https://github.com/ddddxxx/LyricsX/releases/download/v#{version}/LyricsX.app.zip"
   appcast 'https://github.com/ddddxxx/LyricsX/releases.atom',
-          checkpoint: '380de848d028e25585aaed73dcda5360d8b137eee6d9493b1c8efeae00a793ec'
+          checkpoint: 'e20af0eae301c46b006fae0b658d3112e53db357dc58f752ee5dcbfe9b8578d3'
   name 'LyricsX'
   homepage 'https://github.com/ddddxxx/LyricsX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.