### PR TITLE
Update little-snitch to 4.0.3

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -37,6 +37,9 @@ cask 'little-snitch' do
                 '~/Library/Logs/Little Snitch Network Monitor.log',
                 '~/Library/Saved Application State/at.obdev.LittleSnitchInstaller.savedState',
                 '~/Library/WebKit/at.obdev.LittleSnitchConfiguration',
+                # These kext's should not be uninstalled by Cask
+                '/Library/Extensions/LittleSnitch.kext',
+                '/Library/StagedExtensions/Library/Extensions/LittleSnitch.kext',
               ],
       trash:  [
                 '~/Library/Application Support/Little Snitch',

--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -16,21 +16,27 @@ cask 'little-snitch' do
 
   uninstall launchctl: [
                          'at.obdev.LittleSnitchUIAgent',
+                         'at.obdev.LittleSnitchHelper',
                          'at.obdev.littlesnitchd',
                        ]
 
   zap delete: [
                 '/Library/Application Support/Objective Development/Little Snitch',
+                '/Library/Caches/at.obdev.LittleSnitchConfiguration',
+                '/Library/Little Snitch',
                 '/Library/Logs/LittleSnitchDaemon.log',
                 '~/Library/Caches/at.obdev.LittleSnitchAgent',
                 '~/Library/Caches/at.obdev.LittleSnitchConfiguration',
+                '~/Library/Caches/at.obdev.LittleSnitchHelper',
                 '~/Library/Caches/at.obdev.LittleSnitchSoftwareUpdate',
                 '~/Library/Caches/com.apple.helpd/Generated/at.obdev.LittleSnitchConfiguration.help',
                 '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/at.obdev.LittleSnitchConfiguration.help',
                 '~/Library/Logs/Little Snitch Agent.log',
+                '~/Library/Logs/Little Snitch Helper.log',
                 '~/Library/Logs/Little Snitch Installer.log',
                 '~/Library/Logs/Little Snitch Network Monitor.log',
                 '~/Library/Saved Application State/at.obdev.LittleSnitchInstaller.savedState',
+                '~/Library/WebKit/at.obdev.LittleSnitchConfiguration',
               ],
       trash:  [
                 '~/Library/Application Support/Little Snitch',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.