### PR TITLE
Install binary when installing Keybase.app 1.0.30

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -11,6 +11,7 @@ cask 'keybase' do
   auto_updates true
 
   app 'Keybase.app'
+  binary "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase"
 
   postflight do
     system_command "#{appdir}/Keybase.app/Contents/Resources/KeybaseInstaller.app/Contents/MacOS/Keybase",


### PR DESCRIPTION
should fix https://github.com/keybase/keybase-issues/issues/2552 for mac users

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.