### PR TITLE
Update lego-mindstorms-ev3 to 1.3.0

### DIFF
--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -1,10 +1,10 @@
 cask 'lego-mindstorms-ev3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '1.2.2'
-  sha256 '79bbb5931e674c80de6bd59c1da3732b2b2de731a0aefd3369eff7ff2e580626'
+  version '1.3.0'
+  sha256 '498a80affcb726235bcb8df4e90267ebdd7550e6436ce2570fd2ca20ff3ce898'
 
-  # esd.lego.com.edgesuite.net/digitaldelivery/mindstorms was verified as official when first introduced to the cask
-  url 'http://esd.lego.com.edgesuite.net/digitaldelivery/mindstorms/6ecda7c2-1189-4816-b2dd-440e22d65814/public/LMS-EV3-OSX-ENUS-01-02-02-full-setup.dmg'
+  # le-www-live-s.legocdn.com/downloads was verified as official when first introduced to the cask
+  url 'https://le-www-live-s.legocdn.com/downloads/LMS-EV3/LMS-EV3_Full-setup_1.3.0_de-de_osx.dmg'
   name 'Lego Mindstorms EV3 Home Edition'
   homepage 'https://www.lego.com/en-us/mindstorms'
 

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -1,19 +1,19 @@
 cask 'lego-mindstorms-ev3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
   version '1.3.0'
-  sha256 '498a80affcb726235bcb8df4e90267ebdd7550e6436ce2570fd2ca20ff3ce898'
+  sha256 'ce5e0b047c096886d1a74540b306e704d6249c0c7eb09c76f58389841abe3528'
 
-  # le-www-live-s.legocdn.com/downloads was verified as official when first introduced to the cask
-  url 'https://le-www-live-s.legocdn.com/downloads/LMS-EV3/LMS-EV3_Full-setup_1.3.0_de-de_osx.dmg'
+  # le-www-live-s.legocdn.com/downloads/LMS-EV3 was verified as official when first introduced to the cask
+  url "https://le-www-live-s.legocdn.com/downloads/LMS-EV3/LMS-EV3_Full-setup_#{version}_en-us_osx.dmg"
   name 'Lego Mindstorms EV3 Home Edition'
   homepage 'https://www.lego.com/en-us/mindstorms'
 
   pkg 'LEGO MINDSTORMS EV3 Home Edition.pkg'
 
   uninstall pkgutil: [
-                       "com.ni.pkg.lego.ev3.Eng.#{version}",
-                       "com.ni.pkg.lego.x3.#{version}.core",
-                       "com.ni.pkg.lego.x3.#{version}.update",
+                       "com.ni.pkg.lego.ev3.Eng.#{version.major_minor}",
+                       "com.ni.pkg.lego.x3.#{version.major_minor}.core",
+                       "com.ni.pkg.lego.x3.#{version.major_minor}.update",
                      ]
 
   zap pkgutil: 'com.ni.pkg.legodriver'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: