### PR TITLE
Update feeder to 3.5

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.4.6'
-  sha256 '7992036e6ab5a5df7ee077aeba926d745a02a89a83b37ff5d1d62fd669c48978'
+  version '3.5'
+  sha256 'c19e9b5d4819931c91b2581ef990419c85041edab849f04239e022bc1850f1d6'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: 'eb54f81d111e9b6afa48b9d41c56edae9341e3b0a39464ed5510458e8ed9ab87'
+          checkpoint: '6d49c00af99ecf3b8cae9e88e31de55bddecdcc15b854aa2065c85d4991a496e'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.