### PR TITLE
Update graphql-playground to 1.3.20

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.3.10'
-  sha256 '46b0ce4ecad80b33ba9b651605874ae56efc273395b38cc1fb687a2d8cfef095'
+  version '1.3.20'
+  sha256 'e237210a5a619bf058b38ac844b56287ebe0a717d14a0b931fb2be92beaa7411'
 
-  url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/playground-#{version}-mac.zip"
+  url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: 'd11c2858f808c0f84fcc0be20b3177e057187e17772cb123eb3fbb615fade47c'
+          checkpoint: '04cdc070876aa86f3bd4be668b2ecb6065949f478f8288ef781cade95d95de88'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.