### PR TITLE
nordvpn.rb: use new download url (cdn), bump version to 3.3.10

### DIFF
--- a/Casks/nordvpn.rb
+++ b/Casks/nordvpn.rb
@@ -2,7 +2,8 @@ cask 'nordvpn' do
   version '3.3.10'
   sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
 
-  url "https://downloads.nordcdn.com/apps/macos/10.10/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
+  # downloads.nordcdn.com/apps was verified as official when first introduced to the cask
+  url "https://downloads.nordcdn.com/apps/macos/10.12/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
   appcast 'https://downloads.nordvpn.com/apps/osx/update.xml',
           checkpoint: '589e0827c0a95f54ba267fdd61bc61d7cde34068951828e151b8578415385955'
   name 'NordVPN'

--- a/Casks/nordvpn.rb
+++ b/Casks/nordvpn.rb
@@ -1,8 +1,22 @@
 cask 'nordvpn' do
-  version '3.3.8'
-  sha256 'e274d18c42f7f3397bf195f027a51b21f1add2b7b57578a46498888d41104713'
+  if MacOS.version <= :yosemite
+    version '3.3.10'
+    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
+    url "https://downloads.nordcdn.com/apps/macos/10.10/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
+  elsif MacOS.version <= :el_capitan
+    version '3.3.10'
+    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
+    url "https://downloads.nordcdn.com/apps/macos/10.11/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
+  elsif MacOS.version <= :sierra
+    version '3.3.10'
+    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
+    url "https://downloads.nordcdn.com/apps/macos/10.12/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
+  elsif MacOS.version <= :high_sierra
+    version '3.3.10'
+    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
+    url "https://downloads.nordcdn.com/apps/macos/10.12/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
+  end
 
-  url 'https://nordvpn.com/api/osxapp/latest'
   appcast 'https://downloads.nordvpn.com/apps/osx/update.xml',
           checkpoint: '589e0827c0a95f54ba267fdd61bc61d7cde34068951828e151b8578415385955'
   name 'NordVPN'

--- a/Casks/nordvpn.rb
+++ b/Casks/nordvpn.rb
@@ -1,22 +1,8 @@
 cask 'nordvpn' do
-  if MacOS.version <= :yosemite
-    version '3.3.10'
-    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
-    url "https://downloads.nordcdn.com/apps/macos/10.10/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
-  elsif MacOS.version <= :el_capitan
-    version '3.3.10'
-    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
-    url "https://downloads.nordcdn.com/apps/macos/10.11/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
-  elsif MacOS.version <= :sierra
-    version '3.3.10'
-    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
-    url "https://downloads.nordcdn.com/apps/macos/10.12/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
-  elsif MacOS.version <= :high_sierra
-    version '3.3.10'
-    sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
-    url "https://downloads.nordcdn.com/apps/macos/10.12/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
-  end
+  version '3.3.10'
+  sha256 'b5d1f687db32714a6aeb6b5b3046f5381e2e30528a1a58eacd3606b35bb09dfe'
 
+  url "https://downloads.nordcdn.com/apps/macos/10.10/NordVPN-OpenVPN/#{version}/NordVPN.dmg"
   appcast 'https://downloads.nordvpn.com/apps/osx/update.xml',
           checkpoint: '589e0827c0a95f54ba267fdd61bc61d7cde34068951828e151b8578415385955'
   name 'NordVPN'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Tested on high sierra, it works fine. For now, there is no download link for 10.13, so I set it to 10.12.