### PR TITLE
Update qtox to 1.12.1

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.12.0'
-  sha256 '94e1e3de7a2aef703405b0abc4ce151740ab0b1806e28f9fc21ba7291ff88c86'
+  version '1.12.1'
+  sha256 '7620d78a8e35e91bc7b731ba4ad373466d8664a8da137d9cb7f0b5558f9a4a15'
 
   # github.com/qTox/qTox was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/qTox/qTox/releases.atom',
-          checkpoint: 'fd55e7e69da1a0b43d2270170719538a61a61d175b67721ccab04effa93fe13d'
+          checkpoint: '09de94d91a1d5db757deff6766bcad402d7513260935ebd1a534e27ebd621c97'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: