### PR TITLE
Update netron to 1.2.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.2.1'
-  sha256 '8abe5fbfe27ef11c7bfee1c4ea0eed514a074dc3bde2755ba51698cca7dd84cc'
+  version '1.2.2'
+  sha256 '72650b9bdec5ba5901e2db95a96ad8209cfa5b0c31f2b189b5c18a1aebf45744'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'f8d696ce4dc0499f3d1a20890e535c808e34c036b15504f6dfe4f20ec403d50a'
+          checkpoint: '740cc9c67a70e35b9603e54f34e3ed998d0589676eb3b3bcdf24328dc6f875f7'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.