### PR TITLE
Update bitpay to 3.9.1

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.9.0'
-  sha256 'fb3f7eea26b2d62e9f22ba243bbfdaec45b7f9ff8081c17f11f11bc8cb7ad117'
+  version '3.9.1'
+  sha256 'f528d754e299a66dde1c09044ec65895e9175c1307209acd96765c18f6835d7a'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: '22862b67fb0a0944a96297989fe70fab4473a278990719ca62b5bd95ab8d01da'
+          checkpoint: '3497b2ab135e91925c0fb786ffab656fffe92e64331106971ba872af92e05bc3'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.