### PR TITLE
Update vuescan to 9.5.90

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.90'
-  sha256 '0c77e72b7ee929820b06973bb5e953c4b4b66d7aae6f6c201b57ae5f433b8072'
+  version '9.5.91'
+  sha256 '344e8cee4acdcc83cceda2214347edb92a88afe6795691058bcb4003bb86a6d0'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '105d346d578b815e7d1eeb5fdbe5e8c329af7ae6e76c331f663bdb1cf8f05e2c'
+          checkpoint: '90d27e6b0350bf3d8f649f9162c28fd9039598f77900e9ec319bbd31ab8eae4f'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.