### PR TITLE
Update brave to 0.18.36

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.18.29'
-  sha256 'acd98078d16271dbe52f38dca41101d7a4e63365447b0ddf8e6b81a12d6c77f7'
+  version '0.18.36'
+  sha256 '0aa0ebfd310a627f4ba50c518bd141764a4b0335d5bc244d3cc8fa1538bfaef0'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '9297b46ccde5ec5493b739b1d3ca5b787477c49fc88d0011dffbe9ba9805d25c'
+          checkpoint: '9732ab3236b80c416500a6110da0a298494b1a07fe74835c3caad5f630226bcb'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.