### PR TITLE
Update fastonosql to 1.9.2

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,10 +1,10 @@
 cask 'fastonosql' do
-  version '1.9.1'
-  sha256 '2754220bf38a8891f82029176b81c4a33c7c61126a800c61123110eb86985f2a'
+  version '1.9.2'
+  sha256 '54010766df62d596e904c57ae9e8543d841243532ea1c09528a62285a225f4bf'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom',
-          checkpoint: 'b2db1cebdb5ab9665fa41451eae277577d8af3dc828a0b00b7c99dae9903b623'
+          checkpoint: '1a27b6cd3a616007e28b3951c28d545e2882da288cde661c10d7ed2e9b326583'
   name 'FastoNoSQL'
   homepage 'https://www.fastonosql.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).