### PR TITLE
Update the-unarchiver to 3.11.2

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,10 +1,10 @@
 cask 'the-unarchiver' do
-  version '3.11.1'
+  version '3.11.2'
   sha256 '12d1af6475149647f996f1b0510e067f057444852f1aa08a8dad75d6debe6ddf'
 
   url 'https://theunarchiver.com/downloads/TheUnarchiver.zip'
   appcast 'https://theunarchiver.com/updates.rss',
-          checkpoint: 'ccc12c475bce837e293f6ac608eb6f5a8a3ff07728410899a39d9b3c48457aa3'
+          checkpoint: '96b0d76d58d91ed48f16edd2567ca314b2e833d7f1baa23a9f5e076201cb3bf6'
   name 'The Unarchiver'
   homepage 'https://theunarchiver.com/'
 

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,10 +1,11 @@
 cask 'the-unarchiver' do
-  version '3.11.2'
-  sha256 '12d1af6475149647f996f1b0510e067f057444852f1aa08a8dad75d6debe6ddf'
+  version '3.11.2,113:1504002485'
+  sha256 'fd7c412af8da923429878d33343b05c9fe8dd8906488875050212f4424a048aa'
 
-  url 'https://theunarchiver.com/downloads/TheUnarchiver.zip'
-  appcast 'https://theunarchiver.com/updates.rss',
-          checkpoint: '96b0d76d58d91ed48f16edd2567ca314b2e833d7f1baa23a9f5e076201cb3bf6'
+  # devmate.com/cx.c3.theunarchiver was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/cx.c3.theunarchiver/#{version.after_comma.before_colon}/#{version.after_colon}/TheUnarchiver-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/cx.c3.theunarchiver.xml',
+          checkpoint: 'b76f0a4ff7cc381181e7c46d5fea6d0b62dc07d10aa1751b882a0b6674fa82aa'
   name 'The Unarchiver'
   homepage 'https://theunarchiver.com/'
 
@@ -16,6 +17,7 @@ cask 'the-unarchiver' do
   zap delete: [
                 '~/Library/Caches/cx.c3.theunarchiver',
                 '~/Library/Cookies/cx.c3.theunarchiver.binarycookies',
+                '~/Library/Saved Application State/cx.c3.theunarchiver.savedState',
               ],
       trash:  '~/Library/Preferences/cx.c3.theunarchiver.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.