### PR TITLE
Update atext to 2.22.1

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,10 +1,10 @@
 cask 'atext' do
-  version '2.22'
-  sha256 '316a86e63e8f6cd87a545185a0aa7033ce426ca707d391d9dc18d69ec8a3461d'
+  version '2.22.1'
+  sha256 'f3ccc0330aef9bee47c4d80367d700d2eea532848fa3966f42deb81c98d93d4d'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml',
-          checkpoint: 'dcceb0392ef64634fd7aae8cbfd9813e8cbd0bc0955ee3959e7f15826274ed12'
+          checkpoint: 'bd048b20c0cfc8623845254e605433737ec290acf69acc5b57184f12e7727642'
   name 'aText'
   homepage 'https://www.trankynam.com/atext/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.