### PR TITLE
Update gotomeeting to 8.16.0.7881,ka338000000L6kiAAC

### DIFF
--- a/Casks/gotomeeting.rb
+++ b/Casks/gotomeeting.rb
@@ -1,6 +1,6 @@
 cask 'gotomeeting' do
-  version '8.15.0.7759,ka338000000L6agAAC'
-  sha256 '717dbc41e4ef0322ce3e98bf49ec784a0673fcdb3414ca42a0164b226c518e23'
+  version '8.16.0.7881,ka338000000L6kiAAC'
+  sha256 'df26df961b04c339b14f2f3e1066546b77665ae31d61e0717c89ef35bea85540'
 
   # support.citrixonline.com was verified as official when first introduced to the cask
   url "https://support.citrixonline.com/servlet/fileField?entityId=#{version.after_comma}&field=Content__Body__s"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.