### PR TITLE
Update launchcontrol to 1.35

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -1,10 +1,10 @@
 cask 'launchcontrol' do
-  version '1.34'
-  sha256 'd3738e150521ab47508debce7445865df046d8f8e8da2338ea1d4cce62010270'
+  version '1.35'
+  sha256 'b23eb7cebccad7e6fb3ff3e2cc60350eea6cde136b0872353b20b34ad4ef9966'
 
   url "http://www.soma-zone.com/download/files/LaunchControl_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/LaunchControl/a/appcast.xml',
-          checkpoint: '27bc5748f894f69326f4ef6bf4c938524fa4a49416495f7a1bf1891b829d85dc'
+          checkpoint: '776efea8c485dc3c33aad071ee5ebfe77ba4a0329ad2971d3c7801b40e23ccda'
   name 'LaunchControl'
   homepage 'http://www.soma-zone.com/LaunchControl/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).