### PR TITLE
Update prime95 to 29.3

### DIFF
--- a/Casks/prime95.rb
+++ b/Casks/prime95.rb
@@ -1,7 +1,7 @@
 cask 'prime95' do
   # note: "95" is not a version number, but an intrinsic part of the product name
-  version '28.9'
-  sha256 'c8e58f032dbbf0402d97ea81272153faeae61d6ef4461c1f88c99ecbf3fdcc32'
+  version '29.3'
+  sha256 '2ded6c91ba068ffae48219e441aa6a4bafb50d727df89dc04370fb71f47b809a'
 
   url "https://www.mersenne.org/ftp_root/gimps/p95v#{version.no_dots}.MacOSX.zip"
   name 'Prime95'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.