### PR TITLE
Update botframework-emulator to 3.5.34

### DIFF
--- a/Casks/botframework-emulator.rb
+++ b/Casks/botframework-emulator.rb
@@ -1,10 +1,10 @@
 cask 'botframework-emulator' do
-  version '3.5.33'
-  sha256 '7ecb8b5600693a95fca6100242d41b9c4c60f9b24218b0aacdee893609cbf809'
+  version '3.5.34'
+  sha256 '5417066a0eac202480a24fc4f509082bf831e4b62c85b3971e8c68922bc9a76e'
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom',
-          checkpoint: 'fa847cea797c780c5dc595d284081cf5485130b0c8949967770bb69b0f052f08'
+          checkpoint: '030e0b4532b9df70cf382acb8e0cf58393ee0ccd42e9572b614b712fe0cc8f00'
   name 'Microsoft Bot Framework Emulator'
   homepage 'https://github.com/Microsoft/BotFramework-Emulator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.