### PR TITLE
Update tankix to 6951

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '6729'
-  sha256 '7f147946658655acf44b91d6d2d8a78a1886cb1b2c8e708f29517985993df787'
+  version '6951'
+  sha256 'e360d3fc5d0799c1d281711bfd86c543a7ce2c7312a94f56261a6960210b3e9a'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.