### PR TITLE
Update vuescan to 9.5.85

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.84'
-  sha256 '7187b58a0c0bc86c73bb2bf3ecb01f4e0264ed2f8d9efced4e370e4bb3aeb1ae'
+  version '9.5.85'
+  sha256 '11ad3cfa8b4fb2aed4bc27ca39dcda1b846d308cd94b06871350a03f4fd10355'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '5cb317c34f55aac7d9b6d82913da74e621290053dbac6a77bca10e85bf454f3e'
+          checkpoint: '6e4df0585b1aaf87d25cc2da4824d4dbe3ad4767c80b5567981f5174bfcd44c9'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.