### PR TITLE
Update signal to 1.0.39

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.0.38'
-  sha256 'c53b10de3e5f3aa471735d5146b50ae9b7aec79a93cc84e287810d740162a2a7'
+  version '1.0.39'
+  sha256 '957b55782351d912f7261a3018e6f2be87a5fa9c130271b45a753cc81882a251'
 
   url "https://updates.signal.org/desktop/Signal-mac-#{version}.zip"
   appcast 'https://github.com/WhisperSystems/Signal-Desktop/releases.atom',
-          checkpoint: 'bb52ad1e877fff1d9aacfd5d9bf8b1374273ea7a5a37370f7bda8d3aa74becc3'
+          checkpoint: '7bd0f4cd30a17d56bcd93ff7df8979fa990be88f064f93a79f50046011e60864'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.