### PR TITLE
Update freecad to 0.16-6712.da2d364

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,11 +1,11 @@
 cask 'freecad' do
-  version '0.16-6706.f86a4e4'
-  sha256 '9d05b21103bfe0dd7de2ec006fc4c1baca3e7ff32d4b570d91e627caded40178'
+  version '0.16-6712.da2d364'
+  sha256 '8b1d6410a2b276de393b99ff21bbd4888c31bcae6bdf0d400e198b291333f345'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/0.16/FreeCAD_#{version}-OSX-x86_64.dmg"
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/0.16.6712/FreeCAD_#{version}-OSX-x86_64.dmg"
   appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom',
-          checkpoint: '198392755d0e3a9209111491b130b4f932f8d1d36f7aa88c47826f0103bff4e0'
+          checkpoint: '49ced24895e84a20852ec3eb2e50669496a821b7e63e420f4824ef243400c210'
   name 'FreeCAD'
   homepage 'https://www.freecadweb.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.