### PR TITLE
Update typora to 0.9.9.10.8

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.10.7'
-  sha256 'f9ccf84dfb64b1a165b24b1792d95a7fbab8a2ef7cad26f9b380eb2af6ec0c94'
+  version '0.9.9.10.8'
+  sha256 'fb10530170ba2fbab885f7fea9d23e1e5c1ab3370fdf982ac8dbfc6c14ca1c98'
 
   url 'https://typora.io/download/Typora.dmg'
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: 'bcaa6eac63601b54973c407044159b7a6578a5396260ce4fa9149863fa61de28'
+          checkpoint: '5824207ab434e6a2db6cf5e8493803645c68dd8c123b3cd72c0bf8fde589c817'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.