### PR TITLE
Update opera to 49.0.2725.39

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '49.0.2725.34'
-  sha256 'd5625bc153c1506bb3bccda941019025cf4e8be6eba454a963ebbb822ebb6f94'
+  version '49.0.2725.39'
+  sha256 '0f5600822c5ab3ab1e1689d5e76eeef23267eb31fc670f62a02c58ce4bfdafcc'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.