### PR TITLE
Update downie to 3.1.5,1749

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.1.4,1745'
-  sha256 '2758627dd4b2b6bcc52e00c64e731b97f4ca39cc74d24d6936878d77da5c511c'
+  version '3.15,1749'
+  sha256 '64925cae531bf0e9e59d8a4f7d8ce4b1f395bea9e6dba87999711b7ec8a6a9a6'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: '91e08912b025cff408f89878d311561471813311d89957a7ef681851b3274329'
+          checkpoint: '3e5e2de5facbd979275ccf514b24772bd39f19e49167eb28fbe080a147bfad89'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 

--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,5 +1,5 @@
 cask 'downie' do
-  version '3.15,1749'
+  version '3.1.5,1749'
   sha256 '64925cae531bf0e9e59d8a4f7d8ce4b1f395bea9e6dba87999711b7ec8a6a9a6'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.