### PR TITLE
Add zap stanza to db-browser-for-sqlite 3.10.1

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -10,4 +10,9 @@ cask 'db-browser-for-sqlite' do
   homepage 'http://sqlitebrowser.org/'
 
   app 'DB Browser for SQLite.app'
+
+  zap trash: [
+               '~/Library/Preferences/net.sourceforge.sqlitebrowser.plist',
+               '~/Library/Saved Application State/net.sourceforge.sqlitebrowser.savedState',
+             ]
 end

--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -5,7 +5,7 @@ cask 'db-browser-for-sqlite' do
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom',
-          checkpoint: 'b481ca94a0597036e14c729767e4307ec871d9febce53415b87770adda7acf26'
+          checkpoint: 'd129cfaccad20b50de9517688af7a38a4bcbab156bb2e46db2b55efddc1fab81'
   name 'SQLite Database Browser'
   homepage 'http://sqlitebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.