### PR TITLE
Update spotify: url / zap

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -2,8 +2,7 @@ cask 'spotify' do
   version :latest
   sha256 :no_check
 
-  # download.scdn.co/Spotify.dmg was verified as official when first introduced to the cask
-  url 'https://download.scdn.co/Spotify.dmg'
+  url 'https://download.spotify.com/Spotify.dmg'
   name 'Spotify'
   homepage 'https://www.spotify.com/'
 
@@ -16,13 +15,15 @@ cask 'spotify' do
             login_item: 'Spotify'
 
   zap delete: [
+                '~/Library/Caches/com.spotify.client',
+                '~/Library/Caches/com.spotify.client.helper',
+                '~/Library/Cookies/com.spotify.client.binarycookies',
+                '~/Library/Logs/Spotify',
+                '~/Library/Saved Application State/com.spotify.client.savedState',
+              ],
+      trash:  [
                 '~/Library/Application Support/Spotify',
                 '~/Library/Preferences/com.spotify.client.plist',
                 '~/Library/Preferences/com.spotify.client.helper.plist',
-                '~/Library/Caches/com.spotify.client',
-                '~/Library/Caches/com.spotify.client.helper',
-                '~/Library/Saved Application State/com.spotify.client.savedState',
-                '~/Library/Logs/Spotify',
-                '~/Library/Cookies/com.spotify.client.binarycookies',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This reverts https://github.com/caskroom/homebrew-cask/pull/33949