### PR TITLE
Update qutebrowser to 1.0.2

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,11 +1,11 @@
 cask 'qutebrowser' do
-  version '1.0.1'
-  sha256 '6f012524d1d66d1201a024b4971dca5fe8f93693617670dba081b0e467a2f779'
+  version '1.0.2'
+  sha256 'f24491e725d089c66a870c321c89f6b228bc8fa0d30adc885d0b2d9a387dab87'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
-          checkpoint: '750270f95b68b1b5f699d03250d7eea3be544ecf21686d0526734465aa4e8c87'
+          checkpoint: '84277963356ff7826c4a03cf358ae22231b1cbcd995beba14814a13876b34808'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.