### PR TITLE
Update tinderbox to 7.2.2

### DIFF
--- a/Casks/tinderbox.rb
+++ b/Casks/tinderbox.rb
@@ -8,8 +8,8 @@ cask 'tinderbox' do
     sha256 '765a6245d25f9c2185802f36caa1f620f276637b884260fffa74bf639670e211'
     app 'TinderboxSix.app'
   else
-    version '7.1.0'
-    sha256 '7e9b6b18dbeaa5fd1451e5d79d2e4ecb4f86ae322a6ebbf07fb8751bf1ec10be'
+    version '7.2.2'
+    sha256 '8d047ba46c178e2b961e2192100733c3dbeedcd4c038aee3fc6d8e0aecc7a196'
     app "Tinderbox #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.