### PR TITLE
Update emacs to 25.3

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,10 +1,10 @@
 cask 'emacs' do
-  version '25.2'
-  sha256 '3d5cee1839132bc997b9312b9a205864cb3e5650c79534ac626a160c2fd2c405'
+  version '25.3'
+  sha256 'b2bfc1e90a2e3a9e138fdd42ec1796bf38eeaf06021905f9ffbaf8b397ca64ac'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/release',
-          checkpoint: '489333e27856d07d50138d32676668084801ebd6186b21016fd6d471b770fd32'
+          checkpoint: 'dd284d2f08cac506fc34711eff27ac68268dbe0d2deab602d23c602222f88249'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.