### PR TITLE
Update bisq to 0.6.1

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.6.0'
-  sha256 'e1f5a6f996a3b51776aea104a5a1dd5db171cc0460636d5646a08ff92e8b9125'
+  version '0.6.1'
+  sha256 '433d2636b73a0857433ce5c045ef8097a79e7cb4e899c3c5e8543288740d4e0a'
 
   # github.com/bisq-network/exchange was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/exchange/releases.atom',
-          checkpoint: '02d60696e68d56180fcd3f2e7a152980e649096d384bf9f60adabb6af0a65aab'
+          checkpoint: '02710167f24eb93a9f91ddbf111defd6378cb941481c928a1c6bd6b1bc2dea66'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.