### PR TITLE
Update archi to 4.0.3

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,10 +1,10 @@
 cask 'archi' do
-  version '4.0.2'
-  sha256 'ad5c59e14ff09a1bd8cecb6bb739a5e8ff60bd9644fb8a0772224469d652686f'
+  version '4.0.3'
+  sha256 '3a7afa02de7ce642436e7bad3aaf1420bbadb7dfb1098ea15b97b28d13c448c5'
 
   url "http://www.archimatetool.com/downloads/release/v#{version.major}/Archi-mac-#{version}.zip"
   appcast 'https://github.com/archimatetool/archi/releases.atom',
-          checkpoint: '53c09c7b5f52da00c23cd94c9b0870b1a655292eb4377d7660eb832f5032374a'
+          checkpoint: '6f986fc47533c4bd2892dafbba61e49033c522c9e3be690a9aad9322be1e837b'
   name 'Archi'
   homepage 'https://www.archimatetool.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.