### PR TITLE
Update powerphotos to 1.3.4

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,13 +8,13 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.3.3'
-    sha256 'be37361f6111422adc84d4ef7cff91108151670a4c4fdb95e7056c0c8363275e'
+    version '1.3.4'
+    sha256 'f2ba90528403737ba77e55a0527a0f9d946928cfde6382df84582eea9ed4924c'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: '116ac0eb996f211271b97bfd35f06fd2b36f0c5ff7713cb6f8a3b3add2396d7c'
+          checkpoint: '7af8bf476d184b74c14047fe844aa83859556a8c46466bbe7b535faa78057d1a'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.