### PR TITLE
Update electron-cash to 2.9.4

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '2.9.3'
-  sha256 'bc0b983c1adbd13be3cf19cde15353872bb5ff91929b1a9271f9e3115ba8dacd'
+  version '2.9.4'
+  sha256 '834154ffecc6a1e77c5d0bd868905b573eef4e201bfd459aff2ab731dafb176d'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   name 'Electron Cash'


### PR DESCRIPTION
Updated from 2.9.3 to 2.9.4

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
