### PR TITLE
Update metasploit to 4.16.31+20180106131746

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.29+20180102131846'
-  sha256 '1c2aa4b9334828da20046c3c55995a9a28271273bc0116c41073e79417deb651'
+  version '4.16.31+20180106131746'
+  sha256 'b2e60d75921df8f0f72f7700e5db0735153c0a43a63a1737021fcd51131523d6'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '97d245722fad4b566fc339e2b0cdc0f69975e01a3d8f45c70f8158b95dcdfdb6'
+          checkpoint: '7940bb51d24e8ce4c940aff34970acf25762139eb7cd86c858aadeb52d11aae6'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.