### PR TITLE
Update exodus to 1.39.5

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.39.4'
-  sha256 '4e44b3c8a33f7abd91b431866f1eb40aa951f417c51aa4cf3ef7b1474647329e'
+  version '1.39.5'
+  sha256 'ed623b6300e622a63b322b1b0fe54f4a309c20f4d27750913e4f57323afe8528'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '84c6e41850e354840eaeabb56f689b4c2b9fca7fda64620ef0b705ad20c60ad8'
+          checkpoint: '04c979220f4109909893b99e0e276111c71ea52264e8d5be37999e5637cdaace'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.