### PR TITLE
Update hyper to 1.4.6

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.4.4'
-  sha256 'c387acba8d4f7996a17b51540540f0dc1ae61d813cb3465c478f0b5c3717fcae'
+  version '1.4.6'
+  sha256 '183fe4f2823d4c3a817aac72f70cb4af621a68263d55c71da643256f006b0893'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: 'f3e046e446d65843580af469db1e1e9a90eff00953923f7845cfa642a8e6f128'
+          checkpoint: '49467ab3ad2c9171c9afcac7b8d11755f78d46f13cc51d83cada12bfa3cc8602'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.