### PR TITLE
Update iris to 0.9.2.5

### DIFF
--- a/Casks/iris.rb
+++ b/Casks/iris.rb
@@ -1,6 +1,6 @@
 cask 'iris' do
-  version '0.9.1.7'
-  sha256 '2f44e0bcb32a87f421536efc4fda931d34f722ffe637f70c8e42c139383113a3'
+  version '0.9.2.5'
+  sha256 '4c93b0c9391302470ad53940cec32f7ce6f9f67b74aadec498c6368e344f44c3'
 
   # raw.github.com/danielng01/Iris-Builds/master/OSX was verified as official when first introduced to the cask
   url "https://raw.github.com/danielng01/Iris-Builds/master/OSX/Iris-#{version}-OSX.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.