### PR TITLE
Update borgbackup to 1.1.3

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.1.2'
-  sha256 'ac858cb8819826bb428639359b20c7504924c26dbab760cd1c5bf54adf93ad6d'
+  version '1.1.3'
+  sha256 '59e0886799d6551a61cbc994e120337ff4af522c5a977a1b5ee6e365d7404682'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '0591e2e2ef86207649efa5dbf5307eaf50a47c6c14273d80ab311f789da4a089'
+          checkpoint: '4d46d5e6feabbc7ae94e76fdb557d1873ae6a804dff544e99baa853ffe5e582f'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.io/en/stable/'
   gpg "#{url}.asc", key_id: '51F78E01'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.