### PR TITLE
Update gyazo to 3.5.3

### DIFF
--- a/Casks/gyazo.rb
+++ b/Casks/gyazo.rb
@@ -1,6 +1,6 @@
 cask 'gyazo' do
-  version '3.5.0'
-  sha256 'b1123c34d967724687a17773ebed112d6a57832c45332c3f45f6a7ac0090c667'
+  version '3.5.3'
+  sha256 'e828ba162c69ca2f9b4cde7346e08d669d610702d3a205701d9b4e4c8e3c99c8'
 
   url "https://files.gyazo.com/setup/Gyazo-#{version}.dmg"
   name 'Nota Gyazo GIF'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.