### PR TITLE
adium v1.5.10.4: add conflict with adium-beta

### DIFF
--- a/Casks/adium.rb
+++ b/Casks/adium.rb
@@ -9,6 +9,7 @@ cask 'adium' do
   homepage 'https://www.adium.im/'
 
   auto_updates true
+  conflicts_with cask: 'adium'
 
   app 'Adium.app'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.