### PR TITLE
Update iboostup to 5.9.55

### DIFF
--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -1,10 +1,10 @@
 cask 'iboostup' do
-  version '5.9.3'
-  sha256 'e748361f6cb6b7e372f5bfbdbb2b92a0511edb579eef0e7bff9dee6d1fcc315b'
+  version '5.9.55'
+  sha256 '990760306e648d365d38b64ebf8f7fc0b8f89378dd9266cb59ed236475b16943'
 
   url 'https://www.iboostup.com/iboostup.dmg'
   appcast 'https://www.iboostup.com/updates',
-          checkpoint: 'd9ae453bb0bde58cc42b932d35a2798572c0a3ffbee8554b92af63b9649bbd97'
+          checkpoint: '4cefbea13cdd94240b8f0455eab0d50b43b5c047a6029f2d918a8181a5c28be9'
   name 'iBoostUp'
   homepage 'https://www.iboostup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.