### PR TITLE
Update universalmailer to 3b19

### DIFF
--- a/Casks/universalmailer.rb
+++ b/Casks/universalmailer.rb
@@ -9,13 +9,13 @@ cask 'universalmailer' do
     version '2.1.6'
     sha256 '873f2606f1bf4168775ad48213638d2ede3dee4d8925c84049a42e31a38a9137'
   else
-    version '3b18'
-    sha256 '0fbdfb03a74854963c4ba33c0fb83fbc3c3406c2de2754fdac0bb68275c41cbe'
+    version '3b19'
+    sha256 'ad672b846f623c194e63d9c67c72209afd1e99d72f1af6edb34249ace00e105d'
   end
 
   url "https://universalmailer.github.io/UniversalMailer/zips/UniversalMailer-v#{version.dots_to_underscores}.zip"
   appcast 'https://universalmailer.github.io/UniversalMailer/download.html',
-          checkpoint: 'db0ab0a479729ebf4d9810f1dc19d1db217cf253344f4569a7a205ee35e02edc'
+          checkpoint: 'ee2e7a88ad264cb61ca8c24674a61f129f130142086e13aaeb459f17a2b69724'
   name 'Universal Mailer'
   homepage 'https://universalmailer.github.io/UniversalMailer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.