### PR TITLE
Update cerebro to 0.3.2

### DIFF
--- a/Casks/cerebro.rb
+++ b/Casks/cerebro.rb
@@ -1,11 +1,11 @@
 cask 'cerebro' do
-  version '0.3.1'
-  sha256 '83fe4fa5baae56052eb44ae0a94a93880e2d99e52ad5d2e0d4201ddd2f960889'
+  version '0.3.2'
+  sha256 'a4df90aca836d6110ac65cd5c1427fb9121f93bdd36ed8527816befbda3dc833'
 
   # github.com/KELiON/cerebro was verified as official when first introduced to the cask
   url "https://github.com/KELiON/cerebro/releases/download/v#{version}/cerebro-#{version}.dmg"
   appcast 'https://github.com/KELiON/cerebro/releases.atom',
-          checkpoint: '868bc9ed6937baa629020e6338898aed949e76c5a367006ffe5112a1f4f9ce91'
+          checkpoint: '0e51537bf31af3bff4797bbaed69cc3df6c2a68c99a5440f1e287ed59939d704'
   name 'Cerebro'
   homepage 'https://cerebroapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.