### PR TITLE
Update checksum for webex-wrf-player

### DIFF
--- a/Casks/webex-wrf-player.rb
+++ b/Casks/webex-wrf-player.rb
@@ -1,6 +1,6 @@
 cask 'webex-wrf-player' do
   version 'T31L'
-  sha256 'ab7a11c78c9c0e97ea4c823efbdec97f151ff9af9d762cac9729d42fa1f821b9'
+  sha256 'bc4a62cca340e13933be580599611688c5bde5ab88576449be7d5f4f0317eb90'
 
   url "https://welcome.webex.com/client/#{version}/mac/intel/webexplayer_intel.dmg"
   name 'WebEx Player'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

I don't know why Webex updated the binary without changing the version number. I'm just fixing this cask.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
