### PR TITLE
Update latexit.rb: convert to zap trash

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -11,9 +11,9 @@ cask 'latexit' do
 
   app 'LaTeXiT.app'
 
-  zap delete: [
-                '~/Library/Caches/fr.chachatelier.pierre.LaTeXiT',
-                '~/Library/Cookies/fr.chachatelier.pierre.LaTeXiT.binarycookies',
-              ],
-      trash:  '~/Library/Preferences/fr.chachatelier.pierre.LaTeXiT.plist'
+  zap trash: [
+               '~/Library/Caches/fr.chachatelier.pierre.LaTeXiT',
+               '~/Library/Cookies/fr.chachatelier.pierre.LaTeXiT.binarycookies',
+               '~/Library/Preferences/fr.chachatelier.pierre.LaTeXiT.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.