### PR TITLE
Update pd-l2ork to 2.4.3

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,11 +1,11 @@
 cask 'pd-l2ork' do
-  version '2.2.1'
-  sha256 'f11c122dcabfdec9acbfd78e4ca4654f6fe6fe61bb7e612d54825a0289908753'
+  version '2.4.3'
+  sha256 '8a9f9e7829de08882ed1732c107f001fa27c2796c6a3751a69ea9405f3edfc2e'
 
   # github.com/agraef/purr-data was verified as official when first introduced to the cask
-  url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-amd64.dmg"
+  url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-x86_64.zip"
   appcast 'https://github.com/agraef/purr-data/releases.atom',
-          checkpoint: '97a5f064e9efe23c3ef5b95afac77b5398e5f9464fb52d886b75b85bd198ae5e'
+          checkpoint: 'f07544a779166c15ef77d9255e3619cb9acb0ee798d0d6f17198e2f111196272'
   name 'Pd-l2ork'
   name 'Purr Data'
   homepage 'https://agraef.github.io/purr-data/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.