### PR TITLE
Add the official Pocket Casts.app

### DIFF
--- a/Casks/mortenjust-pocketcasts.rb
+++ b/Casks/mortenjust-pocketcasts.rb
@@ -1,10 +1,10 @@
-cask 'pocketcasts' do
+cask 'mortenjust-pocketcasts' do
   version '1.30'
   sha256 '9fee8fec0b5c5c3205a24c6b127064077dd6792ddf5d811b4df2dc84a34020da'
 
   url "https://github.com/mortenjust/PocketCastsOSX/releases/download/#{version}/PocketCasts.zip"
   appcast 'https://github.com/mortenjust/PocketCastsOSX/releases.atom',
-          checkpoint: '503438969aa8948af77fdcf08d2ea57535301c837e4690413679f9c652015212'
+          checkpoint: '671af329c2c010938ca567636af9fd5e9fdd83ab9dcab3b46be9792524e6dfbf'
   name 'Pocket Casts for Mac'
   homepage 'https://github.com/mortenjust/PocketCastsOSX'
 

--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,0 +1,10 @@
+cask 'pocket-casts' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
+  name 'Pocket Casts'
+  homepage 'https://play.pocketcasts.com/'
+
+  app 'Pocket Casts.app'
+end

--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,8 +1,10 @@
 cask 'pocket-casts' do
-  version :latest
-  sha256 :no_check
+  version '0.9.3'
+  sha256 '4af0278884064bad621f242699cda3ba0f0c00e57b855f1b63063db6ac267e80'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
+  appcast 'https://static2.pocketcasts.com/mac/appcast.xml',
+          checkpoint: '00117ca16ba52210f3f4d51fb9f06f13ffe9ca3949ef1722e2d6f1a731340d77'
   name 'Pocket Casts'
   homepage 'https://play.pocketcasts.com/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

The download URL's hostname is different from the home-page's.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

**Important note**: [There exists a Cask for the unofficial Pocket Casts app](https://github.com/caskroom/homebrew-cask/blob/master/Casks/pocketcasts.rb). Shift Jelly just released an official app (currently beta) recently. (https://blog.shiftyjelly.com/2017/09/25/web-player-2-0-beta/)

Somehow we need to differentiate the `pocketcasts` from `pocket-casts` as they are too similar & it's not clear which one is official based on name alone.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
