### PR TITLE
Update sysdig-inspect to 0.2.0

### DIFF
--- a/Casks/sysdig-inspect.rb
+++ b/Casks/sysdig-inspect.rb
@@ -1,11 +1,11 @@
 cask 'sysdig-inspect' do
-  version '0.1.43'
-  sha256 '9ec74a9abb4748a038a4e98927ca711fa4795a6a199c4a72f071d4ee7ae7d652'
+  version '0.2.0'
+  sha256 '1c4d8dd87c44362603bcee752d31f3f3f7b2b6677eef6f5d8219dfcfa0607900'
 
   # download.sysdig.com/stable/sysdig-inspect was verified as official when first introduced to the cask
   url "https://download.sysdig.com/stable/sysdig-inspect/sysdig-inspect-#{version}-mac.dmg"
   appcast 'https://github.com/draios/sysdig-inspect/releases.atom',
-          checkpoint: 'd27e19ccf95ebab391b94762f40dd47778a1accf8f086fdc4ae53dc9d5ee3f65'
+          checkpoint: 'fcdc73d10fc08b495dac33350230e7f4df1903856c4695be14716f0709bbdadf'
   name 'Sysdig Inspect'
   homepage 'https://github.com/draios/sysdig-inspect'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.