### PR TITLE
Update trash-it to 7.0.1

### DIFF
--- a/Casks/trash-it.rb
+++ b/Casks/trash-it.rb
@@ -1,15 +1,10 @@
 cask 'trash-it' do
-  if MacOS.version <= :snow_leopard
-    version '5.2'
-    sha256 '2428fcf10f8641488e1a43f8d64dfa7256129aab9813c1f841c72bf75f11c821'
-    url "http://nonamescriptware.com/wp-content/uploads/TrashIt#{version.no_dots}.zip"
-    app "TrashIt #{version}/Drag content to Desktop/Trash It!.app"
-  else
-    version :latest
-    sha256 :no_check
-    url 'http://nonamescriptware.com/wp-content/uploads/Trashit.zip'
-    app "Trash It! #{version}/Drag content to Desktop/Trash It!.app"
-  end
+  version '7.0.1'
+  sha256 'aaffb0ab43a163178b9b6d230eef9ed5ee096461163ee001cd2c98e6ede43bc5'
+
+  url 'http://nonamescriptware.com/wp-content/uploads/Trashit.zip'
   name 'Trash It!'
   homepage 'http://nonamescriptware.com/'
+
+  app "Trash It! #{version}/Drag app to Desktop/Trash It! #{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #39781.