### PR TITLE
Update canary to 1.6.8,351

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '1.6.7,347'
-  sha256 '2e83c30cf4f2ac03b0fdc7c2e1ac65519e5b4dc4023f1afb23291d045adc2bb6'
+  version '1.6.8,351'
+  sha256 'b27751f158728422e4b1a8f6f1a10cf1f43cee47b57bb4ad26c2be953c5f0ba1'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: 'b0e02181e1b5557143e876685a31e96757d1f1771a2b232e43bc705c7aaf02bc'
+          checkpoint: '24803d0b202511e4e2d9452ad745c07010d090dce0af9776d44b2373dbc1f7e8'
   name 'Canary'
   homepage 'https://canarymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.