### PR TITLE
Update unity-ios-support-for-editor to 2017.2.1f1,94bf3f9e6b5e

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,8 +1,8 @@
 cask 'unity-ios-support-for-editor' do
-  version '2017.2.0f3,46dda1414e51'
-  sha256 'c3e2c8601e3624e23d897cc969e6c865d605450209ce047bd6cc75b5250e7170'
+  version '2017.2.1f1,94bf3f9e6b5e'
+  sha256 'da40632cea02d2342b5acf5123dd949f312b5a6fb71b22d3e7ecdfc4cbda9750'
 
-  url "http://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity iOS Build Support'
   homepage 'https://unity3d.com/unity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.