### PR TITLE
Update amanote to 1.0.8

### DIFF
--- a/Casks/amanote.rb
+++ b/Casks/amanote.rb
@@ -1,9 +1,11 @@
 cask 'amanote' do
-  version '0.9.7'
-  sha256 'c4a6844de39f5b3efc6dc11b34bab5f34e9e6d8eb3ee1fcc87ad6b0a82ade0b4'
+  version '1.0.8'
+  sha256 '461fa54acfe1d072ccfaf409f5b5dbf043b9e1b72571db8d1b9b8e5e05fc07fa'
 
-  # amazonaws.com/release.amanote.com was verified as official when first introduced to the cask
-  url "https://s3-eu-west-1.amazonaws.com/release.amanote.com/beta/v#{version}/Amanote-#{version}.dmg"
+  # d3p3yxvb2sk2hj.cloudfront.net/release was verified as official when first introduced to the cask
+  url "https://d3p3yxvb2sk2hj.cloudfront.net/release/Amanote-#{version}.dmg"
+  appcast 'https://amanote.com/assets/js/download.js',
+          checkpoint: '8ac7cc510474c08c5cd4368d6a59e21feba0c6be716c4a629bb7e53c9a4a7779'
   name 'Amanote'
   homepage 'https://amanote.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.