### PR TITLE
Update burp-suite to 1.7.28

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,20 +1,20 @@
 cask 'burp-suite' do
-  version '1.7.27'
-  sha256 'eb215ee1a453634685d5ec302ccd9c07031869ca72c9f2cce10cc8dd6c9989a2'
+  version '1.7.28'
+  sha256 'ba1aad6c20104db4d14d4bc6b48302d4099ffac3180942b0b090831b25df76f8'
 
-  url "https://portswigger.net/burp/releases/download?product=free&version=#{version}&type=macosx"
-  appcast 'https://portswigger.net/burp/freereleasesarchive',
-          checkpoint: '90e7612ec2b3f962f086bb85b9e9402731b9cfbb367b30f09e24d12e54e63bc8'
+  url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=macosx"
+  appcast 'https://portswigger.net/burp/releasesarchive/community',
+          checkpoint: '3689c040408fdc1cbd6c302f00b65a8f04494c091da120f5a2300cac68395bd3'
   name 'Burp Suite'
   homepage 'https://portswigger.net/burp/'
 
   installer script: {
-                      executable: 'Burp Suite Free Edition Installer.app/Contents/MacOS/JavaApplicationStub',
+                      executable: 'Burp Suite Community Edition Installer.app/Contents/MacOS/JavaApplicationStub',
                       args:       ['-q'],
                       sudo:       true,
                     }
 
-  uninstall delete: '/Applications/Burp Suite Free Edition.app'
+  uninstall delete: '/Applications/Burp Suite Community Edition.app'
 
   zap trash: '~/.BurpSuite'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.