### PR TITLE
Update telegram to 3.7.2-113207

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.7.1-111991'
-  sha256 'abd54b3724b9f71b1599851bff92f7ae7ededfa10195f07e503ef19759e41c65'
+  version '3.7.2-113207'
+  sha256 '7bd99034439e9aed1b9ea4e7d8c558c2c11a67cca738f755f16a87b58e0d49f7'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '15e8393107b159617aa6e59c9c80793a334fd45f6cfcfe5cf474bc56cf436864'
+          checkpoint: 'ba6ef02b5113f029a25cfb9afcede126bf1c0253b5716c0dfd00066d1b6b8e11'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.