### PR TITLE
Update powerphotos to 1.3.1

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,13 +8,13 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.3'
-    sha256 '14d3430343f1f7397c784f3822738a8b40968579fc01de3ad2a29f77c888fc3b'
+    version '1.3.1'
+    sha256 '81ac820240feb5c83af6defcc6ba974a6d306f9a50aa0038aa9c639129289b3c'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: '95d57b67703e526753d3b68fd1aab38fb386ed37f9d03eb96d6d50d2b1e6fed5'
+          checkpoint: '562403b3a18fb21cea39f2fefc877c37d57ff7980ac7b56cc1a72463819e0c8c'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
