### PR TITLE
Update airmedia to 2.0.14

### DIFF
--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -1,10 +1,12 @@
 cask 'airmedia' do
-  version '1.0.5.6'
-  sha256 'caaf1226a6d24f0ece418b0e1ec98b294f842fcec4eb2f33196f87fa61412b7f'
+  version '2.0.14'
+  sha256 'f40761616c814d005f4d47bc8b5ef6aba40fdb518c5e40358e2224d24429fb9b'
 
-  url "https://www.crestron.com/downloads/software/airmedia_guest_os_x_#{version}.dmg"
+  url "https://www.crestron.com/downloads/software/airmedia_#{version}_macOS_guest_dmg.zip"
   name 'Crestron AirMedia'
   homepage 'https://www.crestron.com/microsites/airmedia-mobile-wireless-hd-presentations'
 
-  app 'AirMedia.app'
+  container nested: "airmedia_#{version}_macOS_guest_dmg/airmedia_#{version}_macOS_guest.dmg"
+
+  app 'Crestron AirMedia.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.