### PR TITLE
Update sweet-home3d to 5.5

### DIFF
--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -1,11 +1,11 @@
 cask 'sweet-home3d' do
-  version '5.4'
-  sha256 'fb3d2561684daabaee51bc1805e24a451ecf06ffd8367be7c19758bf3ffcff3b'
+  version '5.5'
+  sha256 'd63636a0e83f5959c2aaabf85bc17057a157ca08dca7b67417a9eb92700ff822'
 
   # sourceforge.net/sweethome3d was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/sweethome3d/SweetHome3D/SweetHome3D-#{version}/SweetHome3D-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/sweethome3d/rss?path=/SweetHome3D',
-          checkpoint: '2b33dbd17e85f76c0d053a6c105ce41291c81d04b040e0c796d3a68a72cec705'
+          checkpoint: '31ceb4539b9ef405f00bc7330bbe489ab42a6ab6c529f945c95634e1376e0fa9'
   name 'Sweet Home 3D'
   homepage 'http://www.sweethome3d.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.