### PR TITLE
Update 1password-cli to 0.1.1

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,13 +1,15 @@
 cask '1password-cli' do
-  version '0.1'
-  sha256 'fccec086ef70d9fab464c8e5cb4b1748236cb7633c9aae52512fd6502686ad09'
+  version '0.1.1'
+  sha256 '95eb4cfd62a5bf1eab99d4acb24ab9229fc4dfb16a931dd7f9628f88b54c1fc7'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/CLI',
-          checkpoint: 'd33d33c7e3ee8eecdc68d529fd81c8a5291bce8ebf3125e674e58870ec039823'
+          checkpoint: 'a0c73938742c33399b0d408dac38e5aaa23a56e8a76ba0603876398f7cc38ccb'
   name '1Password CLI'
   homepage 'https://support.1password.com/command-line/'
 
   binary 'op'
+
+  zap trash: '~/.op'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.