### PR TITLE
Update fly to 3.6.0

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.5.0'
-  sha256 '2580407ca4bbd46ca4d42dd95372fcab48c9380a54bb3681cfc8716022202652'
+  version '3.6.0'
+  sha256 '1d32f0d59a04f8680d62c7db156bde413c8ff423dcfe06d3e4788e482e071f51'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: '757019e10310a17a85319dddfaf37887db6e9d48ac57a4f31be6445e29efb25d'
+          checkpoint: '8213af44f8a5813996d978aed99eeb1a9193c1bc3357dd4e0e703b384177931d'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.