### PR TITLE
Update ieasemusic to 1.1.2

### DIFF
--- a/Casks/ieasemusic.rb
+++ b/Casks/ieasemusic.rb
@@ -1,10 +1,10 @@
 cask 'ieasemusic' do
-  version '1.1.1'
-  sha256 'a57a0f3b2ce3d1b6507852034c269bb6642c5f37b9901bc16d299ba94b9675cb'
+  version '1.1.2'
+  sha256 '0edc36c2d0325a6d88af7653fffc4cf2550ad862c769e0591156992a28dcd135'
 
   url "https://github.com/trazyn/ieaseMusic/releases/download/v#{version}/ieaseMusic-#{version}-mac.dmg"
   appcast 'https://github.com/trazyn/ieaseMusic/releases.atom',
-          checkpoint: '0e7bac3f05ae903d30a268f255db4b4b847418cfb39ae40b067d49301a760969'
+          checkpoint: 'a50228a2a93def01a5e00b64a9e7ab772999c9b7fa217993c7d8a8b130d85749'
   name 'ieaseMusic'
   homepage 'https://github.com/trazyn/ieaseMusic'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.