### PR TITLE
Update psychopy to 1.85.6

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,10 +1,10 @@
 cask 'psychopy' do
-  version '1.85.4'
-  sha256 '218989341215f0c4cfdab12663fbcb828774ded22aa6c51c9650983f9190f7e7'
+  version '1.85.6'
+  sha256 'a81918e7029b8ff4cebf5e1626f7089f3c765d9762b8fc3f37163af24291be21'
 
-  url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}b-OSX_64bit.dmg"
+  url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}-OSX_64bit.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom',
-          checkpoint: '037f4b3fbe0cbcd18978ec7ff530975838345c55ce6aadc80fffbfb3b3389bad'
+          checkpoint: '2e674bdbcdb5af84d0ab01a3b83858f7297696a578e29b2fcc8533719e32bf12'
   name 'PsychoPy'
   homepage 'https://github.com/psychopy/psychopy'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.