### PR TITLE
Update shotcut to 17.12.03

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '17.11.07'
-  sha256 '94522ffd61bd0c1f664939e818de995f5fb34cbddf4a365bb021ba9011592481'
+  version '17.12.03'
+  sha256 '0709d27608922b1f57d7c59abddcfd980500756e13b17297c830610ad291011a'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '2681d9a45f92dac8df116bd8be9a999908dafa7420f13bf4091b2d1246940056'
+          checkpoint: '68f903e0b3577c2d4e814023a23c49d83f1739c21286c3a7bc6ab075312fd23f'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.