### PR TITLE
Update bitpay to 3.8.2

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.7.1'
-  sha256 '9851b5ea2bea9a84de3d4b327ab8acb78a7bcd8738a8ad38497e91362cc58917'
+  version '3.8.2'
+  sha256 'b575724fb840c6af5c3824dfb80d374b9e9bb700c5ac5208085d040d16f46643'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'a489cf8938c1d1b05fc10ddc9101271030b52fa78d17d81315eac244e7bdfd23'
+          checkpoint: 'de635cd22d229ec1d0500232b41ea387061e5695f797ecc81e6cc262cff37999'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.