### PR TITLE
Update navicat-for-sqlite to 12.0.19

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.18'
-  sha256 'c4e788719cb19a84fcb21e369bee27991fc5b59d77ab2c7fef4ec04fc8ec3356'
+  version '12.0.19'
+  sha256 '21235a891909177423b2b5403f9890a57f0525524f9f4576e4ceec46b6be988a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlite-release-note',
-          checkpoint: 'f1d142f2d226bf4895f7ae41458860226e9e6c669750be18522b827c7bf94f7c'
+          checkpoint: '9ad09b2d459e8e9dd8e3574857ed3e8dbef0725d03bd288bb38248a3a904525b'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.