### PR TITLE
Update altair to 1.6.0

### DIFF
--- a/Casks/altair.rb
+++ b/Casks/altair.rb
@@ -1,11 +1,11 @@
 cask 'altair' do
-  version '1.5.8'
-  sha256 '2df44e3d0841c69723c5bfab44c63ec25156dd2a17d5271c426bc1da2f33794e'
+  version '1.6.0'
+  sha256 'd09347764ce6e896a946542a10fbadabf65c841ad2dead935ce06489e47a9405'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"
   appcast 'https://github.com/imolorhe/altair/releases.atom',
-          checkpoint: '3b6b754665cdc3f1d1f1994c5177de35360019cc2316515b785e5c2c830fe128'
+          checkpoint: 'be31919b80d1523da960cbf834b6c18e69b740e86818ed0b490017b12b995456'
   name 'Altair GraphQL Client'
   homepage 'https://altair.sirmuel.design/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.