### PR TITLE
Update cookie to 5.6

### DIFF
--- a/Casks/cookie.rb
+++ b/Casks/cookie.rb
@@ -1,10 +1,10 @@
 cask 'cookie' do
-  version '5.5.8'
-  sha256 'f6835442c37b5e2ab346c99fcd0c269b78b4fc3b5b3eac820752d0e66428ca66'
+  version '5.6'
+  sha256 'dd5bc8549cddf151afc776941f627fbe26e001f0df95ec6eb263f50d820df246'
 
   url "https://sweetpproductions.com/products/cookie#{version.major}/Cookie#{version.major}.dmg"
   appcast "https://sweetpproductions.com/products/cookie#{version.major}/appcast.xml",
-          checkpoint: '452c6e76fc11f28b6de0a45a0cf5fd69db3803175206eef4cc35efae6c6c1c09'
+          checkpoint: '506c3864219b0c59087077e5a011c9a25518618479047bd231dbde89090b3885'
   name 'Cookie'
   homepage 'https://sweetpproductions.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.