### PR TITLE
Update grabbox to 2.0.4

### DIFF
--- a/Casks/grabbox.rb
+++ b/Casks/grabbox.rb
@@ -1,10 +1,10 @@
 cask 'grabbox' do
-  version '2.0.2'
-  sha256 '4413c7e9035b4b0e18e979d3cb74dade8c9672bdca409cf3771af80e592ec3e3'
+  version '2.0.4'
+  sha256 '0609b8c1a4f03e3f458ac9e2053ff3c06d4b8de8867f7b5e786d2e4bb0bac3a2'
 
   url "https://grabbox.bitspatter.com/updates/GrabBox-#{version}.zip"
   appcast 'https://grabbox.bitspatter.com/updates/appcast.xml',
-          checkpoint: 'fd68ecdde99fa9c2ef46c5954487c9429d6035db816afac20902a53ad072bc88'
+          checkpoint: 'fab4b41695425327aab483578be941494d5d741fe7793e3c70f08676a145b8e6'
   name 'GrabBox'
   homepage 'https://grabbox.bitspatter.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.