### PR TITLE
Update ransomwhere to 1.2.3

### DIFF
--- a/Casks/ransomwhere.rb
+++ b/Casks/ransomwhere.rb
@@ -1,11 +1,11 @@
 cask 'ransomwhere' do
-  version '1.2.2'
-  sha256 '7f502e4e21991c5d294d383fbc65664c3fd0cccefabf7569b907bfe3fe2c61c3'
+  version '1.2.3'
+  sha256 'c9f21c0d5ba0512e97a89e12635f6380ada2b294ba49ce45d97bb8db3b53cefe'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/RansomWhere_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/RansomWhere.txt',
-          checkpoint: 'ef351ca13e242fa46dea36eada86c407c3c4cb1b6531331d5d4f0c4bd446ca17'
+          checkpoint: '597301ae2d39100b0edb041933a5aa51cf07f481bb4363790bb4eca428e2964d'
   name 'RansomWhere'
   homepage 'https://objective-see.com/products/ransomwhere.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.