### PR TITLE
Update qt-creator version to 4.5.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -2,7 +2,7 @@ cask 'qt-creator' do
   version '4.5.0'
   sha256 'cb3aac65ddadaccef1bf62a95120f8d74d3e4454f7afcdcb5425f20051d24b5b'
 
-  url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
+  url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'
   homepage 'https://www1.qt.io/developers/'
 

--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,8 +1,8 @@
 cask 'qt-creator' do
-  version '4.4.1'
-  sha256 '6e048a113f34bd3333fbcecdbf916aa292c5fe510662c4ad7cf8d65a515a0d64'
+  version '4.5.0'
+  sha256 'cb3aac65ddadaccef1bf62a95120f8d74d3e4454f7afcdcb5425f20051d24b5b'
 
-  url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
+  url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'
   homepage 'https://www1.qt.io/developers/'
 


### PR DESCRIPTION
√    `brew cask audit --download {{cask_file}}` is error-free.
√    `brew cask style --fix {{cask_file}}` left no offenses.
√    The commit message includes the cask’s name and version.

Update qt-creator version to 4.5.0 and use https for downloading

Version and hash taken from https://download.qt.io/official_releases/qtcreator/4.5/4.5.0/qt-creator-opensource-mac-x86_64-4.5.0.dmg.mirrorlist
HTTPS link checked and it works

P.S.: I don't know why but Github didn't insert the template message here and I don't know how to do these square checkbox thing, I hope it's readable enough like it is.