### PR TITLE
Update yujitach-menumeters download url

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -2,6 +2,7 @@ cask 'yujitach-menumeters' do
   version '1.9.6'
   sha256 'c2fe26a31743b9d4a0216a4415b8253dd0c2a1fd4d6d1fc7d2d4b9e33d9cc588'
 
+  # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
   url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version}.zip"
   appcast 'https://github.com/yujitach/MenuMeters/releases.atom',
           checkpoint: '3fc1845ad638f6b32312a4dd61c640d60d5ef4cf2684f7470c98c2b3eaeb54d9'

--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -2,7 +2,7 @@ cask 'yujitach-menumeters' do
   version '1.9.6'
   sha256 'c2fe26a31743b9d4a0216a4415b8253dd0c2a1fd4d6d1fc7d2d4b9e33d9cc588'
 
-  url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
+  url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version}.zip"
   appcast 'https://github.com/yujitach/MenuMeters/releases.atom',
           checkpoint: '3fc1845ad638f6b32312a4dd61c640d60d5ef4cf2684f7470c98c2b3eaeb54d9'
   name 'MenuMeters for El Capitan (and later)'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download Casks/yujitach-menumeters.rb` is error-free.
- [x] `brew cask style --fix Casks/yujitach-menumeters.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Per https://github.com/yujitach/MenuMeters/issues/64#issuecomment-333415155
