### PR TITLE
Update paintbrush to 2.2

### DIFF
--- a/Casks/paintbrush.rb
+++ b/Casks/paintbrush.rb
@@ -1,10 +1,10 @@
 cask 'paintbrush' do
-  version '2.1.2'
-  sha256 '3bf18908a191b65efec2a15af0c5f5e95f76e1ec00d71063e235a146b9f6c417'
+  version '2.2'
+  sha256 '8cf110b7d9063f738dbcbbc3122e1125275adc06496eea2dbfdd79e2e916115f'
 
   url "https://downloads.sourceforge.net/paintbrush/Paintbrush%202.x/Paintbrush%20#{version}/Paintbrush-#{version}.zip"
   appcast "https://paintbrush.sourceforge.io/updates#{version.major}x.xml",
-          checkpoint: '776d288198003cdbdc854c58ecf5a89afc6676c56aaa2c66fdfc4ea9646e8fd6'
+          checkpoint: '1dec7d587b2c7c806df31a1ac62ef27371dc7ea6034608aa9de1f216c58e1c18'
   name 'Paintbrush'
   homepage 'http://paintbrush.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.