### PR TITLE
Update imageoptim to 1.7.2

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,10 +1,10 @@
 cask 'imageoptim' do
-  version '1.7.1'
-  sha256 '7d5dfb69568559d6932cbe5a512e0d0b4af56fbc364e67302affe2bef07b8a7f'
+  version '1.7.2'
+  sha256 '78a8b53cdb1be8edfb526a87ca9ad8f613889dab258928a68ff8770fe9ddb2e6'
 
   url "https://imageoptim.com/ImageOptim#{version}.tar.bz2"
   appcast 'https://imageoptim.com/appcast.xml',
-          checkpoint: '931c407d8ceddf9d2a1c4c5de280c6ed0602118a9f35b6466d296f74a109b53f'
+          checkpoint: '0b74ecce5d10b49bdb7b3ff0962db28c1e212e35230e3d82183530d576ceafb9'
   name 'ImageOptim'
   homepage 'https://imageoptim.com/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.