### PR TITLE
Update sqlectron to 1.28.0

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -1,11 +1,11 @@
 cask 'sqlectron' do
-  version '1.27.0'
-  sha256 '1088bf9d689d5d703f696770a462fd1d9cd05182219fe8b44e27986918d88891'
+  version '1.28.0'
+  sha256 'b21cc0642797fd1aa708352ba8961e41606c4b25738e6fbecffdfa8c19cf24e2'
 
   # github.com/sqlectron/sqlectron-gui was verified as official when first introduced to the cask
   url "https://github.com/sqlectron/sqlectron-gui/releases/download/v#{version}/Sqlectron-#{version}-mac.zip"
   appcast 'https://github.com/sqlectron/sqlectron-gui/releases.atom',
-          checkpoint: 'ec2abdb82dcecf733e960da80b3e88a3d37af1f070d6bc5ab3ae40609eb771b1'
+          checkpoint: '871a62b58ff8e58d0c4fedbafad3c19d411028b290455285531dd9aa4720c46f'
   name 'Sqlectron'
   homepage 'https://sqlectron.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.