### PR TITLE
Update ivpn to 2.6.6

### DIFF
--- a/Casks/ivpn.rb
+++ b/Casks/ivpn.rb
@@ -1,6 +1,6 @@
 cask 'ivpn' do
-  version '2.6.2'
-  sha256 '283ec6bec4c231ce408afe06c133305fd6dd569b543259b787b678e777c74062'
+  version '2.6.6'
+  sha256 '1ba8daa7246503192c0283c3d4b1406aa82e5fc7699c72567eff760a8ecfa3be'
 
   url "https://www.ivpn.net/releases/osx/IVPN-#{version}.dmg"
   name 'IVPN'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.