### PR TITLE
Update polymail to 1.47

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.46'
-  sha256 '38e1e91bf18df9d3430bdacb15542e5f7e843aff473751ffa6a0bd8d3f7da2cc'
+  version '1.47'
+  sha256 'a9854e47e904514db4f0794fbf50e45ad0976e32c2bdf756cbe4bc26a9f7cc90'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'e6ff8cf1aff7be4d13f80b9ef1d10b4766105174707eb1b633225fae8bf339a8'
+          checkpoint: '0187ecdaeb94b5b7e0294b01e9add4e71f67ecb2e6bb2e473301032c855b4a10'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.