### PR TITLE
Update sogouinput to 4.4.0.4883

### DIFF
--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -1,23 +1,35 @@
 cask 'sogouinput' do
-  version '3.8.0.2054'
-  sha256 '18807c27d26460d8db76a086d403efe783f7406d90cad7248b829111f981ed09'
+  version '4.4.0.4883,1507781284'
+  sha256 '5eb17ef3f7bd48b13f230eba7293c91c4511a765faffbfc04ea7fbcd1b52fa2d'
 
-  url "http://cdn1.ime.sogou.com/SogouInput_V#{version}.dmg"
+  url "http://cdn2.ime.sogou.com/dl/index/#{version.after_comma}/sogou_mac_#{version.major_minor.no_dots}b.dmg"
   name 'Sogou Input Method'
   name '搜狗输入法'
   homepage 'https://pinyin.sogou.com/mac/'
 
   installer manual: '安装搜狗输入法.app'
 
-  uninstall delete: '/Library/Input Methods/SogouInput.app'
+  uninstall delete: [
+                      '/Library/Input Methods/SogouInput.app',
+                      '/Library/LaunchAgents/com.sogou.SogouServices.plist',
+                      '/Library/QuickLook/SogouSkinFileQuickLook.qlgenerator',
+                    ]
 
-  zap delete: [
-                '/Library/LaunchAgents/com.sogou.SogouServices.plist',
+  zap trash:  [
                 '~/.sogouinput',
-                '~/Library/Application Support/Sogou',
+                '~/Library/Application Support/Sogou/EmojiPanel',
+                '~/Library/Application Support/Sogou/InputMethod',
+                '~/Library/Preferences/com.sogou.SogouPreference.plist',
+              ],
+      delete: [
                 '~/Library/Caches/SogouServices',
                 '~/Library/Caches/com.sogou.SGAssistPanel',
+                '~/Library/Caches/com.sogou.SogouPreference',
+                '~/Library/Caches/com.sogou.inputmethod.sogou',
                 '~/Library/Cookies/SogouServices.binarycookies',
+                '~/Library/Cookies/com.sogou.SogouPreference.binarycookies',
+                '~/Library/Cookies/com.sogou.inputmethod.sogou.binarycookies',
                 '~/Library/Saved Application State/com.sogou.SogouInstaller.savedState',
-              ]
+              ],
+      rmdir:  '~/Library/Application Support/Sogou'
 end

--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -9,11 +9,11 @@ cask 'sogouinput' do
 
   installer manual: '安装搜狗输入法.app'
 
-  uninstall delete: [
-                      '/Library/Input Methods/SogouInput.app',
-                      '/Library/LaunchAgents/com.sogou.SogouServices.plist',
-                      '/Library/QuickLook/SogouSkinFileQuickLook.qlgenerator',
-                    ]
+  uninstall delete:    [
+                         '/Library/Input Methods/SogouInput.app',
+                         '/Library/QuickLook/SogouSkinFileQuickLook.qlgenerator',
+                       ],
+            launchctl: 'com.sogou.SogouServices'
 
   zap trash:  [
                 '~/.sogouinput',


### PR DESCRIPTION
Update sogouinput to 4.4.0.4883

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
