### PR TITLE
Update fontbase to 2.2.3

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.1.2'
-  sha256 '850157757b70196860862303e84944056bfab0719567c21c80a5868323e1b019'
+  version '2.2.3'
+  sha256 '258d6d021de3a2ef2cef7a3fb15a69fc6dacc5f4cb75f0d580dc108057a9f0c8'
 
   url "http://releases.fontba.se/mac/#{version}/FontBase-#{version}.dmg"
   name 'FontBase'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.