### PR TITLE
Update toggldesktop to 7.4.58

### DIFF
--- a/Casks/toggldesktop.rb
+++ b/Casks/toggldesktop.rb
@@ -1,6 +1,6 @@
 cask 'toggldesktop' do
-  version '7.4.68'
-  sha256 'bc758867fb5bb6e6c1058bc562f4c4d476cda68dfc8c89f8df0f430baddd1b2a'
+  version '7.4.58'
+  sha256 'd911ec53fdc4c0ffc678d024eb47cd3a1564c0882afd1884e4be4a434f5a52fe'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**:
___

Reverts to current stable version.