### PR TITLE
Update bitpay to 3.9.0

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.8.2'
-  sha256 '2c501d536d69ceb56344e06ed8999285bdd4d6191eef7402c324964b55f51346'
+  version '3.9.0'
+  sha256 'fb3f7eea26b2d62e9f22ba243bbfdaec45b7f9ff8081c17f11f11bc8cb7ad117'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'de635cd22d229ec1d0500232b41ea387061e5695f797ecc81e6cc262cff37999'
+          checkpoint: '22862b67fb0a0944a96297989fe70fab4473a278990719ca62b5bd95ab8d01da'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.