### PR TITLE
Update the-hit-list to 1.1.29,355

### DIFF
--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,10 +1,10 @@
 cask 'the-hit-list' do
-  version '1.1.28,352'
-  sha256 '4262813521d6b0459d4580aebc7e3d4b1b6080731888d26c45253e4587e95952'
+  version '1.1.29,355'
+  sha256 'd4846927351bf7b48c10a4af740bf129bd4245a34be8189e709c83ba011e4e46'
 
   url "https://distrib.karelia.com/downloads/TheHitList-#{version.after_comma}.zip"
   appcast 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List',
-          checkpoint: 'a4bc0e34599ed0ea03435c3db10011e0213d59957b4a8f8a0bdb8dab53234550'
+          checkpoint: '5c4d0a25485671d8023dc58a9fb77d30f3f993697f5cb3c49f2fd85bbdd92768'
   name 'The Hit List'
   homepage 'https://www.karelia.com/products/the-hit-list/mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.