### PR TITLE
Update metaz to 1.0.beta-34

### DIFF
--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -1,11 +1,11 @@
 cask 'metaz' do
-  version '1.0a15'
-  sha256 '7dcc71a917bed0d5686884c4ec198275a1f656ce09db71fa49cc73e46933820c'
+  version '1.0.beta-34'
+  sha256 '3ea8c1d12c5415ea818497e07e125f8de27b45f2a748305e9bb62442c0a83847'
 
   # github.com/griff/metaz was verified as official when first introduced to the cask
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"
   appcast 'https://github.com/griff/metaz/releases.atom',
-          checkpoint: '0b1060381bbfe19bc63ee537eade9fa422dd9cc8a1c0810be0bbdd03b9e21994'
+          checkpoint: '58f754b6189dd83ce26d86fcedc6c738d607be3c126c3b97dab7d14fa9dc7834'
   name 'MetaZ'
   homepage 'https://griff.github.io/metaz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.