### PR TITLE
Update tankix to 7912

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '7742'
-  sha256 '323ca464918d2f43179441425212aa4539fb8b815f84091163c11bd0706bc023'
+  version '7912'
+  sha256 'a50a1e1070145f738de133e56340d823028d2222e9a6ac3b6d592359ffe07940'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.