### PR TITLE
Update netron to 1.1.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.0.9'
-  sha256 '4a72ff66dc8ee6d7eeb4fdd2ea9b3782520e88c3e5ef31f4baa7fb7554c53b0a'
+  version '1.1.0'
+  sha256 '5d39ace56ada2949feec974d1c59c4f54ca90e102dd956a7dffdff3747bbac73'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'dcdfdade43a7f784dbcc7b230277b4ae215a00928ed0fa212f19e0f25bba9fac'
+          checkpoint: '938c1eab2cbc153ba44000d285eb0bd349e3eb0a7708622caaa8b1816a8bc98c'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.