### PR TITLE
Fix 360-total-security 1.1.2

### DIFF
--- a/Casks/360-total-security.rb
+++ b/Casks/360-total-security.rb
@@ -9,5 +9,5 @@ cask '360-total-security' do
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
-  app '360Safe.app', target: '360 Total Security.app'
+  app '360Safe.app', target: '360Safe.app'
 end

--- a/Casks/360-total-security.rb
+++ b/Casks/360-total-security.rb
@@ -4,10 +4,10 @@ cask '360-total-security' do
 
   url "https://free.360totalsecurity.com/totalsecurity/mac/360ts_mac_#{version}.dmg"
   appcast 'https://www.360totalsecurity.com/en/version/360-total-security-mac/',
-          checkpoint: 'a265dc1b1421f71e170af65ba5e703d608f46a6ef703bfd8b37b4a65212067fd'
+          checkpoint: 'cbbe129c78691310d2ffa8274aa5709ce28cddfaa6f4f74ad0877716ec917b8e'
   name '360 Total Security'
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 
-  # Renamed for consistency: app name is different in the Finder and in a shell.
-  app '360Safe.app', target: '360Safe.app'
+  # App name is different in the Finder and in a shell.
+  app '360Safe.app'
 end

--- a/Casks/360safe.rb
+++ b/Casks/360safe.rb
@@ -1,4 +1,4 @@
-cask '360-total-security' do
+cask '360safe' do
   version '1.1.2'
   sha256 '6fdef1e93f9930f48ecf7144ed2412663138a1cee492aaa371550907999db8d9'
 
@@ -8,6 +8,5 @@ cask '360-total-security' do
   name '360 Total Security'
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 
-  # App name is different in the Finder and in a shell.
   app '360Safe.app'
 end


### PR DESCRIPTION
Changed not to rename the .app-file therby resolving an error that would show up upon application launch complaining about an invalid location of the app.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
