### PR TITLE
Update now to 3.3.1

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.3.0'
-  sha256 '0df775e078e898f9338ec109ac432f82c61d5ef38b848a19fe3ef65a29b83a3d'
+  version '3.3.1'
+  sha256 'c3bd81baa0a9865ac54a65fdb495aec4b64b422e5a28b40cb9c714d4f47deb4d'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '13067c0b0c9cea9d13ee20cd6eb66c4dbd1f0470fc70ef9e6175822f8b0fd25f'
+          checkpoint: '59636f21ad47c745606c9ea9d96f5215978b5d565a0231535d81d441ebf1bb33'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.