### PR TITLE
Private Internet Access v75

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,6 +1,6 @@
 cask 'private-internet-access' do
-  version '74'
-  sha256 'f5d86132dca72b1cfae13ca84d9322e5c8402c12aab44f8089bb7be8aa927fc3'
+  version '75'
+  sha256 'c1a01cf56cfc593ef1a27a6cdd318f96a02359e68d16aa6dca9b19221f96055b'
 
   url "https://installers.privateinternetaccess.com/download/pia-v#{version}-installer-mac.dmg"
   name 'Private Internet Access'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download private-internet-access` is error-free.
- [x] `brew cask style --fix private-internet-access` reports no offenses.
- [x] The commit message includes the cask’s name and version.
