### PR TITLE
Update mal-updater to 2.3.7.2

### DIFF
--- a/Casks/mal-updater.rb
+++ b/Casks/mal-updater.rb
@@ -1,13 +1,15 @@
 cask 'mal-updater' do
-  version '2.3.5.3'
-  sha256 '655753754bfb50d0c159ba3b5db135bdc08adc8b21d7bb89a9432bd61ecf4d27'
+  version '2.3.7.2'
+  sha256 '0da0863a3779217795934e4c54f9bf4e79652dacd48effb8e75f28c2f02e7e42'
 
   # github.com/Atelier-Shiori/malupdaterosx-cocoa was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases/download/#{version}/malupdaterosx-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases.atom',
-          checkpoint: '7ebb3a95686b8a2f775a5d8a4f45bf3d578388fc3faef2b7b17434a13e7727d4'
+          checkpoint: 'c00465cd0c1e0cad45e4a0939678eae9436dcab0151296972529bc1083890ee9'
   name 'MAL Updater OS X'
   homepage 'https://malupdaterosx.ateliershiori.moe/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'MAL Updater OS X.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.