### PR TITLE
Update framer to 9693

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '9612'
-  sha256 '8b5d3f713eed8997e88979084c12ae8032ef704b1a8cc2e965b25f6a71ba2af7'
+  version '9693'
+  sha256 '091de6bf11174b9c65e023f4b7327384f1f4f16372ebf363d332d0c4f1711901'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: 'ed44bad48a44e2af8a887badaf4578ec8a1486ebbea424ebc9e6e2c011520db6'
+          checkpoint: '08bb934f1d3243c9f2ffb54d3eb39e50d4a2e8451e1c18b5bacfb4401a47a964'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.