### PR TITLE
Update opera to 48.0.2685.32

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '47.0.2631.83'
-  sha256 'c72548a3fda1153e1ff75b7f4d68209ece811d04480d2e0ee87c2017208f6c5b'
+  version '48.0.2685.32'
+  sha256 'fe41234c429e56320097cd76b5cb25170d7264f8b10ea26b2e7fb36bb9f81666'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.