### PR TITLE
Update cacher to 1.1.21

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,9 +1,11 @@
 cask 'cacher' do
-  version '1.1.20'
-  sha256 '6372c5032b04adfc56382f5b4ff3ff92590acdd7c10d67db2987c0c9c9057915'
+  version '1.1.21'
+  sha256 '3a9baa7814d69f57c8a5c6008b2e2a7a6e8824af35b7d4dfe7292752244eecdc'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
+  appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
+          checkpoint: 'cbfe494ade2d227dc864ee3d15339ec779fdd34fa497123871eaee3a3bdff91f'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.