### PR TITLE
Updated Onyx for High Sierra to 3.3.6

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -23,8 +23,8 @@ cask 'onyx' do
     version '3.3.0'
     sha256 'd8f521bd348044fc2d1696f43910bfb193a9641968013cd5bbaada55e46e4799'
   else
-    version '3.3.5'
-    sha256 '07a61c661c4553bce9ecf98b741e711c64f1ac12eac4452b832e1f1e6bf21dee'
+    version '3.3.6'
+    sha256 '4dbfb9a5c41fb70b28cc409ce7cfb8221e07f3351e780beb0a5bb8c9182f9a73'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/OnyX.dmg"

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -29,7 +29,7 @@ cask 'onyx' do
 
   url "https://www.titanium-software.fr/download/#{macos_release}/OnyX.dmg"
   appcast 'http://www.titanium-software.fr/en/release_onyx.html',
-          checkpoint: '7f954ebd126e9109ca9c362f3f8ef370cbceaa29c5c331dff7a5f15f552a3e98'
+          checkpoint: 'e29b0b300fdbd324f6a07ec414387ea98c809d5b41e58646cf8227c91bf3d186'
   name 'OnyX'
   homepage 'https://www.titanium-software.fr/en/onyx.html'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
I wasn't able to do this because the audit tool pulls the Sierra version instead of the High Sierra version (doesn't seem to recognize the OS correctly.)
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?][version-checksum]</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide][version-checksum].