### PR TITLE
Fix checksum in appcast and add zap to BitPay.app

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -5,10 +5,12 @@ cask 'bitpay' do
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'de673f5a2182368cbb1d0edf10d9d68c99cbecc3391b06d4e834467abe21696c'
+          checkpoint: 'a489cf8938c1d1b05fc10ddc9101271030b52fa78d17d81315eac244e7bdfd23'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'
 
   app 'BitPay.app'
+
+  zap trash: '~/Library/Application Support/bitpay'
 end


### PR DESCRIPTION
- The appcast checksum was incorrect, it now passes audits.
- The Cask did not have a zap stanza to delete user settings, it now does.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version. (It only includes name, version is unchanged).

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below. (No, because neither the version or the main checksum have changed).

Additionally, if **adding a new cask**:

(Not adding a new cask).

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256