### PR TITLE
Update mactracker to 7.6.6

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -1,10 +1,10 @@
 cask 'mactracker' do
-  version '7.6.5'
-  sha256 '18cb264dc9a3d9bbdc02d88aca814c0067c0854b2430983c9a54bd8f2b44ce7d'
+  version '7.6.6'
+  sha256 '8fe86a66162fd60d8d7f2f29a7e00affb2050dd46a04efd28a0fb1b24fde8edc'
 
   url "https://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
   appcast 'https://update.mactracker.ca/appcast-b.xml',
-          checkpoint: '54058c7fe90fd6842b24277de8152144c56d5bfc1433b9f3c169198cef6fb566'
+          checkpoint: '87c6e3faa3bad3201d2e5a0bfa003f04f0dc75d421d0514b7698ac6030f27161'
   name 'Mactracker'
   homepage 'https://mactracker.ca/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.