### PR TITLE
Update exodus to 1.38.1

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.38.0'
-  sha256 'fb6acee30c487d8d524e8a2b5ebb54c73916a0b06adfb2d9e774a7ab25a34553'
+  version '1.38.1'
+  sha256 '2c49e0970d2d1b05a97bbce196caae1eb62a64e76c62ac6076bebf09e2e0a826'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '117387d0c9609c5c6f18fe3135fa6524bbee2f51bbe08045b71cf3d4c7dba2ce'
+          checkpoint: '23329ff424c94a6b83938f27b4bbdab481be782e8650a36b97e8373259adf9c6'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.