### PR TITLE
Update pdfpenpro to 920.0,1504750884

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '911.1,1503633565'
-  sha256 '1385502192334f9c69c8e5ef38a69185dbd26742615a8184199d81552ff886e6'
+  version '920.0,1504750884'
+  sha256 'cc664ae529cb067a5adf7e3c8c4c284b6f7b3e7ea4df94869fa371988f737fec'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '5f91f9a37b7a3a4e86b57eb3cd02d4d393b3725deb85879bc151d425947d328d'
+          checkpoint: '6b76b227e4a9b779dc4e2945a602714d95b1289c8ed644e6b28f4d0e9ddfccfc'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.