### PR TITLE
Update neteasemusic to 1.5.8_612

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask 'neteasemusic' do
-  version '1.5.8_604'
-  sha256 '14027d6d3145c9bd88db94b88a5f84d51d248cffc5ccbcf753b2fc593bd8818a'
+  version '1.5.8_612'
+  sha256 '7d81f27094cb52c17ad58cfcfad4dc022a653353780f63be17b4f10546c1698b'
 
   # d1.music.126.net was verified as official when first introduced to the cask
   url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.