### PR TITLE
Update folx URL

### DIFF
--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -2,9 +2,9 @@ cask 'folx' do
   version '5.2.1.13690'
   sha256 'f00214b419756505410fefcf312c7d2fc2f81ed8e4ba134918c22232d23af1bd'
 
-  url "http://www.eltima.com/download/folx-update/downloader_mac_#{version}.dmg"
+  url "https://cdn.eltima.com/download/folx-updater/downloader_mac_#{version}.dmg"
   appcast 'http://mac.eltima.com/download/folx-updater/folx.xml',
-          checkpoint: '8b3c2be9b61ecc1c5b317750b803b3199649d6cfbb87c716aec000b86f86019d'
+          checkpoint: 'f59ab26d33f3fa694a1d9d8898d19622cb2c6486b714e959e83156f8b7461dda'
   name 'Folx'
   homepage 'https://mac.eltima.com/download-manager.html'
 

--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -3,7 +3,7 @@ cask 'folx' do
   sha256 'f00214b419756505410fefcf312c7d2fc2f81ed8e4ba134918c22232d23af1bd'
 
   url "https://cdn.eltima.com/download/folx-updater/downloader_mac_#{version}.dmg"
-  appcast 'http://mac.eltima.com/download/folx-updater/folx.xml',
+  appcast 'https://cdn.eltima.com/download/folx-updater/folx.xml',
           checkpoint: 'f59ab26d33f3fa694a1d9d8898d19622cb2c6486b714e959e83156f8b7461dda'
   name 'Folx'
   homepage 'https://mac.eltima.com/download-manager.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download folx` is error-free.
- [x] `brew cask style --fix folx` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Version is not included because it does not introduce a new version. Eltima just moved the file to another URL.