### PR TITLE
Update subler to 1.4.5

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.4.4'
-  sha256 'b93feb24fa884fa60c0be66f5b0ecde4ebd1fcb815d0f57e5199ab43469832f7'
+  version '1.4.5'
+  sha256 '243c6493710a615a209581b7b90baf35732620b374f7eef9565143aea591a3da'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: '8f4450dd1bfae079857c7dd7c7c096d59d1345c280b8bc6dbf2420bd66f43050'
+          checkpoint: '38e175567df9d64d16b2082b4a59752ccd3029bd1b127883a4ce464e6c5e96d2'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.