### PR TITLE
Update now to 2.5.7

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.5.5'
-  sha256 '883680640b023f1b72cc55e9470c518eae6edb0d2acbb2dbe34c39d85635d3ef'
+  version '2.5.7'
+  sha256 '8df327b5e06d60d221582c7aea89e9dd16ac3c0a81896a18a02c43f743aa9ee5'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '2580e95417e04320c1db89a2deff0633c06e294f52d9bd01efe66384940ff412'
+          checkpoint: '28b64f6a89995187262218fd75c024c8a5ada7e4ab1b7dc4321caaba8a6d7284'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.