### PR TITLE
Update kapow to 1.5.4

### DIFF
--- a/Casks/kapow.rb
+++ b/Casks/kapow.rb
@@ -1,6 +1,6 @@
 cask 'kapow' do
-  version '1.5.3'
-  sha256 '980ed8ec68045eb42c1d94a9fe809f50586a3b9a0248713aebf33ca62a37e625'
+  version '1.5.4'
+  sha256 '98d7bf3820a5ce8cb2e9ea7bf6746f0dabd9b15fae509410e1259fdbe7a5b609'
 
   url "https://gottcode.org/kapow/Kapow_#{version}.dmg"
   name 'Kapow'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.