### PR TITLE
LiteIDE x33

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,10 +1,11 @@
 cask 'liteide' do
-  version '32.2'
-  sha256 'e879e227e29503d6af16101031fb0039fb56688366b608b4b5c520fbfe0441d4'
+  version '33'
+  sha256 '76f87d67599a787676c8cf65284009b20f957d39a13f203a486bba0f6a079b1a'
 
-  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macosx-qt5.zip"
+  # downloads.sourceforge.net/liteide/liteidex was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/liteide/liteidex#{version}.macosx-qt5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom',
-          checkpoint: 'bebcfa57d03a1dc5a101bc57f6a4c449157dbc84d550bd85165e6c21c2505fb6'
+          checkpoint: 'dc7b56da16d71a7fb457ce0d12a74da6c4f31a99df129167e88c4a554deeab4e'
   name 'LiteIDE'
   homepage 'https://github.com/visualfc/liteide'
 

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -5,7 +5,7 @@ cask 'liteide' do
   # downloads.sourceforge.net/liteide/liteidex was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/liteide/liteidex#{version}.macosx-qt5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom',
-          checkpoint: 'dc7b56da16d71a7fb457ce0d12a74da6c4f31a99df129167e88c4a554deeab4e'
+          checkpoint: '9cfb38e688538cc323b96ba3dc99569f7a32b30f0759f532e64f02fecccc3245'
   name 'LiteIDE'
   homepage 'https://github.com/visualfc/liteide'
 

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -2,12 +2,12 @@ cask 'liteide' do
   version '33'
   sha256 '76f87d67599a787676c8cf65284009b20f957d39a13f203a486bba0f6a079b1a'
 
-  # downloads.sourceforge.net/liteide/liteidex was verified as official when first introduced to the cask
+  # downloads.sourceforge.net/liteide was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/liteide/liteidex#{version}.macosx-qt5.zip"
-  appcast 'https://github.com/visualfc/liteide/releases.atom',
-          checkpoint: '9cfb38e688538cc323b96ba3dc99569f7a32b30f0759f532e64f02fecccc3245'
+  appcast 'https://sourceforge.net/projects/liteide/rss',
+          checkpoint: '6b4b8a37bfb57c6b71abaa22af6c70baa1d0630132ea6e67046a360e1422c207'
   name 'LiteIDE'
-  homepage 'https://github.com/visualfc/liteide'
+  homepage 'http://liteide.org/'
 
   app 'liteide/LiteIDE.app'
 end


### PR DESCRIPTION
* Bump LideIDE to x33 version

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.