### PR TITLE
Update netron to 1.2.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.2.0'
-  sha256 '6f7b7678f33460c53801769b770c24110ac405bf96767d6eb912d16d023a5381'
+  version '1.2.1'
+  sha256 '8abe5fbfe27ef11c7bfee1c4ea0eed514a074dc3bde2755ba51698cca7dd84cc'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '7e6fb4b2b2b8fc98c805347cdf5d43c4c897ce0242c7f67a198676c9331e08d1'
+          checkpoint: 'f8d696ce4dc0499f3d1a20890e535c808e34c036b15504f6dfe4f20ec403d50a'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.