### PR TITLE
Update lyn to 1.9.1

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,10 +1,10 @@
 cask 'lyn' do
-  version '1.9'
-  sha256 'a7d7b453545f940201d55a11165b22deff0b5d15c19051f351ba16f9bd20896e'
+  version '1.9.1'
+  sha256 '5edefc06f70c114fb2caeb645f09601d8a3c490b555d9e6be93460c443f9bc31'
 
   url "http://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'http://www.lynapp.com/lyn/update.xml',
-          checkpoint: 'a225399645faae2a4160a36a5a597c56e2067254936df3f7a66a9bee6d83f162'
+          checkpoint: 'aaf177d9709d170177d2b8d38a37137dd702fcdb9527b77905864340bbb73b17'
   name 'Lyn'
   homepage 'https://www.lynapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.