### PR TITLE
Update amazon-chime to 4.7.5885

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,10 +1,10 @@
 cask 'amazon-chime' do
-  version '4.6.5869'
-  sha256 '915393cc60895f5e3f3a4badbcf4e55c16076ae64f9793985b9a8916dcbf1316'
+  version '4.7.5885'
+  sha256 '840ae712f711bb15afe6925ca2781252400448b2097bb8e6ebdb128ad11906fa'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast',
-          checkpoint: 'bc6607a3c09ed1439ef8e09e98341ea862e414324108c38006db728b6cd6864d'
+          checkpoint: '59db08b9c0e458c72419f79790da24b1c9d09ab2e54da6983f10dd536b94f825'
   name 'Amazon Chime'
   homepage 'https://chime.aws/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.