### PR TITLE
Update anaconda to 5.0.1

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,6 +1,6 @@
 cask 'anaconda' do
-  version '5.0.0'
-  sha256 '23df1e3a38a6b4aaa0ab559d0c1e51be76eca5d75cb595d473d223c8d17e762d'
+  version '5.0.1'
+  sha256 'f438a0af923bc1edc7bca53f496c59a668d1a08b48c768f443ad7f5ea2b8b3f8'
 
   # repo.continuum.io/archive was verified as official when first introduced to the cask
   url "https://repo.continuum.io/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.