### PR TITLE
Update github-desktop to 1.0.3

### DIFF
--- a/Casks/github-desktop.rb
+++ b/Casks/github-desktop.rb
@@ -1,11 +1,11 @@
 cask 'github-desktop' do
-  version '1.0.2-0a90898a'
-  sha256 '39cb01b6d858fc732199f33da9365f401c3141d1546ef87fa7fd1c1ec3be6bf4'
+  version '1.0.3'
+  sha256 '7b5fb1b392a984da8a97c8f3c8e2e9991fc0f9137ec34597eeec47f342b63d1a'
 
   # githubusercontent.com was verified as official when first introduced to the cask
-  url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
+  url 'https://central.github.com/deployments/desktop/desktop/latest/darwin'
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: 'ee46361f397432e6ab0bb9a07bd6e6a9defed9c2996b804b0f9f4bd54840ab06'
+          checkpoint: 'c3f920e60ef14231b99a7f366475377cf9ec10823ac73682c95b586270eba4bd'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.