### PR TITLE
Update tenor to 2.0.3

### DIFF
--- a/Casks/tenor.rb
+++ b/Casks/tenor.rb
@@ -1,11 +1,11 @@
 cask 'tenor' do
-  version '2.0.2'
-  sha256 'c3faf005a6454d4ddfdaa73796ccf86579a7e2a62580e8be85a43e2dba329c59'
+  version '2.0.3'
+  sha256 '5d3fd1098f5fb01f1ce0e42cb31011c9517c90c4770e0513db69e77099e6db02'
 
   # media.tenor.co/mac/bin was verified as official when first introduced to the cask
   url 'https://media.tenor.co/mac/bin/GIFforMac.dmg'
   appcast 'https://media.tenor.co/mac/gif_for_mac_appcast.xml',
-          checkpoint: '5730b07c9aa3ddf9964a14ac5f905ba26c74f80496a5d00066f5a8926aa54d0d'
+          checkpoint: '7586e7ae85c17b626297abc252cd543df7b84cc82ab4a5921edbf54893404b32'
   name 'Tenor'
   homepage 'https://tenor.com/mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.