### PR TITLE
Update freefilesync to 9.5

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '9.4'
-  sha256 'ba62b487b0f13351a2fb61e47b0a4b68c720a8183286bb18e3bb1d539b6caabe'
+  version '9.5'
+  sha256 'e53c7889b424fc8bee0ea4a23788bde998b4886a63a705614fb12b1cf5d9b2d3'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.