### PR TITLE
Update slicer to 4.8.0.26489,700005

### DIFF
--- a/Casks/slicer.rb
+++ b/Casks/slicer.rb
@@ -1,11 +1,11 @@
 cask 'slicer' do
-  version '4.6.2,561385'
-  sha256 '1b732c6901897707bc6edc568dadf1c7e79ee152ede400dd286b7b6290921041'
+  version '4.8.0.26489,700005'
+  sha256 '9a13ef5084b1aee1fd56891c7c61cd5d8f093f17168fe996f067548cf4e825c8'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"
   appcast 'https://github.com/Slicer/Slicer/releases.atom',
-          checkpoint: 'cf03b970cc317124c0aacad963f5abb6c76d7742cbf722a210cb738a17bf9dd8'
+          checkpoint: '51525b99e07c45a2001ee17dbd400a25060d465255498344d9e132931787b91d'
   name '3D Slicer'
   homepage 'https://www.slicer.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: