### PR TITLE
Update downie to 3.0.8,1701

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.1693'
-  sha256 '419dc42e48ad6aa8adc7efa5cbb72e18cd21da6719ba7f8df2625628642b644c'
+  version '3.0.8,1701'
+  sha256 '83ba692cf332ba39ef959d67946230c529a3af646d988733a9786e6d101f9a4e'
 
-  url "https://trial.charliemonroe.net/downie/Downie_#{version.dots_to_underscores}.zip"
-  appcast 'https://trial.charliemonroe.net/downie/updates_3.xml',
-          checkpoint: '0e8c6ea3c0c3b48c91b1b278efc235619b2939269da719dfd5a5add9d8e7f28a'
+  url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
+  appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
+          checkpoint: 'ee7c2f0473b0896baa7b539b0a9d76c8d8b508b06a589e325c3568fd81661f08'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.