### PR TITLE
Update fantastical to 2.4.2

### DIFF
--- a/Casks/fantastical.rb
+++ b/Casks/fantastical.rb
@@ -1,10 +1,10 @@
 cask 'fantastical' do
-  version '2.4.1'
-  sha256 '1d6c59dcc3bcc9e4c87974d028ce88621a12b98f6cf7279eca2a1d0076fd3847'
+  version '2.4.2'
+  sha256 'c885cae9e546cf0d6349ae1496b0d18e1405c78cbd2a7b03c1a1b6156ac2bb13'
 
   url "http://cdn.flexibits.com/Fantastical_#{version}.zip"
   appcast 'https://flexibits.com/fantastical/appcast2.php',
-          checkpoint: '8c9634eb1bfc76338375e16c255f25dda5265c8ded432b1128b38b05e4a25e78'
+          checkpoint: 'e34a6efab9a7bbeb8cccb4a73dbc00ded20bf937a0ced86122831e9ab39332bc'
   name 'Fantastical'
   homepage 'https://flexibits.com/fantastical'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.