### PR TITLE
Update navicat-for-oracle to 12.0.14

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.13'
-  sha256 'b4a5633fa1941eca2771be8862daae85ffa6f1f793d419c78f1617bdfbb037c6'
+  version '12.0.14'
+  sha256 '392fa02858bef21c8deb65c947d8d80f53e37d0ee008552af2489dc72c73adf2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note#M',
-          checkpoint: 'f1fedac035fa882716f62197132b6a086d5ac75d164d32f6e96bd4bb6fd9f239'
+          checkpoint: 'a127175298b63f7b4266109feb0c131b04d6ddc4c17225319a7fb7c67c49c5a5'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.