### PR TITLE
Update bisq to 0.6.2

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.6.1'
-  sha256 '433d2636b73a0857433ce5c045ef8097a79e7cb4e899c3c5e8543288740d4e0a'
+  version '0.6.2'
+  sha256 '4b774299d0fe8f2da5e3bd09b90bc1d72d21f203dadc80fdc3c5475e1f8cb3eb'
 
   # github.com/bisq-network/exchange was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/exchange/releases.atom',
-          checkpoint: '02710167f24eb93a9f91ddbf111defd6378cb941481c928a1c6bd6b1bc2dea66'
+          checkpoint: 'bffb806705ece1331ee2fd351698f0b922daed3695178c5eaf60baa5e3e5bfb2'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.