### PR TITLE
Update bluemix-cli to 0.5.6

### DIFF
--- a/Casks/bluemix-cli.rb
+++ b/Casks/bluemix-cli.rb
@@ -1,6 +1,6 @@
 cask 'bluemix-cli' do
-  version '0.5.4'
-  sha256 '9d9df4be6faaef93395de4737f45a153c689c2b3425bd157b4dd18dac1b24549'
+  version '0.5.6'
+  sha256 '2157d7bf92328e5e3e7e122feaf0a69c8c2d30aa8cef812fb45582002c41fd57'
 
   # public.dhe.ibm.com was verified as official when first introduced to the cask
   url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.