### PR TITLE
Update electorrent to 2.1.11

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.10'
-  sha256 '1d21744666942f2bebd2ecc4032928051352bb9fa1d422a50d376f6b5d2530f4'
+  version '2.1.11'
+  sha256 'aa9d08dbfcb0ad0db13c7bc48f6edfc22b7d4ee38fa58e797fe0a9596ffdb8b7'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '54448b7b27af6ba9691f333a02337a517a8703e23ade960e99a09ee39fe2a33e'
+          checkpoint: '29d34fd944b71d90ac251f0ee91a1b094ea298a6b1db415bbbbdb3ca106e067d'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.