### PR TITLE
Update kitty to 0.6.0

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,10 +1,10 @@
 cask 'kitty' do
-  version '0.5.1'
-  sha256 'a34c3e08717129315d89382afc01bd6dc9b0b9853f5bceff81cbcf05590c18f9'
+  version '0.6.0'
+  sha256 'd729d64afa0b1cd5246026033c335368787a685124317f27e52064d4e0afee08'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom',
-          checkpoint: 'e9397b9547432552e13e9d9d942cb74f17cb49c37147fa9738ad27cb3cf1f1d9'
+          checkpoint: '8cb124b70b7fb15881fee47cba6f1c60bd438449e358e8a67a5da772381c0015'
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
