### PR TITLE
Update netron to 1.1.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.1.1'
-  sha256 '45b101fd76c5d9c282f94dbfca30b49cb21d288b335a4356db0ff7f466b09eeb'
+  version '1.1.2'
+  sha256 '6fe40a030853f0a48a125b49194e7c37805ae12d616d8e55956788e509acd908'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'd75c95a321100e6111802c46b2599c4053f8787b5d0a446ef4eef709034af1cd'
+          checkpoint: 'cb58de8ee905a849df80ba7d1a8aabe04cc52aa5378a99030056696ac347a99e'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.