### PR TITLE
Update now to 3.8.0

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.6.2'
-  sha256 'b6cada4d48445dafef3353af0dc8393bc3b284bac4f44a3e080fe02f5f1f71c2'
+  version '3.8.0'
+  sha256 '253ef49bc10267726c214dff1d5ebb65d8702331cc50a84ed4c484473610bf56'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'cf4dd5f2fc88d1fa075a93107b82e40d7e4a80971126a3f7c0e67d703da58811'
+          checkpoint: '2ada73ffb17ff08fa046fe53b765249a695da2ac57a1fe637ecf65a5f73bb1b5'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.