### PR TITLE
Update paparazzi to 1.0b8

### DIFF
--- a/Casks/paparazzi.rb
+++ b/Casks/paparazzi.rb
@@ -1,10 +1,10 @@
 cask 'paparazzi' do
-  version '1.0b7'
-  sha256 '1a61891c7ae8214c84b4b193f3a464c70d4c772e2d49af78a1ca74769078bbd2'
+  version '1.0b8'
+  sha256 '2abe968b1b7d96b9faeeeee3cae7e17dd892c9619eaf9a312a2e3b26d6c9cf1e'
 
   url "https://derailer.org/paparazzi/Paparazzi!%20#{version}.dmg"
   appcast 'https://derailer.org/paparazzi/appcast/',
-          checkpoint: 'e7b9cae1cb6d300785d1edba04954abafec7af0043792e74f2236e5d19cca494'
+          checkpoint: 'e82fbce2d463f80b46dec1f37af447700ca51b20b3482f944a9fff3a48197009'
   name 'Paparazzi!'
   homepage 'https://derailer.org/paparazzi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.