### PR TITLE
Update hipchat to 4.30.1-749

### DIFF
--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -1,6 +1,6 @@
 cask 'hipchat' do
-  version '4.30.1-748'
-  sha256 '95a8675c6a9d63c781fc23c9bfa35f247d12fa997a9e2ff53c738fe5ebf34c9a'
+  version '4.30.1-749'
+  sha256 'd690e6b4dd000dee0e849c73b202944b9bb2bcbe998b047b0ce113c1a4eec5ee'
 
   # amazonaws.com/downloads.hipchat.com/osx was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.hipchat.com/osx/HipChat-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.