### PR TITLE
Update whatsapp to 0.2.6426

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,10 +1,10 @@
 cask 'whatsapp' do
-  version '0.2.6424'
-  sha256 'ab2df2067986409901cdaa8dbe59b003fcf623a18c9423e7ccdb15876c85863e'
+  version '0.2.6426'
+  sha256 'b627184f20a8753ae7e27a6f28c9434ade1e494fe42a11e6d268d3138d3fc8c2'
 
   url 'https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg'
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64',
-          checkpoint: 'bc33c8de0caf113c719eec6b7d46a51cb322cbbba89e52fb0fd83527da03785e'
+          checkpoint: 'd5d17500d8071b2bba1c2711e41e323fa33732d004139e8e28bbc4cf40f2f9ac'
   name 'WhatsApp'
   homepage 'https://www.whatsapp.com/'
 

--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -4,7 +4,7 @@ cask 'whatsapp' do
 
   url 'https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg'
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64',
-          checkpoint: 'd5d17500d8071b2bba1c2711e41e323fa33732d004139e8e28bbc4cf40f2f9ac'
+          checkpoint: 'd53dc98316026dc25cab82eee7ec47a9cdcae158d60530971533c4ebb0d76862'
   name 'WhatsApp'
   homepage 'https://www.whatsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: