### PR TITLE
Update fantastical to 2.4.3

### DIFF
--- a/Casks/fantastical.rb
+++ b/Casks/fantastical.rb
@@ -1,16 +1,19 @@
 cask 'fantastical' do
-  version '2.4.2'
-  sha256 'c885cae9e546cf0d6349ae1496b0d18e1405c78cbd2a7b03c1a1b6156ac2bb13'
+  version '2.4.3'
+  sha256 '48c9113bb545096815e2a96aabd9f958288d000435a3991409aeb3b627964c1c'
 
   url "http://cdn.flexibits.com/Fantastical_#{version}.zip"
-  appcast 'https://flexibits.com/fantastical/appcast2.php',
-          checkpoint: 'e34a6efab9a7bbeb8cccb4a73dbc00ded20bf937a0ced86122831e9ab39332bc'
+  appcast "https://flexibits.com/fantastical/appcast#{version.major}.php",
+          checkpoint: 'd0bb699231574c1b414bdd108026c7a86b2cd46fa5b00002c58e9b05103b5470'
   name 'Fantastical'
   homepage 'https://flexibits.com/fantastical'
 
   auto_updates true
 
   app "Fantastical #{version.major}.app"
+
+  uninstall launchctl: "com.flexibits.fantastical#{version.major}.mac.launcher",
+            quit:      "com.flexibits.fantastical#{version.major}.mac"
 
   zap trash: '~/Library/Preferences/com.flexibits.fantastical.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.