### PR TITLE
Update cyberduck to 6.2.6.26405

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '6.2.4.26305'
-  sha256 '599045f48970d7f2f901157c7386067fe1d6b76025f63523a4664152aec6168d'
+  version '6.2.6.26405'
+  sha256 '606c11b4e7a5af15e692b54f48c65ae795936a77f9f6c3339dbbaed05118ff2c'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: 'f86f616aee2f7f7ac87f1c5c5534e4e430952663fe6de98d221f813e77543ae5'
+          checkpoint: 'dd8946f8c9a4718e6ce0ad8d5e176a04d08fc943dd916f1c16a764453a08f1cd'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.