### PR TITLE
Update webex-nbr-player to T31L

### DIFF
--- a/Casks/webex-nbr-player.rb
+++ b/Casks/webex-nbr-player.rb
@@ -1,6 +1,6 @@
 cask 'webex-nbr-player' do
   version 'T31L'
-  sha256 '83bf06780d8fbea07ac7e7f590e7b7d9030db62524725a3a24416c0c44fbc0ea'
+  sha256 '76be3ec4e8d8c7d7efab8b6900e8d3d1e933faa9e9587293547d612c5b34b311'
 
   url "https://welcome.webex.com/client/#{version}/mac/intel/webexnbrplayer_intel.dmg"
   name 'Webex Network Recording player'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.