### PR TITLE
Update hyper to 1.4.7

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,25 +1,27 @@
 cask 'hyper' do
-  version '1.4.6'
-  sha256 '183fe4f2823d4c3a817aac72f70cb4af621a68263d55c71da643256f006b0893'
+  version '1.4.7'
+  sha256 '49f530ca76ece244e0c03b905ca6855d58ad962a717bf15d2f8c8766449e1b92'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '49467ab3ad2c9171c9afcac7b8d11755f78d46f13cc51d83cada12bfa3cc8602'
+          checkpoint: '37ad97df5744c71ad69cdf3feace8038daa5ff7ed747b589f9c59def429fe587'
   name 'Hyper'
   homepage 'https://hyper.is/'
 
   app 'Hyper.app'
 
   zap delete: [
-                '~/.hyper.js',
-                '~/.hyper_plugins',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.zeit.hyper.sfl',
-                '~/Library/Application Support/Hyper',
                 '~/Library/Caches/co.zeit.hyper',
                 '~/Library/Caches/co.zeit.hyper.ShipIt',
+                '~/Library/Saved Application State/co.zeit.hyper.savedState',
+              ],
+      trash:  [
+                '~/.hyper.js',
+                '~/.hyper_plugins',
+                '~/Library/Application Support/Hyper',
                 '~/Library/Preferences/co.zeit.hyper.plist',
                 '~/Library/Preferences/co.zeit.hyper.helper.plist',
-                '~/Library/Saved Application State/co.zeit.hyper.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.