### PR TITLE
flash-npapi, flash-player, flash-player-debugger, flash-player-debugg…

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '27.0.0.170'
-  sha256 '86cc201f1b7558ac378f6a5da18f6b3d49718f45bd9904df315b81419f2425c8'
+  version '27.0.0.183'
+  sha256 '69258e17b46abea59a4411abf085f0ad66267eaa6f0abf57dbd5d05398750c13'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"

--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-npapi' do
-  version '27.0.0.170'
-  sha256 '4befa1e9cd8e41bd7904592ca08f7e3e1bc3f157f1907eaa6f516ab707a6c30e'
+  version '27.0.0.183'
+  sha256 '26792bfa28555e5ef962ebee81e8550f8e138d4cb24f43db2788cc7b3b5e5ceb'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"

--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-ppapi' do
-  version '27.0.0.170'
-  sha256 'f474e254503e25c29ecf32e8afc15eefb6b54a4c757af840e989d9e37b4ab8b4'
+  version '27.0.0.183'
+  sha256 '787fd7e945ce3bd0f4be2f8fcaf8861d504639b53c202b16890cebdc97597820'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"

--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger' do
-  version '27.0.0.170'
-  sha256 '80011462b51969925a5999e1ce538e1315ad05b3a66a767b1aafe1a5939e8aeb'
+  version '27.0.0.183'
+  sha256 '3f0accb488dd674517ee673e369b0ed48f6b42bb286820a2588f5e675e521db7'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,6 +1,6 @@
 cask 'flash-player' do
-  version '27.0.0.170'
-  sha256 '8568dc4e3aa15aa8a43d38135a1a7ef746caa07acda4bb101f3c5de7c227ac8b'
+  version '27.0.0.183'
+  sha256 '5ceacbde22ff5b6c00262ff21405d2870323d65609ff4225811dcf2a4628b0f6'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"

--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-ppapi' do
-  version '27.0.0.170'
-  sha256 '67b5f3e72e77aa4666e8e3b2a44747ff1043fb90342b062094665729975baf3c'
+  version '27.0.0.183'
+  sha256 '5e513d2f276467efd0e5b4ae331be722bbcf5cbb54c5e912606e36a45c116559'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
Again, Adobe somehow released a new version but the [webpage](https://www.adobe.com/support/flashplayer/debug_downloads.html) and the [appcast](http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml) are not updated, probably due to some caching issue. They say the latest version is 27.0.0.170, which is not true, and doesn't match with the files.

The https://get.adobe.com/flashplayer/ page correctly shows that the latest version is 27.0.0.183.

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.