### PR TITLE
Added ExpressVPN 6.6.2.2812

### DIFF
--- a/Casks/expressvpn.rb
+++ b/Casks/expressvpn.rb
@@ -1,0 +1,14 @@
+cask 'expressvpn' do
+  version '6.6.2.2819'
+  sha256 'ed262fa96879b8ebfa4349e5c163ed96d7756f3e32b79185d2b8b0ce7230632d'
+
+  url "https://download.expressvpn.xyz/clients/mac/expressvpn-install_v#{version}.pkg"
+  name 'ExpressVPN'
+  homepage 'https://www.expressvpn.xyz/'
+
+  auto_updates true
+
+  pkg "expressvpn-install_v#{version}.pkg"
+
+  uninstall pkgutil: 'com.expressvpn.ExpressVPN'
+end


### PR DESCRIPTION
ExpressVPN was removed in 2015 because the download was walled, but this download is from the source and is not behind an auth wall.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
