### PR TITLE
Update zap stanza for iStat Menus

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -13,10 +13,11 @@ cask 'istat-menus' do
 
   uninstall delete:    "/Library/Application Support/iStat Menus #{version.major}",
             launchctl: [
-                         'com.bjango.istatmenusagent',
-                         'com.bjango.istatmenusdaemon',
+                         'com.bjango.istatmenus.agent',
+                         'com.bjango.istatmenus.daemon',
                          'com.bjango.istatmenusnotifications',
-                         'com.bjango.istatmenusstatus',
+                         'com.bjango.istatmenus.status',
+                         'com.bjango.istatmenus.installerhelper',
                        ],
             signal:    [
                          ['TERM', 'com.bjango.iStat-Menus-Notifications'],
@@ -28,13 +29,21 @@ cask 'istat-menus' do
 
   zap trash: [
                '~/Library/Application Support/iStat Menus',
+               '~/Library/Application Scripts/com.bjango.istatmenus.iStat-Menus-Widget',
                '~/Library/Caches/com.bjango.istatmenus',
-               '~/Library/Caches/com.bjango.istatmenusstatus',
+               '~/Library/Caches/com.bjango.istatmenus.status',
+               '~/Library/Caches/com.bjango.istatmenus.agent',
                '~/Library/Caches/com.bjango.iStat-Menus-Updater',
                '~/Library/Caches/com.bjango.iStatMenusAgent',
+               '~/Library/Caches/iStat Menus',
+               '~/Library/Containers/com.bjango.istatmenus.iStat-Menus-Widget',
+               '~/Library/Cookies/com.bjango.istatmenus.binarycookies',
                '~/Library/Logs/iStat Menus',
                '~/Library/Preferences/com.bjango.istatmenus.plist',
                "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
-               '~/Library/Preferences/com.bjango.istatmenusstatus.plist',
+               '~/Library/Preferences/com.bjango.istatmenus.status.plist',
+               '/Library/PrivilegedHelperTools/com.bjango.istatmenus.installerhelper',
+               '/Library/Logs/iStat Menus',
+               '/Users/Shared/.iStatMenus',
              ]
 end

--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -11,7 +11,10 @@ cask 'istat-menus' do
 
   app 'iStat Menus.app'
 
-  uninstall delete:    "/Library/Application Support/iStat Menus #{version.major}",
+  uninstall delete:    [
+                         "/Library/Application Support/iStat Menus #{version.major}",
+                         '/Library/PrivilegedHelperTools/com.bjango.istatmenus.installerhelper',
+                       ],
             launchctl: [
                          'com.bjango.istatmenus.agent',
                          'com.bjango.istatmenus.daemon',
@@ -42,7 +45,6 @@ cask 'istat-menus' do
                '~/Library/Preferences/com.bjango.istatmenus.plist',
                "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
                '~/Library/Preferences/com.bjango.istatmenus.status.plist',
-               '/Library/PrivilegedHelperTools/com.bjango.istatmenus.installerhelper',
                '/Library/Logs/iStat Menus',
                '/Users/Shared/.iStatMenus',
              ]


### PR DESCRIPTION
Updated zap stanza for the latest version.

There are still some remains, that I'm not sure, how to remove, those are located in `/private/var/folders/` folder under a hash, which I'm not sure if is changing or not, can someone take a look? 