### PR TITLE
Update hopper-disassembler to 4.3.5

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.3.4'
-  sha256 '015d4f401812b864b4e5b217047beee4dedfa2983698cbbf42e1e3b7009975e3'
+  version '4.3.5'
+  sha256 '81abbdf4bb2c91f72738b78b877c36f9f046a63d398b07e56ee4972bea81bef0'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: 'efdbbacbaf09c9a6b6d89241c763c0d9324903a162cb4f269d6950cb3ae31cab'
+          checkpoint: '4de71b08e80a2d30bb027ffdef1a604507b4c2523342d70c1fccdcf5a37cae9b'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.