### PR TITLE
Update standard-notes to 2.1.0

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.0.1'
-  sha256 '26b4cec434256815cf95836067f99741224c288348197ef93df61e98120fea12'
+  version '2.1.0'
+  sha256 '415e5775cf928627e711b290d7114679bb45869f8da6aeff5c66b733a1c1a218'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/standard-notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '73fd9efce25a7b9dc4e34a504f0d62a4fe4766ce0b50765b7fc5078da92c2564'
+          checkpoint: '81e3bf9dc464b74c1ec4366634f4c710e7d27a6963e3157b3c9b8ee241b6d957'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.