### PR TITLE
Update atom.rb: convert to zap trash

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -16,19 +16,17 @@ cask 'atom' do
   binary "#{appdir}/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm", target: 'apm'
   binary "#{appdir}/Atom.app/Contents/Resources/app/atom.sh", target: 'atom'
 
-  zap delete: [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl*',
-                '~/Library/Application Support/ShipIt_stderr.log',
-                '~/Library/Application Support/ShipIt_stdout.log',
-                '~/Library/Caches/com.github.atom',
-                '~/Library/Caches/com.github.atom.ShipIt',
-                '~/Library/Saved Application State/com.github.atom.savedState',
-              ],
-      trash:  [
-                '~/.atom',
-                '~/Library/Application Support/Atom',
-                '~/Library/Application Support/com.github.atom.ShipIt',
-                '~/Library/Preferences/com.github.atom.helper.plist',
-                '~/Library/Preferences/com.github.atom.plist',
-              ]
+  zap trash: [
+               '~/.atom',
+               '~/Library/Application Support/Atom',
+               '~/Library/Application Support/ShipIt_stderr.log',
+               '~/Library/Application Support/ShipIt_stdout.log',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl*',
+               '~/Library/Application Support/com.github.atom.ShipIt',
+               '~/Library/Caches/com.github.atom',
+               '~/Library/Caches/com.github.atom.ShipIt',
+               '~/Library/Preferences/com.github.atom.helper.plist',
+               '~/Library/Preferences/com.github.atom.plist',
+               '~/Library/Saved Application State/com.github.atom.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
