### PR TITLE
Update navicat-for-sql-server to 12.0.17

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.15'
-  sha256 'c30781b244146d53855ea5e7051e1a81ecac603c8c58247235f76c5a5aef1751'
+  version '12.0.17'
+  sha256 '09c04352dbc9d87d0289090cddcc740315ba95418b5abbad8fa238b2e87b5270'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note',
-          checkpoint: '0bdb1f454b32b8f421997c0f5bf0b3d0fcd660996dc2357912b0d7d0689ff9a8'
+          checkpoint: '50b205329cb0845bd871a2803390aa6599977971aedf7f32a7f42abc59d80eb6'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.