### PR TITLE
Update openmw to 0.43.0

### DIFF
--- a/Casks/openmw.rb
+++ b/Casks/openmw.rb
@@ -1,11 +1,10 @@
 cask 'openmw' do
-  version '0.42.0'
-  sha256 '17d08886bb722a0614980201b432a4c9d75582e7a5112e319b2cdab8e0f53b59'
+  version '0.43.0'
+  sha256 '1ed16a237d652749594c78715e47b1943afc18a4004fe12e3c74bcd314070793'
 
-  # github.com/OpenMW/openmw was verified as official when first introduced to the cask
-  url "https://github.com/OpenMW/openmw/releases/download/openmw-#{version}/OpenMW-#{version}.dmg"
+  url "https://downloads.openmw.org/osx/OpenMW-#{version}.dmg"
   appcast 'https://github.com/OpenMW/openmw/releases.atom',
-          checkpoint: 'd23841a67532f150fd31aa207b5e15220bfa8250e76932242d13813ac064e7d2'
+          checkpoint: '374ed37cd709f8af1916d00b700a462fe58d378f7b6194f3da7b4873154f5511'
   name 'OpenMW'
   homepage 'https://openmw.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.