### PR TITLE
Update liteicon to 3.8.1

### DIFF
--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -1,10 +1,10 @@
 cask 'liteicon' do
-  version '3.7.1'
-  sha256 'b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432'
+  version '3.8.1'
+  sha256 '11c055b968eba4a8949e87f96ca894530f24e38527d14ac8c797ce0886ca9269'
 
   url "https://www.freemacsoft.net/downloads/LiteIcon_#{version}.zip"
   appcast 'https://freemacsoft.net/liteicon/updates.xml',
-          checkpoint: 'd011430ae0b99504d66d4367803f4fd008a54c1c03f8ffc69407867eda22925b'
+          checkpoint: '3690ac894e3d8e1be71eeda725ff5d4fa5794f9e73381be122f188cd8269939a'
   name 'LiteIcon'
   homepage 'https://freemacsoft.net/liteicon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.