### PR TITLE
Update opera to 50.0.2762.45

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '49.0.2725.64'
-  sha256 '155198225494683d29ab0af67fef04ad93a560bea69aa2226141070bd3819e06'
+  version '50.0.2762.45'
+  sha256 '8df8f02e06d8715f6fe5de01bdffba526aeca5b256436eb8057877adca3cfc67'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.