### PR TITLE
Update mailspring to latest

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,10 +1,10 @@
 cask 'mailspring' do
   version '1.0.1'
-  sha256 '029d685fc2e3784ffda56caaada911f2c6f01d246d1be2e91015871cf27e4b87'
+  sha256 '4081550429898431dd3fd632af12be6dbcf9a5954d80f0d2c0f0ddbc71bb623e'
 
   url 'https://updates.getmailspring.com/download?platform=darwin'
   appcast 'https://github.com/Foundry376/Mailspring/releases.atom',
-          checkpoint: '4a7b2ad0b5a3851387b5af80aa1db5eaef0960b2ea6f364e4ba96b62490735dd'
+          checkpoint: '8e8f8ed372265019d0d9bc8280a2d241d5b41dadb6408468ae149cc2a09962a9'
   name 'Mailspring'
   homepage 'https://getmailspring.com/'
 

--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,10 +1,8 @@
 cask 'mailspring' do
-  version '1.0.1'
-  sha256 '4081550429898431dd3fd632af12be6dbcf9a5954d80f0d2c0f0ddbc71bb623e'
+  version :latest
+  sha256 :no_check
 
   url 'https://updates.getmailspring.com/download?platform=darwin'
-  appcast 'https://github.com/Foundry376/Mailspring/releases.atom',
-          checkpoint: '8e8f8ed372265019d0d9bc8280a2d241d5b41dadb6408468ae149cc2a09962a9'
   name 'Mailspring'
   homepage 'https://getmailspring.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).