### PR TITLE
Update get-iplayer-automator to 1.9.9.b20171029001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.9.7.b20171007004'
-  sha256 'df328ef57d132711ca5977d9a9c2c06a27f9a94e6dcff37f1c03a6264d5c6f84'
+  version '1.9.9.b20171029001'
+  sha256 '76f78a75d82b66964f4fb774bfa99bdbe7218cd36a3535521a02ef7eb5574091'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          checkpoint: '9fea70d5cea96eab97dd350e4aab97b1afa1035fa2f4f44749ee1d2103397968'
+          checkpoint: '95b4efbb463aa12eca8afc9ea7646791b287679c1b20a916fd13adf92aef9c60'
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.