### PR TITLE
Update exodus to 1.42.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.41.0'
-  sha256 'd6141dd7beaf6fb9b462ac0f2734a7fa54b3f9e1324d57037a68676ec93a1ebf'
+  version '1.42.0'
+  sha256 '94c09cfed194c5a9cf6ad932bda92ca535a7c589390aa6f62eeb99497ebdaffb'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '9a56c7a8fdb2c86f8b8b0c72d8fe555ef137c4bc857ffc6c6b64ad6365311411'
+          checkpoint: '06c703709aa152a41b0acb85eda05a0a17e1bd3e4784b21378db7fc72b53d09f'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.