### PR TITLE
Update joplin to 0.10.39

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '0.10.38'
-  sha256 'c9f4f654249c77545795d8122cc0ff8774523b3cd5f4f788c1dc97f079928e9e'
+  version '0.10.39'
+  sha256 '96239c5bb7d9ededcbe32a622ba849838053eb4ffeeda031c714d54f0f743258'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '8180a76b1505137ddbf95faf15b6251bf58974b81326f7021a4a0265266bf9b4'
+          checkpoint: '560340963bf0596a23be00190ef81e3f60a61a01c6e2e492271fc50d76f5052a'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.