### PR TITLE
Update tankix to 6377

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '5847'
-  sha256 '748232a830bf9cd2dc362f2bceb20f7b8255ccdad64c3c9cc2164f7b3c509d14'
+  version '6377'
+  sha256 '3adfd0a5c3450831c0da023b22daa13bc1adbd05956732951fc16ba513860b8e'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.