### PR TITLE
Update exodus to 1.34.1

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.33.2'
-  sha256 '64f289fd74ca04f06063dbbad3310ac6bb57dda55e51749d018e6fabc8f82eca'
+  version '1.34.1'
+  sha256 '57723e1ad927b72170bf834b5221e4cf40c4ef213041a5dcbe793ff6b7d65a43'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '567a0ecd874058dc4a8d2233340866131d07bbda35ece1885717228989ad9abd'
+          checkpoint: '121753bfa066ae1758ee2bf073df1d754ee4e09489e1ef501174c2603c61e70d'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.