### PR TITLE
Update shotcut to 17.11.07

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '17.10.02'
-  sha256 '4a2c0dec91fc59714277ccecfa245bbf1b5be265dadce88696e6a1fd73fff021'
+  version '17.11.07'
+  sha256 '94522ffd61bd0c1f664939e818de995f5fb34cbddf4a365bb021ba9011592481'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '236fed6581d7db50aa7a4bc85b052f7de44a51be9ebd1ef303cc994fb87f74f0'
+          checkpoint: '2681d9a45f92dac8df116bd8be9a999908dafa7420f13bf4091b2d1246940056'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.