### PR TITLE
Update coqide to 8.7.0

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,10 +1,10 @@
 cask 'coqide' do
-  version '8.6.1'
-  sha256 '6c9f672fb40e5f0ede8f159fe21b75637831854665c3a310a038de31ae10a022'
+  version '8.7.0'
+  sha256 '2ce75694a60b45d9f43e3d138a974959bda7e82615b8527116ab7cc8e517bcf3'
 
-  url "https://coq.inria.fr/distrib/V#{version}/files/CoqIDE_#{version}.dmg"
+  url "https://coq.inria.fr/distrib/V#{version}/files/coq-#{version}-installer-macos.dmg"
   appcast 'https://coq.inria.fr/rss.xml',
-          checkpoint: 'ede0841fe4c8fd9d29d988c313a1235c3dc4098326a6135d96c9ce35d628dc36'
+          checkpoint: '2ab7b35d14b268d07799a2d57ea36795a9e47fc2cc1678284a072a38cd9f3737'
   name 'Coq'
   homepage 'https://coq.inria.fr/'
 

--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -3,8 +3,8 @@ cask 'coqide' do
   sha256 '2ce75694a60b45d9f43e3d138a974959bda7e82615b8527116ab7cc8e517bcf3'
 
   url "https://coq.inria.fr/distrib/V#{version}/files/coq-#{version}-installer-macos.dmg"
-  appcast 'https://coq.inria.fr/rss.xml',
-          checkpoint: '2ab7b35d14b268d07799a2d57ea36795a9e47fc2cc1678284a072a38cd9f3737'
+  appcast 'https://github.com/coq/coq/releases.atom',
+          checkpoint: '940220c743905372e20c0e5edaaff11920a8b7765d722cf18b71426e4ad8c7c8'
   name 'Coq'
   homepage 'https://coq.inria.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.