### PR TITLE
update swimat.rb to 1.5.0

### DIFF
--- a/Casks/swimat.rb
+++ b/Casks/swimat.rb
@@ -1,10 +1,10 @@
 cask 'swimat' do
-  version '1.4.0'
-  sha256 'd413943c2dc80281f6839ba77a0751c165e930542861c0787e9e6680ee0acbc0'
+  version '1.5.0'
+  sha256 '8a88598c20841e52af2f8160d1dde9c1173f65e878e4c918c32c7f67b0077d71'
 
   url "https://github.com/Jintin/Swimat/releases/download/v#{version}/Swimat.zip"
   appcast 'https://github.com/Jintin/Swimat/releases.atom',
-          checkpoint: '28c55a1bbd012267ec621d911daf55288a6cce7ca6dcbb74371879ec2bb7dbd0'
+          checkpoint: '8e888809ec82489edd6f00f0b0cc7d506e801d65373d8a278993832bd1a9a025'
   name 'Swimat'
   homepage 'https://github.com/Jintin/Swimat'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
