### PR TITLE
Update xamarin-android to 8.0.0-33

### DIFF
--- a/Casks/xamarin-android.rb
+++ b/Casks/xamarin-android.rb
@@ -1,10 +1,10 @@
 cask 'xamarin-android' do
-  version '7.4.5-1'
-  sha256 '0a23f464523d010d7f83c45f200880cb45591e75b1360aa450eabf142b10f651'
+  version '8.0.0-33'
+  sha256 '30ec0c1ff1b622ec7bbcb5e5f1aa40db9de90edba05c4ac161b279a229f69905'
 
   url "https://dl.xamarin.com/MonoforAndroid/Mac/xamarin.android-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: 'd060f69255a71e32aa0b00d74750c04cd5fe27df410929deec0abac8fe2956bb'
+          checkpoint: '796e78c229d3accc035db4eb28032362cd75666b907f0b8eb8169b00c883dd41'
   name 'Xamarin.Android'
   homepage 'https://www.xamarin.com/platform'
 


### PR DESCRIPTION
Sorry was using an old cask-repair
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?][version-checksum]</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide][version-checksum].