### PR TITLE
Update find-any-file to 1.9

### DIFF
--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -1,11 +1,11 @@
 cask 'find-any-file' do
-  version '1.8.9'
-  sha256 'fde3cd23b38f5baa626f557ac40148795a5afee6cc84ecb28b74b439bdae0189'
+  version '1.9'
+  sha256 'd01964c2a61df8c80ae925559025b21d95cd2436f528f14266c09ecd3382ed74'
 
   # files.tempel.org.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.tempel.org.s3.amazonaws.com/FindAnyFile_#{version}.zip"
   appcast 'http://apps.tempel.org/FindAnyFile/appcast.xml',
-          checkpoint: '5d25f92c40bee0bdf20067a321ae8d6718a5d8a3415e9067a1b7378de43905f6'
+          checkpoint: '2b434e83f0c478ddd58e4b8864f5f5b3df276e6e892f4f6532c787f689073ff9'
   name 'Find Any File'
   homepage 'http://apps.tempel.org/FindAnyFile/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.