### PR TITLE
Update xmind to 8-update4

### DIFF
--- a/Casks/xmind.rb
+++ b/Casks/xmind.rb
@@ -1,6 +1,6 @@
 cask 'xmind' do
-  version '8-update3'
-  sha256 '3312d8bdd00b12662114d20144ee5aaf2daa990c2d39b2cd082ed87557606825'
+  version '8-update4'
+  sha256 '817221ea6870bce623e3e09d9c4492a11b59c5970808d11fe275253ab2fccc85'
 
   url "https://www.xmind.net/xmind/downloads/xmind-#{version}-macosx.dmg"
   name 'XMind'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.