### PR TITLE
Update freesmug-chromium to 62.0.3202.94

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '62.0.3202.89'
-  sha256 '4d09dd096c87c0d0c2cf7742fce2b57b64a03fb08e8b738fc95958b4f9457a82'
+  version '62.0.3202.94'
+  sha256 '54f5a7f27a5d97c1014bde2e0378ec25544b0cb83c6978680e5811ee1773f7ff'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '1bf5f5f0d8b69f86c949926d4ac66245ef2ecdc00adaddc330c78752c4cb65e1'
+          checkpoint: 'd488b3877b2a989ad2d3dbeee08f3d6a218f1c35d5fbb32a0451c00dafb8b152'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.