### PR TITLE
Update integrity to 6.11.5

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,11 +1,11 @@
 cask 'integrity' do
-  version '6.11.4'
-  sha256 '6f880c4a635b25715320defea5a08ca448c822251aac8dba876de08137193efb'
+  version '6.11.5'
+  sha256 '5b44cb83a9db1415006c6b9a50ec2214c27d2c5a0f4f0d8cf062f6b61ca85797'
 
   # peacockmedia.co.uk/integrity was verified as official when first introduced to the cask
   url 'http://peacockmedia.co.uk/integrity/integrity.dmg'
   appcast 'http://peacockmedia.software/mac/integrity/version_history.html',
-          checkpoint: 'ba3950c56d4859dc399485a9cea3ed44224de4c18de862b9890a4b061c6a0c37'
+          checkpoint: 'fe6aabee56d5d92f6d8f2114fe0130e6f6a28e2d64c545890be70926aaf08eb9'
   name 'Integrity'
   homepage 'http://peacockmedia.software/mac/integrity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.