### PR TITLE
Update sqleditor to 3.2.2

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,10 +1,10 @@
 cask 'sqleditor' do
-  version '3.1.9'
-  sha256 '8419446979c5e6fd4c6ab4753bf7ccb7e6fdbbf59a93c6bb9b3b1d0007249603'
+  version '3.2.2'
+  sha256 '114e1df1fc6e96a5eb7932a3127543c970aeefbe248a3cf4eb2f1ad7139e96de'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml',
-          checkpoint: '53be5419c1a2c4479ff42c771a99913e4157d63312c63e9709ead5a26c91b20e'
+          checkpoint: 'd3f41bedfdb1ef7c2bf85d8b04f33aaf7ac8ac34a84452cd84c685662e7de8c3'
   name 'SQLEditor'
   homepage 'https://www.malcolmhardie.com/sqleditor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.