### PR TITLE
Update pomodone to 1.5.1163

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,6 +1,6 @@
 cask 'pomodone' do
-  version '1.5.1126'
-  sha256 'd9f3131a2a7172b9842672acb36d694f7c552b3be75488f539169f29763f933d'
+  version '1.5.1163'
+  sha256 '476d22afec5932be416792e4ced8d8b7407607ccaf0efaef2329efd513785a36'
 
   url "https://app.pomodoneapp.com/installers/PomoDoneApp-#{version}.dmg"
   name 'PomoDone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.