### PR TITLE
Update telegram to 3.7.1-111991

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
   version '3.7.1-111991'
-  sha256 '37c0559a24a7906a4a0a4111c5f51ec4286d614906983ed1ba751f74b30f91b4'
+  sha256 'abd54b3724b9f71b1599851bff92f7ae7ededfa10195f07e503ef19759e41c65'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: 'edcb52d7978b932c6a170f3f7d715ec5075c86faba6a471ad0b68f9570499de4'
+          checkpoint: '15e8393107b159617aa6e59c9c80793a334fd45f6cfcfe5cf474bc56cf436864'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.