### PR TITLE
Update xamarin-ios to 11.2.0.11

### DIFF
--- a/Casks/xamarin-ios.rb
+++ b/Casks/xamarin-ios.rb
@@ -1,10 +1,10 @@
 cask 'xamarin-ios' do
-  version '11.2.0.8'
-  sha256 '855c079d80ee312fbda4c4ff82fe9bfc00146f4b7a0d164f051f41c6734d0310'
+  version '11.2.0.11'
+  sha256 'de18878b280fb7a9c9c8f0e3279f2781d128ea0899ea46db4b09b469e0041bde'
 
   url "https://dl.xamarin.com/MonoTouch/Mac/xamarin.ios-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: '796e78c229d3accc035db4eb28032362cd75666b907f0b8eb8169b00c883dd41'
+          checkpoint: 'ae14679a7064f0aba35c3117a65dd47a8c61e8ed560c7b166ac514fb45195e67'
   name 'Xamarin.iOS'
   homepage 'https://www.xamarin.com/platform'
 

--- a/Casks/xamarin-ios.rb
+++ b/Casks/xamarin-ios.rb
@@ -4,7 +4,7 @@ cask 'xamarin-ios' do
 
   url "https://dl.xamarin.com/MonoTouch/Mac/xamarin.ios-#{version}.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: 'ae14679a7064f0aba35c3117a65dd47a8c61e8ed560c7b166ac514fb45195e67'
+          checkpoint: '6c0206cd7b4e66ca36952c28faba171fee84cb5af10ef6e6701b59e97745a88a'
   name 'Xamarin.iOS'
   homepage 'https://www.xamarin.com/platform'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).