### PR TITLE
Update downie to 3.0.9,1706

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.0.8,1701'
-  sha256 '83ba692cf332ba39ef959d67946230c529a3af646d988733a9786e6d101f9a4e'
+  version '3.0.9,1706'
+  sha256 '9568dc97b1fcfea0b70620ae43d67bcd7ab249da06913f06c0899c5da2596618'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: 'ee7c2f0473b0896baa7b539b0a9d76c8d8b508b06a589e325c3568fd81661f08'
+          checkpoint: '321af3b463106fa8c96555e618802d27d9316517f1f0d29f4c14475cd2715d18'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.