### PR TITLE
Update jira-client to 3.8.4

### DIFF
--- a/Casks/jira-client.rb
+++ b/Casks/jira-client.rb
@@ -1,6 +1,6 @@
 cask 'jira-client' do
-  version '3.8.3'
-  sha256 '8de427e61fdde8d6c2e3bfe59d7d8dee19fbb6690d9b2b494055eb9ecf27ffcb'
+  version '3.8.4'
+  sha256 '674cb80876659ec82999c14ba74596f878f18f544aa1bc8ce41f4d0ade8aab40'
 
   url "https://d1.almworks.com/.files/jiraclient-#{version.dots_to_underscores}.dmg"
   name 'JIRA Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.