### PR TITLE
Update stellarium to 0.16.1.1

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,11 +1,11 @@
 cask 'stellarium' do
-  version '0.16.1'
-  sha256 '938ef9e99dfcb403ee6cd4a6708bdfbaf3196d682513e32688cd05ab045fe75d'
+  version '0.16.1.1'
+  sha256 '2c9c54724720ed5cf1f5263af8a50c9ebcf2e69d8fa4fcdfaed83d2ced0c2ae8'
 
   # sourceforge.net/stellarium was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/stellarium/Stellarium-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/stellarium/rss',
-          checkpoint: '9b8b8e21e413a85e3413bb2426465c4ce195c5e7865be1037c30dbc223b77b2c'
+          checkpoint: '1f39827e6294cfd1b623d2999d3e7fe66d6e3917b4c4cd1cb199e7dec4082f44'
   name 'Stellarium'
   homepage 'http://stellarium.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.