### PR TITLE
Update little-snitch - fix install

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -10,8 +10,9 @@ cask 'little-snitch' do
 
   auto_updates true
   depends_on macos: '>= :el_capitan'
+  container type: :naked
 
-  installer manual: 'Little Snitch Installer.app'
+  installer manual: "LittleSnitch-#{version}.dmg/Little Snitch Installer.app"
 
   uninstall launchctl: [
                          'at.obdev.LittleSnitchUIAgent',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/38901
____

This skips extracting the `dmg`, there isn't much point in doing more than this because this is `installer manual` anyway.