### PR TITLE
Update brave to 0.19.88

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.19.80'
-  sha256 '4c20399d7e23c6c7df1c41e6ded4c3f59fb98acc9b1de41ab21562df6c987d63'
+  version '0.19.88'
+  sha256 '8b09fff865693ddf54acc403819db92ac87335d19bf55103a4cc862e404f5179'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '738e3b5ededb7bb06e51a619155c8fecd24bd7e5c251af846b7959533ca00d90'
+          checkpoint: '795ec0f309546ede51f67e5b11971464adf8732e7e540dbed12adb5929c7d3ee'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.