### PR TITLE
Update compositor to 0.9.13

### DIFF
--- a/Casks/compositor.rb
+++ b/Casks/compositor.rb
@@ -1,10 +1,10 @@
 cask 'compositor' do
-  version '0.9.12'
-  sha256 '687926305522eb51ad6ffa6a760e012e809cbd9dfc97b1094bca9d72ae5891bf'
+  version '0.9.13'
+  sha256 'abb96825560e865c82b7d4f24cffbcfb4d24b79833b0e4ec81bf27766ee107cd'
 
   url 'http://compositorapp.com/downloads/Compositor.dmg'
   appcast 'http://compositorapp.com/updates/appcast.xml',
-          checkpoint: 'b30d4bf758f57f7fb1492d89cdde068799f2f4f85a6fa30d479b94c9f59939e6'
+          checkpoint: '651ee81e0edf3d86849ab8bf0f811a09cc5686d279e44ee23446949752c74c39'
   name 'Compositor'
   homepage 'http://compositorapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: