### PR TITLE
Update bluemix-cli to 0.6.2

### DIFF
--- a/Casks/bluemix-cli.rb
+++ b/Casks/bluemix-cli.rb
@@ -1,11 +1,11 @@
 cask 'bluemix-cli' do
-  version '0.6.0'
-  sha256 'f26a947fc6bf2b5c57bf80309c78641d76cd9fa0ba7104370ce6038ae7811132'
+  version '0.6.2'
+  sha256 '383a920469908b2371651fa4e181d0d071d7f0590ac9e5594df77c7fc5e3f25e'
 
   # public.dhe.ibm.com was verified as official when first introduced to the cask
-  url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_#{version}.pkg"
-  appcast 'https://clis.ng.bluemix.net/ui/all_versions.html',
-          checkpoint: 'cd618fc6668b264a6e5ab31305b9868b5df9298baba8870b1bf0dd47b0b5e8b6'
+  url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/Bluemix_CLI_#{version}.pkg"
+  appcast 'https://github.com/IBM-Bluemix/bluemix-cli-release/releases.atom',
+          checkpoint: 'a8b4534e53a5e92e1092fa12f436d3951ba33ecfd52eab99359790fa30543fb5'
   name 'Bluemix-CLI'
   homepage 'https://clis.ng.bluemix.net/ui/home.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.