### PR TITLE
Update zotero to 5.0.33

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.32'
-  sha256 '88153f98a52d3702c0f195415091aa5429678412dbe85075dd61edc07cc8959c'
+  version '5.0.33'
+  sha256 '0dad0bb44855d8dcfedb78d254f15c8dcf69dbb38a80aa186e35d53e931af674'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '6c54ed5945a2bad7a6206000de19c3575851e061138f5a833a2eef3cfd7ae02a'
+          checkpoint: 'c513cf6f253c0dfe3c7e99bed72805cb0e3afccf37798f08d8bb499f0f5e9ad5'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.