### PR TITLE
Update popclip to 1.5.8

### DIFF
--- a/Casks/popclip.rb
+++ b/Casks/popclip.rb
@@ -1,6 +1,6 @@
 cask 'popclip' do
-  version '1.5.7'
-  sha256 '1e6feba9e365d7802e22b0fd682e61740fab6707b655c71e37b3e6fd65ad8d75'
+  version '1.5.8'
+  sha256 '323707f9933c798a909ddb5536839d755f4bbf29d698d4eaec229c29596c888f'
 
   url "https://pilotmoon.com/downloads/PopClip-#{version}.zip"
   name 'Popclip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.