### PR TITLE
Update blockstack to 0.21.3

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.21.1'
-  sha256 'c04c53fb31a66d9682374682961c89411db85d1e019942a3e8f930a09e00ed1c'
+  version '0.21.3'
+  sha256 '8d380d877c36975873a041d6740ac5760162326be7624798ec41eda44c30b082'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '324dc2d1ab7a4dd64c003150f45cd7585ad6cfe479d4b04a4d502203b1cfca7a'
+          checkpoint: '54c83ef1f8db9176b612f52d38c30e3b45ddb8296e79942e1019bd8ad8557d0b'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.