### PR TITLE
Update wireshark-chmodbpf to 2.4.2

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,10 +1,10 @@
 cask 'wireshark-chmodbpf' do
-  version '2.4.1'
-  sha256 'cbf1f66020d049e645edd9ee8f0ebdd7d71d019d3fb2c44e028fcd65195b268b'
+  version '2.4.2'
+  sha256 '111ff7313055ebbc72a2fee4f7b691c723e182c777f5341fd74b279b106686e8'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.wireshark.org/download/osx/',
-          checkpoint: '4a217edc73d35668ce432c60a01043c8e32a21d38b91d5e4654ae4f4cbf23af1'
+          checkpoint: 'cbc1a63057cb15e99867a1b890a8eb4c5e434968d466a547d8def6096f94fabb'
   name 'Wireshark-ChmodBPF'
   homepage 'https://www.wireshark.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).