### PR TITLE
Update dotnet-sdk to 2.1.3

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk' do
-  version '2.1.2'
-  sha256 '822201fa6ef0c053a97a805b6d66abba2304a2b9c6db9228d9a7f0818ebad252'
+  version '2.1.3'
+  sha256 '589fc8292443a23ebf5711cecbe29c26cff79cadd226f9196fb14822a4a8f378'
 
-  url "https://download.microsoft.com/download/5/D/F/5DF4B836-7DFD-4CCF-AC96-101E2A4C7421/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.microsoft.com/download/2/9/3/293BC432-348C-4D1C-B628-5AC8AB7FA162/dotnet-sdk-#{version}-osx-x64.pkg"
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.