### PR TITLE
Update sabaki to 0.31.3

### DIFF
--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,11 +1,11 @@
 cask 'sabaki' do
-  version '0.31.2'
-  sha256 'b99b480ede7bb352d12fd0789a791ffb691dcba435ee54203d1de3c766dfbf2c'
+  version '0.31.3'
+  sha256 '37e7e5384d2c405fb3fb64196a0e2dea37f9a33edce7b4ecc61126d48c287b6d'
 
   # github.com/yishn/Sabaki was verified as official when first introduced to the cask
   url "https://github.com/yishn/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-x64.7z"
   appcast 'https://github.com/yishn/Sabaki/releases.atom',
-          checkpoint: '98d940460e29b4092294cc759f5c917e51d474ee6ddd8a67ae7404400c05f6a0'
+          checkpoint: 'd061c56e4ce86fb56b81c536e9efe40e47cc6eeeb650c19d22583530062ee992'
   name 'Sabaki'
   homepage 'http://sabaki.yichuanshen.de/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.