### PR TITLE
Update hab to 0.50.3-20171201233208

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.40.0-20171128173702'
-  sha256 'f5a6293da056c7432205db94b60776f9573c8bf34af5b87b9dda3b98a98e045a'
+  version '0.50.3-20171201233208'
+  sha256 '5311d0d80df04179e6dd98a5caa6eff6e9580a01eec9a0904d6836d03fc47f5a'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '915ac94023d077cad5aa5f14b9d703b11815db833636ce53e64e158d4181989d'
+          checkpoint: '86cda9a62d4d9318465bd5d458b81fa7573358a53cff1ba2d8f01da3e0f47751'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 

--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -5,7 +5,7 @@ cask 'hab' do
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '86cda9a62d4d9318465bd5d458b81fa7573358a53cff1ba2d8f01da3e0f47751'
+          checkpoint: 'c0be8b9df2ae5bf0f05f0a8c70aeacb4f5f4d21060af4d1ed46d042fee5fcf86'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.