### PR TITLE
Update nrf5x-command-line-tools to 53406.17.93573317

### DIFF
--- a/Casks/nrf5x-command-line-tools.rb
+++ b/Casks/nrf5x-command-line-tools.rb
@@ -1,6 +1,6 @@
 cask 'nrf5x-command-line-tools' do
-  version '53412.12.75215164'
-  sha256 '40342170b40cc4a930b695a3695f1b47b29d4ba1362af280a74f6cbbbf1c925d'
+  version '53406.17.93573317'
+  sha256 '19c918e8fa44964d570721b204bf460451eabbc90030ccdc5f1eeb6513a0ace1'
 
   url "https://www.nordicsemi.com/eng/nordic/download_resource/#{version.major}/#{version.minor}/#{version.patch}"
   name 'nRF5x Command Line Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.