### PR TITLE
Update goodsync to 10.6.1

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,10 +1,10 @@
 cask 'goodsync' do
-  version '10.5.8'
-  sha256 '98fb97a8d726dd6a5acb73f56b3edb0e499b2e54f9f2283fd281fa98449f91fb'
+  version '10.6.1'
+  sha256 '06f3ec8b89e8ae966b5325f8f8a651c0e4473a3957615ee328729dc1a9fecd40'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast 'https://www.goodsync.com/download',
-          checkpoint: 'a12feb047903fa12cb6aef6bbf2259ed20b50b718df03a098ffe251caa21d4d3'
+          checkpoint: '442f3147449d9b1864dca173e7cb03cb64726c2732d307fc519fefd168c26dd5'
   name 'GoodSync'
   homepage 'https://www.goodsync.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.