### PR TITLE
Update aquaterm to 1.1.1

### DIFF
--- a/Casks/aquaterm.rb
+++ b/Casks/aquaterm.rb
@@ -1,10 +1,10 @@
 cask 'aquaterm' do
   version '1.1.1'
-  sha256 '94b33efea2ec037e6c06beef54b4b3cc48595453c874de863f25c26b3a7ffdb2'
+  sha256 '7a07d3f7cca5c0b38ca811984ef8da536da32932d68c1a6cce33ec2462b930bf'
 
   url "https://downloads.sourceforge.net/aquaterm/AquaTerm/v#{version}/AquaTerm-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/aquaterm/rss?path=/AquaTerm',
-          checkpoint: '919b1aaf6bdb5814d370b76ea198c20ee2595a738ba0697f3dd88c4b96b46050'
+          checkpoint: '7a07d3f7cca5c0b38ca811984ef8da536da32932d68c1a6cce33ec2462b930bf'
   name 'AquaTerm'
   homepage 'https://sourceforge.net/projects/aquaterm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.