### PR TITLE
Fix sourcetree appname on case-sensitive filesystem

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -9,8 +9,8 @@ cask 'sourcetree' do
 
   auto_updates true
 
-  app 'SourceTree.app'
-  binary "#{appdir}/SourceTree.app/Contents/Resources/stree"
+  app 'Sourcetree.app'
+  binary "#{appdir}/Sourcetree.app/Contents/Resources/stree"
 
   uninstall launchctl: 'com.atlassian.SourceTreePrivilegedHelper2',
             quit:      'com.torusknot.SourceTreeNotMAS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The Appname is Sourcetree.app not SourceTree.app