### PR TITLE
Update wireshark casks: uninstall

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -43,18 +43,16 @@ cask 'wireshark-chmodbpf' do
 
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
-
-    system_command '/usr/sbin/dseditgroup',
-                   args: [
-                           '-o',
-                           'delete',
-                           'access_bpf',
-                         ],
-                   sudo: true
   end
 
   uninstall pkgutil:   'org.wireshark.ChmodBPF.pkg',
-            launchctl: 'org.wireshark.ChmodBPF'
+            launchctl: 'org.wireshark.ChmodBPF',
+            script:    {
+                         executable:   '/usr/sbin/dseditgroup',
+                         args:         ['-o', 'delete', 'access_bpf'],
+                         must_succeed: false,
+                         sudo:         true,
+                       }
 
   caveats do
     reboot

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -26,14 +26,6 @@ cask 'wireshark' do
 
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
-
-    system_command '/usr/sbin/dseditgroup',
-                   args: [
-                           '-o',
-                           'delete',
-                           'access_bpf',
-                         ],
-                   sudo: true
   end
 
   uninstall pkgutil:   'org.wireshark.*',
@@ -51,7 +43,13 @@ cask 'wireshark' do
                          '/usr/local/bin/text2pcap',
                          '/usr/local/bin/tshark',
                          '/usr/local/bin/wireshark',
-                       ]
+                       ],
+            script:    {
+                         executable:   '/usr/sbin/dseditgroup',
+                         args:         ['-o', 'delete', 'access_bpf'],
+                         must_succeed: false,
+                         sudo:         true,
+                       }
 
   zap delete: '~/Library/Saved Application State/org.wireshark.Wireshark.savedState'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Change `uninstall_preflight` `dseditgroup` to `uninstall script`

Allows `dseditgroup` to fail if `access_bpf` group does not exist.