### PR TITLE
Update syncmate to 7.0.365

### DIFF
--- a/Casks/syncmate.rb
+++ b/Casks/syncmate.rb
@@ -1,12 +1,12 @@
 cask 'syncmate' do
-  version '6.6.336'
-  sha256 'cd8c0115fea98c353b6c1e7ab945c87d406a92c0eda11e1b285b2df401f2e968'
+  version '7.0.365'
+  sha256 '617143bd9b5405d44a543cfca859a4fe7c03558c9001c09d419029f8ef1bbdca'
 
-  url 'http://www.sync-mac.com/download/syncmate.dmg'
+  url 'https://mac.eltima.com/download/syncmate.dmg'
   appcast "http://www.eltima.com/download/syncmate-update/syncmate#{version.major}.xml",
-          checkpoint: 'a057f63a65f4b4156f7847a777db21fa5d7328f5f47ea17e1d9e6977f603049b'
+          checkpoint: 'aa5c21ff6516c2bc37f351b2a0dc695c370c7f2eb289dc44eafbbe6626f20b0d'
   name 'SyncMate'
-  homepage 'https://www.sync-mac.com/'
+  homepage 'https://mac.eltima.com/'
 
   app 'SyncMate.app'
 end

--- a/Casks/syncmate.rb
+++ b/Casks/syncmate.rb
@@ -2,11 +2,11 @@ cask 'syncmate' do
   version '7.0.365'
   sha256 '617143bd9b5405d44a543cfca859a4fe7c03558c9001c09d419029f8ef1bbdca'
 
-  url 'https://mac.eltima.com/download/syncmate.dmg'
+  url "https://mac.eltima.com/download/syncmate#{version.major}.dmg"
   appcast "http://www.eltima.com/download/syncmate-update/syncmate#{version.major}.xml",
           checkpoint: 'aa5c21ff6516c2bc37f351b2a0dc695c370c7f2eb289dc44eafbbe6626f20b0d'
   name 'SyncMate'
-  homepage 'https://mac.eltima.com/'
+  homepage 'https://mac.eltima.com/sync-mac.html'
 
   app 'SyncMate.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.