### PR TITLE
Update parallels-virtualization-sdk to 13.2.0-43213

### DIFF
--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -1,6 +1,6 @@
 cask 'parallels-virtualization-sdk' do
-  version '13.1.1-43120'
-  sha256 '22d69e191be8611ab1dcaf9cb4a660301e855eec05abb7d7ae906b2f96c0c774'
+  version '13.2.0-43213'
+  sha256 '07e1a4cc36f167735b3ed891c61f8286d00ca61acf7181f96fbf8ac27fa8abdf'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsVirtualizationSDK-#{version}-mac.dmg"
   name 'Parallels Virtualization SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.