### PR TITLE
Update nitroshare to 0.3.4

### DIFF
--- a/Casks/nitroshare.rb
+++ b/Casks/nitroshare.rb
@@ -1,10 +1,10 @@
 cask 'nitroshare' do
-  version '0.3.3'
-  sha256 'a22ee3450f2dc8b72b98709fc44cc7cac4f43e95bb3a367b2b523331c82e0ba2'
+  version '0.3.4'
+  sha256 'c76fc72f25dca27b371e8ed37488a11da625063a339452702d350f5ec6e557f7'
 
   url "https://launchpad.net/nitroshare/#{version.major_minor}/#{version}/+download/nitroshare-#{version}-osx.dmg"
   appcast 'https://github.com/nitroshare/nitroshare-desktop/releases.atom',
-          checkpoint: 'a88fd7b641c51db4f4ee08c7259249d60de071db4823dee3706240e8b9aca560'
+          checkpoint: '45c7228a8a574c480784af8e6e25d3a667cf7063872fbb95a3c6a119f4d12247'
   name 'NitroShare'
   homepage 'https://launchpad.net/nitroshare'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.