### PR TITLE
Add zap stanza to atext 2.22.2

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -9,4 +9,14 @@ cask 'atext' do
   homepage 'https://www.trankynam.com/atext/'
 
   app 'aText.app'
+
+  zap trash: [
+               '~/Library/Application Scripts/com.trankynam.aText',
+               '~/Library/Application Support/com.trankynam.aText',
+               '~/Library/Caches/com.trankynam.aText',
+               '~/Library/Containers/com.trankynam.aText',
+               '~/Library/Cookies/com.trankynam.aText.binarycookies',
+               '~/Library/Preferences/com.trankynam.aText.plist',
+               '~/Library/Saved Application State/com.trankynam.aText.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.