### PR TITLE
Update arduino to 1.8.5

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -1,10 +1,10 @@
 cask 'arduino' do
-  version '1.8.4'
-  sha256 'b6cab054eb58d17213d7467bcee0256c0661b4c2befd8ca1dc3b319a65050b17'
+  version '1.8.5'
+  sha256 '49d0a255802167fc7644f4cc5b3d8b41c94859343c0c4d1f90816f18b11f3fd9'
 
   url "https://downloads.arduino.cc/arduino-#{version}-macosx.zip"
   appcast 'https://www.arduino.cc/en/Main/ReleaseNotes',
-          checkpoint: '01096ced1b85f8db8bb970adeb37f815c31e3f36a73af31d03ab58af98b514c4'
+          checkpoint: '8d819ee505a981d873ea7e2858007cf6941bdec4b76e63eacbfae9dd16372da4'
   name 'Arduino'
   homepage 'https://www.arduino.cc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.