### PR TITLE
Update play to 2.0.11

### DIFF
--- a/Casks/play.rb
+++ b/Casks/play.rb
@@ -1,11 +1,11 @@
 cask 'play' do
-  version '2.0.9'
-  sha256 'e6197879e2c36ea6157b242dfd7d5558f4980ce39eaae2b1131242b6be6533c1'
+  version '2.0.11'
+  sha256 '5c2aba096705afb89714bbe666dce1949039cc9bf551b3fa812db6096ba43b2c'
 
   # github.com/pmsaue0/play was verified as official when first introduced to the cask
   url "https://github.com/pmsaue0/play/releases/download/v#{version}/play_#{version}.dmg.zip"
   appcast 'https://github.com/pmsaue0/play/releases.atom',
-          checkpoint: 'f1356020301196f8f9be551d68fae2adc8cf798e70e09f94fc24c6698654cc9f'
+          checkpoint: '28a81faf794a167b2c293bddd45188cd6be2bd2f1a81d79536d87fbbb557409f'
   name 'Play'
   homepage 'https://pmsaue0.github.io/play/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.