### PR TITLE
Update koala to 2.3.0

### DIFF
--- a/Casks/koala.rb
+++ b/Casks/koala.rb
@@ -1,11 +1,11 @@
 cask 'koala' do
-  version '2.2.0'
-  sha256 '3c8f0358a347b51c7efc7f8437888caaac0091bcfbd4f5bd6deed92e8c7cabf1'
+  version '2.3.0'
+  sha256 '6494408132c8818956a0a0423ed284120506bad0d5dc2349e8ffa7e16c9696bc'
 
   # github.com/oklai/koala was verified as official when first introduced to the cask
   url "https://github.com/oklai/koala/releases/download/v#{version}/Koala.dmg"
   appcast 'https://github.com/oklai/koala/releases.atom',
-          checkpoint: '081f97357bc5ec3522d6403d7808828f4daf73ad7a511243c381b5e0e0260d90'
+          checkpoint: 'eb41b1f9b5834ab1f4150a3c784dbcf301ff163097d06bf0222ed5bc618dcc64'
   name 'Koala'
   homepage 'http://koala-app.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.