### PR TITLE
Update gitkraken to 3.1.0

### DIFF
--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -1,6 +1,6 @@
 cask 'gitkraken' do
-  version '3.0.2'
-  sha256 'edf7f1a00579303095170e0680751979937739b9367f314062c2535cd23d003f'
+  version '3.1.0'
+  sha256 'f9230813da10816d46f62ebdb0ef41a0cb141875dc01142f4ed90ca485c92316'
 
   url "https://release.gitkraken.com/darwin/v#{version}.zip"
   appcast 'https://release.gitkraken.com/darwin/RELEASES',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.