### PR TITLE
Update gitkraken to 3.0.2

### DIFF
--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -1,6 +1,6 @@
 cask 'gitkraken' do
-  version '3.0.1'
-  sha256 '5d1f75802de4b8d114bb0afdd2ef6313c3284baac56caaf051baa52d8c4f0fc2'
+  version '3.0.2'
+  sha256 'edf7f1a00579303095170e0680751979937739b9367f314062c2535cd23d003f'
 
   url "https://release.gitkraken.com/darwin/v#{version}.zip"
   appcast 'https://release.gitkraken.com/darwin/RELEASES',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.