### PR TITLE
Update sourcetree to 2.6.2b

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.6.1b'
-    sha256 '1bce5f24bf0ddf91ed85a5a5ecca6f1e6c271d9550b1b9690bcda4b6afc89286'
+    version '2.6.2b'
+    sha256 '68f5d435ceb66fea17db548c640a8e7408e443eb34fac31eeb5120e2ce416534'
   end
 
   # atlassian.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version