### PR TITLE
Update yourkit-java-profiler to 2017.02-b66

### DIFF
--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,8 +1,8 @@
 cask 'yourkit-java-profiler' do
-  version '2017.02-b63'
-  sha256 '8456f0544c6ddb9c641a12c489080aa905ecbf70419a833778ee1bcd8365d332'
+  version '2017.02-b66'
+  sha256 '3fae1cfbd25ad5d7676f7e26d7a87ad9a98f3943cda167a751948c3757847a9c'
 
-  url "https://www.yourkit.com/download/yjp-#{version}-mac.zip"
+  url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version}-mac.zip"
   name 'YourKit Java Profiler'
   homepage 'https://www.yourkit.com/features/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.