### PR TITLE
Update alfred to 3.5.1_883

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -1,6 +1,6 @@
 cask 'alfred' do
-  version '3.5_876'
-  sha256 'bf914d8228111c962ea689652b5daefdc12f4a68a0ba69baaf8d42a0b54fab12'
+  version '3.5.1_883'
+  sha256 '782ac85d76500f6b2968ebd2dda820331ba0567e509194799b0eaede2138e204'
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.dmg"
   name 'Alfred'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.