### PR TITLE
Update j to 806

### DIFF
--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -1,6 +1,6 @@
 cask 'j' do
   version '806'
-  sha256 'acfcf0f666b85259ff77b042d5cf1e3980d5284ccd24863bdd3a18c76ef0dcf5'
+  sha256 'abd0ac83a106d1e351834a7d52b5f7ec927a8e8d728cf64fb73e47b09be873aa'
 
   url "http://www.jsoftware.com/download/j#{version}/install/j#{version}_mac64.zip"
   name 'J'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.