### PR TITLE
Add ipfs-update 1.5.2

### DIFF
--- a/Casks/ipfs-update.rb
+++ b/Casks/ipfs-update.rb
@@ -1,0 +1,10 @@
+cask 'ipfs-update' do
+  version '1.5.2'
+  sha256 '9f7017fe7453fd42b35a52d631ba4765fdc0e6d0cd890f0eb1a12a64f086c922'
+
+  url "https://dist.ipfs.io/ipfs-update/v1.5.2/ipfs-update_v#{version}_darwin-amd64.tar.gz"
+  name 'ipfs-update'
+  homepage 'https://dist.ipfs.io/#ipfs-update'
+
+  binary 'ipfs-update/ipfs-update'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

`ipfs-update` is a CLI-only prebuilt binary. It was [submitted first to Homebrew/core and rejected](https://github.com/Homebrew/homebrew-core/pull/22213).