### PR TITLE
Update mongodb-compass to 1.10.8

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.8.2'
-  sha256 'f0e32480bb8ffa86f0e2626c67442996c3acba348efdd48a0f887c78edd17064'
+  version '1.10.8'
+  sha256 'e2aff6f4faa0983f9ece83977cb44234a45cf03cdc5fe1a0aff5f8570a20a13d'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.