### PR TITLE
Update exodus to 1.39.4

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.39.3'
-  sha256 '38735b9f0e473cee73e4ba5cf22c4093861de7e1659f972444365dc3de4e437b'
+  version '1.39.4'
+  sha256 '4e44b3c8a33f7abd91b431866f1eb40aa951f417c51aa4cf3ef7b1474647329e'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '83cf6dc46133a6735af8ac34f93f6ad0ca587b74ca9eafee7c2c521fda7160c2'
+          checkpoint: '84c6e41850e354840eaeabb56f689b4c2b9fca7fda64620ef0b705ad20c60ad8'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.