### PR TITLE
Update navicat-for-oracle to 12.0.15

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.14'
-  sha256 '392fa02858bef21c8deb65c947d8d80f53e37d0ee008552af2489dc72c73adf2'
+  version '12.0.15'
+  sha256 '51475f5711db126ff22c30abb89db1a4a8a59a92b5261714b79e869d693e1597'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
-  appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note#M',
-          checkpoint: 'a127175298b63f7b4266109feb0c131b04d6ddc4c17225319a7fb7c67c49c5a5'
+  appcast 'https://www.navicat.com/products/navicat-for-oracle-release-note',
+          checkpoint: 'a99e1fbc6fbf4e283183859812b6c4e31ef81598629930d049ddc267cde39ad2'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: