### PR TITLE
Update skype-for-business to 16.10.0.97

### DIFF
--- a/Casks/skype-for-business.rb
+++ b/Casks/skype-for-business.rb
@@ -1,6 +1,6 @@
 cask 'skype-for-business' do
-  version '16.8.0.196'
-  sha256 'a9b713ba254e035a0535d5ad2857d2ab8e890d02721c84dc39057f128ed0dfd1'
+  version '16.10.0.97'
+  sha256 '2e3782256c2971dc2cff2a40f73aeba02ef0f262e06c75ae073c77498f933f37'
 
   url "https://download.microsoft.com/download/D/0/5/D055DA17-C7B8-4257-89A1-78E7BBE3833F/SkypeForBusinessInstaller-#{version}.pkg"
   name 'Skype for Business'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.