### PR TITLE
Update poi to 7.10.1

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,11 +1,11 @@
 cask 'poi' do
-  version '7.10.0'
-  sha256 '0c80361ca4a66f6c5b90ee0f9a03d2fd7cc0ab98561ca50c88f48cb375bfd12d'
+  version '7.10.1'
+  sha256 '6048228a6e772d71804049752c0c061ef150ff31865dd47e503e57ee0beda325'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}.dmg"
   appcast 'https://github.com/poooi/poi/releases.atom',
-          checkpoint: 'e877afee72dd7da60b18d3c650b72d79ba1e80b6611a5bb84bd51de4cc64be54'
+          checkpoint: '162d8738f1ffb78f6ffb522f80c7fd75642cbd2f18f8640ca443d18ab20b20ad'
   name 'poi'
   homepage 'https://poi.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.