### PR TITLE
Update mailpluginfix to 1.4.0

### DIFF
--- a/Casks/mailpluginfix.rb
+++ b/Casks/mailpluginfix.rb
@@ -1,6 +1,6 @@
 cask 'mailpluginfix' do
-  version '1.3.0'
-  sha256 '921a65b098f7def758cbafcdfd1ed5f8459cb9cdb958e589679d6e9bc67d8184'
+  version '1.4.0'
+  sha256 '811cf27322a08d4ddbc4780c78cf34ea07595a269902b62ccdcdb6ac00142cf3'
 
   url "https://code2k.net/app/MailPluginFix-#{version}.zip"
   name 'MailPluginFix'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.