### PR TITLE
Update buttercup to 0.23.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -5,7 +5,7 @@ cask 'buttercup' do
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '6e7cf74a4f1e1515e5c2060c6956cd4912ab6cef83c94b51bc6c3b928c8b731e'
+          checkpoint: 'e0f718fabadedc4b6ad8593a83dd5e90ec4e5a291cc2b15b96851ff6a402db41'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 

--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.22.3'
-  sha256 'ed3aa1bef79892dad63ee4c048862451e7fd59f51d47bde039283f3c566660a5'
+  version '0.23.0'
+  sha256 'd2213fadafb457ae6f16d3faa39a9059b93d2519477abc7037216d7981cc4018'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '1049a07a07eb7e38b6b8cd4ffa47b1809334460fa6098bb02a558a64769a21d4'
+          checkpoint: '6e7cf74a4f1e1515e5c2060c6956cd4912ab6cef83c94b51bc6c3b928c8b731e'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.