### PR TITLE
Update openoffice to 4.1.4

### DIFF
--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -1,35 +1,35 @@
 cask 'openoffice' do
-  version '4.1.3'
+  version '4.1.4'
 
   language 'en', default: true do
-    sha256 '2eac3c6630ddbd6be771337001c8f877c2ff811620042e6071ef396788d480d8'
+    sha256 'ec5f1b8ed570736a58fec93d6b6e52065e3e6662fe863716e2a5dbe166d3c1f4'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'a302fdff1deb65cc443a46884c37b3da5e29ae5679f9e36db038d0e0b9b40a3f'
+    sha256 '5b3e7eeba133186e382e79fdf2c36b8833af5463d4f5cb89cc01b987bb6a2de4'
     'fr'
   end
 
   language 'gl' do
-    sha256 'f1db7dd745d7ed3b8ea01e459d0e2506e6e2fe39f0c498bdecdedb5f738260ec'
+    sha256 'b27988df0ceea64e2a1bde8e148dcd0dd9f322979320778027c63270d2967a0b'
     'gl'
   end
 
   language 'pt-BR' do
-    sha256 '31b6697151561d5d53134439e4bc18682626fe79a4d17cb8d309b4b02af84e45'
+    sha256 '54effa845b73388e814df9936b9960fd2ab8d9e80c087d8c10ee92c08492448c'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '3e53f8f842945e6a191e8863824f7d4a4cea7065bda5d7e88cf2c63522506380'
+    sha256 '39ce75f2dbf1df1d5b10163921d492f5bad36291dedac963cc8e170df086c77f'
     'pt'
   end
 
   # sourceforge.net/openofficeorg.mirror was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_#{language}.dmg"
   appcast 'https://sourceforge.net/projects/openofficeorg.mirror/rss',
-          checkpoint: 'd8e2de0c68d131c8548113c6f46d062af1721f8501aad420be84640cc704c504'
+          checkpoint: '5af9e638312f0728a6ada93777c209b1d660f5e582b2ea2374febcc7ad829756'
   name 'Apache OpenOffice'
   homepage 'https://www.openoffice.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.