### PR TITLE
Update zotero to 5.0.23

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.4'
-  sha256 'a504a86ea1921260b905c5da54917bb34c3c0df97933add8214fe3a334616bf9'
+  version '5.0.23'
+  sha256 '605e83f2465b7793724d30d40e89f862e633335cbf56d4ebfeb7d67eea32bfd6'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: 'f447e76548240b1aa2cdf29b0dcc9bb1600924705870b661225408b756c07b69'
+          checkpoint: '8ce5e1e5a94cc103d8c4f0df76794074215e51a4dadd64deab45b647f35b13a9'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.