### PR TITLE
Update logdna-cli to 1.2.2

### DIFF
--- a/Casks/logdna-cli.rb
+++ b/Casks/logdna-cli.rb
@@ -1,11 +1,11 @@
 cask 'logdna-cli' do
-  version '1.2.1'
-  sha256 '55f692548582ba72ecde64bc2a2318ed4c92e75e788d789ad88a1f147e9db28d'
+  version '1.2.2'
+  sha256 'd7d62422f20df8210b168404ba377c9c632e682e54005ce5ab608c720a181ccc'
 
   # github.com/logdna/logdna-cli was verified as official when first introduced to the cask
   url "https://github.com/logdna/logdna-cli/releases/download/#{version}/logdna-cli.pkg"
   appcast 'https://github.com/logdna/logdna-cli/releases.atom',
-          checkpoint: 'f0b4a7663d8f48a3e6c810191834afe8a60d723c5d026f2e7b5c8539ff9d3533'
+          checkpoint: '4c27044f3f87e451277966068e6d82526c2af20eda2adfe0a31e6a836720f24a'
   name 'LogDNA CLI'
   homepage 'https://logdna.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.