### PR TITLE
Update netron to 1.2.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.2.2'
-  sha256 '72650b9bdec5ba5901e2db95a96ad8209cfa5b0c31f2b189b5c18a1aebf45744'
+  version '1.2.3'
+  sha256 'e65b164672d052b25a1a14cd1cef261bde0c53a9b45576dd7fabeec4ee346f7c'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '740cc9c67a70e35b9603e54f34e3ed998d0589676eb3b3bcdf24328dc6f875f7'
+          checkpoint: '2c968d38d3ee0a535840123f366978714a8c1e61e682f586c451f91282daa600'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.