### PR TITLE
Update vellum to 2.0.7

### DIFF
--- a/Casks/vellum.rb
+++ b/Casks/vellum.rb
@@ -1,11 +1,11 @@
 cask 'vellum' do
-  version '20500'
-  sha256 '18299e204edc4aff335146632a64245956265f5db55b91856bdf28410e1d1f9f'
+  version '2.0.7'
+  sha256 '0180bf11eb19a5f7ee41a2844d3b39ba16b14f04e5a44f58661894c7cf582b84'
 
   # 180g.s3.amazonaws.com/downloads was verified as official when first introduced to the cask
-  url "https://180g.s3.amazonaws.com/downloads/Vellum-#{version}.zip"
+  url "https://180g.s3.amazonaws.com/downloads/Vellum-#{version.no_dots}00.zip"
   appcast 'https://get.180g.co/updates/vellum/',
-          checkpoint: 'e4148c4a5415ac31d1b92b1a17005dd7e4ebd91fe8da45ed55664603758c114c'
+          checkpoint: '1d5b7219f00c5f6e8be05102dbb43a85ca90001ab6fe6a1ababb77fead142723'
   name 'Vellum'
   homepage 'https://vellum.pub/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.