### PR TITLE
Update vox to 3.1

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '3.0.1'
-  sha256 '54c5972c5c6fb509efd72b62ce29829eca9fbb7aee3c48fea840c41095e9f339'
+  version '3.1'
+  sha256 '0d2388b9da421032ae9aa0f6b23c47d1d14deec8a8e21829ba7fdd36deeb34f7'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: '6181faa9bf011813dd34c4d49009a44c8586b575d30af15bc049b6f68ebda80e'
+          checkpoint: '6a6fefd1083763d3776b280410b6b284513bd0de4bb4563f85d5055118c27b71'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.