### PR TITLE
Update clipy: uninstall / zap

### DIFF
--- a/Casks/clipy.rb
+++ b/Casks/clipy.rb
@@ -4,12 +4,27 @@ cask 'clipy' do
 
   # github.com/Clipy/Clipy was verified as official when first introduced to the cask
   url "https://github.com/Clipy/Clipy/releases/download/#{version}/Clipy_#{version}.dmg"
-  appcast 'https://clipy-app.com/appcast.xml',
-          checkpoint: '9285449aa0a030aac01058fd77b815636aba1eee88b351277b1e2e2950e96032'
+  appcast 'https://github.com/Clipy/Clipy/releases.atom',
+          checkpoint: 'ff61df8e08b943de0835016a5cd76aa72e16b33e44483812174d3adfe9200bc2'
   name 'Clipy'
   homepage 'https://clipy-app.com/'
 
   depends_on macos: '>= :yosemite'
 
   app 'Clipy.app'
+
+  uninstall login_item: 'Clipy',
+            quit:       'com.clipy-app.Clipy'
+
+  zap delete: [
+                '~/Library/Caches/com.clipy-app.Clipy',
+                '~/Library/Caches/com.crashlytics.data/com.clipy-app.Clipy',
+                '~/Library/Caches/io.fabric.sdk.mac.data/com.clipy-app.Clipy',
+                '~/Library/Cookies/com.clipy-app.Clipy.binarycookies',
+              ],
+      trash:  [
+                '~/Library/Application Support/Clipy',
+                '~/Library/Application Support/com.clipy-app.Clipy',
+                '~/Library/Preferences/com.clipy-app.Clipy.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.