### PR TITLE
Update Bartender to 3.12

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -3,14 +3,14 @@ cask 'bartender' do
     version '2.1.6'
     sha256 '013bb1f5dcc29ff1ecbc341da96b6e399dc3c85fc95bd8c7bee153ab0d8756f5'
   else
-    version '3.0.11'
-    sha256 '49b12fac268e404b0981f039caecbc2f9c5e10c269345ad021447a49a35baa21'
+    version '3.0.12'
+    sha256 '121e47f4da7b606bc0297b2dd34cc5de89911175e46234b6197384ea416ea31d'
   end
 
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",
       referer: 'https://www.macbartender.com'
   appcast 'https://www.macbartender.com/B2/updates/Appcast.xml',
-          checkpoint: '5de6b86db8c35136b502e4351ce3348da40e5667a1c45a4396043af09aace284'
+          checkpoint: '164ad62f5e279c24043f4f9a87f40fefeb058a57030789cfcbd536c0fe32e7b9'
   name 'Bartender'
   homepage 'https://www.macbartender.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download bartender` is error-free.
- [x] `brew cask style --fix bartender` reports no offenses.
- [x] The commit message includes the cask’s name and version.
