### PR TITLE
Update microsoft-teams to 1.0.00.34151

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '1.0.00.19452'
-  sha256 '4b13e4ac981e88fb8be520b357f29eb5ad1ef569c7a4d5381c6fe9b32ab91851'
+  version '1.0.00.34151'
+  sha256 '9fcef200e161a6f658310f98f22426eb405155404df4599540e8c14bc4931246'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: 'f7a0012359bba498872b4caa27701ad1612c3b81d2beb67930bded38984e8b4d'
+          checkpoint: '7226846d98dad3978958848f5040a18d021c5cc4ad58de5479b1195c4096ac8e'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.