### PR TITLE
Update kactus to 0.2.13

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.2.12'
-  sha256 'f0b28adc55513dcca3519c600f23fc1ce59fea8dc113c535793b5e2015e6f4d8'
+  version '0.2.13'
+  sha256 '30dcc3117c9dcb14caf5a3ca6a0e74e9bed7431e15ffb850ec33cd8cece6ec6f'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: '04630539b7172a74a4d5054b5e607a724643d83f60c913ebd996af8793711ba3'
+          checkpoint: '3d8d90cfcaf865f31bc4c94b88f125d8750acdfc70b4c9fb85871df125288c77'
   name 'Kactus'
   homepage 'https://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.