### PR TITLE
Update qutebrowser zap

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -5,9 +5,15 @@ cask 'qutebrowser' do
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
-          checkpoint: '84277963356ff7826c4a03cf358ae22231b1cbcd995beba14814a13876b34808'
+          checkpoint: '36765055620918390d2ef6507087adea18f18ef0bdadd69213d077489a298a60'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 
   app 'qutebrowser.app'
+
+  zap delete: [
+                '~/Library/Application Support/qutebrowser',
+                '~/Library/Preferences/qutebrowser',
+                '~/Library/Caches/qutebrowser',
+              ]
 end

--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -11,9 +11,9 @@ cask 'qutebrowser' do
 
   app 'qutebrowser.app'
 
-  zap delete: [
+  zap delete: '~/Library/Caches/qutebrowser',
+      trash:  [
                 '~/Library/Application Support/qutebrowser',
                 '~/Library/Preferences/qutebrowser',
-                '~/Library/Caches/qutebrowser',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).