### PR TITLE
Update exodus to 1.35.5

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.35.2'
-  sha256 '5cd8299378a24a71a0357c26eda1e165fee9742442d4bce094da440159afcd62'
+  version '1.35.5'
+  sha256 'c1d420857f3a16fd30a5c2b56bfbf897a28f5989e21da1124d92a10196357d71'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '1ac706f3f8407d2c9d89b6a33c32cf93da70e029bad2b9566ca43db3157230ab'
+          checkpoint: 'e096d7333f0312c914b2a2272573c532deeb65becba1168c8081cf15dfb2c334'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.