### PR TITLE
Update fotomagico to 5.5-22722

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,10 +1,10 @@
 cask 'fotomagico' do
-  version '5.4.3-22666'
-  sha256 '27666b42b4cc1a4fd2ce01381610a94a35e304f6c400b43f764ecc6c5355e00e'
+  version '5.5-22722'
+  sha256 'd4cd426191a296244c034257b20de10a9baf4637a0b565025eb4f07adf328912'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://www.boinx.com/d/connect/histories/fotomagico',
-          checkpoint: '9727c0a09a7f2ce884677cdd74963cb201899f2f552b1d85ea6a5ec25e2faea7'
+          checkpoint: 'b5f89d69eec1142b892cf57fa154dd52dc1a4f62cde7f0289d40dbf124d07823'
   name 'FotoMagico'
   homepage 'https://boinx.com/fotomagico/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.