### PR TITLE
Update navicat-for-sqlite to 12.0.20

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.19'
-  sha256 '21235a891909177423b2b5403f9890a57f0525524f9f4576e4ceec46b6be988a'
+  version '12.0.20'
+  sha256 'c28bc5a1b87fe7aa83cd970a2f6a65570c1a6be8edeb80266cb3a197229c211e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlite-release-note',
-          checkpoint: '9ad09b2d459e8e9dd8e3574857ed3e8dbef0725d03bd288bb38248a3a904525b'
+          checkpoint: '477e0813c77d7f109bee060585b8e4ee3860b3f8198c31798232fed63e267a01'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.