### PR TITLE
Update losslesscut to 1.8.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,10 +1,10 @@
 cask 'losslesscut' do
-  version '1.7.0'
-  sha256 '4bec87f6e63c003b889a714a2c2e01598a3614dd7779ff2544e5466d52cd8244'
+  version '1.8.0'
+  sha256 '16446cfbe44ebcdc769dd3ce72211a7054bdaf2e2b48ac35c727bd3940c049b9'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-darwin-x64.zip"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom',
-          checkpoint: 'c7a899db1ecbdc4e133c2f69253b6eeebbb632c1c5822b50aad27d7af6749210'
+          checkpoint: '36635a3858f53da649718b2f21c033c7124310e5d50823e862e2588fd2b7019c'
   name 'Loslesscut'
   homepage 'https://github.com/mifi/lossless-cut'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: