### PR TITLE
Update iboostup to 5.9.81

### DIFF
--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -1,10 +1,10 @@
 cask 'iboostup' do
-  version '5.9.55'
-  sha256 '990760306e648d365d38b64ebf8f7fc0b8f89378dd9266cb59ed236475b16943'
+  version '5.9.81'
+  sha256 '6eb7a40dbe54b60064403980cfda3e33b89f35be3570978d4a51a312f82b2080'
 
   url 'https://www.iboostup.com/iboostup.dmg'
   appcast 'https://www.iboostup.com/updates',
-          checkpoint: '4cefbea13cdd94240b8f0455eab0d50b43b5c047a6029f2d918a8181a5c28be9'
+          checkpoint: '169038ac2747ec13607379452b11fa2e8b090e6928275f997dc512fca51b4044'
   name 'iBoostUp'
   homepage 'https://www.iboostup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.