### PR TITLE
Update flash-player-debugger-ppapi to 27.0.0.130

### DIFF
--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-ppapi' do
-  version '26.0.0.151'
-  sha256 '11edfe8fd8b1ce2fdcef76ea051d7fe6b2d39f4ae2d0185f6be538861340c773'
+  version '27.0.0.130'
+  sha256 '966ae538b235011cb8744435619a6e00c1338337ffea59d7b108f3503ab77505'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.