### PR TITLE
Update digikam to 5.7.0-01

### DIFF
--- a/Casks/digikam.rb
+++ b/Casks/digikam.rb
@@ -1,11 +1,11 @@
 cask 'digikam' do
-  version '5.6.0-01'
-  sha256 '69b79d983534d0111c0c9cba5a211d594fa449706bada2c60826f319238f5fe3'
+  version '5.7.0-01'
+  sha256 '709d6c417470cc426a5b97db2b174852f625149df10161e3d2139396c7898755'
 
   # kde.org/stable/digikam was verified as official when first introduced to the cask
   url "https://download.kde.org/stable/digikam/digiKam-#{version}-MacOS-x86-64.pkg"
   appcast 'https://download.kde.org/stable/digikam/',
-          checkpoint: '20038497c4e4a4455925ef921328cc30c06f740759ab7ab7b6852b06fbd86fd8'
+          checkpoint: '676349272c062e2f9011c1ac4c29b304728f9f4eb31ed4d1eedb442fb9f5e83e'
   name 'digiKam'
   homepage 'https://www.digikam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.