### PR TITLE
Update plex-media-server to 1.9.1.4272-b207937f1

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,10 +1,10 @@
 cask 'plex-media-server' do
-  version '1.8.4.4249-3497d6779'
-  sha256 'af5da8413e29470943024fdc1cca936f3c972601735cb01fa8a6b05b60171b88'
+  version '1.9.1.4272-b207937f1'
+  sha256 'db9f7f047dd1251ee6a053dc936650410cd0081611bd1abdd701283bfefe28e4'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   appcast 'https://plex.tv/api/downloads/1.json',
-          checkpoint: 'cd3569d942ca20718436b445229620ffbf56517fbd5ba3953095ecbb16c82671'
+          checkpoint: '3aaff7d131397d270de8e3b5deeb949df2ae6e1dcebb1ba5eda9e4dc104ea457'
   name 'Plex Media Server'
   homepage 'https://www.plex.tv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.