### PR TITLE
Update zoc to 7.16.2

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,10 +1,10 @@
 cask 'zoc' do
-  version '7.16.1'
-  sha256 '2aa0cd9df0ea82d3d3e6ba1afe396151f0f062484eabd7cd98f54ad2573b69d4'
+  version '7.16.2'
+  sha256 'c8432649c263132f1d993d09d81f3141072f86d4169bc4503ff27f080a423d61'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast "https://www.emtec.com/downloads/zoc/zoc#{version.major}_previous/",
-          checkpoint: 'e1932edb54cd11a8290aaae0ea26e0c5ec7800f452644b41fdda6edfeb7dc938'
+          checkpoint: '9356113d224e407ef2f96e95dc8d910cc3990d886517edc0aa872bff12874578'
   name 'ZOC'
   homepage 'https://www.emtec.com/zoc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.