### PR TITLE
Update hab to 0.36.0-20171009050124

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.34.1-20171002011028'
-  sha256 'c0ed40914484f7cdcb2ff12cd5369ec23a262ce8c165185e037bbb4e33b69781'
+  version '0.36.0-20171009050124'
+  sha256 '3c4ca43b1206c56cd61e4bb22d7659913528378b7b5a1d192105318887a77e86'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'a4156b9c996e66c337db61e8836b751ae921bafeccb81738009cd8ddf7d448f0'
+          checkpoint: '713909977879a74f58f72233fd2aa060a5ef1975fb01c54996754a8bf72d1654'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: