### PR TITLE
Update unity-download-assistant to 2017.2.1f1,94bf3f9e6b5e

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2017.2.0f3,46dda1414e51'
-  sha256 'b6ab2196d938b28e8e86739051f5cc9010c943fe318fbe50145a9b8d414838d2'
+  version '2017.2.1f1,94bf3f9e6b5e'
+  sha256 'ac07ff052f1ab81bb59d2233e6639777b33de33bd7ed79701d4e427b13db9c0c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   name 'Unity'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.