### PR TITLE
Update iboostup to 5.9.3

### DIFF
--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -1,10 +1,10 @@
 cask 'iboostup' do
-  version '5.8.0'
-  sha256 '5339ea61c113e4ed60d73a154755ed25ea9950f0e72a99cca952788cb69f75df'
+  version '5.9.3'
+  sha256 'e748361f6cb6b7e372f5bfbdbb2b92a0511edb579eef0e7bff9dee6d1fcc315b'
 
   url 'https://www.iboostup.com/iboostup.dmg'
   appcast 'https://www.iboostup.com/updates',
-          checkpoint: 'd37b22fcbf272751e0ec67f3b36d3909f5bfbf8d422e49353dac030e1fe5e6eb'
+          checkpoint: 'd9ae453bb0bde58cc42b932d35a2798572c0a3ffbee8554b92af63b9649bbd97'
   name 'iBoostUp'
   homepage 'https://www.iboostup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.