### PR TITLE
Update betterzipql to 4.0.2

### DIFF
--- a/Casks/betterzipql.rb
+++ b/Casks/betterzipql.rb
@@ -1,8 +1,8 @@
 cask 'betterzipql' do
-  version :latest
-  sha256 :no_check
+  version '4.0.2'
+  sha256 '843f6a1c651ea07092a5828b55559f2eb11016f3793ad010b8d92b89ddd7187f'
 
-  url 'https://macitbetter.com/BetterZipQL.zip'
+  url 'https://macitbetter.com/dl/BetterZip-4.0.2.zip'
   name 'BetterZipQL'
   homepage 'https://macitbetter.com/BetterZip-Quick-Look-Generator/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.