### PR TITLE
Update iina to 0.0.14-build47

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -1,11 +1,11 @@
 cask 'iina' do
-  version '0.0.14'
-  sha256 '0b0de3238fde6cef6afd82993eb08ea6fa567c786f6fab67ab3346b2e2c7fc3b'
+  version '0.0.14-build47'
+  sha256 'bb43bdf91cc62ebbe121f210904e4d3bb9502e69dd4f8e6da1fa871fd151eeff'
 
   # dl-portal.iina.io was verified as official when first introduced to the cask
   url "https://dl-portal.iina.io/IINA.v#{version}.dmg"
   appcast 'https://www.iina.io/appcast.xml',
-          checkpoint: '9e3447a8bd8b7e27c9de094e0309fad4fa38eed8e1f41a868d07790b9d01b1f1'
+          checkpoint: '982def998324872ea80a1fedf9ee15cfc16d2b4a4e79e0dfcffbd95590c2152b'
   name 'IINA'
   homepage 'https://lhc70000.github.io/iina/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.