### PR TITLE
Update flume to 2.8.3

### DIFF
--- a/Casks/flume.rb
+++ b/Casks/flume.rb
@@ -1,10 +1,10 @@
 cask 'flume' do
-  version '2.8.2'
-  sha256 'fcaf509db286979a713c73d23755b2f9927f23e108383fda2738d61ea60cadee'
+  version '2.8.3'
+  sha256 'f5b07c5e4155a12cb099e2e39b4f08da09e599bcccf8567bfad6d40b2266435b'
 
   url "https://flumeapp.com/files/Flume-#{version}.zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/c88c56b02dcd4dd3acceb6d7a24f7122',
-          checkpoint: 'b05bf16264e66bfe94cd090d515f74015eed0243cd3d0a0a8e6c463fd0df60ca'
+          checkpoint: '7ead805aef0221f3ca99bd3dfe893c7165b42f8ba22e08cc3635170dcc6e71bc'
   name 'Flume'
   homepage 'https://flumeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.