### PR TITLE
Update munki to 3.1.0.3430

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,15 +1,16 @@
 cask 'munki' do
-  version '3.0.2.3348'
-  sha256 'ded633688981b600aacfc07db99c29b888cb4c33f64fdc830eb85847831221c1'
+  version '3.1.0.3430'
+  sha256 '2ab26ab0cc87b28e390a30d37539a551f8b3c6a6a0723fd4fc480f997a503d2e'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
-  url "https://github.com/munki/munki/releases/download/v#{version.sub(%r{^(\d+\.\d+.\d+).*}, '\1')}/munkitools-#{version}.pkg"
+  url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: 'c8d4df84e5acb4f360c15331045752bad77c9ae71a2a5e5ae71fa7a8eb8e28f3'
+          checkpoint: 'a667c3087f5496dbc9c0ca5eab3093ea1da7c6d4fbea471f7cbaad7f85aa70f7'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 
   pkg "munkitools-#{version}.pkg"
 
-  uninstall pkgutil: 'com.googlecode.munki.*'
+  uninstall pkgutil:   'com.googlecode.munki.*',
+            launchctl: 'com.googlecode.munki.app_usage_monitor'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.