### PR TITLE
Update opensesame to 3.1.9

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -4,12 +4,12 @@ cask 'opensesame' do
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'
     url "https://files.cogsci.nl/software/opensesame/opensesame_#{version}-macos-2.zip"
   else
-    version '3.1.6'
-    sha256 '6b9bd3a88a09bfefdb1697a9524c508a7fa615792468f7f69ee25818f17ddc19'
+    version '3.1.9'
+    sha256 '593664ae5b88f03e845a837cf0cd062a6ebca97fcfb47e7017adf00c5f44b274'
     # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
     url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
     appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: '8a82d4c98339aca6ffcb5286805340a54e1e11a87a98fd416c3f2975fc6381ee'
+            checkpoint: 'dd285e93f1cfd611c42e135a837ee7239bf55819bf99f4f9a228d75ca9f0f68c'
   end
 
   name 'OpenSesame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.