### PR TITLE
Update dbeaver-enterprise to 4.2.0

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,10 +1,10 @@
 cask 'dbeaver-enterprise' do
-  version '4.1.1'
-  sha256 '345fa36b74a08512d868e0232a3f5e043c132d1fa1e90ad57040d4d48c85fa6c'
+  version '4.2.0'
+  sha256 'be79572cdabee2ba108a8a50ff42dea7d9bb6b9061ddaeaf22e2c9ac4b4c886c'
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
   appcast 'https://dbeaver.com/files/',
-          checkpoint: 'e96df7f78b09351188ce5e9eb0d0952fe14c0322e4b41b1d1ce6760d9cbab16a'
+          checkpoint: '3c4c8b473915ee3d7a2b78d96c1ba171be65af702377c21ca98aa27374d76cf4'
   name 'DBeaver Enterprise Edition'
   homepage 'https://dbeaver.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.