### PR TITLE
Update navicat-for-mysql to 12.0.17

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.15'
-  sha256 '11287f9ca018c1b4ce8378dfc25e0f521d5aa96bce5b4132629836924242af50'
+  version '12.0.17'
+  sha256 'b119e428faaab56272cab4f1846c32794f794ca2539c6ef8a251ddee3296cae5'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-mysql-release-note',
-          checkpoint: 'b98a0fc35c0bfd95ee348825084a88a6ea92fada77fabd8717f7bdbb00931cfb'
+          checkpoint: '9c61560177490e622ee7f523e42794e78df4a1168624f98c7ab37187107e37a7'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.