### PR TITLE
Update airtable to 1.2.1

### DIFF
--- a/Casks/airtable.rb
+++ b/Casks/airtable.rb
@@ -1,6 +1,6 @@
 cask 'airtable' do
-  version '1.1.12'
-  sha256 '3d54d45b7f65119dc2b94cc0a6d086b65cd1d188ddd2b4b1b7d22dc5e1def14c'
+  version '1.2.1'
+  sha256 '48de85c8d98dc5acb9b5f7436a292000f622b0d4f298232edb762c6e0f3a5ab1'
 
   url "https://static.airtable.com/download/macos/Airtable-#{version}.dmg"
   name 'Airtable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.