### PR TITLE
Update TiddlyWiki to 0.0.9

### DIFF
--- a/Casks/tiddlywiki.rb
+++ b/Casks/tiddlywiki.rb
@@ -1,10 +1,10 @@
 cask 'tiddlywiki' do
-  version '0.0.8'
-  sha256 'a4f54bb838f40fb0020d663be8d65aa155e4c8d03659d10d0ddc44776d723e29'
+  version '0.0.9'
+  sha256 '85ca27b3819643f46c20fea16bcdc1c426bdf691fa124d49d96a71e76982b34c'
 
   url "https://github.com/Jermolene/TiddlyDesktop/releases/download/v#{version}/tiddlydesktop-mac64-v#{version}.zip"
   appcast 'https://github.com/Jermolene/TiddlyDesktop/releases.atom',
-          checkpoint: '3d35a2b54c339e8c1641bd4917f60a54259928f63800c04898b985ad042e925f'
+          checkpoint: '2b31415d87ec8d870bf0fdf39f1b27f9f8b60e28eac39dd050175d7caa29cc4e'
   name 'TiddlyWiki'
   homepage 'https://github.com/Jermolene/TiddlyDesktop'
 


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.