### PR TITLE
Update tankix to 3074

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '2820'
-  sha256 '04de9469cf163e3e205b0d015d4e127a5e1b4fc3c2494fa2b7d5b3d5f8a78845'
+  version '3074'
+  sha256 'ad07254d2a1760d5afeaf0a8ce48485f920cba6c26c0080922617cbc9f49d2db'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.