### PR TITLE
Update fork to 1.0.59.6

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.59'
-  sha256 '20a0cb6dfd74cdc9e5c9c6da904c3513a06eeb02625f402bdc7ba8f7870bf690'
+  version '1.0.59.6'
+  sha256 'c12fda82cc636315601d0ea6e039ba976114768d1063ad835a212f5e1d8c5b8c'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '7bf5d999501cc8bf550178c7add8421ae95ea66f778813c65467196558e75986'
+          checkpoint: '839712df80ba9f8e7080aa9c022497ca4a65ee0c721758420f0090b05b36a24e'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.