### PR TITLE
Update syncmate to 7.0.365

### DIFF
--- a/Casks/syncmate.rb
+++ b/Casks/syncmate.rb
@@ -3,8 +3,8 @@ cask 'syncmate' do
   sha256 '617143bd9b5405d44a543cfca859a4fe7c03558c9001c09d419029f8ef1bbdca'
 
   url "https://mac.eltima.com/download/syncmate#{version.major}.dmg"
-  appcast "http://www.eltima.com/download/syncmate-update/syncmate#{version.major}.xml",
-          checkpoint: 'aa5c21ff6516c2bc37f351b2a0dc695c370c7f2eb289dc44eafbbe6626f20b0d'
+  appcast 'http://www.eltima.com/download/syncmate-update/syncmate6.xml',
+          checkpoint: 'f387499c262793dc24a6a1afc0d8db3f2467a166101867ac0a7d91af13ccb848'
   name 'SyncMate'
   homepage 'https://mac.eltima.com/sync-mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.