### PR TITLE
Update red to 0.6.3

### DIFF
--- a/Casks/red.rb
+++ b/Casks/red.rb
@@ -1,6 +1,6 @@
 cask 'red' do
-  version '0.6.2'
-  sha256 'c2d8cca6bf9735a4787be0331697d82b927d02b64368b4611b9f81fa6ba97492'
+  version '0.6.3'
+  sha256 '8fa0aecd8c0cc21ea87c2b26ce940a8cb53ef61d78f1b9e350d2fa8a4e5e7990'
 
   url "http://static.red-lang.org/dl/mac/red-#{version.no_dots}"
   name 'Red Programming Language'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}