### PR TITLE
Update rocket-chat to 2.10.0

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,11 +1,11 @@
 cask 'rocket-chat' do
-  version '2.9.0'
-  sha256 '2a1091e27bc0032feb1497f69a801cab7c906ea2b83219b981dcefc616d5a227'
+  version '2.10.0'
+  sha256 'ee1b46aa60b638d5508da99e9b92e79ade65bf0c3160a5f196d1661aebe34eff'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"
   appcast 'https://github.com/RocketChat/Rocket.Chat.Electron/releases.atom',
-          checkpoint: '552a543e93b85edb6731c400984c0d64cfcf9f54c0ed414efb46be16ca9720c8'
+          checkpoint: 'a6273d5d694155bd29115d5cc56698aabba304a87f990ef2b220d4e7644f6838'
   name 'Rocket.Chat'
   homepage 'https://rocket.chat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.