### PR TITLE
Update scap-workbench to 1.1.5-1

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,11 +1,11 @@
 cask 'scap-workbench' do
-  version '1.1.4'
-  sha256 '506ea96f69f1c67cc1b836c357d1b7accf616ffb676c19713ebdc8c379a713e7'
+  version '1.1.5-1'
+  sha256 'ae77bd74be0c1438fdc25ddf775b4bdf220b846946381c4cbbeb0c178fe4b1ac'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
-  url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version}/scap-workbench-#{version}.dmg"
+  url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version.sub(%r{-.+}, '')}/scap-workbench-#{version}.dmg"
   appcast 'https://github.com/OpenSCAP/scap-workbench/releases.atom',
-          checkpoint: '1725f812a7fd7b6f97ef71fea73e3c70be6904be0de6cbdccc4307485cbd4863'
+          checkpoint: 'f62b4f5a51ab4c6cab59752c5b6e125541fafcb8dd283f9a72e3fbafb2f6e1b5'
   name 'scap-workbench'
   homepage 'https://www.open-scap.org/tools/scap-workbench/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.