### PR TITLE
Update macpass to 0.7.1

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -1,11 +1,11 @@
 cask 'macpass' do
-  version '0.7'
-  sha256 '970e877e0a83b5f35dcd2f1925dcd1cc4ba3fcf488300dd9caab7479186a2eef'
+  version '0.7.1'
+  sha256 '7fd585aff756be13c211a2d8f587da827312f44c3f0c9fb91d14295170afbdfc'
 
   # github.com/mstarke/MacPass was verified as official when first introduced to the cask
   url "https://github.com/mstarke/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
   appcast 'https://github.com/mstarke/MacPass/releases.atom',
-          checkpoint: '42772c052f4e95723428c49866086734d02061ea03ae905007cfa852c64bcdcf'
+          checkpoint: 'dbef902cb05c6628310fe575219bea3faab596420c02e4269d2c810572446e52'
   name 'MacPass'
   homepage 'https://mstarke.github.io/MacPass/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.