### PR TITLE
Update fork to 1.0.58

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.57.6'
-  sha256 '78ac3fe54b407e4606605c5d757fe076ff13444c000a285f87008a575e5849de'
+  version '1.0.58'
+  sha256 'ba4d868918d92b65f3db125b2895c50de1932d9cd56af063f2789134762c8e5d'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '43486b1530df29b89614a82fa85c1dc83faec9a74c9c31e47082c4d8abc93c2d'
+          checkpoint: 'e47f58ae2f1bef6d6b8d75ea2df0bb6ee9eb65e7511bb953defe4c41578c2a3a'
   name 'Fork'
   homepage 'https://git-fork.com/'
 
@@ -13,9 +13,11 @@ cask 'fork' do
   app 'Fork.app'
 
   zap delete: [
-                '~/Library/Application Support/com.DanPristupov.Fork',
                 '~/Library/Caches/com.DanPristupov.Fork',
-                '~/Library/Preferences/com.DanPristupov.Fork.plist',
                 '~/Library/Saved Application State/com.DanPristupov.Fork.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/com.DanPristupov.Fork',
+                '~/Library/Preferences/com.DanPristupov.Fork.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.