### PR TITLE
Update logdna-cli to 1.2.1

### DIFF
--- a/Casks/logdna-cli.rb
+++ b/Casks/logdna-cli.rb
@@ -1,11 +1,11 @@
 cask 'logdna-cli' do
-  version '1.2.0'
-  sha256 '6655f39122ec9497f9613099951fe8d2735b40ba12fe378f28687f4b68ac11e9'
+  version '1.2.1'
+  sha256 '55f692548582ba72ecde64bc2a2318ed4c92e75e788d789ad88a1f147e9db28d'
 
   # github.com/logdna/logdna-cli was verified as official when first introduced to the cask
   url "https://github.com/logdna/logdna-cli/releases/download/#{version}/logdna-cli.pkg"
   appcast 'https://github.com/logdna/logdna-cli/releases.atom',
-          checkpoint: '1ff99ed137d57f571581482c8b625b447a7adaf62cd1095874a23d8ecca12dc6'
+          checkpoint: 'f0b4a7663d8f48a3e6c810191834afe8a60d723c5d026f2e7b5c8539ff9d3533'
   name 'LogDNA CLI'
   homepage 'https://logdna.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.