### PR TITLE
Update golly to 3.0

### DIFF
--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -1,24 +1,13 @@
 cask 'golly' do
-  if MacOS.version <= :mountain_lion
-    version '2.6'
-    sha256 '6fee35e8e4f63ee2c1b0913b7e8009b2548c4e4469050f9c31791900e1e97f16'
+  version '3.0'
+  sha256 '1540f8278d60e75aa13d908a9e8c2bb2f5c958720e03ebf2b33ed6469eb725a1'
 
-    url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/golly-#{version}-mac106.zip"
-
-    app "golly-#{version}-mac106/Golly.app"
-    binary "golly-#{version}-mac106/bgolly"
-  else
-    version '2.8'
-    sha256 '3ee7488591f97547ba69ce52172384f6e9bfd12baf0c1fbf062b17afaf51fafc'
-
-    url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/Golly-#{version}-Mac.dmg"
-    appcast 'https://sourceforge.net/projects/golly/rss?path=/golly',
-            checkpoint: '5bd057ed02b659d4a6ff2f363bc2dd751f41f7ce4d46ae34c4c35b5d8a6ec49f'
-
-    app "golly-#{version}-mac/Golly.app"
-    binary "golly-#{version}-mac/bgolly"
-  end
-
+  url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/Golly-#{version}-Mac.dmg"
+  appcast 'https://sourceforge.net/projects/golly/rss?path=/golly',
+          checkpoint: '6550a211f72b108f5b7d1f5fc3cd02691d3da1ed755446fcf1e842cc3a0fc10d'
   name 'Golly'
   homepage 'http://golly.sourceforge.net/'
+
+  suite "golly-#{version}-mac"
+  binary "#{appdir}/golly-#{version}-mac/bgolly"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Changed to use `suite`
```
ls -1 golly-3.0-mac/
Golly.app
Help
License.html
Patterns
ReadMe.html
Rules
Scripts
bgolly
```