### PR TITLE
Update controllermate to 4.10.3

### DIFF
--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -11,12 +11,28 @@ cask 'controllermate' do
 
   pkg '#temp#/ControllerMate.pkg'
 
-  uninstall pkgutil: 'com.orderedbytes.controllermate.*'
+  uninstall launchctl: [
+                         'com.orderedbytes.ControllerMateHelper',
+                         'com.orderedbytes.ControllerMate.KextHelper',
+                       ],
+            kext:      [
+                         'com.orderedbytes.driver.CMUSBDevices',
+                         'com.orderedbytes.driver.ControllerMateFamily',
+                       ],
+            pkgutil:   'com.orderedbytes.controllermate.*',
+            signal:    [
+                         ['TERM', "com.orderedbytes.ControllerMate#{version.major}"],
+                         ['TERM', 'com.orderedbytes.ControllerMateHelper'],
+                       ]
 
-  zap       delete: [
-                      '~/Library/Application Support/ControllerMate',
-                      '~/Library/Caches/com.orderedbytes.ControllerMate4',
-                      '~/Library/Logs/ControllerMate MIDI',
-                      '~/Library/Logs/ControllerMate',
-                    ]
+  zap delete: [
+                '~/Library/Application Support/ControllerMate',
+                '~/Library/Caches/com.orderedbytes.ControllerMate4',
+                '~/Library/Logs/ControllerMate MIDI',
+                '~/Library/Logs/ControllerMate',
+              ]
+
+  caveats do
+    reboot
+  end
 end

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,11 +1,11 @@
 cask 'controllermate' do
-  version '4.10.2'
-  sha256 'fbbfe4bf7140314a732f1d9ed0b42ddf54d0ee30a13c3d8f9560e5933da8addf'
+  version '4.10.3'
+  sha256 'a20f24420084fdaeccfd0e116f0d51d6195132892a6ff81bf24c2c0dbac621f2'
 
   # amazonaws.com/orderedbytes was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/orderedbytes/ControllerMate#{version.no_dots}.zip"
   appcast 'https://www.orderedbytes.com/sparkle/appcast_cm460.xml',
-          checkpoint: '745392e35517416f967acbb0fa5831acd50f7a57187b81c4f062c12488a8dabf'
+          checkpoint: '684bfc150d43530aabc7563ba0ad16f249eb90d3dca70c435f99314ae51f2cf7'
   name 'ControllerMate'
   homepage 'https://www.orderedbytes.com/controllermate/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: