### PR TITLE
Update exodus to 1.33.2

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.33.1'
-  sha256 'e2fc7862492350f7fbda02df8757d41b99c007040690fef1d6f698d77ffb86b8'
+  version '1.33.2'
+  sha256 '64f289fd74ca04f06063dbbad3310ac6bb57dda55e51749d018e6fabc8f82eca'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: 'ffb83d411b6d5b6cbde18e0167ed4de9710fe2722c50cd797ab04ca7d5770968'
+          checkpoint: '567a0ecd874058dc4a8d2233340866131d07bbda35ece1885717228989ad9abd'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.