### PR TITLE
Add mavericks version to hammerspoon

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -1,6 +1,11 @@
 cask 'hammerspoon' do
-  version '0.9.57'
-  sha256 '33844074066446e98e97c10deb68e3934126b2e7ce740bc925ec58060ba59b92'
+  if MacOS.version <= :mavericks
+    version '0.9.46'
+    sha256 '20f7e81624b6f007d6fdd8944cab3d9ba48c36fd0b4f1405a590526b5d4859bc'
+  else
+    version '0.9.57'
+    sha256 '33844074066446e98e97c10deb68e3934126b2e7ce740bc925ec58060ba59b92'
+  end
 
   # github.com/Hammerspoon/hammerspoon was verified as official when first introduced to the cask
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip"


### PR DESCRIPTION
The version number isn't documented anywhere but based on my tests
0.9.46 is the latest version working on mavericks.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.