### PR TITLE
Update mediainfo to 0.7.99

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,10 +1,10 @@
 cask 'mediainfo' do
-  version '0.7.98'
-  sha256 '96f952e71e1a302a52bdb9a226c4246496af892e769d4b396191227436264017'
+  version '0.7.99'
+  sha256 '34650dd22250e698d2c8c0468f68fe75380594c9cedc58ce4651ef108506df1f'
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   appcast 'https://mediaarea.net/rss/mediainfo_updates.xml',
-          checkpoint: '0650eb4cc0a43924c65afe9490c46614cf59f1f8cd7c611fdb2466da6faa3545'
+          checkpoint: '93299a75547fe7a09abc95044b0eccd9615084f98b3359e604154fc4e24f0dc0'
   name 'MediaInfo'
   homepage 'https://mediaarea.net/en/MediaInfo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.