### PR TITLE
Update ubar to 4.0.1

### DIFF
--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -1,10 +1,10 @@
 cask 'ubar' do
-  version '3.2.6'
-  sha256 '76f87ebb3a74b40d6299354cd4f34c63480cd5951c2276a3a4d95c65882dd1a0'
+  version '4.0.1'
+  sha256 '2ebc0cf7d74553f44308eb93f72f2a897e8d403a961cc16023cc843471b3e1f0'
 
   url "http://www.brawersoftware.com/downloads/ubar/ubar#{version.no_dots}.zip"
   appcast "https://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
-          checkpoint: 'bd56dabff2625be4c5843c8cd67eeac340dc7f38f0e05487336bb3907202b7c0'
+          checkpoint: '25f9839af108389ace53991d20df808e5f58de71bd3906bdab310244729b067a'
   name 'uBar'
   homepage 'https://brawersoftware.com/products/ubar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.