### PR TITLE
Update bitcoin-classic to 1.3.7

### DIFF
--- a/Casks/bitcoin-classic.rb
+++ b/Casks/bitcoin-classic.rb
@@ -1,11 +1,11 @@
 cask 'bitcoin-classic' do
-  version '1.3.6'
-  sha256 'b0653602cd520bff0aedef6b45d2c4a05ed3b014eb9bfe94058233dd8da29812'
+  version '1.3.7'
+  sha256 '0aafe8f34820da51810b60658234dc55bd05f5b96d6e5d5c99ef0c40569761b5'
 
   # github.com/bitcoinclassic was verified as official when first introduced to the cask
   url "https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v#{version}/bitcoin-#{version}-osx.dmg"
   appcast 'https://github.com/bitcoinclassic/bitcoinclassic/releases.atom',
-          checkpoint: '35b072f8e2cd41764ff64e252ad24989e698752678073352cfd14407086ae33c'
+          checkpoint: '4a64ea7c3b998d4abeabb3ce6f58ffab270b8a2f35ae7c7c531c422091062ec9'
   name 'Bitcoin Classic'
   homepage 'https://bitcoinclassic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.