### PR TITLE
Update clover-configurator to 4.54.0.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,10 +1,10 @@
 cask 'clover-configurator' do
-  version '4.53.0.0'
-  sha256 '7cebdc5551cdebc597c4ae3b3272e01a1053ac032f2ff7fab709a1669e0e832c'
+  version '4.54.0.0'
+  sha256 'd797a0225d6296552a4a4c63bb00844fe42bb6db19b394e3c0c69cdf427b50a6'
 
   url 'http://mackie100projects.altervista.org/download-mac.php?version=vibrant'
   appcast 'http://mackie100projects.altervista.org/apps/cloverconf/10.10/update.xml',
-          checkpoint: '7083a1a5af803234e8390650c62234581e44688bba4611891b12407ef6602608'
+          checkpoint: '423df19534d2526a9fb119b6274bd6d0519481eb16216b021750ddccffd9045a'
   name 'Clover Configurator'
   homepage 'http://mackie100projects.altervista.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: