### PR TITLE
Update mountain-duck to 2.0.1.8029

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '2.0.0.8014'
-  sha256 '65b0662f4bcef00a89c66e79d494018e8d5b149dc363d5610695d56e90646753'
+  version '2.0.1.8029'
+  sha256 '243e33a32437576ccb39cae358bfdc4c746cd30f58389553d16bad42ca764059'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'ddd141012250ba0f4817bd3f1318c08eda359590716a18eb82a001b91941398d'
+          checkpoint: '2139ad260e7e54b712952ef006934b248616c5cbe4557c1006ecc2d28bcd5a76'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.