### PR TITLE
Update facebook-ios-sdk to 4.28.0

### DIFF
--- a/Casks/facebook-ios-sdk.rb
+++ b/Casks/facebook-ios-sdk.rb
@@ -1,6 +1,6 @@
 cask 'facebook-ios-sdk' do
-  version '4.27.1'
-  sha256 '59beecf6941906c77c286ffa41c924bcd757026ee5b6acbd5679263835d7d99b'
+  version '4.28.0'
+  sha256 '5d74214cb924de1467c0e6f45a7b44a0fb84c536cfa41b88671ab4d1b7f5102a'
 
   url "https://origincache.facebook.com/developers/resources/?id=FacebookSDKs-iOS-#{version}.zip"
   name 'Facebook SDK for iOS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.