### PR TITLE
Update devonthink to 2.9.16

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.15'
-  sha256 '3d2383c7a2f634e2a2726c85bd002f420de90e230ebf4a63e46b1f2baf744e7b'
+  version '2.9.16'
+  sha256 '85e474a8603f00838a66e0db4989c894a96254a88c7cca8de2723d6bb8c68708'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: '2cbb09a07a917effa2fbafe8f9459718c4191cdf5590c638cb1db737824f5121'
+          checkpoint: '5f42b7fff77c3c1113edc0b8575f441416d5e8d293879f594e6cc69244e844f7'
   name 'DEVONthink Personal'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.