### PR TITLE
Update downie to 3.1672

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.1661'
-  sha256 'dc0c1f0183756a5199f26f81c3274c18ab151cc0b1e8e6dab919df63484e99d7'
+  version '3.1672'
+  sha256 '2efcdb4ab6ae28f2bdc6671dea9b334170d61521a3e40522f5b61298684c7a86'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.dots_to_underscores}.zip"
   appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).