### PR TITLE
update appgate-client to 11.2.7

### DIFF
--- a/Casks/appgate-client.rb
+++ b/Casks/appgate-client.rb
@@ -1,6 +1,6 @@
 cask 'appgate-client' do
-  version '11.2.4'
-  sha256 '897912245bdd11903d2417da1227bf582e566dcf17af211fdc0f6cf568a7f9ad'
+  version '11.2.7'
+  sha256 '6188c0f0ba36bcc1f6876e75af28a2d645cf46c247c026e995061991c691dc9c'
 
   url "http://download.cryptzone.com/files/download/AppGate-#{version}/Clients/MacOSX/AppGate_Client.dmg"
   name 'AppGate (classic)'


### PR DESCRIPTION
After making all changes to the cask:

 [x] brew cask audit --download {{cask_file}} is error-free.
 [x] brew cask style --fix {{cask_file}} left no offenses.
 [x] The commit message includes the cask’s name and version.

Additionally, if updating a cask:

 [ ] sha256 changed but version stayed the same (what is this?).
I’m providing public confirmation below.