### PR TITLE
Update deploystudio to 1.7.8

### DIFF
--- a/Casks/deploystudio.rb
+++ b/Casks/deploystudio.rb
@@ -1,6 +1,6 @@
 cask 'deploystudio' do
-  version '1.7.7'
-  sha256 '9c21ce8e325b7ed5a244e1830244f10f8a09180030eaca8fb28a429e0a532d09'
+  version '1.7.8'
+  sha256 'a7d71ed8e72498c8f7b37349458afd0cd74ba7a95313f26ea1ba05f4d1362071'
 
   url "http://www.deploystudio.com/Downloads/DeployStudioServer_v#{version}.dmg"
   name 'DeployStudio Server'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.