### PR TITLE
Update simplenote to 1.1.2

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,10 +1,10 @@
 cask 'simplenote' do
-  version '1.1.1'
-  sha256 '135022c922dbbafe112ecdf3de7089618569ea1517ea373021f81f2b374b4b81'
+  version '1.1.2'
+  sha256 '59092b964afdb8ba6bd335f8b0cb05a4bba3c87282d06c7d46394cf87d031342'
 
   url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.zip"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom',
-          checkpoint: '934f1480041814a09fabe1b4f8ee3fb6f5d835d31b4c12a4cb47bcae4de72586'
+          checkpoint: '6f8a954c631476a564c6093524636fefc8fd71bc1ae97d135922aef05c5bbd1c'
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.