### PR TITLE
Update cmake to 3.10.1

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.10.0'
-  sha256 'dd8383916ee1559edd64ce890dc1838ad90474aa06c838378aa3309009cf4618'
+  version '3.10.1'
+  sha256 'd4926678fe1a348f620545c3664140737ae3001dd684df682e168fb0054602f5'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.