### PR TITLE
Update iueditor to 2.0.6.13

### DIFF
--- a/Casks/iueditor.rb
+++ b/Casks/iueditor.rb
@@ -1,6 +1,6 @@
 cask 'iueditor' do
-  version '2.0.6.1'
-  sha256 'd03c18a5caa32af1e732ef5ac951f1bc9cc50952da9fa64fafc44341bd04e2ea'
+  version '2.0.6.13'
+  sha256 '4b21e63cda4808b1f29f78fb61f75d9e7c5b9694b9b63bc153fb3fa62a888794'
 
   url "https://cdn.iueditor.org/release/IUEditorV#{version}.pkg"
   name 'JDLab IUEditor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.