### PR TITLE
Update metasploit to 4.16.5+20170902102008

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.4+20170829163706.git.3.7235e4c'
-  sha256 '482345ca14f5664e50d07c8f5b23bac1d1d753dda357e85e43e5bfdf0eaf6587'
+  version '4.16.5+20170902102008'
+  sha256 '9e79ea41a8aaa7a9a90268babd204de7dea1a8aa4263d525ea4cdf4274797b9a'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '0c20f967ce47e83fa3fc67e719a0ff160b1fe5f91b4722d1639e483c633a35bf'
+          checkpoint: 'b2fc482cf7ac0ed18674258cfba7ce8d4e848b3a205826bfe703f921b0cb0f5b'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.