### PR TITLE
Update overture to 2.5.4

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.4.8'
-  sha256 'b2d93c06529bef563b7ee0bbd1e4488c02c22ccf8dd977c5be6e1ff1e912d871'
+  version '2.5.4'
+  sha256 '8dc6b714ce3bc811e5f3c83bf689b164f7101956cf5a6a3615b4b1e87d94a8ef'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: '33c6493d0bf533dd560165333c18b05884c22cb3baa97d58b771214d318ebf42'
+          checkpoint: '45f8c70a788dd81c8c1938af50bca548c6b2f9c4f1d9af4358b0108e11820077'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 

--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -9,5 +9,5 @@ cask 'overture' do
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 
-  app 'Overture.app'
+  app "Overture-#{version}-macosx.cocoa.x86_64/Overture.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.