### PR TITLE
Update hopper-disassembler to 4.2.15

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.2.14'
-  sha256 '3005c857bda87f80360658273613c0dd4aa54d95707f65cf7393d6c5e15b7bb4'
+  version '4.2.15'
+  sha256 '55d74d126dfccfc20536eb09b2ba0004773b2f8a1c2886d072de41eef8343292'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '176a0d9cf2a3cefa0e4a4a1cc9d125c3a9d77f00647f58475473faf2c023edb4'
+          checkpoint: '05b4561af8e028abb2a21d798a20aa61da7332bf64e538ca132fdc8e175914c2'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.