### PR TITLE
Update cura to 2.7.0

### DIFF
--- a/Casks/cura.rb
+++ b/Casks/cura.rb
@@ -1,6 +1,6 @@
 cask 'cura' do
-  version '2.6.2'
-  sha256 'd288f5ea5f00ae5d2c6b0a586ad28a67a7487962d5443b38a2feee7ccfdf9ed5'
+  version '2.7.0'
+  sha256 '01a15bd937b9bf39442c0368566c4d953cba6254814af3083084e96fb46cd745'
 
   url "https://software.ultimaker.com/current/Cura-#{version}-Darwin.dmg"
   name 'Cura'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.