### PR TITLE
Update Tripmode to 2.1.0

### DIFF
--- a/Casks/tripmode.rb
+++ b/Casks/tripmode.rb
@@ -1,8 +1,8 @@
 cask 'tripmode' do
-  version '2.0.1-492'
-  sha256 '03ff98645a6512b9f2dba8f05d4e6437340b1a2eeea0701dafdea2213d511317'
+  version '2.1.0-583'
+  sha256 '98ccbe84fa054ce160c2ebe1823b7362605090a3330fb16ae21e41a9260d0353'
 
-  url "https://www.tripmode.ch/app/TripMode-#{version}-app.dmg"
+  url "https://www.tripmode.ch/app/TripMode-#{version}-app-Release.dmg"
   appcast 'http://updates.tripmode.ch/app/appcast.xml',
           checkpoint: '1c589ebad8ed5f9c36a702b070882b73612030eb42bd23587d2106c1399d5e8e'
   name 'TripMode'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download tripmode` is error-free.
- [x] `brew cask style --fix tripmode` reports no offenses.
- [x] The commit message includes the cask’s name and version.


