### PR TITLE
Update qsync-client to 3.2.1.1017

### DIFF
--- a/Casks/qsync-client.rb
+++ b/Casks/qsync-client.rb
@@ -1,8 +1,8 @@
 cask 'qsync-client' do
-  version :latest
-  sha256 :no_check
+  version '3.2.1.1017'
+  sha256 '59b51e7aa8b5a42f60d6ddfa780e8753d748365f2086d22b62bd6332c8ac188c'
 
-  url 'https://download.qnap.com/webstart/QNAPQsync_Mac.dmg'
+  url "https://download.qnap.com/Storage/Utility/QNAPQsyncClientMac-#{version}.dmg"
   name 'Qnap Qsync'
   homepage 'https://www.qnap.com/i/in/utility/#block_3'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #41281.