### PR TITLE
Update lando to 3.0.0-beta.22

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,11 +1,11 @@
 cask 'lando' do
-  version '3.0.0-beta.21'
-  sha256 '9788612286c111b78383ddc387501ebd5fcba35a2860014e8d0d52fff95751d8'
+  version '3.0.0-beta.22'
+  sha256 'f83a2416d7f363024d56f1e04845f5f9e84df18f411a24552469b28de1fc52e0'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"
   appcast 'https://github.com/lando/lando/releases.atom',
-          checkpoint: '09affcada3ee0acff5159f9b412dbed7dd3951a01c4e21895636531345d4e1dd'
+          checkpoint: '0b8ffe24f170735e6f388c95ae0754593a8ec254f7bf5a7a8c8e8946c9b00faf'
   name 'Lando'
   homepage 'https://docs.devwithlando.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.