### PR TITLE
Update switchhosts to 3.3.7.5324

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.6.5287'
-  sha256 'deda73aeff1945fee6db09039b6f5a8d36e32b4e29530510b4717adfc8ff4536'
+  version '3.3.7.5324'
+  sha256 'fde259873a684636d0965203b3a5236bdba910193a81e9d9043c4df3c4fe55c0'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: '152d4cfe878cf7c89e48ea39f3bb2baa098d4b41946ec981c10f870c3d20a933'
+          checkpoint: 'd36657870946ef7fb30faee5b0f174c4bc8d5af762a2901c852677086ee4f9d1'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.