### PR TITLE
Update vienna to 3.1.12

### DIFF
--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,11 +1,11 @@
 cask 'vienna' do
-  version '3.1.11'
-  sha256 '3c1d425c2499c5ad4acc231829c05c004cfeb64b9e2c598ac31baa53370d1be3'
+  version '3.1.12'
+  sha256 '094a28b1f4a7f62d5073ace41bc0281d46d8e2214f8db5efe33601f49d19a405'
 
   # bintray.com/viennarss was verified as official when first introduced to the cask
   url "https://dl.bintray.com/viennarss/vienna-rss/Vienna#{version}.tar.gz"
   appcast 'https://viennarss.github.io/sparkle-files/changelog.xml',
-          checkpoint: '4f5b48c2237f8935566e6f40048e7f557aec30e28ef509074cd6efb71e7eb0b9'
+          checkpoint: '24c69d084e38f3e71f09fa2eea536cf9452d3702a67eb011b565bfb779ba2c9b'
   name 'Vienna'
   homepage 'http://www.vienna-rss.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.