### PR TITLE
Update opera to 48.0.2685.50

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '48.0.2685.39'
-  sha256 '5d125cf7f32cb10547332bf903924a210a2f67b80a0ae4dc19899efbcc580076'
+  version '48.0.2685.50'
+  sha256 '630003b30a435fa0d7ddc30d1610fb08d630c2c75ae60c2bbe03ff535d830a51'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.