### PR TITLE
Update get-backup-pro to 3.4.1

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.4'
-  sha256 '5ab883193f8129506c43369bb75fc23feeb12b307fa57f51094dde0455fe9de5'
+  version '3.4.1'
+  sha256 'cc45cf7299bc1e6c7de4011785a72565227bb84e36d966acf664757b866ed278'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: '8c150fdff091eb3f91aad83ad62088797af7cb87b41bacfb277ab6e078a14c35'
+          checkpoint: 'b8c319ce4e8a6eeafb05ca207d20248372a4a2570b106e95b4f495dd592f3b91'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.