### PR TITLE
Add malware caveat to andy cask

### DIFF
--- a/Casks/andy.rb
+++ b/Casks/andy.rb
@@ -14,4 +14,3 @@ cask 'andy' do
     malware('35212266')
   end
 end
-

--- a/Casks/andy.rb
+++ b/Casks/andy.rb
@@ -9,4 +9,9 @@ cask 'andy' do
   pkg 'Andy.pkg'
 
   uninstall pkgutil: 'net.andyroid.andy.player.osx'
+
+  caveats do
+    malware('35212266')
+  end
 end
+


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Reference [this VirusTotal report](https://www.virustotal.com/#/file/f67940a8f5138decafc9d487b29f129e9676f4e380e717361b2fe16f71231248/detection) and [this one](https://www.virustotal.com/#/domain/andyroid.net) to see that the Andyroid website distributes malware. I could not scan the actual file downloaded by the cask because it exceeds VirusTotal's upload size limit, but the file scanned in the first report listed installs the same software as the package file downloaded by the cask.