### PR TITLE
Update xiami to 3.1.0-1ac

### DIFF
--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -1,6 +1,6 @@
 cask 'xiami' do
-  version '3.0.10-9e6'
-  sha256 'dded5b66993604646468ca74d1a4da7d1b1995009670d4aef4bd8931113b6db4'
+  version '3.1.0-1ac'
+  sha256 'e2723e2832d49fac3f27dbb8d13454733c551afbd7a47359634bfde950b226c9'
 
   # gxiami.alicdn.com/xiami-desktop was verified as official when first introduced to the cask
   url "http://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"

--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -3,7 +3,7 @@ cask 'xiami' do
   sha256 'e2723e2832d49fac3f27dbb8d13454733c551afbd7a47359634bfde950b226c9'
 
   # gxiami.alicdn.com/xiami-desktop was verified as official when first introduced to the cask
-  url "http://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"
+  url "https://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"
   name 'Xiami'
   name '虾米音乐'
   homepage 'http://www.xiami.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.