### PR TITLE
Update eagle to 8.5.1

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -3,9 +3,7 @@ cask 'eagle' do
   sha256 '04e9f900d75e9c13cf4b6d4a6f34dfec8d6f71fb6bb5e845c329a35a79af4870'
 
   # eagle-updates.circuits.io was verified as official when first introduced to the cask
-  url "https://eagle-updates.circuits.io/downloads/#{version.split('.').join('_')}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
-  appcast 'http://eagle.autodesk.com/eagle/release-notes',
-          checkpoint: 'e44c3a72240f3a910f73f6d1900317d9d742844187610d94d5e47df00072b286'
+  url "https://eagle-updates.circuits.io/downloads/#{version.dots_to_underscores}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   name 'Autodesk EAGLE'
   homepage 'https://www.autodesk.com/products/eagle/overview'
 

--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,8 +1,11 @@
 cask 'eagle' do
-  version '8.5.0'
-  sha256 '7058053c05fdf542ed53b15db151e362fa67147e3dc90231283be7b2efbac8e7'
+  version '8.5.1'
+  sha256 '04e9f900d75e9c13cf4b6d4a6f34dfec8d6f71fb6bb5e845c329a35a79af4870'
 
-  url "https://trial2.autodesk.com/NET17SWDLD/2017/EGLPRM/ESD/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
+  # eagle-updates.circuits.io was verified as official when first introduced to the cask
+  url "https://eagle-updates.circuits.io/downloads/#{version.split('.').join('_')}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
+  appcast 'http://eagle.autodesk.com/eagle/release-notes',
+          checkpoint: 'e44c3a72240f3a910f73f6d1900317d9d742844187610d94d5e47df00072b286'
   name 'Autodesk EAGLE'
   homepage 'https://www.autodesk.com/products/eagle/overview'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}