### PR TITLE
Update jaxx to 1.3.9

### DIFF
--- a/Casks/jaxx.rb
+++ b/Casks/jaxx.rb
@@ -1,11 +1,11 @@
 cask 'jaxx' do
-  version '1.3.7'
-  sha256 '5a71960a98cf4f09ce1e37d7d50a4d1341210253dc714553d7f2d8180e4ee68a'
+  version '1.3.9'
+  sha256 '0e1756d95c68e7d44e4faeba916ba27608584692dd2f67f89aa19d73c5109e05'
 
   # github.com/Jaxx-io/Jaxx was verified as official when first introduced to the cask
   url "https://github.com/Jaxx-io/Jaxx/releases/download/v#{version}/Jaxx-#{version}.dmg"
   appcast 'https://github.com/Jaxx-io/Jaxx/releases.atom',
-          checkpoint: '071a1ed39d4940ed96347ca4aa645b1ee199f4af2736b1cda367536949340358'
+          checkpoint: '2670f07ef7e62cf6752333fbcef16a6be192ff340099eb64a071582fe86470b4'
   name 'Jaxx Blockchain Wallet'
   homepage 'https://jaxx.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.