### PR TITLE
Update aqua-data-studio to 18.0.19

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,10 +1,10 @@
 cask 'aqua-data-studio' do
-  version '18.0.18'
-  sha256 'a0bb9550c865f212a7574fff7bb8639ad87173b9d3d04e0fa0c90832e6c6e9b5'
+  version '18.0.19'
+  sha256 '873ad0fb9783f277638bfbce35541ef55ae8bafbecbbe84c99cf04c99e39c04e'
 
   url "http://www.aquafold.com/download/v#{version.major}.0.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'http://www.aquafold.com/download/',
-          checkpoint: '7bc27eccc6c2c9c4624a55ff74c86256c3c3146ad120d0ee834bbe15c80807ad'
+          checkpoint: '1add5c4b11ef92db0cb739b3048181c9403a94d80459efd14cdafe180dc187a7'
   name 'Aquafold Aqua Data Studio'
   homepage 'http://www.aquafold.com/aquadatastudio.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.