### PR TITLE
Update disk-arbitrator to 0.8.0

### DIFF
--- a/Casks/disk-arbitrator.rb
+++ b/Casks/disk-arbitrator.rb
@@ -1,11 +1,11 @@
 cask 'disk-arbitrator' do
-  version '0.7.0'
-  sha256 '1f27fccef99ffa65f4bcf7a266789bb6310aca0063f2accf34703bbf2db09cc8'
+  version '0.8.0'
+  sha256 '4dd2467c4a3a896ae0267087fe11df7bfc9d98c9f1bc049f401b58a59fca8533'
 
   # kainjow.com was verified as official when first introduced to the cask
   url "https://github.com/aburgh/Disk-Arbitrator/releases/download/v#{version}/Disk.Arbitrator-#{version.major_minor}.dmg"
   appcast 'https://github.com/aburgh/Disk-Arbitrator/releases.atom',
-          checkpoint: '982ad9843fdc9cf39b31d45010a9eab3ffe07fb71156759ba2a667d7e9923a51'
+          checkpoint: '2f0e338fe6f6b7d0adcfe2202b237154b94a0c041a2e8c233dcfb56e5330e243'
   name 'Disk Arbitrator'
   homepage 'https://github.com/aburgh/Disk-Arbitrator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.