### PR TITLE
Update spamsieve to 2.9.29

### DIFF
--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -1,6 +1,6 @@
 cask 'spamsieve' do
-  version '2.9.28'
-  sha256 '4a33813d05de530b686374815622c0d3629f2ae28c68e05f7adeb0378945ce96'
+  version '2.9.29'
+  sha256 '750fd469d1c5049d461c03fbab0fc91486eb0bb08c46f96248d3efe95e53e4de'
 
   url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
   name 'SpamSieve'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.