### PR TITLE
Update arq to 5.9.6

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,10 +1,10 @@
 cask 'arq' do
-  version '5.9.4'
-  sha256 'a9d47ba7ea72e36d8de69b8734af839a23a0c20d94d0ea9d68944715a2147128'
+  version '5.9.6'
+  sha256 '300c7b838a90e4db35a73478121647e269d8ec3f8adf82f5508f7ac39d6eac9c'
 
   url "https://www.arqbackup.com/download/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arq#{version.major}.xml",
-          checkpoint: '28abc03fca70e072d26da055ab44490c6839efcf06921db2ea43c155b024af1a'
+          checkpoint: '9eae1bfb48f1f41a689c66876faed5a1913c34b6f6cd7d988dffd5bc417b1662'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.