### PR TITLE
Update vimr to 0.20.0-238

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.19.1-229'
-  sha256 'fc2b0fdf37f57683c60c81951bb4f6c154f1b4b9e773f6caccbf1e5aa3a59b8b'
+  version '0.20.0-238'
+  sha256 'a15817f80ca25cf16aa6c496d612b1b51006dfb6901d408100457682151f747d'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '8e750ed2e2b859f319e2a93923ce5f4cc807ee2b25f72b09e009eeb18c7291e4'
+          checkpoint: '6d31f76a355994fdb4e588dbedb5d5eb8d3e492a6b3874b3f67bf00c7035609c'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.