### PR TITLE
Update telegram to 3.2-104070

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.1.1-101770'
-  sha256 'e9362eab45998b28d6d4946741ecc7652474d7ab002ead9552094f1d49a093af'
+  version '3.2-104070'
+  sha256 '8f1d1c0a6e6e4b937207d1386a3923b0bdda3fd30e491317e21bb17879d8dbd5'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '7faa9ab246ce31cfbf8357e8dd80e733a33763658c4fdb523ddacbf9b9f34dfc'
+          checkpoint: '279f649bbe40ffc5260ba80bd3f7c595fa63d417539a5ec334a7e47dba91ef57'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.
