### PR TITLE
Update popchar to 8.2

### DIFF
--- a/Casks/popchar.rb
+++ b/Casks/popchar.rb
@@ -1,11 +1,11 @@
 cask 'popchar' do
-  version '8.1'
-  sha256 '6fa7f2de944baa44c778ccc62be48ff0183e2b468fa0034cde455623a0d7860c'
+  version '8.2'
+  sha256 '32cab3a02c9fc867a6e668ba6804ffa2c573e0719b6fdaf3fa59668ba67b5bf8'
 
   url "http://www.ergonis.com/downloads/products/popcharx/PopCharX#{version.no_dots}-Install.dmg",
       user_agent: :fake
   appcast 'http://www.ergonis.com/products/popcharx/history.html',
-          checkpoint: '0aa80cebf90408f4a58b602bad14d53108b2d485a47b1f3893141c5136bcbd02'
+          checkpoint: 'a79e524cb513ae1ca80a4a08875e1f9dea0f77427abeeef9456edf7f662f3f59'
   name 'PopChar X'
   homepage 'http://www.ergonis.com/products/popcharx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.