### PR TITLE
Update houdahspot to 4.3.1

### DIFF
--- a/Casks/houdahspot.rb
+++ b/Casks/houdahspot.rb
@@ -1,10 +1,10 @@
 cask 'houdahspot' do
-  version '4.3'
-  sha256 '9f6f1a1d60880ea629eb9b9bcbd2f29136452325a11598f3c910bb25a4f653e1'
+  version '4.3.1'
+  sha256 '1f4b7b0b591ef7fa799654ef33c5370170846656c11748d476b8f08249572b3a'
 
   url "https://www.houdah.com/houdahSpot/updates/cast#{version.major}_assets/HoudahSpot#{version}.zip"
   appcast "https://www.houdah.com/houdahSpot/updates/cast#{version.major}.xml",
-          checkpoint: 'befa8f693c6688bc216a0d4153eb98c47a5133a1e01687375a280f57482bb7cc'
+          checkpoint: 'fe4e9c2c244624547de7cc2c3bfe14f14ff4eada68600b4d43f2a727c416ed46'
   name 'HoudahSpot'
   homepage 'https://www.houdah.com/houdahSpot/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.