### PR TITLE
Fix standard notes url and make it autoupdating

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -9,5 +9,7 @@ cask 'standard-notes' do
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 
+  auto_updates true
+
   app 'Standard Notes.app'
 end

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -3,7 +3,7 @@ cask 'standard-notes' do
   sha256 '99b5146b0b26a99bf261e478512070315fe6b16c4e8a2be778ec1479fdfe567c'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
-  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard.Notes-#{version}-mac.zip"
+  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
           checkpoint: '361cefecd86033b616fbd32f06ccf6d9b1616d2a7c6a953330e29c86dafedd05'
   name 'Standard Notes'


### PR DESCRIPTION
Standard Notes autoupdates, so it shouldn't be listed by `brew cask outdated`, to achieve this, I added `auto_updates true`.

Also, in [#40347](https://github.com/caskroom/homebrew-cask/pull/40347), one character in the url was changed, causing downloads to fail. See [https://github.com/standardnotes/desktop/releases](https://github.com/standardnotes/desktop/releases) for standard file name. With this, I am correcting it.

Because this PR is not related to any specific version of Standard Notes, I didn't check the third box below.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.