### PR TITLE
downgrade eqmac to 2.0.6

### DIFF
--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -1,11 +1,11 @@
 cask 'eqmac' do
-  version '2.0.7'
-  sha256 'caa97a681371f60173aabd3949e381f8b53234fb9642340d49795a495df0fa15'
+  version '2.0.6'
+  sha256 '565544e1c7b12f3cf361176896fd8917857f188ff8b875d2e18e9da8231be79f'
 
   # github.com/romankisil/eqMac was verified as official when first introduced to the cask
   url "https://github.com/romankisil/eqMac#{version.major}/releases/download/v#{version}/eqMac#{version.major}.dmg"
   appcast "https://github.com/romankisil/eqMac#{version.major}/releases.atom",
-          checkpoint: '734ff65d148b0f3d7ef6988ecdc5a84870f7523986ee8cbe5bede0b905536e4e'
+          checkpoint: '03e18588a03e2b6efb51da18b709589a2dc30df15a717d17581cc09a904bdc1a'
   name 'eqMac'
   homepage 'https://www.bitgapp.com/eqmac/'
 


### PR DESCRIPTION
2.0.7 was deemed unstable. Therefore downgrading to 2.0.6
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
