### PR TITLE
Update now to 3.8.3

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.2'
-  sha256 '8ce973de6c8bfeebafc382507f2c5bcf0b9a64b62521a0c784cb4dc67969f806'
+  version '3.8.3'
+  sha256 '3a1b07132d8844811554d25f1ce86c96e3d8696503c9287d9014907ef5d66189'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'c799d46a3d7366cfcee0136abf6b04735efae8a2b095832a9b6a7b9f25846fee'
+          checkpoint: '3460abd1998d13b0e6111baa96d0969e8db5beff4d21fd54fd18094b4bf38822'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.