### PR TITLE
Update navicat-for-postgresql to 12.0.17

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.15'
-  sha256 'e09d4d09366789c12c36e51950a63b54120fd970bb242f6a93440cb56d1e2d2f'
+  version '12.0.17'
+  sha256 '23e124f2ae80778ef780507441aaa72a2d05e259152f26a3bb18749c1bf5d4a4'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note',
-          checkpoint: 'fbecfed612e5f5aa5de874f408db86db301e60e182705f08a40538b533e712d9'
+          checkpoint: '55005bb76022ef4c7ac7b8b5575716695a39b4a2474bb9cf6f26dfa9055f974e'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.