### PR TITLE
Update cocoaspell to 2.5

### DIFF
--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -9,21 +9,23 @@ cask 'cocoaspell' do
   name 'cocoAspell'
   homepage 'http://people.ict.usc.edu/~leuski/cocoaspell/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: [:el_capitan, :sierra]
 
   pkg 'cocoAspell.pkg'
 
   uninstall pkgutil: 'net.leuski.cocoaspell.*',
             delete:  [
                        '/Application Support/cocoAspell/aspell6-en-6.0-0',
+                       '/Library/Application Support/cocoAspell',
                        '/Library/PreferencePanes/Spelling.prefPane',
                      ]
 
-  zap delete: [
-                '~/.aspell.conf',
-                '~/.aspell.en.prepl',
-                '~/.aspell.en.pws',
-              ]
+  zap trash: [
+               '~/.aspell.conf',
+               '~/.aspell.en.prepl',
+               '~/.aspell.en.pws',
+               '~/Library/Preferences/cocoAspell',
+             ]
 
   caveats <<~EOS
     Non-English dictionaries must be installed separately.  For more information, see

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -9,7 +9,7 @@ cask 'cocoaspell' do
   name 'cocoAspell'
   homepage 'http://people.ict.usc.edu/~leuski/cocoaspell/'
 
-  depends_on macos: >= :el_capitan
+  depends_on macos: '>= :el_capitan'
 
   pkg 'cocoAspell.pkg'
 

--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -9,7 +9,7 @@ cask 'cocoaspell' do
   name 'cocoAspell'
   homepage 'http://people.ict.usc.edu/~leuski/cocoaspell/'
 
-  depends_on macos: [:el_capitan, :sierra]
+  depends_on macos: >= :el_capitan
 
   pkg 'cocoAspell.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.