### PR TITLE
Update unity-download-assistant to 2017.2.0f3,46dda1414e51

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2017.1.1f1,5d30cf096e79'
-  sha256 '8e65fb669e0e72ad42ec958330a18126209c79b2cd6f79b99e94af1b3fedca13'
+  version '2017.2.0f3,46dda1414e51'
+  sha256 'b6ab2196d938b28e8e86739051f5cc9010c943fe318fbe50145a9b8d414838d2'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   name 'Unity'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: