### PR TITLE
Update hider to 2.4.1

### DIFF
--- a/Casks/hider.rb
+++ b/Casks/hider.rb
@@ -1,11 +1,11 @@
 cask 'hider' do
-  version '2.2.4'
-  sha256 '236361356ed7aae1c49dff5be2e5d0f18a4e880701a346f41a55c361271ba552'
+  version '2.4.1'
+  sha256 'afecc482336869fa4ae6f8d8bb4801282a058722cbf89b89a02cdc1593f13820'
 
   # dl.devmate.com/com.macpaw.site.Hider was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Hider#{version.major}/MacPawHider#{version.major}.dmg"
   appcast "https://updates.devmate.com/com.macpaw.site.Hider#{version.major}.xml",
-          checkpoint: 'e1fa46d71681313c8f476a800d7d28b2d61644dc093331db97bfbcb0a583d071'
+          checkpoint: 'f64732e5a7e15ef678e7dd4b1d8beeaa0a5bbe3ff8fa2071fc7a3903410274dc'
   name 'MacPaw Hider'
   homepage 'https://macpaw.com/hider'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.