### PR TITLE
Update asset-catalog-tinkerer to 2.5.1

### DIFF
--- a/Casks/asset-catalog-tinkerer.rb
+++ b/Casks/asset-catalog-tinkerer.rb
@@ -1,10 +1,10 @@
 cask 'asset-catalog-tinkerer' do
-  version '2.5'
-  sha256 '2efdd8039fcd68474bbbb20962c5e73328da75b2a9bd4f4145d8e3b2603775af'
+  version '2.5.1'
+  sha256 '75788e83f27ba5d2fc76916339b2f39eb1d5b233cce5e5bd39dbc0461e4d513a'
 
   url "https://github.com/insidegui/AssetCatalogTinkerer/releases/download/#{version}/AssetCatalogTinkerer_v#{version}.zip"
   appcast 'https://github.com/insidegui/AssetCatalogTinkerer/releases.atom',
-          checkpoint: 'a1a11ef5ebe65978f31dd93039911862022963f4e8600c7c131986a6980dbb67'
+          checkpoint: '9acaca3d75d331c50c6922c8ef5d968f9eb0dd8b26a847a33e66e24fcf992601'
   name 'Asset Catalog Tinkerer'
   homepage 'https://github.com/insidegui/AssetCatalogTinkerer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.