### PR TITLE
Update clyang-welly to 3.1.0

### DIFF
--- a/Casks/clyang-welly.rb
+++ b/Casks/clyang-welly.rb
@@ -1,10 +1,10 @@
 cask 'clyang-welly' do
-  version '3.0.2'
-  sha256 '015a579f92bdf6a7a47db591bbb52d5ab9b1842d758eb783e0a1aae6ad07210c'
+  version '3.1.0'
+  sha256 '3cf2affca536c788e5f96e67cd4dab3fdeb20e115f1fa242285ed9a8ab1f316e'
 
   url "https://github.com/clyang/welly/releases/download/#{version}/Welly.v#{version}.zip"
   appcast 'https://github.com/clyang/welly/releases.atom',
-          checkpoint: 'df6f6353cfeef2c71dec2d9066dc79d496a9cf603fb18daf465285720f1ca076'
+          checkpoint: '47fc74ce4e81906bf418bbf8bc99160720572c9cf5a1ef053b71905bd8ab0b1c'
   name 'Welly'
   homepage 'https://github.com/clyang/welly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.