### PR TITLE
Update totalfinder to version 1.10.2

### DIFF
--- a/Casks/totalfinder.rb
+++ b/Casks/totalfinder.rb
@@ -1,6 +1,11 @@
 cask 'totalfinder' do
-  version '1.9.3'
-  sha256 'cde59340d0bfcbca36208a1b0ea0d811cf54355b42220214586477514039b2e2'
+  if MacOS.version <= :yosemite
+  	version '1.9.3'
+  	sha256 'cde59340d0bfcbca36208a1b0ea0d811cf54355b42220214586477514039b2e2'
+  else
+    version '1.10.2'
+    sha256 'c1809a245dd899cb51c54f0bc5b93492eb9611451ba5df9ce0c1bf22544ecf87'
+  end
 
   url "http://downloads.binaryage.com/TotalFinder-#{version}.dmg"
   name 'TotalFinder'

--- a/Casks/totalfinder.rb
+++ b/Casks/totalfinder.rb
@@ -1,7 +1,7 @@
 cask 'totalfinder' do
   if MacOS.version <= :yosemite
-  	version '1.9.3'
-  	sha256 'cde59340d0bfcbca36208a1b0ea0d811cf54355b42220214586477514039b2e2'
+    version '1.9.3'
+    sha256 'cde59340d0bfcbca36208a1b0ea0d811cf54355b42220214586477514039b2e2'
   else
     version '1.10.2'
     sha256 'c1809a245dd899cb51c54f0bc5b93492eb9611451ba5df9ce0c1bf22544ecf87'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
