### PR TITLE
Update kicad-extras to 4.0.7

### DIFF
--- a/Casks/kicad-extras.rb
+++ b/Casks/kicad-extras.rb
@@ -1,6 +1,6 @@
 cask 'kicad-extras' do
-  version '4.0.6'
-  sha256 '06a9f9c7ad99dd82115011e63dd40e21519ccc433ccd091b363106afe45302aa'
+  version '4.0.7'
+  sha256 '913dd8553d72a79ae94b5746ce78b44ee1ff9479238b70b05cea17086f059487'
 
   url "http://downloads.kicad-pcb.org/osx/stable/kicad-extras-#{version}.dmg"
   name 'KiCad Extras'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.