### PR TITLE
Update dash-dash to 0.12.2.2

### DIFF
--- a/Casks/dash-dash.rb
+++ b/Casks/dash-dash.rb
@@ -1,11 +1,11 @@
 cask 'dash-dash' do
-  version '0.12.2.1'
-  sha256 'dd6363895c6b15dcff4aec873b19d7fcee857e8de4f5331a85693d92c039d19f'
+  version '0.12.2.2'
+  sha256 '53fe3ec4d0572d906c7ef0f47deaa3c1c18ba57ba3f2121eb18d836f1201aa1c'
 
   # github.com/dashpay/dash was verified as official when first introduced to the cask
   url "https://github.com/dashpay/dash/releases/download/v#{version}/dashcore-#{version}-osx.dmg"
   appcast 'https://github.com/dashpay/dash/releases.atom',
-          checkpoint: '15ad74f7f67d923ed4989824d5fc6a39171398708d107bf8f812d854d3e6d078'
+          checkpoint: 'ed223b7aca79e10abb51ee21e3e8232962dc63072cfeec4a9b41ae56ff1d34d0'
   name 'Dash'
   homepage 'https://www.dash.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.