### PR TITLE
boxcryptor 2.16

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,10 +1,10 @@
 cask 'boxcryptor' do
-  version '2.15.875'
-  sha256 '51fd06157dfb630257cbfdff167fccfe310f4d9f8864f1bb4d869c3c4421efdc'
+  version '2.16.880'
+  sha256 '47c0a9486d9b80ca0582d875a22307ff31320e36d036d5ee79bf4f2a55aafa02'
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://rink.hockeyapp.net/api/2/apps/7fd6db3e51a977132e3b120c613eaea8',
-          checkpoint: 'c96c7962d552975cdff7f8aa8d29a37fc71b3e0ff2235f892a67d45627bd659a'
+          checkpoint: '5294c8d43ba3e498dce1e23fe1cf11279292237eb22823573d88bf5f75b22efb'
   name 'Boxcryptor'
   homepage 'https://www.boxcryptor.com/en/'
 


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?][version-checksum]</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide][version-checksum].
