### PR TITLE
Updating Pharo version to 6.1

### DIFF
--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -1,5 +1,5 @@
 cask 'pharo' do
-  version '6.0'
+  version '6.1'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "http://files.pharo.org/platform/Pharo#{version}-64-mac.zip"

--- a/Casks/pharo.rb
+++ b/Casks/pharo.rb
@@ -6,5 +6,5 @@ cask 'pharo' do
   name 'Pharo'
   homepage 'https://pharo.org/'
 
-  app "Pharo#{version}.app"
+  app "Pharo#{version}-64.app"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

*note*: The original cask skipped the sha256 check.
