### PR TITLE
Update navicat-for-sqlite to 12.0.18

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.17'
-  sha256 'ed657b61a0d3394c6aecccfda58e570de520fa27ef723ebc8b3caefa6583c51d'
+  version '12.0.18'
+  sha256 'c4e788719cb19a84fcb21e369bee27991fc5b59d77ab2c7fef4ec04fc8ec3356'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlite-release-note',
-          checkpoint: '2c578768e65443cc18d845b539daa99d19dc80a8a763b04b087d953baa650a83'
+          checkpoint: 'f1d142f2d226bf4895f7ae41458860226e9e6c669750be18522b827c7bf94f7c'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.