### PR TITLE
Update filezilla to 3.30.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,11 +1,11 @@
 cask 'filezilla' do
-  version '3.29.0'
-  sha256 'e7264da974dc95ffb36af0bbe2a0233fbbb876a11f67e69417fa3e15f52fc1c2'
+  version '3.30.0'
+  sha256 '946051d8349caf6707093e1d6a97931b8d80f33c31d247c7d10316d06079f4c2'
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: 'ddb618d0a52162617c69b8f2036cbd006ae7127c17d21da1ae48d0f93edfeb77'
+          checkpoint: '23b6f61812fb31de664aad70a3dc9de6a23ca93591bbc1ee6b1ea02e9c901f9f'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.