### PR TITLE
Update komodo-edit to 11.0.1-18119

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,6 +1,6 @@
 cask 'komodo-edit' do
-  version '11.0.0-18063'
-  sha256 'b5dbc8a031679e29143136113082af98dcbcc1c4410ed0d4a457fc242d728cfc'
+  version '11.0.1-18119'
+  sha256 '74be0c20c4fb96bbbf697f6b52b4ea0abbda1d06381906e224ecf8eddd08f7c9'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"
   name 'Komodo Edit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.