### PR TITLE
Update airdroid to 3.5.2.0

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
   version '3.5.2.0'
-  sha256 'eb79c44c7fb7ef509910ea106c6587059d018f7ce1ef7e0c22a365e7a869d69e'
+  sha256 '262d06802774513d3cca5f242660ec3e2667d608670445219f9433a5e05f227e'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.