### PR TITLE
Update travis.yml to xcode 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 matrix:
   include:
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode8.3
       rvm: system
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.1
       rvm: system
   fast_finish: true
 


### PR DESCRIPTION
`xcode8.3` has been updated and is currently the "newest" image.

https://blog.travis-ci.com/2017-10-16-a-new-default-os-x-image-is-coming