### PR TITLE
Update droplr to 4.7.1,104

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version '4.6.9,101'
-  sha256 '17b7477a3c7ee86374f59c80b0c78ce3aca2c648f9fcdb83126d389317d7d8f8'
+  version '4.7.1,104'
+  sha256 '58ce39d1f786f8430040e0cfe166d62c311f7724cbe965fc9f44e3f2a2f13284'
 
   # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.