### PR TITLE
Update twist to 1.0.22,3279

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,10 +1,10 @@
 cask 'twist' do
-  version '1.0.14,3053'
-  sha256 '0ab4a357d2492d1b29e3bedf1147a0eac09440a05d99693823d3642ab77a118f'
+  version '1.0.22,3279'
+  sha256 'aca89630774fa53f7cda305e525174e21307ed5455aba48e2cb9df6c32615e7a'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml',
-          checkpoint: 'ef6e6a0ab4aa1d5671c8e7fb6358a9fab4ad0beb6d76a54efde56fd5ee2ade15'
+          checkpoint: '5aa976bc5fcce3706328408fbc81d788316845b3eb4a783c82adfd7d7ae8d227'
   name 'Twist'
   homepage 'https://twistapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.