### PR TITLE
Onyx 3.3.0 URL fix for High Sierra

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -1,14 +1,13 @@
 cask 'onyx' do
   if MacOS.version == :el_capitan
-    version '3.1.9'
+    version '3.1.9,1011'
     sha256 '7f8df2c9e97eb465aba88b000fa2f58958421efeba1239303ff0071e9b7b0536'
-    url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
   else
-    version '3.3.0'
+    version '3.3.0,1012'
     sha256 'd8f521bd348044fc2d1696f43910bfb193a9641968013cd5bbaada55e46e4799'
-    url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
   end
 
+  url "https://www.titanium-software.fr/download/#{version.after_comma}/OnyX.dmg"
   appcast 'http://www.titanium-software.fr/en/release_onyx.html',
           checkpoint: '8264f1465f06db34e1c36e22f002d2200e7d50449be174ae614e7d5341a1dc90'
   name 'OnyX'

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -2,12 +2,13 @@ cask 'onyx' do
   if MacOS.version == :el_capitan
     version '3.1.9'
     sha256 '7f8df2c9e97eb465aba88b000fa2f58958421efeba1239303ff0071e9b7b0536'
+    url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
   else
     version '3.3.0'
     sha256 'd8f521bd348044fc2d1696f43910bfb193a9641968013cd5bbaada55e46e4799'
+    url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
   end
 
-  url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/OnyX.dmg"
   appcast 'http://www.titanium-software.fr/en/release_onyx.html',
           checkpoint: '8264f1465f06db34e1c36e22f002d2200e7d50449be174ae614e7d5341a1dc90'
   name 'OnyX'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

There is no High Sierra version available ATM, but if update run on it, it tried to download the app from wrong URL (URL for High Sierra and not Sierra, which is it meant for)

After making all changes to the cask:

- [x] `brew cask audit --download onyx` is error-free.
- [x] `brew cask style --fix onyx` reports no offences.
- [x] The commit message includes the cask’s name and version.

