### PR TITLE
Update dbvisualizer to 10.0.1

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -1,6 +1,6 @@
 cask 'dbvisualizer' do
-  version '10.0'
-  sha256 '5494129ce0f19e996af90b5386d148e93e545a7890cf91afc58fb8521be9eafa'
+  version '10.0.1'
+  sha256 '238eaa28affaa53a27d5991cba470928f76850c67b0c689d22dbc5b2b9d03d54'
 
   url "https://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.dots_to_underscores}.dmg"
   name 'DbVisualizer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.