### PR TITLE
Update buttercup to 0.22.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.22.1'
-  sha256 'c555b334ca8a8f02ecf7f142ec5b026cd8e81e9bc948571714ebac0de1a5f345'
+  version '0.22.2'
+  sha256 '55e114184fdfc3a488c0466edc09e1106bf68788f83232f4fb121c7769004e8d'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '062d5cab08dc746270be1d02ab8dd737923a68041f25c61f03b2d1dcf7cb4ea2'
+          checkpoint: 'b97ad5f00cd503bc2ca70321d45c307d4a78d1e1535b1179a5d67071296005bd'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.