### PR TITLE
Update mimolive to 3.1-23321

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,10 +1,10 @@
 cask 'mimolive' do
-  version '2.9.2-23125'
-  sha256 '590fad1c33bf30a105ca78557a6c7defc376735acafb373970a2772cf72c8fb4'
+  version '3.1-23321'
+  sha256 '8f6ab66d1c41af9c9f70ac006e5e83c560a558f429d89e7784a22e8f9364b5dd'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/mimolive',
-          checkpoint: '5b569a3ae5aaf8986b02d1e0188de9bf6f6c2ecc7b58991feea3298b2fe9b8a0'
+          checkpoint: '04a7a26aa4b3f38c8fbe6b9385f9894a8e1faee099be1010f6b9f6bf9d6e37ee'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.