### PR TITLE
Update serial to 1.3.5

### DIFF
--- a/Casks/serial.rb
+++ b/Casks/serial.rb
@@ -1,10 +1,10 @@
 cask 'serial' do
-  version '1.3.4'
-  sha256 '0567d01acb62db7a1607cf27c47f632c0adbb7942bc0c453287bf1aabd4d4941'
+  version '1.3.5'
+  sha256 '5c6b7b31d8265a4d592a59af7b2cc96e1f89826a126b1057dc7ab4ae2a8424c1'
 
   url "https://download.decisivetactics.com/products/serial/dl/Serial_#{version}.zip"
   appcast 'https://www.decisivetactics.com/products/serial/release-notes',
-          checkpoint: '76b57f7849454980d4f22452981fe2b514891b7e4e5dbea60af547c020fefb6f'
+          checkpoint: '158ac5ee1d1d4311c623b744e5f9c65116826e49e3259bacd03cee4ee9538ddd'
   name 'Serial'
   homepage 'https://www.decisivetactics.com/products/serial/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.