### PR TITLE
Update emby-server to 3.2.50.0

### DIFF
--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -5,7 +5,7 @@ cask 'emby-server' do
   # github.com/MediaBrowser/Emby was verified as official when first introduced to the cask
   url "https://github.com/MediaBrowser/Emby/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"
   appcast 'https://github.com/MediaBrowser/Emby/releases.atom',
-          checkpoint: '4753cd74957ef927b539ba5b3b5d1a18eaa75ce6a5e27a9ce63650badf3625d0'
+          checkpoint: 'bbafec4c3a8be87398119c2817428486a4c17335a77f57bb12576917db988d31'
   name 'Emby Server'
   homepage 'https://emby.media/'
 

--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -1,11 +1,11 @@
 cask 'emby-server' do
-  version '3.2.40.0'
-  sha256 'aa0037e889329425a4a6a666b5430ce672fe9e8cfef440692d0178d644db046d'
+  version '3.2.50.0'
+  sha256 'bb5a6bf701d604a751fdec8183db48cf457aa431040e9d0813a3634bd592705b'
 
   # github.com/MediaBrowser/Emby was verified as official when first introduced to the cask
   url "https://github.com/MediaBrowser/Emby/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"
   appcast 'https://github.com/MediaBrowser/Emby/releases.atom',
-          checkpoint: '383a5fddba34b06fbeac266600a2755095f8fca2257c68dfc5472eb1cc59392d'
+          checkpoint: '4753cd74957ef927b539ba5b3b5d1a18eaa75ce6a5e27a9ce63650badf3625d0'
   name 'Emby Server'
   homepage 'https://emby.media/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.