### PR TITLE
Update textexpander to 6.2.3

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,11 +1,11 @@
 cask 'textexpander' do
-  version '6.2.2'
-  sha256 '669b1653659cdb2eb2907a1577313a53365a7f90579421f646c6f5366b74c9e3'
+  version '6.2.3'
+  sha256 '76ed5c10c970dcda5ee2b7b70bd4961d2db88812874457aaf9cb8b28417c10e5'
 
   # cdn.textexpander.com/mac was verified as official when first introduced to the cask
   url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"
   appcast "https://smilesoftware.com/appcast/TextExpander#{version.major}.xml",
-          checkpoint: 'f9de2c98be639250b79b9cc6d37d502b42b32e332dac8a3ed109d57b138aedd9'
+          checkpoint: '4225f92d3c5586165e76e69b35f5a4d70d0ff9e730be90bacfb5cb03bbc563a9'
   name 'TextExpander'
   homepage 'https://smilesoftware.com/TextExpander'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: