### PR TITLE
Update buttercup to 0.22.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.22.0'
-  sha256 'e7944cf5eb785c5032e318540d74b09a782d345fb3239df5c1bb9e920709ea02'
+  version '0.22.1'
+  sha256 'c555b334ca8a8f02ecf7f142ec5b026cd8e81e9bc948571714ebac0de1a5f345'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '40327d93aac63afd3204f645d970668f309ca375086d4cd8488d2f9ee948ef26'
+          checkpoint: '062d5cab08dc746270be1d02ab8dd737923a68041f25c61f03b2d1dcf7cb4ea2'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.