### PR TITLE
Update itubedownloader to 6.3.2,1509417770

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,11 +1,11 @@
 cask 'itubedownloader' do
-  version '6.2.9,1498780358'
-  sha256 '7835755265557c0d5962838e8591e49fec23cd4166458ce7781828156e030102'
+  version '6.3.2,1509417770'
+  sha256 'dfdf21331a24da4f2e85532112c13b3d88b354d3fdc3b6afa01fb02061a5a651'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/#{version.before_comma.no_dots}/#{version.after_comma}/iTubeDownloader-#{version.before_comma.no_dots}.zip"
   appcast 'https://updates.devmate.com/com.AlphaSoft.iTubeDownloader.xml',
-          checkpoint: '1672d923f9a6b9d6a8ba899a82a441f56445fb83deda3d008288712402ecaf24'
+          checkpoint: 'd534df0b9b617b025c1243aef2c743cf59faac2807a0b59967fcd7964ba90459'
   name 'iTubeDownloader'
   homepage 'http://alphasoftware.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.