### PR TITLE
Update lima to 1.4.5

### DIFF
--- a/Casks/lima.rb
+++ b/Casks/lima.rb
@@ -1,6 +1,6 @@
 cask 'lima' do
-  version '1.4.3'
-  sha256 '64a9950e77a735b43010ac451eb4dd96284c7e142de2492526baca2408c8b822'
+  version '1.4.5'
+  sha256 '57a83f9fa61658f27b0be07c5ab7c3795dba744f5f4212e2bb1319c6e9436182'
 
   url "https://update.api.meetlima.com/downloads/osx/dist/Lima_#{version}.dmg"
   name 'Lima'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: