### PR TITLE
Update owncloud to 2.3.4.8537

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -1,10 +1,10 @@
 cask 'owncloud' do
-  version '2.3.3.8242'
-  sha256 '61536572d1dbc627677e373e69a5a01a785d099ddacf25f50a42b05699c52388'
+  version '2.3.4.8537'
+  sha256 '04a48607fb2ecbbc88b00ebf00b74875ad3dc53b104a6749d0f865f038737255'
 
   url "https://download.owncloud.com/desktop/stable/ownCloud-#{version}.pkg"
   appcast 'https://github.com/owncloud/client/releases.atom',
-          checkpoint: '24cdfdc52c2ae6ec670cfbfaed696257aafca1b2228ddbd0cb069ab56eecc16c'
+          checkpoint: 'b6b882ce94c26e285527e49f02c3e9ea91d37bb6276e95d8c513224f052564cf'
   name 'ownCloud'
   homepage 'https://owncloud.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.