### PR TITLE
Update clipy to 1.1.4

### DIFF
--- a/Casks/clipy.rb
+++ b/Casks/clipy.rb
@@ -1,11 +1,11 @@
 cask 'clipy' do
-  version '1.1.3'
-  sha256 '688c137eab7a625e3582ccc23e9372740e505e1834f0598e21ebfad15ab130f8'
+  version '1.1.4'
+  sha256 'ad1199738cdd55eae433de8aed97acebf704d9075613391f65badf5dc5020b3c'
 
   # github.com/Clipy/Clipy was verified as official when first introduced to the cask
   url "https://github.com/Clipy/Clipy/releases/download/#{version}/Clipy_#{version}.dmg"
   appcast 'https://clipy-app.com/appcast.xml',
-          checkpoint: 'c5ae56a12075d8473a0c69f4d7adec5ce3a8caf9678a7f1b3f8b9297ed2ec7d8'
+          checkpoint: '9285449aa0a030aac01058fd77b815636aba1eee88b351277b1e2e2950e96032'
   name 'Clipy'
   homepage 'https://clipy-app.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.