### PR TITLE
Update freefilesync to 9.6

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,8 +1,8 @@
 cask 'freefilesync' do
-  version '9.5'
-  sha256 'e53c7889b424fc8bee0ea4a23788bde998b4886a63a705614fb12b1cf5d9b2d3'
+  version '9.6'
+  sha256 '899bc5db4760494f159a43dd1c6545f99a52232cd5ad802da69b96482a4c6653'
 
-  url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
+  url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake
   name 'FreeFileSync'
   homepage 'https://www.freefilesync.org/'

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -2,7 +2,7 @@ cask 'freefilesync' do
   version '9.6'
   sha256 '899bc5db4760494f159a43dd1c6545f99a52232cd5ad802da69b96482a4c6653'
 
-  url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
+  url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake
   name 'FreeFileSync'
   homepage 'https://www.freefilesync.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.