### PR TITLE
Update navicat-for-postgresql to 12.0.20

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.19'
-  sha256 'c36589c1808db80793cc268eb2c00f95e772937c9d75fa79a0b01b3e773cc53c'
+  version '12.0.20'
+  sha256 '207d510e6d3117f72b8681395502cf2eb869242a62284ddfb7a18c25e84eee16'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-postgresql-release-note',
-          checkpoint: '83461ad788bd536f09477c4890c438805006a24b2423d714cf2d1139629e4575'
+          checkpoint: '22dd1c33a056d670771100fff9d92a584136e9743a2743089a5c5509af1d0283'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.