### PR TITLE
script.sh: add pkgutil

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -25,6 +25,9 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
     for cask in "${modified_casks[@]}"; do
       run brew cask reinstall --verbose "${cask}"
       run brew cask uninstall --verbose "${cask}"
+      if brew cask _stanza uninstall "${cask}" &> /dev/null; then
+        run "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_loaded_launchjob_ids"
+      fi
       if brew cask _stanza pkg "${cask}" &> /dev/null; then
         run "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_recent_pkg_ids"
       fi

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -26,7 +26,7 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
       run brew cask reinstall --verbose "${cask}"
       run brew cask uninstall --verbose "${cask}"
       if brew cask _stanza pkg "${cask}" &> /dev/null; then
-        run /usr/sbin/pkgutil --pkgs | /usr/bin/grep --ignore-case --invert-match apple | /usr/bin/sort
+        run "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_recent_pkg_ids"
       fi
     done
   else

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -26,7 +26,7 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
       run brew cask reinstall --verbose "${cask}"
       run brew cask uninstall --verbose "${cask}"
       if brew cask _stanza pkg "${cask}" &> /dev/null; then
-        run /usr/sbin/pkgutil --pkgs | /usr/bin/grep -iv apple | /usr/bin/sort
+        run /usr/sbin/pkgutil --pkgs | /usr/bin/grep --ignore-case --invert-match apple | /usr/bin/sort
       fi
     done
   else

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -25,6 +25,9 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
     for cask in "${modified_casks[@]}"; do
       run brew cask reinstall --verbose "${cask}"
       run brew cask uninstall --verbose "${cask}"
+      if brew cask _stanza pkg "${cask}" > /dev/null 2>&1; then
+        run /usr/sbin/pkgutil --pkgs | /usr/bin/grep -iv apple | /usr/bin/sort
+      fi
     done
   else
     ohai 'More than 3 Casks modified, skipping install'

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -25,7 +25,7 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
     for cask in "${modified_casks[@]}"; do
       run brew cask reinstall --verbose "${cask}"
       run brew cask uninstall --verbose "${cask}"
-      if brew cask _stanza pkg "${cask}" > /dev/null 2>&1; then
+      if brew cask _stanza pkg "${cask}" &> /dev/null; then
         run /usr/sbin/pkgutil --pkgs | /usr/bin/grep -iv apple | /usr/bin/sort
       fi
     done


### PR DESCRIPTION
This is intended to help with checking `uninstall` stanzas that remove pkgs with `pkgutil` or `script`.

```
==> Uninstalling Cask powershell
==> Running uninstall process for powershell; your password may be necessary
==> Uninstalling packages:

>>> /usr/sbin/pkgutil --pkgs
com.hipbyte.rubymotion.pkg
com.microsoft.powershell
com.oracle.jdk8u112
com.oracle.jre
com.vmware.tools.macos.pkg.files
org.macosforge.xquartz.pkg
```