### PR TITLE
Update fly to 3.8.0

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.6.0'
-  sha256 '1d32f0d59a04f8680d62c7db156bde413c8ff423dcfe06d3e4788e482e071f51'
+  version '3.8.0'
+  sha256 'fe00de8aadc09c8a4395fd03fa99d1e371eb26214a3ffc7aa79df94d4d8dad91'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: '8213af44f8a5813996d978aed99eeb1a9193c1bc3357dd4e0e703b384177931d'
+          checkpoint: 'ca61b5b64d280d6c83a22631d981071a67f6a7115eda6da506fe6f09def66fac'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.