### PR TITLE
Update devrantron to 1.4.5

### DIFF
--- a/Casks/devrantron.rb
+++ b/Casks/devrantron.rb
@@ -1,11 +1,11 @@
 cask 'devrantron' do
-  version '1.3.6'
-  sha256 'a23f1d2231e1f5e15c740ef3b1e59b66ce0b37172e74207908c3be4b9df1338d'
+  version '1.4.5'
+  sha256 'e717559d9988df7a967c7d1f85a1f2f8432b2b2e888bd50f17f090b95c0a3815'
 
   # github.com/tahnik/devRantron was verified as official when first introduced to the cask
   url "https://github.com/tahnik/devRantron/releases/download/v#{version}/devrantron-#{version}.dmg"
   appcast 'https://github.com/tahnik/devRantron/releases.atom',
-          checkpoint: 'a868a47445ae4369c428c21bbce0697a0c24d6d386bc78c1bc921ceba8b72eda'
+          checkpoint: '742c19d694fcf688bd9a5eba1027e876055458dbf07c18f78e9e3fa92e5f7031'
   name 'devRantron'
   homepage 'https://devrantron.firebaseapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.