### PR TITLE
Update canary to 1.7.0,354

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '1.7.0,354'
-  sha256 '1f50c23b54748cd0a90d3b6bc3760984eee51b6b36519b2634bd9f5499281623'
+  version '1.7.0,355'
+  sha256 '17c934547c55c6270e273cbef1ac8d35f821f35755829ea149f909cc9476b270'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: '92b04e7859877e6ac713d4ba1543cfe96d4a1e18887d908924e0f0ac42b190c4'
+          checkpoint: 'da4242a274d8f4a49a2c8f9568fa709759a0c837398e79177365c910f3d1b3c9'
   name 'Canary'
   homepage 'https://canarymail.io/'
 

--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '1.6.8,351'
-  sha256 'b27751f158728422e4b1a8f6f1a10cf1f43cee47b57bb4ad26c2be953c5f0ba1'
+  version '1.7.0,354'
+  sha256 '1f50c23b54748cd0a90d3b6bc3760984eee51b6b36519b2634bd9f5499281623'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: '24803d0b202511e4e2d9452ad745c07010d090dce0af9776d44b2373dbc1f7e8'
+          checkpoint: '92b04e7859877e6ac713d4ba1543cfe96d4a1e18887d908924e0f0ac42b190c4'
   name 'Canary'
   homepage 'https://canarymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.