### PR TITLE
Update wechatwebdevtools to 1.00.170830

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '0.20.191900'
-  sha256 '5b72cc4383e8f0776e57ac31127bd3ff05b3d1113a6571cb58005a0d5961e5e7'
+  version '1.00.170830'
+  sha256 '2e18b1a91f82b07e2eddf9efa97ed4ab74b1a7c046bab2f3556ef6d86153da76'
 
-  url "https://dldir1.qq.com/WechatWebDev/#{version.no_dots}/wechat_web_devtools_#{version}.dmg"
+  url 'https://dldir1.qq.com/WechatWebDev/1.0.0/20170830/wechat_devtools_1.00.170830.dmg'
   name 'wechat web devtools'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'
 

--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '1.00.170830'
+  version '1.0.0,170830'
   sha256 '2e18b1a91f82b07e2eddf9efa97ed4ab74b1a7c046bab2f3556ef6d86153da76'
 
-  url 'https://dldir1.qq.com/WechatWebDev/1.0.0/20170830/wechat_devtools_1.00.170830.dmg'
+  url "https://dldir1.qq.com/WechatWebDev/#{version.before_comma}/20#{version.after_comma}/wechat_devtools_#{version.major_minor}#{version.patch}.#{version.after_comma}.dmg"
   name 'wechat web devtools'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.