### PR TITLE
Update gqrx to 2.8-1

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,11 +1,11 @@
 cask 'gqrx' do
-  version '2.6-1'
-  sha256 '3622b2e4f744afc21e1894f3c6b509d53c05072334934cad645b7cdd4cf9c76b'
+  version '2.8-1'
+  sha256 '2ce8a1d28b60197d45c3c1925e21c68b8724b7297e3eed4afb2d081a6e21f1d7'
 
   # github.com/csete/gqrx was verified as official when first introduced to the cask
   url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor}/Gqrx-#{version}.dmg"
   appcast 'https://github.com/csete/gqrx/releases.atom',
-          checkpoint: '868109cceeb9e6551defa48fc6959e619e5ff98a23e63e65b3cbcfc30d1d4e6f'
+          checkpoint: '64b9804ba7ee2a695d6fe91f4bac8067111b75bca5e79fcc5769b67450620ca0'
   name 'Gqrx'
   homepage 'http://gqrx.dk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.