### PR TITLE
Update fly to 3.5.0

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.4.1'
-  sha256 '8ae189e40ee77e74946e4a7d930ed924189a76575334c7f3c759ca3755066871'
+  version '3.5.0'
+  sha256 '2580407ca4bbd46ca4d42dd95372fcab48c9380a54bb3681cfc8716022202652'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: 'd0863da02be2c7b36bdeb29f312ca108a5069a9773de01dbb29422ee4cedef9a'
+          checkpoint: '757019e10310a17a85319dddfaf37887db6e9d48ac57a4f31be6445e29efb25d'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.