### PR TITLE
Update postgres to 2.0.5

### DIFF
--- a/Casks/crashplan-pro.rb
+++ b/Casks/crashplan-pro.rb
@@ -1,0 +1,19 @@
+cask 'crashplan-pro' do
+  version '4.9.0'
+  sha256 'e48fb5dc79c86538c8c31f6633e50e5606f9566998d6b25cbf2b465aa7ac2894'
+
+  url 'https://web-fam-msp.crashplan.com/client/installers/CrashPlanPRO_4.9.0_1436674888490_33_Mac.dmg'
+  name 'CrashPlan PRO'
+  homepage 'https://www.crashplan.com/en-us/business/'
+
+  auto_updates true
+
+  pkg 'Install CrashPlan PRO.pkg'
+
+  uninstall launchctl: 'com.backup42.desktop',
+            pkgutil:   'com.crashplan.app.pkg',
+            script:    {
+                         executable: 'Uninstall.app/Contents/Resources/uninstall.sh',
+                         sudo:       true,
+                       }
+end

--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,11 +1,11 @@
 cask 'postgres' do
-  version '2.0.4'
-  sha256 '505eebee7dffd3a37b3801279e0cdf31e9fc8ebf18942bc69933133847f18b48'
+  version '2.0.5'
+  sha256 '7d842467266ce12360bee0aa285d453b1662e3389d1b2a8e5a3679849f4578bf'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
-          checkpoint: 'f1a89c7384d7a8e302b2a95cf96c25b73adc4c0f886b6fda53a78e66e875f8b7'
+          checkpoint: '16e8eef992742b0a7afe01c477fd6c9886128e361efb828827bde40a79f09bcc'
   name 'Postgres'
   homepage 'https://postgresapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.