### PR TITLE
Update carbon-copy-cloner to 5.0.5.5213

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.0.4.5163'
-  sha256 '357abb873767aa2c28073a51d29c84bffde29960477d4896af25a0cc47bf8012'
+  version '5.0.5.5213'
+  sha256 'cfbea03ba62097e2872a1b610a610ed141017ef6df6024d695cc5020d553d6a8'
 
   # bombich.scdn1.secure.raxcdn.com/software/files was verified as official when first introduced to the cask
   url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.