### PR TITLE
chefdk.rb: don't install on high sierra

### DIFF
--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -9,7 +9,7 @@ cask 'chefdk' do
   name 'ChefDK'
   homepage 'https://downloads.chef.io/chefdk'
 
-  depends_on macos: '>= :yosemite'
+  depends_on macos: [:yosemite, :el_capitan, :sierra]
 
   pkg "chefdk-#{version}-1.pkg"
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

---

Doing this since there’s no download for it on the website. Can anyone on High Sierra confirm if manually installing the Sierra version works?