### PR TITLE
Update firefox to 56.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,114 +1,114 @@
 cask 'firefox' do
-  version '56.0.1'
+  version '56.0.2'
 
   language 'cs' do
-    sha256 'fe7a8a7c6b29e4c90b1a8a08d575772227dcb0bce464e03b95aee419318b2da5'
+    sha256 'fbc387096b9e50238a1311de6b89e7a828589fecdc1788abd4821804e6503c56'
     'cs'
   end
 
   language 'de' do
-    sha256 '42b7f8b7e510be2364af9a2c300e1a6851302c2320fcdb8842eada55f4a80d42'
+    sha256 'd536bd88658e00cac08bfe77de0a7326d86e466b3ce1564edf638869b59bc687'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'fdc2c54538fb46c15aa94946a6a911855ff12289e6884b12a8e0e3af20078b13'
+    sha256 'c7bf8b9680ac47bed147408d567c34a731cbafb30910246ee6e490fe2d1d89ba'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '1733d60d2501e06a820cecf3d7fc3dda408b887043128160e21ad403ac967244'
+    sha256 '1a11cf1bb57c8bc7c538f1fbe88a29e64ab5a4d1f9879fa617e6b57559d6e5d5'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 'f9ab9c6d37463ade9760a4e7da04a32f69b71c9ad15b35e683dc075c4e974303'
+    sha256 '1a573afddcaa6ab8d33a529744859cc2cb31da9951f6346ce898c451d18fef15'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '139ee54b82de5842359097d403db491d63355d252d4feabc328f09b721be4f30'
+    sha256 '14bee6c3ef4798ee5189488fca2c5b34325c57dbe9eaa95c1a2a235eada5f39e'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '2c1319c519dc33d39b71578cfd86c518be021f151120df8cfe2a4b2474ea813f'
+    sha256 'a2dae4b4df09676aa66735b2bfdbb47dcc126dc7b26d56af665c8b3eb9c79d7a'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '7d7e50f8a8f6bae98109ee9ad833476270251c40fc28f517bf40070c81d0ff13'
+    sha256 'c33d607b2c708eaf1d0c43c32139346118bb275045dbf36f5a1183f493b36562'
     'fi'
   end
 
   language 'fr' do
-    sha256 'a735b2d3ad1eb4be21f3dd4b985ce7a6790f064c71738ed5c2e48bf881924217'
+    sha256 'bc8fef2315d0082772d4771aa4dd2986ae513ac3c0dce4a9d67151cbd894239f'
     'fr'
   end
 
   language 'gl' do
-    sha256 'fc29a3bc8027d0ee09c2d47dddc8be6d7cea992199e00e2ea2aedf9ac89d7fba'
+    sha256 '0f21d58f144bb5aa9f7bbdab952eb75bc672372b975d7c92925924b1fe29a242'
     'gl'
   end
 
   language 'in' do
-    sha256 '7e4b59475db55606925c10eddfe8c07bcbf634c446abfbe62b69bdd185d5a5fd'
+    sha256 'a3724337bda897e4b0429958137b8a5afacb44233369b2185261df106a28fe3f'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 'f5d7f9d9489ebcb888135cb97f4742043bd3899225df1308cc1b171faff48c7f'
+    sha256 '0dfdae4880ed1f099e45754ab5154bbd4463976ef8a36829b3fd29b34933fecb'
     'it'
   end
 
   language 'ja' do
-    sha256 '7815d8ec5c08a03a5a6f62fb59499cbabbff004f5f7948a5ea6297253fb70d84'
+    sha256 'ac7f9ce9cf2d85fda25a487c02d9b050ea5eb4108793f60feb930b4283acb985'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'b198c94745b5fdfdbb35241aa897c22e6bc78b9cc5dd906982c98ebd3f323704'
+    sha256 '4b7b137c55714a37a9974b85b7d790c26e44cd474b7be4ee7a033436779b63e9'
     'nl'
   end
 
   language 'pl' do
-    sha256 'b38ef7ced7ecd7180013cf85278715716566f1d55025aae087464767231be97e'
+    sha256 '2a3c984b89523ac19bc7454cbccc73a4f1c02edc4fe0899631497abdb4f00ef2'
     'pl'
   end
 
   language 'pt' do
-    sha256 'f7576df5e8190f743e720cec8cd00ef1c94dd5b9e6bf3c7359558140f3e52ed4'
+    sha256 '7e328d2bb73aec87122419684b7c6a9cc1d6d891b3d7b0514641222ffb50c364'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 'bacc5da9342ecc368e8e0dbf9ed9f13f9234dea86ff9311918bc8078f7d516ee'
+    sha256 'da7920871e111ea9b39774dbe102163372b9a33d510092ead960c510a7dbdbab '
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '17311ec37a9c2b4b069b1eca94d1c605750005d44b3d2ca4b37f8a3fe68c633a'
+    sha256 '169fe1f6f58ffa94b1c4c7417e38a1af4b5cd0f3bb8634b183e66d4f6f1f111b'
     'ru'
   end
 
   language 'uk' do
-    sha256 'b37aa2858fdbf73eedd9cb71ac81800aaed532f7a4ff5d97171e1f8c49b7d21e'
+    sha256 'a5692b7799f5fd967b8aaacdf256400925039d1acd3d5eeb23bfc084c9f8f4d9'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '2161259176506d9d6d304623b8de8654e7d368c7f38e95a04696bdd947916c33'
+    sha256 'd4667737ec5297b813ff32093edf689077a0c475e05d9e48c2971c8a4aecb969'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '0632278b85a649647094f156a3325d87fa1a74b336be4464a307929dd93074d1'
+    sha256 '0871966d5197367a02faa15fce5217f7ee34ac2ed4df391276788a5040aec11c'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: 'e0dadbc9cd1f1bd8ce3118cc3383e0d0f6d147f055265d498d99deea956ba00f'
+          checkpoint: 'f2ac1ccfd7f5342bdab5589bb5d803b45e5a5fb31997a3503d2f9e72efa4cf55'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.