### PR TITLE
Update picat to 2.2

### DIFF
--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,10 +1,10 @@
 cask 'picat' do
-  version '2.1'
-  sha256 '2a51c892388ffc48a7a55b336dfcf7c7dbb0c347bbcaf4038d2f1ea10f9b0097'
+  version '2.2'
+  sha256 '9d08e44f155982600bb54c8b4890e08baaaa38d20f2919f9346a000c5fcac798'
 
   url "http://picat-lang.org/download/picat#{version.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt',
-          checkpoint: 'c2e35787d2c61d8e73ef38369fa0c139e153a24169d43bb8f43a33ba58ae0a39'
+          checkpoint: '83b1ef8773629f7608539b747f3dfc6317278e83d69988e83d06d258883c5009'
   name 'Picat'
   homepage 'http://www.picat-lang.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.