### PR TITLE
Update ship to 2.6.3

### DIFF
--- a/Casks/ship.rb
+++ b/Casks/ship.rb
@@ -1,10 +1,10 @@
 cask 'ship' do
-  version '2.6.1'
-  sha256 '69ed0b391662f585cb94e7364288a82896b8a147be6aeb4ea38bb2943b666cfb'
+  version '2.6.3'
+  sha256 '67588cdfedf1b94edbdf79ce45c07583ec2ad1c7bacb9bcbbf66cfe72827698e'
 
   url "https://www.realartists.com/builds/#{version.major}.0/Ship.app.zip"
   appcast "https://www.realartists.com/builds/#{version.major}.0/sparkle.xml",
-          checkpoint: 'ff13d107d4a23501b61b9395bef03006b54f40aa5319fd50b0f73fca54b61348'
+          checkpoint: '32810777a8715056dcd5250a250d324f0ab8edf92c4dcf989f22b27906354332'
   name 'Ship'
   homepage 'https://www.realartists.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.