### PR TITLE
Upgrade Paperspace from latest to 5.4.0.20

### DIFF
--- a/Casks/paperspace.rb
+++ b/Casks/paperspace.rb
@@ -1,9 +1,9 @@
 cask 'paperspace' do
-  version :latest
-  sha256 :no_check
+  version '5.4.0.20'
+  sha256 '6931d734fbee3ba7e8812d0cd57a7721674ba946d8d0f7429ee8cb64ead6e72d'
 
   # s3-us-west-1.amazonaws.com/ps-receiver was verified as official when first introduced to the cask
-  url 'https://s3-us-west-1.amazonaws.com/ps-receiver/darwin/Paperspace.dmg'
+  url "https://s3-us-west-1.amazonaws.com/ps-receiver/darwin/Paperspace-#{version}.dmg"
   name 'Paperspace'
   homepage 'https://www.paperspace.com/'
 


### PR DESCRIPTION
Paperspace download URLs switched to including the specific version, so
now including that along with the new checksum.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).
      I’m providing public confirmation below.

`sha256` changed because the `version` changed.