### PR TITLE
Bug fix for changed file name

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -2,7 +2,7 @@ cask 'cityofzion-neon' do
   version '0.0.9'
   sha256 '5e76baeb7ae51a233270364a50886500b5ccfb5e5f6bd4c72eb0c49a344992c3'
 
-  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.dmg"
+  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
           checkpoint: '00888edfcf0a1f09c9002ea4ce2fea014e1089a82b6f3aa2dc24eb2e44a1a4b3'
   name 'Neon Wallet'

--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -4,7 +4,7 @@ cask 'cityofzion-neon' do
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: '00888edfcf0a1f09c9002ea4ce2fea014e1089a82b6f3aa2dc24eb2e44a1a4b3'
+          checkpoint: '6b1d962ba9941f2063cba44e7dc6346efe2e9d641397038ff4e9c027a8675d99'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
```
==> Found outdated apps
     Cask             Current  Latest  A/U    Result    
1/1  cityofzion-neon           0.0.9        [OUTDATED]  

Do you want to upgrade 1 app [y/N]? y
==> Upgrading cityofzion-neon to 0.0.9
==> Satisfying dependencies
==> Downloading https://github.com/CityOfZion/neon-wallet/releases/download/0.0.9/Neon-0.0.9.dmg

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'cityofzion-neon' with message: Download failed: https://github.com/CityOfZion/neon-wallet/releases/download/0.0.9/Neon-0.0.9.dmg
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
