### PR TITLE
Update black-ink to 1.6.9

### DIFF
--- a/Casks/black-ink.rb
+++ b/Casks/black-ink.rb
@@ -1,10 +1,10 @@
 cask 'black-ink' do
-  version '1.6.8'
-  sha256 '7d9c2f2db5bc1967355ebc346047d6df9f99c747a46f69fa7cd6627b67221584'
+  version '1.6.9'
+  sha256 'e731b896c552d3585d5b22f8236029d0b765c2b8b2ed0ee24c29bb6083accbab'
 
   url "https://red-sweater.com/blackink/BlackInk#{version}.zip"
   appcast 'https://red-sweater.com/blackink/appcast1.php',
-          checkpoint: '69246c15127250855cf291db0613053da3583dcff4532f1bff0b8fc39b583b44'
+          checkpoint: '8b5d7573b18866fc604e866270bd88ecf86482e6d7089374750b67b68235f4e7'
   name 'Black Ink'
   homepage 'https://red-sweater.com/blackink/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: