### PR TITLE
Update tankix to 5847

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '5650'
-  sha256 'e84f8ea2b167ca213fb6127a4f086b0b203b98a1e3475cdc4d012236c1f923a6'
+  version '5847'
+  sha256 '748232a830bf9cd2dc362f2bceb20f7b8255ccdad64c3c9cc2164f7b3c509d14'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.