### PR TITLE
Update nvalt to 2.2.8-128

### DIFF
--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -1,6 +1,6 @@
 cask 'nvalt' do
-  version '2.2.7-126'
-  sha256 '496e0fb87b255ac6b6746395ff676b788cc455eccd1e65b49a63d0e2812754c3'
+  version '2.2.8-128'
+  sha256 '85420c2a8d505a580b4aa4f0ef4662f08aa4af6139fb4ed448752b6b6e8fd671'
 
   # updates.designheresy.com/nvalt was verified as official when first introduced to the cask
   url "http://updates.designheresy.com/nvalt/nvALT#{version.no_hyphens}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.