### PR TITLE
Update unity-linux-support-for-editor to 2017.1.1f1,5d30cf096e79

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2017.1.0f3,472613c02cf7'
-  sha256 '21b7304b4f47f75a41bcbef685f48ab6f28b0c89b7a8d1e499fe69b6ab766178'
+  version '2017.1.1f1,5d30cf096e79'
+  sha256 '15ddf1bcd1f614dfee9d8d60342133808449fa4b66ca1117a914fa7758a22c7a'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Linux Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.