### PR TITLE
Update neteasemusic.rb for https and zap

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -12,7 +12,7 @@ cask 'neteasemusic' do
 
   uninstall quit: 'com.netease.163music'
 
-  zap delee: [
+  zap delete: [
                '~/Library/Caches/com.netease.163music',
                '~/Library/Cookies/com.netease.163music.binarycookies',
                '~/Library/Saved Application State/com.netease.163music.savedState',

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -12,13 +12,11 @@ cask 'neteasemusic' do
 
   uninstall quit: 'com.netease.163music'
 
-  zap delete: [
+  zap trash: [
                '~/Library/Caches/com.netease.163music',
-               '~/Library/Cookies/com.netease.163music.binarycookies',
-               '~/Library/Saved Application State/com.netease.163music.savedState',
-             ],
-      trash: [
                '~/Library/Containers/com.netease.163music',
+               '~/Library/Cookies/com.netease.163music.binarycookies',
                '~/Library/Preferences/com.netease.163music.plist',
+               '~/Library/Saved Application State/com.netease.163music.savedState',
              ]
 end

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -3,20 +3,22 @@ cask 'neteasemusic' do
   sha256 'a1ede5a8e3ec027ec670fb989dbefa23bd5a5c021af56f16c2c24fa0ff26489a'
 
   # d1.music.126.net was verified as official when first introduced to the cask
-  url "http://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"
+  url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"
   name 'NetEase cloud music'
   name '网易云音乐'
-  homepage 'http://music.163.com/#/download'
+  homepage 'https://music.163.com/'
 
   app 'NeteaseMusic.app'
 
   uninstall quit: 'com.netease.163music'
 
-  zap trash: [
+  zap delee: [
                '~/Library/Caches/com.netease.163music',
-               '~/Library/Containers/com.netease.163music',
                '~/Library/Cookies/com.netease.163music.binarycookies',
-               '~/Library/Preferences/com.netease.163music.plist',
                '~/Library/Saved Application State/com.netease.163music.savedState',
+             ],
+      trash: [
+               '~/Library/Containers/com.netease.163music',
+               '~/Library/Preferences/com.netease.163music.plist',
              ]
 end


### PR DESCRIPTION
Update neteasemusic.rb for https and zap

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
