### PR TITLE
Update macvim to 8.0.138

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,10 +1,10 @@
 cask 'macvim' do
-  version '8.0.137'
-  sha256 'cc28c1390c701a66b0110ba26c2be0f8e4b66629c15ab1c37e124308ae6ce9f0'
+  version '8.0.138'
+  sha256 '13d53e8833fe494226e8a37c5ae6bd36d4e1c655295e611d7139f515d5cf0a3b'
 
   url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.patch}/MacVim.dmg"
   appcast 'https://github.com/macvim-dev/macvim/releases.atom',
-          checkpoint: '79628619d4afa4cde9756fd6cd883e1875c2809cde379e6ed0d45ec0a64ca7c7'
+          checkpoint: '81f241ff9d734b8f4971ce72060a20c672183c8ce4345a056cd23dfafb3de4df'
   name 'MacVim'
   homepage 'https://github.com/macvim-dev/macvim'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.