### PR TITLE
Update lyx to 2.2.3

### DIFF
--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -2,9 +2,10 @@ cask 'lyx' do
   version '2.2.3'
   sha256 '845766b6e5deda4e5147211fea0e24d3e24dd3cceff014ed1269c942ef9e7883'
 
-  url "ftp://ftp.lyx.org/pub/lyx/bin/#{version}/LyX-#{version}+qt5-x86_64-cocoa.dmg"
+  # mirror.ufs.ac.za/applications/lyx was verified as official when first introduced to the cask
+  url 'http://mirror.ufs.ac.za/applications/lyx/bin/2.2.3/LyX-2.2.3+qt5-x86_64-cocoa.dmg'
   appcast 'https://www.lyx.org/misc/rss/lyx_news_feed.xml',
-          checkpoint: '30ba8c1a0446a8071ce2b5ef85cf7933fcf9081097dc566393b3280e67d28df4'
+          checkpoint: 'd3ec643d18ca7c882289d3679b0f1d0a391b295c3be70e55287bccb3c5a94aa0'
   name 'LyX'
   homepage 'https://www.lyx.org/'
   gpg "#{url}.sig", key_id: 'de7a44fac7fb382d'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.