### PR TITLE
Update hab to 0.39.1-20171117234750

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.38.0-20171026215116'
-  sha256 '2ffcbf5520445ff0471b71657bb24005e11adb94644d6c4e5f953e68efb74df4'
+  version '0.39.1-20171117234750'
+  sha256 'ca735f66c701a74285ccae6dfef2427fbdc2322cb658610e40c85c5f650e5c2e'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'a63d8468e5986f9eb9d1152563e63147deb3798cb63da9303ebc12eeb91851ab'
+          checkpoint: '66ba2eabc5e064f9231d0ca3761346b8502c0979de6b4284e643a6801741e618'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.