### PR TITLE
Update zotero to 5.0.25

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.24'
-  sha256 '1f153317893bce0f8236259089ede9804726063b7aab99faadeec4249175ea9f'
+  version '5.0.25'
+  sha256 '90989e396a61259af09717b4d78d3d7718c5ae4ae0b751f9ce4245f0731476c8'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '8ce5e1e5a94cc103d8c4f0df76794074215e51a4dadd64deab45b647f35b13a9'
+          checkpoint: 'd358a2e32cd2bba5ed3f4bea2a87f7fd768d70a99dc3d0950252ee697d5c2106'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.