### PR TITLE
Update now to 3.6.0

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.3.2'
-  sha256 '0f6d65207b7d8a0c15aea30ef101cf7b15d81fe6da106f6f1e8b158faa8ae727'
+  version '3.6.0'
+  sha256 '79e81184e17942c90a6b221af36ed4b3da711d7b06cd7984ee143be20f1edf76'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'ab9a71aa5b243b85afc80f8985d3d691ddce7d96c5e7c05e09e5ca2bd1d34275'
+          checkpoint: '49681a587571589eb35c65a70df6ebf5abfce406623d78f22672fd796dd743aa'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.