### PR TITLE
Update latexdraw to 3.3.6

### DIFF
--- a/Casks/latexdraw.rb
+++ b/Casks/latexdraw.rb
@@ -9,4 +9,8 @@ cask 'latexdraw' do
   homepage 'http://latexdraw.sourceforge.net/'
 
   app "LaTexDraw-#{version}.app"
+
+  caveats do
+    depends_on_java('8')
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.