### PR TITLE
Update byteball to 1.11.5

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,11 +1,11 @@
 cask 'byteball' do
-  version '1.11.1'
-  sha256 'f67a287f04c0e49d5ed6eab237c9006e5eefbd6f11026097ad119748725e3e12'
+  version '1.11.5'
+  sha256 'e4f6128a2de9ee716b72825ccbf077163746c8df1c7b73bbdd006e2d5a1099f3'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"
   appcast 'https://github.com/byteball/byteball/releases.atom',
-          checkpoint: '51782cb795fc22ce346a968d33814c9eeb4e5f5f42fa035a8b0b581c971355b7'
+          checkpoint: '432423798003751f17f1e7bb6ba3a9c1a8f48602aea71e91b9322b9be7e531ac'
   name 'Byteball'
   homepage 'https://byteball.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.