### PR TITLE
Update openlp to 2.4.6

### DIFF
--- a/Casks/openlp.rb
+++ b/Casks/openlp.rb
@@ -1,6 +1,6 @@
 cask 'openlp' do
-  version '2.2.1'
-  sha256 '9a26ef78fa8de4ab884033d635edda690f62f78755a5ac7eef0e09a1408d71b6'
+  version '2.4.6'
+  sha256 '5994c41d3b7aefbd84624fb4d8fc09bf63eda7693e2ed68e1a36b4f8abe60094'
 
   url "https://get.openlp.org/#{version}/OpenLP-#{version}.dmg"
   name 'OpenLP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.