### PR TITLE
Update keycue to 8.6

### DIFF
--- a/Casks/keycue.rb
+++ b/Casks/keycue.rb
@@ -1,6 +1,6 @@
 cask 'keycue' do
-  version '8.5'
-  sha256 'f08c3cc847fbc08c3c31fcb5b77d773450c71b7f0a04f9d15584bf756feb4226'
+  version '8.6'
+  sha256 '59ff165f8f9bac1bc5bbe2127792d13c88f06111d937d8c7b42348cfe95944fe'
 
   url "http://www.ergonis.com/downloads/products/keycue/KeyCue#{version.no_dots}-Install.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.