### PR TITLE
Update kid3 to 3.5.1

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,11 +1,11 @@
 cask 'kid3' do
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  version '3.5.0'
-  sha256 '316fd954cb27b076fab1f98d59cf4d670a7f69af6f2ef0bc6e31ed6585d580a7'
+  version '3.5.1'
+  sha256 'a601637270b6a90774d3486fa1f6726dc9e4ae8d653220ab9b66d510d5cab60d'
 
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin.dmg"
   appcast 'https://sourceforge.net/projects/kid3/rss',
-          checkpoint: '2abcba1fb7b61a782a27b33197700c0d7adcf86c55413c65c450dcecde24e2bd'
+          checkpoint: '63fc23772c0c7a7fd284922bd27d5e9e388225cbd7bd9f62ffe1a916c7b36ec2'
   name 'Kid3'
   homepage 'http://kid3.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.