### PR TITLE
Update android-platform-tools to 27.0.0

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,6 +1,6 @@
 cask 'android-platform-tools' do
-  version '26.0.2'
-  sha256 'a6d0504e560713af2a3ae71449bcadf011b50ba78f7bf303a9d6d69bf855c73f'
+  version '27.0.0'
+  sha256 '93720ae10382d54cc31d0d97f1e016ae91e1e1eb68d38ac15a3c396adb0da1c7'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.