### PR TITLE
SubutaiTray: Add versioning/github tracking appcast

### DIFF
--- a/Casks/subutaitray.rb
+++ b/Casks/subutaitray.rb
@@ -1,9 +1,11 @@
 cask 'subutaitray' do
-  version :latest
-  sha256 :no_check
+  version '6.0.2'
+  sha256 '26de83957d95ae38d2ef124a3e00462e44bf47e31f70b12a2e350bf276a465b9'
 
   # cdn.subut.ai:8338/kurjun/rest/raw/ was verified as official when first introduced to the cask
   url 'https://cdn.subut.ai:8338/kurjun/rest/raw/get?name=subutai-tray.pkg'
+  appcast 'https://github.com/subutai-io/tray/releases.atom',
+          checkpoint: '26de83957d95ae38d2ef124a3e00462e44bf47e31f70b12a2e350bf276a465b9'
   name 'Subutai Tray'
   homepage 'https://subutai.io/'
 

--- a/Casks/subutaitray.rb
+++ b/Casks/subutaitray.rb
@@ -5,7 +5,7 @@ cask 'subutaitray' do
   # cdn.subut.ai:8338/kurjun/rest/raw/ was verified as official when first introduced to the cask
   url 'https://cdn.subut.ai:8338/kurjun/rest/raw/get?name=subutai-tray.pkg'
   appcast 'https://github.com/subutai-io/tray/releases.atom',
-          checkpoint: '26de83957d95ae38d2ef124a3e00462e44bf47e31f70b12a2e350bf276a465b9'
+          checkpoint: '49db1d9212bc91293be4d38869e38c2c9f22539ae72d32b72291dec867167534'
   name 'Subutai Tray'
   homepage 'https://subutai.io/'
 


### PR DESCRIPTION
Adding github `release.atom` versioning

`pkg` still lives on remote CDN at the moment.

Still requires odd ".pkg/directory" install work around 
---
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.