### PR TITLE
Update tipp10 to 2.1.0

### DIFF
--- a/Casks/tipp10.rb
+++ b/Casks/tipp10.rb
@@ -1,9 +1,9 @@
 cask 'tipp10' do
   # note: "10" is not a version number, but an intrinsic part of the product name
-  version :latest
-  sha256 :no_check
+  version '2.1.0'
+  sha256 '023f9545b78a7ca35eea3b23597b6380a4f4d42cc75ace72dcadf645be9edb93'
 
-  url "https://www.tipp10.com/en/download/getfile/1/#{Time.now.to_i}/"
+  url "https://www.tipp10.com/en/download/tipp10_mac_v#{version.dots_to_hyphens}.dmg"
   name 'TIPP10'
   homepage 'https://www.tipp10.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #42439.