### PR TITLE
Update unity to 2017.1.1f1,5d30cf096e79

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2017.1.0f3,472613c02cf7'
-  sha256 '008140a181a0fdb6d1c3866ff8fa19eebf62b9dc2ccc3c1ba523db459c35a33a'
+  version '2017.1.1f1,5d30cf096e79'
+  sha256 '461a101910459e7ea4e884e28b8b442303d20b7c78e5ed610ce151ca6b4eb0a7'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity.pkg"
   name 'Unity Editor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.