### PR TITLE
Update sejda-pdf from 3.1.0 to 3.2.5

### DIFF
--- a/Casks/sejda-pdf.rb
+++ b/Casks/sejda-pdf.rb
@@ -1,6 +1,6 @@
 cask 'sejda-pdf' do
-  version '3.1.0'
-  sha256 'e88105fa61ebf1d9c7c4a21dc85abaaf9c3fdbdf723e031c893b376bf968fa49'
+  version '3.2.5'
+  sha256 'adc2012860abba6717c81ba6b6a0e260929f3234a89c7c9dc3d38cf31400bc67'
 
   # bitbucket.org/sejdapdf/sejda-desktop-public was verified as official when first introduced to the cask
   url "https://bitbucket.org/sejdapdf/sejda-desktop-public/downloads/sejda-desktop_#{version}.dmg"


### PR DESCRIPTION
Install failed with current version as it is pulled from the bitbucked downloads folder.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
