### PR TITLE
Update vfuse to 2.0.0

### DIFF
--- a/Casks/vfuse.rb
+++ b/Casks/vfuse.rb
@@ -1,21 +1,16 @@
 cask 'vfuse' do
-  version '1.0.6'
-  sha256 'dfc1714826891af823e541d646e0a7f888a40c22630bdd0e5d7466bef4dc4028'
+  version '2.0.0'
+  sha256 '5818e292500427a968b17007315e45de9bce3319248298e5f361fd3940704994'
 
   url "https://github.com/chilcote/vfuse/releases/download/#{version}/vfuse-#{version}.pkg"
   appcast 'https://github.com/chilcote/vfuse/releases.atom',
-          checkpoint: '08a362d2a9399f7d276f65bc52f0c700066f6819dae821326b4dab0006ff6a0b'
+          checkpoint: '796026ea80a5adc3846abab852d5342f87c8203524ef2923fb7617f2fa47b61d'
   name 'vfuse'
   homepage 'https://github.com/chilcote/vfuse'
 
   pkg "vfuse-#{version}.pkg"
-  binary '/usr/local/vfuse/vfuse'
 
-  uninstall delete:    '/usr/local/vfuse',
-            launchctl: 'com.chilcote.vfused',
-            pkgutil:   'com.github.vfuse'
-
-  zap trash: '~/Library/Preferences/com.chilcote.vfused.plist'
+  uninstall pkgutil: 'com.github.vfuse'
 
   caveats do
     files_in_usr_local


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.