### PR TITLE
Fix Docker: broken symlinks after uninstall

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -13,16 +13,17 @@ cask 'docker' do
   depends_on macos: '>= :yosemite'
 
   app 'Docker.app'
-  bin = "#{appdir}/Docker.app/Contents/Resources/bin"
-  binary "#{bin}/docker"
-  binary "#{bin}/docker-compose"
-  binary "#{bin}/docker-credential-osxkeychain.bin", target: 'docker-credential-osxkeychain'
-  binary "#{bin}/docker-machine"
-  binary "#{bin}/hyperkit"
-  binary "#{bin}/notary.bin", target: 'notary'
-  binary "#{bin}/vpnkit"
 
-  uninstall delete:    '/Library/PrivilegedHelperTools/com.docker.vmnetd',
+  uninstall delete:    [
+                         '/Library/PrivilegedHelperTools/com.docker.vmnetd',
+                         '/usr/local/bin/docker',
+                         '/usr/local/bin/docker-compose',
+                         '/usr/local/bin/docker-credential-osxkeychain',
+                         '/usr/local/bin/docker-machine',
+                         '/usr/local/bin/hyperkit',
+                         '/usr/local/bin/notary',
+                         '/usr/local/bin/vpnkit',
+                       ],
             launchctl: [
                          'com.docker.helper',
                          'com.docker.vmnetd',

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -13,6 +13,14 @@ cask 'docker' do
   depends_on macos: '>= :yosemite'
 
   app 'Docker.app'
+  bin = "#{appdir}/Docker.app/Contents/Resources/bin"
+  binary "#{bin}/docker"
+  binary "#{bin}/docker-compose"
+  binary "#{bin}/docker-credential-osxkeychain.bin", target: 'docker-credential-osxkeychain'
+  binary "#{bin}/docker-machine"
+  binary "#{bin}/hyperkit"
+  binary "#{bin}/notary.bin", target: 'notary'
+  binary "#{bin}/vpnkit"
 
   uninstall delete:    '/Library/PrivilegedHelperTools/com.docker.vmnetd',
             launchctl: [


### PR DESCRIPTION
Broken symlinks are left in `$HOMEBREW_PREFIX/bin` after uninstallation.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
