### PR TITLE
Update story-writer to 3.2.0

### DIFF
--- a/Casks/story-writer.rb
+++ b/Casks/story-writer.rb
@@ -1,11 +1,11 @@
 cask 'story-writer' do
-  version '3.1.1'
-  sha256 'fc381d66ac8db4a81833ed024603405cb5cef626d0d00d18b47df97f6541737c'
+  version '3.2.0'
+  sha256 '491d0418abfc79caf753b5291bcbd9133f33c2fbd945099dba52968c1c333b9b'
 
   # github.com/suziwen/markdownxiaoshujiang was verified as official when first introduced to the cask
   url "https://github.com/suziwen/markdownxiaoshujiang/releases/download/v#{version}/Story-writer-osx64.zip"
   appcast 'https://github.com/suziwen/markdownxiaoshujiang/releases.atom',
-          checkpoint: '04fe34d677d7250f1295653b23de040bfcce1809e7f2874165a360d490b61e79'
+          checkpoint: '39dd9ac6bd55b0a98ec9efd160bbed229e28b836f56b4cbbb7dd318798d57a29'
   name 'Story Writer'
   homepage 'http://soft.xiaoshujiang.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.