### PR TITLE
Update subler to 1.4.6

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.4.5'
-  sha256 '243c6493710a615a209581b7b90baf35732620b374f7eef9565143aea591a3da'
+  version '1.4.6'
+  sha256 '110a961df24ee8c9b23a050e98dfb77452487bf6f133af2afbde6b1ebcf8a40e'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: '38e175567df9d64d16b2082b4a59752ccd3029bd1b127883a4ce464e6c5e96d2'
+          checkpoint: '86bbe748dffcab012b7f2c808afbf2c76d3d964d4aaa2b54460dfd39a0d1e5a2'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.