### PR TITLE
Update riot to 0.12.7

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,10 +1,10 @@
 cask 'riot' do
-  version '0.12.4'
-  sha256 '4353d9c343574960404734de56f331a3a73d1e237eaeb88296acde2553635bc7'
+  version '0.12.7'
+  sha256 '905e165d94efd2eae0803f0e7fa972d88c43aa6a95cfd8f9e41d7b0e2d202003'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-web/releases.atom',
-          checkpoint: 'e26202132045f455c4f059952c32e8acb567d6d76d26cdae606733bf0c408067'
+          checkpoint: '98b00a9a54ef0854ae165d3c597a407eccbaa2f36da3dc42b5c3f363c6842b4c'
   name 'Riot'
   homepage 'https://about.riot.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.