### PR TITLE
Update macdive to 2.8.4

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,10 +1,10 @@
 cask 'macdive' do
-  version '2.8.3'
-  sha256 '4c39a54b585137fbaabac85d639400fc2c16991440e620fa7c5d102a6d4815a0'
+  version '2.8.4'
+  sha256 'd55ee1f3274bfadfc0c4e61ba4b5071457b86603861081cd3a0c323c8f679a63'
 
   url "http://mac-dive.com/shimmer/?download&appName=MacDive&appVariant=&appVersion=#{version}"
   appcast 'https://mac-dive.com/shimmer/?appcast&appName=MacDive',
-          checkpoint: '4920ce219477bc4f30f4f90e8e0bb01e17e40b57c71095d446be2e7542760957'
+          checkpoint: '4238d595796f6334775933bd654c9b5a30994ebe27f81ba772174ef551a56d4f'
   name 'MacDive'
   homepage 'https://www.mac-dive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.