### PR TITLE
Update aluxian-messenger homepage

### DIFF
--- a/Casks/aluxian-messenger.rb
+++ b/Casks/aluxian-messenger.rb
@@ -7,7 +7,7 @@ cask 'aluxian-messenger' do
   appcast 'https://github.com/aluxian/Messenger-for-Desktop/releases.atom',
           checkpoint: '6e086c442958580c749ef28b6fda0946a9f8ae20215407548f476380963bf00b'
   name 'Messenger for Desktop'
-  homepage 'https://messengerfordesktop.com/'
+  homepage 'https://messengerfordesktop.org/'
 
   auto_updates true
 


### PR DESCRIPTION
The current page for `aluxian-messenger` (https://messengerfordesktop.com) is a clone of the [official](https://messengerfordesktop.org) and it's known to spread releases with malware (lame app owner sold the .com domain). Community moved the official page to https://messengerfordesktop.org - check out https://github.com/aluxian/Messenger-for-Desktop/issues/1153#issuecomment-283514347 for more info.

This PR updates the Cask homepage to the correct (and malware free) official website.

Checklist:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. (Note: **commit only includes name because version was maintained/not updated**, only homepage/metadata was changed.)