### PR TITLE
Update tistoryeditor to 0.5.4

### DIFF
--- a/Casks/tistoryeditor.rb
+++ b/Casks/tistoryeditor.rb
@@ -1,11 +1,11 @@
 cask 'tistoryeditor' do
-  version '0.3.9'
-  sha256 '358b730cd8d5cb372e0b59cc737fec7e4f2bc26de59bcb00790690e386ba2def'
+  version '0.5.4'
+  sha256 '506f314619abf37d73ddc0593af2dccb50164b96184dee3f4d8cc5ce7d82c0da'
 
   # github.com/joostory/tistory-editor/ was verified as official when first introduced to the cask
   url "https://github.com/joostory/tistory-editor/releases/download/#{version}/TistoryEditor-#{version}-mac.zip"
   appcast 'https://github.com/joostory/tistory-editor/releases.atom',
-          checkpoint: '4aee7565d8afdb70673547fa35972a95d922c6f4dceb6ea7c8ba5fd80b775031'
+          checkpoint: 'be5341d25533aedf7c89061d92ceb1525b777a2b5ca069c494623f4efbbbead8'
   name 'TistoryEditor'
   homepage 'https://joostory.github.io/tistory-editor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.