### PR TITLE
Update aptible to 0.14.1

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,6 +1,6 @@
 cask 'aptible' do
-  version '0.14.0+20171010141911,155'
-  sha256 '64e5026a673aa749c9c7fc363e7f8ab92f8fbea231cd66cec230c9eeb59eab55'
+  version '0.14.1+20171024084138,157'
+  sha256 '5e45265f4492eaa25bada3c88e1593a3a28741b4fc7cacfd25c70c44ccb03a01'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.before_comma.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.