### PR TITLE
Update 4k-slideshow-maker to 1.6.2.948

### DIFF
--- a/Casks/4k-slideshow-maker.rb
+++ b/Casks/4k-slideshow-maker.rb
@@ -4,7 +4,7 @@ cask '4k-slideshow-maker' do
 
   url "https://downloads2.4kdownload.com/app/4kslideshowmaker_#{version.major_minor}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '9b7b2dfa4aa59157701cff076b8e877ebb922521c4ba7adabd6bee2038e9e962'
+          checkpoint: 'c54b263fa24e27e9adf0941a0339b323768dce5b037022ba6f44e2c632ed1051'
   name '4K Slideshow Maker'
   homepage 'https://www.4kdownload.com/products/product-slideshowmaker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.