### PR TITLE
Update duckietv to 1.1.5

### DIFF
--- a/Casks/duckietv.rb
+++ b/Casks/duckietv.rb
@@ -1,11 +1,11 @@
 cask 'duckietv' do
-  version '1.1.4'
-  sha256 '93516a16197256d05c7a575c3a6932b9384ee8c1cfc41afe103d9fdb2a0dda5f'
+  version '1.1.5'
+  sha256 '9c2f72c011cd477071e51238d5bfa0c202babdd263c1e4ea6b3d4e4605da2907'
 
   # github.com/SchizoDuckie/DuckieTV was verified as official when first introduced to the cask
   url "https://github.com/SchizoDuckie/DuckieTV/releases/download/#{version}/DuckieTV-#{version}-OSX-x64.pkg"
   appcast 'https://github.com/SchizoDuckie/DuckieTV/releases.atom',
-          checkpoint: 'aa8437be4c7e2b850a5538c56e75c1c04ff2cab08ecff1867997c7765e8a5c99'
+          checkpoint: 'e7660106640d75125840fa6d96d219a30ea65e70bcc20450f7b22bc0cdabbff1'
   name 'duckieTV'
   homepage 'https://schizoduckie.github.io/DuckieTV/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.