### PR TITLE
Update netron to 1.3.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.0'
-  sha256 '3d0648357bee47cce3e4ef9bc543b4a93326f87eaf3a909da96a0731c124ee2f'
+  version '1.3.3'
+  sha256 '7240e30504b63622050028b90fc908a0ff694354397c72a1f7948b695636446e'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '1f35f23b60a9ba52fae875dc1004b46da57375b3692ffd2f920883ae39628330'
+          checkpoint: '72f0e985ed90edd5108ff4627df9c0aca31929320d3bc80077fcb9f0bfa2928e'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.