### PR TITLE
Update java to 1.9,181

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,38 +1,37 @@
 cask 'java' do
-  version '1.8.0_144-b01,090f390dda5b47b9b721c7dfaa008135'
-  sha256 '2450b35e10295ccf3fb1596bdea6f8f5670f7200ae3ac592eb6a54cc030cf94b'
+  version '1.9,181'
+  sha256 '0755e848c061419313510a88508512b8d58ae9c79bd01d460e6b436dc13dfac1'
 
-  java_update = version.sub(%r{.*_(\d+)-.*}, '\1')
-  url "http://download.oracle.com/otn-pub/java/jdk/#{version.minor}u#{version.before_comma.split('_').last}/#{version.after_comma}/jdk-#{version.minor}u#{java_update}-macosx-x64.dmg",
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.minor}+#{version.after_comma}/jdk-#{version.minor}_osx-x64_bin.dmg",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
   name 'Java Standard Edition Development Kit'
-  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.minor}-downloads-2133151.html"
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.minor}-downloads-3848520.html"
 
-  pkg "JDK #{version.minor} Update #{java_update}.pkg"
+  pkg "JDK #{version.minor}.pkg"
 
   postflight do
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home", '/Library/Java/Home'],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home", '/Library/Java/Home'],
                    sudo: true
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home/bundle/Libraries"],
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home/bundle/Libraries"],
                    sudo: true
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home/jre/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
                    sudo: true
 
     if MacOS.version <= :mavericks
@@ -40,7 +39,7 @@ cask 'java' do
                      args: ['-rf', '--', '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
                      sudo: true
       system_command '/bin/ln',
-                     args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
+                     args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
                      sudo: true
     end
   end
@@ -49,14 +48,10 @@ cask 'java' do
     if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/java-jdk-javadoc")
       system_command 'brew', args: ['cask', 'uninstall', 'java-jdk-javadoc']
     end
-
-    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/jce-unlimited-strength-policy")
-      system_command 'brew', args: ['cask', 'uninstall', 'jce-unlimited-strength-policy']
-    end
   end
 
   uninstall pkgutil:   [
-                         "com.oracle.jdk#{version.minor}u#{java_update}",
+                         "com.oracle.jdk-#{version.minor}",
                          'com.oracle.jre',
                        ],
             launchctl: [
@@ -69,7 +64,7 @@ cask 'java' do
                        ],
             delete:    [
                          '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin',
-                         "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents",
+                         "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents",
                          '/Library/PreferencePanes/JavaControlPanel.prefPane',
                          '/Library/Java/Home',
                          if MacOS.version <= :mavericks
@@ -86,13 +81,19 @@ cask 'java' do
                 '~/Library/Caches/net.java.openjdk.cmd',
               ],
       trash:  [
+                '/Library/Application Support/Oracle/Java',
+                '/Library/Preferences/com.oracle.java.Deployment.plist',
+                '/Library/Preferences/com.oracle.java.Helper-Tool.plist',
                 '~/Library/Application Support/Java/',
                 '~/Library/Application Support/Oracle/Java',
                 '~/Library/Preferences/com.oracle.java.Java-Updater.plist',
                 '~/Library/Preferences/com.oracle.java.JavaAppletPlugin.plist',
                 '~/Library/Preferences/com.oracle.javadeployment.plist',
               ],
-      rmdir:  '~/Library/Application Support/Oracle/'
+      rmdir:  [
+                "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk",
+                '~/Library/Application Support/Oracle/',
+              ]
 
   caveats <<-EOS.undent
     This Cask makes minor modifications to the JRE to prevent issues with


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.