### PR TITLE
Update mojibar to 2.6.2

### DIFF
--- a/Casks/mojibar.rb
+++ b/Casks/mojibar.rb
@@ -1,10 +1,10 @@
 cask 'mojibar' do
-  version '2.6.1'
-  sha256 '96d3ede16691391a1772ce65f7c7fe69b1bc147a76b7f4939e360a25e5d988d8'
+  version '2.6.2'
+  sha256 '28e9811bb9a43c15f7a7ba9100e86cc5f45e4f53c093cd9f08972fda8694b363'
 
   url "https://github.com/muan/mojibar/releases/download/#{version}/mojibar.zip"
   appcast 'https://github.com/muan/mojibar/releases.atom',
-          checkpoint: '60418016208b618c82bd6fffbb7390a6a9b136a2b7e1e96c78f68d7ceac7bca2'
+          checkpoint: '8a9b3dd42d021da9443792f418635c9c5cbea6514bdf75c63d8638a765e8b592'
   name 'Mojibar'
   homepage 'https://github.com/muan/mojibar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.