### PR TITLE
Update telegram to 3.2-104075

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.2-104070'
-  sha256 '8f1d1c0a6e6e4b937207d1386a3923b0bdda3fd30e491317e21bb17879d8dbd5'
+  version '3.2-104075'
+  sha256 '28c16afb4500073ddfb6d835c9c5a6c276af9ff50a503e5759e62c0cb805d514'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '279f649bbe40ffc5260ba80bd3f7c595fa63d417539a5ec334a7e47dba91ef57'
+          checkpoint: '98c8f9d48f220460227fe66cc5743524f56e664fb9f9567587aca709deb8d20d'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.