### PR TITLE
Update crypter to 3.1.0

### DIFF
--- a/Casks/crypter.rb
+++ b/Casks/crypter.rb
@@ -1,10 +1,10 @@
 cask 'crypter' do
-  version '3.0.0'
-  sha256 '72f2c6a2ab93b538865c59c8940376a9f475517e82e0c582e751f9732c06926d'
+  version '3.1.0'
+  sha256 '2f2f62f23beb03dd391ad3775ab85804c34038a4483877a4805a711f58beacfb'
 
   url "https://github.com/HR/Crypter/releases/download/v#{version}/Crypter-#{version}.dmg"
   appcast 'https://github.com/HR/Crypter/releases.atom',
-          checkpoint: 'e0858d3f61c773b3c4d6bc567036ca3258875dd804657b36c41e04b4c64b0553'
+          checkpoint: '3d2158d9e671541e5fd7ce2c8e32e7c883aa9b9221681c16d4b753caef6b1fe5'
   name 'Crypter'
   homepage 'https://github.com/HR/Crypter'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.