### PR TITLE
Update wavesurfer to 1.8.8p5

### DIFF
--- a/Casks/wavesurfer.rb
+++ b/Casks/wavesurfer.rb
@@ -1,10 +1,10 @@
 cask 'wavesurfer' do
   version '1.8.8p5'
-  sha256 '961fb77a12d1de94f38b1af896ddd017f65f0bc13f335862cf6392631006bd9a'
+  sha256 '798f0eb2c542742892d1541554ff58245040b49c450ba93fbdcaacca129e8dca'
 
   url "https://downloads.sourceforge.net/wavesurfer/wavesurfer-#{version}-osx-i386.dmg"
   appcast 'https://sourceforge.net/projects/wavesurfer/rss',
-          checkpoint: '620ae6885b402e925edfd9901f176336d056697bf9dc187da55cdb5047cc91bf'
+          checkpoint: '2765fb7d69157d742529e0fdf2adbec8648aecf56ad1b30bd57c33e555001f68'
   name 'WaveSurfer'
   homepage 'https://sourceforge.net/projects/wavesurfer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.