### PR TITLE
Update armory to 0.96.3.99

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -1,11 +1,11 @@
 cask 'armory' do
-  version '0.96.3'
-  sha256 '851f218b78dbf0acb84c111b8989254155828d8f9fdfa5ab21c25fda10745fdc'
+  version '0.96.3.99'
+  sha256 '6129856a042b153185a06f0745cf5313477191cc89a8f8c3e5dc08fa0b49c8a0'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: '46af4ad65f91f3ae92d812b63a8efbce244d14c2b290b5e2c0f8d25e8f9ba7e0'
+          checkpoint: '4f71fb59453d47d90216ac261bffe9c3c1760b62bacc32fe19f637711e5cf4f8'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.