### PR TITLE
Update reaper to 5.50c

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,10 +1,10 @@
 cask 'reaper' do
-  version '5.40'
-  sha256 '7b4d257b3716a3d2bcefcb64a863115ae221c25da3be3088ca7f1b1af80b8195'
+  version '5.50c'
+  sha256 '20e0111817520634eebf85990dd3f15e112ade5a87b84487eb60dea6baa88938'
 
-  url "http://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
-  appcast 'http://www.reaper.fm/whatsnew.txt',
-          checkpoint: 'adf9905d3a534285a4c1394dd9d40a7b857071ab98cd0cc1a88df296be2674cf'
+  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
+  appcast 'https://www.reaper.fm/download.php',
+          checkpoint: '788eb6237892ad58506adf14d795b0474f7148d1e8ace4bbfb4fb9b2d073fb63'
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 
@@ -12,10 +12,10 @@ cask 'reaper' do
   app 'ReaMote64.app'
 
   zap delete: [
-                '~/Library/Application Support/REAPER',
                 '~/Library/Saved Application State/com.cockos.reaper.savedState',
                 '~/Library/Saved Application State/com.cockos.reaperhosti386.savedState',
                 '~/Library/Saved Application State/com.cockos.reaperhostx8664.savedState',
                 '~/Library/Saved Application State/com.cockos.ReaMote.savedState',
-              ]
+              ],
+      trash:  '~/Library/Application Support/REAPER'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The changelog `appcast` seems to be broken.
```
audit for reaper: failed
 - exception while auditing reaper: invalid byte sequence in UTF-8
Error: audit failed for casks: reaper
```