### PR TITLE
Update bartender to 3.0.12

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -1,11 +1,11 @@
 cask 'bartender' do
-  version '2.1.6'
-  sha256 '013bb1f5dcc29ff1ecbc341da96b6e399dc3c85fc95bd8c7bee153ab0d8756f5'
+  version '3.0.12'
+  sha256 '121e47f4da7b606bc0297b2dd34cc5de89911175e46234b6197384ea416ea31d'
 
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",
       referer: 'https://www.macbartender.com'
-  appcast "https://www.macbartender.com/B#{version.major}/updates/updates.php",
-          checkpoint: 'b119cbc503ce671c5aa1a16dc11704b5baed00a6de3d4b344837b854cc47d4c1'
+  appcast "https://www.macbartender.com/B2/updates/updatesB#{version.major}.php",
+          checkpoint: 'aec0acd5c0af73c12fe57a932fff8c3dfdeb39f00d4dfd39c5406aa27914e74e'
   name 'Bartender'
   homepage 'https://www.macbartender.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.