### PR TITLE
Update tortoisehg to 4.4.1

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.3.1'
-  sha256 '7ef1964adfc50eb4c9614c09058eb15f99af99be42f6a782447339ba4896a4ac'
+  version '4.4.1'
+  sha256 '63d454bd54f83f9f9dd4e30caa984834700f56fab7618c701362d1590834b986'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.