### PR TITLE
Update fission to 2.4.0

### DIFF
--- a/Casks/fission.rb
+++ b/Casks/fission.rb
@@ -1,6 +1,6 @@
 cask 'fission' do
-  version '2.3.3'
-  sha256 '569adde95c98453b2fcc8ddce76ba757a9470b6b308666bad125a5f992b2ca48'
+  version '2.4.0'
+  sha256 '851874e74369aa43aa18ee1134e75497dd8bb65707e26d361a8feab1929eceb8'
 
   url 'https://rogueamoeba.com/fission/download/Fission.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Fission&version=2000000',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.