### PR TITLE
Update vuescan to 9.6.02

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.5.92'
-  sha256 'c6c7a720769d9f5605bcabe45d765ffa56d30e2e0c4e8937e4ab98bd5e18fe30'
+  version '9.6.02'
+  sha256 '48e1a43e6e1990e33b0894010474a594d0c41af62cc56136f76235d016c0bce0'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: '3bae093a924139a76d31e6d339e428e3386a69ad4731ffd33da737ac384e8f7c'
+          checkpoint: '9f143b1a0be1bbae50169ba36c5ba7139bdd57fd87607efadfac8c3aabb83484'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.