### PR TITLE
Update radarr to 0.2.0.870

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,11 +1,11 @@
 cask 'radarr' do
-  version '0.2.0.852'
-  sha256 'f00282767fbc64b6e0d337f3a20662097c8c042ca52a4e1d32367895cbde3e5e'
+  version '0.2.0.870'
+  sha256 '2b071f7e32595a06f4d22fa523aa1c3a5850244347bffa0890774a3b7b45eec9'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"
   appcast 'https://github.com/Radarr/Radarr/releases.atom',
-          checkpoint: '1b7185786f9e53aabd71c71bdac3ace0b5ca7220ee6b7364cd5484a5f7eb3f5a'
+          checkpoint: '4f99bfc047db51333fa4e58da7edf5a946306e39a10faa4911eac1e915b1aa76'
   name 'Radarr'
   homepage 'https://radarr.video/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.