### PR TITLE
Update fldigi to 4.0.13

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.12'
-  sha256 'ebbab8f04ac20f2d1b4b6236ccf865d73e215fc16f190563e3012259c69c3a04'
+  version '4.0.13'
+  sha256 '3c73f1d09c9dac4c9c9285f02e4f3bc7d0a59f44c014b2ae5b3ec9a82af5328c'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}.univ.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}.64bit.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: 'b51b27ac8eba6d9592913d9f4d4444fb52f50f46c933b156eb1c80cdf0675a53'
+          checkpoint: '6f3dfb43aca05a45ba4eb31100260d294c82770db55e112b89c68ea9b2d6345a'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.