### PR TITLE
Update iota-wallet to 2.5.3

### DIFF
--- a/Casks/iota-wallet.rb
+++ b/Casks/iota-wallet.rb
@@ -1,11 +1,11 @@
 cask 'iota-wallet' do
-  version '2.5.1'
-  sha256 '89c5ad91c3a0bb5c8769be5cf8b0b7f4b6faed5af9b7feb32f687d6fde941ac7'
+  version '2.5.3'
+  sha256 '5a017f703baf1c0649c805aa9346d546305c4655716a1047fd57304d7815c340'
 
   # github.com/iotaledger/wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/wallet/releases/download/v#{version}/IOTA.Wallet-#{version}.dmg"
   appcast 'https://github.com/iotaledger/wallet/releases.atom',
-          checkpoint: '2c7e5c5101b457aadbe8e42b56288088e78d3ec61490cda4ae961bcf39cef950'
+          checkpoint: '1e7de9b14e3b53ca8786a450847b0b457508482c654bd46987e31946082abe3c'
   name 'IOTA Wallet'
   homepage 'https://iota.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.