### PR TITLE
Update hab to 0.51.0-20171218220542

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.50.3-20171201233208'
-  sha256 '5311d0d80df04179e6dd98a5caa6eff6e9580a01eec9a0904d6836d03fc47f5a'
+  version '0.51.0-20171218220542'
+  sha256 'aece1e1e503b039a3180052763698157f3e981c0a8da9a867415ff83d6c630ae'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'c0be8b9df2ae5bf0f05f0a8c70aeacb4f5f4d21060af4d1ed46d042fee5fcf86'
+          checkpoint: '81deb90de6c8ce04568fbc1937aedaa1456c3b8ec2f121a57b5e490beb6752e3'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.