### PR TITLE
Update downie to 2.9.13,1533

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '2.9.12,1530'
-  sha256 '832ba36cafaf8757a1cd6f9d5c89ff22a9dd5f9f4b9a5b9cee2b735ef09c1505'
+  version '2.9.13,1533'
+  sha256 '30607298a4950fd1453991f4432d4f3716900718cc524b3087e934567a4d8c96'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.after_comma}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
-          checkpoint: '88e681ee32f24ec2298d4754e7ece00dc102b81e140e277638a30e9de8c60345'
+          checkpoint: '70ea087a3e53f986c9777fce53adfe0afc1df3d2bc8674636fb759ae967ac8e7'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.