### PR TITLE
Update fldigi to 4.0.9

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.8'
-  sha256 '9d45400b1b3942b5a79d01042bd284c99cf9575157542be152160717f17c6f5e'
+  version '4.0.9'
+  sha256 '1e092632d0f29de3911121c12685c60e9bd602a9fa06139266679c1439c4a832'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'f27999aae707e424c0d55062a925f2af154563bb4479dbfd87cead956b975d1c'
+          checkpoint: 'e5ffd672f246bebb73f677f1b771b69f8b8751df2c9da437f51591a77265b3ef'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -4,7 +4,7 @@ cask 'fldigi' do
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'e5ffd672f246bebb73f677f1b771b69f8b8751df2c9da437f51591a77265b3ef'
+          checkpoint: '2baa7fe03d9a6f22e8388d3533713a59ff4f6170881afdec34732ed0cad3c139'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.