### PR TITLE
Update webcatalog to 7.6.1

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,11 +1,11 @@
 cask 'webcatalog' do
-  version '7.3.0'
-  sha256 '08f644cb713d2ca22717b80d3b4f6a85767010858a30c2171b8e773bff6110a9'
+  version '7.6.1'
+  sha256 '65c11319aba490df7dca12cb096b0b5df05bebbd81f0b3c19ce6269428b9c0dd'
 
   # github.com/webcatalog/desktop/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/desktop/releases/download/v#{version}/WebCatalog-#{version}.dmg"
   appcast 'https://github.com/webcatalog/desktop/releases.atom',
-          checkpoint: '4659c71da5dcfd4c818e0b6b3dda4b9763613b91904b08cf27c285f9d54b7ca9'
+          checkpoint: 'a88aa7cf434a5e3e4ccc13cd35a9600d9d2b9f9a287842b4516c4da8aabeb173'
   name 'WebCatalog'
   homepage 'https://webcatalog.io/download/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.