### PR TITLE
Update borgbackup to 1.1.4

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.1.3'
-  sha256 '59e0886799d6551a61cbc994e120337ff4af522c5a977a1b5ee6e365d7404682'
+  version '1.1.4'
+  sha256 'ed205a17eb2c881b421317f76b35f2800a743455ee1b81d4f47451e42f690826'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '4d46d5e6feabbc7ae94e76fdb557d1873ae6a804dff544e99baa853ffe5e582f'
+          checkpoint: '5a573388701b1016807563c5f925ecebb0db52235803ed91a2b89d6556b1ec92'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.io/en/stable/'
   gpg "#{url}.asc", key_id: '51F78E01'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.