### PR TITLE
Update graphql-playground to 1.3.7

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.3.5'
-  sha256 '9f5fae194811f250e18d2f8b51dfb6bd71d95f967e206b5ed99aba0c3749245b'
+  version '1.3.7'
+  sha256 '59319011c690eb724c57a2b4618068246534977331d2a0bae9eda3643b4edbb1'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/playground-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: 'ac2d4c0ed7344c8e880721d603cb5148996b7ea9f9e0569eac4d95dc6aa004c5'
+          checkpoint: 'd88ff50212c417c51a62be4169a28f29324d9ea5a134fe98ac7603599a2f228b'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.