### PR TITLE
Update now to 2.5.4

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.5.3'
-  sha256 'bdf53aafdbee7d1168c61c688230b9a5b02c737f29cb6a4db8414c79a8f92467'
+  version '2.5.4'
+  sha256 'ee284c2aa7a7875e3861c676e5640b9fab37ff95c34b844d663ba4b9184d8899'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '39a7858a79fdeeda406ebed6f717ae228e7c5a36bf75cebee2011c020681469c'
+          checkpoint: 'd11c49e7fcd265fafb1d706717a8f47badf4df55c44c41ff6361b93ee432084c'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.