### PR TITLE
Update hopper-disassembler to 4.2.17

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.2.16'
-  sha256 '0eaf7f787632ea9364fe738cb22f000603f2ba4bdd704cc1a07abfa430c086c3'
+  version '4.2.17'
+  sha256 'e14393b1b3e34e05a3337dfe1fa9a25992fdc695badf69b2be729f43f48eada8'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '4eb6da143cc668c3f8647409c1fc49d9462d2bf1d270e894e69625a889bccf5f'
+          checkpoint: 'e07725eb60c39524e2b33215260509cf1c0b0b662b128b43b286b23866ba7e5b'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.