### PR TITLE
Update freesmug-chromium to 61.0.3163.79

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '60.0.3112.113'
-  sha256 'ebdbcdb244f1b80a4ee8e2829f7fda826d0ccda64bd462764103f00a3dbbea0a'
+  version '61.0.3163.79'
+  sha256 'deba35e6ee962a9a772615084ede3f51b8403328f3c8a442568adf3c8e538e67'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: 'd974b533339f427cd0843c7e5516e42428390413f8d388c3b21beb0d946f4512'
+          checkpoint: '54def49cdfb89caad24773d89a855264dacb4e153f3e27d8f4b5f83f82142f5c'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.