### PR TITLE
Update freefilesync to 9.6

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '9.6'
-  sha256 '899bc5db4760494f159a43dd1c6545f99a52232cd5ad802da69b96482a4c6653'
+  sha256 '0b5459cb863bd6a3ee17b4f649826f0831ee80a2a9055be1b1750bfb340c2468'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
Current `sha256` of freefilesync 9.6 is incorrect.
Fix it to the correct one.

[Details on VirusTotal](https://www.virustotal.com/#/file/0b5459cb863bd6a3ee17b4f649826f0831ee80a2a9055be1b1750bfb340c2468/details).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.