### PR TITLE
Update wifi-explorer to 2.3.3

### DIFF
--- a/Casks/wifi-explorer.rb
+++ b/Casks/wifi-explorer.rb
@@ -1,11 +1,11 @@
 cask 'wifi-explorer' do
-  version '2.3.2'
-  sha256 '96cf78ae761e68ecf4141b919d1fa8a578e665ed678066cfcb75380dff54b990'
+  version '2.3.3'
+  sha256 '1482e44c892c89de0f449778b9414db02960de302bbaded4f52e4931002341aa'
 
   # s3.amazonaws.com/apps.adriangranados.com was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/apps.adriangranados.com/wifiexplorer.zip'
   appcast 'https://www.adriangranados.com/appcasts/wifiexplorercast.xml',
-          checkpoint: 'ab789ce78c00e1ba7490aa4741205244d0bb00e956e1c1d0e413a6e8449538f4'
+          checkpoint: 'ea19112b9a7fdf2ec468459e33e513bd008a7438700e6c7f2c12a5df91148b4f'
   name 'WiFi Explorer'
   homepage 'https://www.adriangranados.com/apps/wifi-explorer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.