### PR TITLE
Update julia to 0.6.2

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,8 +1,8 @@
 cask 'julia' do
-  version '0.6.1'
-  sha256 '600c981780e5c4248e826db8a2e21f73063f4bc775fc66bb482235627f15993a'
+  version '0.6.2'
+  sha256 'caeb50ed975ebc9ccd154eba9e8fbc04098a2a532042a573ac31ecef5b8fada7'
 
-  url "https://julialang-s3.julialang.org/bin/osx/x64/#{version.major_minor}/julia-#{version}-osx10.7+.dmg"
+  url "https://julialang-s3.julialang.org/bin/mac/x64/#{version.major_minor}/julia-#{version}-mac64.dmg"
   name 'Julia'
   homepage 'https://julialang.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

The URL seems to have changed slightly- #35714 may have foreshadowed it. Despite the URL for 0.6.0 containing 10.7+, evidently it was 10.8+ only. The new URL seems to reflect this better. See https://julialang.org/downloads/.
