### PR TITLE
Update electrum to 3.0.5

### DIFF
--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -1,10 +1,10 @@
 cask 'electrum' do
-  version '3.0.4'
-  sha256 'b4f2b57a30880f9762b8ab31abaa3e7c853693223f4fad65c8c9241bb0d0ab70'
+  version '3.0.5'
+  sha256 'dd04e0cb0701af1a38cabe83607a66f5be8b89d3d13ad28bf6367627249270f8'
 
   url "https://download.electrum.org/#{version}/electrum-#{version}.dmg"
   appcast 'https://github.com/spesmilo/electrum/releases.atom',
-          checkpoint: '6be2c04177a9fbcc607f54b171a88c4690223d80ab373186387e201af5099310'
+          checkpoint: '1c7ddc706e9fcc142f66b7dedf88eeaad84bedb46e7d0a898b8efd46d79b4abe'
   name 'Electrum'
   homepage 'https://electrum.org/'
   gpg "#{url}.asc", key_id: '6694d8de7be8ee5631bed9502bd5824b7f9470e6'


### PR DESCRIPTION
Fixes a potential vulnerability.

- [x] `brew cask audit --download electrum` is error-free.
- [x] `brew cask style --fix electrum` reports no offenses.
- [x] The commit message includes the cask’s name and version.

  