### PR TITLE
Update mountain-duck to 2.0.3.8407

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '2.0.2.8111'
-  sha256 '7efcc1adb305434f4275e7601066feb16ad44a12df7a0dfeb2a9837da6c2cce1'
+  version '2.0.3.8407'
+  sha256 '61b6ebc9282436b06ca7d34a74f57ef1e463360697b743532faeff76b031b243'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: 'dc6882a9aa9df8db3047cff716001d4126e826c02845c98132d8efb8243c3a7f'
+          checkpoint: 'e793cad7647fa061fa0189d3db3be8244694c5f73dff6e50f12dd893d0140188'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: