### PR TITLE
Update emby-server to 3.2.34.0

### DIFF
--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -1,13 +1,13 @@
 cask 'emby-server' do
-  version :latest
-  sha256 :no_check
+  version '3.2.34.0'
+  sha256 '056ae9eb2c4b8876ae7b28caeb708a80630024f384987949bd40568c62f47668'
 
-  # github.com/MediaBrowser/MediaBrowser.Releases was verified as official when first introduced to the cask
-  url 'https://github.com/MediaBrowser/MediaBrowser.Releases/raw/master/Server/Emby.Server.Mac.pkg'
+  # github.com/MediaBrowser/Emby was verified as official when first introduced to the cask
+  url "https://github.com/MediaBrowser/Emby/releases/download/v#{version}/embyserver-osx-x64-v#{version}.zip"
   name 'Emby Server'
   homepage 'https://emby.media/'
 
-  pkg 'Emby.Server.Mac.pkg'
+  app 'EmbyServer.app'
 
-  uninstall pkgutil: 'com.MediaBrowser.MediaBrowser.Server.Mac'
+  zap trash: '~/.config/emby-server'
 end

--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -3,7 +3,9 @@ cask 'emby-server' do
   sha256 '056ae9eb2c4b8876ae7b28caeb708a80630024f384987949bd40568c62f47668'
 
   # github.com/MediaBrowser/Emby was verified as official when first introduced to the cask
-  url "https://github.com/MediaBrowser/Emby/releases/download/v#{version}/embyserver-osx-x64-v#{version}.zip"
+  url "https://github.com/MediaBrowser/Emby/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"
+  appcast 'https://github.com/MediaBrowser/Emby/releases.atom',
+          checkpoint: '8f88cb5bb9235fbca62f72c974d559aa4bbe419bf6ce83b27735a5b2375520bc'
   name 'Emby Server'
   homepage 'https://emby.media/'
 


### PR DESCRIPTION
There was a change of location for the download of the new releases of emby-server. Now they are using the main repository `github.com/MediaBrowser/Emby` and Github's releases instead of the `github.com/MediaBrowser/MediaBrowser.Releases` repo, so I updated the cask accordingly.

New download location can be verified here:
https://emby.media/mac-server.html

- [X] `brew cask audit --download emby-server` is error-free.
- [X] `brew cask style --fix emby-server` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask install emby-server` worked successfully.
- [X] `brew cask uninstall emby-server` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
