### PR TITLE
Update gtkwave to 3.3.84

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.83'
-  sha256 'e69abb812f5533c12cd8f3499ba14d7b825c1d7ec4ced270f45faeca438abcba'
+  version '3.3.84'
+  sha256 'c503fb140f94a433dcfdc6417110890c77938b97f4d32cd4640155585d738b7c'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: '272dbc66b1cd6541141748429764cad8cd0df9fba8125ff66efd4fe51d76c23a'
+          checkpoint: '32f014bffe849d4bc2a975e662ecb6a38ce83507dd39f03ebc874252d551bc33'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.