### PR TITLE
Update unity-android-support-for-editor to 2017.3.0f3,a9f86dcd79df

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2017.2.1f1,94bf3f9e6b5e'
-  sha256 '67fdf0959c8ed5ad8ce241c5cbab44a53e2c2fc74d6ef44bbf0ec4f18b8a12fd'
+  version '2017.3.0f3,a9f86dcd79df'
+  sha256 '8a74ef8af15dc5d12d37ceb288a9675ddca285bd2daf02e600fcbe736681e865'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Android Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.