### PR TITLE
Update now to 2.5.0

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.4.2'
-  sha256 'b5974ee8a8522961af2392c021466d0aa74b5b3615dbec3529b64610b41bfa78'
+  version '2.5.0'
+  sha256 '32089bde0497058db369984dd001efa60ccc290f5690f93e6cf2ba337637cca1'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'e4f5e47b5f2306bef3edbfe4409bf5e4e817368cdb3e73eacddc6ad41499ff42'
+          checkpoint: '2b012db5fee403c24704bdc95676f62bb6977f39ea6c55bf1dab78c2a13da980'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.