### PR TITLE
360-total-security: Change to keep name of .app file

### DIFF
--- a/Casks/360-total-security.rb
+++ b/Casks/360-total-security.rb
@@ -9,5 +9,5 @@ cask '360-total-security' do
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
-  app '360Safe.app', target: '360 Total Security.app'
+  app '360Safe.app', target: '360Safe.app'
 end


### PR DESCRIPTION
This fixes an error message complaining about the application being launched from an improper path (upon launch of 360-total-security)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [  ] The commit message includes the cask’s name and version.  (totally forgot about this but includes name at least)



[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
