### PR TITLE
Update disk-drill to 3.3.846

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,10 +1,10 @@
 cask 'disk-drill' do
-  version '3.2.831'
-  sha256 'aabc6555196cf87528c5d09c32f019ce1d301145a71c8986c334adc147d4c14b'
+  version '3.3.846'
+  sha256 'cda0c421eee775e878dd2c1ddd1b331892f07c7ca76568ce2dd041e6dd7b8845'
 
   url "https://www.cleverfiles.com/releases/DiskDrill_#{version}.zip"
   appcast 'https://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml',
-          checkpoint: '629e981f5994872e96fac0df0aa3d9606f1de90014e00305ed24ede0b902048e'
+          checkpoint: '75dd8f852613d43d2d7644da172700fd4133e10404d41bc0c6593a5530c02121'
   name 'Disk Drill'
   homepage 'https://www.cleverfiles.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.