### PR TITLE
Update ksdiff to 2.2.0 (122)

### DIFF
--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -1,6 +1,6 @@
 cask 'ksdiff' do
-  version '2.1.0 (122)'
-  sha256 '9570f53dcbeb558c53f4808ba58e8c9f394a3026e8bdd122277200a1cdf11e52'
+  version '2.2.0 (122)'
+  sha256 'cf32401d631e61cbbc3dc9947626174b45e8317a6cac39380067e7017e8d4c87'
 
   url "https://cdn.kaleidoscopeapp.com/releases/ksdiff-#{version.sub(%r{.*?\((\d+)\)}, '\1')}.zip"
   name 'ksdiff'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.