### PR TITLE
Update pdfsam-basic to 3.3.4

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,11 +1,11 @@
 cask 'pdfsam-basic' do
-  version '3.3.2'
-  sha256 '06b48c3da25d674f319131dc9f93ad68471f403fd33b2b2e6a6b940eda8686d8'
+  version '3.3.4'
+  sha256 '81188773b21d129dc2b7637d8a260ae28603f7ce37e84ac8742aab30df184e88'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}/PDFsam-#{version}.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom',
-          checkpoint: 'd5596d303eef7216985f2e5b6e87609bbe693eeaefc3ee52eb307f123269b997'
+          checkpoint: 'f32526db8fb329d4483c582b59b4510dfd3e70810eae8085e609542045bec1d9'
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.