### PR TITLE
Update haskell-platform to 8.2.2

### DIFF
--- a/Casks/haskell-platform.rb
+++ b/Casks/haskell-platform.rb
@@ -1,10 +1,10 @@
 cask 'haskell-platform' do
-  version '8.2.1'
-  sha256 '05fc22d2cefdf67f1da2f62a90fda73a746accd08b44ec197046972b82afee06'
+  version '8.2.2'
+  sha256 '24d6ec3a30e06a6484108a6f6ca01a3260b1aadcef2ba4c4404348945ad77b92'
 
   url "https://haskell.org/platform/download/#{version}/Haskell%20Platform%20#{version}%20Full%2064bit-signed.pkg"
   appcast 'https://github.com/haskell/haskell-platform/releases.atom',
-          checkpoint: 'b2f433fe2215a578fe7f1315b737c7d39d7d69e1a27ef58f0e68ee3e62c6ac63'
+          checkpoint: '7eb030d6bca927ea8cb39a42191efc44a407bda40b2cae74816fa35db0a0683c'
   name 'Haskell Platform'
   homepage 'https://www.haskell.org/platform/'
 


### PR DESCRIPTION
Updated version and sha256 fields to point to new version of haskell-platform. Also updated appcast checkpoint with most recent checksum.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
