### PR TITLE
Update postman to 5.2.0

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,9 +1,9 @@
 cask 'postman' do
-  version :latest
-  sha256 :no_check
+  version '5.2.0'
+  sha256 'fe0f2ea868e7938f54118c85f8542ac19e7f3746add11b6e1d423030670b542f'
 
-  # dl.pstmn.io/download/latest/osx was verified as official when first introduced to the cask
-  url 'https://dl.pstmn.io/download/latest/osx'
+  # dl.pstmn.io/download/version/ was verified as official when first introduced to the cask
+  url "https://dl.pstmn.io/download/version/#{version}/osx64"
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 


### PR DESCRIPTION
Postman has versions and versioned URL's. So why use `:latest` if we can just version it.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.