### PR TITLE
Update pi-filler to 2.0.1

### DIFF
--- a/Casks/pi-filler.rb
+++ b/Casks/pi-filler.rb
@@ -1,10 +1,10 @@
 cask 'pi-filler' do
-  version '1.3'
-  sha256 '06179b365be0f86027f89ab634e98f5101899ccfe5378f44b4b9330aedf0a9b3'
+  version '2.0.1'
+  sha256 'f52d661a1c777d64432c89e925a40f5e7ced45258549249fbdb34b17be4d4314'
 
   url 'http://ivanx.com/raspberrypi/files/PiFiller.zip'
   appcast 'http://ivanx.com/raspberrypi/',
-          checkpoint: '3231cbc5d1c4d41d7e9122becd74c5f6b2284c541a46a9a8327668214f3d34a6'
+          checkpoint: '25718cf29e3fc47d3d9bc47e92d2b84319bbb33a2088d1952aa04bf29f6a663a'
   name 'Pi Filler'
   homepage 'http://ivanx.com/raspberrypi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.