### PR TITLE
Update hab to 0.38.0-20171026215116

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.36.0-20171009050124'
-  sha256 '3c4ca43b1206c56cd61e4bb22d7659913528378b7b5a1d192105318887a77e86'
+  version '0.38.0-20171026215116'
+  sha256 '2ffcbf5520445ff0471b71657bb24005e11adb94644d6c4e5f953e68efb74df4'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '713909977879a74f58f72233fd2aa060a5ef1975fb01c54996754a8bf72d1654'
+          checkpoint: 'a63d8468e5986f9eb9d1152563e63147deb3798cb63da9303ebc12eeb91851ab'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.