### PR TITLE
Update tinymediamanager to 2.9.7_8513bee

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -1,10 +1,10 @@
 cask 'tinymediamanager' do
-  version '2.9.5_1bf3695'
-  sha256 '2056707e47746c5aa3c568fe264f1534a44eed9206e774aefd86921557d49552'
+  version '2.9.7_8513bee'
+  sha256 '5efc8c2ac5ea52f515c6a9bc3bb168190d337e79f85e1d7e2c2559dd4f11f766'
 
   url "https://release.tinymediamanager.org/dist/tmm_#{version}_mac.zip"
   appcast 'https://release.tinymediamanager.org/',
-          checkpoint: 'c4d3197a686e085fe1052b4fa26d024557cd64e256c190344ab75a57f7f2cab0'
+          checkpoint: '2f3d4f22d255adbad6220670675b4c8390cab776edbd80d9281f83bccabb6cbb'
   name 'tinyMediaManager'
   homepage 'https://www.tinymediamanager.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.