### PR TITLE
Update catlight: remove `depends_on macos`

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -6,7 +6,5 @@ cask 'catlight' do
   name 'catlight'
   homepage 'https://catlight.io/'
 
-  depends_on macos: '<= 10.12'
-
   app 'Catlight.app'
 end


### PR DESCRIPTION
Reverts https://github.com/caskroom/homebrew-cask/pull/39038

I'm 👎  on adding these to Casks that don't _currently_ work because of a bug.  In most cases it will only be a temporary problem that will be fixed in a new version. People may also want to install the Cask so they can report issues upstream.

I think this should only be added if upstream says they aren't going to support 10.13 at all.