### PR TITLE
Update flux to 39.987

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,10 +1,10 @@
 cask 'flux' do
-  version '39.984'
-  sha256 'c91c43641f6e6d41a10a8831aecae638cd402ef0c4bb0a0eafc90300d3e6e9ce'
+  version '39.987'
+  sha256 'a94f0adc267700c933dba0ed71b3dd6ef4891499e94bbb6be0903a3dbc0692b2'
 
   url "https://justgetflux.com/mac/Flux#{version}.zip"
   appcast 'https://justgetflux.com/mac/macflux.xml',
-          checkpoint: 'e25f6de1ea73a8a63230af8221a6f532feaa4b2bdedf3ee186f3af9a4f746350'
+          checkpoint: 'ee801644f709e7dd5517823626eb7b2096610fd66004b65e210909cc7d5c1d77'
   name 'f.lux'
   homepage 'https://justgetflux.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.