### PR TITLE
Update metaz to 1.0.beta-35

### DIFF
--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -1,11 +1,11 @@
 cask 'metaz' do
-  version '1.0.beta-34'
-  sha256 '3ea8c1d12c5415ea818497e07e125f8de27b45f2a748305e9bb62442c0a83847'
+  version '1.0.beta-35'
+  sha256 '9b778eea86ac68a38bc40b88d5a74da6e6cb4a521e2ed1e8b62957309a286ffd'
 
   # github.com/griff/metaz was verified as official when first introduced to the cask
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"
   appcast 'https://github.com/griff/metaz/releases.atom',
-          checkpoint: '58f754b6189dd83ce26d86fcedc6c738d607be3c126c3b97dab7d14fa9dc7834'
+          checkpoint: '64ad5ec7895d8b890eab9abef034c46083d783d1d4f40c7e41f3ed978bf49921'
   name 'MetaZ'
   homepage 'https://griff.github.io/metaz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.