### PR TITLE
Update get-iplayer-automator to 1.9.13.b20171126001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.9.11.b20171115001'
-  sha256 'bfbcab722dbaaa9d090a4fbaaa55e70ef15d89da9018fb74dbe3680f030d1de9'
+  version '1.9.13.b20171126001'
+  sha256 '76f2d95274f304970a98ae9adad584ce2360fa428aae09c84ab582d9484a0e33'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          checkpoint: 'fc33398738b37d6348640c36e6f59e04363094357ea6151a822b30a1038cd71a'
+          checkpoint: '7cb9ac2896d1efdb580873cfe559ce6e3c01cf312e4c418c509449960036f33b'
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.