### PR TITLE
Update kite to 0.20171214.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20171114.0'
-  sha256 '83cf7a8c8a07391195ecf1c7b144053291d3743261f194d398f8b09c0803560d'
+  version '0.20171214.0'
+  sha256 '9b2bf75749900c3682d458d6f228a1163e134344d9dff395d1f5606ffbba9bee'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '7995d2d44a2f8aabd3014e06fab625f4bebd44d83020081d5912574816fdab6e'
+          checkpoint: '70a8f62f1aa1d21c9903eb66f7d91fd73516cfdd26cbc31b5e64454ba962a4d4'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.