### PR TITLE
enable Deeper 2.2.6 for macOS High Sierra 10.13

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -19,6 +19,7 @@ cask 'deeper' do
                       :yosemite,
                       :el_capitan,
                       :sierra,
+                      :high_sierra,
                     ]
 
   app 'Deeper.app'


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

