### PR TITLE
Update scrivener to 3.0.1

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,11 +1,11 @@
 cask 'scrivener' do
-  version '3.0-75'
-  sha256 '3cd33159b2d03a1e5b60a44f6d9e1ae5847c01fd5e9bc31c99e224b9d0b98950'
+  version '3.0.1'
+  sha256 '4524ed2816bee4a11b336e6a066792c8d12cef5efb484111d26edf4f606cf900'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
   appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
-          checkpoint: '9e63b07d3337a6bb1366d0b04adb569ffb6e3826b72bf07caf52d6fc183a4c37'
+          checkpoint: '91069b462bee4454285dada0ee550a6712d317ce2101d12b2f72403fb24e939e'
   name 'Scrivener'
   homepage 'https://literatureandlatte.com/scrivener.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.