### PR TITLE
Update gog-galaxy to 1.2.25.13

### DIFF
--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -1,6 +1,6 @@
 cask 'gog-galaxy' do
-  version '1.2.24.87'
-  sha256 'b10f79cb071cd32e6c86c99d9bbf51ef907b442da5bc837fe42c01a6d6326d2c'
+  version '1.2.25.13'
+  sha256 '12c7faec5f6438656aab39b4560aaef98384ef63ed1ce2c599dfade6552bd3a2'
 
   url "https://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
   name 'GOG Galaxy Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.