### PR TITLE
Update minikube to 0.24.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,11 +1,11 @@
 cask 'minikube' do
-  version '0.23.0'
-  sha256 '3d0c5581cd14f85637fb888c1e2e124152c4c9643a257ba90c8cd929d2c2b8b3'
+  version '0.24.0'
+  sha256 '7db2045495db05a885c3ad9a0e5e7ff017ae1f2f1a835d9151142df0c6f1d192'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: '9af1de2ccd5f79cf4774c5770d8b6a2ecb26d063097f0fff57e162cff32dbd02'
+          checkpoint: '9aad5d4359047267fe531775ccbcf2cfc650bee9d4e8c4fc4b96f32370797f7d'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 

--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -5,7 +5,7 @@ cask 'minikube' do
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: '9aad5d4359047267fe531775ccbcf2cfc650bee9d4e8c4fc4b96f32370797f7d'
+          checkpoint: '887bdc0d27dd79bb5a0326f0c7b248a2a62d1c22b80f172f0c3d530116ddf344'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.