### PR TITLE
Update iconjar to 1.5.1,23478:1502744181

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,11 +1,11 @@
 cask 'iconjar' do
-  version '1.5.0,23382:1501437355'
-  sha256 '51b024ae70a448ca45e6e851e8d7f0f6da88b67f4dcc93dfbc5ba18a5f41274e'
+  version '1.5.1,23478:1502744181'
+  sha256 'afb6e99284816e918c283ddae31a8b1726b12a6511af7391e8b062fef41001a0'
 
   # dl.devmate.com/com.iconjar.iconjar was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.iconjar.iconjar/#{version.after_comma.before_colon}/#{version.after_colon}/Iconjar-#{version.after_comma.before_colon}.zip"
   appcast 'https://updates.devmate.com/com.iconjar.iconjar.xml',
-          checkpoint: 'fb5f4480508778dd008a650894156f5bc0d5f241ac85a4b34943e02b8ed58e46'
+          checkpoint: '52d71a83f754582fe7c2491204fe5778a64d607d5d7e85f6bc7fd266f06967f1'
   name 'IconJar'
   homepage 'https://geticonjar.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.