### PR TITLE
Update sublime-text to 3143

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text' do
-  version '3126'
-  sha256 '2bbd357cd29303b05770ef479e2f86ea8166ac43062ae9e84dc07abfd0ce2c96'
+  version '3143'
+  sha256 '952f81f79efb1a0a103fe87328af6a0dd8adf64e16636ecb221e79e453564b6c'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/stable/appcast_osx.xml',
-          checkpoint: '34717c4ad8bc4fd51b211effcc67fb84a04acff65126a77ba9789811659cb6d6'
+          checkpoint: 'cf1732de74c0ef572bb401b068bbf563e39c475078fb8d9f33a337b87c488e11'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.