### PR TITLE
Update komodo-ide to 11.0.0-90668

### DIFF
--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -1,11 +1,10 @@
 cask 'komodo-ide' do
-  version '10.2.3-89902'
-  sha256 '7c46e4252d12f6c5083b8bd2869c92f7205c44f3f0d949a1b154738e2144c7a7'
+  version '11.0.0-90668'
+  sha256 '442c7f79ed67d76bba57898ab50e8a1ecd01f557d6fe687342c5697d833341ce'
 
-  # activestate.com/Komodo was verified as official when first introduced to the cask
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
   name 'Komodo IDE'
-  homepage 'https://komodoide.com/'
+  homepage 'https://www.activestate.com/komodo-ide/'
 
   app "Komodo IDE #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.