### PR TITLE
Update anki to 2.0.48

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -1,10 +1,10 @@
 cask 'anki' do
-  version '2.0.47'
-  sha256 'f03b414991abc9fb881af0e7b2c97d60d2ea09ccbe313e9e99ec2bd23d115bf5'
+  version '2.0.48'
+  sha256 '5593a8dbd8059bd1fcd1c68d68b9c14dd74a67ae368cfe3925207c17a857c6e1'
 
   url "https://apps.ankiweb.net/downloads/current/anki-#{version}.dmg"
   appcast 'https://apps.ankiweb.net/docs/changes.html',
-          checkpoint: 'bf5c4919534b2a51ac056da68bd56c0b333ee7a4b7b4bdc715c53bcf2326ab6b'
+          checkpoint: 'd0d8b455fb926ce727ed0ae1290afd5f816f4bf22b3ab28aee97ae5a2bb25bb1'
   name 'Anki'
   homepage 'https://apps.ankiweb.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: