### PR TITLE
Update comparemerge to 2.04x

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,10 +1,10 @@
 cask 'comparemerge' do
-  version '2.03x'
-  sha256 'ed6f53dd59481868ff29dc1d8800f5a821d918ce7fee1677f450bf302f23025c'
+  version '2.04x'
+  sha256 'ae931453d050686f36c3a7dffe2660e85a95df4a2627dfa6da32f915e491a268'
 
   url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss',
-          checkpoint: '0f230c9700bd27af2530109a80f788da31766bbcc708f98f9401256f62fa3d16'
+          checkpoint: '327ed1761975d44d1fc05aa459ff69f4931759e5881e9e68030a38dea4379ba2'
   name 'CompareMerge'
   homepage 'https://sourceforge.net/projects/comparemergenosandbox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.