### PR TITLE
Update screaming-frog-seo-spider to 8.3

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -3,13 +3,13 @@ cask 'screaming-frog-seo-spider' do
     version '2.40'
     sha256 'f37a517cb1ddb13a0621ae2ef98eba148027b3a2b5ce56b6e6b4ca756e40329b'
   else
-    version '7.2'
-    sha256 'd3654be1c66e4c8fb4a5530a35eff62582a5272a2064243679795cc7d2f1d3ad'
+    version '8.3'
+    sha256 '4ac1924c2be29bac37b730ba0a406e7d5367a07a72e2dfc9f0ac02b7db879b06'
   end
 
   url "https://www.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php',
-          checkpoint: '4741066c7036d2499b440c4528a3b2d1416c296e620bbb08fa3a942d628dc7ab'
+          checkpoint: '25054900a5f73770ce702561681f366552b070932c63a1ae582459650c9a82ff'
   name 'Screaming Frog SEO Spider'
   homepage 'https://www.screamingfrog.co.uk/seo-spider/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.