### PR TITLE
Updated gtkwave to 3.3.85

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.84'
-  sha256 'c503fb140f94a433dcfdc6417110890c77938b97f4d32cd4640155585d738b7c'
+  version '3.3.85'
+  sha256 'a553e6d463b466a00a63842bf4a06bf0c0546e73539f3c023c1f1961729cd7b3'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: '32f014bffe849d4bc2a975e662ecb6a38ce83507dd39f03ebc874252d551bc33'
+          checkpoint: 'e322b1d3d5717bc14c834647783817a9d418a837e17175f73afd8d96295efc6c'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.