### PR TITLE
Update dupin to 2.12.1

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,11 +3,11 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.11.2'
-    sha256 'c5f8ab3dc16eebf2fb7205e88a000e68bb6256aa86f96539083b6c6b344768e4'
+    version '2.12.1'
+    sha256 'e194413a676a047f8cb9c35dad00d6d812310a058a276d243383b45519d076ca'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml',
-            checkpoint: 'fa1d7890a2e25dc093172271be546ae3e40dc473814859c7f403c61047c6d124'
+            checkpoint: 'e8a511f460f953e957bbed0a8cd491fa0c797dbf34c852e651b35889d0b5b6bf'
   end
 
   url "https://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.