### PR TITLE
Update sweet-home3d to 5.6

### DIFF
--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -1,11 +1,11 @@
 cask 'sweet-home3d' do
-  version '5.5.2'
-  sha256 '095e859b09b9e6863da82f531ac1c988c1c990104333c8a3ada26efa13dfffe4'
+  version '5.6'
+  sha256 '73eb054e9039a38e7ed32bbb66ba3581831dfd69a07faa9dc8d2765937fbac68'
 
   # sourceforge.net/sweethome3d was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/sweethome3d/SweetHome3D/SweetHome3D-#{version}/SweetHome3D-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/sweethome3d/rss?path=/SweetHome3D',
-          checkpoint: '1f228a05f8dfa97c3b238c8e2eb0d1258d25e6bb0d837a2b597b7a2f8036a2c7'
+          checkpoint: '71d73604ae3f2d9c88a242733081bc6cb0fc4e83f7040fd055f3b40651995ab0'
   name 'Sweet Home 3D'
   homepage 'http://www.sweethome3d.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.