### PR TITLE
Update browser-chooserx to 1.4.2

### DIFF
--- a/Casks/browser-chooserx.rb
+++ b/Casks/browser-chooserx.rb
@@ -1,10 +1,10 @@
 cask 'browser-chooserx' do
-  version '1.4.1'
-  sha256 '816e16381055883dc684a39894937ed5477f7a060dbd9b17fe552f9cd65266d4'
+  version '1.4.2'
+  sha256 '94086afa8f3a6fde82b6f8a1f1af757df72510349993ec8fb7bd4b8b92bf3b28'
 
   url 'https://www.bdevapps.com/files/downloads/Browser%20ChooserX.zip'
   appcast "https://www.bdevapps.com/files/downloads/BrowserChooserXAppCast#{version.major}.xml",
-          checkpoint: 'c2348984d6d79b0fafdb2dc0966ec687be1240584adc03aeabaa95d751d3bf4a'
+          checkpoint: '5646a3e99849ac88ca08b837d4958ffed2e17d2824d2cdeef210e3f2a67048c8'
   name 'Browser ChooserX'
   homepage 'https://bdevapps.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.