### PR TITLE
Update astro to 2.0.26,3342

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '2.0.24,3267'
-  sha256 'f78572a0258adc6dca0a9e47092a44fd21e3f0db4548094c8a537652c3d29358'
+  version '2.0.26,3342'
+  sha256 'c187a8f924f55d9fccc52c226ed94dcc13aef0c66f3fde9ac5d7458cb9da0cad'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: '541578d702c96a48300e966f77d3c90843ba3712b0b5fd782b1feee36dedb78d'
+          checkpoint: 'c7e03c0336d519cd6be9a5ed7a58c6c736f5593a7da0dc6e5d71dabc181540ef'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.