### PR TITLE
Update blockstack to 0.21.5

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.21.3'
-  sha256 '8d380d877c36975873a041d6740ac5760162326be7624798ec41eda44c30b082'
+  version '0.21.5'
+  sha256 '43dd48ed2dc9e198182b4ecc861b901c8575392a37f1f125aa8418cba391bf20'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '54c83ef1f8db9176b612f52d38c30e3b45ddb8296e79942e1019bd8ad8557d0b'
+          checkpoint: 'df341c1e52a89a14d899dd7d39cddc5e5f92b5a02cdeb60e892a1b0986b64ef4'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.