### PR TITLE
Update keeweb to 1.5.6

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,11 +1,11 @@
 cask 'keeweb' do
-  version '1.5.4'
-  sha256 '4ec4e2d9bd7bd9a562f0f419d67d3a0e926eab6b82fce3334cfa3f9e96843e89'
+  version '1.5.6'
+  sha256 '06d245a0c1245331943404282cc7cdfc6fbbdf74ce5922da65f7d0d0b2eb7e7b'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"
   appcast 'https://github.com/keeweb/keeweb/releases.atom',
-          checkpoint: '4ad0e816ad5a75a9e8f45519abba391be51c0d16b48608109f2d33d0745c9eb7'
+          checkpoint: '3f58da4a70b6d2ccd5719552670a83fcced02e328e0a5c97425ec855f3e04fee'
   name 'KeeWeb'
   homepage 'https://keeweb.info/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.