### PR TITLE
Update bluej to 4.1.1

### DIFF
--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -1,6 +1,6 @@
 cask 'bluej' do
-  version '4.0.1'
-  sha256 '9277ec8d133d27111b933cbc4fb38f335200e8623d3bb41ac67c314ba33f0525'
+  version '4.1.1'
+  sha256 'b29a430489333ff5ee6aa459a1568ed73b799a828ab5e34f7eff94a0ae3402b3'
 
   url "https://www.bluej.org/download/files/BlueJ-mac-#{version.no_dots}.zip"
   name 'BlueJ'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.