### PR TITLE
Update lacona to 1.1.4

### DIFF
--- a/Casks/lacona.rb
+++ b/Casks/lacona.rb
@@ -1,10 +1,10 @@
 cask 'lacona' do
-  version '1.1.3'
-  sha256 '7fe34e71a8854de24396ca0b3c0dbf26f71bdbb75394c292f53450db85083be2'
+  version '1.1.4'
+  sha256 '5a84412185c8cc8de6f627eb4400b81b314742a56e779db1cb65ba3e2b504230'
 
   url "https://download.lacona.io/packages/#{version}/Lacona.zip"
   appcast 'https://download.lacona.io/appcast.xml',
-          checkpoint: 'c7fcb976766ce370cea8326d97b538a20fe6f6e2dc05c4f119664c9d3f352ee3'
+          checkpoint: '9452b814e95942b3310d42eb3d2f3873555bb134db81940f6058dea7c9759390'
   name 'Lacona'
   homepage 'https://www.lacona.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.