### PR TITLE
Update rawtherapee to 5.3

### DIFF
--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,6 +1,6 @@
 cask 'rawtherapee' do
-  version '5.2'
-  sha256 '12cddd1ea1e827b17bc81f23381641e6788902f3403c054dec99ab0d451a7abe'
+  version '5.3'
+  sha256 '5428d5a1f222ce948894df2cddc6359790fe48e7fc1bd39c23d08a557b8d40a7'
 
   url "http://www.rawtherapee.com/shared/builds/mac/RawTherapee_OSX_10.9_64_#{version}.zip"
   name 'RawTherapee'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.