### PR TITLE
Improve google-drive-file-stream zap stanza

### DIFF
--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -20,6 +20,7 @@ cask 'google-drive-file-stream' do
 
   zap delete: '~/Library/Caches/com.google.drivefs',
       trash:  [
+                '~/Library/Application Support/Google/DriveFS',
                 '~/Library/Preferences/Google Drive File Stream Helper.plist',
                 '~/Library/Preferences/com.google.drivefs.plist',
               ]


### PR DESCRIPTION
Google Drive File Stream creates a `~/Library/Application Support/Google/DriveFS` directory that is not yet handled by the zap stanza. This PR trashes this directory in zap, similar to what is done in `google-backup-and-sync.rb`and `google-photos-backup-and-sync.rb` and as suggested [here](https://productforums.google.com/forum/#!topic/google-education/0eC4he6E4Mg).

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
