### PR TITLE
Update airflow to 2.1.0

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,11 +1,11 @@
 cask 'airflow' do
-  version '2.0.0-gm5'
-  sha256 'f96a2b9612f703c35a901e47085cf67df31e36db880b042f2a3aa75f4b1edb7d'
+  version '2.1.0'
+  sha256 'e0788cad97dc74cc35366ab2070b9605de9d0fd190be779625340342ca12108d'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.dmg"
   appcast 'https://s3.amazonaws.com/Airflow/Updates/appcast-osx.xml',
-          checkpoint: '733bb541641a9fb183331b7133314773b973dde622be918a287ee8fd733e4e41'
+          checkpoint: 'dd12776f0c8ecd80c3adeb55ed4c3f72eef95dfccaa266a5a49ebe0f937cf26d'
   name 'Airflow'
   homepage 'https://airflowapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.