### PR TITLE
Update expandrive to 6.0.16

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,6 +1,6 @@
 cask 'expandrive' do
-  version '6.0.15'
-  sha256 'e87525ac6b701fad014b5fab1a9447fcf7cf9c22ee3e363ffa0a8efef0ad62e6'
+  version '6.0.16'
+  sha256 '44b2e869898574f2d7ee19b4f9e5ebddfd81ef5d32e7e742270536d35676d953'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
   appcast 'https://updates.expandrive.com/appcast/expandrive.xml',

--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -3,8 +3,6 @@ cask 'expandrive' do
   sha256 '44b2e869898574f2d7ee19b4f9e5ebddfd81ef5d32e7e742270536d35676d953'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
-  appcast 'https://updates.expandrive.com/appcast/expandrive.xml',
-          checkpoint: '5ef57ba7165a2afc67ab96fd08e68aed3a2a90a273fa717b887c0c34040b2ca7'
   name 'ExpanDrive'
   homepage 'https://www.expandrive.com/apps/expandrive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.