### PR TITLE
Update github to 1.0.5-21de72f2

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,11 +1,11 @@
 cask 'github' do
-  version '1.0.4-6e5e9664'
-  sha256 'd9a42e8ba064c1870b4d1499895a2c39d9c787eec74b033f1dc292b91aaa2dd5'
+  version '1.0.5-21de72f2'
+  sha256 '6df80e88a1633c632e2351729f5823b5c096c37f119217a928d8f7fc3724fd73'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: '552ef7130866a5149974e9232452dd34f9b483b40195a01b080073c52f1cfc71'
+          checkpoint: 'c45ec70a7a8004ead2958cced74d9378b6095cb30a6d89bc813d2c9caeb83496'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.