### PR TITLE
Update bisq to 0.5.3

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -2,10 +2,10 @@ cask 'bisq' do
   version '0.5.3'
   sha256 'fa3b44ea298f66be697556b967d53e78964abc8b9da52bc8bad5e0500fd4b65b'
 
-  # github.com/bitsquare/bitsquare was verified as official when first introduced to the cask
-  url "https://github.com/bitsquare/bitsquare/releases/download/v#{version}/Bisq-#{version}.dmg"
-  appcast 'https://github.com/bitsquare/bitsquare/releases.atom',
-          checkpoint: 'a4a386edb7bedaffe3f2f282a42042fed68a086538af81dc08ca4689b008221e'
+  # github.com/bisq-network/exchange was verified as official when first introduced to the cask
+  url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
+  appcast 'https://github.com/bisq-network/exchange/releases.atom',
+          checkpoint: 'bead53dd88aa63b03eeffb93868ec02b972c9bc8fe1950f4a149d8d2b36fb075'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.