### PR TITLE
rstudio 1.1.383: Recommend brew cask install r-app

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -13,10 +13,18 @@ cask 'rstudio' do
 
   caveats <<~EOS
     #{token} depends on R.
-    There are different ways to satisfy that dependency and we don’t want to impose one, so it is up to you to satisfy it.
-    We suggest you do so by running one of:
+    There are different ways to satisfy that dependency. RStudio recommends installing R from The R Project, which is required to install binary R packages, without needing to compile packages from source.
+
+    https://support.rstudio.com/hc/en-us/articles/217799238
+
+    To install the R Project package run:
+
+      brew cask install r-app
+
+    Alternative ways to satisfy the dependency are:
 
       brew install r
-      brew cask install r-app
+
+    This requires compiling R packages from source.
   EOS
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

-----

Rstudio depends on R. There are two ways of satisfying that dependency.
Option 1 is recommended to be able to use precompiled binary packages.
Option 2 is not recommended, as it requires compiling R packages from source.

1. `brew cask install r-app`
2. `brew install r`