### PR TITLE
Update iota-wallet to 2.5.1

### DIFF
--- a/Casks/iota-wallet.rb
+++ b/Casks/iota-wallet.rb
@@ -1,11 +1,11 @@
 cask 'iota-wallet' do
-  version '2.4.0'
-  sha256 '6e129bc2800e67a5a4434c2ff27cd1cb936caaf6cbff67c905b6c78d329ea46b'
+  version '2.5.1'
+  sha256 '89c5ad91c3a0bb5c8769be5cf8b0b7f4b6faed5af9b7feb32f687d6fde941ac7'
 
   # github.com/iotaledger/wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/wallet/releases/download/v#{version}/IOTA.Wallet-#{version}.dmg"
   appcast 'https://github.com/iotaledger/wallet/releases.atom',
-          checkpoint: 'f1e4a8683d0bc575989ca022baf66cabbdff143f509e4db3ba5b7f645c858fb0'
+          checkpoint: '2c7e5c5101b457aadbe8e42b56288088e78d3ec61490cda4ae961bcf39cef950'
   name 'IOTA Wallet'
   homepage 'https://iota.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.