### PR TITLE
Update j to 805

### DIFF
--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -1,6 +1,6 @@
 cask 'j' do
-  version '806'
-  sha256 'acfcf0f666b85259ff77b042d5cf1e3980d5284ccd24863bdd3a18c76ef0dcf5'
+  version '805'
+  sha256 '55acaed87895dddcfe8dc08ae3c5045b6705830622c923c6852296cd0f5720a5'
 
   url "http://www.jsoftware.com/download/j#{version}/install/j#{version}_mac64.zip"
   name 'J'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

This reverts `j` to the current stable release `805`. http://www.jsoftware.com/stable.htm

Current `sha256` matches the previous `805` `sha256`: https://github.com/caskroom/homebrew-cask/pull/32729/commits/24c1fe5e68b3b1c21e34ca471c9796a2a15aa319