### PR TITLE
Update ganache to 1.0.2

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,11 +1,11 @@
 cask 'ganache' do
-  version '1.0.1'
-  sha256 '40f1600a81737b653349152af9d94af8bc46233978584bf47d8182404e973d56'
+  version '1.0.2'
+  sha256 'fd79850eb2a7a6b28022cdf31724873c225817fdb06d00315aab50719bd69394'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}.dmg"
   appcast 'https://github.com/trufflesuite/ganache/releases.atom',
-          checkpoint: '4ec6dfca043d894dab810fa8284b25773e53a4cad38496342e7cc9105253f9b2'
+          checkpoint: '238b0de58cc42ce87403dcbe28bcb4f2a67acd28a23dfc0bd9092fc4f16d4a81'
   name 'Ganache'
   homepage 'http://truffleframework.com/ganache/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.