### PR TITLE
Update mirador to 1.4.2

### DIFF
--- a/Casks/mirador.rb
+++ b/Casks/mirador.rb
@@ -1,11 +1,11 @@
 cask 'mirador' do
-  version '1.4.1'
-  sha256 '654288f08d66ae18372c422260b891d2d89126eca76ea51fea40205974c135c9'
+  version '1.4.2'
+  sha256 '39980fc8e391d9e832fb56c862e7177dcb33c16e571338dce058f3dd74e8e753'
 
   # github.com/mirador/mirador was verified as official when first introduced to the cask
-  url "https://github.com/mirador/mirador/releases/download/#{version}/mirador-macosx-#{version}.zip"
+  url "https://github.com/mirador/mirador/releases/download/latest-macos/mirador-#{version}-macos.zip"
   appcast 'https://github.com/mirador/mirador/releases.atom',
-          checkpoint: 'db4792b5a0250149a701fa881d53177cb58d4e5e94157ee91c7c9e7b70fcd4f4'
+          checkpoint: 'd941f12631b7d90773a77e345d03def8bde1b36a963d2079e9083778e06283d6'
   name 'Mirador'
   homepage 'https://fathom.info/mirador/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.