### PR TITLE
Update dynamite to 3.2.6

### DIFF
--- a/Casks/dynamite.rb
+++ b/Casks/dynamite.rb
@@ -1,10 +1,10 @@
 cask 'dynamite' do
-  version '3.2.5'
-  sha256 'd8f68bb331ae7e6201ad62bcee7483f73a91fefbb3ac0e3db28e3d87dcbae3d4'
+  version '3.2.6'
+  sha256 '8aceec8920ba0ca0fe143b646aa42539640eee941050f0b01ce0e89772e66bd6'
 
   url "https://mediaatelier.com/DynaMite3/DynaMite_#{version}.zip"
   appcast 'https://mediaatelier.com/DynaMite3/feed.xml',
-          checkpoint: 'e2ca62d7b2b3a650b30d572a0cb9a004588d7795eec6e550b206baef33e5bdfa'
+          checkpoint: 'b204b7b36cf64ce83d1d23034e458da365c256f10e87721994501ffd9901ea0b'
   name 'DynaMite'
   homepage 'https://www.mediaatelier.com/DynaMite3/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.