### PR TITLE
Update usage guidelines for keys `trash:` and `delete:`

### DIFF
--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -35,7 +35,7 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
   - `sudo:` - set to `true` if the script needs `sudo`
 * `delete:` (string or array) - single-quoted, absolute paths of files or directory trees to remove. `delete:` should only be used as a last resort. `pkgutil:` is strongly preferred.
 * `rmdir:` (string or array) - single-quoted, absolute paths of directories to remove if empty
-* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash. `trash:` should only be used for user-generated data (i.e. preferences).
+* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash. `trash:` should only be used for user-generated data (i.e. preferences, application support).
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the Cask file is ignored.
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -173,13 +173,11 @@ Arguments to `uninstall delete:` should use the following basic rules:
 * Paths must be absolute.
 * Glob expansion is performed using the [standard set of characters](https://en.wikipedia.org/wiki/Glob_(programming)).
 
-To delete user-specific files such as caches and saved application states, use the `zap` stanza instead of `uninstall`.
+To remove user-specific files, use the [`zap` stanza](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/zap.md).
 
 ## uninstall Key trash:
 
 `trash:` arguments follow the same rules listed above for `delete:`.
-
-To trash user-specific files such as preferences and application support, use the `zap` stanza instead of `uninstall`.
 
 ## Working With a pkg File Manually
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -35,7 +35,7 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
   - `sudo:` - set to `true` if the script needs `sudo`
 * `delete:` (string or array) - single-quoted, absolute paths of files or directory trees to remove. `delete:` should only be used as a last resort. `pkgutil:` is strongly preferred.
 * `rmdir:` (string or array) - single-quoted, absolute paths of directories to remove if empty
-* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash. `trash:` should onl be used as a last resort. `pkgutil:` is strongly preferred.
+* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash. `trash:` should only be used for user-generated data (i.e. preferences).
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the Cask file is ignored.
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -35,7 +35,7 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
   - `sudo:` - set to `true` if the script needs `sudo`
 * `delete:` (string or array) - single-quoted, absolute paths of files or directory trees to remove. `delete:` should only be used as a last resort. `pkgutil:` is strongly preferred.
 * `rmdir:` (string or array) - single-quoted, absolute paths of directories to remove if empty
-* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash. `trash:` should only be used for user-generated data (i.e. preferences, application support).
+* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash.
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the Cask file is ignored.
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -173,11 +173,13 @@ Arguments to `uninstall delete:` should use the following basic rules:
 * Paths must be absolute.
 * Glob expansion is performed using the [standard set of characters](https://en.wikipedia.org/wiki/Glob_(programming)).
 
-To remove user-specific files, use the `zap` stanza.
+To delete user-specific files such as caches and saved application states, use the `zap` stanza instead of `uninstall`.
 
 ## uninstall Key trash:
 
-*stub* - currently a synonym for `delete:`. In the future this will cause files to be moved to the Trash. It is best not to use this stub until it gains the proper functionality.
+`trash:` arguments follow the same rules listed above for `delete:`.
+
+To trash user-specific files such as preferences and application support, use the `zap` stanza instead of `uninstall`.
 
 ## Working With a pkg File Manually
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -35,7 +35,7 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
   - `sudo:` - set to `true` if the script needs `sudo`
 * `delete:` (string or array) - single-quoted, absolute paths of files or directory trees to remove. `delete:` should only be used as a last resort. `pkgutil:` is strongly preferred.
 * `rmdir:` (string or array) - single-quoted, absolute paths of directories to remove if empty
-* `trash:` (string or array) - single-quoted, absolute paths of files or directory to move to Trash.
+* `trash:` (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash. `trash:` should onl be used as a last resort. `pkgutil:` is strongly preferred.
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the Cask file is ignored.
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -35,7 +35,7 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
   - `sudo:` - set to `true` if the script needs `sudo`
 * `delete:` (string or array) - single-quoted, absolute paths of files or directory trees to remove. `delete:` should only be used as a last resort. `pkgutil:` is strongly preferred.
 * `rmdir:` (string or array) - single-quoted, absolute paths of directories to remove if empty
-* `trash:` (string or array) - currently a synonym for `delete:`. In the future this will cause files to be moved to the Trash.
+* `trash:` (string or array) - single-quoted, absolute paths of files or directory to move to Trash.
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the Cask file is ignored.
 

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -19,7 +19,6 @@ $ brew cask zap td-toolbelt             # also removes org.ruby-lang.installer
 
 ## zap Stanza Syntax
 
-The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. The `trash:` key should be used rather than `delete:`.
-
+The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. The `trash:` key is preferred over `delete:`.
 
 Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/31cd96cc0e00dab1bff74d622e32d816bafd1f6f/Casks/dropbox.rb#L17-L35)

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -19,8 +19,7 @@ $ brew cask zap td-toolbelt             # also removes org.ruby-lang.installer
 
 ## zap Stanza Syntax
 
-The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. Unlike with `uninstall`, however, `delete:` is not discouraged in `zap`.
+The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. The `trash:` key should be used rather than `delete:`.
 
-To remove user-generated data such as preferences and application support files and folders, use only the `trash:` key. For data such as caches and saved application states, use the `delete:` key.
 
-Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L15-L33)
+Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/31cd96cc0e00dab1bff74d622e32d816bafd1f6f/Casks/dropbox.rb#L17-L35)

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -23,4 +23,4 @@ The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of 
 
 For removing user-generated data such as preferences and application support files and folders, use only the `trash:` key.
 
-Example: [injection.rb](https://github.com/caskroom/homebrew-cask/blob/312ae841f1f1b2ec07f4d88b7dfdd7fbdf8d4f94/Casks/injection.rb#L16)
+Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L26)

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -23,4 +23,4 @@ The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of 
 
 To remove user-generated data such as preferences and application support files and folders, use only the `trash:` key. For data such as caches and saved application states, use the `delete:` key.
 
-Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L26-L33)
+Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L15-L33)

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -21,4 +21,6 @@ $ brew cask zap td-toolbelt             # also removes org.ruby-lang.installer
 
 The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. Unlike with `uninstall`, however, `delete:` is not discouraged in `zap`.
 
+For removing user-generated data such as preferences and application support files and folders, use only the `trash:` key.
+
 Example: [injection.rb](https://github.com/caskroom/homebrew-cask/blob/312ae841f1f1b2ec07f4d88b7dfdd7fbdf8d4f94/Casks/injection.rb#L16)

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -23,4 +23,4 @@ The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of 
 
 For removing user-generated data such as preferences and application support files and folders, use only the `trash:` key.
 
-Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L26)
+Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L26-L33)

--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -21,6 +21,6 @@ $ brew cask zap td-toolbelt             # also removes org.ruby-lang.installer
 
 The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. Unlike with `uninstall`, however, `delete:` is not discouraged in `zap`.
 
-For removing user-generated data such as preferences and application support files and folders, use only the `trash:` key.
+To remove user-generated data such as preferences and application support files and folders, use only the `trash:` key. For data such as caches and saved application states, use the `delete:` key.
 
 Example: [dropbox.rb](https://github.com/caskroom/homebrew-cask/blob/4690b1cfe65ab4bec1b1a2545e2275450aba52d5/Casks/dropbox.rb#L26-L33)


### PR DESCRIPTION
I couldn't find a commit in which this was done, but it seems like `trash:` does move files to Trash, and is no longer a synonym for `delete:`.