### PR TITLE
Update angry-ip-scanner to 3.5.2

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -1,11 +1,11 @@
 cask 'angry-ip-scanner' do
-  version '3.5.1'
-  sha256 '3283db621b621cbd7761709125c8097dc52ef0b9329bd25c9eb79a162b86eb12'
+  version '3.5.2'
+  sha256 '461c507d612d0d88c91ef4dde79f266ecbaa3b5518df24597b8b40af6dc90ddb'
 
   # github.com/angryip/ipscan was verified as official when first introduced to the cask
   url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"
   appcast 'https://github.com/angryip/ipscan/releases.atom',
-          checkpoint: '361e1b18d29be11a526cc85ff7fd2e56c2ea1daff7cd261e9fc58f99e84a0cf5'
+          checkpoint: 'e02fcc8d4e65077392bb92aefc66eb7876d6f8c52b90641362ddff5355104ee1'
   name 'Angry IP Scanner'
   homepage 'http://angryip.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.