### PR TITLE
Update oryoki to 0.2.1

### DIFF
--- a/Casks/oryoki.rb
+++ b/Casks/oryoki.rb
@@ -1,11 +1,11 @@
 cask 'oryoki' do
-  version '0.2.0'
-  sha256 'cf1c7ef670a59d7d057124d4c317c3364ddf9b5af56d7a5a6bb04cb265a84d0a'
+  version '0.2.1'
+  sha256 '08ae4ef31e8d4712ff4159ea81c087db03be6ea51e51185051959992aee9ed82'
 
   # github.com/thmsbfft/oryoki was verified as official when first introduced to the cask
   url "https://github.com/thmsbfft/oryoki/releases/download/#{version}/Oryoki-#{version}.zip"
   appcast 'https://github.com/thmsbfft/oryoki/releases.atom',
-          checkpoint: '5d4623ac6726b9fd837312f0f02f2ed2658e43d7e91793431896c3363648d7fb'
+          checkpoint: 'ee8d0b12e4b14ff2e03e3f162552d89c2d9aa4430d645987702c9e68bdcbc2c5'
   name 'Oryoki'
   name 'Ōryōki'
   name '応量器'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.