### PR TITLE
Update spriteilluminator to 1.4.1

### DIFF
--- a/Casks/spriteilluminator.rb
+++ b/Casks/spriteilluminator.rb
@@ -1,10 +1,10 @@
 cask 'spriteilluminator' do
-  version '1.4.0'
-  sha256 '111d8df09a4fe622be8f0478ed2cb1f45dc2b31cf3d2c99510cfcfe6a2e1123c'
+  version '1.4.1'
+  sha256 'f170610a2871fbc2c256e54052e679e6f7d23c61c403a2be5a294594bed3a253'
 
   url "https://www.codeandweb.com/download/spriteilluminator/#{version}/SpriteIlluminator-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/SpriteIlluminator/appcast-mac-release.xml',
-          checkpoint: '7a3684dfc6d725649c818593de6e825476f1a1091518a47d59622a87ee2aac2d'
+          checkpoint: 'e08d170722a688cecb7d4b0b22c93c88c0290dd7e8d1a898323604b5e1587d5a'
   name 'SpriteIlluminator'
   homepage 'https://www.codeandweb.com/spriteilluminator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.