### PR TITLE
Update macports to 2.4.2

### DIFF
--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -1,40 +1,45 @@
 cask 'macports' do
-  version '2.4.1'
+  version '2.4.2'
 
   if MacOS.version <= :mountain_lion
-    sha256 '4f7989fa6f289df52c540b698eddb581a76d7f5c084bfa4831269f29e24605d4'
+    sha256 'd88a54392a0238e00987572f7a622ede98a8a95dc388549e658ba548c8d1ff82'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.8-MountainLion.pkg"
     pkg "MacPorts-#{version}-10.8-MountainLion.pkg"
   elsif MacOS.version <= :mavericks
-    sha256 'ce5b0bd75df423f759886b1ab8fc09c1e456eb8e63c3dff6b28884344c587136'
+    sha256 '1297ee748ba4748ff626ee5c23b3cc8b759d3fdb652f01f2ade3b1557603639c'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.9-Mavericks.pkg"
     pkg "MacPorts-#{version}-10.9-Mavericks.pkg"
   elsif MacOS.version <= :yosemite
-    sha256 '3698ccfcc6b38fba9f4b1db6518f069794c9e086b8cc70926931b11c4413f62a'
+    sha256 '6f15410bcb80b557a8f87ba92790792df76bba22c6937275b41282107ba4b6fd'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.10-Yosemite.pkg"
     pkg "MacPorts-#{version}-10.10-Yosemite.pkg"
   elsif MacOS.version <= :el_capitan
-    sha256 '113b64df06a8f4c2d91d5fa280a09ddff2a1b403d1cc7a572948d423bb2df1d3'
+    sha256 '9763a407a9e7d3fcfb85280927d47ae0d3c291fe78a5bc0debf2134ca6ca9953'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.11-ElCapitan.pkg"
     pkg "MacPorts-#{version}-10.11-ElCapitan.pkg"
-  else
-    sha256 'fc6c718dd7659d48d3d0764e9ded90b54439b0ed322804d7e58fec8914242479'
+  elsif MacOS.version <= :sierra
+    sha256 '85344a9be97824a6f241ab80e8ff7b9067d39b2bbdac9edc2ea51865ece7f1c7'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.12-Sierra.pkg"
     pkg "MacPorts-#{version}-10.12-Sierra.pkg"
+  else
+    sha256 '7296251c0388e27307191d23f8a37e1a981de8d9b1c781a677801fcd63e2738e'
+    # github.com/macports/macports-base was verified as official when first introduced to the cask
+    url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.13-HighSierra.pkg"
+    pkg "MacPorts-#{version}-10.13-HighSierra.pkg"
   end
 
   appcast 'https://github.com/macports/macports-base/releases.atom',
-          checkpoint: '52f4a89e16cfb5751203f37432a58e2f067d125f1c799d339f3952794a5bdc50'
+          checkpoint: '6ddfb734b6c7633e383f699856b15f72aeadcf36a9c5d24e3d31bbcee13cc6a6'
   name 'MacPorts'
   homepage 'https://www.macports.org/'
   gpg "#{url}.asc", key_id: '01ff673fb4aae6cd'
 
   uninstall pkgutil: 'org.macports.MacPorts'
 
-  zap       delete: '~/.macports'
+  zap trash: '~/.macports'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.