### PR TITLE
Update webrecorder-player to 1.0.5

### DIFF
--- a/Casks/webrecorder-player.rb
+++ b/Casks/webrecorder-player.rb
@@ -1,10 +1,10 @@
 cask 'webrecorder-player' do
-  version '1.0.4'
-  sha256 '7cfe5db210b0d0a371346f40ba6ab098a3509bfe8c1cea4072945b8b3db93686'
+  version '1.0.5'
+  sha256 '43b6a05068d867b39e2c7b596485c611b43ddf7afbe0f13109c5a1e93eeffcc2'
 
   url "https://github.com/webrecorder/webrecorderplayer-electron/releases/download/v#{version}/webrecorderplayer-electron-#{version}.dmg"
   appcast 'https://github.com/webrecorder/webrecorderplayer-electron/releases.atom',
-          checkpoint: '13eef2224833812bfc2608d1a88a2f12177a3ba7b356668c64099abc62a3f5cc'
+          checkpoint: '4b1bd7d5071576486bbbacf42051b1ffb59cb3f55c15182b885b835da7222e0d'
   name 'Webrecorder Player'
   homepage 'https://github.com/webrecorder/webrecorderplayer-electron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.