### PR TITLE
Update tableplus to 1.0,81

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
-  version '1.0,80'
-  sha256 '9b94cf47d08df9025139c751c9771a4bae6008d0b0455aa4a549be10e164a875'
+  version '1.0,81'
+  sha256 '5289ec4f5c42d14f98e5be46ae48bb899c165f117a56146bd92f3699ad4378ce'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: '38f9fdefd8b64b7d4986b2dcfaa03ed783abdd11087a85b80ff93c41051088a6'
+          checkpoint: '074c1f91d52368c268cf9f149a03eae4d2c159dcf0a2849b7092ca10466ef16d'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.