### PR TITLE
Updates Mist to 0.9.2

### DIFF
--- a/Casks/mist.rb
+++ b/Casks/mist.rb
@@ -1,10 +1,10 @@
 cask 'mist' do
-  version '0.9.1'
-  sha256 '0c8a03232fbb8493e8b146812d0d553e49b8054bd7a7801b1e5046b901ab5e29'
+  version '0.9.2'
+  sha256 '2480301ee8c94e791131b05f560523fc1aac24a8e65756173851a1dcf0abc8d3'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: 'dcb48d1e593f132f3c46cfcf9488a4fb8ce4aaa0c74ab13805eb56e1a341259a'
+          checkpoint: '57df8c5cd893fad8ce1da4771e54bf9890f7fba40065428c10299c53e7652088'
   name 'Mist'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>][version-checksum] and **am providing confirmation below**:

2480301ee8c94e791131b05f560523fc1aac24a8e65756173851a1dcf0abc8d3
