### PR TITLE
Update gnucash to 2.7.1-1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,16 +1,15 @@
 cask 'gnucash' do
-  version '2.6.18-1'
-  sha256 '75b4cea0e786a0844507aa89fc8f2f5c3761825b540b224427f1c9f2f346a257'
+  version '2.7.1-1'
+  sha256 'e3f712cee91716da16a0f994db626ed134eb9d8a7e36a25a55d4f6edd51ab219'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}/Gnucash-Intel-#{version}.dmg"
   appcast 'https://github.com/Gnucash/gnucash/releases.atom',
-          checkpoint: '62f568904f2ed87b78599b5579ebd3616849d2c3f17fb692f6982988528d7c48'
+          checkpoint: '5f3e9e9dca2bfbd983a0fe6dfd140e6f2e8bc979425f05f033349031d808d7e4'
   name 'GnuCash'
   homepage 'https://www.gnucash.org/'
 
   app 'Gnucash.app'
-  app 'FinanceQuote Update.app'
 
   zap trash: [
                '~/Library/Application Support/Gnucash',


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.