### PR TITLE
Add dynamodb-local Latest

### DIFF
--- a/Casks/dynamodb-local.rb
+++ b/Casks/dynamodb-local.rb
@@ -1,0 +1,25 @@
+cask 'dynamodb-local' do
+  version :latest
+  sha256 :no_check
+
+  # s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz'
+  name 'Amazon DynamoDB Local'
+  homepage 'http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html'
+
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/dynamodb-local.wrapper.sh"
+  binary shimscript, target: 'dynamodb-local'
+
+  preflight do
+    IO.write shimscript, <<-EOS.undent
+      #!/bin/sh
+      cd "$(dirname "$(readlink -n "${0}")")" && \
+        java -Djava.library.path='./DynamoDBLocal_lib' -jar 'DynamoDBLocal.jar' "$@"
+    EOS
+  end
+
+  caveats do
+    depends_on_java('6+')
+  end
+end

--- a/Casks/dynamodb-local.rb
+++ b/Casks/dynamodb-local.rb
@@ -2,10 +2,10 @@ cask 'dynamodb-local' do
   version :latest
   sha256 :no_check
 
-  # s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
+  # s3-us-west-2.amazonaws.com/dynamodb-local was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz'
   name 'Amazon DynamoDB Local'
-  homepage 'http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html'
+  homepage 'https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html'
 
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/dynamodb-local.wrapper.sh"


### PR DESCRIPTION
dynamodb-local used to live in homebrew-core, but it was removed in https://github.com/Homebrew/homebrew-core/pull/9175 because "Upstream has stopped providing versioned URLs, and this package is not open source."

In this comment (and the following few), moving to Cask was proposed (and tentatively approved by @vitorgalvao): https://github.com/Homebrew/homebrew-core/pull/9175#issuecomment-275711581, but it looks like that never happened prior to this PR right now.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
