### PR TITLE
Update minizincide to 2.1.6

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,11 +1,11 @@
 cask 'minizincide' do
-  version '2.1.5'
-  sha256 'fd427fda74ba0972a9706a09c52fe8bbd19947e54c7c7e52e4c809122acb76b8'
+  version '2.1.6'
+  sha256 'f352d27136da50f0c33d3372d30dc061e7f5f9cf0a7e654b53a5dde53940417d'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"
   appcast 'https://github.com/MiniZinc/MiniZincIDE/releases.atom',
-          checkpoint: '209b6573001b7200fbf592591124c31a8d77baa0076410a1af445b63e8b504c3'
+          checkpoint: '70888ec595a2ceea223addec1ad904f14721180fd5142cd6420df6924404e221'
   name 'MiniZincIDE'
   homepage 'http://www.minizinc.org/ide/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.