### PR TITLE
Update plex-media-player to 1.3.7.701-bbc09c96

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,14 +1,14 @@
 cask 'plex-media-player' do
-  version '1.3.5.689-a36fa532'
-  sha256 '2b7a4f83e7b4504e08a5cff325c23782e4a0c68601b8c323c9d583ee7bb33424'
+  version '1.3.7.701-bbc09c96'
+  sha256 '2af4356545ccb18f9689084019f37d00d6ddfc903a383e14bee0115ce4d8cbb8'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json',
-          checkpoint: 'd469ecaaa1d96f403789e64422f804a382607c606fc877b418733580138ef25b'
+          checkpoint: 'ed80780ae92a6c909d1b8cdf6a977f40a77e9661e74d9eb2f3e08d324d301e04'
   name 'Plex Media Player'
   homepage 'https://www.plex.tv/'
 
-  depends_on macos: '>= :mavericks'
+  depends_on macos: '>= :yosemite'
 
   app 'Plex Media Player.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.