### PR TITLE
Update vagrant to 2.0.0

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,11 +1,11 @@
 cask 'vagrant' do
-  version '1.9.8'
-  sha256 '11b1bfac9e58d6189cd08d77e2943c89e0a6629f5a84abe1629f270813d5e818'
+  version '2.0.0'
+  sha256 '596fba741f99a083eed9751973b4a3016c99de611165ca561922008d23008494'
 
   # hashicorp.com/vagrant was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"
   appcast 'https://github.com/mitchellh/vagrant/releases.atom',
-          checkpoint: '8e386a3c32f4bcf86112aefa93c8dfc5817981ccaf9ad64fb81e68e60689f794'
+          checkpoint: 'ffd65a83a3f2c2ee644ff9754a80675e169ccd6101642a7c2f6da9a93432e444'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.