### PR TITLE
Update backuploupe to 2.13.1

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,10 +1,10 @@
 cask 'backuploupe' do
-  version '2.13'
-  sha256 '8e331325883aaaa6ef3e654d1406ee1ce24a29eec5af1f3e43c7ba9cd655637c'
+  version '2.13.1'
+  sha256 'f36f95de4e96088e3d023329f9e8cd0ae24e694a748b4567309457e49d0df374'
 
   url "http://www.soma-zone.com/download/files/BackupLoupe_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/BackupLoupe/a/appcast.xml',
-          checkpoint: 'b2f78994e7e5fdc81a7bd9bd2dc446e72a5d8befcf1abd3ae0478bac33bf2e21'
+          checkpoint: '9a712ba4a09dd4563e6e915631a88bb22229ac6e32694d99efa905766c8784c8'
   name 'BackupLoupe'
   homepage 'http://www.soma-zone.com/BackupLoupe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.