### PR TITLE
Update soulver to 2.6.5-5864

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,10 +1,10 @@
 cask 'soulver' do
-  version '2.6.4-5791'
-  sha256 'e30d4c58636f6d0d47693a859c1efb269b342f1aac2fa1a4526603dd74be2aa8'
+  version '2.6.5-5864'
+  sha256 '46f615f08f0037d617e2a998059be3fe29923f7ec3986258984b00ed1768ab65'
 
   url "http://www.acqualia.com/files/sparkle/soulver_#{version}.zip"
   appcast "http://www.acqualia.com/soulver/appcast/soulver#{version.major}.xml",
-          checkpoint: 'e98716acd4bf3d8955f26e0e83f453d7191e6b45c6d453ba03c65656e3df9f24'
+          checkpoint: '13b888bc45c4b3d2df76112300ce7201dae445e75c4dcef266f87c6ec6fa8254'
   name 'Soulver'
   homepage 'http://www.acqualia.com/soulver/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: