### PR TITLE
Update pomotodo to 3.4.2,1508736942

### DIFF
--- a/Casks/pomotodo.rb
+++ b/Casks/pomotodo.rb
@@ -1,11 +1,11 @@
 cask 'pomotodo' do
-  version '3.3.0,1499943104'
-  sha256 '429c1235bb4a0279723bf141ad92690acf1a2e0c813affb38e0d510cf107821b'
+  version '3.4.2,1508736942'
+  sha256 '7726496a48eeb2901c9762de2a2df743b2010e7ad0b6ccd2cab5a4f49a496f93'
 
   # cdn.hackplan.com/theair was verified as official when first introduced to the cask
-  url "http://cdn.hackplan.com/theair/#{version.after_comma}/Pomotodo_v#{version.before_comma}.dmg"
+  url "https://cdn.hackplan.com/theair/#{version.after_comma}/Pomotodo.#{version.before_comma}.dmg"
   appcast "https://air.pomotodo.com/v1/p/com.pomotodo.PomotodoMac#{version.major}/latest.xml",
-          checkpoint: '21ebb47c0df9fa1e7af72db365b4f76f9bc0db105e16d866d36f6ad2512a7ba3'
+          checkpoint: '91adc2d35a01e0b2cd65e87da42573474bc023a6e852dcc06bdd0e8816fa147d'
   name 'Pomodoro'
   homepage 'https://pomotodo.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.