### PR TITLE
Update nextcloud to 2.3.3.84

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -1,10 +1,10 @@
 cask 'nextcloud' do
-  version '2.3.2.1'
-  sha256 '2b2afb95d015726f35533d98dc4b7682736ea10f6272b3c280ee1801013dbf55'
+  version '2.3.3.84'
+  sha256 '87c551d015a4e64bffe39f775b8ba46a3b9a424988e03ae8a5d753de2b4a7a8e'
 
   url "https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-#{version}.pkg"
   appcast 'https://github.com/nextcloud/client_theming/releases.atom',
-          checkpoint: '2a12315ea22a0100ebcb20ab75e33c9f925b5d76849187086031e4fcfc6f5c5b'
+          checkpoint: '9f7680eb001a3452083604f6e077bf998305cc82f71310c8fdd29a4f4f2c3a33'
   name 'Nextcloud'
   homepage 'https://nextcloud.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.