### PR TITLE
Update station to 1.0.8

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.0.7'
-  sha256 '41ebff3778a5eaa9030100b500a66cc9f80bbe865e69af1bc87ab1f0864e183c'
+  version '1.0.8'
+  sha256 'c8e3735d0cf290341163991cfcd0fbf3ae0523debcb953e23c04a6479f78044b'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: 'd373b7966ba6467445a5134690089543a74c9732e7b0837d5f9ddb18d03eb092'
+          checkpoint: '723eff7d78895433fc218e4209e8037e1a988821781be1d4c351e7c4b7016f5a'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.