### PR TITLE
Update privatetunnel to 2.8

### DIFF
--- a/Casks/privatetunnel.rb
+++ b/Casks/privatetunnel.rb
@@ -1,6 +1,6 @@
 cask 'privatetunnel' do
   version '2.8'
-  sha256 '0ae1175dabe078a6776d483c53b760ae599099d00f954de724581ff94718a9b4'
+  sha256 '924c19ecbc7794e5ca09a79be21e04a8b7733ecba57ff0d048335218371c56c5'
 
   # swupdate.openvpn.org/privatetunnel was verified as official when first introduced to the cask
   url "https://swupdate.openvpn.org/privatetunnel/client/privatetunnel-mac-#{version}.dmg"


### PR DESCRIPTION
- `brew cask audit --download {{cask_file}}` is error-free.
- `brew cask style --fix {{cask_file}}` left no offenses.

To the best of my knowledge, this change looks legitimate

``` sh
# Downloaded from http://swupdate.openvpn.net/privatetunnel/client/privatetunnel-mac-2.8.dmg
$ shasum -a 256 /tmp/privatetunnel-mac-2.8.dmg
924c19ecbc7794e5ca09a79be21e04a8b7733ecba57ff0d048335218371c56c5  /tmp/privatetunnel-mac-2.8.dmg
```