### PR TITLE
Update freac to 1.1-alpha-20170902

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,11 +1,11 @@
 cask 'freac' do
-  version '20170729'
-  sha256 '5bef885fb4d714a8d3e768daffd30457711dbbdf0172f4ad83c97bf213ca53d0'
+  version '1.1-alpha-20170902'
+  sha256 '31e591e88e3540b102e8f2606ec06a73af3b7a5b30980cae22e84e7f915ea6c9'
 
   # sourceforge.net/bonkenc was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/bonkenc/rss',
-          checkpoint: '0672e279e9a47574d7dba80dd21e007e3cdabd30a296d957da8cbdbfe3db6660'
+          checkpoint: '4939b8a5daf8bce38ddb7ec635408f75396d109b0d8f0f936130b28c2ef8f848'
   name 'fre:ac'
   homepage 'https://www.freac.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.