### PR TITLE
Update react-native-debugger (0.7.9)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.8'
-  sha256 '04db2558d22d5624e4fff8e36727e5f79ff6efd436e3ee5fdc73c244d08d9823'
+  version '0.7.9'
+  sha256 'ba341e302eb175c3bb7bd5bca8d7eba541d0ed84fda9a031743feea83365d826'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '14455f6b88a69b3c33f14eeed43db0f003bbe5c80288fd5780e774a4a16de5ac'
+          checkpoint: '2e282f01373db67bcb426bc2f6ce7014f68bf2a955ae6086de9551cf6da43b7d'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
