### PR TITLE
Update encryptme to 4.0.6.1

### DIFF
--- a/Casks/encryptme.rb
+++ b/Casks/encryptme.rb
@@ -1,10 +1,10 @@
 cask 'encryptme' do
-  version '4.0.5.2'
-  sha256 'cd3f2ea6c678cdbb5ffcc9fcc8844fd89e3c1322de48cc85ca71ba481dda124a'
+  version '4.0.6.1'
+  sha256 '856ddf10498c1c8bc58961c4e8b757af14bcc7bf844b58001fe41dad9d6188cc'
 
   url "https://static.encrypt.me/downloads/osx/updates/Release/EncryptMe-#{version}.dmg"
   appcast 'https://www.getcloak.com/updates/osx/public/',
-          checkpoint: '398ad0487607d6533ad138453b82e31e0453cb26733fa01324a84f7a335cba2b'
+          checkpoint: 'cc2cd3a296eb8cb667426e368ad13b0231d038dca9b564d04cd0eac3b2255ca5'
   name 'EncryptMe'
   name 'Cloak'
   homepage 'https://encrypt.me/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.