### PR TITLE
Update crystax-ndk to version 10.3.2

### DIFF
--- a/Casks/crystax-ndk.rb
+++ b/Casks/crystax-ndk.rb
@@ -1,6 +1,6 @@
 cask 'crystax-ndk' do
-  version '10.3.1'
-  sha256 '6469c37e8fa107db51f9ada26fe3e27fddf3d6c3c51272a783fed36b110550ef'
+  version '10.3.2'
+  sha256 '382bc6bf8bf4fb1278372ac70f4b86cf6a633d60b33f30b6895f5c9975d3d7bf'
 
   url "https://www.crystax.net/download/crystax-ndk-#{version}-darwin-x86_64.tar.xz"
   name 'Crystax NDK'
@@ -11,11 +11,11 @@ cask 'crystax-ndk' do
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/ndk_exec.sh"
   preflight do
-    FileUtils.ln_sf("#{staged_path}/crystax-ndk-r#{version}", "#{HOMEBREW_PREFIX}/share/crystax-ndk")
+    FileUtils.ln_sf("#{staged_path}/crystax-ndk-#{version}", "#{HOMEBREW_PREFIX}/share/crystax-ndk")
 
     IO.write shimscript, <<-EOS.undent
       #!/bin/bash
-      readonly executable="#{staged_path}/crystax-ndk-r#{version}/$(basename ${0})"
+      readonly executable="#{staged_path}/crystax-ndk-#{version}/$(basename ${0})"
       test -f "${executable}" && exec "${executable}" "${@}"
     EOS
   end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
