### PR TITLE
Update textexpander to 6.2.4

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,11 +1,11 @@
 cask 'textexpander' do
-  version '6.2.3'
-  sha256 '76ed5c10c970dcda5ee2b7b70bd4961d2db88812874457aaf9cb8b28417c10e5'
+  version '6.2.4'
+  sha256 '9cbd0455bc4f67f1240d80a78988c750943e70cf9e749c6dfb4c852a5828110b'
 
   # cdn.textexpander.com/mac was verified as official when first introduced to the cask
   url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"
   appcast "https://smilesoftware.com/appcast/TextExpander#{version.major}.xml",
-          checkpoint: '4225f92d3c5586165e76e69b35f5a4d70d0ff9e730be90bacfb5cb03bbc563a9'
+          checkpoint: 'c63a30d1119b5f61331a1de5038bfe1ee61fc72d32928d010d9f4998dede4c8c'
   name 'TextExpander'
   homepage 'https://smilesoftware.com/TextExpander'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.