### PR TITLE
Update licecap to 1.28

### DIFF
--- a/Casks/licecap.rb
+++ b/Casks/licecap.rb
@@ -1,10 +1,10 @@
 cask 'licecap' do
-  version '1.25'
-  sha256 '0ed33667b3e19ee47fc09b3619499816e229bc678884fd5c27e24e785472f6ba'
+  version '1.28'
+  sha256 '130c8cd34b0048297433df9bce5dbc1b52e0e5b3d798c2cbc5be68773f3adbc6'
 
   url "https://www.cockos.com/licecap/licecap#{version.no_dots}.dmg"
   appcast 'https://www.cockos.com/licecap/',
-          checkpoint: '3213076943b13521614da283c34456831dc9cf09f74bbf204bb08921dc8aa581'
+          checkpoint: 'a93421693ad496a7c66d11218c67491f2472c523b189ade1d02700708ee924d4'
   name 'LICEcap'
   homepage 'https://www.cockos.com/licecap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.