### PR TITLE
Update wavebox to 3.5.0

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.4.0'
-  sha256 '1284b70eaee976175edb33ae319ba09a2466530d12ffe6612ae245beea0a6f8e'
+  version '3.5.0'
+  sha256 '5467674300011446eb2c41eb6bfdd0ee24ca5be2ba59ea984438133f8e2a8614'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: 'd08e5f3197cbd7a6d3efb12fed9d00cc039d6d9bbc689ae65db937aae1a775d7'
+          checkpoint: 'd409404369e3bc067c7cc3c4b3742d67f42881549e89f21a5957caea749b3c10'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.