### PR TITLE
Update telegram-desktop to 1.1.22

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -1,11 +1,11 @@
 cask 'telegram-desktop' do
-  version '1.1.21'
-  sha256 '1507f8ed633174ef60dbb88af1688750a50257d84ec3134007df1ad3c48cef1c'
+  version '1.1.22'
+  sha256 'cf8e6da873d9a91619ccafd6166d21f24b835903919ae06ad73be17c8279b41e'
 
   # github.com/telegramdesktop/tdesktop/releases/download was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"
   appcast 'https://github.com/telegramdesktop/tdesktop/releases.atom',
-          checkpoint: 'ad2bfcb10c8e8dc20132c01f1e463ba0c31719a8421e653e52cdeba00a5ca511'
+          checkpoint: 'b00074dceadef03399305ffb349f69974ff77ec943f119217a0c555412f6af30'
   name 'Telegram Desktop'
   homepage 'https://desktop.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.