### PR TITLE
Update ransomwhere to 1.2.1

### DIFF
--- a/Casks/ransomwhere.rb
+++ b/Casks/ransomwhere.rb
@@ -1,11 +1,11 @@
 cask 'ransomwhere' do
-  version '1.2.0'
-  sha256 'b36433e335f4c25de885cfa9af79f07395cf5d2e929900442a00b85983544a52'
+  version '1.2.1'
+  sha256 'fa60764a7e90c2efc5028133becccc3b602b5dd30a305b81c7bf8a0eb5f0de31'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/RansomWhere_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/RansomWhere.txt',
-          checkpoint: '1021aba2b54083b9d794406402eb89f2a38dac6fd23b843aad9ed5b42b2edd90'
+          checkpoint: '8d7fe5d289e50cf88c6a079f235d62549cc4b8bdb182f7ea4b1af1dd8b39a76f'
   name 'RansomWhere'
   homepage 'https://objective-see.com/products/ransomwhere.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.