### PR TITLE
Update backuploupe to 2.11

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,10 +1,10 @@
 cask 'backuploupe' do
-  version '2.10'
-  sha256 '17c72fb27c93fe36a4ba5d46dcea5e4bf78c326541867fb926eed0f7feacc17e'
+  version '2.11'
+  sha256 '619a1c23cc3796395eee71c08e9b4a8a2bd715118bf71c10f5a766be3cfe7530'
 
   url "http://www.soma-zone.com/download/files/BackupLoupe_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/BackupLoupe/a/appcast.xml',
-          checkpoint: '0f0123717142216f86264df1275a2f67787158b0caf59da37f034b234f54a5be'
+          checkpoint: 'f3e77b07c93b1c88d3f13ae85c2ddb71056d1e0909ee05acbc085394fac36583'
   name 'BackupLoupe'
   homepage 'http://www.soma-zone.com/BackupLoupe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.