### PR TITLE
Update adobe-digital-editions to 4.5

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,12 +1,12 @@
 cask 'adobe-digital-editions' do
-  version '4.5.4'
+  version '4.5'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version.major_minor}_Installer.dmg"
+  url "https://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version}_Installer.dmg"
   name 'Adobe Digital Editions'
   homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
 
-  pkg "Digital Editions #{version.major_minor} Installer.pkg"
+  pkg "Digital Editions #{version} Installer.pkg"
 
   uninstall pkgutil: 'com.adobe.adobedigitaleditions.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).