### PR TITLE
Update wingide to 6.0.7-1

### DIFF
--- a/Casks/wingide.rb
+++ b/Casks/wingide.rb
@@ -1,6 +1,6 @@
 cask 'wingide' do
-  version '6.0.6-1'
-  sha256 '01bfc10c433faea67d7afe0c7b1279347abd0639dda84b91eebbbaecc7192070'
+  version '6.0.7-1'
+  sha256 '4f577ad8f5083b828f43863119a625ac66c68c3f282e1234e667ed410d0427cb'
 
   url "https://wingware.com/pub/wingide/#{version.sub(%r{-\d+}, '')}/wingide-#{version}.dmg"
   name 'WingIDE'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.