### PR TITLE
Update rsyncosx to 4.9.0

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '4.8.6'
-  sha256 '5cffd6718791b4842412e498d4269c375cf5bd00d1d001f7dce5b40eeb377290'
+  version '4.9.0'
+  sha256 '786211087a427e1162157ef13a245a3c7b99be4e11e6651ecc041d99a79de1b2'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: 'aa9036664db725fc14e77bad0d334441183a4ffd36cf2639de5ff849635d94e2'
+          checkpoint: '63ad7be4c92e6c594a9d372ad6e790973769c31bb3dca4b680dbf349dc27ed69'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.