### PR TITLE
Update now to 3.8.1

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.0'
-  sha256 '253ef49bc10267726c214dff1d5ebb65d8702331cc50a84ed4c484473610bf56'
+  version '3.8.1'
+  sha256 'cdef384f07c927010837021942411d1a29d2f03954188cc0da97c25f93f50b7f'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '2ada73ffb17ff08fa046fe53b765249a695da2ac57a1fe637ecf65a5f73bb1b5'
+          checkpoint: '751a63f0f8376244a2406adb3657c3e84dec890714a65abc1e9b9c51bab966e0'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.