### PR TITLE
Update gephi to 0.9.2

### DIFF
--- a/Casks/gephi.rb
+++ b/Casks/gephi.rb
@@ -1,11 +1,11 @@
 cask 'gephi' do
-  version '0.9.1'
-  sha256 'c2a2f5c84f822303a3b314d43bc18f183dfa1d15545050bd8125d32a84e64f94'
+  version '0.9.2'
+  sha256 'e83641108bcab4326526293acf2da48ac107c95b811d7f23e1fc1c621489f097'
 
   # github.com/gephi/gephi was verified as official when first introduced to the cask
   url "https://github.com/gephi/gephi/releases/download/v#{version}/gephi-#{version}-macos.dmg"
   appcast 'https://github.com/gephi/gephi/releases.atom',
-          checkpoint: '69dacb6508d264fcd35789495674f909c6166cdae43625b208fed0c854082418'
+          checkpoint: 'a5e31f07ca40cb990942681ae1ee30889d98b77e7dcc6210872d2c3ba2fae974'
   name 'Gephi'
   homepage 'https://gephi.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.