### PR TITLE
Update qgis to 2.18.13-1

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,6 +1,6 @@
 cask 'qgis' do
-  version '2.18.9-1'
-  sha256 'bc8bd9a63244b89145b0e346c6a242f7055b4b61a14229c9cf54c34e0b8ecb98'
+  version '2.18.13-1'
+  sha256 '529835ee80f24fa05648402481aed4c0fd691ff5db60dda10bbc51e8db494624'
 
   url "http://www.kyngchaos.com/files/software/qgis/QGIS-#{version}.dmg"
   name 'QGIS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.