### PR TITLE
Update astro to 2.0.24,3267

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '2.0.20,3183'
-  sha256 '6d71eff13e7a18961a1c54eb70919d2ced27d783373587afa939df88eadc99f8'
+  version '2.0.24,3267'
+  sha256 'f78572a0258adc6dca0a9e47092a44fd21e3f0db4548094c8a537652c3d29358'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: 'b62c9e05a3e9cd282a5980547a75cf316a2935d5158fd2c079d89e9442cf6278'
+          checkpoint: '541578d702c96a48300e966f77d3c90843ba3712b0b5fd782b1feee36dedb78d'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.