### PR TITLE
Update expo-xde to 2.20.1

### DIFF
--- a/Casks/expo-xde.rb
+++ b/Casks/expo-xde.rb
@@ -1,9 +1,9 @@
 cask 'expo-xde' do
-  version :latest
-  sha256 :no_check
+  version '2.20.1'
+  sha256 '53309014713ea1064499891767b1137d0d0202afc23c56f7fd513fe6284e7b1e'
 
-  # exponentjs.com was verified as official when first introduced to the cask
-  url 'https://xde-updates.exponentjs.com/download/mac'
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/expo/xde/releases/download/v#{version}/xde-#{version}.dmg"
   name 'Expo Development Environment (XDE)'
   homepage 'https://expo.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.