### PR TITLE
Update wavebox to 3.6.0

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.5.0'
-  sha256 '5467674300011446eb2c41eb6bfdd0ee24ca5be2ba59ea984438133f8e2a8614'
+  version '3.6.0'
+  sha256 '78b8fdf837c51d1f1c63e7d6dd5b2360de78f545303a27390bd71f1227a65c95'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: 'd409404369e3bc067c7cc3c4b3742d67f42881549e89f21a5957caea749b3c10'
+          checkpoint: '46668306a8be19e684fc1cb2e1ce7c761527eeec2c02df2808261e626ea73665'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.