### PR TITLE
Update netron to 1.1.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.1.0'
-  sha256 '5d39ace56ada2949feec974d1c59c4f54ca90e102dd956a7dffdff3747bbac73'
+  version '1.1.1'
+  sha256 '45b101fd76c5d9c282f94dbfca30b49cb21d288b335a4356db0ff7f466b09eeb'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '938c1eab2cbc153ba44000d285eb0bd349e3eb0a7708622caaa8b1816a8bc98c'
+          checkpoint: 'd75c95a321100e6111802c46b2599c4053f8787b5d0a446ef4eef709034af1cd'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.