### PR TITLE
Update prepros to 6.0.18

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.0.16'
-  sha256 '331e3774ba0738c0190a85a2c791873df7c3bc55f37e33bd7397987c58e835b5'
+  version '6.0.18'
+  sha256 'c9ffe7884803b26bfa35e28779230a6395f73ec71795820f74d91d2bc38257ce'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: '4d1f4365b4ec86f8eeb6c253550de249e36c1dc221f2cf7a063e3d3cfe8e2963'
+          checkpoint: '85831615c1cd9a7e4c00ac75d084737c910ed9ee8f0c746db1b74fcd23816c5b'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.