### PR TITLE
Update linear to 1.3.0

### DIFF
--- a/Casks/linear.rb
+++ b/Casks/linear.rb
@@ -12,12 +12,12 @@ cask 'linear' do
   app 'linear.app'
 
   zap delete: [
-                '~/.linear',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.linear.sfl',
                 '~/Library/Caches/linear',
                 '~/Library/Saved Application State/com.electron.linear.savedState',
               ],
       trash:  [
+                '~/.linear',
                 '~/Library/Application Support/linear',
                 '~/Library/Preferences/com.electron.linear.plist',
               ]

--- a/Casks/linear.rb
+++ b/Casks/linear.rb
@@ -5,7 +5,7 @@ cask 'linear' do
   # github.com/mikaa123/linear was verified as official when first introduced to the cask
   url "https://github.com/mikaa123/linear/releases/download/#{version}/linear.zip"
   appcast 'https://github.com/mikaa123/linear/releases.atom',
-          checkpoint: 'a1c7e5f02188f3d28e8c90e4514e28de280564d50a85b20007969af076739ad6'
+          checkpoint: '619cb997369fe4ab9ab93026dbd7d19470fee853398a57cbfa56d462aaf05a4c'
   name 'Linear'
   homepage 'http://linear.theuxshop.com/'
 
@@ -14,9 +14,11 @@ cask 'linear' do
   zap delete: [
                 '~/.linear',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.linear.sfl',
-                '~/Library/Application Support/linear',
                 '~/Library/Caches/linear',
-                '~/Library/Preferences/com.electron.linear.plist',
                 '~/Library/Saved Application State/com.electron.linear.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/linear',
+                '~/Library/Preferences/com.electron.linear.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.