### PR TITLE
Update filezilla to 3.29.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,11 +1,11 @@
 cask 'filezilla' do
-  version '3.28.0'
-  sha256 'dda2556ea2a5b92b11284fcfd21ec0f4555219916fe7f723fac2fda0c2506025'
+  version '3.29.0'
+  sha256 'e7264da974dc95ffb36af0bbe2a0233fbbb876a11f67e69417fa3e15f52fc1c2'
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '4010f5aa4d8cc14bfa1ed4cea4f901326172b04c921b066ac5e0ac9ca28c821f'
+          checkpoint: 'ddb618d0a52162617c69b8f2036cbd006ae7127c17d21da1ae48d0f93edfeb77'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 
@@ -14,9 +14,11 @@ cask 'filezilla' do
   app 'FileZilla.app'
 
   zap delete: [
-                '~/.config/filezilla',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/de.filezilla.sfl',
-                '~/Library/Preferences/de.filezilla.plist',
                 '~/Library/Saved Application State/de.filezilla.savedState',
+              ],
+      trash:  [
+                '~/.config/filezilla',
+                '~/Library/Preferences/de.filezilla.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.