### PR TITLE
Update colour-contrast-analyser to 2.4

### DIFF
--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -1,11 +1,11 @@
 cask 'colour-contrast-analyser' do
-  version '2.3'
-  sha256 '1f7e71e75df0f7893b6bbcc1d22655f9d084586d4f5d71111e222bdc030df67e'
+  version '2.4'
+  sha256 'bf8559d329675e776d4b5be382d789b2c94087d8f5f88386112406e6e59f02c9'
 
   # github.com/ThePacielloGroup/CCA-OSX was verified as official when first introduced to the cask
   url "https://github.com/ThePacielloGroup/CCA-OSX/releases/download/#{version}/Colour.Contrast.Analyser.app.zip"
   appcast 'https://github.com/ThePacielloGroup/CCA-OSX/releases.atom',
-          checkpoint: 'b61166779a9aa65f2b42468fb272235940f5ecf2eb75ab113bc9231033a2923c'
+          checkpoint: '10d49088990922251df30f27f96eb0a75a2d9ffe3495574336bed6ae0b918ab7'
   name 'Colour Contrast Analyser'
   homepage 'https://www.paciellogroup.com/resources/contrastanalyser/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: