### PR TITLE
Update evernote to 6.12.2_455489

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -6,13 +6,13 @@ cask 'evernote' do
     version '6.8_453748'
     sha256 '53fb93884fbd8f966ef43248dad3a7570ad18eb43fd289ad614ee8cff3a26d33'
   else
-    version '6.12.1_455453'
-    sha256 '88baf9d58e3595d08eccb6eb168a32085df2da19e26a4410f44ee7589d869a7f'
+    version '6.12.2_455489'
+    sha256 '0f9441a07a6659b060325397a096b737c18d4624f4bae37cf5752a551163474b'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
   appcast 'https://update.evernote.com/public/ENMacSMD/EvernoteMacUpdate.xml',
-          checkpoint: 'bee6fcbb4a51470e36556df74e37c836045c2ee1d156df693b857e81b99f8975'
+          checkpoint: '695a5a12783602df101dc95526b13fe66eb2e4f10bda60c37fdb9b2e1457d195'
   name 'Evernote'
   homepage 'https://evernote.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.