### PR TITLE
Update now to 3.8.5

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.4'
-  sha256 'aa8dc7795cb143700c859ccf37e59d830b463aa50616eb9a00294e209716d1b7'
+  version '3.8.5'
+  sha256 'ee9f733ab12283b6d745be51747d271f4c7daecda6da3c12653489f207d57be6'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'b737ae9de26a35c2ac96a53860749a5ebdf0807e517b7814b1f1b48e6807f897'
+          checkpoint: '862c29c137bd9374e1c89f6d8c5bbd2327c3c137398664eb8da6ef254f4a6bc6'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.