### PR TITLE
Use cache.agilebits.com for 1Password

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -3,6 +3,7 @@ cask '1password' do
     version '3.8.22'
     sha256 '3afd75f1bddf791dc7dbc9a7d92ab6eb91ee891407d750cedb7b5aff5fe8bf17'
 
+    # cache.agilebits.com/dist/1P/mac was verified as official when first introduced to the cask
     url "https://cache.agilebits.com/dist/1P/mac/1Password-#{version}.zip"
 
     app '1Password.app'
@@ -10,6 +11,7 @@ cask '1password' do
     version '4.4.3'
     sha256 '6657fc9192b67dde63fa9f67b344dc3bc6b7ff3e501d3dbe0f5712a41d8ee428'
 
+    # cache.agilebits.com/dist/1P/mac4 was verified as official when first introduced to the cask
     url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"
@@ -17,6 +19,7 @@ cask '1password' do
     version '6.8.4'
     sha256 '6d86d1d7c75e1f2245af955c9c94ce49d5293c1cde7be98ca3268c0d3106b342'
 
+    # cache.agilebits.com/dist/1P/mac4 was verified as official when first introduced to the cask
     url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -3,24 +3,21 @@ cask '1password' do
     version '3.8.22'
     sha256 '3afd75f1bddf791dc7dbc9a7d92ab6eb91ee891407d750cedb7b5aff5fe8bf17'
 
-    # d13itkw33a7sus.cloudfront.net was verified as official when first introduced to the cask
-    url "https://d13itkw33a7sus.cloudfront.net/dist/1P/mac/1Password-#{version}.zip"
+    url "https://cache.agilebits.com/dist/1P/mac/1Password-#{version}.zip"
 
     app '1Password.app'
   elsif MacOS.version <= :mavericks
     version '4.4.3'
     sha256 '6657fc9192b67dde63fa9f67b344dc3bc6b7ff3e501d3dbe0f5712a41d8ee428'
 
-    # d13itkw33a7sus.cloudfront.net was verified as official when first introduced to the cask
-    url "https://d13itkw33a7sus.cloudfront.net/dist/1P/mac4/1Password-#{version}.zip"
+    url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"
   else
     version '6.8.4'
     sha256 '6d86d1d7c75e1f2245af955c9c94ce49d5293c1cde7be98ca3268c0d3106b342'
 
-    # d13itkw33a7sus.cloudfront.net was verified as official when first introduced to the cask
-    url "https://d13itkw33a7sus.cloudfront.net/dist/1P/mac4/1Password-#{version}.zip"
+    url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"
   end

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -26,7 +26,7 @@ cask '1password' do
   end
 
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: 'dbdda372503c53ee9f720fdeb8d32d28b77fcc7acee1ca46c46ae808cece0761'
+          checkpoint: '6dfb8fc9495094ee9af5fb9f603aed25391449119fefd35d7d374e8c97ad3be8'
   name '1Password'
   homepage 'https://1password.com/'
 


### PR DESCRIPTION
Hello! This is just a little change to grab 1Password from a different host.

`cache.agilebits.com` is linked to from the official [Downloads page](https://1password.com/downloads/), and seems to be much faster:

```
$ wget https://cache.agilebits.com/dist/1P/mac/1Password-3.8.22.zip
--2017-11-16 21:56:26--  https://cache.agilebits.com/dist/1P/mac/1Password-3.8.22.zip
Resolving cache.agilebits.com... 205.234.175.175
Connecting to cache.agilebits.com|205.234.175.175|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 19583840 (19M) [application/zip]
Saving to: ‘1Password-3.8.22.zip.1’

1Password-3.8.22.zip. 100%[=======================>]  18.68M  39.5MB/s    in 0.5s    

2017-11-16 21:56:27 (39.5 MB/s) - ‘1Password-3.8.22.zip.1’ saved [19583840/19583840]

$ wget https://d13itkw33a7sus.cloudfront.net/dist/1P/mac/1Password-3.8.22.zip
--2017-11-16 21:57:05--  https://d13itkw33a7sus.cloudfront.net/dist/1P/mac/1Password-3.8.22.zip
Resolving d13itkw33a7sus.cloudfront.net... 52.84.27.130, 52.84.27.100, 52.84.27.123, ...
Connecting to d13itkw33a7sus.cloudfront.net|52.84.27.130|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 19583840 (19M) [application/zip]
Saving to: ‘1Password-3.8.22.zip.2’

1Password-3.8.22.zip.2            54%[=============================>                          ]  10.10M   185KB/s    eta 32s    
```

It seems a shame to make other people wait, so I thought I'd submit a little patch :tada:
Cheers!

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256