### PR TITLE
Update paparazzi to 1.0b7

### DIFF
--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -1,10 +1,10 @@
 cask 'paparazzi' do
-  version '1.0b6'
-  sha256 'f5362e23ba840247a03dea426e3d3f4fdf9b3f832cf3cf4e27498564da7af0c9'
+  version '1.0b7'
+  sha256 '1a61891c7ae8214c84b4b193f3a464c70d4c772e2d49af78a1ca74769078bbd2'
 
   url "https://derailer.org/paparazzi/Paparazzi!%20#{version}.dmg"
   appcast 'https://derailer.org/paparazzi/appcast/',
-          checkpoint: 'ca001383f08caeaa53ecf37407f5ec589aecd2dc1a2cfd705bffbaf9416a3628'
+          checkpoint: 'e7b9cae1cb6d300785d1edba04954abafec7af0043792e74f2236e5d19cca494'
   name 'Paparazzi!'
   homepage 'https://derailer.org/paparazzi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.