### PR TITLE
Update navicat-for-mysql to 12.0.20

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.19'
-  sha256 '1ff2c3c7755a8f3151e14cb3b1ab3b6911a2145cfc4f12a3d7696b76f2e5c6c5'
+  version '12.0.20'
+  sha256 '71bd7d9d8abcb7cb14506d61158a025f3c4ebecfc95ff2398248c7c39b78e0cd'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: '727d30bc018771deea10d6fb3480f7424ee6e41055bd7a2f5aa1a8bc88a7a4e3'
+          checkpoint: 'a713bea84facc0985f3b4b4d3a2bde66b9661a1734c9fa3ddb7376ee96df5b92'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.