### PR TITLE
Update wire to 3.1.2822

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,11 +1,11 @@
 cask 'wire' do
-  version '3.0.2814'
-  sha256 'f4a000ce3a0bf73deef0f480a7219ca08832504ad08dd65bede3fcab0da1e386'
+  version '3.1.2822'
+  sha256 '969feb5757b956583d6da33445b840e51fa616924208eb941cb6e1610e0d90c4'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
   url "https://github.com/wireapp/wire-desktop/releases/download/release%2F#{version}/wire-#{version}.pkg"
   appcast 'https://github.com/wireapp/wire-desktop/releases.atom',
-          checkpoint: 'a9da6b1ca1c36852f49529338ac583d2da3b5ee090bc0577fc5e0da42b3222d2'
+          checkpoint: 'ba06d3cc4687d5c1c2229eb2c5b14dd485e51a338ec267636553ce304581be6a'
   name 'Wire'
   homepage 'https://wire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.