### PR TITLE
Update deepstream to 3.1.0

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,11 +1,11 @@
 cask 'deepstream' do
-  version '3.0.1'
-  sha256 '83ffa43ccf95ef2057870f5b6bf2bb9a60ef0fea4464d083fb163244b6877816'
+  version '3.1.0'
+  sha256 '210b14ae1460b7e5956313ad67d492846f997c77de2d760fcd436d0186827d85'
 
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"
   appcast 'https://github.com/deepstreamIO/deepstream.io/releases.atom',
-          checkpoint: '894a5b3237f92e60c4ed15649085ff73acc117adf50fb21cadd0d723b54e73db'
+          checkpoint: 'a232cf01164ec7966d1e3849af6703ca936f4c04caaa5d707fbf09ea50547a8e'
   name 'deepstream'
   homepage 'https://deepstream.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.