### PR TITLE
Update hopper-disassembler to 4.3.12

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.3.11'
-  sha256 'e62a62337badd38464f7e77d2fd18e305b72bc562d83a54e32f1d5eea95bfaed'
+  version '4.3.12'
+  sha256 'eb5072c8c4321b80e0e8d825142c30e8091cb8dd54d3c31d6a2566debaf8e778'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: 'b8a8df25dbfc5a1525fb28a33bb597b12bbc38d2b2e25a517ccaac6ddf7ce992'
+          checkpoint: '5035cf320fb0a243671d59469c2845a2cee585708306c108bf5edf5cb1ba61de'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.