### PR TITLE
Update atom to 1.21.2

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -18,15 +18,17 @@ cask 'atom' do
 
   zap delete: [
                 '~/.atom',
+                '~/Library/Caches/com.github.atom',
+                '~/Library/Caches/com.github.atom.ShipIt',
+                '~/Library/Saved Application State/com.github.atom.savedState',
+              ],
+      trash:  [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
                 '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
                 '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Application Support/com.github.atom.ShipIt',
-                '~/Library/Caches/com.github.atom',
-                '~/Library/Caches/com.github.atom.ShipIt',
                 '~/Library/Preferences/com.github.atom.helper.plist',
                 '~/Library/Preferences/com.github.atom.plist',
-                '~/Library/Saved Application State/com.github.atom.savedState',
               ]
 end

--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -18,15 +18,15 @@ cask 'atom' do
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
+                '~/Library/Application Support/ShipIt_stderr.log',
+                '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Caches/com.github.atom',
                 '~/Library/Caches/com.github.atom.ShipIt',
                 '~/Library/Saved Application State/com.github.atom.savedState',
               ],
       trash:  [
                 '~/.atom',
-                '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
-                '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Application Support/com.github.atom.ShipIt',
                 '~/Library/Preferences/com.github.atom.helper.plist',
                 '~/Library/Preferences/com.github.atom.plist',

--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -18,12 +18,12 @@ cask 'atom' do
 
   zap delete: [
                 '~/.atom',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
                 '~/Library/Caches/com.github.atom',
                 '~/Library/Caches/com.github.atom.ShipIt',
                 '~/Library/Saved Application State/com.github.atom.savedState',
               ],
       trash:  [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
                 '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
                 '~/Library/Application Support/ShipIt_stdout.log',

--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -17,13 +17,13 @@ cask 'atom' do
   binary "#{appdir}/Atom.app/Contents/Resources/app/atom.sh", target: 'atom'
 
   zap delete: [
-                '~/.atom',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
                 '~/Library/Caches/com.github.atom',
                 '~/Library/Caches/com.github.atom.ShipIt',
                 '~/Library/Saved Application State/com.github.atom.savedState',
               ],
       trash:  [
+                '~/.atom',
                 '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
                 '~/Library/Application Support/ShipIt_stdout.log',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.