### PR TITLE
Update steveschow-gfxcardstatus to 2.4.4i

### DIFF
--- a/Casks/steveschow-gfxcardstatus.rb
+++ b/Casks/steveschow-gfxcardstatus.rb
@@ -1,10 +1,10 @@
 cask 'steveschow-gfxcardstatus' do
-  version '2.4.3i'
-  sha256 '511ebc665cff319186753213684bf44bb7d0517716e65bd19ffd8db2fac2113e'
+  version '2.4.4i'
+  sha256 '69c0d6602808cca60158a6d833eab8d82d59f683d3c25de34d977c83fe208dd0'
 
   url "https://github.com/steveschow/gfxCardStatus/releases/download/v#{version}/gfxCardStatus.app.zip"
   appcast 'https://github.com/steveschow/gfxCardStatus/releases.atom',
-          checkpoint: 'd567b3d2bd83568e434fac95018230436e5c14ea832e30279e2a43a9815ef6f5'
+          checkpoint: '74b2f5f7a67db8d1b780184557a8fa4c981b86a7414bd7ea951e72034fbf249f'
   name 'gfxCardStatus'
   homepage 'https://github.com/steveschow/gfxCardStatus'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.