### PR TITLE
Update virtualc64 to 1.5.2

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,11 +1,11 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.5.1'
-  sha256 '7029b58d62887a81c9c6d984a2ae8d54335276c2fe6ff818b5bcfefa047fe62d'
+  version '1.5.2'
+  sha256 '182c68c7cf60e124f737c688f77daa4f8d62ae2fcb9c637bdf9d74f6974f1ef8'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml',
-          checkpoint: '8665d923f94636c8b9a2ae31afe31ede39099425e26bf5c94509eb5b3be0f0a5'
+          checkpoint: 'd04e817b06f25640e2b2ba25653b3ca8a59a04c39b74aed6a4778f30c92a3792'
   name 'Virtual C64'
   homepage 'http://www.dirkwhoffmann.de/virtualc64/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.