### PR TITLE
Update mist to 0.9.3

### DIFF
--- a/Casks/mist.rb
+++ b/Casks/mist.rb
@@ -1,10 +1,10 @@
 cask 'mist' do
-  version '0.9.2'
-  sha256 '2480301ee8c94e791131b05f560523fc1aac24a8e65756173851a1dcf0abc8d3'
+  version '0.9.3'
+  sha256 '36c96d79f9b1bff15c0b152754a9d85a19eaf9ecc39d739455b1801a99baeee7'
 
   url "https://github.com/ethereum/mist/releases/download/v#{version}/Mist-macosx-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/ethereum/mist/releases.atom',
-          checkpoint: '57df8c5cd893fad8ce1da4771e54bf9890f7fba40065428c10299c53e7652088'
+          checkpoint: '3b1579bde3cc402ac1fd41a873b7ca38db1f58831f2347c098010d90cbe4ff55'
   name 'Mist'
   homepage 'https://github.com/ethereum/mist'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.