### PR TITLE
Update hopper-disassembler to 4.2.18

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.2.17'
-  sha256 'e14393b1b3e34e05a3337dfe1fa9a25992fdc695badf69b2be729f43f48eada8'
+  version '4.2.18'
+  sha256 'e2a843e2ca055e40e64362b47265b90a350ab9cb9df145fdc8330af3a3be0f08'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: 'e07725eb60c39524e2b33215260509cf1c0b0b662b128b43b286b23866ba7e5b'
+          checkpoint: 'dcdd4b9db27c43feac8f1afd2a99c7086f5f76754cc1a909713eedbe6808da46'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 
@@ -16,10 +16,12 @@ cask 'hopper-disassembler' do
   binary "#{appdir}/Hopper Disassembler v#{version.major}.app/Contents/MacOS/hopper"
 
   zap delete: [
+                "~/Library/Caches/com.cryptic-apps.hopper-web-#{version.major}",
+                "~/Library/Saved Application State/com.cryptic-apps.hopper-web-#{version.major}.savedState",
+              ],
+      trash:  [
                 '~/Library/Application Support/Hopper',
                 "~/Library/Application Support/Hopper Disassembler v#{version.major}",
-                "~/Library/Caches/com.cryptic-apps.hopper-web-#{version.major}",
                 "~/Library/Preferences/com.cryptic-apps.hopper-web-#{version.major}.plist",
-                "~/Library/Saved Application State/com.cryptic-apps.hopper-web-#{version.major}.savedState",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.