### PR TITLE
Update studio-3t to 5.6.4

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.6.3'
-  sha256 '46e944f9800f5a8a47efc8adb3f14de6619abf07aabb495c8489a509b7736b62'
+  version '5.6.4'
+  sha256 '11b78151abd5bbf0fddd3f39209bdf61777af3e29d5bd676cc008ad1a25539ea'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'http://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '038f68111ad92ade55341348e691ef5515fac96e6730768455835e1b83da5af1'
+          checkpoint: '18c1baa32e9e91a5a7dd27ac990371d617ce34e9039e693f05dd6c7ca24e94e1'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.