### PR TITLE
Update carbon-copy-cloner to 5.0.3.5115

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,8 +1,9 @@
 cask 'carbon-copy-cloner' do
-  version '5.0.2.5103'
-  sha256 '85d563c0499544f85fb32a069be37a6ddb529fbc8dcc56e45a3a4f5cecedcb0c'
+  version '5.0.3.5115'
+  sha256 'e4cc6bc7a667db8fb5f70b6a5aebd839f5399c0166c5ca14d26aa54f4101c28b'
 
-  url "https://bombich.com/software/download_ccc.php?v=#{version}"
+  # bombich.scdn1.secure.raxcdn.com/software/files was verified as official when first introduced to the cask
+  url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.