### PR TITLE
Trash gimp plist file on zap

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -12,9 +12,9 @@ cask 'gimp' do
     set_permissions "#{appdir}/GIMP.app/Contents/MacOS/GIMP", 'a+rx'
   end
 
-  zap delete: [
+  zap delete: '~/Library/Saved Application State/org.gnome.gimp.savedState',
+      trash:  [
+                '~/Library/Preferences/org.gnome.gimp.plist',
                 '~/Library/Application Support/GIMP',
-                '~/Library/Saved Application State/org.gnome.gimp.savedState',
-              ],
-      trash:  '~/Library/Preferences/org.gnome.gimp.plist'
+              ]
 end

--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -15,5 +15,6 @@ cask 'gimp' do
   zap delete: [
                 '~/Library/Application Support/GIMP',
                 '~/Library/Saved Application State/org.gnome.gimp.savedState',
-              ]
+              ],
+      trash:  '~/Library/Preferences/org.gnome.gimp.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

No version stated, this change is an enhancement to gimp zap stanza.