### PR TITLE
Add Homespun Instant Access v2.9.3

### DIFF
--- a/Casks/homespun-instant-access.rb
+++ b/Casks/homespun-instant-access.rb
@@ -1,0 +1,17 @@
+cask 'homespun-instant-access' do
+  version :latest
+  sha256 :no_check
+
+  # vault.platformpurple.com/static/installers/homespun_installer was verified as official when first introduced to the cask
+  url 'http://vault.platformpurple.com/static/installers/homespun_installer.zip'
+  name 'Homespun Instant Access'
+  homepage 'https://www.homespun.com/direct-download/'
+
+  installer script: {
+                      executable: "#{staged_path}/Homespun Instant Access Installer.app/Contents/MacOS/Homespun Instant Access Installer",
+                      sudo:       true,
+                    }
+
+  uninstall quit:   'com..mm_launcher',
+            delete: '/Applications/Homespun Instant Access.app'
+end

--- a/Casks/homespun-instant-access.rb
+++ b/Casks/homespun-instant-access.rb
@@ -7,10 +7,7 @@ cask 'homespun-instant-access' do
   name 'Homespun Instant Access'
   homepage 'https://www.homespun.com/direct-download/'
 
-  installer script: {
-                      executable: "#{staged_path}/Homespun Instant Access Installer.app/Contents/MacOS/Homespun Instant Access Installer",
-                      sudo:       true,
-                    }
+  installer manual: 'Homespun Instant Access Installer.app'
 
   uninstall quit:   'com..mm_launcher',
             delete: '/Applications/Homespun Instant Access.app'


### PR DESCRIPTION
Homespun is a music instruction site.
Homespun Instant Access is the application to play Homespun lessons.

I am not sure if I implemented this cask correctly. The Application requires an installer script to be run. I was able to start this script, but It still requires manual input (clicks) from the user. (First a confirmation and then a screen to accept the license agreement)

![screen shot 2017-12-27 at 19 55 52](https://user-images.githubusercontent.com/6319634/34390487-50eb761a-eb40-11e7-805f-8e13330109fe.png)

![screen shot 2017-12-27 at 19 56 15](https://user-images.githubusercontent.com/6319634/34390490-57016906-eb40-11e7-9e22-62096f5cc492.png)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].
