### PR TITLE
Update julia to 0.6.1

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask 'julia' do
-  version '0.6.0'
-  sha256 '0ad3eb9e52a1c38850d04c833fd2375f588fdc4c48804e976ec7bc9c563bf717'
+  version '0.6.1'
+  sha256 '600c981780e5c4248e826db8a2e21f73063f4bc775fc66bb482235627f15993a'
 
   url "https://julialang-s3.julialang.org/bin/osx/x64/#{version.major_minor}/julia-#{version}-osx10.7+.dmg"
   name 'Julia'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.