### PR TITLE
Update tla-plus-toolbox to 1.5.4

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'tla-plus-toolbox' do
-  version '1.5.3'
-  sha256 'a6cb45ec112930a208d63fe31f0f42f45e07c4bbdf977ffc9ef656269e9eb1d5'
+  version '1.5.4'
+  sha256 '33b122e20b4b6474a2b4de6a8634ce5b090660f363bdde2e7990bd75f4366c63'
 
   # github.com/tlaplus/tlaplus/releases/download was verified as official when first introduced to the cask
   url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/tlaplus/tlaplus/releases.atom',
-          checkpoint: '63d6d8ff6410ea03083cd1ca9bc12668613fb43ae9935d6a2c89ba086e35f1c4'
+          checkpoint: '189b5da1be2bfb55c188c83f42953aba71eb346895f09881ea93f35c02872065'
   name 'TLA+ Toolbox'
   homepage 'https://lamport.azurewebsites.net/tla/toolbox.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
