### PR TITLE
Update sqlectron to 1.27.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.26.0'
-  sha256 '2bf1f80f52f4523618b09e9d0c4ef3bf2995afeefbd5d67c1cf012589c80f440'
+  version '1.27.0'
+  sha256 '1088bf9d689d5d703f696770a462fd1d9cd05182219fe8b44e27986918d88891'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: '8f6025f9d2ab79728bb94ced4f595ec27eeddfe1a1e16d9dc1e5f680d14e3e5f'
+          checkpoint: 'ec2abdb82dcecf733e960da80b3e88a3d37af1f070d6bc5ab3ae40609eb771b1'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.