### PR TITLE
Update brackets to 1.11

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,11 +1,11 @@
 cask 'brackets' do
-  version '1.10'
-  sha256 'a4faac726671439590e462af46d228e97ed70ede2e101bbd195b1f03143b00db'
+  version '1.11'
+  sha256 '67a4a1d3eb394c838f14d65348858649927cc8811f1db275f2160fc514e614c3'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
   appcast 'https://github.com/adobe/brackets/releases.atom',
-          checkpoint: '593cb947ceb3b2b02102c979debfc0c6dc777de6db3b82efef64ed21ba753760'
+          checkpoint: 'e525c92ad8a10ef3d867a48bf043b688d58d6991acb1e177cc97ead215b4e0db'
   name 'Brackets'
   homepage 'http://brackets.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.