### PR TITLE
Update kite to 0.20171114.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20171102.0'
-  sha256 '21f783026690a1621305c9d83976b8e9ab1f9751faebfde133512660e373af13'
+  version '0.20171114.0'
+  sha256 '83cf7a8c8a07391195ecf1c7b144053291d3743261f194d398f8b09c0803560d'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '53cc82b5d6414bc62f85a95087a7e3ad32ae1bf0ba452f278e9d8c7faa628691'
+          checkpoint: '7995d2d44a2f8aabd3014e06fab625f4bebd44d83020081d5912574816fdab6e'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.