### PR TITLE
Update qldds to 1.32

### DIFF
--- a/Casks/qldds.rb
+++ b/Casks/qldds.rb
@@ -1,10 +1,10 @@
 cask 'qldds' do
-  version '1.31'
-  sha256 'f2528c7c0dde9378ab8ba76d164161560a3c6170cd036a165c1231b6579962bc'
+  version '1.32'
+  sha256 '790e28919fe353834a85d3418bfd91583e593fe1aacf556e0481215e449568a8'
 
   url "https://github.com/Marginal/QLdds/releases/download/rel-#{version.no_dots}/QLdds_#{version.no_dots}.pkg"
   appcast 'https://github.com/Marginal/QLdds/releases.atom',
-          checkpoint: '181e68ea01116ea45693afbe33962a6b8a453c6e2804c4ab4a1ece9b2f23253b'
+          checkpoint: 'e3b021c381331a745d5192f8a406093bbbd06643bb6d6341ccb35c922fefcda6'
   name 'QuickLook DDS'
   homepage 'https://github.com/Marginal/QLdds'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.