### PR TITLE
Update acorn to 6.0.4

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,10 +1,10 @@
 cask 'acorn' do
-  version '6.0.3'
-  sha256 '31c92aac15f1073b1563eb68f5f9142d6e464c23d15d5f9185070cba163df564'
+  version '6.0.4'
+  sha256 :no_check
 
   url 'https://secure.flyingmeat.com/download/Acorn.zip'
-  appcast "http://www.flyingmeat.com/download/acorn#{version.major}update.xml",
-          checkpoint: '79a430c630b3b96137418a36dd1c80187330b22e3d4c263fedc9f7bf4bf149c2'
+  appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml",
+          checkpoint: '33b181f83680dc40fe97173807902171b6d1cf0120fe3578af43d31114e7497e'
   name 'Acorn'
   homepage 'https://flyingmeat.com/acorn/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.