### PR TITLE
Update gitkraken to 3.1.2

### DIFF
--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -1,10 +1,10 @@
 cask 'gitkraken' do
-  version '3.1.1'
-  sha256 'de22c6ba4186b18feac3600f560efd0174c8d791a965f0c755c72669525f22bd'
+  version '3.1.2'
+  sha256 'aa07a214252487f1bc251c1d44534153d37d290b8135b6d016d0868f7a94e4b4'
 
   url "https://release.gitkraken.com/darwin/v#{version}.zip"
   appcast 'https://release.gitkraken.com/darwin/RELEASES',
-          checkpoint: '4fc73da44574c4651ee59fc54195182d5f07f49c6cd92ed1fd21389fd6cf86c6'
+          checkpoint: 'b1df3bcfb2ac13044246a91ea5cb2da1a70d79e4ddf24c03bc081b1aeef0e669'
   name 'GitKraken'
   homepage 'https://www.gitkraken.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: