### PR TITLE
Update cloudapp to 4.3.2

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,11 +1,11 @@
 cask 'cloudapp' do
-  version '4.3.1'
-  sha256 '55222f91ac19e1809baa8488da6b843f0c3dd69b1ddd80ef1fdc1aed231d6381'
+  version '4.3.2'
+  sha256 'e5fff35d271c1ef26428b37e5ecb983be48f16f63f2e1f74dba8eb0a38666c2c'
 
   # amazonaws.com/downloads.getcloudapp.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://updates.getcloudapp.com/appcast.xml',
-          checkpoint: '4c7363e7d6e5cec86236da951fee7e57337c860590d6612b19c4afb487ab8df6'
+          checkpoint: 'c38fc4b75def18c8270b651da1bc87fe1917b5a6e90544231158730550bfc435'
   name 'CloudApp'
   homepage 'https://www.getcloudapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.