### PR TITLE
Update slack to 2.9.0

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -1,6 +1,6 @@
 cask 'slack' do
-  version '2.8.2'
-  sha256 '2fef59b83e6a8d4f3ac99f44f4e8e9bbeca6d9c7788c640d854c8e6daf1799e9'
+  version '2.9.0'
+  sha256 '043b1a795a5f6465b97b3fdc69d6e77dd78f6c5c80cbec5423c75e868537dd6b'
 
   # downloads.slack-edge.com was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/mac_releases/Slack-#{version}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.