### PR TITLE
Update multimc to 0.5.1-908

### DIFF
--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -6,5 +6,5 @@ cask 'multimc' do
   name 'Multi MC'
   homepage 'https://multimc.org/'
 
-  app 'mmc-stable-osx64-0.5.1-908/MultiMC.app'
+  app "mmc-stable-osx64-#{version}/MultiMC.app"
 end

--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -1,10 +1,10 @@
 cask 'multimc' do
-  version :latest
-  sha256 :no_check
+  version '0.5.1-908'
+  sha256 'cf963b590b1be1be57fde76cc1b5a2bd5af99c041b34f82549ed3efe4868eb4e'
 
   url 'https://files.multimc.org/downloads/mmc-stable-osx64.tar.gz'
   name 'Multi MC'
   homepage 'https://multimc.org/'
 
-  app 'MultiMC/MultiMC.app'
+  app 'mmc-stable-osx64-0.5.1-908/MultiMC.app'
 end

--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -2,7 +2,10 @@ cask 'multimc' do
   version '0.5.1-908'
   sha256 'cf963b590b1be1be57fde76cc1b5a2bd5af99c041b34f82549ed3efe4868eb4e'
 
-  url 'https://files.multimc.org/downloads/mmc-stable-osx64.tar.gz'
+  # github.com/MultiMC/MultiMC5 was verified as official when first introduced to the cask
+  url "https://github.com/MultiMC/MultiMC5/releases/download/#{version.major_minor_patch}/mmc-stable-osx64-#{version}.tar.gz"
+  appcast 'https://github.com/MultiMC/MultiMC5/releases.atom',
+          checkpoint: 'd7e8647e53c6dcb5d1ce8b9850641a9928e5ed1b44e72d909a78077882352a5e'
   name 'Multi MC'
   homepage 'https://multimc.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.