### PR TITLE
Update gifox to 010400.02

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -1,11 +1,11 @@
 cask 'gifox' do
-  version '010301.00'
-  sha256 '09dc7b2c357e30f2d0ec3600bd522d6cfb95d2c9821f54164c53066e5c5ca7f1'
+  version '010400.02'
+  sha256 'c0f9fb1be9f1086ad54f85e6d02319dbdfbd1f2c155cb67642cd2240c57692b8'
 
   # s3.eu-central-1.amazonaws.com/dstlalgzor/gifox was verified as official when first introduced to the cask
   url "https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/#{version}.dmg"
   appcast 'https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/appcast.xml',
-          checkpoint: '57e6492b681ed9c6489b0cc1491cbe7975aadab4c5b24845122460782a8ab23c'
+          checkpoint: '56064af28f246bba075adbb0f18f01f7a19c0922f1445e83c777e4bb35fc3522'
   name 'gifox'
   homepage 'https://gifox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.