### PR TITLE
Update nucleo to 2.1.4

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,11 +1,11 @@
 cask 'nucleo' do
-  version '2.0.5'
-  sha256 '0a8a26891d938f9406e71126407e7d277a1dcd6429aff9d842cd6a4c390f5d91'
+  version '2.1.4'
+  sha256 'ad651aeb3203f590975884ceafbd8c985ec27b6096e89a481f0129176cd56701'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"
   appcast 'https://nucleoapp.com/updates',
-          checkpoint: '5182b46d00306264b2047e1f207c2a22c5226cc20e8d122bde8bd6bb018ade31'
+          checkpoint: 'cc4fa5213a3131104cb2b71422c6ab434f7fe349f4ef2af526e25afc4354867f'
   name 'Nucleo'
   homepage 'https://nucleoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.