### PR TITLE
Update karabiner-elements to 11.3.0

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -12,10 +12,14 @@ cask 'karabiner-elements' do
 
   pkg 'Karabiner-Elements.sparkle_guided.pkg'
 
-  uninstall quit:    'org.pqrs.Karabiner-Elements',
+  uninstall signal:  [
+                       ['TERM', 'org.pqrs.Karabiner-Elements'],
+                       ['TERM', 'karabiner_grabber'],
+                       ['TERM', 'karabiner_console_user_server'],
+                     ],
             pkgutil: 'org.pqrs.Karabiner-Elements',
             script:  {
-                       executable: '/Library/Application Support/org.pqrs/Karabiner-Elements/uninstall.sh',
+                       executable: '/Library/Application Support/org.pqrs/Karabiner-Elements/uninstall_core.sh',
                        sudo:       true,
                      }
 

--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '11.2.0'
-  sha256 'd2923653e746543b582bedc1903e49cddc0814cb919e90245a52eb164d346399'
+  version '11.3.0'
+  sha256 'd9b4cc01775faa2925090f44fa7b61e0a8aefee14f1eeb5d239ac58537c5c949'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: '8d0488cce5c3055d50450559519835ebefd9f8239ec4ad2d1bd27f649587a2c3'
+          checkpoint: '11524b8894d76c099b5689e5700ce79ca572b859b3e51b31c8bbf137403b97d7'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.