### PR TITLE
Update image2icon to 2.8

### DIFF
--- a/Casks/image2icon.rb
+++ b/Casks/image2icon.rb
@@ -1,6 +1,6 @@
 cask 'image2icon' do
-  version '2.7'
-  sha256 '377399ee8f7fbb3fea16fa4da8bcd5cd6e9d7caf46d15e48212061eb627967ae'
+  version '2.8'
+  sha256 'ba8e0f29bab556bc8d8a3630351d4321cdb990d89ec11a2cca90c7fd69a2328a'
 
   # sf-applications.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://sf-applications.s3.amazonaws.com/Image2Icon/app-releases/Image2icon#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: