### PR TITLE
Update nomachine to 5.3.12_10

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '5.3.10_1'
-  sha256 '66af32d921ebbdecadfc72e1dda074b63bc6857b092111f70240fc440686df41'
+  version '5.3.12_10'
+  sha256 '2e2e3e2f8974aa2e1b9dd1d1eceefd514cb1225021154c9b5cb116f800a03b48'
 
   url "http://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.