### PR TITLE
Update meld to 3.19.0-r1,osx-10

### DIFF
--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -1,11 +1,11 @@
 cask 'meld' do
-  version '3.16.0-r1,osx-9'
-  sha256 '324e096e0253e8ad4237f64a90cdda200fe427db8cf7ebc78143fc98e2d33ebc'
+  version '3.19.0-r1,osx-10'
+  sha256 '675ffcbaab4c1515a418f025a4a9aefd2374e4a40a7dae5e851e2b0eda92b91a'
 
   # github.com/yousseb/meld was verified as official when first introduced to the cask
   url "https://github.com/yousseb/meld/releases/download/#{version.after_comma}/meldmerge.dmg"
   appcast 'https://github.com/yousseb/meld/releases.atom',
-          checkpoint: 'ef52bbf506323d079d2d1d7d2767ba9bf70944996202da672cf19e0c684af82d'
+          checkpoint: 'bc0ffb4d3204e050b12515688989c3fbb501b25c04e71acbd0c1493e5cdd5240'
   name 'Meld for OSX'
   homepage 'https://yousseb.github.io/meld/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.