### PR TITLE
Update torbrowser to 7.0.8

### DIFF
--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,83 +1,83 @@
 cask 'torbrowser' do
-  version '7.0.7'
+  version '7.0.8'
 
   language 'ar' do
-    sha256 'afd53cbe34c6c3c9d33a77a4e44cb5fa3b33e4e0490cb0258e4cccffb67faf7a'
+    sha256 'd377e6b1346a0b691e6d178f0766d6b29c843f120c9ef44836957f206dbefdcc'
     'ar'
   end
 
   language 'de' do
-    sha256 'a3b8d38a700430dddcfd2a3cc675f948067635a56fac16f6690bbfe744f68289'
+    sha256 '12983a9e28b5ca6efe4cb966d211a740ff1576cf27e09c91a8d2d65d1060fed4'
     'de'
   end
 
   language 'en', default: true do
-    sha256 '8d5b82630675341d8555f8714c2558e793698c8ecd4af1f4067ac3d5a1a5bb3f'
+    sha256 '11ad9163a5bfb82c5c3985b6c7c5f258b9677b4ae1ccfa3a5aee6dfc12e09d80'
     'en-US'
   end
 
   language 'es' do
-    sha256 '59921fb6ebdf89fedb8ea5690cf4b6eb1e74f48cdcccae5c01c08d2b1e7ae8f3'
+    sha256 '508871d7b0667f192196fcc982b638ba371db67054cf4a6284c7abe857a745b0'
     'es-ES'
   end
 
   language 'fa' do
-    sha256 'f9e0c8905a1e11ffb6eed81e0ec48632d63d7747e3cbf60733eca81fb7fd127e'
+    sha256 '50f77c9641bc515d365f62f0b33ced8661b879f3844af1656947fcb8d3fa040c'
     'fa'
   end
 
   language 'fr' do
-    sha256 '8258b37a6b0354bd9ac9fec4ae7ae5a33aaff0b451e899f3ae560d05cfe4984c'
+    sha256 'ec162f9fbf9f8e0801f33be43f595ba3c4a65e43d1bb2fc9edd0e54ab253cf66'
     'fr'
   end
 
   language 'it' do
-    sha256 'e1447b10902101ae17a492409f5c47259c70d96a7b6e9d8ab87451d99e2f5e6d'
+    sha256 '1a3296c7e05d6e4ed0c52c5e4be72147f85664a0e05f9b690bb9b16477d3a49d'
     'it'
   end
 
   language 'ja' do
-    sha256 '1337e03ea9f5fec80c67bf3b01fa605850da390dd8960b5cf39e8dae09466e9a'
+    sha256 'd88456d30ecb26ab73ab32c6d4a86487bf230a7da5b3807a7fad532edc9f6824'
     'ja'
   end
 
   language 'ko' do
-    sha256 '2d2e6db38988e7260dbe2053ee128204435e82245de2b2a3dcffc2945ee69f14'
+    sha256 'd29d8959a182e7cde35abd72becdc8f91c575885848d844694d145724f4c08e3'
     'ko'
   end
 
   language 'nl' do
-    sha256 '494426e6697e0a1124839df4368d61769241425b229b37bcbbf4afcbb99581f7'
+    sha256 'ea8bd84b85c858b0ce55ddf49da786121f235e86a301cb53908efa98a2d9836a'
     'nl'
   end
 
   language 'pl' do
-    sha256 'c764a2adddd457f15fb70cdab7fbb85039c9ec9977000eacd2a7e8835c7f68cb'
+    sha256 'ec201a210227e3302c559f538296d6946eef6b1eec1d3a184525fc73b8a65a70'
     'pl'
   end
 
   language 'pt' do
-    sha256 '0d30e18ed20614ddd6d4a4eaea4912a1d0ea91218c2c982cfdb7ecf19b4e8982'
+    sha256 '670feec0442900470e4409ab1251bf1162ae2c2f2c8be24e3bdce4575873db3f'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 'eb45a68cf7e740a81e48816c052af1b7ece5ad69603e1261d59edeb0c6161012'
+    sha256 '84b5c5cffa5d00ef6c35d7ae82ae92ea9e2de641928cb3d8e24b283e71f72d71'
     'ru'
   end
 
   language 'tr' do
-    sha256 '0550358b3aca699a2a7e3bea821ff21a37542c4cc28a093c7d1ae6bcd3e59a06'
+    sha256 'deef751d92db374f3cf6810850c54c36251c6fbf263c812eac00193bd0db51a9'
     'tr'
   end
 
   language 'vi' do
-    sha256 '8262cfb465238f5412a162e6f63205cd6afdc75ea1a5bc9d27243663935cb6d0'
+    sha256 '9ce2d13a868425e98266aee0bc7d3407acb0587dc0eee7d7219ef9854689c7cb'
     'vi'
   end
 
   language 'zh' do
-    sha256 'c1b099d701266d406cdbd4eac30cb2370a46085d8d49e85daa4e49ef7010eec7'
+    sha256 'bfe6a143b20dc17a8d55d18bd7d55757fc2976ca8bdd6a8fba73858d442fcfdb'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.