### PR TITLE
Update screens to 4.3,11036

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,11 +1,11 @@
 cask 'screens' do
-  version '4.2.2,10054'
-  sha256 '158422fa98a06ee46538153dfba341ee3e5c8ae9555db37d9bc3b45c7d40630f'
+  version '4.3,11036'
+  sha256 '18aa501ec38c5141ff7787ee04ece6b1d62f98d41af5a2359e4ee05863892fdc'
 
   # dl.devmate.com was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.edovia.screens4.mac/Screens#{version.major}.dmg"
   appcast "https://updates.devmate.com/com.edovia.screens#{version.major}.mac.xml",
-          checkpoint: 'a45dbe4433e116e2392aabdde21d99cfb306f0566d059a81da23cd7e4db5426f'
+          checkpoint: 'f78f39f6351b45a5c55b3abc3f3bdd68d35405c0132895cb9e941d0f182cf16d'
   name 'Screens'
   homepage 'https://edovia.com/screens-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.