### PR TITLE
Update clover-configurator to 4.50.0.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,10 +1,10 @@
 cask 'clover-configurator' do
-  version '4.49.0.0'
-  sha256 '14ec078b0f6bc23788f0774428f7a3d1fc8d0ff4d89f8a60f38bc69f37b9b82b'
+  version '4.50.0.0'
+  sha256 'de27be5aeeea22f93fe0f76471aa5e38be9af42949b88cb80038f6d5f912b1a7'
 
   url 'http://mackie100projects.altervista.org/download-mac.php?version=vibrant'
   appcast 'http://mackie100projects.altervista.org/apps/cloverconf/10.10/update.xml',
-          checkpoint: '0cb0ea1f7d6195a63b1f628a59ebd9d372e3b283410fbf776b45de4f47d8ad99'
+          checkpoint: '1294f78b37e114238d74b78efb6cd9fefef29995c2308eae1a679cfc3849f247'
   name 'Clover Configurator'
   homepage 'http://mackie100projects.altervista.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.