### PR TITLE
update catlight to version 2.12/2.14

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,14 +1,12 @@
 cask 'catlight' do
-  if MacOS.version < '10.12'
-    version '2.12.5'
-    sha256 'e69a1dca258583d5fb16d45b71a04fe06f6f845d11bb4a4d9e909c7c3f3a835b'
-  elsif MacOS.version >= '10.12'
-    version '2.14.5'
-    sha256 '912a85e9da25eb65707869cee69c8eb84cbcc5c5169f98ef55df4910300b106e'
-  end
+  version '2.14.5'
+  sha256 '912a85e9da25eb65707869cee69c8eb84cbcc5c5169f98ef55df4910300b106e'
+
   url "https://www.catlight.io/dl/mac/beta/setup-#{version}.zip"
   name 'catlight'
   homepage 'https://catlight.io/'
+
+  depends_on macos: '>= :sierra'
 
   app 'Catlight.app'
 end

--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,7 +1,11 @@
 cask 'catlight' do
-  version '2.10.3'
-  sha256 '2b58a1c8e3d3f7b64d63330d668a294d1fb45afd76b8d9bccd1898563d0d2269'
-
+  if MacOS.version < '10.12'
+    version '2.12.5'
+    sha256 'e69a1dca258583d5fb16d45b71a04fe06f6f845d11bb4a4d9e909c7c3f3a835b'
+  elsif MacOS.version >= '10.12'
+    version '2.14.5'
+    sha256 '912a85e9da25eb65707869cee69c8eb84cbcc5c5169f98ef55df4910300b106e'
+  end
   url "https://www.catlight.io/dl/mac/beta/setup-#{version}.zip"
   name 'catlight'
   homepage 'https://catlight.io/'


### PR DESCRIPTION
A new version is out for MacOS 10.13 however it only supports 10.12 and up
i couldn't find if 2.12 is supported by 10.12 and down but i think its safe enough to assume that

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.