### PR TITLE
Update 4k-stogram to 2.6.2

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,10 +1,10 @@
 cask '4k-stogram' do
-  version '2.5.2.1356'
-  sha256 '76d818c38d1ab294bc2b520b3a93e81fc4f5271d87d9283d8d5033904991e6a8'
+  version '2.6.2'
+  sha256 '1f053da82ad48f787e84a82d48ea639ffdf2c624ff5fb88c8724361616f72654'
 
-  url "https://downloads2.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
+  url "https://dl.4kdownload.com/app/4kstogram_#{version}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: 'c54b263fa24e27e9adf0941a0339b323768dce5b037022ba6f44e2c632ed1051'
+          checkpoint: 'd8308646431af31e59db7ed294e4449a4f4af524c29bb0b4bff39a56a65cad3a'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.