### PR TITLE
Update simplenote to 1.1.0

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,14 +1,14 @@
 cask 'simplenote' do
-  version '1.0.8'
-  sha256 '7bdc8d27b8936e53e1f2b9319d5a685ac85363db6fca5e566529ad36a22e5813'
+  version '1.1.0'
+  sha256 '053e48f1fedea2bc38643c26a8d95e27191f56dbb69a8945c781deba63819b72'
 
   url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.zip"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom',
-          checkpoint: 'c64f7c766c1225fd0eb4443ab72bd6656abe7e0f2028c514219a073ba7b7c3e4'
+          checkpoint: 'fbd69511b4c38ef247aa5f9c443d59495758900c907de13af1c9ad98e8d7ef55'
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'
 
-  app 'Simplenote-darwin-x64/Simplenote.app'
+  app 'Simplenote.app'
 
   zap trash: [
                '~/Library/Application Support/Simplenote',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.