### PR TITLE
Update cockatrice to 2.4.0,2017-11-19:Unwrapped

### DIFF
--- a/Casks/cockatrice.rb
+++ b/Casks/cockatrice.rb
@@ -1,11 +1,11 @@
 cask 'cockatrice' do
-  version '2.3.17,2017-05-05:Trials_of_the_Gods'
-  sha256 'd0400d5a23acb8e54e1a02196d1db83fccfc7259f28e9d16a74ddc92cc3fd797'
+  version '2.4.0,2017-11-19:Unwrapped'
+  sha256 'bd422d2ed42a1d15b7f83e1be9ace6b6b99b0e3130357dc087a9d554c54fecba'
 
   # github.com/Cockatrice/Cockatrice was verified as official when first introduced to the cask
   url "https://github.com/Cockatrice/Cockatrice/releases/download/#{version.after_comma.before_colon}-Release-#{version.before_comma}/Cockatrice-#{version.after_colon}-#{version.before_comma}.dmg"
   appcast 'https://github.com/Cockatrice/Cockatrice/releases.atom',
-          checkpoint: '991c461dc909462135a6f3c3aff9d1b55dc0ea2917ae853c9ab0b31367ced52b'
+          checkpoint: '590f24d47778ff6abff0335f427c540a574b8553219add1d85876d01235a5713'
   name 'Cockatrice'
   homepage 'http://www.woogerworks.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.