### PR TITLE
Update blockstack to 0.21.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -9,5 +9,7 @@ cask 'blockstack' do
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Blockstack.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #40565.

https://github.com/blockstack/blockstack-browser/issues/1043 `10.11` is not supported.