### PR TITLE
Update golly to 3.1

### DIFF
--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -1,10 +1,10 @@
 cask 'golly' do
-  version '3.0'
-  sha256 '1540f8278d60e75aa13d908a9e8c2bb2f5c958720e03ebf2b33ed6469eb725a1'
+  version '3.1'
+  sha256 '6084bc2464212366a03940d419f438af7df093c8b10ec84123e0fd0d912683db'
 
   url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/Golly-#{version}-Mac.dmg"
   appcast 'https://sourceforge.net/projects/golly/rss?path=/golly',
-          checkpoint: '6550a211f72b108f5b7d1f5fc3cd02691d3da1ed755446fcf1e842cc3a0fc10d'
+          checkpoint: '247566a932034bb028d6a88c12826f5683183e68a7f7de95a236d8f41c23a735'
   name 'Golly'
   homepage 'http://golly.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.