### PR TITLE
Update playmemories-home to version 3.5.00

### DIFF
--- a/Casks/playmemories-home.rb
+++ b/Casks/playmemories-home.rb
@@ -1,9 +1,9 @@
 cask 'playmemories-home' do
-  version '3.4.00'
-  sha256 'fca410865b2aed641bfbe2bb498d8225d7b651820767ce187e0fe446ca249de7'
+  version '3.5.00'
+  sha256 '3b3ab315fd203c64b07d00b82d8a6ae46a677ad3e604e955a42c4ce209d0ca93'
 
   # pmb.update.sony.net/PMH was verified as official when first introduced to the cask
-  url "http://pmb.update.sony.net/PMH/74jlw3pwMn/PMHOME_#{version.no_dots}DL.dmg"
+  url "http://pmb.update.sony.net/PMH/6XZpdMN1Ie/PMHOME_#{version.no_dots}DL.dmg"
   name 'PlayMemories Home'
   homepage 'https://support.d-imaging.sony.co.jp/www/disoft/int/download/playmemories-home/mac/en/'
 

--- a/Casks/playmemories-home.rb
+++ b/Casks/playmemories-home.rb
@@ -1,9 +1,9 @@
 cask 'playmemories-home' do
-  version '3.5.00'
+  version '3.5.00,6XZpdMN1Ie'
   sha256 '3b3ab315fd203c64b07d00b82d8a6ae46a677ad3e604e955a42c4ce209d0ca93'
 
   # pmb.update.sony.net/PMH was verified as official when first introduced to the cask
-  url "http://pmb.update.sony.net/PMH/6XZpdMN1Ie/PMHOME_#{version.no_dots}DL.dmg"
+  url "http://pmb.update.sony.net/PMH/#{version.after_comma}/PMHOME_#{version.before_comma.no_dots}DL.dmg"
   name 'PlayMemories Home'
   homepage 'https://support.d-imaging.sony.co.jp/www/disoft/int/download/playmemories-home/mac/en/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>][version-checksum] and **am providing confirmation below**:
