### PR TITLE
Update qcad to 3.18.1

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,8 +1,8 @@
 cask 'qcad' do
-  version '3.18.0'
-  sha256 'd8b68dc4867fb2ac7591ec084c9979fad2322c717d54363ce003bdc6e04e0b46'
+  version '3.18.1'
+  sha256 'b2c8a9ab627466735cef953affa23555ae623a44769e4e02fa7b790958219954'
 
-  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.12.dmg"
+  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.13.dmg"
   name 'QCAD'
   homepage 'https://www.qcad.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.