### PR TITLE
Add free TAL audio plugins

### DIFF
--- a/Casks/tal-noisemaker.rb
+++ b/Casks/tal-noisemaker.rb
@@ -1,0 +1,16 @@
+cask 'tal-noisemaker' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://tal-software.com//downloads/plugins/TAL-NoiseMaker-installer.pkg'
+  name 'TAL-NoiseMaker'
+  homepage 'https://tal-software.com/products/tal-noisemaker'
+
+  pkg 'TAL-NoiseMaker-installer.pkg'
+
+  uninstall pkgutil: [
+                       'com.talsoftware.pkg.TAL-NoiseMaker-AAX',
+                       'com.talsoftware.pkg.TAL-NoiseMaker-AU',
+                       'com.talsoftware.pkg.TAL-NoiseMaker-VST',
+                     ]
+end

--- a/Casks/tal-reverb-2.rb
+++ b/Casks/tal-reverb-2.rb
@@ -1,0 +1,16 @@
+cask 'tal-reverb-2' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://tal-software.com/downloads/plugins/TAL-Reverb-2-installer.pkg'
+  name 'TAL-Reverb-2'
+  homepage 'https://tal-software.com/products/tal-reverb'
+
+  pkg 'TAL-Reverb-2-installer.pkg'
+
+  uninstall pkgutil: [
+                       'com.talsoftware.pkg.TAL-Reverb-4-AAX',
+                       'com.talsoftware.pkg.TAL-Reverb-4-AU',
+                       'com.talsoftware.pkg.TAL-Reverb-4-VST',
+                     ]
+end

--- a/Casks/tal-reverb-3.rb
+++ b/Casks/tal-reverb-3.rb
@@ -1,0 +1,16 @@
+cask 'tal-reverb-3' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://tal-software.com/downloads/plugins/TAL-Reverb-3-installer.pkg'
+  name 'TAL-Reverb-3'
+  homepage 'https://tal-software.com/products/tal-reverb'
+
+  pkg 'TAL-Reverb-2-installer.pkg'
+
+  uninstall pkgutil: [
+                       'com.talsoftware.pkg.TAL-Reverb-4-AAX',
+                       'com.talsoftware.pkg.TAL-Reverb-4-AU',
+                       'com.talsoftware.pkg.TAL-Reverb-4-VST',
+                     ]
+end

--- a/Casks/tal-reverb-4.rb
+++ b/Casks/tal-reverb-4.rb
@@ -1,0 +1,16 @@
+cask 'tal-reverb-4' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://tal-software.com/downloads/plugins/TAL-Reverb-4-installer.pkg'
+  name 'TAL-Reverb-4'
+  homepage 'https://tal-software.com/products/tal-reverb-4'
+
+  pkg 'TAL-Reverb-4-installer.pkg'
+
+  uninstall pkgutil: [
+                       'com.talsoftware.pkg.TAL-Reverb-4-AAX',
+                       'com.talsoftware.pkg.TAL-Reverb-4-AU',
+                       'com.talsoftware.pkg.TAL-Reverb-4-VST',
+                     ]
+end

--- a/Casks/tal-vocoder.rb
+++ b/Casks/tal-vocoder.rb
@@ -1,0 +1,16 @@
+cask 'tal-vocoder' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://tal-software.com/downloads/plugins/TAL-Vocoder-2-installer.pkg'
+  name 'TAL-Vocoder'
+  homepage 'https://tal-software.com/products/tal-vocoder'
+
+  pkg 'TAL-Vocoder-2-installer.pkg'
+
+  uninstall pkgutil: [
+                       'com.talsoftware.pkg.TAL-Vocoder-2-AAX',
+                       'com.talsoftware.pkg.TAL-Vocoder-2-AU',
+                       'com.talsoftware.pkg.TAL-Vocoder-2-VST',
+                     ]
+end


### PR DESCRIPTION
- [x] ``brew cask audit --download {{cask_file}}`` is error-free.
- [x] ``brew cask style --fix {{cask_file}}`` left no offenses.
- [ ] The commit message includes the cask’s name and version.

The added casks are:
- ``tal-reverb-2``
- ``tal-reverb-3``
- ``tal-reverb-4``
- ``tal-vocoder``
- ``tal-noisemaker``