### PR TITLE
Update yate to 3.17.1.2

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,11 +1,11 @@
 cask 'yate' do
-  version '3.17.1'
-  sha256 'e9de30bb90d1cfbc1d031e070358a5355c9ba0cf8477ab4d7113e1056dd86e5c'
+  version '3.17.1.2'
+  sha256 '87aece064d852565537e36ce837e8325b7a5743e99d7145fadc1b0fb0cb11e7d'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip',
       using: :post
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml',
-          checkpoint: '82be8965830e57d9a871bab2635370349cbf8832b65d64359c9589f5eef53884'
+          checkpoint: '93e803aff283698f2af96675f378caeeb0000ac72ca0fc6f0045e73a739bf23f'
   name 'Yate'
   homepage 'https://2manyrobots.com/yate/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.