### PR TITLE
Update graphql-ide to 1.1.1

### DIFF
--- a/Casks/graphql-ide.rb
+++ b/Casks/graphql-ide.rb
@@ -1,12 +1,12 @@
 cask 'graphql-ide' do
-  version '1.1.0'
-  sha256 'df90c88d0963987d51d766c956f1ef9221c5463b4c1358b1d0c1de90e5bd1500'
+  version '1.1.1'
+  sha256 'e7aa74f9dfc4874138d9fa74af33eb701130f5abe8ff70735c38c506f732408c'
 
-  url "https://github.com/redound/graphql-ide/releases/download/v#{version}/GraphQL.IDE.app.zip"
-  appcast 'https://github.com/redound/graphql-ide/releases.atom',
-          checkpoint: '85a07b3f3077bd2139c2b4d42942c1a724a6a27c5e55387489d86c6aeb4d2b17'
+  url "https://github.com/andev-software/graphql-ide/releases/download/v#{version}/GraphQL.IDE.zip"
+  appcast 'https://github.com/andev-software/graphql-ide/releases.atom',
+          checkpoint: 'cbe93f7235810ac6bdfb29498bb265cddcb536d03a4410d271aa35abc92dcce2'
   name 'GraphQL IDE'
-  homepage 'https://github.com/redound/graphql-ide'
+  homepage 'https://github.com/andev-software/graphql-ide'
 
   app 'GraphQL IDE.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.