### PR TITLE
Update beyond-compare to 4.2.3.22587

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,10 +1,10 @@
 cask 'beyond-compare' do
-  version '4.2.2.22384'
-  sha256 '53d6394b4751a50e14cd5c8dcd1650c09d662b6b46c067f8f3bf879634f26724'
+  version '4.2.3.22587'
+  sha256 'b33fc8925757801bc35a7ae3d11627f26b4ebde9d82a61a7c0f17e27385a359f'
 
   url "http://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "http://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx",
-          checkpoint: 'd124591e52265bd641981b99d9ab0307cbd01f4641e3b8b744aded4552d5e53f'
+          checkpoint: '49e6135f03914bc71bb68ae2c05326441e302eba963ed5a078365a41b9cb1942'
   name 'Beyond Compare'
   homepage 'https://www.scootersoftware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.