### PR TITLE
Update drawio to 7.3.5

### DIFF
--- a/Casks/drawio.rb
+++ b/Casks/drawio.rb
@@ -1,11 +1,11 @@
 cask 'drawio' do
-  version '7.1.9'
-  sha256 'fbeee024af7a989a62a8c24429ba459febf7e0ec767b5f83b0b49edd3a799d12'
+  version '7.3.5'
+  sha256 '6d24cfd31cacfc5edfc6c12be0d3c36e8bd7680a1451d3ed0d1c0d26044509d0'
 
   # github.com/jgraph/drawio-desktop was verified as official when first introduced to the cask
   url "https://github.com/jgraph/drawio-desktop/releases/download/v#{version}/draw.io-#{version}.dmg"
   appcast 'https://github.com/jgraph/drawio-desktop/releases.atom',
-          checkpoint: 'af7b466134abfb2550fa47f70f1fc076e3fa6014d82492a8779162e1c6e133d3'
+          checkpoint: 'bcc61225089b83663f044378319447da4ff05bd6107cae5309280d60cbf38fe4'
   name 'draw.io Desktop'
   homepage 'https://www.draw.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.