### PR TITLE
Update authy-desktop to 1.1.0

### DIFF
--- a/Casks/authy-desktop.rb
+++ b/Casks/authy-desktop.rb
@@ -1,9 +1,9 @@
 cask 'authy-desktop' do
-  version '1.0.13'
-  sha256 '7e0939f473f4a8169d5c41f15ef8de9da08988245474536401216b6614a08bae'
+  version '1.1.0'
+  sha256 '672580bcc520514ad68e54fb9b43956a84cf429407e58d66033056b2e797cc63'
 
   # s3.amazonaws.com/authy-electron-repository-production was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/authy-electron-repository-production/stable/#{version}/darwin/x64/authy-installer.dmg"
+  url "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/#{version}/darwin/x64/authy-installer.dmg"
   name 'Authy Desktop'
   homepage 'https://authy.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.