### PR TITLE
Update keystore-explorer to 5.3.1

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -9,5 +9,5 @@ cask 'keystore-explorer' do
   name 'KeyStore Explorer'
   homepage 'http://keystore-explorer.org/'
 
-  app "KeyStore Explorer #{version}.app"
+  app 'KeyStore Explorer.app'
 end

--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,11 +1,11 @@
 cask 'keystore-explorer' do
-  version '5.3.0'
-  sha256 '8ccf57e1282d2a4538d9a2b551bc0825cc3144c18068b0fd492251340497a5a7'
+  version '5.3.1'
+  sha256 '172afbb9a2c47d9f549ed8efc3a6751da0b8659c2602594a107ee7c0d282354a'
 
   # github.com/kaikramer/keystore-explorer was verified as official when first introduced to the cask
-  url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version.major_minor}/kse-#{version.no_dots}.dmg"
+  url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version}/kse-#{version.no_dots}.dmg"
   appcast 'https://github.com/kaikramer/keystore-explorer/releases.atom',
-          checkpoint: '5712e8f8baedb730cd02b27274daf3a052116caba13ce6e12d97f3a2ac93513d'
+          checkpoint: 'a3a5556f83c974e9d36a9aec59d7f4a8358d159f7f3241c303714463444ff6af'
   name 'KeyStore Explorer'
   homepage 'http://keystore-explorer.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.