### PR TITLE
abyss-web-server: rename from abyss

### DIFF
--- a/Casks/abyss-web-server.rb
+++ b/Casks/abyss-web-server.rb
@@ -1,4 +1,4 @@
-cask 'abyss' do
+cask 'abyss-web-server' do
   version 'x1'
   sha256 '2130e3da4d97c71d2c932261f51ed31cbb3bcadfc600db5eb6b7f646ccf31707'
 


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/18354. This cask has a name conflict with the formula `abyss`. The app is also actually called "Abyss Web Server".

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.