### PR TITLE
Update kitematic to 0.17.2

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -1,11 +1,11 @@
 cask 'kitematic' do
-  version '0.17.1'
-  sha256 '1d59f334a29ed142e1a0feddb2db602eec5c4932c5fe0941708b5991c1ac3f3e'
+  version '0.17.2'
+  sha256 'f16ce273d15cb3e133f6f36eb0a152de7faaad49dc904259b40d649116c7c0ba'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
-          checkpoint: '8199061bc7bde330a90cb6cc1de62494eae566081473f5d9549c9b275d599e6a'
+          checkpoint: '44b691b3c62380ff7e2d39424eb5bcc5070f29decaa29c3d59c7eee588983de3'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.