### PR TITLE
Update netlogo to 6.0.2

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,10 +1,10 @@
 cask 'netlogo' do
-  version '6.0.1'
-  sha256 '081b34feb3357eaee21f3b91355efa9f9471e05029697c24c0f55a2e4d5af5f5'
+  version '6.0.2'
+  sha256 '952954567aeed7da12340e024718e4ff62e2ee3cfcb7d8270845e07de0f26e80'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml',
-          checkpoint: '8f6e88b9ad1d1e73ee9e7c152ba03bf88f47706b59e95004033151fe5cb1f5c7'
+          checkpoint: '3dee474eb1e89e0db506c115172b236f2c2b41b5d4d9c58238f6dd8cd5c1a3b8'
   name 'NetLogo'
   homepage 'https://ccl.northwestern.edu/netlogo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.