### PR TITLE
Update navicat-for-oracle to 12.0.13

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.12'
-  sha256 'a40c2310fe3b97a8d871a1ecf8e158caa155c3cb72308a2841bafc5b623cc1cb'
+  version '12.0.13'
+  sha256 'b4a5633fa1941eca2771be8862daae85ffa6f1f793d419c78f1617bdfbb037c6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note#M',
-          checkpoint: 'eca4933d1021c0a51c96126eb80023c153c09d738f17c9ce11e1ef00ed57eb8d'
+          checkpoint: 'f1fedac035fa882716f62197132b6a086d5ac75d164d32f6e96bd4bb6fd9f239'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.