### PR TITLE
Update and rename lulzbot-cura to cura-lulzbot 2.6.52

### DIFF
--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -6,8 +6,6 @@ cask 'cura-lulzbot' do
   name 'Cura LulzBot Edition'
   homepage 'https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-osx'
 
-  conflicts_with cask: 'cura'
-
   app 'cura-lulzbot.app'
 
   zap trash: [

--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -2,7 +2,7 @@ cask 'cura-lulzbot' do
   version '2.6.52'
   sha256 '7ee482ba4823bcf36585c99b001c25cbe8881a94e0a65a0db0dfafa0a2f46435'
 
-  url "http://download.lulzbot.com/Software/cura-lulzbot/mac/cura-lulzbot_#{version}.dmg"
+  url "https://download.lulzbot.com/Software/cura-lulzbot/mac/cura-lulzbot_#{version}.dmg"
   name 'Cura LulzBot Edition'
   homepage 'https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-osx'
 

--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -1,4 +1,4 @@
-cask 'lulzbot-cura' do
+cask 'cura-lulzbot' do
   version '2.6.52'
   sha256 '7ee482ba4823bcf36585c99b001c25cbe8881a94e0a65a0db0dfafa0a2f46435'
 
@@ -8,7 +8,7 @@ cask 'lulzbot-cura' do
 
   conflicts_with cask: 'cura'
 
-  app 'cura-lulzbot.app', target: 'Cura.app'
+  app 'cura-lulzbot.app'
 
   zap trash: [
                '~/.cura',

--- a/Casks/cura.rb
+++ b/Casks/cura.rb
@@ -6,8 +6,6 @@ cask 'cura' do
   name 'Cura'
   homepage 'https://ultimaker.com/en/products/cura-software'
 
-  conflicts_with cask: 'lulzbot-cura'
-
   app 'Cura.app'
 
   uninstall quit: 'nl.ultimaker.cura'

--- a/Casks/lulzbot-cura.rb
+++ b/Casks/lulzbot-cura.rb
@@ -1,22 +1,19 @@
 cask 'lulzbot-cura' do
-  version '21.08-f2748'
-  sha256 'c03ee9aec222641408c0a98d957aead05a2f4fa037e7380f6226a74b37952d0f'
+  version '2.6.52'
+  sha256 '7ee482ba4823bcf36585c99b001c25cbe8881a94e0a65a0db0dfafa0a2f46435'
 
-  # download.alephobjects.com/lulzbot was verified as official when first introduced to the cask
-  url "https://download.alephobjects.com/lulzbot/Software/Cura/Packages/Cura_#{version.major_minor}/cura_#{version}.dmg"
+  url "http://download.lulzbot.com/Software/cura-lulzbot/mac/cura-lulzbot_#{version}.dmg"
   name 'Cura LulzBot Edition'
   homepage 'https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-osx'
 
   conflicts_with cask: 'cura'
 
-  app 'Cura/Cura.app'
-
-  uninstall quit: "com.ultimaker.Cura-#{version.major_minor}"
+  app 'cura-lulzbot.app', target: 'Cura.app'
 
   zap trash: [
                '~/.cura',
-               '~/Library/Application Support/Cura',
-               "~/Library/Preferences/com.ultimaker.Cura-#{version.major_minor}.plist",
-               "~/Library/Saved Application State/com.ultimaker.Cura-#{version.major_minor}.savedState",
+               '~/Library/Application Support/cura-lulzbot',
+               '~/Library/Preferences/org.pythonmac.unspecified.cura-lulzbot.cura-lulzbot',
+               '~/Library/Saved Application State/org.pythonmac.unspecified.cura-lulzbot.savedState',
              ]
 end


### PR DESCRIPTION
**Note to maintainer**: Lulzbot Cura Edition changed their versioning scheme beginning with this release. With this change, Aleph Objects has also changed the download location and naming scheme. I've set the cask target to `Cura.app` for consistency with prior versions.

https://www.lulzbot.com/cura `Current Version: 2.6.52, replacing version 21.08.`

-----------

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
