### PR TITLE
Update min to 1.6.1

### DIFF
--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -1,11 +1,11 @@
 cask 'min' do
-  version '1.6.0'
-  sha256 '33259c28da7eb86a50df2a7fc7e890060dabc6f69956da2480e06adbbc6df327'
+  version '1.6.1'
+  sha256 '01292fce4ce5f50255656c15e4f62891efc10b6dc3150f1663de931dd4905963'
 
   # github.com/minbrowser/min was verified as official when first introduced to the cask
   url "https://github.com/minbrowser/min/releases/download/v#{version}/Min-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/minbrowser/min/releases.atom',
-          checkpoint: 'ab42fa79c0f95aa75422a48cd99d5d8ab8a3d12be8a20b617b1ddd13786e1183'
+          checkpoint: 'b45e63197e5bed028d6cdb2f7417359067b789daeff3e79d7b5ee5de416ffa32'
   name 'Min'
   homepage 'https://minbrowser.github.io/min/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.