### PR TITLE
Update disk-sensei to 1.6.1

### DIFF
--- a/Casks/disk-sensei.rb
+++ b/Casks/disk-sensei.rb
@@ -1,11 +1,11 @@
 cask 'disk-sensei' do
-  version '1.6'
-  sha256 '9cc8025ef584703ca5df39829a8004070eb43587017709133b1641be62e1542f'
+  version '1.6.1'
+  sha256 '0260cdf936512c94f9867cdfe5e7e29c4629426d0eb561474dbbf467f88156d6'
 
   # amazonaws.com/cindori was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/cindori/DiskSensei.zip'
   appcast 'https://www.cindori.org/updates/disksensei/DiskSensei.xml',
-          checkpoint: '1966ae75c1b009f934886556936ffe2b79f1acf3116ae1285006149d0c838d60'
+          checkpoint: '65d0b4c09f93480e71ccbf745ab6fe538b9326ece94e3e7c01799d788b9a395a'
   name 'Disk Sensei'
   homepage 'https://cindori.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.