### PR TITLE
Update react-native-debugger (0.7.8)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.7'
-  sha256 '89f938869e88e6d858d7461cf70c1c7f85eb60305fce0afa9f6cc4d2f52c97f8'
+  version '0.7.8'
+  sha256 '04db2558d22d5624e4fff8e36727e5f79ff6efd436e3ee5fdc73c244d08d9823'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: 'dae5ff699885587929e724a09f3c3e27298490759106e7f8b3cd0fc9969fbe34'
+          checkpoint: '14455f6b88a69b3c33f14eeed43db0f003bbe5c80288fd5780e774a4a16de5ac'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
