### PR TITLE
Update contexts to 3.1.1

### DIFF
--- a/Casks/contexts.rb
+++ b/Casks/contexts.rb
@@ -1,10 +1,10 @@
 cask 'contexts' do
-  version '3.0.1'
-  sha256 'ce0c36f282d4d87267f5218d298e32f3dfc4827dd790a789fb6f505b32e4e6d7'
+  version '3.1.1'
+  sha256 'a3e8cc2d58c83aed137db91a6c862b0ec3dd95ef5095b593a40e8d4897d063cd'
 
   url "https://contexts.co/releases/Contexts-#{version}.dmg"
   appcast 'https://contexts.co/appcasts/stable.xml',
-          checkpoint: '16223ae7b370f760ded25abfa5d66e23de3776ebad193ce5760c9435271e7fb0'
+          checkpoint: '18ea9561873f97ef4864e8160bd87fd87a719cd6df655a1cf278a37bbf47c8b3'
   name 'Contexts'
   homepage 'https://contexts.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.