### PR TITLE
Update anvil to 1.1.8,132

### DIFF
--- a/Casks/anvil.rb
+++ b/Casks/anvil.rb
@@ -1,13 +1,13 @@
 cask 'anvil' do
-  version '2016-02-24_11-50-56'
-  sha256 'a4ddaa21b8c5b52b2a21620253aba64546f565e944b76e43c052c7a022007749'
+  version '1.1.8,132'
+  sha256 '485fd6cdd21edbbb2c3801fa0f4a5f6a4ef7da65316946ef5599497c676d6b68'
 
-  # amazonaws.com/sparkler_versions was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/sparkler_versions/versions/uploads/000/000/129/original/Anvil_#{version}.zip"
+  # sparkler.herokuapp.com/apps/3/versions was verified as official when first introduced to the cask
+  url "https://sparkler.herokuapp.com/apps/3/versions/#{version.after_comma}/download"
   appcast 'https://sparkler.herokuapp.com/apps/3/updates.xml',
-          checkpoint: 'f0f573475cd91a1154878775ee459b5ecc3d6164adedaa589fc9d4ac02f18e23'
+          checkpoint: 'e1c2efbeaf5f2ca79f6881360e0122d858774a5754a9e5876e215f5a917b2a51'
   name 'Anvil'
   homepage 'https://anvilformac.com/'
 
-  app "Anvil #{version.sub('_', ' ')}/Anvil.app"
+  app 'Anvil.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.