### PR TITLE
Update depends on for catlight

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -6,5 +6,7 @@ cask 'catlight' do
   name 'catlight'
   homepage 'https://catlight.io/'
 
+  depends_on macos: '<= 10.12'
+
   app 'Catlight.app'
 end


### PR DESCRIPTION
There is a bug with catlight and macos 10.13 as seen here
https://catlight.helprace.com/i278-osx-localweb-segmentation-fault

i have no idea what minimum version of macos is needed to it just depends on anything .12 and down
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
