### PR TITLE
Update vuescan to 9.5.84

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.82'
-  sha256 '6dc65687bc41a721ad6ff05d2f98bfffabd983064f240ae311901722bc8fec2b'
+  version '9.5.84'
+  sha256 '7187b58a0c0bc86c73bb2bf3ecb01f4e0264ed2f8d9efced4e370e4bb3aeb1ae'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: 'cb79c782f7d4c997550dd4f35fbe96925034166966c7fce846d36ce72547b164'
+          checkpoint: '5cb317c34f55aac7d9b6d82913da74e621290053dbac6a77bca10e85bf454f3e'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.