### PR TITLE
Update deepstream to 3.0.1

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,11 +1,11 @@
 cask 'deepstream' do
-  version '3.0.0'
-  sha256 'aa58555ff79d63db05d3b11944903af365551e06958c1eae932bb33de69b2f40'
+  version '3.0.1'
+  sha256 '83ffa43ccf95ef2057870f5b6bf2bb9a60ef0fea4464d083fb163244b6877816'
 
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"
   appcast 'https://github.com/deepstreamIO/deepstream.io/releases.atom',
-          checkpoint: '7a21c27360fecf2d2001b02b3a9049d304dfa61f44497936f095530f362aff05'
+          checkpoint: '894a5b3237f92e60c4ed15649085ff73acc117adf50fb21cadd0d723b54e73db'
   name 'deepstream'
   homepage 'https://deepstream.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.