### PR TITLE
Update stretchly to 0.12.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.11.0'
-  sha256 '6de1894590c12e9f8a0a7393a6fa28edbd9344baffc2d9c5e9674f12f233102e'
+  version '0.12.0'
+  sha256 'a73906fd189caa81913907d081cac7425d191639b75c59ec105f39f7c25648a0'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: 'abdfd168229c8cda8612a7487b183223c9b01dca3c2069641b281de0eb58e45b'
+          checkpoint: 'c7411c3ed3ca7ceb1307611a10171ae4906542cd7ab278f2606aaf37740f7662'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.