### PR TITLE
Update astro to 2.0.27,3410

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '2.0.26,3342'
-  sha256 'c187a8f924f55d9fccc52c226ed94dcc13aef0c66f3fde9ac5d7458cb9da0cad'
+  version '2.0.27,3410'
+  sha256 'af6906dd7ee1866bc605ee8877a2f8116bc532c0db45b762d79965c44fc9ae63'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: 'c7e03c0336d519cd6be9a5ed7a58c6c736f5593a7da0dc6e5d71dabc181540ef'
+          checkpoint: '532a1152e0202a846bf3c9413218bd777779a36a723a555aea78477ff67818df'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.