### PR TITLE
Update fips to 3.2.0

### DIFF
--- a/Casks/fips.rb
+++ b/Casks/fips.rb
@@ -1,11 +1,11 @@
 cask 'fips' do
-  version '3.1.1'
-  sha256 'bc7e2d401dd577f2edf1c0e02b7b309e002df4b5069dd995e241a2c64337e69f'
+  version '3.2.0'
+  sha256 '7cfdc22654208a5017dde4c181ca6ada2e67e682de8b903a3ed2d69ca650a055'
 
   # github.com/matwey/fips3/releases was verified as official when first introduced to the cask
   url "https://github.com/matwey/fips3/releases/download/#{version}/Fips-#{version}-Darwin.dmg"
   appcast 'https://github.com/matwey/fips3/releases.atom',
-          checkpoint: '86ab8bd37a91e7e2d93de73ede1255507c1b6704e6d3146c2e2b981d70810850'
+          checkpoint: 'e4cd19f9d0d9da47637a9d0bac136a68190a6a17dac0f83aba535527c701c1e5'
   name 'Fips'
   homepage 'http://fips.space/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.