### PR TITLE
Update ethereum-wallet to 0.9.2

### DIFF
--- a/Casks/ethereum-wallet.rb
+++ b/Casks/ethereum-wallet.rb
@@ -1,10 +1,10 @@
 cask 'ethereum-wallet' do
-  version '0.9.1'
-  sha256 '53023d0b3d2724ca2656b5a21c6c0516534906cfe62c69d3bef4439e59ca3040'
+  version '0.9.2'
+  sha256 '6d87f99ad8e53e5a1cbcaab19552ee042b17d1e297a3b025b1edf630b0a0b100'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Ethereum-Wallet-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: 'dcb48d1e593f132f3c46cfcf9488a4fb8ce4aaa0c74ab13805eb56e1a341259a'
+          checkpoint: '57df8c5cd893fad8ce1da4771e54bf9890f7fba40065428c10299c53e7652088'
   name 'Ethereum Wallet'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: