### PR TITLE
Update handy-outliner to 1.1.6.3

### DIFF
--- a/Casks/handy-outliner.rb
+++ b/Casks/handy-outliner.rb
@@ -1,10 +1,10 @@
 cask 'handy-outliner' do
-  version '1.1.6.2'
-  sha256 'a67a21650d29114c058e1f50bce3675e7c7b427abdd67a60e49098a31046d14d'
+  version '1.1.6.3'
+  sha256 '418b6f67c55ef76d537941ec258160dd845d4027ff1e2f81bcbca713510d392d'
 
   url "https://downloads.sourceforge.net/handyoutlinerfo/handyoutliner_#{version}.zip"
   appcast 'https://sourceforge.net/projects/handyoutlinerfo/rss',
-          checkpoint: 'cecb51c6c4341e9527776b119dee4b9774b73e5f710dd8221f2af8d626fa05e2'
+          checkpoint: '0f43ad62d6adadfa40c7928650735a454dce0181fb7b4805702503de17aba282'
   name 'HandyOutliner for DjVu and PDF'
   homepage 'http://handyoutlinerfo.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.