### PR TITLE
Add MiCloud 0.1.19

### DIFF
--- a/Casks/micloud.rb
+++ b/Casks/micloud.rb
@@ -2,7 +2,7 @@ cask 'micloud' do
   version '0.1.19'
   sha256 'b862efef50fd177c53861625f08090bc2b8eea6a2de32a3375d6e38963d196e6'
 
-  # update.micloud.xiaomi.net was verified as official when first introduced to the cask
+  # update.micloud.xiaomi.net/download was verified as official when first introduced to the cask
   url "https://update.micloud.xiaomi.net/download/#{version}/osx_64/MiCloud-#{version}.dmg"
   name 'Mi Cloud'
   name '小米云服务'
@@ -13,11 +13,13 @@ cask 'micloud' do
   uninstall quit: 'micloud.pc.xiaomi'
 
   zap delete: [
-                '~/Library/Application Support/MiCloud',
-                '~/Library/Saved Application State/micloud.pc.xiaomi.savedState',
-                '~/Library/Preferences/micloud.pc.xiaomi.plist',
-                '~/Library/Preferences/micloud.pc.xiaomi.helper.plist',
                 '~/Library/Caches/micloud.pc.xiaomi',
                 '~/Library/Caches/micloud.pc.xiaomi.ShipIt',
+                '~/Library/Saved Application State/micloud.pc.xiaomi.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/MiCloud',
+                '~/Library/Preferences/micloud.pc.xiaomi.helper.plist',
+                '~/Library/Preferences/micloud.pc.xiaomi.plist',
               ]
 end

--- a/Casks/micloud.rb
+++ b/Casks/micloud.rb
@@ -1,0 +1,23 @@
+cask 'micloud' do
+  version '0.1.19'
+  sha256 'b862efef50fd177c53861625f08090bc2b8eea6a2de32a3375d6e38963d196e6'
+
+  # update.micloud.xiaomi.net was verified as official when first introduced to the cask
+  url "https://update.micloud.xiaomi.net/download/#{version}/osx_64/MiCloud-#{version}.dmg"
+  name 'Mi Cloud'
+  name '小米云服务'
+  homepage 'https://i.mi.com/'
+
+  app '小米云服务.app'
+
+  uninstall quit: 'micloud.pc.xiaomi'
+
+  zap delete: [
+                '~/Library/Application Support/MiCloud',
+                '~/Library/Saved Application State/micloud.pc.xiaomi.savedState',
+                '~/Library/Preferences/micloud.pc.xiaomi.plist',
+                '~/Library/Preferences/micloud.pc.xiaomi.helper.plist',
+                '~/Library/Caches/micloud.pc.xiaomi',
+                '~/Library/Caches/micloud.pc.xiaomi.ShipIt',
+              ]
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

Although the version is 0.1.19 and it mentions **beta** in [download page], it becomes public available for a long time and **should be consider as stable**. (Its windows version is 0.1.20)

[download page]: https://i.mi.com/static2?filename=MicloudWebStatic/res/home/mi-lab.htm&locale=zh_CN#3