### PR TITLE
Update cacher to 1.2.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.1.21'
-  sha256 '3a9baa7814d69f57c8a5c6008b2e2a7a6e8824af35b7d4dfe7292752244eecdc'
+  version '1.2.1'
+  sha256 '1788d7bf0a5bbb2ae43ec3adf81c4b021b69ba5addefe336523f2fc67b054517'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'cbfe494ade2d227dc864ee3d15339ec779fdd34fa497123871eaee3a3bdff91f'
+          checkpoint: 'b9f55e13a163da807aaa2c8b56b375679ea43d86200d99104ba782e83d697371'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.