### PR TITLE
Upgrade FontForge.app to 20170731

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,11 +1,11 @@
 cask 'fontforge' do
-  version '20161005'
-  sha256 '30398f6e0ee7cff1c4dd77297fc9ae550dd554538fc7dcde00bb77903d183144'
+  version '20170731'
+  sha256 '980c66e00f0f5c7a722eadd8b78a0ef2b20a7ccd952149cbfdfeaae9e66e4d4e'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
-  url "https://github.com/fontforge/fontforge/releases/download/#{version}/FontForge-20161004-Mac.zip"
+  url "https://github.com/fontforge/fontforge/releases/download/#{version}/FontForge-20170730-Mac.dmg"
   appcast 'https://github.com/fontforge/fontforge/releases.atom',
-          checkpoint: 'd6f82294326df6025cb352188bcc48ec0a1fba2beb3a18b7bd54602518598a9f'
+          checkpoint: 'aa306109b766f07dd7d0a1b7bea26df861d85c35d813a424d470b70539d084ed'
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.