### PR TITLE
Update kactus to 0.2.10

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.2.6'
-  sha256 'e689e10903196cab231b372a0f5b811fe7881bef30d8eaa7a973c0bccc0937b1'
+  version '0.2.10'
+  sha256 'd745e0efb5caaf003fbc288b1ddf26df5c56d93200b74d8dbb8bd012d216347c'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: 'bcfb454afb3d4069a76e153e0e7068502c18844ab8166133ae1e74eb05b179c9'
+          checkpoint: '530498862bcf0ad5af71fd7830d8848376738a54d363b926ed861c504455655a'
   name 'Kactus'
   homepage 'https://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.