### PR TITLE
Update java-jdk-javadoc to 9.0.1,11

### DIFF
--- a/Casks/java-jdk-javadoc.rb
+++ b/Casks/java-jdk-javadoc.rb
@@ -1,8 +1,8 @@
 cask 'java-jdk-javadoc' do
-  version '9,181'
-  sha256 '54d65f4b8f4192a51a5d90816a2e118da45377be21091351d05389b5a2cfa127'
+  version '9.0.1,11'
+  sha256 '79c375220326cfcd38c6ae15bce6e99ae866c7e477fb48fdf9221fe5742b786c'
 
-  url "http://download.oracle.com/otn-pub/java/jdk/#{version.major}+#{version.after_comma}/jdk-#{version.major}_doc-all.zip",
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
@@ -10,7 +10,7 @@ cask 'java-jdk-javadoc' do
   homepage "http://www.oracle.com/technetwork/java/javase/documentation/jdk#{version.major}-doc-downloads-3850606.html"
 
   postflight do
-    `/usr/libexec/java_home -v #{version.major} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
+    `/usr/libexec/java_home -v #{version.before_comma} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
       system_command '/bin/cp',
                      args: ['-rp', "#{staged_path}/docs", "#{path}/"],
                      sudo: true
@@ -18,7 +18,7 @@ cask 'java-jdk-javadoc' do
   end
 
   uninstall_postflight do
-    `/usr/libexec/java_home -v #{version.major} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
+    `/usr/libexec/java_home -v #{version.before_comma} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|
       system_command '/bin/rm',
                      args: ['-rf', "#{path}/docs"],
                      sudo: true


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.