### PR TITLE
Update cocktail to 11.1

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -21,26 +21,26 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml',
             checkpoint: 'ffe079c9b71d0f356c8a4d45ecf4f5a50e1d284c972b0a1e5cf92234d7a1010e'
   elsif MacOS.version == :el_capitan
-    version '9.6.2'
-    sha256 '9534da88b075da6df3655da1781b7c849646b3eb4da1b97760e75f3e499cc43f'
+    version '9.7'
+    sha256 'ca6b4a264ca60a08ff45761f82b0b6161cbe3412bd6cbeedd5dbecebc8d26712'
 
     url "https://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
-            checkpoint: 'caf773ffc53978e4d0469056f0822c5acb9d85fc0ae1f43c51732c7e1dccfcca'
+            checkpoint: '7d3fd5bf0b5816bc3971adfea9e571619e589ee6c30c6fcd6f0c5a1de21026da'
   elsif MacOS.version == :sierra
-    version '10.4.4'
-    sha256 '612087f32460093c24c950971b203118969ceae132eb72d0853d490a31c99523'
+    version '10.4.5'
+    sha256 '0c9b45c04ac98914059196582558e02beef911187338795b609094161becf933'
 
     url "https://www.maintain.se/downloads/sparkle/sierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml',
-            checkpoint: '3905bc1b0fdd069a2b7fef2f7b95c55cccfd68e6f5d9423fa76a4fd031390daf'
+            checkpoint: '29028cf40b72d33b757a6cba69abbddd9077afb02f343951cd1fbf8730f8dfe4'
   else
-    version '11.0.1'
-    sha256 '7032d75df09df04d788998729a39c4712745bd1197f14709149aacfd37ff397c'
+    version '11.1'
+    sha256 'ac397c8ab30ba84805df3962393e455a91f1de0946f972a93afb0720e2d34405'
 
     url "https://www.maintain.se/downloads/sparkle/highsierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/highsierra/highsierra.xml',
-            checkpoint: '082c744b01431a399c195d12e58ddfa9f9eb1fb535020738896c7f93374472b6'
+            checkpoint: '6d15e4e32c4664bc8a172ffa962643db2c7d4bcf2ac1a83ee1314f9ad4cd28f4'
   end
 
   name 'Cocktail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`11.1`, `10.4.5`, `9.7`