### PR TITLE
New Cask Mac-Cantonese-Input

### DIFF
--- a/Casks/mac-cantonese-input.rb
+++ b/Casks/mac-cantonese-input.rb
@@ -1,0 +1,11 @@
+cask 'mac-cantonese-input' do
+  version :latest
+  sha256 '5701252f752f14454184c2a60677d5b085a11bd53f197ffecf821b10482dfdce'
+
+  # raw.githubusercontent.com/ache051/mac_cantonese was verified as official when first introduced to the cask
+  url 'https://raw.githubusercontent.com/ache051/mac_cantonese/master/mac_cantonese.inputplugin'
+  name 'Mac Cantonese Input'
+  homepage 'https://github.com/ache051/mac_cantonese'
+
+  input_method 'mac-cantonese-input--latest.inputplugin'
+end


### PR DESCRIPTION
I see that the `openvanilla` Cask is an `input_method`. This cask similarly is an input_method, and needs to be copied over to `~/Library/Input\ Methods/`

Could you help me to write the proper Cask formula? Thank you. 