### PR TITLE
Update ubar to 4.0.4

### DIFF
--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -1,10 +1,10 @@
 cask 'ubar' do
-  version '4.0.1'
-  sha256 '2ebc0cf7d74553f44308eb93f72f2a897e8d403a961cc16023cc843471b3e1f0'
+  version '4.0.4'
+  sha256 'a8609cde9e128cfa29aabdbd067480e93e7e2e004a3af483891918164211cb1c'
 
   url "http://www.brawersoftware.com/downloads/ubar/ubar#{version.no_dots}.zip"
   appcast "https://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
-          checkpoint: '25f9839af108389ace53991d20df808e5f58de71bd3906bdab310244729b067a'
+          checkpoint: '46820c6898656f017fa37f691fa7a674c52de1575f1adb88959368703ec90530'
   name 'uBar'
   homepage 'https://brawersoftware.com/products/ubar'
 
@@ -13,9 +13,11 @@ cask 'ubar' do
   app 'uBar.app'
 
   zap delete: [
-                '~/Library/Application Support/uBar',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/ca.brawer.ubar.sfl',
                 '~/Library/Caches/ca.brawer.uBar',
+              ],
+      trash:  [
+                '~/Library/Application Support/uBar',
                 '~/Library/Preferences/ca.brawer.uBar.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.