### PR TITLE
Update mailbutler to 6888

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '6872'
-  sha256 '3225cefe4333313022c7efd24d83a79a02b75fabec484c0a0a99299f0c42a4cc'
+  version '6888'
+  sha256 'cdeba09c32e317681d0d15cbd0a51e096ab986f58a533bcfeea4ce29f3ebd981'
 
   # mailbutler-io.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-io.s3.amazonaws.com/files/MailButler_#{version}.zip"
   appcast 'https://www.feingeist.io/fg-library/appcast.php?appName=MailButler',
-          checkpoint: 'b8a7508a9a733e592234d655bf5850943e9e59f4317f28a0ab1f86e3dc19ae1b'
+          checkpoint: '7aa96dc82458b21a8738e43c190a9d54ee9bc66f5a23a979ca5b497b930c0fcb'
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).