### PR TITLE
Update zoc to 7.15.6

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,10 +1,10 @@
 cask 'zoc' do
-  version '7.15.5'
-  sha256 'ea47e43bfd206feef3b29719a88411017e2eb81378394555b4f9aff856c9e1c1'
+  version '7.15.6'
+  sha256 '3d272cbe3668e3dcace83cee2d758e99fe437931579be6dba1a18d6137605b4a'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast "http://www.emtec.com/downloads/zoc/zoc#{version.no_dots}_changes.txt",
-          checkpoint: '16f02544eb74a551feb8f905da64c32f35243600d5b288bf7fd8b91865c38d50'
+          checkpoint: 'ca1bd0b7def835a58a930542f45ce3d3b8d9ce57d35421d9ba694ca2efc2f099'
   name 'ZOC'
   homepage 'https://www.emtec.com/zoc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.