### PR TITLE
Update graphql-playground to 1.3.10

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.3.7'
-  sha256 '59319011c690eb724c57a2b4618068246534977331d2a0bae9eda3643b4edbb1'
+  version '1.3.10'
+  sha256 '46b0ce4ecad80b33ba9b651605874ae56efc273395b38cc1fb687a2d8cfef095'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/playground-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: 'd88ff50212c417c51a62be4169a28f29324d9ea5a134fe98ac7603599a2f228b'
+          checkpoint: 'd11c2858f808c0f84fcc0be20b3177e057187e17772cb123eb3fbb615fade47c'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.