### PR TITLE
Update joplin to 0.10.41

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '0.10.40'
-  sha256 '54c60dafdb9f85b800c4890eaa5de977eca5e2b0d8b84e1ad1ad8a9b629d7875'
+  version '0.10.41'
+  sha256 '9c9f4207b4e5213f08d309441572146f0c0b9d5f11507fe7702afe3a1ef10bf9'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: 'fcc8d71d9917ab76f3c6a54d0d8ae06c3f015fa59de1f728dae33461077b051b'
+          checkpoint: '451bac8612a53d14d25dd74a7cc5fe4035dc5210ca9d05ac71ab42c32754828d'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.