### PR TITLE
Update boostnote to 0.8.19

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.16'
-  sha256 '1b6d76101b8abcfdee5dff8babd6c5c478991cc4eecd50f9af00129ebf286309'
+  version '0.8.19'
+  sha256 '25fd1e37469e430075a0f06212b90bbd2a888c4b83382a434aaebe5de5352553'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: 'd3b9b4c1aa721ab754eacac0716aca15d420b670cc3bef3e086cfc92587d88fd'
+          checkpoint: '00226291f218a64789dfc281ac2c33ef459b6ad1fc3f1bbe1ae1a2a9389f6b2f'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.