### PR TITLE
New Cask: gfortran 6.1

### DIFF
--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -1,16 +1,22 @@
 cask 'gfortran' do
-  version '6.1'
-  sha256 'eb817bce64bf9032595e09166bdaaf740c83bf7258f900b79cd6786437bacbf4'
-
   # coudert.name/software was verified as official when first introduced to the cask
-  url "http://coudert.name/software/gfortran-#{version}-ElCapitan.dmg"
+  if MacOS.version == :el_capitan
+    version '6.1'
+    sha256 'eb817bce64bf9032595e09166bdaaf740c83bf7258f900b79cd6786437bacbf4'
+    url "http://coudert.name/software/gfortran-#{version}-ElCapitan.dmg"
+    pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
+  else
+    version '6.3'
+    sha256 '38b81bc878dba41cfdbb0c335aec5a97554a5d1766fb3e3ca6be7da0df9e8e09'
+    url "http://coudert.name/software/gfortran-#{version}-Sierra.dmg"
+    pkg 'gfortran.pkg'
+  end
+
   name 'gfortran'
   homepage 'https://gcc.gnu.org/wiki/GFortranBinaries'
 
   conflicts_with formula: 'gcc'
   depends_on macos: '>= :el_capitan'
-
-  pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
 
   uninstall delete:  [
                        '/usr/local/gfortran',

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -7,14 +7,16 @@ cask 'gfortran' do
   name 'gfortran'
   homepage 'https://gcc.gnu.org/wiki/GFortranBinaries'
 
+  conflicts_with formula: 'gcc'
   depends_on macos: '>= :el_capitan'
 
   pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
 
-  uninstall delete: [
-                      '/usr/local/gfortran',
-                      '/usr/local/bin/gfortran',
-                    ]
+  uninstall delete:  [
+                       '/usr/local/gfortran',
+                       '/usr/local/bin/gfortran',
+                     ],
+            pkgutil: 'com.gnu.gfortran'
 
   caveats do
     files_in_usr_local

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -1,13 +1,16 @@
 cask 'gfortran' do
-  # coudert.name/software was verified as official when first introduced to the cask
   if MacOS.version == :el_capitan
     version '6.1'
     sha256 'eb817bce64bf9032595e09166bdaaf740c83bf7258f900b79cd6786437bacbf4'
+
+    # coudert.name/software was verified as official when first introduced to the cask
     url "http://coudert.name/software/gfortran-#{version}-ElCapitan.dmg"
     pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
   else
     version '6.3'
     sha256 '38b81bc878dba41cfdbb0c335aec5a97554a5d1766fb3e3ca6be7da0df9e8e09'
+
+    # coudert.name/software was verified as official when first introduced to the cask
     url "http://coudert.name/software/gfortran-#{version}-Sierra.dmg"
     pkg 'gfortran.pkg'
   end

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -1,0 +1,22 @@
+cask 'gfortran' do
+  version '6.1'
+  sha256 'eb817bce64bf9032595e09166bdaaf740c83bf7258f900b79cd6786437bacbf4'
+
+  # coudert.name/software was verified as official when first introduced to the cask
+  url "http://coudert.name/software/gfortran-#{version}-ElCapitan.dmg"
+  name 'gfortran'
+  homepage 'https://gcc.gnu.org/wiki/GFortranBinaries'
+
+  depends_on macos: '>= :el_capitan'
+
+  pkg 'gfortran-6.1-ElCapitan/gfortran.pkg'
+
+  uninstall delete: [
+                      '/usr/local/gfortran',
+                      '/usr/local/bin/gfortran',
+                    ]
+
+  caveats do
+    files_in_usr_local
+  end
+end

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -9,7 +9,7 @@ cask 'gfortran' do
 
   depends_on macos: '>= :el_capitan'
 
-  pkg 'gfortran-6.1-ElCapitan/gfortran.pkg'
+  pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
 
   uninstall delete: [
                       '/usr/local/gfortran',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

Provides the official GNU gfortran builds. Technically, this is a dependency of the `r-app` Cask, but in practice it is only needed to install R packages with fortran code. More details are given on the [r-project website](https://cran.r-project.org/bin/macosx/tools/) in particular this fragment:

> __Important note__: R 3.4.0 El Capitan binaries are using Clang 4.0.0 and GNU Fortran 6.1 to provide OpenMP parallelization support and C++17 standard features. If you want to compile R packages from sources, please download GNU Fortran binary from the official GNU Fortran Binaries page - in particular OS X 10.11 gfortran 6.1. 

The build gfortran that ships with homebrew `gcc` is incompatible with the gfortran runtime that ships with `r-app`. Thanks for considering.