### PR TITLE
Update standard-notes to 2.0.42

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.0.41'
-  sha256 '464907bdd2cf7302720637d603e4b67d519e2c6bea93727ae5a93e864b82cb15'
+  version '2.0.42'
+  sha256 'aa3e88989b3b9c81fb3b1629fd9945fd8a09b7a83933f6bc2d81035871e61bc1'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'b0c7fd6e9e577061cebebe516679c6e2aacc3671c87f6ecb67eaae439ec4274a'
+          checkpoint: 'b03f5bd462074dbd0caf7c69065b9c79c25e79d93c6971ca4a9bafcb44a2e61f'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.