### PR TITLE
Update daylite to 6.2.2

### DIFF
--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -1,6 +1,6 @@
 cask 'daylite' do
-  version '6.2'
-  sha256 'e4229c3cacabddb74008e774420c2e3912138bce16f95b84d63ae1178ad3d696'
+  version '6.2.2'
+  sha256 '0d06044df60535f6b36164c081ab3133a283a2bd9a3b92c5dd13270e8636e38a'
 
   url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.dmg"
   name 'Daylite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.