### PR TITLE
Update rapidweaver to 7.5.2,18795.1507885111

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,11 +1,11 @@
 cask 'rapidweaver' do
-  version '7.4.1,18708.1496675639'
-  sha256 'be4336a72fd659f8a7706e482e74e5a4a8b026f02542d5f6278e30ff7909df5f'
+  version '7.5.2,18795.1507885111'
+  sha256 '043110fb69a20e7f839989641841f494a7412bccd6615cb66a0b587a4e26d763'
 
   # devmate.com/com.realmacsoftware.rapidweaver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.realmacsoftware.rapidweaver/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver-#{version.after_comma.major}.zip"
   appcast 'https://updates.devmate.com/com.realmacsoftware.rapidweaver.xml',
-          checkpoint: 'eab532b0ac3a667aa4b1f43581144a62d6e1229f93ae5451659d5c44ddb1398a'
+          checkpoint: '505de31ff607478affdc18ccf875bdecac28d62f389407ed32f1bd0ea4e136f9'
   name 'RapidWeaver'
   homepage 'https://www.realmacsoftware.com/rapidweaver/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: