### PR TITLE
Update wordpresscom to 3.0.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '2.5.0'
-  sha256 '8f6a520d3ffbdc65fa21f76a8f6347c049ca35172003a6d3c301d85e9843864c'
+  version '3.0.0'
+  sha256 'fb24600098bc5c5b2dc4f50e8dc63b5fc81a1b0d3ddcf123f80434618b304626'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: 'd4040433b138f7d6fae6e70ff560b01bef5a40118f2309d49c4f313227a8f14e'
+          checkpoint: 'e3347a2f3f8da08899fc62f01649265c3d5ef56088b7a0bdd4ab51be1f7f806a'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.