### PR TITLE
Update file-juicer to 4.59

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,6 +1,6 @@
 cask 'file-juicer' do
   version '4.59'
-  sha256 '8186265cc569e06f3cee363bec4836da742d9f0825d7f579c2a58ef254d21ad2'
+  sha256 '929ec7e436a8785d3afdf7475a82c073eb4465ced48bc11486efb1d5152a8ede'
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   name 'File Juicer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.