### PR TITLE
Update qcad to 3.18.0

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,6 +1,6 @@
 cask 'qcad' do
-  version '3.17.3'
-  sha256 'f5cf331d7151d669d359014ebff878c9bc5db8d70b09c7b034618a5546a53d82'
+  version '3.18.0'
+  sha256 'd8b68dc4867fb2ac7591ec084c9979fad2322c717d54363ce003bdc6e04e0b46'
 
   url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.12.dmg"
   name 'QCAD'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.