### PR TITLE
Update trim-enabler: uninstall / zap

### DIFF
--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -1,34 +1,31 @@
 cask 'trim-enabler' do
-  if MacOS.version <= :snow_leopard
-    version '2.2'
-    sha256 '3d9a7ad184435c05c4d8d5bf74484dcd9ac0f6eeb6a7a78e22709ca1557ff108'
-    url 'https://cindori.org/trimenabler/TrimEnabler_old.dmg'
-  elsif MacOS.version <= :mavericks
-    version '3.6.3'
-    sha256 'd07165d76714abf34537dc1dfd8219b501236c9b5a44a91065dede7ab79883fd'
-    # amazonaws.com/cindori was verified as official when first introduced to the cask
-    url 'https://s3.amazonaws.com/cindori/TrimEnabler.dmg'
-  else
-    version :latest
-    sha256 :no_check
-    url 'https://dl.devmate.com/org.cindori.TrimEnabler4/TrimEnabler.zip'
-  end
+  version '4'
+  sha256 :no_check # required as upstream package is updated in-place
 
+  # dl.devmate.com/org.cindori.TrimEnabler was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/org.cindori.TrimEnabler#{version}/TrimEnabler.zip"
   name 'Trim Enabler'
   homepage 'https://cindori.org/trimenabler/'
 
+  depends_on macos: '>= :yosemite'
+
   app 'Trim Enabler.app'
 
+  uninstall delete:    '/Library/PrivilegedHelperTools/org.cindori.TEHelper',
+            launchctl: 'org.cindori.TEHelper'
+
   zap delete: [
-                '/Library/LaunchDaemons/org.cindori.TEHelper.plist',
-                '/Library/PrivilegedHelperTools/org.cindori.TEHelper',
-                '~/Library/Application Support/CrashReporter/Trim Enabler_*.plist',
+                "~/Library/Caches/org.cindori.TrimEnabler#{version}",
+                "~/Library/Caches/com.plausiblelabs.crashreporter.data/org.cindori.TrimEnabler#{version}",
+                "~/Library/Cookies/org.cindori.TrimEnabler#{version}.binarycookies",
+                "~/Library/Logs/DiagnosticReports/Trim Enabler_#{version}.crash",
+                "~/Library/Saved Application State/org.cindori.TrimEnabler#{version}.savedState",
+              ],
+      trash:  [
+                "~/Library/Application Support/CrashReporter/Trim Enabler_#{version}.plist",
+                "~/Library/Application Support/org.cindori.TrimEnabler#{version}",
                 '~/Library/Application Support/Trim Enabler',
-                '~/Library/Application Support/org.cindori.TrimEnabler4',
-                '~/Library/Caches/org.cindori.TrimEnabler4',
-                '~/Library/Cookies/org.cindori.TrimEnabler4.binarycookies',
-                '~/Library/Logs/DiagnosticReports/Trim Enabler_*.crash',
                 '~/Library/Preferences/org.cindori.TrimEnabler.plist',
-                '~/Library/Preferences/org.cindori.TrimEnabler4.plist'
+                "~/Library/Preferences/org.cindori.TrimEnabler#{version}.plist",
               ]
 end

--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -18,4 +18,17 @@ cask 'trim-enabler' do
   homepage 'https://cindori.org/trimenabler/'
 
   app 'Trim Enabler.app'
+
+  zap delete: [
+                '/Library/LaunchDaemons/org.cindori.TEHelper.plist',
+                '/Library/PrivilegedHelperTools/org.cindori.TEHelper',
+                '~/Library/Application Support/CrashReporter/Trim Enabler_*.plist',
+                '~/Library/Application Support/Trim Enabler',
+                '~/Library/Application Support/org.cindori.TrimEnabler4',
+                '~/Library/Caches/org.cindori.TrimEnabler4',
+                '~/Library/Cookies/org.cindori.TrimEnabler4.binarycookies',
+                '~/Library/Logs/DiagnosticReports/Trim Enabler_*.crash',
+                '~/Library/Preferences/org.cindori.TrimEnabler.plist',
+                '~/Library/Preferences/org.cindori.TrimEnabler4.plist'
+              ]
 end


### PR DESCRIPTION
Zap stanza added to TrimEnabler

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
