### PR TITLE
Update get-backup-pro to 3.4

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.3.3'
-  sha256 'e454f031dd9cd417ad8065eba95bc125fcdc5978663588f2aba97faf65075fcf'
+  version '3.4'
+  sha256 '5ab883193f8129506c43369bb75fc23feeb12b307fa57f51094dde0455fe9de5'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: '16bf6fe0fc9bde97bb1a3d34f0ddcc668007a68b7bc460d482a8235c4d25df95'
+          checkpoint: '8c150fdff091eb3f91aad83ad62088797af7cb87b41bacfb277ab6e078a14c35'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.