### PR TITLE
Update flash-npapi to 28.0.0.137

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-npapi' do
-  version '28.0.0.126'
-  sha256 '19f875722d34f985acc82c9369ace1a7053005ea22c31fe43dafc21c14f40553'
+  version '28.0.0.137'
+  sha256 '5d70c1c4767886b6cf60a4f9c064f9a54eb3eda280beb09546b3ff8d82b9dafc'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '6674b9b037cf5dbd0dd77b4e34b88c7b1c9113091d2911daa87b1fdd0163369b'
+          checkpoint: '0e62296da997de154e620ca99f77fd9842641dbaf5970a8dc41dc927fedcc2cc'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox)'
   homepage 'https://get.adobe.com/flashplayer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.