### PR TITLE
Update gns3 to 2.1.0

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.0.3'
-  sha256 'f10f1ad5b0622f09f4c9e0c84c5bdd9ce7b29c14ad26d2dec0f7b884822d9dea'
+  version '2.1.0'
+  sha256 '681547dc725a0f1dbe708afa3d309a40cb11ba8010adb453bef24c414ea1d655'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: '7f9723fb47b9666f132c1d1fc0fbd3bf5dbed340cf7fd46450d38e97908aefec'
+          checkpoint: 'd769daa82fdfdeb8750b7a9f0ba4d1b5f1b835edc1f7b59ff5b029caaedf6a11'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.