### PR TITLE
Update netron to 1.3.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.0'
-  sha256 '3d0648357bee47cce3e4ef9bc543b4a93326f87eaf3a909da96a0731c124ee2f'
+  version '1.3.4'
+  sha256 '9bb8dd34b19c52c69eae351d8f6553809289407c92483e605ca01a9e4e250555'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '1f35f23b60a9ba52fae875dc1004b46da57375b3692ffd2f920883ae39628330'
+          checkpoint: '41153f2afbbf25014e3dd61c125a381a3bc1737a5c87128087b40c40c9e3d324'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.