### PR TITLE
Update gpodder to 3.9.6_0

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -5,7 +5,7 @@ cask 'gpodder' do
   # sourceforge.net/gpodder was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpodder/gPodder-#{version}.zip"
   appcast 'https://sourceforge.net/projects/gpodder/rss?path=/macosx',
-          checkpoint: '65b8641fafee1be3dee696f40b6632f256ae93c5b4fc9053af89dfeb26334b62'
+          checkpoint: '31aeb7ab1379e2e01eb2bc809c40334183e1ef5912aa6fb0151d08bd21ec96f9'
   name 'gPodder'
   homepage 'https://gpodder.github.io/'
 

--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,11 +1,11 @@
 cask 'gpodder' do
-  version '3.9.3_1'
-  sha256 'dc9f9464965715bc54699bf6fe1c1a67af3f009e55dd15ef82cf3920b6da27aa'
+  version '3.9.6_0'
+  sha256 '0709a6e6405c07ee14c548c70a2a57abc34b06c62a5542f47fd22e17851be222'
 
   # sourceforge.net/gpodder was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpodder/gPodder-#{version}.zip"
   appcast 'https://sourceforge.net/projects/gpodder/rss?path=/macosx',
-          checkpoint: 'd6eebd0c44c0ba73cda2175ec319524e3d6e63ce219f87985f26cb392094a11b'
+          checkpoint: '65b8641fafee1be3dee696f40b6632f256ae93c5b4fc9053af89dfeb26334b62'
   name 'gPodder'
   homepage 'https://gpodder.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.