### PR TITLE
Link Zsh completion for Docker CLI

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -14,7 +14,18 @@ cask 'docker' do
 
   app 'Docker.app'
 
-  uninstall delete:    '/Library/PrivilegedHelperTools/com.docker.vmnetd',
+  preflight do
+    ['docker', 'docker-compose', 'docker-machine'].each do |cmd|
+      system_command '/bin/ln', args: ['-s', "#{appdir}/Docker.app/Contents/Resources/etc/#{cmd}.zsh-completion", "/usr/local/share/zsh/site-functions/_#{cmd}"]
+    end
+  end
+
+  uninstall delete:    [
+                         '/Library/PrivilegedHelperTools/com.docker.vmnetd',
+                         '/usr/local/share/zsh/site-functions/_docker',
+                         '/usr/local/share/zsh/site-functions/_docker-compose',
+                         '/usr/local/share/zsh/site-functions/_docker-machine',
+                       ],
             launchctl: [
                          'com.docker.helper',
                          'com.docker.vmnetd',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Version is not included because this does not involve a new version. It only installs completions to proper location.

If this looks good then I may also update `docker-edge`.