### PR TITLE
Fix kitematic 0.17.2 download url

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -3,9 +3,9 @@ cask 'kitematic' do
   sha256 '5a7c569d96461199dfb96bbb0df40452fe71698fd624b9e36a3edfd6228dacca'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
-  url "https://github.com/docker/kitematic/releases/download/#{version}/Kitematic-#{version}-Mac.zip"
+  url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
   appcast 'https://github.com/docker/kitematic/releases.atom',
-          checkpoint: '2965b3453eca2649575ec9b6fa255345b295485111f3e8386da50a47cf81bc50'
+          checkpoint: 'c9dbc8608ef45d697ebd2279781750acdde28da1ae4c5f74fc2891c894be9fe0'
   name 'Kitematic'
   homepage 'https://kitematic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Resolves Kitematic 0.17.2 download URL.