### PR TITLE
Update brave to 0.18.29

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.18.23'
-  sha256 '4fa819c9a08d91dfd644a1c476e8c6c614301f91b98f951bcb3bf7255b8b3e41'
+  version '0.18.29'
+  sha256 'acd98078d16271dbe52f38dca41101d7a4e63365447b0ddf8e6b81a12d6c77f7'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '0cfb69cbf42db5b8550b472297d9e41f0b5eec9e37d77e67ca9966f10297be80'
+          checkpoint: '54529584d3c1a9c7c5835d1856abb46915dea81f451319bd16138313f888b63a'
   name 'Brave'
   homepage 'https://brave.com/'
 

--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -5,7 +5,7 @@ cask 'brave' do
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '54529584d3c1a9c7c5835d1856abb46915dea81f451319bd16138313f888b63a'
+          checkpoint: '209322263d943d71cf62082115b46d18ae1c23d5d36ab3c12500f0f9e520abe5'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.