### PR TITLE
Update veusz to 2.0.1

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,11 +1,11 @@
 cask 'veusz' do
-  version '2.0'
-  sha256 '48d4fdc44b24fbc1062ab9d9c68f1d93f725faaa0d7be36d83aaac6c2ae42905'
+  version '2.0.1'
+  sha256 'dbf5a1c9ae26f2a40e05bf1afd537ad4927ab41c15a0ad4d717a216909f37ceb'
 
   # github.com/veusz/veusz was verified as official when first introduced to the cask
   url "https://github.com/veusz/veusz/releases/download/veusz-#{version}/veusz-#{version}-AppleOSX.dmg"
   appcast 'https://github.com/veusz/veusz/releases.atom',
-          checkpoint: '3e6b3474dee11e0a122fb826365c17a39203868a58680c17058eca18ad3a5064'
+          checkpoint: '0467aa1c96bee854e07fbeacb97232e73daa2d15921050f2f850935ea85e292b'
   name 'Veusz'
   homepage 'https://veusz.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.