### PR TITLE
Update kite to 0.20171102.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20170914.0'
-  sha256 '19eb4c90f9c0235b53313ad548a3c5b37ed0d587f99ecd83e1cffc45f0f53f8e'
+  version '0.20171102.0'
+  sha256 '21f783026690a1621305c9d83976b8e9ab1f9751faebfde133512660e373af13'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '1f734d2ea6693eab842071edc512c6d6dae1e905a1dfe1d5e9f40881653bb0ae'
+          checkpoint: '53cc82b5d6414bc62f85a95087a7e3ad32ae1bf0ba452f278e9d8c7faa628691'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.