### PR TITLE
Update jaxx and exodus with zap info

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -10,4 +10,11 @@ cask 'exodus' do
   homepage 'https://www.exodus.io/'
 
   app 'Exodus.app'
+
+  zap trash: [
+               '~/Library/Application Support/Exodus',
+               '~/Library/Preferences/com.electron.exodus.helper.plist',
+               '~/Library/Preferences/com.electron.exodus.plist',
+               '~/Library/Saved Application State/com.electron.exodus.savedState',
+             ]
 end

--- a/Casks/jaxx.rb
+++ b/Casks/jaxx.rb
@@ -10,4 +10,9 @@ cask 'jaxx' do
   homepage 'https://jaxx.io/'
 
   app 'Jaxx.app'
+
+  zap trash: [
+               '~/Library/Application Support/jaxx',
+               '~/Library/Logs/jaxx',
+             ]
 end


### PR DESCRIPTION
This PR adds zap info for the casks `exodus` and `jaxx`.

Tested locally with `brew cask zap <name> && brew cask install <name>`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.