### PR TITLE
Update ransomwhere to 1.2.2

### DIFF
--- a/Casks/ransomwhere.rb
+++ b/Casks/ransomwhere.rb
@@ -1,11 +1,11 @@
 cask 'ransomwhere' do
-  version '1.2.1'
-  sha256 'fa60764a7e90c2efc5028133becccc3b602b5dd30a305b81c7bf8a0eb5f0de31'
+  version '1.2.2'
+  sha256 '7f502e4e21991c5d294d383fbc65664c3fd0cccefabf7569b907bfe3fe2c61c3'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/RansomWhere_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/RansomWhere.txt',
-          checkpoint: '8d7fe5d289e50cf88c6a079f235d62549cc4b8bdb182f7ea4b1af1dd8b39a76f'
+          checkpoint: 'ef351ca13e242fa46dea36eada86c407c3c4cb1b6531331d5d4f0c4bd446ca17'
   name 'RansomWhere'
   homepage 'https://objective-see.com/products/ransomwhere.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.