### PR TITLE
Update affinic-debugger to 2.0.1

### DIFF
--- a/Casks/affinic-debugger.rb
+++ b/Casks/affinic-debugger.rb
@@ -1,10 +1,15 @@
 cask 'affinic-debugger' do
-  version :latest
-  sha256 :no_check
+  version '2.0.1'
+  sha256 '52a8cd20e0c73d6334336ff7d5e00d8223ad46bb96c44267e535df6dc51481b6'
 
-  url 'http://www.affinic.com/download/adg_macosx.dmg'
+  url "http://www.affinic.com/download/adg_#{version}/adg_macosx.dmg"
+  appcast 'http://www.affinic.com/download/adg_macosx.xml',
+          checkpoint: '0da3ee6631d5e2c31403c42e4b9ecc2433dbbb7d69e1d2d92b63cdbf864b11ea'
   name 'Affinic Debugger'
   homepage 'http://www.affinic.com/?page_id=109'
 
   app 'Affinic Debugger.app'
+
+  zap delete: '~/Library/Saved Application State/com.affinic.adg.savedState',
+      trash:  '~/Library/Preferences/com.adg-setting.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.