### PR TITLE
Update mpv to 0.27.0

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -1,11 +1,11 @@
 cask 'mpv' do
-  version '0.26.0'
-  sha256 '0f3c7a2f8c0e37f8542a12170149ff9b9a462abd10e35fe6e88e689fe1815443'
+  version '0.27.0'
+  sha256 '5e4bf23c59dfe0c2e48e6e67f695ace93a38bbb6361f53cfd37d32f5ce1c2c41'
 
   # laboratory.stolendata.net/~djinn/mpv_osx was verified as official when first introduced to the cask
   url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv-#{version}.tar.gz"
   appcast 'https://laboratory.stolendata.net/~djinn/mpv_osx/',
-          checkpoint: 'd67d83f050d09749a8f92082f343d0f363e39b804ab0a590145dda170ea56d45'
+          checkpoint: '4b64933554b8bd0da096fcc602f2ac9048bf8caa2bfe64f51ff161f1a323d040'
   name 'mpv'
   homepage 'https://mpv.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.