### PR TITLE
Update daemon-tools to 6.0.337

### DIFF
--- a/Casks/daemon-tools.rb
+++ b/Casks/daemon-tools.rb
@@ -1,11 +1,11 @@
 cask 'daemon-tools' do
-  version '5.3.303'
-  sha256 'e64610e757d2ed67fc22ef32dbe2f3b424a19139cea6189ad6de480ee802e959'
+  version '6.0.337'
+  sha256 'a1553c5ab597014e2cae5d7a040dbc0f62bbf776bc10d4ebb9a6a8f71c0c3c02'
 
   # web-search-home.com was verified as official when first introduced to the cask
   url 'http://web-search-home.com/download/dtLiteMac'
   appcast 'http://resources.web-search-home.com/xml/DAEMONToolsLite-appcast.xml',
-          checkpoint: '134a30f7b2fe753e5ec6508801a23b76c55b3944b0f165d9f4b1eb7b6be165f1'
+          checkpoint: 'bffaabaaf98203bb4a10974796e5a66c8180744c01c7e435ec1bd39e16825b99'
   name 'DAEMON Tools'
   homepage 'https://www.daemon-tools.cc/home'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.