### PR TITLE
Update gpgtools to 2017.1

### DIFF
--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -39,10 +39,15 @@ cask 'gpgtools' do
                          'org.gpgtools.macgpg2.shutdown-gpg-agent',
                          'org.gpgtools.macgpg2.updater',
                          'org.gpgtools.macgpg2.gpg-agent',
+                         'org.gpgtools.gpgmail.enable-bundles',
+                         'org.gpgtools.gpgmail.user-uuid-patcher',
+                         'org.gpgtools.gpgmail.uuid-patcher',
+                         'org.gpgtools.updater',
                        ],
             delete:    [
                          '/Library/Services/GPGServices.service',
                          '/Library/Mail/Bundles/GPGMail.mailbundle',
+                         '/Library/Mail/Bundles.gpgmail*',
                          '/Network/Library/Mail/Bundles/GPGMail.mailbundle',
                          '/usr/local/MacGPG2',
                          '/private/etc/paths.d/MacGPG2',
@@ -58,12 +63,14 @@ cask 'gpgtools' do
                 '~/Library/Mail/Bundles/GPGMail.mailbundle',
                 '~/Library/PreferencePanes/GPGPreferences.prefPane',
                 '~/Library/LaunchAgents/org.gpgtools.*',
-                '~/Library/Preferences/org.gpgtools.*',
                 '~/Library/Containers/com.apple.mail/Data/Library/Preferences/org.gpgtools.*',
-                '~/Library/Application Support/GPGTools',
                 '~/Library/Frameworks/Libmacgpg.framework',
                 '~/Containers/com.apple.mail/Data/Library/Frameworks/Libmacgpg.framework',
                 '~/Library/Caches/org.gpgtools.gpg*',
+              ],
+      trash:  [
+                '~/Library/Application Support/GPGTools',
+                '~/Library/Preferences/org.gpgtools.*',
               ]
 
   caveats do

--- a/Casks/gpgtools.rb
+++ b/Casks/gpgtools.rb
@@ -1,6 +1,6 @@
 cask 'gpgtools' do
-  version '2016.10_v2'
-  sha256 '8dbc5821876ca5c470d0127087f782ba02a842c52e6e19336cd935db7c5859ab'
+  version '2017.1'
+  sha256 '01705da33b9dadaf5282d28f9ef58f2eb7cd8ff6f19b4ade78861bf87668a061'
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast 'https://gpgtools.org/releases/gka/appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.