### PR TITLE
Update buttercup to 0.20.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.18.2'
-  sha256 '50363f92e9200348401730f7c77373ebdb4db784693ff98190cfddd6b947a4e7'
+  version '0.20.0'
+  sha256 'a59cb86f0a87fcf4d06091aa100f523afd1d00034158d3ec16180c11645e9fec'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '3a9d8e91cfbd9a4402e807c0d3af5de29a18350ce750d02f98df826c505c9a7c'
+          checkpoint: '3edcf38a0cff67ae04b4f5f3ae4f0d9fd639d3d84ddb3ef2d8e0ae3a9c590aea'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.