### PR TITLE
Update sqlectron to 1.26.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.25.0'
-  sha256 'd6a268a7603cd2916cd4ab5411fa9d1ff005dfac334cf6ead46620f89bb3c29a'
+  version '1.26.0'
+  sha256 '2bf1f80f52f4523618b09e9d0c4ef3bf2995afeefbd5d67c1cf012589c80f440'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: '2790b29015d69f11f9ddb0d1071135dfa37d2661c607972182419372c78565b7'
+          checkpoint: '8f6025f9d2ab79728bb94ced4f595ec27eeddfe1a1e16d9dc1e5f680d14e3e5f'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).