### PR TITLE
Update downie to 3.1,1730

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.1,1727'
-  sha256 'b89c33b2f2c70a405b31ca24022a892fac44b08a12df310f0d8c4adb1c3dc5f1'
+  version '3.1,1730'
+  sha256 'b3fd6c2d75b0fd6ca28481e918c90205fdb16502b5a208d188704e901c06691f'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: '80e13d8e97f50bd4c9927fe1f2425dcaae2af079080e28d623a1dd2ddb1d69a0'
+          checkpoint: 'ce0f33e7dba3c676d4c4517e897dbbdd31fe4f3b35a464cd396009142ec63a0a'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.