### PR TITLE
Update fedora-media-writer to 4.1.1

### DIFF
--- a/Casks/fedora-media-writer.rb
+++ b/Casks/fedora-media-writer.rb
@@ -1,11 +1,11 @@
 cask 'fedora-media-writer' do
-  version '4.1.0'
-  sha256 '747e7862563cabaea9d8a9151d6be728df33e400be62a07f12f3bbc3c4f51f65'
+  version '4.1.1'
+  sha256 'aefc333e274145b620f29b281068159999e90dba3eb9cd854a3acfb15381e306'
 
   # github.com/MartinBriza/MediaWriter was verified as official when first introduced to the cask
   url "https://github.com/MartinBriza/MediaWriter/releases/download/#{version}/FedoraMediaWriter-osx-#{version}.dmg"
   appcast 'https://github.com/MartinBriza/MediaWriter/releases.atom',
-          checkpoint: 'c4b473faa782ec2a58121900e3f48c236370f049f5580b20db119f5cb6cb988a'
+          checkpoint: '184ae18aab6984ddbb002d71c05e6e32286e402e43e43fa9c19c4fac6f61af85'
   name 'Fedora Media Writer'
   homepage 'https://fedoraproject.org/wiki/How_to_create_and_use_Live_USB'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.