### PR TITLE
Update omnioutliner to 5.1.4

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,10 +1,10 @@
 cask 'omnioutliner' do
-  version '5.1.2'
-  sha256 'dad422b24ef079fda6dddc8f67ce661ac4649330ec62188869d7e529a5915c6e'
+  version '5.1.4'
+  sha256 '91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}",
-          checkpoint: 'ddef8a1b4610bb0b23f5df5ff9468e74b080e4afe3d548602f494da7d398edac'
+          checkpoint: '9966a34bf39bb4d5d2aaebdf38953a8b63fbf851ede9a2cd3f70370b87585322'
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.