### PR TITLE
Update dbeaver-community to 4.2.1

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.2.0'
-  sha256 '989594ad9775af5519a1150926c1ccd8b5c6093c08360c77a56840ae2818fd33'
+  version '4.2.1'
+  sha256 '44018036bdc8b165fd7b92d66863c04506b953382fc04d791822e0eba4a1cf0a'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '413c6d626d947b2c237423af5a936161c05a3699a8650519960953efcee55a57'
+          checkpoint: '12f9b8d414026dbea590c0aa42b9693e25a7c178f6e3f4a7260d091a65551bb0'
   name 'DBeaver Community Edition'
   homepage 'https://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.