### PR TITLE
Update google-chrome to 62.0.3202.94: add appcast

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,8 +1,10 @@
 cask 'google-chrome' do
-  version :latest
-  sha256 :no_check
+  version '62.0.3202.94'
+  sha256 '86c3885a1341f5b2d90900746dddd555cf7a31dcfae629ccc731391ff278177a'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
+  appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable',
+          checkpoint: '23bbc300523376a22704ff7f308ccd5812516ca460121673aa4306bda000e7db'
   name 'Google Chrome'
   homepage 'https://www.google.com/chrome/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

> https://github.com/caskroom/homebrew-cask/issues/15357#issuecomment-159103232
> Omahaproxy is run by Chrome Infra team.

https://omahaproxy.appspot.com/

https://omahaproxy.appspot.com/history?os=mac;channel=stable