### PR TITLE
Update patchwork to 3.7.1

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,10 +1,10 @@
 cask 'patchwork' do
-  version '3.6.6'
-  sha256 'da627845e0b7978f9dd86f990d411f7be3586cc267ea0273e274b19cbdd30702'
+  version '3.7.1'
+  sha256 '9e0524cab2a74bf07e7f01950e5a00bd9e0a4d9834a55c177beeb3f95d94aac3'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom',
-          checkpoint: '8cdc768452e1fcfc21628ffd6a7a3992084316e5a351f665716564f58db13c6b'
+          checkpoint: '47a110913c5fa382e4f5f9ac7301eb939cdc8682abe859c3f3d639bd6ab42072'
   name 'Patchwork'
   homepage 'https://github.com/ssbc/patchwork'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.