### PR TITLE
Update navicat-premium-essentials to 12.0.15

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '12.0.14'
-  sha256 '377464c230a2bb802cd08c4fa8df18f51633e5fac1ae654f252aa7c1ec6d2bbe'
+  version '12.0.15'
+  sha256 '4c7967abf3b14326796d5dfb5c0b6678633183e889f677d802f7f4fd0e0042e3'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   name 'Navicat Premium Essentials'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: