### PR TITLE
Update navicat-for-mariadb to 12.0.18

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.17'
-  sha256 'f4b8fdb44852f5075d56728ea05f5ec38c58b49d731c7b36d1e9f55d679cbd00'
+  version '12.0.18'
+  sha256 '32191c0fa8c36b5ba32f16b71e282afd63126696e9a92a767031155a054b58f5'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note',
-          checkpoint: '8e9527fc2342aacca66f104589a927eed7bbac7c6ee06048d828d01bf8b8590e'
+          checkpoint: '7f0a59d9e6839d21aeba46ec6a80d92125a2659b899e7afe5a2419dd502b7fa4'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.