### PR TITLE
Update tankix to 10223

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '10116'
-  sha256 'f45389c6ef9112cfcef4e100c4f38bdd64ff2afc0fd99ac642ce49dab722637b'
+  version '10223'
+  sha256 '7f96002d54bacb436ab8ef2efb2f19d1ec0f9b3212bfdfdc181b9aadcb4c9be0'
 
   url "https://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.