### PR TITLE
Update react-native-debugger (0.7.11)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.10'
-  sha256 '35b22528297b5ff8a2a3266d7679a9942938409f88c3781809fd5cc569d7c490'
+  version '0.7.11'
+  sha256 '54ab7583dc5cf316bc285a55143861a8290fb122dcd5ccf80eaa11a9e0e1ccc4'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: 'be66a2d99c185477c54552f622aadbe0651786613a7167832913bd21fe34145c'
+          checkpoint: 'e10c588774abead73288a9e437ff91bc08128afbe2f2f519294a0171bec6705c'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.