### PR TITLE
Update soapui to 5.4.0

### DIFF
--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -1,9 +1,9 @@
 cask 'soapui' do
-  version '5.3.0'
-  sha256 '3d82a64d0573f136511b3591c060d59d78e8db356fc03df4d003dce83ec967c8'
+  version '5.4.0'
+  sha256 '9528936b416f8b4925c65d72a486108f8bf251cf102ebdcef5146a61a83ca9b5'
 
-  # cdn01.downloads.smartbear.com/soapui was verified as official when first introduced to the cask
-  url "http://cdn01.downloads.smartbear.com/soapui/#{version}/SoapUI-#{version}.dmg"
+  # s3.amazonaws.com/downloads.eviware/soapuios was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/downloads.eviware/soapuios/#{version}/SoapUI-#{version}.dmg"
   name 'SmartBear SoapUI'
   homepage 'https://www.soapui.org/'
 
@@ -45,14 +45,6 @@ cask 'soapui' do
                                     '-Vsys.component.714$Boolean=true',
                                   ],
                     }
-
-  postflight do
-    soapui_sh = "/Applications/SoapUI-#{version}.app/Contents/java/app/bin/soapui.sh"
-    IO.write(soapui_sh, IO.read(soapui_sh).gsub('#   JAVA_OPTS="$JAVA_OPTS -Dsoapui.browser.disabled=true"', '   JAVA_OPTS="$JAVA_OPTS -Dsoapui.browser.disabled=true"'))
-
-    vmoptions_txt = "/Applications/SoapUI-#{version}.app/Contents/vmoptions.txt"
-    IO.write(vmoptions_txt, '-Dsoapui.browser.disabled=true')
-  end
 
   uninstall delete: "/Applications/SoapUI-#{version}.app"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The workaround added in https://github.com/caskroom/homebrew-cask/pull/37594 doesn't seem to be required. `app` launches (and runs.)