### PR TITLE
Update carbon-copy-cloner to 5.0.2.5103

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.0.2.5102'
-  sha256 'be70082a5208407efdb071ef6d6b1fb0c7284e0aeb195d0112d34a7d7db6165d'
+  version '5.0.2.5103'
+  sha256 '85d563c0499544f85fb32a069be37a6ddb529fbc8dcc56e45a3a4f5cecedcb0c'
 
   url "https://bombich.com/software/download_ccc.php?v=#{version}"
   name 'Carbon Copy Cloner'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.