### PR TITLE
Update textexpander: remove outdated versions

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,23 +1,11 @@
 cask 'textexpander' do
-  if MacOS.version <= :snow_leopard
-    version '3.4.2'
-    sha256 '87859d7efcbfe479e7b78686d4d3f9be9983b2c7d68a6122acea10d4efbb1bfa'
+  version '6.2.2'
+  sha256 '669b1653659cdb2eb2907a1577313a53365a7f90579421f646c6f5366b74c9e3'
 
-    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
-  elsif MacOS.version <= :mavericks
-    version '4.3.6'
-    sha256 'ec90d6bd2e76bd14c0ca706d255c9673288f406b772e5ae6022e2dbe27848ee9'
-
-    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
-  else
-    version '6.2.2'
-    sha256 '669b1653659cdb2eb2907a1577313a53365a7f90579421f646c6f5366b74c9e3'
-
-    url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"
-    appcast 'https://smilesoftware.com/appcast/TextExpander6.xml',
-            checkpoint: 'f9de2c98be639250b79b9cc6d37d502b42b32e332dac8a3ed109d57b138aedd9'
-  end
-
+  # cdn.textexpander.com/mac was verified as official when first introduced to the cask
+  url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"
+  appcast 'https://smilesoftware.com/appcast/TextExpander6.xml',
+          checkpoint: 'f9de2c98be639250b79b9cc6d37d502b42b32e332dac8a3ed109d57b138aedd9'
   name 'TextExpander'
   homepage 'https://smilesoftware.com/TextExpander'
 

--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -4,7 +4,7 @@ cask 'textexpander' do
 
   # cdn.textexpander.com/mac was verified as official when first introduced to the cask
   url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"
-  appcast 'https://smilesoftware.com/appcast/TextExpander6.xml',
+  appcast "https://smilesoftware.com/appcast/TextExpander#{version.major}.xml",
           checkpoint: 'f9de2c98be639250b79b9cc6d37d502b42b32e332dac8a3ed109d57b138aedd9'
   name 'TextExpander'
   homepage 'https://smilesoftware.com/TextExpander'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Legacy version added to `versions` https://github.com/caskroom/homebrew-versions/pull/4542