### PR TITLE
Add zap stanza to Standard Notes

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -13,5 +13,5 @@ cask 'standard-notes' do
 
   app 'Standard Notes.app'
 
-  zap delete: '~/Library/Application Support/Standard Notes'
+  zap trash: '~/Library/Application Support/Standard Notes'
 end

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -12,4 +12,6 @@ cask 'standard-notes' do
   auto_updates true
 
   app 'Standard Notes.app'
+  
+  zap trash: '~/Library/Application Support/Standard Notes'
 end

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -13,9 +13,14 @@ cask 'standard-notes' do
 
   app 'Standard Notes.app'
 
-  zap trash: [
-               '~/Library/Application Support/Standard Notes',
-               '~/Library/Preferences/org.standardnotes.standardnotes.plist',
-               '~/Library/Preferences/org.standardnotes.standardnotes.helper.plist',
-             ]
+  zap delete: [
+                '~/Library/Caches/org.standardnotes.standardnotes',
+                '~/Library/Caches/org.standardnotes.standardnotes.ShipIt',
+                '~/Library/Saved Application State/org.standardnotes.standardnotes.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/Standard Notes',
+                '~/Library/Preferences/org.standardnotes.standardnotes.plist',
+                '~/Library/Preferences/org.standardnotes.standardnotes.helper.plist',
+              ]
 end

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -12,6 +12,6 @@ cask 'standard-notes' do
   auto_updates true
 
   app 'Standard Notes.app'
-  
-  zap trash: '~/Library/Application Support/Standard Notes'
+
+  zap delete: '~/Library/Application Support/Standard Notes'
 end

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -13,5 +13,9 @@ cask 'standard-notes' do
 
   app 'Standard Notes.app'
 
-  zap trash: '~/Library/Application Support/Standard Notes'
+  zap trash: [
+               '~/Library/Application Support/Standard Notes',
+               '~/Library/Preferences/org.standardnotes.standardnotes.plist',
+               '~/Library/Preferences/org.standardnotes.standardnotes.helper.plist',
+             ]
 end


### PR DESCRIPTION
Added `zap trash`.
There seems to be no standard whether to go with `trash` or with `delete` for a zap stanza. I would generally prefer `trash`.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

(PR not in reference to a specific version of the package)