### PR TITLE
Update screenflick to 2.7.27

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,10 +1,10 @@
 cask 'screenflick' do
-  version '2.7.26'
-  sha256 'ff15883534369658225eb2a830169cd9ba1b30167db8e2e8de1c601f6ab695a4'
+  version '2.7.27'
+  sha256 '12fa339ded27f11c444e421ec688f94ac14ae3f276cbfdb3952456badc53de6a'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml",
-          checkpoint: 'e2118080efe6b2cbe7f2a8b932f895a74982e3590f1c7787e2d836e2797514b8'
+          checkpoint: '950fb37bb1bbcf0abef5a7518d1f67de79951b7417f121e0cdd47f5dd8e6ef04'
   name 'Screenflick'
   homepage 'https://www.araelium.com/screenflick/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
