### PR TITLE
Update graphicconverter to 10.5.1,2894

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,11 +1,11 @@
 cask 'graphicconverter' do
-  version '10.5,2872'
-  sha256 '342ff0785a1bf875b827b1262015cce42d16693e1917ffdef41334cbf4be3a1e'
+  version '10.5.1,2894'
+  sha256 'fae4fdc950167ecda11cc7319edc0bc71df6daf63f55b6148929ea7f215c351a'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
   appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml",
-          checkpoint: '95af0a7b6f48146ff2db7a33560aa7f7c2ebe20c45c569c99169b7a5b2ddcc47'
+          checkpoint: 'cc7683df2adfaf3714453a6d689513b0e6f59f52017e166996bd244c018eff70'
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.