### PR TITLE
Update fontplop to 1.3.0

### DIFF
--- a/Casks/fontplop.rb
+++ b/Casks/fontplop.rb
@@ -1,11 +1,11 @@
 cask 'fontplop' do
-  version '1.2.0'
-  sha256 'b842509b4208c9a0b9a3c82a850b066e6fb395bede746b2ec2710a0555bc3dd0'
+  version '1.3.0'
+  sha256 '0ada8c9040bb3da489965b917990f6d88da23c8fec5602f798c91db7e2aafb0e'
 
   # github.com/matthewgonzalez/fontplop was verified as official when first introduced to the cask
   url "https://github.com/matthewgonzalez/fontplop/releases/download/v#{version}/fontplop-#{version}.dmg"
   appcast 'https://github.com/matthewgonzalez/fontplop/releases.atom',
-          checkpoint: 'f44322ad99ee9f7609997e1be5d9a7215397fccf60ca265023c73f5186a2edb8'
+          checkpoint: '7b9ac9820050a5079b096960e60203fe63c3e2a46cd610a0847c4e42fe224794'
   name 'Fontplop'
   homepage 'http://www.fontplop.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.