### PR TITLE
Update navicat-for-mysql to 12.0.13

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.12'
-  sha256 '063aa7b6f8671b2d27b0f4f6d72d67eddad40d26d0b066452b0c95d626208db0'
+  version '12.0.13'
+  sha256 '9b69651d2a2e97ec3e1093f87c864298735c3680d7334b33d2ea057d6df26b44'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note#M',
-          checkpoint: '7c03a3eb712c392e4255a9775ee816b9be0ba08c54da0c63c42079a7aeaea4e3'
+          checkpoint: '461ab64daf06e4b4ab8093f39978b0792e71c6a263a4580c5cc194e694d67310'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.