### PR TITLE
Update inspec to 1.45.9-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.44.8-1'
-  sha256 '343da0f4c68191fd5938a8847a03b0cc85ef2f634af9e7d0050f88ce77a5a295'
+  version '1.45.9-1'
+  sha256 '941eb14d6d4c8244e09ca5d36e3133acb96f7b7ed8bf74d2fb282aed287a7197'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.13/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: '7b6935a1db75b5087e69df4e1529aa321ee50a7b6610346569b8c0030b603cbd'
+          checkpoint: '258068d87ceb42345489532f668d14a631c37c50fed79659f5a0df8e9a1008a4'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.