### PR TITLE
Update feeder to 3.5.7

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.5.6'
-  sha256 '267e4e8b50345d53948d378a9f36f90edbe7f4c7023b8e22e2406ede51bcfe93'
+  version '3.5.7'
+  sha256 'ce0ff58e504854314fddefffefa571fb3ca3be346ca0e4a8a69752ff6d49311d'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: '4f3d28521c56636c0b1264476c32ce1374ba4522920f641ee3d9f320f24c1a75'
+          checkpoint: '4ff6f7fa424ddfcaf2aed5311ae298835917545a2276d59acd63fdf39f8f8812'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.