### PR TITLE
Update blender to 2.79

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -1,6 +1,6 @@
 cask 'blender' do
   version '2.79'
-  sha256 '953fbb77080300466cb084ad02f847d188e94573f1dd4a6edaa7c505dd55c88e'
+  sha256 '25d9c6d083726e19229ece4a7e4a5ebfb74ed53f575303e90d4db1e43f7817f1'
 
   url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macOS-10.6.tar.gz"
   name 'Blender'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.