### PR TITLE
Update jtool URL

### DIFF
--- a/Casks/jtool.rb
+++ b/Casks/jtool.rb
@@ -2,7 +2,7 @@ cask 'jtool' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.newosxbook.com/files/jtool.tar'
+  url 'http://www.newosxbook.com/tools/jtool.tar'
   name 'jtool'
   homepage 'http://newosxbook.com/tools/jtool.html'
 


### PR DESCRIPTION
The author of jtool moved the tarball on his website.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name ~~and version~~.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
