### PR TITLE
Update doomsday-engine to 2.0.3

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,11 +1,11 @@
 cask 'doomsday-engine' do
   version '2.0.3'
-  sha256 '8dd5fb6a780f5d53918b5bb96af95cc69041387c34f070a00196604f52539018'
+  sha256 '0a6258ed1c061b3a80f1573c7845bce39cd8c8d66ade8d3f29531b7cc658e9d5'
 
   # sourceforge.net/deng was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/deng/rss',
-          checkpoint: 'db1e7243b5c785310d09237ecd00547f5fc99878db982ad1f341f8e4b1266be7'
+          checkpoint: '8628643798d476dbf82420b8bb6fafaa3445a95b774b83454d24fc2103a9b473'
   name 'Doomsday Engine'
   homepage 'https://dengine.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.