### PR TITLE
Plex Media Player 1.3.11.729-4be89b5c

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,10 +1,10 @@
 cask 'plex-media-player' do
-  version '1.3.10.720-dfcd90a6'
-  sha256 'bd5319cc68b4848c935538a38c85575279b808fe15a6474160ebf4374596a8e9'
+  version '1.3.11.729-4be89b5c'
+  sha256 '25ea9237db368b59b9958d72c3c22b062ce660afa5e00748ff54d5de045d0ec4'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json',
-          checkpoint: 'f45603d95a95ac2d72dd1f9a7489ea1fd5f54a362bf9d8acfad969fdc17ded15'
+          checkpoint: 'c36dacd6e217a3f1fb49fa0d17724a7f6fb7b6ace920b17bda72ea7f431e0af8'
   name 'Plex Media Player'
   homepage 'https://www.plex.tv/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download plex-media-player` is error-free.
- [x] `brew cask style --fix plex-media-player` reports no offenses.
- [x] The commit message includes the cask’s name and version.
