### PR TITLE
Update waterfox to 56.0.1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.0'
-  sha256 'b8efd2ca07743e5581f7cf42faa35732e7aeb952b4bed0a9b617f66f6f4c1842'
+  version '56.0.1'
+  sha256 'd866debae8e9df3527582186a9ee9c7f602458348b8082e850ec6bf6e8bd13e3'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.