### PR TITLE
Update decrediton to 1.1.2

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,10 +1,10 @@
 cask 'decrediton' do
-  version '1.1.1'
-  sha256 '1345e9764ee33be1aea3ed16fcdcd8ab02871341c451574f5b42c56b4e796df3'
+  version '1.1.2'
+  sha256 'b251fdb8f8db0a54866f2c41275cc7daa4a0fdc08e02e252b257cfc41b2b3221'
 
-  url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-#{version}.dmg"
+  url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom',
-          checkpoint: '40be85f45c399e503576299dbd46f5345d9737b01ca16b64501be4e80abfd2e4'
+          checkpoint: '24946ce113ef6ae1e621ae495c228035e4b777005ac92fc4a41e9d1fdf0eea78'
   name 'Decrediton'
   homepage 'https://github.com/decred/decrediton'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.