### PR TITLE
Update kite to 0.20170914.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170907.0'
-  sha256 '976af2fd252bb79d54bafef9b5f9187b60e1ca6759a784141368b8ea16b7ca32'
+  version '0.20170914.0'
+  sha256 '19eb4c90f9c0235b53313ad548a3c5b37ed0d587f99ecd83e1cffc45f0f53f8e'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '3bb95d37fad56868852fa0e113c167e1be5dadde433b519f8d7fd73af190728e'
+          checkpoint: '1f734d2ea6693eab842071edc512c6d6dae1e905a1dfe1d5e9f40881653bb0ae'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.