### PR TITLE
Update praat to 6.0.35

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,11 +1,11 @@
 cask 'praat' do
-  version '6.0.32'
-  sha256 'f76d5bbc8417a9352aa812cd00a92da89927ceb3c3aafe1b224f1b33959ee6e0'
+  version '6.0.35'
+  sha256 '04185cdf2cc82c970250c5e9e1fc80bdbbf0e9b461919b60ab8f6e17cc66ee97'
 
   # github.com/praat/praat/releases was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom',
-          checkpoint: 'aee47c1fd244741e83beee9d29c987a9ca1cc4c7a53455890ecb4f3930cd91b3'
+          checkpoint: '83328a6e18cda9f1038916cee83314c47d3b58ff46b64df7bca53f402542eee5'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.