### PR TITLE
Update bonjeff to 1.0.2

### DIFF
--- a/Casks/bonjeff.rb
+++ b/Casks/bonjeff.rb
@@ -1,10 +1,10 @@
 cask 'bonjeff' do
-  version '1.0.0'
-  sha256 '7d0a8631a1ff2d6dac635bfe222f08d27d0ef21ab7d1ea143c2d84940398704f'
+  version '1.0.2'
+  sha256 '4b5b2e277200698130dc3e9a5c656799c618ea2032c47da5c7c7a79edf97b91c'
 
   url "https://github.com/lapcat/Bonjeff/releases/download/v#{version}/Bonjeff.#{version}.zip"
   appcast 'https://github.com/lapcat/Bonjeff/releases.atom',
-          checkpoint: 'f2a1fd88272bcff67512db40c5bb637ed688e3ffaa706b7aa8f9ab7db93109c7'
+          checkpoint: '545f99d377a875b39d03ad037d298bbf44d6622f77f282ad6fc1ea1fd565eaa3'
   name 'Bonjeff'
   homepage 'https://github.com/lapcat/Bonjeff'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: