### PR TITLE
Update coqide to 8.6.1

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,10 +1,10 @@
 cask 'coqide' do
-  version '8.6'
-  sha256 'abd00fc22b7a99a214d8b6977c982d6be26060d769f79f42d3ddcc8761bb4f49'
+  version '8.6.1'
+  sha256 '6c9f672fb40e5f0ede8f159fe21b75637831854665c3a310a038de31ae10a022'
 
   url "https://coq.inria.fr/distrib/V#{version}/files/CoqIDE_#{version}.dmg"
   appcast 'https://coq.inria.fr/rss.xml',
-          checkpoint: '6a51f27b585a42e8debc0cf9fcc2a55b4fc2ca0853490ba483568ba306d83d85'
+          checkpoint: 'ede0841fe4c8fd9d29d988c313a1235c3dc4098326a6135d96c9ce35d628dc36'
   name 'Coq'
   homepage 'https://coq.inria.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.