### PR TITLE
Update glyphs to 2.4.4-1075

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.4.2-1043'
-  sha256 'fbde454ade6b88afbfb5af0df617576d27bbcd6c046370f3b7358d6d02e50062'
+  version '2.4.4-1075'
+  sha256 '56cddfbc4acd5c74ca71e29ec3d01850bf9a833a0ce4638d6cdbf7c7e461bfcb'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: '6e53ed25e0b8f96f0fd708a88fc087d6c7da349940cf6f3fe8f91d7cb9c079b5'
+          checkpoint: '5788ef93598cdb76dbb905646ca26a336b39968eb64e0de82b6677d63be1b5c9'
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.