### PR TITLE
Update natron to 2.3.3

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.3.0'
-  sha256 '882e7869e65f29fbe0b2c97adb0065a86bfe47f9f01622dbddd64deeba89a32a'
+  version '2.3.3'
+  sha256 '3efe76aa82872b2bdd80ec96746151d3997c9662967d008d22a010eff241e483'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: '4d89bf0b2b8449a032f002135c79c38bba5110d46a8262f7c8a8fbd44254cfcb'
+          checkpoint: '03c0144b1f5a17998020f8c05dbf13e9d8b9d9db322576cb9746c5bf183db2aa'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.