### PR TITLE
Update chatty to 0.8.7

### DIFF
--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -1,11 +1,11 @@
 cask 'chatty' do
-  version '0.8.6'
-  sha256 'cb3f1081186f67b843d8a8290a8926bd3518f542fd37696ef6fe4769328cfddd'
+  version '0.8.7'
+  sha256 '7c0759fc6a07c0137766f2c9715589c5f25294475ef9c99812ed935b973d26fb'
 
   # github.com/chatty/chatty was verified as official when first introduced to the cask
   url "https://github.com/chatty/chatty/releases/download/v#{version}/Chatty_#{version}.zip"
   appcast 'https://github.com/chatty/chatty/releases.atom',
-          checkpoint: '035870cac761b38711fecfdddf49589661d1a69c510863f32e19a3c626a1ed9e'
+          checkpoint: '7c3a3fcdc7587ff38c8fab9634a8fee70cf80afe830a4870d9a83ca06e2e1454'
   name 'Chatty'
   homepage 'https://chatty.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.