### PR TITLE
Update frostwire to 6.6.0

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.5.6'
-  sha256 '65e1eee77ed8da863b2962ccae09e333ae1bfc69732c839e662d14c77f06e419'
+  version '6.6.0'
+  sha256 'd6cc9ba8dc514eaed2092db29ea6a2ddae79bad1df9d4ffd6e76b45eeea8baa0'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '0ae1ad63804e445824f9c6454ad2a46491ee1e97c9a409f868f893b579d62230'
+          checkpoint: '6b1194f4d2e2b83acb9fc8abf737755d64d35bf7220120be9da471a4d7a44844'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 

--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -5,7 +5,7 @@ cask 'frostwire' do
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '6b1194f4d2e2b83acb9fc8abf737755d64d35bf7220120be9da471a4d7a44844'
+          checkpoint: 'eab124727e648e21235cb2ec584816311d41c2bacbf43292025084a75a4ef103'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.