### PR TITLE
token_reference.md: remove desktop

### DIFF
--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -43,6 +43,8 @@ Details of software names and brands will inevitably be lost in the conversion t
 
 * Remove from the end: “Launcher”, “Quick Launcher”.
 
+* Remove from the end: strings such as “Desktop”, “for Desktop”.
+
 * Remove from the end: strings such as “Mac”, “for Mac”, “for OS X”, “macOS”, “for macOS”. These terms are generally added to ported software such as “MAME OS X.app”. Exception: when the software is not a port, and “Mac” is an inseparable part of the name, without which the name would be inherently nonsensical, as in [PlayOnMac.app](../../Casks/playonmac.rb).
 
 * Remove from the end: hardware designations such as “for x86”, “32-bit”, “ppc”.


### PR DESCRIPTION
Ping @caskroom/maintainers.

HBC only works in macOS, *every app* is “Desktop”.

`brew cask search desktop (not all are relevant, but most):

- acquia-dev-desktop
- authy-desktop
- bimedesktop
- chrome-remote-desktop-host
- colwiz-desktop
- desktop-log
- desktoputility
- freeswitch-desktop
- github-desktop
- github-desktop-beta
- google-play-music-desktop-player
- isyncr-desktop
- jump-desktop
- lytro-desktop
- macupdate-desktop
- mediafire-desktop
- mendeley-desktop
- messenger-for-desktop
- microsoft-remote-desktop-beta
- myphonedesktop
- parallels-desktop
- parallels-desktop11
- parallels-desktop12
- pb-for-desktop
- polycom-realpresence-desktop
- printer-pro-desktop
- qdesktop
- qobuz-desktop
- quickbooks-desktop
- quickbooks-desktop2014
- quickbooks-desktop2015
- readytalk-desktop
- remote-desktop-manager
- sejda-pdf-desktop
- slingplayer-desktop
- telegram-desktop
- telegram-desktop-dev
- toggldesktop
- toggldesktop-beta
- toggldesktop-dev
- transporter-desktop
- veertu-desktop
- vorlon-desktop
- whatsdesktop