### PR TITLE
Update gns3 to 2.1.2

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.1'
-  sha256 'b912355bca574fe9be3cf3635d7b33b61fa3a87e7f6ef47ca7669c18ded6b6bd'
+  version '2.1.2'
+  sha256 'dc355aba87d897dbd5d10706232aa9d35195515436261157bcf823f90dba5d98'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: 'fb86f8f02b9cf1a6fa7ce8fb37537b8bc944fd6512073a94bfd85813df592ccc'
+          checkpoint: '1d9a8fe5e093cd50cefeeb96e5faa15218ab3e6ee8b0e2eed92555513d2738b0'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.