### PR TITLE
Update plex-media-server to 1.10.0.4523-648bc61d4

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,10 +1,10 @@
 cask 'plex-media-server' do
-  version '1.9.7.4460-a39b25852'
-  sha256 '744d13182986fccc7ef428667399612933091ebdbf6fcfe405a1fba513d3cac8'
+  version '1.10.0.4523-648bc61d4'
+  sha256 '79872b380923c3ce754030bace9d88c449d46c2872316d06bb5f6cd12bc53cb8'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   appcast 'https://plex.tv/api/downloads/1.json',
-          checkpoint: '02a37175941120bc9cbc49b93e2031f554eb3e936ea7abeb3dab871563fe915c'
+          checkpoint: '6a8c90ce1340da41c0f1f06334c7e6f1f77a12010a54e9365a0715404795b378'
   name 'Plex Media Server'
   homepage 'https://www.plex.tv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.