### PR TITLE
Update 4k-stogram to 2.6.2.1467

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,12 +1,14 @@
 cask '4k-stogram' do
-  version '2.6.2'
+  version '2.6.2.1467'
   sha256 '1f053da82ad48f787e84a82d48ea639ffdf2c624ff5fb88c8724361616f72654'
 
-  url "https://dl.4kdownload.com/app/4kstogram_#{version}.dmg"
+  url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: 'd8308646431af31e59db7ed294e4449a4f4af524c29bb0b4bff39a56a65cad3a'
+          checkpoint: 'bcc9ec5479e3d7db1f10175083eb4c73dd6590b8bfe3cab26f6d78efbbc4c583'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 
   app '4K Stogram.app'
+
+  zap trash: '~/Pictures/4K Stogram'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.