### PR TITLE
Update quicken to 2018

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,10 +1,8 @@
 cask 'quicken' do
-  version '2018,5.2.2'
-  sha256 'cc7ba946e8439617bdf2ff744829baea368d7ec67bf3acfde5658664387237ea'
+  version '2018'
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://download.quicken.com/mac/QuickenSub#{version.before_comma}/Quicken#{version.before_comma}.dmg"
-  appcast "https://www.quicken.com/support/#{version.before_comma}-release-quicken-mac-release-notes",
-          checkpoint: '7cf2eee2ccb80c9d7f771c3e5568c76b3f266392dec9e793cd2a5f6bedf48b5f'
+  url "https://download.quicken.com/mac/QuickenSub#{version}/Quicken#{version}.dmg"
   name 'Quicken'
   homepage 'https://www.quicken.com/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.