### PR TITLE
Update fork to 1.0.57.6

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.56.1'
-  sha256 '8eed688e1f485c0359f4aabb10738c90cdd463d49e82383da00e29260ee5bde0'
+  version '1.0.57.6'
+  sha256 '78ac3fe54b407e4606605c5d757fe076ff13444c000a285f87008a575e5849de'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: 'f2dcdba5cba2673311590ed3f757e6ac3abfa6a75b05af899d9061508ebe2a52'
+          checkpoint: '43486b1530df29b89614a82fa85c1dc83faec9a74c9c31e47082c4d8abc93c2d'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).