### PR TITLE
[NEW Cask] Juicebox 1.5.2 (STABLE-20170921)

### DIFF
--- a/Casks/juicebox.rb
+++ b/Casks/juicebox.rb
@@ -1,11 +1,15 @@
 cask 'juicebox' do
-  version '1.5.2'
-  sha256 '94e577f362033829c1e9dc4016ad9681b949d75141a13689869f77c3dee4808c'
+  version :latest
+  sha256 :no_check
 
   # s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox/Juicebox.dmg'
   name 'Juicebox'
-  homepage 'https://github.com/theaidenlab/juicebox/wiki'
+  homepage 'http://aidenlab.org/juicebox/'
 
   app 'Juicebox.app'
+  
+  caveats do
+    depends_on_java('8')
+  end
 end

--- a/Casks/juicebox.rb
+++ b/Casks/juicebox.rb
@@ -1,0 +1,11 @@
+cask 'juicebox' do
+  version '1.5.2'
+  sha256 '94e577f362033829c1e9dc4016ad9681b949d75141a13689869f77c3dee4808c'
+
+  # s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox/Juicebox.dmg'
+  name 'Juicebox'
+  homepage 'https://github.com/theaidenlab/juicebox/wiki'
+
+  app 'Juicebox.app'
+end

--- a/Casks/juicebox.rb
+++ b/Casks/juicebox.rb
@@ -8,7 +8,7 @@ cask 'juicebox' do
   homepage 'http://aidenlab.org/juicebox/'
 
   app 'Juicebox.app'
-  
+
   caveats do
     depends_on_java('8')
   end


### PR DESCRIPTION
Juicebox is a piece of java based bioinformatics visualization software. While the code and wiki  is on github the `.dmg` sits in an `S3` bucket. 

---

It was recently the subject of a "Nature" paper:
https://www.nature.com/news/plot-a-course-through-the-genome-1.22553

---

Lab and github addresses:
http://aidenlab.org/juicebox/
https://github.com/theaidenlab/juicebox
https://github.com/theaidenlab/juicebox/wiki

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].