### PR TITLE
Update vnc-viewer to 6.17.731

### DIFF
--- a/Casks/vnc-viewer.rb
+++ b/Casks/vnc-viewer.rb
@@ -1,6 +1,6 @@
 cask 'vnc-viewer' do
-  version '6.1.1'
-  sha256 'a7a6a8aecc657509957f840ef76b614b67f4dddaf7f2fd7849974a360bc3b4c0'
+  version '6.17.731'
+  sha256 '53b70a8eb86c32906957d0c49693396d9e31f73ad99b631e3ece7590987da015'
 
   url "https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-#{version}-MacOSX-x86_64.dmg"
   name 'Real VNC Viewer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [x] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**:
Hash is correct, see:
https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-6.17.731-MacOSX-x86_64.dmg