### PR TITLE
Update copyq to 3.1.1

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -1,11 +1,11 @@
 cask 'copyq' do
-  version '3.0.3'
-  sha256 '631ede047c31b7c51f5f306bbd86462d95970859c2978f74f81f58e545b0b5eb'
+  version '3.1.1'
+  sha256 '04cf492536128e15bb7875d9df407265f828f1ca4ec82f970f25ee3087598724'
 
   # github.com/hluk/CopyQ was verified as official when first introduced to the cask
   url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ.dmg"
   appcast 'https://github.com/hluk/CopyQ/releases.atom',
-          checkpoint: 'bb82d7ded0e3a50d83b7128aa9476e6481047792cf202b202fefc17b805b7e7b'
+          checkpoint: '1753c610fd2594b436fbba4fd4c927aa372c6c37cbd261b9d29533ea1d465865'
   name 'CopyQ'
   homepage 'https://hluk.github.io/CopyQ/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.