### PR TITLE
Update mysimbl to 0.5.3

### DIFF
--- a/Casks/mysimbl.rb
+++ b/Casks/mysimbl.rb
@@ -1,11 +1,10 @@
 cask 'mysimbl' do
-  version '0.5.3'
+  version '0.5.3,29'
   sha256 '809930f5b3260a905aa07b5dabfeef52c6cbfff08081c2ce2b271b12f4f658b1'
 
-  # githubusercontent.com/w0lfschild/app_updates/master/mySIMBL was verified as official when first introduced to the cask
-  url 'https://github.com/w0lfschild/mySIMBL/releases/download/0.5.3/mySIMBL-29.zip'
-  appcast 'https://raw.githubusercontent.com/w0lfschild/app_updates/master/mySIMBL/appcast.xml',
-          checkpoint: '7923369a4c5ca5e6df3a493697327505a974abd0bb7b25b893a31151c7150555'
+  url "https://github.com/w0lfschild/mySIMBL/releases/download/#{version.before_comma}/mySIMBL-#{version.after_comma}.zip"
+  appcast 'https://github.com/w0lfschild/mySIMBL/releases.atom',
+          checkpoint: 'cffdd993f9a158de17b8dcfd2daf56059d8817c83748c1b93a597cf3254c46c3'
   name 'mySIMBL'
   homepage 'https://github.com/w0lfschild/mySIMBL'
 

--- a/Casks/mysimbl.rb
+++ b/Casks/mysimbl.rb
@@ -1,9 +1,9 @@
 cask 'mysimbl' do
-  version '0.5.1'
-  sha256 'c57c40a4d93eee94c7f2a68f1ef4aa314eb61fa1012e6ebe248afef42bc48090'
+  version '0.5.3'
+  sha256 '809930f5b3260a905aa07b5dabfeef52c6cbfff08081c2ce2b271b12f4f658b1'
 
   # githubusercontent.com/w0lfschild/app_updates/master/mySIMBL was verified as official when first introduced to the cask
-  url "https://raw.githubusercontent.com/w0lfschild/app_updates/master/mySIMBL/mySIMBL_#{version}.zip"
+  url 'https://github.com/w0lfschild/mySIMBL/releases/download/0.5.3/mySIMBL-29.zip'
   appcast 'https://raw.githubusercontent.com/w0lfschild/app_updates/master/mySIMBL/appcast.xml',
           checkpoint: '7923369a4c5ca5e6df3a493697327505a974abd0bb7b25b893a31151c7150555'
   name 'mySIMBL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.