### PR TITLE
Update navicat-for-postgresql to 12.0.14

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.13'
-  sha256 '86cecf7ce39e0eec562c4ed9224eb2d5d6b8e8d77626dfc56106976522a5ad3a'
+  version '12.0.14'
+  sha256 '0e2e857afdad9d59b6b87dc3ef7e3b12de92f8bc56aa5b337e46777d69afeef3'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
-          checkpoint: 'dd5bdda2015254cae1e37febd33a3bb82e4bea013890493aa10e4259492c8d4a'
+          checkpoint: 'f3b7a2c39e4abddd57528e9a71782ae5f407336a6341df71d8013e93e4480508'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.