### PR TITLE
Update reactotron to 1.13.0

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,10 +1,10 @@
 cask 'reactotron' do
-  version '1.11.2'
-  sha256 '0623c34811aa3dbf9dfb8ce10694f9bc4a66dbf1c812f12e1b2e9bf2cc152271'
+  version '1.13.0'
+  sha256 '8c19b5c306430b09600c673afd2342617590940aaaea787b8eb751b842c6e9ac'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron.app.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom',
-          checkpoint: '3a2a82a6f76b63bc823f33b246165bf45752ab176bc45937f175138d7461ba7e'
+          checkpoint: '35f4d4263a32f2c963565f45e529b9621b84e209d28e9ad58146c92df9f10f54'
   name 'Reactotron'
   homepage 'https://github.com/infinitered/reactotron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.