### PR TITLE
Update netron to 1.1.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.1.2'
-  sha256 '6fe40a030853f0a48a125b49194e7c37805ae12d616d8e55956788e509acd908'
+  version '1.1.3'
+  sha256 'ca777824cb49a8bf8164f5ad5a7a43226e0b88e0d4a17ca7e800c4ad8bde310c'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'cb58de8ee905a849df80ba7d1a8aabe04cc52aa5378a99030056696ac347a99e'
+          checkpoint: 'afaf68e2c328536a5a65ecba5492671c0beb08cffa114cd4ba5d130ddb85e0f2'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.