### PR TITLE
Add 'allow_untrusted' to odrive 6271

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -8,7 +8,7 @@ cask 'odrive' do
   name 'odrive'
   homepage 'https://www.odrive.com/'
 
-  pkg "odrive.#{version}.pkg"
+  pkg "odrive.#{version}.pkg", allow_untrusted: true
 
   uninstall pkgutil: 'com.oxygen.odrive.*'
 end


### PR DESCRIPTION
Package installer needs `-allowUntrusted` flag in order to be installed

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.