### PR TITLE
Update unity-download-assistant to 2017.1.1f1,5d30cf096e79

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2017.1.0f3,472613c02cf7'
-  sha256 'b0f30d984884f1ac90072334a5e98f97f0e42ecb93dac7d592b26ec750769674'
+  version '2017.1.1f1,5d30cf096e79'
+  sha256 '8e65fb669e0e72ad42ec958330a18126209c79b2cd6f79b99e94af1b3fedca13'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   name 'Unity'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.