### PR TITLE
Update mp3tag to 2.84a

### DIFF
--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -1,10 +1,10 @@
 cask 'mp3tag' do
-  version '2.82'
-  sha256 'a74dfc61889240468b2d4c05c86a712a2c148162e777696782007f09c3c9f87b'
+  version '2.84a'
+  sha256 'b4e7ac357e8359ea99492c420f019aa600bf291b65b9dd3637620732fe00502f'
 
-  url "http://download.mp3tag.de/mp3tagv#{version.no_dots}-MacOSX-Wine.zip"
+  url "http://download.mp3tag.de/mp3tagv#{version.no_dots}-macOS-Wine.zip"
   name 'MP3TAG'
   homepage 'http://www.mp3tag.de/en/'
 
-  app "mp3tagv#{version.no_dots}-MacOSX-Wine/Mp3tag.app"
+  app "mp3tagv#{version.no_dots}-macOS-Wine/Mp3tag.app"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.