### PR TITLE
Update vimr to 0.20.3-255

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.20.2-254'
-  sha256 '24521fd7c512e045b8279400f2115694769d48254bf4e35fe085f714f79a1b04'
+  version '0.20.3-255'
+  sha256 '695cf4c0c50e6848e5eefdc7e794d4cfef339fed18615f60c882714e263f2fd3'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'cea2cdb96abae94d5dcd9559c0840656ce0c8d4af73c019c79fb7b0b8b8a8538'
+          checkpoint: '3f272052bc4d53e90dc35eada12918d2191ce1ca0ff6f64f37dd7e984bbf180c'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.