### PR TITLE
Update coconutbattery to 3.6.5

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -4,8 +4,8 @@ cask 'coconutbattery' do
     sha256 '0edf6bdaf28fb3cc9c242fd916c348fbbae30a5356ddc1d6e5158d50f96d740d'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.dots_to_underscores}.zip"
   else
-    version '3.6.4'
-    sha256 '8e289fb4a75cb117fc1d7861020c9ab2384b09dfd18f066c7fadfc9d42c3ac56'
+    version '3.6.5'
+    sha256 '1325a7d339de7ef2f97ec61c5e7a3a24f2998c563725581db86086b2c2e40973'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml',
             checkpoint: '4320a20538efeba285345daa0451b306af6e1269bc9530033e847ab638b7ee57'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`3.6.5` is the current download on the homepage and is listed in the release notes 
http://www.coconut-flavour.com/coconutbattery/releasenotes.html