### PR TITLE
Update brave to 0.19.121

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.19.116'
-  sha256 'd81da83761ed45da15fe5de163aa45eb27657cdc756edfb07c95a2ae4dd9d4d7'
+  version '0.19.121'
+  sha256 '69c5f59edd672f070c044387fb2a831b3b1e79f1a23fb96e62a25791f41c419d'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '0dc35cfd5477c6fdea94756fdde0e83723bed8784957b89d69b7d0c7ba1f606d'
+          checkpoint: '22c43af2ac2214cc5a6404c75bd38be6cf96f666a17141fbeb1bbdac126e6a93'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.