### PR TITLE
Update gifox to 010301.00

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -1,11 +1,11 @@
 cask 'gifox' do
-  version '010300.00'
-  sha256 'c5e1bd3bf6595bdf43463a2a150a20f1459dd9c239a79af8c3b86b54f7888c7a'
+  version '010301.00'
+  sha256 '09dc7b2c357e30f2d0ec3600bd522d6cfb95d2c9821f54164c53066e5c5ca7f1'
 
   # s3.eu-central-1.amazonaws.com/dstlalgzor/gifox was verified as official when first introduced to the cask
   url "https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/#{version}.dmg"
   appcast 'https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/appcast.xml',
-          checkpoint: '28c984b4a54afb70cc6820d7e4d0af841d64cf0ae306ef0fcb222f46f7834a6b'
+          checkpoint: '57e6492b681ed9c6489b0cc1491cbe7975aadab4c5b24845122460782a8ab23c'
   name 'gifox'
   homepage 'https://gifox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.