### PR TITLE
Update gitup to 1.0.8

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,11 +1,11 @@
 cask 'gitup' do
-  version '1.0.7'
-  sha256 'b5bfe8c1802b1c7f72359214e58b2c768c5b7a573d6579a3101f8932b81d308f'
+  version '1.0.8'
+  sha256 'dfc7572c36807cbc70ef3c5d28429be1988ffc1c872e13ba092d643ddc964393'
 
   # s3-us-west-2.amazonaws.com/gitup-builds was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/gitup-builds/stable/GitUp.zip'
   appcast 'https://github.com/git-up/GitUp/releases.atom',
-          checkpoint: '6a0a080b65c4c9c4f8a2605759c1955eba2550a6b1314f6b53fa47f59e83cd58'
+          checkpoint: '37bf09620ee73ca5dbae0a6a54b1afa595d4e432e2054b51274e93999ccfccbe'
   name 'GitUp'
   homepage 'http://gitup.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.