### PR TITLE
Update prusa-slic3r to 1.37.1,201709141215

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,11 +1,11 @@
 cask 'prusa-slic3r' do
-  version '1.36.1,201707251232'
-  sha256 'f0b72d3bbf6a08be09b61ec3a41a63f29fab7ed7430690581b9dbecd297c54a6'
+  version '1.37.1,201709141215'
+  sha256 'a7cfc43ae8ea05eb77dd7b25b49309558688a7926d1ce157c6e0041118686729'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3r-#{version.before_comma}-prusa3d-full-#{version.after_comma}.dmg"
   appcast 'https://github.com/prusa3d/Slic3r/releases.atom',
-          checkpoint: '13fb6d5c7b1c2eb1c2b5b4758b84bc21c487de079188024f8b2b12faff46f801'
+          checkpoint: '2dfc5c83b39db928a7df55f9b4dfb0d344e857e3621c8caee75fdb046612cd73'
   name 'Slic3r - Prusa Edition'
   homepage 'https://www.prusa3d.com/slic3r-prusa-edition/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.