### PR TITLE
Update cuppa to 1.8

### DIFF
--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -1,10 +1,10 @@
 cask 'cuppa' do
-  version '1.7.9'
-  sha256 '03172c74f887358bdb21678831f608226c6e17816befc11a8c01b16ec192e820'
+  version '1.8'
+  sha256 '53b5441b277073c78a3f885e08009ef55f288b1577a035b0f2a038d8504ab7a9'
 
   url "https://www.nathanatos.com/software/downloads/Cuppa-#{version}.zip"
   appcast 'https://www.nathanatos.com/software/cuppa.xml',
-          checkpoint: '0a5d7da8744a77eb818aa12dcc6a033d70c5fa18c5cb7b81787e21670621974f'
+          checkpoint: '3d52ac23d6d41e07cb6f394e4dc510d4ee60be80e3b8426277069eda4e4bd804'
   name 'Cuppa'
   homepage 'https://www.nathanatos.com/software/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.