### PR TITLE
Update inssider to 4.2.3.4

### DIFF
--- a/Casks/inssider.rb
+++ b/Casks/inssider.rb
@@ -1,6 +1,6 @@
 cask 'inssider' do
-  version '4.2.2'
-  sha256 '4fa595ea3598543ed2f6027d18012266a86944622f5d87ea8f90f7b3ed28efd7'
+  version '4.2.3.4'
+  sha256 'f499dce56c59a2a3091bcd994a85adc5a26c9e14917daa1f3bacabc0fc87a4b1'
 
   # metageek.net was verified as official when first introduced to the cask
   url "http://files.metageek.net/downloads/inSSIDer#{version.major}-installer.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.