### PR TITLE
Update espresso to 5.0.4

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,11 +1,10 @@
 cask 'espresso' do
-  version '5.0.3'
-  sha256 '462a57b2364764f15b62da95cab24633cb59b3dca1c4f05ac6ad85701372dda4'
+  version '5.0.4'
+  sha256 '336312d0a8940a553018eef1d019f47b4673ca8c2419ab47e839812917f5f538'
 
-  # static.macrabbit.com was verified as official when first introduced to the cask
-  url "https://static.macrabbit.com/downloads/Espresso%20v#{version.major}.zip"
+  url "https://presto.espressoapp.com/downloads/Espresso%20v#{version}.zip"
   appcast "https://update.macrabbit.com/espresso/#{version}.xml",
-          checkpoint: '1a136a83d4663679501479c433d99ad45e8284a1f5296701686e974d357fa143'
+          checkpoint: '19fce25d2f4bad0db881c5c48d99f42ea2176618ef9e4cd47aa892a6d52b49ec'
   name 'Espresso'
   homepage 'https://espressoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).