### PR TITLE
Fix breakage of jsl 0.3.0 install.

### DIFF
--- a/Casks/jsl.rb
+++ b/Casks/jsl.rb
@@ -8,7 +8,7 @@ cask 'jsl' do
   name 'JavaScript Lint'
   homepage 'http://www.javascriptlint.com/'
 
-  binary 'jsl'
+  binary "jsl-#{version}-mac/jsl"
 
   caveats <<-EOS.undent
     Test and configuration files for JavaScript Lint are available in


### PR DESCRIPTION
Reverting #29176, which breaks install of jsl as follows:

```
$ brew cask install jsl
...
==> Downloading http://www.javascriptlint.com/download/jsl-0.3.0-mac.tar.gz
==> Installing Cask jsl
Error: It seems the symlink source '/usr/local/Caskroom/jsl/0.3.0/jsl' is not there.
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
