### PR TITLE
Update buttercup to 0.21.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.20.0'
-  sha256 'a59cb86f0a87fcf4d06091aa100f523afd1d00034158d3ec16180c11645e9fec'
+  version '0.21.1'
+  sha256 'c717b320b6b773fe69ff5cce49d54e8ac7fcca436459ae1b4c813252e867a824'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '3edcf38a0cff67ae04b4f5f3ae4f0d9fd639d3d84ddb3ef2d8e0ae3a9c590aea'
+          checkpoint: '87e8300417b516a1ad7f653e455fc36fdde39297226ba6f38b4da05e55cbf7b3'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.