### PR TITLE
Update skype to 7.58

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version :latest
-  sha256 :no_check
+  version '7.58'
+  sha256 '14dfca8f79f35b4c994c11d3a514b2d7537640803c72d1b18dc8631e80db515a'
 
   url 'https://www.skype.com/go/getskype-macosx.dmg'
   name 'Skype'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.