### PR TITLE
Update qownnotes to 17.09.5,b3236-200126

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.07.9,b3124-102541'
-  sha256 '529a039151fd99a22dfedc9f42cd1500de693555e9915ce1b5683ae0a265102e'
+  version '17.09.5,b3236-200126'
+  sha256 '354492236495ce80fa8a04538898784f5d1f72b5c3b6c916f5b5e30472efe4a3'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '1fd46c8e2420d29d8ceace6780009a381f44b62b1cf7424802d6630024067d27'
+          checkpoint: '9779fbe629a2ddc7e3743138aa31e566afde434fd287ad480b03a0f8cbc696b6'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.