### PR TITLE
Add 1Password-CLI v0.1

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -2,9 +2,12 @@ cask '1password-cli' do
   version '0.1'
   sha256 'fccec086ef70d9fab464c8e5cb4b1748236cb7633c9aae52512fd6502686ad09'
 
-  url "https://cache.agilebits.com/dist/1P/op/pkg/v0.1/op_darwin_amd64_v#{version}.zip"
+  # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
+  url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"
+  appcast 'https://app-updates.agilebits.com/product_history/CLI',
+          checkpoint: 'd33d33c7e3ee8eecdc68d529fd81c8a5291bce8ebf3125e674e58870ec039823'
   name '1Password CLI'
-  homepage 'https://app-updates.agilebits.com/product_history/CLI'
+  homepage 'https://support.1password.com/command-line/'
 
   binary 'op'
 end

--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,0 +1,10 @@
+cask '1password-cli' do
+  version '0.1'
+  sha256 'fccec086ef70d9fab464c8e5cb4b1748236cb7633c9aae52512fd6502686ad09'
+
+  url "https://cache.agilebits.com/dist/1P/op/pkg/v0.1/op_darwin_amd64_v#{version}.zip"
+  name '1Password CLI'
+  homepage 'https://app-updates.agilebits.com/product_history/CLI'
+
+  binary 'op'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

The official token name for this should be `op`, but that's a bit cryptic when searching/listing. Additionally, there is already a `1password` cask, so `1password-cli` shows up nicely next to when listing installed casks and searching.
