### PR TITLE
Update pdfpen to 923.0,1510025892

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,10 +1,10 @@
 cask 'pdfpen' do
-  version '902.1,1495072427'
-  sha256 '8acb8ed471d1788777d5cb4f9f8f30c4b017de6b3b6bd577b6d9286ff13f02ab'
+  version '923.0,1510025892'
+  sha256 '9c93c5350abd73e474911cf800a44ac197700e800cd6163f4dd4a5ffe5049357'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml',
-          checkpoint: '63a003b38a869e2657902628136836476157aa6c4c8d9d6ed24fb6895bef4c63'
+          checkpoint: 'd525517260e70f14efde2ba786f176aa506f6d36d80359832cae1bf6de11c352'
   name 'PDFpen'
   homepage 'https://smilesoftware.com/PDFpen'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.