### PR TITLE
Add Google Keep menubar app v0.4.0

### DIFF
--- a/Casks/keep.rb
+++ b/Casks/keep.rb
@@ -1,6 +1,6 @@
 cask 'keep' do
   version '0.4.0'
-  sha256 :no_check
+  sha256 'e7a750deb250f21ef8b0e11bb01c62299d1574779bcfc83d74c5e238f1e40889'
 
   url "https://github.com/tmcinerney/keep/releases/download/v#{version}/keep.v#{version}.zip"
   appcast 'https://github.com/tmcinerney/keep/releases.atom',
@@ -12,12 +12,17 @@ cask 'keep' do
 
   app 'Keep.app'
 
-  uninstall quit: 'com.electron.keep'
+  uninstall signal: [
+                      ['TERM', 'com.electron.keep'],
+                      ['TERM', 'com.electron.keep.helper'],
+                    ]
 
-  zap delete: '~/Library/Caches/com.electron.keep',
+  zap delete: [
+                '~/Library/Caches/com.electron.keep',
+                '~/Library/Saved Application State/com.electron.keep.savedState',
+              ],
       trash:  [
                 '~/Library/Application Support/Keep',
-                '~/Library/Saved Application State/com.electron.keep.savedState',
                 '~/Library/Preferences/com.electron.keep.plist',
                 '~/Library/Preferences/com.electron.keep.helper.plist',
               ]

--- a/Casks/keep.rb
+++ b/Casks/keep.rb
@@ -8,8 +8,6 @@ cask 'keep' do
   name 'Keep'
   homepage 'https://github.com/tmcinerney/keep/'
 
-  auto_updates true
-
   app 'Keep.app'
 
   uninstall signal: [

--- a/Casks/keep.rb
+++ b/Casks/keep.rb
@@ -1,0 +1,24 @@
+cask 'keep' do
+  version '0.4.0'
+  sha256 :no_check
+
+  url "https://github.com/tmcinerney/keep/releases/download/v#{version}/keep.v#{version}.zip"
+  appcast 'https://github.com/tmcinerney/keep/releases.atom',
+        checkpoint: 'dfbb63243f9d2c22b82e0b9fca0b5c0c0956be55feb19e77b341d0de3662f0a7'
+  name 'Keep'
+  homepage 'https://github.com/tmcinerney/keep/'
+
+  auto_updates true
+
+  app 'Keep.app'
+
+  uninstall quit: 'com.electron.keep'
+
+  zap delete: '~/Library/Caches/com.electron.keep',
+      trash:  [
+                '~/Library/Application Support/Keep',
+                '~/Library/Saved Application State/com.electron.keep.savedState',
+                '~/Library/Preferences/com.electron.keep.plist',
+                '~/Library/Preferences/com.electron.keep.helper.plist',
+              ]
+end

--- a/Casks/keep.rb
+++ b/Casks/keep.rb
@@ -4,7 +4,7 @@ cask 'keep' do
 
   url "https://github.com/tmcinerney/keep/releases/download/v#{version}/keep.v#{version}.zip"
   appcast 'https://github.com/tmcinerney/keep/releases.atom',
-        checkpoint: 'dfbb63243f9d2c22b82e0b9fca0b5c0c0956be55feb19e77b341d0de3662f0a7'
+          checkpoint: 'dfbb63243f9d2c22b82e0b9fca0b5c0c0956be55feb19e77b341d0de3662f0a7'
   name 'Keep'
   homepage 'https://github.com/tmcinerney/keep/'
 


### PR DESCRIPTION
This is a macOS app that allows you to access [Google Keep](https://www.google.com/keep/) in your menubar.

It was created by [Travers McInerney](https://github.com/tmcinerney/keep) but I like it so much, I wanted to add it to my dotfiles but then I realized there wasn't a cask so here I am.

---

Signed-off-by: Frances Coronel <hello@fvcproductions.com>

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
