### PR TITLE
Update blockstack to 0.21.1

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.21.0'
-  sha256 '00eb8d6f544e321faf7beedd3b0f84beb00237506c0cc8f06890f05416badff4'
+  version '0.21.1'
+  sha256 'c04c53fb31a66d9682374682961c89411db85d1e019942a3e8f930a09e00ed1c'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '2edeb690cfe6078664007697f7796eed7f7c9e956d8ebefc2a664ea87a9ee526'
+          checkpoint: '324dc2d1ab7a4dd64c003150f45cd7585ad6cfe479d4b04a4d502203b1cfca7a'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.