### PR TITLE
Update hammerspoon to 0.9.57

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -1,11 +1,11 @@
 cask 'hammerspoon' do
-  version '0.9.56'
-  sha256 'bd3a5eed4f8e82f707b8555d008f19f090882709e19146ea755e1409881d0e6b'
+  version '0.9.57'
+  sha256 '33844074066446e98e97c10deb68e3934126b2e7ce740bc925ec58060ba59b92'
 
   # github.com/Hammerspoon/hammerspoon was verified as official when first introduced to the cask
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip"
   appcast 'https://github.com/Hammerspoon/hammerspoon/releases.atom',
-          checkpoint: '4d51d09c7123b46a47b364dfa3951e88d1b8564bb260396b6aeb65c0fa877c40'
+          checkpoint: '4bb2c2969a7d0497a425de893184074b03ea099bdab0600eed7b91eac9fcb1dc'
   name 'Hammerspoon'
   homepage 'http://www.hammerspoon.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}