### PR TITLE
Update mendeley-desktop to 1.17.11

### DIFF
--- a/Casks/mendeley-desktop.rb
+++ b/Casks/mendeley-desktop.rb
@@ -1,6 +1,6 @@
 cask 'mendeley-desktop' do
-  version '1.17.10'
-  sha256 'bd3dc8748ec29fb7e76aa171e36df1e68b0c792e58d252d3491236e4d953f53d'
+  version '1.17.11'
+  sha256 '5f953c5e6d68216d4cc14e8375ab8a3639dc2fc9e91ab9233248439de7897495'
 
   url "https://desktop-download.mendeley.com/download/Mendeley-Desktop-#{version}-OSX-Universal.dmg"
   name 'Mendeley'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.