### PR TITLE
Update the-escapers-flux to 7.1.7

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.1.6'
-  sha256 'e63cfdd5ea5f824890c1c7a4e4dd6f49b2b124cf8a0bb441632c464496819ce8'
+  version '7.1.7'
+  sha256 '64566f1b18753f05f6ec5e437b928e44f68f3087841f7b47f87c13d43a64d65a'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '61152db3d88c25b14525e3a3c7661ae5e3191fb631a1b8fb22ffc4e28fa0f52f'
+          checkpoint: '6f7fa5ad33cc8d8724ddb00249744751d1866217a3205619b70b0daaba363b65'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.