### PR TITLE
Update transmission-remote-gui to 5.13.0

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,10 +1,10 @@
 cask 'transmission-remote-gui' do
-  version '5.12.0'
-  sha256 'af0fd073fe266d88bb0c6e7c4f3852d54ffc3f591616977ff97cce2bf4ca4037'
+  version '5.13.0'
+  sha256 '6e91ab6e9a8c8d704fb38bdb6b37647f05635a2d75dd3a3738d5ddf5097fb712'
 
   url "https://github.com/transmission-remote-gui/transgui/releases/download/v#{version}/transgui-#{version}.dmg"
   appcast 'https://github.com/transmission-remote-gui/transgui/releases.atom',
-          checkpoint: '08e0f3ecf8ab4840650e1a10a4fbf9f5fecd7583a2ff6c7ce8d9334b83eff5f8'
+          checkpoint: '07003f14d0c8962865be85459fe5acf625175db1a69c3ca1f27d851d186bf09c'
   name 'Transmission Remote GUI'
   homepage 'https://github.com/transmission-remote-gui/transgui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.