### PR TITLE
Update subler to 1.3.8

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.3.7'
-  sha256 '1d278ded9c40211b723873144cc9a70126d946d193b170341602dd3dc763a3ba'
+  version '1.3.8'
+  sha256 '78a6071b8cf6a039f65c22a7202c4f7af230983ab797e39d172c58efae267cbc'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: 'fd7b4fe7aadfa0aaa8211c76a05f6c11b333502fbbcf9b969327827a18604864'
+          checkpoint: '187cffe4df021aeb6ac4ae7c47ad61131c6f03d21ec07383ce109319d10c3e12'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.