### PR TITLE
Update mysql-connector-python to 2.1.7

### DIFF
--- a/Casks/mysql-connector-python.rb
+++ b/Casks/mysql-connector-python.rb
@@ -1,12 +1,12 @@
 cask 'mysql-connector-python' do
-  version '2.1.5'
-  sha256 'd95dec32546fd7c3ca96bd3f65da374d2e9861ab3c145e2dddb80ac40acc1331'
+  version '2.1.7'
+  sha256 '983b63a816fa73e63efe2a6e2da6fa7e52b71df6da1f1be95c8097fe3c646e46'
 
-  url "https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-macos10.12.dmg"
+  url "https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-osx10.12.dmg"
   name 'MySQL Connector for Python'
   homepage 'https://dev.mysql.com/downloads/connector/python/'
 
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :sierra'
 
   pkg "mysql-connector-python-cext-#{version}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.