### PR TITLE
Update scala-ide to 4.7.0,2.12:20170929

### DIFF
--- a/Casks/scala-ide.rb
+++ b/Casks/scala-ide.rb
@@ -1,9 +1,9 @@
 cask 'scala-ide' do
-  version '4.6.1,2.12:20170609'
-  sha256 'fb0868c0ce8559964d5b316d71f15681feccb13ab6b230928c789c562afa7b5c'
+  version '4.7.0,2.12:20170929'
+  sha256 'b86a37066cb375615c2a9a61a0152b66a0b172b90e15a33c339f89d2516315f9'
 
   # downloads.typesafe.com/scalaide-pack was verified as official when first introduced to the cask
-  url "https://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-neon-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"
+  url "https://downloads.typesafe.com/scalaide-pack/#{version.before_comma}-vfinal-oxygen-#{version.before_colon.after_comma.no_dots}-#{version.after_colon}/scala-SDK-#{version.before_comma}-vfinal-#{version.before_colon.after_comma}-macosx.cocoa.x86_64.zip"
   name 'Scala IDE'
   homepage 'http://scala-ide.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.