### PR TITLE
Fix openoffice downloading link

### DIFF
--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -26,8 +26,8 @@ cask 'openoffice' do
     'pt'
   end
 
-  # sourceforge.net/openofficeorg.mirror was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_#{language}.dmg"
+  # sourceforge.net/project/openofficeorg.mirror was verified at 4.1.3 (2017-09-23)
+  url "https://downloads.sourceforge.net/project/openofficeorg.mirror/#{version}/binaries/#{language}/Apache_OpenOffice_#{version}_MacOS_x86-64_install_#{language}.dmg"
   appcast 'https://sourceforge.net/projects/openofficeorg.mirror/rss',
           checkpoint: 'd8e2de0c68d131c8548113c6f46d062af1721f8501aad420be84640cc704c504'
   name 'Apache OpenOffice'


### PR DESCRIPTION
I didn't fixed the style check as well as wrong commit message. But it fixes the problem when downloading from sourceforge. The cask is not sufficient to finish the installation. I suspected sourceforge has changed their downloading URL which results in a HTML page being downloaded.  


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
