### PR TITLE
Updating odrive to 6344.

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,6 +1,6 @@
 cask 'odrive' do
-  version '6306'
-  sha256 'e3b5287a8a0c1d61f3cbcf9af2ebb6c7ea7ab08d08b1f5c433a9474a4ff10a59'
+  version '6344'
+  sha256 'f6af36bfef76b9d6b5d192392f3d807d31f21320e7b80567131d4055c2ba7ab8'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net was verified as official when first introduced to the cask


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
==> Downloading https://d3huse1s6vwzq6.cloudfront.net/odrivesync.6344.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask odrive
audit for odrive: passed
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
==> Installing or updating 'rubocop-cask' gem
Fetching: public_suffix-3.0.1.gem (100%)
Successfully installed public_suffix-3.0.1
Fetching: parallel-1.12.0.gem (100%)
Successfully installed parallel-1.12.0
Fetching: ast-2.3.0.gem (100%)
Successfully installed ast-2.3.0
Fetching: parser-2.4.0.2.gem (100%)
Successfully installed parser-2.4.0.2
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: rainbow-2.2.2.gem (100%)
Building native extensions.  This could take a while...
Successfully installed rainbow-2.2.2
Fetching: ruby-progressbar-1.9.0.gem (100%)
Successfully installed ruby-progressbar-1.9.0
Fetching: unicode-display_width-1.3.0.gem (100%)
Successfully installed unicode-display_width-1.3.0
Fetching: rubocop-0.51.0.gem (100%)
Successfully installed rubocop-0.51.0
Fetching: rubocop-cask-0.15.1.gem (100%)
Successfully installed rubocop-cask-0.15.1
10 gems installed

1 file inspected, no offenses detected
- [x] The commit message includes the cask’s name and version.
