### PR TITLE
Update karabiner-elements to 11.4.0

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '11.3.0'
-  sha256 'd9b4cc01775faa2925090f44fa7b61e0a8aefee14f1eeb5d239ac58537c5c949'
+  version '11.4.0'
+  sha256 'c9870fbf87d7042ff518a4b844288cf006ddf48c27acbe230ec7471ba5fb1d8f'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: '11524b8894d76c099b5689e5700ce79ca572b859b3e51b31c8bbf137403b97d7'
+          checkpoint: '4d3ffeefb18d928d47096e2c28305368efff7d080f847d813fb110a0a864fe31'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.