### PR TITLE
Update dbeaver-community to 4.2.2

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,11 +1,11 @@
 cask 'dbeaver-community' do
-  version '4.2.1'
-  sha256 '44018036bdc8b165fd7b92d66863c04506b953382fc04d791822e0eba4a1cf0a'
+  version '4.2.2'
+  sha256 '9c8c4f16ff9cf5be2abcf729d985b433f8196b51f4cedc488d993a5ff1eee5cc'
 
   # github.com/serge-rider/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/serge-rider/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"
   appcast 'https://github.com/serge-rider/dbeaver/releases.atom',
-          checkpoint: '12f9b8d414026dbea590c0aa42b9693e25a7c178f6e3f4a7260d091a65551bb0'
+          checkpoint: '47716cee28119d038dcff9474d25cc94940ec26f220ec561bcea5e061bc33765'
   name 'DBeaver Community Edition'
   homepage 'https://dbeaver.jkiss.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.