### PR TITLE
Update atext to 2.21

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,10 +1,10 @@
 cask 'atext' do
   version '2.21'
-  sha256 '67539d037aee39e56329070cf1d151bdfa79a8d7c0b41897d8af0c468af7d08b'
+  sha256 '8ef2fc8f136f15ab4c1218a74097a9a83407ede3f79e6e616eade920bfff02ba'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml',
-          checkpoint: '606782e61ba768bd9d3daa26d5d3451d37ea9dabdb6c9b658b95e7a0d186ca03'
+          checkpoint: '9d96d77e7584acfe70ee83f0d00342fbe0b9d0b39e23685f9c92001bbd12f983'
   name 'aText'
   homepage 'https://www.trankynam.com/atext/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.