### PR TITLE
Update icons8 to 5.6.4

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -1,11 +1,11 @@
 cask 'icons8' do
   # note: "8" is not a version number, but an intrinsic part of the product name
-  version '5.6.3'
-  sha256 '820b3eb24c6868d272f995d44220aa121c1483be30c676a19ce465229712982c'
+  version '5.6.4'
+  sha256 '01dd5ca5fbc412ba8a515200d6f50e7b27a1e696257af0ac87e293758e8e55bd'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
   appcast 'https://desktop.icons8.com/updates/mac/icons8_cast.xml',
-          checkpoint: '622623074f09dcca53259515f60d9d0302c5b675e45fb0ec3963dcb1dce9e460'
+          checkpoint: '9b997f3161fb2a6b83d4cd3098c0798587971e358161d3b8b87543a36d78a48f'
   name 'Icons8 App'
   homepage 'https://icons8.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.