### PR TITLE
Update cyberduck to 6.3.2.27291

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,10 +1,10 @@
 cask 'cyberduck' do
-  version '6.3.1.27228'
-  sha256 'afcc3fa63da2228a743681c9a439091867c9143fa2cac66db8d1838db4b28985'
+  version '6.3.2.27291'
+  sha256 'c7e4b39e044f3a9ad555b5e19e0d16529c12af16c2db3d7739f276e89b628d61'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss',
-          checkpoint: '30eae1d80f71d716d7abd54696a077b7c799ed18318bfb2d7e1c9c7c0a4ff48d'
+          checkpoint: 'be68a9b362c2fe3776a1d0c2680a9966b7075605d04cb13d5f42e3ce9c932f53'
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.