### PR TITLE
Update inspec to 1.43.8-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.32.1-1'
-  sha256 'c2fcce3f239f749c0ea3356da26da9cb4d48dac3ae7fe0bf61f79fd5d3da7270'
+  version '1.43.8-1'
+  sha256 '2ea506db6b77f2b7e8610a25134704f3f848ab058b4edf445bdbc7a0e8bc59da'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: '78f296772661942094895dc2ee832f4e9ad7c7210cd7144d92629a6a454bc01e'
+          checkpoint: 'b6293e16ee18e3d3f9250d072e2e12e04b8f626a0f5f4b2ace801b8599f7ce5f'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 

--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -5,7 +5,7 @@ cask 'inspec' do
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.12/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'b6293e16ee18e3d3f9250d072e2e12e04b8f626a0f5f4b2ace801b8599f7ce5f'
+          checkpoint: '07108375f3cba12f42f376ca06d2f9f2c1b9d3254ef08413d3d7e10906fa6fcb'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
Update inspec to 1.43.8-1

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask's name and version.