### PR TITLE
Update rambox to 0.5.13

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,11 +1,11 @@
 cask 'rambox' do
-  version '0.5.12'
-  sha256 '607da630812d3144f4ec32ef30a56e2a505846cc819bcd282fc93dd971bb82af'
+  version '0.5.13'
+  sha256 '8ec83ac8a82179aad47d30fdc326fc5571ca871e8cf48d2db8f5d2e52f68e51a'
 
   # github.com/saenzramiro/rambox was verified as official when first introduced to the cask
   url "https://github.com/saenzramiro/rambox/releases/download/#{version}/Rambox-#{version}-mac.zip"
   appcast 'https://github.com/saenzramiro/rambox/releases.atom',
-          checkpoint: '6bead2754d8c013a125dda858ffe5fde84183fa9c5eecada8032dc0965f521a0'
+          checkpoint: '06b7e301ccad5de7627c038237b36a2325e931774399c6789099bad806a7f1e6'
   name 'Rambox'
   homepage 'http://rambox.pro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.