### PR TITLE
Update zoomus to version 4.1.17379.1218

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
   version '4.1.17379.1218'
-  sha256 '111640bbf99308aa57b60b49ad4f62a9a20a3c44b71870a7856e901e41690b72'
+  sha256 '68d4a9b58ee523f66fcbe3e8d6ea6443adf32819a33861e89d60b701ef16580d'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   name 'Zoom.us'

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,5 +1,5 @@
 cask 'zoomus' do
-  version '4.1.11049.1024'
+  version '4.1.17379.1218'
   sha256 '111640bbf99308aa57b60b49ad4f62a9a20a3c44b71870a7856e901e41690b72'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"


### PR DESCRIPTION
Just updated the version to the newest published on their website

Ref: [Zoom download page](https://zoom.us/download)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
