### PR TITLE
Update telegram to 3.2.1-104303

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.2-104084'
-  sha256 '8c812810336308f73d59c4e4e93faa98ef47949dba7f9989dc48b5c2b141e711'
+  version '3.2.1-104303'
+  sha256 '760155e57f75ace1d9e098cd0b9ec779de9865e0452c755c594cbe50b80dacbf'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '81655cd46def358467ee7e7cb1a8e9ab27d672177f6be4dbc0012dad95d97d49'
+          checkpoint: '57f9815196a577f164e28a05a046b3b4fc5a16bcbc68dd9f5c30956e37f99ae0'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.