### PR TITLE
Update atext to 2.22

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,10 +1,10 @@
 cask 'atext' do
-  version '2.21'
-  sha256 '8ef2fc8f136f15ab4c1218a74097a9a83407ede3f79e6e616eade920bfff02ba'
+  version '2.22'
+  sha256 '316a86e63e8f6cd87a545185a0aa7033ce426ca707d391d9dc18d69ec8a3461d'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml',
-          checkpoint: '9d96d77e7584acfe70ee83f0d00342fbe0b9d0b39e23685f9c92001bbd12f983'
+          checkpoint: 'dcceb0392ef64634fd7aae8cbfd9813e8cbd0bc0955ee3959e7f15826274ed12'
   name 'aText'
   homepage 'https://www.trankynam.com/atext/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.