### PR TITLE
Update c0 to 0.2.0

### DIFF
--- a/Casks/c0.rb
+++ b/Casks/c0.rb
@@ -1,10 +1,10 @@
 cask 'c0' do
-  version '0.1.0'
-  sha256 '593ed4ca0df3dc4111b65330ff56a3e02867ff1f3ef48aaf977e582fe8987363'
+  version '0.2.0'
+  sha256 '3d6214858a2141af95d44f090f62f8a9cf80d26448855b5b4d864d30c1ce6a6f'
 
   url "https://github.com/smdls/C0/releases/download/v#{version}/C0-#{version}.dmg"
   appcast 'https://github.com/smdls/C0/releases.atom',
-          checkpoint: 'efdb309378d49e6788a6350d483c19362f3fe7d3503ea3ef20730b337adf183c'
+          checkpoint: 'c305a92b833c89d8c17feb6eb77dac91f3707d78ea8e045774bbd9eaacf35754'
   name 'C0'
   homepage 'https://github.com/smdls/C0'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.