### PR TITLE
Update rsyncosx to 4.9.1

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '4.9.0'
-  sha256 '786211087a427e1162157ef13a245a3c7b99be4e11e6651ecc041d99a79de1b2'
+  version '4.9.1'
+  sha256 '099d0b6c01b99b9e9a33d7428008b937fe8227a5eb21d34c79b1ecdcf3965519'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: '63ad7be4c92e6c594a9d372ad6e790973769c31bb3dca4b680dbf349dc27ed69'
+          checkpoint: 'e0051f20e9fca44ed3c11f2091631fb2759431053d5944f2c07b02ff2a689515'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.