### PR TITLE
Switch spotify from latest to 1.0.68.407.g6864aaaf-37

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,17 +1,18 @@
 cask 'spotify' do
-  version :latest
-  sha256 :no_check
+  version '1.0.68.407.g6864aaaf-37'
+  sha256 '56081655d0b559d69fc2b3ed894c0ef77d82c53b6c9ae0336c6dd94131885264'
 
-  url 'https://download.spotify.com/Spotify.dmg'
+  url "https://upgrade.spotify.com/upgrade/client/osx-x86_64/spotify-autoupdate-#{version}.tbz"
   name 'Spotify'
   homepage 'https://www.spotify.com/'
 
   auto_updates true
   depends_on macos: '>= :lion'
 
-  app 'Spotify.app'
+  app '.', target: 'Spotify.app'
 
-  uninstall launchctl:  'com.spotify.webhelper',
+  uninstall quit:       'com.spotify.client',
+            launchctl:  'com.spotify.webhelper',
             login_item: 'Spotify'
 
   zap trash: [


### PR DESCRIPTION
After making all changes to the 
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
---
This switches Spotify cask from `:latest` and `:no_check` to the current version. The versioned download is the same as the one used by the auto-updater, it seems to have the same content as the offline installer but without `Spotify.app` root dir. For further updates the version can typically be found in `CFBundleVersion` property of `/Applications/Spotify.app/Contents/Info.plist` after auto-updating. In rare cases of a mismatch - eg. at the moment `CFBundleVersion` is `1.0.68.407.g6864aaaf-36` but the download is `1.0.68.407.g6864aaaf-37` - it can be found by inspecting the app calls with a proxy tool.

I've tried (hard) to find an `appcast` without any success: app seems to get it via an encrypted TCP connection to one of the ["ap" servers](http://apresolve.spotify.com/), and they [decided](https://community.spotify.com/t5/Live-Ideas/All-Platforms-Changelog-after-each-Update-In-App/idc-p/1412187#M85424) to stop providing release notes. So although automating version upgrades for this cask at the moment doesn't look easy, I've decided to give this a try since this is one of the [few remaining](https://github.com/Homebrew/brew/pull/3396#issuecomment-347625451) popular casks with both `:latest` and `auto_updates` that won't work well with the shiny new `brew cask upgrade`.

Please feel free to weigh in, I would love to get maintainers' input before looking into other `:latest` casks I use.