### PR TITLE
Update cubicsdr to 0.2.2

### DIFF
--- a/Casks/cubicsdr.rb
+++ b/Casks/cubicsdr.rb
@@ -5,7 +5,7 @@ cask 'cubicsdr' do
   # github.com/cjcliffe/CubicSDR was verified as official when first introduced to the cask
   url "https://github.com/cjcliffe/CubicSDR/releases/download/#{version}/CubicSDR-#{version}-Darwin.dmg"
   appcast 'https://github.com/cjcliffe/CubicSDR/releases.atom',
-          checkpoint: '5683e9da113bc2e07f43b57837d80d02ac3853df256b34a9bbd8eb76e633d842'
+          checkpoint: '6ca500dc8de9dafd9b142be8c3b40120b19809cd19d7bc610b19ee0ab7c9ae64'
   name 'CubicSDR'
   homepage 'http://cubicsdr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}