### PR TITLE
Update djay-pro to 1.4.4,201709270943

### DIFF
--- a/Casks/djay-pro.rb
+++ b/Casks/djay-pro.rb
@@ -1,10 +1,10 @@
 cask 'djay-pro' do
-  version '1.4.3,201703200957'
-  sha256 'a2d1af6130a5e2de76c3abe85fafff8047f4160b98d7a55ba5df39b30c6e13e0'
+  version '1.4.4,201709270943'
+  sha256 '78a5ff0a2d5f72ff69a62b037e5fbdb773a726ac7ca0a23b7b592ddae2a8f55d'
 
   url "http://download.algoriddim.com/djay/#{version.after_comma}/djay_Pro_#{version.before_comma}.zip"
   appcast 'https://www.algoriddim.com/djay-pro-mac/releasenotes/appcast',
-          checkpoint: '6c669e49621bc10770238d0207b157789a534ba3b952a463354cc8d1e340fdcb'
+          checkpoint: '6dca3dbb45cda0623d16461f6fde35d2f628e79064579e6b02ca39ae932ef49b'
   name 'Algoriddim djay Pro'
   homepage 'https://www.algoriddim.com/djay-pro-mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).