### PR TITLE
Update lego-digital-designer: new download url

### DIFF
--- a/Casks/lego-digital-designer.rb
+++ b/Casks/lego-digital-designer.rb
@@ -2,7 +2,8 @@ cask 'lego-digital-designer' do
   version '4.3.10'
   sha256 'd48ccbf6b3eb6cf0115d07cf499c45c10c479f7f6e8ac32a3d44821325b56908'
 
-  url "http://cache.lego.com/downloads/ldd2.0/installer/setupLDD-MAC-#{version.dots_to_underscores}.zip"
+  # lc-www-live-s.legocdn.com was verified as official when first introduced to the cask
+  url "https://lc-www-live-s.legocdn.com/downloads/ldd2.0/installer/setupLDD-MAC-#{version.dots_to_underscores}.zip"
   name 'Lego Digital Designer'
   homepage 'http://ldd.lego.com/'
 


### PR DESCRIPTION
The previous url no longer works. Updated Cask to reflect new location.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.