### PR TITLE
Update now to 3.3.2

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.3.1'
-  sha256 'c3bd81baa0a9865ac54a65fdb495aec4b64b422e5a28b40cb9c714d4f47deb4d'
+  version '3.3.2'
+  sha256 '0f6d65207b7d8a0c15aea30ef101cf7b15d81fe6da106f6f1e8b158faa8ae727'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '59636f21ad47c745606c9ea9d96f5215978b5d565a0231535d81d441ebf1bb33'
+          checkpoint: 'ab9a71aa5b243b85afc80f8985d3d691ddce7d96c5e7c05e09e5ca2bd1d34275'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.