### PR TITLE
Update now to 3.1.0

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '2.6.1'
-  sha256 '3d1b0fada8686b4efd52a8967d37d7410df431fe82208dbc1c191110c5dbbe08'
+  version '3.1.0'
+  sha256 '4a2540d2c733d760fe1548d21f62330fd623b3cea1eee935231efa6fface6c5d'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '2b0fae36365393ef4c9255d15a16b7bf93b4aa7fff9bfdfa5eefa02d532b59ed'
+          checkpoint: 'aab35c0199d71f54491dbdb974fe3c2e5adc7f5c7cee6bedce3340c88c783762'
   name 'Now'
   homepage 'https://zeit.co/now'
 

--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -5,7 +5,7 @@ cask 'now' do
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'aab35c0199d71f54491dbdb974fe3c2e5adc7f5c7cee6bedce3340c88c783762'
+          checkpoint: '89f3da13a4f3fe6378f80091070e8c88b2f7961a60133d75a2807e72aa24e7b8'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: