### PR TITLE
Update mjml to 2.6.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,11 +1,11 @@
 cask 'mjml' do
-  version '2.4.0'
-  sha256 '4fe41eeb778a03e5708fedc7c36b3a14ac403d7589c57f7dfc50a4b3474a8b9e'
+  version '2.6.0'
+  sha256 'c6033e655bd6205ca88364ff4e81913bf8a808498f7e0d78d7b86aa5ab2b28d9'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-osx_#{version}.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom',
-          checkpoint: '0531d2a62140c7c6d5fb2e457f979a17673705d97869800bd93549ad1e30a69f'
+          checkpoint: 'e51c5b449d90f4d594c9966426a80256e456d1b078a3a66202b15e6a4bd9d6b1'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.