### PR TITLE
Update bitpay to 3.8.2

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,6 +1,6 @@
 cask 'bitpay' do
   version '3.8.2'
-  sha256 'b575724fb840c6af5c3824dfb80d374b9e9bb700c5ac5208085d040d16f46643'
+  sha256 '2c501d536d69ceb56344e06ed8999285bdd4d6191eef7402c324964b55f51346'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.