### PR TITLE
Update bitshares to 2.0.171219

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.171205'
-  sha256 'cd55231877860860938fbdbca7b788feb2f711638ba03dc8fc11361fcece92a5'
+  version '2.0.171219'
+  sha256 'b52681b75824eceaedf9068936e0afea50533747ecef1bf56e629f26b375fb52'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: '897827f7f4efc6c97ae73eb1448dfff1aba43c1ea33a12d578bc5bff0f557674'
+          checkpoint: 'b94c394a522a3507452749b57d1c01b6bba5ff875a6c5da1f077b695241cb717'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.