### PR TITLE
Update brisk to 1.1.2

### DIFF
--- a/Casks/brisk.rb
+++ b/Casks/brisk.rb
@@ -1,10 +1,10 @@
 cask 'brisk' do
-  version '1.1.1'
-  sha256 '0a4ba3fe9a48ad95ebd313b09dab57e11b1940238019bbb9e77ce72dc2c3864b'
+  version '1.1.2'
+  sha256 '5bc8e1e72cae618045875f1fbed9102413f056ea19b3c46dadf430ae618ae40e'
 
   url "https://github.com/br1sk/brisk/releases/download/#{version}/Brisk.app.tar.gz"
   appcast 'https://github.com/br1sk/brisk/releases.atom',
-          checkpoint: 'caf4d4d20cb70c806f92e01d30b8e8dc213da21c54a1449a37b18f5d7ea50cca'
+          checkpoint: '6b691d92be5028c5ddbdd74e1f7627d59ace0cac77eba41d2c42f33a04336287'
   name 'Brisk'
   homepage 'https://github.com/br1sk/brisk'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.