### PR TITLE
OmniOutliner 5.2

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,8 +1,8 @@
 cask 'omnioutliner' do
-  version '5.1.4'
-  sha256 '91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0'
+  version '5.2'
+  sha256 '7d009220ce74570235e25d3c3855c804dec13a6d1e678ffd4e243bb9788938ac'
 
-  url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
+  url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}",
           checkpoint: '9966a34bf39bb4d5d2aaebdf38953a8b63fbf851ede9a2cd3f70370b87585322'
   name 'OmniOutliner'

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -4,7 +4,7 @@ cask 'omnioutliner' do
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}",
-          checkpoint: '9966a34bf39bb4d5d2aaebdf38953a8b63fbf851ede9a2cd3f70370b87585322'
+          checkpoint: '2ecf4e7b9111151f69d363e21d4e3b48bb3e5eb6a656a445eabb09cc525952de'
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
 


### PR DESCRIPTION
Core URL changed from 10.11 to 10.12 for the OmniOutliner 5.2 update

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
