### PR TITLE
Update 360-total-security to 1.1.2

### DIFF
--- a/Casks/360-total-security.rb
+++ b/Casks/360-total-security.rb
@@ -4,7 +4,7 @@ cask '360-total-security' do
 
   url "https://free.360totalsecurity.com/totalsecurity/mac/360ts_mac_#{version}.dmg"
   appcast 'https://www.360totalsecurity.com/en/version/360-total-security-mac/',
-          checkpoint: 'c685b0fff73b631e5eaa20e1ac07d37999807191be9e297fef3ac70378f7cf42'
+          checkpoint: 'a265dc1b1421f71e170af65ba5e703d608f46a6ef703bfd8b37b4a65212067fd'
   name '360 Total Security'
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.