### PR TITLE
Update blockblock to 0.9.9

### DIFF
--- a/Casks/blockblock.rb
+++ b/Casks/blockblock.rb
@@ -1,11 +1,11 @@
 cask 'blockblock' do
-  version '0.9.8'
-  sha256 'c374461e3de75d0c258d48864ea76d4bbc5457340f41fd2b8bc51adde41542e2'
+  version '0.9.9'
+  sha256 '133ebdffd9847e17af048cdeb069ba5d1978595f6855d7fabf0cface0e562609'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/BlockBlock_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/BlockBlock.txt',
-          checkpoint: '47a60649e6d63911b95a8d522011287117e9c7bddf201580a8d4d2053e36131e'
+          checkpoint: '143a59e168fcbdb4c391bf55d371ee09ea689246c25c005a2d2ffb0b7a62da11'
   name 'BlockBlock'
   homepage 'https://objective-see.com/products/blockblock.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.