### PR TITLE
Update rubitrack-pro to 4.4.5

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '4.4.4'
-  sha256 'fdaa6b12d77996c0806bea2230ba935ea3d9399ca356e696d9f5e56bfa406792'
+  version '4.4.5'
+  sha256 'eb29912f3511fad5175446395e84e8f15c5e9d13c3d1d04ba78cbb9617d1d6e0'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}_u.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: 'f285ddb3feb516b8ce18066ddf2f2d9cded8ba80b2ec0a8bf9fc3ac1bfba2935'
+          checkpoint: 'ae47d04bcfdeaa6281c683e5f6c633c0b08dbc51552c90a0e583137c38963e0b'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.