### PR TITLE
Rename bluegill-katana to washedoutco-katana

### DIFF
--- a/Casks/bluegill-katana.rb
+++ b/Casks/bluegill-katana.rb
@@ -2,12 +2,11 @@ cask 'bluegill-katana' do
   version '1.1.1'
   sha256 'bb618628bd335c60dab87bc82c4e5d72df8e80e0baf5510c861962afda915fbc'
 
-  # github.com/bluegill/katana was verified as official when first introduced to the cask
-  url "https://github.com/bluegill/katana/releases/download/v#{version}/katana-#{version}-mac.zip"
-  appcast 'https://github.com/bluegill/katana/releases.atom',
-          checkpoint: '4ea7ef6c6c4aca75a63b6fff9bb15b78a53a40112e660a1d980e4d825e93e38f'
+  url "https://github.com/washedoutco/katana/releases/download/v#{version}/katana-#{version}-mac.zip"
+  appcast 'https://github.com/washedoutco/katana/releases.atom',
+          checkpoint: '39ca93772f2b3236537672f582296ce6eeafc652807ec475a11728d370ced13c'
   name 'Katana'
-  homepage 'https://getkatana.com/'
+  homepage 'https://github.com/washedoutco/katana/'
 
   app 'Katana.app'
 end

--- a/Casks/washedoutco-katana.rb
+++ b/Casks/washedoutco-katana.rb
@@ -1,4 +1,4 @@
-cask 'bluegill-katana' do
+cask 'washedoutco-katana' do
   version '1.1.1'
   sha256 'bb618628bd335c60dab87bc82c4e5d72df8e80e0baf5510c861962afda915fbc'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.