### PR TITLE
Update koa11y to 3.0.0

### DIFF
--- a/Casks/koa11y.rb
+++ b/Casks/koa11y.rb
@@ -1,11 +1,11 @@
 cask 'koa11y' do
-  version '2.0.0'
-  sha256 '2225730263c538d58c4deb4b08704c3f60a534e227fd7740c088b37b3233dc27'
+  version '3.0.0'
+  sha256 '38eee107e25b9595955c0ef53f0dcfa44630f94003da781e2607a396469bc4da'
 
   # github.com/open-indy/Koa11y was verified as official when first introduced to the cask
   url "https://github.com/open-indy/Koa11y/releases/download/v#{version}/OSX_Koa11y_#{version}.zip"
   appcast 'https://github.com/open-indy/Koa11y/releases.atom',
-          checkpoint: '63edcb8ec43963f6f0dc6166bd002aa535d5b0a66991d8fd1a5c4928d6464f06'
+          checkpoint: '7aef34815af55a47089cadf45a459dd8635772789afdb91e3ed6470d55df67f8'
   name 'Koa11y'
   homepage 'https://open-indy.github.io/Koa11y/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.