### PR TITLE
Add `pt-PT` language to Thunderbird 52.5.0

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -52,6 +52,11 @@ cask 'thunderbird' do
   end
 
   language 'pt' do
+    sha256 'ac77e37151fb35bf90c92330950a8b67b4d789b28d2df76d9fef04d68c191763'
+    'pt-PT'
+  end
+
+  language 'pt-BR' do
     sha256 '6318bf0448a6a81b685b88fb7af8d2af4e309ae7f3527dffe1f15be07b805230'
     'pt-BR'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

I don't have enough bandwidth to run the audit.
Also, my original commit didn't mention the version. I did an amend. Hope I didn't screw it up.
