### PR TITLE
Update iterm2 to 3.1.3

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,11 +1,11 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.2'
-  sha256 '720eccece544ae8765f91c4c0348bb2819e47a2b794ce0adabc14934c00fee38'
+  version '3.1.3'
+  sha256 '4f35d70f4420fa736ed158663ecf114baeb61836b5a8b30652595ab4fcf68544'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml',
-          checkpoint: '82460c7319416475f17022188b53561bd021f006f3a8aef9cf156f9b9806a836'
+          checkpoint: 'f6cde834cc7849656cd6c5a54a582dbd7370a0ed7772f6d2c4af9aaf5ad8c4e8'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.