### PR TITLE
Update mjml to 2.7.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,11 +1,11 @@
 cask 'mjml' do
-  version '2.6.0'
-  sha256 'c6033e655bd6205ca88364ff4e81913bf8a808498f7e0d78d7b86aa5ab2b28d9'
+  version '2.7.0'
+  sha256 '639a2ea8c9d1ecbab59ecc0639e8145a62358db28fa52ac469bc146e8ce6ed65'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-osx_#{version}.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom',
-          checkpoint: 'e51c5b449d90f4d594c9966426a80256e456d1b078a3a66202b15e6a4bd9d6b1'
+          checkpoint: 'd244ffec521ac75518b2c74bc9718b59ac95cac8c7708c878c97c1500fc689f5'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.