### PR TITLE
Update lehreroffice-zusatz to 2017.19.3

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2017.19.2'
-  sha256 '6bae74545e3f4d98b471a90f7970b31f4e0bbe3f09a29845f7bb598bcd93f253'
+  version '2017.19.3'
+  sha256 '2d56a81aedeb9c0374d6bf76a7b766bdfd8b0c9dc641e310e0c1e060c0b07fae'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '951662e2da7713050ae216bb179ab2e11489198f5ae1926c76e7ee45c7e6578a'
+          checkpoint: '32b8b23b90ed403f037066a66cf97764e429c004c88406a798a0c7d3e34c15aa'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.