### PR TITLE
Update gnucash to 2.6.18-1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,20 +1,20 @@
 cask 'gnucash' do
-  version '2.6.17-1'
-  sha256 'f60238bc7bced79bc50e223ba0d4047d3235e71a7f815a375745242977ecfdeb'
+  version '2.6.18-1'
+  sha256 '75b4cea0e786a0844507aa89fc8f2f5c3761825b540b224427f1c9f2f346a257'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
-  url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}b/Gnucash-Intel-#{version}.dmg"
+  url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}/Gnucash-Intel-#{version}.dmg"
   appcast 'https://github.com/Gnucash/gnucash/releases.atom',
-          checkpoint: '3cf2598a33e81e50ebd801d8fb0c72b0a80cf921137e28f5e61e3b719d45a41f'
+          checkpoint: '62f568904f2ed87b78599b5579ebd3616849d2c3f17fb692f6982988528d7c48'
   name 'GnuCash'
   homepage 'https://www.gnucash.org/'
 
   app 'Gnucash.app'
   app 'FinanceQuote Update.app'
 
-  zap delete: [
+  zap delete: '~/Library/Saved Application State/org.gnucash.Gnucash.savedState',
+      trash:  [
                 '~/Library/Application Support/Gnucash',
                 '~/Library/Preferences/org.gnucash.Gnucash.plist',
-                '~/Library/Saved Application State/org.gnucash.Gnucash.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.