### PR TITLE
Update byteball to 2.1.0

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,11 +1,11 @@
 cask 'byteball' do
-  version '1.11.5'
-  sha256 'e4f6128a2de9ee716b72825ccbf077163746c8df1c7b73bbdd006e2d5a1099f3'
+  version '2.1.0'
+  sha256 '60e1d4adade4b3a38a930ee70a5c24397aba5be93950d39141a5792df1abde2b'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"
   appcast 'https://github.com/byteball/byteball/releases.atom',
-          checkpoint: '432423798003751f17f1e7bb6ba3a9c1a8f48602aea71e91b9322b9be7e531ac'
+          checkpoint: 'bc766ea84b52d2f54a8965fe229c349293a4c925fe33de07da4452ff209ce219'
   name 'Byteball'
   homepage 'https://byteball.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.