### PR TITLE
Update exodus to 1.37.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.36.1'
-  sha256 '001108f4339fe34590bd76d451303e6efb2fd66b00a558d8562b88157c408151'
+  version '1.37.0'
+  sha256 'dbaae9c9c81743ab416715529d4ef1150d51ab9c3afd4c459d000774d4a3ad18'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: 'a8c7bdd46c65a48f7a9f157705a8fe328a43188ece35c10ff5189accbf4036f3'
+          checkpoint: '94f049bdfa545759ec763eeebc5369981209310c2c3bf479fa4efe637b918156'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.