### PR TITLE
Update keybase: fix `postflight` install

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -13,8 +13,8 @@ cask 'keybase' do
   app 'Keybase.app'
 
   postflight do
-    system_command "#{appdir}/Keybase.app/Contents/Resources/KeybaseInstaller.app/Contents/MacOS/Keybase",
-                   args: ["--app-path=#{appdir}/Keybase.app", '--run-mode=prod', '--timeout=10']
+    system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
+                   args: ['install-auto']
   end
 
   uninstall delete:     '/Library/PrivilegedHelperTools/keybase.Helper',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This changes the `postflight` to run the CLI `install-auto` command.
___
```
==> Moving App 'Keybase.app' to '/Applications/Keybase.app'.
==> Installing artifact of class Hbc::Artifact::PostflightBlock
==> Executing: ["/Applications/Keybase.app/Contents/SharedSupport/bin/keybase", "install-auto"]
==> 2017-09-20T11:10:26.163758+10:00 ▶ [INFO keybase install_darwin.go:524] 001 Checking /usr/local/bin/keybase (/Applications/Keybase.app/Contents/SharedSupport/bin/keybase)
==> 2017-09-20T11:10:26.163985+10:00 ▶ [INFO keybase install.go:199] 002 Linking /usr/local/bin/keybase to /Applications/Keybase.app/Contents/SharedSupport/bin/keybase
==> 2017-09-20T11:10:26.180862+10:00 ▶ [INFO keybase launchd.go:270] 003 Saving /Users/commitay/Library/LaunchAgents/keybase.updater.plist
==> 2017-09-20T11:10:26.183905+10:00 ▶ [INFO keybase launchd.go:95] 004 Starting keybase.updater
==> 2017-09-20T11:10:26.190447+10:00 ▶ [INFO keybase launchd.go:176] 005 Waiting for keybase.updater to be loaded...
==> 2017-09-20T11:10:27.231065+10:00 ▶ [INFO keybase launchd.go:270] 006 Saving /Users/commitay/Library/LaunchAgents/keybase.service.plist
==> 2017-09-20T11:10:27.231676+10:00 ▶ [INFO keybase launchd.go:95] 007 Starting keybase.service
==> 2017-09-20T11:10:27.237415+10:00 ▶ [INFO keybase launchd.go:176] 008 Waiting for keybase.service to be loaded...
==> 2017-09-20T11:10:28.684391+10:00 ▶ [INFO keybase launchd.go:270] 009 Saving /Users/commitay/Library/LaunchAgents/keybase.kbfs.plist
==> 2017-09-20T11:10:28.684935+10:00 ▶ [INFO keybase launchd.go:95] 00a Starting keybase.kbfs
==> 2017-09-20T11:10:28.690252+10:00 ▶ [INFO keybase launchd.go:176] 00b Waiting for keybase.kbfs to be loaded...
==> 2017-09-20T11:10:29.726250+10:00 ▶ [INFO keybase install_darwin.go:635] 00c Installing KBNM NativeMessaging whitelists for binary: /Applications/Keybase.app/Contents/SharedSupport/bin/kbnm
🍺  keybase was successfully installed!
```