### PR TITLE
Update expo-xde to 2.21.0

### DIFF
--- a/Casks/expo-xde.rb
+++ b/Casks/expo-xde.rb
@@ -1,11 +1,11 @@
 cask 'expo-xde' do
-  version '2.20.1'
-  sha256 '53309014713ea1064499891767b1137d0d0202afc23c56f7fd513fe6284e7b1e'
+  version '2.21.0'
+  sha256 '52e5f64d130a04fcaeebe50b9f6eca05a5eae01e09f95faa48beac3771eb72a1'
 
   # github.com/expo/xde was verified as official when first introduced to the cask
   url "https://github.com/expo/xde/releases/download/v#{version}/xde-#{version}.dmg"
   appcast 'https://github.com/expo/xde/releases.atom',
-          checkpoint: '9025e19a272b131861a341d778fc044acb47fda005b6d80dd01b5f4654ff5dd2'
+          checkpoint: '438612414e5882774c8b0b0c4580d50f7bd9623bad1b5f4e64668c714ae061c9'
   name 'Expo Development Environment (XDE)'
   homepage 'https://expo.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.