### PR TITLE
Update powerphotos to 1.3.5

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,13 +8,13 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.3.4'
-    sha256 'f2ba90528403737ba77e55a0527a0f9d946928cfde6382df84582eea9ed4924c'
+    version '1.3.5'
+    sha256 '0672fd3743ce9905ba742003b86ea188b60628ccacd301bfbabc75bb7869205f'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: '7af8bf476d184b74c14047fe844aa83859556a8c46466bbe7b535faa78057d1a'
+          checkpoint: '6a3b876929b2491630f6b14f3156455d4054ce4484c6b17802034b90d0ad1222'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.