### PR TITLE
Update synalyze-it-pro to 1.20

### DIFF
--- a/Casks/synalyze-it-pro.rb
+++ b/Casks/synalyze-it-pro.rb
@@ -1,11 +1,11 @@
 cask 'synalyze-it-pro' do
-  version '1.18'
-  sha256 '9f860e7369529c12c195e2d831b5985139387c9235418744e7fac5285e7d5396'
+  version '1.20'
+  sha256 '41328634b2a6058bf2fc96b4174baf4027a45273bc4a93908f38a4ec4b5b8120'
 
   # synalyze-it.com/Downloads was verified as official when first introduced to the cask
   url "https://www.synalyze-it.com/Downloads/SynalyzeItProTA_#{version}.zip"
   appcast 'https://www.synalyze-it.com/SynalyzeItPro/appcast.xml',
-          checkpoint: 'a707c86c78b38306eadf830802d60a913c22b9050a04f0d6f97785071dff0f28'
+          checkpoint: '1c82898fd8f85619065cd82a4d09328e4c60f9385400de6e6a083bec75e16cbb'
   name 'Synalyze It! Pro'
   homepage 'https://www.synalysis.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.