### PR TITLE
Update sourcetree to 2.6.3a

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -1,23 +1,9 @@
 cask 'sourcetree' do
-  if MacOS.version <= :snow_leopard
-    version '1.8.1'
-    sha256 '37a42f2d83940cc7e1fbd573a70c3c74a44134c956ac3305f6b153935dc01b80'
-  elsif MacOS.version <= :mountain_lion
-    version '2.0.5.5'
-    sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
-  else
-    version '2.6.3a'
-    sha256 '4b951e2d113a2ca5f8bb88be06b64c9390eae13b4339f983b4a0867c602dca53'
-  end
+  version '2.6.3a'
+  sha256 '4b951e2d113a2ca5f8bb88be06b64c9390eae13b4339f983b4a0867c602dca53'
 
-  # atlassian.com was verified as official when first introduced to the cask
-  if version == '2.6.3a'
-    url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
-  else
-    url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
-  end
-  appcast 'https://www.sourcetreeapp.com/update/SparkleAppcast.xml',
-          checkpoint: '6031bd143374559a84872d0b9ecef5420173e11fb3a0453cfaa092878c6bc908'
+  # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
+  url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 
@@ -30,10 +16,12 @@ cask 'sourcetree' do
             quit:      'com.torusknot.SourceTreeNotMAS'
 
   zap delete: [
-                '~/Library/Application Support/SourceTree',
                 '~/Library/Caches/com.torusknot.SourceTreeNotMAS',
+                '~/Library/Saved Application State/com.torusknot.SourceTreeNotMAS.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/SourceTree',
                 '~/Library/Preferences/com.torusknot.SourceTreeNotMAS.plist',
                 '~/Library/Preferences/com.torusknot.SourceTreeNotMAS.LSSharedFileList.plist',
-                '~/Library/Saved Application State/com.torusknot.SourceTreeNotMAS.savedState',
               ]
 end

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,12 +6,16 @@ cask 'sourcetree' do
     version '2.0.5.5'
     sha256 'f23129587703a706a37d5fdd9b2390875305b482a2b4e4b0e34bd49cba9b63c9'
   else
-    version '2.6.2c'
-    sha256 '488e7077afd3f493f9a32678eb6c11087ab3917a15f2ee220cecff6a5cee5b0d'
+    version '2.6.3a'
+    sha256 '4b951e2d113a2ca5f8bb88be06b64c9390eae13b4339f983b4a0867c602dca53'
   end
 
   # atlassian.com was verified as official when first introduced to the cask
-  url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
+  if version == '2.6.3a'
+    url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
+  else
+    url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
+  end
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcast.xml',
           checkpoint: '6031bd143374559a84872d0b9ecef5420173e11fb3a0453cfaa092878c6bc908'
   name 'Atlassian SourceTree'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.