### PR TITLE
Update bettertouchtool to 2.313x

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -3,22 +3,28 @@ cask 'bettertouchtool' do
     version '0.939'
     sha256 'fad5e9d36259c379bdb33188cf15d179fd9ff73023035c98f5734e7e3e13bb75'
 
-    # bettertouchtool.net was verified as official when first introduced to the cask
+    # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"
   elsif MacOS.version <= :lion
     version '1.922'
+
+    # bettertouchtool.net/releases was verified as official when first introduced to the cask
     sha256 '7a5a7cc9a9e5ae77f4ee7470f26453d327ccb55c7fac7f78f1bbe14ae9f0e70c'
     url "https://bettertouchtool.net/releases/btt#{version}_lion.zip"
   elsif MacOS.version <= :mavericks
     version '2.05'
     sha256 '41013cfeffee286a038363651db3dd315ff3a1e0cf07774d9ce852111be50a5a'
+
+    # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.310b'
-    sha256 '292084f1e4766703f5b59158ec4a5686ce9a10e517c8d45a40cb20f69479da85'
+    version '2.313x'
+    sha256 'c662702b082459840e138ad3361ec40a38ae5fde95b74cd2c57f660faec08f2e'
+
+    # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"
     appcast 'https://updates.bettertouchtool.net/appcast.xml',
-            checkpoint: 'b3a037ae63b2f95f67da654b21af82357b3d42be47c2e3f4f87a1d6cf52c59a4'
+            checkpoint: '23c5085d483ccf2cc22b19325ba5d4e8a59fead696ed1c33c7b23fc8701861f6'
   end
 
   name 'BetterTouchTool'
@@ -31,8 +37,8 @@ cask 'bettertouchtool' do
 
   uninstall login_item: 'BetterTouchTool'
 
-  zap delete: [
-                '~/Library/Preferences/com.hegenberg.BetterTouchTool.plist',
-                '~/Library/Application Support/BetterTouchTool',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.hegenberg.BetterTouchTool.plist',
+               '~/Library/Application Support/BetterTouchTool',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.