### PR TITLE
Update hyper to 1.4.4

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.4.3'
-  sha256 '61b964489e89c46473fab4e9c0a109c274be2336a360df06385871e241f87eab'
+  version '1.4.4'
+  sha256 'c387acba8d4f7996a17b51540540f0dc1ae61d813cb3465c478f0b5c3717fcae'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '97bc21b70bbb39dca1a7475b5c41d85373ca39c732b835afec459822c4379499'
+          checkpoint: 'f3e046e446d65843580af469db1e1e9a90eff00953923f7845cfa642a8e6f128'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}