### PR TITLE
Update dropzone to 3.6.5

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,10 +1,10 @@
 cask 'dropzone' do
-  version '3.6.4'
-  sha256 '41fcdb7eb2f8bbcaa1a860e8aa63a9fdf66932168bcb693485fdbdb26d422a93'
+  version '3.6.5'
+  sha256 '2807a2b1d963b6a93f95a05839e962b39809e78d8319951d434f2e5799a1e5df'
 
   url "https://aptonic.com/dropzone3/sparkle/Dropzone-#{version}.zip"
   appcast 'https://aptonic.com/sparkle/updates.xml',
-          checkpoint: 'c31c4a066ab90115e80741f800a518c0d3546f581b9fa9d7d0fb08fc5ff07be8'
+          checkpoint: '36c621138ad2cd6703eb16d508f73fcf08e4610c6e84fa022014978bbb51a593'
   name 'Dropzone'
   homepage 'https://aptonic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.