### PR TITLE
Update burp-suite to 1.7.27

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,10 +1,10 @@
 cask 'burp-suite' do
-  version '1.7.26'
-  sha256 '859b1625e411c58b6b6d64f8e7516bc74449849ceddc082622f8cfa4ddffe36d'
+  version '1.7.27'
+  sha256 'eb215ee1a453634685d5ec302ccd9c07031869ca72c9f2cce10cc8dd6c9989a2'
 
   url "https://portswigger.net/burp/releases/download?product=free&version=#{version}&type=macosx"
   appcast 'https://portswigger.net/burp/freereleasesarchive',
-          checkpoint: '6dbcb76fdab04c8abbf115d2416993b0a274a6d1a0195701c9673a36341706e7'
+          checkpoint: '90e7612ec2b3f962f086bb85b9e9402731b9cfbb367b30f09e24d12e54e63bc8'
   name 'Burp Suite'
   homepage 'https://portswigger.net/burp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.