### PR TITLE
Update whatpulse to 2.8.1

### DIFF
--- a/Casks/whatpulse.rb
+++ b/Casks/whatpulse.rb
@@ -2,7 +2,7 @@ cask 'whatpulse' do
   version '2.8.1'
   sha256 'e9b0435874830fb9de0ee32411e918e12a8651c0e676daf9eccf84946d8ffd6d'
 
-  url "http://amcdn.whatpulse.org/files/whatpulse-mac-#{version}.dmg"
+  url "https://static.whatpulse.org/files/whatpulse-mac-#{version}.dmg"
   name 'WhatPulse'
   homepage 'https://whatpulse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.