### PR TITLE
Update rsyncosx to 4.8.6

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '4.8.2'
-  sha256 'a272ec0c2804af40b7ab9632972658ec3e0e913f413cc3df257cab7d782e367e'
+  version '4.8.6'
+  sha256 '5cffd6718791b4842412e498d4269c375cf5bd00d1d001f7dce5b40eeb377290'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: '2c03f2b32881d887f81939093f215faf22e276cd3b19929e1a61b3f152bce908'
+          checkpoint: 'aa9036664db725fc14e77bad0d334441183a4ffd36cf2639de5ff849635d94e2'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.