### PR TITLE
Update remote-desktop-manager to 4.5.1.0

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,13 +1,21 @@
 cask 'remote-desktop-manager' do
-  version '4.4.2.0'
-  sha256 '49b833f23f5a88d1ba6ab84ac1967044d0423f233f843e08bddd1e376189cca8'
+  version '4.5.1.0'
+  sha256 'd19a3cac0c5c9e879f0374fb41c3271cb66b9cfcb0b8534a673f9ed3be9df76d'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"
   appcast 'http://cdn.devolutions.net/download/Mac/RemoteDesktopManager.xml',
-          checkpoint: 'd28958f114906feb9433ca50cc6d9d037340d5c75bf8b969dc73c6508513e4bf'
+          checkpoint: '2a177c8d2bd99879aa048ee9a724f10285da6e187485c7d5c3bbf10233a461c9'
   name 'Remote Desktop Manager'
   homepage 'https://mac.remotedesktopmanager.com/'
 
   app 'Remote Desktop Manager.app'
+
+  zap delete: [
+                '~/Library/Application Support/Remote Desktop Manager',
+                '~/Library/Application Support/com.devolutions.remotedesktopmanager',
+                '~/Library/Caches/com.devolutions.remotedesktopmanager',
+                '~/Library/Preferences/com.devolutions.remotedesktopmanager.plist',
+                '~/Library/Saved Application State/com.devolutions.remotedesktopmanager.savedState',
+              ]
 end

--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -12,10 +12,12 @@ cask 'remote-desktop-manager' do
   app 'Remote Desktop Manager.app'
 
   zap delete: [
+                '~/Library/Caches/com.devolutions.remotedesktopmanager',
+                '~/Library/Saved Application State/com.devolutions.remotedesktopmanager.savedState',
+              ],
+      trash:  [
                 '~/Library/Application Support/Remote Desktop Manager',
                 '~/Library/Application Support/com.devolutions.remotedesktopmanager',
-                '~/Library/Caches/com.devolutions.remotedesktopmanager',
                 '~/Library/Preferences/com.devolutions.remotedesktopmanager.plist',
-                '~/Library/Saved Application State/com.devolutions.remotedesktopmanager.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.