### PR TITLE
Update netron to 1.3.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.2.9'
-  sha256 'db4aa40f18f88bf6a574b4351ffd76fffb8f07cf742fa01f9cc557eb2f2b3f18'
+  version '1.3.0'
+  sha256 '3d0648357bee47cce3e4ef9bc543b4a93326f87eaf3a909da96a0731c124ee2f'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'd67a69a1bea5ce15d9ac15f72da6212fc9b24a23b38843ec2140a493a3c84304'
+          checkpoint: '1f35f23b60a9ba52fae875dc1004b46da57375b3692ffd2f920883ae39628330'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.