### PR TITLE
Update 1password-cli to 0.2

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,11 +1,11 @@
 cask '1password-cli' do
-  version '0.1.1'
-  sha256 '95eb4cfd62a5bf1eab99d4acb24ab9229fc4dfb16a931dd7f9628f88b54c1fc7'
+  version '0.2'
+  sha256 'a3d36a67fa3cdd6c6869d2c0e3d2d369e75a1f6ce3724454f467db0944c7a8ba'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/CLI',
-          checkpoint: 'a0c73938742c33399b0d408dac38e5aaa23a56e8a76ba0603876398f7cc38ccb'
+          checkpoint: 'd4a70e7c8b221f5e1ff36d543175b3332523c0b9782b5663279e8245daf87846'
   name '1Password CLI'
   homepage 'https://support.1password.com/command-line/'
   gpg 'op.sig', key_url: 'https://keybase.io/1password/pgp_keys.asc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.