### PR TITLE
Update lingon-x to 5.2.4

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.2.3'
-  sha256 '0b4a6d69e3d080952cc4c642c2aaa1716ebb9cccbc7d6d33669dea446a4e68a8'
+  version '5.2.4'
+  sha256 'ab5e57426f231646531c88acb2d6baf879a7ee3070e1322e3fc8036cb84e5758'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '3b281f0fbc6c31f764c588c19c9044fe2308c7ae26911e63458461c83317fafc'
+          checkpoint: 'd928e8bb4cbef1a65641ee76cca5cab21e67ef2c628dd19e7d45df3aed586c53'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.