### PR TITLE
Update coteditor to 3.2.2

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -15,14 +15,14 @@ cask 'coteditor' do
     # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
     url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   else
-    version '3.2.1'
-    sha256 'fc07dccb149a5573867f2b9dd184a2d4c1a4a5b6f54862561dd28467aa6d9b08'
+    version '3.2.2'
+    sha256 '40fc060e10ae03a7172a1d1c5856271e3943918c03f13b7c6970e867345fcd1f'
     # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
     url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   end
 
   appcast 'https://github.com/coteditor/CotEditor/releases.atom',
-          checkpoint: 'c65c61afeb7cabae98b92fd04743e2620b4fe1c5bb8274926dca56ea19f53626'
+          checkpoint: 'd6e78513668e4b6fa6b74e1f3508a48f9a45790dbc36a3a5a14af625a919dec4'
   name 'CotEditor'
   homepage 'https://coteditor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.