### PR TITLE
Update displaycal to 3.3.4.1

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,11 +1,11 @@
 cask 'displaycal' do
-  version '3.3.4.0'
-  sha256 '0be4018e6d51adbf998ffbff1f4fa14c8dfb09ea466140fc60670c5a6237948f'
+  version '3.3.4.1'
+  sha256 '4f2bd73325f9b32d11318b2c588c26e479342f311617dea88a49311b0ab3c37c'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/dispcalgui/rss?path=/release',
-          checkpoint: 'fad7680973b066a62715e9a954adb0304a28ac285ac1c47a5b93c8d2a259c97d'
+          checkpoint: 'e5e8e56969e1a0693a97a0b85be2945cd12d853938ae8149fd334b2a0c20a836'
   name 'DisplayCAL'
   homepage 'https://displaycal.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.