### PR TITLE
Update bitshares to 2.0.171121

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.171102'
-  sha256 'cc06cff51605714bdb8c07d74cf38012e159c5b7142b1598c87c66bf21306205'
+  version '2.0.171121'
+  sha256 'bf31558becacb9129aa026d75bf9abed11f72df527812582df0467587e74648c'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: '9f070dafd1a6116440cdbf90f1d5609bf528fd07aba8936745ace8423721868f'
+          checkpoint: '81efea8fca25cc2c87cf8fdd5f4e9c2506352008786892881f19b02307d50c08'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.