### PR TITLE
Update ThingsMacHelper to 3.9

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -1,11 +1,11 @@
 cask 'thingsmacsandboxhelper' do
-  version '3.5'
-  sha256 '5df5902a0e28ebd1da5b6b02776ae78fb16ff69fb9a644841884cff8d6ce8cbd'
+  version '3.9'
+  sha256 '844273f52b848b8417d72de2ab3bc1a86beadf0c986b706ac2d09087ab0585aa'
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"
   name 'ThingsMacSandboxHelper'
-  homepage 'https://culturedcode.com/things/mac/help/things-sandboxing-helper-download/'
+  homepage 'https://culturedcode.com/things/mac/help/things-sandboxing-helper-things3/'
 
   app 'ThingsMacSandboxHelper.app'
 end

--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -5,7 +5,7 @@ cask 'thingsmacsandboxhelper' do
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"
   name 'ThingsMacSandboxHelper'
-  homepage 'https://culturedcode.com/things/mac/help/things-sandboxing-helper-things3/'
+  homepage "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things#{version.major}/"
 
   app 'ThingsMacSandboxHelper.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.