### PR TITLE
Update downie to 3.1.2,1735

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.1,1730'
-  sha256 'b3fd6c2d75b0fd6ca28481e918c90205fdb16502b5a208d188704e901c06691f'
+  version '3.1,1735'
+  sha256 '0213c05c9878d72645fed228c955f739691ec0d1a52f1dec16ea94ed82edae34'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: 'ce0f33e7dba3c676d4c4517e897dbbdd31fe4f3b35a464cd396009142ec63a0a'
+          checkpoint: 'c6db67fec97f3251d9aa552e6974a370d4116659c49000973fd314bc5d8e0693'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 

--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,5 +1,5 @@
 cask 'downie' do
-  version '3.1,1735'
+  version '3.1.2,1735'
   sha256 '0213c05c9878d72645fed228c955f739691ec0d1a52f1dec16ea94ed82edae34'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.