### PR TITLE
Update teamsql to 2.2.132

### DIFF
--- a/Casks/teamsql.rb
+++ b/Casks/teamsql.rb
@@ -1,11 +1,11 @@
 cask 'teamsql' do
-  version '2.1.127'
-  sha256 'c42088adcbeb42973248f6f54430172adca477386a3db72dc3bb1f1d2fabc298'
+  version '2.2.132'
+  sha256 '487d100881c89d5778f6eb8389a074ccb273afb09670add44fe20af6de83b001'
 
   # dlpuop5av9e02.cloudfront.net/osx/stable was verified as official when first introduced to the cask
   url "https://dlpuop5av9e02.cloudfront.net/osx/stable/#{version}/TeamSQL-#{version}.dmg"
   appcast 'https://teamsql.io/whats-new',
-          checkpoint: 'df6f5a929bda1168b146a0f1896e14985b75a95d62c59a4ff12abb195db60f93'
+          checkpoint: 'ca593ee9b4645934c2f877a012cea6cf72da6f62e5a47b15e17ebef6d5852e51'
   name 'TeamSQL'
   homepage 'https://teamsql.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.