### PR TITLE
Update navicat-premium to 12.0.15

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '12.0.14'
-  sha256 '368afc85f9412bf4683eedf0ae6336e1acc674e47531c413e54b816426b86afd'
+  version '12.0.15'
+  sha256 '60f9a1d21ab55bf22eee1bcf6a86e9f8754e998e5de6437e727ddfb0a119cace'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: