### PR TITLE
Update riot to 0.13.1

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,10 +1,10 @@
 cask 'riot' do
-  version '0.13.0'
-  sha256 'eec87f7bb11c8ad0e50189327c5ebead6a386c84aa2f42d3d87ed8498e1cbefc'
+  version '0.13.1'
+  sha256 '24fc4feb8d03d5793f9a6cd38665d0f8a1b2d4cb2f21bfee5357e84d965bbf63'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-web/releases.atom',
-          checkpoint: 'ecb2125693ffd99730e68cc8d9848593c5d5f26b50ec7da0f6e353892cac2298'
+          checkpoint: 'dc496f84ae62082186c719e60ccc3f1c2fe50616c288ccc5ce0711ff76debbff'
   name 'Riot'
   homepage 'https://about.riot.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.