### PR TITLE
Update react-native-debugger (0.7.10)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.9'
-  sha256 'ba341e302eb175c3bb7bd5bca8d7eba541d0ed84fda9a031743feea83365d826'
+  version '0.7.10'
+  sha256 '35b22528297b5ff8a2a3266d7679a9942938409f88c3781809fd5cc569d7c490'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '2e282f01373db67bcb426bc2f6ce7014f68bf2a955ae6086de9551cf6da43b7d'
+          checkpoint: 'be66a2d99c185477c54552f622aadbe0651786613a7167832913bd21fe34145c'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
