### PR TITLE
Update freesmug-chromium to 63.0.3239.132

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '63.0.3239.108'
-  sha256 '789a2ec9b753b0448ec27665b30aae2c597c6f98ed2d906e2a54e1bd40c82733'
+  version '63.0.3239.132'
+  sha256 '9255680e9a07d493ab7af071c3b9781ecc7672bcdb83fcb42684fbad512961f0'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '2aa7f29434fec83c60470a5686e5aa0adec5962d8a019f3e588dfc9d65672115'
+          checkpoint: '890507a835ef1b4d95f4640c565e936265f0f6a6f5060f286f9a579d12fcdc24'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.