### PR TITLE
Update unity-download-assistant to 2017.3.0f3,a9f86dcd79df

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2017.2.1f1,94bf3f9e6b5e'
-  sha256 'ac07ff052f1ab81bb59d2233e6639777b33de33bd7ed79701d4e427b13db9c0c'
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 'd2e3d1184cdad2698dfcba83843fb2732727ff37aa01b66d689b5ece376b645e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   name 'Unity'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.