### PR TITLE
Update go-agent to 17.11.0-5520

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,11 +1,11 @@
 cask 'go-agent' do
-  version '17.7.0-5147'
-  sha256 'd94731c867b678c9fc4b51ce7ddf60fa5e3474fe36d67fd15604f146689806af'
+  version '17.11.0-5520'
+  sha256 'ead9a105b5a8d1a807a8465cbb757cfd0f9df5b33bd07990ee8df935fbce8e74'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: 'f1cba4692ca4f0878fd95f276a55c43a4c2a435a96eae547070ac430689e19f1'
+          checkpoint: '9e3a88815202ffed76a1665fe59343076982308a8fcaa193606cbf3f92a03235'
   name 'Go Agent'
   homepage 'https://www.gocd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.