### PR TITLE
Update exodus to 1.35.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.35.0'
-  sha256 '46b50933ce4b57ad01bf7f9c810b480240c44f6af110f4972fc5fe173981d972'
+  version '1.35.2'
+  sha256 '5cd8299378a24a71a0357c26eda1e165fee9742442d4bce094da440159afcd62'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: 'd0b89dd19fea59f250929c893eeb80b78c2ee5a0a33da6da2a50d880e0e89c80'
+          checkpoint: '1ac706f3f8407d2c9d89b6a33c32cf93da70e029bad2b9566ca43db3157230ab'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

---

Closes #.