### PR TITLE
Update fsmonitor to 87: uninstall / zap

### DIFF
--- a/Casks/fsmonitor.rb
+++ b/Casks/fsmonitor.rb
@@ -1,6 +1,6 @@
 cask 'fsmonitor' do
-  version '84'
-  sha256 '9f835c5d257bd6ef66bd2f8ddc0229ff3829bd556bbde75521b98b794f32a164'
+  version '87'
+  sha256 '0e5f482a74889a57bbed00553f50405ee86626635e77b32e69a4e373693604e3'
 
   # tristan-software.ch/FSMonitor was verified as official when first introduced to the cask
   url "https://tristan-software.ch/FSMonitor/Archives/FSMonitor_#{version}.zip"
@@ -11,13 +11,17 @@ cask 'fsmonitor' do
 
   app 'FSMonitor.app'
 
+  uninstall delete:    '/Library/PrivilegedHelperTools/com.tristan.fseventstool',
+            launchctl: 'com.tristan.fseventstool'
+
   zap delete: [
-                '/Library/LaunchDaemons/com.tristan.fseventstool.plist',
-                '/Library/PrivilegedHelperTools/com.tristan.fseventstool',
+                '~/Library/Caches/com.tristan.FSMonitor',
+                '~/Library/Saved Application State/com.tristan.FSMonitor.savedState',
+              ],
+      trash:  [
                 '/Users/Shared/FSMonitor',
                 '~/Library/Application Support/FSMonitor',
                 '~/Library/Application Support/com.tristan.FSMonitor',
-                '~/Library/Caches/com.tristan.FSMonitor',
                 '~/Library/Preferences/com.tristan.FSMonitor.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.