### PR TITLE
Update onyx to 3.3.0

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -3,13 +3,13 @@ cask 'onyx' do
     version '3.1.9'
     sha256 '7f8df2c9e97eb465aba88b000fa2f58958421efeba1239303ff0071e9b7b0536'
   else
-    version '3.2.9'
-    sha256 '0d712ddedcac1891950990716ba1b3b3d6d0abb86fd5c837ff0bf272dbed52bc'
+    version '3.3.0'
+    sha256 'd8f521bd348044fc2d1696f43910bfb193a9641968013cd5bbaada55e46e4799'
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/OnyX.dmg"
   appcast 'http://www.titanium-software.fr/en/release_onyx.html',
-          checkpoint: '4fdfa4577656faee686f58227e6cb6ecd93300cd0f8bd7addfdf207348fc5c42'
+          checkpoint: '8264f1465f06db34e1c36e22f002d2200e7d50449be174ae614e7d5341a1dc90'
   name 'OnyX'
   homepage 'https://www.titanium-software.fr/en/onyx.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.