### PR TITLE
Update wordpresscom to 3.1.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '3.0.0'
-  sha256 'fb24600098bc5c5b2dc4f50e8dc63b5fc81a1b0d3ddcf123f80434618b304626'
+  version '3.1.0'
+  sha256 '794184637abe04bee5a193b3b085c29c25d632b26b1a53413d0085d65733f48f'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: 'e3347a2f3f8da08899fc62f01649265c3d5ef56088b7a0bdd4ab51be1f7f806a'
+          checkpoint: 'f8651571a5797bc35fb9ace9feae6ca25c8253d277ae650c287971fada15dfbc'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.