### PR TITLE
Update mocksmtp: depends on <= :yosemite

### DIFF
--- a/Casks/mocksmtp.rb
+++ b/Casks/mocksmtp.rb
@@ -6,5 +6,7 @@ cask 'mocksmtp' do
   name 'MockSMTP'
   homepage 'http://mocksmtpapp.com/'
 
+  depends_on macos: '<= :yosemite'
+
   app 'MockSmtp.app'
 end


### PR DESCRIPTION
Refs: https://github.com/caskroom/homebrew-cask/issues/38933

Doesn't work  10.12. https://twitter.com/mocksmtpapp/status/780289850348036097

Also doesn't seem to work on 10.11.