### PR TITLE
Update framer to 9612

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '9520'
-  sha256 '2ff5bcbf98e71c2b77bd4bd28fd3fa0d30826c48449e3a257508c935fd8694b3'
+  version '9612'
+  sha256 '8b5d3f713eed8997e88979084c12ae8032ef704b1a8cc2e965b25f6a71ba2af7'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '934532390e02d0b5a5f9a2909a27356442f8775c0cb25ebbada19da11c6ee614'
+          checkpoint: 'ed44bad48a44e2af8a887badaf4578ec8a1486ebbea424ebc9e6e2c011520db6'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.