### PR TITLE
Fix bad download URL for kitematic 0.17.2

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -3,7 +3,7 @@ cask 'kitematic' do
   sha256 'f16ce273d15cb3e133f6f36eb0a152de7faaad49dc904259b40d649116c7c0ba'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
-  url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
+  url "https://github.com/docker/kitematic/releases/download/#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
           checkpoint: '44b691b3c62380ff7e2d39424eb5bcc5070f29decaa29c3d59c7eee588983de3'
   name 'Kitematic'

--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -1,11 +1,11 @@
 cask 'kitematic' do
   version '0.17.2'
-  sha256 'f16ce273d15cb3e133f6f36eb0a152de7faaad49dc904259b40d649116c7c0ba'
+  sha256 '5a7c569d96461199dfb96bbb0df40452fe71698fd624b9e36a3edfd6228dacca'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
-          checkpoint: '44b691b3c62380ff7e2d39424eb5bcc5070f29decaa29c3d59c7eee588983de3'
+          checkpoint: '2965b3453eca2649575ec9b6fa255345b295485111f3e8386da50a47cf81bc50'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
 


### PR DESCRIPTION
The goal of this PR is to resolve a 404 when attempting to download the latest kitematic (0.17.2) from Github via cask, resulting in the error:  `The requested URL returned error: 404 Not Found`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
