### PR TITLE
Update freesmug-chromium to 61.0.3163.91

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '61.0.3163.79'
-  sha256 'deba35e6ee962a9a772615084ede3f51b8403328f3c8a442568adf3c8e538e67'
+  version '61.0.3163.91'
+  sha256 '7777aea7f7e87d63fbb8ae36c5e28e22833a73cb4d8626084228134c468ac8f4'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '54def49cdfb89caad24773d89a855264dacb4e153f3e27d8f4b5f83f82142f5c'
+          checkpoint: '6cd429e20437b9b5bcab6d887d0ad9cd0138549c432d7f3dcb04b348972cc7de'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.