### PR TITLE
Update launchcontrol to 1.36

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -1,10 +1,10 @@
 cask 'launchcontrol' do
-  version '1.35.2'
-  sha256 'a0e811775a0e8e7f93ed3a5e0e7dd46d287e1fa237f867b21c7c6754a9e0759d'
+  version '1.36'
+  sha256 'a91987113fe2e2192480b5e3b91f6d6bea1321529629bc0994115afb0d3cf883'
 
   url "http://www.soma-zone.com/download/files/LaunchControl_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/LaunchControl/a/appcast.xml',
-          checkpoint: '2e848c780119df0aa862e02363dfa9d8d57b73f1af9b3be3bf9ec75058e57d0f'
+          checkpoint: '20fc25258291a4adb430ba72a97a6682161cdda7bb9f4ea109f6098e070dfb14'
   name 'LaunchControl'
   homepage 'http://www.soma-zone.com/LaunchControl/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.