### PR TITLE
Update feeder to 3.5.6

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.5.5'
-  sha256 'da842a18b6589bca7a3e9669b06590ce80444d6f3967c8414498e11c907426f1'
+  version '3.5.6'
+  sha256 '267e4e8b50345d53948d378a9f36f90edbe7f4c7023b8e22e2406ede51bcfe93'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: '5ae4817d34e2483e02d8da49f3a21d7be34ba3af6de8b3d679d8de3d76f79c38'
+          checkpoint: '4f3d28521c56636c0b1264476c32ce1374ba4522920f641ee3d9f320f24c1a75'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.