### PR TITLE
Update neofinder to 7.1.3

### DIFF
--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,11 +1,11 @@
 cask 'neofinder' do
-  version '7.1.2'
-  sha256 '88693244a23edd7e07becf323e3f2671822577eb497418502ae53758606b6975'
+  version '7.1.3'
+  sha256 '86fd8716f36bbae309355cf61f219335e68bfc1cda677e8c462f6f55a3a24a45'
 
   # wfs-apps.de was verified as official when first introduced to the cask
   url "https://www.wfs-apps.de/updates/neofinder.#{version}.zip"
   appcast 'https://www.wfs-apps.de/updates/neofinder-appcast-64.xml',
-          checkpoint: 'fc593ae0aa0ccf78e35c7833c32d47dd18404ee2d44e7dc8c43ecc2361ec857e'
+          checkpoint: '916ebab0a87a38ba361548d487c00427a7b45f222a0e470b1a94a038dd7db554'
   name 'NeoFinder'
   homepage 'https://www.cdfinder.de/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: