### PR TITLE
Update polymail to 1.46

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.45'
-  sha256 'd9fa84eab933d8fb1ec67926eeb22a983a5d615a968da9a21f898d0a55d2552d'
+  version '1.46'
+  sha256 '38e1e91bf18df9d3430bdacb15542e5f7e843aff473751ffa6a0bd8d3f7da2cc'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: '3851c258b5693be2e5501f7db58781e16434b4157896a42c4493f5504029ac00'
+          checkpoint: 'e6ff8cf1aff7be4d13f80b9ef1d10b4766105174707eb1b633225fae8bf339a8'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.