### PR TITLE
Update bitshares to 2.0.171205

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.171121'
-  sha256 'bf31558becacb9129aa026d75bf9abed11f72df527812582df0467587e74648c'
+  version '2.0.171205'
+  sha256 'cd55231877860860938fbdbca7b788feb2f711638ba03dc8fc11361fcece92a5'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: '81efea8fca25cc2c87cf8fdd5f4e9c2506352008786892881f19b02307d50c08'
+          checkpoint: '897827f7f4efc6c97ae73eb1448dfff1aba43c1ea33a12d578bc5bff0f557674'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.