### PR TITLE
Update lepton to 1.4.2

### DIFF
--- a/Casks/lepton.rb
+++ b/Casks/lepton.rb
@@ -1,11 +1,11 @@
 cask 'lepton' do
-  version '1.4.0'
-  sha256 '2b9bb68dc03951641dc5e1dad78e51bd8695f9b8a2e6029327dc9c7679d17fa6'
+  version '1.4.2'
+  sha256 'a349b99911207d602bf15cf1dc70e25d53327a9224f666a06e67dfc6313aacaf'
 
   # github.com/hackjutsu/Lepton was verified as official when first introduced to the cask
   url "https://github.com/hackjutsu/Lepton/releases/download/v#{version}/Lepton-#{version}-mac.zip"
   appcast 'https://github.com/hackjutsu/Lepton/releases.atom',
-          checkpoint: '88a670eba018a3308f3c157e3ec544bf44db6fa2b8c4b65b289c064af3b3f500'
+          checkpoint: '8f2d23a548abf7334aed2b57df36bd6063c2335849ae483e39cbac491348c05c'
   name 'Lepton'
   homepage 'http://hackjutsu.com/Lepton/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.