### PR TITLE
Update xtrafinder to 0.27

### DIFF
--- a/Casks/xtrafinder.rb
+++ b/Casks/xtrafinder.rb
@@ -1,6 +1,6 @@
 cask 'xtrafinder' do
-  version '0.26'
-  sha256 '09714b41e29496465986f776b6a6b7e401258656c8eb0ec1c04928f582d0b2f7'
+  version '0.27'
+  sha256 'dd34c5eeb5b5330ab341ebe9beeb033911239d316f7ced30be0009dd1dd1ec3e'
 
   url 'https://www.trankynam.com/xtrafinder/downloads/XtraFinder.dmg'
   appcast 'https://www.trankynam.com/xtrafinder/XtraFinder-Appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.