### PR TITLE
Update navicat-for-mysql to 12.0.18

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.17'
-  sha256 'b119e428faaab56272cab4f1846c32794f794ca2539c6ef8a251ddee3296cae5'
+  version '12.0.18'
+  sha256 '220250ffb4f162e2ccd26ff16298f37a3e01cf50828fdf05beae1f16a071c88a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: '9c61560177490e622ee7f523e42794e78df4a1168624f98c7ab37187107e37a7'
+          checkpoint: '27b473e57167cc4eaadd9cead4baf4afd39635aa32e37e37c9b8e1d8e0595b97'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.