### PR TITLE
Update exodus to 1.39.3

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.39.1'
-  sha256 'ee0a7bf335f554b2de175add87c63cc0d0b953886c5c48444e45c2db9cf06df9'
+  version '1.39.3'
+  sha256 '38735b9f0e473cee73e4ba5cf22c4093861de7e1659f972444365dc3de4e437b'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '80558fc9f90f87a966b85d4ee24db6f02b11f546de407fcf52bcbc209a12d8a6'
+          checkpoint: '83cf6dc46133a6735af8ac34f93f6ad0ca587b74ca9eafee7c2c521fda7160c2'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.