### PR TITLE
Update bartender to 3.0.12: add version comment

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -4,6 +4,8 @@ cask 'bartender' do
     sha256 '013bb1f5dcc29ff1ecbc341da96b6e399dc3c85fc95bd8c7bee153ab0d8756f5'
   else
     version '3.0.12'
+    # This version should match the appcast version
+    # https://github.com/caskroom/homebrew-cask/issues/41211
     sha256 '121e47f4da7b606bc0297b2dd34cc5de89911175e46234b6197384ea416ea31d'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Add a temporary comment re: version / appcast.