### PR TITLE
Update github-desktop to 0.8.2-77b74af1

### DIFF
--- a/Casks/github-desktop.rb
+++ b/Casks/github-desktop.rb
@@ -1,11 +1,11 @@
 cask 'github-desktop' do
-  version '0.8.1-10b8069c'
-  sha256 '48f223ca152539b888d2a96af688f83d466f7c1efa407f0caad85d2457637c05'
+  version '0.8.2-77b74af1'
+  sha256 'd3b25e834f554313d2e6b293b29a2c8f2e1ac98be5a48c6bdd6436ef3f31d0fa'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: '9f1c8496ca238136aad1eae06839f8a82d267360fee2528f2dcd75bea7a7fa1f'
+          checkpoint: 'cc12ede72ba7ae440b24a5fb4ab2c61f3660623666e8535b2b957911d382ec27'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.