### PR TITLE
Update reaper to 5.52

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,10 +1,10 @@
 cask 'reaper' do
-  version '5.51'
-  sha256 '1b37f2ad46373825e4cac487b1dcde1359212168e37fe1d6367e6e8bd4aaeb01'
+  version '5.52'
+  sha256 '8834de7d806d530206634ebdfc76430f5c092c2fb7dc604cc60093f628f762a1'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
   appcast 'https://www.reaper.fm/download.php',
-          checkpoint: '06ec6403d1b48178149d5399f1998ace3907d2c12b12aed4a324355df6dba052'
+          checkpoint: '81350794dc588bdee83ed5e93ee215b8d02dc7645e924de8c7d60ad9430c8363'
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.