### PR TITLE
Update logdna-agent to 1.4.5

### DIFF
--- a/Casks/logdna-agent.rb
+++ b/Casks/logdna-agent.rb
@@ -1,11 +1,11 @@
 cask 'logdna-agent' do
-  version '1.4.1'
-  sha256 '07bdde9b4908ab957ad31a9f7b7966d77c97aa849908c2941dc7abaed0df76cf'
+  version '1.4.5'
+  sha256 '947982b99b60e3df674e16de3ec486c36525e3a85dacfd473c1dcfa6e9cf35bf'
 
   # github.com/logdna/logdna-agent was verified as official when first introduced to the cask
   url "https://github.com/logdna/logdna-agent/releases/download/#{version}/logdna-agent-#{version}.pkg"
   appcast 'https://github.com/logdna/logdna-agent/releases.atom',
-          checkpoint: 'cee7186ede988c251a7212238182afa99a5a31814b581c7c6567caa1d0bd49c9'
+          checkpoint: '6fe65c59799dcee2d5260977940a3e9c1de9c378f2e867a91245b5fb13d21a92'
   name 'LogDNA Agent'
   homepage 'https://logdna.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.