### PR TITLE
Add java8 formula

### DIFF
--- a/Casks/java8.rb
+++ b/Casks/java8.rb
@@ -1,0 +1,96 @@
+cask 'java8' do
+  version '1.8.0_144-b01,090f390dda5b47b9b721c7dfaa008135'
+  sha256 '2450b35e10295ccf3fb1596bdea6f8f5670f7200ae3ac592eb6a54cc030cf94b'
+
+  java_update = version.sub(%r{.*_(\d+)-.*}, '\1')
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.minor}u#{version.before_comma.split('_').last}/#{version.after_comma}/jdk-#{version.minor}u#{java_update}-macosx-x64.dmg",
+      cookies: {
+                 'oraclelicense' => 'accept-securebackup-cookie',
+               }
+  name 'Java Standard Edition Development Kit'
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.minor}-downloads-2133151.html"
+
+  auto_updates true
+
+  pkg "JDK #{version.minor} Update #{java_update}.pkg"
+
+  postflight do
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home", '/Library/Java/Home'],
+                   sudo: true
+    system_command '/bin/mkdir',
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home/bundle/Libraries"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home/jre/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   sudo: true
+
+    if MacOS.version <= :mavericks
+      system_command '/bin/rm',
+                     args: ['-rf', '--', '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
+                     sudo: true
+      system_command '/bin/ln',
+                     args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents", '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK'],
+                     sudo: true
+    end
+  end
+
+  uninstall pkgutil:   [
+                         "com.oracle.jdk#{version.minor}u#{java_update}",
+                         'com.oracle.jre',
+                       ],
+            launchctl: [
+                         'com.oracle.java.Helper-Tool',
+                         'com.oracle.java.Java-Updater',
+                       ],
+            quit:      [
+                         'com.oracle.java.Java-Updater',
+                         'net.java.openjdk.cmd', # Java Control Panel
+                       ],
+            delete:    [
+                         '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin',
+                         "/Library/Java/JavaVirtualMachines/jdk#{version.split('-')[0]}.jdk/Contents",
+                         '/Library/PreferencePanes/JavaControlPanel.prefPane',
+                         '/Library/Java/Home',
+                         if MacOS.version <= :mavericks
+                           [
+                             '/usr/lib/java/libjdns_sd.jnilib',
+                             '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK',
+                           ]
+                         end,
+                       ].keep_if { |v| !v.nil? }
+
+  zap       delete: [
+                      '~/Library/Application Support/Oracle/Java',
+                      '~/Library/Caches/com.oracle.java.Java-Updater',
+                      '~/Library/Caches/net.java.openjdk.cmd',
+                    ],
+            rmdir:  '~/Library/Application Support/Oracle/'
+
+  caveats <<-EOS.undent
+    This Cask makes minor modifications to the JRE to prevent issues with
+    packaged applications, as discussed here:
+
+      https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
+
+    If your Java application still asks for JRE installation, you might need
+    to reboot or logout/login.
+
+    Installing this Cask means you have AGREED to the Oracle Binary Code
+    License Agreement for Java SE at
+
+      https://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
+end


### PR DESCRIPTION
This pull request resolves the issue #39375 

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].



**This-MacBook-Pro:~ vagrant$ brew cask install https://raw.githubusercontent.com/Juan-Moreno/homebrew-cask/feature/add-java8-formula/Casks/java8.rb**
==> Downloading https://raw.githubusercontent.com/Juan-Moreno/homebrew-cask/feature/add-java8-formula/Casks/java8.rb.
######################################################################## 100.0%
==> Caveats
This Cask makes minor modifications to the JRE to prevent issues with
packaged applications, as discussed here:

  https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361

If your Java application still asks for JRE installation, you might need
to reboot or logout/login.

Installing this Cask means you have AGREED to the Oracle Binary Code
License Agreement for Java SE at

  https://www.oracle.com/technetwork/java/javase/terms/license/index.html

==> Satisfying dependencies
==> Downloading http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-macosx-x64.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask java8
==> Installing Cask java8
==> Running installer for java8; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
==> installer: Package name is JDK 8 Update 144
==> installer: Installing at base path /
==> installer: The install was successful.
🍺  java8 was successfully installed!

**This-MacBook-Pro:~ vagrant$ java -version**
java version "1.8.0_144"
Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed mode)

**This-MacBook-Pro:~ vagrant$ brew cask uninstall https://raw.githubusercontent.com/Juan-Moreno/homebrew-cask/feature/add-java8-formula/Casks/java8.rb**
==> Downloading https://raw.githubusercontent.com/Juan-Moreno/homebrew-cask/feature/add-java8-formula/Casks/java8.rb.
######################################################################## 100.0%
curl: (22) The requested URL returned error: 416
######################################################################## 100.0%
==> Uninstalling Cask java8
==> Running uninstall process for java8; your password may be necessary
==> Removing launchctl service com.oracle.java.Helper-Tool
==> Removing launchctl service com.oracle.java.Java-Updater
==> Quitting application ID com.oracle.java.Java-Updater
==> Quitting application ID net.java.openjdk.cmd
==> Uninstalling packages:
com.oracle.jdk8u144
com.oracle.jre
==> Removing files:
/Library/Internet Plug-Ins/JavaAppletPlugin.plugin
/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents
/Library/PreferencePanes/JavaControlPanel.prefPane
/Library/Java/Home

**This-MacBook-Pro:~ vagrant$ java -version**
No Java runtime present, requesting install.