### PR TITLE
Update quip to 5.1.51

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.1.07'
-  sha256 'a27d1846790ba75150aa83f8f361bccf6be567a36399a5938993401a1e83cd0b'
+  version '5.1.51'
+  sha256 'e8891d44a1e60174ad2b9e51d60b6cb18c6800778d78df9b52b7aa72544b1802'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.