### PR TITLE
Update cloudera-impala-odbc to 2.5.41

### DIFF
--- a/Casks/cloudera-impala-odbc.rb
+++ b/Casks/cloudera-impala-odbc.rb
@@ -1,6 +1,6 @@
 cask 'cloudera-impala-odbc' do
-  version '2.5.40.1025'
-  sha256 '3f6e513881f30fcce4f9cceb82e0d0b7f06dbafba9e1e872fe65e314741b6b0f'
+  version '2.5.41.1029'
+  sha256 '84519e6582be94d7ac1f1fa3946da224966b4cde0f2eb566edfb864576ac90f6'
 
   url "https://downloads.cloudera.com/connectors/impala_odbc_#{version}/OSX/ClouderaImpalaODBC.dmg"
   name 'Cloudera ODBC Driver for Impala'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
