### PR TITLE
Update adobe-dng-converter to 9.12.1

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -6,8 +6,8 @@ cask 'adobe-dng-converter' do
     version '9.6.1'
     sha256 '087eac5026667e4e6e3c156fd13243c9ea00f6c0238cbbb94d3099ae8772603f'
   else
-    version '9.12'
-    sha256 'd0416718aa096b928b5877544077f480fc56c771cb9eb27a2a2aa712d233b56c'
+    version '9.12.1'
+    sha256 '1663d38cf697bcac1b9c95d899e4b207c49a917cdede31d90d52c7c31da3a87f'
   end
 
   url "http://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.