### PR TITLE
Update pomodone to 1.5.1227

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,6 +1,6 @@
 cask 'pomodone' do
-  version '1.5.1190'
-  sha256 '529de40429a02589dd699d257393076b1e854801225b2600966e442594da801f'
+  version '1.5.1227'
+  sha256 '079c3ddde0c117b10a5f434d66baa4bdc5bbb9a1f2fbb707ac2aa2dae9d24cd2'
 
   url "https://app.pomodoneapp.com/installers/PomoDoneApp-#{version}.dmg"
   name 'PomoDone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.