### PR TITLE
Updated Spotify Download URL from actual installer

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -2,7 +2,7 @@ cask 'spotify' do
   version :latest
   sha256 :no_check
 
-  url 'https://download.spotify.com/Spotify.dmg'
+  url 'https://download.scdn.co/Spotify.dmg'
   name 'Spotify'
   homepage 'https://www.spotify.com/'
 

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -2,6 +2,7 @@ cask 'spotify' do
   version :latest
   sha256 :no_check
 
+  # scdn.co was verified as official when first introduced to the cask
   url 'https://download.scdn.co/Spotify.dmg'
   name 'Spotify'
   homepage 'https://www.spotify.com/'


### PR DESCRIPTION
old URL actually resolves to 1.0.69.336.g7edcc575, new URL to 1.0.70.388.g8e1ed5af

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
  - no cask version as long it is a permanent URL which is updated anytime