### PR TITLE
Fix battle-net cask installation for latest version

### DIFF
--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -6,14 +6,14 @@ cask 'battle-net' do
     url 'https://www.battle.net/download/getInstallerForGame?os=mac&locale=enUS&version=LIVE&gameProgram=BATTLENET_APP'
     homepage 'https://battle.net/'
 
-    installer manual: 'Battle.net-Setup.app'
+    app 'Battle.net.app'
   end
 
   language 'zh', 'CN' do
     url 'https://www.battle.net/download/getInstallerForGame?os=mac&installer=Battle.net-Setup-zhCN.zip'
     homepage 'http://www.battle.net/'
 
-    installer manual: 'Battle.net-Setup-zhCN.app'
+    app 'Battle.net.app'
   end
 
   name 'Blizzard Battle.net'

--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -4,31 +4,29 @@ cask 'battle-net' do
 
   language 'en', default: true do
     url 'https://www.battle.net/download/getInstallerForGame?os=mac&locale=enUS&version=LIVE&gameProgram=BATTLENET_APP'
-    homepage 'https://battle.net/'
-
-    app 'Battle.net.app'
   end
 
   language 'zh', 'CN' do
     url 'https://www.battle.net/download/getInstallerForGame?os=mac&installer=Battle.net-Setup-zhCN.zip'
-    homepage 'http://www.battle.net/'
-
-    app 'Battle.net.app'
   end
 
   name 'Blizzard Battle.net'
+  homepage 'https://www.battle.net/'
 
-  uninstall delete: '/Applications/Battle.net.app'
+  app 'Battle.net.app'
 
   zap trash: [
+               '~/Library/Application Support/Battle.net',
+               '~/Library/Caches/net.battle.bootstrapper',
                '~/Library/Preferences/net.battle.net.app.plist',
+               '~/Library/Preferences/net.battle.app.helper.plist',
                '~/Library/Preferences/net.battle.Authenticator.prefs',
                '~/Library/Preferences/net.battle.Identity.prefs',
+               '~/Library/Preferences/net.battle.plist',
                '~/Library/Preferences/net.battnet.battle.plist',
+               '~/Library/Saved Application State/net.battle.app.savedState',
                '/Users/Shared/Battle.net',
                '/Users/Shared/Blizzard',
              ],
       rmdir: '~/Blizzard'
-
-  caveats 'If you pick an installation directory other than /Applications when installing this cask, you will need to uninstall it manually'
 end


### PR DESCRIPTION
One day installer was replaced to zipped app, so changing cask accordingly.

Signed-off-by: Igor Shishkin <me@teran.ru>

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
