### PR TITLE
Add zap stanza for desmume

### DIFF
--- a/Casks/desmume.rb
+++ b/Casks/desmume.rb
@@ -9,4 +9,11 @@ cask 'desmume' do
   homepage 'https://sourceforge.net/projects/desmume/'
 
   app 'DeSmuME.app'
+
+  zap trash: [
+               '~/Library/Application Support/DeSmuME',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.desmume.desmume.sfl*',
+               '~/Library/Saved Application State/org.desmume.DeSmuME.savedState',
+               '~/Library/Preferences/org.desmume.DeSmuME.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Adding zap stanza for the same version of cask.