### PR TITLE
Update bonjeff to 1.0.0

### DIFF
--- a/Casks/bonjeff.rb
+++ b/Casks/bonjeff.rb
@@ -12,5 +12,8 @@ cask 'bonjeff' do
 
   app 'Bonjeff.app'
 
-  zap delete: '~/Library/Application Scripts/com.lapcatsoftware.bonjeff'
+  zap delete: [
+                '~/Library/Application Scripts/com.lapcatsoftware.bonjeff',
+                '~/Library/Containers/com.lapcatsoftware.bonjeff',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).