### PR TITLE
Update chefdk to 2.3.3

### DIFF
--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -1,10 +1,10 @@
 cask 'chefdk' do
-  version '2.2.1'
-  sha256 'd140708f6b41dc5bd25b3e4f8a2f277ad0f26f7bd3f0ce4331bb2f8676993ca7'
+  version '2.3.3'
+  sha256 'b12347a9af2c4899be30d36f1f13ec6fb41fe32d8ad2cce64cffbf7ae5dfe04f'
 
   url "https://packages.chef.io/files/stable/chefdk/#{version}/mac_os_x/#{MacOS.version}/chefdk-#{version}-1.dmg"
   appcast "https://www.chef.io/chef/metadata-chefdk?p=mac_os_x&pv=#{MacOS.version}&m=x86_64&v=latest&prerelease=false",
-          checkpoint: 'fabeb329afd9269a87708e5097f88581dc0d6badaa4598e185f560d54a4641ab'
+          checkpoint: 'f1238a06a1b7a2e491840ef90349df7538e0e64f2c28081f215be000b6a268c7'
   name 'Chef Development Kit'
   name 'ChefDK'
   homepage 'https://downloads.chef.io/chefdk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.