### PR TITLE
Update tankix to 7511

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '7433'
-  sha256 '0b673c634bebe4a26d63fb672db927df689a325f89b0d5fb3ff6b60f8a7b74e1'
+  version '7511'
+  sha256 '43dcb0ec0d7f466820a815202000f0018757c361db183910c40b14732a6deece'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.