### PR TITLE
Update downie to 3.1693

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.1676'
-  sha256 '522aee338184f5665d30105c71fc5f4bc2ff2b49bd7f49c95eab9f9856433a34'
+  version '3.1693'
+  sha256 '419dc42e48ad6aa8adc7efa5cbb72e18cd21da6719ba7f8df2625628642b644c'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.dots_to_underscores}.zip"
-  appcast 'https://trial.charliemonroe.net/downie/updates_2.0.xml',
-          checkpoint: '99690af028f2a82d3b25618a0513fb9ac83d7be98e22a36fe7da8834f113202c'
+  appcast 'https://trial.charliemonroe.net/downie/updates_3.xml',
+          checkpoint: '0e8c6ea3c0c3b48c91b1b278efc235619b2939269da719dfd5a5add9d8e7f28a'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.