### PR TITLE
Update deepstream to 3.1.1

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,11 +1,11 @@
 cask 'deepstream' do
-  version '3.1.0'
-  sha256 '210b14ae1460b7e5956313ad67d492846f997c77de2d760fcd436d0186827d85'
+  version '3.1.1'
+  sha256 '652fdb2c19ffba27cf455cb0b3f8919afe0ba7572bf8558e247e5e45b20fba04'
 
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"
   appcast 'https://github.com/deepstreamIO/deepstream.io/releases.atom',
-          checkpoint: 'a232cf01164ec7966d1e3849af6703ca936f4c04caaa5d707fbf09ea50547a8e'
+          checkpoint: '6791a562a7593bb0f3cddc9b08dc52b923628031f663679c5e5b47f39d580531'
   name 'deepstream'
   homepage 'https://deepstream.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: