### PR TITLE
Update festify to 0.2.8

### DIFF
--- a/Casks/festify.rb
+++ b/Casks/festify.rb
@@ -1,10 +1,10 @@
 cask 'festify' do
-  version '0.2.6'
-  sha256 '3d6c789f92988d197b8d4bba0782adb83e6a81b9a38f73c9e5233f3ff3390804'
+  version '0.2.8'
+  sha256 'd465c7e2df2762a2e39e05f56086be36a6707834fac1420a95fe9201329d2856'
 
   url "https://github.com/festify/app/releases/download/v#{version}/Festify-#{version}.dmg"
   appcast 'https://github.com/Festify/app/releases.atom',
-          checkpoint: '03af11f99136809bbc144b48fb06ff51cb404e58af6a3bbe3487c7c932530056'
+          checkpoint: 'b23017ef4a2fa2efd2ba9a4c738f2eb0ba801cb0505de8bbf65730f7ebb1a4a9'
   name 'Festify'
   homepage 'https://github.com/festify/app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.