### PR TITLE
Update houdahgeo to 5.1.10

### DIFF
--- a/Casks/houdahgeo.rb
+++ b/Casks/houdahgeo.rb
@@ -1,6 +1,6 @@
 cask 'houdahgeo' do
-  version '5.1.9'
-  sha256 '281fecfc41209f36b34d37ba730a3d03c1aac07c27b6eb3b8e085bef36c82358'
+  version '5.1.10'
+  sha256 '27814d3dbf69eedeac7b7d53acf37af55d03d1599087febfc14d28fdf7cad130'
 
   url "https://www.houdah.com/houdahGeo/download_assets/HoudahGeo#{version}.zip"
   name 'HoudahGeo'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).