### PR TITLE
Update borgbackup to 1.1.0

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.0.11'
-  sha256 'e197a7b830760ddec8b33bdc241312b50e6c27701384e2aafed01c22805395e3'
+  version '1.1.0'
+  sha256 'e87a8e597d3d87dc4df79befbfd6a5c68576e99d66cb209a7ae34018b6daacd0'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '79f4f919971110b412e3008d8f51645b6ca068d7bcbc0ea0ae99e84220b36038'
+          checkpoint: '99df3e9400b721345bd8c21e6e94b9957ce8d38fbff0b88d1be8d984b0d40147'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.io/en/stable/'
   gpg "#{url}.asc", key_id: '51F78E01'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: