### PR TITLE
Update kaleidoscope to 2.2.2-1376

### DIFF
--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -1,10 +1,10 @@
 cask 'kaleidoscope' do
-  version '2.2.1-1158'
-  sha256 '5c31bf6130edc6df84a2a6482718d598a23d5995dfac9c82b1bca2c25a6262a6'
+  version '2.2.2-1376'
+  sha256 '318ce7f2a32cb3330ada05f8099492e1ca5fe41d7b73ecbfd977845ebb5bc016'
 
   url "https://cdn.kaleidoscopeapp.com/releases/Kaleidoscope-#{version}.zip"
   appcast 'https://updates.blackpixel.com/updates?app=ks',
-          checkpoint: '4c3a9669d41c0a644a6dde8da1ef1ebe08df45d260ef1a4641ac9aec8facacf1'
+          checkpoint: '95b390ff5876bce7cd69f2117b2efa925caab3871b543a05416a2755408933d1'
   name 'Kaleidoscope'
   homepage 'https://www.kaleidoscopeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.