### PR TITLE
Update compositor to 0.9.11

### DIFF
--- a/Casks/compositor.rb
+++ b/Casks/compositor.rb
@@ -1,10 +1,10 @@
 cask 'compositor' do
-  version '0.9.10'
-  sha256 '498977bb8c560cc618905662a8b908f3d7f8ed6d421f7884df2d4d5de94b961b'
+  version '0.9.11'
+  sha256 '3f67e7366dd19be708d78be1643011b62bca1171757eb327917824f4fb536353'
 
   url 'http://compositorapp.com/downloads/Compositor.dmg'
   appcast 'http://compositorapp.com/updates/appcast.xml',
-          checkpoint: '12862f51c50d1e295ce676a478ae08da124ebbda4a9cffe02ffbed09038e8d76'
+          checkpoint: 'd2118fafc69857d046943962361123ffc97838b877bb217da2e6e4745ee278e8'
   name 'Compositor'
   homepage 'http://compositorapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.