### PR TITLE
Update fastonosql to 1.10.0

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,10 +1,10 @@
 cask 'fastonosql' do
-  version '1.9.3'
-  sha256 '7ece42999d3d98976061d5a57903eef0a97bc4069b3f4500eaa1096281d61003'
+  version '1.10.0'
+  sha256 '38bf2c7b272040d8e25ec4cace4799c7a378bbf9e742192bff9d350e75d35292'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom',
-          checkpoint: 'a955fe4b8687a66d1c6636ce296dd434055abb1b750196ff164fe62425e3805a'
+          checkpoint: 'efc5b58bbfdeed9f028c65295b17774b0e5cb99548c160c91fa6a1085c3f13f4'
   name 'FastoNoSQL'
   homepage 'https://www.fastonosql.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.