### PR TITLE
Update qt-creator to 4.4.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.3.1'
-  sha256 '0098a420d43578b064382a73a706bf145ed04e352277a9609ee2970b6146d546'
+  version '4.4.0'
+  sha256 'd9e3de1116cc32605452ff6c5ff564e0803c913c8746c21d6efde15c09fc3a23'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.


