### PR TITLE
Update reflector to 3.0.1

### DIFF
--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -1,10 +1,10 @@
 cask 'reflector' do
-  version '2.7.2'
-  sha256 'a7b18caa4ae4bcb5a695037d3855d1fcb127c4c573b3b6c628f4631574ffa97e'
+  version '3.0.1'
+  sha256 '6df2608e11a08cb0b71faf9b9267f442d04225eccfc01f646ac1dd2d3603c3a9'
 
   url "https://download.airsquirrels.com/Reflector#{version.major}/Mac/Reflector-#{version}.dmg"
   appcast "https://updates.airsquirrels.com/Reflector#{version.major}/Mac/Reflector#{version.major}.xml",
-          checkpoint: '38ab599bebca2d67ec695ac14440cfb62e9dddefe81b8f4cdf07d931c2851f65'
+          checkpoint: '833bcaf099971d31531ea65dbfda4aa09f7ec37ff52e0b344aa8bc52a58638c3'
   name "Reflector #{version.major}"
   homepage 'http://www.airsquirrels.com/reflector/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.