### PR TITLE
Update android-platform-tools to 26.0.2

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,9 +1,9 @@
 cask 'android-platform-tools' do
-  version :latest
-  sha256 :no_check
+  version '26.0.2'
+  sha256 'a6d0504e560713af2a3ae71449bcadf011b50ba78f7bf303a9d6d69bf855c73f'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
-  url 'https://dl.google.com/android/repository/platform-tools-latest-darwin.zip'
+  url 'https://dl.google.com/android/repository/platform-tools_r26.0.2-darwin.zip'
   name 'Android SDK Platform-Tools'
   homepage 'https://developer.android.com/studio/releases/platform-tools.html'
 

--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -3,7 +3,7 @@ cask 'android-platform-tools' do
   sha256 'a6d0504e560713af2a3ae71449bcadf011b50ba78f7bf303a9d6d69bf855c73f'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
-  url 'https://dl.google.com/android/repository/platform-tools_r26.0.2-darwin.zip'
+  url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip"
   name 'Android SDK Platform-Tools'
   homepage 'https://developer.android.com/studio/releases/platform-tools.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.