### PR TITLE
Update sqlectron to 1.25.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.24.0'
-  sha256 '196b301333a0b23845c5f034af2a189ee96f6c2d8ad28f368970a7ff6115bee9'
+  version '1.25.0'
+  sha256 'd6a268a7603cd2916cd4ab5411fa9d1ff005dfac334cf6ead46620f89bb3c29a'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: 'a12e74043c449cd66768ed02b08881304223a138a47bf9cee1732d8dae6151ab'
+          checkpoint: '2790b29015d69f11f9ddb0d1071135dfa37d2661c607972182419372c78565b7'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.