### PR TITLE
Update bibdesk to 1.6.12

### DIFF
--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -11,7 +11,12 @@ cask 'bibdesk' do
   app 'BibDesk.app'
 
   zap delete: [
-                '~/Library/Preferences/edu.ucsd.cs.mmccrack.bibdesk.plist',
+                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/edu.ucsd.cs.mmccrack.bibdesk.help*',
+                '~/Library/Caches/edu.ucsd.cs.mmccrack.bibdesk',
+                '~/Library/Cookies/edu.ucsd.cs.mmccrack.bibdesk.binarycookies',
+              ],
+      trash:  [
                 '~/Library/Application Support/BibDesk',
+                '~/Library/Preferences/edu.ucsd.cs.mmccrack.bibdesk.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.