### PR TITLE
Update now to 3.6.2

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.6.1'
-  sha256 '010292576ac55c2eca614727dc29ddcb0d220fc9049f038b69420f001256133a'
+  version '3.6.2'
+  sha256 'b6cada4d48445dafef3353af0dc8393bc3b284bac4f44a3e080fe02f5f1f71c2'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '8753dff28c7281582375f33dce67e0f987ab820ec9247511e322b2efa4d8ee7b'
+          checkpoint: 'cf4dd5f2fc88d1fa075a93107b82e40d7e4a80971126a3f7c0e67d703da58811'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.