### PR TITLE
Move Native Access to subfolder

### DIFF
--- a/Casks/native-access.rb
+++ b/Casks/native-access.rb
@@ -6,5 +6,5 @@ cask 'native-access' do
   name 'Native Access'
   homepage 'https://www.native-instruments.com/en/specials/native-access/'
 
-  app 'Native Access.app'
+  app 'Native Access.app', target: '/Applications/Native Instruments/Native Access.app'
 end


### PR DESCRIPTION
Most NI products install to `/Applications/Native Instruments`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
