### PR TITLE
Update downie to 2.9.12,1530

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.9.10,1524'
-  sha256 '52db6b431777b2f0374f62ab507e8b64b74a83fbb74d4297d613d403826ad904'
+  version '2.9.12,1530'
+  sha256 '832ba36cafaf8757a1cd6f9d5c89ff22a9dd5f9f4b9a5b9cee2b735ef09c1505'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
-          checkpoint: 'e7bc1bfdec2745883bb2c8d6b178bdda729e5f2a56dd66de30e6d19a55ca14e3'
+          checkpoint: '88e681ee32f24ec2298d4754e7ece00dc102b81e140e277638a30e9de8c60345'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.