### PR TITLE
Update the-hit-list to 1.1.31,363

### DIFF
--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,10 +1,10 @@
 cask 'the-hit-list' do
-  version '1.1.30,358'
-  sha256 'fe5489a238adbe026b654b1ac527be6bec2ca25fbc8553ec5d243663292e124a'
+  version '11.1.31,363'
+  sha256 'e1313860db752b2be1f17dad267417eac569e4ed3bc54d32c7545ea086772443'
 
   url "https://distrib.karelia.com/downloads/TheHitList-#{version.after_comma}.zip"
   appcast 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List',
-          checkpoint: 'acec182e0b21aae87f3f6eb668ed55b732a5dcc2d0adeb1954b2b6449ee1efa1'
+          checkpoint: '74a931f715728367315e70304fb3d27d8a3f32b0ea23c57ddfb24de4d7cd419b'
   name 'The Hit List'
   homepage 'https://www.karelia.com/products/the-hit-list/mac.html'
 

--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,5 +1,5 @@
 cask 'the-hit-list' do
-  version '11.1.31,363'
+  version '1.1.31,363'
   sha256 'e1313860db752b2be1f17dad267417eac569e4ed3bc54d32c7545ea086772443'
 
   url "https://distrib.karelia.com/downloads/TheHitList-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.