### PR TITLE
Update xamarin-android to 7.4.5-1

### DIFF
--- a/Casks/xamarin-android.rb
+++ b/Casks/xamarin-android.rb
@@ -1,6 +1,6 @@
 cask 'xamarin-android' do
-  version '7.4.3-1'
-  sha256 '456c0d5c94f21cabbfeef2b73a46580c547ee51a8a159c436a0faa3e7dde03e3'
+  version '7.4.5-1'
+  sha256 '0a23f464523d010d7f83c45f200880cb45591e75b1360aa450eabf142b10f651'
 
   url "https://dl.xamarin.com/MonoforAndroid/Mac/xamarin.android-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.