### PR TITLE
Update microsoft-r-open to 3.4.1

### DIFF
--- a/Casks/microsoft-r-open.rb
+++ b/Casks/microsoft-r-open.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-r-open' do
-  version '3.4.0'
-  sha256 'ae725bd1ff8a21bf68a06ca033c11f59781cb8dd8068f7b224cc44dcb2e04fab'
+  version '3.4.1'
+  sha256 '643c5e953a02163ae73273da27f9c1752180f55bf836b127b6e1829fd1756fc8'
 
   url "https://mran.microsoft.com/install/mro/#{version}/microsoft-r-open-#{version}.pkg"
   name 'Microsoft R Open'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.