### PR TITLE
Update pritunl to 1.0.1561.31

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -16,7 +16,8 @@ cask 'pritunl' do
                          'com.pritunl.client',
                          'com.pritunl.service',
                        ],
-            signal:    ['TERM', 'com.electron.pritunl']
+            signal:    ['TERM', 'com.electron.pritunl'],
+            delete:    '/Applications/Pritunl.app'
 
   zap trash: [
                '~/Library/Application Support/pritunl',

--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,11 +1,11 @@
 cask 'pritunl' do
-  version '1.0.1543.29'
-  sha256 'f13c7835ec6aefd505e0f113a2cee7d7be958ca2409a1d6179715063fd4426d0'
+  version '1.0.1561.31'
+  sha256 'f0e2a15ae55135523a2d9f1e59bb3c16db4e4559335592452cf5cc5fcf7ef626'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"
   appcast 'https://github.com/pritunl/pritunl-client-electron/releases.atom',
-          checkpoint: 'e8deb100dd948cef10960203370cb43580d6067126d3ccd70e5b8168c4f63a0d'
+          checkpoint: '47c39a3f7e75d73a271148bfa7b6290cf54e567f4f0a2727728289d32cb35645'
   name 'Pritunl OpenVPN Client'
   homepage 'https://client.pritunl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.