### PR TITLE
Update shifty to 0.3

### DIFF
--- a/Casks/shifty.rb
+++ b/Casks/shifty.rb
@@ -1,11 +1,11 @@
 cask 'shifty' do
-  version '0.2'
-  sha256 '2810714ef55f09dbadd3ba2ae7b8126aaba8dd397651726b06b4f816c3af0c84'
+  version '0.3'
+  sha256 'a84e0cef821dcdd77c7cd00e6ac474c7a2081feea63998e44f3a132c1a5ac349'
 
   # github.com/thompsonate/Shifty was verified as official when first introduced to the cask
   url "https://github.com/thompsonate/Shifty/releases/download/#{version}/Shifty-#{version}.dmg"
   appcast 'https://github.com/thompsonate/Shifty/releases.atom',
-          checkpoint: '76467b5b95772d424c2fdb843fdc4c8f4021a5638d3a9496a2cff305e9ec5340'
+          checkpoint: '65de5b4a6c2a41b1f4a398500c44ed61956e23d7c541e73844273940a67799d2'
   name 'Shifty'
   homepage 'http://shifty.natethompson.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.