### PR TITLE
Update navicat-for-sql-server to 12.0.13

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.12'
-  sha256 'a703722275b71cb1092a112aefff94bdfdd329556e5200d08afd7ca6774b29e1'
+  version '12.0.13'
+  sha256 'c09035fff2361088cf732bd6f4f37438b270ec812a5e765c3597b0308a54e340'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note#M',
-          checkpoint: '4a0d2813984fb9efd1328783e6424ac302c3395b8f8e9513cd7384e91a22c0b6'
+          checkpoint: '16b91bcdfa356d464140831f0cdf704be00ef83e2e37c4d370134f1362d3557f'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.