### PR TITLE
Update stretchly to 0.11.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.10.0'
-  sha256 'a055d94ceb3b54ba2ea6bcf89ca7f9d5703866caaa50ca6f811d9eefdc350e81'
+  version '0.11.0'
+  sha256 '6de1894590c12e9f8a0a7393a6fa28edbd9344baffc2d9c5e9674f12f233102e'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '26ac344151004fed93bdeac8e177836e03fe206ff946781de792c664ed40c3de'
+          checkpoint: 'abdfd168229c8cda8612a7487b183223c9b01dca3c2069641b281de0eb58e45b'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.