### PR TITLE
Update pacifist to 3.6

### DIFF
--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -3,13 +3,13 @@ cask 'pacifist' do
     version '3.2.17'
     sha256 'd38e12293bc6087ddb09275e3c5ab34faa670e87e9dd41e04a587dd387f7b1d3'
   else
-    version '3.5.13'
-    sha256 'df4778ede2b9664bda6153fc13b0f52cfa6e6e6ce2367c54f945b8d176367736'
+    version '3.6'
+    sha256 'bea5b1d6566516cf373068b4ffcdc54ba4cfcad1ba327b9ccfefcaf2a5f9884a'
   end
 
   url "https://www.charlessoft.com/pacifist_download/Pacifist_#{version}.dmg"
   appcast 'https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi',
-          checkpoint: '2d0b41688b27880f5046d3ad99fe0f242b1595d1dc027747026ddb600a387adc'
+          checkpoint: '7a416fcb387bab753bb583c1ac2d8d220da671c8fbfca1aac1f73e8d2834fb34'
   name 'Pacifist'
   homepage 'https://www.charlessoft.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.