### PR TITLE
Update canary to 1.7.1,367

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '1.7.0,355'
-  sha256 '17c934547c55c6270e273cbef1ac8d35f821f35755829ea149f909cc9476b270'
+  version '1.7.1,367'
+  sha256 '3696368498dcea6e2b26ac9a0de004357613c0ea1f89b492d10c41c7dd152be3'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: 'da4242a274d8f4a49a2c8f9568fa709759a0c837398e79177365c910f3d1b3c9'
+          checkpoint: 'fbe44a32bcbe17a86a26cd7cc7c18f2688dffd99c2dc08a65795894038130ffe'
   name 'Canary'
   homepage 'https://canarymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.