### PR TITLE
Update xact to 2.41

### DIFF
--- a/Casks/xact.rb
+++ b/Casks/xact.rb
@@ -1,10 +1,10 @@
 cask 'xact' do
-  version '2.40'
-  sha256 '25466ec73a00de87db9f0c45926d55c4ced50444e5739f92456e329390054434'
+  version '2.41'
+  sha256 'bb46554ea4092d3ad905a787466a2dc10db956cb0e30750d51fad2f25f7f27b0'
 
   url "http://xact.scottcbrown.org/xACT#{version}.zip"
   appcast 'http://xactupdate.scottcbrown.org/xACT.xml',
-          checkpoint: '95e91191e16dd18be47b2462fc861a78cdf47a85ec000f40577a7f246c335395'
+          checkpoint: '53320b5b35c5497b28f20a9cf85990474fb5b4efd33351c2a83d61d2671f4fbf'
   name 'xACT'
   homepage 'http://xact.scottcbrown.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.