### PR TITLE
Subutai p2p :latest [new cask] resource sharing daemon

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -1,0 +1,20 @@
+cask 'subutaip2p' do
+  version :latest
+  sha256 :no_check
+
+  # cdn.subut.ai:8338/kurjun/rest/raw/ was verified as official when first introduced to the cask
+  url 'https://cdn.subut.ai:8338/kurjun/rest/raw/get?name=subutai-p2p.pkg'
+  name 'Subutai P2P'
+  homepage 'https://subutai.io/'
+
+  auto_updates true
+
+  pkg 'subutai-p2p.pkg'
+
+  # This is a hack to force the file extension.
+  preflight do
+    system_command '/bin/mv', args: ['--', staged_path.join('get'), staged_path.join('subutai-p2p.pkg')]
+  end
+
+  uninstall pkgutil: 'com.Subutai.P2P'
+end


### PR DESCRIPTION
This is the actual  Subutai-p2p sharing application/daemon.

Subutai is a new distributed "personal" cloud, where resources can be "donated": https://www.subutai.io/

It is endorsed by "Maddog" which is how I learned about it: http://www.linux-magazine.com/Online/Blogs/Paw-Prints-Writings-of-the-maddog/Subutai-Peer-to-peer-private-secure-stable-cloud-software-that-gives-you-control

Using install hack from caskroom/homebrew-cask#39050 by @commitay (THANK YOU!)

https://github.com/caskroom/homebrew-cask/blob/master/Casks/subutaitray.rb is a menubar management tool for this daemon.

---
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].