### PR TITLE
Update workflowy to 1.0.8

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,11 +1,11 @@
 cask 'workflowy' do
-  version '1.0.5'
-  sha256 'f2ca4aabdd41254aa44357bba9624ca4bb03fb70043b0d0fc9e0482c737b8a2c'
+  version '1.0.8'
+  sha256 'ab8156ed42d767270600c2be9ac7ccaa37ec9f4ab1958ea600e16511f4b77ad0'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"
   appcast 'https://github.com/workflowy/desktop/releases.atom',
-          checkpoint: '369cbee3f43529cd59a0026a66f0325994958d02a3a3844dfb1356c102c5dd47'
+          checkpoint: 'bc483a7758f8ca5a8124b57c4e4b7ad0f5f5801be384a4fb55175eeab563b867'
   name 'WorkFlowy'
   homepage 'https://workflowy.com/downloads/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.