### PR TITLE
Update buttercup to 0.24.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.23.0'
-  sha256 'd2213fadafb457ae6f16d3faa39a9059b93d2519477abc7037216d7981cc4018'
+  version '0.24.0'
+  sha256 'f6ae763bc0ece507b86f0bbde4f1931dad66adc311f04b72b49093422f602298'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: 'e0f718fabadedc4b6ad8593a83dd5e90ec4e5a291cc2b15b96851ff6a402db41'
+          checkpoint: '911f37e643e1b7c5fcbe2aac86ee762adffa14dbac500805cebd9034f263ebbf'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.