### PR TITLE
Update sketchbook to 8.5.0

### DIFF
--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -1,6 +1,6 @@
 cask 'sketchbook' do
-  version '8.4.3'
-  sha256 'ceeb4409312c2712ee636e7709e943680edc970f8da794aa9500d67c97468d1f'
+  version '8.5.0'
+  sha256 'adf0b2185c1a24fc78cad597d5c02decc6b23c50894fbb7827b680cc0601729d'
 
   url "https://cdn.sketchbook.com/mac/SketchBook_v#{version}_mac.dmg"
   name 'Autodesk Sketchbook'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.