### PR TITLE
Update appcode to 2017.3

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -1,10 +1,10 @@
 cask 'appcode' do
-  version '2017.2.6,172.4343.31'
-  sha256 'a86136b0764ea3372d1d1537cf259ab76809e7336a4bf7a5554a28e5d3b8f96a'
+  version '2017.3'
+  sha256 '41ec2773f7e58f7c9fb6e86931e73f72e156cfb9d3f2bd1c25fad80af8e8b9b8'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=AC&latest=true&type=release',
-          checkpoint: '5649bf09a36c5374f151da119fa3c54c31b608ffddb99128082e4da7d7ef4572'
+          checkpoint: 'b80f1bfa6882b58d30a851d2ea12007b329714affc628f5d9a92595082ec2b5b'
   name 'AppCode'
   homepage 'https://www.jetbrains.com/objc/'
 

--- a/Casks/flawlessapp.rb
+++ b/Casks/flawlessapp.rb
@@ -1,0 +1,13 @@
+cask 'flawlessapp' do
+  version '15,1510910181'
+  sha256 'a97272d778224066a9dedb97c48128a39437b01fb32acf862b73e8a36e205ae4'
+
+  # dl.devmate.com/com.flawless.app.FlawlessMac was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/com.flawless.app.FlawlessMac/#{version.before_comma}/#{version.after_comma}/FlawlessMac-#{version.before_comma}.zip"
+  appcast 'http://updates.devmate.com/com.flawless.app.FlawlessMac.xml',
+          checkpoint: '549d6cc2b59b07467eb6a80524f879ce3a7197427b05daf632a4014f8df73cfc'
+  name 'Flawless App'
+  homepage 'https://flawlessapp.io/'
+
+  app 'FlawlessApp.app'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.