### PR TITLE
Update istat-server to 3.03

### DIFF
--- a/Casks/istat-server.rb
+++ b/Casks/istat-server.rb
@@ -1,6 +1,6 @@
 cask 'istat-server' do
-  version '3.02'
-  sha256 '032a1f51bd34e850b0f930676361606a6b260cc0b7b35d9a1bca390a87d2bf41'
+  version '3.03'
+  sha256 '0d6df9abe88aa7b29f53abb63413ede2853823cf6fd75b75818ef0190a07e8c7'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatserver#{version.major}/istatserver#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.