### PR TITLE
Update kitty to 0.5.1

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,10 +1,10 @@
 cask 'kitty' do
-  version '0.5.0'
-  sha256 'e9acfffc615713bc456c3e2c343de12877c4e437deb12ad4c6f6348b5f798858'
+  version '0.5.1'
+  sha256 'a34c3e08717129315d89382afc01bd6dc9b0b9853f5bceff81cbcf05590c18f9'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom',
-          checkpoint: '5fd4fcf782fcf970da87fafa4e964a9a5042ee94f2c8fefe45ccf2f15e3602ca'
+          checkpoint: 'e9397b9547432552e13e9d9d942cb74f17cb49c37147fa9738ad27cb3cf1f1d9'
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.