### PR TITLE
Update canary to 1.6.4,339

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '0.995.321,252'
-  sha256 '980b674823fd764401c4d2b7bd92a57fb67ef6f8b94714fde9c635789256a7ae'
+  version '1.6.4,339'
+  sha256 '66242cf9fd8698435cbda7610b663b8ad275a6e8b8a2b88f4a6cf743694ce61b'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: 'c368a6200653c9f4a5e734cd3e9b61ba11b855c9a061aaea125285056dc265cd'
+          checkpoint: 'ecca273a50f9dabb15c2593eff6d7fa71964334a648281656f59fb4efde675ed'
   name 'Canary'
   homepage 'https://canarymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.