### PR TITLE
Upgrade HSTracker.app to v1.2.1

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.1.0'
-  sha256 '3e4cc33e2ca25e873ad9d7170cdd905274dc3761ed30acbbbcc010a84bb0e6e4'
+  version '1.2.1'
+  sha256 '79592533e27ae9a7fab510073a0f461eebef4fb56cc44eded68b5184e449cdea'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: '91b6829e6db43a691771dad82a1e456803fcd89c4b90cc517e4879345c6ab4cf'
+          checkpoint: '7ca80a3290e597c3e7a1681e418800b3de8681f7b1a62c02034d0b9f9f56b367'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.