### PR TITLE
Update zeroinstall to 2.12.3

### DIFF
--- a/Casks/zeroinstall.rb
+++ b/Casks/zeroinstall.rb
@@ -1,11 +1,11 @@
 cask 'zeroinstall' do
-  version '2.8'
+  version '2.12.3'
   sha256 'ab0fbf7fc43c5ff6429d5686bde3ecef01c78894c46c8bd554c2f4a1f0e10e66'
 
   # sourceforge.net/zero-install was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/zero-install/0install/#{version}/ZeroInstall.pkg"
   appcast 'https://sourceforge.net/projects/zero-install/rss',
-          checkpoint: '0be67ce3cbd5f614c861a0f2154b4974a92c37fd531fd0afaf0add0697bda4f7'
+          checkpoint: 'aaa8811cf87665e543dafa79edbaa7e1d3ba6c3922e3ea3406db58d084a76ce4'
   name 'Zero Install'
   homepage 'http://0install.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.