### PR TITLE
Update astah-community to 7.2.0,1ff236

### DIFF
--- a/Casks/astah-community.rb
+++ b/Casks/astah-community.rb
@@ -1,10 +1,11 @@
 cask 'astah-community' do
-  version '7.1.0,f2c212'
-  sha256 'b2736dc7b980b6e617b5bc49bdcc986581a91a80644bf737759f9da54fed6297'
+  version '7.2.0,1ff236'
+  sha256 '81b12fc1145ec28ca82d87a0f13d2763362d55136759fe324192c65943215194'
 
-  url "http://cdn.astah.net/downloads/astah-community-#{version.before_comma.dots_to_underscores}-#{version.after_comma}-MacOs.dmg"
+  # cdn.change-vision.com was verified as official when first introduced to the cask
+  url "http://cdn.change-vision.com/files/astah-community-#{version.before_comma.dots_to_underscores}-#{version.after_comma}-MacOs.dmg"
   appcast 'http://astah.net/release-notes/community',
-          checkpoint: '0c7f285cde1fcf69800947f9d5405fb1458f4ba20965231405c16695d11a335c'
+          checkpoint: '10700fb03bcc1534619812005dc11abb16f010f81418bb0ccb98fa3f750c862d'
   name 'Change Vision Astah Community'
   homepage 'http://astah.net/editions/community'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.
