### PR TITLE
Update rambox to 0.5.11

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,11 +1,11 @@
 cask 'rambox' do
-  version '0.5.10'
-  sha256 '7d2c6bbacf361d73bfb59e2dd714f8664be5cc45b476f11502a8603b9e0ac097'
+  version '0.5.11'
+  sha256 'f0f10974e40921ffcc54f9b2c6e8f1a8f451109f27223c1b4f6a967e8785f526'
 
   # github.com/saenzramiro/rambox was verified as official when first introduced to the cask
-  url "https://github.com/saenzramiro/rambox/releases/download/#{version}/Rambox-#{version}.dmg"
+  url "https://github.com/saenzramiro/rambox/releases/download/#{version}/Rambox-#{version}-mac.zip"
   appcast 'https://github.com/saenzramiro/rambox/releases.atom',
-          checkpoint: '43453ca275449cfb6212d33fe7b6605497e4d0c093b7ba2bf1ad2db3be6a6e16'
+          checkpoint: 'f25a6a527cb4b06e1c56c8b286a550290f1cece157876dcdccaeed9b5b75716d'
   name 'Rambox'
   homepage 'http://rambox.pro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.