### PR TITLE
Update lilypond to 2.18.2-1

### DIFF
--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -1,11 +1,11 @@
 cask 'lilypond' do
-  version '2.19.80-1'
-  sha256 'c73e4f9856b94a3ea760634ec3829f87495d4c392af95889a584987fe6260a38'
+  version '2.18.2-1'
+  sha256 '0009bf234db6a598e30940ae9a5cef50ffe939992c9bf0c7959ecd9c0d179c80'
 
   # linuxaudio.org/lilypond was verified as official when first introduced to the cask
-  url "http://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
-  appcast 'http://download.linuxaudio.org/lilypond/binaries/darwin-x86/',
-          checkpoint: '6b3a7b7c7d81127925fefca4379633d42216ea7e9a58d588338a9fc7efe5c0a7'
+  url "https://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
+  appcast 'https://download.linuxaudio.org/lilypond/binaries/darwin-x86/',
+          checkpoint: 'dd561bea122f7be6e6314bd39f42d6325bd5cc701e1ea75ca5f866294da7f3c5'
   name 'LilyPond'
   homepage 'http://lilypond.org/'
 

--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -4,8 +4,8 @@ cask 'lilypond' do
 
   # linuxaudio.org/lilypond was verified as official when first introduced to the cask
   url "https://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
-  appcast 'https://download.linuxaudio.org/lilypond/binaries/darwin-x86/',
-          checkpoint: 'dd561bea122f7be6e6314bd39f42d6325bd5cc701e1ea75ca5f866294da7f3c5'
+  appcast 'http://lilypond.org/macos-x.html',
+          checkpoint: '1b49752034aa258d4ff5dedbb2c09d73910d1dfe004b30801664e3e7f5b95871'
   name 'LilyPond'
   homepage 'http://lilypond.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Reverts to current stable. http://lilypond.org/macos-x.html