### PR TITLE
Update script-debugger to 6.0.7-6A217

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,11 +1,11 @@
 cask 'script-debugger' do
-  version '6.0.5-6A205'
-  sha256 '30955f15be8c2502d49e9002065e0aa44260fb4b38616f0d498cbf00848cbb6a'
+  version '6.0.7-6A217'
+  sha256 'b4c234e77dcf6b04427888eabaffaceefcbf99030729f4c6cfb45038912aed6f'
 
   # s3.amazonaws.com/latenightsw.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg"
-  appcast 'https://river.yodns.com/~alldritt/versions/com.latenightsw.ScriptDebugger6.php',
-          checkpoint: 'ac33f1a22a8106f2a990271bb45dd8f0931fd8046039a87b9903f5e12eb9d932'
+  appcast 'https://www.latenightsw.com/versions/com.latenightsw.ScriptDebugger6.php',
+          checkpoint: '36f8c4638dd2281f170026d8c3fc5154b1ce7d8c9de33798097d5312a25ed56b'
   name 'Script Debugger'
   homepage 'http://latenightsw.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.