### PR TITLE
Update parallels-virtualization-sdk to 13.1.1-43120

### DIFF
--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -1,6 +1,6 @@
 cask 'parallels-virtualization-sdk' do
-  version '13.1.0-43108'
-  sha256 '18b63c6b9cb7f26c3c812c54d8d3a19571b13b6da3b51189a25771c14e6e2dac'
+  version '13.1.1-43120'
+  sha256 '22d69e191be8611ab1dcaf9cb4a660301e855eec05abb7d7ae906b2f96c0c774'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsVirtualizationSDK-#{version}-mac.dmg"
   name 'Parallels Virtualization SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.