### PR TITLE
Update clarify to 2.0.8-209

### DIFF
--- a/Casks/clarify.rb
+++ b/Casks/clarify.rb
@@ -1,10 +1,11 @@
 cask 'clarify' do
-  version '2.0.5r4'
-  sha256 '454bff1e655bd8aee1c5bcb3c85339b2d09a386637b1cdb0246ab849c6283654'
+  version '2.0.8-209'
+  sha256 '76450580681426d12bea14fb4cc199d2a7b3c3febe5d2508d080fb7e7265abf3'
 
-  url "http://files.clarify-it.com/v#{version.major}/updaters/#{version}/Clarify.app.zip"
+  # amazonaws.com/files.clarify-it.com was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/files.clarify-it.com/v2/installers/Clarify%20#{version}.dmg"
   appcast "https://www.bluemangolearning.com/download/clarify/#{version.major_minor.dots_to_underscores}/auto_update/release/clarify_appcast.xml",
-          checkpoint: 'f2a5e10edb7f9d72167455e3629c0ffc516f0addafc71b40d8f1d1f822113ae9'
+          checkpoint: '168b1e6e383df8232bd9e3ac645975500c92705234f3188a9e1f89db18c23eef'
   name 'Clarify'
   homepage 'http://www.clarify-it.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.