### PR TITLE
Updated tifig to v0.8.0

### DIFF
--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -1,11 +1,11 @@
 cask 'tifig' do
-  version '0.7.0-201708110628'
-  sha256 '5e34a2271adc0aa70cab11b46d73c4fd838799b278939f3cb856305932061dec'
+  version '0.8.0-201712302054'
+  sha256 'b1dbbf70664d2d0cbfc92a9a1d28efebf60133a6a5f148a464882487c074f0a0'
 
   # tifig-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tifig-downloads.s3.amazonaws.com/tifig-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.tifig.net/download/',
-          checkpoint: 'ed1edfbbda20e164397fe91f2f14cf2d14a14a7f5a24620158fb1a54fa84e1ee'
+          checkpoint: '1ce587c6a5dfca6b3670e10249b1e0732e6b01cd40d314a3383b701850a50340'
   name 'Tifig'
   homepage 'https://www.tifig.net/'
 


### PR DESCRIPTION
This pull request updates the cask for the Tifig Swift IDE to v0.8.0.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.