### PR TITLE
Update transmit to 5.0.4

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,10 +1,10 @@
 cask 'transmit' do
-  version '5.0.3'
-  sha256 'b4a38fac2c7ae3c39a4aacf6f6029cdbe3a4f5775f1d594812359c168e02e1f7'
+  version '5.0.4'
+  sha256 '60b9a34b336e6b634091c6d6670eed0ee28fbff87acf7a53354190f8cfcfee32'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}",
-          checkpoint: '015159a7a1fd6a1cb14729e22fd4d2bb6b561539c084e9dac15f2cba4ae13392'
+          checkpoint: 'dfaf1b0045811da2c019e5af68d7cb9c02ff1ed30275d26d369bdbe58fecc0f0'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.