### PR TITLE
Update 2 Casks: remove uninstall_preflight

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -44,12 +44,6 @@ cask 'java' do
     end
   end
 
-  uninstall_preflight do
-    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/java-jdk-javadoc")
-      system_command 'brew', args: ['cask', 'uninstall', 'java-jdk-javadoc']
-    end
-  end
-
   uninstall pkgutil:   [
                          "com.oracle.jdk-#{version.before_comma}",
                          'com.oracle.jre',

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -10,12 +10,6 @@ cask 'virtualbox' do
 
   pkg 'VirtualBox.pkg'
 
-  uninstall_preflight do
-    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack")
-      system_command 'brew', args: ['cask', 'uninstall', 'virtualbox-extension-pack']
-    end
-  end
-
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',
                        args:       ['--unattended'],


### PR DESCRIPTION
The `uninstall_preflight` will break the `upgrade` of the dependent Cask when https://github.com/Homebrew/brew/pull/3396 is merged.