### PR TITLE
Update nteract to 0.4.3

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,10 +1,10 @@
 cask 'nteract' do
-  version '0.4.2'
-  sha256 '848513a52554888c096c648866c281f57b481b831e40ce652b6a91e165302326'
+  version '0.4.3'
+  sha256 '7673b19d2e893bed67d71e816139cf55bd19277aefc06e20fa5d85807a2d8816'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: 'df4f60423863e4a7239e99e8cb60ead047b0dad023922f111881193f5168ef9c'
+          checkpoint: 'f90213db1b6a5b6848ddf8338e3eda23ab8d6d685446650f2437259c24d77fc1'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.