### PR TITLE
Add Storyboarder.app v1.3.0

### DIFF
--- a/Casks/storyboarder.rb
+++ b/Casks/storyboarder.rb
@@ -1,0 +1,20 @@
+cask 'storyboarder' do
+  version '1.3.0'
+  sha256 '1a73f734b9a64a5387637d131145620f96e2bc52a2b78d6de80d3f9b210aa593'
+
+  # github.com/wonderunit/storyboarder was verified as official when first introduced to the cask
+  url "https://github.com/wonderunit/storyboarder/releases/download/v#{version}/storyboarder-#{version}-mac.zip"
+  appcast 'https://github.com/wonderunit/storyboarder/releases.atom',
+          checkpoint: 'afa62955c90a0fb627cc3cd3d21dcc36875e55f337ba19705fec70390c071e6c'
+  name 'Wonder Unit Storyboarder'
+  homepage 'https://wonderunit.com/storyboarder/'
+
+  app 'Storyboarder.app'
+
+  zap trash: [
+               '~/Library/Application Support/Storyboarder',
+               '~/Library/Preferences/com.wonderunit.storyboarder.helper.plist',
+               '~/Library/Preferences/com.wonderunit.storyboarder.plist',
+               '~/Library/Saved Application State/com.wonderunit.storyboarder.savedState',
+             ]
+end


### PR DESCRIPTION
There is a [rejected pull request for the Storyboard Fountain app](https://github.com/caskroom/homebrew-cask/pull/36774) that is no longer maintained, but the author of that PR did not submit a new PR for the maintained Storyboarder app, which replaces Storyboard Fountain. This PR introduces a cask for the Storyboarder app, which is actively maintained.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256