### PR TITLE
Update telegram to 3.5-107595

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.4-106100'
-  sha256 'b9c40a8fbd9b85bc9b7e3dea890e75134a34096e562f99bec896a2dd31226aee'
+  version '3.5-107595'
+  sha256 '942cceb9a82ea5a745d0d99855956c52f725d81aa9d62c673b6dc7c567e69874'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '83fd9243a02329cce7d836d6a84f020ad611bfbdd16c1c14cc257bdea0c2b48c'
+          checkpoint: '4dfe40fef781f0d1e6915556b4172f5e95000ef9fd7be960433cb6999686c6f7'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: