### PR TITLE
Add nylas-mail-lives 2.2.0

### DIFF
--- a/Casks/nylas-mail-lives.rb
+++ b/Casks/nylas-mail-lives.rb
@@ -1,0 +1,27 @@
+cask 'nylas-mail-lives' do
+  version '2.2.0'
+  sha256 '84dfaeff9f5b2658169f0ee6e1bafac1f265cee8916e4a3eef434bc06a0a144e'
+
+  url "https://github.com/nylas-mail-lives/nylas-mail/releases/download/#{version}/nylas-#{version}.dmg"
+  appcast 'https://github.com/nylas-mail-lives/nylas-mail/releases.atom',
+          checkpoint: '745e3750c0293d39210d2bc4bef742724d59b02fc88ab26453f99bbe2b83526f'
+  name 'Nylas Mail'
+  homepage 'https://github.com/nylas-mail-lives/nylas-mail'
+
+  app 'Nylas Mail.app'
+
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.nylas.nylas-mail.sfl',
+                '~/Library/Caches/com.nylas.nylas-mail',
+                '~/Library/Caches/com.nylas.nylas-mail.ShipIt',
+                '~/Library/Caches/Nylas Mail',
+                '~/Library/Saved Application State/com.nylas.nylas-mail.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/com.nylas.nylas-mail.ShipIt',
+                '~/Library/Application Support/Nylas Mail',
+                '~/Library/Preferences/com.nylas.nylas-mail.helper.plist',
+                '~/Library/Preferences/com.nylas.nylas-mail.plist',
+                '~/.nylas-mail',
+              ]
+end

--- a/Casks/nylas-mail-lives.rb
+++ b/Casks/nylas-mail-lives.rb
@@ -5,7 +5,7 @@ cask 'nylas-mail-lives' do
   url "https://github.com/nylas-mail-lives/nylas-mail/releases/download/#{version}/nylas-#{version}.dmg"
   appcast 'https://github.com/nylas-mail-lives/nylas-mail/releases.atom',
           checkpoint: '745e3750c0293d39210d2bc4bef742724d59b02fc88ab26453f99bbe2b83526f'
-  name 'Nylas Mail'
+  name 'Nylas Mail Lives'
   homepage 'https://github.com/nylas-mail-lives/nylas-mail'
 
   conflicts_with cask: 'nylas-mail'

--- a/Casks/nylas-mail-lives.rb
+++ b/Casks/nylas-mail-lives.rb
@@ -8,6 +8,8 @@ cask 'nylas-mail-lives' do
   name 'Nylas Mail'
   homepage 'https://github.com/nylas-mail-lives/nylas-mail'
 
+  conflicts_with cask: 'nylas-mail'
+
   app 'Nylas Mail.app'
 
   zap delete: [


### PR DESCRIPTION
The original project was deprecated. This PR updates the cask to use the forked community project instead.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256