### PR TITLE
Update jabref to 4.1

### DIFF
--- a/Casks/jabref.rb
+++ b/Casks/jabref.rb
@@ -1,11 +1,11 @@
 cask 'jabref' do
-  version '4.0'
-  sha256 '790ba8ace0a11a1bbab18d7b83f784eba03f4e1185919e305bdf2b0c9b249701'
+  version '4.1'
+  sha256 'f22108d6bda73978a51ca5759dd2a46619678427f3d9154e55f935004fa93751'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
   url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: '88a417195c23af92097ac0f6b18c6c6ede391eecedff0476acb99fde6ad8694d'
+          checkpoint: 'b6c57f7f4d664af53f25a39d33ec06140eb4418da209ab3a49ea7230761fef8f'
   name 'JabRef'
   homepage 'https://www.jabref.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.