### PR TITLE
Update downie to 3.1,1725

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.0.9,1706'
-  sha256 '9568dc97b1fcfea0b70620ae43d67bcd7ab249da06913f06c0899c5da2596618'
+  version '3.1,1725'
+  sha256 '716fca2304ad151b403d283426529a52950d71f2a06dcb01b241eddf34659529'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: '321af3b463106fa8c96555e618802d27d9316517f1f0d29f4c14475cd2715d18'
+          checkpoint: '6ea56d16b17a49fcbc08b511e3ba720de95ba02e23f651ec587f82dee3caf17f'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.