### PR TITLE
Update navicat-for-oracle to 12.0.18

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.17'
-  sha256 'faa3a630916e8232f83bfcc2a286f90ea9014f858370a00699cb88ced37b865a'
+  version '12.0.18'
+  sha256 '69427cd14a792bba89abb677e696d3802754db7c9c14ac222c5779143527c407'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-oracle-release-note',
-          checkpoint: '32b19739cb35bd01d3271dfe541c91f0bb051760333e763a542cee21fd6ec214'
+          checkpoint: '52046f97fa476cfaa11eda18ebb34bc77884f7647529927bf3f4547f0e76e4dc'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.