### PR TITLE
Update etrecheck to latest

### DIFF
--- a/Casks/etrecheck.rb
+++ b/Casks/etrecheck.rb
@@ -8,9 +8,9 @@ cask 'etrecheck' do
 
   app 'EtreCheck.app'
 
-  zap trash:  '~/Library//Preferences/com.etresoft.EtreCheck.plist',
-      delete: [
+  zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.etresoft.etrecheck.sfl',
                 '~/Library/Caches/com.etresoft.EtreCheck',
-              ]
+              ],
+      trash:  '~/Library//Preferences/com.etresoft.EtreCheck.plist'
 end

--- a/Casks/etrecheck.rb
+++ b/Casks/etrecheck.rb
@@ -8,5 +8,9 @@ cask 'etrecheck' do
 
   app 'EtreCheck.app'
 
-  zap delete: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.etresoft.etrecheck.sfl'
+  zap trash:  '~/Library//Preferences/com.etresoft.EtreCheck.plist',
+      delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.etresoft.etrecheck.sfl',
+                '~/Library/Caches/com.etresoft.EtreCheck',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).