### PR TITLE
Update gtkwave to 3.3.87

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.86'
-  sha256 'feee8e20efe4048f8a4ac6e77948b95ac59b860ec6fe4aac560da566864f1f87'
+  version '3.3.87'
+  sha256 'e9e3cdfd06f76ed4de8b29d55a29f9b714a68a00501b13b4741078a506d1cc8a'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: 'd51fe0e06f25569c0d9fbabb5c89374da0dcd77f8c7a092ae47164f5ac2fd093'
+          checkpoint: 'bea1232122ff24237497ea61cbfabc2900cc2590059eb32b66524bfbcd9515bf'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.