### PR TITLE
Update djview to 4.10.6

### DIFF
--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -1,8 +1,8 @@
 cask 'djview' do
-  version '4.10.6'
+  version '4.10.6,57c'
   sha256 '6ad1fe387434da4d103cbe343a7d6bb0da0fa139787069b3ba76f124651402a2'
 
-  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-qt57c-intel64.dmg"
+  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version.before_comma}-qt#{version.after_comma}-intel64.dmg"
   appcast 'https://sourceforge.net/projects/djvu/rss',
           checkpoint: '608eefef3e99391add5aa043ba70bee99d2cea3a7276fab6d96398e11877dd39'
   name 'DjView'

--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -1,10 +1,10 @@
 cask 'djview' do
   version '4.10.6'
-  sha256 '46b6042e9414e800d651d7dd484126737d379a7a4a79137a81a142cb35d5e5d0'
+  sha256 '6ad1fe387434da4d103cbe343a7d6bb0da0fa139787069b3ba76f124651402a2'
 
-  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-qt57b-intel64.dmg"
+  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.27%2BDjView-#{version}-qt57c-intel64.dmg"
   appcast 'https://sourceforge.net/projects/djvu/rss',
-          checkpoint: 'aeacee2c4f4de38de4aad7d682d2728a3b10153c943f386e30b0621879efd920'
+          checkpoint: '608eefef3e99391add5aa043ba70bee99d2cea3a7276fab6d96398e11877dd39'
   name 'DjView'
   homepage 'http://djvu.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).