### PR TITLE
Update tortoisehg to 4.4.2

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.4.1'
-  sha256 '63d454bd54f83f9f9dd4e30caa984834700f56fab7618c701362d1590834b986'
+  version '4.4.2'
+  sha256 'd38633707ff9c4e0c8971ddfba4c85c730b8ba2d3478d72c00baace34cb244b0'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.