### PR TITLE
Update navicat-for-mysql to 12.0.14

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.13'
-  sha256 '9b69651d2a2e97ec3e1093f87c864298735c3680d7334b33d2ea057d6df26b44'
+  version '12.0.14'
+  sha256 '77f2814a64953d49d2104b5df88e74277dfe225d59051cb938ba4dafae40a50c'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note#M',
-          checkpoint: '461ab64daf06e4b4ab8093f39978b0792e71c6a263a4580c5cc194e694d67310'
+          checkpoint: 'a57241eaa8bb4ddeecfd714bc20713ce9d244914da7ade128d1959c8ee12a4b2'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.