### PR TITLE
Update typinator to 7.3

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,11 +1,11 @@
 cask 'typinator' do
-  version '7.2'
-  sha256 '153ae0ac3441744c369d08ff376e6856bbb49a9a379351f1d3cd7a31f7889de9'
+  version '7.3'
+  sha256 '654de96328eb766b3879ebed83b2f6479b19614f3978958f054fd1fb227f802d'
 
   url "http://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake
   appcast 'http://www.ergonis.com/products/typinator/history.html',
-          checkpoint: 'bf00eb396aec76a1a501756d237e20a91f959793e9343a7cc19bbf6f0e54c005'
+          checkpoint: '3af9687b6004c0ba8a71f3b1a227ad70544428189abdccdd44d260b153f1e707'
   name 'Typinator'
   homepage 'http://www.ergonis.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.