### PR TITLE
Update karabiner-elements to 11.0.0

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '0.91.16'
-  sha256 'd966f103b205d08721ba018cf69b694bbec30fa25ccf44de8c547eb2d21a0d3e'
+  version '11.0.0'
+  sha256 '1fcefe8abc844ed5f0cd7a1cb0cbe1ebde852e5d7168494501311309768824bc'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: 'f05a420339a45b2739219fbd32f4eb03380cad130e88acac20d08d7884b86570'
+          checkpoint: '1d56b49600f2248b4cfef371087f736de9756277829324e0fb2ec047a2ffdc84'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.