### PR TITLE
Update championify to 2.1.1

### DIFF
--- a/Casks/championify.rb
+++ b/Casks/championify.rb
@@ -1,10 +1,10 @@
 cask 'championify' do
-  version '2.0.8'
-  sha256 '3180dfde7410a35b32227578877bd4519f1aca7fd724eca575052a9b0023435c'
+  version '2.1.1'
+  sha256 'eedcae6c28811691af71b0c509a8b968b19889e3ad84b2b670c8478617a772d4'
 
   url "https://github.com/dustinblackman/Championify/releases/download/#{version}/Championify-OSX-#{version}.dmg"
   appcast 'https://github.com/dustinblackman/Championify/releases.atom',
-          checkpoint: '9cc381f0732e78e888d4580a96dc817ca91342ad45e404f24174419e18699653'
+          checkpoint: '08971007fff83c5c18964a1e3c6a2838000718d8c56a3a09444a5ca532a140d6'
   name 'Championify'
   homepage 'https://github.com/dustinblackman/Championify/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.