### PR TITLE
Update whatsapp to 0.2.6424

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,10 +1,10 @@
 cask 'whatsapp' do
-  version '0.2.5863'
-  sha256 '1f6f7a2cd93ec1ae71d8a1e12b0f6bf698263de3d64767f762ed2fc788869592'
+  version '0.2.6424'
+  sha256 'a5b58bbe475377bc42ae2ef641661ca6ef37cfb7b1855e56a0a55881f5eedc96'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64',
-          checkpoint: 'b52e065acd795ced7bba8401c695a17997e94dd49ca5fcf92f96d1dce773e1e0'
+          checkpoint: 'bc33c8de0caf113c719eec6b7d46a51cb322cbbba89e52fb0fd83527da03785e'
   name 'WhatsApp'
   homepage 'https://www.whatsapp.com/'
 

--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,8 +1,8 @@
 cask 'whatsapp' do
   version '0.2.6424'
-  sha256 'a5b58bbe475377bc42ae2ef641661ca6ef37cfb7b1855e56a0a55881f5eedc96'
+  sha256 'ab2df2067986409901cdaa8dbe59b003fcf623a18c9423e7ccdb15876c85863e'
 
-  url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
+  url 'https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg'
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64',
           checkpoint: 'bc33c8de0caf113c719eec6b7d46a51cb322cbbba89e52fb0fd83527da03785e'
   name 'WhatsApp'
@@ -12,10 +12,10 @@ cask 'whatsapp' do
 
   app 'WhatsApp.app'
 
-  zap delete: [
+  zap delete: '~/Library/Caches/WhatsApp',
+      trash:  [
                 '~/Library/Application Support/WhatsApp',
                 '~/Library/Application Support/WhatsApp.ShipIt',
-                '~/Library/Caches/WhatsApp',
                 '~/Library/Preferences/WhatsApp.plist',
                 '~/Library/Preferences/WhatsApp-Helper.plist',
               ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.