### PR TITLE
Update studio-3t to 5.6.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.5.1'
-  sha256 '6304de674ff1af793028fd0b8c0aedd910bb3dfb9a4ded42dec6a545c650ad56'
+  version '5.6.1'
+  sha256 '8de6578e8c130d9ef8f06b151f1ea9cab69b3f43319fdb1a74e69919c7b4c090'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '6d2829db05a17f0d61215d945003b7ad262b665101e2258bfa2e108b59ccea50'
+          checkpoint: 'bdf23d7f5edd55867999b553b5f42fceec4bd21d86b4aeb1e74d0ff26aa024f4'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}