### PR TITLE
Update stella to 5.0.2

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,11 +1,11 @@
 cask 'stella' do
-  version '5.0.1'
-  sha256 'e8339f66b23a18eb73af304c6ba55740fa09a7e248fad87ba23f63e1336c351c'
+  version '5.0.2'
+  sha256 'f09be7c5419276da275488a734fc5b27c3d37ac1bc0fe77445ec568f42f7fa26'
 
   # github.com/stella-emu/stella/releases/download was verified as official when first introduced to the cask
   url "https://github.com/stella-emu/stella/releases/download/#{version}/Stella-#{version}-macosx.dmg"
   appcast 'https://github.com/stella-emu/stella/releases.atom',
-          checkpoint: '611f56c8e6171c42253e5b4f7a134f5445f1cb712297af18d4c366894c2d4472'
+          checkpoint: '6bedf88b8daec318a44ecd520a27095db806df6d9b1b92494778883eb4be7713'
   name 'Stella'
   homepage 'https://stella-emu.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.