### PR TITLE
Update remote-desktop-manager to 4.4.2.0

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,11 +1,11 @@
 cask 'remote-desktop-manager' do
-  version '4.3.0.0'
-  sha256 '233ead2c31c627626c6bff34cf158441602e4a439263a94c235fef2bf894febf'
+  version '4.4.2.0'
+  sha256 '49b833f23f5a88d1ba6ab84ac1967044d0423f233f843e08bddd1e376189cca8'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"
   appcast 'http://cdn.devolutions.net/download/Mac/RemoteDesktopManager.xml',
-          checkpoint: '0f20dc31c6a641a3c4dee2a135bba73e432a1a8b00329cf2d63c54bcf720dde0'
+          checkpoint: 'd28958f114906feb9433ca50cc6d9d037340d5c75bf8b969dc73c6508513e4bf'
   name 'Remote Desktop Manager'
   homepage 'https://mac.remotedesktopmanager.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.