### PR TITLE
Update sabnzbd to 2.3.0

### DIFF
--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -1,6 +1,6 @@
 cask 'sabnzbd' do
   version '2.3.0'
-  sha256 'cafe5a7d106b83f273c50cd5450e8d5e25e6d8655b65f48687cc783756a42e82'
+  sha256 '2f501d77c9dac0f889443bc4187e2da66664163b1e1b5b8a13c96547ed9f866c'
 
   # github.com/sabnzbd/sabnzbd was verified as official when first introduced to the cask
   url "https://github.com/sabnzbd/sabnzbd/releases/download/#{version}/SABnzbd-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

https://github.com/caskroom/homebrew-cask/issues/38995

> https://www.virustotal.com/#/file/2f501d77c9dac0f889443bc4187e2da66664163b1e1b5b8a13c96547ed9f866c/details