### PR TITLE
Update metadatics to 1.5.7

### DIFF
--- a/Casks/metadatics.rb
+++ b/Casks/metadatics.rb
@@ -2,7 +2,7 @@ cask 'metadatics' do
   version '1.5.7'
   sha256 'c8baea464a742d35ca0793128d7d2606e59358b7f3e156ac7e7a27694db67927'
 
-  url 'http://www.markvapps.com/applications/metadatics/Metadatics.zip'
+  url 'https://www.markvapps.com/applications/metadatics/Metadatics.zip'
   appcast 'https://www.markvapps.com/applications/metadatics/metadatics_appcast.xml',
           checkpoint: '5e5f3ccd1d7718ab02dc32fd1f36ef1b0fe29d6d096b74429a575cb1d1489bee'
   name 'Metadatics'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.