### PR TITLE
Update qutebrowser to 0.11.0

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,11 +1,11 @@
 cask 'qutebrowser' do
-  version '0.10.1'
-  sha256 '1160cd7553fa1304a4c437e3b08004115399e034ecb92db710d96523afeaae0a'
+  version '0.11.0'
+  sha256 '89878ea8586f16e092587c66eee5a1033b91a2d4afa463b04bfa24d1b3922d80'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
-          checkpoint: '0e7edb3eb9988922c7d30fa64606db787e981c52a0b780d0e6b4c06abcf94327'
+          checkpoint: '2f35a22a0b3814b39fc7b2faea531c43768846b18e3219c3f2fa017a04cd711c'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.