### PR TITLE
Update thunderbird to 52.5.0

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,84 +1,84 @@
 cask 'thunderbird' do
-  version '52.4.0'
+  version '52.5.0'
 
   language 'cs' do
-    sha256 '0e67c76a3d601bb9e3ced2ae7ae57e1b74df35408391c1e6644646a419bda992'
+    sha256 '0fc91d516cf2bfefc4877c96d086049b649095f6452fca56946762cd120c4010'
     'cs'
   end
 
   language 'de' do
-    sha256 '13ed860b36d17d1801edc2c567b1c0ee86c41cd59bd396b3b62df13fd70cbd76'
+    sha256 '106dc6d09f96b692a7c9b2112fcb875900a4becb456ec2a9f043588ccd807e74'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'fc5fa5b26083225f9616dd4209eaa0f11aab67d786a6e9999b9d29545e7daf81'
+    sha256 '338f0de8292490341231973c6781c246638d322f3d8fb328417b8d9417efa64c'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '624714f188daecafaad14ad756ba11715dcb5e286f7f8e2177c3164ba8903784'
+    sha256 '98437d8c7fc30d67fb29e5d891ec47c41181abd12b9b809d48506ff16a769ba0'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '673a6bf285a92bf766254d60463c103a5d74e820cfcbb957d598192bc22f650c'
+    sha256 '8a0634729a35eb0284148ba49437775083627fcda6a96de2b6732b1c2c4cbabd'
     'fr'
   end
 
   language 'gl' do
-    sha256 '6a23ae2e761b012b2c1ecee84c60bf1ab698205720d9714ebb5d305a84f9c58c'
+    sha256 '01c79487f3c309b27371f09b909712599afc2d7fabfb257318105e0f2e893443'
     'gl'
   end
 
   language 'it' do
-    sha256 'd99677efd7f409ef46d1a749d99aec7bee423089a7d026f881c03c7fcce315dd'
+    sha256 '21ae030bb5e89d634f4c8d40014fe9f7624e752856adc3ff35ec1189c3756079'
     'it'
   end
 
   language 'ja' do
-    sha256 'b81491185a7eebc806cccac48b1e97ef4edb24e9d1fc26948880296e75f491b9'
+    sha256 '846b8fa8c4a3f509ae8fe587e37245cffccae09876a62b766edcb69db09a7897'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '6aa6a8cc2bce5bb81aef335815e41b8e7553108fd33fee6c7e01b4df5013fd4f'
+    sha256 '8c8fea5559f5bf852b634ae7e1f35c1102f7c58f2c08cfebbf66e096fdfd9088'
     'nl'
   end
 
   language 'pl' do
-    sha256 '94205dc0dd2a357e87bea73f48fc4c190523d61121a302de9a35d24be6b59182'
+    sha256 '8ab9235cd9cc86cd989161c7d2e365a0b5dc234b6ac80e2eb3661f201b122ea4'
     'pl'
   end
 
   language 'pt' do
-    sha256 '3241274f7a21cf944ca98cb268b7e8a1ad757d6f9822618ed8c75140fcd0a22e'
+    sha256 '6318bf0448a6a81b685b88fb7af8d2af4e309ae7f3527dffe1f15be07b805230'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 'bc3f1814f8d69f0e4873e34493d8e07fc7ff60d097dbdce0994cad087bf5c8c3'
+    sha256 '6b5bc7831b394f8af18ad15034d02bf2050e9646d467a4e210cf023e32ee2bdc'
     'ru'
   end
 
   language 'uk' do
-    sha256 'c4010ee70a3cfb459e9c84ff9c34f7138d6eb731f5435381ad6d9b6284481119'
+    sha256 'f2af0dbbb31edc04531862c559610df0405f618c061b77b4441f7dec96547c7d'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '72f70fb45b654af6c80d1b555ecbdeaec31f5e0f605e0865d80fa327b022dcd9'
+    sha256 'aae9fa5cc0e19e0e7c85ffca0804f21eb96bb70c4f7f1c95d27937082e181625'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'cfe61dbcba8b018d7be8c79af00a4fcaf6410c490bb6820beb1b14c64275c6ca'
+    sha256 'c9a6ea4359dbaa9240cebae8cfdb127d6175ec292145bbca56dc7dead8d4efa4'
     'zh-CN'
   end
 
   url "https://ftp.mozilla.org/pub/thunderbird/releases/#{version}/mac/#{language}/Thunderbird%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Thunderbird/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '0b7c668b0b71f53f2daa451dd06e30181f416104f1e7f75bb74d8daab6deae6d'
+          checkpoint: 'dddf138345d902d490e3cdf0adb32c89d6cd3f82a68e5cb2587bd8fa0d729711'
   name 'Mozilla Thunderbird'
   homepage 'https://www.mozilla.org/thunderbird/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
