### PR TITLE
Update diskmaker-x to 7

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,12 +1,12 @@
 cask 'diskmaker-x' do
-  version '6rc5'
-  sha256 'bfbaf4db47d2553cbe94773f20eff97b95bdf246bd7145d4fbdafe2117b4744d'
+  version '7'
+  sha256 'd0c80961ca06dca436c0c784e8779defe56a0675d032f054064215a1b193a184'
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version}.dmg"
   appcast 'https://diskmakerx.com/feed/',
-          checkpoint: 'fbe8f4d4b56239101361e209d451be39637f77a5f2a97ebf5b17c76255caf77a'
+          checkpoint: 'cde4b4adc3d2988a6616df0856c1f77ccb599ff516993c3a65cb2728909f6ae3'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
 
-  app "DiskMaker X #{version.major}.app"
+  app "DiskMaker X #{version.major} for High Sierra.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.