### PR TITLE
Update jclasslib-bytecode-viewer to 5.2.1

### DIFF
--- a/Casks/jclasslib-bytecode-viewer.rb
+++ b/Casks/jclasslib-bytecode-viewer.rb
@@ -1,10 +1,10 @@
 cask 'jclasslib-bytecode-viewer' do
-  version '5.2'
-  sha256 '50771508ee35f57f138f46a0def4f31927f00d3f1275c25259247faf223fa7b4'
+  version '5.2.1'
+  sha256 '471bd9d5d9b68a0fbfda08f1c16005aa842bfe7ee52b2b0431fa25df125c3491'
 
   url "https://github.com/ingokegel/jclasslib/releases/download/#{version}/jclasslib_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/ingokegel/jclasslib/releases.atom',
-          checkpoint: 'bc4fe9a7dd836e7b5c3fc8b628bfcc8cb376570b999894742c350a0843c3a918'
+          checkpoint: '486fc5816652f92e974547e0e03d944904fe12bfc8463a2e20a22c8aced071a6'
   name 'jclasslib bytecode viewer'
   homepage 'https://github.com/ingokegel/jclasslib'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.