### PR TITLE
Update texturepacker to 4.5.0

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -1,10 +1,10 @@
 cask 'texturepacker' do
-  version '4.4.0'
-  sha256 '1177a22edee36cd200a52950f7ca06a3bb933a2931f8fad496047e21d42268d6'
+  version '4.5.0'
+  sha256 '1937c600e7c3877d7ead99d3f5e791fcc0e8b58b83368512bc4821b6decb2be6'
 
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/TexturePacker/appcast-mac-release.xml',
-          checkpoint: '5c51a647cb446128326169b77fb82d9d38c974d046f308fb9c9b556e8f6b4dac'
+          checkpoint: '543e35872bd93b43ed18d7ce0db8dc7cab7ea7a7e2658f560e7d7e0f35e935e3'
   name 'TexturePacker'
   homepage 'https://www.codeandweb.com/texturepacker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.