### PR TITLE
Update drivedx to 1.6.0

### DIFF
--- a/Casks/drivedx.rb
+++ b/Casks/drivedx.rb
@@ -1,6 +1,6 @@
 cask 'drivedx' do
-  version '1.5.1'
-  sha256 '32c9cc2cc5c28ce8a1800d4dc805fcdea040c0aab86f8ae9f658d94c5ff13668'
+  version '1.6.0'
+  sha256 'ddcc2717fa069ffd198f52044594ed71a2a00865ee3aa1ceedc4fdcfb6496146'
 
   url "https://binaryfruit.com/download/drivedx/mac/1/bin/DriveDx.#{version}.zip"
   name 'DriveDX'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.