### PR TITLE
Update android-studio to 3.0.0.18,171.4408382

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '2.3.3.0,162.4069837'
-  sha256 'e9e11f1d20e6d3b40b4a69cf453037465d4a1f37946fd5949833d38720c84efd'
+  version '3.0.0.18,171.4408382'
+  sha256 'f75c99356259c42e00b05af1627bc06c74819850b02b95e7ff4c28e9b397120f'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).