### PR TITLE
Update graphql-playground to 1.3.22

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.3.20'
-  sha256 'e237210a5a619bf058b38ac844b56287ebe0a717d14a0b931fb2be92beaa7411'
+  version '1.3.22'
+  sha256 '490dfaf6d2121660073ec1c762757e6777ae88ec2635e65c1f5f1d1f4c99ec22'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: '04cdc070876aa86f3bd4be668b2ecb6065949f478f8288ef781cade95d95de88'
+          checkpoint: '898abe2cf2f46e394ffe14fec40123aeaeb9e473128dd93b51ed85c84204578c'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.