### PR TITLE
Update musictube to 1.8.1

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,10 +1,10 @@
 cask 'musictube' do
-  version '1.7.1'
-  sha256 'bb36b058c585cc1c3fa9e46f8e6925ef9df6ab6d9d6284993e3cc74b97f48291'
+  version '1.8.1'
+  sha256 'e2d39cc371db386b625b4741a9bc1c3089671fc3bd04cf951e40d934d7fe540d'
 
   url 'http://flavio.tordini.org/files/musictube/musictube.dmg'
   appcast 'http://flavio.tordini.org/musictube-ws/appcast.xml',
-          checkpoint: '806dc502e2b1786674fedd215cbbb3391e0200f752aa46cd06e71dd2166047c3'
+          checkpoint: '0b1a0f027759eb2d6516a7350a24cd4aba8586a8318dd9e3b4fd247bf9495419'
   name 'Musictube'
   homepage 'http://flavio.tordini.org/musictube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.