### PR TITLE
Update docker to 17.09.0-ce-mac35,19611

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '17.09.0-ce-mac33,19543'
-  sha256 'f42f41174f9cc88d050e4e005171035bdea7d683dd17b6afbff13b434691db23'
+  version '17.09.0-ce-mac35,19611'
+  sha256 '488ae64a9bec7650d3349c7bfc0347026147712b3d5827e24860869796ac0a8f'
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: '812169c95f6aa75964815e00d3e799b4c90b916dc9a6e335027355e3c47dc14e'
+          checkpoint: '3eca966b5e6154051b3270cbf4ebd1afdfd1ba8145f8ae2b88bea6408eb49143'
   name 'Docker Community Edition'
   name 'Docker CE'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.