### PR TITLE
Update macvim to 8.0.140

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,10 +1,10 @@
 cask 'macvim' do
-  version '8.0.139'
-  sha256 '4418b153068dd3b8dea66d9eabbbaf1be990ae654869b9f609f04006e55a27fe'
+  version '8.0.140'
+  sha256 '67ffcce194211338e685054490b88198989a4168e2870f60500c06650a48ec85'
 
   url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.patch}/MacVim.dmg"
   appcast 'https://github.com/macvim-dev/macvim/releases.atom',
-          checkpoint: '8f8214ccdf583fcc39b94137ba497c1303e2a511806338ce65223b264a485f26'
+          checkpoint: 'cf549cfac6c25d731b87d50b620752d7017cf27a473b4f0eb3cb96f4d2a43b45'
   name 'MacVim'
   homepage 'https://github.com/macvim-dev/macvim'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.