### PR TITLE
Update qbittorrent to 3.3.16

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,11 +1,11 @@
 cask 'qbittorrent' do
-  version '3.3.15'
-  sha256 '10b9f6afc250de301ef95f65107539296d8ebb93df776245bec2f57b5598f85e'
+  version '3.3.16'
+  sha256 'a936369ed8ecfee7f7d87132288b454a15b203b2eaa26c487dc41e86fa0b28b2'
 
   # sourceforge.net/qbittorrent was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/qbittorrent/rss?path=/qbittorrent-mac',
-          checkpoint: 'd188cd20ca406a4f1085eb79e2a4b148204764d9043894bea841f1089104457f'
+          checkpoint: '5d6edd54ca3c18c49af71dbae522c553af914a27a8180a5e3fe7720bc92bb225'
   name 'qBittorrent'
   homepage 'https://www.qbittorrent.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.