### PR TITLE
Update bartender to 3.0.30

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -3,8 +3,8 @@ cask 'bartender' do
     version '2.1.6'
     sha256 '013bb1f5dcc29ff1ecbc341da96b6e399dc3c85fc95bd8c7bee153ab0d8756f5'
   else
-    version '3.0.28'
-    sha256 'd05bbda030ee039266b86b8a6c63bc36016eb0fc3cf819a8c3248df97775b50f'
+    version '3.0.30'
+    sha256 '7ac2d7f2cfe733f85f91718363e05310f2a2dfde3354ad2994254e94b039a0bb'
   end
 
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.