### PR TITLE
Update rsyncosx to 4.9.6

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '4.9.2'
-  sha256 'e9ac68a05c8c61a6f9c9d2cbb70f405670f8c29bdd89dbea0288514a1038611e'
+  version '4.9.6'
+  sha256 'ed4970ff6a985f31145c3b08d06c9445a793021e9f1219d83c1e53dc4c926fa1'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: 'f9e657e4e0fc17e50efd0e67ff3ed4efc1f9e0c02736d817d736666e2294adbb'
+          checkpoint: 'eb9d4ad5e6bed25387745715eb339b8c4cf485a727c7021c5eb7a419ab2c5133'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.