### PR TITLE
Update bzflag to 2.4.12

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -1,10 +1,10 @@
 cask 'bzflag' do
-  version '2.4.10'
-  sha256 '7e7147380f03e51acf5f12353454f539a25ccc3b90a853b8cf8fcabc11b0afc0'
+  version '2.4.12'
+  sha256 '5bf28fab219bae32cdfd32765289b3454b7e658ffe49d05ea49c2c03d6749fe7'
 
   url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom',
-          checkpoint: '3977e768b79641b31bccaddf102b29a8c8e53ed1f5f238bd70a2bb28d9ec5196'
+          checkpoint: 'bd9b9100c950397795323125b82cf5b21c789cb6defa9ded7962892b24a71df0'
   name 'BZFlag'
   homepage 'https://www.bzflag.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.