### PR TITLE
Update default-folder-x to 5.1.6

### DIFF
--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -1,6 +1,6 @@
 cask 'default-folder-x' do
-  version '5.1.5'
-  sha256 'b50021ac99e1ea2390570ab28ec8f9f2d4c5deb8e7200a9bee0ea07173f9a200'
+  version '5.1.6'
+  sha256 'c9a201b8958276d7342ab9807f770f66b5afed65124519e2e1109ee386a530e4'
 
   url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   name 'Default Folder X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.