### PR TITLE
Update airparrot to 2.7.3

### DIFF
--- a/Casks/airparrot.rb
+++ b/Casks/airparrot.rb
@@ -1,10 +1,10 @@
 cask 'airparrot' do
-  version '2.7.2'
-  sha256 '4fab55cc61ee24cfc04a91ccb7c4160b3ed1d79390f8dc5f118e52daa4f28e7f'
+  version '2.7.3'
+  sha256 '5eea2a81ed32941ed8a169d53a3b3dcda26f5a3dcb30c4c0403f205f5de8577d'
 
   url "https://download.airsquirrels.com/AirParrot#{version.major}/Mac/AirParrot-#{version}.dmg"
   appcast "https://updates.airsquirrels.com/AirParrot#{version.major}/Mac/AirParrot#{version.major}.xml",
-          checkpoint: '9da80e53b07a19c8c80a3500d3baa0e8553a4839b2bdbaf489f06ec518df076a'
+          checkpoint: '0a7c1ee211fbcabe028d708234bc035826d8fc20737d5864d510d43159cbd5eb'
   name 'AirParrot'
   homepage 'http://www.airsquirrels.com/airparrot/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.