### PR TITLE
Update ngrok to 2.2.8

### DIFF
--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -1,6 +1,6 @@
 cask 'ngrok' do
-  version :latest
-  sha256 :no_check
+  version '2.2.8'
+  sha256 'ad6b987444321929d3338f3ca8267fffb63d91d4cbb8723b353ed8a8726c51c9'
 
   # bin.equinox.io was verified as official when first introduced to the cask
   url 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.