### PR TITLE
Update pyfa to 1.32.0,yc119.9-1.3

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.31.0,yc119.8-1.0'
-  sha256 'e09bb2ae6200b16c13b426d30c0e7fbc544e2280fc70d72a44fb83d105920314'
+  version '1.32.0,yc119.9-1.3'
+  sha256 'f64f3be3fe3ebcd2bf729948e72e196c49e865ce3b17e0b9b362fbb9dcc624f9'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: 'a0bb97da000210bf06816326ce523053a6ce3ffad2a6c7faf1dbf57cb022f31b'
+          checkpoint: 'd14fc399f50d9fcb8dce0386df4a0e6f5a6d4480b659e12ae5754474a8ab920d'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.