### PR TITLE
Add Guild Wars 2 native Mac client

### DIFF
--- a/Casks/guild-wars2.rb
+++ b/Casks/guild-wars2.rb
@@ -1,0 +1,11 @@
+cask 'guild-wars2' do
+  version :latest
+  sha256 :no_check
+
+  # s3.amazonaws.com/gw2cdn was verified as official when first introduced to the cask
+  url 'http://s3.amazonaws.com/gw2cdn/client/branches/Gw2Setup-64.dmg'
+  name 'Guild Wars 2'
+  homepage 'https://www.guildwars2.com/'
+
+  app 'Guild Wars 2 64-bit.app'
+end

--- a/Casks/guild-wars2.rb
+++ b/Casks/guild-wars2.rb
@@ -1,4 +1,5 @@
 cask 'guild-wars2' do
+  # note: "2" is not a version number, but an intrinsic part of the product name
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
I'm aware of #14721 and those issues.
This one is a native client, as opposed to previous Wine wrapper.
Also, it's now accessible without any registration/login: go to https://guildwars2.com, click "Play for free" on the right and under the form, there will be a link to directly go to the client download page.
Sadly, redirections to Amazon AWS are still in place.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256