### PR TITLE
Update Forklift 3.1 to use https

### DIFF
--- a/Casks/forklift.rb
+++ b/Casks/forklift.rb
@@ -2,9 +2,9 @@ cask 'forklift' do
   version '3.1'
   sha256 '34021c8ca7458cdaff1c4835b0348cb4bf0093196a779502de1871f4178606be'
 
-  url "http://download.binarynights.com/ForkLift#{version}.zip"
+  url "https://download.binarynights.com/ForkLift#{version}.zip"
   appcast "https://updates.binarynights.com/ForkLift#{version.major}/update.xml",
-          checkpoint: 'a7104287e5c3fec703f7215e66f2bf1ca4bf8cc9569be9a7a954cc3e6d9d5036'
+          checkpoint: '90f84ac818b7b7d3987978d671e618dadc4213b682efc0c20bfe56d4065d2b2c'
   name 'ForkLift'
   homepage 'https://binarynights.com/forklift/'
 


### PR DESCRIPTION
Change url from `http` to `https` because the unsecured one no longer works

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

<img width="835" alt="screenshot 2018-01-06 19 14 28" src="https://user-images.githubusercontent.com/679017/34645545-1d37f518-f316-11e7-99f2-0831319419b1.png">

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
  