### PR TITLE
Update vox to 3.0.1

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '3.0'
-  sha256 'b5ab51ff85fe8b952c1e7701b033a5141bfa9ff124289c97357a7a1c53e239cf'
+  version '3.0.1'
+  sha256 '54c5972c5c6fb509efd72b62ce29829eca9fbb7aee3c48fea840c41095e9f339'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: 'c6adf9777f25c56126b7c5504d18c2ff7a17e60e43f6d4cc356303b6d12cfe91'
+          checkpoint: '6181faa9bf011813dd34c4d49009a44c8586b575d30af15bc049b6f68ebda80e'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.