### PR TITLE
Update feeder to 3.5.5

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.5.3'
-  sha256 '9b493309c60ab6d570aade2506dc40006ab487e627a5799800e794bd21b70ccc'
+  version '3.5.5'
+  sha256 'da842a18b6589bca7a3e9669b06590ce80444d6f3967c8414498e11c907426f1'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: 'bb2c8d6cf1f72404598fbce1cae60b7abb091cd07f911aa0fda2ca9b4d80922d'
+          checkpoint: '5ae4817d34e2483e02d8da49f3a21d7be34ba3af6de8b3d679d8de3d76f79c38'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.