### PR TITLE
Update printnode to 4.17.14

### DIFF
--- a/Casks/printnode.rb
+++ b/Casks/printnode.rb
@@ -1,8 +1,8 @@
 cask 'printnode' do
-  version '4.10.1,2e8'
-  sha256 'cf762200b9a8bb842aa9842a20f392d33b7f76d73286f06ff4859a2cdd185431'
+  version '4.17.14'
+  sha256 'e3ea051a22112ef18bb35d1d37834555df08ba2dcd542eb1244cabf670b5249b'
 
-  url "https://app.printnode.com/bundles/printnodemain/downloads/printnode/#{version.major_minor}.0/PrintNode-#{version.tr(',', '+')}.dmg"
+  url "https://app.printnode.com/bundles/printnodemain/downloads/printnode/#{version}/PrintNode-#{version}.dmg"
   name 'PrintNode'
   homepage 'https://www.printnode.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.