### PR TITLE
Update mqttfx to 1.5.1

### DIFF
--- a/Casks/mqttfx.rb
+++ b/Casks/mqttfx.rb
@@ -1,6 +1,6 @@
 cask 'mqttfx' do
-  version '1.5.0'
-  sha256 '894708779e1db41a7cd8f26d9e3d0776558921be1c10dba6a32f46df5b41e2f9'
+  version '1.5.1'
+  sha256 '7a6b75862f3d77afaf5195d5a34fa49be7c65817a0c08fbdeac5929b12e95fd5'
 
   # jensd.de/apps/mqttfx was verified as official when first introduced to the cask
   url "http://www.jensd.de/apps/mqttfx/#{version}/mqttfx-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: