### PR TITLE
Upgrade vagrant-manager to 2.6.0

### DIFF
--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -11,6 +11,9 @@ cask 'vagrant-manager' do
 
   app 'Vagrant Manager.app'
 
+  uninstall login_item: 'Vagrant Manager',
+            quit:       'lanayo.Vagrant-Manager'
+
   zap delete: '~/Library/Caches/lanayo.Vagrant-Manager',
       trash:  '~/Library/Preferences/lanayo.Vagrant-Manager.plist'
 end

--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -1,11 +1,11 @@
 cask 'vagrant-manager' do
-  version '2.5.4'
-  sha256 '9ad9d9f5d6eca2ef0f4493004f06acc6862701b1b731fe20ddbc7c5970079824'
+  version '2.6.0'
+  sha256 'ed9ad3f1b6a97e82c959812b0779036946903630627914b02684d53ad71b1052'
 
   # github.com/lanayotech/vagrant-manager was verified as official when first introduced to the cask
   url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
   appcast 'https://github.com/lanayotech/vagrant-manager/releases.atom',
-          checkpoint: 'a6d3c3340cdfba7d45050e104530e7ad480d378975bf8217b8daa9863d92da9e'
+          checkpoint: 'bb3f4660861c88890122d0a388d847c54501de7109967d2f63484b3865a351d4'
   name 'Vagrant Manager'
   homepage 'http://vagrantmanager.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.