### PR TITLE
Update ring to 0.74

### DIFF
--- a/Casks/ring.rb
+++ b/Casks/ring.rb
@@ -1,11 +1,11 @@
 cask 'ring' do
-  version '0.67'
-  sha256 '6207ca367e0979e944d2b9caa2f56c185d2ec7231ca74a6e96b78285c577df90'
+  version '0.74'
+  sha256 'de434bdea5264d458f697075d92e992496a510f9b2185a9044c1ca05689d2753'
 
   # ring-mac-app-assets.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ring-mac-app-assets.s3.amazonaws.com/production/Ring_#{version}.zip"
   appcast 'https://ring-mac-app-assets.s3.amazonaws.com/production/ring-appcast.xml',
-          checkpoint: 'e12f99e8f9c17d6afd11cd185b955cd08421c9c8d910471e12d38f51412a39e7'
+          checkpoint: '68784e331c692110b9a5d05bd5231178998a38d96ef1151e96eaee39099f7ae7'
   name 'Ring'
   homepage 'https://ring.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.