### PR TITLE
Update ableton-live-suite to 9.7.4

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,12 +1,12 @@
 cask 'ableton-live-suite' do
-  version '9.7.3'
-  sha256 '97a8083b2b8776421a4f6a67f5074ce2f3b36def6b01f7d16e28ffdd86354dac'
+  version '9.7.4'
+  sha256 '45924ea6bab5d40fc8ec4f2a0e9c21795740776ae524dfb458dc002a2f90ff36'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   name 'Ableton Live Suite'
   homepage 'https://www.ableton.com/en/live/'
 
-  app "Ableton Live #{version[0]} Suite.app"
+  app "Ableton Live #{version.major} Suite.app"
 
   zap delete: '~/Library/*/*[Aa]bleton*',
       rmdir:  '~/Music/Ableton/Factory Packs'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.