### PR TITLE
Update stretchly to 0.13.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.12.0'
-  sha256 'a73906fd189caa81913907d081cac7425d191639b75c59ec105f39f7c25648a0'
+  version '0.13.0'
+  sha256 'c2923f83bb340f1f948f4ebda2c1d724903a4cd1c275a5133206e4554908dec6'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: 'c7411c3ed3ca7ceb1307611a10171ae4906542cd7ab278f2606aaf37740f7662'
+          checkpoint: '039589c498b163116d42861f770e9db379e3137c4bb06c7cdefe83bc2c7d66af'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.