### PR TITLE
jbidwatcher: upgrade to latest release version (2.99pre5)

### DIFF
--- a/Casks/jbidwatcher.rb
+++ b/Casks/jbidwatcher.rb
@@ -1,6 +1,6 @@
 cask 'jbidwatcher' do
-  version '2.5.6'
-  sha256 '659de073d9e0d71fa86e21db1524b7df57b36ff7826600a01ed93da6df5f5c9f'
+  version '2.99pre5'
+  sha256 '72357173a462a834795241bd5b55e140e1b5aa0a147a1555a68463468c01aeb6'
 
   url "https://www.jbidwatcher.com/download/JBidwatcher-#{version}.dmg"
   appcast 'https://www.jbidwatcher.com/sparkle/updates.xml',


### PR DESCRIPTION
- 2.5/2.6 versions are no longer available
- the appcast/sparkle url specifies this version

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
