### PR TITLE
Update scrivener to 3.0.1

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,11 +1,11 @@
 cask 'scrivener' do
   version '3.0.1'
-  sha256 '4524ed2816bee4a11b336e6a066792c8d12cef5efb484111d26edf4f606cf900'
+  sha256 '8cdeb3a27eb4f0ca9fb12ff6e987ad699e23a9d8497f352d68e1dffc18347a85'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
   appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
-          checkpoint: '91069b462bee4454285dada0ee550a6712d317ce2101d12b2f72403fb24e939e'
+          checkpoint: '86ba4658751c0ebb95046ca0c836e81c6d21259da8c051f41c4986cd59b6302b'
   name 'Scrivener'
   homepage 'https://literatureandlatte.com/scrivener.php'
 

--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,9 +1,9 @@
 cask 'scrivener' do
-  version '3.0.1'
-  sha256 '8cdeb3a27eb4f0ca9fb12ff6e987ad699e23a9d8497f352d68e1dffc18347a85'
+  version '3.0.1,966'
+  sha256 '704ae6632026a6b18f4f84df383696ca7bda37ea79ce5f3a269cd04ef3c622d4'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://scrivener.s3.amazonaws.com/Scrivener.dmg'
+  url "https://scrivener.s3.amazonaws.com/mac_updates/Scrivener_1012_#{version.after_comma}.zip"
   appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
           checkpoint: '86ba4658751c0ebb95046ca0c836e81c6d21259da8c051f41c4986cd59b6302b'
   name 'Scrivener'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.