### PR TITLE
Update transmit to 5.0.3

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,10 +1,10 @@
 cask 'transmit' do
-  version '5.0.1'
-  sha256 '0ca64381d9b2e6970a7e43340ad53d90fc1ec8eb0f6e354d27e307d3dd9b957f'
+  version '5.0.3'
+  sha256 'b4a38fac2c7ae3c39a4aacf6f6029cdbe3a4f5775f1d594812359c168e02e1f7'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}",
-          checkpoint: '2e117f0d3f16d822f081af54d85db24ac224c6ed4f9951d135f4e5a44b13a88d'
+          checkpoint: 'bca72152497f631aea8bd4bd44a6f792cc45cbf167f497f31b8a2eac8405a25a'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 

--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -4,7 +4,7 @@ cask 'transmit' do
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}",
-          checkpoint: 'bca72152497f631aea8bd4bd44a6f792cc45cbf167f497f31b8a2eac8405a25a'
+          checkpoint: '015159a7a1fd6a1cb14729e22fd4d2bb6b561539c084e9dac15f2cba4ae13392'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.