### PR TITLE
Update printrun to 18Nov2017

### DIFF
--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,11 +1,11 @@
 cask 'printrun' do
-  version '03Feb2015'
-  sha256 '707a3c985f32ec156b4dc85dae3d3434a3a052bbf239d768423d94c1b7f86998'
+  version '18Nov2017'
+  sha256 '426229043a2a33a6768dcca12135f0751c007595af078665eb854cf87e4e2999'
 
   # koti.kapsi.fi/~kliment/printrun was verified as official when first introduced to the cask
   url "http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-#{version}.zip"
   appcast 'http://koti.kapsi.fi/~kliment/printrun/',
-          checkpoint: 'bfbdb42c2e55b3903a785df3a16b62bf8a506c5ce690a5305f66b4f89b5161b9'
+          checkpoint: '8b00c0ea9cbf9040a86eb73fecda80b45397517bfc7fe4377148126a8b989318'
   name 'Printrun'
   homepage 'https://github.com/kliment/Printrun'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.