### PR TITLE
Remove conflict between google-backup-and-sync and google-drive-file-stream

### DIFF
--- a/Casks/google-backup-and-sync.rb
+++ b/Casks/google-backup-and-sync.rb
@@ -8,7 +8,6 @@ cask 'google-backup-and-sync' do
 
   conflicts_with cask: [
                          'google-photos-backup-and-sync',
-                         'google-drive-file-stream',
                        ]
   depends_on macos: '>= :mavericks'
 
@@ -26,4 +25,6 @@ cask 'google-backup-and-sync' do
                '~/Library/Group Containers/google_drive',
                '~/Library/Preferences/com.google.GoogleDrive.plist',
              ]
+
+  caveats "Although #{token} may be installed alongside google-drive-file-stream, you should not use the same account with both."
 end

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -7,7 +7,6 @@ cask 'google-drive-file-stream' do
   homepage 'https://www.google.com/drive/'
 
   conflicts_with cask: [
-                         'google-backup-and-sync',
                          'google-photos-backup-and-sync',
                        ]
   depends_on macos: '>= :el_capitan'
@@ -24,4 +23,6 @@ cask 'google-drive-file-stream' do
                '~/Library/Preferences/Google Drive File Stream Helper.plist',
                '~/Library/Preferences/com.google.drivefs.plist',
              ]
+
+  caveats "Although #{token} may be installed alongside google-backup-and-sync, you should not use the same account with both."
 end


### PR DESCRIPTION
Replace with a caveat indicating that while they may be used simultaneously, the same account should not be used with both.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.