### PR TITLE
Update karabiner-elements to 11.2.0

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '11.1.0'
-  sha256 '337dcfd072f698691e4b2070b77301d0e3dd7568722f9f451af999aa123e5d93'
+  version '11.2.0'
+  sha256 'd2923653e746543b582bedc1903e49cddc0814cb919e90245a52eb164d346399'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: '27f0cde29e146524a347a9c199414a4721a76aa1af3c262e70641591a27760d5'
+          checkpoint: '8d0488cce5c3055d50450559519835ebefd9f8239ec4ad2d1bd27f649587a2c3'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.