### PR TITLE
Update viscosity to 1.7.4

### DIFF
--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,10 +1,10 @@
 cask 'viscosity' do
-  version '1.7.3'
-  sha256 'e28e9a3e0f02198eee105d73cc8b867cef6b05a2239974349d1a13e4ece6eadb'
+  version '1.7.4'
+  sha256 'c92579006cef1cf2ec34722d8629b2847aa64177ee79e06ed2ea7cacd8ad01d2'
 
   url "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%20#{version}.dmg"
   appcast 'https://swupdate.sparklabs.com/appcast/mac/release/viscosity/',
-          checkpoint: '328ccdcdabed28c790cb1de6439b175dad597bb36ec6b2df19b52aba63f34a43'
+          checkpoint: '0244a672b9a81852460cd9192fa6afda6f821f1a59bc68f7e9e46513e2c557f7'
   name 'Viscosity'
   homepage 'https://www.sparklabs.com/viscosity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.