### PR TITLE
Update macdive to 2.8.5

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,10 +1,10 @@
 cask 'macdive' do
-  version '2.8.4'
-  sha256 'd55ee1f3274bfadfc0c4e61ba4b5071457b86603861081cd3a0c323c8f679a63'
+  version '2.8.5'
+  sha256 '1c0bd668bcc78fd7dcf6bb206076ce5d7f259a97c6c4e560822b184f7b2beb45'
 
   url "http://mac-dive.com/shimmer/?download&appName=MacDive&appVariant=&appVersion=#{version}"
   appcast 'https://mac-dive.com/shimmer/?appcast&appName=MacDive',
-          checkpoint: '4238d595796f6334775933bd654c9b5a30994ebe27f81ba772174ef551a56d4f'
+          checkpoint: '0784880b303bb6d532c86233b3616da5990d401161d3d29b809eeea245b31c1a'
   name 'MacDive'
   homepage 'https://www.mac-dive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.