### PR TITLE
Update fldigi to 4.0.10

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.9'
-  sha256 '1e092632d0f29de3911121c12685c60e9bd602a9fa06139266679c1439c4a832'
+  version '4.0.10'
+  sha256 '01d977ea0046a382b40f7699ae1f33013f1aa51671ed2ab8c5a97784a0ccc3ea'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_i386.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: '2baa7fe03d9a6f22e8388d3533713a59ff4f6170881afdec34732ed0cad3c139'
+          checkpoint: 'dc482a426612074db67e3a5c734f90ba35a15095ebfbfdf2081849fd7b4330bf'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.