### PR TITLE
Update keka to 1.0.12

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,11 +1,11 @@
 cask 'keka' do
-  version '1.0.11'
-  sha256 '3b4d136df8c8bf9a30ec2a5d15f6223eb0f55f1ffc1ef358ea49c8aa09a92329'
+  version '1.0.12'
+  sha256 '3faea86fe3e281cf3e2f4134692386e4075b7522f153c7d2e5eda5c1d99557c6'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: 'ebdd68bd35a39d9d72c7924ae18dfa1afb9264c42b4366d6d5931eda4a8bd6ed'
+          checkpoint: '24eef394dc33b0a7aeb79a96b0b84830e863a75e4ecc7c6b3bec882937cba8ba'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.