### PR TITLE
Update paw to 3.1.5,3

### DIFF
--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -1,10 +1,10 @@
 cask 'paw' do
-  version '3.1.4,2'
-  sha256 'eeda0dbcd25a2d8407bf3784f19f0e5325be2920dbccd6440b92cb2aaea5e0f5'
+  version '3.1.5,3'
+  sha256 '7a4c658ac371539335090d7ed714b6efee566a46ea94d1ebaed06346328d4a92'
 
   url "https://cdn-builds.paw.cloud/paw/Paw-#{version.major_minor_patch}-#{version.major}#{version.minor.rjust(3, '0')}#{version.patch.rjust(3, '0')}#{version.after_comma.rjust(3, '0')}.zip"
   appcast 'https://paw.cloud/api/v2/updates/appcast',
-          checkpoint: '7cadb0a1fb7e74deb55b0df24cefeaefb2bd5a8b6ca5d73590eee0bacceab058'
+          checkpoint: 'a68a175c6dea0a667403dfcf829a968fd00db3fed98e2e7ee09d3c609cea149a'
   name 'Paw'
   homepage 'https://paw.cloud/'
 
@@ -14,7 +14,7 @@ cask 'paw' do
                 '~/Library/Application Scripts/com.luckymarmot.Paw',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.luckymarmot.paw.sfl',
                 '~/Library/Containers/com.luckymarmot.Paw',
-                '~/Library/Preferences/com.luckymarmot.Paw.plist',
                 '~/Library/Saved Application State/com.luckymarmot.Paw.savedState',
-              ]
+              ],
+      trash:  '~/Library/Preferences/com.luckymarmot.Paw.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: