### PR TITLE
Update snapndrag to 4.2.6

### DIFF
--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -1,10 +1,10 @@
 cask 'snapndrag' do
-  version '4.2.4'
-  sha256 '5e4ed74cf420f2c41b69c77d9963dec58a5fd0ed2f11f07eee613ea56054a768'
+  version '4.2.6'
+  sha256 'd91037d537cef7148427b814f1114a9a2e19ac110d2330e3c31ee542fc5b963c'
 
   url "http://yellowmug.com/download/SnapNDrag_#{version}.dmg"
   appcast 'http://yellowmug.com/snapndrag/appcast-1012.xml',
-          checkpoint: '5fd344a724f6fbf98d42bb7a31e29fd787838fb232a9d91482575b280ae6cf71'
+          checkpoint: '4a3e65ba7e4792b95d9adbbdcc5f40b9c91fe8dbf85983b9a69efc66af1b4cf4'
   name 'SnapNDrag'
   homepage 'http://www.yellowmug.com/snapndrag/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.