### PR TITLE
Update studio-3t to 5.6.3

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.6.2'
-  sha256 '09c02e48627244941dff791f5e77a32723691f1b54889b35fc53890147f78c7f'
+  version '5.6.3'
+  sha256 '46e944f9800f5a8a47efc8adb3f14de6619abf07aabb495c8489a509b7736b62'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '7a41ead4099736f2eec72fcf8728c02d764dee91122f796d69fc8969b9bbb1f3'
+          checkpoint: '038f68111ad92ade55341348e691ef5515fac96e6730768455835e1b83da5af1'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.