### PR TITLE
Update dungeon-crawl-stone-soup-tiles to 0.21.0

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,10 +1,10 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.20.1'
-  sha256 '81bc57bb307b99d89dc8e5559ee8f30a5211b71eb162771ae07534c9f1d49948'
+  version '0.21.0'
+  sha256 '2acb43ac451e579c67d360727c271086ad5f5391d92f52ef69df1bde9e515862'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom',
-          checkpoint: '957a105056d323391f7fb641d3b2443f87b02ec3fcc92eb15e3382bfac2a042c'
+          checkpoint: 'dd96d66f02bc77ccf322d3031ca3b8a59f3870901cd6013b9e2c915ecce7e1b6'
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.