### PR TITLE
Update teamsql to 1.3.117

### DIFF
--- a/Casks/teamsql.rb
+++ b/Casks/teamsql.rb
@@ -1,11 +1,11 @@
 cask 'teamsql' do
-  version '1.3.116'
-  sha256 '32f1ca793c9fa706abcfc308f98a5f451db36e2dbf568444149294e7c39629b4'
+  version '1.3.117'
+  sha256 'db044e789b2e6882a886d14d0576760b52968a3cca2fe03b0ea06b0d33cdf7e5'
 
   # dlpuop5av9e02.cloudfront.net/osx/stable was verified as official when first introduced to the cask
   url "https://dlpuop5av9e02.cloudfront.net/osx/stable/#{version}/TeamSQL-#{version}.dmg"
   appcast 'https://teamsql.io/whats-new',
-          checkpoint: '546c184b30f35d38d1c3683057d47e760c5d3dbf755ffecb8434530a6070087c'
+          checkpoint: '36724deaed29c01892d36d87fffd79e450e826b33d409cbdedf3e1ee0c4325a5'
   name 'TeamSQL'
   homepage 'https://teamsql.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.