### PR TITLE
Update ticktick to 1.9.52,53

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '1.8.00,39'
-  sha256 'a767a2e678c92388522c56c728242b53d08c13c79e31f8072c97319b0e72d710'
+  version '1.9.52,53'
+  sha256 '7ad7a48ec81bb955426b0a057d72a0273668176c5a01bfa91618c559bfda4426'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.