### PR TITLE
Update navicat-for-sqlite to 12.0.14

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.13'
+  version '12.0.14'
   sha256 'd460be532c13872e04ac22a8f67b2e88f63a76a84272b52b1c17664b8070900e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note#M',
-          checkpoint: '1aeaef5a300b05baa976ae24c67402ccea61dce3fb099ee6af18796825be1814'
+          checkpoint: '95232262586a64f399b04b81d084382b966e4abc20a1ad5bfc35f7d0e566e3d6'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.