### PR TITLE
Update atext to 2.22.3

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,10 +1,10 @@
 cask 'atext' do
-  version '2.22.2'
-  sha256 '287fc6498430e88cf48cae0ac15a881f3a6681f775a075b9260b843334338fd8'
+  version '2.22.3'
+  sha256 '553957237e7dbbcc25208ba030f2efc1ce428efef93766b12141ba665f528edd'
 
-  url 'https://www.trankynam.com/atext/downloads/aText.dmg'
+  url 'http://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml',
-          checkpoint: '1ac415d196ae88529c955a7682ec2b2065eb5315492d7b0eb0eed3d5d055e34b'
+          checkpoint: '01816bad0f3226f4d9941b5c889f7042717486b5aeb5e3847b8538d90ea939a9'
   name 'aText'
   homepage 'https://www.trankynam.com/atext/'
 

--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -2,7 +2,7 @@ cask 'atext' do
   version '2.22.3'
   sha256 '553957237e7dbbcc25208ba030f2efc1ce428efef93766b12141ba665f528edd'
 
-  url 'http://www.trankynam.com/atext/downloads/aText.dmg'
+  url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml',
           checkpoint: '01816bad0f3226f4d9941b5c889f7042717486b5aeb5e3847b8538d90ea939a9'
   name 'aText'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.