### PR TITLE
Update cityofzion-neon to 0.0.6

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,10 +1,10 @@
 cask 'cityofzion-neon' do
-  version '0.0.5'
-  sha256 'aea6c39528f8104c938343ef0101bd8be0f089a217792092988691eda6fb71e8'
+  version '0.0.6'
+  sha256 '8085100f0fa0b30b6c70ae54a546f336609b0e6d6bf9015fd360f293a9039435'
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Mac.Neon-#{version}.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: 'cf5659c03278421d494586a23cb9d97c35a0ef5a71fad87415e6a8857253f368'
+          checkpoint: '55742dae6d64b78fbfee66358fb11b573e005ae80a6039a0d3da95ebafdcc746'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: