### PR TITLE
Update brave to 0.19.116

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.19.105'
-  sha256 '7fbc1f5a9fb26e8c98f6dfe82c457cb8302443e1e29dc7cca532226ca6b1fcff'
+  version '0.19.116'
+  sha256 'd81da83761ed45da15fe5de163aa45eb27657cdc756edfb07c95a2ae4dd9d4d7'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '7757fac2cf1e16998f6fff6bb810b584a9bcce3b39986e8fc462bc6985ba84c1'
+          checkpoint: '0dc35cfd5477c6fdea94756fdde0e83723bed8784957b89d69b7d0c7ba1f606d'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.