### PR TITLE
Update vuescan to 9.5.86

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.85'
-  sha256 '1844372f0636edeffde47ebbca0c342bbd28395af037ff064201b22ad3f1f910'
+  version '9.5.86'
+  sha256 'e83b7212b658fd148fd2b4b21559b704ffb2fd9bf42ab9a37e1bbdab37a265ab'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '6e4df0585b1aaf87d25cc2da4824d4dbe3ad4767c80b5567981f5174bfcd44c9'
+          checkpoint: '7154c82944cc635229233bbdf0db27d8d4378cf900bdfd6a5fab84f3d23ae70b'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.