### PR TITLE
Update netron to 1.2.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.1.9'
-  sha256 'e377b7181d05c344b3c7a65690088f97376769d0ee77911bfd1b3191f7d24fe4'
+  version '1.2.0'
+  sha256 '6f7b7678f33460c53801769b770c24110ac405bf96767d6eb912d16d023a5381'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '9ba3648d90cd1fff5b51b20acde9aa2f032893031d725abfb49d75f6a6916783'
+          checkpoint: '7e6fb4b2b2b8fc98c805347cdf5d43c4c897ce0242c7f67a198676c9331e08d1'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.