### PR TITLE
Update flash-player-debugger to 27.0.0.170

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger' do
-  version '27.0.0.159'
-  sha256 '38e69d54e2ebdd0adfd345561ccb419ac529d592da0b25bbd8c2ad36fcc73201'
+  version '27.0.0.170'
+  sha256 '80011462b51969925a5999e1ce538e1315ad05b3a66a767b1aafe1a5939e8aeb'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',
-          checkpoint: 'f9cdc3e74103ce8f2bf46664475ec4ab55be96fe3bd71cc5b9a31d052ecb9eca'
+          checkpoint: 'dc42e381042fe881263b4462e00b306254e6defcc1faa54978364e2c8c14d182'
   name 'Adobe Flash Player projector content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: