### PR TITLE
awips-python 17.1.1 and awips2-cave 17.1.1

### DIFF
--- a/Casks/awips-python.rb
+++ b/Casks/awips-python.rb
@@ -1,10 +1,12 @@
 cask 'awips-python' do
-  version '17.1.1'
-  sha256 '48fd4fd41994c1b7321dcadd723b71fb7719512ac6f7bb47aadca42b417f7af0'
+  version :latest
+  sha256 :no_check
 
   url 'http://www.unidata.ucar.edu/downloads/awips2/awips-python.pkg'
-  name 'awips-python.pkg'
+  name 'AWIPS Python'
   homepage 'http://www.unidata.ucar.edu/software/awips2/'
 
   pkg 'awips-python.pkg'
+
+  uninstall pkgutil: 'com.mygreatcompany.pkg.aiwps-python'
 end

--- a/Casks/awips-python.rb
+++ b/Casks/awips-python.rb
@@ -1,0 +1,10 @@
+cask 'awips-python' do
+  version '17.1.1'
+  sha256 '48fd4fd41994c1b7321dcadd723b71fb7719512ac6f7bb47aadca42b417f7af0'
+
+  url 'http://www.unidata.ucar.edu/downloads/awips2/awips-python.pkg'
+  name 'awips-python.pkg'
+  homepage 'http://www.unidata.ucar.edu/software/awips2/'
+
+  pkg 'awips-python.pkg'
+end

--- a/Casks/awips2-cave.rb
+++ b/Casks/awips2-cave.rb
@@ -1,0 +1,13 @@
+cask 'awips2-cave' do
+  version '17.1.1'
+  sha256 '20c8b6a0d3f71bcdb8735af75898ccfa58dc5eeacfe424b5a3b7a804120f5cf6'
+
+  url 'http://www.unidata.ucar.edu/downloads/awips2/awips2-cave-17.1.1.dmg'
+  name 'awips2-cave'
+  homepage 'http://www.unidata.ucar.edu/software/awips2/'
+  
+  depends_on cask: 'awips-python'
+
+  app 'Cave.app'
+
+end

--- a/Casks/awips2-cave.rb
+++ b/Casks/awips2-cave.rb
@@ -5,9 +5,8 @@ cask 'awips2-cave' do
   url 'http://www.unidata.ucar.edu/downloads/awips2/awips2-cave-17.1.1.dmg'
   name 'awips2-cave'
   homepage 'http://www.unidata.ucar.edu/software/awips2/'
-  
+
   depends_on cask: 'awips-python'
 
   app 'Cave.app'
-
 end

--- a/Casks/cave.rb
+++ b/Casks/cave.rb
@@ -1,9 +1,9 @@
-cask 'awips2-cave' do
+cask 'cave' do
   version '17.1.1'
   sha256 '20c8b6a0d3f71bcdb8735af75898ccfa58dc5eeacfe424b5a3b7a804120f5cf6'
 
-  url 'http://www.unidata.ucar.edu/downloads/awips2/awips2-cave-17.1.1.dmg'
-  name 'awips2-cave'
+  url "http://www.unidata.ucar.edu/downloads/awips2/awips2-cave-#{version}.dmg"
+  name 'AWIPS Cave'
   homepage 'http://www.unidata.ucar.edu/software/awips2/'
 
   depends_on cask: 'awips-python'


### PR DESCRIPTION
Casks for installing awips-cave app on OSX along with it's dependency awips-python package cask.

Unidata AWIPS CAVE is a meteorological display and analysis package used by weather forecasters and researchers to visualize weather data.  Access to weather data formatted for AWIPS and publicly available has been historically extremely limited.  There have been great improvements in ability of NOAA and their partners to make both the data and the visualization/analysis tools more widely available.

Historically it was very difficult to access the data but that has been changing in recent years.  Unitdata themselves offers a public end point.

Name:  AWIPS2 Cave Viz Client

Homepage: http://www.unidata.ucar.edu/software/awips2/

Download URL: http://www.unidata.ucar.edu/software/awips2/

Description: Unidata AWIPS (formerly AWIPS II) is a meteorological display and analysis package originally developed by the National Weather Service and Raytheon, repackaged by Unidata to support non-operational use in research and education by UCAR member institutions.

## check list

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

## new cask check list

- [ ] Named the cask according to the [token reference].
  * `awips-python` is great name
  * `awips2-cave` could possibly be simplified to just awips-cave.  The app thinks of it as just Cave.app which would imply calling this just `cave`. Don't think this is a widely used enough application to warrant just a single name like that.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].
  * yeah - this stuff is very rarely updated and they don't offer multiple build options for stable vs build that I'm aware of.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
