### PR TITLE
Update signal to 1.0.40

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.0.39'
-  sha256 '957b55782351d912f7261a3018e6f2be87a5fa9c130271b45a753cc81882a251'
+  version '1.0.40'
+  sha256 '5b4ae797fba7687a5ec22906af9713e05b27f899b4f8a82f883b643937d06a99'
 
   url "https://updates.signal.org/desktop/Signal-mac-#{version}.zip"
   appcast 'https://github.com/WhisperSystems/Signal-Desktop/releases.atom',
-          checkpoint: '7bd0f4cd30a17d56bcd93ff7df8979fa990be88f064f93a79f50046011e60864'
+          checkpoint: 'fead8006f28924ff4e3e643670ac4d888edccebc5ee5902692c742a1ac8e77f2'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.