### PR TITLE
Add myCloudDesktop.app 17.43.26

### DIFF
--- a/Casks/mycloud.rb
+++ b/Casks/mycloud.rb
@@ -1,16 +1,13 @@
-cask 'myclouddesktop' do
+cask 'mycloud' do
   version '17.43.26'
   sha256 '3d30ee7389686fce876949f7214881cceeb044f6ca0212021f5c06a83b969bd3'
 
   # download-syncclient-mac.prod.mdl.swisscom.ch was verified as official when first introduced to the cask
-  url 'https://download-syncclient-mac.prod.mdl.swisscom.ch/mac/myCloudDesktop-installer-17.43.26.dmg'
+  url "https://download-syncclient-mac.prod.mdl.swisscom.ch/mac/myCloudDesktop-installer-#{version}.dmg"
   name 'Swisscom myCloud Desktop'
   homepage 'https://desktop.mycloud.ch/'
 
-  installer script: {
-                      executable: "#{staged_path}/myCloudDesktop-installer.app/Contents/MacOS/myCloudDesktop-installer",
-                      sudo:       false,
-                    }
+  installer script: "#{staged_path}/myCloudDesktop-installer.app/Contents/MacOS/myCloudDesktop-installer"
 
   uninstall quit:       'ch.swisscom.mycloud.desktop.finder',
             signal:     ['KILL', 'ch.swisscom.mycloud.desktop'],

--- a/Casks/mycloud.rb
+++ b/Casks/mycloud.rb
@@ -7,10 +7,17 @@ cask 'mycloud' do
   name 'Swisscom myCloud Desktop'
   homepage 'https://desktop.mycloud.ch/'
 
-  installer script: "#{staged_path}/myCloudDesktop-installer.app/Contents/MacOS/myCloudDesktop-installer"
+  container nested: 'myCloudDesktop-installer.app/Contents/Resources/app/application.zip'
 
-  uninstall quit:       'ch.swisscom.mycloud.desktop.finder',
-            signal:     ['KILL', 'ch.swisscom.mycloud.desktop'],
-            delete:     '/Applications/myCloudDesktop.app',
-            login_item: 'myCloudDesktop'
+  app 'myCloudDesktop.app'
+
+  uninstall login_item: 'myCloudDesktop',
+            quit:       'ch.swisscom.mycloud.desktop.finder',
+            signal:     ['TERM', 'ch.swisscom.mycloud.desktop']
+
+  zap trash: [
+               '~/Library/Application Support/myCloudDesktop',
+               '~/Library/Preferences/ch.swisscom.mycloud.desktop.plist',
+               '~/Library/Preferences/ch.swisscom.mycloud.desktop.helper.plist',
+             ]
 end

--- a/Casks/myclouddesktop.rb
+++ b/Casks/myclouddesktop.rb
@@ -1,0 +1,19 @@
+cask 'myclouddesktop' do
+  version '17.43.26'
+  sha256 '3d30ee7389686fce876949f7214881cceeb044f6ca0212021f5c06a83b969bd3'
+
+  # download-syncclient-mac.prod.mdl.swisscom.ch was verified as official when first introduced to the cask
+  url 'https://download-syncclient-mac.prod.mdl.swisscom.ch/mac/myCloudDesktop-installer-17.43.26.dmg'
+  name 'Swisscom myCloud Desktop'
+  homepage 'https://desktop.mycloud.ch/'
+
+  installer script: {
+                      executable: "#{staged_path}/myCloudDesktop-installer.app/Contents/MacOS/myCloudDesktop-installer",
+                      sudo:       false,
+                    }
+
+  uninstall quit:       'ch.swisscom.mycloud.desktop.finder',
+            signal:     ['KILL', 'ch.swisscom.mycloud.desktop'],
+            delete:     '/Applications/myCloudDesktop.app',
+            login_item: 'myCloudDesktop'
+end


### PR DESCRIPTION
myCloudDesktop is an app for the cloud offering of Swisscom, one of the local
telecom operators in Switzerland.

The application is similar to well known alternatives like dropbox or
google drive and will synchronize a local directory with contents
stored on the cloud service.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].

I had to violate the following rule: `Remove from the end: strings such as “Desktop”, “for Desktop”.`  The reason is, that the product is really called `myCloud Desktop`. This is the official product name (How users will call the application). Therefore I propose to use the token `myclouddesktop`.

- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

