### PR TITLE
Subutai-p2p: Add versioning/github tracking appcast

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -1,9 +1,11 @@
 cask 'subutaip2p' do
-  version :latest
-  sha256 :no_check
+  version '6.0.2'
+  sha256 '8aae2da5d1226c8e8239aa15d9507a0b7e99a4e384ea7e75378f113496f2425e'
 
   # cdn.subut.ai:8338/kurjun/rest/raw/ was verified as official when first introduced to the cask
   url 'https://cdn.subut.ai:8338/kurjun/rest/raw/get?name=subutai-p2p.pkg'
+  appcast 'https://github.com/subutai-io/p2p/releases.atom',
+          checkpoint: 'adba3a6bba0ae5a1c08de017c4dd3a2321c61200007d41a3fd5784d1c8374b6c'
   name 'Subutai P2P'
   homepage 'https://subutai.io/'
 


### PR DESCRIPTION
Adding github `release.atom` versioning

`pkg` still lives on remote CDN at the moment.

Still requires odd ".pkg/directory" install work around 

---
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.