### PR TITLE
Update yed to 3.17.1

### DIFF
--- a/Casks/yed.rb
+++ b/Casks/yed.rb
@@ -1,6 +1,6 @@
 cask 'yed' do
-  version '3.17'
-  sha256 '3e94a3d307420ccfc611d2192b572ed5ae83f0e1b35bc2ee14246dd404552519'
+  version '3.17.1'
+  sha256 '9af86544fbfd86e2add60d8ebcb7e49783e51d111b40105cb9e8e568368dfa95'
 
   url "https://www.yworks.com/products/yed/demo/yEd-#{version}_with-JRE8.dmg"
   name 'yWorks yEd'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.