### PR TITLE
Update unity-windows-support-for-editor to 2017.1.1f1,5d30cf096e79

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2017.1.0f3,472613c02cf7'
-  sha256 'cb403ba4c64b5faf9ef74982b35c8bfa299abbdc24075ddcfc9fbfe3eb13ceb5'
+  version '2017.1.1f1,5d30cf096e79'
+  sha256 '5ffbb2f04e67c836a82ecb1aab56b6cfb64db00e12f378398c54e05152ab15f4'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Windows Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.