### PR TITLE
Update file-juicer to 4.61

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,6 +1,6 @@
 cask 'file-juicer' do
-  version '4.59'
-  sha256 '8186265cc569e06f3cee363bec4836da742d9f0825d7f579c2a58ef254d21ad2'
+  version '4.61'
+  sha256 '63fe2f3d9927aaa2eaec7ccb09cbce9255970bf16fa9456d7dae7eea9a0414f6'
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   name 'File Juicer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.