### PR TITLE
Update redis-app to 4.0.2-build.1

### DIFF
--- a/Casks/redis-app.rb
+++ b/Casks/redis-app.rb
@@ -1,11 +1,11 @@
 cask 'redis-app' do
-  version '3.2.7-build.2'
-  sha256 'd1a044ccce03ac1e96911dcd137d0c2e567719133c88cf036b11c8a8b9e331e7'
+  version '4.0.2-build.1'
+  sha256 '1a4c0c82739a2bddbd5fa78f598cd28dd2c348467a12cb8de6687114f2bad4da'
 
   # github.com/jpadilla/redisapp was verified as official when first introduced to the cask
   url "https://github.com/jpadilla/redisapp/releases/download/#{version}/Redis.zip"
   appcast 'https://github.com/jpadilla/redisapp/releases.atom',
-          checkpoint: '7e4ef66a2f3fe10da84aaf00b93d3d6200816269c8637abd77f42f296dc18b40'
+          checkpoint: '4d483ef1a5aed23e6e4405d8454aff54e42eb8de3e45622ddfbfe5a590385957'
   name 'Redis'
   homepage 'https://jpadilla.github.io/redisapp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.