### PR TITLE
Update razorsql to 7.3.6

### DIFF
--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -1,10 +1,10 @@
 cask 'razorsql' do
-  version '7.3.5'
-  sha256 '84541b0f16c02a485829419af1a0990284849163ece11783b077924715b249a3'
+  version '7.3.6'
+  sha256 '344ad00378ec88dd6bb28171d98875aa919d63bab419da7f00048d7d919bf9d0'
 
   url "http://downloads.razorsql.com/downloads/#{version.dots_to_underscores}/razorsql#{version.dots_to_underscores}_x64.dmg"
   appcast 'https://razorsql.com/updates.html',
-          checkpoint: 'fc3322b12e1f71c86f56a11fa35deb3b22889d67ae66b857babff19648b0cb25'
+          checkpoint: '3d3996956b4378c211925a4317db24ba609622b7b3816ca22e59a91a28733b99'
   name 'RazorSQL'
   homepage 'https://razorsql.com/download_mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.