### PR TITLE
Update freesmug-chromium to 62.0.3202.75

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '62.0.3202.62'
-  sha256 'a611f13e786a49417f10ce3c294d12d6383281a57e3af590145b45daca2bbc6f'
+  version '62.0.3202.75'
+  sha256 '6592f14e0a412351062ce91ac4b6a57e79cdb8f7b555f504b3b0f809cb0d3fdc'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: 'c3d181c69cfd9530b0931d169a9d61a9a8ddf077bb22de7d3f5c67db3c61c162'
+          checkpoint: '141dcbee9fd37091297253c9d3abe616690226830a2f94e858f688790b222b07'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.