### PR TITLE
Update studio-3t to 5.7.3

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.7.2'
-  sha256 'a316ef16b9ffa00c7c0191bd6c3527ab8ad50c77b461d529159dcea99b68703f'
+  version '5.7.3'
+  sha256 '77757691fa21fbabc6215a227ec5427919ca98eaa5a84aa4ab3c7d0b5e981816'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: 'f5d50389dff6ce327227c96fda439209f84c4063005f5d93a24d4c9467587c88'
+          checkpoint: '8cc9326cbb07cd9843f1b554de7dcefd0a292abe8612b79eadc281a65495f8bc'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.