### PR TITLE
Update flash-ppapi to 27.0.0.130

### DIFF
--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-ppapi' do
-  version '26.0.0.151'
-  sha256 'a848828c6f852374412de2a59af8834817751ca184eff107f4d65da0c48f44e4'
+  version '27.0.0.130'
+  sha256 'f0429125904e103da53a17440509ed483b8e9bcec26cba27445c3631075770e2'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.