### PR TITLE
Update espresso to 5.0.2

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,11 +1,11 @@
 cask 'espresso' do
-  version '5.0.1'
+  version '5.0.2'
   sha256 '462a57b2364764f15b62da95cab24633cb59b3dca1c4f05ac6ad85701372dda4'
 
   # static.macrabbit.com was verified as official when first introduced to the cask
   url "https://static.macrabbit.com/downloads/Espresso%20v#{version.major}.zip"
   appcast "https://update.macrabbit.com/espresso/#{version}.xml",
-          checkpoint: '15bb98f284a0b4171c89b16254c77d2f4d9df7989ed0725cc0911153c155f615'
+          checkpoint: 'bce000fa6fee673d2df9c3e73b096ee8e45e832d79e3d7b698506181d946db48'
   name 'Espresso'
   homepage 'https://espressoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.