### PR TITLE
Update Focuswriter v1.6.7 to use versioned download

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,10 +1,12 @@
 cask 'focuswriter' do
-  version :latest
-  sha256 :no_check
+  version '1.6.7'
+  sha256 'b41d6a8b0b2e679c2035839ceaa85bbe00d281361cc4190ff1d1db8a3cc658e0'
 
-  url 'https://gottcode.org/focuswriter/download/?os=mac'
+  url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   name 'FocusWriter'
   homepage 'https://gottcode.org/focuswriter/'
 
   app 'FocusWriter.app'
+
+  zap trash: '~/Library/Application Support/GottCode/FocusWriter'
 end

--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -8,5 +8,6 @@ cask 'focuswriter' do
 
   app 'FocusWriter.app'
 
-  zap trash: '~/Library/Application Support/GottCode/FocusWriter'
+  zap trash: '~/Library/Application Support/GottCode/FocusWriter',
+      rmdir: '~/Library/Application Support/GottCode'
 end


### PR DESCRIPTION
Noticed this one whilst creating PR https://github.com/caskroom/homebrew-cask/pull/39384. 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below. _**Kinda: moving from `:latest` to versioned**_

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256