### PR TITLE
Update dropzone to 3.6.4

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,10 +1,10 @@
 cask 'dropzone' do
-  version '3.6.3'
-  sha256 '97c217771313ab85f1bfe9035d62f1572c7e0dbfab3463b027f790ded543d13e'
+  version '3.6.4'
+  sha256 '41fcdb7eb2f8bbcaa1a860e8aa63a9fdf66932168bcb693485fdbdb26d422a93'
 
   url "https://aptonic.com/dropzone3/sparkle/Dropzone-#{version}.zip"
   appcast 'https://aptonic.com/sparkle/updates.xml',
-          checkpoint: '2359652041c439eed3e4da25d262b24250984cf6789b1e998427701dace700d5'
+          checkpoint: 'c31c4a066ab90115e80741f800a518c0d3546f581b9fa9d7d0fb08fc5ff07be8'
   name 'Dropzone'
   homepage 'https://aptonic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.