### PR TITLE
Update qtox to 1.13.0

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.12.1'
-  sha256 '7620d78a8e35e91bc7b731ba4ad373466d8664a8da137d9cb7f0b5558f9a4a15'
+  version '1.13.0'
+  sha256 '0485ff362d3c14afc92ef34619f53824ca5a1652a0f7a3ea883c891526acd07a'
 
   # github.com/qTox/qTox was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/qTox/qTox/releases.atom',
-          checkpoint: '09de94d91a1d5db757deff6766bcad402d7513260935ebd1a534e27ebd621c97'
+          checkpoint: '7bddd2fe85e63620b6428ac275d6d55dfc194ccbcd3213aff8a891a364c6881c'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.