### PR TITLE
Update oolite to 1.86

### DIFF
--- a/Casks/oolite.rb
+++ b/Casks/oolite.rb
@@ -9,5 +9,5 @@ cask 'oolite' do
   name 'oolite'
   homepage 'http://www.oolite.org/'
 
-  app "Oolite #{version}/Oolite.app"
+  app 'Oolite.app'
 end

--- a/Casks/oolite.rb
+++ b/Casks/oolite.rb
@@ -1,11 +1,11 @@
 cask 'oolite' do
-  version '1.84'
-  sha256 '8a10338202d46d6b1621e7ad86914c76c11f5ff5c08781fb5bc1f053c99e0e74'
+  version '1.86'
+  sha256 'bee8226c78fee15ae7c20180ca2587f2397bfa48e592339b1e59a1da0de91906'
 
   # github.com/OoliteProject/oolite was verified as official when first introduced to the cask
   url "https://github.com/OoliteProject/oolite/releases/download/#{version}/Oolite-#{version}.zip"
   appcast 'https://github.com/OoliteProject/oolite/releases.atom',
-          checkpoint: 'e2043a4b70ccdce152a6c4f723bd7946656be29da56dccfeb3389066c462ba49'
+          checkpoint: 'c5d48ac5a3abc26df3333685ef890a61e51938a3f049472922d9e60a04551ad4'
   name 'oolite'
   homepage 'http://www.oolite.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.