### PR TITLE
Update atraci to 0.7.0

### DIFF
--- a/Casks/atraci.rb
+++ b/Casks/atraci.rb
@@ -4,7 +4,7 @@ cask 'atraci' do
 
   url "https://github.com/Atraci/Atraci/releases/download/#{version}/Atraci-mac.zip"
   appcast 'https://github.com/Atraci/Atraci/releases.atom',
-          checkpoint: 'a8819ada26bd29deaf289bc9c47cea03cfaa2e9bb2dd25910967cd4c29a50c71'
+          checkpoint: 'f05d668c20684c63804b6355d1d074ba53eb6428cfe06fae7a9403dd25f89883'
   name 'Atraci'
   homepage 'https://github.com/Atraci/Atraci/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.