### PR TITLE
Update subler to 1.4.4

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.4.3'
-  sha256 '423f444b7986fb18391a5af878765bfaf7a842278191d7f245b41b38bc5d4faf'
+  version '1.4.4'
+  sha256 'b93feb24fa884fa60c0be66f5b0ecde4ebd1fcb815d0f57e5199ab43469832f7'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: 'cc5d2680ce37c60c1840176c37cda4c52f99584e55a75723c77767bba42a0d75'
+          checkpoint: '8f4450dd1bfae079857c7dd7c7c096d59d1345c280b8bc6dbf2420bd66f43050'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.