### PR TITLE
Update eclipse packages to Oxygen 1a (4.7.1a)

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-cpp' do
-  version '4.7.0,oxygen:R'
-  sha256 'd2fe97226f85319a9390ed91f8cefc61e072219e8b0f7032634ea2a37cb123be'
+  version '4.7.1,oxygen:1a'
+  sha256 'ca93c932cadba573db04e08454c49bc9e5e93e3f6902ec8f91570cab8522b9a8'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-cpp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for C/C++ Developers'

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.7.0,oxygen:R'
-  sha256 '6c8967ef10d6bf4c6314ac0a0484321fac01957594d0c6eefc6c05ee73927f2e'
+  version '4.7.1,oxygen:1a'
+  sha256 '7beeec0531181da673086568cfe14151ac8b96e76b0bfeaf3880d7ca495b9068'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-java' do
-  version '4.7.0,oxygen:R'
-  sha256 '3a078c191c668364422e9990c36beb7429a86ca394cb99f795f053aed45d162a'
+  version '4.7.1,oxygen:1a'
+  sha256 'c34cfb1cc7d781f652c3695d1dfe03e5e852bf465bbeb2262e602b49dc035e03'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java Developers'

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-jee' do
-  version '4.7.0,oxygen:R'
-  sha256 'b23f7765399739b2986cae13dfe8d8ec29e7a45843fdbae9bef9906177a53172'
+  version '4.7.1,oxygen:1a'
+  sha256 '1beeb84970513846da0f08998cdae150588993fa91c0e5d1e4444967ec5f11bc'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java EE Developers'

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-modeling' do
-  version '4.7.0,oxygen:R'
-  sha256 '3e5d3e6cf6044854510e18fd5c7173fbf846a33241da39490d77b8ab070ef4a6'
+  version '4.7.1,oxygen:1a'
+  sha256 'b4fd0e241b51edfe5fd42032b63ddb32e82dd0beb640b6ecf051ee9ae06e59ca'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-modeling-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse Modeling Tools'

--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-php' do
-  version '4.7.0,oxygen:R'
-  sha256 'cbaa369bfcea3bbc4692ec56791290cf752249c3e5d762facc631346129e9ebe'
+  version '4.7.1,oxygen:1a'
+  sha256 'ed9f433f5e8f5ad03a9bbbcf8d35b237d246c63826e583c9ff3a2fde2bfa7168'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-php-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for PHP Developers'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.7,201706120950'
-  sha256 '4773d1615a400ce8033f47813143b67394c71799d255f97d149ed207855400ec'
+  version '4.7.1a,201710090410'
+  sha256 'fcbdc9f97dd209a303e49d431f173004b5d3c16dfa4ea18b31945de44d6c15aa'
 
   url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg"
   name 'Eclipse SDK'

--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ptp' do
-  version '4.7.0,oxygen:R'
-  sha256 'af09c7d670ae12fb2c41de996028a516ab35d3285e07fff45845191c166f8754'
+  version '4.7.1,oxygen:1a'
+  sha256 '6fd11c3758b82d32c0c28d19635cc024d37c5b29dcabc3e23a24b210ac07942c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-parallel-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for Parallel Application Developers'

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-rcp' do
-  version '4.7.0,oxygen:R'
-  sha256 '4036f1ef2f7943f4bc0e6827b976007de1575c06f33312156b5efce1a9b5e000'
+  version '4.7.1,oxygen:1a'
+  sha256 'd5ee6433f2f47c000e82a492bd49da6c8241bee000d834a0132009adbd0a8ac1'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-rcp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for RCP and RAP Developers'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.


Note: eclipse-installer was intentionally not changed, as there does not appear to be a new release for it.