### PR TITLE
Update qgroundcontrol to 3.2.5

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.2.1'
-  sha256 '9131b3175b7a3fb380f453bdcf9c4b4311996924c80bbcb06090b22d6acc14f2'
+  version '3.2.5'
+  sha256 '246ab87302945861782230ddc5f171e5f226d728ff7974a2628230045f6c860f'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: 'c0d30ed2eb0172cb4e2cbaa12551c5042f15cf95ae591e01af441c684724bc1d'
+          checkpoint: '74f3d5dd1fc403aeef01d151d8960d0db72ea24c3a7e0cd1957adff2f033c43e'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.