### PR TITLE
Update gtkwave to 3.3.86

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.85'
-  sha256 'a553e6d463b466a00a63842bf4a06bf0c0546e73539f3c023c1f1961729cd7b3'
+  version '3.3.86'
+  sha256 'feee8e20efe4048f8a4ac6e77948b95ac59b860ec6fe4aac560da566864f1f87'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: 'e322b1d3d5717bc14c834647783817a9d418a837e17175f73afd8d96295efc6c'
+          checkpoint: 'd51fe0e06f25569c0d9fbabb5c89374da0dcd77f8c7a092ae47164f5ac2fd093'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.