### PR TITLE
Update station to 1.0.9

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.0.8'
-  sha256 'c8e3735d0cf290341163991cfcd0fbf3ae0523debcb953e23c04a6479f78044b'
+  version '1.0.9'
+  sha256 'b1b656c8394f7da5d72ec4809e5877599565a0a56fcf9d9d1b20b24759199394'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '723eff7d78895433fc218e4209e8037e1a988821781be1d4c351e7c4b7016f5a'
+          checkpoint: '2927f13727accded93b5a72dae1f649d1f3d6a4f227bbdf254e3ccbc8603c02b'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.