### PR TITLE
Update aptible to 0.12.0

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,6 +1,6 @@
 cask 'aptible' do
-  version '0.11.2+20170824190602,149'
-  sha256 '4d90610e23ea934f3f17eabcc7b81c3e521d21687988a56aebca054a3df422cd'
+  version '0.12.0+20170921181235,151'
+  sha256 'fafd7499c6fba9ce44740c1a9aa3fdf328011cd4d8d56421be215cdf8b3264b2'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.before_comma.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.