### PR TITLE
Update amm to 0.4.3

### DIFF
--- a/Casks/amm.rb
+++ b/Casks/amm.rb
@@ -1,10 +1,10 @@
 cask 'amm' do
-  version '0.4.2'
-  sha256 '95286bf5237c31bb8c8bff5013aca580625d499a96889251e049bbd0c32f38d8'
+  version '0.4.3'
+  sha256 '181410cc890f9f13fb7500fcda3b51be205f150ab6ee8706340429f07d750510'
 
   url "https://github.com/15cm/AMM/releases/download/v#{version}/AMM_v#{version}.dmg"
   appcast 'https://github.com/15cm/AMM/releases.atom',
-          checkpoint: 'acc5467eb73151d7f5e848ddf38308e51c2ab71d57674de50603a45230074310'
+          checkpoint: 'bf9903a6b584c3024b65045d8633ca4bfa112177af58af044f52f6fc263f04bd'
   name 'AMM'
   homepage 'https://github.com/15cm/AMM'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.