### PR TITLE
Update proxifier to 2.21

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -3,8 +3,8 @@ cask 'proxifier' do
   sha256 '139887d2f4468af222af2b8a1b806169918f359113547a918078792b47471540'
 
   url 'https://www.proxifier.com/distr/ProxifierMac.dmg'
-  appcast 'https://www.proxifier.com/distr/last_versions/ProxifierMac.txt',
-          checkpoint: '5c316b2043de3d51392e3b60fc0894167c9b2c8abb5d1fe91ccf9d9c0a2056c9'
+  appcast 'https://www.proxifier.com/mac/new.htm',
+          checkpoint: '602cadf245901c60c6fd178f80f5e0771ce290a1b03446f1d949ed310f7b97a2'
   name 'Proxifier'
   homepage 'https://www.proxifier.com/mac/'
 

--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -1,8 +1,8 @@
 cask 'proxifier' do
-  version '2.19'
-  sha256 'dcefba17e07a11d2ce8c12f949e9c59f80994588f3910516b58669e9e740854c'
+  version '2.21'
+  sha256 '139887d2f4468af222af2b8a1b806169918f359113547a918078792b47471540'
 
-  url 'https://www.proxifier.com/distr/ProxifierMac.zip'
+  url 'https://www.proxifier.com/distr/ProxifierMac.dmg'
   appcast 'https://www.proxifier.com/distr/last_versions/ProxifierMac.txt',
           checkpoint: '5c316b2043de3d51392e3b60fc0894167c9b2c8abb5d1fe91ccf9d9c0a2056c9'
   name 'Proxifier'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.