### PR TITLE
Update polymail to 1.44

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.43'
-  sha256 '8b0c5beebcbdb164137a428c4b58c57a818efe66f92e581c2d95b146dad7dece'
+  version '1.44'
+  sha256 '220fccabca5e6f3eed9f6304f77f484839c2a41b197c26e0a8b95bc43fd47580'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'cf84dceae53d4240f02ced76d299bd5e8131332a4702b5e3417dc06778b01f47'
+          checkpoint: 'cc0e83cc80221e25ce65736c7ca619b0f0c0c59c3ad17b61a045dec0d564499f'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}