### PR TITLE
Update dingtalk to 4.2.9

### DIFF
--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,6 +1,6 @@
 cask 'dingtalk' do
-  version '4.0.201'
-  sha256 '3518ed9caba3f41788aadb3accf8f6b4bfbe20a18bec02c40fa11c20bfe68ddc'
+  version '4.2.9'
+  sha256 '248dfb32734e386424a88f4d92ef79312e5f65e9de786409a2b55de4e57d0d82'
 
   # download.alicdn.com/dingtalk-desktop was verified as official when first introduced to the cask
   url "https://download.alicdn.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download dingtalk` is error-free.
- [x] `brew cask style --fix dingtalk` reports no offenses.
- [x] The commit message includes the cask’s name and version.