### PR TITLE
Update workflowy to 1.0.5

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,11 +1,11 @@
 cask 'workflowy' do
-  version '0.1.8'
-  sha256 '46dac2678b55e4711bd46e6aab6e5ba1b2c49797d5e8f4a091d28a83b4650ac8'
+  version '1.0.5'
+  sha256 'f2ca4aabdd41254aa44357bba9624ca4bb03fb70043b0d0fc9e0482c737b8a2c'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"
   appcast 'https://github.com/workflowy/desktop/releases.atom',
-          checkpoint: 'cb2315841a1f0912b22e7337bf3b86667d812c6980cf58c1c028a20cd83e971a'
+          checkpoint: '369cbee3f43529cd59a0026a66f0325994958d02a3a3844dfb1356c102c5dd47'
   name 'WorkFlowy'
   homepage 'https://workflowy.com/downloads/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.