### PR TITLE
Update exodus to 1.37.1

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.37.0'
-  sha256 'dbaae9c9c81743ab416715529d4ef1150d51ab9c3afd4c459d000774d4a3ad18'
+  version '1.37.1'
+  sha256 '5d18bc5df12729ff6f76fc478fdda96bab6fb3ca66a83672babdf261ea221a7f'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '94f049bdfa545759ec763eeebc5369981209310c2c3bf479fa4efe637b918156'
+          checkpoint: '426cc8fedce9cfe30827ed465093b737434d000a2618b2b3d8715ec080ce843d'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.