### PR TITLE
Update flash-player to 25.0.0.163

### DIFF
--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,11 +1,11 @@
 cask 'flash-player' do
   version '25.0.0.163'
-  sha256 '2ceeb89cf6c52802d7adb2af01dc73ca68c343280ce4563f4f19af755c132940'
+  sha256 'fdf6971ccb1b2662ad07e41b870b55b139a50e6350c639ef1568d2b42e14328f'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '37d060409d160f996740ff19f376f78997fe743290fe7b055c67cfc6817ccc6d'
+          checkpoint: 'f9cdc3e74103ce8f2bf46664475ec4ab55be96fe3bd71cc5b9a31d052ecb9eca'
   name 'Adobe Flash Player projector'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 

--- a/Casks/scrabble3d.rb
+++ b/Casks/scrabble3d.rb
@@ -1,0 +1,19 @@
+cask 'scrabble3d' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://downloads.sourceforge.net/project/scrabble/Main_Program/MacOS/Scrabble3D-darwin.pkg'
+  name 'Scrabble3D'
+  homepage 'https://scrabble.sourceforge.io/'
+
+  pkg 'Scrabble3D-darwin.pkg'
+
+  uninstall pkgutil: 'com.company.Scrabble3D'
+
+  zap delete: [
+                '~/.config/Scrabble3D',
+                '~/Library/Preferences/com.company.Scrabble3D.plist',
+                '~/Library/Logs/Homebrew/scrabble3d',
+                '~/Library/Saved Application State/com.company.Scrabble3D.savedState',
+              ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).