### PR TITLE
Add TrueFire 3.1.7

### DIFF
--- a/Casks/truefire.rb
+++ b/Casks/truefire.rb
@@ -1,0 +1,10 @@
+cask 'truefire' do
+  version '3.1.7'
+  sha256 'd2e527e5f048c56e0106a868e95c60b65371c5d9d90affb84543b58655298a55'
+
+  url 'https://truefire.com/player/TrueFireInstaller.dmg'
+  name 'TrueFire'
+  homepage 'https://truefire.com/apps'
+
+  app "TrueFire #{version.major}.app"
+end

--- a/Casks/truefire.rb
+++ b/Casks/truefire.rb
@@ -1,10 +1,10 @@
 cask 'truefire' do
-  version '3.1.7'
-  sha256 'd2e527e5f048c56e0106a868e95c60b65371c5d9d90affb84543b58655298a55'
+  version '3'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://truefire.com/player/TrueFireInstaller.dmg'
   name 'TrueFire'
   homepage 'https://truefire.com/apps'
 
-  app "TrueFire #{version.major}.app"
+  app "TrueFire #{version}.app"
 end


### PR DESCRIPTION
TrueFire is an online guitar lesson website.
This application allows to play TrueFire lessons.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].