### PR TITLE
Update cityofzion-neon to 0.0.7

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,10 +1,10 @@
 cask 'cityofzion-neon' do
-  version '0.0.6'
-  sha256 '8085100f0fa0b30b6c70ae54a546f336609b0e6d6bf9015fd360f293a9039435'
+  version '0.0.7'
+  sha256 '21510de71999ed23cac15a3d07069cca8f83cf0f2492e45260fa51ead33fac73'
 
-  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Mac.Neon-#{version}.dmg"
+  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: '55742dae6d64b78fbfee66358fb11b573e005ae80a6039a0d3da95ebafdcc746'
+          checkpoint: 'ed3bfa1d3af402723e24dda6183cd5abc7a9f0103be6a82fbc80a189958147dd'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.