### PR TITLE
Update cocktail to 11.2.1

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -28,12 +28,12 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
             checkpoint: '7d3fd5bf0b5816bc3971adfea9e571619e589ee6c30c6fcd6f0c5a1de21026da'
   elsif MacOS.version == :sierra
-    version '10.5'
-    sha256 'f46cc161e9d1fa5286124d2b55739c6728ad18ea3574416711decdb460705d9f'
+    version '10.6'
+    sha256 '1f4537d47ddbf6f8611d34f26389dc402146ca79782e876cb5a637ee13d93c59'
 
     url "https://www.maintain.se/downloads/sparkle/sierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml',
-            checkpoint: '14e56e7ee6de6655d987c68a48e8a794a039bced79241ef4a95243ddd5d00ba3'
+            checkpoint: '857abd14b79507e364a006d51d05b90b1ccaafaa35d2504dbd12d550f65e00f5'
   else
     version '11.2.1'
     sha256 '0537f51b3145b88c5ac09e6f07c50f8dd0c868ff1e8c89c48ec8158580f099e0'

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -35,12 +35,12 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml',
             checkpoint: '14e56e7ee6de6655d987c68a48e8a794a039bced79241ef4a95243ddd5d00ba3'
   else
-    version '11.2'
-    sha256 'a5de4c2f9b58f0d2a07eeacfdd74eb1f161a0400b86fb41d591c309f411efbee'
+    version '11.2.1'
+    sha256 '0537f51b3145b88c5ac09e6f07c50f8dd0c868ff1e8c89c48ec8158580f099e0'
 
     url "https://www.maintain.se/downloads/sparkle/highsierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/highsierra/highsierra.xml',
-            checkpoint: '3855ed5fb8b8e1a742f4338f362adbf1653db90ee7ac0ac175f282f5d19d2024'
+            checkpoint: 'd08d5eb1c9bdb14ceeda0cfa591a2f90f13b06639690d1ef45c46f203211f0b5'
   end
 
   name 'Cocktail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.