### PR TITLE
Update wireshark-chmodbpf to 2.4.4

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,10 +1,10 @@
 cask 'wireshark-chmodbpf' do
-  version '2.4.3'
-  sha256 '61f500c923b729be56b4bf453c2fca865cd921b8cc153da8a79d45a3f932bdd3'
+  version '2.4.4'
+  sha256 'eb6d9a304b2697a90f267bd8734926a9fe37939aab8394a550cd4c272dd15e11'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.wireshark.org/download/osx/',
-          checkpoint: 'ed58220a9b13fb3ddcfce3202b526284f66d6236cb98e3b5a44a786731878105'
+          checkpoint: '21ad6f76ce959441d89535a491cfef75e855c48a54213a22aaa55e83e4117127'
   name 'Wireshark-ChmodBPF'
   homepage 'https://www.wireshark.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.