### PR TITLE
Update qz-tray to 2.0.4-1

### DIFF
--- a/Casks/qz-tray.rb
+++ b/Casks/qz-tray.rb
@@ -1,11 +1,11 @@
 cask 'qz-tray' do
-  version '2.0.4'
-  sha256 '8f58eb7eef7670e1e930b02c0218e76fb5209e3b79d1502ef2e84302b88dc114'
+  version '2.0.4-1'
+  sha256 'f388fa0d696ad90cdcdd9a7e81bff2a8755f3f2817dc171763e2e26f0e6d404c'
 
   # github.com/qzind/tray was verified as official when first introduced to the cask
-  url "https://github.com/qzind/tray/releases/download/v#{version}/qz-tray-#{version}.pkg"
+  url "https://github.com/qzind/tray/releases/download/v#{version.sub('-1', '')}/qz-tray-#{version}.pkg"
   appcast 'https://github.com/qzind/tray/releases.atom',
-          checkpoint: '5fab370b4376f9aebd6c8b2d519564d057be8495708d33f4964c5b9773090b83'
+          checkpoint: '991f92c10fd6208642d8f21e6947687a02f2e8a69d1ddbca7a3fa77220cfa73d'
   name 'QZ Tray'
   homepage 'https://qz.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.