### PR TITLE
Update arq to 5.9.4

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,10 +1,10 @@
 cask 'arq' do
-  version '5.9.3'
-  sha256 '5d4673c10e1817ae5ee0f4818a68e0f2bd621169ebc80bcdadb7ba44dbce61f1'
+  version '5.9.4'
+  sha256 'a9d47ba7ea72e36d8de69b8734af839a23a0c20d94d0ea9d68944715a2147128'
 
   url "https://www.arqbackup.com/download/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arq#{version.major}.xml",
-          checkpoint: '93ce230bb0b38ea40a6ec9e0d245a12f6002b722b92457227e9760c251e3fa62'
+          checkpoint: '28abc03fca70e072d26da055ab44490c6839efcf06921db2ea43c155b024af1a'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.