### PR TITLE
Update scrutiny to 7.6.7

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,10 +1,10 @@
 cask 'scrutiny' do
-  version '7.6.2'
-  sha256 '80e31ec3ef603abbd2386b365970d60b647fd35dde4a644e77b021e2a54a18e5'
+  version '7.6.7'
+  sha256 'a5719ae285226caacfce3605dab1b9b9fc18e1f7a36cdda130607f44e46e52a2'
 
   url 'http://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'http://peacockmedia.software/mac/scrutiny/version_history.html',
-          checkpoint: '6b9de75d92f40a14eb322f1a82a549cdde642e76c36a4c403561b6f1613ed509'
+          checkpoint: '6088ea67ac40515b89f25c9fa1f13cb584f51e44b07d7a6df6eac2b965db68a7'
   name 'Scrutiny'
   homepage 'http://peacockmedia.software/mac/scrutiny/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.