### PR TITLE
yujitach-menumeters 1.9.6 download is available via https

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -2,7 +2,7 @@ cask 'yujitach-menumeters' do
   version '1.9.6'
   sha256 'c2fe26a31743b9d4a0216a4415b8253dd0c2a1fd4d6d1fc7d2d4b9e33d9cc588'
 
-  url "http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
+  url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
   appcast 'https://github.com/yujitach/MenuMeters/releases.atom',
           checkpoint: '3fc1845ad638f6b32312a4dd61c640d60d5ef4cf2684f7470c98c2b3eaeb54d9'
   name 'MenuMeters for El Capitan (and later)'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
