### PR TITLE
Update packetsender to v5.4.1, 2017-09-01

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,11 +1,11 @@
 cask 'packetsender' do
-  version '5.4.1,2017-08-08'
-  sha256 '63c6886bb85e11ffaa0436d56fc0f07ef24b4b90efab213e2945905f92db612d'
+  version '5.4.2,2017-09-01'
+  sha256 'b65428cda04eadcf956976fe30e9eb78e422c13602ff66f3134e7b6aa48fba7c'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
   url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}/PacketSender_v#{version.before_comma.dots_to_underscores}_#{version.after_comma}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom',
-          checkpoint: '2bf02ae63dae040084a67a6a3554177a8d41b016e2e939621bfd684a8861d2a7'
+          checkpoint: '272e1505776fff4d212eb4f3dd468fb595d3712973cd077e834f99f89baa4055'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'
 


### PR DESCRIPTION
New Packet Sender release.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
