### PR TITLE
Update burp-suite to 1.7.30

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,10 +1,10 @@
 cask 'burp-suite' do
-  version '1.7.29'
-  sha256 'ec475c8cf7e4b70f73ff53b3e5630bf9adcda033cb05552e266b54ffda514b2e'
+  version '1.7.30'
+  sha256 'abca4f8aaaf07b58692f3b12c5b3dd2e1d3e6e655c17691f99644bf799465f4d'
 
   url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=macosx"
   appcast 'https://portswigger.net/burp/releasesarchive/community',
-          checkpoint: 'c68f717624e967052f5d68880152348f001eab592ffa5d677efa413f1d7a8e31'
+          checkpoint: '76124f8b68ee23f1ed61425318e497fc48a61ce4d56633ad3070ecb2499bbf6c'
   name 'Burp Suite'
   homepage 'https://portswigger.net/burp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.