### PR TITLE
Update zotero to 5.0.27

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.25'
-  sha256 '90989e396a61259af09717b4d78d3d7718c5ae4ae0b751f9ce4245f0731476c8'
+  version '5.0.27'
+  sha256 'b4f339c5b4392c80ad126e8083becdc01e14b41b7067daea15bc14b9c56a1560'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: 'd358a2e32cd2bba5ed3f4bea2a87f7fd768d70a99dc3d0950252ee697d5c2106'
+          checkpoint: '3bcdaff9b1cf6e6c7fe573047f7941e2491febcaa401fefd7691df3f157aba42'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.