### PR TITLE
Update gramps to 4.2.6-1

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,11 +1,11 @@
 cask 'gramps' do
-  version '4.2.5-1'
-  sha256 'a1b7e57c9349bf4137ee0d932f23882ff461460dcf99e7f03e3620e0edbf8d58'
+  version '4.2.6-1'
+  sha256 'b38648187e2eae04d4e4012e64754c721960582118c05c4ae61726bafc1bad93'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"
   appcast 'https://github.com/gramps-project/gramps/releases.atom',
-          checkpoint: '602bb379cf541c40cbc5abd0d1a2b9aafdb731354b4f38b32fdddaa06b1c6a60'
+          checkpoint: '381bfc19f192623005e03ce6a1b63e63bc3d7271c70d6b27c031ad3f287ab7b5'
   name 'Gramps'
   homepage 'https://gramps-project.org/introduction-WP/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.