### PR TITLE
Update witgui to 2.2.7

### DIFF
--- a/Casks/witgui.rb
+++ b/Casks/witgui.rb
@@ -1,10 +1,10 @@
 cask 'witgui' do
-  version '2.2.6'
-  sha256 'd147cf2d06623641a0e2b49bb5780e7f20a8da5d71e68aa067fad837dc678e8b'
+  version '2.2.7'
+  sha256 '2c30472736110d77c9de26dea37fa1f695a15bcceca148d551a2ef9a9389970f'
 
   url "http://desairem.altervista.org/witgui/download.php?version=#{version}"
   appcast 'http://desairem.altervista.org/witgui/appcast.xml',
-          checkpoint: '385d3a172a15b155e9ed72e5f41c14ed4c3d6cd696a978814e92c3d297eeb884'
+          checkpoint: '5f94e932722b7e10c080a3d6fb92f70fe88f0aa06d13a1bf3b22a53eba05d349'
   name 'Witgui'
   homepage 'http://desairem.altervista.org/wordpress/witgui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.