### PR TITLE
Update kite to 0.20170907.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170803.2'
-  sha256 'dbaa67e1dcfd2cf47f1b4052cd80c3eab04a3b866874e34dfd261c0d6a2ccf78'
+  version '0.20170907.0'
+  sha256 '976af2fd252bb79d54bafef9b5f9187b60e1ca6759a784141368b8ea16b7ca32'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: 'a48ebed15a1a1027ce60506fc9c38f2d06f0ddd2d8355f6736eae340c79e048e'
+          checkpoint: '3bb95d37fad56868852fa0e113c167e1be5dadde433b519f8d7fd73af190728e'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.