### PR TITLE
Update fotomagico to 5.5.3-22746

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,10 +1,10 @@
 cask 'fotomagico' do
-  version '5.5.2-22736'
-  sha256 '9e15aabd479ad9a1ebc75ef7b55ca3f75e9a43b42c458d4c4b1c89c2f2f179ae'
+  version '5.5.3-22746'
+  sha256 '328adfcfd6185506568ac80f6e73960c8ca3d7ae881e7069e9dfa83b340ca11c'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/fotomagico',
-          checkpoint: 'e6cce1179ccb2dfc1c9ea01f22175c54927fc9173fc6ef30be61bf819df94138'
+          checkpoint: 'b36423d7aff5d47b941a80738adb504c80a9b3c02f75a6b7daedb3c57e1878c7'
   name 'FotoMagico'
   homepage 'https://boinx.com/fotomagico/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.