### PR TITLE
Update caprine to 2.8.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.7.1'
-  sha256 '3825602f4d185edb14529c42f09d045eeb3ca7cd6686681a76c96212a30bd31a'
+  version '2.8.0'
+  sha256 'c16b8864c1ceb01cbbc2d2137faf4f583bd7a819ac84bbf2689611dc352f81d0'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: 'd9b742c389b0867308bda584c8ebe59a191dcfe5514349e3cfef758a948851e9'
+          checkpoint: '4d4b1e0a9f742d9cda7642279e24c508317741e1a7e937d0a0a5fc9f55be7ae3'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.