### PR TITLE
Update arq to 5.9.2

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,10 +1,10 @@
 cask 'arq' do
-  version '5.9.1'
-  sha256 '03b65bf90bfa6374e9969f6144e8d3d1ca8c1bbde495fb499566ed566d734025'
+  version '5.9.2'
+  sha256 'a4f1b25d0d3848df6dc9eeb095891234f6ff13974ffae1076480d829028d9b4f'
 
   url "https://www.arqbackup.com/download/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arq#{version.major}.xml",
-          checkpoint: '5793fd0f019458cb2050a2879293e1140ff8e31bbda0e0f6b8361e5be4ab7680'
+          checkpoint: '2d6445a7dfb0f6294a15081a5ecb9cafdefbe02ef4459517b56441d7d5bb3738'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.