### PR TITLE
Fix comma-chameleon (0.5.2) unpacking

### DIFF
--- a/Casks/comma-chameleon.rb
+++ b/Casks/comma-chameleon.rb
@@ -9,5 +9,5 @@ cask 'comma-chameleon' do
   name 'Comma Chameleon'
   homepage 'https://comma-chameleon.io/'
 
-  app 'comma-chameleon-darwin-x64/comma-chameleon.app'
+  app 'Comma Chameleon-darwin-x64/Comma Chameleon.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

----

CC appear to have renamed the folder and containing app but this wasn't caught in the latest version bump.  The installer would error with:

```
Error: It seems the App source '/usr/local/Caskroom/comma-chameleon/0.5.2/comma-chameleon-darwin-x64/comma-chameleon.app' is not there.
Error: Install incomplete.
```