### PR TITLE
Update postgres to 2.1.1

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,11 +1,11 @@
 cask 'postgres' do
-  version '2.1'
-  sha256 'aac88f5072ae8b93d32e0530c08da0c0e361324e9217dfcd15d2bd06f762387c'
+  version '2.1.1'
+  sha256 'ac0656b522a58fd337931313f09509c09610c4a6078fe0b8e469e69af1e1750b'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
-          checkpoint: '2acc426803b758b7347f1de0ba8615383a043d702d69482017ac8a1dcddd4a9d'
+          checkpoint: '0ee22c7ae06eb17d6ea9d65ee3ee3233b4e69e3d6ebcbcaaac63081366104ca7'
   name 'Postgres'
   homepage 'https://postgresapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.