### PR TITLE
Update cloudapp to 4.3.1

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,11 +1,11 @@
 cask 'cloudapp' do
   version '4.3.1'
-  sha256 'f3cfee8d40b7de45b43bf3e99c5f3c88fdb50f468513bc6feb6ed21bc83d311c'
+  sha256 '55222f91ac19e1809baa8488da6b843f0c3dd69b1ddd80ef1fdc1aed231d6381'
 
   # amazonaws.com/downloads.getcloudapp.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://updates.getcloudapp.com/appcast.xml',
-          checkpoint: '1c250b628b810cb5c3cdbf38ec793c8c53e4ad47d51c69d7a5ac33082720cda0'
+          checkpoint: '4c7363e7d6e5cec86236da951fee7e57337c860590d6612b19c4afb487ab8df6'
   name 'CloudApp'
   homepage 'https://www.getcloudapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

> https://www.virustotal.com/#/file/55222f91ac19e1809baa8488da6b843f0c3dd69b1ddd80ef1fdc1aed231d6381/details