### PR TITLE
Update aquaterm to 1.1.1

### DIFF
--- a/Casks/aquaterm.rb
+++ b/Casks/aquaterm.rb
@@ -10,7 +10,8 @@ cask 'aquaterm' do
 
   pkg 'AquaTermInstaller.pkg'
 
-  uninstall pkgutil: 'net.sourceforge.aquaterm.aquaterm.*'
+  uninstall pkgutil: 'net.sourceforge.aquaterm.aquaterm.*',
+            delete:  '/Library/Frameworks/AquaTerm.framework'
 
   zap trash: '~/Library/Preferences/net.sourceforge.aquaterm.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.