### PR TITLE
Update framer to 15656

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '15539'
-  sha256 'a5defef626cd537ab368faa739592be3a12a50f5e4d22bbe9b6ecce88e621ff8'
+  version '15656'
+  sha256 '30b4d99f4c34bc31f44806f8e3cb3e3f3f56dc84e99adb6015353f09741c1022'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.motif.framer/FramerStudio.zip'
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '0f090155d53ff71498717b6cd835dec1edb6b8bc0e7d408e1a5ede7ba028adae'
+          checkpoint: '64b47c2f780a597e3ddb3c53afcdb7047d6ecf952feccfe97870e026657a8ed7'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.