### PR TITLE
Update sloth to 2.0

### DIFF
--- a/Casks/sloth.rb
+++ b/Casks/sloth.rb
@@ -1,10 +1,10 @@
 cask 'sloth' do
-  version '1.9'
-  sha256 '73cfaa5fade026916c83c90cb8a69230e74e69718b2d10924fba862b10b1f671'
+  version '2.0'
+  sha256 '7b2aa0e5234e862ed8b9f2a7640e74d170030f56dd27e3419fcd7252e2d7a6f4'
 
   url 'http://sveinbjorn.org/files/software/sloth.zip'
   appcast 'http://sveinbjorn.org/files/appcasts/SlothAppcast.xml',
-          checkpoint: '86890c2179e85e5101375e3d75fe6d390654fb6342cb3383038b5853a1b24a52'
+          checkpoint: 'cd8eaa41fa7b240923196574b5a5afa74842fbffd5e26aaa40a14187a45df469'
   name 'Sloth'
   homepage 'https://sveinbjorn.org/sloth'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.