### PR TITLE
Updated Moo.do to 1.0.8

### DIFF
--- a/Casks/moodo.rb
+++ b/Casks/moodo.rb
@@ -1,11 +1,11 @@
 cask 'moodo' do
-  version '1.0.6'
-  sha256 'c4d7d446cee0faa37cce36f930ddcc8b68d423e8e6dadf4776d6ac9580e404f1'
+  version '1.0.8'
+  sha256 '55d67cfc5513ea459ddbd740fac25c88888a54875e02792a79639e224647b055'
 
   # github.com/MooDoApp/MooDoApp.github.io was verified as official when first introduced to the cask
   url "https://github.com/MooDoApp/MooDoApp.github.io/releases/download/v#{version}/Moo.do-#{version}-mac.zip"
   appcast 'https://github.com/MooDoApp/MooDoApp.github.io/releases.atom',
-          checkpoint: 'd95a5384b386f950183595d4dd703764d41b634cf96627dfcafc0021a9519d9d'
+          checkpoint: 'a4667e31813407a62c223bbbb797ca875be49b4c325f671defc696e232fb4fd2'
   name 'Moo.do'
   homepage 'https://www.moo.do/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

