### PR TITLE
Update hstracker to 1.2.4

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.2.1'
-  sha256 '79592533e27ae9a7fab510073a0f461eebef4fb56cc44eded68b5184e449cdea'
+  version '1.2.4'
+  sha256 '72b4695444ca43eb4fe66ca285efaa9479da36ee1634b1809d8a2724d6911b07'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: '7ca80a3290e597c3e7a1681e418800b3de8681f7b1a62c02034d0b9f9f56b367'
+          checkpoint: '473ad9fe2b90ee2b4c8323c4b7cebb965063297fdda6f6659564331b1c069aea'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.