### PR TITLE
Update cumulus to 0.10.1

### DIFF
--- a/Casks/cumulus.rb
+++ b/Casks/cumulus.rb
@@ -5,7 +5,7 @@ cask 'cumulus' do
   # github.com/gillesdemey/Cumulus was verified as official when first introduced to the cask
   url "https://github.com/gillesdemey/Cumulus/releases/download/v#{version}/Cumulus-#{version}.dmg"
   appcast 'https://github.com/gillesdemey/Cumulus/releases.atom',
-          checkpoint: '23d90b127f93df3db3c2199508ea31d3ce850699ceb937f505d33f389b7c8d9b'
+          checkpoint: '8e41bcf826fc11c3d86f122294242fe3a15ccadc45b55652afb3ffdcca7a0eb3'
   name 'Cumulus'
   homepage 'https://gillesdemey.github.io/Cumulus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}