### PR TITLE
Update netron to 1.1.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.1.4'
-  sha256 'e7f6ed6f6e276c6145375b1d2167e6284817e7c3d64f21e8a4956ff1dc6ff031'
+  version '1.1.5'
+  sha256 '43800d78d708ae6bea338bcd40f77048beef6723cb7417510816a2853bea9d28'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '1663dbf622200c976f92cd036b229bedbd47c7f46842b5dacdcc94f7ac81f7d6'
+          checkpoint: '2a7d1adfdc69303749ab1de19341e1a2532f22beb1c386aed2a74db4a66d5e07'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.