### PR TITLE
Update puppet-agent: URL

### DIFF
--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -3,16 +3,20 @@ cask 'puppet-agent' do
 
   if MacOS.version == :yosemite
     sha256 'e9c2dd30c2a81cf004f168782e2cc49161e2bd4ea041e43116a7d0be5b854dfb'
+    # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
+    url "https://downloads.puppetlabs.com/mac/10.10/PC1/x86_64/puppet-agent-#{version}.osx10.10.dmg"
   elsif MacOS.version == :el_capitan
     sha256 'e37067d3a337492021895ca14a60e50be4eea82e0b9c431b63ecc95b63bf4876'
+    # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
+    url "https://downloads.puppetlabs.com/mac/10.11/PC1/x86_64/puppet-agent-#{version}.osx10.11.dmg"
   else
     sha256 '32ff2b3dafbc9e98df979d4a3bb0ebc42963277430a5f5be7ae07e5123bbd143'
+    # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
+    url "https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/puppet-agent-#{version}.osx10.12.dmg"
   end
 
-  # downloads.puppetlabs.com was verified as official when first introduced to the cask
-  url "https://downloads.puppetlabs.com/mac/#{MacOS.version}/PC1/x86_64/puppet-agent-#{version}.osx#{MacOS.version}.dmg"
   appcast 'https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/',
-          checkpoint: '349c8d077a54dc2d481626a58512f3be63d0287799928ce0fc6feaff5edf5baf'
+          checkpoint: '695383430ebcfa2ff989958986134a1c07bc2bebd46abeb4d731dc5e49f6d82b'
   name 'Puppet Agent'
   homepage 'https://docs.puppet.com/puppet/4.5/about_agent.html'
 

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -13,10 +13,10 @@ cask 'puppet-agent' do
     sha256 '32ff2b3dafbc9e98df979d4a3bb0ebc42963277430a5f5be7ae07e5123bbd143'
     # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
     url "https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/puppet-agent-#{version}.osx10.12.dmg"
+    appcast 'https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/',
+            checkpoint: '695383430ebcfa2ff989958986134a1c07bc2bebd46abeb4d731dc5e49f6d82b'
   end
 
-  appcast 'https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/',
-          checkpoint: '695383430ebcfa2ff989958986134a1c07bc2bebd46abeb4d731dc5e49f6d82b'
   name 'Puppet Agent'
   homepage 'https://docs.puppet.com/puppet/4.5/about_agent.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This removes `#{MacOS.version}` from the URL to avoid 10.13 download issues.