### PR TITLE
Update audioscrobbler to 0.9.15

### DIFF
--- a/Casks/audioscrobbler.rb
+++ b/Casks/audioscrobbler.rb
@@ -4,7 +4,7 @@ cask 'audioscrobbler' do
 
   url "https://github.com/mxcl/Audioscrobbler.app/releases/download/#{version}/Audioscrobbler-#{version}.zip"
   appcast 'https://github.com/mxcl/Audioscrobbler.app/releases.atom',
-          checkpoint: 'c222292ffd9650b768c3d0777af0afcba066cd7c099870f7bb47da8c54c33956'
+          checkpoint: '1edc614869d23531590f02ca14870b2a439d98cf23fb141c9f23412b8b822d35'
   name 'Audioscrobbler'
   homepage 'https://github.com/mxcl/Audioscrobbler.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.