### PR TITLE
Update mammon to latest

### DIFF
--- a/Casks/mammon.rb
+++ b/Casks/mammon.rb
@@ -2,8 +2,8 @@ cask 'mammon' do
   version :latest
   sha256 :no_check
 
-  # dl.dropboxusercontent.com/u/5790728 was verified as official when first introduced to the cask
-  url 'https://dl.dropboxusercontent.com/u/5790728/Mammon-latest.zip'
+  # dropbox.com/s/kc8a9rcq2kpt94x was verified as official when first introduced to the cask
+  url 'https://www.dropbox.com/s/kc8a9rcq2kpt94x/Mammon-latest.zip'
   name 'Mammon'
   homepage 'https://teamfox.co/mammon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.