### PR TITLE
Update hazel to 4.2.1

### DIFF
--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -1,11 +1,11 @@
 cask 'hazel' do
-  version '4.2'
-  sha256 'fb7220270b710df3d27b32104a1d84cc3c57b5be5666ca949b571bdb96ae30a8'
+  version '4.2.1'
+  sha256 '8a35d92620bd311f3fb67edf540cb88a35dff96ef8919aa84dff8eef39f6f5fe'
 
   # s3.amazonaws.com/Noodlesoft was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Noodlesoft/Hazel-#{version}.dmg"
   appcast 'https://www.noodlesoft.com/Products/Hazel/generate-appcast.php',
-          checkpoint: 'fcd51f51f393afc55abe318b78d209362e15c3ef32289f8f4b2ee7486c3e8d09'
+          checkpoint: 'a13e761bd4969ce3a2f25168a61876ad7f5e75324b92e198378af9743da78887'
   name 'Hazel'
   homepage 'https://www.noodlesoft.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.