### PR TITLE
Update docker to 17.06.2-ce-mac27,19124

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '17.06.1-ce-mac24,18950'
-  sha256 'b2614dba7a75eb31c5f00ee3a80341c50903a797349559fd90e815aa945bc573'
+  version '17.06.2-ce-mac27,19124'
+  sha256 '2622992cb2e56291748548e904b1e19c22e947b73dd7012535efedf1de86122a'
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: '981d89d39c4a5395475ced1e02cdc384c6b4f39a663b1c2809450daa75011033'
+          checkpoint: 'bfc1c47f408ed0781822f9e36912d1dee69f75659223b96f5fe220c86e0b79fe'
   name 'Docker Community Edition'
   name 'Docker CE'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.