### PR TITLE
Update pdfpenpro to 922.1,1508811074

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '920.0,1504750884'
-  sha256 'cc664ae529cb067a5adf7e3c8c4c284b6f7b3e7ea4df94869fa371988f737fec'
+  version '922.1,1508811074'
+  sha256 'b97542911f5cb30b2a4bd9bd9b11584a02ffae8d786ff1d96202cc7733e7e20d'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '6b76b227e4a9b779dc4e2945a602714d95b1289c8ed644e6b28f4d0e9ddfccfc'
+          checkpoint: '298fe1b97a3f429af40730c7040842e3c82ba325bdd298772a1443ac7b97ae48'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.