### PR TITLE
Update auristor-client to 0.162

### DIFF
--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -10,9 +10,12 @@ cask 'auristor-client' do
   elsif MacOS.version == :el_capitan
     sha256 'ec5e76c06d8a1342dfb41173cac303999fbfa31779acdcb9e0d472d22688cf17'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.11/AuriStor-client-#{version}-ElCapitan.dmg"
-  else
+  elsif MacOS.version == :sierra
     sha256 '6577b6fa6c723dd703132650215aec0a1c300b832afe4b6525cb989407eb530a'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.12/AuriStor-client-#{version}-Sierra.dmg"
+  else
+    sha256 'b01815f0b3c4eb60bc0c19e17fa45da20fba7670cd156ca5f76a2b0260883690'
+    url "https://www.auristor.com/downloads/auristor/osx/macos-10.13/AuriStor-client-#{version}-HighSierra.dmg"
   end
 
   name 'AuriStor File System Client'
@@ -24,6 +27,7 @@ cask 'auristor-client' do
                       :yosemite,
                       :el_capitan,
                       :sierra,
+                      :high_sierra,
                     ]
 
   pkg 'Auristor-Lite.pkg'

--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -1,17 +1,17 @@
 cask 'auristor-client' do
-  version '0.150'
+  version '0.162'
 
   if MacOS.version == :mavericks
-    sha256 'e79579c9ac2cd609bedd2e01104c113a3417e082e6b5a9f8d333d74e8a6d5030'
+    sha256 'cd147e18b2fd7e03530ce4ac8d08a802329e811bbcc6ca49c54a032552961d88'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.9/AuriStor-client-#{version}-Mavericks.dmg"
   elsif MacOS.version == :yosemite
-    sha256 '966c115c1d87f239fb63521940e4a4142cf17e096548e9aaed92912c91f7202b'
+    sha256 '416124a68e9c925cb73d5ae253ba9c2affa952a8ea19e793378323693872359b'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.10/AuriStor-client-#{version}-Yosemite.dmg"
   elsif MacOS.version == :el_capitan
-    sha256 'b0a7eee25398e265304a7adfe672f8daa942b916ed7e069d45c3b871d023086f'
+    sha256 'ec5e76c06d8a1342dfb41173cac303999fbfa31779acdcb9e0d472d22688cf17'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.11/AuriStor-client-#{version}-ElCapitan.dmg"
   else
-    sha256 '2e7ca7a7d0759d4f25db904035c0b00c59abdb2667f9dcd2e4a75892c5a60968'
+    sha256 '6577b6fa6c723dd703132650215aec0a1c300b832afe4b6525cb989407eb530a'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.12/AuriStor-client-#{version}-Sierra.dmg"
   end
 


### PR DESCRIPTION


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
