### PR TITLE
Update flash-npapi to 27.0.0.130

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '26.0.0.151'
-  sha256 'cf077b9de6ae053d4cf271c8907f9e7c771d49bbfc457680ef5e10d1f72bcaef'
+  version '27.0.0.130'
+  sha256 'a63ec8398336b5270b4c35c6c3758ee4a0e33b5cd3aada8c65aeff37e221b6e5'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.