### PR TITLE
Fix URL for refresh-finder 1.5.0

### DIFF
--- a/Casks/refresh-finder.rb
+++ b/Casks/refresh-finder.rb
@@ -2,7 +2,7 @@ cask 'refresh-finder' do
   version '1.5.0'
   sha256 'd7e5faec85b3910776ca77f09c98b1b90e540cc3d493853e46eaeb8c7332472e'
 
-  url "https://soderhavet.com/refresh/Refresh_Finder_#{version}.dmg.zip"
+  url "https://web.archive.org/web/20140624055314/https://soderhavet.com/refresh/Refresh_Finder_#{version}.dmg.zip"
   name 'Refresh Finder'
   homepage 'https://soderhavet.com/refresh/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
