### PR TITLE
Update openvisualtraceroute to 1.7.0

### DIFF
--- a/Casks/openvisualtraceroute.rb
+++ b/Casks/openvisualtraceroute.rb
@@ -1,11 +1,11 @@
 cask 'openvisualtraceroute' do
-  version '1.6.5'
-  sha256 'ae5c37fe3e8bb5348c9e03b326a91eadfe50e84a365677825a8fd7ddc3a6cfe5'
+  version '1.7.0'
+  sha256 '29e76aff13e15cd6123238ce6673e7de74ce98ca0f0940d100423aac7e0bce42'
 
   # downloads.sourceforge.net/openvisualtrace was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/openvisualtrace/#{version}/OpenVisualTraceRoute#{version}.dmg"
   appcast 'https://sourceforge.net/projects/openvisualtrace/rss',
-          checkpoint: 'a9d378d7cbe829d31479a38307d89b95509520e2ccd06ca2b3b49c7db69f498a'
+          checkpoint: '407fb59baa4b9eb7651d9243b89c30b7481590947ef78bd5a4c24f5810f56531'
   name 'OpenVisualTraceroute'
   homepage 'http://visualtraceroute.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.