### PR TITLE
Update commander-one to 1.7.4

### DIFF
--- a/Casks/commander-one.rb
+++ b/Casks/commander-one.rb
@@ -1,10 +1,10 @@
 cask 'commander-one' do
-  version '1.7.3'
-  sha256 'a3f807fc687b2a779cc542ea5b202a9dcc6ad476681f58b23924f7dba3f7d495'
+  version '1.7.4'
+  sha256 '817b8268fb115b15eda107d304f05dc42185e7dc6b3a803cfdbf99a57b9626e1'
 
   url 'http://mac.eltima.com/download/commander.dmg'
   appcast 'http://www.eltima.com/download/commander-update/settings.xml',
-          checkpoint: '5f66f8dc28e57803c5b33b37b120d927782bb796d2b2e63dadf142ebe0dbbbe3'
+          checkpoint: 'a8ff91be0ebacdd3fc00fbdec002a1f9cc8590416f8a103ce04c5562534e21df'
   name 'Commander One'
   homepage 'https://mac.eltima.com/file-manager.html'
 

--- a/Casks/commander-one.rb
+++ b/Casks/commander-one.rb
@@ -2,8 +2,8 @@ cask 'commander-one' do
   version '1.7.4'
   sha256 '817b8268fb115b15eda107d304f05dc42185e7dc6b3a803cfdbf99a57b9626e1'
 
-  url 'http://mac.eltima.com/download/commander.dmg'
-  appcast 'http://www.eltima.com/download/commander-update/settings.xml',
+  url 'https://mac.eltima.com/download/commander.dmg'
+  appcast 'https://www.eltima.com/download/commander-update/settings.xml',
           checkpoint: 'a8ff91be0ebacdd3fc00fbdec002a1f9cc8590416f8a103ce04c5562534e21df'
   name 'Commander One'
   homepage 'https://mac.eltima.com/file-manager.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.