### PR TITLE
Update get-backup-pro to 3.4.2

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.4.1'
-  sha256 'cc45cf7299bc1e6c7de4011785a72565227bb84e36d966acf664757b866ed278'
+  version '3.4.2'
+  sha256 '01d7e4bd623ed7b079ec8bf0c38a418675e50de8396dfc3a453270c7a33dceeb'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: 'b8c319ce4e8a6eeafb05ca207d20248372a4a2570b106e95b4f495dd592f3b91'
+          checkpoint: 'd7762347d2ff3c6995fbf00ad36c7409126faad67706ccb17911bb6a55eeebaa'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.