### PR TITLE
Update xamarin-mac to 3.8.0.49

### DIFF
--- a/Casks/xamarin-mac.rb
+++ b/Casks/xamarin-mac.rb
@@ -1,10 +1,10 @@
 cask 'xamarin-mac' do
-  version '3.6.3.3'
-  sha256 '812f5ea6e50d23fa8d11f1ee8e3f793ec5699e3df353ee02f911e0d7ec4f610a'
+  version '3.8.0.49'
+  sha256 '4b3d236df92979f969fd04bd666719d4f591f84e562c7a0976cfbdc50ae16a02'
 
   url "https://dl.xamarin.com/XamarinforMac/Mac/xamarin.mac-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: 'd060f69255a71e32aa0b00d74750c04cd5fe27df410929deec0abac8fe2956bb'
+          checkpoint: '796e78c229d3accc035db4eb28032362cd75666b907f0b8eb8169b00c883dd41'
   name 'Xamarin Mac'
   homepage 'https://www.xamarin.com/platform'
 


### PR DESCRIPTION
Sorry was using an old cask-repair
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?][version-checksum]</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide][version-checksum].