### PR TITLE
Add zap stanza to dropzone 3.6.5

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -9,4 +9,15 @@ cask 'dropzone' do
   homepage 'https://aptonic.com/'
 
   app "Dropzone #{version.major}.app"
+
+  zap trash: [
+               '~/Library/Application Scripts/com.aptonic.Dropzone3',
+               '~/Library/Application Scripts/com.aptonic.LaunchAtLogin',
+               '~/Library/Application Support/Dropzone 3',
+               '~/Library/Caches/com.aptonic.Dropzone3',
+               '~/Library/Containers/com.aptonic.Dropzone3',
+               '~/Library/Containers/com.aptonic.LaunchAtLogin',
+               '~/Library/Preferences/com.aptonic.Dropzone3.plist',
+               '~/Library/Saved Application State/com.aptonic.Dropzone3.savedState',
+             ]
 end

--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -17,7 +17,7 @@ cask 'dropzone' do
                "~/Library/Caches/com.aptonic.Dropzone#{version.major}",
                "~/Library/Containers/com.aptonic.Dropzone#{version.major}",
                '~/Library/Containers/com.aptonic.LaunchAtLogin',
-               "~/Library/Preferences/com.aptonic.Dropzone.plist#{version.major}",
+               "~/Library/Preferences/com.aptonic.Dropzone#{version.major}.plist",
                "~/Library/Saved Application State/com.aptonic.Dropzone#{version.major}.savedState",
              ]
 end

--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -11,13 +11,13 @@ cask 'dropzone' do
   app "Dropzone #{version.major}.app"
 
   zap trash: [
-               '~/Library/Application Scripts/com.aptonic.Dropzone3',
+               "~/Library/Application Scripts/com.aptonic.Dropzone#{version.major}",
                '~/Library/Application Scripts/com.aptonic.LaunchAtLogin',
-               '~/Library/Application Support/Dropzone 3',
-               '~/Library/Caches/com.aptonic.Dropzone3',
-               '~/Library/Containers/com.aptonic.Dropzone3',
+               "~/Library/Application Support/Dropzone #{version.major}",
+               "~/Library/Caches/com.aptonic.Dropzone#{version.major}",
+               "~/Library/Containers/com.aptonic.Dropzone#{version.major}",
                '~/Library/Containers/com.aptonic.LaunchAtLogin',
-               '~/Library/Preferences/com.aptonic.Dropzone3.plist',
-               '~/Library/Saved Application State/com.aptonic.Dropzone3.savedState',
+               "~/Library/Preferences/com.aptonic.Dropzone.plist#{version.major}",
+               "~/Library/Saved Application State/com.aptonic.Dropzone#{version.major}.savedState",
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.