### PR TITLE
Update navicat-for-mariadb to 12.0.19

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.18'
-  sha256 '32191c0fa8c36b5ba32f16b71e282afd63126696e9a92a767031155a054b58f5'
+  version '12.0.19'
+  sha256 'a5af6ce1a7d75c6974b008a5fc11a084752eed3b3593469b250b3d9d4587bba1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note',
-          checkpoint: '7f0a59d9e6839d21aeba46ec6a80d92125a2659b899e7afe5a2419dd502b7fa4'
+          checkpoint: 'b5645856b6d6eade3ba672d0cdea8e269c1cc18427d32585cb3a75c533653f58'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.