### PR TITLE
Update the-escapers-flux to 7.1.8

### DIFF
--- a/Casks/the-escapers-flux.rb
+++ b/Casks/the-escapers-flux.rb
@@ -1,11 +1,11 @@
 cask 'the-escapers-flux' do
-  version '7.1.7'
-  sha256 '64566f1b18753f05f6ec5e437b928e44f68f3087841f7b47f87c13d43a64d65a'
+  version '7.1.8'
+  sha256 '1b1830a1425b63cf3b2cc4e1ed5baf9d993b9622fe2107ecd1577831ee1064ad'
 
   # amazonaws.com/Flux was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Flux/FluxV#{version.major}.zip"
   appcast 'http://s3.amazonaws.com/Flux/flux.xml',
-          checkpoint: '6f7fa5ad33cc8d8724ddb00249744751d1866217a3205619b70b0daaba363b65'
+          checkpoint: '2110a36e0cb430eca9b84e45e4088d38b2a946461e908e569debd07509bab351'
   name 'Flux'
   homepage 'http://www.theescapers.com/product.php?product=flux'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.