### PR TITLE
Update retroshare to 0.6.3,20170821-cebcc4b4

### DIFF
--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -9,5 +9,5 @@ cask 'retroshare' do
   name 'RetroShare'
   homepage 'http://retroshare.sourceforge.net/'
 
-  app "retroshare.app"
+  app 'retroshare.app'
 end

--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -1,11 +1,11 @@
 cask 'retroshare' do
-  version '0.6.0,20160209-4033f35f'
-  sha256 'f568f399a3f2956be0e0137d16fc654af4942a112ba6d297395e07989bd01f92'
+  version '0.6.3,20170821-cebcc4b4'
+  sha256 'ea908eb98f3af69486b4b950635dff9774c004488bdb950db27f8bac92bdf45a'
 
   # github.com/RetroShare/RetroShare was verified as official when first introduced to the cask
   url "https://github.com/RetroShare/RetroShare/releases/download/v#{version.before_comma}/Retroshare-#{version.before_comma}-OSX-#{version.after_comma}.dmg"
   appcast 'https://github.com/RetroShare/RetroShare/releases.atom',
-          checkpoint: 'd2927acaf91cc42399574ff1805c75bec21b249670e47a7c0e1ef31ee140a875'
+          checkpoint: '336c2f3110552dfc7a2b18807ea2273cbfa837e2b4df1a26e295e055fc44b152'
   name 'RetroShare'
   homepage 'http://retroshare.sourceforge.net/'
 

--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -9,5 +9,5 @@ cask 'retroshare' do
   name 'RetroShare'
   homepage 'http://retroshare.sourceforge.net/'
 
-  app "Retroshare#{version.major_minor.no_dots}.app"
+  app "retroshare.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.