### PR TITLE
Update waterfox to 56.0

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '55.2.2'
-  sha256 '58278907504c8c08adb8e11e7a855b0b43d244af6cc2d180ef1ad152f3f56c32'
+  version '56.0'
+  sha256 'b8efd2ca07743e5581f7cf42faa35732e7aeb952b4bed0a9b617f66f6f4c1842'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.