### PR TITLE
Update ddnet to 10.8.6

### DIFF
--- a/Casks/ddnet.rb
+++ b/Casks/ddnet.rb
@@ -1,6 +1,6 @@
 cask 'ddnet' do
-  version '10.6.3'
-  sha256 '9d3015e9630f24d366c02d771f4ab20a0fbfd9ffe508900d73bc931fca1f3682'
+  version '10.8.6'
+  sha256 '94997c5c51057cef48a51ce670cefe49e67a8650b7d7918851d6fc65f184b94d'
 
   url "https://ddnet.tw/downloads/DDNet-#{version}-osx.dmg"
   name 'DDNet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.