### PR TITLE
Fix #41432, flattens delete array in java.rb

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -67,6 +67,8 @@ cask 'java' do
                              '/usr/lib/java/libjdns_sd.jnilib',
                              '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK',
                            ]
+                         else
+                           []
                          end
                        ).keep_if { |v| !v.nil? }
 

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -61,13 +61,14 @@ cask 'java' do
                          "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
                          '/Library/PreferencePanes/JavaControlPanel.prefPane',
                          '/Library/Java/Home',
+                       ].concat(
                          if MacOS.version <= :mavericks
                            [
                              '/usr/lib/java/libjdns_sd.jnilib',
                              '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK',
                            ]
-                         end,
-                       ].keep_if { |v| !v.nil? }
+                         end
+                       ).keep_if { |v| !v.nil? }
 
   zap trash: [
                '/Library/Application Support/Oracle/Java',


### PR DESCRIPTION
For OS X below than 10.9 Mavericks, `delete` array is not flat, which causes `Error: no implicit conversion of Array into String` when this array is iterated over to remove those directories.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
