### PR TITLE
Update wechatwebdevtools to 1.0.1,171019

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.0.1,170913'
-  sha256 '9bb46d15ec1ae4014f434ebdb39b7e67fd31dc0af5e0ed72aaf5bc479daded06'
+  version '1.0.1,171019'
+  sha256 '80554a42badb14ccc7c66cb5ecca5e59f680eddf35105b3700b30d81dde2bcf5'
 
   url "https://dldir1.qq.com/WechatWebDev/1.0.0/20#{version.after_comma}/wechat_devtools_#{version.major_minor}#{version.patch}.#{version.after_comma}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.