### PR TITLE
Update vuescan to 9.5.89

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.88'
-  sha256 'e71ee71d83aff50933b2cb5121e5d878fd305b7ad54606f0d24c318ff9090f50'
+  version '9.5.89'
+  sha256 '3fc9e1572c82c8f95c433ff33e9a3b3d89c06a47f36c6e774601c4613659958e'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '31fce8f00d3b42d08370beccff4f8131ecfc8e21f24c2dbb579badca9c6f1618'
+          checkpoint: '01ce8ee270c8a90e6d25fa2714b709c26e8f8e3ae04168cf90ae96fcfe42f640'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: