### PR TITLE
Update keytty to 1.2.4,1510374995

### DIFF
--- a/Casks/keytty.rb
+++ b/Casks/keytty.rb
@@ -1,11 +1,11 @@
 cask 'keytty' do
-  version '1.2.1,1478523599'
-  sha256 'c10a61be158ade8d8505dd87fcfafb9577c4db1c746dc44f223710540d884dc2'
+  version '1.2.4,1510374995'
+  sha256 'ff6b8fa7d919e0f83ffe2a6787c998afda7bdf8541f679aa4cfcd0c7e5aafa8c'
 
   # dl.devmate.com/com.keytty.Keytty was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.keytty.Keytty/#{version.before_comma}/#{version.after_comma}/keytty-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.keytty.Keytty.xml',
-          checkpoint: '7fd0b94dd90eab19e4be001ec520fb3ad5c1558c6d53acf8631639b561818b53'
+          checkpoint: 'b9f59064f4adf618ee15fd434d4616c9affa565bbbbdcdc808504f55e0892ced'
   name 'Keytty'
   homepage 'https://keytty.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.