### PR TITLE
Update rubitrack-pro to 4.4.4

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '4.4.3'
-  sha256 '3f34db51fc8312a73306ee7b3b9f4b5fbdb9911bf7dc4813659742262365a026'
+  version '4.4.4'
+  sha256 'fdaa6b12d77996c0806bea2230ba935ea3d9399ca356e696d9f5e56bfa406792'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}_u.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: 'e8c05e82d571d59ba22d83db7914b3430503ed41800b48bbaee84eaeb1fd3e7a'
+          checkpoint: 'f285ddb3feb516b8ce18066ddf2f2d9cded8ba80b2ec0a8bf9fc3ac1bfba2935'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.