### PR TITLE
Update file-juicer to 4.64

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,6 +1,6 @@
 cask 'file-juicer' do
   version '4.64'
-  sha256 '8ae0daae1764440a09fb68b2db1739e5fae2f209261efb85ce1594b77526bab5'
+  sha256 '184236048e1e687d9b3717231644f08bc5ed6b3469393da89ed6c8f17510cd35'
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   name 'File Juicer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.