### PR TITLE
Update versions to 1.4.0-1126

### DIFF
--- a/Casks/versions.rb
+++ b/Casks/versions.rb
@@ -1,10 +1,10 @@
 cask 'versions' do
-  version '1.3.3-1069'
-  sha256 'a8e281f2d0b3981a2af36a518aa6d1122c6cdfedd6c258505ca9c6a35c14a573'
+  version '1.4.0-1126'
+  sha256 '2012bbf92bba601e781fbd74a956fe2702f283c3c1017fa1735f3c3f96d2f73f'
 
   url "https://cdn.versionsapp.com/releases/Versions-#{version}.zip"
   appcast 'https://updates.blackpixel.com/updates?app=vs',
-          checkpoint: 'c21288f5920256d3fe7fa74bd9bc18163631ba4a1551e5a5ce237a2df1b93fcf'
+          checkpoint: 'b30875c95642cb07ffebc209298634efbc34650d152a53c511dde8002abea32d'
   name 'Versions'
   homepage 'https://versionsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.