### PR TITLE
Update byteball to 1.10.1

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,11 +1,11 @@
 cask 'byteball' do
-  version '1.10.0'
-  sha256 '7180e99ae30db400955e29cc8b87c138c0f7d6d5640636f7c7bc0c44feea3348'
+  version '1.10.1'
+  sha256 'dfa748bfc055133b2da9d8c5d66294b2c7d0983398e0b38a719a9610763ef947'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"
   appcast 'https://github.com/byteball/byteball/releases.atom',
-          checkpoint: '566d628ad47525ad75c4ca0692845a0d63d7167f7fc0618c4f0e3677432915b3'
+          checkpoint: '94fb6f10ab5d85357cad4af114143e92e22ea60b2f0a0c29b19d5c0d7464b6a3'
   name 'Byteball'
   homepage 'https://byteball.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.