### PR TITLE
Update ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,15 +22,3 @@
 ```
 {{replace this}}
 ```
-
-#### Output of `brew doctor`
-
-```
-{{replace this}}
-```
-
-#### Output of `brew config`
-
-```
-{{replace this}}
-```


### PR DESCRIPTION
Reverts https://github.com/caskroom/homebrew-cask/pull/40018 in favour of adding macOS and Java versions to `brew cask doctor`.

https://github.com/Homebrew/brew/commit/1d5e1afa28517d3e8445c29b7e33c6a5570f4f6f
___

Most of the output of `brew config` and `brew doctor` isn't relevant to Cask. 