### PR TITLE
Update gnucash to 2.6.19-1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,11 +1,11 @@
 cask 'gnucash' do
-  version '2.6.18-1'
-  sha256 '75b4cea0e786a0844507aa89fc8f2f5c3761825b540b224427f1c9f2f346a257'
+  version '2.6.19-1'
+  sha256 'd40de55c75fdb754c717ae37e25de5e411fce4ce1f7684f071fc492f939408d2'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}/Gnucash-Intel-#{version}.dmg"
   appcast 'https://github.com/Gnucash/gnucash/releases.atom',
-          checkpoint: '62f568904f2ed87b78599b5579ebd3616849d2c3f17fb692f6982988528d7c48'
+          checkpoint: '6735ed4e007673033c8c7d78eec7a76c7ab32ee57dc646f7d2662d89402688d6'
   name 'GnuCash'
   homepage 'https://www.gnucash.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.