### PR TITLE
Update caprine to 2.7.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.6.2'
-  sha256 '466e51dbdf7c82284b0c3a81a50a363935eaac3268975a838581215e56ae991b'
+  version '2.7.0'
+  sha256 '46726138b692151038431c4f9e3e2a0cab739fa5f2de5dc2c899107ba7a81081'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: '62ae797427421ec174267fe60eea203f9441efc07d857e7419fe247634d6dc0e'
+          checkpoint: '717aa946e8fd56396b5d3882f883d2a60f7c8054ad8ed82a1ec75b5bbd954fee'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.