### PR TITLE
Update visit to 2.13.0

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,15 +1,15 @@
 cask 'visit' do
-  version '2.12.3'
-  sha256 '1b057d50caf835bb25052f8277db080bbd8918b840e363a2e575a0b013b7fb3f'
+  version '2.13.0'
+  sha256 'e04668ee5bdfcb352e238eca579543ec548c995d4a9e1ce0d4b5be2877bfb045'
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
-  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
+  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}-10.11.dmg"
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables',
-          checkpoint: '7517244498494b4822c1c405ed0c95ece2bd5e7964a1cf5f2610ec10a09c7652'
+          checkpoint: 'af9ad999de6149081917bc2f37a2ab0de3527b442d5e8cee8372e20735a02f18'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :el_capitan'
 
   app 'VisIt.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.