### PR TITLE
Update pocket-casts to 0.9.4

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,10 +1,10 @@
 cask 'pocket-casts' do
-  version '0.9.3'
-  sha256 '4af0278884064bad621f242699cda3ba0f0c00e57b855f1b63063db6ac267e80'
+  version '0.9.4'
+  sha256 '04eea0f1434598f8385e0bc320d4ac4a11e7dfc93228f1ef9a92982ca2081f49'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
   appcast 'https://static2.pocketcasts.com/mac/appcast.xml',
-          checkpoint: '00117ca16ba52210f3f4d51fb9f06f13ffe9ca3949ef1722e2d6f1a731340d77'
+          checkpoint: '70deef38c45ca95b95147207f261fab7811ff853dc3baf6dea6b73aa3c23f7cd'
   name 'Pocket Casts'
   homepage 'https://play.pocketcasts.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.