### PR TITLE
Update metasploit to 4.16.17+20171201130403

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.17+20171127130641'
-  sha256 '5cdda99cbd9103fca632b4094a121ca7abf74446c3d8f1c808e2d7c190ec2035'
+  version '4.16.17+20171201130403'
+  sha256 '4e368dd8c64f4323ac2cdd54a7f1db307d4b7890d6da92533b07060c970e79ad'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '5f49dd6d6f88a13e1a8ee32571e535c190c844dc41500c1617554c4d98054c16'
+          checkpoint: '0088dfef55a5d5e5c7aa9830c44b62781d168df9070519903c724451e81e0d64'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.