### PR TITLE
Update lehreroffice-zusatz to 2017.19.2

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2017.19.1'
-  sha256 '0448ea88d5286ca2a7bd0f924018cc4e4fe7266c57d88553fe8fd5407432c8d4'
+  version '2017.19.2'
+  sha256 '6bae74545e3f4d98b471a90f7970b31f4e0bbe3f09a29845f7bb598bcd93f253'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '891f6ad23d0554d4e2c87f2667d64ab326d8858883ff80fcd7fa92118a4607f7'
+          checkpoint: '951662e2da7713050ae216bb179ab2e11489198f5ae1926c76e7ee45c7e6578a'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.