### PR TITLE
Update flash-player to 28.0.0.126

### DIFF
--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,11 +1,11 @@
 cask 'flash-player' do
-  version '27.0.0.187'
-  sha256 'aa8aa414c38a205f20254b6a61e193592bc45a1f4ffbe04455c8bb6182a832a6'
+  version '28.0.0.126'
+  sha256 '7b1cb7a44539a8a4ad2fceab43db5d98803e14a5dcd641e4ad7f3a3769e6b615'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '26279ca81dea1717dec4c2d638ee46a14c9caa731f6bd2bc9ac35380bdef0ec9'
+          checkpoint: '6674b9b037cf5dbd0dd77b4e34b88c7b1c9113091d2911daa87b1fdd0163369b'
   name 'Adobe Flash Player projector'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.