### PR TITLE
Update 4k-stogram to 2.5.2.1356

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,10 +1,10 @@
 cask '4k-stogram' do
-  version '2.5.1.1346'
-  sha256 '68366a9a51879193f260e9e8634ddb09c05316ed6f665f8526e060c3a034c745'
+  version '2.5.2.1356'
+  sha256 '76d818c38d1ab294bc2b520b3a93e81fc4f5271d87d9283d8d5033904991e6a8'
 
   url "https://downloads2.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '8de0a5725c670e5fa688b8f7ede33e197766ff2acd12e1de4b8d6bb5a267fdd3'
+          checkpoint: 'c54b263fa24e27e9adf0941a0339b323768dce5b037022ba6f44e2c632ed1051'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.