### PR TITLE
Update cool-retro-term to 1.0.1

### DIFF
--- a/Casks/cool-retro-term.rb
+++ b/Casks/cool-retro-term.rb
@@ -1,10 +1,10 @@
 cask 'cool-retro-term' do
-  version '1.0.0'
-  sha256 'ccb1c78b54e1c2dcde1a660730da2b0f6d2e4213e3748e5ad81a5653926c920e'
+  version '1.0.1'
+  sha256 '1cddb173251290388cee2d24fc668585da03d3cb1f30123efd70c0500ba74b5a'
 
-  url "https://github.com/Swordfish90/cool-retro-term/releases/download/v#{version}/cool-retro-term#{version.delete('.')}.dmg"
+  url "https://github.com/Swordfish90/cool-retro-term/releases/download/#{version}/cool-retro-term.dmg"
   appcast 'https://github.com/Swordfish90/cool-retro-term/releases.atom',
-          checkpoint: 'a789607a40af3f9b0c7c534b27c781b48b221fc14fb3ec132d68acc0b79eddac'
+          checkpoint: '1fa432ae6057c8ab1677b1bcd084348381d9a2190b0ec8e7cd10bd94936cd352'
   name 'cool-retro-term'
   homepage 'https://github.com/Swordfish90/cool-retro-term'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.