### PR TITLE
Update gqrx to 2.9-1

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,11 +1,11 @@
 cask 'gqrx' do
-  version '2.8-1'
-  sha256 '2ce8a1d28b60197d45c3c1925e21c68b8724b7297e3eed4afb2d081a6e21f1d7'
+  version '2.9-1'
+  sha256 'd6fdb4ee405c8e0652e0502a2fe6670ad7baf66eb202b0bf8ab6f0aad3100130'
 
   # github.com/csete/gqrx was verified as official when first introduced to the cask
   url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor}/Gqrx-#{version}.dmg"
   appcast 'https://github.com/csete/gqrx/releases.atom',
-          checkpoint: '64b9804ba7ee2a695d6fe91f4bac8067111b75bca5e79fcc5769b67450620ca0'
+          checkpoint: 'ceec115a1c11b2d8c4600fb9448b8ff2de1939c53e4616180e55eb7d2c2000b5'
   name 'Gqrx'
   homepage 'http://gqrx.dk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.