### PR TITLE
Update brave to 0.19.48

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.18.36'
-  sha256 '0aa0ebfd310a627f4ba50c518bd141764a4b0335d5bc244d3cc8fa1538bfaef0'
+  version '0.19.48'
+  sha256 '6b681ca7fa45859a0becf5d997d3bbb04bf6fa30086cab1a973f66033aa582e4'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '9732ab3236b80c416500a6110da0a298494b1a07fe74835c3caad5f630226bcb'
+          checkpoint: '2f89242bb17df1f9f4e87de2f286ec80d432971f8391999c78c8b1456f0b92ea'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: