### PR TITLE
Update Codeship Jet to v1.19.3

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,11 +1,11 @@
 cask 'jet' do
-  version '1.19.0'
-  sha256 '7247424d9dc760efe7faae4f9621c156ea3070a5ffc90bb24819cfb5234aefac'
+  version '1.19.3'
+  sha256 '355c4073cd6bf5f5dadf779749cba472ab09aaccbebef1379bcc2747f9c423d4'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"
   name 'Codeship Jet'
-  homepage 'https://documentation.codeship.com/pro/'
+  homepage 'https://documentation.codeship.com/pro/builds-and-configuration/cli/'
 
   binary 'jet'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
