### PR TITLE
Update reflector to 3.0.2

### DIFF
--- a/Casks/reflector.rb
+++ b/Casks/reflector.rb
@@ -1,10 +1,10 @@
 cask 'reflector' do
-  version '3.0.1'
-  sha256 '6df2608e11a08cb0b71faf9b9267f442d04225eccfc01f646ac1dd2d3603c3a9'
+  version '3.0.2'
+  sha256 '52b11529455e014aba83a5a683aa64a5c65fba873f27a7766a0a2182f93547df'
 
   url "https://download.airsquirrels.com/Reflector#{version.major}/Mac/Reflector-#{version}.dmg"
   appcast "https://updates.airsquirrels.com/Reflector#{version.major}/Mac/Reflector#{version.major}.xml",
-          checkpoint: '833bcaf099971d31531ea65dbfda4aa09f7ec37ff52e0b344aa8bc52a58638c3'
+          checkpoint: 'dbd337002b4eeb9d63cf4a12c6b63c8ed94dddf2787975e5281b684610777e5e'
   name "Reflector #{version.major}"
   homepage 'http://www.airsquirrels.com/reflector/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.