### PR TITLE
Update blocs to 2.4.4

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,11 +1,11 @@
 cask 'blocs' do
-  version '2.4.2'
-  sha256 '27d1fcb38efe5af51a461ff7c0945c5bacb1437d3de46fe7e61c090eb00b2dca'
+  version '2.4.4'
+  sha256 '0e31a825d64f67556613d4def1d1943b8f54abe2c5b3e605de3c0f6d49152dc3'
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
   appcast "https://uistore.io/blocs/#{version.major}.0/info.xml",
-          checkpoint: 'f2ddabae0cedaca8811798c2d2eba7eed2537c0699106cdf23d74c90fece2cab'
+          checkpoint: 'bdd646ca2fba5b7cd2ec742bbc3adc273489a806d4bb0eb570cc027cf34aa399'
   name 'Blocs'
   homepage 'https://blocsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.