### PR TITLE
Update coteditor to 3.2.4

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -15,14 +15,14 @@ cask 'coteditor' do
     # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
     url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   else
-    version '3.2.3'
-    sha256 '7d47baf63976787673cb1efd49808b62bcb49ed2868e3697f773dd4d82da6179'
+    version '3.2.4'
+    sha256 'f7ff7bb309c11716c4c9231e96cd06ab9ee1051a68c7cd1ce4cf1590e863c92b'
     # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
     url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   end
 
   appcast 'https://github.com/coteditor/CotEditor/releases.atom',
-          checkpoint: '6251bf8b0ec2dd34807d085201fe9a3697f27483524bdae926398b65418d8033'
+          checkpoint: 'bb68d4aa03bad3aeb15b0b0a36daa91da28ca99efe3fb26e6299f02e9d8f51c6'
   name 'CotEditor'
   homepage 'https://coteditor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.