### PR TITLE
Update vuescan to 9.5.87

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.86'
-  sha256 'e83b7212b658fd148fd2b4b21559b704ffb2fd9bf42ab9a37e1bbdab37a265ab'
+  version '9.5.87'
+  sha256 'bdbfbc948daee135976ede9e8f740e9e8a4ea65c9c42fa942f4bd8fdda94fdc5'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '7154c82944cc635229233bbdf0db27d8d4378cf900bdfd6a5fab84f3d23ae70b'
+          checkpoint: 'a9b303f2a9721b41a57e4b4513e2db7a31b068e5af35a83c40bc677cac69c81d'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.