### PR TITLE
Update typora to 0.9.9.10.8

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.10.6'
-  sha256 '8991e21820be31016544a6875aeb7e8ebc17d15f63422c9c5e984751c6ad5ab7'
+  version :latest
+  sha256 :no_check
 
   url 'https://typora.io/download/Typora.dmg'
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '20cf84715096508a4d806147cef2e02ffccef8be1665b28ebea9f54073552156'
+          checkpoint: '5824207ab434e6a2db6cf5e8493803645c68dd8c123b3cd72c0bf8fde589c817'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

-----

Fix the error
```
Error: Checksum for Cask 'typora' does not match.

Expected: 8991e21820be31016544a6875aeb7e8ebc17d15f63422c9c5e984751c6ad5ab7
Actual:   fb10530170ba2fbab885f7fea9d23e1e5c1ab3370fdf982ac8dbfc6c14ca1c98
File:     /Users/sjackman/Library/Caches/Homebrew/Cask/typora--0.9.9.10.6.dmg
```