### PR TITLE
Update pyfa to 1.33.2,lifeblood-1.7

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.33.1,lifeblood-1.0'
-  sha256 '78a08e42220d9493042e964a71d24d05742864614bc57a2fc62b916280057571'
+  version '1.33.2,lifeblood-1.7'
+  sha256 '48ec3cf6f57998fa5b30da1a4abcce89e9f8ebe977fccd90d50056d9ccd17521'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '974a3b8ef7df6131b4f205180589172694d03f3f7f8d79b8d099bee2fc1f5875'
+          checkpoint: 'f61628f93b75a335d22f31539204c767d3faba4a90418af51caea863310dfd80'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.