### PR TITLE
Update java Casks (2): adjust versioning

### DIFF
--- a/Casks/java-jdk-javadoc.rb
+++ b/Casks/java-jdk-javadoc.rb
@@ -1,16 +1,16 @@
 cask 'java-jdk-javadoc' do
-  version '1.9,181'
+  version '9,181'
   sha256 '54d65f4b8f4192a51a5d90816a2e118da45377be21091351d05389b5a2cfa127'
 
-  url "http://download.oracle.com/otn-pub/java/jdk/#{version.minor}+#{version.after_comma}/jdk-#{version.minor}_doc-all.zip",
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.major}+#{version.after_comma}/jdk-#{version.major}_doc-all.zip",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
   name 'Java Standard Edition Development Kit Documentation'
-  homepage "http://www.oracle.com/technetwork/java/javase/documentation/jdk#{version.minor}-doc-downloads-3850606.html"
+  homepage "http://www.oracle.com/technetwork/java/javase/documentation/jdk#{version.major}-doc-downloads-3850606.html"
 
   postflight do
-    `/usr/libexec/java_home -v #{version.minor} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
+    `/usr/libexec/java_home -v #{version.major} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
       system_command '/bin/cp',
                      args: ['-rp', "#{staged_path}/docs", "#{path}/"],
                      sudo: true
@@ -18,7 +18,7 @@ cask 'java-jdk-javadoc' do
   end
 
   uninstall_postflight do
-    `/usr/libexec/java_home -v #{version.minor} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
+    `/usr/libexec/java_home -v #{version.major} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
       system_command '/bin/rm',
                      args: ['-rf', "#{path}/docs"],
                      sudo: true

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,37 +1,37 @@
 cask 'java' do
-  version '1.9,181'
+  version '9,181'
   sha256 '0755e848c061419313510a88508512b8d58ae9c79bd01d460e6b436dc13dfac1'
 
-  url "http://download.oracle.com/otn-pub/java/jdk/#{version.minor}+#{version.after_comma}/jdk-#{version.minor}_osx-x64_bin.dmg",
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.major}+#{version.after_comma}/jdk-#{version.major}_osx-x64_bin.dmg",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
   name 'Java Standard Edition Development Kit'
-  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.minor}-downloads-3848520.html"
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.major}-downloads-3848520.html"
 
-  pkg "JDK #{version.minor}.pkg"
+  pkg "JDK #{version.major}.pkg"
 
   postflight do
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Info.plist"],
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Info.plist"],
                    sudo: true
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home", '/Library/Java/Home'],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Home", '/Library/Java/Home'],
                    sudo: true
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home/bundle/Libraries"],
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Home/bundle/Libraries"],
                    sudo: true
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
                    sudo: true
 
     if MacOS.version <= :mavericks
@@ -39,7 +39,7 @@ cask 'java' do
                      args: ['-rf', '--', '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
                      sudo: true
       system_command '/bin/ln',
-                     args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
+                     args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
                      sudo: true
     end
   end
@@ -51,7 +51,7 @@ cask 'java' do
   end
 
   uninstall pkgutil:   [
-                         "com.oracle.jdk-#{version.minor}",
+                         "com.oracle.jdk-#{version.major}",
                          'com.oracle.jre',
                        ],
             launchctl: [
@@ -64,7 +64,7 @@ cask 'java' do
                        ],
             delete:    [
                          '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin',
-                         "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk/Contents",
+                         "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents",
                          '/Library/PreferencePanes/JavaControlPanel.prefPane',
                          '/Library/Java/Home',
                          if MacOS.version <= :mavericks
@@ -91,7 +91,7 @@ cask 'java' do
                 '~/Library/Preferences/com.oracle.javadeployment.plist',
               ],
       rmdir:  [
-                "/Library/Java/JavaVirtualMachines/jdk-#{version.minor}.jdk",
+                "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk",
                 '~/Library/Application Support/Oracle/',
               ]
 


### PR DESCRIPTION
- `java`
- `java-jdk-javadoc`

I completely missed that Oracle has dropped the `1.*` versions.

http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html

```
$ java --version
java 9
Java(TM) SE Runtime Environment (build 9+181)
Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)
```