### PR TITLE
Update Standard Notes to 2.0.3

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.0.2'
-  sha256 '99b5146b0b26a99bf261e478512070315fe6b16c4e8a2be778ec1479fdfe567c'
+  version '2.0.3'
+  sha256 'f16be6ee64ce1ccca09f1c923a7339aed5655c6ee9c4fb56c61f8511d76c8cdc'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: '361cefecd86033b616fbd32f06ccf6d9b1616d2a7c6a953330e29c86dafedd05'
+          checkpoint: '97a6545e773c73ab9995f0f4b76d910dfe73f2bf3bb3c7ec483b65fa8e506f90'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.