### PR TITLE
Update synergy 1.8.8,25a8cb2 appcast

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -3,8 +3,8 @@ cask 'synergy' do
   sha256 'b09d8ffdb47ecde761e06e9beea672ad4b6999e09104fa9239ae30ae0f69b9c2'
 
   url "https://binaries.symless.com/v#{version.before_comma}/synergy-v#{version.before_comma}-stable-#{version.after_comma}-MacOSX-x86_64.dmg"
-  appcast 'https://github.com/symless/synergy/releases.atom',
-          checkpoint: '7805c24e0b75550d5803bef652d74804d796976096a7682821d166f938165a08'
+  appcast 'https://github.com/symless/synergy-core/releases.atom',
+          checkpoint: '627fed8c44fa46631f2041e8080615dbbb7fe1f4b28be9269464ecd41b30ef1f'
   name 'Synergy'
   homepage 'https://symless.com/synergy'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Symless changed the Synergy repository name.  Updated the appcast to reflect this change.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
