### PR TITLE
Update nteract to 0.4.2

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -4,7 +4,7 @@ cask 'nteract' do
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: '91c108d7b5c3ee20d639ba0fffb3b3db39df23c4cdc82473e53f10fcbc804ca3'
+          checkpoint: 'df4f60423863e4a7239e99e8cb60ead047b0dad023922f111881193f5168ef9c'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 

--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,10 +1,10 @@
 cask 'nteract' do
-  version '0.4.0'
-  sha256 'a3ef74afb2bb7c44c0df41a41fb12c99895ca244cf4b96f1a46082b04b842e2f'
+  version '0.4.2'
+  sha256 '848513a52554888c096c648866c281f57b481b831e40ce652b6a91e165302326'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: '3fcfea4a9441900b5c33cb7850c60beccc2349471f7693eea290c8a3306fff70'
+          checkpoint: '91c108d7b5c3ee20d639ba0fffb3b3db39df23c4cdc82473e53f10fcbc804ca3'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.