### PR TITLE
Update fork to 1.0.56.1

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.55'
-  sha256 '1f7a052cd9aecf0075156e61bd3f245ba76ee7730e97db44b4f5799dad4a963f'
+  version '1.0.56.1'
+  sha256 '8eed688e1f485c0359f4aabb10738c90cdd463d49e82383da00e29260ee5bde0'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '0c30d4bbab7c4e0b04405d3494eee9a3d33778696172128f5721687e84472d0c'
+          checkpoint: 'f2dcdba5cba2673311590ed3f757e6ac3abfa6a75b05af899d9061508ebe2a52'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.