### PR TITLE
Update amazon-chime to 4.8.5921

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,10 +1,10 @@
 cask 'amazon-chime' do
-  version '4.7.5885'
-  sha256 '840ae712f711bb15afe6925ca2781252400448b2097bb8e6ebdb128ad11906fa'
+  version '4.8.5921'
+  sha256 'aabdbe8ce599c082ece67b6e11d1403fcb74b715c8406ad5ecd7a00d389c6d8e'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast',
-          checkpoint: '59db08b9c0e458c72419f79790da24b1c9d09ab2e54da6983f10dd536b94f825'
+          checkpoint: '3f47c425bd3dfd32455697e24bf64f374e19fc59572a74591b2696ff44db2802'
   name 'Amazon Chime'
   homepage 'https://chime.aws/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: