### PR TITLE
Update dockstation to 1.3.0

### DIFF
--- a/Casks/dockstation.rb
+++ b/Casks/dockstation.rb
@@ -1,11 +1,11 @@
 cask 'dockstation' do
-  version '1.2.4'
-  sha256 '86826de5da20f9eb6ecf0cc2ca1d14ef6d1964eef9e2a11c703cbf011064f081'
+  version '1.3.0'
+  sha256 'cc22247295e0714a888b8d5dae1cc53c1f95cfcf8345c35a8c7c05b12afd0b5b'
 
   # github.com/DockStation/dockstation was verified as official when first introduced to the cask
   url "https://github.com/DockStation/dockstation/releases/download/v#{version}/dockstation-#{version}.dmg"
   appcast 'https://github.com/DockStation/dockstation/releases.atom',
-          checkpoint: '5e48f61d0e862dab3df692d9fb9023d8707e36018b52a6713fa9a7a1450e3b50'
+          checkpoint: '78a34cbf5e41f237e83c3ac7edb7d5f17819bb12b2f118c5f9dd4ecede62587c'
   name 'DockStation'
   homepage 'https://dockstation.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.