### PR TITLE
Update navicat-for-postgresql to 12.0.18

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.17'
-  sha256 '23e124f2ae80778ef780507441aaa72a2d05e259152f26a3bb18749c1bf5d4a4'
+  version '12.0.18'
+  sha256 '50f9c800ff571406ee3e6c9b073454e41acc79bc613e3b2230f71106876c9d44'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-postgresql-release-note',
-          checkpoint: '55005bb76022ef4c7ac7b8b5575716695a39b4a2474bb9cf6f26dfa9055f974e'
+          checkpoint: '5d22dba09aa7c0f5f3e57334b883ac713fabb6da4cec8ef2085eb6b2e549973c'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.