### PR TITLE
Update xtrafinder to 0.27

### DIFF
--- a/Casks/xtrafinder.rb
+++ b/Casks/xtrafinder.rb
@@ -8,6 +8,8 @@ cask 'xtrafinder' do
   name 'XtraFinder'
   homepage 'https://www.trankynam.com/xtrafinder/'
 
+  depends_on macos: '<= :yosemite'
+
   pkg 'XtraFinderInstaller.pkg'
 
   uninstall pkgutil: 'com.trankynam.xtrafinder.*'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

Refs https://github.com/caskroom/homebrew-cask/issues/38746.