### PR TITLE
Update wifispoof to 3.0.6

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,11 +1,11 @@
 cask 'wifispoof' do
-  version '3.0.4.1'
-  sha256 'ae6ad4e57b1e2f991cd90a25773b6bda83230a5267e6b1eefdb163bcaec60ab9'
+  version '3.0.6'
+  sha256 'a384c8ff6754252fe1b4ff008ee161f260ee9d819b9f1df12c47e884d79d7e9f'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"
   appcast 'https://sweetpproductions.com/products/wifispoof3/appcast.xml',
-          checkpoint: 'eff33d438f8aa5b91576f8b6891f44e923a833806a4a32d4ce16f988d2e811ae'
+          checkpoint: '6b566d4e65e3254a51a32577dd7e51b111a65b4eb45fec2686ba926b1ab930fd'
   name 'WiFiSpoof'
   homepage 'https://wifispoof.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.