### PR TITLE
Update MinBrowser to 1.6.3

### DIFF
--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -1,11 +1,11 @@
 cask 'min' do
-  version '1.6.1'
-  sha256 '01292fce4ce5f50255656c15e4f62891efc10b6dc3150f1663de931dd4905963'
+  version '1.6.3'
+  sha256 'c79e32dcaeb170a4276bb9981642359135716731d1457d9cc3fc25db51e941c8'
 
   # github.com/minbrowser/min was verified as official when first introduced to the cask
   url "https://github.com/minbrowser/min/releases/download/v#{version}/Min-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/minbrowser/min/releases.atom',
-          checkpoint: 'b45e63197e5bed028d6cdb2f7417359067b789daeff3e79d7b5ee5de416ffa32'
+          checkpoint: 'd2616d784b1a20887718c7d5480b43a11ff8e94912889ee2040344f8cffa6b32'
   name 'Min'
   homepage 'https://minbrowser.github.io/min/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.