### PR TITLE
Update patchwork to 3.8.6

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,10 +1,10 @@
 cask 'patchwork' do
-  version '3.7.1'
-  sha256 '9e0524cab2a74bf07e7f01950e5a00bd9e0a4d9834a55c177beeb3f95d94aac3'
+  version '3.8.6'
+  sha256 '14d0ca43f5fb94805d64dfb2a198054e8ddbc265d4951e0ae7f6b85a887fda46'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom',
-          checkpoint: '47a110913c5fa382e4f5f9ac7301eb939cdc8682abe859c3f3d639bd6ab42072'
+          checkpoint: '59837a5ffc3ed04be9a9af01aa907f0eb36d02e6156d0f44a67741a554b42397'
   name 'Patchwork'
   homepage 'https://github.com/ssbc/patchwork'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.