### PR TITLE
Update cmdtap to 1.9.4

### DIFF
--- a/Casks/cmdtap.rb
+++ b/Casks/cmdtap.rb
@@ -1,6 +1,6 @@
 cask 'cmdtap' do
-  version '1.9.3'
-  sha256 '9813a68ca99dd1ed060487f5a33b03324388fc245c3cc42e0d5baae4bdc77ec6'
+  version '1.9.4'
+  sha256 '7e31179f044f3a834ea51daf250ad5085d6c8ea4bbabb8c1b193cff103d3f5ea'
 
   url "http://www.yingdev.com/Content/Projects/CmdTap/Release/#{version}/CmdTap.zip"
   name 'CmdTap'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.