### PR TITLE
Update insomnia to 5.8.4

### DIFF
--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -1,10 +1,10 @@
 cask 'insomnia' do
-  version '5.8.3'
-  sha256 '6b9a70efa26e8b95dba86a3dc353935ef0a8d1a470d4516ee3b683b50ce9603c'
+  version '5.8.4'
+  sha256 '40c01e94b13f9ceb8ee50b097be37b012be6c3da539bbc41fbe2497753101bfb'
 
   url "https://builds.insomnia.rest/downloads/mac/#{version}"
   appcast 'https://insomnia.rest/changelog/index.xml',
-          checkpoint: '21a856dbb8f6cbe5eed366078ad2720a1b4217283e29ed16658453da16992087'
+          checkpoint: 'f3788c8691cadd6ffe1733d406d3651d683ef6a91c9dc90ae84568f9cfd6a2f0'
   name 'Insomnia'
   homepage 'https://insomnia.rest/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.