### PR TITLE
Update natron to 2.3.4

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,11 +1,11 @@
 cask 'natron' do
-  version '2.3.3'
-  sha256 '3efe76aa82872b2bdd80ec96746151d3997c9662967d008d22a010eff241e483'
+  version '2.3.4'
+  sha256 '8c7febdc66cc651777ad66a9a462bf170990bf3a452c315fd751206dca803972'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'
   appcast 'https://github.com/MrKepzie/Natron/releases.atom',
-          checkpoint: '03c0144b1f5a17998020f8c05dbf13e9d8b9d9db322576cb9746c5bf183db2aa'
+          checkpoint: 'b891b1da77199c0f4e027c17053cf1dc506616c97bf88b851eaa154a4ff90db2'
   name 'Natron'
   homepage 'https://natron.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.