### PR TITLE
Add CoreOs Container Linux Config Transpiler latest

### DIFF
--- a/Casks/coreos-ct.rb
+++ b/Casks/coreos-ct.rb
@@ -1,0 +1,15 @@
+cask 'coreos-ct' do
+  version '0.4.2'
+  sha256 'eb38e78ff40c9fc41592fb6521d8f95e0a0433d42901f51d6b6d294e487f0118'
+
+  url "https://github.com/coreos/container-linux-config-transpiler/releases/download/v#{version}/ct-v#{version}-x86_64-apple-darwin"
+  name 'Container Linux Config Transpiler'
+  homepage 'https://github.com/coreos/container-linux-config-transpiler'
+  gpg "#{url}.asc", key_id: '18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E'
+
+  preflight do
+    system_command '/bin/mv', args:
+                                    ["/usr/local/Caskroom/coreos-ct/#{version}/ct-v#{version}-x86_64-apple-darwin",
+                                     '/usr/local/Caskroom/coreos-ct/0.4.2/coreos-ct']
+  end
+end


### PR DESCRIPTION
The original binary name is way too long; formula renames it
to match the token with a preflight stanza.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

The commit message contains the public/common name of the program, not the token (`coreos-ct`).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
