### PR TITLE
Update gog-galaxy to 1.2.32.21

### DIFF
--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -1,6 +1,6 @@
 cask 'gog-galaxy' do
-  version '1.2.31.8'
-  sha256 '325fa53d340e3bf05da9f7448c4c6070d893e1074da63cb21d27e962fc63ee54'
+  version '1.2.32.21'
+  sha256 '0687b8b973f7fdb17c930e639d93de0cd756f9aef78204442192241709fb9c64'
 
   url "https://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
   name 'GOG Galaxy Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.