### PR TITLE
Update hab to 0.34.0-20170930005624

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.33.2-20170925042638'
-  sha256 '6d935ebf64b49afe2cf4763cce7d2383af019bfec833c36b7687e0db91aeaffa'
+  version '0.34.0-20170930005624'
+  sha256 '239f84aea1307fa986aa8cc906704ae6a2f0f40bfba46c8856084621effdc1ce'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '85520ab7cbdb3c768f27216b6eb27d5de6b3445ffc6c9d3e3d043394d670e770'
+          checkpoint: 'ef81f123f0722ac4a3a18c879ef642d99efb1ca683bf533c2dc4352e4c2451d8'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.