### PR TITLE
Update querious to 2.1.1

### DIFF
--- a/Casks/querious.rb
+++ b/Casks/querious.rb
@@ -1,10 +1,10 @@
 cask 'querious' do
-  version '2.0'
-  sha256 '4c5ee422fe2d37e365574541a6565dc8b9a81dacc8ca0da8fa5898b67d736b47'
+  version '2.1.1'
+  sha256 'd3973d28a860a66548ff94862123f00b2b2fb11715015cede784f502914cffe6'
 
   url "https://www.araelium.com/querious/downloads/versions/Querious#{version}.zip"
   appcast 'https://arweb-assets.s3.amazonaws.com/downloads/querious/prerelease-updates.xml',
-          checkpoint: '72b9051269861bacefd1f4614e34f4edf22b6176c576b250c7f07290b3916135'
+          checkpoint: 'f0d6f135fe4cd1400bd9f287aa29092b8c63eb3321b9afeaccc70904dd49351d'
   name "Querious #{version.major}"
   homepage 'https://www.araelium.com/querious/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.