### PR TITLE
Update thonny to 2.1.13

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,11 +1,11 @@
 cask 'thonny' do
-  version '2.1.11'
-  sha256 '346d5ba542d37ece44732c4b438ba0b45bc5e4323e251892457ceef4bb777ac4'
+  version '2.1.13'
+  sha256 'bd3e162d5e95c50adae290565ad60e468f8d65e93e811aba9778033dd799021f'
 
   # bitbucket.org/plas/thonny/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/plas/thonny/downloads/thonny-#{version}.dmg"
   appcast 'http://thonny.org/blog/categories/releases.html',
-          checkpoint: 'eb0fb54be52ef849e2a5b7e69ef161d15b699b85e4535e4be491cbe39b7491f1'
+          checkpoint: 'b5f3b66d7bbcd46a4b5b880e1e167c7dced47afa7bc14d4ff8f4a553a7776e00'
   name 'Thonny'
   homepage 'http://thonny.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.