### PR TITLE
updating haskell-platform hash

### DIFF
--- a/Casks/haskell-platform.rb
+++ b/Casks/haskell-platform.rb
@@ -1,6 +1,6 @@
 cask 'haskell-platform' do
   version '8.2.1'
-  sha256 'b0182bb721b5dff3d66794cbdcea93cec562dc254fcf23c0e7a1a7a8d680aaa7'
+  sha256 '05fc22d2cefdf67f1da2f62a90fda73a746accd08b44ec197046972b82afee06'
 
   url "https://haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%20Full%2064bit-signed.pkg"
   appcast 'https://github.com/haskell/haskell-platform/releases.atom',


### PR DESCRIPTION
Cask Name: haskell-platform
Cask Version: 8.2.1

The upstream haskell-platform project recently pushed some bug fixes for
the full (v. core) macOS package, which means a new hash, but not a new
version number. This change updates the SHA256 accordingly. See
haskell/haskell-platform/issues/290 for details.

- [x] `brew cask audit --download haskell-platform` is error-free.
- [x] `brew cask style --fix haskell-platform` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same: I verified this change on the [upstream website](https://www.haskell.org/platform/#osx-none) and confirmed that information with the maintainers via haskell/haskell-platform/issues/290.