### PR TITLE
Update tunnelblick to 3.7.4a,4920

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,11 +1,11 @@
 cask 'tunnelblick' do
-  version '3.7.4,4900'
-  sha256 '497127ce8a8790b38f7b5ab77240b69ca3d348b9e8cd3bd43e8dca89ad7957e7'
+  version '3.7.4a,4920'
+  sha256 '139199d10bc125806d3686305b033da4c3dd6b7905b3bfefcaf8fc13ae5a1689'
 
   # github.com/Tunnelblick/Tunnelblick/releases/download was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://github.com/Tunnelblick/Tunnelblick/releases.atom',
-          checkpoint: '25fed445d9974e8a0450a826a991ee4b79268f0ef072f22ead6f5b50887469d0'
+          checkpoint: 'c9a34948008a7abf8f21434a36aa3b90e0b8e5735a3f2fe7cb94f08fab3e5470'
   name 'Tunnelblick'
   homepage 'https://www.tunnelblick.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.