### PR TITLE
Update prusa-slic3r to 1.37.2,201710211402

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,11 +1,11 @@
 cask 'prusa-slic3r' do
-  version '1.37.1,201709141215'
-  sha256 'a7cfc43ae8ea05eb77dd7b25b49309558688a7926d1ce157c6e0041118686729'
+  version '1.37.2,201710211402'
+  sha256 'ef68fe1e5665dd08fd624c5415859a86ae0986ebdc67e1d037d40cafc58fa574'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3r-#{version.before_comma}-prusa3d-full-#{version.after_comma}.dmg"
   appcast 'https://github.com/prusa3d/Slic3r/releases.atom',
-          checkpoint: '2dfc5c83b39db928a7df55f9b4dfb0d344e857e3621c8caee75fdb046612cd73'
+          checkpoint: '75f9ef2abcf48d0425ed06dd1f99acd0a265fc47b75de9fe945173e74e76c6af'
   name 'Slic3r - Prusa Edition'
   homepage 'https://www.prusa3d.com/slic3r-prusa-edition/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.