### PR TITLE
Update yate to 3.17.1.1

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,11 +1,11 @@
 cask 'yate' do
-  version '3.17.1'
-  sha256 'e9de30bb90d1cfbc1d031e070358a5355c9ba0cf8477ab4d7113e1056dd86e5c'
+  version '3.17.1.1'
+  sha256 '73474d2770fa45e9e429b2d815ab851cb6b306515385498440806e2f6f32febe'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip',
       using: :post
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml',
-          checkpoint: '82be8965830e57d9a871bab2635370349cbf8832b65d64359c9589f5eef53884'
+          checkpoint: 'c06a35fb5f41bc6d409517167b2b9a7bdf3092bc6c3ac7289f64941e00b1dcac'
   name 'Yate'
   homepage 'https://2manyrobots.com/yate/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.