### PR TITLE
Update cartographica to 1.4.8

### DIFF
--- a/Casks/cartographica.rb
+++ b/Casks/cartographica.rb
@@ -1,11 +1,11 @@
 cask 'cartographica' do
-  version '1.4.7'
-  sha256 '12a559c076cca3f4c0e3b59edf79a7f0ddec38d140ded7016c31a4fcc59ce6cc'
+  version '1.4.8'
+  sha256 '82fed47a4da82dcb149d8337db219037e23389f359b8f0c5e24568126c1dea5d'
 
   # cluetrust.com was verified as official when first introduced to the cask
   url 'https://www.cluetrust.com/Downloads/Cartographica.dmg'
   appcast 'https://www.cluetrust.com/AppCasts/Cartographica.xml',
-          checkpoint: '9f4ea3a33cf21d744dc3d25f7ab12f7a2dfa4216c2dd389ac8511e629e07b85f'
+          checkpoint: '4724e8450e080ac2e780cba94651b1ff312333a68d3682c48c6c2e76bc10d951'
   name 'Cartographica'
   homepage 'https://www.macgis.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.