### PR TITLE
Update graphicconverter to 10.5.2,2911

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,11 +1,11 @@
 cask 'graphicconverter' do
-  version '10.5.1,2894'
-  sha256 'fae4fdc950167ecda11cc7319edc0bc71df6daf63f55b6148929ea7f215c351a'
+  version '10.5.2,2911'
+  sha256 'cf705720d3ab710300376e1114029c1eb276724e9ef9a275fe36df626c9d8926'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
   appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml",
-          checkpoint: 'cc7683df2adfaf3714453a6d689513b0e6f59f52017e166996bd244c018eff70'
+          checkpoint: 'd81276fa9cce65c47078aa20516134d573a2c4b670073b2fc94e108d25c695e8'
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.