### PR TITLE
Update time-out to 2.3

### DIFF
--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -6,8 +6,8 @@ cask 'time-out' do
     version '1.7.1'
     sha256 '3c9892344c8313b8ccf0a76cceb00834ddbe26e5114bcd674c4fd53aeb44e310'
   else
-    version '2.2.1'
-    sha256 '1e99900cc0fac14dc226d450943e8af396c02bb054cfb0277fc204c9f554c5a0'
+    version '2.3'
+    sha256 '89efede76841e2d7bc0d8759a90411b3b619705cb34372778409d7988c9fbb6c'
   end
 
   url "http://www.dejal.com/download/timeout-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.