### PR TITLE
Update dollydrive to 3.98,39850

### DIFF
--- a/Casks/dollydrive.rb
+++ b/Casks/dollydrive.rb
@@ -1,10 +1,10 @@
 cask 'dollydrive' do
-  version '3.97,39700'
-  sha256 '7b9ff26dd871ea7b899875707539c99d61060818669bbbe4906fa77a7e49c3ac'
+  version '3.98,39850'
+  sha256 'c9c74636485ebd6c2f6377ae0ca3b60c50b2082b545d3a6309795c940fc1419d'
 
   url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.before_comma}_#{version.after_comma}_CERTIFIED.zip"
   appcast "http://www.dollydrive.com/dolly#{version.major}.xml",
-          checkpoint: '1ced9e101f9709ba80ab6303e71b8fba4a1c4f95374838b1c1c3803b0f870d10'
+          checkpoint: '306c616fa81dda21d26b26af52ff14bef91cea308a6585bcf23d9dec16d16922'
   name 'DollyDrive'
   homepage 'http://www.dollydrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.