### PR TITLE
Update iterm2 to 3.1.5

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,11 +1,11 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.4'
-  sha256 '202b2803b514eedd942dac94640cfaee45668e3e6939f88eb29730890dc6d66c'
+  version '3.1.5'
+  sha256 '7159ce6c96fe5c61653a6d6a9a45facfe4a9abff5bfa063e361efd70f89fd769'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml',
-          checkpoint: '7ddf5dfdceb82b8ea6f616f5daf2f1539e5a8db7e5b6a1b83ebbbbf1fab5e7f9'
+          checkpoint: '02bc714d270d449dab9c2c4955623654e8de8e9abfe3ad6460036b507b876331'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.