### PR TITLE
Update expandrive to 6.1.8

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,6 +1,6 @@
 cask 'expandrive' do
-  version '6.1.7'
-  sha256 '09712bbe12a35fa54ba908d379446f89c320883dc8ce63f60b9a22633d68675b'
+  version '6.1.8'
+  sha256 '66595ec42b1da6c792f7d4e2c4207968207f81150c734012c98a92d9eceffdcf'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
   name 'ExpanDrive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.