### PR TITLE
Move StemCreator to subfolder

### DIFF
--- a/Casks/stemcreator.rb
+++ b/Casks/stemcreator.rb
@@ -6,7 +6,7 @@ cask 'stemcreator' do
   name 'Stem Creator'
   homepage 'http://www.stems-music.com/stem-creator-tool/'
 
-  app 'StemCreator.app'
+  app 'StemCreator.app', target: '/Applications/Native Instruments/StemCreator.app'
   artifact 'Documentation', target: Pathname.new(File.expand_path('~')).join('Library/Application Support/Native Instruments/Stem Creator/Documentation')
 
   zap trash: '~/Library/Application Support/Native Instruments/Stem Creator'


### PR DESCRIPTION
Most NI products install to `/Applications/Native Instruments`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.