### PR TITLE
Update qownnotes to 17.12.2,b3382-173425

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '17.11.3,b3342-180420'
-  sha256 '346db08d82526d9e01c3ab385457f065ed8274ca2a8976312a6cc70343c86d91'
+  version '17.12.2,b3382-173425'
+  sha256 'c904bffbe8d40284d228b0641ecbb954143832879abde8a049d4370a30346442'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '956d137cc880e8776e3b20eeee0fbe20d019db18d303634addd19338c04d9bb4'
+          checkpoint: '306338026d8a4fb3cc89fbe2a7633bd6654cea6b6a3749c1baaadb02353eb516'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.