### PR TITLE
Update glip to 17.08.1

### DIFF
--- a/Casks/glip.rb
+++ b/Casks/glip.rb
@@ -1,6 +1,6 @@
 cask 'glip' do
-  version '3.0.1727'
-  sha256 'eca4a1dd80f66f0cfa6ed1a1936b2b528426cf745a1472e0459d8c9cceb8637d'
+  version '17.08.1'
+  sha256 'e1699beb6eed3033da1dee81f607a657bce8e68747f135470c593297f4eca8b9'
 
   # downloads.ringcentral.com/glip/rc was verified as official when first introduced to the cask
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/Glip-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.