### PR TITLE
Update propresenter to 6.2.10_b16063

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.2.6_b16042'
-  sha256 '016fb476f7cd6a5bdc623df1e5529889a4292524bb5f349b087cb7ccccfeaef5'
+  version '6.2.10_b16063'
+  sha256 'c63fcd8023969f999a3fc6b9a28a9be56fe84cea0181ea1845c0035e1914b804'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: '0b41476856b9ca6d25f0ffafdde524c17a68f8ec9f675908b57b238125c95345'
+          checkpoint: '5fcec2a859b9658707c93f10bcbe7e790d9ec774febfe383f0bfe6ffbcb30b5a'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.