### PR TITLE
Update station to 1.0.5

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.0.4'
-  sha256 'a27192f678bde5f5c63256daffef71e1be0b826ed0af50a684f4a9a393060b85'
+  version '1.0.5'
+  sha256 '5efeb8a88a6e3ed18ea2f8e8341d20fbeaf312ed22693e160b9dc3fd15525e45'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '8d5079c463f3b837cf971290c7e42b81e80f14d0481b1de1a2524fc1ff4f0588'
+          checkpoint: '0608fa00c895bea3a8c2ed357ce9fecda735d74347fcb477f595383f741b412b'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.