### PR TITLE
Update keyboard-maestro to 8.0.1

### DIFF
--- a/Casks/keyboard-maestro.rb
+++ b/Casks/keyboard-maestro.rb
@@ -1,6 +1,6 @@
 cask 'keyboard-maestro' do
-  version '8.0'
-  sha256 '4081278b459bd9c606fcc7a3793b2041d117a9026abfe6a01e463e94c767d51e'
+  version '8.0.1'
+  sha256 '2701f9a597e133d779693ade14e2ca3d72974a605fddc6c9f17987418683bf4c'
 
   # stairways.com was verified as official when first introduced to the cask
   url "https://files.stairways.com/keyboardmaestro-#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.