### PR TITLE
Update mono-mdk 5.4.1.6: uninstall

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -10,8 +10,15 @@ cask 'mono-mdk' do
 
   pkg "MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
 
-  uninstall delete:  '/private/etc/paths.d/mono-commands',
-            pkgutil: 'com.xamarin.mono-*'
+  uninstall delete:  [
+                       "/Library/Frameworks/Mono.framework/Versions/#{version.major_minor_patch}",
+                       '/private/etc/paths.d/mono-commands',
+                     ],
+            pkgutil: 'com.xamarin.mono-*',
+            rmdir:   [
+                       '/Library/Frameworks/Mono.framework/Versions',
+                       '/Library/Frameworks/Mono.framework',
+                     ]
 
   caveats <<~EOS
     Installing #{token} removes mono and mono dependant formula binaries in


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.