### PR TITLE
Update lepton to 1.5.1

### DIFF
--- a/Casks/lepton.rb
+++ b/Casks/lepton.rb
@@ -1,11 +1,11 @@
 cask 'lepton' do
   version '1.5.1'
-  sha256 '80d918988362e9d67446e4330d85d66d6c2f0905c18ed4ba74510712e410a567'
+  sha256 'cc88cdeef38bd3023237ceb6b33efdfcfcfe8b7dfd065609234ee9a4e69eb5c3'
 
   # github.com/hackjutsu/Lepton was verified as official when first introduced to the cask
   url "https://github.com/hackjutsu/Lepton/releases/download/v#{version}/Lepton-#{version}-mac.zip"
   appcast 'https://github.com/hackjutsu/Lepton/releases.atom',
-          checkpoint: '9ae3739c36d98d4e1651f375fe38222016ec66a6c5eac2825cd14e20833b6671'
+          checkpoint: '40a55bd5f283759cde6523c72c27aa0d64ef4263be9beee3bbc209221c8ae823'
   name 'Lepton'
   homepage 'http://hackjutsu.com/Lepton/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.