### PR TITLE
Update bitshares to 2.0.171102

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.171015'
-  sha256 '5ac099fe6f1ebd63e8d40b8c972a7b8636f8d1676f30dba5e0b84c01a4cef805'
+  version '2.0.171102'
+  sha256 'cc06cff51605714bdb8c07d74cf38012e159c5b7142b1598c87c66bf21306205'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: '03974de305239c42b1e9cb146c4934e1c43587e98a0f442fe49c422645a9bbe4'
+          checkpoint: '9f070dafd1a6116440cdbf90f1d5609bf528fd07aba8936745ace8423721868f'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.