### PR TITLE
Update expo-xde to 2.22.0

### DIFF
--- a/Casks/expo-xde.rb
+++ b/Casks/expo-xde.rb
@@ -1,11 +1,11 @@
 cask 'expo-xde' do
-  version '2.21.0'
-  sha256 '52e5f64d130a04fcaeebe50b9f6eca05a5eae01e09f95faa48beac3771eb72a1'
+  version '2.22.0'
+  sha256 '1ed0228ebfdcb0516a77f2d5a9109be1ae4ec5fae8f5b5f92ea364c4bfea6ac0'
 
   # github.com/expo/xde was verified as official when first introduced to the cask
   url "https://github.com/expo/xde/releases/download/v#{version}/xde-#{version}.dmg"
   appcast 'https://github.com/expo/xde/releases.atom',
-          checkpoint: '438612414e5882774c8b0b0c4580d50f7bd9623bad1b5f4e64668c714ae061c9'
+          checkpoint: 'd8b3587d746b09616a1e2ec661ba2b508297cd6813ed916dc40459c2465be907'
   name 'Expo Development Environment (XDE)'
   homepage 'https://expo.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.