### PR TITLE
Update bisq to 0.6.0

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.5.3'
-  sha256 'fa3b44ea298f66be697556b967d53e78964abc8b9da52bc8bad5e0500fd4b65b'
+  version '0.6.0'
+  sha256 'e1f5a6f996a3b51776aea104a5a1dd5db171cc0460636d5646a08ff92e8b9125'
 
   # github.com/bisq-network/exchange was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/exchange/releases.atom',
-          checkpoint: 'bead53dd88aa63b03eeffb93868ec02b972c9bc8fe1950f4a149d8d2b36fb075'
+          checkpoint: '02d60696e68d56180fcd3f2e7a152980e649096d384bf9f60adabb6af0a65aab'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.