### PR TITLE
Update proxifier to 2.21

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -1,5 +1,5 @@
 cask 'proxifier' do
-  version '2.19'
+  version '2.21'
   sha256 'dcefba17e07a11d2ce8c12f949e9c59f80994588f3910516b58669e9e740854c'
 
   url 'https://www.proxifier.com/distr/ProxifierMac.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.