### PR TITLE
Update adobe-photoshop-lightroom: remove uninstall_preflight

### DIFF
--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -27,10 +27,6 @@ cask 'adobe-photoshop-lightroom' do
                    sudo: true
   end
 
-  uninstall_preflight do
-    system_command 'brew', args: ['cask', 'uninstall', 'adobe-photoshop-lightroom600']
-  end
-
   zap trash: [
                '~/Library/Application Support/Adobe/Lightroom',
                "~/Library/Preferences/com.adobe.Lightroom#{version.major}.plist",


### PR DESCRIPTION
This is also break when https://github.com/Homebrew/brew/pull/3396 is merged.

As this is a patch installer on top of another Cask it doesn't need an `uninstall` itself, the `app` can be removed by uninstalling `lightroom600`.

The patch upgrade can be applied on top of the previous patch.