### PR TITLE
Update physicseditor to 1.6.2

### DIFF
--- a/Casks/physicseditor.rb
+++ b/Casks/physicseditor.rb
@@ -1,10 +1,10 @@
 cask 'physicseditor' do
-  version '1.6.0'
-  sha256 '9c31915cb942b97833f1e6090a5bfc192a7025396dc590e83c6c36b8368f1b79'
+  version '1.6.2'
+  sha256 '33539869b0d6eeae7ac361d06e01cc5d809af2b069745ea62a19c72f4a38a523'
 
   url "https://www.codeandweb.com/download/physicseditor/#{version}/PhysicsEditor-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/PhysicsEditor/appcast-mac-release.xml',
-          checkpoint: 'b34a3acb9519cc5bd760643cefe38f608f9235b8ac2cacf7306422b2a1fde360'
+          checkpoint: 'b8f60214da08549fc365bbc64b0e1084d99365e7b3f658265a3242a5bb422857'
   name 'PhysicsEditor'
   homepage 'https://www.codeandweb.com/physicseditor'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.