### PR TITLE
Update blocs to 2.4.1

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,11 +1,11 @@
 cask 'blocs' do
-  version '2.4.0'
-  sha256 'db25b668409208e2bb99c9944db96cc4e9269d2ea95a4bcd1983c87f54dd5fe5'
+  version '2.4.1'
+  sha256 'f022bf425eda5e1ff55821eef6deab8ce51a8fc3891d69f89820638c16fdd462'
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
   appcast "https://uistore.io/blocs/#{version.major}.0/info.xml",
-          checkpoint: '91ed25ffc6ca9d764691883d477d40e081406452de328d0bac46dbcd515b13d3'
+          checkpoint: 'e469d67b60a6064df706e56c98de6803affeadc8c7f9f0f94520e7eaeb969ebb'
   name 'Blocs'
   homepage 'https://blocsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.