### PR TITLE
Update liteicon to 3.8.2

### DIFF
--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -1,6 +1,11 @@
 cask 'liteicon' do
-  version '3.8.2'
-  sha256 'ede528b762f4f979b488973db002442260c6eda36d4875655887956e62576e62'
+  if MacOS.version <= :sierra
+    version '3.7.1'
+    sha256 'b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432'
+  else
+    version '3.8.2'
+    sha256 'ede528b762f4f979b488973db002442260c6eda36d4875655887956e62576e62'
+  end
 
   url "https://www.freemacsoft.net/downloads/LiteIcon_#{version}.zip"
   appcast 'https://freemacsoft.net/liteicon/updates.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #42144.