### PR TITLE
Update omnifocus to 2.11.1

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -12,13 +12,13 @@ cask 'omnifocus' do
     sha256 'a273e55c15f82540fe305344f9e49ad7d0d9c326ba2c37c312076ffd73780f80'
     url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
   else
-    version '2.11'
-    sha256 '54471afe11b382ae5c23b57dc907f46f0eac8ec9adcb5a9257201f3ed2047801'
+    version '2.11.1'
+    sha256 'a728caec06d17844270b243eafc0615b208d87cf4f2c6df4293e590646858acc'
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
   end
 
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniFocus#{version.major}",
-          checkpoint: 'b180e8cd533edbbe724334abc7b301134456c74e9623752c8fc727356012c09b'
+          checkpoint: '8024489488e25689fe08ec047f3f47e1f7a26e662665e6efdff66b4f074b7328'
   name 'OmniFocus'
   homepage 'https://www.omnigroup.com/omnifocus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.