### PR TITLE
Update docker-toolbox to 17.10.0-ce

### DIFF
--- a/Casks/docker-toolbox.rb
+++ b/Casks/docker-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'docker-toolbox' do
-  version '17.06.2-ce'
-  sha256 '8cb8d05869124d80788a8163ae124cffea6bc05aa69596f0dbe85edc4b88f700'
+  version '17.10.0-ce'
+  sha256 '6a69ff2a8d0318cb14fe37c6b5c084e18b64d40430ffd8f54889ed8d2eed6e56'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"
   appcast 'https://github.com/docker/toolbox/releases.atom',
-          checkpoint: '45252ce7f240adb6f1df6e249367ec8cfe83c808ec6f01e960c40a9567e00ec5'
+          checkpoint: '9df417105101a43ecddaa0f0d2bacc482a5974e93d86d4d3d51d915b284dfdf7'
   name 'Docker Toolbox'
   homepage 'https://www.docker.com/products/docker-toolbox'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.