### PR TITLE
Update soulver to 2.6.6-5881

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,18 +1,18 @@
 cask 'soulver' do
-  version '2.6.5-5864'
-  sha256 '46f615f08f0037d617e2a998059be3fe29923f7ec3986258984b00ed1768ab65'
+  version '2.6.6-5881'
+  sha256 'a95219084fba53c99a0aec44e283d6acfad157399b004eae7cd1597b12f935ae'
 
   url "http://www.acqualia.com/files/sparkle/soulver_#{version}.zip"
   appcast "http://www.acqualia.com/soulver/appcast/soulver#{version.major}.xml",
-          checkpoint: '13b888bc45c4b3d2df76112300ce7201dae445e75c4dcef266f87c6ec6fa8254'
+          checkpoint: 'a4e78d3e73ac5772ff213c2b2bfe700294afce50b1b745e79d7e448959d7669b'
   name 'Soulver'
   homepage 'http://www.acqualia.com/soulver/'
 
   app 'Soulver.app'
 
-  zap delete: [
-                '~/Library/Application Support/Soulver',
-                '~/Library/Preferences/com.acqualia.soulver.plist',
-                '~/Library/Autosave Information/Unsaved Soulver Document*',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Soulver',
+               '~/Library/Preferences/com.acqualia.soulver.plist',
+               '~/Library/Autosave Information/Unsaved Soulver Document*',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.