### PR TITLE
Update docker to 17.12.0-ce-mac46,21698

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '17.09.1-ce-mac42,21090'
-  sha256 'a88be43d90b76cd5055c0c53cf6b65a0769488a5afa4db3be0eecd4f6b3429b8'
+  version '17.12.0-ce-mac46,21698'
+  sha256 'c1938b19416408dc127fd28fa3069a448398a39db596ecaaf6bd9b7dd505487b'
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: '3fb23f4bb724212ad48c52f2f51d7fb6a0d6708561fca4f1f902f936f9a27ffb'
+          checkpoint: 'ca0c386c79e09d874294a1b64429a5e72a346f9412a454b0741e9ef7c5c6b0f2'
   name 'Docker Community Edition'
   name 'Docker CE'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.