### PR TITLE
Update lingon-x to 5.2.3

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.2.2'
-  sha256 'd301daeed3f66fc5f1a8534778a008d97575fdfe5bf8577f396adc64039a9d5a'
+  version '5.2.3'
+  sha256 '0b4a6d69e3d080952cc4c642c2aaa1716ebb9cccbc7d6d33669dea446a4e68a8'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'fd7c0d26c1af08efa432a9d653b73453c54dc57571b0c98a78e75195163f646f'
+          checkpoint: '3b281f0fbc6c31f764c588c19c9044fe2308c7ae26911e63458461c83317fafc'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 
@@ -13,7 +13,7 @@ cask 'lingon-x' do
   app 'Lingon X.app'
 
   zap trash: [
-               '~/Library/Application Scripts/com.peterborgapps.LingonX5',
-               '~/Library/Containers/com.peterborgapps.LingonX5',
+               "~/Library/Application Scripts/com.peterborgapps.LingonX#{version.major}",
+               "~/Library/Containers/com.peterborgapps.LingonX#{version.major}",
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.