### PR TITLE
Update hyper to 1.4.8

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,11 +1,11 @@
 cask 'hyper' do
-  version '1.4.7'
-  sha256 '49f530ca76ece244e0c03b905ca6855d58ad962a717bf15d2f8c8766449e1b92'
+  version '1.4.8'
+  sha256 'a8e48a5f7a810ff67a4524491f360d622284f76058344baab909b21352df8985'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '37ad97df5744c71ad69cdf3feace8038daa5ff7ed747b589f9c59def429fe587'
+          checkpoint: 'e9ffa6b15e4033dacd8a4fe8fdfb8de8cdec5354cdd35a61087fee5af64b48f4'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.