### PR TITLE
Update a-better-finder-rename to 10.23

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,10 +1,10 @@
 cask 'a-better-finder-rename' do
-  version '10.22'
-  sha256 '3360cd0ae34361d82277c6b25f919d73c66c002a3fbc816c302e1492b846ef84'
+  version '10.23'
+  sha256 '39e77a39f3a6e62826bfff38a0fa71c019eb3da5c0e3160c4754b2fc759be54a'
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml",
-          checkpoint: '618c3590373b928313b04cf70cf53edcebafe2ee0905b418f1cbe11774e20606'
+          checkpoint: 'ac8e74fb0effbde77f3f6f877024af9fac3fe78383edac47a75a2eb66e2d0b9d'
   name 'A Better Finder Rename'
   homepage 'http://www.publicspace.net/ABetterFinderRename/'
 
@@ -14,11 +14,13 @@ cask 'a-better-finder-rename' do
   app "A Better Finder Rename #{version.major}.app"
 
   zap delete: [
-                "~/Library/Application Support/A Better Finder Rename #{version.major}",
                 "~/Library/Caches/com.apple.helpd/Generated/net.publicspace.abfr#{version.major}.help",
                 "~/Library/Caches/net.publicspace.abfr#{version.major}",
                 "~/Library/Cookies/net.publicspace.abfr#{version.major}.binarycookies",
-                "~/Library/Preferences/net.publicspace.abfr#{version.major}.plist",
                 "~/Library/Saved Application State/net.publicspace.abfr#{version.major}.savedState",
+              ],
+      trash:  [
+                "~/Library/Application Support/A Better Finder Rename #{version.major}",
+                "~/Library/Preferences/net.publicspace.abfr#{version.major}.plist",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.