### PR TITLE
Update flash-player-debugger-npapi to 28.0.0.137

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger-npapi' do
-  version '28.0.0.126'
-  sha256 '8d3140ecaae5a940fc24472f2e8e34587dcbbb26ad51e7353ed38f728c0b2c57'
+  version '28.0.0.137'
+  sha256 '87893b6267b50cc4b24c376077d276ff861e7d99bcf9ac29000f3080abe0165a'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '6674b9b037cf5dbd0dd77b4e34b88c7b1c9113091d2911daa87b1fdd0163369b'
+          checkpoint: '0e62296da997de154e620ca99f77fd9842641dbaf5970a8dc41dc927fedcc2cc'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.