### PR TITLE
Update waterfox to 55.2.0

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '55.1.0.1'
-  sha256 '9d1cacde04a5fa27994e4b6d0cfa789d6890fbe1bd33aca0e62fc3d1b21eca48'
+  version '55.2.0'
+  sha256 '2996b69cd69c08e342ddbf547810960dc0707b4b44c866603ebf7f1f7f959909'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.