### PR TITLE
Update virtualbox-extension-pack: uninstall_postflight

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -24,6 +24,7 @@ cask 'virtualbox-extension-pack' do
   end
 
   uninstall_postflight do
+    next unless File.exist?('/usr/local/bin/VBoxManage')
     system_command '/usr/local/bin/VBoxManage',
                    args: [
                            'extpack', 'uninstall',


### PR DESCRIPTION
https://github.com/caskroom/homebrew-cask/pull/40615

This allows the uninstall step to be skipped if the dependant Cask has been uninstalled, which would have removed the files installed by this Cask.