### PR TITLE
Update clyang-welly to 3.1.1.1

### DIFF
--- a/Casks/clyang-welly.rb
+++ b/Casks/clyang-welly.rb
@@ -1,10 +1,10 @@
 cask 'clyang-welly' do
-  version '3.1.0'
-  sha256 '3cf2affca536c788e5f96e67cd4dab3fdeb20e115f1fa242285ed9a8ab1f316e'
+  version '3.1.1.1'
+  sha256 'f17aa74d8668d02ff7c6eee81ae7e0c06d76a51d4aa50624ffe757c95f498ecf'
 
   url "https://github.com/clyang/welly/releases/download/#{version}/Welly.v#{version}.zip"
   appcast 'https://github.com/clyang/welly/releases.atom',
-          checkpoint: '47fc74ce4e81906bf418bbf8bc99160720572c9cf5a1ef053b71905bd8ab0b1c'
+          checkpoint: 'c8c5b24aa48e9914680ee0313b7e3e4d7663f73b23110ab269235d5f8ad5520e'
   name 'Welly'
   homepage 'https://github.com/clyang/welly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.