### PR TITLE
Update insomnia to 5.11.7

### DIFF
--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -1,11 +1,11 @@
 cask 'insomnia' do
-  version '5.11.5'
-  sha256 '71f4b0ea9a72b6b835573a85b2323646bc25f4d2caac62f7e36fbc06c7cf4417'
+  version '5.11.7'
+  sha256 'd724fd3b0ae97f771c55db00c56d54482312355e3f3a305e141a9d56cd0ed1d1'
 
   # github.com/getinsomnia/insomnia was verified as official when first introduced to the cask
   url "https://github.com/getinsomnia/insomnia/releases/download/v#{version}/Insomnia-#{version}.dmg"
   appcast 'https://github.com/getinsomnia/insomnia/releases.atom',
-          checkpoint: '39b1cb9ca5b151bafd88e907be5e5b3fa7dcd42af12e94e63b58a15bc24a77f2'
+          checkpoint: '06117303f694f91f06c919299e14297072b3ac051fa77ddc0acc45ea62cd4498'
   name 'Insomnia'
   homepage 'https://insomnia.rest/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Current version on https://insomnia.rest/