### PR TITLE
Update cyberduck to 6.3.0.27105

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '6.2.10.26754'
-  sha256 '40b4eb869dc5913bcf34110bbb8a555edde3c1c6f7d1e40a9c557cac45311e7b'
+  version '6.3.0.27105'
+  sha256 'c1418eac70e9b5b637e35dedf85ef0b2bc1f5286e1b2eb89241dcfcb286921e4'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: '0912576949d6bd413bd6b682cddf87c0e1ceaed8ea891e0eca2ebd9bf0827673'
+          checkpoint: '098caeb300d121bacf388d2ad359fca946719032295f6581f9e9ba4e8ce087b9'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.