### PR TITLE
Update powerphotos to 1.3.3

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,13 +8,13 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.3.2'
-    sha256 '92c368a9ba1d60af82242d946a9166fc8e399463a686ee58ee69af296d74db4f'
+    version '1.3.3'
+    sha256 'be37361f6111422adc84d4ef7cff91108151670a4c4fdb95e7056c0c8363275e'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: 'c354ca71424e31df598b4f27a75361be9ce06001aa5f752bea51c0e6fbea60dd'
+          checkpoint: '116ac0eb996f211271b97bfd35f06fd2b36f0c5ff7713cb6f8a3b3add2396d7c'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.