### PR TITLE
Mark Signal as auto-updating

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -4,7 +4,7 @@ cask 'signal' do
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/WhisperSystems/Signal-Desktop/releases.atom',
-          checkpoint: '536df6a136bec10125e216e1a8b0f286f3c952eb04628676a9d3226d59d2f601'
+          checkpoint: '004bd795c9fcc9aebc3a78952208b3f0cf6ceb63138013b35045b4c1294c9b78'
   name 'Signal'
   homepage 'https://signal.org/'
 

--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -8,6 +8,8 @@ cask 'signal' do
   name 'Signal'
   homepage 'https://signal.org/'
 
+  auto_updates true
+
   app 'Signal.app'
 
   zap trash: [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
Version probably (?) not applicable, change is version-agnostic. Can change if desired.

Signal has been auto-updating since the beginning so this change is long overdue. Proof:

![screen shot 2018-01-13 at 13 22 40](https://user-images.githubusercontent.com/732062/34905775-84673184-f868-11e7-936e-9a386569d588.png)
