### PR TITLE
Update trailer to 1.6.2

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,10 +1,11 @@
 cask 'trailer' do
-  version '1.6.0'
-  sha256 'f877b0e2dd5a553c9d8b28fbe2a620f6d9dad4ab0847e879ee415d4f5cc7b580'
+  version '1.6.2'
+  sha256 '939bd7f8774ce696bb2011a21887299f3a004c65956c15ea6a2f761c9390b55c'
 
-  url "https://ptsochantaris.github.io/trailer/trailer#{version.no_dots}.zip"
-  appcast 'https://ptsochantaris.github.io/trailer/appcast.xml',
-          checkpoint: '880ea5e7a776c53524c30c8bfc5fabf05efc5e4e0a812174c2caec82b0e1e66b'
+  # github.com/ptsochantaris/trailer was verified as official when first introduced to the cask
+  url "https://github.com/ptsochantaris/trailer/releases/download/#{version}/trailer#{version.no_dots}.zip"
+  appcast 'https://github.com/ptsochantaris/trailer/releases.atom',
+          checkpoint: 'dabe111e97585b27014985752208576d2413aee1287e00a53352c98371022b98'
   name 'Trailer'
   homepage 'https://ptsochantaris.github.io/trailer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.