### PR TITLE
Update baidunetdisk to 2.2.1

### DIFF
--- a/Casks/baidunetdisk.rb
+++ b/Casks/baidunetdisk.rb
@@ -1,6 +1,6 @@
 cask 'baidunetdisk' do
-  version '2.2.0'
-  sha256 'efcf567403a3ffbf685b27f0427ba007f806b40df1a8d1d0274bafc27e8ef481'
+  version '2.2.1'
+  sha256 '55c248ea2380b56c025be91bc301daae8287cfe64dcba8a2d77eb484dd9b627d'
 
   # baidupcs.com/issue/netdisk/MACguanjia was verified as official when first introduced to the cask
   url "https://issuecdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.