### PR TITLE
Update adobe-air-sdk to 27.0

### DIFF
--- a/Casks/adobe-air-sdk.rb
+++ b/Casks/adobe-air-sdk.rb
@@ -1,6 +1,6 @@
 cask 'adobe-air-sdk' do
-  version '26.0'
-  sha256 'dececd6dc01f6fdd53f410a6c7dc70037f34af07de49ca8ccd54c945c4284af1'
+  version '27.0'
+  sha256 '15378bc0dfa8d46f1f95c3cab4974e0fb6cb8f6362dd0590e74480e29a9d463a'
 
   url "https://airdownload.adobe.com/air/mac/download/#{version}/AIRSDK_Compiler.dmg"
   name 'Adobe AIR SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.