### PR TITLE
Update tankix to 6729

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '6649'
-  sha256 'b2ed8e6e1ce9d228145002fbcfbd77e0110c1089b5afb3cd8a4062dc4e9ee686'
+  version '6729'
+  sha256 '7f147946658655acf44b91d6d2d8a78a1886cb1b2c8e708f29517985993df787'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.