### PR TITLE
Update whatsize to 6.6.2

### DIFF
--- a/Casks/whatsize.rb
+++ b/Casks/whatsize.rb
@@ -1,6 +1,6 @@
 cask 'whatsize' do
-  version '6.5.4'
-  sha256 '116a45be975f37896c1f88cf6684f89f74c2b709e6c5a5201c7022e5ac14e9f8'
+  version '6.6.2'
+  sha256 '9e1c6c81ef3ca4a251f4a1313d0ec6fa353cc92bbb8160335d45411cc156033d'
 
   url "https://www.whatsizemac.com/software/whatsize#{version.major}/whatsize.dmg"
   appcast 'http://www.id-design.com/software/whatsize/release/notes.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [x] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: