### PR TITLE
Update dyn-updater to 5.4.2

### DIFF
--- a/Casks/dyn-updater.rb
+++ b/Casks/dyn-updater.rb
@@ -1,6 +1,6 @@
 cask 'dyn-updater' do
-  version :latest
-  sha256 :no_check
+  version '5.4.2'
+  sha256 '3fa46a028288ed7fee2cce7c10796b651af40b9293085ddf8aa4baad15bb6fd3'
 
   url 'http://cdn.dyn.com/dynupdater/DynUpdater.dmg'
   name 'Dyn Updater'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.