### PR TITLE
Update tableplus to 1.0,71

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,10 +1,10 @@
 cask 'tableplus' do
   version '1.0,71'
-  sha256 '4c07f7f485a5387d8c5fdbc7f0e118880722b47e06ee22779eb376a6d6f3d437'
+  sha256 '4dcfce19ac6076350761793d864791346ba10e0f44c024af8e4a965c72469bcf'
 
   url 'https://tableplus.io/release/osx/tableplus_latest.zip'
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: '4eac0dc2540f31e9f1d9f50032c574fafdd8f03796a68413082961161539804c'
+          checkpoint: '5072f1f4da09d5b73ba5f2f3cee5d455111eaec390401d05df4c4cd50f034fdc'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
Update failed due to wrong checksum, can't really seem to find an official explanation as to why this happen.

EDIT: Scan available at https://www.virustotal.com/#/file/4dcfce19ac6076350761793d864791346ba10e0f44c024af8e4a965c72469bcf/detection

-----

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.