### PR TITLE
Added zap stanzas in key-codes v2.1

### DIFF
--- a/Casks/key-codes.rb
+++ b/Casks/key-codes.rb
@@ -11,4 +11,9 @@ cask 'key-codes' do
   auto_updates true
 
   app 'Key Codes.app'
+
+  zap delete: [
+                '~/Library/Caches/com.manytricks.KeyCodes',
+                '~/Library/Preferences/com.manytricks.KeyCodes.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Added zap stanzas for key-codes v2.1.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
