### PR TITLE
Update bartender to 3.0.8

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -1,11 +1,11 @@
 cask 'bartender' do
-  version '2.1.6'
-  sha256 '013bb1f5dcc29ff1ecbc341da96b6e399dc3c85fc95bd8c7bee153ab0d8756f5'
+  version '3.0.8'
+  sha256 '4aace5381d4d96794ff2ebe155c1f7b55d6fa0aa805ba77cbe6ac6431c8d7ef3'
 
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",
       referer: 'https://www.macbartender.com'
-  appcast "https://www.macbartender.com/B#{version.major}/updates/updates.php",
-          checkpoint: 'b119cbc503ce671c5aa1a16dc11704b5baed00a6de3d4b344837b854cc47d4c1'
+  appcast 'https://www.macbartender.com/B2/updates/Appcast.xml',
+          checkpoint: '5de6b86db8c35136b502e4351ce3348da40e5667a1c45a4396043af09aace284'
   name 'Bartender'
   homepage 'https://www.macbartender.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.