### PR TITLE
Update little-snitch to 4.0.3

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -4,7 +4,7 @@ cask 'little-snitch' do
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html',
-          checkpoint: 'e22f14013a36a533eda2a657a92867edc70451365c0343ec9024c91affeba9e4'
+          checkpoint: 'ca02c011efa7e8899f3a817d31024ecfdc8daf0d11c53c2feef66a95acdfc88b'
   name 'Little Snitch'
   homepage 'https://www.obdev.at/products/littlesnitch/index.html'
 
@@ -22,7 +22,6 @@ cask 'little-snitch' do
   zap delete: [
                 '/Library/Application Support/Objective Development/Little Snitch',
                 '/Library/Logs/LittleSnitchDaemon.log',
-                '~/Library/Application Support/Little Snitch',
                 '~/Library/Caches/at.obdev.LittleSnitchAgent',
                 '~/Library/Caches/at.obdev.LittleSnitchConfiguration',
                 '~/Library/Caches/at.obdev.LittleSnitchSoftwareUpdate',
@@ -34,6 +33,7 @@ cask 'little-snitch' do
                 '~/Library/Saved Application State/at.obdev.LittleSnitchInstaller.savedState',
               ],
       trash:  [
+                '~/Library/Application Support/Little Snitch',
                 '~/Library/Preferences/at.obdev.LittleSnitchAgent.plist',
                 '~/Library/Preferences/at.obdev.LittleSnitchConfiguration.plist',
                 '~/Library/Preferences/at.obdev.LittleSnitchInstaller.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.