### PR TITLE
Update xamarin-mac to 3.6.3.3

### DIFF
--- a/Casks/xamarin-mac.rb
+++ b/Casks/xamarin-mac.rb
@@ -1,6 +1,6 @@
 cask 'xamarin-mac' do
-  version '3.6.0.19'
-  sha256 'b8a206fe15f6bd71e27cf00f6adbc0cdfc3d636d31cdf7059872ba2f5418b535'
+  version '3.6.3.3'
+  sha256 '812f5ea6e50d23fa8d11f1ee8e3f793ec5699e3df353ee02f911e0d7ec4f610a'
 
   url "https://dl.xamarin.com/XamarinforMac/Mac/xamarin.mac-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.