### PR TITLE
Update ethereum-wallet to 0.9.1

### DIFF
--- a/Casks/ethereum-wallet.rb
+++ b/Casks/ethereum-wallet.rb
@@ -1,10 +1,10 @@
 cask 'ethereum-wallet' do
-  version '0.9.0'
-  sha256 '4077b08122b5d3480191a1c9d52b09934202cc5af755f172b276581b2729c8b2'
+  version '0.9.1'
+  sha256 '53023d0b3d2724ca2656b5a21c6c0516534906cfe62c69d3bef4439e59ca3040'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Ethereum-Wallet-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: '1b8e9586304e2320fbee37b398f77f04b86f9337ddf232232e58f4311c82d314'
+          checkpoint: 'dcb48d1e593f132f3c46cfcf9488a4fb8ce4aaa0c74ab13805eb56e1a341259a'
   name 'Ethereum Wallet'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.