### PR TITLE
Update flightgear to 2017.3.1

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2017.2.1'
-  sha256 '117fb9d18681e52007895c876ab9864aaf99f5b7a7899928bc7e365de4f1b6d7'
+  version '2017.3.1'
+  sha256 '902100088b1f572be919660779160414c6eaa6b3cf196fcff9f416fa8f017f13'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: 'f3173cad3e18b44b9297ef200ea4d1ea9e171818af279e6fb834f5131d879574'
+          checkpoint: 'a89692e0882503af216e22ea381e20ce4ef7bfdd78fb3ee4f8b360ed634f4950'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -5,7 +5,7 @@ cask 'flightgear' do
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: 'a89692e0882503af216e22ea381e20ce4ef7bfdd78fb3ee4f8b360ed634f4950'
+          checkpoint: '0647d44d57b299e8f68e2157d01befc45138b97470eda127b7e72309607a8584'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: