### PR TITLE
Update resolume-avenue to 6.0.1

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,13 +1,13 @@
 cask 'resolume-avenue' do
-  version '4.6.4'
-  sha256 'e6adfd60d07cfa025bd61c1047b4451c07407e1bf67746fa741952c3efbde7ae'
+  version '6.0.1'
+  sha256 '0c09ba4f28d227d487153e9f2a93895f2a053ea51a9b5dffb95f348008aa8a3a'
 
   # d19j6z4lvv1vde.cloudfront.net was verified as official when first introduced to the cask
   url "https://d19j6z4lvv1vde.cloudfront.net/Resolume_Avenue_#{version.dots_to_underscores}_Installer.dmg"
   name 'Resolume Avenue'
   homepage 'https://resolume.com/'
 
-  pkg "Resolume Avenue #{version} Installer.pkg"
+  pkg 'Resolume Avenue Installer.pkg'
 
   uninstall pkgutil: 'com.resolume.pkg.ResolumeAvenue*'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.