### PR TITLE
Update codekit to 3.4.2,26148

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,10 +1,10 @@
 cask 'codekit' do
-  version '3.4.26097'
-  sha256 'b761e34f145f43c16c11d3fe1946a59d754da25ac0b94bfc609bc68429cd7c39'
+  version '3.4.2,26148'
+  sha256 'c97497966ae00b2ef376a02de6757a028f12382791ae2a8ef202543f5b39bc69'
 
-  url "https://codekitapp.com/binaries/codekit-#{version.patch}.zip"
+  url "https://codekitapp.com/binaries/codekit-#{version.after_comma}.zip"
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml",
-          checkpoint: '66e0a8ce33076f240677268afb523247881da9f50e667494879008907283e37e'
+          checkpoint: 'afce2fdbda6da6845517d70e7b221c95254cf4953fcf6eb19a9278c06707e47e'
   name 'CodeKit'
   homepage 'https://codekitapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.