### PR TITLE
Update flash-player-debugger-npapi to 27.0.0.170

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger-npapi' do
-  version '27.0.0.159'
-  sha256 '4c63abbf0250f5ed3c75031f2dbe4b771ee16eb882808c9bb4f794557e7b3005'
+  version '27.0.0.170'
+  sha256 '4befa1e9cd8e41bd7904592ca08f7e3e1bc3f157f1907eaa6f516ab707a6c30e'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: 'f9cdc3e74103ce8f2bf46664475ec4ab55be96fe3bd71cc5b9a31d052ecb9eca'
+          checkpoint: 'dc42e381042fe881263b4462e00b306254e6defcc1faa54978364e2c8c14d182'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: