### PR TITLE
Update launchcontrol to 1.33

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -1,10 +1,10 @@
 cask 'launchcontrol' do
-  version '1.32.5'
-  sha256 '2458635c03af2bfce27d29b5deea98b96b91015e67e96464f64c65e88025d228'
+  version '1.33'
+  sha256 'c05b20f07bf0dfb4d0cdca112a70aa2e1bac7461b22efb81635e498688cd506a'
 
   url "http://www.soma-zone.com/download/files/LaunchControl_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/LaunchControl/a/appcast.xml',
-          checkpoint: '734968c03179d95238248e411fb5837b5afa8e061d2c666154accde24bdc0c03'
+          checkpoint: 'dfa393365348c6d439953f9fca3e9adb3345a234f1f94f71c3847072ea47f3a7'
   name 'LaunchControl'
   homepage 'http://www.soma-zone.com/LaunchControl/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.