### PR TITLE
Update sha256.md

### DIFF
--- a/doc/cask_language_reference/stanzas/sha256.md
+++ b/doc/cask_language_reference/stanzas/sha256.md
@@ -27,7 +27,7 @@ The confirmation of the updated `sha256` should ideally be publicly available. S
    - If confirmed on GitHub, @mention [one of the Homebrew-Cask maintainers](https://github.com/orgs/caskroom/people).
    - Otherwise, post a link to the developer's confirmation.
  - By codesign:
-   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. 
+   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. **If there is no *Signature Info* section, VirusTotal verrification is not enough**.
    
      Here's an example for [Brave-0.18.14.dmg](https://www.virustotal.com/en/file/0a3d15b924a4ad85a51d3c1b62943ea6aa92381a80bea4933284174fd0c13f11/analysis/):
    

--- a/doc/cask_language_reference/stanzas/sha256.md
+++ b/doc/cask_language_reference/stanzas/sha256.md
@@ -22,16 +22,15 @@ When updating the `sha256` stanza of an existing Cask, the `version` also has to
 
 The confirmation of the updated `sha256` should ideally be publicly available. Specifically:
 
- - By the developer:
-   - Post a link to the developer's confirmation.
- - By codesign:
-   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “Details” tab. 
+- Post a link to the developer's confirmation.
 
-     **If there is no *Signature Info* section, VirusTotal verification is not enough**.
+- If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “Details” tab. 
 
-     Maintainers will confirm the VirusTotal submission is legitimate by comparing its `sha256` with the one on the updated cask.
+   **If there is no *Signature Info* section, VirusTotal verification is not enough**.
+
+   Maintainers will confirm the VirusTotal submission is legitimate by comparing its `sha256` with the one on the updated cask.
    
-     Here's an example for [Brave-0.18.36.dmg](https://www.virustotal.com/#/file/0aa0ebfd310a627f4ba50c518bd141764a4b0335d5bc244d3cc8fa1538bfaef0/details):
+   Here's an example for [Brave-0.18.36.dmg](https://www.virustotal.com/#/file/0aa0ebfd310a627f4ba50c518bd141764a4b0335d5bc244d3cc8fa1538bfaef0/details):
    
-     <img src="https://i.imgur.com/Jiyllps.png" width="1080px" alt="VirusTotal codesigning">
+    <img src="https://i.imgur.com/Jiyllps.png" width="1080px" alt="VirusTotal codesigning">
 

--- a/doc/cask_language_reference/stanzas/sha256.md
+++ b/doc/cask_language_reference/stanzas/sha256.md
@@ -23,14 +23,15 @@ When updating the `sha256` stanza of an existing Cask, the `version` also has to
 The confirmation of the updated `sha256` should ideally be publicly available. Specifically:
 
  - By the developer:
-   - If confirmed on Twitter, @mention [@homebrewcask](https://twitter.com/homebrewcask).
-   - If confirmed on GitHub, @mention [one of the Homebrew-Cask maintainers](https://github.com/orgs/caskroom/people).
-   - Otherwise, post a link to the developer's confirmation.
+   - Post a link to the developer's confirmation.
  - By codesign:
-   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. **If there is no *Signature Info* section, VirusTotal verification is not enough**.
-   
-     Here's an example for [Brave-0.18.14.dmg](https://www.virustotal.com/en/file/0a3d15b924a4ad85a51d3c1b62943ea6aa92381a80bea4933284174fd0c13f11/analysis/):
-   
-     <img src="https://i.imgur.com/iW9NhEH.png" width="1280px" alt="VirusTotal codesigning">
+   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. 
 
-Maintainers will confirm the VirusTotal submission is legitimate by comparing its `sha256` with the one on the updated cask.
+     **If there is no *Signature Info* section, VirusTotal verification is not enough**.
+
+     Maintainers will confirm the VirusTotal submission is legitimate by comparing its `sha256` with the one on the updated cask.
+   
+     Here's an example for [Brave-0.18.36.dmg](https://www.virustotal.com/#/file/0aa0ebfd310a627f4ba50c518bd141764a4b0335d5bc244d3cc8fa1538bfaef0/details):
+   
+     <img src="https://i.imgur.com/Jiyllps.png" width="1080px" alt="VirusTotal codesigning">
+

--- a/doc/cask_language_reference/stanzas/sha256.md
+++ b/doc/cask_language_reference/stanzas/sha256.md
@@ -25,7 +25,7 @@ The confirmation of the updated `sha256` should ideally be publicly available. S
  - By the developer:
    - Post a link to the developer's confirmation.
  - By codesign:
-   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. 
+   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “Details” tab. 
 
      **If there is no *Signature Info* section, VirusTotal verification is not enough**.
 

--- a/doc/cask_language_reference/stanzas/sha256.md
+++ b/doc/cask_language_reference/stanzas/sha256.md
@@ -27,7 +27,7 @@ The confirmation of the updated `sha256` should ideally be publicly available. S
    - If confirmed on GitHub, @mention [one of the Homebrew-Cask maintainers](https://github.com/orgs/caskroom/people).
    - Otherwise, post a link to the developer's confirmation.
  - By codesign:
-   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. **If there is no *Signature Info* section, VirusTotal verrification is not enough**.
+   - If the Cask is an `.app` that is [codesigned](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/codesign.1.html) (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “File Details” tab. **If there is no *Signature Info* section, VirusTotal verification is not enough**.
    
      Here's an example for [Brave-0.18.14.dmg](https://www.virustotal.com/en/file/0a3d15b924a4ad85a51d3c1b62943ea6aa92381a80bea4933284174fd0c13f11/analysis/):
    


### PR DESCRIPTION
Updated VirusTotal link and screenshot.

Removed the "mentions" section, easier to just post a link in the PR to the tweet, issue, etc.

(I've seen a couple of contributors `@` maintainers who are not active.)