### PR TITLE
Update ghost to 1.5.1

### DIFF
--- a/Casks/ghost.rb
+++ b/Casks/ghost.rb
@@ -1,11 +1,11 @@
 cask 'ghost' do
-  version '1.5.0'
-  sha256 'f670cd54bf52d435510060990afadf401eefe7e7cfae90f9a72cc27080d8000f'
+  version '1.5.1'
+  sha256 'b49c1775d606a88469b6795104ae193266785f71626624fbdd85614206889c86'
 
   # github.com/TryGhost/Ghost-Desktop was verified as official when first introduced to the cask
   url "https://github.com/TryGhost/Ghost-Desktop/releases/download/v#{version}/ghost-desktop-#{version}-osx.zip"
   appcast 'https://github.com/TryGhost/Ghost-Desktop/releases.atom',
-          checkpoint: '31039d22fc7e3f02378f4013fc67ad47acae02736cab48b34e8ee9905c74c349'
+          checkpoint: '87c67012cd25110002db39e8f7ba051b11093b1322aa31d37b6e109863865e79'
   name 'Ghost Desktop'
   homepage 'https://ghost.org/downloads/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.