### PR TITLE
Update hands-off to 3.2.4

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,14 +1,14 @@
 cask 'hands-off' do
-  version '3.2.3'
-  sha256 'd0bd5bc3085ab68f3f02ab8f3eac1e291ddba879c131aae2d523d1ba50c09c7a'
+  version '3.2.4'
+  sha256 '057c750c586178b3d149b3b49bc14a9097a6bccff850ac9ff370b4195860b45b'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml",
-          checkpoint: '06fc57c034f4563e17ead4dfd359c94ebcb380f71dcd3eaf2c68fb88400b0387'
+          checkpoint: 'b78b5f03082c5e6dd91963b3191f2dd6731abc7fd2252ef5ba7caa7f5fc7ce89'
   name 'Hands Off!'
   homepage 'https://www.oneperiodic.com/products/handsoff/'
 
   app 'Hands Off!.app'
 
-  zap delete: '~/Library/Preferences/com.metakine.handsoff.plist'
+  zap trash: '~/Library/Preferences/com.metakine.handsoff.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).