### PR TITLE
Update cookie to 5.6.1

### DIFF
--- a/Casks/cookie.rb
+++ b/Casks/cookie.rb
@@ -1,10 +1,10 @@
 cask 'cookie' do
-  version '5.6'
-  sha256 'dd5bc8549cddf151afc776941f627fbe26e001f0df95ec6eb263f50d820df246'
+  version '5.6.1'
+  sha256 'a8e0902cbf5d65d4cbb9e79fb9412d241b2b3dc6769774f82ba201ecfe94aa51'
 
   url "https://sweetpproductions.com/products/cookie#{version.major}/Cookie#{version.major}.dmg"
   appcast "https://sweetpproductions.com/products/cookie#{version.major}/appcast.xml",
-          checkpoint: '506c3864219b0c59087077e5a011c9a25518618479047bd231dbde89090b3885'
+          checkpoint: 'fac18c823b408f9c3833b5b8703ee508a99e031bc9d93c58ee9ca64d38c7a429'
   name 'Cookie'
   homepage 'https://sweetpproductions.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.