### PR TITLE
Update pdfsam-basic to 3.3.5

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,11 +1,11 @@
 cask 'pdfsam-basic' do
-  version '3.3.4'
-  sha256 '81188773b21d129dc2b7637d8a260ae28603f7ce37e84ac8742aab30df184e88'
+  version '3.3.5'
+  sha256 'a053c1c1815d66110b7da8e598099896841dd36cb3672a5e79f3843fdc872688'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}/PDFsam-#{version}.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom',
-          checkpoint: 'f32526db8fb329d4483c582b59b4510dfd3e70810eae8085e609542045bec1d9'
+          checkpoint: 'd3f42385f6d99a2c1458ac801f3d7fae143338a6cc27844e3e9fc75c8f1aa508'
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.