### PR TITLE
Update camunda-modeler to 1.11.3

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.11.0'
-  sha256 'c567eab9ca71c5529edbca0d38b0acc63eed16c500d495de395950fbe82097a7'
+  version '1.11.3'
+  sha256 '4eadc23e7ad822acb7c1ece018c0bf6b23c1bd5d6e1bc9355249cae44b06d508'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.