### PR TITLE
Update altair to 1.5.4

### DIFF
--- a/Casks/altair.rb
+++ b/Casks/altair.rb
@@ -1,11 +1,11 @@
 cask 'altair' do
-  version '1.5.2'
-  sha256 '51a8910d0f3ba18beb66c4a141590b80938b68a03f2af6de3595607908a3ac3a'
+  version '1.5.4'
+  sha256 'dfa06f1f07fc5d62ed00ffa4d99394e879e3915d3188822f8bf59441974e3b3d'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-darwin-x64-#{version}.zip"
   appcast 'https://github.com/imolorhe/altair/releases.atom',
-          checkpoint: '6bd586fc8f3b1d8c0160ef0f6c3d794e94acd56b48a7eae93c285623f9df21b7'
+          checkpoint: 'b65660182062a10f1cba531c6300cec1988982920c6fe95a94ae58ea27197083'
   name 'Altair GraphQL Client'
   homepage 'https://altair.sirmuel.design/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.