### PR TITLE
Add caveat to Nylas Mail

### DIFF
--- a/Casks/nylas-mail.rb
+++ b/Casks/nylas-mail.rb
@@ -28,4 +28,8 @@ cask 'nylas-mail' do
                 '~/Library/Preferences/com.nylas.nylas-mail.plist',
                 '~/.nylas-mail',
               ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Nylas Mail is discontinued.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name.