### PR TITLE
Update reactotron to 1.15.0

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,10 +1,10 @@
 cask 'reactotron' do
-  version '1.14.0'
-  sha256 'eee19bd59d4267c6f9e20d12c26fa908ddc1b66eb0bc1d5e489f4b0fca61f567'
+  version '1.15.0'
+  sha256 '56c166b1b09dc8863422656dc7a23f2cf22a0c85bb8bef5532fe2a95e7bdaf44'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron.app.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom',
-          checkpoint: '4c5d939b788fb2073057b56b729e27afb91a1ab8c73e64e86d0bbed678da48d5'
+          checkpoint: 'a6b99979214ffc8cdc9ddb8cd9d5386c6ecd69bec44bdbddc3ea2f194a01e39d'
   name 'Reactotron'
   homepage 'https://github.com/infinitered/reactotron'
 

--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -4,7 +4,7 @@ cask 'reactotron' do
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron.app.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom',
-          checkpoint: 'a6b99979214ffc8cdc9ddb8cd9d5386c6ecd69bec44bdbddc3ea2f194a01e39d'
+          checkpoint: '9a1788a7e3ee20e68ccc146673425acaf64561bd2c374598c4b52b2263b7b817'
   name 'Reactotron'
   homepage 'https://github.com/infinitered/reactotron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.