### PR TITLE
Update texshop to 3.87

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,10 +1,10 @@
 cask 'texshop' do
-  version '3.86'
-  sha256 'd186d4bb9ead44d67ae8b08f3d6f3387c187f6c8750fe6b37e06276f3d9fd267'
+  version '3.87'
+  sha256 'fe1164aa9c8a4898b390ea00568b74a42b29ab7e91a2c872198f40d66487619b'
 
   url "http://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'http://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml',
-          checkpoint: 'eebcb6ed2860e844923ed0cdb8890df9eb67161fff9a5afcadab03a36871f1c5'
+          checkpoint: '792050c8090854eb117d2abded51517f626e78512d9e9cafe2a3d27aa44f5944'
   name 'TeXShop'
   homepage 'http://pages.uoregon.edu/koch/texshop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.