### PR TITLE
Update riot to 0.13.3

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,10 +1,10 @@
 cask 'riot' do
-  version '0.13.1'
-  sha256 '24fc4feb8d03d5793f9a6cd38665d0f8a1b2d4cb2f21bfee5357e84d965bbf63'
+  version '0.13.3'
+  sha256 '59d3e16936ceb7f52fc6ad456fd6bcb1aeb258ce6ebe9a1d97b4bf23616da4fc'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-web/releases.atom',
-          checkpoint: 'dc496f84ae62082186c719e60ccc3f1c2fe50616c288ccc5ce0711ff76debbff'
+          checkpoint: '6eb112447422c24e92e48d2d108e9b480699bae09856dcc68d613da9a4c53961'
   name 'Riot'
   homepage 'https://about.riot.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.