### PR TITLE
Update fredm-fuse to 1.4.1

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -4,7 +4,7 @@ cask 'fredm-fuse' do
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '9cbe56c59a4765930fba325d9d7c11399171a4dcc3ee684fe33dbc25421c45d0'
+          checkpoint: '7316e29750413452be8e76ec1f35f7a3fbaa4e720fb5de6070e9c90933ba38ff'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 

--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,10 +1,10 @@
 cask 'fredm-fuse' do
-  version '1.3.7'
-  sha256 'c86c2820ca65af064bb9971cfb7cdff81f2f974c3492ea10d7cc7d0c82493a08'
+  version '1.4.1'
+  sha256 '3c638d34fa8f015332bf71e4ed4d67aa29e4bdf3191556aaf2df8de05cbfd3bd'
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '9b4362ea3a1b8e0eae268315258065061af8bd4f0a58f4e3cb7684e51c9de025'
+          checkpoint: '9cbe56c59a4765930fba325d9d7c11399171a4dcc3ee684fe33dbc25421c45d0'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.