### PR TITLE
Update codekit to 3.4-26097

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,10 +1,10 @@
 cask 'codekit' do
-  version '3.3-25900'
-  sha256 '2b064f1248530dc1c67fa28757c3ef7c45db8eaab10711472bc4eafcb88d9836'
+  version '3.4-26097'
+  sha256 'b761e34f145f43c16c11d3fe1946a59d754da25ac0b94bfc609bc68429cd7c39'
 
   url "https://codekitapp.com/binaries/codekit-#{version.sub(%r{.*-}, '')}.zip"
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml",
-          checkpoint: '27ff20c84b5d9c9f587d9818539ff7c533eea8658434a39f309c310bd93b5633'
+          checkpoint: '66e0a8ce33076f240677268afb523247881da9f50e667494879008907283e37e'
   name 'CodeKit'
   homepage 'https://codekitapp.com/'
 

--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -2,7 +2,7 @@ cask 'codekit' do
   version '3.4.26097'
   sha256 'b761e34f145f43c16c11d3fe1946a59d754da25ac0b94bfc609bc68429cd7c39'
 
-  url "https://codekitapp.com/binaries/codekit-#{version.minor}.zip"
+  url "https://codekitapp.com/binaries/codekit-#{version.patch}.zip"
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml",
           checkpoint: '66e0a8ce33076f240677268afb523247881da9f50e667494879008907283e37e'
   name 'CodeKit'

--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,8 +1,8 @@
 cask 'codekit' do
-  version '3.4-26097'
+  version '3.4.26097'
   sha256 'b761e34f145f43c16c11d3fe1946a59d754da25ac0b94bfc609bc68429cd7c39'
 
-  url "https://codekitapp.com/binaries/codekit-#{version.sub(%r{.*-}, '')}.zip"
+  url "https://codekitapp.com/binaries/codekit-#{version.minor}.zip"
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml",
           checkpoint: '66e0a8ce33076f240677268afb523247881da9f50e667494879008907283e37e'
   name 'CodeKit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.