### PR TITLE
Add Suitcase Fusion.app v19.0.2

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,8 +1,10 @@
 cask 'suitcase-fusion' do
-  version '19.0.2'
+  version '8,19.0.2'
   sha256 '50b716fe0dd2ceddd2d14741bcfb99ee67b1f845583a68c260a62c95f26f884f'
 
-  url 'https://bin.extensis.com/SuitcaseFusion8-M-19-0-2.dmg'
+  url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
+  appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml",
+          checkpoint: 'aaab9eda125164ff1604297600e10028851be078aa622f78ded2b6e91d069ea8'
   name 'Extensis Suitcase Fusion'
   homepage 'https://www.extensis.com/'
 

--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,0 +1,10 @@
+cask 'suitcase-fusion' do
+  version '19.0.2'
+  sha256 '50b716fe0dd2ceddd2d14741bcfb99ee67b1f845583a68c260a62c95f26f884f'
+
+  url 'https://bin.extensis.com/SuitcaseFusion8-M-19-0-2.dmg'
+  name 'Extensis Suitcase Fusion'
+  homepage 'https://www.extensis.com/'
+
+  app 'Suitcase Fusion.app'
+end


### PR DESCRIPTION
Created a new Cask for Extensis Suitcase Fusion, a font manager for macOS.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
