### PR TITLE
Update zoc to 7.15.4

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,10 +1,10 @@
 cask 'zoc' do
-  version '7.15.3'
-  sha256 '67d51014ce461260330198a5f0ecc3edf2c7c595e836db0bee1112152434ef42'
+  version '7.15.4'
+  sha256 '6a21db9b5d3c9d05d30d518b0fd2e0f3c1b3d147fc173632571812bf3ecb52eb'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast "http://www.emtec.com/downloads/zoc/zoc#{version.no_dots}_changes.txt",
-          checkpoint: '80eed1e255a1bbf6abacb189cbb08ed725f5a31a98ba2bed07acd36fdeebffe9'
+          checkpoint: '0347cdd5482d262c41dd1da68bee7a43ec1c598252b8685129c766e83fbc8250'
   name 'ZOC'
   homepage 'https://www.emtec.com/zoc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.