### PR TITLE
Update servetome to 4.0.0156

### DIFF
--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -1,10 +1,10 @@
 cask 'servetome' do
-  version '4.0.0144'
-  sha256 '32e9ab67641a22051e4e879f8aeb6d723fa2e7ac5aee961c155bacb735d59be7'
+  version '4.0.0156'
+  sha256 '4540c0ef25008cb7aa810d192d7246b8b10675ac3df9d311ed9951127dc06b8e'
 
   url "http://downloads.zqueue.com/ServeToMe-v#{version}.dmg"
   appcast 'https://www.zqueue.com/servetome/changehistory.html',
-          checkpoint: 'feed3e29ad59f08e1add12b87f065fc7f6daa2977790dd0fc744e2caf4a4f566'
+          checkpoint: '3c89abbf1c60da5589be4301100828df0fcc11d90beb384a2e3fdc81b550d74a'
   name 'ServeToMe'
   homepage 'https://www.zqueue.com/servetome/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.