### PR TITLE
Update sparkleshare to 2.0.1

### DIFF
--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -1,11 +1,11 @@
 cask 'sparkleshare' do
-  version '1.5'
-  sha256 '5000d3484e864c2ca94fb9e3ed40cdcb5d23664fe5708f351b73b8abe6d34f2a'
+  version '2.0.1'
+  sha256 'e8c393e380cd26bcf9dd28f02c74d5532b69a98723de8b85bfdf9c13972f826c'
 
-  # bitbucket.org/hbons/sparkleshare was verified as official when first introduced to the cask
-  url "https://bitbucket.org/hbons/sparkleshare/downloads/sparkleshare-mac-#{version}.zip"
+  # github.com/hbons/SparkleShare was verified as official when first introduced to the cask
+  url "https://github.com/hbons/SparkleShare/releases/download/#{version}/sparkleshare-mac-#{version}.zip"
   appcast 'https://github.com/hbons/SparkleShare/releases.atom',
-          checkpoint: '65e48f97e46f2c031347253bb72e60e23a4fe5ba7e9f874b536f4ddf49b994e6'
+          checkpoint: 'c89ad2c18fd529f96f7822eda90b3ac8f7aac25d137ebb736191f22d8e3ddf93'
   name 'SparkleShare'
   homepage 'https://sparkleshare.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.