### PR TITLE
Update letterfix to 2.6.0,68346

### DIFF
--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -1,10 +1,10 @@
 cask 'letterfix' do
-  version '2.5.3,67423'
-  sha256 'b6125a0f55ef0c52711403613473ba6fc396745f7d2ace88cc46f9d9df57b41d'
+  version '2.6.0,68346'
+  sha256 '89de44a2b0e6cb43915d9584615226811f939a42aed6d2a14ba099de18db2768'
 
   url "http://onet.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
   appcast 'https://ja.osdn.net/projects/letter-fix/releases/rss',
-          checkpoint: 'bdb6da9001b4a915f5059542ea8152bb4103fec4df47e028afbefce63d4e1b34'
+          checkpoint: 'd02aac9f8264e4f388054fddf2f7e0574dc568b41bb2845bce24785fa12b216a'
   name 'LetterFix'
   homepage 'https://osdn.jp/projects/letter-fix/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.