### PR TITLE
Update brave to 0.19.80

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.19.70'
-  sha256 '0ea2b99bd8b421ea49679fd62dd11a1af5a6146502aa3af02fbb2238be05a9d2'
+  version '0.19.80'
+  sha256 '4c20399d7e23c6c7df1c41e6ded4c3f59fb98acc9b1de41ab21562df6c987d63'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '5c3cfdc0162b55a329c55fc8d7218c7f3ccb10105f4458fa84e377686f66b957'
+          checkpoint: '738e3b5ededb7bb06e51a619155c8fecd24bd7e5c251af846b7959533ca00d90'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.