### PR TITLE
Update scopebox to 3.5.5

### DIFF
--- a/Casks/scopebox.rb
+++ b/Casks/scopebox.rb
@@ -1,6 +1,6 @@
 cask 'scopebox' do
-  version '3.5.4'
-  sha256 'a5368385fb88ab8d5d9458649a97d0d9085c586ab6e738e562392f033c455cec'
+  version '3.5.5'
+  sha256 '6f5b880dc7c4cb16b4407117dd1ddc619020b906aa122a6cf20caaf90da726cf'
 
   url "https://www.divergentmedia.com/filedownload/ScopeBox%20#{version}.dmg"
   name 'ScopeBox'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.