### PR TITLE
Update omegat to 3.6.0_07

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,11 +1,11 @@
 cask 'omegat' do
-  version '3.6.0_05'
-  sha256 '7140f71701523a13cc79791aafca105bfa6ed5b401a1cad25954a3007d1b68a2'
+  version '3.6.0_07'
+  sha256 'd6f1a60f5270efcbb1bd494824cc276b595e44b32fa01cbcaeaef6dce53f3d0b'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}%20update%204/OmegaT_#{version}_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard',
-          checkpoint: '2155252f798843886b330aa944c9c41f8b53790d3c9fbd36a1a1f332d5248390'
+          checkpoint: '9b605bfd9a498c9175151e05860be306fc956aa3a651bdc4eb5785cbc5fe211f'
   name 'OmegaT'
   homepage 'https://omegat.org/'
 

--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -9,7 +9,7 @@ cask 'omegat' do
   name 'OmegaT'
   homepage 'https://omegat.org/'
 
-  app "OmegaT_#{version}_Mac_Signed/OmegaT.app"
+  app 'OmegaT.app'
 
   caveats do
     depends_on_java('8+')


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.