### PR TITLE
Update ridibooks to 2.3.0

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,9 +1,8 @@
 cask 'ridibooks' do
-  version '2.2.4'
-  sha256 '90e7c5646e6117f0cd85d52d1ed9e4f6b3743010f9fdfb87335fe95397b02c32'
+  version '2.3.0'
+  sha256 'f62343cb25fe4ba2ab0b076c53a4623bbe2c81d723263fff7d74ca3b87610a02'
 
-  # ridicorp.com was verified as official when first introduced to the cask
-  url "https://cdn.ridicorp.com/app/mac/ridibooks-#{version}.dmg"
+  url "https://viewer-ota.ridibooks.com/mac/ridibooks-#{version}.dmg"
   name 'Ridibooks'
   homepage 'https://ridibooks.com/support/app/download'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.