### PR TITLE
Update cityofzion-neon to 0.0.8

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,10 +1,10 @@
 cask 'cityofzion-neon' do
-  version '0.0.7'
-  sha256 '21510de71999ed23cac15a3d07069cca8f83cf0f2492e45260fa51ead33fac73'
+  version '0.0.8'
+  sha256 'a075a996462a4579f1f8084529dfc4925db7f5a3475cef405d840a3682079123'
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: 'ed3bfa1d3af402723e24dda6183cd5abc7a9f0103be6a82fbc80a189958147dd'
+          checkpoint: '0bac389b7416826dd0526fdd06aa6bac9e1fe15564083635313faad451078a3d'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.