### PR TITLE
Update gotomeeting to 8.13.1.7713,ka338000000L6MHAA0

### DIFF
--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,6 +1,6 @@
 cask 'gotomeeting' do
-  version '8.10.0.7495,ka338000000L63XAAS'
-  sha256 'ba920089687a1ae78b13560e1a6392f2dd1afbd7a6207e2d51b4f9d3729b44dc'
+  version '8.13.1.7713,ka338000000L6MHAA0'
+  sha256 'ff7e03cb81884a9d788937a0fb00b3a42186aa55308845b11285e6de68602af4'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
   url "https://support.citrixonline.com/servlet/fileField?entityId=#{version.after_comma}&field=Content__Body__s"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.