### PR TITLE
Update webrecorder-player to 1.0.8

### DIFF
--- a/Casks/webrecorder-player.rb
+++ b/Casks/webrecorder-player.rb
@@ -1,10 +1,10 @@
 cask 'webrecorder-player' do
-  version '1.0.5'
-  sha256 '43b6a05068d867b39e2c7b596485c611b43ddf7afbe0f13109c5a1e93eeffcc2'
+  version '1.0.8'
+  sha256 '0bf5a72be2683995530b531114fc95338a798de4e49a9bebcfe839f2ea199ced'
 
-  url "https://github.com/webrecorder/webrecorderplayer-electron/releases/download/v#{version}/webrecorderplayer-electron-#{version}.dmg"
+  url "https://github.com/webrecorder/webrecorderplayer-electron/releases/download/v#{version}/webrecorderplayer-electron-osx-#{version}.dmg"
   appcast 'https://github.com/webrecorder/webrecorderplayer-electron/releases.atom',
-          checkpoint: '4b1bd7d5071576486bbbacf42051b1ffb59cb3f55c15182b885b835da7222e0d'
+          checkpoint: 'c1090fe8bed42cd599b321694ccb14962a370b8c79caad18006ab722f14cc84e'
   name 'Webrecorder Player'
   homepage 'https://github.com/webrecorder/webrecorderplayer-electron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.