### PR TITLE
Update satellite-eyes to 1.4.2

### DIFF
--- a/Casks/satellite-eyes.rb
+++ b/Casks/satellite-eyes.rb
@@ -1,11 +1,11 @@
 cask 'satellite-eyes' do
-  version '1.4.1'
-  sha256 '06778b404bb928c81a4861b511b12293762b4f75918fec3ad5967b7f0d29f165'
+  version '1.4.2'
+  sha256 'aab5f1d05ff9a96b33407f85075373569b90f425dee948986cb245fcc5d4373f'
 
   # satellite-eyes.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://satellite-eyes.s3.amazonaws.com/satellite-eyes-#{version}.zip"
   appcast 'https://satellite-eyes.s3.amazonaws.com/appcast.xml',
-          checkpoint: '7aa15b81afb44ee79d373a352b2ea2480da0d95474c394d48e57142514967e9b'
+          checkpoint: 'dd1aad6e1a3ccf91e4ed36daddc83b040efae2b77e74c04a9e4538081d901ee2'
   name 'Satellite Eyes'
   homepage 'http://satelliteeyes.tomtaylor.co.uk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.