### PR TITLE
Update debookee to 6.0.1

### DIFF
--- a/Casks/debookee.rb
+++ b/Casks/debookee.rb
@@ -1,22 +1,26 @@
 cask 'debookee' do
-  version '5.2.3'
-  sha256 '6adb304cd2c8fc232a13c8596a2ba2a311207024a9bc201b9cb37fcd04fd80e9'
+  version '6.0.1'
+  sha256 '91a22725d62e3aab9485e354e50f1419cd76f9bf5ee1d310d4515ad45c1623dc'
 
-  # iwaxx.com/debookee/ was verified as official when first introduced to the cask
+  # iwaxx.com/debookee was verified as official when first introduced to the cask
   url 'https://www.iwaxx.com/debookee/debookee.zip'
   appcast 'https://www.iwaxx.com/debookee/appcast.php',
-          checkpoint: 'e604e18bc376cc0561f6ccc875f45b79f4f17a207c4faa93960e53fda4f413ac'
+          checkpoint: '26a2d6527de7d97c8aab3ffde56903adc8e2fcde02e3873458015a39f27d2fc2'
   name 'Debookee'
   homepage 'https://debookee.com/'
 
-  app "Debookee #{version}/Debookee.app"
+  depends_on macos: '>= :sierra'
+
+  app 'Debookee.app'
 
   uninstall delete:    '/Library/PrivilegedHelperTools/com.iwaxx.Debookee.PacketTool',
             launchctl: 'com.iwaxx.Debookee.PacketTool'
 
   zap trash: [
+               '~/Library/Application Support/com.iwaxx.Debookee',
                '~/Library/Caches/com.iwaxx.Debookee',
                '~/Library/Cookies/com.iwaxx.Debookee.binarycookies',
+               '~/Library/Logs/Debookee',
                '~/Library/Preferences/com.iwaxx.Debookee.plist',
                '~/Library/Saved Application State/com.iwaxx.Debookee.savedState',
                '~/Library/WebKit/com.iwaxx.Debookee',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.