### PR TITLE
Update navicat-for-sql-server to 12.0.18

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.17'
-  sha256 '09c04352dbc9d87d0289090cddcc740315ba95418b5abbad8fa238b2e87b5270'
+  version '12.0.18'
+  sha256 '1d420cfa9968fb7708309da5beb31dbb4edfdec4ff86ec48128666662fec5aec'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlserver-release-note',
-          checkpoint: '50b205329cb0845bd871a2803390aa6599977971aedf7f32a7f42abc59d80eb6'
+          checkpoint: 'ae4d403aec645f802aeea759736a488da8a174398ba5c506169fb9707812d59c'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.