### PR TITLE
Update freeplane to 1.6.12

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,10 +1,10 @@
 cask 'freeplane' do
-  version '1.6.10'
-  sha256 '9635d901e23a8c547956e2027337a44605738d66fd9842f4ec0e0f46683664e6'
+  version '1.6.12'
+  sha256 '97b79f51fae95cc5890b55417c2e6c02019687c847eaf14c7f8b875d2251a757'
 
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app_jre-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable',
-          checkpoint: '49b21ea5e5a65bf06f8676b3b994451316ccae1f505c0d97c621e8e37d039952'
+          checkpoint: 'cb369a16417ceb1f2b0250b119d5cfa1a9537ee01f69807fd1733464a6b5eb24'
   name 'Freeplane'
   homepage 'http://freeplane.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.