### PR TITLE
Update qtpass to 1.2.1

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -1,11 +1,11 @@
 cask 'qtpass' do
-  version '1.2.0'
-  sha256 'b1b013e3eeab3634a8544e055295cf5ab985d2a1c08ac94c2b7487ab467b5489'
+  version '1.2.1'
+  sha256 '9da6c00fcc57087c00079a89f225a48b008b0fba1f9f50c0ea67261d3f7de58b'
 
   # github.com/IJHack/qtpass was verified as official when first introduced to the cask
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: '858fe6539b9c0757a5bae0b7323c98ecdbf23cd0c720740465a32e4537f9fa23'
+          checkpoint: '4469441746cad35ff53aa44c10d7b60bcab34d487ee8c054c64a469a0f7e28bd'
   name 'QtPass'
   homepage 'https://qtpass.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.