### PR TITLE
Fix checksum for rerelease of ganache 1.0.2. Fixes trufflesuite/ganache#260.

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,11 +1,11 @@
 cask 'ganache' do
   version '1.0.2'
-  sha256 'fd79850eb2a7a6b28022cdf31724873c225817fdb06d00315aab50719bd69394'
+  sha256 '80ccdf1a7da83912c38af35bcdb325f971b56474afb6d1b9e5502831a0593026'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}.dmg"
   appcast 'https://github.com/trufflesuite/ganache/releases.atom',
-          checkpoint: '238b0de58cc42ce87403dcbe28bcb4f2a67acd28a23dfc0bd9092fc4f16d4a81'
+          checkpoint: 'ec43ed8e40d1fdcffbccccc3a6b659849222a34ba3e609c8dcdda67928a6f99f'
   name 'Ganache'
   homepage 'http://truffleframework.com/ganache/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.