### PR TITLE
Update hopper-disassembler to 4.2.20

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.2.19'
-  sha256 '23c0cea411864e7bb745870351b14cdd436edf393cc930c6aa098be4a6aef992'
+  version '4.2.20'
+  sha256 '58f6878850bc69400e73c18730aacb31544ff815898cc364fabd7d70e840309b'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '470b78778daed0173edc172d1bdcf2fed099858a5fc67823b8fed4839538aec2'
+          checkpoint: '336d7001e1dea74bef3a3372f386e01e9fce674d75a9438b57104e9a23772f4a'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.