### PR TITLE
Update kactus to 0.2.12

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.2.10'
-  sha256 'd745e0efb5caaf003fbc288b1ddf26df5c56d93200b74d8dbb8bd012d216347c'
+  version '0.2.12'
+  sha256 'f0b28adc55513dcca3519c600f23fc1ce59fea8dc113c535793b5e2015e6f4d8'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: '530498862bcf0ad5af71fd7830d8848376738a54d363b926ed861c504455655a'
+          checkpoint: '04630539b7172a74a4d5054b5e607a724643d83f60c913ebd996af8793711ba3'
   name 'Kactus'
   homepage 'https://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.