### PR TITLE
Update react-native-debugger (0.7.13)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.12'
-  sha256 'ceebe1de7adee9bec082e4716c6fc1a170e23e16387613aea7bca285b4f937c8'
+  version '0.7.13'
+  sha256 'd90700e91f83e7ef058a9c969303436b283abd38c4350d3b8b713ae6daa4e3d6'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: 'fdeb6bbdc1452ab26b49af7d2cbd6ae5441ab916ac8fbdf05f4b9daa2f4e20b7'
+          checkpoint: '36ddde5747147c1db9dbeed87f82278039cb8896f7ab79505dd1580c63513d95'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
