### PR TITLE
Update x2goclient to 4.1.1.0

### DIFF
--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -1,6 +1,6 @@
 cask 'x2goclient' do
     version '4.1.1.0'
-    
+
     if MacOS.version <= :mavericks
         sha256 '0502fb19866824d4df6c7f75623f07a74202cb13143f6041df30457453f9100e'
         url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029_OSX_10_9.dmg"
@@ -11,16 +11,16 @@ cask 'x2goclient' do
         sha256 '4b35b9002f5a328c98dab213abade2d5a176c6c74efaead9e54987e408a290dd'
         url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_12.dmg"
     end
-    
+
     name 'X2Go Client'
     homepage 'https://wiki.x2go.org/doku.php'
-    
+
     depends_on cask: 'xquartz'
-    
+
     app 'x2goclient.app'
-    
+
     uninstall delete: '/Applications/x2goclient.app'
-    
+
     zap trash: [
     '~/Library/Preferences/x2goclient.plist',
     ]

--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -1,16 +1,27 @@
 cask 'x2goclient' do
-  version '4.1.0.0'
-
-  if MacOS.version <= :mountain_lion
-    sha256 '8fbb806167461af5cfc15b5662a6a6ab5a4459c7f3c8efc61087ade80f919a4c'
-    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}-20170222_OSX_10_6.dmg"
-  else
-    sha256 'e0ba49333b0748dbe66a732435ecfe8f98b5c72f334b239d974f8bc58943606d'
-    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}-20170222_OSX_10_9.dmg"
-  end
-
-  name 'X2Go Client'
-  homepage 'https://wiki.x2go.org/doku.php'
-
-  app 'x2goclient.app'
+    version '4.1.1.0'
+    
+    if MacOS.version <= :mavericks
+        sha256 '0502fb19866824d4df6c7f75623f07a74202cb13143f6041df30457453f9100e'
+        url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029_OSX_10_9.dmg"
+        elsif MacOS.version == :yosemite || MacOS.version == :el_capitan
+        sha256 'daa29f7cb697ce04e70ee0401978e2318ff979d97cb0035f12dce4dc061a57c1'
+        url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_10.dmg"
+        elsif MacOS.version == :sierra
+        sha256 '4b35b9002f5a328c98dab213abade2d5a176c6c74efaead9e54987e408a290dd'
+        url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_12.dmg"
+    end
+    
+    name 'X2Go Client'
+    homepage 'https://wiki.x2go.org/doku.php'
+    
+    depends_on cask: 'xquartz'
+    
+    app 'x2goclient.app'
+    
+    uninstall delete: '/Applications/x2goclient.app'
+    
+    zap trash: [
+    '~/Library/Preferences/x2goclient.plist',
+    ]
 end

--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -2,13 +2,13 @@ cask 'x2goclient' do
   version '4.1.1.0'
 
   if MacOS.version <= :mavericks
-    sha256 '0502fb19866824d4df6c7f75623f07a74202cb13143f6041df30457453f9100e'
+    sha256 '459ac9363a32601b078c43586e0c5b6a42f3f6eb98947877ef7eacae8fc3181c'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029_OSX_10_9.dmg"
   elsif MacOS.version == :yosemite || MacOS.version == :el_capitan
-    sha256 'daa29f7cb697ce04e70ee0401978e2318ff979d97cb0035f12dce4dc061a57c1'
+    sha256 'a852dbcd134a30f0d442001707982b7fc11c64d5fed5813feec20d06de274301'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_10.dmg"
   elsif MacOS.version == :sierra
-    sha256 '4b35b9002f5a328c98dab213abade2d5a176c6c74efaead9e54987e408a290dd'
+    sha256 'e6e2c4384218711d6b4480c8c9f8f44a726930a594f4c15431ecbd2092f77cb4'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_12.dmg"
   end
 

--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -1,27 +1,27 @@
 cask 'x2goclient' do
-    version '4.1.1.0'
+  version '4.1.1.0'
 
-    if MacOS.version <= :mavericks
-        sha256 '0502fb19866824d4df6c7f75623f07a74202cb13143f6041df30457453f9100e'
-        url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029_OSX_10_9.dmg"
-        elsif MacOS.version == :yosemite || MacOS.version == :el_capitan
-        sha256 'daa29f7cb697ce04e70ee0401978e2318ff979d97cb0035f12dce4dc061a57c1'
-        url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_10.dmg"
-        elsif MacOS.version == :sierra
-        sha256 '4b35b9002f5a328c98dab213abade2d5a176c6c74efaead9e54987e408a290dd'
-        url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_12.dmg"
-    end
+  if MacOS.version <= :mavericks
+    sha256 '0502fb19866824d4df6c7f75623f07a74202cb13143f6041df30457453f9100e'
+    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029_OSX_10_9.dmg"
+  elsif MacOS.version == :yosemite || MacOS.version == :el_capitan
+    sha256 'daa29f7cb697ce04e70ee0401978e2318ff979d97cb0035f12dce4dc061a57c1'
+    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_10.dmg"
+  elsif MacOS.version == :sierra
+    sha256 '4b35b9002f5a328c98dab213abade2d5a176c6c74efaead9e54987e408a290dd'
+    url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_12.dmg"
+  end
 
-    name 'X2Go Client'
-    homepage 'https://wiki.x2go.org/doku.php'
+  name 'X2Go Client'
+  homepage 'https://wiki.x2go.org/doku.php'
 
-    depends_on cask: 'xquartz'
+  depends_on cask: 'xquartz'
 
-    app 'x2goclient.app'
+  app 'x2goclient.app'
 
-    uninstall delete: '/Applications/x2goclient.app'
+  uninstall delete: '/Applications/x2goclient.app'
 
-    zap trash: [
-    '~/Library/Preferences/x2goclient.plist',
-    ]
+  zap trash: [
+               '~/Library/Preferences/x2goclient.plist',
+             ]
 end

--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -4,10 +4,10 @@ cask 'x2goclient' do
   if MacOS.version <= :mavericks
     sha256 '459ac9363a32601b078c43586e0c5b6a42f3f6eb98947877ef7eacae8fc3181c'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029_OSX_10_9.dmg"
-  elsif MacOS.version == :yosemite || MacOS.version == :el_capitan
+  elsif MacOS.version <= :el_capitan
     sha256 'a852dbcd134a30f0d442001707982b7fc11c64d5fed5813feec20d06de274301'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_10.dmg"
-  elsif MacOS.version == :sierra
+  else
     sha256 'e6e2c4384218711d6b4480c8c9f8f44a726930a594f4c15431ecbd2092f77cb4'
     url "https://code.x2go.org/releases/binary-macosx/x2goclient/releases/#{version}/x2goclient-#{version}.20171029.OSX_10_12.dmg"
   end
@@ -19,9 +19,5 @@ cask 'x2goclient' do
 
   app 'x2goclient.app'
 
-  uninstall delete: '/Applications/x2goclient.app'
-
-  zap trash: [
-               '~/Library/Preferences/x2goclient.plist',
-             ]
+  zap trash: '~/Library/Preferences/x2goclient.plist'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Comments:
- I ran the audit utility and it passed for MacOS 10.12, but I am not sure if I did it correctly.
- Besides updating the version number, also dependence on the xquartz cask and uninstall and zap stanzas are added.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256