### PR TITLE
Update textsoap to 8.4.4

### DIFF
--- a/Casks/textsoap.rb
+++ b/Casks/textsoap.rb
@@ -1,23 +1,25 @@
 cask 'textsoap' do
-  version '8.4.1'
-  sha256 '07f7d3cbec9f6a4d278002bccf79a2e023467bc1aaf901ad9d3e1e083dafa761'
+  version '8.4.4'
+  sha256 '73c4663eb304cd53c476f64212b5e6a1cf081270b4e8d3d481092d961d78b94b'
 
   # unmarked.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://unmarked.s3.amazonaws.com/textsoap#{version.major}.zip"
   appcast "https://unmarked.s3.amazonaws.com/appcast/textsoap#{version.major}.xml",
-          checkpoint: '81d08a8ba867ce47c4439dc95658c59779640ea120c85bfa2d5370356c4be0b9'
+          checkpoint: '910590772b84838bb1aab9c3bc700a629dec5c0f28d88aecd045415e62bebaef'
   name 'TextSoap'
   homepage 'https://www.unmarked.com/textsoap/'
 
   app "textsoap#{version.major}.app"
 
   zap delete: [
-                '~/Library/Application Support/TextSoap',
-                "~/Library/Application Support/com.unmarked.textsoap#{version.major}",
                 "~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/com.unmarked.textsoap#{version.major}.help",
                 "~/Library/Caches/com.unmarked.textsoap#{version.major}",
                 "~/Library/Cookies/com.unmarked.textsoap#{version.major}.binarycookies",
-                "~/Library/Preferences/com.unmarked.textsoap#{version.major}.plist",
                 "~/Library/Saved Application State/com.unmarked.textsoap#{version.major}.savedState",
+              ],
+      trash:  [
+                '~/Library/Application Support/TextSoap',
+                "~/Library/Application Support/com.unmarked.textsoap#{version.major}",
+                "~/Library/Preferences/com.unmarked.textsoap#{version.major}.plist",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.