### PR TITLE
Update espresso to 5.0.3

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,11 +1,11 @@
 cask 'espresso' do
-  version '5.0.2'
+  version '5.0.3'
   sha256 '462a57b2364764f15b62da95cab24633cb59b3dca1c4f05ac6ad85701372dda4'
 
   # static.macrabbit.com was verified as official when first introduced to the cask
   url "https://static.macrabbit.com/downloads/Espresso%20v#{version.major}.zip"
   appcast "https://update.macrabbit.com/espresso/#{version}.xml",
-          checkpoint: 'bce000fa6fee673d2df9c3e73b096ee8e45e832d79e3d7b698506181d946db48'
+          checkpoint: '1a136a83d4663679501479c433d99ad45e8284a1f5296701686e974d357fa143'
   name 'Espresso'
   homepage 'https://espressoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.