### PR TITLE
Update addaps to 0.4.29

### DIFF
--- a/Casks/addaps.rb
+++ b/Casks/addaps.rb
@@ -1,6 +1,6 @@
 cask 'addaps' do
-  version '0.3.10'
-  sha256 'b9b48d38e7e17db6bc1e8fe2e8ad99ed9a723b6becf5b666f9d8c6b8f3b630fb'
+  version '0.4.29'
+  sha256 'f3b4dc1d002b0ce5b39be3e27aac11516172bbc984970560494b10295c102f46'
 
   # s3.amazonaws.com/addaps-beta was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/addaps-beta/Addap's+beta-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.