### PR TITLE
Fix wrong checksum wondershare-video-converter-ultimate '5.7.2,735'

### DIFF
--- a/Casks/wondershare-video-converter-ultimate.rb
+++ b/Casks/wondershare-video-converter-ultimate.rb
@@ -1,6 +1,6 @@
 cask 'wondershare-video-converter-ultimate' do
   version '5.7.2,735'
-  sha256 'd8e5d2359d89d53f917d8722d9f9fb3e6c40d1d9fd44431b121d192b0fd404d6'
+  sha256 'a7b9e39bdb7022014a36f10b4257f78c4b52a6636988895cc6caa846d713d617'
 
   url "http://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full#{version.after_comma}.dmg"
   name 'Wondershare Video Converter Ultimate'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [x] I verified this change is legitimate [<sup>How do I do that?</sup>][version-checksum] and **am providing confirmation below**:
https://www.virustotal.com/#/file/a7b9e39bdb7022014a36f10b4257f78c4b52a6636988895cc6caa846d713d617/details

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256