### PR TITLE
Update hopper-disassembler to 4.3.0

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.2.21'
-  sha256 'bb7b0536ef72675988bc1572c55dae129b595413fe72eb91d199cfe9fb0b4371'
+  version '4.3.0'
+  sha256 '3e760d15089adff13c0ee978fbc4043ae1581cd16e2540ac6047064b5f11ad04'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: '38559bdbceafdd8fd5da974445e542f4feb790258fc589777ca7211a6ae70fbb'
+          checkpoint: '9e06d1742a729e34c0772303919625cd1fb5e57c1b1d315f7738e961b2911fe2'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.