### PR TITLE
Update papers to 3.4.12,550

### DIFF
--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -1,11 +1,11 @@
 cask 'papers' do
-  version '3.4.10,548'
-  sha256 'cef4ecc8f0968b500db1fe1cd0d525a6912d8e3e9b5035d416fe77236ba74132'
+  version '3.4.12,550'
+  sha256 '7825647a1a6a21594acbb643d664751dc727cf5238c0b7d35a01ba6778715971'
 
   # appcaster.papersapp.com/apps/mac/production/download was verified as official when first introduced to the cask
   url "http://appcaster.papersapp.com/apps/mac/production/download/#{version.after_comma}/papers_#{version.before_comma.no_dots}_#{version.after_comma}.dmg"
   appcast 'https://appcaster.papersapp.com/apps/mac/production/appcast.xml',
-          checkpoint: '211d6e5e84a12cb510842970d9e1ba096ad3206a3a3574b4ea266969f93fb9b0'
+          checkpoint: 'ef674d808bf92ee6f004af91bb6ba89c636c3336cfeaa5210bfb10fbc05f18bc'
   name 'Papers'
   homepage 'https://www.readcube.com/papers/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.