### PR TITLE
Update studio-3t to 5.5.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.5.0'
-  sha256 '613745aec2500aae6eef72e80196b615fe2fb001844ff1776852b6bf667c82b2'
+  version '5.5.1'
+  sha256 '6304de674ff1af793028fd0b8c0aedd910bb3dfb9a4ded42dec6a545c650ad56'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '1cd11a3f42735dea49c6b4a1c91d09a310ef6789745df4249acfd57ac2658002'
+          checkpoint: '6d2829db05a17f0d61215d945003b7ad262b665101e2258bfa2e108b59ccea50'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: