### PR TITLE
Update 115browser to 8.6.1.12

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,10 +1,10 @@
 cask '115browser' do
-  version '8.4.0.19'
-  sha256 '0097f09f4cbf0db887d9ccf47ec35bcebaedb0252cf56938785857015a20c207'
+  version '8.6.1.12'
+  sha256 'cd882959237004eb5c7ad5b88424ec2d16a09a783dec59b16399c1c92f643feb'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
-  appcast 'https://pc.115.com/#mac',
-          checkpoint: 'e2ea2eb6965afff80577b6faf59e14b696a40db8a0e1a1c7caa14c3f689ed982'
+  appcast 'http://anxia.com/m/115brv84019dmg',
+          checkpoint: '5c607ad71eda1b808c35d9747cfe3255977b6808a2faf5178318f2ef6371109e'
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'

--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -3,8 +3,6 @@ cask '115browser' do
   sha256 'cd882959237004eb5c7ad5b88424ec2d16a09a783dec59b16399c1c92f643feb'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
-  appcast 'http://anxia.com/m/115brv84019dmg',
-          checkpoint: '5c607ad71eda1b808c35d9747cfe3255977b6808a2faf5178318f2ef6371109e'
   name '115Browser'
   name '115浏览器'
   homepage 'https://pc.115.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.