### PR TITLE
Update apache-couchdb to 2.1.1

### DIFF
--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -1,11 +1,11 @@
 cask 'apache-couchdb' do
-  version '2.1.0'
-  sha256 '54682d6f2ca9771ec967f301d414855634941200b39fc143746f9dba59b01479'
+  version '2.1.1'
+  sha256 '31f780432af0d9cdbe942beb56e181de9f0e1fb69535d6e5af957fd4ccb9e147'
 
   # bintray.com/apache/couchdb was verified as official when first introduced to the cask
   url "https://dl.bintray.com/apache/couchdb/mac/#{version}/Apache-CouchDB-#{version}.zip"
   appcast 'https://github.com/apache/couchdb/releases.atom',
-          checkpoint: '37db2b080b18e2fcc03bb1df8596e05cf32f5c3551025aa9b71d752b3faa21a1'
+          checkpoint: '9b6339769352a4b5e9396691b84174c0b8f0e92b361fa8deca33aaa558f638d9'
   name 'Apache CouchDB'
   homepage 'https://couchdb.apache.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.