### PR TITLE
Update xiami to 3.0.10-9e6

### DIFF
--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -1,6 +1,6 @@
 cask 'xiami' do
-  version '3.0.9-0A5FCD0'
-  sha256 '82e6d417da739211c0b70ea0f770754807d4f86837e1055bc7569794d3e3853b'
+  version '3.0.10-9e6'
+  sha256 'dded5b66993604646468ca74d1a4da7d1b1995009670d4aef4bd8931113b6db4'
 
   # gxiami.alicdn.com/xiami-desktop was verified as official when first introduced to the cask
   url "http://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.