### PR TITLE
Update toggldesktop to 7.4.68

### DIFF
--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -1,6 +1,6 @@
 cask 'toggldesktop' do
   version '7.4.68'
-  sha256 '092f4ad3bb8939741ea7b6627c0e3292662fdbbce3059a845ff04b5ea0d4731a'
+  sha256 'bc758867fb5bb6e6c1058bc562f4c4d476cda68dfc8c89f8df0f430baddd1b2a'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).

https://www.virustotal.com/#/file/bc758867fb5bb6e6c1058bc562f4c4d476cda68dfc8c89f8df0f430baddd1b2a/details