### PR TITLE
Update tiled to 1.0.3

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,11 +1,11 @@
 cask 'tiled' do
-  version '1.0.1'
-  sha256 'db21bb075ba19bcf92234ab70313edff688bf03a0a18a2adad1532c975ae3a21'
+  version '1.0.3'
+  sha256 '4086f611debbf793e986be7defc55b481f35d52c7607bb4f3e48efd8732ed9d4'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
   appcast 'https://github.com/bjorn/tiled/releases.atom',
-          checkpoint: '963dc752b96cd16496b68bf2ea68e3b6ed65e71f587f9b3a100b7a97b5cdd0e8'
+          checkpoint: '4762e77bcd9e2f41c9ad72635ace6dfb7d83dd295bf28c6bb33014c150714387'
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.