### PR TITLE
Update wechatwebdevtools to 1.01.1711160

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '1.0.1,171019'
-  sha256 '80554a42badb14ccc7c66cb5ecca5e59f680eddf35105b3700b30d81dde2bcf5'
+  version '1.01.1711160'
+  sha256 'db99b31ff22c6351427bfc54fc1d99441e368025ea498b9a1e917693e55ff643'
 
-  url "https://dldir1.qq.com/WechatWebDev/1.0.0/20#{version.after_comma}/wechat_devtools_#{version.major_minor}#{version.patch}.#{version.after_comma}.dmg"
+  url "https://dldir1.qq.com/WechatWebDev/1.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.