### PR TITLE
Update psi to 1.3

### DIFF
--- a/Casks/psi.rb
+++ b/Casks/psi.rb
@@ -1,11 +1,11 @@
 cask 'psi' do
-  version '0.15'
-  sha256 '76d50b5314d0a7d9f9a0a71d90e0f806f2da25436135dbd90bd1959286747742'
+  version '1.3'
+  sha256 '6dc17cc1583d6f5f921a13af9667391950537c5c268fd10d0f8bddfbc5b4d8c7'
 
   # sourceforge.net/psi was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/psi/Psi-#{version}.dmg"
+  url "https://downloads.sourceforge.net/psi/psi-#{version}-mac.dmg"
   appcast 'https://sourceforge.net/projects/psi/rss',
-          checkpoint: '892f3ae46a1c0f761b3b97451cb94081ff45a0796f8821725994f5f6009d495f'
+          checkpoint: '785e92bcbeaa2c7ee2e2e06e43952ff74a449a63e9ee34c47c4266353393ad06'
   name 'Psi'
   homepage 'http://psi-im.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.