### PR TITLE
Update framer to 9691

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '9840'
-  sha256 '3b781c56d0639fe2f398170780be900ec131da79196e81dd30bb495a02fc8b1d'
+  version '9691'
+  sha256 'b74b764686414ea7efad7b96225e75d7e3e513fd395ab0ccf0aac95f662b977b'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '4e882f5ba475c44bf5957e71b910c00fdf1462baf44edaed5cfc074fd805c9b3'
+          checkpoint: '5bb851ffb369f7b592182f67c25056bd0fd841f35ff24769493d9122100196fc'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.