### PR TITLE
Add zap stanza to caret 3.4.6

### DIFF
--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -5,7 +5,7 @@ cask 'caret' do
   # github.com/careteditor/caret was verified as official when first introduced to the cask
   url "https://github.com/careteditor/caret/releases/download/#{version}/Caret.dmg"
   appcast 'https://github.com/careteditor/caret/releases.atom',
-          checkpoint: 'ea4a97f560e9bb80b8abf96c107b14576018d6cb41ca0914080c38ed67ea5e76'
+          checkpoint: '3f9502e8588d2afa2bf0b84dbd589c6f548de07916814f34daec130723c1b99c'
   name 'Caret'
   homepage 'https://caret.io/'
 

--- a/Casks/caret.rb
+++ b/Casks/caret.rb
@@ -10,4 +10,14 @@ cask 'caret' do
   homepage 'https://caret.io/'
 
   app 'Caret.app'
+
+  zap trash: [
+               '~/Library/Application Support/Caret',
+               '~/Library/Caches/io.caret',
+               '~/Library/Caches/io.caret.ShipIt',
+               '~/Library/Cookies/io.caret.binarycookies',
+               '~/Library/Preferences/io.caret.helper.plist',
+               '~/Library/Preferences/io.caret.plist',
+               '~/Library/Saved Application State/io.caret.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.