### PR TITLE
Update netnewswire to 4.0.4-545

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,12 +1,17 @@
 cask 'netnewswire' do
-  version '4.0.3-353'
-  sha256 '1441baedc7497d998bc4941c0db2c1ca3254b03dc3ee7e202eb1b23355f49b59'
+  version '4.0.4-545'
+  sha256 '18b74389a379760ad9ca240e3d907d5e5f7aaee8e897293df7d7c4c653ce4018'
 
   url "https://cdn.netnewswireapp.com/releases/NetNewsWire-#{version}.zip"
   appcast 'https://updates.blackpixel.com/updates?app=nnw',
-          checkpoint: 'c8c5f8d024115ed4e0541336c4de7e5ba58846958b436fbdaab73c8da6f229dd'
+          checkpoint: '1ffaca043dda0e1b3bfa5fe456d94ba3dd185c9565b80ed1427df7885552ab49'
   name 'NetNewsWire'
   homepage 'http://netnewswireapp.com/'
 
   app 'NetNewsWire.app'
+
+  zap delete: [
+                '~/Library/Application Scripts/com.blackpixel.netnewswire',
+                '~/Library/Containers/com.blackpixel.netnewswire',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.