### PR TITLE
Update unity-standard-assets to 2017.2.0f3,46dda1414e51

### DIFF
--- a/Casks/unity-standard-assets.rb
+++ b/Casks/unity-standard-assets.rb
@@ -1,6 +1,6 @@
 cask 'unity-standard-assets' do
-  version '2017.1.1f1,5d30cf096e79'
-  sha256 '988c57c6208930b69e5832e632bda6d11b04e66b8f64cc3bcb44b0283c800da2'
+  version '2017.2.0f3,46dda1414e51'
+  sha256 'cc4db99b7ccac84040e53478045cba3d8272f27528a927e0e563f7ee0395e0d6'
 
   url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacStandardAssetsInstaller/StandardAssets-#{version.before_comma}.pkg"
   name 'Unity Standard Assets'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: