### PR TITLE
Rename sqlitebrowser to db-browser-for-sqlite

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,11 +1,11 @@
-cask 'sqlitebrowser' do
+cask 'db-browser-for-sqlite' do
   version '3.10.1'
   sha256 '9456e8ff081004bd16711959dcf3b5ecf9d304ebb0284c51b520d6ad1e0283ed'
 
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom',
-          checkpoint: 'a7b9929b01b4c4b67da144d2dedd26c8f0db460bc96de76fede907062458de67'
+          checkpoint: 'b481ca94a0597036e14c729767e4307ec871d9febce53415b87770adda7acf26'
   name 'SQLite Database Browser'
   homepage 'http://sqlitebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.