### PR TITLE
Update gotomeeting to 8.15.0.7759,ka338000000L6agAAC

### DIFF
--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,6 +1,6 @@
 cask 'gotomeeting' do
-  version '8.13.1.7713,ka338000000L6MHAA0'
-  sha256 'ff7e03cb81884a9d788937a0fb00b3a42186aa55308845b11285e6de68602af4'
+  version '8.15.0.7759,ka338000000L6agAAC'
+  sha256 '717dbc41e4ef0322ce3e98bf49ec784a0673fcdb3414ca42a0164b226c518e23'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
   url "https://support.citrixonline.com/servlet/fileField?entityId=#{version.after_comma}&field=Content__Body__s"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.