### PR TITLE
Download url fix for Microsoft R Open cask (microsoft-r-open 3.4.2)

### DIFF
--- a/Casks/microsoft-r-open.rb
+++ b/Casks/microsoft-r-open.rb
@@ -2,7 +2,7 @@ cask 'microsoft-r-open' do
   version '3.4.2'
   sha256 'f533bcef949162d1036d92e9d12c414a4713c98a81641dee95b7f71717669832'
 
-  url "https://mran.microsoft.com/install/mro/#{version}/microsoft-r-open-#{version}.pkg"
+  url "https://mran.blob.core.windows.net/install/mro/#{version}/microsoft-r-open-#{version}.pkg"
   name 'Microsoft R Open'
   name 'MRO'
   homepage 'https://mran.microsoft.com/'

--- a/Casks/microsoft-r-open.rb
+++ b/Casks/microsoft-r-open.rb
@@ -2,6 +2,7 @@ cask 'microsoft-r-open' do
   version '3.4.2'
   sha256 'f533bcef949162d1036d92e9d12c414a4713c98a81641dee95b7f71717669832'
 
+  # mran.blob.core.windows.net was verified as official when first introduced to the cask
   url "https://mran.blob.core.windows.net/install/mro/#{version}/microsoft-r-open-#{version}.pkg"
   name 'Microsoft R Open'
   name 'MRO'


### PR DESCRIPTION
After making all changes to the cask:

- [x]  brew cask audit --download {{cask_file}} is error-free.
- [x]  brew cask style --fix {{cask_file}} left no offenses.
- [x]  The commit message includes the cask’s name and version.
