### PR TITLE
Update mattermost to 3.7.1

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -4,7 +4,7 @@ cask 'mattermost' do
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: 'c6603f09018f6b6aed410862479a67886be33e32f00ac331da6e9e2105e35858'
+          checkpoint: '547ac8a75d459980ae21a9fbd2de8188a04b9c6aefc6a6d987435a182f51dbf5'
   name 'Mattermost'
   homepage 'https://about.mattermost.com/'
 

--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,10 +1,10 @@
 cask 'mattermost' do
-  version '3.7.0'
-  sha256 '9d5c7a870b85dc162c5d761dee00532c78817d38cc2b11ba8038d3ca35ac2a83'
+  version '3.7.1'
+  sha256 'b9d280b90825795c04ecd3092a921fbc1681304ed9bbad36661c64cc1ea2a335'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: 'cf4f4fa6b146283e79f00671d03436a610b973475bdf774a24a2f43e8128fc41'
+          checkpoint: 'c6603f09018f6b6aed410862479a67886be33e32f00ac331da6e9e2105e35858'
   name 'Mattermost'
   homepage 'https://about.mattermost.com/'
 

--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
   version '3.7.1'
-  sha256 'b9d280b90825795c04ecd3092a921fbc1681304ed9bbad36661c64cc1ea2a335'
+  sha256 '348c9321ee81114794d098998490a64f99b511497cd6b95454420685301e115a'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.