### PR TITLE
Update boostnote to 0.8.16

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.15'
-  sha256 'b7007164c1d86ffac8010d818a8a36e737bae6756a2f6ab610493772c48a91b1'
+  version '0.8.16'
+  sha256 '1b6d76101b8abcfdee5dff8babd6c5c478991cc4eecd50f9af00129ebf286309'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '97a21251b4d3a2d671bdc260548ebc1a556f9a51710ba141c7d28d247fc762f9'
+          checkpoint: 'd3b9b4c1aa721ab754eacac0716aca15d420b670cc3bef3e086cfc92587d88fd'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.